### PR TITLE
Extension points and upgrade

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -161,6 +161,7 @@
     <ClCompile Include="..\..\src\herder\Herder.cpp" />
     <ClCompile Include="..\..\src\herder\HerderImpl.cpp" />
     <ClCompile Include="..\..\src\herder\HerderTests.cpp" />
+    <ClCompile Include="..\..\src\herder\LedgerCloseData.cpp" />
     <ClCompile Include="..\..\src\herder\PendingEnvelopes.cpp" />
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp" />
     <ClCompile Include="..\..\src\history\CatchupStateMachine.cpp" />
@@ -309,6 +310,7 @@
     <ClInclude Include="..\..\src\generated\StellarXDR.h" />
     <ClInclude Include="..\..\src\herder\HerderImpl.h" />
     <ClInclude Include="..\..\src\herder\Herder.h" />
+    <ClInclude Include="..\..\src\herder\LedgerCloseData.h" />
     <ClInclude Include="..\..\src\herder\PendingEnvelopes.h" />
     <ClInclude Include="..\..\src\herder\TxSetFrame.h" />
     <ClInclude Include="..\..\src\history\CatchupStateMachine.h" />

--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -447,6 +447,9 @@
     <ClCompile Include="..\..\src\scp\SCPDriver.cpp">
       <Filter>scp</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\herder\LedgerCloseData.cpp">
+      <Filter>herder</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ledger\LedgerManager.h">
@@ -757,6 +760,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\scp\SCPDriver.h">
       <Filter>scp</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\herder\LedgerCloseData.h">
+      <Filter>herder</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,7 @@ FMT_SRCS =                                      \
     src/herder/Herder.cpp                       \
     src/herder/HerderImpl.cpp                   \
     src/herder/HerderTests.cpp                  \
+    src/herder/LedgerCloseData.cpp              \
     src/herder/PendingEnvelopes.cpp             \
     src/herder/TxSetFrame.cpp                   \
     src/history/FileTransferInfo.cpp            \
@@ -133,6 +134,7 @@ FMT_HDRS =                                      \
     src/scp/Slot.h                              \
     src/herder/Herder.h                         \
     src/herder/HerderImpl.h                     \
+    src/herder/LedgerCloseData.h                \
     src/herder/PendingEnvelopes.h               \
     src/herder/TxSetFrame.h                     \
     src/history/FileTransferInfo.h              \

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,96 @@
+# Overview
+
+This document describes the various mechanisms used to keep the overall system working as it evolves.
+
+# Ledger versioning
+## ledgerVersion
+This uint32 stored in the ledger header describes the version number of the overall protocol.
+Protocol in this case is defined both as "wire format" (ie, the serialized forms of all objects stored in the ledger) and its behavior.
+
+This version number is incremented every time the protocol changes.
+
+### Integration with consensus
+Most of the time consensus is simply reached on which transaction set needs to be applied to the previous ledger.
+
+However consensus can in addition be reached on upgrade steps.
+
+One such upgrade step is something like "update ledgerVersion to value X after ledger N".
+
+If nodes do not consider that the upgrade set is valid they simply drop the upgrade step from their vote.
+A node considers a step invalid either because they do not understand it or some condition is not met (in the previous example it could be that X is not supported by the node or that the ledger number didn't reach N yet).
+
+Upgrade steps are applied before applying the transaction set, this ensures that the logic scheduling steps is the same processing it (otherwise, the steps would have to be applied after the ledger is closed).
+
+### Supported versions
+Each node has its own way of tracking which version it supports, for example a "min version", "max version"; but it can also include things like "black listed versions". This is not tracked from within the protocol.
+
+Note that minProtocolVersion is distinct from the version an instance understands:
+typically an implementation understands versions n .. maxProtocolVersion, where n <= minProtocolVersion.
+The reason for this is that nodes must be able to replay transactions from history (down to version 'n'), yet there might be some issue/vulnerability that we don't want to be exploitable for new transactions.
+
+## Ledger object versioning
+
+Data structures that are likely to evolve over time contain the following extension point:
+```C++
+    union switch(int v)
+    {
+    case 0:
+        void;
+    } ext;
+```
+
+The version 'v' in this case refers to the version of the object and permits the addition of new arms.
+
+This scheme offers several benefits:
+* implementations become wire compatible without code changes only by updating their protocol definition files
+* even without updating the protocol definition files, older implementations continue to function as long as they don't encounter newer formats
+* promotes code sharing between versions of the objects
+
+note that while this scheme promotes code sharing for components consuming those objects, this is not necessarily true for core itself as the behavior has to be preserved for all versions: in order to reconstruct the ledger chain from arbitrary points in time, the behavior has to be 100% compatible.
+
+## Operations versioning
+
+Operations are versioned as a whole: if a new parameter needs to be added or changed, versioning is achieved by adding a new operation.
+This causes some duplication of logic in client but avoids introducing potential bugs in clients. For example: code that would sign only certain types of transactions have to be fully aware of what they are signing.
+
+## Envelope versioning
+
+The pattern used to allow for extensibility of envelopes (signed content) is
+```C++
+union TransactionEnvelope switch (int v)
+{
+case 0:
+    struct
+    {
+        Transaction tx;
+        DecoratedSignature signatures<20>;
+    } v0;
+};
+```
+
+This allows to both have the capability to modify the envelope if needed while enforcing that clients don't blindly consume content that they could not validate.
+
+## Upgrading objects that don't have an extension point
+
+The object's schema has to be cloned and its parent object has to be updated to use the new object type. The assumption here is that there is no unversioned "root" object.
+
+## Supported implementations lifetime considerations
+
+In order to keep the code base in a maintainable state, implementations may not preserve the ability to playback from genesis and instead opt to support a limited range, for example only preserve the capability to replay the previous 3 months of transactions (assuming that the network's minProtocolVersion is more recent than this).
+This does not change the ability for the node to (re)join or participate in the network; it only effects the ability for a node to do historical validation.
+
+# Overlay versioning
+
+Overlay follows a similar pattern for versioning: it has a min-maxOverlayVersion.
+
+The versioning policy at the overlay layer is a lot more aggressive when it comes to the deprecation schedule as the set of nodes involved is limited to the ones that connect directly to the instance.
+
+With this in mind, structures follow the "clone" model at this layer:
+if a message needs to be modified, a new message is defined by cloning the old message type using a new type identifier.
+The advantage of the clone model is that it makes it possible to refactor large parts of the code, knowing that the older implementation will be deleted anyways (and therefore avoiding the headache of maintaining older versions).
+Also, at this layer, it is acceptable to modify the behavior of older versions as long as it stays compatible.
+The implementation may decide to share the underlying code (by converting legacy messages into the new format internally for example).
+
+The "HELLO" message exchanged when peers connect to each other contains the min and max version the instance supports, the other endpoint may decide to disconnect right away if it's not compatible.
+
+

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -564,10 +564,10 @@ closeLedger(Application& app)
         << "Artificially closing ledger " << lm.getLedgerNum()
         << " with lcl=" << hexAbbrev(lclHash) << ", buckets="
         << hexAbbrev(app.getBucketManager().getBucketList().getHash());
-    StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION, lclHash,
-                    lm.getCloseTime(), static_cast<uint32>(lm.getTxFee()));
-    LedgerCloseData lcd(lm.getLedgerNum(),
-                        std::make_shared<TxSetFrame>(lclHash), sv);
+    auto txSet = std::make_shared<TxSetFrame>(lclHash);
+    StellarValue sv(txSet->getContentsHash(), lm.getCloseTime(),
+                    emptyUpgradeSteps, 0);
+    LedgerCloseData lcd(lm.getLedgerNum(), txSet, sv);
     lm.externalizeValue(lcd);
     return lm.getLastClosedLedgerHeader().hash;
 }

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -565,7 +565,7 @@ closeLedger(Application& app)
         << hexAbbrev(app.getBucketManager().getBucketList().getHash());
     LedgerCloseData lcd(lm.getLedgerNum(),
                         std::make_shared<TxSetFrame>(lclHash),
-                        lm.getCloseTime(), static_cast<int32_t>(lm.getTxFee()));
+                        lm.getCloseTime(), static_cast<uint32>(lm.getTxFee()));
     lm.externalizeValue(lcd);
     return lm.getLastClosedLedgerHeader().hash;
 }

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -14,6 +14,7 @@
 #include "bucket/BucketManagerImpl.h"
 #include "crypto/Hex.h"
 #include "ledger/LedgerManager.h"
+#include "herder/LedgerCloseData.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/test.h"
@@ -563,9 +564,10 @@ closeLedger(Application& app)
         << "Artificially closing ledger " << lm.getLedgerNum()
         << " with lcl=" << hexAbbrev(lclHash) << ", buckets="
         << hexAbbrev(app.getBucketManager().getBucketList().getHash());
+    StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION, lclHash,
+                    lm.getCloseTime(), static_cast<uint32>(lm.getTxFee()));
     LedgerCloseData lcd(lm.getLedgerNum(),
-                        std::make_shared<TxSetFrame>(lclHash),
-                        lm.getCloseTime(), static_cast<uint32>(lm.getTxFee()));
+                        std::make_shared<TxSetFrame>(lclHash), sv);
     lm.externalizeValue(lcd);
     return lm.getLastClosedLedgerHeader().hash;
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -11,17 +11,10 @@
 #include "scp/SCP.h"
 #include "lib/json/json-forwards.h"
 #include "util/Timer.h"
+#include "TxSetFrame.h"
 
 namespace stellar
 {
-
-
-class TxSetFrame;
-typedef std::shared_ptr<TxSetFrame> TxSetFramePtr;
-
-class TransactionFrame;
-typedef std::shared_ptr<TransactionFrame> TransactionFramePtr;
-
 class Application;
 class Peer;
 typedef std::shared_ptr<Peer> PeerPtr;
@@ -78,16 +71,17 @@ class Herder
 
     virtual void bootstrap() = 0;
 
-    virtual void recvSCPQuorumSet(Hash hash, SCPQuorumSet const& qset)=0;
+    virtual void recvSCPQuorumSet(Hash hash, SCPQuorumSet const& qset) = 0;
     virtual void recvTxSet(Hash hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
     virtual TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) = 0;
-    virtual void peerDoesntHave(stellar::MessageType type, uint256 const& itemID, PeerPtr peer) = 0;
+    virtual void peerDoesntHave(stellar::MessageType type,
+                                uint256 const& itemID, PeerPtr peer) = 0;
     virtual TxSetFramePtr getTxSet(Hash hash) = 0;
-    virtual SCPQuorumSetPtr getQSet(Hash const & qSetHash) = 0;
+    virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // We are learning about a new envelope.
-    virtual void recvSCPEnvelope(SCPEnvelope const & envelope) = 0;
+    virtual void recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
 
     // returns the latest known ledger seq using consensus information
     // and local state

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -7,6 +7,7 @@
 #include "crypto/SHA.h"
 #include "crypto/Base58.h"
 #include "herder/TxSetFrame.h"
+#include "herder/LedgerCloseData.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
 #include "main/Config.h"
@@ -286,24 +287,21 @@ HerderImpl::validateValue(uint64 slotIndex, NodeID const& nodeID,
 std::string
 HerderImpl::getValueString(Value const& v) const
 {
-    std::ostringstream oss;
     StellarValue b;
     if (v.empty())
     {
-        return "[empty]";
+        return "[:empty:]";
     }
 
     try
     {
         xdr::xdr_from_opaque(v, b);
-        uint256 valueHash = sha256(xdr::xdr_to_opaque(b));
 
-        oss << "[ h:" << hexAbbrev(valueHash) << " ]";
-        return oss.str();
+        return stellarValueToString(b);
     }
     catch (...)
     {
-        return "[invalid]";
+        return "[:invalid:]";
     }
 }
 
@@ -363,8 +361,7 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
     // tell the LedgerManager that this value got externalized
     // LedgerManager will perform the proper action based on its internal
     // state: apply, trigger catchup, etc
-    LedgerCloseData ledgerData(lastConsensusLedgerIndex(), externalizedSet,
-                               b.closeTime, b.baseFee);
+    LedgerCloseData ledgerData(lastConsensusLedgerIndex(), externalizedSet, b);
     mLedgerManager.externalizeValue(ledgerData);
 
     // perform cleanups

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -847,8 +847,7 @@ HerderImpl::getMaxSeqInPendingTxs(AccountID const& acc)
     {
         for (auto oldTX : list)
         {
-            if (oldTX->getSourceID() == acc &&
-                oldTX->getSeqNum() > highSeq)
+            if (oldTX->getSourceID() == acc && oldTX->getSeqNum() > highSeq)
             {
                 highSeq = oldTX->getSeqNum();
             }
@@ -1037,14 +1036,14 @@ HerderImpl::herderOutOfSync()
 }
 
 Value
-HerderImpl::buildValue(Hash const& txSetHash, uint64 closeTime, int32 baseFee)
+HerderImpl::buildValue(Hash const& txSetHash, uint64 closeTime, uint32 baseFee)
 {
     return xdr::xdr_to_opaque(buildStellarValue(txSetHash, closeTime, baseFee));
 }
 
 StellarValue
 HerderImpl::buildStellarValue(Hash const& txSetHash, uint64 closeTime,
-                              int32 baseFee)
+                              uint32 baseFee)
 {
     StellarValue b;
     b.txSetHash = txSetHash;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -45,8 +45,9 @@ class HerderImpl : public Herder, public SCPDriver
     void bootstrap() override;
 
     // SCP methods
-    bool validateValue(uint64 slotIndex, NodeID const& nodeID,
-                       Value const& value) override;
+    bool validateValue(uint64 slotIndex, Value const& value) override;
+
+    Value extractValidValue(uint64 slotIndex, Value const& value) override;
 
     std::string getValueString(Value const& v) const override;
 
@@ -103,6 +104,12 @@ class HerderImpl : public Herder, public SCPDriver
     void ledgerClosed();
     void removeReceivedTx(TransactionFramePtr tx);
     void expireBallot(uint64 slotIndex, SCPBallot const& ballot);
+
+    // returns true if upgrade is a valid upgrade step
+    // in which case it also sets upgradeType
+    bool validateUpgradeStep(uint64 slotIndex, UpgradeType const& upgrade,
+                             LedgerUpgradeType& upgradeType);
+    bool validateValueHelper(uint64 slotIndex, StellarValue const& sv);
 
     void startRebroadcastTimer();
     void rebroadcast();

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -183,9 +183,9 @@ class HerderImpl : public Herder, public SCPDriver
 
     // helper functions to build a 'Value' or 'StellarValue'
     static Value buildValue(Hash const& txSetHash, uint64 closeTime,
-                            int32 baseFee);
+                            uint32 baseFee);
     static StellarValue buildStellarValue(Hash const& txSetHash,
-                                          uint64 closeTime, int32 baseFee);
+                                          uint64 closeTime, uint32 baseFee);
 
     struct SCPMetrics
     {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -181,12 +181,6 @@ class HerderImpl : public Herder, public SCPDriver
     Application& mApp;
     LedgerManager& mLedgerManager;
 
-    // helper functions to build a 'Value' or 'StellarValue'
-    static Value buildValue(Hash const& txSetHash, uint64 closeTime,
-                            uint32 baseFee);
-    static StellarValue buildStellarValue(Hash const& txSetHash,
-                                          uint64 closeTime, uint32 baseFee);
-
     struct SCPMetrics
     {
         medida::Meter& mValueValid;

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -14,6 +14,9 @@ LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
                                  StellarValue const& v)
     : mLedgerSeq(ledgerSeq), mTxSet(txSet), mValue(v)
 {
+    Value x;
+    Value y(x.begin(), x.end());
+
     using xdr::operator==;
     assert(txSet->getContentsHash() == mValue.txSetHash);
 }

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -1,0 +1,23 @@
+﻿#include "LedgerCloseData.h"
+#include "main/Application.h"
+#include "crypto/Hex.h"
+#include <overlay/OverlayManager.h>
+#include <xdrpp/marshal.h>
+#include "util/Logging.h"
+
+using namespace std;
+
+namespace stellar
+{
+std::string
+stellarValueToString(StellarValue const& sv)
+{
+    std::stringstream res;
+
+    res << "[ "
+        << " h: " << hexAbbrev(sv.txSetHash) << ", ct: " << sv.closeTime
+        << ", fee: " << sv.baseFee << ", v: " << sv.ledgerVersion << " ]";
+
+    return res.str();
+}
+}

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -9,6 +9,15 @@ using namespace std;
 
 namespace stellar
 {
+
+LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
+                                 StellarValue const& v)
+    : mLedgerSeq(ledgerSeq), mTxSet(txSet), mValue(v)
+{
+    using xdr::operator==;
+    assert(txSet->getContentsHash() == mValue.txSetHash);
+}
+
 std::string
 stellarValueToString(StellarValue const& sv)
 {
@@ -16,7 +25,40 @@ stellarValueToString(StellarValue const& sv)
 
     res << "[ "
         << " h: " << hexAbbrev(sv.txSetHash) << ", ct: " << sv.closeTime
-        << ", fee: " << sv.baseFee << ", v: " << sv.ledgerVersion << " ]";
+        << " upgrades: [";
+    for (auto const& upgrade : sv.upgrades)
+    {
+        if (upgrade.empty())
+        {
+            // should not happen as this is not valid
+            res << "<empty>";
+        }
+        else
+        {
+            try
+            {
+                LedgerUpgrade lupgrade;
+                xdr::xdr_from_opaque(upgrade, lupgrade);
+                switch (lupgrade.type())
+                {
+                case LEDGER_UPGRADE_BASE_FEE:
+                    res << "BASE_FEE=" << lupgrade.newBaseFee();
+                    break;
+                case LEDGER_UPGRADE_VERSION:
+                    res << "VERSION=" << lupgrade.newLedgerVersion();
+                    break;
+                default:
+                    res << "<unsupported>";
+                }
+            }
+            catch (std::exception&)
+            {
+                res << "<unknown>";
+            }
+        }
+        res << ", ";
+    }
+    res << " ] ]";
 
     return res.str();
 }

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -27,7 +27,7 @@ stellarValueToString(StellarValue const& sv)
     std::stringstream res;
 
     res << "[ "
-        << " h: " << hexAbbrev(sv.txSetHash) << ", ct: " << sv.closeTime
+        << " txH: " << hexAbbrev(sv.txSetHash) << ", ct: " << sv.closeTime
         << " upgrades: [";
     for (auto const& upgrade : sv.upgrades)
     {
@@ -44,11 +44,11 @@ stellarValueToString(StellarValue const& sv)
                 xdr::xdr_from_opaque(upgrade, lupgrade);
                 switch (lupgrade.type())
                 {
-                case LEDGER_UPGRADE_BASE_FEE:
-                    res << "BASE_FEE=" << lupgrade.newBaseFee();
-                    break;
                 case LEDGER_UPGRADE_VERSION:
                     res << "VERSION=" << lupgrade.newLedgerVersion();
+                    break;
+                case LEDGER_UPGRADE_BASE_FEE:
+                    res << "BASE_FEE=" << lupgrade.newBaseFee();
                     break;
                 default:
                     res << "<unsupported>";

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -26,11 +26,10 @@ class LedgerCloseData
     StellarValue mValue;
 
     LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
-                    StellarValue const& v)
-        : mLedgerSeq(ledgerSeq), mTxSet(txSet), mValue(v)
-    {
-    }
+                    StellarValue const& v);
 };
 
 std::string stellarValueToString(StellarValue const& sv);
+
+#define emptyUpgradeSteps (xdr::xvector<UpgradeType, 4>(0))
 }

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -1,0 +1,36 @@
+#pragma once
+
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "generated/StellarXDR.h"
+#include "TxSetFrame.h"
+#include <string>
+
+namespace stellar
+{
+
+/**
+* Helper class that describes a single ledger-to-close -- a set of transactions
+* and auxiliary values -- as decided by the Herder (and ultimately: SCP). This
+* does not include the effects of _performing_ any transactions, merely the
+* values that the network has agreed _to apply_ to the current ledger,
+* atomically, in order to produce the next ledger.
+*/
+class LedgerCloseData
+{
+  public:
+    uint32_t mLedgerSeq;
+    TxSetFramePtr mTxSet;
+    StellarValue mValue;
+
+    LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
+                    StellarValue const& v)
+        : mLedgerSeq(ledgerSeq), mTxSet(txSet), mValue(v)
+    {
+    }
+};
+
+std::string stellarValueToString(StellarValue const& sv);
+}

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -133,30 +133,33 @@ TxSetFrame::sortForApply()
     return retList;
 }
 
-struct SurgeSorter 
+struct SurgeSorter
 {
     Application& mApp;
-    SurgeSorter(Application& app) : mApp(app) {}
-    bool operator () (TransactionFramePtr const& tx1, TransactionFramePtr const& tx2)
+    SurgeSorter(Application& app) : mApp(app)
+    {
+    }
+    bool operator()(TransactionFramePtr const& tx1,
+                    TransactionFramePtr const& tx2)
     {
         return tx1->getFeeRatio(mApp) < tx2->getFeeRatio(mApp);
     }
 };
 
-
-void 
+void
 TxSetFrame::surgePricingFilter(Application& app)
 {
     int max = app.getConfig().DESIRED_MAX_TX_PER_LEDGER;
-    if(mTransactions.size() > max)
-    {  // surge pricing in effect!
-        CLOG(DEBUG, "Herder") << "surge pricing in effect! " << mTransactions.size();
-        //sort tx by amount of fee they have paid 
+    if (mTransactions.size() > max)
+    { // surge pricing in effect!
+        CLOG(DEBUG, "Herder") << "surge pricing in effect! "
+                              << mTransactions.size();
+        // sort tx by amount of fee they have paid
         // remove the bottom that aren't paying enough
         std::vector<TransactionFramePtr> tempList = mTransactions;
-        std::sort(tempList.begin(), tempList.end(), SurgeSorter(app) );
+        std::sort(tempList.begin(), tempList.end(), SurgeSorter(app));
 
-        for(auto iter = tempList.begin() + max; iter != tempList.end(); iter++)
+        for (auto iter = tempList.begin() + max; iter != tempList.end(); iter++)
         {
             removeTx(*iter);
         }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -11,8 +11,8 @@ namespace stellar
 {
 class Application;
 
-class TransactionFrame;
-typedef std::shared_ptr<TransactionFrame> TransactionFramePtr;
+class TxSetFrame;
+typedef std::shared_ptr<TxSetFrame> TxSetFramePtr;
 
 class TxSetFrame
 {
@@ -22,8 +22,6 @@ class TxSetFrame
     Hash mPreviousLedgerHash;
 
   public:
-    typedef std::shared_ptr<TxSetFrame> pointer;
-
     std::vector<TransactionFramePtr> mTransactions;
 
     TxSetFrame(Hash const& previousLedgerHash);
@@ -41,7 +39,8 @@ class TxSetFrame
     std::vector<TransactionFramePtr> sortForApply();
 
     bool checkValid(Application& app) const;
-    void trimInvalid(Application& app, std::vector<TransactionFramePtr> trimmed);
+    void trimInvalid(Application& app,
+                     std::vector<TransactionFramePtr> trimmed);
     void surgePricingFilter(Application& app);
 
     void removeTx(TransactionFramePtr tx);

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -889,15 +889,13 @@ CatchupStateMachine::applyHistoryFromLastClosedLedger()
             // sense) in CATCHUP_VERIFY phase; we now need to check that the
             // txhash we're about to apply is the one denoted by that ledger
             // header.
-            if (header.txSetHash != txset->getContentsHash())
+            if (header.scpValue.txSetHash != txset->getContentsHash())
             {
                 throw std::runtime_error("replay txset hash differs from txset "
                                          "hash in replay ledger");
             }
 
-            StellarValue sv(header.ledgerVersion, header.txSetHash,
-                            header.closeTime, header.baseFee);
-            LedgerCloseData closeData(header.ledgerSeq, txset, sv);
+            LedgerCloseData closeData(header.ledgerSeq, txset, header.scpValue);
             lm.closeLedger(closeData);
 
             CLOG(DEBUG, "History")

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -17,6 +17,7 @@
 #include "ledger/LedgerDelta.h"
 #include "ledger/LedgerManager.h"
 #include "transactions/TransactionFrame.h"
+#include "herder/LedgerCloseData.h"
 #include "util/Logging.h"
 #include "util/XDRStream.h"
 #include "xdrpp/printer.h"
@@ -894,8 +895,9 @@ CatchupStateMachine::applyHistoryFromLastClosedLedger()
                                          "hash in replay ledger");
             }
 
-            LedgerCloseData closeData(header.ledgerSeq, txset, header.closeTime,
-                                      header.baseFee);
+            StellarValue sv(header.ledgerVersion, header.txSetHash,
+                            header.closeTime, header.baseFee);
+            LedgerCloseData closeData(header.ledgerSeq, txset, sv);
             lm.closeLedger(closeData);
 
             CLOG(DEBUG, "History")

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -19,6 +19,7 @@
 #include "transactions/TxTests.h"
 #include "ledger/LedgerManager.h"
 #include "util/NonCopyable.h"
+#include "herder/LedgerCloseData.h"
 #include <cstdio>
 #include <xdrpp/autocheck.h>
 #include <fstream>
@@ -311,7 +312,9 @@ HistoryTests::generateRandomLedger()
                            << " with " << txSet->size() << " txs (txhash:"
                            << hexAbbrev(txSet->getContentsHash()) << ")";
 
-    mLedgerCloseDatas.emplace_back(ledgerSeq, txSet, closeTime, 10);
+    StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION,
+                    txSet->getContentsHash(), closeTime, 10);
+    mLedgerCloseDatas.emplace_back(ledgerSeq, txSet, sv);
     lm.closeLedger(mLedgerCloseDatas.back());
 
     mLedgerSeqs.push_back(lm.getLastClosedLedgerHeader().header.ledgerSeq);

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -312,8 +312,7 @@ HistoryTests::generateRandomLedger()
                            << " with " << txSet->size() << " txs (txhash:"
                            << hexAbbrev(txSet->getContentsHash()) << ")";
 
-    StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION,
-                    txSet->getContentsHash(), closeTime, 10);
+    StellarValue sv(txSet->getContentsHash(), closeTime, emptyUpgradeSteps, 0);
     mLedgerCloseDatas.emplace_back(ledgerSeq, txSet, sv);
     lm.closeLedger(mLedgerCloseDatas.back());
 

--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -10,6 +10,8 @@
 
 namespace stellar
 {
+using xdr::operator==;
+
 LedgerDelta::LedgerDelta(LedgerDelta& outerDelta)
     : mOuterDelta(&outerDelta)
     , mHeader(&outerDelta.getHeader())
@@ -161,7 +163,6 @@ void
 LedgerDelta::commit()
 {
     checkState();
-    using xdr::operator==;
     // checks if we're not about to override changes
     // (commit a noop should never happen)
     if (!(mPreviousHeaderValue == *mHeader))

--- a/src/ledger/LedgerHeaderFrame.cpp
+++ b/src/ledger/LedgerHeaderFrame.cpp
@@ -11,6 +11,7 @@
 #include "crypto/SHA.h"
 #include "xdrpp/marshal.h"
 #include "database/Database.h"
+#include "util/types.h"
 #include <cereal/external/base64.hpp>
 
 namespace stellar

--- a/src/ledger/LedgerHeaderFrame.cpp
+++ b/src/ledger/LedgerHeaderFrame.cpp
@@ -91,7 +91,7 @@ LedgerHeaderFrame::storeInsert(LedgerManager& ledgerManager) const
                                     "(:h,:ph,:blh,"
                                     ":seq,:ct,:data)",
          use(hash), use(prevHash), use(bucketListHash), use(mHeader.ledgerSeq),
-         use(mHeader.closeTime), use(headerEncoded));
+         use(mHeader.scpValue.closeTime), use(headerEncoded));
     {
         auto timer = db.getInsertTimer("ledger-header");
         st.execute(true);

--- a/src/ledger/LedgerHeaderTests.cpp
+++ b/src/ledger/LedgerHeaderTests.cpp
@@ -10,6 +10,7 @@
 #include "util/Logging.h"
 #include "crypto/Base58.h"
 #include "ledger/LedgerManager.h"
+#include "herder/LedgerCloseData.h"
 
 #include "main/Config.h"
 
@@ -29,11 +30,13 @@ TEST_CASE("ledgerheader", "[ledger]")
         Application::pointer app = Application::create(clock, cfg);
         app->start();
 
-        TxSetFramePtr txSet = make_shared<TxSetFrame>(
-            app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
+        auto const& lastHash = lcl.hash;
+        TxSetFramePtr txSet = make_shared<TxSetFrame>(lastHash);
 
         // close this ledger
-        LedgerCloseData ledgerData(1, txSet, 1, 10);
+        StellarValue sv(cfg.LEDGER_PROTOCOL_VERSION, lastHash, 1, 10);
+        LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
 
         saved = app->getLedgerManager().getLastClosedLedgerHeader().hash;

--- a/src/ledger/LedgerHeaderTests.cpp
+++ b/src/ledger/LedgerHeaderTests.cpp
@@ -35,7 +35,7 @@ TEST_CASE("ledgerheader", "[ledger]")
         TxSetFramePtr txSet = make_shared<TxSetFrame>(lastHash);
 
         // close this ledger
-        StellarValue sv(cfg.LEDGER_PROTOCOL_VERSION, lastHash, 1, 10);
+        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps, 0);
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -4,42 +4,15 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "herder/TxSetFrame.h"
 #include "history/HistoryManager.h"
 #include <memory>
 
 namespace stellar
 {
 
-class TxSetFrame;
-typedef std::shared_ptr<TxSetFrame> TxSetFramePtr;
 class LedgerHeaderFrame;
+class LedgerCloseData;
 class Database;
-
-/**
- * Helper class that describes a single ledger-to-close -- a set of transactions
- * and auxiliary values -- as decided by the Herder (and ultimately: SCP). This
- * does not include the effects of _performing_ any transactions, merely the
- * values that the network has agreed _to apply_ to the current ledger,
- * atomically, in order to produce the next ledger.
- */
-class LedgerCloseData
-{
-  public:
-    uint32_t mLedgerSeq;
-    TxSetFramePtr mTxSet;
-    uint64_t mCloseTime;
-    uint32_t mBaseFee;
-
-    LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet, uint64_t closeTime,
-                    uint32_t baseFee)
-        : mLedgerSeq(ledgerSeq)
-        , mTxSet(txSet)
-        , mCloseTime(closeTime)
-        , mBaseFee(baseFee)
-    {
-    }
-};
 
 /**
  * LedgerManager maintains, in memory, a logical pair of ledgers:
@@ -105,7 +78,7 @@ class LedgerManager
     // close event. This is the most common cause of LedgerManager advancing
     // from one ledger to the next: the network reached consensus on
     // `ledgerData`.
-    virtual void externalizeValue(LedgerCloseData ledgerData) = 0;
+    virtual void externalizeValue(LedgerCloseData const& ledgerData) = 0;
 
     // Return the current ledger header.
     virtual LedgerHeader const& getCurrentLedgerHeader() const = 0;

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -29,10 +29,10 @@ class LedgerCloseData
     uint32_t mLedgerSeq;
     TxSetFramePtr mTxSet;
     uint64_t mCloseTime;
-    int32_t mBaseFee;
+    uint32_t mBaseFee;
 
     LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet, uint64_t closeTime,
-                    int32_t baseFee)
+                    uint32_t baseFee)
         : mLedgerSeq(ledgerSeq)
         , mTxSet(txSet)
         , mCloseTime(closeTime)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -146,8 +146,10 @@ LedgerManagerImpl::startNewLedger()
     masterAccount.getAccount().balance = 100000000000000000;
     LedgerHeader genesisHeader;
 
-    genesisHeader.baseFee = mApp.getConfig().DESIRED_BASE_FEE;
-    genesisHeader.baseReserve = mApp.getConfig().DESIRED_BASE_RESERVE;
+    // all fields are initialized by default to 0
+    // set the ones that are not 0
+    genesisHeader.baseFee = 10;
+    genesisHeader.baseReserve = 10000000;
     genesisHeader.totalCoins = masterAccount.getAccount().balance;
     genesisHeader.ledgerSeq = 1;
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -291,7 +291,8 @@ LedgerManagerImpl::externalizeValue(LedgerCloseData const& ledgerData)
 {
     CLOG(INFO, "Ledger") << "Got consensus: "
                          << "[seq=" << ledgerData.mLedgerSeq << ", prev="
-                         << ", txs=" << ledgerData.mTxSet->size()
+                         << hexAbbrev(ledgerData.mTxSet->previousLedgerHash())
+                         << ", tx_count=" << ledgerData.mTxSet->size()
                          << ", sv: " << stellarValueToString(ledgerData.mValue)
                          << "]";
 
@@ -590,6 +591,9 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         }
         switch (lupgrade.type())
         {
+        case LEDGER_UPGRADE_VERSION:
+            mCurrentLedger->mHeader.ledgerVersion = lupgrade.newLedgerVersion();
+            break;
         case LEDGER_UPGRADE_BASE_FEE:
             mCurrentLedger->mHeader.baseFee = lupgrade.newBaseFee();
             break;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -60,7 +60,7 @@ class LedgerManagerImpl : public LedgerManager
     State getState() const override;
     std::string getStateHuman() const override;
 
-    void externalizeValue(LedgerCloseData ledgerData) override;
+    void externalizeValue(LedgerCloseData const& ledgerData) override;
 
     uint32_t getLedgerNum() const override;
     uint32_t getLastClosedLedgerNum() const override;

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -16,6 +16,7 @@
 #include "main/Config.h"
 #include "main/PersistentState.h"
 #include "simulation/Simulation.h"
+#include "herder/LedgerCloseData.h"
 #include <soci.h>
 #include "crypto/Base58.h"
 #include "bucket/BucketManager.h"
@@ -135,9 +136,11 @@ class LedgerPerformanceTests : public Simulation
             tx.recordExecution(baseFee);
         }
 
-        LedgerCloseData ledgerData(
-            mApp->getLedgerManager().getLedgerNum(), txSet,
+        StellarValue sv(
+            mApp->getConfig().LEDGER_PROTOCOL_VERSION, txSet->getContentsHash(),
             VirtualClock::to_time_t(mApp->getClock().now()), baseFee);
+        LedgerCloseData ledgerData(mApp->getLedgerManager().getLedgerNum(),
+                                   txSet, sv);
 
         mApp->getLedgerManager().closeLedger(ledgerData);
     }

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -136,9 +136,9 @@ class LedgerPerformanceTests : public Simulation
             tx.recordExecution(baseFee);
         }
 
-        StellarValue sv(
-            mApp->getConfig().LEDGER_PROTOCOL_VERSION, txSet->getContentsHash(),
-            VirtualClock::to_time_t(mApp->getClock().now()), baseFee);
+        StellarValue sv(txSet->getContentsHash(),
+                        VirtualClock::to_time_t(mApp->getClock().now()),
+                        emptyUpgradeSteps, 0);
         LedgerCloseData ledgerData(mApp->getLedgerManager().getLedgerNum(),
                                    txSet, sv);
 

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -147,7 +147,7 @@ class LedgerPerformanceTests : public Simulation
 };
 }
 
-TEST_CASE("ledger performance test", "[ledger][performance][hide]")
+TEST_CASE("ledger performance test", "[performance][hide]")
 {
     int nAccounts = 10000000;
     int nLedgers =

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -314,7 +314,7 @@ CommandHandler::info(std::string const& params, std::string& retStr)
     root["info"]["ledger"]["hash"] =
         binToHex(lm.getLastClosedLedgerHeader().hash);
     root["info"]["ledger"]["closeTime"] =
-        (int)lm.getLastClosedLedgerHeader().header.closeTime;
+        (int)lm.getLastClosedLedgerHeader().header.scpValue.closeTime;
     root["info"]["ledger"]["age"] = (int)lm.secondsSinceLastLedgerClose();
     root["info"]["numPeers"] = (int)mApp.getOverlayManager().getPeers().size();
 

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -158,8 +158,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
 
     SCPBallot wb = getWorkingBallot(statement);
 
-    if (mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), nodeID,
-                                           wb.value))
+    if (mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), wb.value))
     {
         bool processed = false;
         SCPBallot tickBallot = getWorkingBallot(statement);

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -49,7 +49,10 @@ class NominationProtocol
     static bool isSubsetHelper(xdr::xvector<Value> const& p,
                                xdr::xvector<Value> const& v, bool& notEqual);
 
-    bool isValid(SCPStatement const& st);
+    bool validateValue(Value const& v);
+    Value extractValidValue(Value const& value);
+
+    bool isSane(SCPStatement const& st);
 
     void recordStatement(SCPStatement const& st);
 

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -43,9 +43,20 @@ class SCPDriver
     // with the current state of that node. Unvalidated values can never
     // externalize.
     virtual bool
-    validateValue(uint64 slotIndex, NodeID const& nodeID, Value const& value)
+    validateValue(uint64 slotIndex, Value const& value)
     {
         return true;
+    }
+
+    // `extractValidValue` transforms the value, if possible to a different
+    // value that the local node would agree to.
+    // This is used during nomination when encountering an invalid value (ie
+    // validateValue returned `false` for this value).
+    // returning Value() means no valid value could be extracted
+    virtual Value
+    extractValidValue(uint64 slotIndex, Value const& value)
+    {
+        return Value();
     }
 
     // `getValueString` is used for debugging

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -50,7 +50,7 @@ class TestSCP : public SCPDriver
     }
 
     bool
-    validateValue(uint64 slotIndex, Hash const& nodeID, Value const& value)
+    validateValue(uint64 slotIndex, Value const& value)
     {
         return true;
     }

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -42,7 +42,6 @@ printStats(int& nLedgers, std::chrono::system_clock::time_point tBegin,
 }
 
 #include "lib/util/lrucache.hpp"
-// typedef std::shared_ptr<TxSetFrame> TxSetFramePtr;
 
 TEST_CASE("3 nodes. 2 running. threshold 2", "[simulation][core3]")
 {

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -311,7 +311,8 @@ LoadGenerator::loadAccount(Application& app, AccountInfo& account)
 
     account.mBalance = ret->getBalance();
     account.mSeq = ret->getSeqNum();
-    auto high = app.getHerder().getMaxSeqInPendingTxs(account.mKey.getPublicKey());
+    auto high =
+        app.getHerder().getMaxSeqInPendingTxs(account.mKey.getPublicKey());
     if (high > account.mSeq)
     {
         account.mSeq = high;
@@ -705,7 +706,7 @@ LoadGenerator::TxInfo::toTransactionFrames(
                 signingAccounts.insert(mTo);
             }
 
-            e.tx.fee = 10 * static_cast<int32>(e.tx.operations.size());
+            e.tx.fee = 10 * static_cast<uint32>(e.tx.operations.size());
             TransactionFramePtr res =
                 TransactionFrame::makeTransactionFromWire(e);
             for (auto a : signingAccounts)

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -28,21 +28,21 @@ InflationOpFrame::InflationOpFrame(Operation const& op, OperationResult& res,
 }
 
 bool
-InflationOpFrame::doApply(medida::MetricsRegistry& metrics,
-                          LedgerDelta& delta, LedgerManager& ledgerManager)
+InflationOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
+                          LedgerManager& ledgerManager)
 {
     LedgerDelta inflationDelta(delta);
 
     auto& lcl = inflationDelta.getHeader();
 
-    time_t closeTime = lcl.closeTime;
+    time_t closeTime = lcl.scpValue.closeTime;
     uint32_t seq = lcl.inflationSeq;
 
     time_t inflationTime = (INFLATION_START_TIME + seq * INFLATION_FREQUENCY);
     if (closeTime < inflationTime)
     {
-        metrics.NewMeter({"op-inflation", "failure", "not-time"},
-                         "operation").Mark();
+        metrics.NewMeter({"op-inflation", "failure", "not-time"}, "operation")
+            .Mark();
         innerResult().code(INFLATION_NOT_TIME);
         return false;
     }
@@ -143,8 +143,7 @@ InflationOpFrame::doApply(medida::MetricsRegistry& metrics,
 
     inflationDelta.commit();
 
-    metrics.NewMeter({"op-inflation", "success", "apply"},
-                     "operation").Mark();
+    metrics.NewMeter({"op-inflation", "success", "apply"}, "operation").Mark();
     return true;
 }
 

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -316,9 +316,8 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
         txSet->sortForHash();
     }
 
-    StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION,
-                    txSet->getContentsHash(), getTestDate(day, month, year),
-                    10);
+    StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
+                    emptyUpgradeSteps, 0);
     LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -7,6 +7,7 @@
 #include "main/Config.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerDelta.h"
+#include "herder/LedgerCloseData.h"
 #include "main/test.h"
 #include "lib/catch.hpp"
 #include "util/Logging.h"
@@ -315,8 +316,10 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
         txSet->sortForHash();
     }
 
-    LedgerCloseData ledgerData(ledgerSeq, txSet, getTestDate(day, month, year),
-                               10);
+    StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION,
+                    txSet->getContentsHash(), getTestDate(day, month, year),
+                    10);
+    LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 
     REQUIRE(app.getLedgerManager().getLedgerNum() == (ledgerSeq + 1));

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include "util/Logging.h"
 #include "ledger/LedgerDelta.h"
+#include "transactions/TransactionFrame.h"
 #include "transactions/AllowTrustOpFrame.h"
 #include "transactions/CreateAccountOpFrame.h"
 #include "transactions/ManageOfferOpFrame.h"
@@ -44,7 +45,8 @@ OperationFrame::makeHelper(Operation const& op, OperationResult& res,
     case MANAGE_OFFER:
         return shared_ptr<OperationFrame>(new ManageOfferOpFrame(op, res, tx));
     case CREATE_PASSIVE_OFFER:
-        return shared_ptr<OperationFrame>(new CreatePassiveOfferOpFrame(op, res, tx));
+        return shared_ptr<OperationFrame>(
+            new CreatePassiveOfferOpFrame(op, res, tx));
     case SET_OPTIONS:
         return shared_ptr<OperationFrame>(new SetOptionsOpFrame(op, res, tx));
     case CHANGE_TRUST:
@@ -128,8 +130,9 @@ OperationFrame::checkValid(Application& app, bool forApply)
     {
         if (forApply || !mOperation.sourceAccount)
         {
-            app.getMetrics().NewMeter(
-                {"operation", "invalid", "no-account"}, "operation").Mark();
+            app.getMetrics()
+                .NewMeter({"operation", "invalid", "no-account"}, "operation")
+                .Mark();
             mResult.code(opNO_ACCOUNT);
             return false;
         }
@@ -142,8 +145,9 @@ OperationFrame::checkValid(Application& app, bool forApply)
 
     if (!checkSignature())
     {
-        app.getMetrics().NewMeter(
-            {"operation", "invalid", "bad-auth"}, "operation").Mark();
+        app.getMetrics()
+            .NewMeter({"operation", "invalid", "bad-auth"}, "operation")
+            .Mark();
         mResult.code(opBAD_AUTH);
         return false;
     }

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -168,7 +168,7 @@ TEST_CASE("payment", "[tx][payment]")
         SequenceNumber b1Seq = getAccountSeqNum(b1, app) + 1;
 
         // raise the reserve
-        int32 addReserve = 100000;
+        uint32 addReserve = 100000;
         app.getLedgerManager().getCurrentLedgerHeader().baseReserve +=
             addReserve;
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -13,6 +13,7 @@
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
 #include "database/Database.h"
+#include "herder/TxSetFrame.h"
 #include "crypto/Hex.h"
 #include <cereal/external/base64.hpp>
 
@@ -24,10 +25,10 @@ namespace stellar
 
 using namespace std;
 
-TransactionFrame::pointer
+TransactionFramePtr
 TransactionFrame::makeTransactionFromWire(TransactionEnvelope const& msg)
 {
-    TransactionFrame::pointer res = make_shared<TransactionFrame>(msg);
+    TransactionFramePtr res = make_shared<TransactionFrame>(msg);
     return res;
 }
 
@@ -85,13 +86,13 @@ TransactionFrame::getEnvelope()
     return mEnvelope;
 }
 
-float 
+float
 TransactionFrame::getFeeRatio(Application& app) const
 {
     return ((float)getFee() / (float)getMinFee(app));
 }
 
-int64_t 
+int64_t
 TransactionFrame::getFee() const
 {
     return mEnvelope.tx.fee;
@@ -209,9 +210,10 @@ TransactionFrame::checkValid(Application& app, bool applying,
 
     if (mOperations.size() == 0)
     {
-        app.getMetrics().NewMeter(
-            {"transaction", "invalid", "missing-operation"},
-            "transaction").Mark();
+        app.getMetrics()
+            .NewMeter({"transaction", "invalid", "missing-operation"},
+                      "transaction")
+            .Mark();
         getResult().result.code(txMISSING_OPERATION);
         return false;
     }
@@ -221,8 +223,10 @@ TransactionFrame::checkValid(Application& app, bool applying,
         if (mEnvelope.tx.timeBounds->minTime >
             app.getLedgerManager().getLastClosedLedgerHeader().header.closeTime)
         {
-            app.getMetrics().NewMeter(
-                {"transaction", "invalid", "too-early"}, "transaction").Mark();
+            app.getMetrics()
+                .NewMeter({"transaction", "invalid", "too-early"},
+                          "transaction")
+                .Mark();
             getResult().result.code(txTOO_EARLY);
             return false;
         }
@@ -231,27 +235,29 @@ TransactionFrame::checkValid(Application& app, bool applying,
                                                     .getLastClosedLedgerHeader()
                                                     .header.closeTime))
         {
-            app.getMetrics().NewMeter(
-                {"transaction", "invalid", "too-late"}, "transaction").Mark();
+            app.getMetrics()
+                .NewMeter({"transaction", "invalid", "too-late"}, "transaction")
+                .Mark();
             getResult().result.code(txTOO_LATE);
             return false;
         }
     }
 
-  
     if (mEnvelope.tx.fee < getMinFee(app))
     {
-        app.getMetrics().NewMeter(
-            {"transaction", "invalid", "insufficient-fee"},
-            "transaction").Mark();
+        app.getMetrics()
+            .NewMeter({"transaction", "invalid", "insufficient-fee"},
+                      "transaction")
+            .Mark();
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;
     }
 
     if (!loadAccount(app))
     {
-        app.getMetrics().NewMeter(
-            {"transaction", "invalid", "no-account"}, "transaction").Mark();
+        app.getMetrics()
+            .NewMeter({"transaction", "invalid", "no-account"}, "transaction")
+            .Mark();
         getResult().result.code(txNO_ACCOUNT);
         return false;
     }
@@ -263,16 +269,18 @@ TransactionFrame::checkValid(Application& app, bool applying,
 
     if (current + 1 != mEnvelope.tx.seqNum)
     {
-        app.getMetrics().NewMeter(
-            {"transaction", "invalid", "bad-seq"}, "transaction").Mark();
+        app.getMetrics()
+            .NewMeter({"transaction", "invalid", "bad-seq"}, "transaction")
+            .Mark();
         getResult().result.code(txBAD_SEQ);
         return false;
     }
 
     if (!checkSignature(*mSigningAccount, mSigningAccount->getLowThreshold()))
     {
-        app.getMetrics().NewMeter(
-            {"transaction", "invalid", "bad-auth"}, "transaction").Mark();
+        app.getMetrics()
+            .NewMeter({"transaction", "invalid", "bad-auth"}, "transaction")
+            .Mark();
         getResult().result.code(txBAD_AUTH);
         return false;
     }
@@ -285,9 +293,10 @@ TransactionFrame::checkValid(Application& app, bool applying,
     if (mSigningAccount->getAccount().balance - mEnvelope.tx.fee <
         mSigningAccount->getMinimumBalance(app.getLedgerManager()))
     {
-        app.getMetrics().NewMeter(
-            {"transaction", "invalid", "insufficient-balance"},
-            "transaction").Mark();
+        app.getMetrics()
+            .NewMeter({"transaction", "invalid", "insufficient-balance"},
+                      "transaction")
+            .Mark();
         getResult().result.code(txINSUFFICIENT_BALANCE);
         return false;
     }
@@ -301,9 +310,10 @@ TransactionFrame::checkValid(Application& app, bool applying,
                 // it's OK to just fast fail here and not try to call
                 // checkValid on all operations as the resulting object
                 // is only used by applications
-                app.getMetrics().NewMeter(
-                    {"transaction", "invalid", "invalid-op"},
-                    "transaction").Mark();
+                app.getMetrics()
+                    .NewMeter({"transaction", "invalid", "invalid-op"},
+                              "transaction")
+                    .Mark();
                 markResultFailed();
                 return false;
             }
@@ -311,9 +321,10 @@ TransactionFrame::checkValid(Application& app, bool applying,
         auto b = checkAllSignaturesUsed();
         if (!b)
         {
-            app.getMetrics().NewMeter(
-                {"transaction", "invalid", "bad-auth-extra"},
-                "transaction").Mark();
+            app.getMetrics()
+                .NewMeter({"transaction", "invalid", "bad-auth-extra"},
+                          "transaction")
+                .Mark();
         }
         return b;
     }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -220,8 +220,9 @@ TransactionFrame::checkValid(Application& app, bool applying,
 
     if (mEnvelope.tx.timeBounds)
     {
-        if (mEnvelope.tx.timeBounds->minTime >
-            app.getLedgerManager().getLastClosedLedgerHeader().header.closeTime)
+        uint64 closeTime =
+            app.getLedgerManager().getCurrentLedgerHeader().scpValue.closeTime;
+        if (mEnvelope.tx.timeBounds->minTime > closeTime)
         {
             app.getMetrics()
                 .NewMeter({"transaction", "invalid", "too-early"},
@@ -231,9 +232,7 @@ TransactionFrame::checkValid(Application& app, bool applying,
             return false;
         }
         if (mEnvelope.tx.timeBounds->maxTime &&
-            (mEnvelope.tx.timeBounds->maxTime < app.getLedgerManager()
-                                                    .getLastClosedLedgerHeader()
-                                                    .header.closeTime))
+            (mEnvelope.tx.timeBounds->maxTime < closeTime))
         {
             app.getMetrics()
                 .NewMeter({"transaction", "invalid", "too-late"}, "transaction")

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -28,6 +28,9 @@ class SecretKey;
 class XDROutputFileStream;
 class SHA256;
 
+class TransactionFrame;
+typedef std::shared_ptr<TransactionFrame> TransactionFramePtr;
+
 class TransactionFrame
 {
   protected:
@@ -54,13 +57,11 @@ class TransactionFrame
     void markResultFailed();
 
   public:
-    typedef std::shared_ptr<TransactionFrame> pointer;
-
     TransactionFrame(TransactionEnvelope const& envelope);
     TransactionFrame(TransactionFrame const&) = delete;
     TransactionFrame() = delete;
 
-    static TransactionFrame::pointer
+    static TransactionFramePtr
     makeTransactionFromWire(TransactionEnvelope const& msg);
 
     Hash const& getFullHash() const;

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -411,7 +411,9 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         txSet->add(txFrame);
 
         // close this ledger
-        LedgerCloseData ledgerData(1, txSet, 1, 10);
+        StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION,
+                        txSet->getContentsHash(), 1, 10);
+        LedgerCloseData ledgerData(1, txSet, sv);
         app.getLedgerManager().closeLedger(ledgerData);
 
         REQUIRE(app.getLedgerManager().getLedgerNum() == 3);

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -411,8 +411,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         txSet->add(txFrame);
 
         // close this ledger
-        StellarValue sv(app.getConfig().LEDGER_PROTOCOL_VERSION,
-                        txSet->getContentsHash(), 1, 10);
+        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps, 0);
         LedgerCloseData ledgerData(1, txSet, sv);
         app.getLedgerManager().closeLedger(ledgerData);
 

--- a/src/transactions/TxTests.h
+++ b/src/transactions/TxTests.h
@@ -10,13 +10,13 @@
 #include "ledger/OfferFrame.h"
 #include "ledger/TrustFrame.h"
 #include "util/optional.h"
+#include "herder/LedgerCloseData.h"
 
 namespace stellar
 {
 class TransactionFrame;
 class LedgerDelta;
 class OperationFrame;
-typedef std::shared_ptr<TransactionFrame> TransactionFramePtr;
 namespace txtest
 {
 

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -57,6 +57,14 @@ struct AccountEntry
     Thresholds thresholds;
 
     Signer signers<20>; // possible signers for this account
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 /* TrustLineEntry
@@ -80,6 +88,14 @@ struct TrustLineEntry
 
     int64 limit;  // balance cannot be above this
     uint32 flags; // see TrustLineFlags
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 enum OfferEntryFlags
@@ -110,16 +126,22 @@ struct OfferEntry
     */
     Price price;
     uint32 flags; // see OfferEntryFlags
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 union LedgerEntry switch (LedgerEntryType type)
 {
 case ACCOUNT:
     AccountEntry account;
-
 case TRUSTLINE:
     TrustLineEntry trustLine;
-
 case OFFER:
     OfferEntry offer;
 };

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -36,6 +36,14 @@ struct LedgerHeader
                       // each slot contains the oldest ledger that is mod of
                       // either 50  5000  50000 or 500000 depending on index
                       // skipList[0] mod(50), skipList[1] mod(5000), etc
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 /* Entries used to define the bucket list */
@@ -104,18 +112,42 @@ struct TransactionHistoryEntry
 {
     uint32 ledgerSeq;
     TransactionSet txSet;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 struct TransactionHistoryResultEntry
 {
     uint32 ledgerSeq;
     TransactionResultSet txResultSet;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 struct LedgerHeaderHistoryEntry
 {
     Hash hash;
     LedgerHeader header;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 // represents the meta in the transaction table history

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -28,8 +28,8 @@ struct LedgerHeader
 
     uint64 idPool; // last used global ID, used for generating objects
 
-    int32 baseFee;     // base fee per operation in stroops
-    int32 baseReserve; // account base reserve in stroops
+    uint32 baseFee;     // base fee per operation in stroops
+    uint32 baseReserve; // account base reserve in stroops
 
     Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
                       // in time without walking the chain back ledger by ledger

--- a/src/xdr/Stellar-overlay.x
+++ b/src/xdr/Stellar-overlay.x
@@ -7,14 +7,6 @@
 namespace stellar
 {
 
-struct StellarValue
-{
-    uint32 ledgerVersion;
-    Hash txSetHash;
-    uint64 closeTime;
-    uint32 baseFee;
-};
-
 struct Error
 {
     int code;

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -206,7 +206,7 @@ Result: InflationResult
 struct Operation
 {
     // sourceAccount is the account used to run the operation
-    // if not set, the runtime defaults to "account" specified at
+    // if not set, the runtime defaults to "sourceAccount" specified at
     // the transaction level
     AccountID* sourceAccount;
 
@@ -290,6 +290,14 @@ struct Transaction
     Memo memo;
 
     Operation operations<100>;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 /* A TransactionEnvelope wraps a transaction with signatures. */
@@ -645,5 +653,13 @@ struct TransactionResult
         void;
     }
     result;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 }

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -279,7 +279,7 @@ struct Transaction
     AccountID sourceAccount;
 
     // the fee the sourceAccount will pay
-    int32 fee;
+    uint32 fee;
 
     // sequence number to consume in the account
     SequenceNumber seqNum;


### PR DESCRIPTION
Future proofing of ledger structures - resolves #499 

updates to the way we make changes to the ledger header: use "upgrades" that are steps decided during consensus. Implemented upgrade steps for updating the base fee and for updating the protocol version (this last one still needs some work to be really useful - right now the behavior is basically going to force nodes to move to the version as an older version is considered "invalid").