### PR TITLE
Perf caches

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -15,12 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
-Additional files found in the subdirectory src/lib are copies of liberally
+Additional files found in the subdirectory lib are copies of liberally
 licensed external libraries (that we believe to be compatible with the license
 text of the collective work, above). The following are restatements of license
 information found in those files and/or their respective upstream repositories:
 
-src/lib/autocheck:
+lib/autocheck:
 
   The Autocheck library,
   Copyright 2012-2013 John Freeman
@@ -28,7 +28,7 @@ src/lib/autocheck:
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
 
-src/lib/asio:
+lib/asio:
 
   The ASIO library,
   Copyright 2003-2014 Christopher M. Kohlhoff
@@ -36,7 +36,7 @@ src/lib/asio:
   Licensed under the Boost Software License 1.0
   (http://www.boost.org/LICENSE_1_0.txt)
 
-src/lib/catch.hpp:
+lib/catch.hpp:
 
   The Catch library,
   Copyright 2012 Two Blue Cubes Ltd.
@@ -44,7 +44,7 @@ src/lib/catch.hpp:
   Licensed under the Boost Software License 1.0
   (http://www.boost.org/LICENSE_1_0.txt)
 
-src/lib/http:
+lib/http:
 
   Example HTTP server from the ASIO library,
   Copyright 2003-2014 Christopher M. Kohlhoff
@@ -52,7 +52,7 @@ src/lib/http:
   Licensed under the Boost Software License 1.0
   (http://www.boost.org/LICENSE_1_0.txt)
 
-src/lib/util/easylogging++.h:
+lib/util/easylogging++.h:
 
   The EasyLogging++ library,
   Copyright 2014 Majid Khan
@@ -60,7 +60,7 @@ src/lib/util/easylogging++.h:
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
 
-src/lib/util/getopt.h and getopt_long.c:
+lib/util/getopt.h and getopt_long.c:
 
   NetBSD's getopt/getopt_long libraries,
   Copyright 2000 The NetBSD Foundation, Inc.
@@ -68,7 +68,7 @@ src/lib/util/getopt.h and getopt_long.c:
   Licensed under the 2-clause BSD license
   (http://opensource.org/licenses/BSD-2-Clause)
 
-src/lib/util/cpptoml.h:
+lib/util/cpptoml.h:
 
   The cpptoml library,
   Copyright 2013-2014 Chase Geigle
@@ -76,7 +76,7 @@ src/lib/util/cpptoml.h:
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
 
-src/lib/util/format.cc and format.h:
+lib/util/format.cc and format.h:
 
   The cppformat library,
   Copyright 2012, Victor Zverovich
@@ -84,7 +84,7 @@ src/lib/util/format.cc and format.h:
   Licensed under the 2-clause BSD license
   (http://opensource.org/licenses/BSD-2-Clause)
 
-src/lib/json/:
+lib/json/:
 
   The JsonCpp library,
   Copyright (c) 2007-2010 Baptiste Lepilleur
@@ -92,7 +92,7 @@ src/lib/json/:
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
 
-src/lib/cereal:
+lib/cereal:
 
   The cereal library,
   Copyright 2014, Randolph Voorhies, Shane Grant
@@ -100,7 +100,7 @@ src/lib/cereal:
   Licensed under the 3-clause BSD license
   (http://opensource.org/licenses/BSD-3-Clause)
 
-src/lib/cereal/external/rapidjson:
+lib/cereal/external/rapidjson:
 
   The RapidJSON library,
   Copyright 2011 Milo Yip
@@ -108,13 +108,13 @@ src/lib/cereal/external/rapidjson:
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
 
-src/lib/sqlite:
+lib/sqlite:
 
   The SQLite library,
   dedicated to the public domain
   (https://www.sqlite.org/copyright.html)
 
-src/lib/soci:
+lib/soci:
 
   The SOCI library,
   Copyright 2008 Maciej Sobczak
@@ -122,17 +122,41 @@ src/lib/soci:
   Licensed under the Boost Software License 1.0
   (http://www.boost.org/LICENSE_1_0.txt)
 
-src/lib/libmedida:
+lib/libmedida:
 
   The Medida library,
   Copyright 2012 Daniel Lundin
   Licensed under the Apache License, Version 2.0
   (https://www.apache.org/licenses/LICENSE-2.0)
 
-src/lib/util/uint128_t.{cpp,h}
+lib/util/uint128_t.{cpp,h}
 
   The uint128_t library,
   Copyright 2013 2014 Jason Lee
   (calccrypto@gmail.com)
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
+
+lib/util/lrucache.hpp
+
+  The LRUCache libary
+  Copyright 2014 Alexander Ponomarev
+  Licensed under the 3-clause BSD license
+  (http://opensource.org/licenses/BSD-3-Clause)
+
+lib/util/basen.h
+
+  The Base-n library
+  Copyright 2012 Andrzej Zawadzki
+  (azawadzki@gmail.com)
+  Licensed under the MIT license
+  (http://opensource.org/licenses/MIT)
+
+lib/util/crc16.cpp
+
+  CRC16 function
+  Copyright 2001-2010 Georges Menie
+  (www.menie.org)
+  Copyright 2010-2012 Salvatore Sanfilippo
+  Licensed under the 3-clause BSD license
+  (http://opensource.org/licenses/BSD-3-Clause)

--- a/lib/util/lrucache.hpp
+++ b/lib/util/lrucache.hpp
@@ -78,6 +78,19 @@ namespace cache {
             }
         }
 
+        void erase_if_exists(const key_t& key) {
+            auto it = _cache_items_map.find(key);
+            if (it != _cache_items_map.end()) {
+                _cache_items_list.erase(it->second);
+                _cache_items_map.erase(it);
+            }
+        }
+
+        void clear() {
+            _cache_items_map.clear();
+            _cache_items_list.clear();
+        }
+
         bool exists(const key_t& key) const {
             return _cache_items_map.find(key) != _cache_items_map.end();
         }

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -67,6 +67,7 @@ Database::Database(Application& app)
     : mApp(app)
     , mStatementsSize(
           app.getMetrics().NewCounter({"database", "memory", "statements"}))
+    , mEntryCache(4096)
 {
     registerDrivers();
     CLOG(INFO, "Database") << "Connecting to: " << app.getConfig().DATABASE;
@@ -175,6 +176,13 @@ Database::getPool()
     assert(mPool);
     return *mPool;
 }
+
+cache::lru_cache<std::string, std::shared_ptr<LedgerEntry const>>&
+Database::getEntryCache()
+{
+    return mEntryCache;
+}
+
 
 class SQLLogContext : NonCopyable
 {

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -12,6 +12,7 @@
 #include "ledger/TrustFrame.h"
 #include "medida/timer_context.h"
 #include "util/NonCopyable.h"
+#include "util/lrucache.hpp"
 
 namespace medida
 {
@@ -91,6 +92,8 @@ class Database : NonMovableOrCopyable
     std::map<std::string, std::shared_ptr<soci::statement>> mStatements;
     medida::Counter& mStatementsSize;
 
+    cache::lru_cache<std::string, std::shared_ptr<LedgerEntry const>> mEntryCache;
+
     static bool gDriversRegistered;
     static void registerDrivers();
 
@@ -135,5 +138,11 @@ class Database : NonMovableOrCopyable
     // Access the optional SOCI connection pool available for worker
     // threads. Throws an error if !canUsePool().
     soci::connection_pool& getPool();
+
+    // Access the LedgerEntry cache. Note: clients are responsible for
+    // invalidating entries in this cache as they perform statements
+    // against the database. It's kept here only for ease of access.
+    cache::lru_cache<std::string, std::shared_ptr<LedgerEntry const>>&
+        getEntryCache();
 };
 }

--- a/src/ledger/EntryFrame.h
+++ b/src/ledger/EntryFrame.h
@@ -41,6 +41,20 @@ class EntryFrame : public NonMovableOrCopyable
 
     static pointer FromXDR(LedgerEntry const& from);
     static pointer storeLoad(LedgerKey const& key, Database& db);
+
+    // Static helpers for working with the DB LedgerEntry cache.
+    static void flushCachedEntry(LedgerKey const& key, Database& db);
+    static bool cachedEntryExists(LedgerKey const& key, Database& db);
+    static std::shared_ptr<LedgerEntry const> getCachedEntry(
+        LedgerKey const& key, Database& db);
+    static void putCachedEntry(LedgerKey const& key,
+                               std::shared_ptr<LedgerEntry const> p,
+                               Database& db);
+
+    // Member helpers that call cache flush/put for self.
+    void flushCachedEntry(Database& db) const;
+    void putCachedEntry(Database& db) const;
+
     static void checkAgainstDatabase(LedgerEntry const& entry,
                                      Database& db);
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -245,12 +245,13 @@ TEST_CASE("Stress test on 2 nodes 3 accounts 10 random transactions 10tx/sec",
 
 TEST_CASE("Auto-calibrated single node load test", "[autoload][hide]")
 {
-    Config const& cfg =
+    Config cfg =
 #ifdef USE_POSTGRES
         !force_sqlite
         ? getTestConfig(0, Config::TESTDB_POSTGRESQL) :
 #endif
         getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE);
+    cfg.RUN_STANDALONE = false;
     VirtualClock clock(VirtualClock::REAL_TIME);
     Application::pointer appPtr = Application::create(clock, cfg);
     appPtr->start();


### PR DESCRIPTION
This adds two very conservative and simple caches to the process, one for `LedgerEntry` values (at the database layer -- constant XDR objects only) and one for signature verifications (globally, since it's a pure function). Each gains us a major perf win without inducing much in the way of code complexity or fragility, so despite my displeasure with caching I suspect these might be worth taking.

The `LedgerEntry` cache I only enabled for `AccountFrame` loads since they appear to be the main bottleneck. But I made the cache general enough to easily accommodate `TrustFrame` and `OfferFrame` if we choose to cache them too. See c7210a38cf7c66be29d37b188970e2ed6d213902 for the amount of work `AccountFrame` took. It's pretty straightforward.

I made no attempt at interacting with `LedgerDeltas` or being conservative about flushing; every write to account, in a transaction or otherwise, invalidates the associated cache entry and goes back to the DB.

For the most part this all appears to be compensating for crude "verify everything, always" logic on the txset receive path. I think it's probably safer to do this down at the DB and crypto level than try to inject state and cache-invalidation up at that level, but I'm open to the opposing argument. Figured this would be a good proof of concept of the angle @MonsieurNicolas and I were thinking of taking.