### PR TITLE
Use prepared statements more extensively.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,7 +123,10 @@ if test yes != "$enable_shared"; then
    ac_configure_args="$ac_configure_args --disable-shared"
 fi
 
-PKG_CHECK_MODULES(sqlite3, sqlite3, :, sqlite3_INTERNAL=yes)
+# NB: A bug present before sqlite 3.7.11 concerning the interaction
+# of non-reset prepared statements and ROLLBACK means we require 3.7.11
+# or later. Do not weaken this requirement.
+PKG_CHECK_MODULES(sqlite3, [sqlite3 >= 3.7.11], :, sqlite3_INTERNAL=yes)
 AM_CONDITIONAL(SQLITE3_INTERNAL, [test yes = "$sqlite3_INTERNAL"])
 if test yes = "$sqlite3_INTERNAL"; then
    sqlite3_CFLAGS=-I'$(top_srcdir)/lib/sqlite'

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -230,7 +230,7 @@ TrustFrame::storeChange(LedgerDelta& delta, Database& db) const
     auto& st = prep.statement();
     st.exchange(use(mTrustLine.balance));
     st.exchange(use(mTrustLine.limit));
-    st.exchange(use((int)mTrustLine.flags));
+    st.exchange(use(mTrustLine.flags));
     st.exchange(use(actIDStrKey));
     st.exchange(use(issuerStrKey));
     st.exchange(use(assetCode));
@@ -270,7 +270,7 @@ TrustFrame::storeAdd(LedgerDelta& delta, Database& db) const
     st.exchange(use(assetCode));
     st.exchange(use(mTrustLine.balance));
     st.exchange(use(mTrustLine.limit));
-    st.exchange(use((int)mTrustLine.flags));
+    st.exchange(use(mTrustLine.flags));
     st.define_and_bind();
     {
         auto timer = db.getInsertTimer("trust");

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -170,10 +170,16 @@ TrustFrame::exists(Database& db, LedgerKey const& key)
     getKeyFields(key, actIDStrKey, issuerStrKey, assetCode);
     int exists = 0;
     auto timer = db.getSelectTimer("trust-exists");
-    db.getSession()
-        << "SELECT EXISTS (SELECT NULL FROM trustlines "
-           "WHERE accountid=:v1 and issuer=:v2 and assetcode=:v3)",
-        use(actIDStrKey), use(issuerStrKey), use(assetCode), into(exists);
+    auto prep = db.getPreparedStatement(
+        "SELECT EXISTS (SELECT NULL FROM trustlines "
+        "WHERE accountid=:v1 and issuer=:v2 and assetcode=:v3)");
+    auto& st = prep.statement();
+    st.exchange(use(actIDStrKey));
+    st.exchange(use(issuerStrKey));
+    st.exchange(use(assetCode));
+    st.exchange(into(exists));
+    st.define_and_bind();
+    st.execute(true);
     return exists != 0;
 }
 
@@ -217,18 +223,22 @@ TrustFrame::storeChange(LedgerDelta& delta, Database& db) const
     std::string actIDStrKey, issuerStrKey, assetCode;
     getKeyFields(getKey(), actIDStrKey, issuerStrKey, assetCode);
 
-    auto timer = db.getUpdateTimer("trust");
-    statement st =
-        (db.getSession().prepare
-             << "UPDATE trustlines "
-                "SET balance=:b, tlimit=:tl, flags=:a "
-                "WHERE accountid=:v1 AND issuer=:v2 AND assetcode=:v3",
-         use(mTrustLine.balance), use(mTrustLine.limit),
-         use((int)mTrustLine.flags), use(actIDStrKey), use(issuerStrKey),
-         use(assetCode));
-
-    st.execute(true);
-
+    auto prep = db.getPreparedStatement(
+        "UPDATE trustlines "
+        "SET balance=:b, tlimit=:tl, flags=:a "
+        "WHERE accountid=:v1 AND issuer=:v2 AND assetcode=:v3");
+    auto& st = prep.statement();
+    st.exchange(use(mTrustLine.balance));
+    st.exchange(use(mTrustLine.limit));
+    st.exchange(use((int)mTrustLine.flags));
+    st.exchange(use(actIDStrKey));
+    st.exchange(use(issuerStrKey));
+    st.exchange(use(assetCode));
+    st.define_and_bind();
+    {
+        auto timer = db.getUpdateTimer("trust");
+        st.execute(true);
+    }
     if (st.get_affected_rows() != 1)
     {
         throw std::runtime_error("Could not update data in SQL");
@@ -249,16 +259,23 @@ TrustFrame::storeAdd(LedgerDelta& delta, Database& db) const
     unsigned int assetType = getKey().trustLine().asset.type();
     getKeyFields(getKey(), actIDStrKey, issuerStrKey, assetCode);
 
-    auto timer = db.getInsertTimer("trust");
-    statement st = (db.getSession().prepare
-                        << "INSERT INTO trustlines (accountid, "
-                           "assettype, issuer, assetcode, balance, tlimit, flags) "
-                           "VALUES (:v1,:v2,:v3,:v4,:v5,:v6,:v7)",
-                    use(actIDStrKey), use(assetType), use(issuerStrKey), use(assetCode),
-                    use(mTrustLine.balance), use(mTrustLine.limit),
-                    use((int)mTrustLine.flags));
-
-    st.execute(true);
+    auto prep = db.getPreparedStatement(
+        "INSERT INTO trustlines "
+        "(accountid, assettype, issuer, assetcode, balance, tlimit, flags) VALUES "
+        "(:v1,      :v2,       :v3,    :v4,       :v5,     :v6,    :v7)");
+    auto& st = prep.statement();
+    st.exchange(use(actIDStrKey));
+    st.exchange(use(assetType));
+    st.exchange(use(issuerStrKey));
+    st.exchange(use(assetCode));
+    st.exchange(use(mTrustLine.balance));
+    st.exchange(use(mTrustLine.limit));
+    st.exchange(use((int)mTrustLine.flags));
+    st.define_and_bind();
+    {
+        auto timer = db.getInsertTimer("trust");
+        st.execute(true);
+    }
 
     if (st.get_affected_rows() != 1)
     {
@@ -312,18 +329,20 @@ TrustFrame::loadTrustLine(AccountID const& accountID, Asset const& asset,
         assetCodeToStr(asset.alphaNum12().assetCode, assetStr);
         issuerStr = PubKeyUtils::toStrKey(asset.alphaNum12().issuer);
     }
-   
-    session& session = db.getSession();
 
-    details::prepare_temp_type sql =
-        (session.prepare << trustLineColumnSelector
-                         << " WHERE accountid=:id AND "
-                            "issuer=:issuer AND assetcode=:asset",
-         use(accStr), use(issuerStr), use(assetStr));
+    auto query = std::string(trustLineColumnSelector);
+    query += (" WHERE accountid = :id "
+              " AND issuer = :issuer "
+              " AND assetcode = :asset");
+    auto prep = db.getPreparedStatement(query);
+    auto& st = prep.statement();
+    st.exchange(use(accStr));
+    st.exchange(use(issuerStr));
+    st.exchange(use(assetStr));
 
     pointer retLine;
     auto timer = db.getSelectTimer("trust");
-    loadLines(sql, [&retLine](LedgerEntry const& trust)
+    loadLines(prep, [&retLine](LedgerEntry const& trust)
               {
                   retLine = make_shared<TrustFrame>(trust);
               });
@@ -335,18 +354,20 @@ TrustFrame::hasIssued(AccountID const& issuerID, Database& db)
 {
     std::string accStrKey;
     accStrKey = PubKeyUtils::toStrKey(issuerID);
-
-    session& session = db.getSession();
-
-    details::prepare_temp_type sql =
-        (session.prepare << "SELECT balance FROM trustlines WHERE issuer=:id "
-                            "AND balance>0 LIMIT 1",
-         use(accStrKey));
-
-    auto timer = db.getSelectTimer("trust");
     int balance = 0;
-    statement st = (sql, into(balance));
-    st.execute(true);
+
+    auto prep = db.getPreparedStatement(
+        "SELECT balance FROM trustlines WHERE issuer=:id "
+        "AND balance>0 LIMIT 1");
+    auto& st = prep.statement();
+    st.exchange(use(accStrKey));
+    st.exchange(into(balance));
+    st.define_and_bind();
+
+    {
+        auto timer = db.getSelectTimer("trust");
+        st.execute(true);
+    }
     if (st.got_data())
     {
         return true;
@@ -355,7 +376,7 @@ TrustFrame::hasIssued(AccountID const& issuerID, Database& db)
 }
 
 void
-TrustFrame::loadLines(details::prepare_temp_type& prep,
+TrustFrame::loadLines(StatementContext& prep,
                       std::function<void(LedgerEntry const&)> trustProcessor)
 {
     string actIDStrKey;
@@ -367,9 +388,15 @@ TrustFrame::loadLines(details::prepare_temp_type& prep,
 
     TrustLineEntry& tl = le.trustLine();
 
-    statement st = (prep, into(actIDStrKey), into(assetType), into(issuerStrKey), 
-                    into(assetCode),
-                    into(tl.limit), into(tl.balance), into(tl.flags));
+    auto& st = prep.statement();
+    st.exchange(into(actIDStrKey));
+    st.exchange(into(assetType));
+    st.exchange(into(issuerStrKey));
+    st.exchange(into(assetCode));
+    st.exchange(into(tl.limit));
+    st.exchange(into(tl.balance));
+    st.exchange(into(tl.flags));
+    st.define_and_bind();
 
     st.execute(true);
     while (st.got_data())
@@ -399,14 +426,14 @@ TrustFrame::loadLines(AccountID const& accountID,
     std::string actIDStrKey;
     actIDStrKey = PubKeyUtils::toStrKey(accountID);
 
-    session& session = db.getSession();
-
-    details::prepare_temp_type sql =
-        (session.prepare << trustLineColumnSelector << " WHERE accountid=:id",
-         use(actIDStrKey));
+    auto query = std::string(trustLineColumnSelector);
+    query += (" WHERE accountid = :id ");
+    auto prep = db.getPreparedStatement(query);
+    auto& st = prep.statement();
+    st.exchange(use(actIDStrKey));
 
     auto timer = db.getSelectTimer("trust");
-    loadLines(sql, [&retLines](LedgerEntry const& cur)
+    loadLines(prep, [&retLines](LedgerEntry const& cur)
               {
                   retLines.emplace_back(make_shared<TrustFrame>(cur));
               });

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -20,6 +20,7 @@ namespace stellar
 {
 
 class TrustSetTx;
+class StatementContext;
 
 class TrustFrame : public EntryFrame
 {
@@ -32,7 +33,7 @@ class TrustFrame : public EntryFrame
                              std::string& assetCode);
 
     static void
-    loadLines(soci::details::prepare_temp_type& prep,
+    loadLines(StatementContext& prep,
               std::function<void(LedgerEntry const&)> trustProcessor);
 
     TrustLineEntry& mTrustLine;

--- a/src/overlay/PeerRecord.cpp
+++ b/src/overlay/PeerRecord.cpp
@@ -125,16 +125,27 @@ optional<PeerRecord>
 PeerRecord::loadPeerRecord(Database& db, string ip, unsigned short port)
 {
     auto ret = make_optional<PeerRecord>();
-    auto timer = db.getSelectTimer("peer");
     tm tm;
     // SOCI only support signed short, using intermediate int avoids ending up
     // with negative numbers in the database
     uint32_t lport;
-    db.getSession() << "SELECT ip,port, nextattempt, numfailures, rank FROM "
-                       "peers WHERE ip = :v1 AND port = :v2",
-        into(ret->mIP), into(lport), into(tm), into(ret->mNumFailures),
-        into(ret->mRank), use(ip), use(uint32_t(port));
-    if (db.getSession().got_data())
+    auto prep = db.getPreparedStatement(
+        "SELECT ip,port, nextattempt, numfailures, rank FROM "
+        "peers WHERE ip = :v1 AND port = :v2");
+    auto& st = prep.statement();
+    st.exchange(into(ret->mIP));
+    st.exchange(into(lport));
+    st.exchange(into(tm));
+    st.exchange(into(ret->mNumFailures));
+    st.exchange(into(ret->mRank));
+    st.exchange(use(ip));
+    st.exchange(use(uint32_t(port)));
+    st.define_and_bind();
+    {
+        auto timer = db.getSelectTimer("peer");
+        st.execute(true);
+    }
+    if (st.got_data())
     {
         ret->mPort = static_cast<unsigned short>(lport);
         ret->mNextAttempt = VirtualClock::tmToPoint(tm);
@@ -151,18 +162,27 @@ PeerRecord::loadPeerRecords(Database& db, uint32_t max,
 {
     try
     {
-        auto timer = db.getSelectTimer("peer");
         tm tm = VirtualClock::pointToTm(nextAttemptCutoff);
         PeerRecord pr;
         uint32_t lport;
-        statement st = (db.getSession().prepare
-                            << "SELECT ip, port, nextattempt, "
-                               "numfailures, rank FROM peers "
-                               "WHERE nextattempt <= :nextattempt "
-                               "ORDER BY rank DESC,numfailures ASC limit :max ",
-                        use(tm), use(max), into(pr.mIP), into(lport), into(tm),
-                        into(pr.mNumFailures), into(pr.mRank));
-        st.execute();
+        auto prep = db.getPreparedStatement(
+            "SELECT ip, port, nextattempt, numfailures, rank "
+            "FROM peers "
+            "WHERE nextattempt <= :nextattempt "
+            "ORDER BY rank DESC,numfailures ASC limit :max ");
+        auto& st = prep.statement();
+        st.exchange(use(tm));
+        st.exchange(use(max));
+        st.exchange(into(pr.mIP));
+        st.exchange(into(lport));
+        st.exchange(into(tm));
+        st.exchange(into(pr.mNumFailures));
+        st.exchange(into(pr.mRank));
+        st.define_and_bind();
+        {
+            auto timer = db.getSelectTimer("peer");
+            st.execute();
+        }
         while (st.fetch())
         {
             pr.mPort = static_cast<unsigned short>(lport);
@@ -204,7 +224,6 @@ PeerRecord::isStored(Database& db)
 bool
 PeerRecord::insertIfNew(Database& db)
 {
-    auto timer = db.getInsertTimer("peer");
     auto tm = VirtualClock::pointToTm(mNextAttempt);
 
     auto other = loadPeerRecord(db, mIP, mPort);
@@ -215,16 +234,22 @@ PeerRecord::insertIfNew(Database& db)
     }
     else
     {
-        statement stIn =
-            (db.getSession().prepare << "INSERT INTO peers "
-                                        "(ip,port,nextattempt,numfailures,"
-                                        "rank) values (:v1, :v2, :v3, :v4, "
-                                        ":v5)",
-             use(mIP), use(uint32_t(mPort)), use(tm), use(mNumFailures),
-             use(mRank));
-
-        stIn.execute(true);
-        return (stIn.get_affected_rows() == 1);
+        auto prep = db.getPreparedStatement(
+            "INSERT INTO peers "
+            "( ip,  port, nextattempt, numfailures, rank) VALUES "
+            "(:v1, :v2,  :v3,         :v4,         :v5)");
+        auto& st = prep.statement();
+        st.exchange(use(mIP));
+        st.exchange(use(uint32_t(mPort)));
+        st.exchange(use(tm));
+        st.exchange(use(mNumFailures));
+        st.exchange(use(mRank));
+        st.define_and_bind();
+        {
+            auto timer = db.getInsertTimer("peer");
+            st.execute(true);
+        }
+        return (st.get_affected_rows() == 1);
     }
 }
 
@@ -234,16 +259,23 @@ PeerRecord::storePeerRecord(Database& db)
     if (!insertIfNew(db))
     {
         auto tm = VirtualClock::pointToTm(mNextAttempt);
-        statement stUp =
-            (db.getSession().prepare << "UPDATE peers SET "
-                                        "nextattempt=:v1,numfailures=:v2,rank=:"
-                                        "v3 WHERE ip=:v4 AND port=:v5",
-             use(tm), use(mNumFailures), use(mRank), use(mIP),
-             use(uint32_t(mPort)));
+        auto prep = db.getPreparedStatement(
+            "UPDATE peers SET "
+            "nextattempt = :v1, "
+            "numfailures = :v2, "
+            "rank = :v3 "
+            "WHERE ip = :v4 AND port = :v5");
+        auto& st = prep.statement();
+        st.exchange(use(tm));
+        st.exchange(use(mNumFailures));
+        st.exchange(use(mRank));
+        st.exchange(use(mIP));
+        st.exchange(use(uint32_t(mPort)));
+        st.define_and_bind();
         {
             auto timer = db.getUpdateTimer("peer");
-            stUp.execute(true);
-            if (stUp.get_affected_rows() != 1)
+            st.execute(true);
+            if (st.get_affected_rows() != 1)
             {
                 throw runtime_error("PeerRecord::storePeerRecord: failed on " +
                                     toString());

--- a/src/overlay/PeerRecord.cpp
+++ b/src/overlay/PeerRecord.cpp
@@ -240,7 +240,8 @@ PeerRecord::insertIfNew(Database& db)
             "(:v1, :v2,  :v3,         :v4,         :v5)");
         auto& st = prep.statement();
         st.exchange(use(mIP));
-        st.exchange(use(uint32_t(mPort)));
+        uint32_t port = uint32_t(mPort);
+        st.exchange(use(port));
         st.exchange(use(tm));
         st.exchange(use(mNumFailures));
         st.exchange(use(mRank));
@@ -270,7 +271,8 @@ PeerRecord::storePeerRecord(Database& db)
         st.exchange(use(mNumFailures));
         st.exchange(use(mRank));
         st.exchange(use(mIP));
-        st.exchange(use(uint32_t(mPort)));
+        uint32_t port = uint32_t(mPort);
+        st.exchange(use(port));
         st.define_and_bind();
         {
             auto timer = db.getUpdateTimer("peer");


### PR DESCRIPTION
Spent a little while during recent CD runs profiling and shaving SQL-based I/O. Large costs around prepared statements, so I started knocking out a few of the heavy hitters. So far showing a pretty good improvement in per-transaction latency (numbers here in milliseconds):

~~~~
before:

  "median": 3.12307,
  "75%": 6.62283,
  "95%": 9.78209
  "98%": 11.3386,
  "99%": 12.408,
  "99.9%": 14.4683,

after:

  "median": 1.9426,
  "75%": 3.49644,
  "95%": 5.81299
  "98%": 7.21962,
  "99%": 7.58433,
  "99.9%": 9.98144,
~~~~

This is completely mechanical work. I'll do more of it tomorrow and gather new I/O profiles then. Might want to activate the XDR cache for trustlines and offers while I'm at it, but it's getting late.