### PR TITLE
 (signing weight) must be > threshold

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -133,7 +133,7 @@ TransactionFrame::checkSignature(AccountFrame& account, int32_t neededWeight)
             {
                 mUsedSignatures[i] = true;
                 totalWeight += (*it).weight;
-                if (totalWeight >= neededWeight)
+                if (totalWeight > neededWeight)
                     return true;
 
                 keyWeights.erase(it); // can't sign twice


### PR DESCRIPTION
jed [1:45 PM] 
ok thats right it is:  (signing weight) must be > threshold
jed [1:47 PM] 
make a PR. cause that is wrong :)