### PR TITLE
add sqlite3 to ubuntu build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,7 +13,7 @@ Installation Instructions
 
     # sudo add-apt-repository ppa:ubuntu-toolchain-r/test
     # apt-get update
-    # sudo apt-get install git build-essential pkg-config autoconf libtool bison flex libpq-dev clang++-3.5 gcc-4.9 g++-4.9 cpp-4.9
+    # sudo apt-get install git build-essential pkg-config autoconf libtool bison flex libpq-dev clang++-3.5 gcc-4.9 g++-4.9 cpp-4.9 sqlite3 libsqlite3-dev
 
 
 See [installing gcc 4.9 on ubuntu 14.04](http://askubuntu.com/questions/428198/getting-installing-gcc-g-4-9-on-ubuntu)


### PR DESCRIPTION
I tested the install instructions on a fresh Ubuntu 14.04 AMI provided by Amazon on AWS. Installing sqlite3 was needed to build on this ami base image.

Might wanna split the file at the 80 character line though. If so, we can replace the edited line with:
```bash
    # sudo apt-get install git build-essential pkg-config autoconf libtool \
        bison flex libpq-dev clang++-3.5 gcc-4.9 g++-4.9 cpp-4.9 sqlite3 \
        libsqlite3-dev
```