### PR TITLE
Add fast path to catchup state machine, greatly accelerate download phase.

### DIFF
--- a/src/history/CatchupStateMachine.h
+++ b/src/history/CatchupStateMachine.h
@@ -137,7 +137,8 @@ private:
     void enterBeginState();
     void enterAnchoredState(HistoryArchiveState const& has);
     void enterRetryingState(uint64_t nseconds=2);
-    void enterFetchingState();
+    bool advanceFileState(std::shared_ptr<FileTransferInfo<FileCatchupState>> fi);
+    void enterFetchingState(std::shared_ptr<FileTransferInfo<FileCatchupState>> fi = nullptr);
 
     void enterVerifyingState();
     void advanceVerifyingState(std::shared_ptr<LedgerHeaderHistoryEntry> prev,


### PR DESCRIPTION
When we have, say, 10,000 files to download, this avoids doing a 10,000-value linear scan every time there's a state change in the catchup subsystem. It still does them occasionally (when a file enters a terminal state) but not during the first several steps.

More work can be done here but this is simple and helps.