### PR TITLE
Auto rate load gen

### DIFF
--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -197,7 +197,8 @@ class Application
 
     // If config.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true, generate some load
     // against the current application.
-    virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs, uint32_t txRate) = 0;
+    virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs, uint32_t txRate,
+                              bool autoRate) = 0;
 
     // Execute any administrative commands written in the Config.COMMANDS
     // variable of the config file. This permits scripting certain actions to

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -310,14 +310,14 @@ ApplicationImpl::manualClose()
 
 void
 ApplicationImpl::generateLoad(uint32_t nAccounts, uint32_t nTxs,
-                              uint32_t txRate)
+                              uint32_t txRate, bool autoRate)
 {
     if (!mLoadGenerator)
     {
         mLoadGenerator = make_unique<LoadGenerator>();
     }
     getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
-    mLoadGenerator->generateLoad(*this, nAccounts, nTxs, txRate);
+    mLoadGenerator->generateLoad(*this, nAccounts, nTxs, txRate, autoRate);
 }
 
 void

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -66,7 +66,8 @@ class ApplicationImpl : public Application
 
     virtual void generateLoad(uint32_t nAccounts,
                               uint32_t nTxs,
-                              uint32_t txRate) override;
+                              uint32_t txRate,
+                              bool autoRate) override;
 
     virtual void applyCfgCommands() override;
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -163,7 +163,7 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "triggers the instance to write an immediate history checkpoint."
         "</p><p><h1> /connect?peer=NAME&port=NNN</h1>"
         "triggers the instance to connect to peer NAME at port NNN."
-        "</p><p><h1> /generateload</h1>"
+        "</p><p><h1> /generateload[?accounts=N&txs=M&txrate=R&autorate=true]</h1>"
         "artificially generate load for testing; must be used with "
         "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING set to true"
         "</p><p><h1> /help</h1>"
@@ -247,12 +247,12 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
 {
     if (mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
     {
-        // Defaults are 10M accounts, 10M txs, 500 tx/s. This load-test will
+        // Defaults are 200k accounts, 200k txs, 10 tx/s. This load-test will
         // therefore take 40k secs or about 12 hours.
 
-        uint32_t nAccounts = 10000000;
-        uint32_t nTxs = 10000000;
-        uint32_t txRate = 500;
+        uint32_t nAccounts = 200000;
+        uint32_t nTxs = 200000;
+        uint32_t txRate = 10;
 
         std::map<std::string, std::string> map;
         http::server::server::parseParams(params, map);
@@ -266,8 +266,10 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         if (!parseOptionalNumParam(map, "txrate", txRate, retStr))
             return;
 
+        bool autoRate = map["autorate"] == "true";
+
         double hours = ((nAccounts + nTxs) / txRate) / 3600.0;
-        mApp.generateLoad(nAccounts, nTxs, txRate);
+        mApp.generateLoad(nAccounts, nTxs, txRate, autoRate);
         retStr = fmt::format(
             "Generating load: {:d} accounts, {:d} txs, {:d} tx/s = {:f} hours",
             nAccounts, nTxs, txRate, hours);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -47,17 +47,19 @@ class LoadGenerator
 
     std::unique_ptr<VirtualTimer> mLoadTimer;
     int64 mMinBalance;
+    uint64_t mLastSecond;
 
     // Schedule a callback to generateLoad() STEP_MSECS miliseconds from now.
     void scheduleLoadGeneration(Application& app, uint32_t nAccounts,
-                                uint32_t nTxs, uint32_t txRate);
+                                uint32_t nTxs, uint32_t txRate,
+                                bool autoRate);
 
     // Generate one "step" worth of load (assuming 1 step per STEP_MSECS) at a
     // given target number of accounts and txs, and a given target tx/s rate.
     // If work remains after the current step, call scheduleLoadGeneration()
     // with the remainder.
     void generateLoad(Application& app, uint32_t nAccounts, uint32_t nTxs,
-                      uint32_t txRate);
+                      uint32_t txRate, bool autoRate);
 
     bool maybeCreateAccount(uint32_t ledgerNum, std::vector<TxInfo>& txs);
 


### PR DESCRIPTION
This adds an auto-calibrator for the load generator's transaction rate. It can be invoked by the `generateload` command by adding `&autorate=true` to the command parameter list. There's also a new testcase tagged as `[autoload]`, so running `stellar-core --test [autoload]` will give you a reasonable single-node performance test against the best database available (postgresql if it's compiled in, otherwise sqlite).

Note: it's a little conservative at first, starts at 10tx/s and waits there for 10 ledgers before it starts trying to recalibrate. Don't worry if you see this happening, it's intentional: the "not enough data yet" behavior of some of the metrics makes this the easiest way to measure and adapt. It adjusts relatively quickly once it's got a clear reading.