### PR TITLE
Added Math.{h,cpp} with two `rand_fraction` and `rand_pareto`

### DIFF
--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -1,0 +1,28 @@
+
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the ISC License. See the COPYING file at the top-level directory of
+// this distribution or at http://opensource.org/licenses/ISC
+#include <cstdlib>
+#include <cmath>
+#include "Math.h"
+
+
+namespace stellar
+{
+
+float rand_fraction()
+{
+    auto result = static_cast<float>(rand()) / static_cast<float>(RAND_MAX + 1);
+    return result;
+}
+
+
+size_t rand_pareto(float alpha, size_t max)
+{
+    // from http://www.pamvotis.org/vassis/RandGen.htm
+    float f = static_cast<float>(1) / static_cast<float>(pow(rand_fraction(), static_cast<float>(1) / alpha));
+    auto result = static_cast<size_t>((f / 10) * max) % max;
+    // LOG(INFO) << "rand_pareto " << result << " of " << max;
+    return result;
+}
+}

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -1,0 +1,10 @@
+#pragma once
+
+
+namespace stellar
+{
+float rand_fraction();
+
+size_t rand_pareto(float alpha, size_t max);
+
+}


### PR DESCRIPTION
Line 24 in `rand_pareto` is a hack to turn a infinite-tail pareto into a truncated pareto. @jedmccaleb has a less-hacky version to apply.
