### PR TITLE
Crypto agility updates

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -467,8 +467,8 @@ $(SolutionDir)$(Platform)\$(Configuration)\xdrc.exe -hh -o ../../src/generated/S
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">running xdrc</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../src/generated/Stellar-types.h</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../src/generated/Stellar-types.h</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../src/xdr/Stellar-types.x;../../src/generated/Stellar-SCP.h</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../src/xdr/Stellar-types.x;../../src/generated/Stellar-SCP.h</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../src/xdr/Stellar-types.x</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../src/xdr/Stellar-types.x</AdditionalInputs>
     </CustomBuild>
     <CustomBuild Include="..\..\src\xdr\Stellar-overlay.x">
       <FileType>Document</FileType>
@@ -500,6 +500,8 @@ $(SolutionDir)$(Platform)\$(Configuration)\xdrc.exe -hh -o ../../src/generated/S
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)$(Platform)\$(Configuration)\xdrc.exe -hh -o ../../src/generated/Stellar-SCP.h ../../src/scp/Stellar-SCP.x</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">running xdrc</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../src/generated/Stellar-SCP.h</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">../../src/generated/Stellar-types.h</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">../../src/generated/Stellar-types.h</AdditionalInputs>
     </CustomBuild>
     <None Include="..\..\src\overlay\readme.md" />
     <None Include="..\..\src\scp\readme.md" />

--- a/Makefile.am
+++ b/Makefile.am
@@ -379,7 +379,7 @@ src/generated/StellarCoreVersion.h: Makefile
        echo "#define STELLAR_CORE_VERSION \"unknown\"" >$@;                     \
     fi
 
-src/generated/Stellar-types.h: src/xdr/Stellar-types.x src/generated/Stellar-SCP.h Makefile $(XDRC)
+src/generated/Stellar-types.h: src/xdr/Stellar-types.x Makefile $(XDRC)
 	$(AM_V_GEN)mkdir -p src/generated; \
 	$(XDRC) -hh -o $@ $<
 
@@ -399,11 +399,11 @@ src/generated/Stellar-ledger.h: src/xdr/Stellar-ledger.x src/generated/Stellar-t
 	$(AM_V_GEN)mkdir -p src/generated; \
 	$(XDRC) -hh -o $@ $<
 
-src/generated/StellarXDR.h: src/overlay/StellarXDR.x src/generated/Stellar-overlay.h Makefile $(XDRC)
+src/generated/StellarXDR.h: src/overlay/StellarXDR.x src/generated/Stellar-SCP.h src/generated/Stellar-overlay.h Makefile $(XDRC)
 	$(AM_V_GEN)mkdir -p src/generated; \
 	$(XDRC) -hh -o $@ $<
 
-src/generated/Stellar-SCP.h: src/scp/Stellar-SCP.x Makefile $(XDRC)
+src/generated/Stellar-SCP.h: src/scp/Stellar-SCP.x src/generated/Stellar-types.h Makefile $(XDRC)
 	$(AM_V_GEN)mkdir -p src/generated
 	$(XDRC) -hh -o $@ $<
 

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -96,13 +96,13 @@ TEST_CASE("skip list", "[bucket]")
         test()
         {
             Hash h0;
-            Hash h1 = SecretKey::random().getSeed();
-            Hash h2 = SecretKey::random().getSeed();
-            Hash h3 = SecretKey::random().getSeed();
-            Hash h4 = SecretKey::random().getSeed();
-            Hash h5 = SecretKey::random().getSeed();
-            Hash h6 = SecretKey::random().getSeed();
-            Hash h7 = SecretKey::random().getSeed();
+            Hash h1 = HashUtils::random();
+            Hash h2 = HashUtils::random();
+            Hash h3 = HashUtils::random();
+            Hash h4 = HashUtils::random();
+            Hash h5 = HashUtils::random();
+            Hash h6 = HashUtils::random();
+            Hash h7 = HashUtils::random();
 
             // up first entry
             LedgerHeader header;

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -8,6 +8,7 @@
 
 namespace stellar
 {
+using xdr::operator<;
 
 // Helper for getting a LedgerKey from a LedgerEntry.
 LedgerKey LedgerEntryKey(LedgerEntry const& e);
@@ -53,10 +54,9 @@ struct LedgerEntryIdCmp
             auto const& btl = b.trustLine();
             if (atl.accountID < btl.accountID)
                 return true;
-            if (atl.accountID > btl.accountID)
+            if (btl.accountID < atl.accountID)
                 return false;
             {
-                using xdr::operator<;
                 return atl.currency < btl.currency;
             }
         }
@@ -67,7 +67,7 @@ struct LedgerEntryIdCmp
             auto const& bof = b.offer();
             if (aof.accountID < bof.accountID)
                 return true;
-            if (aof.accountID > bof.accountID)
+            if (bof.accountID < aof.accountID)
                 return false;
             return aof.offerID < bof.offerID;
         }

--- a/src/crypto/Base58.cpp
+++ b/src/crypto/Base58.cpp
@@ -66,8 +66,8 @@ baseEncode(std::string const& alphabet, ByteSlice const& bytes)
     std::transform(digits.rbegin(), digits.rend(), ret.begin(),
                    [&alphabet](uint8_t digit)
                    {
-        return alphabet.at(digit);
-    });
+                       return alphabet.at(digit);
+                   });
     return ret;
 }
 
@@ -131,8 +131,8 @@ baseDecode(std::string const& alphabet, std::string const& encoded)
     std::vector<uint8_t> ret(bytes.size(), 0);
     std::transform(bytes.rbegin(), bytes.rend(), ret.begin(), [](uint16_t i)
                    {
-        return static_cast<uint8_t>(i);
-    });
+                       return static_cast<uint8_t>(i);
+                   });
     return ret;
 }
 

--- a/src/crypto/Base58.h
+++ b/src/crypto/Base58.h
@@ -18,12 +18,12 @@ namespace stellar
 
 typedef enum
 {
-    VER_NONE = 1,
-    VER_ACCOUNT_ID = 0, // 'g'
-    VER_SEED = 33       // 's'
+    B58_PUBKEY_ED25519 = 0, // 'g'
+    B58_SEED_ED25519 = 33   // 's'
 } Base58CheckVersionByte;
 
-// Encode a version byte and ByteSlice into Base58Check (with the stellar alphabet).
+// Encode a version byte and ByteSlice into Base58Check (with the stellar
+// alphabet).
 std::string toBase58Check(Base58CheckVersionByte ver, ByteSlice const& bin);
 
 // Decode a version byte and bytes from Base58Check (with the stellar alphabet).

--- a/src/crypto/CryptoTests.cpp
+++ b/src/crypto/CryptoTests.cpp
@@ -247,10 +247,8 @@ TEST_CASE("sign tests", "[crypto]")
 {
     auto sk = SecretKey::random();
     auto pk = sk.getPublicKey();
-    LOG(DEBUG) << "generated random secret key seed: "
-               << toBase58Check(VER_SEED, sk);
-    LOG(DEBUG) << "corresponding public key: " << toBase58Check(VER_ACCOUNT_ID,
-                                                                pk);
+    LOG(DEBUG) << "generated random secret key seed: " << sk.getBase58Seed();
+    LOG(DEBUG) << "corresponding public key: " << PubKeyUtils::toBase58(pk);
 
     CHECK(SecretKey::fromBase58Seed(sk.getBase58Seed()) == sk);
 
@@ -260,14 +258,14 @@ TEST_CASE("sign tests", "[crypto]")
     LOG(DEBUG) << "formed signature: " << binToHex(sig);
 
     LOG(DEBUG) << "checking signature-verify";
-    CHECK(pk.verify(sig, msg));
+    CHECK(PubKeyUtils::verifySig(pk, sig, msg));
 
     LOG(DEBUG) << "checking verify-failure on bad message";
-    CHECK(!pk.verify(sig, std::string("helloo")));
+    CHECK(!PubKeyUtils::verifySig(pk, sig, std::string("helloo")));
 
     LOG(DEBUG) << "checking verify-failure on bad signature";
     sig[4] ^= 1;
-    CHECK(!pk.verify(sig, msg));
+    CHECK(!PubKeyUtils::verifySig(pk, sig, msg));
 }
 
 struct SignVerifyTestcase
@@ -284,7 +282,7 @@ struct SignVerifyTestcase
     void
     verify()
     {
-        CHECK(pub.verify(sig, msg));
+        CHECK(PubKeyUtils::verifySig(pub, sig, msg));
     }
     static SignVerifyTestcase
     create()

--- a/src/crypto/CryptoTests.cpp
+++ b/src/crypto/CryptoTests.cpp
@@ -273,7 +273,7 @@ struct SignVerifyTestcase
     SecretKey key;
     PublicKey pub;
     std::vector<uint8_t> msg;
-    uint512 sig;
+    Signature sig;
     void
     sign()
     {

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -175,4 +175,18 @@ PubKeyUtils::fromBase58(std::string const& s)
     return pk;
 }
 
+SignatureHint
+PubKeyUtils::getHint(PublicKey const& pk)
+{
+    SignatureHint res;
+    memcpy(res.data(), &pk.ed25519().back() - res.size(), sizeof(res));
+    return res;
+}
+
+bool
+PubKeyUtils::hasHint(PublicKey const& pk, SignatureHint const& hint)
+{
+    return memcmp(&pk.ed25519().back() - hint.size(), hint.data(),
+                  sizeof(hint)) == 0;
+}
 }

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -56,7 +56,7 @@ SecretKey::getBase58Seed() const
 {
     assert(mKeyType == KEY_TYPES_ED25519);
 
-    return toBase58Check(VER_SEED, getSeed().mSeed);
+    return toBase58Check(B58_SEED_ED25519, getSeed().mSeed);
 }
 
 std::string
@@ -124,7 +124,7 @@ SecretKey
 SecretKey::fromBase58Seed(std::string const& base58Seed)
 {
     auto pair = fromBase58Check(base58Seed);
-    if (pair.first != VER_SEED)
+    if (pair.first != B58_SEED_ED25519)
     {
         throw std::runtime_error(
             "unexpected version byte on secret key base58 seed");
@@ -164,15 +164,15 @@ PubKeyUtils::toShortString(PublicKey const& pk)
 std::string
 PubKeyUtils::toBase58(PublicKey const& pk)
 {
-    // uses VER_ACCOUNT_ID prefix for ed25519
-    return toBase58Check(VER_ACCOUNT_ID, pk.ed25519());
+    // uses B58_PUBKEY_ED25519 prefix for ed25519
+    return toBase58Check(B58_PUBKEY_ED25519, pk.ed25519());
 }
 
 PublicKey
 PubKeyUtils::fromBase58(std::string const& s)
 {
     PublicKey pk;
-    pk.ed25519() = fromBase58Check256(VER_ACCOUNT_ID, s);
+    pk.ed25519() = fromBase58Check256(B58_PUBKEY_ED25519, s);
     return pk;
 }
 

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -11,15 +11,14 @@
 namespace stellar
 {
 
+SecretKey::SecretKey() : mKeyType(KEY_TYPES_ED25519)
+{
 static_assert(crypto_sign_PUBLICKEYBYTES == sizeof(uint256),
               "Unexpected public key length");
 static_assert(crypto_sign_SECRETKEYBYTES == sizeof(uint512),
               "Unexpected secret key length");
 static_assert(crypto_sign_BYTES == sizeof(uint512),
               "Unexpected signature length");
-
-SecretKey::SecretKey() : mKeyType(KEY_TYPES_ED25519)
-{
 }
 
 PublicKey

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -77,12 +77,12 @@ SecretKey::isZero() const
     return true;
 }
 
-uint512
+Signature
 SecretKey::sign(ByteSlice const& bin) const
 {
     assert(mKeyType == KEY_TYPES_ED25519);
 
-    uint512 out(crypto_sign_BYTES, 0);
+    Signature out(crypto_sign_BYTES, 0);
     if (crypto_sign_detached(out.data(), NULL, bin.data(), bin.size(),
                              mSecretKey.data()) != 0)
     {
@@ -147,7 +147,7 @@ SecretKey::fromBase58Seed(std::string const& base58Seed)
 }
 
 bool
-PubKeyUtils::verifySig(PublicKey const& key, uint512 const& signature,
+PubKeyUtils::verifySig(PublicKey const& key, Signature const& signature,
                        ByteSlice const& bin)
 {
     return crypto_sign_verify_detached(signature.data(), bin.data(), bin.size(),

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -36,13 +36,15 @@ SecretKey::getPublicKey() const
     return pk;
 }
 
-uint256
+SecretKey::Seed
 SecretKey::getSeed() const
 {
     assert(mKeyType == KEY_TYPES_ED25519);
 
-    uint256 seed;
-    if (crypto_sign_ed25519_sk_to_seed(seed.data(), mSecretKey.data()) != 0)
+    Seed seed;
+    seed.mKeyType = mKeyType;
+    if (crypto_sign_ed25519_sk_to_seed(seed.mSeed.data(), mSecretKey.data()) !=
+        0)
     {
         throw std::runtime_error("error extracting seed from secret key");
     }
@@ -54,7 +56,7 @@ SecretKey::getBase58Seed() const
 {
     assert(mKeyType == KEY_TYPES_ED25519);
 
-    return toBase58Check(VER_SEED, getSeed());
+    return toBase58Check(VER_SEED, getSeed().mSeed);
 }
 
 std::string
@@ -187,5 +189,13 @@ PubKeyUtils::hasHint(PublicKey const& pk, SignatureHint const& hint)
 {
     return memcmp(&pk.ed25519().back() - hint.size(), hint.data(),
                   sizeof(hint)) == 0;
+}
+
+Hash
+HashUtils::random()
+{
+    Hash res;
+    randombytes_buf(res.data(), res.size());
+    return res;
 }
 }

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -66,5 +66,10 @@ std::string toShortString(PublicKey const& pk);
 std::string toBase58(PublicKey const& pk);
 
 PublicKey fromBase58(std::string const& s);
+
+// returns hint from key
+SignatureHint getHint(PublicKey const& pk);
+// returns true if the hint matches the key
+bool hasHint(PublicKey const& pk, SignatureHint const& hint);
 }
 }

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -22,11 +22,17 @@ class SecretKey
   public:
     SecretKey();
 
+    struct Seed
+    {
+        CryptoKeyTypes mKeyType;
+        uint256 mSeed;
+    };
+
     // Get the public key portion of this secret key.
     PublicKey getPublicKey() const;
 
     // Get the seed portion of this secret key.
-    uint256 getSeed() const;
+    Seed getSeed() const;
 
     // Get the seed portion of this secret key as as Base58Check string.
     std::string getBase58Seed() const;
@@ -72,5 +78,10 @@ PublicKey fromBase58(std::string const& s);
 SignatureHint getHint(PublicKey const& pk);
 // returns true if the hint matches the key
 bool hasHint(PublicKey const& pk, SignatureHint const& hint);
+}
+
+namespace HashUtils
+{
+Hash random();
 }
 }

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -37,7 +37,7 @@ class SecretKey
     bool isZero() const;
 
     // Produce a signature of `bin` using this secret key.
-    uint512 sign(ByteSlice const& bin) const;
+    Signature sign(ByteSlice const& bin) const;
 
     // Create a new, random secret key.
     static SecretKey random();
@@ -58,7 +58,7 @@ class SecretKey
 namespace PubKeyUtils
 {
 // Return true iff `signature` is valid for `bin` under `key`.
-bool verifySig(PublicKey const& key, uint512 const& signature,
+bool verifySig(PublicKey const& key, Signature const& signature,
                ByteSlice const& bin);
 
 std::string toShortString(PublicKey const& pk);

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -4,26 +4,23 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "generated/StellarXDR.h"
+#include "generated/Stellar-types.h"
 
 namespace stellar
 {
 
+using xdr::operator==;
+
 class ByteSlice;
 
-struct PublicKey : public uint256
+class SecretKey
 {
-    // Return true iff `signature` is valid for `bin` under this key.
-    bool verify(uint512 const& signature, ByteSlice const& bin) const;
+    CryptoKeyTypes mKeyType;
+    uint512 mSecretKey;
 
-    // Return true iff `signature` is valid for `bin` under `key`.
-    static bool verifySig(uint256 const& key, uint512 const& signature,
-                          ByteSlice const& bin);
-};
-
-class SecretKey : public uint512
-{
   public:
+    SecretKey();
+
     // Get the public key portion of this secret key.
     PublicKey getPublicKey() const;
 
@@ -50,5 +47,24 @@ class SecretKey : public uint512
 
     // Decode a secret key from a binary seed value.
     static SecretKey fromSeed(uint256 const& seed);
+
+    bool operator==(SecretKey const& rh)
+    {
+        return (mKeyType == rh.mKeyType) && (mSecretKey == rh.mSecretKey);
+    }
 };
+
+// public key utility functions
+namespace PubKeyUtils
+{
+// Return true iff `signature` is valid for `bin` under `key`.
+bool verifySig(PublicKey const& key, uint512 const& signature,
+               ByteSlice const& bin);
+
+std::string toShortString(PublicKey const& pk);
+
+std::string toBase58(PublicKey const& pk);
+
+PublicKey fromBase58(std::string const& s);
+}
 }

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -15,6 +15,7 @@ class ByteSlice;
 
 class SecretKey
 {
+    using uint512 = xdr::opaque_array<64>;
     CryptoKeyTypes mKeyType;
     uint512 mSecretKey;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -310,16 +310,16 @@ void
 HerderImpl::signEnvelope(SCPEnvelope& envelope)
 {
     mSCPMetrics.mEnvelopeSign.Mark();
-    envelope.signature =
-        mSCP.getSecretKey().sign(xdr::xdr_to_opaque(envelope.statement));
+    envelope.signature = mSCP.getSecretKey().sign(
+        xdr::xdr_to_opaque(ENVELOPE_TYPE_SCP, envelope.statement));
 }
 
 bool
 HerderImpl::verifyEnvelope(SCPEnvelope const& envelope)
 {
-    bool b =
-        PubKeyUtils::verifySig(envelope.statement.nodeID, envelope.signature,
-                               xdr::xdr_to_opaque(envelope.statement));
+    bool b = PubKeyUtils::verifySig(
+        envelope.statement.nodeID, envelope.signature,
+        xdr::xdr_to_opaque(ENVELOPE_TYPE_SCP, envelope.statement));
     if (b)
     {
         mSCPMetrics.mEnvelopeValidSig.Mark();

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -775,7 +775,8 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
     }
 
     CLOG(DEBUG, "Herder") << "recvSCPEnvelope"
-                          << " from: " << hexAbbrev(envelope.statement.nodeID)
+                          << " from: " << PubKeyUtils::toShortString(
+                                              envelope.statement.nodeID)
                           << " s:" << envelope.statement.pledges.type()
                           << " i:" << envelope.statement.slotIndex
                           << " a:" << mApp.getStateHuman();
@@ -1184,7 +1185,7 @@ HerderImpl::envelopeVerified(bool valid)
 void
 HerderImpl::dumpInfo(Json::Value& ret)
 {
-    ret["you"] = hexAbbrev(mSCP.getSecretKey().getPublicKey());
+    ret["you"] = PubKeyUtils::toShortString(mSCP.getSecretKey().getPublicKey());
 
     mSCP.dumpInfo(ret);
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -306,6 +306,32 @@ HerderImpl::validateUpgradeStep(uint64 slotIndex, UpgradeType const& upgrade,
     return res;
 }
 
+void
+HerderImpl::signEnvelope(SCPEnvelope& envelope)
+{
+    mSCPMetrics.mEnvelopeSign.Mark();
+    envelope.signature =
+        mSCP.getSecretKey().sign(xdr::xdr_to_opaque(envelope.statement));
+}
+
+bool
+HerderImpl::verifyEnvelope(SCPEnvelope const& envelope)
+{
+    bool b =
+        PubKeyUtils::verifySig(envelope.statement.nodeID, envelope.signature,
+                               xdr::xdr_to_opaque(envelope.statement));
+    if (b)
+    {
+        mSCPMetrics.mEnvelopeValidSig.Mark();
+    }
+    else
+    {
+        mSCPMetrics.mEnvelopeInvalidSig.Mark();
+    }
+
+    return b;
+}
+
 bool
 HerderImpl::validateValue(uint64 slotIndex, Value const& value)
 {
@@ -1161,25 +1187,6 @@ void
 HerderImpl::acceptedCommit(uint64 slotIndex, SCPBallot const& ballot)
 {
     mSCPMetrics.mAcceptedCommit.Mark();
-}
-
-void
-HerderImpl::envelopeSigned()
-{
-    mSCPMetrics.mEnvelopeSign.Mark();
-}
-
-void
-HerderImpl::envelopeVerified(bool valid)
-{
-    if (valid)
-    {
-        mSCPMetrics.mEnvelopeValidSig.Mark();
-    }
-    else
-    {
-        mSCPMetrics.mEnvelopeInvalidSig.Mark();
-    }
 }
 
 void

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -45,6 +45,10 @@ class HerderImpl : public Herder, public SCPDriver
     void bootstrap() override;
 
     // SCP methods
+
+    void signEnvelope(SCPEnvelope& envelope) override;
+    bool verifyEnvelope(SCPEnvelope const& envelope) override;
+
     bool validateValue(uint64 slotIndex, Value const& value) override;
 
     Value extractValidValue(uint64 slotIndex, Value const& value) override;
@@ -76,8 +80,6 @@ class HerderImpl : public Herder, public SCPDriver
     void confirmedBallotPrepared(uint64 slotIndex,
                                  SCPBallot const& ballot) override;
     void acceptedCommit(uint64 slotIndex, SCPBallot const& ballot) override;
-    void envelopeSigned() override;
-    void envelopeVerified(bool) override;
 
     TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) override;
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -16,6 +16,9 @@ namespace stellar
 
 using namespace std;
 
+using xdr::operator==;
+using xdr::operator<;
+
 TxSetFrame::TxSetFrame(Hash const& previousLedgerHash)
     : mHashIsValid(false), mPreviousLedgerHash(previousLedgerHash)
 {
@@ -96,7 +99,7 @@ TxSetFrame::sortForApply()
     vector<TransactionFramePtr> retList;
 
     vector<vector<TransactionFramePtr>> txBatches(4);
-    map<uint256, size_t> accountTxCountMap;
+    map<AccountID, size_t> accountTxCountMap;
     retList = mTransactions;
     // sort all the txs by seqnum
     std::sort(retList.begin(), retList.end(), SeqSorter);
@@ -173,9 +176,7 @@ TxSetFrame::trimInvalid(Application& app,
 {
     sortForHash();
 
-    using xdr::operator==;
-
-    map<uint256, vector<TransactionFramePtr>> accountTxMap;
+    map<AccountID, vector<TransactionFramePtr>> accountTxMap;
 
     Hash lastHash;
     for (auto tx : mTransactions)
@@ -229,8 +230,6 @@ TxSetFrame::trimInvalid(Application& app,
 bool
 TxSetFrame::checkValid(Application& app) const
 {
-    using xdr::operator==;
-
     // Start by checking previousLedgerHash
     if (app.getLedgerManager().getLastClosedLedgerHeader().hash !=
         mPreviousLedgerHash)
@@ -243,7 +242,7 @@ TxSetFrame::checkValid(Application& app) const
         return false;
     }
 
-    map<uint256, vector<TransactionFramePtr>> accountTxMap;
+    map<AccountID, vector<TransactionFramePtr>> accountTxMap;
 
     Hash lastHash;
     for (auto tx : mTransactions)

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -42,7 +42,7 @@ class AccountFrame : public EntryFrame
     static AccountFrame::pointer makeAuthOnlyAccount(AccountID const& id);
 
     EntryFrame::pointer
-    copy() const
+    copy() const override
     {
         return EntryFrame::pointer(new AccountFrame(*this));
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -622,11 +622,11 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         LedgerDelta delta(ledgerDelta);
         try
         {
-            CLOG(DEBUG, "Tx") << "APPLY: ledger "
-                              << mCurrentLedger->mHeader.ledgerSeq << " tx#"
-                              << index << " = " << hexAbbrev(tx->getFullHash())
-                              << " txseq=" << tx->getSeqNum() << " (@ "
-                              << hexAbbrev(tx->getSourceID()) << ")";
+            CLOG(DEBUG, "Tx")
+                << "APPLY: ledger " << mCurrentLedger->mHeader.ledgerSeq
+                << " tx#" << index << " = " << hexAbbrev(tx->getFullHash())
+                << " txseq=" << tx->getSeqNum() << " (@ "
+                << PubKeyUtils::toShortString(tx->getSourceID()) << ")";
 
             // note that success here just means it got processed
             // a failed transaction collecting a fee is successful at this layer

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -139,7 +139,7 @@ LedgerManagerImpl::startNewLedger()
 {
     auto ledgerTime = mLedgerClose.TimeScope();
     ByteSlice bytes("allmylifemyhearthasbeensearching");
-    std::string b58SeedStr = toBase58Check(VER_SEED, bytes);
+    std::string b58SeedStr = toBase58Check(B58_SEED_ED25519, bytes);
     SecretKey skey = SecretKey::fromBase58Seed(b58SeedStr);
 
     AccountFrame masterAccount(skey.getPublicKey());

--- a/src/ledger/OfferFrame.h
+++ b/src/ledger/OfferFrame.h
@@ -48,7 +48,7 @@ class OfferFrame : public EntryFrame
     static OfferFrame::pointer from(AccountID const & account, ManageOfferOp const& op);
 
     EntryFrame::pointer
-    copy() const
+    copy() const override
     {
         return EntryFrame::pointer(new OfferFrame(*this));
     }

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -47,7 +47,7 @@ class TrustFrame : public EntryFrame
     TrustFrame(LedgerEntry const& from);
 
     EntryFrame::pointer
-    copy() const
+    copy() const override
     {
         return EntryFrame::pointer(new TrustFrame(*this));
     }

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -163,7 +163,8 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "triggers the instance to write an immediate history checkpoint."
         "</p><p><h1> /connect?peer=NAME&port=NNN</h1>"
         "triggers the instance to connect to peer NAME at port NNN."
-        "</p><p><h1> /generateload[?accounts=N&txs=M&txrate=R&autorate=true]</h1>"
+        "</p><p><h1> "
+        "/generateload[?accounts=N&txs=M&txrate=R&autorate=true]</h1>"
         "artificially generate load for testing; must be used with "
         "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING set to true"
         "</p><p><h1> /help</h1>"
@@ -290,13 +291,11 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
     int counter = 0;
     for (auto peer : mApp.getOverlayManager().getPeers())
     {
-        binToHex(peer->getPeerID());
         root["peers"][counter]["ip"] = peer->getIP();
         root["peers"][counter]["port"] = (int)peer->getRemoteListeningPort();
         root["peers"][counter]["ver"] = peer->getRemoteVersion();
         root["peers"][counter]["olver"] = (int)peer->getRemoteOverlayVersion();
-        root["peers"][counter]["id"] =
-            toBase58Check(VER_ACCOUNT_ID, peer->getPeerID());
+        root["peers"][counter]["id"] = PubKeyUtils::toBase58(peer->getPeerID());
 
         counter++;
     }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -91,9 +91,8 @@ loadQset(std::shared_ptr<cpptoml::toml_group> group, SCPQuorumSet& qset,
                 {
                     throw std::invalid_argument("invalid VALIDATORS");
                 }
-                NodeID p = fromBase58Check256(VER_ACCOUNT_ID,
-                                              v->as<std::string>()->value());
-                qset.validators.push_back(p);
+                qset.validators.emplace_back(
+                    PubKeyUtils::fromBase58(v->as<std::string>()->value()));
             }
         }
         else

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -318,7 +318,7 @@ main(int argc, char* const* argv)
             s += cfgFile + " found";
             throw std::invalid_argument(s);
         }
-        Logging::setFmt(hexAbbrev(cfg.PEER_PUBLIC_KEY));
+        Logging::setFmt(PubKeyUtils::toShortString(cfg.PEER_PUBLIC_KEY));
         Logging::setLogLevel(logLevel, nullptr);
 
         if (command.size())

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -145,10 +145,10 @@ Peer::sendPeers()
 void
 Peer::sendMessage(StellarMessage const& msg)
 {
-    CLOG(TRACE, "Overlay") << "("
-                           << binToHex(mApp.getConfig().PEER_PUBLIC_KEY)
-                                  .substr(0, 6) << ")send: " << msg.type()
-                           << " to : " << hexAbbrev(mPeerID);
+    CLOG(TRACE, "Overlay") << "(" << PubKeyUtils::toShortString(
+                                         mApp.getConfig().PEER_PUBLIC_KEY)
+                           << ")send: " << msg.type()
+                           << " to : " << PubKeyUtils::toShortString(mPeerID);
     xdr::msg_ptr xdrBytes(xdr::xdr_to_msg(msg));
     this->sendMessage(std::move(xdrBytes));
 }
@@ -180,11 +180,10 @@ Peer::shouldAbort() const
 void
 Peer::recvMessage(StellarMessage const& stellarMsg)
 {
-    CLOG(TRACE, "Overlay") << "("
-                           << binToHex(mApp.getConfig().PEER_PUBLIC_KEY)
-                                  .substr(0, 6)
+    CLOG(TRACE, "Overlay") << "(" << PubKeyUtils::toShortString(
+                                         mApp.getConfig().PEER_PUBLIC_KEY)
                            << ")recv: " << stellarMsg.type()
-                           << " from:" << hexAbbrev(mPeerID);
+                           << " from:" << PubKeyUtils::toShortString(mPeerID);
 
     if (mState < GOT_HELLO &&
         ((stellarMsg.type() != HELLO) && (stellarMsg.type() != PEERS)))
@@ -344,8 +343,8 @@ Peer::recvSCPMessage(StellarMessage const& msg)
 {
     SCPEnvelope envelope = msg.envelope();
     CLOG(TRACE, "Overlay") << "recvSCPMessage node: "
-                           << binToHex(msg.envelope().statement.nodeID)
-                                  .substr(0, 6);
+                           << PubKeyUtils::toShortString(
+                                  msg.envelope().statement.nodeID);
 
     mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
 
@@ -361,6 +360,7 @@ Peer::recvError(StellarMessage const& msg)
 bool
 Peer::recvHello(StellarMessage const& msg)
 {
+    using xdr::operator==;
     if (msg.hello().peerID == mApp.getConfig().PEER_PUBLIC_KEY)
     {
         CLOG(DEBUG, "Overlay") << "connecting to self";

--- a/src/overlay/StellarXDR.x
+++ b/src/overlay/StellarXDR.x
@@ -1,4 +1,4 @@
-
+%#include "generated/Stellar-SCP.h"
 %#include "generated/Stellar-types.h"
 %#include "generated/Stellar-ledger-entries.h"
 %#include "generated/Stellar-transaction.h"

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -100,32 +100,33 @@ LocalNode::forAllNodes(SCPQuorumSet const& qset,
                         });
 }
 
-// if a validator is repeated multiple times its weight is only the 
-// weight of the first occurrence 
+// if a validator is repeated multiple times its weight is only the
+// weight of the first occurrence
 uint64
 LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
 {
-    float chance = ((float)qset.threshold) /
-        (float)(qset.innerSets.size() + qset.validators.size());
+    double chance = ((double)qset.threshold) /
+                    (double)(qset.innerSets.size() + qset.validators.size());
 
-    for(auto const& qsetNode : qset.validators)
+    for (auto const& qsetNode : qset.validators)
     {
-        if(qsetNode == nodeID)
+        if (qsetNode == nodeID)
         {
-            return UINT64_MAX * chance;
+            return uint64(double(UINT64_MAX) * chance);
         }
     }
 
-    for(auto const& q : qset.innerSets)
+    for (auto const& q : qset.innerSets)
     {
         uint64 result = getNodeWeight(nodeID, q);
-        if(result)
-            return result * chance;
+        if (result)
+        {
+            return uint64(double(result) * chance);
+        }
     }
 
     return 0;
 }
-
 
 bool
 LocalNode::isQuorumSliceInternal(SCPQuorumSet const& qset,

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -12,6 +12,8 @@
 
 namespace stellar
 {
+using xdr::operator==;
+using xdr::operator<;
 
 LocalNode::LocalNode(SecretKey const& secretKey, SCPQuorumSet const& qSet,
                      SCP* scp)
@@ -22,7 +24,7 @@ LocalNode::LocalNode(SecretKey const& secretKey, SCPQuorumSet const& qSet,
     , mSCP(scp)
 {
     CLOG(INFO, "SCP") << "LocalNode::LocalNode"
-                      << "@" << hexAbbrev(mNodeID)
+                      << "@" << PubKeyUtils::toShortString(mNodeID)
                       << " qSet: " << hexAbbrev(mQSetHash);
 
     mSingleQSet = std::make_shared<SCPQuorumSet>(buildSingletonQSet(mNodeID));

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -16,6 +16,7 @@
 
 namespace stellar
 {
+using xdr::operator==;
 
 SCP::SCP(SCPDriver& driver, SecretKey const& secretKey,
          SCPQuorumSet const& qSetLocal)
@@ -116,8 +117,9 @@ SCP::signEnvelope(SCPEnvelope& envelope)
 bool
 SCP::verifyEnvelope(SCPEnvelope const& envelope)
 {
-    bool b = PublicKey::verifySig(envelope.statement.nodeID, envelope.signature,
-                                  xdr::xdr_to_opaque(envelope.statement));
+    bool b =
+        PubKeyUtils::verifySig(envelope.statement.nodeID, envelope.signature,
+                               xdr::xdr_to_opaque(envelope.statement));
     mDriver.envelopeVerified(b);
     return b;
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -29,7 +29,7 @@ SCP::EnvelopeState
 SCP::receiveEnvelope(SCPEnvelope const& envelope)
 {
     // If the envelope is not correctly signed, we ignore it.
-    if (!verifyEnvelope(envelope))
+    if (!mDriver.verifyEnvelope(envelope))
     {
         CLOG(DEBUG, "SCP") << "SCP::receiveEnvelope invalid";
         return SCP::EnvelopeState::INVALID;
@@ -103,25 +103,6 @@ SCP::getSlot(uint64 slotIndex)
         mKnownSlots[slotIndex] = std::make_shared<Slot>(slotIndex, *this);
     }
     return mKnownSlots[slotIndex];
-}
-
-void
-SCP::signEnvelope(SCPEnvelope& envelope)
-{
-    dbgAssert(envelope.statement.nodeID == getSecretKey().getPublicKey());
-    envelope.signature =
-        getSecretKey().sign(xdr::xdr_to_opaque(envelope.statement));
-    mDriver.envelopeSigned();
-}
-
-bool
-SCP::verifyEnvelope(SCPEnvelope const& envelope)
-{
-    bool b =
-        PubKeyUtils::verifySig(envelope.statement.nodeID, envelope.signature,
-                               xdr::xdr_to_opaque(envelope.statement));
-    mDriver.envelopeVerified(b);
-    return b;
 }
 
 void

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -71,10 +71,6 @@ class SCP
     // returns the local node descriptor
     std::shared_ptr<LocalNode> getLocalNode();
 
-    // Envelope signature/verification
-    void signEnvelope(SCPEnvelope& envelope);
-    bool verifyEnvelope(SCPEnvelope const& envelope);
-
     void dumpInfo(Json::Value& ret);
 
     // Purges all data relative to all the slots whose slotIndex is smaller

--- a/src/scp/SCPDriver.cpp
+++ b/src/scp/SCPDriver.cpp
@@ -34,7 +34,7 @@ SCPDriver::computeHash(uint64 slotIndex, bool isPriority, int32_t roundNumber,
     h->add(xdr::xdr_to_opaque(prev));
     h->add(xdr::xdr_to_opaque(isPriority ? hash_P : hash_N));
     h->add(xdr::xdr_to_opaque(roundNumber));
-    h->add(nodeID);
+    h->add(xdr::xdr_to_opaque(nodeID));
     uint256 t = h->finish();
     uint64 res = 0;
     for (int i = 0; i < sizeof(res); i++)

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -23,6 +23,10 @@ class SCPDriver
     {
     }
 
+    // Envelope signature/verification
+    virtual void signEnvelope(SCPEnvelope& envelope) = 0;
+    virtual bool verifyEnvelope(SCPEnvelope const& envelope) = 0;
+
     // Delegates the retrieval of the quorum set designated by `qSetHash` to
     // the user of SCP.
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
@@ -136,17 +140,6 @@ class SCPDriver
     // the local node.
     virtual void
     ballotDidHearFromQuorum(uint64 slotIndex, SCPBallot const& ballot)
-    {
-    }
-
-    // Hooks for subclasses to note signatures and verification pass/fail.
-    virtual void
-    envelopeSigned()
-    {
-    }
-
-    virtual void
-    envelopeVerified(bool)
     {
     }
 };

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -42,6 +42,18 @@ class TestSCP : public SCPDriver
             return (n == secretKey.getPublicKey()) ? 1000 : 1;
         };
     }
+
+    void
+    signEnvelope(SCPEnvelope&) override
+    {
+    }
+
+    bool
+    verifyEnvelope(SCPEnvelope const& envelope) override
+    {
+        return true;
+    }
+
     void
     storeQuorumSet(SCPQuorumSetPtr qSet)
     {

--- a/src/scp/SCPUnitTests.cpp
+++ b/src/scp/SCPUnitTests.cpp
@@ -4,45 +4,44 @@
 
 namespace stellar
 {
-    bool isNear(uint64 r, float target)
-    {
-        float v = (float)r / (float)UINT64_MAX;
-        return(abs(v - target) < .01);
-    }
+bool
+isNear(uint64 r, double target)
+{
+    double v = (double)r / (double)UINT64_MAX;
+    return (std::abs(v - target) < .01);
+}
 
-    TEST_CASE("nomination weight", "[scp]")
-    {
-        SIMULATION_CREATE_NODE(0);
-        SIMULATION_CREATE_NODE(1);
-        SIMULATION_CREATE_NODE(2);
-        SIMULATION_CREATE_NODE(3);
-        SIMULATION_CREATE_NODE(4);
-        SIMULATION_CREATE_NODE(5);
+TEST_CASE("nomination weight", "[scp]")
+{
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+    SIMULATION_CREATE_NODE(3);
+    SIMULATION_CREATE_NODE(4);
+    SIMULATION_CREATE_NODE(5);
 
-        SCPQuorumSet qSet;
-        qSet.threshold = 3;
-        qSet.validators.push_back(v0NodeID);
-        qSet.validators.push_back(v1NodeID);
-        qSet.validators.push_back(v2NodeID);
-        qSet.validators.push_back(v3NodeID);
+    SCPQuorumSet qSet;
+    qSet.threshold = 3;
+    qSet.validators.push_back(v0NodeID);
+    qSet.validators.push_back(v1NodeID);
+    qSet.validators.push_back(v2NodeID);
+    qSet.validators.push_back(v3NodeID);
 
-        uint64 result = LocalNode::getNodeWeight(v2NodeID, qSet);
+    uint64 result = LocalNode::getNodeWeight(v2NodeID, qSet);
 
-        REQUIRE(isNear(result, .75));
+    REQUIRE(isNear(result, .75));
 
-        result = LocalNode::getNodeWeight(v4NodeID, qSet);
-        REQUIRE(result==0);
+    result = LocalNode::getNodeWeight(v4NodeID, qSet);
+    REQUIRE(result == 0);
 
-        SCPQuorumSet iQSet;
-        iQSet.threshold = 1;
-        iQSet.validators.push_back(v4NodeID);
-        iQSet.validators.push_back(v5NodeID);
-        qSet.innerSets.push_back(iQSet);
+    SCPQuorumSet iQSet;
+    iQSet.threshold = 1;
+    iQSet.validators.push_back(v4NodeID);
+    iQSet.validators.push_back(v5NodeID);
+    qSet.innerSets.push_back(iQSet);
 
+    result = LocalNode::getNodeWeight(v4NodeID, qSet);
 
-        result = LocalNode::getNodeWeight(v4NodeID, qSet);
-
-        REQUIRE(isNear(result, .6*.5));
-
-    }
+    REQUIRE(isNear(result, .6 * .5));
+}
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -126,7 +126,7 @@ Slot::createEnvelope(SCPStatement const& statement)
     mySt.nodeID = getSCP().getLocalNodeID();
     mySt.slotIndex = getSlotIndex();
 
-    mSCP.signEnvelope(envelope);
+    mSCP.getDriver().signEnvelope(envelope);
 
     return envelope;
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -265,7 +265,7 @@ Slot::envToStr(SCPStatement const& st) const
 
     Hash qSetHash = getCompanionQuorumSetHashFromStatement(st);
 
-    oss << "{ENV@" << hexAbbrev(st.nodeID) << " | "
+    oss << "{ENV@" << PubKeyUtils::toShortString(st.nodeID) << " | "
         << " i: " << st.slotIndex;
     switch (st.pledges.type())
     {

--- a/src/scp/Stellar-SCP.x
+++ b/src/scp/Stellar-SCP.x
@@ -82,7 +82,7 @@ struct SCPEnvelope
 struct SCPQuorumSet
 {
     uint32 threshold;
-    Hash validators<>;
+    PublicKey validators<>;
     SCPQuorumSet innerSets<>;
 };
 }

--- a/src/scp/Stellar-SCP.x
+++ b/src/scp/Stellar-SCP.x
@@ -1,14 +1,14 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+%#include "generated/Stellar-types.h"
 
 namespace stellar
 {
 
 typedef opaque Signature[64];
-typedef opaque Hash[32];
-typedef opaque uint256[32];
-typedef unsigned int uint32;
-typedef unsigned hyper uint64;
 typedef opaque Value<>;
-typedef opaque NodeID[32];
 
 struct SCPBallot
 {

--- a/src/scp/Stellar-SCP.x
+++ b/src/scp/Stellar-SCP.x
@@ -7,7 +7,6 @@
 namespace stellar
 {
 
-typedef opaque Signature[64];
 typedef opaque Value<>;
 
 struct SCPBallot

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -19,10 +19,12 @@
 #define SIMULATION_CREATE_NODE(N)                                              \
     const Hash v##N##VSeed = sha256("SEED_VALIDATION_SEED_" #N);               \
     const SecretKey v##N##SecretKey = SecretKey::fromSeed(v##N##VSeed);        \
-    const Hash v##N##NodeID = v##N##SecretKey.getPublicKey();
+    const PublicKey v##N##NodeID = v##N##SecretKey.getPublicKey();
 
 namespace stellar
 {
+using xdr::operator<;
+using xdr::operator==;
 
 class Simulation : public LoadGenerator
 {

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -18,6 +18,7 @@ namespace stellar
 {
 
 using namespace std;
+using xdr::operator==;
 
 CreateAccountOpFrame::CreateAccountOpFrame(Operation const& op,
                                            OperationResult& res,

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -180,6 +180,8 @@ doInflation(Application& app, int nbAccounts,
             std::function<int64(int)> getBalance,
             std::function<int(int)> getVote, int expectedWinnerCount)
 {
+    using xdr::operator==;
+
     // simulate the expected inflation based off the current ledger state
     std::map<int, int64> balances;
 

--- a/src/transactions/PathPaymentOpFrame.cpp
+++ b/src/transactions/PathPaymentOpFrame.cpp
@@ -18,6 +18,7 @@ namespace stellar
 {
 
 using namespace std;
+using xdr::operator==;
 
 PathPaymentOpFrame::PathPaymentOpFrame(Operation const& op,
                                        OperationResult& res,
@@ -109,8 +110,6 @@ PathPaymentOpFrame::doApply(medida::MetricsRegistry& metrics,
     {
         int64_t curASent, actualCurBReceived;
         Currency const& curA = fullPath[i];
-
-        using xdr::operator==;
 
         if (curA == curB)
         {

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -19,6 +19,7 @@ namespace stellar
 {
 
 using namespace std;
+using xdr::operator==;
 
 PaymentOpFrame::PaymentOpFrame(Operation const& op, OperationResult& res,
                                TransactionFrame& parentTx)

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -11,6 +11,8 @@
 
 namespace stellar
 {
+using xdr::operator==;
+
 SetOptionsOpFrame::SetOptionsOpFrame(Operation const& op, OperationResult& res,
                                      TransactionFrame& parentTx)
     : OperationFrame(op, res, parentTx)

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -27,6 +27,8 @@ typedef std::unique_ptr<Application> appPtr;
 // minbalance
 TEST_CASE("set options", "[tx][setoptions]")
 {
+    using xdr::operator==;
+
     Config const& cfg = getTestConfig();
 
     VirtualClock clock;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -53,7 +53,7 @@ TransactionFrame::getContentsHash() const
 {
     if (isZero(mContentsHash))
     {
-        mContentsHash = sha256(xdr::xdr_to_opaque(mEnvelope.tx));
+        mContentsHash = sha256(xdr::xdr_to_opaque(ENVELOPE_TYPE_TX, mEnvelope.tx));
     }
     return (mContentsHash);
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -118,7 +118,7 @@ TransactionFrame::addSignature(SecretKey const& secretKey)
     clearCached();
     DecoratedSignature sig;
     sig.signature = secretKey.sign(getContentsHash());
-    memcpy(&sig.hint, secretKey.getPublicKey().data(), sizeof(sig.hint));
+    sig.hint = PubKeyUtils::getHint(secretKey.getPublicKey());
     mEnvelope.signatures.push_back(sig);
 }
 
@@ -144,9 +144,9 @@ TransactionFrame::checkSignature(AccountFrame& account, int32_t neededWeight)
 
         for (auto it = keyWeights.begin(); it != keyWeights.end(); it++)
         {
-            if ((std::memcmp(sig.hint.data(), (*it).pubKey.data(),
-                             sizeof(sig.hint)) == 0) &&
-                PublicKey::verifySig((*it).pubKey, sig.signature, contentsHash))
+            if (PubKeyUtils::hasHint((*it).pubKey, sig.hint) &&
+                PubKeyUtils::verifySig((*it).pubKey, sig.signature,
+                                       contentsHash))
             {
                 mUsedSignatures[i] = true;
                 totalWeight += (*it).weight;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -24,6 +24,7 @@ namespace stellar
 {
 
 using namespace std;
+using xdr::operator==;
 
 TransactionFramePtr
 TransactionFrame::makeTransactionFromWire(TransactionEnvelope const& msg)
@@ -359,7 +360,7 @@ TransactionFrame::setSourceAccountPtr(AccountFrame::pointer signingAccount)
 {
     if (!signingAccount)
     {
-        if (mEnvelope.tx.sourceAccount != signingAccount->getID())
+        if (!(mEnvelope.tx.sourceAccount == signingAccount->getID()))
         {
             throw std::invalid_argument("wrong account");
         }

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -68,7 +68,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         SECTION("bad signature")
         {
             txFrame = createCreateAccountTx(root, a1, rootSeq++, paymentAmount);
-            txFrame->getEnvelope().signatures[0].signature.fill(123);
+            txFrame->getEnvelope().signatures[0].signature = Signature(32, 123);
 
             txFrame->apply(delta, app);
 

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -37,7 +37,7 @@ namespace txtest
 time_t
 getTestDate(int day, int month, int year)
 {
-    std::tm tm = { 0 };
+    std::tm tm = {0};
     tm.tm_hour = 0;
     tm.tm_min = 0;
     tm.tm_sec = 0;
@@ -53,30 +53,29 @@ getTestDate(int day, int month, int year)
 
 void
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
-        TransactionFramePtr tx)
+              TransactionFramePtr tx)
 {
     TxSetFramePtr txSet = std::make_shared<TxSetFrame>(
         app.getLedgerManager().getLastClosedLedgerHeader().hash);
-    if(tx)
+    if (tx)
     {
         txSet->add(tx);
         txSet->sortForHash();
     }
 
     StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
-        emptyUpgradeSteps, 0);
+                    emptyUpgradeSteps, 0);
     LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 
     REQUIRE(app.getLedgerManager().getLedgerNum() == (ledgerSeq + 1));
 }
 
-
 SecretKey
 getRoot()
 {
     std::string b58SeedStr =
-        toBase58Check(VER_SEED, "allmylifemyhearthasbeensearching");
+        toBase58Check(B58_SEED_ED25519, "allmylifemyhearthasbeensearching");
     return SecretKey::fromBase58Seed(b58SeedStr);
 }
 
@@ -87,7 +86,7 @@ getAccount(const char* n)
     std::string name(n);
     while (name.size() < 32)
         name += '.';
-    std::string b58SeedStr = toBase58Check(VER_SEED, name);
+    std::string b58SeedStr = toBase58Check(B58_SEED_ED25519, name);
     return SecretKey::fromBase58Seed(b58SeedStr);
 }
 

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -8,6 +8,8 @@
 
 namespace stellar
 {
+using xdr::operator==;
+
 bool
 isZero(uint256 const& b)
 {

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -7,7 +7,7 @@
 namespace stellar
 {
 
-typedef opaque AccountID[32];
+typedef PublicKey AccountID;
 typedef opaque Thresholds[4];
 typedef string string32<32>;
 typedef uint64 SequenceNumber;
@@ -59,7 +59,7 @@ enum LedgerEntryType
 
 struct Signer
 {
-    uint256 pubKey;
+    AccountID pubKey;
     uint32 weight; // really only need 1byte
 };
 

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -188,4 +188,14 @@ case TRUSTLINE:
 case OFFER:
     OfferEntry offer;
 };
+
+// list of all envelope types used in the application
+// those are prefixes used when building signatures for
+// the respective envelopes
+enum EnvelopeTypes
+{
+    ENVELOPE_TYPE_SCP = 1,
+    ENVELOPE_TYPE_TX = 2
+};
+
 }

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -7,6 +7,49 @@
 namespace stellar
 {
 
+typedef opaque AccountID[32];
+typedef opaque Thresholds[4];
+typedef string string32<32>;
+typedef uint64 SequenceNumber;
+
+enum CurrencyType
+{
+    CURRENCY_TYPE_NATIVE = 0,
+    CURRENCY_TYPE_ALPHANUM = 1
+};
+
+union Currency switch (CurrencyType type)
+{
+case CURRENCY_TYPE_NATIVE:
+    void;
+
+case CURRENCY_TYPE_ALPHANUM:
+    struct
+    {
+        opaque currencyCode[4];
+        AccountID issuer;
+    } alphaNum;
+
+    // add other currency types here in the future
+};
+
+// price in fractional representation
+struct Price
+{
+    int32 n; // numerator
+    int32 d; // denominator
+};
+
+// the 'Thresholds' type is packed uint8_t values
+// defined by these indexes
+enum ThresholdIndexes
+{
+    THRESHOLD_MASTER_WEIGHT = 0,
+    THRESHOLD_LOW = 1,
+    THRESHOLD_MED = 2,
+    THRESHOLD_HIGH = 3
+};
+
 enum LedgerEntryType
 {
     ACCOUNT = 0,

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -566,7 +566,7 @@ enum InflationResultCode
     INFLATION_NOT_TIME = -1
 };
 
-struct inflationPayout // or use PaymentResultAtom to limit types?
+struct InflationPayout // or use PaymentResultAtom to limit types?
 {
     AccountID destination;
     int64 amount;
@@ -575,7 +575,7 @@ struct inflationPayout // or use PaymentResultAtom to limit types?
 union InflationResult switch (InflationResultCode code)
 {
 case INFLATION_SUCCESS:
-    inflationPayout payouts<>;
+    InflationPayout payouts<>;
 default:
     void;
 };

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -9,7 +9,7 @@ namespace stellar
 
 struct DecoratedSignature
 {
-    opaque hint[4];    // first 4 bytes of the public key, used as a hint
+    SignatureHint hint;  // first 4 bytes of the public key, used as a hint
     Signature signature; // actual signature
 };
 

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -10,7 +10,7 @@ namespace stellar
 struct DecoratedSignature
 {
     opaque hint[4];    // first 4 bytes of the public key, used as a hint
-    uint512 signature; // actual signature
+    Signature signature; // actual signature
 };
 
 enum OperationType

--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -29,5 +29,8 @@ case KEY_TYPES_ED25519:
 
 // variable size as the size depends on the signature scheme used
 typedef opaque Signature<64>;
+
+typedef opaque SignatureHint[4];
+
 typedef PublicKey NodeID;
 }

--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -16,5 +16,16 @@ typedef int int32;
 typedef unsigned hyper uint64;
 typedef hyper int64;
 
-typedef opaque NodeID[32];
+enum CryptoKeyTypes
+{
+    KEY_TYPES_ED25519 = 0
+};
+
+union PublicKey switch (CryptoKeyTypes type)
+{
+case KEY_TYPES_ED25519:
+    uint256 ed25519;
+};
+
+typedef PublicKey NodeID;
 }

--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -8,8 +8,6 @@ namespace stellar
 typedef opaque Hash[32];
 typedef opaque uint256[32];
 
-typedef opaque uint512[64];
-
 typedef unsigned int uint32;
 typedef int int32;
 
@@ -33,4 +31,5 @@ typedef opaque Signature<64>;
 typedef opaque SignatureHint[4];
 
 typedef PublicKey NodeID;
+
 }

--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -27,5 +27,7 @@ case KEY_TYPES_ED25519:
     uint256 ed25519;
 };
 
+// variable size as the size depends on the signature scheme used
+typedef opaque Signature<64>;
 typedef PublicKey NodeID;
 }

--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -2,56 +2,19 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-%#include "generated/Stellar-SCP.h"
-
 namespace stellar
 {
 
-// messages
+typedef opaque Hash[32];
+typedef opaque uint256[32];
+
 typedef opaque uint512[64];
-typedef hyper int64;
+
+typedef unsigned int uint32;
 typedef int int32;
-typedef opaque AccountID[32];
-typedef opaque Thresholds[4];
-typedef string string32<32>;
 
-typedef uint64 SequenceNumber;
+typedef unsigned hyper uint64;
+typedef hyper int64;
 
-enum CurrencyType
-{
-    CURRENCY_TYPE_NATIVE = 0,
-    CURRENCY_TYPE_ALPHANUM = 1
-};
-
-union Currency switch (CurrencyType type)
-{
-case CURRENCY_TYPE_NATIVE:
-    void;
-
-case CURRENCY_TYPE_ALPHANUM:
-    struct
-    {
-        opaque currencyCode[4];
-        AccountID issuer;
-    } alphaNum;
-
-    // add other currency types here in the future
-};
-
-// price in fractional representation
-struct Price
-{
-    int32 n; // numerator
-    int32 d; // denominator
-};
-
-// the 'Thresholds' type is packed uint8_t values
-// defined by these indexes
-enum ThresholdIndexes
-{
-    THRESHOLD_MASTER_WEIGHT = 0,
-    THRESHOLD_LOW = 1,
-    THRESHOLD_MED = 2,
-    THRESHOLD_HIGH = 3
-};
+typedef opaque NodeID[32];
 }


### PR DESCRIPTION
Resolves #548 : 
extensibility for crypto scheme used for signing. moved to a union for public key, variable length signatures
Proper domain partitioning for digital signatures

Also resolves #561 (get rid of uint512)

Also
 * fixed typo in .x file - resolves #563 


@nullstyle : this will break Horizon in a way less trivial than usual. Pay particular attention to the "domain separation for digital signature" commit that changes the way we sign transactions with an extra prefix when we compute the hash of the transaction (it's like an implicit uint32 at the beginning of the transaction).