### PR TITLE
Scp fix: properly adjust mPrepared

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -715,6 +715,8 @@ BallotProtocol::attemptPreparedAccept(SCPBallot const& ballot)
     // update our state
     bool didWork = false;
 
+    // as a new ballot prepared, we also see if we can bump b
+    // as there is no point in waiting to trigger the logic in attemptPrepare
     if (!mCurrentBallot)
     {
         bumpToBallot(ballot);
@@ -730,17 +732,17 @@ BallotProtocol::attemptPreparedAccept(SCPBallot const& ballot)
         }
         else if (comp > 0)
         {
-            // our counter is too high
-            CLOG(WARNING, "SCP")
-                << "BallotProtocol::attemptPreparedAccept attempt to bump to "
-                   "a smaller value";
-            return false;
+            // we received an old message that allows to update p
+            // after bumping b (receive some messages after timing out
+            // most likely)
+            CLOG(DEBUG, "SCP") << "BallotProtocol::attemptPreparedAccept "
+                                  "updating p/p' after bumping b";
         }
     }
 
     didWork = setPrepared(ballot);
 
-    // check if we need to clear 'c'
+    // check if we also need to clear 'c'
     if (mCommit && mConfirmedPrepared)
     {
         if ((mPrepared &&

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -269,8 +269,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st)
 
         if (!isOK)
         {
-            CLOG(TRACE, "SCP") << "Malformed PREPARE message";
-            dbgAbort(); // REMOVE in production
+            CLOG(DEBUG, "SCP") << "Malformed PREPARE message";
             res = false;
         }
     }
@@ -282,8 +281,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st)
         res = res && c.commit.counter <= c.nP;
         if (!res)
         {
-            CLOG(TRACE, "SCP") << "Malformed CONFIRM message";
-            dbgAbort(); // REMOVE in production
+            CLOG(DEBUG, "SCP") << "Malformed CONFIRM message";
         }
     }
     break;
@@ -296,8 +294,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st)
 
         if (!res)
         {
-            CLOG(TRACE, "SCP") << "Malformed EXTERNALIZE message";
-            dbgAbort(); // REMOVE in production
+            CLOG(DEBUG, "SCP") << "Malformed EXTERNALIZE message";
         }
     }
     break;


### PR DESCRIPTION
fixed crash (bad state detection) - in some occurrences, nodes were not updating their local state correctly.

also updated code to only crash nodes that generate bad data to only take out the bad node instead of the entire network (this change was scheduled as we get closer to move to production)