### PR TITLE
WIP on a more proper fix for #429

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,6 +14,7 @@ FMT_SRCS =                                      \
     src/bucket/BucketList.cpp                   \
     src/bucket/BucketManagerImpl.cpp            \
     src/bucket/BucketTests.cpp                  \
+    src/bucket/FutureBucket.cpp                 \
     src/crypto/Base58.cpp                       \
     src/crypto/CryptoTests.cpp                  \
     src/crypto/Hex.cpp                          \
@@ -105,6 +106,7 @@ FMT_HDRS =                                      \
     src/bucket/BucketList.h                     \
     src/bucket/BucketManager.h                  \
     src/bucket/BucketManagerImpl.h              \
+    src/bucket/FutureBucket.h                   \
     src/bucket/LedgerCmp.h                      \
     src/crypto/Base58.h                         \
     src/crypto/ByteSlice.h                      \

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -246,13 +246,13 @@ class BucketLevel
   public:
     BucketLevel(size_t i);
     uint256 getHash() const;
-    std::shared_future<std::shared_ptr<Bucket>> getNext() const;
+    FutureBucket const& getNext() const;
+    FutureBucket& getNext();
     std::shared_ptr<Bucket> getCurr() const;
     std::shared_ptr<Bucket> getSnap() const;
-    void setNext(std::shared_ptr<Bucket>);
+    void setNext(FutureBucket const& fb);
     void setCurr(std::shared_ptr<Bucket>);
     void setSnap(std::shared_ptr<Bucket>);
-    void clearPendingMerge();
     void commit();
     void prepare(Application& app, uint32_t currLedger,
                  std::shared_ptr<Bucket> snap,

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include <future>
+#include "bucket/FutureBucket.h"
 #include "generated/StellarXDR.h"
 #include "xdrpp/message.h"
 
@@ -238,7 +239,7 @@ class Bucket;
 class BucketLevel
 {
     size_t mLevel;
-    std::shared_future<std::shared_ptr<Bucket>> mNextCurr;
+    FutureBucket mNextCurr;
     std::shared_ptr<Bucket> mCurr;
     std::shared_ptr<Bucket> mSnap;
 

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -1,0 +1,277 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// ASIO is somewhat particular about when it gets included -- it wants to be the
+// first to include <windows.h> -- so we try to include it before everything
+// else.
+#include "util/asio.h"
+
+#include "bucket/FutureBucket.h"
+#include "bucket/Bucket.h"
+#include "bucket/BucketManager.h"
+#include "crypto/Hex.h"
+#include "main/Application.h"
+#include "util/Logging.h"
+
+#include <chrono>
+
+namespace stellar
+{
+
+FutureBucket::FutureBucket(Application& app,
+                           std::shared_ptr<Bucket> const& curr,
+                           std::shared_ptr<Bucket> const& snap,
+                           std::vector<std::shared_ptr<Bucket>> const& shadows)
+    : mState(FB_LIVE_INPUTS)
+    , mInputCurrBucket(curr)
+    , mInputSnapBucket(snap)
+    , mInputShadowBuckets(shadows)
+{
+    // Constructed with a bunch of inputs, _immediately_ commence merging
+    // them; there's no valid state for have-inputs-but-not-merging, the
+    // presence of inputs implies merging, and vice-versa.
+    assert(curr);
+    assert(snap);
+    mInputCurrBucketHash = binToHex(curr->getHash());
+    mInputSnapBucketHash = binToHex(snap->getHash());
+    for (auto const& b : mInputShadowBuckets)
+    {
+        mInputShadowBucketHashes.push_back(binToHex(b->getHash()));
+    }
+    startMerge(app);
+}
+
+FutureBucket::FutureBucket(std::shared_ptr<Bucket> const& output)
+    : mState(FB_LIVE_OUTPUT)
+    , mOutputBucketHash(binToHex(output->getHash()))
+{
+    // Constructed with an output bucket, fake-up a promise for it connected to
+    // the future so that it can be immediately retrieved.
+    std::promise<std::shared_ptr<Bucket>> promise;
+    mOutputBucket = promise.get_future().share();
+    promise.set_value(output);
+}
+
+static void
+checkHashEq(std::shared_ptr<Bucket> b, std::string const& h)
+{
+    assert(b->getHash() == hexToBin256(h));
+}
+
+void
+FutureBucket::checkHashesMatch() const
+{
+    if (!mInputShadowBuckets.empty())
+    {
+        assert(mInputShadowBuckets.size() == mInputShadowBucketHashes.size());
+        for (size_t i = 0; i < mInputShadowBuckets.size(); ++i)
+        {
+            checkHashEq(mInputShadowBuckets.at(i),
+                        mInputShadowBucketHashes.at(i));
+        }
+    }
+    if (mInputSnapBucket)
+    {
+        checkHashEq(mInputSnapBucket, mInputSnapBucketHash);
+    }
+    if (mInputCurrBucket)
+    {
+        checkHashEq(mInputCurrBucket, mInputCurrBucketHash);
+    }
+    if (mOutputBucket.valid() && mergeComplete() && !mOutputBucketHash.empty())
+    {
+        checkHashEq(mOutputBucket.get(), mOutputBucketHash);
+    }
+}
+
+/**
+ * Note: not all combinations of state and values are valid; we want to limit
+ * states to only those useful for the lifecycles in the program. In particular,
+ * the different hash-only states are mutually exclusive with each other and
+ * with live values.
+ */
+void
+FutureBucket::checkState() const
+{
+    switch (mState)
+    {
+    case FB_CLEAR:
+        assert(mInputShadowBuckets.empty());
+        assert(!mInputSnapBucket);
+        assert(!mInputCurrBucket);
+        assert(!mOutputBucket.valid());
+        assert(mInputShadowBucketHashes.empty());
+        assert(mInputSnapBucketHash.empty());
+        assert(mInputCurrBucketHash.empty());
+        assert(mOutputBucketHash.empty());
+        break;
+
+    case FB_LIVE_INPUTS:
+        assert(mInputSnapBucket);
+        assert(mInputCurrBucket);
+        assert(mOutputBucket.valid());
+        assert(mOutputBucketHash.empty());
+        checkHashesMatch();
+        break;
+
+    case FB_LIVE_OUTPUT:
+        assert(mergeComplete());
+        assert(mOutputBucket.valid());
+        assert(!mOutputBucketHash.empty());
+        checkHashesMatch();
+        break;
+
+    case FB_HASH_INPUTS:
+        assert(!mInputSnapBucket);
+        assert(!mInputCurrBucket);
+        assert(!mOutputBucket.valid());
+        assert(!mInputSnapBucketHash.empty());
+        assert(!mInputCurrBucketHash.empty());
+        assert(mOutputBucketHash.empty());
+        break;
+
+    case FB_HASH_OUTPUT:
+        assert(!mInputSnapBucket);
+        assert(!mInputCurrBucket);
+        assert(!mOutputBucket.valid());
+        assert(mInputSnapBucketHash.empty());
+        assert(mInputCurrBucketHash.empty());
+        assert(!mOutputBucketHash.empty());
+        break;
+    }
+}
+
+void
+FutureBucket::clear()
+{
+    mState = FB_CLEAR;
+    mInputShadowBuckets.clear();
+    mInputSnapBucket.reset();
+    mInputCurrBucket.reset();
+    mOutputBucket = std::shared_future<std::shared_ptr<Bucket>>();
+
+    mInputShadowBucketHashes.clear();
+    mInputSnapBucketHash.clear();
+    mInputCurrBucketHash.clear();
+    mOutputBucketHash.clear();
+}
+
+bool
+FutureBucket::isLive() const
+{
+    return (mState == FB_LIVE_INPUTS || mState == FB_LIVE_OUTPUT);
+}
+
+bool
+FutureBucket::isMerging() const
+{
+    return mState == FB_LIVE_INPUTS;
+}
+
+bool
+FutureBucket::hasHashes() const
+{
+    return (mState == FB_HASH_INPUTS || mState == FB_HASH_OUTPUT);
+}
+
+bool
+FutureBucket::mergeComplete() const
+{
+    assert(isLive());
+    auto status = mOutputBucket.wait_for(std::chrono::nanoseconds(1));
+    return status == std::future_status::ready;
+}
+
+std::shared_ptr<Bucket>
+FutureBucket::commit()
+{
+    checkState();
+    assert(isLive());
+    std::shared_ptr<Bucket> bucket = mOutputBucket.get();
+    if (mOutputBucketHash.empty())
+    {
+        mOutputBucketHash = binToHex(bucket->getHash());
+    }
+    else
+    {
+        checkHashEq(bucket, mOutputBucketHash);
+    }
+    mState = FB_LIVE_OUTPUT;
+    checkState();
+    return bucket;
+}
+
+void
+FutureBucket::startMerge(Application& app)
+{
+    // NB: startMerge starts with FutureBucket in a half-valid state; the inputs
+    // are live but the merge is not yet running. So you can't call checkState()
+    // on entry, only on exit.
+
+    assert(mState == FB_LIVE_INPUTS);
+
+    std::shared_ptr<Bucket> curr = mInputCurrBucket;
+    std::shared_ptr<Bucket> snap = mInputSnapBucket;
+    std::vector<std::shared_ptr<Bucket>> shadows = mInputShadowBuckets;
+
+    assert(curr);
+    assert(snap);
+    assert(!mOutputBucket.valid());
+
+    CLOG(TRACE, "Bucket")
+        << "Preparing merge of curr=" << hexAbbrev(curr->getHash())
+        << " with snap=" << hexAbbrev(snap->getHash());
+
+    BucketManager& bm = app.getBucketManager();
+
+    using task_t = std::packaged_task<std::shared_ptr<Bucket>()>;
+    std::shared_ptr<task_t> task = std::make_shared<task_t>(
+        [curr, snap, &bm, shadows]()
+        {
+            CLOG(TRACE, "Bucket")
+            << "Worker merging curr=" << hexAbbrev(curr->getHash())
+            << " with snap=" << hexAbbrev(snap->getHash());
+
+            auto res = Bucket::merge(bm, curr, snap, shadows);
+
+            CLOG(TRACE, "Bucket")
+            << "Worker finished merging curr=" << hexAbbrev(curr->getHash())
+            << " with snap=" << hexAbbrev(snap->getHash());
+
+            return res;
+        });
+
+    mOutputBucket = task->get_future().share();
+    app.getWorkerIOService().post(bind(&task_t::operator(), task));
+    checkState();
+}
+
+void
+FutureBucket::makeLive(Application& app)
+{
+    checkState();
+    assert(!isLive());
+    assert(hasHashes());
+    auto& bm = app.getBucketManager();
+    mInputCurrBucket = bm.getBucketByHash(hexToBin256(mInputCurrBucketHash));
+    mInputSnapBucket = bm.getBucketByHash(hexToBin256(mInputSnapBucketHash));
+    assert(mInputShadowBuckets.empty());
+    for (auto const& h : mInputShadowBucketHashes)
+    {
+        auto b = bm.getBucketByHash(hexToBin256(h));
+        mInputShadowBuckets.push_back(b);
+    }
+    mState = FB_LIVE_INPUTS;
+    startMerge(app);
+    assert(isLive());
+}
+
+std::shared_future<std::shared_ptr<Bucket>>
+FutureBucket::getSharedFuture() const
+{
+    return mOutputBucket;
+}
+
+
+}

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -75,6 +75,10 @@ class FutureBucket
     void checkState() const;
     void startMerge(Application& app);
 
+    void clearInputs();
+    void clearOutput();
+    void setLiveOutput(std::shared_ptr<Bucket> b);
+
 public:
 
     FutureBucket(Application& app,
@@ -82,7 +86,7 @@ public:
                  std::shared_ptr<Bucket> const& snap,
                  std::vector<std::shared_ptr<Bucket>> const& shadows);
 
-    FutureBucket(std::shared_ptr<Bucket> const& output);
+    FutureBucket(std::shared_ptr<Bucket> output);
 
     FutureBucket() = default;
     FutureBucket(FutureBucket const& other) = default;
@@ -100,7 +104,13 @@ public:
     // Returns whether this object is in a FB_HASH_FOO state.
     bool hasHashes() const;
 
-    // Precondition: isLive(); returns whether a live merge is complete.
+    // Returns whether this object is in FB_HASH_OUTPUT state.
+    bool hasOutputHash() const;
+
+    // Precondition: hasOutputHash(); return the hash.
+    std::string const& getOutputHash() const;
+
+    // Precondition: isLive(); returns whether a live merge is ready to commit.
     bool mergeComplete() const;
 
     // Precondition: isLive(); waits-for and commits to merge completion.
@@ -109,7 +119,8 @@ public:
     // Precondition: !isLive(); transitions from FB_HASH_FOO to FB_LIVE_FOO
     void makeLive(Application& app);
 
-    std::shared_future<std::shared_ptr<Bucket>> getSharedFuture() const;
+    // Return all hashes referenced by this future.
+    std::vector<std::string> getHashes() const;
 
     template <class Archive>
     void load(Archive& ar)

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -42,11 +42,11 @@ class FutureBucket
 
     enum State
     {
-        FB_CLEAR,         // No inputs; no outputs; no hashes.
-        FB_LIVE_INPUTS,   // Inputs; input hashes; no outputs. Merge running.
-        FB_LIVE_OUTPUT,   // Output; output hashes; _maybe_ inputs and hashes.
-        FB_HASH_INPUTS,   // Input hashes; no inputs; no outputs or hashes.
-        FB_HASH_OUTPUT    // Output hash; no output; no inputs or hashes.
+        FB_CLEAR = 0,         // No inputs; no outputs; no hashes.
+        FB_HASH_OUTPUT = 1,   // Output hash; no output; no inputs or hashes.
+        FB_HASH_INPUTS = 2,   // Input hashes; no inputs; no outputs or hashes.
+        FB_LIVE_OUTPUT = 3,   // Output; output hashes; _maybe_ inputs and hashes.
+        FB_LIVE_INPUTS = 4,   // Inputs; input hashes; no outputs. Merge running.
     };
 
     State mState {FB_CLEAR};

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -1,0 +1,124 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "generated/StellarXDR.h"
+#include <string>
+#include <memory>
+#include <vector>
+#include <future>
+
+namespace stellar
+{
+
+class Bucket;
+class Application;
+
+/**
+ * FutureBucket is a minor wrapper around
+ * std::shared_future<std::shared_ptr<Bucket>>, used in merging multiple buckets
+ * together in the BucketList. The reason this is a separate class is that we
+ * need to support a level of persistence: serializing merges-in-progress in a
+ * symbolic fashion, including restarting the merges after we deserialize.
+ *
+ * This class is therefore used not _only_ in the BucketList but also in places
+ * that serialize and deserialize snapshots of it in the form of
+ * HistoryArchiveStates: the LedgerManager, when storing kHistoryArchiveState at
+ * the bottom of closeLedger; and the HistoryManager, when storing and
+ * retrieving HistoryArchiveStates.
+ */
+class FutureBucket
+{
+    // There are two lifecycles of a FutureBucket:
+    //
+    // In one, it's created live, snapshotted at some point in the process
+    // (either before or after the merge completes), and committed/cleared.
+    //
+    // In another, it's created, deserialized (filling in the hashes of either
+    // the inputs or the output, but not both), made-live, and committed/cleared.
+
+    enum State
+    {
+        FB_CLEAR,         // No inputs; no outputs; no hashes.
+        FB_LIVE_INPUTS,   // Inputs; input hashes; no outputs. Merge running.
+        FB_LIVE_OUTPUT,   // Output; output hashes; _maybe_ inputs and hashes.
+        FB_HASH_INPUTS,   // Input hashes; no inputs; no outputs or hashes.
+        FB_HASH_OUTPUT    // Output hash; no output; no inputs or hashes.
+    };
+
+    State mState {FB_CLEAR};
+
+    // These live values hold the input buckets and/or output std::shared_future
+    // for a "live" bucket merge in progress. They will be empty when the
+    // FutureBucket is constructed, when it is reset, or when it is freshly
+    // deserialized and not yet activated. When they are nonempty, they should
+    // have values equal to the subsequent mFooHash values below.
+    std::shared_ptr<Bucket> mInputCurrBucket;
+    std::shared_ptr<Bucket> mInputSnapBucket;
+    std::vector<std::shared_ptr<Bucket>> mInputShadowBuckets;
+    std::shared_future<std::shared_ptr<Bucket>> mOutputBucket;
+
+    // These strings hold the serializable (or deserialized) bucket hashes of
+    // the inputs and outputs of a merge; depending on the state of the
+    // FutureBucket they may be empty strings, but if they are nonempty and the
+    // live values (mInputSnapBucket etc.) are also nonempty, they should agree
+    // on the hash-values.
+    std::string mInputCurrBucketHash;
+    std::string mInputSnapBucketHash;
+    std::vector<std::string> mInputShadowBucketHashes;
+    std::string mOutputBucketHash;
+
+    void checkHashesMatch() const;
+    void checkState() const;
+    void startMerge(Application& app);
+
+public:
+
+    FutureBucket(Application& app,
+                 std::shared_ptr<Bucket> const& curr,
+                 std::shared_ptr<Bucket> const& snap,
+                 std::vector<std::shared_ptr<Bucket>> const& shadows);
+
+    FutureBucket(std::shared_ptr<Bucket> const& output);
+
+    FutureBucket() = default;
+    FutureBucket(FutureBucket const& other) = default;
+    FutureBucket& operator=(FutureBucket const& other) = default;
+
+    // Clear all live values and hashes.
+    void clear();
+
+    // Returns whether this object is in a FB_LIVE_FOO state.
+    bool isLive() const;
+
+    // Returns whether this object is in a FB_LIVE_INPUTS state (a merge is running).
+    bool isMerging() const;
+
+    // Returns whether this object is in a FB_HASH_FOO state.
+    bool hasHashes() const;
+
+    // Precondition: isLive(); returns whether a live merge is complete.
+    bool mergeComplete() const;
+
+    // Precondition: isLive(); waits-for and commits to merge completion.
+    std::shared_ptr<Bucket> commit();
+
+    // Precondition: !isLive(); transitions from FB_HASH_FOO to FB_LIVE_FOO
+    void makeLive(Application& app);
+
+    std::shared_future<std::shared_ptr<Bucket>> getSharedFuture() const;
+
+    template <class Archive>
+    void load(Archive& ar)
+    {
+    }
+
+    template <class Archive>
+    void save(Archive& ar)
+    {
+    }
+};
+
+}

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -726,12 +726,7 @@ CatchupStateMachine::applyBucketsAtLastClosedLedger()
             applying = true;
         }
 
-        existingLevel.clearPendingMerge();
-        auto next = getBucketToApply(i->next);
-        if (n > 0 && !next->getFilename().empty())
-        {
-            existingLevel.setNext(next);
-        }
+        existingLevel.setNext(i->next);
     }
 
     // Start the merges we need to have completed to resume running at LCL

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -8,7 +8,7 @@
 #include <string>
 #include <system_error>
 #include <memory>
-#include <future>
+#include "bucket/FutureBucket.h"
 #include "generated/Stellar-types.h"
 
 namespace asio
@@ -26,8 +26,7 @@ class Bucket;
 struct HistoryStateBucket
 {
     std::string curr;
-    std::shared_future<std::shared_ptr<Bucket>> nextFuture;
-    std::string next;
+    FutureBucket next;
     std::string snap;
 
     template <class Archive>

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -49,6 +49,13 @@ struct HistoryStateBucket
     }
 };
 
+/**
+ * A snapshot of a ledger number and associated set of buckets; this is used
+ * when writing to HistoryArchives as well as when persisting the state of the
+ * BucketList to the local database, as PersistentState kHistoryArchiveState. It
+ * might reasonably be renamed BucketListState or similar, since it really only
+ * describes a BucketList, not an entire HistoryArchive.
+ */
 struct HistoryArchiveState
 {
     unsigned version{0};
@@ -72,9 +79,8 @@ struct HistoryArchiveState
     Hash getBucketListHash();
 
     // Return vector of buckets to fetch/apply to turn 'other' into 'this'.
-    // Vector
-    // is sorted from largest/highest-numbered bucket to smallest/lowest, and
-    // with snap buckets occurring before curr buckets. Zero-buckets are
+    // Vector is sorted from largest/highest-numbered bucket to smallest/lowest,
+    // and with snap buckets occurring before curr buckets. Zero-buckets are
     // omitted.
     std::vector<std::string>
     differingBuckets(HistoryArchiveState const& other) const;

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -355,10 +355,10 @@ StateSnapshot::StateSnapshot(Application& app)
     BucketList& buckets = app.getBucketManager().getBucketList();
     for (size_t i = 0; i < BucketList::kNumLevels; ++i)
     {
-        auto const& level = buckets.getLevel(i);
-        if (level.getNext().valid())
+        auto& level = buckets.getLevel(i);
+        if (level.getNext().isLive())
         {
-            mLocalBuckets.push_back(level.getNext().get());
+            mLocalBuckets.push_back(level.getNext().commit());
         }
         mLocalBuckets.push_back(level.getCurr());
         mLocalBuckets.push_back(level.getSnap());


### PR DESCRIPTION
This is the first 2/3 of a proper fix for #429 (assuming we've diagnosed it correctly -- still no test!) that involves moving the uses of `std::shared_future` out of the BucketList and into a wrapper class that keeps track of the buckets that are inputs to a merge job and admits serialization and restart from serial form.

All that remains at this point is removing the synchronous behavior in cases we don't want it and writing sufficient tests to convince ourselves this is actually responsible for the bug and actually fixes it.