### PR TITLE
Scp fixes: better handling of timeouts

### DIFF
--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -109,6 +109,10 @@ class HerderImpl : public Herder, public SCPDriver
 
     void processSCPQueueAtIndex(uint64 slotIndex);
 
+    // returns true if the local instance is in a state compatible with
+    // this slot
+    bool isSlotCompatibleWithCurrentState(uint64 slotIndex);
+
     // 0- tx we got during ledger close
     // 1- one ledger ago. rebroadcast
     // 2- two ledgers ago.

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -104,6 +104,7 @@ class HerderImpl : public Herder, public SCPDriver
 
     void startRebroadcastTimer();
     void rebroadcast();
+    void broadcast(SCPEnvelope const& e);
 
     void updateSCPCounters();
 
@@ -170,7 +171,6 @@ class HerderImpl : public Herder, public SCPDriver
 
     VirtualTimer mRebroadcastTimer;
     Value mCurrentValue;
-    StellarMessage mLastSentMessage;
 
     // timers used by SCP
     // indexed by slotIndex, timerID

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1426,14 +1426,14 @@ const char* BallotProtocol::phaseNames[SCP_PHASE_NUM] = {"PREPARE", "FINISH",
 void
 BallotProtocol::dumpInfo(Json::Value& ret)
 {
-    Json::Value slotValue;
-    slotValue["heard"] = mHeardFromQuorum;
-    slotValue["ballot"] = mSlot.ballotToStr(mCurrentBallot);
-    slotValue["phase"] = phaseNames[mPhase];
+    Json::Value state;
+    state["heard"] = mHeardFromQuorum;
+    state["ballot"] = mSlot.ballotToStr(mCurrentBallot);
+    state["phase"] = phaseNames[mPhase];
 
-    slotValue["state"] = getLocalState();
+    state["state"] = getLocalState();
 
-    ret["slot"].append(slotValue);
+    ret["ballotProtocol"].append(state);
 }
 
 std::string

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -86,6 +86,12 @@ class BallotProtocol
     // c for EXTERNALIZE messages
     static SCPBallot getWorkingBallot(SCPStatement const& st);
 
+    SCPEnvelope*
+    getLastMessage() const
+    {
+        return mLastEnvelope.get();
+    }
+
   private:
     // attempts to make progress using `ballot` as a hint
     void advanceSlot(SCPBallot const& ballot);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -425,4 +425,13 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
 
     return updated;
 }
+
+void
+NominationProtocol::dumpInfo(Json::Value& ret)
+{
+    Json::Value nomState;
+    nomState["roundnumber"] = mRoundNumber;
+    nomState["started"] = mNominationStarted;
+    ret["nomination"].append(nomState);
+}
 }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -87,5 +87,7 @@ class NominationProtocol
     {
         return mLatestCompositeCandidate;
     }
+
+    void dumpInfo(Json::Value& ret);
 };
 }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -89,5 +89,11 @@ class NominationProtocol
     }
 
     void dumpInfo(Json::Value& ret);
+
+    SCPEnvelope*
+    getLastMessage() const
+    {
+        return mLastEnvelope.get();
+    }
 };
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -153,4 +153,10 @@ SCP::getCumulativeStatemtCount() const
     }
     return c;
 }
+
+std::vector<SCPEnvelope>
+SCP::getLatestMessages(uint64 slotIndex)
+{
+    return getSlot(slotIndex)->getLatestMessages();
+}
 }

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -89,6 +89,9 @@ class SCP
     size_t getKnownSlotsCount() const;
     size_t getCumulativeStatemtCount() const;
 
+    // returns the latest messages for the given slot
+    std::vector<SCPEnvelope> getLatestMessages(uint64 slotIndex);
+
   protected:
     std::shared_ptr<LocalNode> mLocalNode;
     std::map<uint64, std::shared_ptr<Slot>> mKnownSlots;

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -35,6 +35,24 @@ Slot::getLatestCompositeCandidate()
     return mNominationProtocol.getLatestCompositeCandidate();
 }
 
+std::vector<SCPEnvelope>
+Slot::getLatestMessages() const
+{
+    std::vector<SCPEnvelope> res;
+    SCPEnvelope* e;
+    e = mNominationProtocol.getLastMessage();
+    if (e)
+    {
+        res.emplace_back(*e);
+    }
+    e = mBallotProtocol.getLastMessage();
+    if (e)
+    {
+        res.emplace_back(*e);
+    }
+    return res;
+}
+
 void
 Slot::recordStatement(SCPStatement const& st)
 {

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -198,7 +198,8 @@ Slot::dumpInfo(Json::Value& ret)
         slotValue["statements"][count++] = envToStr(item);
     }
 
-    mBallotProtocol.dumpInfo(ret);
+    mNominationProtocol.dumpInfo(slotValue);
+    mBallotProtocol.dumpInfo(slotValue);
 
     ret["slot"].append(slotValue);
 }

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -69,6 +69,9 @@ class Slot : public std::enable_shared_from_this<Slot>
 
     Value const& getLatestCompositeCandidate();
 
+    // returns the latest messages the slot emited
+    std::vector<SCPEnvelope> getLatestMessages() const;
+
     // records the statement in the historical record for this slot
     void recordStatement(SCPStatement const& st);
 


### PR DESCRIPTION
Herder now validates values against the current ledger whenever this is possible.

This allows the instance to recover from going "out of sync" if for some reason a ledger could not close within 30 seconds.

I also improved the rebroadcast code to resend the current slot's messages if possible.

This should work around the issue when nomination stalls for a bit.
