### PR TITLE
Minimize the number of listening sockets for run-and-exit commands.

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -99,6 +99,16 @@ usage(int err = 1)
 }
 
 static void
+setNoListen(Config& cfg)
+{
+    // prevent opening up a port for other peers
+    cfg.RUN_STANDALONE = true;
+    cfg.HTTP_PORT = 0;
+    cfg.MANUAL_CLOSE = true;
+}
+
+
+static void
 sendCommand(std::string const& command, const std::vector<char*>& rest,
             unsigned short port)
 {
@@ -196,11 +206,6 @@ initializeDatabase(Config& cfg)
 int
 initializeHistories(Config& cfg, vector<string> newHistories)
 {
-    // prevent opening up a port for other peers
-    cfg.RUN_STANDALONE = true;
-    cfg.HTTP_PORT = 0;
-    cfg.MANUAL_CLOSE = true;
-
     VirtualClock clock;
     Application::pointer app = Application::create(clock, cfg);
 
@@ -372,6 +377,7 @@ main(int argc, char* const* argv)
 
         if (forceSCP || newDB || getInfo)
         {
+            setNoListen(cfg);
             if (newDB)
                 initializeDatabase(cfg);
             if (forceSCP)
@@ -382,6 +388,7 @@ main(int argc, char* const* argv)
         }
         else if (!newHistories.empty())
         {
+            setNoListen(cfg);
             return initializeHistories(cfg, newHistories);
         }
 


### PR DESCRIPTION
I'm seeing a fairly high rate of bind() failing in complex-topology acceptance tests due to "address already in use", despite using SO_REUSEADDR on all the listening sockets. Possibly this is just docker being flaky somehow wrt. process shutdown or port mapping. Or I am misunderstanding the problem. In any case it seems like a strict improvement to not open listening sockets when we're just going to run -and-exit for a flag-setting or status-reporting command.