### PR TITLE
Add new metrics for ledger age, state transitions.

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -69,6 +69,10 @@ class Herder
     virtual State getState() const = 0;
     virtual std::string getStateHuman() const = 0;
 
+    // Ensure any metrics that are "current state" gauge-like counters reflect
+    // the current reality as best as possible.
+    virtual void syncMetrics() = 0;
+
     virtual void bootstrap() = 0;
 
     virtual void recvSCPQuorumSet(Hash hash, SCPQuorumSet const& qset) = 0;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -16,6 +16,7 @@ namespace medida
 {
 class Meter;
 class Counter;
+class Timer;
 }
 
 namespace stellar
@@ -40,6 +41,8 @@ class HerderImpl : public Herder, public SCPDriver
 
     State getState() const override;
     std::string getStateHuman() const override;
+
+    void syncMetrics() override;
 
     // Bootstraps the HerderImpl if we're creating a new Network
     void bootstrap() override;
@@ -154,6 +157,10 @@ class HerderImpl : public Herder, public SCPDriver
     // reached consensus it can
     std::unique_ptr<ConsensusData> mTrackingSCP;
 
+    // Mark changes to mTrackingSCP in metrics.
+    void stateChanged();
+    VirtualClock::time_point mLastStateChange;
+
     // the ledger index that was last externalized
     uint32
     lastConsensusLedgerIndex() const
@@ -225,6 +232,10 @@ class HerderImpl : public Herder, public SCPDriver
         // Counters for things reached-through the
         // SCP maps: Slots and Nodes
         medida::Counter& mCumulativeStatements;
+
+        // State transition metrics
+        medida::Counter& mHerderStateCurrent;
+        medida::Timer& mHerderStateChanges;
 
         SCPMetrics(Application& app);
     };

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -111,6 +111,10 @@ class LedgerManager
     // Return the (changing) number of seconds since the LCL closed.
     virtual uint64_t secondsSinceLastLedgerClose() const = 0;
 
+    // Ensure any metrics that are "current state" gauge-like counters reflect
+    // the current reality as best as possible.
+    virtual void syncMetrics() = 0;
+
     // Return a mutable reference to the current ledger header; this is used
     // solely by LedgerDelta to _modify_ the current ledger-in-progress.
     virtual LedgerHeader& getCurrentLedgerHeader() = 0;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -38,6 +38,13 @@ class LedgerManagerImpl : public LedgerManager
     Application& mApp;
     medida::Timer& mTransactionApply;
     medida::Timer& mLedgerClose;
+    medida::Timer& mLedgerAgeClosed;
+    medida::Counter& mLedgerAge;
+    medida::Counter& mLedgerStateCurrent;
+    medida::Timer& mLedgerStateChanges;
+    VirtualClock::time_point mLastClose;
+    VirtualClock::time_point mLastStateChange;
+
     medida::Counter& mSyncingLedgersSize;
 
     std::vector<LedgerCloseData> mSyncingLedgers;
@@ -66,6 +73,7 @@ class LedgerManagerImpl : public LedgerManager
     int64_t getTxFee() const override;
     uint64_t getCloseTime() const override;
     uint64_t secondsSinceLastLedgerClose() const override;
+    void syncMetrics() override;
 
     void startNewLedger() override;
     void loadLastKnownLedger(

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -163,6 +163,13 @@ class Application
     // reported through the administrative HTTP interface, see CommandHandler.
     virtual medida::MetricsRegistry& getMetrics() = 0;
 
+    // Ensure any App-local metrics that are "current state" gauge-like counters
+    // reflect the current reality as best as possible.
+    virtual void syncOwnMetrics() = 0;
+
+    // Call syncOwnMetrics on self and syncMetrics all objects owned by App.
+    virtual void syncAllMetrics() = 0;
+
     // Get references to each of the "subsystem" objects.
     virtual TmpDirManager& getTmpDirManager() = 0;
     virtual LedgerManager& getLedgerManager() = 0;

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -9,6 +9,13 @@
 #include "main/Config.h"
 #include "main/PersistentState.h"
 #include <thread>
+#include "medida/timer_context.h"
+
+namespace medida
+{
+class Counter;
+class Timer;
+}
 
 namespace stellar
 {
@@ -37,6 +44,8 @@ class ApplicationImpl : public Application
     virtual bool isStopping() const override;
     virtual VirtualClock& getClock() override;
     virtual medida::MetricsRegistry& getMetrics() override;
+    virtual void syncOwnMetrics() override;
+    virtual void syncAllMetrics() override;
     virtual TmpDirManager& getTmpDirManager() override;
     virtual LedgerManager& getLedgerManager() override;
     virtual BucketManager& getBucketManager() override;
@@ -93,7 +102,6 @@ class ApplicationImpl : public Application
     asio::io_service mWorkerIOService;
     std::unique_ptr<asio::io_service::work> mWork;
 
-    std::unique_ptr<medida::MetricsRegistry> mMetrics;
     std::unique_ptr<Database> mDatabase;
     std::unique_ptr<TmpDirManager> mTmpDirManager;
     std::unique_ptr<OverlayManager> mOverlayManager;
@@ -113,6 +121,11 @@ class ApplicationImpl : public Application
     bool mStopping;
 
     VirtualTimer mStoppingTimer;
+
+    std::unique_ptr<medida::MetricsRegistry> mMetrics;
+    medida::Counter& mAppStateCurrent;
+    medida::Timer& mAppStateChanges;
+    VirtualClock::time_point mLastStateChange;
 
     void shutdownMainIOService();
     void runWorkerThread(unsigned i);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -335,6 +335,7 @@ CommandHandler::info(std::string const& params, std::string& retStr)
 void
 CommandHandler::metrics(std::string const& params, std::string& retStr)
 {
+    mApp.syncAllMetrics();
     medida::reporting::JsonReporter jr(mApp.getMetrics());
     retStr = jr.Report();
 }


### PR DESCRIPTION
Adds metrics:

  "ledger.age.closed" (Timer)
  "ledger.age.current-seconds" (Counter)
  "ledger.state.current" (Counter)
  "ledger.state.changes" (Timer)
  "app.state.current" (Counter)
  "app.state.changes" (Timer)
  "herder.state.current" (Counter)
  "herder.state.changes" (Timer)
