### PR TITLE
Yet more loadgen work

### DIFF
--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -123,12 +123,13 @@ class LedgerPerformanceTests : public Simulation
     closeLedger(vector<Simulation::TxInfo> txs)
     {
         auto baseFee = mApp->getConfig().DESIRED_BASE_FEE;
+        LoadGenerator::TxMetrics txm(mApp->getMetrics());
         TxSetFramePtr txSet = make_shared<TxSetFrame>(
             mApp->getLedgerManager().getLastClosedLedgerHeader().hash);
         for (auto& tx : txs)
         {
             std::vector<TransactionFramePtr> txfs;
-            tx.toTransactionFrames(txfs);
+            tx.toTransactionFrames(txfs, txm);
             for (auto f : txfs)
                 txSet->add(f);
             tx.recordExecution(baseFee);

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -125,7 +125,7 @@ LoadGenerator::maybeCreateAccount(uint32_t ledgerNum, vector<TxInfo> &txs)
             do
             {
                 acc->mSellCredit = rand_element(mGateways);
-            } while (acc->mSellCredit != acc->mBuyCredit);
+            } while (acc->mSellCredit == acc->mBuyCredit);
             acc->mSellCredit->mSellingAccounts.push_back(acc);
             acc->mBuyCredit->mBuyingAccounts.push_back(acc);
             mMarketMakers.push_back(acc);
@@ -533,9 +533,6 @@ LoadGenerator::TxInfo::toTransactionFrames(std::vector<TransactionFramePtr> &txs
                 signingAccounts.insert(mTo);
             }
 
-// FIXME: for the time being, disable offers: they crash in CreatePassiveOfferOpFrame,
-// see https://github.com/stellar/stellar-core/issues/529 for investigation.
-#if 0
             // Add a CREATE_PASSIVE_OFFER op if this account is a market-maker.
             if (mTo->mBuyCredit)
             {
@@ -561,7 +558,6 @@ LoadGenerator::TxInfo::toTransactionFrames(std::vector<TransactionFramePtr> &txs
                 e.tx.operations.push_back(offerOp);
                 signingAccounts.insert(mTo);
             }
-#endif
 
             e.tx.fee = 10 * e.tx.operations.size();
             TransactionFramePtr res = TransactionFrame::makeTransactionFromWire(e);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -46,6 +46,9 @@ class LoadGenerator
     void generateLoad(Application& app, uint32_t nAccounts, uint32_t nTxs,
                       uint32_t txRate);
 
+    bool maybeCreateAccount(uint32_t ledgerNum, std::vector<TxInfo> &txs);
+    size_t fundPendingTrustlines(uint32_t ledgerNum, std::vector<TxInfo> &txs);
+
     std::vector<TxInfo> accountCreationTransactions(size_t n);
     AccountInfoPtr createAccount(size_t i, uint32_t ledgerNum = 0);
     std::vector<AccountInfoPtr> createAccounts(size_t n);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -30,8 +30,10 @@ class LoadGenerator
 
     std::vector<AccountInfoPtr> mAccounts;
     std::vector<AccountInfoPtr> mGateways;
+    std::vector<AccountInfoPtr> mMarketMakers;
     std::vector<AccountInfoPtr> mNeedFund;
 
+    std::vector<AccountInfoPtr> mNeedOffer;
     std::unique_ptr<VirtualTimer> mLoadTimer;
     int64 mMinBalance;
 
@@ -48,6 +50,7 @@ class LoadGenerator
 
     bool maybeCreateAccount(uint32_t ledgerNum, std::vector<TxInfo> &txs);
     size_t fundPendingTrustlines(uint32_t ledgerNum, std::vector<TxInfo> &txs);
+    size_t createPendingOffers(uint32_t ledgerNum, std::vector<TxInfo> &txs);
 
     std::vector<TxInfo> accountCreationTransactions(size_t n);
     AccountInfoPtr createAccount(size_t i, uint32_t ledgerNum = 0);
@@ -63,6 +66,8 @@ class LoadGenerator
 
     TxInfo createEstablishTrustTransaction(AccountInfoPtr from,
                                            AccountInfoPtr issuer);
+
+    TxInfo createEstablishOfferTransaction(AccountInfoPtr from);
 
     AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid,
                                      uint32_t ledgerNum);
@@ -95,9 +100,17 @@ class LoadGenerator
         // Used when this account trusts some other account's credits.
         std::vector<TrustLineInfo> mTrustLines;
 
-        // Reverse map, when other accounts trust this account's credits.
-        std::vector<AccountInfoPtr> mTrustingAccounts;
+        // Currency issued, if a gateway, as well as reverse maps to
+        // those accounts that trust this currency and those who are
+        // buying and selling it.
         std::string mIssuedCurrency;
+        std::vector<AccountInfoPtr> mTrustingAccounts;
+        std::vector<AccountInfoPtr> mBuyingAccounts;
+        std::vector<AccountInfoPtr> mSellingAccounts;
+
+        // Live offers, for accounts that are market makers.
+        AccountInfoPtr mBuyCredit;
+        AccountInfoPtr mSellCredit;
 
         TxInfo creationTransaction();
 
@@ -113,6 +126,7 @@ class LoadGenerator
         {
             TX_CREATE_ACCOUNT,
             TX_ESTABLISH_TRUST,
+            TX_ESTABLISH_OFFER,
             TX_TRANSFER_NATIVE,
             TX_TRANSFER_CREDIT
         } mType;

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -65,6 +65,8 @@ class LoadGenerator
     AccountInfoPtr createAccount(size_t i, uint32_t ledgerNum = 0);
     std::vector<AccountInfoPtr> createAccounts(size_t n);
     bool loadAccount(Application& app, AccountInfo& account);
+    bool loadAccount(Application& app, AccountInfoPtr account);
+    bool loadAccounts(Application& app, std::vector<AccountInfoPtr> accounts);
 
     TxInfo createTransferNativeTransaction(AccountInfoPtr from,
                                            AccountInfoPtr to, int64_t amount);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -28,12 +28,23 @@ class LoadGenerator
     static std::string pickRandomCurrency();
     static const uint32_t STEP_MSECS;
 
+    // Primary store of accounts.
     std::vector<AccountInfoPtr> mAccounts;
+
+    // Subset of accounts that have issued credit in some currency.
     std::vector<AccountInfoPtr> mGateways;
+
+    // Subset of accounts that have made offers to trade in some credits.
     std::vector<AccountInfoPtr> mMarketMakers;
+
+    // Temporary: accounts that turst gateways but haven't been funded with
+    // gateway credit yet.
     std::vector<AccountInfoPtr> mNeedFund;
 
+    // Temporary: accounts that are market makers but haven't put in their
+    // offers yet.
     std::vector<AccountInfoPtr> mNeedOffer;
+
     std::unique_ptr<VirtualTimer> mLoadTimer;
     int64 mMinBalance;
 

--- a/src/transactions/CreatePassiveOfferOpFrame.cpp
+++ b/src/transactions/CreatePassiveOfferOpFrame.cpp
@@ -6,35 +6,28 @@
 
 namespace stellar
 {
-    CreatePassiveOfferOpFrame::CreatePassiveOfferOpFrame(Operation const& op,
-        OperationResult& res,
-        TransactionFrame& parentTx)
-        : ManageOfferOpFrame(createMangeOfferOp(op), res, parentTx)
-    {
-        mCreateOp.body.type(MANAGE_OFFER);
-        mCreateOp.body.manageOfferOp().amount = op.body.createPassiveOfferOp().amount;
-        mCreateOp.body.manageOfferOp().takerGets = op.body.createPassiveOfferOp().takerGets;
-        mCreateOp.body.manageOfferOp().takerPays = op.body.createPassiveOfferOp().takerPays;
-        mCreateOp.body.manageOfferOp().offerID = 0;
-        mCreateOp.body.manageOfferOp().price = op.body.createPassiveOfferOp().price;
-        mCreateOp.sourceAccount = op.sourceAccount;
-        mPassive = true;
 
-    }
+// change from CreatePassiveOfferOp to ManageOfferOp
+ManageOfferOpHolder::ManageOfferOpHolder(Operation const& op)
+{
+    mCreateOp.body.type(MANAGE_OFFER);
+    mCreateOp.body.manageOfferOp().amount = op.body.createPassiveOfferOp().amount;
+    mCreateOp.body.manageOfferOp().takerGets = op.body.createPassiveOfferOp().takerGets;
+    mCreateOp.body.manageOfferOp().takerPays = op.body.createPassiveOfferOp().takerPays;
+    mCreateOp.body.manageOfferOp().offerID = 0;
+    mCreateOp.body.manageOfferOp().price = op.body.createPassiveOfferOp().price;
+    mCreateOp.sourceAccount = op.sourceAccount;
+}
 
-    // change from CreatePassiveOfferOp to ManageOfferOp
-    Operation& CreatePassiveOfferOpFrame::createMangeOfferOp(Operation const& op)
-    {
-        mCreateOp.body.type(MANAGE_OFFER);
-        mCreateOp.body.manageOfferOp().amount = op.body.createPassiveOfferOp().amount;
-        mCreateOp.body.manageOfferOp().takerGets = op.body.createPassiveOfferOp().takerGets;
-        mCreateOp.body.manageOfferOp().takerPays = op.body.createPassiveOfferOp().takerPays;
-        mCreateOp.body.manageOfferOp().offerID = 0;
-        mCreateOp.body.manageOfferOp().price = op.body.createPassiveOfferOp().price;
-        mCreateOp.sourceAccount = op.sourceAccount;
 
-        return mCreateOp;
-    }
+CreatePassiveOfferOpFrame::CreatePassiveOfferOpFrame(Operation const& op,
+                                                     OperationResult& res,
+                                                     TransactionFrame& parentTx)
+    : ManageOfferOpHolder(op)
+    , ManageOfferOpFrame(mCreateOp, res, parentTx)
+{
+    mPassive = true;
+}
 
 }
 

--- a/src/transactions/CreatePassiveOfferOpFrame.h
+++ b/src/transactions/CreatePassiveOfferOpFrame.h
@@ -8,12 +8,19 @@
 
 namespace stellar
 {
-    class CreatePassiveOfferOpFrame : public ManageOfferOpFrame
-    {
-        Operation mCreateOp;
-        Operation& createMangeOfferOp(Operation const& op);
-    public:
-        CreatePassiveOfferOpFrame(Operation const& op, OperationResult& res,
-            TransactionFrame& parentTx);
-    };
+class ManageOfferOpHolder
+{
+public:
+    ManageOfferOpHolder(Operation const& op);
+    Operation mCreateOp;
+};
+
+class CreatePassiveOfferOpFrame : public ManageOfferOpHolder,
+                                  public ManageOfferOpFrame
+{
+public:
+    CreatePassiveOfferOpFrame(Operation const& op, OperationResult& res,
+                              TransactionFrame& parentTx);
+};
+
 }

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -362,7 +362,7 @@ ManageOfferOpFrame::doCheckValid(medida::MetricsRegistry& metrics)
     if (!isCurrencyValid(sheep) || !isCurrencyValid(wheat))
     {
         metrics.NewMeter({ "op-manage-offer", "invalid",
-            "underfunded-absent" },
+            "invalid-currency" },
             "operation").Mark();
         innerResult().code(MANAGE_OFFER_MALFORMED);
         return false;
@@ -370,7 +370,7 @@ ManageOfferOpFrame::doCheckValid(medida::MetricsRegistry& metrics)
     if (compareCurrency(sheep, wheat))
     {
         metrics.NewMeter({ "op-manage-offer", "invalid",
-            "underfunded-absent" },
+            "equal-currencies" },
             "operation").Mark();
         innerResult().code(MANAGE_OFFER_MALFORMED);
         return false;
@@ -379,7 +379,7 @@ ManageOfferOpFrame::doCheckValid(medida::MetricsRegistry& metrics)
         mManageOffer.price.n <= 0)
     {
         metrics.NewMeter({ "op-manage-offer", "invalid",
-            "underfunded-absent" },
+            "negative-or-zero-values" },
             "operation").Mark();
         innerResult().code(MANAGE_OFFER_MALFORMED);
         return false;


### PR DESCRIPTION
This simplifies loadgen to use macro-transactions rather than queues, redoes the metrics gathering and reporting, and puts offer-making code in place. No path-payments use the offers yet, though. That's next.