### PR TITLE
Loadgen fixes

### DIFF
--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -70,23 +70,19 @@ class LedgerPerformanceTests : public Simulation
     vector<TxInfo>
     createRandomTransaction_uniformLoadingCreating()
     {
+        auto from = pickRandomAccount(mAccounts.at(0), 0);
+        auto to = pickRandomAccount(from, 0);
         vector<optional<TxInfo>> txs;
-        size_t iFrom, iTo;
-        do
-        {
-            iFrom = static_cast<int>(rand_fraction() * mAccounts.size());
-            iTo = static_cast<int>(rand_fraction() * mAccounts.size());
-        } while (iFrom == iTo);
 
-        txs.push_back(ensureAccountIsLoadedCreated(iFrom));
-        txs.push_back(ensureAccountIsLoadedCreated(iTo));
+        txs.push_back(ensureAccountIsLoadedCreated(from->mId));
+        txs.push_back(ensureAccountIsLoadedCreated(to->mId));
 
         uint64_t amount = static_cast<uint64_t>(
             rand_fraction() *
             min(static_cast<uint64_t>(1000),
-                (mAccounts[iFrom]->mBalance - mMinBalance) / 3));
+                (from->mBalance - mMinBalance) / 3));
         txs.push_back(make_optional<TxInfo>(
-            createTransferTransaction(iFrom, iTo, amount)));
+            createTransferTransaction(from, to, amount)));
 
         vector<TxInfo> result;
         for (auto tx : txs)

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -128,7 +128,7 @@ class LedgerPerformanceTests : public Simulation
             mApp->getLedgerManager().getLastClosedLedgerHeader().hash);
         for (auto& tx : txs)
         {
-            txSet->add(tx.createPaymentTx());
+            txSet->add(tx.toTransactionFrame());
             tx.recordExecution(baseFee);
         }
 

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -82,7 +82,7 @@ class LedgerPerformanceTests : public Simulation
             min(static_cast<uint64_t>(1000),
                 (from->mBalance - mMinBalance) / 3));
         txs.push_back(make_optional<TxInfo>(
-            createTransferTransaction(from, to, amount)));
+            createTransferNativeTransaction(from, to, amount)));
 
         vector<TxInfo> result;
         for (auto tx : txs)
@@ -128,7 +128,10 @@ class LedgerPerformanceTests : public Simulation
             mApp->getLedgerManager().getLastClosedLedgerHeader().hash);
         for (auto& tx : txs)
         {
-            txSet->add(tx.toTransactionFrame());
+            std::vector<TransactionFramePtr> txfs;
+            tx.toTransactionFrames(txfs);
+            for (auto f : txfs)
+                txSet->add(f);
             tx.recordExecution(baseFee);
         }
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -13,6 +13,8 @@
 #include "util/Timer.h"
 #include "util/make_unique.h"
 
+#include "xdrpp/printer.h"
+
 #include "medida/metrics_registry.h"
 #include "medida/meter.h"
 
@@ -313,6 +315,18 @@ LoadGenerator::TxInfo::execute(Application& app)
     {
         recordExecution(app.getConfig().DESIRED_BASE_FEE);
         return true;
+    }
+    else
+    {
+        static const char* TX_STATUS_STRING[Herder::TX_STATUS_COUNT] =
+            {"PENDING", "DUPLICATE", "ERROR"};
+
+        CLOG(INFO, "LoadGen") << "tx rejected '"
+                             << TX_STATUS_STRING[status]
+                             << "': "
+                              << xdr::xdr_to_string(tx->getEnvelope())
+                              << " ===> "
+                              << xdr::xdr_to_string(tx->getResult());
     }
     return false;
 }

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -307,8 +307,9 @@ LoadGenerator::AccountInfo::creationTransaction()
 bool
 LoadGenerator::TxInfo::execute(Application& app)
 {
-    if (app.getHerder().recvTransaction(createPaymentTx()) ==
-        Herder::TX_STATUS_PENDING)
+    auto tx = toTransactionFrame();
+    auto status = app.getHerder().recvTransaction(tx);
+    if (status == Herder::TX_STATUS_PENDING)
     {
         recordExecution(app.getConfig().DESIRED_BASE_FEE);
         return true;
@@ -317,7 +318,7 @@ LoadGenerator::TxInfo::execute(Application& app)
 }
 
 TransactionFramePtr
-LoadGenerator::TxInfo::createPaymentTx()
+LoadGenerator::TxInfo::toTransactionFrame()
 {
     TransactionFramePtr res;
     if (mCreate)

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -47,12 +47,13 @@ public:
                       uint32_t txRate);
 
     std::vector<TxInfo> accountCreationTransactions(size_t n);
-    AccountInfoPtr createAccount(size_t i);
+    AccountInfoPtr createAccount(size_t i, uint32_t ledgerNum=0);
     std::vector<AccountInfoPtr> createAccounts(size_t n);
     bool loadAccount(Application& app, AccountInfo& account);
 
-    TxInfo createTransferTransaction(size_t iFrom, size_t iTo, uint64_t amount);
-    TxInfo createRandomTransaction(float alpha);
+    TxInfo createTransferTransaction(AccountInfoPtr from, AccountInfoPtr to, uint64_t amount);
+    AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum);
+    TxInfo createRandomTransaction(float alpha, uint32_t ledgerNum=0);
     std::vector<TxInfo> createRandomTransactions(size_t n, float paretoAlpha);
     void updateMinBalance(Application& app);
 

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -80,7 +80,7 @@ public:
         uint64_t mAmount;
 
         bool execute(Application& app);
-        TransactionFramePtr createPaymentTx();
+        TransactionFramePtr toTransactionFrame();
         void recordExecution(uint64_t baseFee);
     };
 };

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include <cstdlib>
+#include <stdexcept>
 #include <random>
 
 namespace stellar

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -16,4 +16,21 @@ size_t rand_pareto(float alpha, size_t max);
 bool rand_flip();
 
 extern std::default_random_engine gRandomEngine;
+
+template<typename T> T
+rand_uniform(T lo, T hi)
+{
+    return std::uniform_int_distribution<T>(lo, hi)(gRandomEngine);
+}
+
+template<typename T> T const&
+rand_element(std::vector<T> const& v)
+{
+    if (v.size() == 0)
+    {
+        throw std::range_error("rand_element on empty vector");
+    }
+    return v.at(rand_uniform<size_t>(0, v.size() - 1));
+}
+
 }


### PR DESCRIPTION
This is a little rough still but it now generates 0 rejects, as well as creating trustlines, funding them, and making transfers between accounts sharing a gateway/currency pair. Sustains about 170tx/s on my laptop on sqlite and single node.