### PR TITLE
README: Fix Travis badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://travis-ci.org/stellar/stellar-core.svg?branch=auto)]
+[![Build Status](https://travis-ci.org/stellar/stellar-core.svg?branch=auto)](https://travis-ci.org/stellar/stellar-core)
 
 # Note this code is pre-beta. 
 It is definitely not ready yet for production.
  
-#stellar-core
+# stellar-core
 
 Stellar-core is a C++ implementation of the [Stellar Consensus Protocol](https://github.com/stellar/stellar-core/blob/master/src/scp/readme.md) that maintains a local copy of the ledger and syncs with other instances of stellar-core on the network. Learn more by reading the [overview document](https://github.com/stellar/stellar-core/blob/master/docs/readme.md).
 
@@ -73,4 +73,3 @@ Then, running
 * `stellar-core --test [stress]` will run all the stress tests,
 * `stellar-core --test [foo-stress]` will run the stress tests for subsystem foo alone, and
 * neither `stellar-core --test` nor `stellar-core --test [foo]` will run stress tests.
-


### PR DESCRIPTION
Currently, the image doesn't link to anywhere.