### PR TITLE
scrub warnings

### DIFF
--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -45,10 +45,10 @@ class BucketManagerImpl : public BucketManager
     medida::Timer& mBucketSnapMerge;
     medida::Counter& mSharedBucketsSize;
 
-protected:
+  protected:
     void calculateSkipValues(LedgerHeader& currentHeader);
 
-public:
+  public:
     BucketManagerImpl(Application& app);
     ~BucketManagerImpl() override;
     std::string const& getTmpDir() override;
@@ -65,15 +65,15 @@ public:
     void addBatch(Application& app, uint32_t currLedger,
                   std::vector<LedgerEntry> const& liveEntries,
                   std::vector<LedgerKey> const& deadEntries) override;
-    void snapshotLedger(LedgerHeader& currentHeader);
+    void snapshotLedger(LedgerHeader& currentHeader) override;
 
-    std::vector<std::string> checkForMissingBucketsFiles(HistoryArchiveState const& has) override;
-    void assumeState(HistoryArchiveState const& has);
+    std::vector<std::string>
+    checkForMissingBucketsFiles(HistoryArchiveState const& has) override;
+    void assumeState(HistoryArchiveState const& has) override;
 };
 
 #define SKIP_1 50
 #define SKIP_2 5000
 #define SKIP_3 50000
 #define SKIP_4 500000
-
 }

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -18,12 +18,12 @@ namespace stellar
 {
 
 PendingEnvelopes::PendingEnvelopes(Application& app, HerderImpl& herder)
-    : mHerder(herder)
-    , mApp(app)
+    : mApp(app)
+    , mHerder(herder)
     , mQsetCache(QSET_CACHE_SIZE)
-    , mTxSetCache(TXSET_CACHE_SIZE)
-    , mQuorumSetFetcher(app)
     , mTxSetFetcher(app)
+    , mQuorumSetFetcher(app)
+    , mTxSetCache(TXSET_CACHE_SIZE)
     , mPendingEnvelopesSize(
           app.getMetrics().NewCounter({"scp", "memory", "pending-envelopes"}))
 {
@@ -307,72 +307,4 @@ PendingEnvelopes::dumpInfo(Json::Value& ret)
     }
     */
 }
-
-///////////////////////////
-//////
-
-/* TODO.1
-
-// returns true if we have been left behind :(
-// see: walter the lazy mouse
-bool
-PendingEnvelopes::isFutureCommitted(uint64 slotIndex)
-{
-    return mIsFutureCommitted.find(slotIndex) != mIsFutureCommitted.end();
-}
-
-
-bool
-PendingEnvelopes::checkFutureCommitted(SCPEnvelope newEnvelope)
-{
-    // is this a committed statement?
-    if (newEnvelope.statement.pledges.type() == COMMITTED)
-    {
-        SCPQuorumSet const& qset = mHerder.getLocalQuorumSet();
-
-        // is it from someone we care about?
-        if (find(qset.validators.begin(), qset.validators.end(),
-            newEnvelope.nodeID) != qset.validators.end())
-        {
-            vector<FetchingRecordPtr> allRecords;
-            auto slot = newEnvelope.statement.slotIndex;
-            copy(mFetching[slot].begin(), mFetching[slot].end(),
-back_inserter(allRecords));
-            copy(mReady[slot].begin(), mReady[slot].end(),
-back_inserter(allRecords));
-
-            auto count = count_if(allRecords.begin(), allRecords.end(),
-[&](FetchingRecordPtr fRecord)
-            {
-                return fRecord->env->statement.ballot.value ==
-                    newEnvelope.statement.ballot.value;
-            });
-
-            // do we have enough of these for the same ballot?
-            if (count >= qset.threshold)
-            {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-
-
-TxSetFramePtr PendingEnvelopes::getTxSet(Hash txSetHash)
-{
-    auto result = mApp.getOverlayManager().getTxSetFetcher().get(txSetHash);
-    assert(result);
-    return result;
-}
-
-SCPQuorumSetPtr PendingEnvelopes::getQuorumSet(Hash qSetHash)
-{
-    auto result = mApp.getOverlayManager().getQuorumSetFetcher().get(qSetHash);
-    assert(result);
-    return result;
-}
-
-*/
 }

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -132,15 +132,6 @@ PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
 
     mPendingEnvelopes[envelope.statement.slotIndex].push_back(envelope);
 
-    /*
-    // if envelope is on the right slot send into SCP
-    // TODO.1 : below
-    if(checkFutureCommitted(envelope))
-    {
-        mIsFutureCommitted.insert(envelope.statement.slotIndex);
-    }
-    */
-
     mApp.getClock().getIOService().post([this]()
                                         {
                                             mHerder.processSCPQueue();

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -12,19 +12,18 @@
 
 /*
 SCP messages that you have received but are waiting to get the info of
-before feeding into SCP 
+before feeding into SCP
 */
-
 
 namespace stellar
 {
-    
+
 class HerderImpl;
 
 class PendingEnvelopes
 {
     Application& mApp;
-    HerderImpl &mHerder;
+    HerderImpl& mHerder;
 
     // ledger# and list of envelopes we have received if they are fetched or not
     std::map<uint64, std::vector<SCPEnvelope>> mReceivedEnvelopes;
@@ -35,44 +34,37 @@ class PendingEnvelopes
     // ledger# and list of envelopes that haven't been sent to SCP yet
     std::map<uint64, std::vector<SCPEnvelope>> mPendingEnvelopes;
 
-     // all the quorum sets we have learned about
+    // all the quorum sets we have learned about
     cache::lru_cache<uint256, SCPQuorumSetPtr> mQsetCache;
-
-    
 
     ItemFetcher<TxSetTracker> mTxSetFetcher;
     ItemFetcher<QuorumSetTracker> mQuorumSetFetcher;
 
     // all the txsets we have learned about per ledger#
     cache::lru_cache<uint256, TxSetFramePtr> mTxSetCache;
-    
-
-    bool checkFutureCommitted(SCPEnvelope envelope);
 
     medida::Counter& mPendingEnvelopesSize;
-public:
-   
 
-
-    PendingEnvelopes(Application& app, HerderImpl &herder);
+  public:
+    PendingEnvelopes(Application& app, HerderImpl& herder);
     ~PendingEnvelopes();
 
-    void recvSCPEnvelope(SCPEnvelope const &envelope);
+    void recvSCPEnvelope(SCPEnvelope const& envelope);
     void recvSCPQuorumSet(Hash hash, const SCPQuorumSet& qset);
     void recvTxSet(Hash hash, TxSetFramePtr txset);
 
-    void peerDoesntHave(MessageType type, uint256 const& itemID, Peer::pointer peer);
+    void peerDoesntHave(MessageType type, uint256 const& itemID,
+                        Peer::pointer peer);
 
-    bool isFullyFetched(SCPEnvelope const &envelope);
+    bool isFullyFetched(SCPEnvelope const& envelope);
     // returns true if already fetched
-    bool startFetch(SCPEnvelope const &envelope);
+    bool startFetch(SCPEnvelope const& envelope);
 
-    void envelopeReady(SCPEnvelope const &envelope);
+    void envelopeReady(SCPEnvelope const& envelope);
 
     bool pop(uint64 slotIndex, SCPEnvelope& ret);
 
     void eraseBelow(uint64 slotIndex);
-
 
     void slotClosed(uint64 slotIndex);
 
@@ -84,9 +76,5 @@ public:
 
     TxSetFramePtr getTxSet(Hash hash);
     SCPQuorumSetPtr getQSet(Hash hash);
-
 };
-
-
-
 }

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -25,7 +25,7 @@ class HistoryManagerImpl : public HistoryManager
     std::unique_ptr<TmpDir> mWorkDir;
     std::unique_ptr<PublishStateMachine> mPublish;
     std::unique_ptr<CatchupStateMachine> mCatchup;
-    bool mManualCatchup { false };
+    bool mManualCatchup{false};
 
     medida::Meter& mPublishSkip;
     medida::Meter& mPublishQueue;
@@ -37,17 +37,19 @@ class HistoryManagerImpl : public HistoryManager
     medida::Meter& mCatchupStart;
     medida::Meter& mCatchupSuccess;
     medida::Meter& mCatchupFailure;
-public:
+
+  public:
     HistoryManagerImpl(Application& app);
     ~HistoryManagerImpl() override;
 
-    uint32_t getCheckpointFrequency();
-    uint32_t prevCheckpointLedger(uint32_t ledger);
-    uint32_t nextCheckpointLedger(uint32_t ledger);
-    uint64_t nextCheckpointCatchupProbe(uint32_t ledger);
+    uint32_t getCheckpointFrequency() override;
+    uint32_t prevCheckpointLedger(uint32_t ledger) override;
+    uint32_t nextCheckpointLedger(uint32_t ledger) override;
+    uint64_t nextCheckpointCatchupProbe(uint32_t ledger) override;
 
-    void verifyHash(std::string const& filename, uint256 const& hash,
-                    std::function<void(asio::error_code const&)> handler) const override;
+    void verifyHash(
+        std::string const& filename, uint256 const& hash,
+        std::function<void(asio::error_code const&)> handler) const override;
 
     void decompress(std::string const& filename_gz,
                     std::function<void(asio::error_code const&)> handler,
@@ -57,34 +59,36 @@ public:
                   std::function<void(asio::error_code const&)> handler,
                   bool keepExisting = false) const override;
 
-    void putFile(std::shared_ptr<HistoryArchive const> archive,
-                 std::string const& local, std::string const& remote,
-                 std::function<void(asio::error_code const&)> handler) const override;
+    void putFile(
+        std::shared_ptr<HistoryArchive const> archive, std::string const& local,
+        std::string const& remote,
+        std::function<void(asio::error_code const&)> handler) const override;
 
-    void getFile(std::shared_ptr<HistoryArchive const> archive,
-                 std::string const& remote, std::string const& local,
-                 std::function<void(asio::error_code const&)> handler) const override;
+    void getFile(
+        std::shared_ptr<HistoryArchive const> archive,
+        std::string const& remote, std::string const& local,
+        std::function<void(asio::error_code const&)> handler) const override;
 
-    void mkdir(std::shared_ptr<HistoryArchive const> archive,
-               std::string const& dir,
-               std::function<void(asio::error_code const&)> handler) const override;
+    void
+    mkdir(std::shared_ptr<HistoryArchive const> archive, std::string const& dir,
+          std::function<void(asio::error_code const&)> handler) const override;
 
-    bool
-    maybePublishHistory(std::function<void(asio::error_code const&)> handler) override;
+    bool maybePublishHistory(
+        std::function<void(asio::error_code const&)> handler) override;
 
     bool hasAnyWritableHistoryArchive() override;
 
-    void publishHistory(std::function<void(asio::error_code const&)> handler) override;
+    void publishHistory(
+        std::function<void(asio::error_code const&)> handler) override;
 
     void downloadMissingBuckets(
         HistoryArchiveState desiredState,
-        std::function<void(asio::error_code const&ec)> handler) override;
+        std::function<void(asio::error_code const& ec)> handler) override;
 
     void catchupHistory(
         uint32_t initLedger, CatchupMode mode,
         std::function<void(asio::error_code const& ec, CatchupMode mode,
-                           LedgerHeaderHistoryEntry const& lastClosed)>
-        handler,
+                           LedgerHeaderHistoryEntry const& lastClosed)> handler,
         bool manualCatchup) override;
 
     void snapshotWritten(asio::error_code const&) override;
@@ -105,7 +109,5 @@ public:
     uint64_t getCatchupStartCount() override;
     uint64_t getCatchupSuccessCount() override;
     uint64_t getCatchupFailureCount() override;
-
 };
-
 }

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -323,8 +323,6 @@ AccountFrame::storeUpdate(LedgerDelta& delta, Database& db, bool insert) const
         inflation_ind = soci::i_ok;
     }
 
-    // TODO.3   KeyValue data
-
     string thresholds(binToHex(mAccountEntry.thresholds));
 
     {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -47,7 +47,6 @@ catching up to network:
     2) Pull history log or static deltas from history archive
     3) Replay or force-apply deltas, depending on catchup mode
 
-    // TODO.3 we need to store some validation history?
 */
 using std::placeholders::_1;
 using std::placeholders::_2;

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -12,13 +12,6 @@
 #include <crypto/Hex.h>
 #include "herder/Herder.h"
 
-// TODO.1 I think we need to add something that after some time it retries to
-// fetch qsets that it really needs.
-// (https://github.com/stellar/stellar-core/issues/81)
-/*
-
-*/
-
 namespace stellar
 {
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -17,8 +17,6 @@
 
 #include <random>
 
-// TODO.3 flood older msgs to people that connect to you
-
 /*
 Connection process:
 A wants to connect to B

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -354,7 +354,6 @@ Peer::recvSCPMessage(StellarMessage const& msg)
 void
 Peer::recvError(StellarMessage const& msg)
 {
-    // TODO.4
 }
 
 bool

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -62,35 +62,19 @@ class TestSCP : public SCPDriver
     }
 
     bool
-    validateValue(uint64 slotIndex, Value const& value)
+    validateValue(uint64 slotIndex, Value const& value) override
     {
         return true;
     }
 
     void
-    ballotDidPrepare(uint64 slotIndex, SCPBallot const& ballot)
-    {
-    }
-    void
-    ballotDidPrepared(uint64 slotIndex, SCPBallot const& ballot)
-    {
-    }
-    void
-    ballotDidCommit(uint64 slotIndex, SCPBallot const& ballot)
-    {
-    }
-    void
-    ballotDidCommitted(uint64 slotIndex, SCPBallot const& ballot)
-    {
-    }
-    void
-    ballotDidHearFromQuorum(uint64 slotIndex, SCPBallot const& ballot)
+    ballotDidHearFromQuorum(uint64 slotIndex, SCPBallot const& ballot) override
     {
         mHeardFromQuorums[slotIndex].push_back(ballot);
     }
 
     void
-    valueExternalized(uint64 slotIndex, Value const& value)
+    valueExternalized(uint64 slotIndex, Value const& value) override
     {
         if (mExternalizedValues.find(slotIndex) != mExternalizedValues.end())
         {
@@ -100,7 +84,7 @@ class TestSCP : public SCPDriver
     }
 
     SCPQuorumSetPtr
-    getQSet(Hash const& qSetHash)
+    getQSet(Hash const& qSetHash) override
     {
         if (mQuorumSets.find(qSetHash) != mQuorumSets.end())
         {
@@ -111,7 +95,7 @@ class TestSCP : public SCPDriver
     }
 
     void
-    emitEnvelope(SCPEnvelope const& envelope)
+    emitEnvelope(SCPEnvelope const& envelope) override
     {
         mEnvs.push_back(envelope);
     }

--- a/src/transactions/AllowTrustOpFrame.h
+++ b/src/transactions/AllowTrustOpFrame.h
@@ -10,7 +10,7 @@ namespace stellar
 {
 class AllowTrustOpFrame : public OperationFrame
 {
-    int32_t getNeededThreshold() const;
+    int32_t getNeededThreshold() const override;
     AllowTrustResult&
     innerResult() const
     {
@@ -23,8 +23,8 @@ class AllowTrustOpFrame : public OperationFrame
     AllowTrustOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(medida::MetricsRegistry& metrics,
-                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
+                 LedgerManager& ledgerManager) override;
     bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static AllowTrustResultCode

--- a/src/transactions/InflationOpFrame.h
+++ b/src/transactions/InflationOpFrame.h
@@ -16,14 +16,15 @@ class InflationOpFrame : public OperationFrame
         return mResult.tr().inflationResult();
     }
 
+    int32_t getNeededThreshold() const override;
+
   public:
     InflationOpFrame(Operation const& op, OperationResult& res,
                      TransactionFrame& parentTx);
 
-    bool doApply(medida::MetricsRegistry& metrics,
-                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
+                 LedgerManager& ledgerManager) override;
     bool doCheckValid(medida::MetricsRegistry& metrics) override;
-    int32_t getNeededThreshold() const override;
 
     static InflationResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -94,9 +94,6 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
 // need to check the counter offers selling wheat for sheep
 // see if this is modifying an old offer
 // see if this offer crosses any existing offers
-
-// TODO: revisit this, offer code should share logic with payment code
-//      to keep the code working, I ended up duplicating the error codes
 bool
 ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
                             LedgerDelta& delta, LedgerManager& ledgerManager)

--- a/src/transactions/MergeOpFrame.h
+++ b/src/transactions/MergeOpFrame.h
@@ -16,13 +16,14 @@ class MergeOpFrame : public OperationFrame
         return mResult.tr().accountMergeResult();
     }
 
+    int32_t getNeededThreshold() const override;
+
   public:
     MergeOpFrame(Operation const& op, OperationResult& res,
                  TransactionFrame& parentTx);
 
-    int32_t getNeededThreshold() const;
-    bool doApply(medida::MetricsRegistry& metrics,
-                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
+                 LedgerManager& ledgerManager) override;
     bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static AccountMergeResultCode

--- a/src/transactions/SetOptionsOpFrame.h
+++ b/src/transactions/SetOptionsOpFrame.h
@@ -10,7 +10,7 @@ namespace stellar
 {
 class SetOptionsOpFrame : public OperationFrame
 {
-    int32_t getNeededThreshold() const;
+    int32_t getNeededThreshold() const override;
     SetOptionsResult&
     innerResult()
     {
@@ -22,8 +22,8 @@ class SetOptionsOpFrame : public OperationFrame
     SetOptionsOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(medida::MetricsRegistry& metrics,
-                 LedgerDelta& delta, LedgerManager& ledgerManager) override;
+    bool doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
+                 LedgerManager& ledgerManager) override;
     bool doCheckValid(medida::MetricsRegistry& metrics) override;
 
     static SetOptionsResultCode


### PR DESCRIPTION
this makes the code base warning free on all 3 compilers (aside from warnings in dependent libraries).

other churn is just clang-format debt and deletion of obsolete & commented out code