### PR TITLE
Write server version to history archives

### DIFF
--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -33,7 +33,7 @@ namespace stellar
 {
 
 unsigned const
-HistoryArchiveState::HISTORY_ARCHIVE_STATE_VERSION = 0;
+HistoryArchiveState::HISTORY_ARCHIVE_STATE_VERSION = 1;
 
 bool
 HistoryArchiveState::futuresAllReady() const

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -32,6 +32,9 @@
 namespace stellar
 {
 
+unsigned const
+HistoryArchiveState::HISTORY_ARCHIVE_STATE_VERSION = 0;
+
 bool
 HistoryArchiveState::futuresAllReady() const
 {
@@ -111,6 +114,12 @@ HistoryArchiveState::load(std::string const& inFile)
     std::ifstream in(inFile);
     cereal::JSONInputArchive ar(in);
     serialize(ar);
+    if (version != HISTORY_ARCHIVE_STATE_VERSION)
+    {
+        CLOG(ERROR, "History")
+            << "unexpected history archive state version: " << version;
+        throw std::runtime_error("unexpected history archive state version");
+    }
     assert(futuresAllResolved());
 }
 

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include "bucket/FutureBucket.h"
 #include "xdr/Stellar-types.h"
+#include "StellarCoreVersion.h"
 
 namespace asio
 {
@@ -60,6 +61,7 @@ struct HistoryArchiveState
     static unsigned const HISTORY_ARCHIVE_STATE_VERSION;
 
     unsigned version{HISTORY_ARCHIVE_STATE_VERSION};
+    std::string server{STELLAR_CORE_VERSION};
     uint32_t currentLedger{0};
     std::vector<HistoryStateBucket> currentBuckets;
 
@@ -90,7 +92,9 @@ struct HistoryArchiveState
     void
     serialize(Archive& ar)
     {
-        ar(CEREAL_NVP(version), CEREAL_NVP(currentLedger),
+        ar(CEREAL_NVP(version),
+           CEREAL_NVP(server),
+           CEREAL_NVP(currentLedger),
            CEREAL_NVP(currentBuckets));
     }
 
@@ -98,7 +102,9 @@ struct HistoryArchiveState
     void
     serialize(Archive& ar) const
     {
-        ar(CEREAL_NVP(version), CEREAL_NVP(currentLedger),
+        ar(CEREAL_NVP(version),
+           CEREAL_NVP(server),
+           CEREAL_NVP(currentLedger),
            CEREAL_NVP(currentBuckets));
     }
 

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -57,7 +57,9 @@ struct HistoryStateBucket
  */
 struct HistoryArchiveState
 {
-    unsigned version{0};
+    static unsigned const HISTORY_ARCHIVE_STATE_VERSION;
+
+    unsigned version{HISTORY_ARCHIVE_STATE_VERSION};
     uint32_t currentLedger{0};
     std::vector<HistoryStateBucket> currentBuckets;
 


### PR DESCRIPTION
This lets us know, at least for diagnostic and debugging purposes, which version of stellar-core wrote a given history archive.