### PR TITLE
Add fuzzing stub.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,6 +53,7 @@ FMT_SRCS =                                      \
     src/main/Config.cpp                         \
     src/main/PersistentState.cpp                \
     src/main/main.cpp                           \
+    src/main/fuzz.cpp                           \
     src/main/test.cpp                           \
     src/overlay/Floodgate.cpp                   \
     src/overlay/ItemFetcher.cpp                 \
@@ -136,6 +137,7 @@ FMT_HDRS =                                      \
     src/main/CommandHandler.h                   \
     src/main/Config.h                           \
     src/main/PersistentState.h                  \
+    src/main/fuzz.h                             \
     src/main/test.h                             \
     src/overlay/FetchableItem.h                 \
     src/overlay/Floodgate.h                     \

--- a/src/main/fuzz.cpp
+++ b/src/main/fuzz.cpp
@@ -1,0 +1,122 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/asio.h"
+#include "crypto/SHA.h"
+#include "crypto/Hex.h"
+#include "main/Application.h"
+#include "generated/StellarCoreVersion.h"
+#include "overlay/OverlayManager.h"
+#include "overlay/LoopbackPeer.h"
+#include "util/Logging.h"
+#include "util/Timer.h"
+#include "util/XDRStream.h"
+#include "main/Config.h"
+
+#include "main/fuzz.h"
+
+#include <xdrpp/autocheck.h>
+#include <xdrpp/printer.h>
+
+/**
+ * This is a very simple fuzzer _stub_. It's intended to be run under an
+ * external fuzzer with some fuzzing brains, AFL or fuzzgrind or whatever.
+ *
+ * It has two modes:
+ *
+ *   - In --genfuzz mode it spits out a small file containing a handful of
+ *     random StellarMessages. This is the mode you use to generate seed data
+ *     for the external fuzzer's corpus.
+ *
+ *   - In --fuzz mode it reads back a file and appplies it to a pair of of
+ *     stellar-cores in loopback mode, cranking the I/O loop to simulate
+ *     receiving the messages one by one. It exits when it's read the input.
+ *     This is the mode the external fuzzer will run its mutant inputs through.
+ *
+ */
+
+namespace stellar
+{
+
+
+std::string
+msgSummary(StellarMessage const& m)
+{
+    xdr::detail::Printer p(0);
+    xdr::archive(p, m.type(), nullptr);
+    return p.buf_.str() + ":" + hexAbbrev(sha256(xdr::xdr_to_msg(m)));
+}
+
+void
+fuzz(std::string const& filename,
+     el::Level logLevel, std::vector<std::string> const& metrics)
+{
+    Logging::setFmt("<fuzz>");
+    Logging::setLogLevel(logLevel, nullptr);
+    LOG(INFO) << "Fuzzing stellar-core " << STELLAR_CORE_VERSION;
+    LOG(INFO) << "Fuzz input is in " << filename;
+
+    Config cfg1, cfg2;
+
+    cfg1.RUN_STANDALONE = true;
+    cfg1.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
+    cfg1.LOG_FILE_PATH = "fuzz-app-1.log";
+    cfg1.TMP_DIR_PATH = "fuzz-tmp-1";
+    cfg1.BUCKET_DIR_PATH = "fuzz-buckets-1";
+
+    cfg2.RUN_STANDALONE = true;
+    cfg2.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
+    cfg1.LOG_FILE_PATH = "fuzz-app-2.log";
+    cfg2.TMP_DIR_PATH = "fuzz-tmp-2";
+    cfg2.BUCKET_DIR_PATH = "fuzz-buckets-2";
+
+    VirtualClock clock;
+    Application::pointer app1 = Application::create(clock, cfg1);
+    Application::pointer app2 = Application::create(clock, cfg2);
+    LoopbackPeerConnection loop(*app1, *app2);
+    while(clock.crank(false) > 0)
+        ;
+
+    XDRInputFileStream in;
+    in.open(filename);
+    StellarMessage msg;
+    size_t i = 0;
+    while (in.readOne(msg))
+    {
+        ++i;
+        if (msg.type() != HELLO)
+        {
+            LOG(INFO) << "Fuzzer injecting message "
+                      << i << ": " << msgSummary(msg);
+            loop.getAcceptor()->Peer::sendMessage(msg);
+        }
+        while(clock.crank(false) > 0)
+            ;
+    }
+}
+
+void genfuzz(std::string const& filename)
+{
+    Logging::setFmt("<fuzz>");
+    size_t n = 8;
+    LOG(INFO) << "Writing " << n << "-message random fuzz file " << filename;
+    XDROutputFileStream out;
+    out.open(filename);
+    autocheck::generator<StellarMessage> gen;
+    for (size_t i = 0; i < n; ++i)
+    {
+        try
+        {
+            StellarMessage m(gen(20));
+            out.writeOne(m);
+            LOG(INFO) << "Message " << i << ": " << msgSummary(m);
+        }
+        catch (xdr::xdr_bad_discriminant &e)
+        {
+            LOG(INFO) << "Message " << i << ": malformed, omitted";
+        }
+    }
+}
+
+}

--- a/src/main/fuzz.h
+++ b/src/main/fuzz.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/Logging.h"
+
+namespace stellar
+{
+
+void fuzz(std::string const& filename, el::Level logLevel, std::vector<std::string> const& metrics);
+void genfuzz(std::string const& filename);
+
+}

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -8,6 +8,7 @@
 #include "util/Timer.h"
 #include "util/Fs.h"
 #include "lib/util/getopt.h"
+#include "main/fuzz.h"
 #include "main/test.h"
 #include "main/Config.h"
 #include "lib/http/HttpClient.h"
@@ -30,10 +31,12 @@ enum opttag
     OPT_VERSION = 0x100,
     OPT_HELP,
     OPT_TEST,
+    OPT_FUZZ,
     OPT_CONF,
     OPT_CMD,
     OPT_FORCESCP,
     OPT_GENSEED,
+    OPT_GENFUZZ,
     OPT_LOGLEVEL,
     OPT_METRIC,
     OPT_NEWDB,
@@ -44,9 +47,11 @@ static const struct option stellar_core_options[] = {
     {"version", no_argument, nullptr, OPT_VERSION},
     {"help", no_argument, nullptr, OPT_HELP},
     {"test", no_argument, nullptr, OPT_TEST},
+    {"fuzz", required_argument, nullptr, OPT_FUZZ},
     {"conf", required_argument, nullptr, OPT_CONF},
     {"c", required_argument, nullptr, OPT_CMD},
     {"genseed", no_argument, nullptr, OPT_GENSEED},
+    {"genfuzz", required_argument, nullptr, OPT_GENFUZZ},
     {"metric", required_argument, nullptr, OPT_METRIC},
     {"newdb", no_argument, nullptr, OPT_NEWDB},
     {"newhist", required_argument, nullptr, OPT_NEWHIST},
@@ -63,13 +68,15 @@ usage(int err = 1)
           "      --help          To display this string\n"
           "      --version       To print version information\n"
           "      --test          To run self-tests\n"
-          "      --metric METRIC Report metric METRIC on exit.\n"
+          "      --fuzz FILE     To run a single fuzz input and exit\n"
+          "      --metric METRIC Report metric METRIC on exit\n"
           "      --newdb         Creates or restores the DB to the genesis "
           "ledger\n"
           "      --newhist ARCH  Initialize the named history archive ARCH\n"
           "      --forcescp      Force SCP to start with the local ledger as "
           "position, close next time stellar-core is run\n"
           "      --genseed       Generate and print a random node seed\n"
+          "      --genfuzz FILE  Generate a random fuzzer input file\n "
           "      --ll LEVEL      Set the log level. LEVEL can be:\n"
           "                      [trace|debug|info|warning|error|fatal|none]\n"
           "      --c             Command to send to local stellar-core. try "
@@ -237,6 +244,9 @@ main(int argc, char* const* argv)
             return test(static_cast<int>(rest.size()), &rest[0], logLevel,
                         metrics);
         }
+        case OPT_FUZZ:
+            fuzz(std::string(optarg), logLevel, metrics);
+            return 0;
         case OPT_CONF:
             cfgFile = std::string(optarg);
             break;
@@ -269,6 +279,9 @@ main(int argc, char* const* argv)
             std::cout << "Public: " << key.getBase58Public() << std::endl;
             return 0;
         }
+        case OPT_GENFUZZ:
+            genfuzz(std::string(optarg));
+            return 0;
 
         default:
             usage(0);


### PR DESCRIPTION
From the comment:

This is a very simple fuzzer _stub_. It's intended to be run under an external fuzzer with some fuzzing brains, [AFL] (http://lcamtuf.coredump.cx/afl/) or [fuzzgrind](http://esec-lab.sogeti.com/pages/Fuzzgrind) or whatever.

It has two modes:

  - In `--genfuzz` mode it spits out a small file containing a handful of random `StellarMessages`. This is the mode you use to generate seed data for the external fuzzer's corpus.
  - In `--fuzz` mode it reads back a file and appplies it to a pair of of stellar-cores in loopback mode, cranking the I/O loop to simulate receiving the messages one by one. It exits when it's read the input. This is the mode the external fuzzer will run its mutant inputs through.


