### PR TITLE
prevent SetOptionsOpFrame::doApply to add already present signer again

### DIFF
--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -116,6 +116,7 @@ SetOptionsOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
                 if (oldSigner.pubKey == mSetOptions.signer->pubKey)
                 {
                     oldSigner.weight = mSetOptions.signer->weight;
+                    found = true;
                 }
             }
             if (!found)


### PR DESCRIPTION
Because of a missing assignment of the `found` variable when SetOptionsOpFrame::doApply is currently called with a signer already present – which is meant to update its weight – it continues and either adds the signer again or fails if the max size is already reached.