### PR TITLE
Capture next curr in snapshot

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -38,6 +38,12 @@ BucketLevel::getHash() const
     return hsh->finish();
 }
 
+std::shared_future<std::shared_ptr<Bucket>>
+BucketLevel::getNext() const
+{
+    return std::shared_future<std::shared_ptr<Bucket>>(mNextCurr);
+}
+
 std::shared_ptr<Bucket>
 BucketLevel::getCurr() const
 {

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -84,7 +84,7 @@ BucketLevel::clearPendingMerge()
 {
     // NB: MSVC future<> implementation doesn't purge the task lambda (and
     // its captures) on invalidation (due to get()); must explicitly reset.
-    mNextCurr = std::future<std::shared_ptr<Bucket>>();
+    mNextCurr = std::shared_future<std::shared_ptr<Bucket>>();
 }
 
 void
@@ -150,7 +150,7 @@ BucketLevel::prepare(Application& app, uint32_t currLedger,
              return res;
         });
 
-    mNextCurr = task->get_future();
+    mNextCurr = task->get_future().share();
     app.getWorkerIOService().post(bind(&task_t::operator(), task));
 
     assert(mNextCurr.valid());

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -44,6 +44,14 @@ BucketLevel::getNext() const
     return std::shared_future<std::shared_ptr<Bucket>>(mNextCurr);
 }
 
+void
+BucketLevel::setNext(std::shared_ptr<Bucket> bucket)
+{
+    std::promise<std::shared_ptr<Bucket>> promise;
+    mNextCurr = promise.get_future().share();
+    promise.set_value(bucket);
+}
+
 std::shared_ptr<Bucket>
 BucketLevel::getCurr() const
 {
@@ -322,6 +330,18 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
 void
 BucketList::restartMerges(Application& app, uint32_t currLedger)
 {
+    /*
+     * FIXME: For the time being, we do not "restart" any merges because we do
+     * not save enough information (in the form of a shadow-list) to restart
+     * them properly. Instead we save the exact "next" bucket (completed but
+     * not-committed merge) and operate synchronously. This is a temporary state
+     * of affairs until we get the code written to handle saving shadow lists
+     * and restarting merges from them properly.
+     */
+
+    return;
+
+    /*
     // Scan the bucketlist, kill all existing merges and start a new merge between any
     // nonzero snap and its subsequent level.
 
@@ -352,6 +372,7 @@ BucketList::restartMerges(Application& app, uint32_t currLedger)
             mLevels[i].prepare(app, currLedger, snap, shadows);
         }
     }
+    */
 }
 
 size_t const BucketList::kNumLevels = 11;

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -245,6 +245,7 @@ class BucketLevel
   public:
     BucketLevel(size_t i);
     uint256 getHash() const;
+    std::shared_future<std::shared_ptr<Bucket>> getNext() const;
     std::shared_ptr<Bucket> getCurr() const;
     std::shared_ptr<Bucket> getSnap() const;
     void setCurr(std::shared_ptr<Bucket>);

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -248,6 +248,7 @@ class BucketLevel
     std::shared_future<std::shared_ptr<Bucket>> getNext() const;
     std::shared_ptr<Bucket> getCurr() const;
     std::shared_ptr<Bucket> getSnap() const;
+    void setNext(std::shared_ptr<Bucket>);
     void setCurr(std::shared_ptr<Bucket>);
     void setSnap(std::shared_ptr<Bucket>);
     void clearPendingMerge();

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -238,7 +238,7 @@ class Bucket;
 class BucketLevel
 {
     size_t mLevel;
-    std::future<std::shared_ptr<Bucket>> mNextCurr;
+    std::shared_future<std::shared_ptr<Bucket>> mNextCurr;
     std::shared_ptr<Bucket> mCurr;
     std::shared_ptr<Bucket> mSnap;
 

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -293,11 +293,12 @@ std::vector<std::string>
 BucketManagerImpl::checkForMissingBucketsFiles(HistoryArchiveState const& has)
 {
     std::vector<std::string> buckets;
-    for (size_t i = 0; i < BucketList::kNumLevels; ++i)
+    for (auto const& level : has.currentBuckets)
     {
-        auto snap = bucketBasename(has.currentBuckets.at(i).snap);
-        buckets.push_back(has.currentBuckets.at(i).curr);
-        buckets.push_back(has.currentBuckets.at(i).snap);
+        assert(!level.next.empty());
+        buckets.push_back(level.next);
+        buckets.push_back(level.curr);
+        buckets.push_back(level.snap);
     }
 
     std::vector<std::string> result;

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -51,6 +51,7 @@ CatchupStateMachine::CatchupStateMachine(
     , mDownloadDir(app.getTmpDirManager().tmpDir("catchup"))
     , mLocalState(localState)
 {
+    mLocalState.resolveAllFutures();
     // We start up in CATCHUP_RETRYING as that's the only valid
     // named pre-state for CATCHUP_BEGIN.
     enterBeginState();

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -725,6 +725,13 @@ CatchupStateMachine::applyBucketsAtLastClosedLedger()
             existingLevel.setCurr(b);
             applying = true;
         }
+
+        existingLevel.clearPendingMerge();
+        auto next = getBucketToApply(i->next);
+        if (n > 0 && !next->getFilename().empty())
+        {
+            existingLevel.setNext(next);
+        }
     }
 
     // Start the merges we need to have completed to resume running at LCL

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -70,11 +70,12 @@ HistoryArchiveState::resolveAllFutures()
     std::string zstr = binToHex(zero);
     for (auto& level : currentBuckets)
     {
-        assert(level.next.empty());
+        if (!level.next.empty())
+        {
+            continue;
+        }
         if (level.nextFuture.valid())
         {
-            auto status = level.nextFuture.wait_for(std::chrono::nanoseconds(1));
-            assert(status == std::future_status::ready);
             level.next = binToHex(level.nextFuture.get()->getHash());
         }
         else
@@ -194,6 +195,7 @@ HistoryArchiveState::getBucketListHash()
 std::vector<std::string>
 HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
 {
+    assert(futuresAllResolved());
     std::set<std::string> inhibit;
     uint256 zero;
     inhibit.insert(binToHex(zero));
@@ -208,6 +210,7 @@ HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
     {
         auto const& s = currentBuckets[i - 1].snap;
         auto const& n = currentBuckets[i - 1].next;
+        assert(!n.empty());
         auto const& c = currentBuckets[i - 1].curr;
         auto bs = { s, n, c };
         for (auto j : bs)

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -134,22 +134,23 @@ HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
     for (auto b : other.currentBuckets)
     {
         inhibit.insert(b.curr);
+        inhibit.insert(b.next);
         inhibit.insert(b.snap);
     }
     std::vector<std::string> ret;
     for (size_t i = BucketList::kNumLevels; i != 0; --i)
     {
         auto const& s = currentBuckets[i - 1].snap;
+        auto const& n = currentBuckets[i - 1].next;
         auto const& c = currentBuckets[i - 1].curr;
-        if (inhibit.find(s) == inhibit.end())
+        auto bs = { s, n, c };
+        for (auto j : bs)
         {
-            ret.push_back(s);
-            inhibit.insert(s);
-        }
-        if (inhibit.find(c) == inhibit.end())
-        {
-            ret.push_back(c);
-            inhibit.insert(c);
+            if (inhibit.find(j) == inhibit.end())
+            {
+                ret.push_back(j);
+                inhibit.insert(j);
+            }
         }
     }
     return ret;

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -24,20 +24,25 @@ class BucketList;
 struct HistoryStateBucket
 {
     std::string curr;
+    std::string next;
     std::string snap;
 
     template <class Archive>
     void
     serialize(Archive& ar) const
     {
-        ar(CEREAL_NVP(curr), CEREAL_NVP(snap));
+        ar(CEREAL_NVP(curr),
+           CEREAL_NVP(next),
+           CEREAL_NVP(snap));
     }
 
     template <class Archive>
     void
     serialize(Archive& ar)
     {
-        ar(CEREAL_NVP(curr), CEREAL_NVP(snap));
+        ar(CEREAL_NVP(curr),
+           CEREAL_NVP(next),
+           CEREAL_NVP(snap));
     }
 };
 

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -53,6 +53,7 @@ HistoryManager::initializeHistoryArchive(Application& app, std::string arch)
     CLOG(INFO, "History") << "Initializing history archive '" << arch << "'";
     bool ok = true;
     bool done = false;
+    has.resolveAllFutures();
     i->second->putState(app, has, [arch, &done, &ok](asio::error_code const& ec)
                         {
                             if (ec)

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -224,6 +224,7 @@ TEST_CASE_METHOD(HistoryTests, "HistoryArchiveState::get_put", "[history]")
     auto archive = i->second;
 
     auto& theApp = this->app; // need a local scope reference
+    has.resolveAllFutures();
     archive->putState(app, has,
                       [&done, &theApp, archive](asio::error_code const& ec)
                       {

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -318,6 +318,7 @@ PublishStateMachine::PublishStateMachine(Application& app)
 bool
 PublishStateMachine::queueSnapshot(SnapshotPtr snap, PublishCallback handler)
 {
+    snap->mLocalState.resolveAllFutures();
     bool delayed = !mPendingSnaps.empty();
     mPendingSnaps.push_back(std::make_pair(snap, handler));
     mPendingSnapsSize.set_count(mPendingSnaps.size());

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -356,6 +356,10 @@ StateSnapshot::StateSnapshot(Application& app)
     for (size_t i = 0; i < BucketList::kNumLevels; ++i)
     {
         auto const& level = buckets.getLevel(i);
+        if (level.getNext().valid())
+        {
+            mLocalBuckets.push_back(level.getNext().get());
+        }
         mLocalBuckets.push_back(level.getCurr());
         mLocalBuckets.push_back(level.getSnap());
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -678,6 +678,7 @@ LedgerManagerImpl::closeLedgerHelper(LedgerDelta const& delta)
     // the bucketlist so we can survive a restart and re-attach to the buckets.
     HistoryArchiveState has(mCurrentLedger->mHeader.ledgerSeq,
                             mApp.getBucketManager().getBucketList());
+    has.resolveAllFutures();
     mApp.getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                        has.toString());
 


### PR DESCRIPTION
This is a quick bandaid over what @MonsieurNicolas thinks (reasonably) is causing #429 : failure to reconstitute in-progress merges due to incorrect reconstituted shadows. I do not have a test in here to demonstrate it since it was blocking the testnet and I wanted to get something sketched out. It should -- or might! -- help; it does not appear to make anything worse. The gist of the change is that there's a `next` field put in each level of `HistoryArchiveState` now capturing the completed but not-yet committed merge.

What happens if the merge is _not_ completed, you ask? Ah good question: see above re: "bandaid". We block until _all_ the merges in a given checkpoint are completed. Both when publishing to archives (this part is easy to fix by just re-queueing incomplete checkpoints) and when closing ledgers and saving the current BL checkpoint (this part is not as trivial to fix since we don't want to delay SQL-commit, will require capturing shadows).

This is not a scalable solution, in other words. It will work until our buckets get big enough that merging them takes more than a second or two, then it'll start to introduce stalls into the network. Given that my workstation can easily merge >200,000 objects per second, we have a little room to test before this is likely to pinch, but we need to fix for real (and have a testcase showing this really fixes the issue) before inviting the world to sign up.