### PR TITLE
Asset code fixes

### DIFF
--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -78,11 +78,11 @@ TrustFrame::getKeyFields(LedgerKey const& key, std::string& actIDStrKey,
         assetCodeToStr(key.trustLine().asset.alphaNum12().assetCode,
             assetCode);
     }
-    
+
     if (actIDStrKey == issuerStrKey)
         throw std::runtime_error("Issuer's own trustline should not be used "
                                  "outside of OperationFrame");
-   
+
 }
 
 int64_t
@@ -255,6 +255,7 @@ TrustFrame::storeAdd(LedgerDelta& delta, Database& db) const
     if (mIsIssuer)
         return;
 
+
     std::string actIDStrKey, issuerStrKey, assetCode;
     unsigned int assetType = getKey().trustLine().asset.type();
     getKeyFields(getKey(), actIDStrKey, issuerStrKey, assetCode);
@@ -295,7 +296,16 @@ TrustFrame::createIssuerFrame(Asset const& issuer)
     pointer res = make_shared<TrustFrame>();
     res->mIsIssuer = true;
     TrustLineEntry& tl = res->mEntry.trustLine();
-    tl.accountID = issuer.alphaNum4().issuer;
+
+    if(issuer.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
+    {
+        tl.accountID = issuer.alphaNum4().issuer;
+    }
+    else if(issuer.type() == ASSET_TYPE_CREDIT_ALPHANUM12)
+    {
+        tl.accountID = issuer.alphaNum12().issuer;
+    }
+
     tl.flags |= AUTHORIZED_FLAG;
     tl.balance = INT64_MAX;
     tl.asset = issuer;
@@ -387,6 +397,7 @@ TrustFrame::loadLines(StatementContext& prep,
     le.type(TRUSTLINE);
 
     TrustLineEntry& tl = le.trustLine();
+
 
     auto& st = prep.statement();
     st.exchange(into(actIDStrKey));

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -95,7 +95,7 @@ isAssetValid(Asset const& cur)
     }
     return false;
 
-    
+
 }
 
 bool
@@ -106,7 +106,7 @@ compareAsset(Asset const& first, Asset const& second)
 
     if (first.type() == ASSET_TYPE_NATIVE)
         return true;
-  
+
     if (second.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
     {
         if ((first.alphaNum4().issuer == second.alphaNum4().issuer) &&
@@ -125,48 +125,22 @@ compareAsset(Asset const& first, Asset const& second)
 
 void assetCodeToStr(xdr::opaque_array<4U> const& code, std::string& retStr)
 {
-    retStr = "    ";
-    for (int n = 0; n < 4; n++)
-    {
-        if (code[n])
-            retStr[n] = code[n];
-        else
-        {
-            retStr.resize(n);
-            return;
-        }
-    }
+    return assetCodeToStr<4U>(code, retStr);
 }
 
 void assetCodeToStr(xdr::opaque_array<12U> const& code, std::string& retStr)
 {
-    retStr = "    ";
-    for(int n = 0; n < 12; n++)
-    {
-        if(code[n])
-            retStr[n] = code[n];
-        else
-        {
-            retStr.resize(n);
-            return;
-        }
-    }
+    return assetCodeToStr<12U>(code, retStr);
 }
 
 void strToAssetCode(xdr::opaque_array<4U>& ret, std::string const& str)
 {
-    for (size_t n = 0; (n < str.size()) && (n < 4); n++)
-    {
-        ret[n] = str[n];
-    }
+    return strToAssetCode<4U>(ret, str);
 }
 
 void strToAssetCode(xdr::opaque_array<12U>& ret, std::string const& str)
 {
-    for(size_t n = 0; (n < str.size()) && (n < 12); n++)
-    {
-        ret[n] = str[n];
-    }
+    return strToAssetCode<12U>(ret, str);
 }
 
 // calculates A*B/C when A*B overflows 64bits

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -123,26 +123,6 @@ compareAsset(Asset const& first, Asset const& second)
     return false;
 }
 
-void assetCodeToStr(xdr::opaque_array<4U> const& code, std::string& retStr)
-{
-    return assetCodeToStr<4U>(code, retStr);
-}
-
-void assetCodeToStr(xdr::opaque_array<12U> const& code, std::string& retStr)
-{
-    return assetCodeToStr<12U>(code, retStr);
-}
-
-void strToAssetCode(xdr::opaque_array<4U>& ret, std::string const& str)
-{
-    return strToAssetCode<4U>(ret, str);
-}
-
-void strToAssetCode(xdr::opaque_array<12U>& ret, std::string const& str)
-{
-    return strToAssetCode<12U>(ret, str);
-}
-
 // calculates A*B/C when A*B overflows 64bits
 bool
 bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C)

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -22,36 +22,26 @@ bool isAssetValid(Asset const& cur);
 // returns true if the currencies are the same
 bool compareAsset(Asset const& first, Asset const& second);
 
-template<int TInt>
-void assetCodeToStr(xdr::opaque_array<TInt> const& code, std::string& retStr){
-  std::fill(retStr.begin(), retStr.begin() + TInt, ' ');
-
-  for(int n = 0; n < TInt; n++)
-  {
-      if(code[n])
-          retStr[n] = code[n];
-      else
-      {
-          retStr.resize(n);
-          return;
-      }
-  }
+template<uint32_t N>
+void assetCodeToStr(xdr::opaque_array<N> const& code, std::string& retStr){
+    retStr.clear();
+    for (auto c : code)
+    {
+        if (!c)
+        {
+            break;
+        }
+        retStr.push_back(c);
+    }
 };
 
-void assetCodeToStr(xdr::opaque_array<4U> const& code, std::string& retStr);
-void assetCodeToStr(xdr::opaque_array<12U> const& code, std::string& retStr);
-
-template<int TInt>
-void strToAssetCode(xdr::opaque_array<TInt>& ret, std::string const& str)
+template<uint32_t N>
+void strToAssetCode(xdr::opaque_array<N>& ret, std::string const& str)
 {
-  for (size_t n = 0; (n < str.size()) && (n < TInt); n++)
-  {
-      ret[n] = str[n];
-  }
+    ret.fill(0);
+    size_t n = std::min(ret.size(), str.size());
+    std::copy(str.begin(), str.begin() + n, ret.begin());
 }
-
-void strToAssetCode(xdr::opaque_array<4U>& ret, std::string const& str);
-void strToAssetCode(xdr::opaque_array<12U>& ret, std::string const& str);
 
 // calculates A*B/C when A*B overflows 64bits
 int64_t bigDivide(int64_t A, int64_t B, int64_t C);

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -22,8 +22,33 @@ bool isAssetValid(Asset const& cur);
 // returns true if the currencies are the same
 bool compareAsset(Asset const& first, Asset const& second);
 
+template<int TInt>
+void assetCodeToStr(xdr::opaque_array<TInt> const& code, std::string& retStr){
+  std::fill(retStr.begin(), retStr.begin() + TInt, ' ');
+
+  for(int n = 0; n < TInt; n++)
+  {
+      if(code[n])
+          retStr[n] = code[n];
+      else
+      {
+          retStr.resize(n);
+          return;
+      }
+  }
+};
+
 void assetCodeToStr(xdr::opaque_array<4U> const& code, std::string& retStr);
 void assetCodeToStr(xdr::opaque_array<12U> const& code, std::string& retStr);
+
+template<int TInt>
+void strToAssetCode(xdr::opaque_array<TInt>& ret, std::string const& str)
+{
+  for (size_t n = 0; (n < str.size()) && (n < TInt); n++)
+  {
+      ret[n] = str[n];
+  }
+}
 
 void strToAssetCode(xdr::opaque_array<4U>& ret, std::string const& str);
 void strToAssetCode(xdr::opaque_array<12U>& ret, std::string const& str);


### PR DESCRIPTION
This just picks up from PR #693 and corrects the boundary conditions:

  - Make sure all unused bytes in the opaque output are set to zero.
  - Don't overshoot the end when converting to string.

I also switched the template parameter to `uint32_t` so that it can just apply directly to the uses in the code via template argument deduction. This removes the need for the two explicit specializations.