### PR TITLE
Tighten up error handling on history functions.

### DIFF
--- a/src/history/HistoryMaster.h
+++ b/src/history/HistoryMaster.h
@@ -146,6 +146,11 @@
  * /cold/history/00/00/0x0000000000000000.xdr.gz
  */
 
+namespace asio
+{
+typedef std::error_code error_code;
+};
+
 namespace stellar
 {
 class Application;
@@ -157,37 +162,40 @@ class HistoryMaster
     template <typename T> void
     saveAndCompressAndPut(std::string const& basename,
                           std::shared_ptr<T> xdrp,
-                          std::function<void(std::string const&)> handler);
+                          std::function<void(asio::error_code const&)> handler);
 
     template <typename T> void
     getAndDecompressAndLoad(std::string const& basename,
-                            std::function<void(std::shared_ptr<T>)> handler);
+                            std::function<void(asio::error_code const&,
+                                               std::shared_ptr<T>)> handler);
 
     void putFile(std::string const& filename,
                  std::string const& basename,
-                 std::function<void(std::string const&)> handler);
+                 std::function<void(asio::error_code const&)> handler);
 
     void getFile(std::string const& basename,
                  std::string const& filename,
-                 std::function<void(std::string const&)> handler);
+                 std::function<void(asio::error_code const&)> handler);
 
     std::string const& getTempDir();
 
   public:
 
     void archiveBucket(std::shared_ptr<CLFBucket> bucket,
-                       std::function<void(std::string const&)> handler);
+                       std::function<void(asio::error_code const&)> handler);
 
     void archiveHistory(std::shared_ptr<History> hist,
-                        std::function<void(std::string const&)> handler);
+                        std::function<void(asio::error_code const&)> handler);
 
     void acquireBucket(uint64_t ledgerSeq,
                        uint32_t ledgerCount,
-                       std::function<void(std::shared_ptr<CLFBucket>)> handler);
+                       std::function<void(asio::error_code const&,
+                                          std::shared_ptr<CLFBucket>)> handler);
 
     void acquireHistory(uint64_t fromLedger,
                         uint64_t toLedger,
-                        std::function<void(std::shared_ptr<History>)> handler);
+                        std::function<void(asio::error_code const&,
+                                           std::shared_ptr<History>)> handler);
 
     HistoryMaster(Application& app);
     ~HistoryMaster();

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -46,20 +46,30 @@ TEST_CASE("Archive and reload history", "[history]")
     bool done = false;
     app.getHistoryMaster().archiveHistory(
         h1,
-        [&app, &done, h1](std::string const& filename)
+        [&app, &done, h1](asio::error_code const& ec)
         {
-            LOG(DEBUG) << "archived " << filename << ", deleting";
-            std::remove(filename.c_str());
-            LOG(DEBUG) << "reloading history for ["
+            CHECK(!ec);
+            if (ec)
+            {
+                done = true;
+                return;
+            }
+            LOG(DEBUG) << "archived history, reloading ["
                        << h1->fromLedger << ", "
                        << h1->toLedger << "]";
             app.getHistoryMaster().acquireHistory(
                 h1->fromLedger,
                 h1->toLedger,
-                [h1, &done](std::shared_ptr<History> h2)
+                [h1, &done](asio::error_code const& ec,
+                            std::shared_ptr<History> h2)
                 {
-                    LOG(DEBUG) << "reloaded history";
-                    CHECK(*h1 == *h2);
+                    CHECK(!ec);
+                    CHECK(h2);
+                    if (!ec && h2)
+                    {
+                        LOG(DEBUG) << "reloaded history";
+                        CHECK(*h1 == *h2);
+                    }
                     done = true;
                 });
         });
@@ -84,20 +94,30 @@ TEST_CASE("Archive and reload bucket", "[history]")
     bool done = false;
     app.getHistoryMaster().archiveBucket(
         b1,
-        [&app, &done, b1](std::string const& filename)
+        [&app, &done, b1](asio::error_code const& ec)
         {
-            LOG(DEBUG) << "archived " << filename << ", deleting";
-            std::remove(filename.c_str());
-            LOG(DEBUG) << "reloading bucket for seq="
+            CHECK(!ec);
+            if (ec)
+            {
+                done = true;
+                return;
+            }
+            LOG(DEBUG) << "archived bucket, reloading seq="
                        << b1->header.ledgerSeq << ", count="
                        << b1->header.ledgerCount;
             app.getHistoryMaster().acquireBucket(
                 b1->header.ledgerSeq,
                 b1->header.ledgerCount,
-                [b1, &done](std::shared_ptr<CLFBucket> b2)
+                [b1, &done](asio::error_code const& ec,
+                            std::shared_ptr<CLFBucket> b2)
                 {
-                    LOG(DEBUG) << "reloaded bucket";
-                    CHECK(*b1 == *b2);
+                    CHECK(!ec);
+                    CHECK(b2);
+                    if (!ec && b2)
+                    {
+                        LOG(DEBUG) << "reloaded bucket";
+                        CHECK(*b1 == *b2);
+                    }
                     done = true;
                 });
         });

--- a/src/lib/asio/src/asio.cpp
+++ b/src/lib/asio/src/asio.cpp
@@ -51,4 +51,8 @@
 #define ASIO_HAS_STD_THREAD
 #endif
 
+#ifndef ASIO_HAS_STD_SYSTEM_ERROR
+#define ASIO_HAS_STD_SYSTEM_ERROR
+#endif
+
 #include "asio/impl/src.hpp"

--- a/src/util/asio.h
+++ b/src/util/asio.h
@@ -52,4 +52,8 @@
 #define ASIO_HAS_STD_THREAD
 #endif
 
+#ifndef ASIO_HAS_STD_SYSTEM_ERROR
+#define ASIO_HAS_STD_SYSTEM_ERROR
+#endif
+
 #include <asio.hpp>


### PR DESCRIPTION
Error conditions were being dropped on the floor; now all (?) failures during history are propagated as error_codes to the handler functions.
