### PR TITLE
Tighten memory use

### DIFF
--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -224,6 +224,13 @@ SecretKey::fromBase58Seed(std::string const& base58Seed)
     return sk;
 }
 
+void
+PubKeyUtils::clearVerifySigCache()
+{
+    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
+    gVerifySigCache.clear();
+}
+
 bool
 PubKeyUtils::verifySig(PublicKey const& key, Signature const& signature,
                        ByteSlice const& bin)

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -78,6 +78,8 @@ namespace PubKeyUtils
 bool verifySig(PublicKey const& key, Signature const& signature,
                ByteSlice const& bin);
 
+void clearVerifySigCache();
+
 std::string toShortString(PublicKey const& pk);
 
 std::string toStrKey(PublicKey const& pk);

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -493,6 +493,11 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
     // current value is not valid anymore
     mCurrentValue.clear();
 
+    // Inessential but to keep memory-use down clear verify-cache.
+    // (It is fixed-size anyways but there's no point keeping around
+    // irrelevant signatures once we've finished a round).
+    PubKeyUtils::clearVerifySigCache();
+
     if (!mTrackingSCP)
     {
         stateChanged();

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -20,8 +20,9 @@ class TCPPeer : public Peer
 {
     std::string mIP;
     std::shared_ptr<asio::ip::tcp::socket> mSocket;
-    VirtualTimer mReadIdle;
-    VirtualTimer mWriteIdle;
+    VirtualTimer mIdleTimer;
+    VirtualClock::time_point mLastRead;
+    VirtualClock::time_point mLastWrite;
     std::vector<uint8_t> mIncomingHeader;
     std::vector<uint8_t> mIncomingBody;
     asio::io_service::strand mStrand;
@@ -37,10 +38,8 @@ class TCPPeer : public Peer
     medida::Meter& mTimeoutRead;
     medida::Meter& mTimeoutWrite;
 
-    void timeoutRead(asio::error_code const& error);
-    void timeoutWrite(asio::error_code const& error);
-    void resetWriteIdle();
-    void resetReadIdle();
+    void startIdleTimer();
+    void idleTimerExpired(asio::error_code const& error);
     void recvMessage();
     bool recvHello(StellarMessage const& msg) override;
     void sendMessage(xdr::msg_ptr&& xdrBytes) override;

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -386,6 +386,7 @@ VirtualTimer::cancel()
             ev->cancel();
         }
         mClock.flushCancelledEvents();
+        mEvents.clear();
     }
 }
 


### PR DESCRIPTION
This primarily fixes two very bad interactions in the timer subsystem:

  - We were producing new timer events on each packet, rather than just updating a timestamp.
  - We were not purging timer events from timers when they are cancelled.

The result was a medium-speed leak, an ever-more-expensive growth in timer buffers, and a lot of asio event loop churn. These have been eliminated.

Also threw in a cache-clean event on the signature verification cache, since at the worst case it can grow relatively large and most of its data is stale after an externalize.