### PR TITLE
Only build auto branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,6 @@ notifications:
   email: false
   slack:
     secure: VYA87p8f6PgmOhL8b8DM4t6k8vPYjULpT7LBhvmNBNe8iiNDtTzLpRbUXg6t6Ij7Y3MU4uOJ5K617hCqs81VfRoOakbiYTWHeYSsMmIrUM4+d5MZM4pVP0/bCE49qt06bZINorh6IHChhfuvod3uyUqbgNrwRf/qDIIboFDIty8=
+branches:
+  only:
+    - auto


### PR DESCRIPTION
Further limits travis to only build the auto branch when it moves, not master; this halves the number of builds.
