### PR TITLE
Change captured racy 'this' in CatchupStateMachine to weak_ptr, cc #264

### DIFF
--- a/src/history/CatchupStateMachine.h
+++ b/src/history/CatchupStateMachine.h
@@ -93,7 +93,7 @@ class HistoryArchive;
 struct HistoryArchiveState;
 class Application;
 
-class CatchupStateMachine
+class CatchupStateMachine : public std::enable_shared_from_this<CatchupStateMachine>
 {
 
 private:
@@ -154,6 +154,8 @@ public:
       std::function<void(asio::error_code const& ec,
                          HistoryManager::CatchupMode mode,
                          LedgerHeaderHistoryEntry const& lastClosed)> handler);
+
+    void begin();
 
   static const std::chrono::seconds SLEEP_SECONDS_PER_LEDGER;
 };

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -24,7 +24,7 @@ class HistoryManagerImpl : public HistoryManager
     Application& mApp;
     std::unique_ptr<TmpDir> mWorkDir;
     std::unique_ptr<PublishStateMachine> mPublish;
-    std::unique_ptr<CatchupStateMachine> mCatchup;
+    std::shared_ptr<CatchupStateMachine> mCatchup;
     bool mManualCatchup{false};
 
     medida::Meter& mPublishSkip;


### PR DESCRIPTION
These two, along with a brief audit I gave to uses of captured `this` elsewhere in the code, should handle #264. All the remaining uses I could see were in lambdas that definitely have their owner outlive them (in fact, all owners that are constructed only once and torn town with the application, which takes all the lambdas with it).