### PR TITLE
Fixes for history catchup

### DIFF
--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -46,7 +46,7 @@ void
 FutureBucket::setLiveOutput(std::shared_ptr<Bucket> output)
 {
     mState = FB_LIVE_OUTPUT;
-    binToHex(output->getHash());
+    mOutputBucketHash = binToHex(output->getHash());
     // Given an output bucket, fake-up a promise for it connected to
     // the future so that it can be immediately retrieved.
     std::promise<std::shared_ptr<Bucket>> promise;

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -67,11 +67,25 @@ CatchupStateMachine::selectRandomReadableHistoryArchive()
     std::vector<std::pair<std::string, std::shared_ptr<HistoryArchive>>>
         archives;
 
+    // First try for archives that _only_ have a get command; they're
+    // archives we're explicitly not publishing to, so likely ones we want.
     for (auto const& pair : mApp.getConfig().HISTORY)
     {
-        if (pair.second->hasGetCmd())
+        if (pair.second->hasGetCmd() && !pair.second->hasPutCmd())
         {
             archives.push_back(pair);
+        }
+    }
+
+    // If we have none of those, accept those with get+put
+    if (archives.size() == 0)
+    {
+        for (auto const& pair : mApp.getConfig().HISTORY)
+        {
+            if (pair.second->hasGetCmd() && pair.second->hasPutCmd())
+            {
+                archives.push_back(pair);
+            }
         }
     }
 

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -231,10 +231,10 @@ TrustFrame::storeAdd(LedgerDelta& delta, Database& db) const
     auto timer = db.getInsertTimer("trust");
     statement st =
         (db.getSession().prepare << "INSERT INTO trustlines (accountid, "
-                                    "issuer, alphanumcurrency, tlimit, flags) "
-                                    "VALUES (:v1,:v2,:v3,:v4,:v5)",
+                                    "issuer, alphanumcurrency, balance, tlimit, flags) "
+                                    "VALUES (:v1,:v2,:v3,:v4,:v5,:v6)",
          use(b58AccountID), use(b58Issuer), use(currencyCode),
-         use(mTrustLine.limit), use((int)mTrustLine.flags));
+         use(mTrustLine.balance), use(mTrustLine.limit), use((int)mTrustLine.flags));
 
     st.execute(true);
 

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -21,7 +21,7 @@ dumpstream(XDRInputFileStream &in)
 void
 dumpxdr(std::string const& filename)
 {
-    std::regex rx("(ledger|bucket|transactions|results)-[[:xdigit:]]+\.xdr");
+    std::regex rx(".*(ledger|bucket|transactions|results)-[[:xdigit:]]+\\.xdr");
     std::smatch sm;
     if (std::regex_match(filename, sm, rx))
     {


### PR DESCRIPTION
The important one here is 626b67d where we fix the rather serious omission of writing trustline balances during minimal catchup.