### PR TITLE
Use default connection parameters for PostgreSQL.

### DIFF
--- a/src/database/DatabaseTests.cpp
+++ b/src/database/DatabaseTests.cpp
@@ -190,7 +190,7 @@ TEST_CASE("sqlite MVCC test", "[db]")
 TEST_CASE("postgres smoketest", "[db]")
 {
     Config const& cfg =
-        getTestConfig(0, Config::TESTDB_TCP_LOCALHOST_POSTGRESQL);
+        getTestConfig(0, Config::TESTDB_POSTGRESQL);
     VirtualClock clock;
     try
     {
@@ -251,7 +251,7 @@ TEST_CASE("postgres smoketest", "[db]")
 
 TEST_CASE("postgres performance", "[db][pgperf][hide]")
 {
-    Config cfg(getTestConfig(0, Config::TESTDB_TCP_LOCALHOST_POSTGRESQL));
+    Config cfg(getTestConfig(0, Config::TESTDB_POSTGRESQL));
     VirtualClock clock;
     std::default_random_engine gen;
     std::uniform_int_distribution<uint64_t> dist;

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -611,10 +611,8 @@ dbModeName(Config::TestDbMode mode)
     case Config::TESTDB_ON_DISK_SQLITE:
         return "TESTDB_ON_DISK_SQLITE";
 #ifdef USE_POSTGRES
-    case Config::TESTDB_UNIX_LOCAL_POSTGRESQL:
-        return "TESTDB_UNIX_LOCAL_POSTGRESQL";
-    case Config::TESTDB_TCP_LOCALHOST_POSTGRESQL:
-        return "TESTDB_TCP_LOCALHOST_POSTGRESQL";
+    case Config::TESTDB_POSTGRESQL:
+        return "TESTDB_POSTGRESQL";
 #endif
     default:
         abort();
@@ -634,10 +632,12 @@ TEST_CASE_METHOD(HistoryTests, "Full history catchup",
         HistoryManager::CATCHUP_MINIMAL, HistoryManager::CATCHUP_COMPLETE};
 
     std::vector<Config::TestDbMode> dbModes = {
+        Config::TESTDB_IN_MEMORY_SQLITE, Config::TESTDB_ON_DISK_SQLITE
+    };
 #ifdef USE_POSTGRES
-        Config::TESTDB_TCP_LOCALHOST_POSTGRESQL,
+    if (!force_sqlite)
+        dbModes.push_back(Config::TESTDB_POSTGRESQL);
 #endif
-        Config::TESTDB_IN_MEMORY_SQLITE, Config::TESTDB_ON_DISK_SQLITE};
 
     for (auto dbMode : dbModes)
     {

--- a/src/ledger/LedgerTests.cpp
+++ b/src/ledger/LedgerTests.cpp
@@ -110,7 +110,8 @@ TEST_CASE("single ledger entry insert SQL", "[singlesql][entrysql][hide]")
 {
     Config::TestDbMode mode = Config::TESTDB_ON_DISK_SQLITE;
 #ifdef USE_POSTGRES
-    mode = Config::TESTDB_TCP_LOCALHOST_POSTGRESQL;
+    if (!force_sqlite)
+        mode = Config::TESTDB_POSTGRESQL;
 #endif
 
     VirtualClock clock;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -27,8 +27,7 @@ class Config : public std::enable_shared_from_this<Config>
         TESTDB_IN_MEMORY_SQLITE,
         TESTDB_ON_DISK_SQLITE,
 #ifdef USE_POSTGRES
-        TESTDB_UNIX_LOCAL_POSTGRESQL,
-        TESTDB_TCP_LOCALHOST_POSTGRESQL,
+        TESTDB_POSTGRESQL,
 #endif
         TESTDB_MODES
     };

--- a/src/main/test.cpp
+++ b/src/main/test.cpp
@@ -2,6 +2,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include <cstdlib>
 #include "test.h"
 #include "generated/StellarCoreVersion.h"
 #include "main/Config.h"
@@ -29,6 +30,8 @@ namespace stellar
 static std::vector<std::string> gTestMetrics;
 static std::vector<std::unique_ptr<Config>> gTestCfg[Config::TESTDB_MODES];
 static std::vector<TmpDir> gTestRoots;
+
+bool force_sqlite = std::getenv("STELLAR_FORCE_SQLITE");
 
 Config const&
 getTestConfig(int instanceNumber, Config::TestDbMode mode)
@@ -100,12 +103,8 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
                    << ".db";
             break;
 #ifdef USE_POSTGRES
-        case Config::TESTDB_UNIX_LOCAL_POSTGRESQL:
+        case Config::TESTDB_POSTGRESQL:
             dbname << "postgresql://dbname=test" << instanceNumber;
-            break;
-        case Config::TESTDB_TCP_LOCALHOST_POSTGRESQL:
-            dbname << "postgresql://host=localhost dbname=test"
-                   << instanceNumber << " user=test password=test";
             break;
 #endif
         default:

--- a/src/main/test.h
+++ b/src/main/test.h
@@ -17,4 +17,6 @@ getTestConfig(int instanceNumber = 0,
               Config::TestDbMode mode = Config::TESTDB_DEFAULT);
 int test(int argc, char* const* argv, el::Level logLevel,
          std::vector<std::string> const& metrics);
+
+extern bool force_sqlite;
 }

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -245,11 +245,12 @@ TEST_CASE("Stress test on 2 nodes 3 accounts 10 random transactions 10tx/sec",
 
 TEST_CASE("Auto-calibrated single node load test", "[autoload][hide]")
 {
+    Config const& cfg =
 #ifdef USE_POSTGRES
-    Config const& cfg = getTestConfig(0, Config::TESTDB_TCP_LOCALHOST_POSTGRESQL);
-#else
-    Config const& cfg = getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE);
+        !force_sqlite
+        ? getTestConfig(0, Config::TESTDB_POSTGRESQL) :
 #endif
+        getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE);
     VirtualClock clock(VirtualClock::REAL_TIME);
     Application::pointer appPtr = Application::create(clock, cfg);
     appPtr->start();

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -460,7 +460,8 @@ TEST_CASE("single create account SQL", "[singlesql][paymentsql][hide]")
 {
     Config::TestDbMode mode = Config::TESTDB_ON_DISK_SQLITE;
 #ifdef USE_POSTGRES
-    mode = Config::TESTDB_TCP_LOCALHOST_POSTGRESQL;
+    if (!force_sqlite)
+        mode = Config::TESTDB_POSTGRESQL;
 #endif
 
     VirtualClock clock;

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -32,11 +32,12 @@ g++ -v
 llvm-symbolizer --version || true
 
 # Create postgres databases
-psql -c "create user test with password 'test';" -U postgres
-psql -c "create database test;" -U postgres
+export PGUSER=postgres
+#psql -c "create user test with password 'test';"
+psql -c "create database test;"
 for i in $(seq 0 8)
 do
-    psql -c "create database test$i;" -U postgres
+    psql -c "create database test$i;"
 done
 
 ccache -s


### PR DESCRIPTION
Also, if the environment variable STELLAR_FORCE_SQLITE is set,
then use SQLite for all tests except postgresql-specific ones.
The postgresql-specific tests seem to be able to fail without making
the tests fail, but that problem is independent of this commit...