### PR TITLE
Flush DB cache entries on ledgerdelta rollback/destruct, close #690.

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -289,12 +289,12 @@ Bucket::apply(Database& db) const
         return;
     }
     BucketEntry entry;
-    LedgerHeader lh; // buckets, by definition are independent from the header
-    LedgerDelta delta(lh);
     XDRInputFileStream in;
     in.open(getFilename());
     while (in && in.readOne(entry))
     {
+        LedgerHeader lh; // buckets, by definition are independent from the header
+        LedgerDelta delta(lh, db);
         if (entry.type() == LIVEENTRY)
         {
             EntryFrame::pointer ep = EntryFrame::FromXDR(entry.liveEntry());
@@ -304,6 +304,8 @@ Bucket::apply(Database& db) const
         {
             EntryFrame::storeDelete(delta, db, entry.deadEntry());
         }
+        // No-op, just to avoid needless rollback.
+        delta.commit();
     }
 }
 

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -142,7 +142,8 @@ class Database : NonMovableOrCopyable
     // Access the LedgerEntry cache. Note: clients are responsible for
     // invalidating entries in this cache as they perform statements
     // against the database. It's kept here only for ease of access.
-    cache::lru_cache<std::string, std::shared_ptr<LedgerEntry const>>&
-        getEntryCache();
+    typedef cache::lru_cache<std::string, std::shared_ptr<LedgerEntry const>>
+        EntryCache;
+    EntryCache& getEntryCache();
 };
 }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -160,7 +160,7 @@ LedgerManagerImpl::startNewLedger()
     genesisHeader.totalCoins = masterAccount.getAccount().balance;
     genesisHeader.ledgerSeq = 1;
 
-    LedgerDelta delta(genesisHeader);
+    LedgerDelta delta(genesisHeader, getDatabase());
     masterAccount.storeAdd(delta, this->getDatabase());
     delta.commit();
 
@@ -633,7 +633,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     auto const& sv = ledgerData.mValue;
     mCurrentLedger->mHeader.scpValue = sv;
 
-    LedgerDelta ledgerDelta(mCurrentLedger->mHeader);
+    LedgerDelta ledgerDelta(mCurrentLedger->mHeader, getDatabase());
 
     // the transaction set that was agreed upon by consensus
     // was sorted by hash; we reorder it so that transactions are

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -45,7 +45,8 @@ createTestAccounts(Application& app, int nbAccounts,
 
     int64 setupBalance = lm.getMinBalance(0);
 
-    LedgerDelta delta(lm.getCurrentLedgerHeader());
+    LedgerDelta delta(lm.getCurrentLedgerHeader(),
+                      app.getDatabase());
     for (int i = 0; i < nbAccounts; i++)
     {
         int64 bal = getBalance(i);
@@ -235,7 +236,8 @@ doInflation(Application& app, int nbAccounts,
 
     // perform actual inflation
     {
-        LedgerDelta delta(lm.getCurrentLedgerHeader());
+        LedgerDelta delta(lm.getCurrentLedgerHeader(),
+                          app.getDatabase());
         REQUIRE(applyCheck(txFrame, delta, app));
         delta.commit();
     }

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -85,7 +85,8 @@ TEST_CASE("merge", "[tx][merge]")
         applyAccountMerge(app, a1, b1, a1_seq++, ACCOUNT_MERGE_HAS_CREDIT);
     }
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
 
     SECTION("success")
     {

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -62,7 +62,8 @@ TEST_CASE("create offer", "[tx][offers]")
 
     const Price oneone(1, 1);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
 
     SECTION("account a1 does not exist")
     {

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -97,7 +97,8 @@ TEST_CASE("payment", "[tx][payment]")
     REQUIRE(rootAccount->getBalance() ==
             (100000000000000000 - paymentAmount - gatewayPayment - txfee * 2));
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
 
     SECTION("Create account")
     {

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -50,7 +50,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
     SECTION("outer envelope")
     {
         TransactionFramePtr txFrame;
-        LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+        LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                          app.getDatabase());
 
         SECTION("no signature")
         {
@@ -131,7 +132,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
             tx->getEnvelope().signatures.clear();
             tx->addSignature(s1);
 
-            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                              app.getDatabase());
 
             applyCheck(tx, delta, app);
             REQUIRE(tx->getResultCode() == txBAD_AUTH);
@@ -147,7 +149,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
             tx->getEnvelope().signatures.clear();
             tx->addSignature(s2);
 
-            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                              app.getDatabase());
 
             applyCheck(tx, delta, app);
             REQUIRE(tx->getResultCode() == txFAILED);
@@ -162,7 +165,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
             tx->addSignature(s1);
             tx->addSignature(s2);
 
-            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                              app.getDatabase());
 
             applyCheck(tx, delta, app);
             REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -181,7 +185,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
             te.tx.seqNum = rootSeq++;
             TransactionFramePtr tx = std::make_shared<TransactionFrame>(te);
             tx->addSignature(root);
-            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                              app.getDatabase());
 
             REQUIRE(!tx->checkValid(app, 0));
 
@@ -213,7 +218,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 SECTION("missing signature")
                 {
                     LedgerDelta delta(
-                        app.getLedgerManager().getCurrentLedgerHeader());
+                        app.getLedgerManager().getCurrentLedgerHeader(),
+                        app.getDatabase());
 
                     REQUIRE(!tx->checkValid(app, 0));
                     applyCheck(tx, delta, app);
@@ -226,7 +232,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 {
                     tx->addSignature(b1);
                     LedgerDelta delta(
-                        app.getLedgerManager().getCurrentLedgerHeader());
+                        app.getLedgerManager().getCurrentLedgerHeader(),
+                        app.getDatabase());
 
                     REQUIRE(tx->checkValid(app, 0));
                     applyCheck(tx, delta, app);
@@ -262,7 +269,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     tx->addSignature(b1);
 
                     LedgerDelta delta(
-                        app.getLedgerManager().getCurrentLedgerHeader());
+                        app.getLedgerManager().getCurrentLedgerHeader(),
+                        app.getDatabase());
 
                     REQUIRE(!tx->checkValid(app, 0));
 
@@ -300,7 +308,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     tx->addSignature(b1);
 
                     LedgerDelta delta(
-                        app.getLedgerManager().getCurrentLedgerHeader());
+                        app.getLedgerManager().getCurrentLedgerHeader(),
+                        app.getDatabase());
 
                     REQUIRE(tx->checkValid(app, 0));
 
@@ -337,7 +346,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     tx->addSignature(b1);
 
                     LedgerDelta delta(
-                        app.getLedgerManager().getCurrentLedgerHeader());
+                        app.getLedgerManager().getCurrentLedgerHeader(),
+                        app.getDatabase());
 
                     REQUIRE(tx->checkValid(app, 0));
 
@@ -380,7 +390,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 tx->addSignature(c1);
 
                 LedgerDelta delta(
-                    app.getLedgerManager().getCurrentLedgerHeader());
+                    app.getLedgerManager().getCurrentLedgerHeader(),
+                    app.getDatabase());
 
                 REQUIRE(tx->checkValid(app, 0));
 
@@ -417,7 +428,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         REQUIRE(app.getLedgerManager().getLedgerNum() == 3);
 
         {
-            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+            LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                              app.getDatabase());
 
             SECTION("Insufficient fee")
             {

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -228,7 +228,8 @@ applyAllowTrust(Application& app, SecretKey& from, SecretKey& trustor,
     TransactionFramePtr txFrame;
     txFrame = createAllowTrust(from, trustor, seq, assetCode, authorize);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -262,7 +263,8 @@ applyCreateAccountTx(Application& app, SecretKey& from, SecretKey& to,
 
     txFrame = createCreateAccountTx(from, to, seq, amount);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -317,7 +319,8 @@ applyPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 
     txFrame = createPaymentTx(from, to, seq, amount);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -355,7 +358,8 @@ applyChangeTrust(Application& app, SecretKey& from, SecretKey& to,
 
     txFrame = createChangeTrust(from, to, seq, assetCode, limit);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -395,7 +399,8 @@ applyCreditPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 
     txFrame = createCreditPaymentTx(from, to, ci, seq, amount);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -445,7 +450,8 @@ applyPathPaymentTx(Application& app, SecretKey& from, SecretKey& to,
     txFrame = createPathPaymentTx(from, to, sendCur, sendMax, destCur,
                                   destAmount, seq, path);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -643,7 +649,8 @@ applySetOptions(Application& app, SecretKey& source, SequenceNumber seq,
     txFrame = createSetOptions(source, seq, inflationDest, setFlags, clearFlags,
                                thrs, signer);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -666,7 +673,8 @@ applyInflation(Application& app, SecretKey& from, SequenceNumber seq,
 {
     TransactionFramePtr txFrame = createInflation(from, seq);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     bool res = applyCheck(txFrame, delta, app);
 
     checkTransaction(*txFrame);
@@ -695,7 +703,8 @@ applyAccountMerge(Application& app, SecretKey& source, SecretKey& dest,
 {
     TransactionFramePtr txFrame = createAccountMerge(source, dest, seq);
 
-    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
     applyCheck(txFrame, delta, app);
 
     REQUIRE(MergeOpFrame::getInnerCode(


### PR DESCRIPTION
This adds a reference to db to the ledger delta object so that it purges all entry-cache entries on rollback. Also runs rollback when the ledger delta is destructed w/o commit. This _should_ solve the stale-read problems pointed out in #690.