### PR TITLE
Improve the default INFO logged while behaving well.

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -540,7 +540,7 @@ HerderImpl::valueExternalized(const uint64& slotIndex, const Value& value)
     if (externalizedSet)
     {
 
-        CLOG(INFO, "Herder")
+        CLOG(DEBUG, "Herder")
             << "HerderImpl::valueExternalized"
             << "@" << hexAbbrev(getLocalNodeID())
             << " txSet: " << hexAbbrev(b.value.txSetHash);
@@ -739,8 +739,7 @@ HerderImpl::recvSCPQuorumSet(SCPQuorumSetPtr qSet)
     CLOG(TRACE, "Herder") << "HerderImpl::recvSCPQuorumSet"
                           << "@" << hexAbbrev(getLocalNodeID())
                           << " qSet: "
-                          << binToHex(sha256(xdr::xdr_to_opaque(*qSet)))
-                                 .substr(0, 6);
+                          << hexAbbrev(sha256(xdr::xdr_to_opaque(*qSet)));
 
     if (mSCPQSetFetcher.recvItem(qSet))
     {
@@ -985,12 +984,11 @@ HerderImpl::triggerNextLedger()
     mCurrentValue = xdr::xdr_to_opaque(b);
 
     uint256 valueHash = sha256(xdr::xdr_to_opaque(mCurrentValue));
-    CLOG(INFO, "Herder") << "HerderImpl::triggerNextLedger"
+    CLOG(DEBUG, "Herder") << "HerderImpl::triggerNextLedger"
                          << "@" << hexAbbrev(getLocalNodeID())
                          << " txSet.size: " << proposedSet->mTransactions.size()
                          << " previousLedgerHash: "
-                         << binToHex(proposedSet->previousLedgerHash())
-                                .substr(0, 6)
+                         << hexAbbrev(proposedSet->previousLedgerHash())
                          << " value: " << hexAbbrev(valueHash)
                          << " slot: " << slotIndex;
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -67,6 +67,7 @@ class LedgerManager
   public:
 
     // Logging helpers, return strings describing the provided ledgers.
+    static std::string ledgerAbbrev(uint32_t seq, uint256 const& hash);
     static std::string ledgerAbbrev(LedgerHeader const& header,
                                     uint256 const& hash);
     static std::string ledgerAbbrev(std::shared_ptr<LedgerHeaderFrame> p);


### PR DESCRIPTION
This changes the default material we log when everything's going well from the gnarly:

```
2015-04-01T14:59:50.548 318c39 [Herder] INFO  HerderImpl::valueExternalized@6e1e87 txSet: f8f193
2015-04-01T14:59:51.527 318c39 [Herder] INFO  HerderImpl::triggerNextLedger@6e1e87 txSet.size: 0 previousLedgerHash: 68f9be value: 0f5271 slot: 218
```

to the much more pleasant:

```
2015-04-01T17:32:31.035 318c39 [Ledger] INFO  Got consensus: [seq=12, prev=3c5ab3, time=216990, txs=0, txhash=80946c, fee=10]
2015-04-01T17:32:31.046 318c39 [Ledger] INFO  Closed ledger: [seq=12, hash=072cba]
2015-04-01T17:32:32.549 318c39 [Ledger] INFO  Got consensus: [seq=13, prev=072cba, time=216991, txs=0, txhash=c0470a, fee=10]
2015-04-01T17:32:32.553 318c39 [Ledger] INFO  Closed ledger: [seq=13, hash=7851a7]
2015-04-01T17:32:35.554 318c39 [Ledger] INFO  Got consensus: [seq=14, prev=7851a7, time=216993, txs=0, txhash=0a06c2, fee=10]
2015-04-01T17:32:35.559 318c39 [Ledger] INFO  Closed ledger: [seq=14, hash=5f022b]
2015-04-01T17:32:38.989 318c39 [Ledger] INFO  Got consensus: [seq=15, prev=5f022b, time=216996, txs=0, txhash=3ad59c, fee=10]
2015-04-01T17:32:38.994 318c39 [Ledger] INFO  Closed ledger: [seq=15, hash=d1ddaf]
```

In addition to not mentioning "herder", and using nice words like "consensus" and "closed", it has the advantage of placing the closed-ledger and prev-ledger hashes in the same columns, making the hash-threading between consensus and closing relatively obvious.
