### PR TITLE
More sql tuning

### DIFF
--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -44,7 +44,7 @@ const char* AccountFrame::kSQLCreateStatement3 =
     "CREATE INDEX signersaccount ON signers (accountid)";
 
 const char* AccountFrame::kSQLCreateStatement4 =
-    "CREATE INDEX accountbalances ON Accounts (balance)";
+    "CREATE INDEX accountbalances ON Accounts (balance) WHERE balance >= 1000000000";
 
 AccountFrame::AccountFrame()
     : EntryFrame(ACCOUNT), mAccountEntry(mEntry.account())

--- a/src/main/test.cpp
+++ b/src/main/test.cpp
@@ -81,7 +81,7 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.PEER_PORT =
             static_cast<unsigned short>(DEFAULT_PEER_PORT + instanceNumber * 2);
         thisConfig.HTTP_PORT = static_cast<unsigned short>(
-            DEFAULT_PEER_PORT + instanceNumber * 2 - 1);
+            DEFAULT_PEER_PORT + instanceNumber * 2 + 1);
 
         // We set a secret key by default as FORCE_SCP is true by
         // default and we do need a VALIDATION_KEY to start a new network

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -252,6 +252,8 @@ TEST_CASE("Auto-calibrated single node load test", "[autoload][hide]")
 #endif
         getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE);
     cfg.RUN_STANDALONE = false;
+    cfg.PARANOID_MODE = false;
+    cfg.DESIRED_MAX_TX_PER_LEDGER = 10000;
     VirtualClock clock(VirtualClock::REAL_TIME);
     Application::pointer appPtr = Application::create(clock, cfg);
     appPtr->start();

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -175,7 +175,11 @@ maybeAdjustRate(double target, double actual, uint32_t& rate, bool increaseOk)
     double acceptableDeviation = 0.1 * target;
     if (fabs(diff) > acceptableDeviation)
     {
-        double pct = diff / actual;
+        // Limit To doubling rate per adjustment period; even if it's measured
+        // as having more room to accelerate, it's likely we'll get a better
+        // measurement next time around, and we don't want to overshoot and
+        // thrash. Measurement is pretty noisy.
+        double pct = std::min(1.0, diff / actual);
         int32_t incr = static_cast<int32_t>(pct * rate);
         if (incr > 0 && !increaseOk)
         {

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -39,8 +39,8 @@ using namespace std;
 // Account amounts are expressed in ten-millionths (10^-7).
 static const uint64_t TENMILLION = 10000000;
 
-// Every loadgen account or trustline gets a 1000 unit balance (10^3).
-static const uint64_t LOADGEN_ACCOUNT_BALANCE = 1000 * TENMILLION;
+// Every loadgen account or trustline gets a 99 unit balance (10^2 - 1).
+static const uint64_t LOADGEN_ACCOUNT_BALANCE = 99 * TENMILLION;
 
 // Trustlines are limited to 1000x the balance.
 static const uint64_t LOADGEN_TRUSTLINE_LIMIT = 1000 * LOADGEN_ACCOUNT_BALANCE;
@@ -51,8 +51,8 @@ const uint32_t LoadGenerator::STEP_MSECS = 100;
 LoadGenerator::LoadGenerator() : mMinBalance(0), mLastSecond(0)
 {
     // Root account gets enough XLM to create 100 million (10^8) accounts, which
-    // thereby uses up 7 + 3 + 8 = 18 decimal digits. Luckily we have 2^63 =
-    // 9.2*10^18, so there's room even in 63bits to do this.
+    // thereby uses up 7 + 2 + 8 = 17 decimal digits. Luckily we have 2^63 =
+    // 9.2*10^18, so there's room even in 62bits to do this.
     auto root = make_shared<AccountInfo>(
         0, txtest::getRoot(), 100000000ULL * LOADGEN_ACCOUNT_BALANCE, 0, *this);
     mAccounts.push_back(root);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -146,6 +146,7 @@ class LoadGenerator
         medida::Meter& mManyOfferPathPayment;
         medida::Meter& mTxnAttempted;
         medida::Meter& mTxnRejected;
+        medida::Meter& mTxnBytes;
 
         medida::Counter& mGateways;
         medida::Counter& mMarketMakers;


### PR DESCRIPTION
This includes a little bit of tidying, a little bit of perf tuning and caching, a fair bit of improvement in autoload's situational awareness, and one _very major change_ to the way we evaluate whether the system is under load. Specifically: after some discussion today we decided that so long as the apply phase completes in a reasonable enough amount of time to keep up with incoming P2P and HTTP traffic (and subject to caveats about network utilization, buffer sizes, I/O rates etc.) then it's not overloaded. This means turning the load-sensor cutoff up a lot, allowing tx-apply to run for -- less arbitrarily than my previous 250ms cutoff -- _half the ledger window_ before we consider it overloaded. This in turn means we get closer to the actual throughput rate on the underlying SQL store, rather than limiting it to a 1/20th timeslice. Now we're getting 1/2 time, so tx/s jumps up by nearly a factor of 10.

There's still more tuning to do and this feels ... vaguely like cheating. On the other hand my workstation handles 150tx/s just fine in this configuration. Postgres has no problem keeping up, load average never goes above 0.7, and at the network level we're only flooding ~75kb/s of tx packets. So it's not like we're especially near hardware limits. I'll keep tuning since per-tx latency is still too high (1.7ms median, 5ms at 99%-ile) but having spent the day watching it operate under this setting it seems like a more reasonable place to set the dial anyways.