### PR TITLE
FBA Rearchitecture

### DIFF
--- a/src/fba/FBA.h
+++ b/src/fba/FBA.h
@@ -16,79 +16,95 @@ class Node;
 class Slot;
 class LocalNode;
 
-//using xdr::operator<;
-
-
 class FBA
 {
+
   public:
-    /**
-     * Users of the FBA library must provide an implementation of the
-     * FBA::Client class. The Client methods are called by the FBA
-     * implementation to:
-     *
-     * 1) hand over the validation of ballots to the user of the library 
-     *    (`validateBallot`)
-     * 2) inform about events happening within the consensus algorithm
-     *    ( `ballotDidPrepare`, `ballotDidCommit`, `valueCancelled`, 
-     *      `valueExternalized`)
-     * 3) trigger the retrieval of data required by the FBA protocol
-     *    (`retrieveQuorumSet`)
-     * 4) trigger the broadcasting of FBA Envelopes to other nodes in the 
-     *    network (`emitEnvelope`) 
-     * 5) hint rentransmissions when it can be detected by the protocol
-     *    (`retransmissionHinted`)
-     *    
-     * The FBA::Client interface not only informs the outside world about the
-     * progress made by FBA but it also permits the abstraction of the
-     * transport layer used from the actual implementation of the FBA protocol. 
-     */
-    class Client
-    {
-      public:
-        virtual void validateBallot(const uint64& slotIndex,
-                                    const uint256& nodeID,
-                                    const FBABallot& ballot,
-                                    std::function<void(bool)> const& cb) = 0;
-        virtual int compareValues(const Value& v1,
-                                  const Value& v2);
-
-        virtual void ballotDidPrepare(const uint64& slotIndex,
-                                      const FBABallot& ballot) {}
-        virtual void ballotDidCommit(const uint64& slotIndex,
-                                     const FBABallot& ballot) {};
-
-        virtual void valueCancelled(const uint64& slotIndex,
-                                    const Value& value) {}
-        virtual void valueExternalized(const uint64& slotIndex,
-                                       const Value& value) {}
-
-        virtual void retrieveQuorumSet(const uint256& nodeID,
-                                       const Hash& qSetHash) = 0;
-        virtual void emitEnvelope(const FBAEnvelope& envelope) = 0;
-        
-        virtual void retransmissionHinted(const uint64& slotIndex,
-                                          const uint256& nodeID) {};
-    };
-
-    // The constructor is passed an FBA::Client object but does not own it. The
-    // FBA::Client must outlive the FBA object itself.
     FBA(const uint256& validationSeed,
-        const FBAQuorumSet& qSetLocal,
-        Client* client);
+        const FBAQuorumSet& qSetLocal);
     ~FBA();
 
-    // FBAQuorumSet/Envelope receival
-    void receiveQuorumSet(const uint256& nodeID,
-                          const FBAQuorumSet& qSet);
-    // Receives an envelope. Returns wether the envelope was validated or not.
+    // Users of the FBA library should inherit from FBA and implement the
+    // following virtual methods which are called by the FBA implementation to:
+    //
+    // 1) hand over the validation of values and ballots.
+    //    (`validateValue`, `validateBallot`)
+    // 2) inform about events happening within the consensus algorithm.
+    //    ( `ballotDidPrepare`, `ballotDidPrepared`, `ballotDidCommit`,
+    //      `ballotDidAbort`, `valueExternalized`)
+    // 3) retrieve data required by the FBA protocol.
+    //    (`retrieveQuorumSet`)
+    // 4) trigger the broadcast of Envelopes to other nodes in the network.
+    //    (`emitEnvelope`) 
+    //
+    // Thes methods are designed to abstract the transport layer used from the
+    // implementation of the FBA protocol
+    
+    virtual void validateValue(const uint64& slotIndex,
+                               const uint256& nodeID,
+                               const Value& value,
+                               std::function<void(bool)> const& cb)
+    {
+        return cb(true);
+    }
+
+    virtual int compareValues(const Value& v1, const Value& v2)
+    {
+        using xdr::operator<;
+
+        if (v1 < v2) return -1;
+        if (v2 < v1) return 1;
+        return 0;
+    }
+
+    virtual void validateBallot(const uint64& slotIndex,
+                                const uint256& nodeID,
+                                const FBABallot& ballot,
+                                std::function<void(bool)> const& cb)
+    {
+        return cb(true);
+    }
+
+
+    virtual void ballotDidPrepare(const uint64& slotIndex,
+                                  const FBABallot& ballot) {}
+    virtual void ballotDidPrepared(const uint64& slotIndex,
+                                  const FBABallot& ballot) {}
+    virtual void ballotDidCommit(const uint64& slotIndex,
+                                 const FBABallot& ballot) {};
+    virtual void ballotDidAbort(const uint64& slotIndex,
+                                const FBABallot& blalot) {};
+
+    virtual void valueExternalized(const uint64& slotIndex,
+                                   const Value& value) {}
+
+    virtual void retrieveQuorumSet(
+        const uint256& nodeID,
+        const Hash& qSetHash,
+        std::function<void(const FBAQuorumSet&)> const& cb) = 0;
+
+    virtual void emitEnvelope(const FBAEnvelope& envelope) = 0;
+
+    // Receives an envelope. `cb` asynchronously returns with a status for the
+    // envelope:
+    enum EnvelopeState
+    {
+        INVALID,            // the envelope is considered invalid 
+        STATEMENTS_MISSING, // the envelope is valid but we miss statements
+        VALID               // the envelope is valid
+    };
+    // If evidences are missing, a retransmisison should take place for that
+    // slot. see `procudeSlotEvidence` to implement such retransmission
+    // mechanism on the other side of the wire.
     void receiveEnvelope(const FBAEnvelope& envelope,
-                         std::function<void(bool)> const& cb = [] (bool) { });
+                         std::function<void(EnvelopeState)> const& cb = 
+                         [] (EnvelopeState) { });
 
-    // Value submission
-    bool attemptValue(const uint64& slotIndex,
-                      const Value& value);
-
+    // Submit a value for the FBA consensus phase
+    bool prepareValue(const uint64& slotIndex,
+                      const Value& value,
+                      bool forceBump = false);
+                       
     // Local QuorumSet interface (can be dynamically updated)
     void updateLocalQuorumSet(const FBAQuorumSet& qSet);
     const FBAQuorumSet& getLocalQuorumSet();
@@ -96,16 +112,24 @@ class FBA
     // Local nodeID getter
     const uint256& getLocalNodeID();
 
+  protected:
+    // Retrieves the highest prepared value for the specified slot.
+    // TODO(spolu) highestPreparedValue
+    // Value highestPreparedValue(const uint64& slotIndex);
+
+
   private:
     // Node getter
     Node* getNode(const uint256& nodeID);
     LocalNode* getLocalNode();
+
     // Slot getter
     Slot* getSlot(const uint64& slotIndex);
-    // FBA::Client getter
-    Client* getClient();
 
-    Client*                        mClient;
+    // Envelope signature/verification
+    void signEnvelope(FBAEnvelope& envelope);
+    bool verifyEnvelope(const FBAEnvelope& envelope);
+
     LocalNode*                     mLocalNode;
     std::map<uint256, Node*>       mKnownNodes;
     std::map<uint64, Slot*>        mKnownSlots;
@@ -114,5 +138,4 @@ class FBA
     friend class Node;
 };
 }
-
 

--- a/src/fba/FBATests.cpp
+++ b/src/fba/FBATests.cpp
@@ -16,17 +16,26 @@ using namespace stellar;
 using xdr::operator<;
 using xdr::operator==;
 
-class TestFBAClient : public FBA::Client
+class TestFBA : public FBA
 {
   public:
-    void setFBA(FBA* FBA)
+    TestFBA(const uint256& validationSeed,
+            const FBAQuorumSet& qSetLocal)
+        : FBA(validationSeed, qSetLocal)
     {
-        mFBA = FBA;
     }
-    void addQuorumSet(FBAQuorumSet qSet)
+    void storeQuorumSet(FBAQuorumSet qSet)
     {
         Hash qSetHash = sha512_256(xdr::xdr_to_msg(qSet));
         mQuorumSets[qSetHash] = qSet;
+    }
+
+    void validateValue(const uint64& slotIndex,
+                       const Hash& nodeID,
+                       const Value& value,
+                       std::function<void(bool)> const& cb)
+    {
+        cb(true);
     }
 
     void validateBallot(const uint64& slotIndex,
@@ -41,15 +50,18 @@ class TestFBAClient : public FBA::Client
                           const FBABallot& ballot)
     {
     }
+    void ballotDidPrepared(const uint64& slotIndex,
+                           const FBABallot& ballot)
+    {
+    }
     void ballotDidCommit(const uint64& slotIndex,
                          const FBABallot& ballot)
     {
     }
-
-    void valueCancelled(const uint64& slotIndex,
-                        const Value& value)
+    void ballotDidAbort(const uint64& slotIndex,
+                        const FBABallot& ballot)
     {
-        mCancelledValues[slotIndex].push_back(value);
+        mAbortedBallots[slotIndex].push_back(ballot);
     }
 
     void valueExternalized(const uint64& slotIndex,
@@ -63,7 +75,8 @@ class TestFBAClient : public FBA::Client
     }
 
     void retrieveQuorumSet(const Hash& nodeID,
-                           const Hash& qSetHash)
+                           const Hash& qSetHash,
+                           std::function<void(const FBAQuorumSet&)> const& cb)
     {
         if (mQuorumSets.find(qSetHash) != mQuorumSets.end())
         {
@@ -71,7 +84,7 @@ class TestFBAClient : public FBA::Client
                       << " " << binToHex(qSetHash).substr(0,6)
                       << "@" << binToHex(nodeID).substr(0,6)
                       << " OK";
-            mFBA->receiveQuorumSet(nodeID, mQuorumSets[qSetHash]);
+            return cb(mQuorumSets[qSetHash]);
         }
         else
         {
@@ -86,19 +99,10 @@ class TestFBAClient : public FBA::Client
         mEnvs.push_back(envelope);
     }
 
-    void retransmissionHinted(const uint64& slotIndex,
-                              const uint256& nodeID)
-    {
-        mRetransmissionHints[slotIndex].push_back(nodeID);
-    }
-
-    std::map<Hash, FBAQuorumSet>           mQuorumSets;
-    std::vector<FBAEnvelope>               mEnvs;
-    std::map<uint64, Value>                mExternalizedValues;
-    std::map<uint64, std::vector<Value>>   mCancelledValues;
-    std::map<uint64, std::vector<uint256>> mRetransmissionHints;
-
-    FBA*                                   mFBA;
+    std::map<Hash, FBAQuorumSet>              mQuorumSets;
+    std::vector<FBAEnvelope>                  mEnvs;
+    std::map<uint64, Value>                   mExternalizedValues;
+    std::map<uint64, std::vector<FBABallot>>  mAbortedBallots;
 };
 
 
@@ -112,10 +116,10 @@ makeEnvelope(const uint256& nodeID,
     FBAEnvelope envelope;
 
     envelope.nodeID = nodeID;
-    envelope.statement.slotIndex = slotIndex;
+    envelope.slotIndex = slotIndex;
     envelope.statement.ballot = ballot;
     envelope.statement.quorumSetHash = qSetHash;
-    envelope.statement.body.type(type);
+    envelope.statement.pledges.type(type);
 
     return envelope;
 }
@@ -144,11 +148,9 @@ TEST_CASE("protocol core4", "[fba]")
 
     uint256 qSetHash = sha512_256(xdr::xdr_to_msg(qSet));
 
-    TestFBAClient C;
-    FBA fba(v0VSeed, qSet, &C);
+    TestFBA fba(v0VSeed, qSet);
 
-    C.setFBA(&fba);
-    C.addQuorumSet(qSet);
+    fba.storeQuorumSet(qSet);
 
     CREATE_VALUE(x);
     CREATE_VALUE(y);
@@ -158,17 +160,19 @@ TEST_CASE("protocol core4", "[fba]")
 
     LOG(INFO) << "<<<< BEGIN FBA TEST >>>>";
 
-    SECTION("attemptValue x")
+    SECTION("prepareValue x")
     {
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
-        REQUIRE(!C.mEnvs[0].statement.body.prepare().prepared);
-        REQUIRE(C.mEnvs[0].statement.body.prepare().excepted.size() == 0);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].slotIndex == 0);
+        REQUIRE(fba.mEnvs[0].statement.quorumSetHash == qSetHash);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
+        REQUIRE(!fba.mEnvs[0].statement.pledges.prepare().prepared);
+        REQUIRE(fba.mEnvs[0].statement.pledges.prepare().excepted.size() == 0);
     }
 
     SECTION("normal round (0,x)")
@@ -184,25 +188,25 @@ TEST_CASE("protocol core4", "[fba]")
                                             FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare1);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         // We send a prepare as we were pristine
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         // We have a quorum including us
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::PREPARED);
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARED);
 
         fba.receiveEnvelope(prepare3);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         FBAEnvelope prepared1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                              FBABallot(0, xValue),
@@ -215,18 +219,18 @@ TEST_CASE("protocol core4", "[fba]")
                                              FBAStatementType::PREPARED);
 
         fba.receiveEnvelope(prepared3);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         fba.receiveEnvelope(prepared2);
-        REQUIRE(C.mEnvs.size() == 3);
+        REQUIRE(fba.mEnvs.size() == 3);
 
-        REQUIRE(C.mEnvs[2].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[2].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[2].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[2].statement.body.type() == FBAStatementType::COMMIT);
+        REQUIRE(fba.mEnvs[2].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[2].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[2].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[2].statement.pledges.type() == FBAStatementType::COMMIT);
         
         fba.receiveEnvelope(prepared1);
-        REQUIRE(C.mEnvs.size() == 3);
+        REQUIRE(fba.mEnvs.size() == 3);
 
         FBAEnvelope commit1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                            FBABallot(0, xValue),
@@ -239,23 +243,23 @@ TEST_CASE("protocol core4", "[fba]")
                                            FBAStatementType::COMMIT);
 
         fba.receiveEnvelope(commit2);
-        REQUIRE(C.mEnvs.size() == 3);
+        REQUIRE(fba.mEnvs.size() == 3);
 
         fba.receiveEnvelope(commit1);
-        REQUIRE(C.mEnvs.size() == 4);
+        REQUIRE(fba.mEnvs.size() == 4);
 
-        REQUIRE(C.mEnvs[3].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[3].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[3].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[3].statement.body.type() == FBAStatementType::COMMITTED);
+        REQUIRE(fba.mEnvs[3].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[3].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[3].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[3].statement.pledges.type() == FBAStatementType::COMMITTED);
 
         fba.receiveEnvelope(commit3);
-        REQUIRE(C.mEnvs.size() == 5);
+        REQUIRE(fba.mEnvs.size() == 5);
 
-        REQUIRE(C.mEnvs[4].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[4].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[4].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[4].statement.body.type() == FBAStatementType::COMMITTED);
+        REQUIRE(fba.mEnvs[4].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[4].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[4].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[4].statement.pledges.type() == FBAStatementType::COMMITTED);
 
         FBAEnvelope committed1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                               FBABallot(0, xValue),
@@ -268,42 +272,31 @@ TEST_CASE("protocol core4", "[fba]")
                                               FBAStatementType::COMMITTED);
 
         fba.receiveEnvelope(committed3);
-        REQUIRE(C.mEnvs.size() == 5);
+        REQUIRE(fba.mEnvs.size() == 5);
         // The slot should not have externalized yet
-        REQUIRE(C.mExternalizedValues.find(0) == 
-            C.mExternalizedValues.end());
+        REQUIRE(fba.mExternalizedValues.find(0) == 
+            fba.mExternalizedValues.end());
 
         fba.receiveEnvelope(committed1);
-        REQUIRE(C.mEnvs.size() == 5);
+        REQUIRE(fba.mEnvs.size() == 5);
         // The slot should have externalized the value
-        REQUIRE(C.mExternalizedValues.size() == 1);
-        REQUIRE(C.mExternalizedValues[0] == xValue);
+        REQUIRE(fba.mExternalizedValues.size() == 1);
+        REQUIRE(fba.mExternalizedValues[0] == xValue);
 
         fba.receiveEnvelope(committed2);
-        REQUIRE(C.mEnvs.size() == 5);
-        REQUIRE(C.mExternalizedValues.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 5);
+        REQUIRE(fba.mExternalizedValues.size() == 1);
     }
 
-    SECTION("x<y, attempt (0,x), prepared (0,y) by v-blocking")
+    SECTION("x<y, prepare (0,x), prepared (0,y) by v-blocking")
     {
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
-
-        FBAEnvelope prepare1 = makeEnvelope(v1NodeID, qSetHash, 0,
-                                            FBABallot(0, yValue),
-                                            FBAStatementType::PREPARE);
-        FBAEnvelope prepare2 = makeEnvelope(v2NodeID, qSetHash, 0,
-                                            FBABallot(0, yValue),
-                                            FBAStatementType::PREPARE);
-
-        fba.receiveEnvelope(prepare1);
-        fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         FBAEnvelope prepared1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                              FBABallot(0, yValue),
@@ -313,38 +306,37 @@ TEST_CASE("protocol core4", "[fba]")
                                              FBAStatementType::PREPARED);
 
         fba.receiveEnvelope(prepared1);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
         fba.receiveEnvelope(prepared2);
-        REQUIRE(C.mEnvs.size() == 4);
+        REQUIRE(fba.mEnvs.size() == 4);
 
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARE);
+        REQUIRE(!fba.mEnvs[1].statement.pledges.prepare().prepared);
+        REQUIRE(fba.mEnvs[1].statement.pledges.prepare().excepted.size() == 0);
 
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::PREPARE);
-        REQUIRE(!C.mEnvs[1].statement.body.prepare().prepared);
-        REQUIRE(C.mEnvs[1].statement.body.prepare().excepted.size() == 0);
+        REQUIRE(fba.mEnvs[2].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[2].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[2].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[2].statement.pledges.type() == FBAStatementType::PREPARED);
 
-        REQUIRE(C.mEnvs[2].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[2].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[2].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[2].statement.body.type() == FBAStatementType::PREPARED);
-
-        REQUIRE(C.mEnvs[3].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[3].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[3].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[3].statement.body.type() == FBAStatementType::COMMIT);
+        REQUIRE(fba.mEnvs[3].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[3].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[3].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[3].statement.pledges.type() == FBAStatementType::COMMIT);
     }
 
-    SECTION("x<y, attempt (0,y), prepared (0,x) by v-blocking")
+    SECTION("x<y, prepare (0,y), prepared (0,x) by v-blocking")
     {
-        REQUIRE(fba.attemptValue(0, yValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, yValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         FBAEnvelope prepare1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                             FBABallot(0, xValue),
@@ -355,7 +347,7 @@ TEST_CASE("protocol core4", "[fba]")
 
         fba.receiveEnvelope(prepare1);
         fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         FBAEnvelope prepared1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                              FBABallot(0, xValue),
@@ -365,23 +357,28 @@ TEST_CASE("protocol core4", "[fba]")
                                              FBAStatementType::PREPARED);
 
         fba.receiveEnvelope(prepared1);
-        REQUIRE(C.mEnvs.size() == 1);
-        fba.receiveEnvelope(prepared2);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        // TODO(spolu): We don't emit a PREPARED here as our mBallot is higher,
-        // but we might want to do so for later PREPARE messages (TBD with dm)
+        fba.receiveEnvelope(prepared2);
+        REQUIRE(fba.mEnvs.size() == 2);
+
+        // We're supposed to emit a PREPARED message here as the smaller ballot
+        // (0,x) effectively prepared.
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARED);
     }
     
-    SECTION("x<y, attempt (0,x), prepare (0,y) by quorum")
+    SECTION("x<y, prepare (0,x), prepare (0,y) by quorum")
     {
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         FBAEnvelope prepare1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                             FBABallot(0, yValue),
@@ -394,33 +391,36 @@ TEST_CASE("protocol core4", "[fba]")
                                             FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare1);
+        REQUIRE(fba.mEnvs.size() == 2);
+
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARE);
+        REQUIRE(!fba.mEnvs[1].statement.pledges.prepare().prepared);
+        REQUIRE(fba.mEnvs[1].statement.pledges.prepare().excepted.size() == 0);
+
         fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 3);
+
+        REQUIRE(fba.mEnvs[2].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[2].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[2].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[2].statement.pledges.type() == FBAStatementType::PREPARED);
+
         fba.receiveEnvelope(prepare3);
-        REQUIRE(C.mEnvs.size() == 3);
-
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::PREPARE);
-        REQUIRE(!C.mEnvs[1].statement.body.prepare().prepared);
-        REQUIRE(C.mEnvs[1].statement.body.prepare().excepted.size() == 0);
-
-        REQUIRE(C.mEnvs[2].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[2].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[2].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[2].statement.body.type() == FBAStatementType::PREPARED);
+        REQUIRE(fba.mEnvs.size() == 3);
     }
 
-    SECTION("x<y, attempt (0,y), prepare (0,x) by quorum")
+    SECTION("x<y, prepare (0,y), prepare (0,x) by quorum")
     {
-        REQUIRE(fba.attemptValue(0, yValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, yValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         FBAEnvelope prepare1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                             FBABallot(0, xValue),
@@ -434,18 +434,23 @@ TEST_CASE("protocol core4", "[fba]")
 
         fba.receiveEnvelope(prepare1);
         fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 1);
-        fba.receiveEnvelope(prepare3);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        // TODO(spolu): We don't emit a PREPARED here as our mBallot is higher,
-        // but we might want to do so for later PREPARE messages (TBD with dm)
+        fba.receiveEnvelope(prepare3);
+        REQUIRE(fba.mEnvs.size() == 2);
+
+        // We're supposed to emit a PREPARED message here as the smaller ballot
+        // (0,x) effectively prepared.
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARED);
     }
 
-    SECTION("attempt (0,x), committed (*,y) by quorum")
+    SECTION("prepare (0,x), committed (*,y) by quorum")
     {
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
         FBAEnvelope committed1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                               FBABallot(1, yValue),
@@ -458,28 +463,28 @@ TEST_CASE("protocol core4", "[fba]")
                                               FBAStatementType::COMMITTED);
 
         fba.receiveEnvelope(committed1);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(committed2);
         // No change yet as a v-blocking set is not enough here
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(committed3);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         // The slot should have externalized the value
-        REQUIRE(C.mExternalizedValues[0] == yValue);
+        REQUIRE(fba.mExternalizedValues[0] == yValue);
 
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 4);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::COMMITTED);
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 4);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::COMMITTED);
     }
 
-    SECTION("x<y, attempt (0,x), committed (0,y) by quorum")
+    SECTION("x<y, prepare (0,x), committed (0,y) by quorum")
     {
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
         FBAEnvelope committed1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                               FBABallot(0, yValue),
@@ -492,28 +497,28 @@ TEST_CASE("protocol core4", "[fba]")
                                               FBAStatementType::COMMITTED);
 
         fba.receiveEnvelope(committed1);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(committed2);
         // No change yet as a v-blocking set is not enough here
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(committed3);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         // The slot should have externalized the value
-        REQUIRE(C.mExternalizedValues[0] == yValue);
+        REQUIRE(fba.mExternalizedValues[0] == yValue);
 
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::COMMITTED);
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::COMMITTED);
     }
 
-    SECTION("x<y, attempt (0,y), committed (0,x) by quorum")
+    SECTION("x<y, prepare (0,y), committed (0,x) by quorum")
     {
-        REQUIRE(fba.attemptValue(0, yValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, yValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
         FBAEnvelope committed1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                               FBABallot(0, xValue),
@@ -526,36 +531,37 @@ TEST_CASE("protocol core4", "[fba]")
                                               FBAStatementType::COMMITTED);
 
         fba.receiveEnvelope(committed1);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(committed2);
         // No change yet as a v-blocking set is not enough here
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(committed3);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         // The slot should have externalized the value
-        REQUIRE(C.mExternalizedValues[0] == xValue);
+        REQUIRE(fba.mExternalizedValues[0] == xValue);
 
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 1);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::COMMITTED);
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 1);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::COMMITTED);
     }
 
-    SECTION("attempt (0,x), prepare (1,y), * (0,z)")
+    SECTION("prepare (0,x), prepare (1,y), * (0,z)")
     {
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 1);
 
         FBAEnvelope prepare1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                             FBABallot(1, yValue),
                                             FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare1);
-        REQUIRE(C.mEnvs.size() == 2);
-        REQUIRE(C.mCancelledValues[0][0] == xValue);
+        REQUIRE(fba.mEnvs.size() == 2);
+        REQUIRE(fba.mAbortedBallots[0][0].counter == 0);
+        REQUIRE(fba.mAbortedBallots[0][0].value == xValue);
 
         FBAEnvelope prepare2 = makeEnvelope(v2NodeID, qSetHash, 0,
                                             FBABallot(0, zValue),
@@ -568,7 +574,7 @@ TEST_CASE("protocol core4", "[fba]")
         fba.receiveEnvelope(commit3);
 
         // The envelopes should have no effect
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
     }
 
     SECTION("x<y, prepare (0,x), prepare (0,y), attempt (0,y)")
@@ -584,30 +590,30 @@ TEST_CASE("protocol core4", "[fba]")
                                             FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare1);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
         fba.receiveEnvelope(prepare3);
+        REQUIRE(fba.mEnvs.size() == 2);
+
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARE);
+
+        REQUIRE(fba.prepareValue(0, yValue));
         // No effect on this round
-        REQUIRE(C.mEnvs.size() == 1);
-
-        REQUIRE(fba.attemptValue(0, yValue));
-        REQUIRE(C.mEnvs.size() == 2);
-
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs.size() == 2);
     }
 
-    SECTION("pledge to commit (0,x), accept cancel on (1,y)")
+    SECTION("x<y, pledge to commit (0,x), accept cancel on (2,y)")
     {
         // 1 and 2 prepare (0,x)
         FBAEnvelope prepare1_x = makeEnvelope(v1NodeID, qSetHash, 0,
@@ -617,29 +623,21 @@ TEST_CASE("protocol core4", "[fba]")
                                               FBABallot(0, xValue),
                                               FBAStatementType::PREPARE);
 
-        // 3 prepares (0,y)
-        FBAEnvelope prepare3_y = makeEnvelope(v3NodeID, qSetHash, 0,
-                                              FBABallot(0, yValue),
-                                              FBAStatementType::PREPARE);
-
         fba.receiveEnvelope(prepare1_x);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
-
-        fba.receiveEnvelope(prepare3_y);
-        REQUIRE(C.mEnvs.size() == 1);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
         fba.receiveEnvelope(prepare2_x);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::PREPARED);
+        REQUIRE(fba.mEnvs[1].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[1].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[1].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[1].statement.pledges.type() == FBAStatementType::PREPARED);
 
         FBAEnvelope prepared1_x = makeEnvelope(v1NodeID, qSetHash, 0,
                                                FBABallot(0, xValue),
@@ -649,15 +647,15 @@ TEST_CASE("protocol core4", "[fba]")
                                                FBAStatementType::PREPARED);
         
         fba.receiveEnvelope(prepared1_x);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 2);
 
         fba.receiveEnvelope(prepared2_x);
-        REQUIRE(C.mEnvs.size() == 3);
+        REQUIRE(fba.mEnvs.size() == 3);
 
-        REQUIRE(C.mEnvs[2].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[2].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[2].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[2].statement.body.type() == FBAStatementType::COMMIT);
+        REQUIRE(fba.mEnvs[2].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[2].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[2].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[2].statement.pledges.type() == FBAStatementType::COMMIT);
 
         // then our node becomes laggy for a while time during which 1, 2, 3
         // confirms prepare on (1,y) but 3 dies. Then we come back and 2
@@ -667,35 +665,36 @@ TEST_CASE("protocol core4", "[fba]")
         FBAEnvelope prepare1_y = makeEnvelope(v1NodeID, qSetHash, 0,
                                               FBABallot(2, yValue),
                                               FBAStatementType::PREPARE);
-        prepare1_y.statement.body.prepare().prepared.activate() = 
+        prepare1_y.statement.pledges.prepare().prepared.activate() = 
             FBABallot(1, yValue);
 
         FBAEnvelope prepare2_y = makeEnvelope(v2NodeID, qSetHash, 0,
                                               FBABallot(2, yValue),
                                               FBAStatementType::PREPARE);
-        prepare2_y.statement.body.prepare().prepared.activate() = 
+        prepare2_y.statement.pledges.prepare().prepared.activate() = 
             FBABallot(1, yValue);
 
         fba.receiveEnvelope(prepare1_y);
-        REQUIRE(C.mEnvs.size() == 4);
-        REQUIRE(C.mCancelledValues[0][0] == xValue);
+        REQUIRE(fba.mEnvs.size() == 4);
+        REQUIRE(fba.mAbortedBallots[0][0].counter == 0);
+        REQUIRE(fba.mAbortedBallots[0][0].value == xValue);
 
-        REQUIRE(C.mEnvs[3].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[3].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[3].statement.ballot.counter == 2);
-        REQUIRE(C.mEnvs[3].statement.body.type() == FBAStatementType::PREPARE);
-        REQUIRE(C.mEnvs[3].statement.body.prepare().excepted.size() == 1);
-        REQUIRE(C.mEnvs[3].statement.body.prepare().excepted[0].counter == 0);
-        REQUIRE(C.mEnvs[3].statement.body.prepare().excepted[0].value == xValue);
-        REQUIRE(!C.mEnvs[3].statement.body.prepare().prepared);
+        REQUIRE(fba.mEnvs[3].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[3].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[3].statement.ballot.counter == 2);
+        REQUIRE(fba.mEnvs[3].statement.pledges.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[3].statement.pledges.prepare().excepted.size() == 1);
+        REQUIRE(fba.mEnvs[3].statement.pledges.prepare().excepted[0].counter == 0);
+        REQUIRE(fba.mEnvs[3].statement.pledges.prepare().excepted[0].value == xValue);
+        REQUIRE(!fba.mEnvs[3].statement.pledges.prepare().prepared);
 
         fba.receiveEnvelope(prepare2_y);
-        REQUIRE(C.mEnvs.size() == 5);
+        REQUIRE(fba.mEnvs.size() == 5);
 
-        REQUIRE(C.mEnvs[4].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[4].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[4].statement.ballot.counter == 2);
-        REQUIRE(C.mEnvs[4].statement.body.type() == FBAStatementType::PREPARED);
+        REQUIRE(fba.mEnvs[4].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[4].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[4].statement.ballot.counter == 2);
+        REQUIRE(fba.mEnvs[4].statement.pledges.type() == FBAStatementType::PREPARED);
 
         FBAEnvelope prepared1_y = makeEnvelope(v1NodeID, qSetHash, 0,
                                                FBABallot(2, yValue),
@@ -705,78 +704,64 @@ TEST_CASE("protocol core4", "[fba]")
                                                FBAStatementType::PREPARED);
         
         fba.receiveEnvelope(prepared1_y);
-        REQUIRE(C.mEnvs.size() == 5);
+        REQUIRE(fba.mEnvs.size() == 5);
 
         fba.receiveEnvelope(prepared2_y);
-        REQUIRE(C.mEnvs.size() == 6);
+        REQUIRE(fba.mEnvs.size() == 6);
 
-        REQUIRE(C.mEnvs[5].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[5].statement.ballot.value == yValue);
-        REQUIRE(C.mEnvs[5].statement.ballot.counter == 2);
-        REQUIRE(C.mEnvs[5].statement.body.type() == FBAStatementType::COMMIT);
+        REQUIRE(fba.mEnvs[5].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[5].statement.ballot.value == yValue);
+        REQUIRE(fba.mEnvs[5].statement.ballot.counter == 2);
+        REQUIRE(fba.mEnvs[5].statement.pledges.type() == FBAStatementType::COMMIT);
 
         // finally things go south and we attempt x again
-        REQUIRE(fba.attemptValue(0, xValue));
-        REQUIRE(C.mEnvs.size() == 7);
+        REQUIRE(fba.prepareValue(0, xValue));
+        REQUIRE(fba.mEnvs.size() == 7);
 
         // we check the prepare message is all in order
-        REQUIRE(C.mEnvs[6].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[6].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[6].statement.ballot.counter == 3);
-        REQUIRE(C.mEnvs[6].statement.body.type() == FBAStatementType::PREPARE);
-        REQUIRE(C.mEnvs[6].statement.body.prepare().excepted.size() == 2);
-        REQUIRE(C.mEnvs[6].statement.body.prepare().excepted[0].counter == 0);
-        REQUIRE(C.mEnvs[6].statement.body.prepare().excepted[0].value == xValue);
-        REQUIRE(C.mEnvs[6].statement.body.prepare().excepted[1].counter == 2);
-        REQUIRE(C.mEnvs[6].statement.body.prepare().excepted[1].value == yValue);
-        REQUIRE(C.mEnvs[6].statement.body.prepare().prepared);
-        REQUIRE((*C.mEnvs[6].statement.body.prepare().prepared).counter == 0);
-        REQUIRE((*C.mEnvs[6].statement.body.prepare().prepared).value == xValue);
+        REQUIRE(fba.mEnvs[6].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[6].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[6].statement.ballot.counter == 3);
+        REQUIRE(fba.mEnvs[6].statement.pledges.type() == FBAStatementType::PREPARE);
+        REQUIRE(fba.mEnvs[6].statement.pledges.prepare().excepted.size() == 2);
+        REQUIRE(fba.mEnvs[6].statement.pledges.prepare().excepted[0].counter == 0);
+        REQUIRE(fba.mEnvs[6].statement.pledges.prepare().excepted[0].value == xValue);
+        REQUIRE(fba.mEnvs[6].statement.pledges.prepare().excepted[1].counter == 2);
+        REQUIRE(fba.mEnvs[6].statement.pledges.prepare().excepted[1].value == yValue);
+        REQUIRE(fba.mEnvs[6].statement.pledges.prepare().prepared);
+        REQUIRE((*fba.mEnvs[6].statement.pledges.prepare().prepared).counter == 0);
+        REQUIRE((*fba.mEnvs[6].statement.pledges.prepare().prepared).value == xValue);
     }
 
-    SECTION("missing prepare (0,y), retransmission hint")
+    SECTION("missing prepared (0,y), commit (0,y)")
     {
         FBAEnvelope prepare1 = makeEnvelope(v1NodeID, qSetHash, 0,
                                             FBABallot(0, xValue),
                                             FBAStatementType::PREPARE);
-        FBAEnvelope prepare2 = makeEnvelope(v2NodeID, qSetHash, 0,
-                                            FBABallot(0, xValue),
-                                            FBAStatementType::PREPARE);
-
-        // never received prepare1
-        fba.receiveEnvelope(prepare2);
-        REQUIRE(C.mEnvs.size() == 1);
-
-        REQUIRE(C.mEnvs[0].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[0].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[0].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[0].statement.body.type() == FBAStatementType::PREPARE);
-
-        FBAEnvelope prepared1 = makeEnvelope(v1NodeID, qSetHash, 0,
-                                             FBABallot(0, yValue),
-                                             FBAStatementType::PREPARED);
-
-        // the node must have hinted a retransmission
-        fba.receiveEnvelope(prepared1);
-        REQUIRE(C.mEnvs.size() == 1);
-        REQUIRE(C.mRetransmissionHints[0].size() == 1);
-        REQUIRE(C.mRetransmissionHints[0][0] == v1NodeID);
-
-        // after retransmission all is in order
         fba.receiveEnvelope(prepare1);
-        REQUIRE(C.mEnvs.size() == 2);
+        REQUIRE(fba.mEnvs.size() == 1);
 
-        REQUIRE(C.mEnvs[1].nodeID == v0NodeID);
-        REQUIRE(C.mEnvs[1].statement.ballot.value == xValue);
-        REQUIRE(C.mEnvs[1].statement.ballot.counter == 0);
-        REQUIRE(C.mEnvs[1].statement.body.type() == FBAStatementType::PREPARED);
+        REQUIRE(fba.mEnvs[0].nodeID == v0NodeID);
+        REQUIRE(fba.mEnvs[0].statement.ballot.value == xValue);
+        REQUIRE(fba.mEnvs[0].statement.ballot.counter == 0);
+        REQUIRE(fba.mEnvs[0].statement.pledges.type() == FBAStatementType::PREPARE);
 
-        fba.receiveEnvelope(prepared1);
-        REQUIRE(C.mEnvs.size() == 2);
+        FBAEnvelope commit1 = makeEnvelope(v1NodeID, qSetHash, 0,
+                                         FBABallot(0, yValue),
+                                         FBAStatementType::COMMIT);
+
+        // the node must have requested evidence
+        fba.receiveEnvelope(
+            commit1, 
+            [] (FBA::EnvelopeState s)
+            {
+                REQUIRE(s == FBA::EnvelopeState::STATEMENTS_MISSING);
+            });
+        REQUIRE(fba.mEnvs.size() == 1);
     }
 
-    // TODO(spolu): add generic test to check that no statement emitted contradict
-    //              itself
+    // TODO(spolu) add generic test to check that no statement emitted 
+    //             contradict itself
 }
 
 

--- a/src/fba/FBAXDR.x
+++ b/src/fba/FBAXDR.x
@@ -7,11 +7,12 @@ typedef opaque uint256[32];
 typedef unsigned uint32;
 typedef unsigned hyper uint64;
 typedef opaque Value<>;
+typedef opaque Evidence<>;
 
 struct FBABallot
 {
-    uint32 counter;   // n
-    Value value;      // x
+    uint32 counter;     // n
+    Value value;        // x
 };
 
 enum FBAStatementType
@@ -24,9 +25,8 @@ enum FBAStatementType
 
 struct FBAStatement
 {
-    uint64 slotIndex;      // i
     FBABallot ballot;      // b
-    Hash quorumSetHash;
+    Hash quorumSetHash;    // D
 	
     union switch (FBAStatementType type)
     {
@@ -40,12 +40,13 @@ struct FBAStatement
         case COMMIT:
         case COMMITTED:
             void;		
-    } body;
+    } pledges;
 };
 
 struct FBAEnvelope
 {
-    uint256 nodeID;
+    uint256 nodeID;         // v
+    uint64 slotIndex;       // i
     FBAStatement statement;
     Signature signature;
 };

--- a/src/fba/LocalNode.h
+++ b/src/fba/LocalNode.h
@@ -34,4 +34,3 @@ class LocalNode : public Node
 };
 }
 
-

--- a/src/fba/Node.cpp
+++ b/src/fba/Node.cpp
@@ -9,7 +9,6 @@
 #include "util/Logging.h"
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
-#include "fba/Slot.h"
 
 
 namespace stellar
@@ -24,13 +23,127 @@ Node::Node(const uint256& nodeID,
 {
 }
 
+bool
+Node::hasQuorum(const Hash& qSetHash,
+                    const std::vector<uint256>& nodeSet)
+{
+    LOG(DEBUG) << ">> Node::hasQuorum" 
+               << "@" << binToHex(mNodeID).substr(0,6)
+               << " " << binToHex(qSetHash).substr(0,6)
+               << " " << nodeSet.size();
+    // This call can throw a `QuorumSetNotFound` if the quorumSet is unknown.
+    const FBAQuorumSet& qSet = retrieveQuorumSet(qSetHash);
+
+    uint32 count = 0;
+    for (auto n : qSet.validators)
+    {
+        auto it = std::find(nodeSet.begin(), nodeSet.end(), n);
+        count += (it != nodeSet.end()) ? 1 : 0;
+    }
+    return (count >= qSet.threshold);
+}
+
+bool 
+Node::isVBlocking(const Hash& qSetHash,
+                  const std::vector<uint256>& nodeSet)
+{
+    LOG(DEBUG) << ">> Node::isVBlocking" 
+               << "@" << binToHex(mNodeID).substr(0,6)
+               << " " << binToHex(qSetHash).substr(0,6)
+               << " " << nodeSet.size();
+    // This call can throw a `QuorumSetNotFound` if the quorumSet is unknown.
+    const FBAQuorumSet& qSet = retrieveQuorumSet(qSetHash);
+
+    // There is no v-blocking set for {\empty}
+    if(qSet.threshold == 0)
+    {
+        return false;
+    }
+
+    uint32 count = 0;
+    for (auto n : qSet.validators)
+    {
+        auto it = std::find(nodeSet.begin(), nodeSet.end(), n);
+        count += (it != nodeSet.end()) ? 1 : 0;
+    }
+    return (qSet.validators.size() - count < qSet.threshold);
+}
+
+template <class T> bool 
+Node::isVBlocking(const Hash& qSetHash,
+                  const std::map<uint256, T>& map,
+                  std::function<bool(const uint256&, const T&)> const& filter)
+{
+    std::vector<uint256> pNodes;
+    for (auto it : map)
+    {
+        if (filter(it.first, it.second))
+        {
+            pNodes.push_back(it.first);
+        }
+    }
+
+    return isVBlocking(qSetHash, pNodes);
+}
+
+template bool 
+Node::isVBlocking<FBAStatement>(
+    const Hash& qSetHash,
+    const std::map<uint256, FBAStatement>& map,
+    std::function<bool(const uint256&, const FBAStatement&)> const& filter);
+
+
+template <class T> bool 
+Node::isQuorumTransitive(const Hash& qSetHash,
+                         const std::map<uint256, T>& map,
+                         std::function<Hash(const T&)> const& qfun,
+                         std::function<bool(const uint256&, const T&)> const&
+                         filter)
+{
+    std::vector<uint256> pNodes;
+    for (auto it : map)
+    {
+        if (filter(it.first, it.second))
+        {
+            pNodes.push_back(it.first);
+        }
+    }
+
+    size_t count = 0;
+    do
+    {
+        count = pNodes.size();
+        std::vector<uint256> fNodes(pNodes.size());
+        auto quorumFilter = [&] (uint256 nodeID) -> bool 
+        {
+            return mFBA->getNode(nodeID)->hasQuorum(
+                qfun(map.find(nodeID)->second),
+                pNodes);
+        };
+        auto it = std::copy_if(pNodes.begin(), pNodes.end(), 
+                               fNodes.begin(), quorumFilter);
+        fNodes.resize(std::distance(fNodes.begin(), it));
+        pNodes = fNodes;
+    } while (count != pNodes.size());
+
+    return hasQuorum(qSetHash, pNodes);
+}
+
+template bool 
+Node::isQuorumTransitive<FBAStatement>(
+    const Hash& qSetHash,
+    const std::map<uint256, FBAStatement>& map,
+    std::function<Hash(const FBAStatement&)> const& qfun,
+    std::function<bool(const uint256&, const FBAStatement&)> const& filter);
+
+
 const FBAQuorumSet& 
 Node::retrieveQuorumSet(const uint256& qSetHash)
 {
     /*
-    LOG(INFO) << "Node::retrieveQuorumSet"
-              << "@" << binToHex(mNodeID).substr(0,6)
-              << " "  << binToHex(qSetHash).substr(0,6);
+    LOG(DEBUG) << "Node::retrieveQuorumSet"
+               << "@" << binToHex(mNodeID).substr(0,6)
+               << " "  << binToHex(qSetHash).substr(0,6);
     */
 
     assert(mCacheLRU.size() == mCache.size());
@@ -42,32 +155,14 @@ Node::retrieveQuorumSet(const uint256& qSetHash)
     throw QuorumSetNotFound(mNodeID, qSetHash);
 }
 
-void 
-Node::addPendingSlot(const uint256& qSetHash, const uint64& slotIndex)
-{
-    /*
-    LOG(INFO) << "Node::addPendingSlot"
-              << "@" << binToHex(mNodeID).substr(0,6)
-              << " " << binToHex(qSetHash).substr(0,6)
-              << " " << slotIndex;
-    */
-    auto it = std::find(mPendingSlots[qSetHash].begin(), 
-                        mPendingSlots[qSetHash].end(),
-                        slotIndex);
-    if(it == mPendingSlots[qSetHash].end())
-    {
-        mPendingSlots[qSetHash].push_back(slotIndex);
-    }
-}
-
 void
 Node::cacheQuorumSet(const FBAQuorumSet& qSet)
 {
     uint256 qSetHash = sha512_256(xdr::xdr_to_msg(qSet));
     /*
-    LOG(INFO) << "Node::cacheQuorumSet"
-              << "@" << binToHex(mNodeID).substr(0,6)
-              << " "  << binToHex(qSetHash).substr(0,6);
+    LOG(DEBUG) << "Node::cacheQuorumSet"
+               << "@" << binToHex(mNodeID).substr(0,6)
+               << " "  << binToHex(qSetHash).substr(0,6);
     */
 
     if (mCache.find(qSetHash) != mCache.end())
@@ -85,12 +180,6 @@ Node::cacheQuorumSet(const FBAQuorumSet& qSet)
     }
     mCacheLRU.push_back(qSetHash);
     mCache[qSetHash] = qSet;
-
-    for (uint64 sIndex : mPendingSlots[qSetHash])
-    {
-        mFBA->getSlot(sIndex)->advanceSlot();
-    }
-    mPendingSlots.erase(qSetHash);
 }
 
 const uint256&

--- a/src/fba/Node.h
+++ b/src/fba/Node.h
@@ -16,10 +16,42 @@ namespace stellar
  */
 class Node
 {
+
   public:
     Node(const uint256& nodeID,
          FBA* FBA,
          int cacheCapacity = 4);
+
+    // Tests this node against nodeSet for the specified qSethash. Triggers the
+    // retrieval of qSetHash for this node and may throw a QuorumSetNotFound
+    // exception
+    bool hasQuorum(const Hash& qSetHash,
+                   const std::vector<uint256>& nodeSet);
+    bool isVBlocking(const Hash& qSetHash,
+                     const std::vector<uint256>& nodeSet);
+
+    // Tests this node against a map of nodeID -> T for the specified qSetHash.
+    // Triggers the retrieval of qSetHash for this node and may throw a
+    // QuorumSetNotFound exception.
+    
+    // `isVBlocking` tests if the filtered nodes V are a v-blocking set for
+    // this node.
+    template <class T> bool isVBlocking(
+        const Hash& qSetHash,
+        const std::map<uint256, T>& map,
+        std::function<bool(const uint256&, const T&)> const& filter =
+        [] (const uint256&, const T&) { return true; });
+    // `isQuorumTransitive` tests if the filtered nodes V are a transitive
+    // quorum for this node (meaning for each v \in V there is q \in Q(v)
+    // included in V and we have quorum on V for qSetHash). `qfun` extracts the
+    // qSetHash from the template T for its associated node in map (required
+    // for transitivity)
+    template <class T> bool isQuorumTransitive(
+        const Hash& qSetHash,
+        const std::map<uint256, T>& map,
+        std::function<Hash(const T&)> const& qfun,
+        std::function<bool(const uint256&, const T&)> const& filter =
+        [] (const uint256&, const T&) { return true; });
 
     /**
      * Exception used to trigger the retrieval of a quorum set based on its
@@ -50,12 +82,7 @@ class Node
     // the FBA module
     const FBAQuorumSet& retrieveQuorumSet(const Hash& qSetHash);
 
-    // Adds a slot to the list of slots awaiting for a quorunm set to be
-    // retrieved. When cacheQuorumSet is called with the specified quorum set
-    // hash, all slots pending on this quorum set are woken up for
-    // re-evaluation.
-    void addPendingSlot(const Hash& qSetHash, const uint64& slotIndex);
-
+    // Cache a quorumSet for this node.
     void cacheQuorumSet(const FBAQuorumSet& qSet);
 
     const uint256& getNodeID();
@@ -63,13 +90,11 @@ class Node
   protected:
     const uint256                          mNodeID;
     FBA*                                   mFBA;
+
   private:
     int                                    mCacheCapacity;
     std::map<Hash, FBAQuorumSet>           mCache;
     std::vector<Hash>                      mCacheLRU;
-
-    std::map<Hash, std::vector<uint64>>    mPendingSlots;
 };
 }
-
 

--- a/src/fba/Slot.cpp
+++ b/src/fba/Slot.cpp
@@ -15,6 +15,8 @@
 
 namespace stellar
 {
+using xdr::operator==;
+using xdr::operator<;
 
 // Static helper to stringify bellot for logging
 static std::string
@@ -36,7 +38,7 @@ envToStr(const FBAEnvelope& envelope)
 {
     std::ostringstream oss;
     oss << "{ENV@" << binToHex(envelope.nodeID).substr(0,6) << "|";
-    switch(envelope.statement.body.type())
+    switch(envelope.statement.pledges.type())
     {
         case FBAStatementType::PREPARE:
             oss << "PREPARE";
@@ -52,27 +54,11 @@ envToStr(const FBAEnvelope& envelope)
             break;
     }
 
-    oss << "|" << ballotToStr(envelope.statement.ballot)
-        << "|" << binToHex(envelope.statement.quorumSetHash).substr(0,6) << "}";
+    Hash qSetHash = envelope.statement.quorumSetHash;
+    oss << "|" << ballotToStr(envelope.statement.ballot);
+    oss << "|" << binToHex(qSetHash).substr(0,6) << "}";
     return oss.str();
 }
-
-// Static helper to sign an envelope
-static void
-signEnv(FBAEnvelope& envelope)
-{
-    // TODO(spolu)
-}
-
-
-// Static helper to verify an envelope signature
-static bool 
-verifyEnv(const FBAEnvelope& envelope)
-{
-    // TODO(spolu)
-    return true;
-}
-
 
 Slot::Slot(const uint64& slotIndex,
            FBA* FBA)
@@ -88,97 +74,89 @@ Slot::Slot(const uint64& slotIndex,
 
 void
 Slot::processEnvelope(const FBAEnvelope& envelope,
-                      std::function<void(bool)> const& cb)
+                      std::function<void(FBA::EnvelopeState)> const& cb)
 {
-    assert(envelope.statement.slotIndex == mSlotIndex);
+    assert(envelope.slotIndex == mSlotIndex);
 
     LOG(INFO) << "Slot::processEnvelope" 
               << "@" << binToHex(mFBA->getLocalNodeID()).substr(0,6)
               << ":" << mSlotIndex
               << " " << envToStr(envelope);
 
-    // If the envelope is not correctly signed, we ignore it.
-    if (!verifyEnv(envelope))
-    {
-        return cb(false);
-    }
-
-    FBABallot b = envelope.statement.ballot;
-    FBAStatementType t = envelope.statement.body.type();
     uint256 nodeID = envelope.nodeID;
     FBAStatement statement = envelope.statement;
+    FBABallot b = statement.ballot;
+    FBAStatementType t = statement.pledges.type();
 
     // We copy everything we need as this can be async (no reference).
-    auto validate_cb = [b,t,nodeID,statement,cb,this] (bool valid)
+    auto value_cb = [b,t,nodeID,statement,cb,this] (bool valid)
     {
-        // If the ballot is not valid, we just ignore it.
+        // If the value is not valid, we just ignore it.
         if (!valid)
         {
-            return cb(false);
+            return cb(FBA::EnvelopeState::INVALID);
         }
 
         if (!mIsCommitted && t == FBAStatementType::PREPARE)
         {
-            // If a new higher ballot has been issued, let's move on to it.
-            if (b.counter > mBallot.counter || isPristine())
+            auto ballot_cb = [b,t,nodeID,statement,cb,this] (bool valid)
             {
-                bumpToBallot(b);
-            }
+                // If the ballot is not valid, we just ignore it.
+                if(!valid)
+                {
+                    return cb(FBA::EnvelopeState::INVALID);
+                }
 
-            // Finally store the statement and advance the slot if possible.
-            mStatements[b][t][nodeID] = statement;
-            advanceSlot();
+                // If a new higher ballot has been issued, let's move on to it.
+                if (compareBallots(b, mBallot) > 0 || isPristine())
+                {
+                    bumpToBallot(b);
+                }
+
+                // Finally store the statement and advance the slot if possible.
+                mStatements[b][t][nodeID] = statement;
+                advanceSlot();
+            };
+
+            mFBA->validateBallot(mSlotIndex, nodeID, b,
+                                 ballot_cb);
         }
         else if (!mIsCommitted && t == FBAStatementType::PREPARED)
         {
-            // We accept PREPARED statements only if we previously saw a valid
-            // PREPARE statement for that round. This prevents node from
-            // emitting phony messages too easily.
-            bool isPrepare = false;
-            for (auto s : getNodeStatements(nodeID, FBAStatementType::PREPARE))
-            {
-                if (s.ballot.counter == b.counter)
-                {
-                    isPrepare = true;
-                }
-            }
-            if (isPrepare)
-            {
-                // Finally store the statement and advance the slot if
-                // possible.
-                mStatements[b][t][nodeID] = statement;
-                advanceSlot();
-            }
-            else
-            {
-                mFBA->getClient()->retransmissionHinted(mSlotIndex, nodeID);
-            }
+            // A PREPARED statement does not imply any PREPARE so we can go
+            // ahead and store it if its value is valid.
+            mStatements[b][t][nodeID] = statement;
+            advanceSlot();
         }
         else if (!mIsCommitted && t == FBAStatementType::COMMIT)
         {
             // We accept COMMIT statements only if we previously saw a valid
-            // PREPARE statement for that ballot and all the PREPARE we saw so
+            // PREPARED statement for that ballot and all the PREPARE we saw so
             // far have a lower ballot than this one or have that COMMIT in
             // their B_c.  This prevents node from emitting phony messages too
             // easily.
-            bool isPrepare = false;
-            for (auto s : getNodeStatements(nodeID, FBAStatementType::PREPARE))
+            bool isPrepared = false;
+            for (auto s : getNodeStatements(nodeID, 
+                                            FBAStatementType::PREPARED))
             {
                 if (compareBallots(b, s.ballot) == 0)
                 {
-                    isPrepare = true;
+                    isPrepared = true;
                 }
+            }
+            for (auto s : getNodeStatements(nodeID, FBAStatementType::PREPARE))
+            {
                 if (compareBallots(b, s.ballot) < 0)
                 {
-                    auto excepted = s.body.prepare().excepted;
+                    auto excepted = s.pledges.prepare().excepted;
                     auto it = std::find(excepted.begin(), excepted.end(), b);
                     if (it == excepted.end())
                     {
-                        return cb(false);
+                        return cb(FBA::EnvelopeState::INVALID);
                     }
                 }
             }
-            if (isPrepare)
+            if (isPrepared)
             {
                 // Finally store the statement and advance the slot if
                 // possible.
@@ -187,7 +165,7 @@ Slot::processEnvelope(const FBAEnvelope& envelope,
             }
             else
             {
-                mFBA->getClient()->retransmissionHinted(mSlotIndex, nodeID);
+                return cb(FBA::EnvelopeState::STATEMENTS_MISSING);
             }
             
         }
@@ -198,7 +176,7 @@ Slot::processEnvelope(const FBAEnvelope& envelope,
             if (getNodeStatements(nodeID, 
                                   FBAStatementType::COMMITTED).size() > 0)
             {
-                return cb(false);
+                return cb(FBA::EnvelopeState::INVALID);
             }
 
             // Finally store the statement and advance the slot if possible.
@@ -213,31 +191,29 @@ Slot::processEnvelope(const FBAEnvelope& envelope,
                 createStatement(FBAStatementType::COMMITTED);
 
             FBAEnvelope env = createEnvelope(stmt);
-            mFBA->getClient()->emitEnvelope(env);
+            mFBA->emitEnvelope(env);
         }
 
         // Finally call the callback saying that this was a valid envelope
-        return cb(true);
+        return cb(FBA::EnvelopeState::VALID);
     };
 
-    mFBA->getClient()->validateBallot(mSlotIndex, nodeID, b, validate_cb);
+    mFBA->validateValue(mSlotIndex, nodeID, b.value, value_cb);
 }
 
 bool
-Slot::attemptValue(const Value& value,
+Slot::prepareValue(const Value& value,
                    bool forceBump)
 {
     if (mIsCommitted)
     {
         return false;
     }
-    else if (isPristine() ||
-             mFBA->getClient()->compareValues(mBallot.value, value) < 0)
+    else if (isPristine() || mFBA->compareValues(mBallot.value, value) < 0)
     {
         bumpToBallot(FBABallot(mBallot.counter, value));
     }
-    else if (forceBump || 
-             mFBA->getClient()->compareValues(mBallot.value, value) > 0)
+    else if (forceBump || mFBA->compareValues(mBallot.value, value) > 0)
     {
         bumpToBallot(FBABallot(mBallot.counter + 1, value));
     }
@@ -255,8 +231,7 @@ Slot::bumpToBallot(const FBABallot& ballot)
 
     if (!isPristine())
     {
-        mFBA->getClient()->valueCancelled(mSlotIndex, 
-                                          mBallot.value);
+        mFBA->ballotDidAbort(mSlotIndex, mBallot);
     }
 
     // We shouldnt have emitted any prepare message for this ballot or any
@@ -280,10 +255,9 @@ Slot::createStatement(const FBAStatementType& type)
 {
     FBAStatement statement;
 
-    statement.slotIndex = mSlotIndex;
     statement.ballot = mBallot;
     statement.quorumSetHash = mFBA->getLocalNode()->getQuorumSetHash();
-    statement.body.type(type);
+    statement.pledges.type(type);
 
     return statement;
 }
@@ -294,8 +268,9 @@ Slot::createEnvelope(const FBAStatement& statement)
     FBAEnvelope envelope;
 
     envelope.nodeID = mFBA->getLocalNodeID();
+    envelope.slotIndex = mSlotIndex;
     envelope.statement = statement;
-    signEnv(envelope);
+    mFBA->signEnvelope(envelope);
 
     /*
     LOG(INFO) << "Slot::createEnvelope" 
@@ -327,49 +302,60 @@ Slot::attemptPrepare()
     {
         if(s.ballot.value == mBallot.value)
         {
-            if(!statement.body.prepare().prepared ||
-               compareBallots(*(statement.body.prepare().prepared),
+            if(!statement.pledges.prepare().prepared ||
+               compareBallots(*(statement.pledges.prepare().prepared),
                               s.ballot) > 0)
             {
-                statement.body.prepare().prepared.activate() = s.ballot;
+                statement.pledges.prepare().prepared.activate() = s.ballot;
             }
         }
     }
     for (auto s : getNodeStatements(mFBA->getLocalNodeID(), 
                                     FBAStatementType::COMMIT))
     {
-        statement.body.prepare().excepted.push_back(s.ballot);
+        statement.pledges.prepare().excepted.push_back(s.ballot);
     }
 
     mIsPristine = false;
-    mFBA->getClient()->ballotDidPrepare(mSlotIndex, mBallot);
+    mFBA->ballotDidPrepare(mSlotIndex, mBallot);
 
     FBAEnvelope envelope = createEnvelope(statement);
-    mFBA->getClient()->emitEnvelope(envelope);
-    processEnvelope(envelope);
+    auto cb = [envelope,this] (bool valid)
+    {
+        mFBA->emitEnvelope(envelope);
+    };
+    processEnvelope(envelope, cb);
+                        
 }
 
 void 
-Slot::attemptPrepared()
+Slot::attemptPrepared(const FBABallot& ballot)
 {
     auto it = 
-        mStatements[mBallot][FBAStatementType::PREPARED]
+        mStatements[ballot][FBAStatementType::PREPARED]
             .find(mFBA->getLocalNodeID());
-    if (it != mStatements[mBallot][FBAStatementType::PREPARED].end())
+    if (it != mStatements[ballot][FBAStatementType::PREPARED].end())
     {
         return;
     }
     LOG(INFO) << "Slot::attemptPrepared" 
               << "@" << binToHex(mFBA->getLocalNodeID()).substr(0,6)
-              << " " << ballotToStr(mBallot);
+              << " " << ballotToStr(ballot);
 
     FBAStatement statement = createStatement(FBAStatementType::PREPARED);
+    statement.ballot = ballot;
 
-    mIsPristine = false;
+    if (ballot == mBallot)
+    {
+        mIsPristine = false;
+    }
 
     FBAEnvelope envelope = createEnvelope(statement);
-    mFBA->getClient()->emitEnvelope(envelope);
-    processEnvelope(envelope);
+    auto cb = [envelope,this] (bool valid)
+    {
+        mFBA->emitEnvelope(envelope);
+    };
+    processEnvelope(envelope, cb);
 }
 
 void 
@@ -389,11 +375,14 @@ Slot::attemptCommit()
     FBAStatement statement = createStatement(FBAStatementType::COMMIT);
 
     mIsPristine = false;
-    mFBA->getClient()->ballotDidCommit(mSlotIndex, mBallot);
+    mFBA->ballotDidCommit(mSlotIndex, mBallot);
 
     FBAEnvelope envelope = createEnvelope(statement);
-    mFBA->getClient()->emitEnvelope(envelope);
-    processEnvelope(envelope);
+    auto cb = [envelope,this] (bool valid)
+    {
+        mFBA->emitEnvelope(envelope);
+    };
+    processEnvelope(envelope, cb);
 }
 
 void 
@@ -416,8 +405,11 @@ Slot::attemptCommitted()
     mIsPristine = false;
 
     FBAEnvelope envelope = createEnvelope(statement);
-    mFBA->getClient()->emitEnvelope(envelope);
-    processEnvelope(envelope);
+    auto cb = [envelope,this] (bool valid)
+    {
+        mFBA->emitEnvelope(envelope);
+    };
+    processEnvelope(envelope, cb);
 }
 
 void 
@@ -434,130 +426,7 @@ Slot::attemptExternalize()
     mIsExternalized = true;
     mIsPristine = false;
 
-    mFBA->getClient()->valueExternalized(mSlotIndex, mBallot.value);
-}
-
-bool 
-Slot::nodeHasQuorum(const uint256& nodeID,
-                    const Hash& qSetHash,
-                    const std::vector<uint256>& nodeSet)
-{
-    LOG(DEBUG) << ">> Slot::nodeHasQuorum" 
-               << "@" << binToHex(mFBA->getLocalNodeID()).substr(0,6)
-               << " [" << binToHex(nodeID).substr(0,6) << "]"
-               << " " << binToHex(qSetHash).substr(0,6)
-               << " " << nodeSet.size();
-    Node* node = mFBA->getNode(nodeID);
-    // This call can throw a `QuorumSetNotFound` if the quorumSet is unknown.
-    // The exception is catched in `advanceSlot`
-    const FBAQuorumSet& qSet = node->retrieveQuorumSet(qSetHash);
-
-    uint32 count = 0;
-    for (auto n : qSet.validators)
-    {
-        auto it = std::find(nodeSet.begin(), nodeSet.end(), n);
-        count += (it != nodeSet.end()) ? 1 : 0;
-    }
-    return (count >= qSet.threshold);
-}
-
-bool 
-Slot::nodeIsVBlocking(const uint256& nodeID,
-                      const Hash& qSetHash,
-                      const std::vector<uint256>& nodeSet)
-{
-    LOG(DEBUG) << ">> Slot::nodeIsVBlocking" 
-               << "@" << binToHex(mFBA->getLocalNodeID()).substr(0,6)
-               << " [" << binToHex(nodeID).substr(0,6) << "]"
-               << " " << binToHex(qSetHash).substr(0,6)
-               << " " << nodeSet.size();
-    Node* node = mFBA->getNode(nodeID);
-    // This call can throw a `QuorumSetNotFound` if the quorumSet is unknown.
-    // The exception is catched in `advanceSlot`
-    const FBAQuorumSet& qSet = node->retrieveQuorumSet(qSetHash);
-
-    // There is no v-blocking set for {\empty}
-    if(qSet.threshold == 0)
-    {
-        return false;
-    }
-
-    uint32 count = 0;
-    for (auto n : qSet.validators)
-    {
-        auto it = std::find(nodeSet.begin(), nodeSet.end(), n);
-        count += (it != nodeSet.end()) ? 1 : 0;
-    }
-    return (qSet.validators.size() - count < qSet.threshold);
-}
-
-bool 
-Slot::isQuorumTransitive(const std::map<uint256, FBAStatement>& statements,
-                         std::function<bool(const uint256&, 
-                                            const FBAStatement&)> const& filter)
-{
-    std::vector<uint256> pNodes;
-    for (auto it : statements)
-    {
-        if (filter(it.first, it.second))
-        {
-            pNodes.push_back(it.first);
-        }
-    }
-
-    size_t count = 0;
-    do
-    {
-        count = pNodes.size();
-        std::vector<uint256> fNodes(pNodes.size());
-        auto quorumFilter = [&] (uint256 nodeID) -> bool
-        {
-            FBAStatement s = statements.find(nodeID)->second;
-            auto qSetHash = s.quorumSetHash;
-            return nodeHasQuorum(nodeID, qSetHash, pNodes);
-        };
-        auto it = std::copy_if(pNodes.begin(), pNodes.end(), 
-                               fNodes.begin(), quorumFilter);
-        fNodes.resize(std::distance(fNodes.begin(), it));
-        pNodes = fNodes;
-    } while (count != pNodes.size());
-
-    return nodeHasQuorum(mFBA->getLocalNodeID(),
-                         mFBA->getLocalNode()->getQuorumSetHash(),
-                         pNodes);
-}
-
-bool 
-Slot::isVBlocking(const std::map<uint256, FBAStatement>& statements,
-                  const uint256& nodeID,
-                  std::function<bool(const uint256&, 
-                                     const FBAStatement&)> const& filter)
-{
-    std::vector<uint256> pNodes;
-    for (auto it : statements)
-    {
-        if (filter(it.first, it.second))
-        {
-            pNodes.push_back(it.first);
-        }
-    }
-
-    Hash qSetHash;
-    if (statements.find(nodeID) != statements.end())
-    {
-        FBAStatement s = statements.find(nodeID)->second;
-        qSetHash = s.quorumSetHash;
-    }
-    else if (nodeID == mFBA->getLocalNodeID())
-    {
-        qSetHash = mFBA->getLocalNode()->getQuorumSetHash();
-    }
-    else 
-    {
-        assert(false);
-    }
-
-    return nodeIsVBlocking(nodeID, qSetHash, pNodes);
+    mFBA->valueExternalized(mSlotIndex, mBallot.value);
 }
 
 bool
@@ -580,8 +449,9 @@ Slot::isPrepared(const FBABallot& ballot)
 
     // Checks if there is a v-blocking set of nodes that accepted the PREPARE
     // statements (this is an optimization).
-    if (isVBlocking(mStatements[ballot][FBAStatementType::PREPARED],
-                    mFBA->getLocalNodeID()))
+    if (mFBA->getLocalNode()->isVBlocking<FBAStatement>(
+            mFBA->getLocalNode()->getQuorumSetHash(),
+            mStatements[ballot][FBAStatementType::PREPARED]))
     {
         return true;
     }
@@ -591,7 +461,7 @@ Slot::isPrepared(const FBABallot& ballot)
                              const FBAStatement& stR) -> bool
     {
         // Either the ratifying node has no excepted B_c ballot
-        if (stR.body.prepare().excepted.size() == 0)
+        if (stR.pledges.prepare().excepted.size() == 0)
         {
             return true;
         }
@@ -600,7 +470,7 @@ Slot::isPrepared(const FBABallot& ballot)
         // aborted. They are aborted if there is a v-blocking set of nodes that
         // prepared a higher ballot
         bool compOrAborted = true;
-        for (auto c : stR.body.prepare().excepted)
+        for (auto c : stR.pledges.prepare().excepted)
         {
             if (c.value == mBallot.value)
             {
@@ -610,9 +480,9 @@ Slot::isPrepared(const FBABallot& ballot)
             auto abortedFilter = [&] (const uint256& nIDA,
                                       const FBAStatement& stA) -> bool
             {
-                if (stA.body.prepare().prepared) 
+                if (stA.pledges.prepare().prepared) 
                 {
-                    FBABallot p = *(stA.body.prepare().prepared);
+                    FBABallot p = *(stA.pledges.prepare().prepared);
                     if (compareBallots(p, c) > 0)
                     {
                         return true;
@@ -621,9 +491,10 @@ Slot::isPrepared(const FBABallot& ballot)
                 return false;
             };
 
-            if (isVBlocking(mStatements[ballot][FBAStatementType::PREPARE],
-                            nIDR,
-                            abortedFilter))
+            if (mFBA->getNode(nIDR)->isVBlocking<FBAStatement>(
+                    stR.quorumSetHash,
+                    mStatements[ballot][FBAStatementType::PREPARE],
+                    abortedFilter))
             {
                 continue;
             }
@@ -634,8 +505,11 @@ Slot::isPrepared(const FBABallot& ballot)
         return compOrAborted;
     };
 
-    if (isQuorumTransitive(mStatements[ballot][FBAStatementType::PREPARE],
-                           ratifyFilter))
+    if (mFBA->getLocalNode()->isQuorumTransitive<FBAStatement>(
+            mFBA->getLocalNode()->getQuorumSetHash(),
+            mStatements[ballot][FBAStatementType::PREPARE],
+            [] (const FBAStatement& s) { return s.quorumSetHash; },
+            ratifyFilter))
     {
         return true;
     }
@@ -657,7 +531,10 @@ Slot::isPreparedConfirmed(const FBABallot& ballot)
 
     // Checks if there is a transitive quorum that accepted the PREPARE
     // statements for the local node.
-    if (isQuorumTransitive(mStatements[ballot][FBAStatementType::PREPARED]))
+    if (mFBA->getLocalNode()->isQuorumTransitive<FBAStatement>(
+            mFBA->getLocalNode()->getQuorumSetHash(),
+            mStatements[ballot][FBAStatementType::PREPARED],
+            [] (const FBAStatement& s) { return s.quorumSetHash; }))
     {
         return true;
     }
@@ -677,7 +554,10 @@ Slot::isCommitted(const FBABallot& ballot)
     }
 
     // Check if we can establish the pledges for a transitive quorum.
-    if (isQuorumTransitive(mStatements[ballot][FBAStatementType::COMMIT]))
+    if (mFBA->getLocalNode()->isQuorumTransitive<FBAStatement>(
+            mFBA->getLocalNode()->getQuorumSetHash(),
+            mStatements[ballot][FBAStatementType::COMMIT],
+            [] (const FBAStatement& s) { return s.quorumSetHash; }))
     {
         return true;
     }
@@ -703,7 +583,10 @@ Slot::isCommittedConfirmed(const Value& value)
 
     // Checks if there is a transitive quorum that accepted the COMMIT
     // statement for the local node.
-    if (isQuorumTransitive(statements))
+    if (mFBA->getLocalNode()->isQuorumTransitive<FBAStatement>(
+            mFBA->getLocalNode()->getQuorumSetHash(),
+            statements,
+            [] (const FBAStatement& s) { return s.quorumSetHash; }))
     {
         return true;
     }
@@ -737,14 +620,14 @@ Slot::compareBallots(const FBABallot& b1,
     {
         return 1;
     }
-    return mFBA->getClient()->compareValues(b1.value, b2.value);
+    return mFBA->compareValues(b1.value, b2.value);
 }
 
 void
 Slot::advanceSlot()
 {
-    // `advanceSlot` will prevent recursive call by setting and checking
-    // `mInAdvanceSlot`. If a recursive call is made, `mRunAdvanceSlot` will be
+    // `advanceSlot` suopports reentrant calls by setting and checking
+    // `mInAdvanceSlot`. If a reentrant call is made, `mRunAdvanceSlot` will be
     // set and `advanceSlot` will be called again after it is done executing.
     if(mInAdvanceSlot)
     {
@@ -768,7 +651,7 @@ Slot::advanceSlot()
 
         if (isPrepared(mBallot))
         {
-            attemptPrepared(); 
+            attemptPrepared(mBallot); 
         }
 
         // If our current ballot is prepared confirmed we can move onto the
@@ -842,20 +725,38 @@ Slot::advanceSlot()
                 attemptCommitted();
             }
 
-            // If a higher ballot has prepared, we can bump to it as our
-            // current ballot has become irrelevant (aborted)
-            if (compareBallots(b, mBallot) > 0 && isPrepared(b))
+            if (isPrepared(b))
             {
-                bumpToBallot(b);
-                mRunAdvanceSlot = true;
+                // If a higher ballot has prepared, we can bump to it as our
+                // current ballot has become irrelevant (aborted)
+                if (compareBallots(b, mBallot) > 0)
+                {
+                    bumpToBallot(b);
+                    mRunAdvanceSlot = true;
+                }
+                // If it's a smaller ballot we must emit a PREPARED for it.
+                // We can't and we won't COMMIT b as `mBallot` only moves
+                // monotically.
+                else
+                {
+                    attemptPrepared(b);
+                }
             }
         }
 
     }
     catch(Node::QuorumSetNotFound e)
     {
-        mFBA->getNode(e.nodeID())->addPendingSlot(e.qSetHash(), mSlotIndex);
-        mFBA->getClient()->retrieveQuorumSet(e.nodeID(), e.qSetHash());
+        auto cb = [this,e] (const FBAQuorumSet& qSet)
+        {
+            uint256 qSetHash = sha512_256(xdr::xdr_to_msg(qSet));
+            if (e.qSetHash() == qSetHash)
+            {
+                mFBA->getNode(e.nodeID())->cacheQuorumSet(qSet);
+                advanceSlot();
+            }
+        };
+        mFBA->retrieveQuorumSet(e.nodeID(), e.qSetHash(), cb);
     }
 
     mInAdvanceSlot = false;

--- a/src/fba/Slot.h
+++ b/src/fba/Slot.h
@@ -8,9 +8,6 @@
 
 namespace stellar 
 {
-using xdr::operator==;
-using xdr::operator<;
-
 class Node;
 
 /**
@@ -24,18 +21,21 @@ class Slot
     Slot(const uint64& slotIndex, FBA* FBA);
 
     // Process a newly received envelope for this slot and update the state of
-    // the slot accordingly. Returns wether the envelope was validated or not.
+    // the slot accordingly. `cb` asynchronously returns wether the envelope
+    // was validated or not. Must exclusively receive envelopes whose payload
+    // type is STATEMENT
     void processEnvelope(const FBAEnvelope& envelope,
-                         std::function<void(bool)> const& cb = [] (bool) { });
+                         std::function<void(FBA::EnvelopeState)> const& cb);
 
-    // Attempts a new value for this slot. If the value is compatible with the
-    // current ballot, and forceBump is false, the current ballot is used.
-    // Otherwise a new ballot is generated with an increased counter value.
-    bool attemptValue(const Value& value, 
+    // Prepares a new ballot with the provided value for this slot. If the
+    // value is less or equal to the current ballot value, and forceBump is
+    // false, the current ballot counter is used. Otherwise a new ballot is
+    // generated with an increased counter value.
+    bool prepareValue(const Value& value, 
                       bool forceBump = false);
 
   private:
-    // bumps to the specified ballot emitting a valueCancelled if needed
+    // bumps to the specified ballot emitting a ballotDidAbort if needed
     void bumpToBallot(const FBABallot& ballot);
 
     // Helper methods to generate a new envelopes
@@ -44,36 +44,14 @@ class Slot
 
     // `attempt*` methods progress the slot to the specified state if it was
     // not already reached previously. They are in charge of emitting events
-    // and envelopes. They are indempotent. 
+    // and envelopes. They are indempotent. `attemptPrepared` takes an extra
+    // ballot argument as we can emit PREPARED messages for ballots different
+    // than our current `mBallot`.
     void attemptPrepare();
-    void attemptPrepared();
+    void attemptPrepared(const FBABallot& ballot);
     void attemptCommit();
     void attemptCommitted();
     void attemptExternalize();
-
-    // Helper functions to test a nodeSet against a specifed quorum set for a
-    // given node.
-    bool nodeHasQuorum(const uint256& nodeID,
-                       const Hash& qSetHash,
-                       const std::vector<uint256>& nodeSet);
-    bool nodeIsVBlocking(const uint256& nodeID,
-                         const Hash& qSetHash,
-                         const std::vector<uint256>& nodeSet);
-
-    // Helper method to test if the filtered set of statements is a transitive
-    // quorum *and* whether this transitive quorum is a quorum for the local
-    // node.
-    bool isQuorumTransitive(
-        const std::map<uint256, FBAStatement>& statements,
-        std::function<bool(const uint256&, const FBAStatement&)> const& filter =
-          [] (const uint256&, const FBAStatement&) { return true; });
-    // Helper method to test if the filtered set of statements is a v-blocking
-    // set for the node specified by nodeID.
-    bool isVBlocking(
-        const std::map<uint256, FBAStatement>& statements,
-        const uint256& nodeID,
-        std::function<bool(const uint256&, const FBAStatement&)> const& filter =
-          [] (const uint256&, const FBAStatement&) { return true; });
 
     // `is*` methods check if the specified state for the current slot has been
     // reached or not. They are called by `advanceSlot` and drive the call of
@@ -110,14 +88,15 @@ class Slot
     bool                                                       mInAdvanceSlot;
     bool                                                       mRunAdvanceSlot;
 
-    struct StatementMap : public std::map<uint256, FBAStatement> {};
-    struct StatementTypeMap : public std::map<FBAStatementType, StatementMap> {};
-    // mEnvelopes keep track of all received and sent envelopes for this slot.
-    std::map<FBABallot, StatementTypeMap> mStatements;
+    // mStatements keep track of all statements seen so far for this slot.
+    struct StatementMap : 
+        public std::map<uint256, FBAStatement> {};
+    struct StatementTypeMap : 
+        public std::map<FBAStatementType, StatementMap> {};
+    std::map<FBABallot, StatementTypeMap>                      mStatements;
 
     friend class Node;
 };
 
 }
-
 

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -24,7 +24,7 @@ class Application;
  * receiving transactions from the network.
  */
 class Herder : public HerderGateway,
-               public FBA::Client
+               public FBA
 {
   public:
     Herder(Application& app);
@@ -33,29 +33,25 @@ class Herder : public HerderGateway,
     // Bootstraps the Herder if we're creating a new Network
     void bootstrap();
     
-    // FBA::Client methods
+    // FBA methods
+    void validateValue(const uint64& slotIndex,
+                       const uint256& nodeID,
+                       const Value& value,
+                       std::function<void(bool)> const& cb);
+
     void validateBallot(const uint64& slotIndex,
                         const uint256& nodeID,
                         const FBABallot& ballot,
                         std::function<void(bool)> const& cb);
 
-    void ballotDidPrepare(const uint64& slotIndex,
-                          const FBABallot& ballot);
-    void ballotDidCommit(const uint64& slotIndex,
-                         const FBABallot& ballot);
-
-    void valueCancelled(const uint64& slotIndex,
-                        const Value& value);
     void valueExternalized(const uint64& slotIndex,
                            const Value& value);
 
     void retrieveQuorumSet(const uint256& nodeID,
-                           const Hash& qSetHash);
+                           const Hash& qSetHash,
+                           std::function<void(const FBAQuorumSet&)> const& cb);
     void emitEnvelope(const FBAEnvelope& envelope);
     
-    void retransmissionHinted(const uint64& slotIndex,
-                              const uint256& nodeID);
-
     // HerderGateway methods
     TxSetFramePtr fetchTxSet(const uint256& setHash, bool askNetwork);
     void recvTxSet(TxSetFramePtr txSet);
@@ -112,6 +108,5 @@ class Herder : public HerderGateway,
     LedgerHeader                                   mLastClosedLedger;
 
     Application&                                   mApp;
-    FBA*                                           mFBA;
 };
 }


### PR DESCRIPTION
FBA Rearchitecture:
- Make FBA exposes overridable methods instead of FBA::Client
- Move node quorum logic to Node.cpp

This is a subset of the previous `ready` PR.
