### PR TITLE
Use virtual time, not real time, when putting timestamps in database.

### DIFF
--- a/Builds/VisualStudio2015/stellarx.vcxproj
+++ b/Builds/VisualStudio2015/stellarx.vcxproj
@@ -218,6 +218,7 @@
     <ClCompile Include="..\..\src\transactions\TxTests.cpp" />
     <ClCompile Include="..\..\src\util\TempDir.cpp" />
     <ClCompile Include="..\..\src\util\Timer.cpp" />
+    <ClCompile Include="..\..\src\util\TimerTests.cpp" />
     <ClCompile Include="..\..\src\util\types.cpp" />
     <ClCompile Include="..\..\src\main\Application.cpp" />
     <ClCompile Include="..\..\src\main\CommandHandler.cpp" />

--- a/Builds/VisualStudio2015/stellarx.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellarx.vcxproj.filters
@@ -339,6 +339,9 @@
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp">
       <Filter>herder</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\TimerTests.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\history\HistoryGateway.h">

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ FMT_SRCS = src/clf/BucketList.cpp src/clf/CLFMaster.cpp src/clf/CLFTests.cpp    
     src/simulation/CycleTests.cpp src/simulation/Simulation.cpp                 \
     src/herder/Herder.cpp src/herder/TxSetFrame.cpp src/herder/HerderTests.cpp  \
     src/util/Logging.cpp src/util/Timer.cpp src/util/types.cpp                  \
-    src/util/TempDir.cpp src/util/Uint128Tests.cpp                              \
+    src/util/TempDir.cpp src/util/Uint128Tests.cpp src/util/TimerTests.cpp      \
     src/transactions/AllowTrustTxFrame.cpp                                      \
     src/transactions/CancelOfferFrame.cpp                                       \
     src/transactions/ChangeTrustTxFrame.cpp                                     \

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -60,6 +60,11 @@ public:
     typedef std::chrono::time_point<std::chrono::steady_clock, duration>
                                         time_point;
     static const bool is_steady       = true;
+
+    static std::tm pointToTm(time_point);
+    static std::string tmToISOString(std::tm const& tm);
+    static std::string pointToISOString(time_point point);
+
 private:
     time_point mNow;
     std::priority_queue<std::shared_ptr<VirtualClockEvent>> mEvents;

--- a/src/util/TimerTests.cpp
+++ b/src/util/TimerTests.cpp
@@ -1,0 +1,32 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the ISC License. See the COPYING file at the top-level directory of
+// this distribution or at http://opensource.org/licenses/ISC
+
+#include "util/Timer.h"
+#include "autocheck/autocheck.hpp"
+#include "main/test.h"
+#include "lib/catch.hpp"
+#include "util/Logging.h"
+
+using namespace stellar;
+
+TEST_CASE("VirtualClock::pointToISOString", "[timer]")
+{
+    VirtualClock clock;
+
+    VirtualClock::time_point now = clock.now();
+    CHECK(VirtualClock::pointToISOString(now) ==
+          std::string("1970-01-01T00:00:00Z"));
+
+    now += std::chrono::hours(36);
+    CHECK(VirtualClock::pointToISOString(now) ==
+          std::string("1970-01-02T12:00:00Z"));
+
+    now += std::chrono::minutes(10);
+    CHECK(VirtualClock::pointToISOString(now) ==
+          std::string("1970-01-02T12:10:00Z"));
+
+    now += std::chrono::seconds(3618);
+    CHECK(VirtualClock::pointToISOString(now) ==
+          std::string("1970-01-02T13:10:18Z"));
+}


### PR DESCRIPTION
Includes conversion routines to both std::tm and std::string (as ISO 8601). Should be sufficient.
