### PR TITLE
Bug 452 forced checkpoint and catchup

### DIFF
--- a/docs/admin.md
+++ b/docs/admin.md
@@ -17,6 +17,11 @@
  It can take up to 5 or 6 minutes to sync to the network anytime you start up.
 
 #Supported commands
+## /catchup?ledger=NNN[&mode=MODE]
+        triggers the instance to catch up to ledger NNN from history;
+        mode is either 'minimal' (the default, if omitted) or 'complete'.
+## /checkpoint
+        triggers the instance to write an immediate history checkpoint.
 ## /connect?peer=NAME&port=NNN
         triggers the instance to connect to peer NAME at port NNN.
 ## /help

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -359,7 +359,7 @@ CatchupStateMachine::enterAnchoredState(HistoryArchiveState const& has)
 
     std::vector<std::shared_ptr<FileCatchupInfo>> fileCatchupInfos;
     auto& hm = mApp.getHistoryManager();
-    uint32_t freq = mApp.getHistoryManager().getCheckpointFrequency();
+    uint32_t freq = hm.getCheckpointFrequency();
     std::vector<std::string> bucketsToFetch;
 
     // Then make sure all the files we _want_ are either present

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -584,7 +584,8 @@ CatchupStateMachine::verifyHistoryFromLastClosedLedger()
             {
                 CLOG(ERROR, "History")
                     << "History chain overshot expected ledger seq "
-                    << expectedSeq;
+                    << expectedSeq << ", got " << curr.header.ledgerSeq
+                    << " instead";
                 return HistoryManager::VERIFY_HASH_BAD;
             }
             if (verifyLedgerHistoryLink(prev.hash, curr) !=
@@ -598,7 +599,9 @@ CatchupStateMachine::verifyHistoryFromLastClosedLedger()
     if (prev.header.ledgerSeq + 1 != mNextLedger)
     {
         CLOG(INFO, "History")
-            << "Insufficient history to connect chain to ledger" << mNextLedger;
+            << "Insufficient history to connect chain to ledger " << mNextLedger;
+        CLOG(INFO, "History")
+            << "History chain ends at " << prev.header.ledgerSeq;
         return HistoryManager::VERIFY_HASH_BAD;
     }
     return lm.verifyCatchupCandidate(prev);

--- a/src/history/FileTransferInfo.h
+++ b/src/history/FileTransferInfo.h
@@ -37,10 +37,10 @@ template <typename T> class FileTransferInfo
     }
 
     FileTransferInfo(T state, TmpDir const& snapDir,
-                     std::string const& snapType, uint32_t checkpointNum)
+                     std::string const& snapType, uint32_t checkpointLedger)
         : mTransferState(state)
         , mType(snapType)
-        , mHexDigits(fs::hexStr(checkpointNum))
+        , mHexDigits(fs::hexStr(checkpointLedger))
         , mLocalPath(snapDir.getName() + "/" + baseName_nogz())
     {
     }

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -358,8 +358,7 @@ HistoryArchive::putState(
 {
     auto local = HistoryArchiveState::localName(app, mName);
     s.save(local);
-    uint32_t freq = app.getHistoryManager().getCheckpointFrequency();
-    uint32_t snap = s.currentLedger / freq;
+    uint32_t snap = app.getHistoryManager().prevCheckpointLedger(s.currentLedger);
     auto self = shared_from_this();
     putStateInDir(app, s, local, HistoryArchiveState::remoteDir(snap),
                   HistoryArchiveState::remoteName(snap),

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -358,10 +358,9 @@ HistoryArchive::putState(
 {
     auto local = HistoryArchiveState::localName(app, mName);
     s.save(local);
-    uint32_t snap = app.getHistoryManager().prevCheckpointLedger(s.currentLedger);
     auto self = shared_from_this();
-    putStateInDir(app, s, local, HistoryArchiveState::remoteDir(snap),
-                  HistoryArchiveState::remoteName(snap),
+    putStateInDir(app, s, local, HistoryArchiveState::remoteDir(s.currentLedger),
+                  HistoryArchiveState::remoteName(s.currentLedger),
                   [&app, s, self, local, handler](asio::error_code const& ec)
                   {
         if (ec)

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -54,12 +54,13 @@
  *
  * While the _most recent_ checkpoint is in .well-known/stellar-history.json,
  * each checkpoint is also stored permanently at a path whose name includes the
- * checkpoint ledger number (as a 32-bit hex string) and stored in a 3-level deep
- * directory tree of hex digit prefixes. For example, checkpoint ledger-number
- * 0x12345678 will be described by file history/12/34/56/history-0x12345678.json
- * and the associated history block will be written to the two files
- * ledger/12/34/56/ledger-0x12345678.xdr.gz and
- * transaction/12/34/56/transaction-0x12345678.xdr.gz
+ * last ledger number in the checkpoint (as a 32-bit hex string) and stored in a
+ * 3-level deep directory tree of hex digit prefixes. For example, checkpoint at
+ * current ledger-number 0x12345678 will write ledgers up to and including
+ * ledger 0x12345677 and be described by file
+ * history/12/34/56/history-0x12345677.json and the associated history block
+ * will be written to the two files ledger/12/34/56/ledger-0x12345677.xdr.gz and
+ * transaction/12/34/56/transaction-0x12345677.xdr.gz
  *
  * Bucket files accompanying each checkpoint are stored by hash name, again
  * separated by 3-level-deep hex prefixing, though as the hash is unpredictable,
@@ -67,11 +68,21 @@
  * bucket's hex hash is <AABBCCDEFG...> then the bucket is stored as
  * bucket/AA/BB/CC/bucket-<AABBCCDEFG...>.xdr.gz
  *
- * The first ledger and transaction files (containing the genesis ledger) can
- * therefore always be found in ledger/00/00/00/ledger-0x00000000.xdr.gz and
- * transaction/00/00/00/transaction-0x00000000.xdr.gz and described by
- * history/00/00/00/history-0x00000000.json. The buckets will all be empty in
- * that state.
+ * The first ledger and transaction files (containing the genesis ledger #1, and
+ * the subsequent 62 ledgers) are checkpointed when LedgerManager's currentLedger
+ * is 64 = 0x40, so the last ledger published into that snapshot is 0x3f, and
+ * it's stored in files ledger/00/00/00/ledger-0x0000003f.xdr.gz and
+ * transaction/00/00/00/transaction-0x0000003f.xdr.gz, and described by
+ * history/00/00/00/history-0x0000003f.json.
+ *
+ * A pseudo-checkpoint describing the system-state before any transactions are
+ * applied -- the fictional "ledger zero" state -- is also made in each history
+ * archive when it is initialized. This is described by
+ * history/00/00/00/history-0x00000000.json, with all-zero buckets. No
+ * transaction or ledger-history XDR files are associated with this
+ * pseudo-checkpoint; its presence simply indicates that the archive has been
+ * initialized, and gives the catchup system something to read when it probes
+ * the archive for a most-recent state.
  *
  *
  * Boundary conditions and counts:
@@ -79,7 +90,7 @@
  *
  * There is no ledger 0 -- that's the sequence number of a _fictional_ ledger
  * with no content, before "ledger 1, the genesis ledger" -- so the initial
- * ledger block (block 0x00000000) has 63 "real" ledger objects in it, not 64 as
+ * ledger block (block 0x0000003f) has 63 "real" ledger objects in it, not 64 as
  * in all subsequent blocks. We could, instead, shift all arithmetic in the
  * system to "count from 1" and have ledger blocks run from [1,64] and [65,128]
  * and so forth; but the disadvantages of propagating counts-from-1 arithmetic

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -297,12 +297,15 @@ class HistoryManager
     // Run catchup, we've just heard `initLedger` from the network. Mode can be
     // CATCHUP_COMPLETE, meaning replay history from last to present, or
     // CATCHUP_MINIMAL, meaning snap to the next state possible and discard
-    // history. See larger comment above for more detail.
+    // history. Pass `manualCatchup=true` for manual catchup mode, in which
+    // catchup adheres to `initLedger` only, avoiding rounding up or down to
+    // checkpoint boundaries. See larger comment above for more detail.
     virtual void catchupHistory(
         uint32_t initLedger, CatchupMode mode,
         std::function<void(asio::error_code const& ec, CatchupMode mode,
                            LedgerHeaderHistoryEntry const& lastClosed)>
-        handler) = 0;
+        handler,
+        bool manualCatchup=false) = 0;
 
     // Call posted after a worker thread has finished taking a snapshot; calls
     // PublishStateMachine::snapshotWritten after bumping counter.

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -54,8 +54,8 @@
  *
  * While the _most recent_ checkpoint is in .well-known/stellar-history.json,
  * each checkpoint is also stored permanently at a path whose name includes the
- * checkpoint number (as a 32-bit hex string) and stored in a 3-level deep
- * directory tree of hex digit prefixes. For example, checkpoint number
+ * checkpoint ledger number (as a 32-bit hex string) and stored in a 3-level deep
+ * directory tree of hex digit prefixes. For example, checkpoint ledger-number
  * 0x12345678 will be described by file history/12/34/56/history-0x12345678.json
  * and the associated history block will be written to the two files
  * ledger/12/34/56/ledger-0x12345678.xdr.gz and
@@ -225,6 +225,9 @@ class HistoryManager
     // This should normally be a constant (64) but in testing cases
     // may be different (see ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING).
     virtual uint32_t getCheckpointFrequency() = 0;
+
+    // Given a ledger, tell when the previous checkpoint occured.
+    virtual uint32_t prevCheckpointLedger(uint32_t ledger) = 0;
 
     // Given a ledger, tell when the next checkpoint will occur.
     virtual uint32_t nextCheckpointLedger(uint32_t ledger) = 0;

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -227,6 +227,11 @@ HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger)
 uint32_t
 HistoryManagerImpl::nextCheckpointLedger(uint32_t ledger)
 {
+    if (mManualCatchup)
+    {
+        return ledger;
+    }
+
     uint32_t freq = getCheckpointFrequency();
     if (ledger == 0)
         return freq;
@@ -528,7 +533,8 @@ void
 HistoryManagerImpl::catchupHistory(
     uint32_t initLedger, CatchupMode mode,
     std::function<void(asio::error_code const& ec, CatchupMode mode,
-                       LedgerHeaderHistoryEntry const& lastClosed)> handler)
+                       LedgerHeaderHistoryEntry const& lastClosed)> handler,
+    bool manualCatchup)
 {
     // To repair buckets, call `downloadMissingBuckets()` instead.
     assert(mode != CATCHUP_BUCKET_REPAIR); 
@@ -538,6 +544,7 @@ HistoryManagerImpl::catchupHistory(
         throw std::runtime_error("Catchup already in progress");
     }
     mCatchupStart.Mark();
+    mManualCatchup = manualCatchup;
 
     mCatchup = make_unique<CatchupStateMachine>(
         mApp, initLedger, mode, 

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -218,6 +218,13 @@ HistoryManagerImpl::getCheckpointFrequency()
 }
 
 uint32_t
+HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger)
+{
+    uint32_t freq = getCheckpointFrequency();
+    return (ledger / freq) * freq;
+}
+
+uint32_t
 HistoryManagerImpl::nextCheckpointLedger(uint32_t ledger)
 {
     uint32_t freq = getCheckpointFrequency();

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -41,6 +41,7 @@ public:
     ~HistoryManagerImpl() override;
 
     uint32_t getCheckpointFrequency();
+    uint32_t prevCheckpointLedger(uint32_t ledger);
     uint32_t nextCheckpointLedger(uint32_t ledger);
     uint64_t nextCheckpointCatchupProbe(uint32_t ledger);
 

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -25,6 +25,7 @@ class HistoryManagerImpl : public HistoryManager
     std::unique_ptr<TmpDir> mWorkDir;
     std::unique_ptr<PublishStateMachine> mPublish;
     std::unique_ptr<CatchupStateMachine> mCatchup;
+    bool mManualCatchup { false };
 
     medida::Meter& mPublishSkip;
     medida::Meter& mPublishQueue;
@@ -83,7 +84,8 @@ public:
         uint32_t initLedger, CatchupMode mode,
         std::function<void(asio::error_code const& ec, CatchupMode mode,
                            LedgerHeaderHistoryEntry const& lastClosed)>
-            handler) override;
+        handler,
+        bool manualCatchup) override;
 
     void snapshotWritten(asio::error_code const&) override;
 

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -339,18 +339,15 @@ StateSnapshot::StateSnapshot(Application& app)
     , mSnapDir(app.getTmpDirManager().tmpDir("snapshot"))
     , mLedgerSnapFile(std::make_shared<FilePublishInfo>(
           FILE_PUBLISH_NEEDED, mSnapDir, HISTORY_FILE_TYPE_LEDGER,
-          app.getHistoryManager().prevCheckpointLedger(
-              mLocalState.currentLedger)))
+          mLocalState.currentLedger))
 
     , mTransactionSnapFile(std::make_shared<FilePublishInfo>(
           FILE_PUBLISH_NEEDED, mSnapDir, HISTORY_FILE_TYPE_TRANSACTIONS,
-          app.getHistoryManager().prevCheckpointLedger(
-              mLocalState.currentLedger)))
+          mLocalState.currentLedger))
 
     , mTransactionResultSnapFile(std::make_shared<FilePublishInfo>(
           FILE_PUBLISH_NEEDED, mSnapDir, HISTORY_FILE_TYPE_RESULTS,
-          app.getHistoryManager().prevCheckpointLedger(
-              mLocalState.currentLedger)))
+          mLocalState.currentLedger))
 {
     BucketList& buckets = app.getBucketManager().getBucketList();
     for (size_t i = 0; i < BucketList::kNumLevels; ++i)

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -339,18 +339,18 @@ StateSnapshot::StateSnapshot(Application& app)
     , mSnapDir(app.getTmpDirManager().tmpDir("snapshot"))
     , mLedgerSnapFile(std::make_shared<FilePublishInfo>(
           FILE_PUBLISH_NEEDED, mSnapDir, HISTORY_FILE_TYPE_LEDGER,
-          uint32_t(mLocalState.currentLedger /
-                   app.getHistoryManager().getCheckpointFrequency())))
+          app.getHistoryManager().prevCheckpointLedger(
+              mLocalState.currentLedger)))
 
     , mTransactionSnapFile(std::make_shared<FilePublishInfo>(
           FILE_PUBLISH_NEEDED, mSnapDir, HISTORY_FILE_TYPE_TRANSACTIONS,
-          uint32_t(mLocalState.currentLedger /
-                   app.getHistoryManager().getCheckpointFrequency())))
+          app.getHistoryManager().prevCheckpointLedger(
+              mLocalState.currentLedger)))
 
     , mTransactionResultSnapFile(std::make_shared<FilePublishInfo>(
           FILE_PUBLISH_NEEDED, mSnapDir, HISTORY_FILE_TYPE_RESULTS,
-          uint32_t(mLocalState.currentLedger /
-                   app.getHistoryManager().getCheckpointFrequency())))
+          app.getHistoryManager().prevCheckpointLedger(
+              mLocalState.currentLedger)))
 {
     BucketList& buckets = app.getBucketManager().getBucketList();
     for (size_t i = 0; i < BucketList::kNumLevels; ++i)

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -152,10 +152,12 @@ class LedgerManager
     // as the current ledger number (to begin catchup from). Normally this
     // happens automatically when LedgerManager detects it is desynchronized
     // from SCP's consensus ledger; this methos is present in the public
-    // interface
-    // to permit testing.
+    // interface to permit testing. Pass `manualCatchup=true` to catch up in
+    // "manual mode", in which rounding up and down to checkpoint frequencies is
+    // disabled.
     virtual void startCatchUp(uint32_t initLedger,
-                              HistoryManager::CatchupMode resume) = 0;
+                              HistoryManager::CatchupMode resume,
+                              bool manualCatchup=false) = 0;
 
     // Called by the history subsystem during catchup: this method asks the
     // LedgerManager whether or not the HistoryManager should trust (thus: begin

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -375,12 +375,14 @@ LedgerManagerImpl::externalizeValue(LedgerCloseData ledgerData)
 
 void
 LedgerManagerImpl::startCatchUp(uint32_t initLedger,
-                                HistoryManager::CatchupMode resume)
+                                HistoryManager::CatchupMode resume,
+                                bool manualCatchup)
 {
     setState(LM_CATCHING_UP_STATE);
     mApp.getHistoryManager().catchupHistory(
         initLedger, resume,
-        std::bind(&LedgerManagerImpl::historyCaughtup, this, _1, _2, _3));
+        std::bind(&LedgerManagerImpl::historyCaughtup, this, _1, _2, _3),
+        manualCatchup);
 }
 
 HistoryManager::VerifyHashStatus

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -80,7 +80,8 @@ class LedgerManagerImpl : public LedgerManager
     Database& getDatabase() override;
 
     void startCatchUp(uint32_t initLedger,
-                      HistoryManager::CatchupMode resume) override;
+                      HistoryManager::CatchupMode resume,
+                      bool manualCatchup=false) override;
     HistoryManager::VerifyHashStatus
     verifyCatchupCandidate(LedgerHeaderHistoryEntry const&) const override;
     void closeLedger(LedgerCloseData ledgerData) override;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerManager.h"
 #include "lib/http/server.hpp"
 #include "lib/json/json.h"
+#include "lib/util/format.h"
 #include "main/Application.h"
 #include "main/CommandHandler.h"
 #include "main/Config.h"
@@ -260,7 +261,8 @@ CommandHandler::checkpoint(std::string const& params, std::string& retStr)
     {
         bool done = false;
         asio::error_code ec;
-        uint32_t ledgerNum = mApp.getLedgerManager().getLastClosedLedgerNum();
+        uint32_t lclNum = mApp.getLedgerManager().getLastClosedLedgerNum();
+        uint32_t ledgerNum = mApp.getLedgerManager().getLedgerNum();
         hm.publishHistory(
             [&done, &ec](asio::error_code const& ec2) {
                 ec = ec2;
@@ -274,8 +276,12 @@ CommandHandler::checkpoint(std::string const& params, std::string& retStr)
         }
         else
         {
-            retStr = std::string("Published checkpoint ")
-                + std::to_string(ledgerNum);
+            retStr = fmt::format(
+                "Forcibly published checkpoint 0x{:08x}, "
+                "at current ledger {};\n"
+                "To force catch up on other peers, "
+                "issue the command 'catchup?ledger={}'",
+                lclNum, ledgerNum, ledgerNum);
         }
     }
     else

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -141,7 +141,12 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
     retStr += "supported commands:<p/>";
 
     retStr +=
-        "<p><h1> /connect?peer=NAME&port=NNN</h1>"
+        "<p><h1> /catchup?ledger=NNN[&mode=MODE]</h1>"
+        "triggers the instance to catch up to ledger NNN from history; "
+        "mode is either 'minimal' (the default, if omitted) or 'complete'."
+        "</p><p><h1> /checkpoint</h1>"
+        "triggers the instance to write an immediate history checkpoint."
+        "</p><p><h1> /connect?peer=NAME&port=NNN</h1>"
         "triggers the instance to connect to peer NAME at port NNN."
         "</p><p><h1> /help</h1>"
         "give a list of currently supported commands"

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -28,6 +28,7 @@ class CommandHandler
 
     void fileNotFound(std::string const& params, std::string& retStr);
 
+    void checkpoint(std::string const& params, std::string& retStr);
     void connect(std::string const& params, std::string& retStr);
     void info(std::string const& params, std::string& retStr);
     void ll(std::string const& params, std::string& retStr);

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -28,6 +28,7 @@ class CommandHandler
 
     void fileNotFound(std::string const& params, std::string& retStr);
 
+    void catchup(std::string const& params, std::string& retStr);
     void checkpoint(std::string const& params, std::string& retStr);
     void connect(std::string const& params, std::string& retStr);
     void info(std::string const& params, std::string& retStr);


### PR DESCRIPTION
This implements the manual force-checkpoint / force-catchup command pair in bug #452. In order to support this, it requires two structural changes to history stores that will invalidate any existing history stores, require rebuilding them:

  - History checkpoints are identified by ledger-number now, not checkpoint-number.
  - The ledger number of a checkpoint is the _last_ ledger in the checkpoint, not the first.

As an unfortunate side effect, checkpoints now have kinda ugly names (`history-0000003f.xdr.gz` rather than `history-00000001.xdr.gz`) but I'm sure we'll adapt. 