### PR TITLE
Make TimeBounds.maxTime optional

### DIFF
--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -238,7 +238,7 @@ case MEMO_RETURN:
 struct TimeBounds
 {
     uint64 minTime;
-    uint64 maxTime;
+    uint64 *maxTime;
 };
 
 /* a transaction is a container for a set of operations


### PR DESCRIPTION
There is already a check in TransactionFrame (https://github.com/stellar/stellar-core/blob/2954283d2137dbdb212540134a0c3643995aac62/src/transactions/TransactionFrame.cpp#L209) to check maxTime exists. Let's make maxTime optional in xdr so that the client doesn't even have to worry about setting it if they want no maxTime bound. 