### PR TITLE
Load generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -74,6 +74,7 @@ FMT_SRCS =                                      \
     src/process/ProcessManagerImpl.cpp          \
     src/process/ProcessTests.cpp                \
     src/simulation/CoreTests.cpp                \
+    src/simulation/LoadGenerator.cpp            \
     src/simulation/Simulation.cpp               \
     src/simulation/Topologies.cpp               \
     src/transactions/AllowTrustOpFrame.cpp      \
@@ -163,6 +164,7 @@ FMT_HDRS =                                      \
     src/process/ProcessManager.h                \
     src/process/ProcessManagerImpl.h            \
     src/simulation/Simulation.h                 \
+    src/simulation/LoadGenerator.h              \
     src/simulation/Topologies.h                 \
     src/transactions/AllowTrustOpFrame.h        \
     src/transactions/ChangeTrustOpFrame.h       \

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -56,7 +56,7 @@ DATABASE="sqlite3://stellar.db"
 # Specifing this servers quorom set
 # can be nested 2 levels: (A,B,C,(D,E,F),(G,H,(I,J,K,L)))
 # The threshold is how many have to agree where the sets are treated as one vote
-# so for exampl in the above there are 5 things that can vote: 
+# so for example in the above there are 5 things that can vote: 
 # individual validators: A,B,C and sets (D,E,F) and set (G,H with subset (I,J,K,L))
 # the sets each have their own threshold.
 # this allows you to for example, treat 3 servers of some enitity as one vote but

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -84,7 +84,7 @@ class LedgerPerformanceTests : public Simulation
         uint64_t amount = static_cast<uint64_t>(
             rand_fraction() *
             min(static_cast<uint64_t>(1000),
-                (mAccounts[iFrom]->mBalance - getMinBalance()) / 3));
+                (mAccounts[iFrom]->mBalance - mMinBalance) / 3));
         txs.push_back(make_optional<TxInfo>(
             createTransferTransaction(iFrom, iTo, amount)));
 

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -30,6 +30,7 @@ class Herder;
 class OverlayManager;
 class Database;
 class PersistentState;
+class LoadGenerator;
 
 /*
  * State of a single instance of the stellar-core application.
@@ -193,6 +194,10 @@ class Application
     // If config.MANUAL_MODE=true, force the current ledger to close and return
     // true. Otherwise return false. This method exists only for testing.
     virtual bool manualClose() = 0;
+
+    // If config.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true, generate some load
+    // against the current application.
+    virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs, uint32_t txRate) = 0;
 
     // Execute any administrative commands written in the Config.COMMANDS
     // variable of the config file. This permits scripting certain actions to

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -17,6 +17,7 @@
 #include "database/Database.h"
 #include "process/ProcessManager.h"
 #include "main/CommandHandler.h"
+#include "simulation/LoadGenerator.h"
 #include "medida/metrics_registry.h"
 #include "medida/reporting/console_reporter.h"
 
@@ -298,6 +299,18 @@ ApplicationImpl::manualClose()
         return true;
     }
     return false;
+}
+
+void
+ApplicationImpl::generateLoad(uint32_t nAccounts,
+                              uint32_t nTxs,
+                              uint32_t txRate)
+{
+    if (!mLoadGenerator)
+    {
+        mLoadGenerator = make_unique<LoadGenerator>();
+    }
+    mLoadGenerator->generateLoad(*this, nAccounts, nTxs, txRate);
 }
 
 void

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -20,6 +20,7 @@ class HistoryManager;
 class ProcessManager;
 class CommandHandler;
 class Database;
+class LoadGenerator;
 
 class ApplicationImpl : public Application
 {
@@ -63,6 +64,10 @@ class ApplicationImpl : public Application
 
     virtual bool manualClose() override;
 
+    virtual void generateLoad(uint32_t nAccounts,
+                              uint32_t nTxs,
+                              uint32_t txRate) override;
+
     virtual void applyCfgCommands() override;
 
     virtual void reportCfgMetrics() override;
@@ -96,6 +101,7 @@ class ApplicationImpl : public Application
     std::unique_ptr<ProcessManager> mProcessManager;
     std::unique_ptr<CommandHandler> mCommandHandler;
     std::unique_ptr<PersistentState> mPersistentState;
+    std::unique_ptr<LoadGenerator> mLoadGenerator;
 
     std::vector<std::thread> mWorkerThreads;
 

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -31,6 +31,7 @@ class CommandHandler
     void catchup(std::string const& params, std::string& retStr);
     void checkpoint(std::string const& params, std::string& retStr);
     void connect(std::string const& params, std::string& retStr);
+    void generateLoad(std::string const& params, std::string& retStr);
     void info(std::string const& params, std::string& retStr);
     void ll(std::string const& params, std::string& retStr);
     void logRotate(std::string const& params, std::string& retStr);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -31,6 +31,7 @@ Config::Config() : PEER_KEY(SecretKey::random())
     RUN_STANDALONE = false;
     MANUAL_CLOSE = false;
     CATCHUP_COMPLETE = false;
+    ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
     ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
     ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = false;
     BREAK_ASIO_LOOP_FOR_FAST_TESTS = false;
@@ -121,6 +122,9 @@ Config::load(std::string const& filename)
                 RUN_STANDALONE = item.second->as<bool>()->value();
             else if (item.first == "CATCHUP_COMPLETE")
                 CATCHUP_COMPLETE = item.second->as<bool>()->value();
+            else if (item.first == "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING")
+                ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING =
+                    item.second->as<bool>()->value();
             else if (item.first == "ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING")
                 ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING =
                     item.second->as<bool>()->value();

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -61,6 +61,12 @@ class Config : public std::enable_shared_from_this<Config>
     // meaning catchup "minimally", using deltas to the most recent snapshot.
     bool CATCHUP_COMPLETE;
 
+    // A config parameter that enables synthetic load generation on demand,
+    // using the `generateload` runtime command (see CommandHandler.cpp). This
+    // option only exists for stress-testing and should not be enabled in
+    // production networks.
+    bool ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING;
+
     // A config parameter that reduces ledger close time to 1s and checkpoint
     // frequency to every 8 ledgers. Do not ever set this in production, as it
     // will make your history archives incompatible with those of anyone else.

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -170,6 +170,21 @@ LoadGenerator::accountCreationTransactions(size_t n)
     return result;
 }
 
+bool
+LoadGenerator::loadAccount(Application& app, AccountInfo& account)
+{
+    AccountFrame::pointer ret;
+    ret = AccountFrame::loadAccount(account.mKey.getPublicKey(),
+                                    app.getDatabase());
+    if (!ret)
+    {
+        return false;
+    }
+
+    account.mBalance = ret->getBalance();
+    account.mSeq = ret->getSeqNum();
+    return true;
+}
 
 LoadGenerator::TxInfo
 LoadGenerator::createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount)

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1,0 +1,175 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "simulation/LoadGenerator.h"
+#include "main/Config.h"
+#include "transactions/TxTests.h"
+#include "herder/Herder.h"
+#include "ledger/LedgerManager.h"
+#include "util/Logging.h"
+#include "util/Math.h"
+#include "util/types.h"
+
+namespace stellar
+{
+
+using namespace std;
+
+LoadGenerator::LoadGenerator()
+{
+    auto root =
+        make_shared<AccountInfo>(0, txtest::getRoot(), 1000000000, 0, *this);
+    mAccounts.push_back(root);
+}
+
+LoadGenerator::~LoadGenerator()
+{
+}
+
+void
+LoadGenerator::updateMinBalance(Application& app)
+{
+    auto b = app.getLedgerManager().getMinBalance(0);
+    if (b > mMinBalance)
+    {
+        mMinBalance = b;
+    }
+}
+
+LoadGenerator::AccountInfoPtr
+LoadGenerator::createAccount(size_t i)
+{
+    auto accountName = "Account-" + to_string(i);
+    return make_shared<AccountInfo>(i, txtest::getAccount(accountName.c_str()),
+                                    0, 0, *this);
+}
+
+vector<LoadGenerator::AccountInfoPtr>
+LoadGenerator::createAccounts(size_t n)
+{
+    vector<AccountInfoPtr> result;
+    for (size_t i = 0; i < n; i++)
+    {
+        auto account = createAccount(mAccounts.size());
+        mAccounts.push_back(account);
+        result.push_back(account);
+    }
+    return result;
+}
+
+vector<LoadGenerator::TxInfo>
+LoadGenerator::accountCreationTransactions(size_t n)
+{
+    vector<TxInfo> result;
+    for (auto account : createAccounts(n))
+    {
+        result.push_back(account->creationTransaction());
+    }
+    return result;
+}
+
+
+LoadGenerator::TxInfo
+LoadGenerator::createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount)
+{
+    return TxInfo{mAccounts[iFrom], mAccounts[iTo], false, amount};
+}
+
+LoadGenerator::TxInfo
+LoadGenerator::createRandomTransaction(float alpha)
+{
+    size_t iFrom, iTo;
+    do
+    {
+        // iFrom = rand_pareto(alpha, mAccounts.size());
+        // iTo = rand_pareto(alpha, mAccounts.size());
+        iFrom = static_cast<int>(rand_fraction() * mAccounts.size());
+        iTo = static_cast<int>(rand_fraction() * mAccounts.size());
+    } while (iFrom == iTo);
+
+    uint64_t amount = static_cast<uint64_t>(
+        rand_fraction() *
+        min(static_cast<uint64_t>(1000),
+            (mAccounts[iFrom]->mBalance - mMinBalance) / 3));
+    return createTransferTransaction(iFrom, iTo, amount);
+}
+
+vector<LoadGenerator::TxInfo>
+LoadGenerator::createRandomTransactions(size_t n, float paretoAlpha)
+{
+    vector<TxInfo> result;
+    for (size_t i = 0; i < n; i++)
+    {
+        result.push_back(createRandomTransaction(paretoAlpha));
+    }
+    return result;
+}
+
+
+//////////////////////////////////////////////////////
+// AccountInfo
+//////////////////////////////////////////////////////
+
+LoadGenerator::AccountInfo::AccountInfo(size_t id, SecretKey key, uint64_t balance,
+                                            SequenceNumber seq,
+                                            LoadGenerator& loadGen)
+    : mId(id)
+    , mKey(key)
+    , mBalance(balance)
+    , mSeq(seq)
+    , mLoadGen(loadGen)
+{
+}
+
+LoadGenerator::TxInfo
+LoadGenerator::AccountInfo::creationTransaction()
+{
+    return TxInfo{mLoadGen.mAccounts[0], shared_from_this(), true,
+                  100 * mLoadGen.mMinBalance +
+                      mLoadGen.mAccounts.size() - 1};
+}
+
+
+//////////////////////////////////////////////////////
+// TxInfo
+//////////////////////////////////////////////////////
+
+void
+LoadGenerator::TxInfo::execute(Application& app)
+{
+    if (app.getHerder().recvTransaction(createPaymentTx()) ==
+        Herder::TX_STATUS_PENDING)
+    {
+        recordExecution(app.getConfig().DESIRED_BASE_FEE);
+    }
+}
+
+TransactionFramePtr
+LoadGenerator::TxInfo::createPaymentTx()
+{
+    TransactionFramePtr res;
+    if (mCreate)
+    {
+        res = txtest::createCreateAccountTx(mFrom->mKey, mTo->mKey,
+                                            mFrom->mSeq + 1, mAmount);
+    }
+    else
+    {
+        res = txtest::createPaymentTx(mFrom->mKey, mTo->mKey, mFrom->mSeq + 1,
+                                      mAmount);
+    }
+    return res;
+}
+
+void
+LoadGenerator::TxInfo::recordExecution(uint64_t baseFee)
+{
+    mFrom->mSeq++;
+    mFrom->mBalance -= mAmount;
+    mFrom->mBalance -= baseFee;
+    mTo->mBalance += mAmount;
+}
+
+
+}

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -21,6 +21,7 @@ using namespace std;
 const uint32_t LoadGenerator::STEP_MSECS = 100;
 
 LoadGenerator::LoadGenerator()
+    : mMinBalance(0)
 {
     auto root =
         make_shared<AccountInfo>(0, txtest::getRoot(), 1000000000, 0, *this);
@@ -64,6 +65,8 @@ LoadGenerator::generateLoad(Application& app,
                             uint32_t nTxs,
                             uint32_t txRate)
 {
+    updateMinBalance(app);
+
     // txRate is "per second"; we're running one "step" worth which is a
     // fraction of txRate determined by STEP_MSECS. For example if txRate
     // is 200 and STEP_MSECS is 100, then we want to do 20 tx per step.

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -83,9 +83,43 @@ LoadGenerator::generateLoad(Application& app,
                       << nAccounts << " accounts and "
                       << nTxs << " txs remaining";
         }
-        nTxs -= txPerStep;
 
-        // FIXME: actually generate some load here.
+        vector<TxInfo> txs;
+        for (uint32_t i = 0; i < txPerStep; ++i)
+        {
+            bool doCreateAccount = false;
+            if (mAccounts.size() < 2)
+            {
+                doCreateAccount = true;
+            }
+            else if (nAccounts > 0)
+            {
+                doCreateAccount = rand_flip();
+            }
+            if (doCreateAccount)
+            {
+                auto acc = createAccount(mAccounts.size());
+                mAccounts.push_back(acc);
+                txs.push_back(acc->creationTransaction());
+                if (nAccounts > 0)
+                {
+                    nAccounts--;
+                }
+            }
+            else
+            {
+                txs.push_back(createRandomTransaction(0.5));
+                if (nTxs > 0)
+                {
+                    nTxs--;
+                }
+            }
+        }
+
+        for (auto& tx : txs)
+        {
+            tx.execute(app);
+        }
 
         scheduleLoadGeneration(app, nAccounts, nTxs, txRate);
     }

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -13,6 +13,8 @@
 namespace stellar
 {
 
+class VirtualTimer;
+
 class LoadGenerator
 {
 public:
@@ -23,8 +25,26 @@ public:
     struct AccountInfo;
     using AccountInfoPtr = std::shared_ptr<AccountInfo>;
 
+    static const uint32_t STEP_MSECS;
+
     std::vector<AccountInfoPtr> mAccounts;
+    std::unique_ptr<VirtualTimer> mLoadTimer;
     uint64 mMinBalance;
+
+    // Schedule a callback to generateLoad() STEP_MSECS miliseconds from now.
+    void scheduleLoadGeneration(Application& app,
+                                uint32_t nAccounts,
+                                uint32_t nTxs,
+                                uint32_t txRate);
+
+    // Generate one "step" worth of load (assuming 1 step per STEP_MSECS) at a
+    // given target number of accounts and txs, and a given target tx/s rate.
+    // If work remains after the current step, call scheduleLoadGeneration()
+    // with the remainder.
+    void generateLoad(Application& app,
+                      uint32_t nAccounts,
+                      uint32_t nTxs,
+                      uint32_t txRate);
 
     std::vector<TxInfo> accountCreationTransactions(size_t n);
     AccountInfoPtr createAccount(size_t i);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -78,7 +78,7 @@ public:
         bool mCreate;
         uint64_t mAmount;
 
-        void execute(Application& app);
+        bool execute(Application& app);
         TransactionFramePtr createPaymentTx();
         void recordExecution(uint64_t baseFee);
     };

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -49,6 +49,8 @@ public:
     std::vector<TxInfo> accountCreationTransactions(size_t n);
     AccountInfoPtr createAccount(size_t i);
     std::vector<AccountInfoPtr> createAccounts(size_t n);
+    bool loadAccount(Application& app, AccountInfo& account);
+
     TxInfo createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount);
     TxInfo createRandomTransaction(float alpha);
     std::vector<TxInfo> createRandomTransactions(size_t n, float paretoAlpha);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -1,0 +1,65 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+#include "crypto/SecretKey.h"
+#include "transactions/TxTests.h"
+#include "generated/Stellar-types.h"
+#include <vector>
+
+namespace stellar
+{
+
+class LoadGenerator
+{
+public:
+    LoadGenerator();
+    ~LoadGenerator();
+
+    struct TxInfo;
+    struct AccountInfo;
+    using AccountInfoPtr = std::shared_ptr<AccountInfo>;
+
+    std::vector<AccountInfoPtr> mAccounts;
+    uint64 mMinBalance;
+
+    std::vector<TxInfo> accountCreationTransactions(size_t n);
+    AccountInfoPtr createAccount(size_t i);
+    std::vector<AccountInfoPtr> createAccounts(size_t n);
+    TxInfo createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount);
+    TxInfo createRandomTransaction(float alpha);
+    std::vector<TxInfo> createRandomTransactions(size_t n, float paretoAlpha);
+    void updateMinBalance(Application& app);
+
+    struct AccountInfo : public std::enable_shared_from_this<AccountInfo>
+    {
+        AccountInfo(size_t id, SecretKey key, uint64_t balance,
+                    SequenceNumber seq, LoadGenerator& loadGen);
+        size_t mId;
+        SecretKey mKey;
+        uint64_t mBalance;
+        SequenceNumber mSeq;
+
+        TxInfo creationTransaction();
+
+      private:
+        LoadGenerator& mLoadGen;
+    };
+
+    struct TxInfo
+    {
+        AccountInfoPtr mFrom;
+        AccountInfoPtr mTo;
+        bool mCreate;
+        uint64_t mAmount;
+
+        void execute(Application& app);
+        TransactionFramePtr createPaymentTx();
+        void recordExecution(uint64_t baseFee);
+    };
+};
+
+}

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -24,18 +24,6 @@ namespace stellar
 
 using namespace std;
 
-uint64
-Simulation::getMinBalance()
-{
-    int64_t mx = 0;
-    for (const auto& n : mNodes)
-    {
-        auto b = n.second->getLedgerManager().getMinBalance(0);
-        mx = (b > mx ? b : mx);
-    }
-    return mx;
-}
-
 Simulation::Simulation(Mode mode)
     : mClock(mode == OVER_TCP ? VirtualClock::REAL_TIME
                               : VirtualClock::VIRTUAL_TIME)
@@ -43,9 +31,6 @@ Simulation::Simulation(Mode mode)
     , mConfigCount(0)
     , mIdleApp(Application::create(mClock, getTestConfig(++mConfigCount)))
 {
-    auto root =
-        make_shared<AccountInfo>(0, txtest::getRoot(), 1000000000, 0, *this);
-    mAccounts.push_back(root);
 }
 
 Simulation::~Simulation()
@@ -84,6 +69,7 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
     uint256 nodeID = nodeKey.getPublicKey();
     mConfigs[nodeID] = cfg;
     mNodes[nodeID] = result;
+    updateMinBalance(*result);
 
     return nodeID;
 }
@@ -321,117 +307,6 @@ Simulation::crankUntil(function<bool()> const& predicate,
     }
 }
 
-Simulation::TxInfo
-Simulation::createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount)
-{
-    return TxInfo{mAccounts[iFrom], mAccounts[iTo], false, amount};
-}
-
-Simulation::TxInfo
-Simulation::createRandomTransaction(float alpha)
-{
-    size_t iFrom, iTo;
-    do
-    {
-        // iFrom = rand_pareto(alpha, mAccounts.size());
-        // iTo = rand_pareto(alpha, mAccounts.size());
-        iFrom = static_cast<int>(rand_fraction() * mAccounts.size());
-        iTo = static_cast<int>(rand_fraction() * mAccounts.size());
-    } while (iFrom == iTo);
-
-    uint64_t amount = static_cast<uint64_t>(
-        rand_fraction() *
-        min(static_cast<uint64_t>(1000),
-            (mAccounts[iFrom]->mBalance - getMinBalance()) / 3));
-    return createTransferTransaction(iFrom, iTo, amount);
-}
-
-void
-Simulation::TxInfo::execute(Application& app)
-{
-    if (app.getHerder().recvTransaction(createPaymentTx()) ==
-        Herder::TX_STATUS_PENDING)
-    {
-        recordExecution(app.getConfig().DESIRED_BASE_FEE);
-    }
-}
-
-TransactionFramePtr
-Simulation::TxInfo::createPaymentTx()
-{
-    TransactionFramePtr res;
-    if (mCreate)
-    {
-        res = txtest::createCreateAccountTx(mFrom->mKey, mTo->mKey,
-                                            mFrom->mSeq + 1, mAmount);
-    }
-    else
-    {
-        res = txtest::createPaymentTx(mFrom->mKey, mTo->mKey, mFrom->mSeq + 1,
-                                      mAmount);
-    }
-    return res;
-}
-
-void
-Simulation::TxInfo::recordExecution(uint64_t baseFee)
-{
-    mFrom->mSeq++;
-    mFrom->mBalance -= mAmount;
-    mFrom->mBalance -= baseFee;
-    mTo->mBalance += mAmount;
-}
-
-vector<Simulation::TxInfo>
-Simulation::createRandomTransactions(size_t n, float paretoAlpha)
-{
-    vector<TxInfo> result;
-    for (size_t i = 0; i < n; i++)
-    {
-        result.push_back(createRandomTransaction(paretoAlpha));
-    }
-    return result;
-}
-
-vector<Simulation::TxInfo>
-Simulation::accountCreationTransactions(size_t n)
-{
-    vector<TxInfo> result;
-    for (auto account : createAccounts(n))
-    {
-        result.push_back(account->creationTransaction());
-    }
-    return result;
-}
-
-Simulation::AccountInfoPtr
-Simulation::createAccount(size_t i)
-{
-    auto accountName = "Account-" + to_string(i);
-    return make_shared<AccountInfo>(i, txtest::getAccount(accountName.c_str()),
-                                    0, 0, *this);
-}
-
-vector<Simulation::AccountInfoPtr>
-Simulation::createAccounts(size_t n)
-{
-    vector<AccountInfoPtr> result;
-    for (size_t i = 0; i < n; i++)
-    {
-        auto account = createAccount(mAccounts.size());
-        mAccounts.push_back(account);
-        result.push_back(account);
-    }
-    return result;
-}
-
-Simulation::TxInfo
-Simulation::AccountInfo::creationTransaction()
-{
-    return TxInfo{mSimulation.mAccounts[0], shared_from_this(), true,
-                  100 * mSimulation.getMinBalance() +
-                      mSimulation.mAccounts.size() - 1};
-}
 
 void
 Simulation::execute(TxInfo transaction)

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -421,27 +421,7 @@ Simulation::loadAccount(AccountInfo& account)
 {
     // assumes all nodes are in sync
     auto app = mNodes.begin()->second;
-
-    AccountFrame::pointer ret;
-    ret = AccountFrame::loadAccount(account.mKey.getPublicKey(),
-                                    app->getDatabase());
-    if (!ret)
-    {
-        return false;
-    }
-
-    account.mBalance = ret->getBalance();
-    account.mSeq = ret->getSeqNum();
-    return true;
-}
-
-void
-Simulation::loadAccounts()
-{
-    for (auto& it : mAccounts)
-    {
-        loadAccount(*it);
-    }
+    return LoadGenerator::loadAccount(*app, account);
 }
 
 class ConsoleReporterWithSum : public medida::reporting::ConsoleReporter

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -14,6 +14,7 @@
 #include "medida/medida.h"
 #include "transactions/TxTests.h"
 #include "generated/Stellar-types.h"
+#include "simulation/LoadGenerator.h"
 
 #define SIMULATION_CREATE_NODE(N)                                              \
     const Hash v##N##VSeed = sha256("SEED_VALIDATION_SEED_" #N);               \
@@ -23,7 +24,7 @@
 namespace stellar
 {
 
-class Simulation
+class Simulation : public LoadGenerator
 {
   public:
     enum Mode
@@ -66,55 +67,6 @@ class Simulation
 
     //////////
 
-    struct TxInfo;
-
-    class AccountInfo : public std::enable_shared_from_this<AccountInfo>
-    {
-      public:
-        AccountInfo(Simulation& simulation) : mSimulation(simulation)
-        {
-        }
-        AccountInfo(size_t id, SecretKey key, uint64_t balance,
-                    SequenceNumber seq, Simulation& simulation)
-            : mId(id)
-            , mKey(key)
-            , mBalance(balance)
-            , mSeq(seq)
-            , mSimulation(simulation)
-        {
-        }
-        size_t mId;
-        SecretKey mKey;
-        uint64_t mBalance;
-        SequenceNumber mSeq;
-
-        TxInfo creationTransaction();
-
-      private:
-        Simulation& mSimulation;
-    };
-    using AccountInfoPtr = std::shared_ptr<AccountInfo>;
-    std::vector<AccountInfoPtr> mAccounts;
-
-    struct TxInfo
-    {
-        AccountInfoPtr mFrom;
-        AccountInfoPtr mTo;
-        bool mCreate;
-        uint64_t mAmount;
-        void execute(Application& app);
-        TransactionFramePtr createPaymentTx();
-        void recordExecution(uint64_t baseFee);
-    };
-
-    std::vector<Simulation::TxInfo> accountCreationTransactions(size_t n);
-    Simulation::AccountInfoPtr createAccount(size_t i);
-    std::vector<Simulation::AccountInfoPtr> createAccounts(size_t n);
-    TxInfo createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount);
-    TxInfo createRandomTransaction(float alpha);
-    std::vector<Simulation::TxInfo> createRandomTransactions(size_t n,
-                                                             float paretoAlpha);
-
     void execute(TxInfo transaction);
     void executeAll(std::vector<TxInfo> const& transaction);
     std::chrono::seconds
@@ -137,7 +89,5 @@ class Simulation
     std::map<uint256, Application::pointer> mNodes;
     std::vector<std::shared_ptr<LoopbackPeerConnection>> mConnections;
 
-  protected:
-    uint64 getMinBalance();
 };
 }

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -76,8 +76,6 @@ class Simulation : public LoadGenerator
     std::vector<AccountInfoPtr>
     accountsOutOfSyncWithDb(); // returns the accounts that don't match
     bool loadAccount(AccountInfo& account);
-    void loadAccounts();
-
     std::string metricsSummary(std::string domain = "");
 
   private:

--- a/src/transactions/AllowTrustOpFrame.h
+++ b/src/transactions/AllowTrustOpFrame.h
@@ -23,8 +23,9 @@ class AllowTrustOpFrame : public OperationFrame
     AllowTrustOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static AllowTrustResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -7,6 +7,9 @@
 #include "ledger/LedgerManager.h"
 #include "database/Database.h"
 
+#include "medida/meter.h"
+#include "medida/metrics_registry.h"
+
 namespace stellar
 {
 
@@ -18,7 +21,8 @@ ChangeTrustOpFrame::ChangeTrustOpFrame(Operation const& op,
 {
 }
 bool
-ChangeTrustOpFrame::doApply(LedgerDelta& delta, LedgerManager& ledgerManager)
+ChangeTrustOpFrame::doApply(medida::MetricsRegistry& metrics,
+                            LedgerDelta& delta, LedgerManager& ledgerManager)
 {
     TrustFrame::pointer trustLine;
     Database& db = ledgerManager.getDatabase();
@@ -31,6 +35,8 @@ ChangeTrustOpFrame::doApply(LedgerDelta& delta, LedgerManager& ledgerManager)
         if (mChangeTrust.limit < 0 ||
             mChangeTrust.limit < trustLine->getBalance())
         { // Can't drop the limit below the balance you are holding with them
+            metrics.NewMeter({"op-change-trust", "failure", "invalid-limit"},
+                             "operation").Mark();
             innerResult().code(CHANGE_TRUST_INVALID_LIMIT);
             return false;
         }
@@ -48,6 +54,8 @@ ChangeTrustOpFrame::doApply(LedgerDelta& delta, LedgerManager& ledgerManager)
         {
             trustLine->storeChange(delta, db);
         }
+        metrics.NewMeter({"op-change-trust", "success", "apply"},
+                         "operation").Mark();
         innerResult().code(CHANGE_TRUST_SUCCESS);
         return true;
     }
@@ -58,6 +66,8 @@ ChangeTrustOpFrame::doApply(LedgerDelta& delta, LedgerManager& ledgerManager)
             AccountFrame::loadAccount(mChangeTrust.line.alphaNum().issuer, db);
         if (!issuer)
         {
+            metrics.NewMeter({"op-change-trust", "failure", "no-issuer"},
+                             "operation").Mark();
             innerResult().code(CHANGE_TRUST_NO_ISSUER);
             return false;
         }
@@ -71,27 +81,37 @@ ChangeTrustOpFrame::doApply(LedgerDelta& delta, LedgerManager& ledgerManager)
 
         if (!mSourceAccount->addNumEntries(1, ledgerManager))
         {
+            metrics.NewMeter({"op-change-trust", "failure", "low-reserve"},
+                             "operation").Mark();
             innerResult().code(CHANGE_TRUST_LOW_RESERVE);
         }
 
         mSourceAccount->storeChange(delta, db);
         trustLine->storeAdd(delta, db);
 
+        metrics.NewMeter({"op-change-trust", "success", "apply"},
+                         "operation").Mark();
         innerResult().code(CHANGE_TRUST_SUCCESS);
         return true;
     }
 }
 
 bool
-ChangeTrustOpFrame::doCheckValid()
+ChangeTrustOpFrame::doCheckValid(medida::MetricsRegistry& metrics)
 {
     if (mChangeTrust.limit < 0)
     {
+        metrics.NewMeter({"op-change-trust", "invalid",
+                          "malformed-negative-limit"},
+                         "operation").Mark();
         innerResult().code(CHANGE_TRUST_MALFORMED);
         return false;
     }
     if (!isCurrencyValid(mChangeTrust.line))
     {
+        metrics.NewMeter({"op-change-trust", "invalid",
+                          "malformed-invalid-currency"},
+                         "operation").Mark();
         innerResult().code(CHANGE_TRUST_MALFORMED);
         return false;
     }

--- a/src/transactions/ChangeTrustOpFrame.h
+++ b/src/transactions/ChangeTrustOpFrame.h
@@ -21,8 +21,9 @@ class ChangeTrustOpFrame : public OperationFrame
     ChangeTrustOpFrame(Operation const& op, OperationResult& res,
                        TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static ChangeTrustResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/CreateAccountOpFrame.h
+++ b/src/transactions/CreateAccountOpFrame.h
@@ -22,8 +22,9 @@ class CreateAccountOpFrame : public OperationFrame
     CreateAccountOpFrame(Operation const& op, OperationResult& res,
                          TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static CreateAccountResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/CreateOfferOpFrame.h
+++ b/src/transactions/CreateOfferOpFrame.h
@@ -18,7 +18,8 @@ class CreateOfferOpFrame : public OperationFrame
 
     OfferFrame::pointer mSellSheepOffer;
 
-    bool checkOfferValid(Database& db);
+    bool checkOfferValid(medida::MetricsRegistry& metrics,
+                         Database& db);
 
     CreateOfferResult&
     innerResult()
@@ -32,8 +33,9 @@ class CreateOfferOpFrame : public OperationFrame
     CreateOfferOpFrame(Operation const& op, OperationResult& res,
                        TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static CreateOfferResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/InflationOpFrame.h
+++ b/src/transactions/InflationOpFrame.h
@@ -20,8 +20,9 @@ class InflationOpFrame : public OperationFrame
     InflationOpFrame(Operation const& op, OperationResult& res,
                      TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
     int32_t getNeededThreshold() const override;
 
     static InflationResultCode

--- a/src/transactions/MergeOpFrame.h
+++ b/src/transactions/MergeOpFrame.h
@@ -21,8 +21,9 @@ class MergeOpFrame : public OperationFrame
                  TransactionFrame& parentTx);
 
     int32_t getNeededThreshold() const;
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static AccountMergeResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -10,6 +10,11 @@
 #include "generated/StellarXDR.h"
 #include "util/types.h"
 
+namespace medida
+{
+class MetricsRegistry;
+}
+
 namespace stellar
 {
 class Application;
@@ -28,8 +33,8 @@ class OperationFrame
 
     bool checkSignature() const;
 
-    virtual bool doCheckValid() = 0;
-    virtual bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) = 0;
+    virtual bool doCheckValid(medida::MetricsRegistry& metrics) = 0;
+    virtual bool doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta, LedgerManager& ledgerManager) = 0;
     virtual int32_t getNeededThreshold() const;
 
   public:

--- a/src/transactions/PathPaymentOpFrame.h
+++ b/src/transactions/PathPaymentOpFrame.h
@@ -22,8 +22,9 @@ class PathPaymentOpFrame : public OperationFrame
     PathPaymentOpFrame(Operation const& op, OperationResult& res,
                        TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static PathPaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/PaymentOpFrame.h
+++ b/src/transactions/PaymentOpFrame.h
@@ -22,8 +22,9 @@ class PaymentOpFrame : public OperationFrame
     PaymentOpFrame(Operation const& op, OperationResult& res,
                    TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static PaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/SetOptionsOpFrame.h
+++ b/src/transactions/SetOptionsOpFrame.h
@@ -22,8 +22,9 @@ class SetOptionsOpFrame : public OperationFrame
     SetOptionsOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(LedgerDelta& delta, LedgerManager& ledgerManager) override;
-    bool doCheckValid() override;
+    bool doApply(medida::MetricsRegistry& metrics,
+                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static SetOptionsResultCode
     getInnerCode(OperationResult const& res)

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -54,6 +54,7 @@ Logging::init()
     el::Loggers::getLogger("Overlay");
     el::Loggers::getLogger("Herder");
     el::Loggers::getLogger("Tx");
+    el::Loggers::getLogger("LoadGen");
 
     gDefaultConf.setToDefault();
     gDefaultConf.setGlobally(el::ConfigurationType::ToStandardOutput, "true");

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -10,6 +10,7 @@ namespace stellar
 
 std::default_random_engine gRandomEngine;
 std::uniform_real_distribution<double> uniformFractionDistribution(0.0, 1.0);
+std::bernoulli_distribution bernoulliDistribution{0.5};
 
 double
 rand_fraction()
@@ -27,4 +28,11 @@ rand_pareto(float alpha, size_t max)
     // modified into a truncated pareto
     return static_cast<size_t>(f * max - 1) % max;
 }
+
+bool
+rand_flip()
+{
+    return bernoulliDistribution(gRandomEngine);
+}
+
 }

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -13,5 +13,7 @@ double rand_fraction();
 
 size_t rand_pareto(float alpha, size_t max);
 
+bool rand_flip();
+
 extern std::default_random_engine gRandomEngine;
 }


### PR DESCRIPTION
This gets some basic load generation working. With it you can send the `generateload` command to the HTTP port (so long as `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` is `true` in your config file) and it'll generate load. By default it generates 10m accounts and runs 10m random payments at a target rate of 500tx/s; though its "target rate" throttling is a little hokey so it tends to only push a lesser number like 200-300 at that target rate. Anyway it's sufficient to get numbers out and do some basic runs. You can adjust the numbers by passing HTTP params for each.

It does not do any offers or path payments or trustlines or options. Very primitive load still. I'll enhance as time permits.

There's also a cset tacked on the end here which adds medida meters for most of the txs and ops, so we can count failures. It's helpful in figuring out why generated load isn't working. I can split it off into a separate PR if you like.