### PR TITLE
Perf tuning

### DIFF
--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -29,6 +29,7 @@ class SHA256Impl : public SHA256, NonCopyable
     bool mFinished;
 public:
     SHA256Impl();
+    void reset() override;
     void add(ByteSlice const& bin) override;
     uint256 finish() override;
 };
@@ -42,10 +43,17 @@ SHA256::create()
 SHA256Impl::SHA256Impl()
     : mFinished(false)
 {
+    reset();
+}
+
+void
+SHA256Impl::reset()
+{
     if (crypto_hash_sha256_init(&mState) != 0)
     {
         throw std::runtime_error("error from crypto_hash_sha256_init");
     }
+    mFinished = false;
 }
 
 void

--- a/src/crypto/SHA.h
+++ b/src/crypto/SHA.h
@@ -20,6 +20,7 @@ class SHA256
   public:
     static std::unique_ptr<SHA256> create();
     virtual ~SHA256() {};
+    virtual void reset() = 0;
     virtual void add(ByteSlice const& bin) = 0;
     virtual uint256 finish() = 0;
 };

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -10,7 +10,8 @@
 #include <sodium.h>
 #include <type_traits>
 #include <memory>
-#include <util/make_unique.h>
+#include "util/make_unique.h"
+#include "util/HashOfHash.h"
 #include <mutex>
 
 #include "util/lrucache.hpp"
@@ -431,5 +432,12 @@ HashUtils::random()
     Hash res;
     randombytes_buf(res.data(), res.size());
     return res;
+}
+}
+
+namespace std {
+size_t hash<stellar::PublicKey>::operator()(stellar::PublicKey const & k) const noexcept
+{
+    return std::hash<stellar::uint256>()(k.ed25519());
 }
 }

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -25,7 +25,7 @@ namespace stellar
 // has no effect on correctness.
 
 static std::mutex gVerifySigCacheMutex;
-static cache::lru_cache<std::string, bool> gVerifySigCache(4096);
+static cache::lru_cache<std::string, bool> gVerifySigCache(0xffff);
 static uint64_t gVerifyCacheHit = 0;
 static uint64_t gVerifyCacheMiss = 0;
 static uint64_t gVerifyCacheIgnore = 0;
@@ -34,7 +34,7 @@ static bool
 shouldCacheVerifySig(PublicKey const& key, Signature const& signature,
                      ByteSlice const& bin)
 {
-    return (bin.size() < 0xffff);
+    return (bin.size() < 0xfff);
 }
 
 static std::string

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -6,6 +6,8 @@
 
 #include "xdr/Stellar-types.h"
 #include <ostream>
+#include <functional>
+#include <array>
 
 namespace stellar
 {
@@ -110,4 +112,12 @@ namespace HashUtils
 {
 Hash random();
 }
+}
+
+namespace std {
+template<>
+struct hash<stellar::PublicKey>
+{
+  size_t operator()(stellar::PublicKey const & x) const noexcept;
+};
 }

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -79,6 +79,9 @@ bool verifySig(PublicKey const& key, Signature const& signature,
                ByteSlice const& bin);
 
 void clearVerifySigCache();
+void flushVerifySigCacheCounts(uint64_t& hits,
+                               uint64_t& misses,
+                               uint64_t& ignores);
 
 std::string toShortString(PublicKey const& pk);
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -493,11 +493,6 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
     // current value is not valid anymore
     mCurrentValue.clear();
 
-    // Inessential but to keep memory-use down clear verify-cache.
-    // (It is fixed-size anyways but there's no point keeping around
-    // irrelevant signatures once we've finished a round).
-    PubKeyUtils::clearVerifySigCache();
-
     if (!mTrackingSCP)
     {
         stateChanged();

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -237,6 +237,12 @@ class HerderImpl : public Herder, public SCPDriver
         medida::Counter& mHerderStateCurrent;
         medida::Timer& mHerderStateChanges;
 
+        // Pending tx buffer sizes
+        medida::Counter& mHerderPendingTxs0;
+        medida::Counter& mHerderPendingTxs1;
+        medida::Counter& mHerderPendingTxs2;
+        medida::Counter& mHerderPendingTxs3;
+
         SCPMetrics(Application& app);
     };
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -193,7 +193,7 @@ TxSetFrame::surgePricingFilter(Application& app)
 // TODO.3 this and checkValid share a lot of code
 void
 TxSetFrame::trimInvalid(Application& app,
-                        std::vector<TransactionFramePtr> trimmed)
+                        std::vector<TransactionFramePtr>& trimmed)
 {
     soci::transaction sqltx(app.getDatabase().getSession());
     app.getDatabase().setCurrentTransactionReadOnly();

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -40,7 +40,7 @@ class TxSetFrame
 
     bool checkValid(Application& app) const;
     void trimInvalid(Application& app,
-                     std::vector<TransactionFramePtr> trimmed);
+                     std::vector<TransactionFramePtr>& trimmed);
     void surgePricingFilter(Application& app);
 
     void removeTx(TransactionFramePtr tx);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -16,6 +16,9 @@
 #include "overlay/PeerRecord.h"
 #include "util/Logging.h"
 
+#include "medida/metrics_registry.h"
+#include "medida/timer.h"
+
 #include "xdrpp/marshal.h"
 
 #include <soci.h>
@@ -36,6 +39,17 @@ Peer::Peer(Application& app, PeerRole role)
     , mState(role == ACCEPTOR ? CONNECTING : CONNECTED)
     , mRemoteOverlayVersion(0)
     , mRemoteListeningPort(0)
+    , mRecvErrorTimer(app.getMetrics().NewTimer({"overlay", "recv", "error"}))
+    , mRecvHelloTimer(app.getMetrics().NewTimer({"overlay", "recv", "hello"}))
+    , mRecvDontHaveTimer(app.getMetrics().NewTimer({"overlay", "recv", "dont-have"}))
+    , mRecvGetPeersTimer(app.getMetrics().NewTimer({"overlay", "recv", "get-peers"}))
+    , mRecvPeersTimer(app.getMetrics().NewTimer({"overlay", "recv", "peers"}))
+    , mRecvGetTxSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "get-txset"}))
+    , mRecvTxSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "txset"}))
+    , mRecvTransactionTimer(app.getMetrics().NewTimer({"overlay", "recv", "transaction"}))
+    , mRecvGetSCPQuorumSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "get-scp-qset"}))
+    , mRecvSCPQuorumSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "scp-qset"}))
+    , mRecvSCPMessageTimer(app.getMetrics().NewTimer({"overlay", "recv", "scp-message"}))
 {
 }
 
@@ -198,66 +212,77 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
     {
     case ERROR_MSG:
     {
+        auto t = mRecvErrorTimer.TimeScope();
         recvError(stellarMsg);
     }
     break;
 
     case HELLO:
     {
+        auto t = mRecvHelloTimer.TimeScope();
         this->recvHello(stellarMsg);
     }
     break;
 
     case DONT_HAVE:
     {
+        auto t = mRecvDontHaveTimer.TimeScope();
         recvDontHave(stellarMsg);
     }
     break;
 
     case GET_PEERS:
     {
+        auto t = mRecvGetPeersTimer.TimeScope();
         recvGetPeers(stellarMsg);
     }
     break;
 
     case PEERS:
     {
+        auto t = mRecvPeersTimer.TimeScope();
         recvPeers(stellarMsg);
     }
     break;
 
     case GET_TX_SET:
     {
+        auto t = mRecvGetTxSetTimer.TimeScope();
         recvGetTxSet(stellarMsg);
     }
     break;
 
     case TX_SET:
     {
+        auto t = mRecvTxSetTimer.TimeScope();
         recvTxSet(stellarMsg);
     }
     break;
 
     case TRANSACTION:
     {
+        auto t = mRecvTransactionTimer.TimeScope();
         recvTransaction(stellarMsg);
     }
     break;
 
     case GET_SCP_QUORUMSET:
     {
+        auto t = mRecvGetSCPQuorumSetTimer.TimeScope();
         recvGetSCPQuorumSet(stellarMsg);
     }
     break;
 
     case SCP_QUORUMSET:
     {
+        auto t = mRecvSCPQuorumSetTimer.TimeScope();
         recvSCPQuorumSet(stellarMsg);
     }
     break;
 
     case SCP_MESSAGE:
     {
+        auto t = mRecvSCPMessageTimer.TimeScope();
         recvSCPMessage(stellarMsg);
     }
     break;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -11,6 +11,11 @@
 #include "database/Database.h"
 #include "util/NonCopyable.h"
 
+namespace medida
+{
+class Timer;
+}
+
 namespace stellar
 {
 
@@ -53,6 +58,18 @@ class Peer : public std::enable_shared_from_this<Peer>,
     std::string mRemoteVersion;
     uint32_t mRemoteOverlayVersion;
     unsigned short mRemoteListeningPort;
+
+    medida::Timer& mRecvErrorTimer;
+    medida::Timer& mRecvHelloTimer;
+    medida::Timer& mRecvDontHaveTimer;
+    medida::Timer& mRecvGetPeersTimer;
+    medida::Timer& mRecvPeersTimer;
+    medida::Timer& mRecvGetTxSetTimer;
+    medida::Timer& mRecvTxSetTimer;
+    medida::Timer& mRecvTransactionTimer;
+    medida::Timer& mRecvGetSCPQuorumSetTimer;
+    medida::Timer& mRecvSCPQuorumSetTimer;
+    medida::Timer& mRecvSCPMessageTimer;
 
     bool shouldAbort() const;
     void recvMessage(StellarMessage const& msg);


### PR DESCRIPTION
In addition to a few bugfixes, this contains two categories of work, both of which lower the latency of receiving messages that are sent very often when under load:

  - Improving the performance and behavior of the signature-verify cache.
  - Improving the structures supporting buffering, duplicate and validity checking of txs in the herder.

The big change is 91fa6aa which switches the herder to nested hashmaps and makes the tx-receive path always O(1). Formerly there were linear and even some quadratic cases in these paths.

With this change, local testing (3-node config, autoload, single machine) surpasses 100 composite tx/s and about 645 op/s. Given that pgbench tops out at 4000 op/s on this hardware and we're running for only half the ledger window, and an op is almost always going to involve a read/write cycle, we might well be approaching DB maximums. Probably not much more than another factor of 1.5-2x to squeeze out.