### PR TITLE
Propagate catchup failures to hard-reset catchup state machine

### DIFF
--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -675,9 +675,6 @@ CatchupStateMachine::enterApplyingState()
     auto& sess = db.getSession();
     soci::transaction sqltx(sess);
 
-    // FIXME: this should do a "pre-apply scan" of the incoming contents
-    // to confirm that it's part of the trusted chain of history we want
-    // to catch up with. Currently it applies blindly.
 
     if (mMode == HistoryManager::CATCHUP_MINIMAL)
     {


### PR DESCRIPTION
This should cause the catchup state machine to fail-hard and restart catchup more aggressively.