### PR TITLE
Fix an error causing periodic failures in acceptance testing

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -293,9 +293,8 @@ Bucket::apply(Database& db) const
     LedgerDelta delta(lh);
     XDRInputFileStream in;
     in.open(getFilename());
-    while (in)
+    while (in && in.readOne(entry))
     {
-        in.readOne(entry);
         if (entry.type() == LIVEENTRY)
         {
             EntryFrame::pointer ep = EntryFrame::FromXDR(entry.liveEntry());


### PR DESCRIPTION
When we apply a bucket, we read the final entry twice. If it's a LIVEENTRY this isn't realy a big problem but if it's a DEADENTRY it causes a double-delete assert. And of course in general it's just a bug.