### PR TITLE
Propagate true value of "didWork" flag rather than overwriting it.

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -741,7 +741,7 @@ BallotProtocol::attemptPreparedAccept(SCPBallot const& ballot)
         }
     }
 
-    didWork = setPrepared(ballot);
+    didWork = setPrepared(ballot) || didWork;
 
     // check if we need to clear 'c'
     if (mCommit && mConfirmedPrepared)


### PR DESCRIPTION
I _think_ we're clobbering the `didWork` flag here in a way that loses work / stalls progress in some cases. I'm not 100% sure, would appreciate review.