### PR TITLE
Update testnet doc for local development quorum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@
 *.suo
 *.trs
 *.db
-*.cfg
 
 # text editors
 *~
@@ -37,6 +36,7 @@
 /autom4te.cache
 /build
 /bin
+/buckets
 /compile
 /config.h
 /config.h.in

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -6,13 +6,13 @@ HTTP_PORT=39132
 PUBLIC_HTTP_PORT=false
 
 
-# every node has a PEER_SEED. 
+# every node has a PEER_SEED.
 # only nodes that want to participate in SCP need to set VALIDATION_SEED
 # what generates the peerID (used for peer connections) used by this node
 # if left off will generate a random one for you
 PEER_SEED="s3vdAQ19YpHzRn3qbNLjLtvE3wD24WLxnoyNxsgsQ3qrRpVp4Ct"
 
-# what generates the nodeID (used in SCP) 
+# what generates the nodeID (used in SCP)
 VALIDATION_SEED="sfmYZRUn4ofZHzitXupxrrz5QJ7b9mij3rSEdrTNRFVvVgigrcS"
 
 
@@ -61,10 +61,15 @@ DATABASE="sqlite3://stellar.db"
 # Specify where to fetch and the the history Archives
 # with template parameters `{0}` and `{1}` in place of the files being transmitted or retrieved.
 # you can specify multiple places to store and fetch from
-[HISTORY.stellar]
-get="curl http://history.stellar.org/{0} -o {1}"
-put="aws s3 cp {0} s3://history.stellar.org/{1}"
+[HISTORY.vs]
+get="cp /tmp/stellar-core/history/vs/{0} {1}"
+put="cp {0} /tmp/stellar-core/history/vs/{1}"
+mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
 
-[HISTORY.backup]
-get="curl http://backupstore.blob.core.windows.net/backupstore/{0} -o {1}"
-put="azure storage blob upload {0} backupstore {1}"
+# [HISTORY.stellar]
+# get="curl http://history.stellar.org/{0} -o {1}"
+# put="aws s3 cp {0} s3://history.stellar.org/{1}"
+
+# [HISTORY.backup]
+# get="curl http://backupstore.blob.core.windows.net/backupstore/{0} -o {1}"
+# put="azure storage blob upload {0} backupstore {1}"

--- a/docs/testnet.md
+++ b/docs/testnet.md
@@ -3,6 +3,18 @@ First, make sure you have copied the example config to your current working dire
 From the TLD of the repo, run
 `cp docs/stellar_core_example.cfg ./bin/stellar-core.cfg`
 
+In order to come to a quorum and make progress when you're running your own network (with one node), change your configuration quorum threshold to 1 and your quorum set to just your validation seed's public key.
+
+```
+# what generates the peerID (used for peer connections) used by this node
+PEER_SEED="s3BCUXncNvghHzKafx4gwYGaEG5rEeMUDdJPDsdjve3ojoFd5tK"
+# what generates the nodeID (used in FBA)
+VALIDATION_SEED="s3BCUXncNvghHzKafx4gwYGaEG5rEeMUDdJPDsdjve3ojoFd5tK"
+
+QUORUM_THRESHOLD=1
+QUORUM_SET=["gxoicA8D962NezYaa4AmrhXKGHYbrELu8rhyKE2vt8osLHL3T5"]
+```
+
 By default stellar-core waits to hear from the network for a ledger close before
 it starts emmiting its own SCP messages. This works fine in the common case but
 when you want to start your own network you need to start SCP manually.


### PR DESCRIPTION
- Instructions to change stellar-core.cfg to use quorum threshold 1
  and validation address as sole quorum address in quorum set.
- Add local paths to be default history archives in stellar-core_example.cfg
- Add buckets/ to gitignore
