### PR TITLE
Initialize transaction isolation level in all soci ctors.

### DIFF
--- a/src/lib/soci/src/core/session.h
+++ b/src/lib/soci/src/core/session.h
@@ -145,7 +145,7 @@ private:
     connection_pool * pool_;
 
     void transaction_commit_helper(bool commit, std::string &sql);
-    int transaction_level;
+    int transaction_level_;
 };
 
 } // namespace soci


### PR DESCRIPTION
The transaction level was only being set in one open() path, whereas there were several possible paths. Moved to the ctors, also renamed to match soci standard naming style for member vars (`foo_`).
