### PR TITLE
protocol updates and fixes

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -524,7 +524,7 @@ checkDBAgainstBuckets(medida::MetricsRegistry& metrics,
             auto& e = *iter;
             if (e.type() == LIVEENTRY)
             {
-                switch (e.liveEntry().type())
+                switch (e.liveEntry().data.type())
                 {
                 case ACCOUNT:
                     ++nAccounts;

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -245,14 +245,14 @@ TEST_CASE("bucket list shadowing", "[bucket]")
         BucketEntry BucketEntryAlice, BucketEntryBob;
         alice.balance++;
         BucketEntryAlice.type(LIVEENTRY);
-        BucketEntryAlice.liveEntry().type(ACCOUNT);
-        BucketEntryAlice.liveEntry().account() = alice;
+        BucketEntryAlice.liveEntry().data.type(ACCOUNT);
+        BucketEntryAlice.liveEntry().data.account() = alice;
         liveBatch.push_back(BucketEntryAlice.liveEntry());
 
         bob.balance++;
         BucketEntryBob.type(LIVEENTRY);
-        BucketEntryBob.liveEntry().type(ACCOUNT);
-        BucketEntryBob.liveEntry().account() = bob;
+        BucketEntryBob.liveEntry().data.type(ACCOUNT);
+        BucketEntryBob.liveEntry().data.account() = bob;
         liveBatch.push_back(BucketEntryBob.liveEntry());
 
         bl.addBatch(*app, i, liveBatch, deadGen(5));
@@ -449,10 +449,10 @@ TEST_CASE("merging bucket entries", "[bucket]")
 
     SECTION("dead account entry annihilates live account entry")
     {
-        liveEntry.type(ACCOUNT);
-        liveEntry.account() = acGen(10);
+        liveEntry.data.type(ACCOUNT);
+        liveEntry.data.account() = acGen(10);
         deadEntry.type(ACCOUNT);
-        deadEntry.account().accountID = liveEntry.account().accountID;
+        deadEntry.account().accountID = liveEntry.data.account().accountID;
         std::vector<LedgerEntry> live{liveEntry};
         std::vector<LedgerKey> dead{deadEntry};
         std::shared_ptr<Bucket> b1 =
@@ -462,11 +462,11 @@ TEST_CASE("merging bucket entries", "[bucket]")
 
     SECTION("dead trustline entry annihilates live trustline entry")
     {
-        liveEntry.type(TRUSTLINE);
-        liveEntry.trustLine() = tlGen(10);
+        liveEntry.data.type(TRUSTLINE);
+        liveEntry.data.trustLine() = tlGen(10);
         deadEntry.type(TRUSTLINE);
-        deadEntry.trustLine().accountID = liveEntry.trustLine().accountID;
-        deadEntry.trustLine().asset = liveEntry.trustLine().asset;
+        deadEntry.trustLine().accountID = liveEntry.data.trustLine().accountID;
+        deadEntry.trustLine().asset = liveEntry.data.trustLine().asset;
         std::vector<LedgerEntry> live{liveEntry};
         std::vector<LedgerKey> dead{deadEntry};
         std::shared_ptr<Bucket> b1 =
@@ -476,11 +476,11 @@ TEST_CASE("merging bucket entries", "[bucket]")
 
     SECTION("dead offer entry annihilates live offer entry")
     {
-        liveEntry.type(OFFER);
-        liveEntry.offer() = ofGen(10);
+        liveEntry.data.type(OFFER);
+        liveEntry.data.offer() = ofGen(10);
         deadEntry.type(OFFER);
-        deadEntry.offer().sellerID = liveEntry.offer().sellerID;
-        deadEntry.offer().offerID = liveEntry.offer().offerID;
+        deadEntry.offer().sellerID = liveEntry.data.offer().sellerID;
+        deadEntry.offer().offerID = liveEntry.data.offer().offerID;
         std::vector<LedgerEntry> live{liveEntry};
         std::vector<LedgerKey> dead{deadEntry};
         std::shared_ptr<Bucket> b1 =
@@ -900,9 +900,10 @@ TEST_CASE("bucket apply", "[bucket]")
 
     for (auto& e : live)
     {
-        e.type(ACCOUNT);
-        e.account() = accGen(5);
-        e.account().balance = 1000000000;
+        e.data.type(ACCOUNT);
+        auto& a = e.data.account();
+        a = accGen(5);
+        a.balance = 1000000000;
         dead.emplace_back(LedgerEntryKey(e));
     }
 
@@ -940,17 +941,18 @@ TEST_CASE("bucket apply bench", "[bucketbench][hide]")
     std::vector<LedgerEntry> live(100000);
     std::vector<LedgerKey> noDead;
 
-    for (auto& e : live)
+    for (auto& l : live)
     {
-        e.type(ACCOUNT);
-        e.account() = accGen(5);
-        e.account().balance = 1000000000;
-        e.account().inflationDest.reset();
-        e.account().homeDomain.clear();
-        e.account().thresholds[0] = 0;
-        e.account().thresholds[1] = 0;
-        e.account().thresholds[2] = 0;
-        e.account().thresholds[3] = 0;
+        l.data.type(ACCOUNT);
+        auto& a = l.data.account();
+        a = accGen(5);
+        a.balance = 1000000000;
+        a.inflationDest.reset();
+        a.homeDomain.clear();
+        a.thresholds[0] = 0;
+        a.thresholds[1] = 0;
+        a.thresholds[2] = 0;
+        a.thresholds[3] = 0;
     }
 
     std::shared_ptr<Bucket> birth =

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -29,7 +29,8 @@ using xdr::operator<;
 struct LedgerEntryIdCmp
 {
     template <typename T, typename U>
-    bool operator()(T const& a, U const& b) const
+    auto operator()(T const& a, U const& b) const -> decltype(a.type(),
+                                                              b.type(), bool())
     {
         LedgerEntryType aty = a.type();
         LedgerEntryType bty = b.type();
@@ -71,6 +72,19 @@ struct LedgerEntryIdCmp
         }
         }
         return false;
+    }
+
+    template <typename T>
+    bool operator()(T const& a, LedgerEntry const& b) const
+    {
+        return (*this)(a, b.data);
+    }
+
+    template <typename T, typename = typename std::enable_if<
+                              !std::is_same<T, LedgerEntry>::value>::type>
+    bool operator()(LedgerEntry const& a, T const& b) const
+    {
+        return (*this)(a.data, b);
     }
 };
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1280,16 +1280,6 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     mSCP.nominate(slotIndex, mCurrentValue, prevValue);
 }
 
-void
-HerderImpl::expireBallot(uint64 slotIndex, SCPBallot const& ballot)
-
-{
-    mSCPMetrics.mBallotExpire.Mark();
-    assert(slotIndex == nextConsensusLedgerIndex());
-
-    mSCP.abandonBallot(slotIndex);
-}
-
 // Extra SCP methods overridden solely to increment metrics.
 void
 HerderImpl::updatedCandidateValue(uint64 slotIndex, Value const& value)

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -119,7 +119,6 @@ class HerderImpl : public Herder, public SCPDriver
   private:
     void ledgerClosed();
     void removeReceivedTxs(std::vector<TransactionFramePtr> const& txs);
-    void expireBallot(uint64 slotIndex, SCPBallot const& ballot);
 
     // returns true if upgrade is a valid upgrade step
     // in which case it also sets upgradeType

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -17,6 +17,7 @@
 #include "util/Fs.h"
 #include "util/make_unique.h"
 #include "util/Logging.h"
+#include "StellarCoreVersion.h"
 #include <cereal/cereal.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/types/vector.hpp>
@@ -235,7 +236,7 @@ HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
     return ret;
 }
 
-HistoryArchiveState::HistoryArchiveState()
+HistoryArchiveState::HistoryArchiveState() : server(STELLAR_CORE_VERSION)
 {
     uint256 u;
     std::string s = binToHex(u);
@@ -250,7 +251,7 @@ HistoryArchiveState::HistoryArchiveState()
 
 HistoryArchiveState::HistoryArchiveState(uint32_t ledgerSeq,
                                          BucketList& buckets)
-    : currentLedger(ledgerSeq)
+    : server(STELLAR_CORE_VERSION), currentLedger(ledgerSeq)
 {
     for (size_t i = 0; i < BucketList::kNumLevels; ++i)
     {

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -10,7 +10,6 @@
 #include <memory>
 #include "bucket/FutureBucket.h"
 #include "xdr/Stellar-types.h"
-#include "StellarCoreVersion.h"
 
 namespace asio
 {
@@ -57,7 +56,7 @@ struct HistoryArchiveState
     static unsigned const HISTORY_ARCHIVE_STATE_VERSION;
 
     unsigned version{HISTORY_ARCHIVE_STATE_VERSION};
-    std::string server{STELLAR_CORE_VERSION};
+    std::string server;
     uint32_t currentLedger{0};
     std::vector<HistoryStateBucket> currentBuckets;
 
@@ -139,8 +138,6 @@ class HistoryArchive : public std::enable_shared_from_this<HistoryArchive>
     bool hasPutCmd() const;
     bool hasMkdirCmd() const;
     std::string const& getName() const;
-    std::string qualifiedFilename(Application& app,
-                                  std::string const& basename) const;
 
     void getMostRecentState(
         Application& app,

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -340,8 +340,10 @@ AccountFrame::storeDelete(LedgerDelta& delta, Database& db,
 }
 
 void
-AccountFrame::storeUpdate(LedgerDelta& delta, Database& db, bool insert) const
+AccountFrame::storeUpdate(LedgerDelta& delta, Database& db, bool insert)
 {
+    touch(delta);
+
     flushCachedEntry(db);
 
     std::string actIDStrKey = PubKeyUtils::toStrKey(mAccountEntry.accountID);
@@ -543,13 +545,13 @@ AccountFrame::storeUpdate(LedgerDelta& delta, Database& db, bool insert) const
 }
 
 void
-AccountFrame::storeChange(LedgerDelta& delta, Database& db) const
+AccountFrame::storeChange(LedgerDelta& delta, Database& db)
 {
     storeUpdate(delta, db, false);
 }
 
 void
-AccountFrame::storeAdd(LedgerDelta& delta, Database& db) const
+AccountFrame::storeAdd(LedgerDelta& delta, Database& db)
 {
     storeUpdate(delta, db, true);
 }

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -48,14 +48,14 @@ const char* AccountFrame::kSQLCreateStatement4 = "CREATE INDEX accountbalances "
                                                  "balance >= 1000000000";
 
 AccountFrame::AccountFrame()
-    : EntryFrame(ACCOUNT), mAccountEntry(mEntry.account())
+    : EntryFrame(ACCOUNT), mAccountEntry(mEntry.data.account())
 {
     mAccountEntry.thresholds[0] = 1; // by default, master key's weight is 1
     mUpdateSigners = false;
 }
 
 AccountFrame::AccountFrame(LedgerEntry const& from)
-    : EntryFrame(from), mAccountEntry(mEntry.account())
+    : EntryFrame(from), mAccountEntry(mEntry.data.account())
 {
     mUpdateSigners = !mAccountEntry.signers.empty();
 }

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -23,7 +23,7 @@ class LedgerManager;
 
 class AccountFrame : public EntryFrame
 {
-    void storeUpdate(LedgerDelta& delta, Database& db, bool insert) const;
+    void storeUpdate(LedgerDelta& delta, Database& db, bool insert);
     bool mUpdateSigners;
 
     AccountEntry& mAccountEntry;
@@ -103,8 +103,8 @@ class AccountFrame : public EntryFrame
 
     // Instance-based overrides of EntryFrame.
     void storeDelete(LedgerDelta& delta, Database& db) const override;
-    void storeChange(LedgerDelta& delta, Database& db) const override;
-    void storeAdd(LedgerDelta& delta, Database& db) const override;
+    void storeChange(LedgerDelta& delta, Database& db) override;
+    void storeAdd(LedgerDelta& delta, Database& db) override;
 
     // Static helper that don't assume an instance.
     static void storeDelete(LedgerDelta& delta, Database& db,

--- a/src/ledger/EntryFrame.cpp
+++ b/src/ledger/EntryFrame.cpp
@@ -7,6 +7,7 @@
 #include "ledger/AccountFrame.h"
 #include "ledger/OfferFrame.h"
 #include "ledger/TrustFrame.h"
+#include "ledger/LedgerDelta.h"
 #include "xdrpp/printer.h"
 #include "xdrpp/marshal.h"
 #include "crypto/Hex.h"
@@ -63,6 +64,18 @@ EntryFrame::storeLoad(LedgerKey const& key, Database& db)
     break;
     }
     return res;
+}
+
+uint32
+EntryFrame::getLastModified() const
+{
+    return mEntry.lastModifiedLedgerSeq;
+}
+
+uint32&
+EntryFrame::getLastModified()
+{
+    return mEntry.lastModifiedLedgerSeq;
 }
 
 void

--- a/src/ledger/EntryFrame.cpp
+++ b/src/ledger/EntryFrame.cpp
@@ -21,7 +21,7 @@ EntryFrame::FromXDR(LedgerEntry const& from)
 {
     EntryFrame::pointer res;
 
-    switch (from.type())
+    switch (from.data.type())
     {
     case ACCOUNT:
         res = std::make_shared<AccountFrame>(from);
@@ -122,9 +122,9 @@ EntryFrame::checkAgainstDatabase(LedgerEntry const& entry, Database& db)
     }
 }
 
-EntryFrame::EntryFrame(LedgerEntryType type)
-    : mKeyCalculated(false), mEntry(type)
+EntryFrame::EntryFrame(LedgerEntryType type) : mKeyCalculated(false)
 {
+    mEntry.data.type(type);
 }
 
 EntryFrame::EntryFrame(LedgerEntry const& from)
@@ -192,25 +192,26 @@ EntryFrame::storeDelete(LedgerDelta& delta, Database& db, LedgerKey const& key)
 LedgerKey
 LedgerEntryKey(LedgerEntry const& e)
 {
+    auto& d = e.data;
     LedgerKey k;
-    switch (e.type())
+    switch (d.type())
     {
 
     case ACCOUNT:
         k.type(ACCOUNT);
-        k.account().accountID = e.account().accountID;
+        k.account().accountID = d.account().accountID;
         break;
 
     case TRUSTLINE:
         k.type(TRUSTLINE);
-        k.trustLine().accountID = e.trustLine().accountID;
-        k.trustLine().asset = e.trustLine().asset;
+        k.trustLine().accountID = d.trustLine().accountID;
+        k.trustLine().asset = d.trustLine().asset;
         break;
 
     case OFFER:
         k.type(OFFER);
-        k.offer().sellerID = e.offer().sellerID;
-        k.offer().offerID = e.offer().offerID;
+        k.offer().sellerID = d.offer().sellerID;
+        k.offer().offerID = d.offer().offerID;
         break;
     }
     return k;

--- a/src/ledger/EntryFrame.cpp
+++ b/src/ledger/EntryFrame.cpp
@@ -79,6 +79,23 @@ EntryFrame::getLastModified()
 }
 
 void
+EntryFrame::touch(uint32 ledgerSeq)
+{
+    getLastModified() = ledgerSeq;
+}
+
+void
+EntryFrame::touch(LedgerDelta const& delta)
+{
+    uint32 ledgerSeq = delta.getHeader().ledgerSeq;
+    // if we're tracking a valid header, mark the entry as modified by it
+    if (ledgerSeq != 0)
+    {
+        touch(ledgerSeq);
+    }
+}
+
+void
 EntryFrame::flushCachedEntry(LedgerKey const& key, Database& db)
 {
     auto s = binToHex(xdr::xdr_to_opaque(key));
@@ -157,7 +174,7 @@ EntryFrame::getKey() const
 }
 
 void
-EntryFrame::storeAddOrChange(LedgerDelta& delta, Database& db) const
+EntryFrame::storeAddOrChange(LedgerDelta& delta, Database& db)
 {
     if (exists(db, getKey()))
     {

--- a/src/ledger/EntryFrame.h
+++ b/src/ledger/EntryFrame.h
@@ -54,6 +54,12 @@ class EntryFrame : public NonMovableOrCopyable
     // helpers to get/set the last modified field
     uint32 getLastModified() const;
     uint32& getLastModified();
+    void touch(uint32 ledgerSeq);
+
+    // touch the entry if the delta is tracking a ledger header with
+    // a sequence that is not 0 (0 is used when importing buckets)
+    void touch(LedgerDelta const& delta);
+
     // Member helpers that call cache flush/put for self.
     void flushCachedEntry(Database& db) const;
     void putCachedEntry(Database& db) const;
@@ -64,10 +70,11 @@ class EntryFrame : public NonMovableOrCopyable
 
     LedgerKey const& getKey() const;
     virtual void storeDelete(LedgerDelta& delta, Database& db) const = 0;
-    virtual void storeChange(LedgerDelta& delta, Database& db) const = 0;
-    virtual void storeAdd(LedgerDelta& delta, Database& db) const = 0;
+    // change/add may update the entry (last modified)
+    virtual void storeChange(LedgerDelta& delta, Database& db) = 0;
+    virtual void storeAdd(LedgerDelta& delta, Database& db) = 0;
 
-    void storeAddOrChange(LedgerDelta& delta, Database& db) const;
+    void storeAddOrChange(LedgerDelta& delta, Database& db);
     static bool exists(Database& db, LedgerKey const& key);
     static void storeDelete(LedgerDelta& delta, Database& db,
                             LedgerKey const& key);

--- a/src/ledger/EntryFrame.h
+++ b/src/ledger/EntryFrame.h
@@ -51,6 +51,9 @@ class EntryFrame : public NonMovableOrCopyable
                                std::shared_ptr<LedgerEntry const> p,
                                Database& db);
 
+    // helpers to get/set the last modified field
+    uint32 getLastModified() const;
+    uint32& getLastModified();
     // Member helpers that call cache flush/put for self.
     void flushCachedEntry(Database& db) const;
     void putCachedEntry(Database& db) const;

--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -46,6 +46,12 @@ LedgerDelta::getHeader()
     return mCurrentHeader.mHeader;
 }
 
+LedgerHeader const&
+LedgerDelta::getHeader() const
+{
+    return mCurrentHeader.mHeader;
+}
+
 LedgerHeaderFrame&
 LedgerDelta::getHeaderFrame()
 {

--- a/src/ledger/LedgerDelta.h
+++ b/src/ledger/LedgerDelta.h
@@ -57,6 +57,7 @@ class LedgerDelta
     ~LedgerDelta();
 
     LedgerHeader& getHeader();
+    LedgerHeader const& getHeader() const;
     LedgerHeaderFrame& getHeaderFrame();
 
     // methods to register changes in the ledger entries

--- a/src/ledger/LedgerTests.cpp
+++ b/src/ledger/LedgerTests.cpp
@@ -40,41 +40,43 @@ clampHigh(T high, T& v)
 auto validLedgerEntryGenerator = autocheck::map(
     [](LedgerEntry&& le, size_t s)
     {
-        switch (le.type())
+        auto& led = le.data;
+        switch (led.type())
         {
         case TRUSTLINE:
         {
-            le.trustLine().asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
-            strToAssetCode(le.trustLine().asset.alphaNum4().assetCode, "USD");
-            clampLow<int64_t>(0, le.trustLine().balance);
-            clampLow<int64_t>(0, le.trustLine().limit);
-            clampHigh<int64_t>(le.trustLine().limit, le.trustLine().balance);
+            led.trustLine().asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+            strToAssetCode(led.trustLine().asset.alphaNum4().assetCode, "USD");
+            clampLow<int64_t>(0, led.trustLine().balance);
+            clampLow<int64_t>(0, led.trustLine().limit);
+            clampHigh<int64_t>(led.trustLine().limit, led.trustLine().balance);
         }
         break;
 
         case OFFER:
         {
-            le.offer().selling.type(ASSET_TYPE_CREDIT_ALPHANUM4);
-            strToAssetCode(le.offer().selling.alphaNum4().assetCode, "CAD");
+            led.offer().selling.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+            strToAssetCode(led.offer().selling.alphaNum4().assetCode, "CAD");
 
-            le.offer().buying.type(ASSET_TYPE_CREDIT_ALPHANUM4);
-            strToAssetCode(le.offer().buying.alphaNum4().assetCode, "EUR");
+            led.offer().buying.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+            strToAssetCode(led.offer().buying.alphaNum4().assetCode, "EUR");
 
-            clampLow<int64_t>(0, le.offer().amount);
-            clampLow(0, le.offer().price.n);
-            clampLow(1, le.offer().price.d);
+            clampLow<int64_t>(0, led.offer().amount);
+            clampLow(0, led.offer().price.n);
+            clampLow(1, led.offer().price.d);
         }
         break;
 
         case ACCOUNT:
         {
-            clampLow<int64_t>(0, le.account().balance);
-            le.account().inflationDest.reset();
-            le.account().homeDomain.clear();
-            le.account().thresholds[0] = 0;
-            le.account().thresholds[1] = 0;
-            le.account().thresholds[2] = 0;
-            le.account().thresholds[3] = 0;
+            auto& a = led.account();
+            clampLow<int64_t>(0, a.balance);
+            a.inflationDest.reset();
+            a.homeDomain.clear();
+            a.thresholds[0] = 0;
+            a.thresholds[1] = 0;
+            a.thresholds[2] = 0;
+            a.thresholds[3] = 0;
             break;
         }
         }
@@ -151,7 +153,7 @@ TEST_CASE("DB cache interaction with transactions", "[ledger][dbcache]")
     do
     {
         le = EntryFrame::FromXDR(validLedgerEntryGenerator(3));
-    } while (le->mEntry.type() != ACCOUNT);
+    } while (le->mEntry.data.type() != ACCOUNT);
 
     auto key = le->getKey();
 

--- a/src/ledger/OfferFrame.cpp
+++ b/src/ledger/OfferFrame.cpp
@@ -48,12 +48,12 @@ static const char* offerColumnSelector =
     "buyingassettype,buyingassetcode,buyingissuer,amount,pricen,priced,flags "
     "FROM offers";
 
-OfferFrame::OfferFrame() : EntryFrame(OFFER), mOffer(mEntry.offer())
+OfferFrame::OfferFrame() : EntryFrame(OFFER), mOffer(mEntry.data.offer())
 {
 }
 
 OfferFrame::OfferFrame(LedgerEntry const& from)
-    : EntryFrame(from), mOffer(mEntry.offer())
+    : EntryFrame(from), mOffer(mEntry.data.offer())
 {
 }
 
@@ -76,7 +76,7 @@ OfferFrame::pointer
 OfferFrame::from(AccountID const& account, ManageOfferOp const& op)
 {
     OfferFrame::pointer res = make_shared<OfferFrame>();
-    OfferEntry& o = res->mEntry.offer();
+    OfferEntry& o = res->mEntry.data.offer();
     o.sellerID = account;
     o.amount = op.amount;
     o.price = op.price;
@@ -164,8 +164,8 @@ OfferFrame::loadOffers(StatementContext& prep,
         sellingIssuerIndicator, buyingIssuerIndicator;
 
     LedgerEntry le;
-    le.type(OFFER);
-    OfferEntry& oe = le.offer();
+    le.data.type(OFFER);
+    OfferEntry& oe = le.data.offer();
 
     statement& st = prep.statement();
     st.exchange(into(actIDStrKey));

--- a/src/ledger/OfferFrame.cpp
+++ b/src/ledger/OfferFrame.cpp
@@ -413,8 +413,10 @@ OfferFrame::computePrice() const
 }
 
 void
-OfferFrame::storeChange(LedgerDelta& delta, Database& db) const
+OfferFrame::storeChange(LedgerDelta& delta, Database& db)
 {
+    touch(delta);
+
     auto timer = db.getUpdateTimer("offer");
     auto prep =
         db.getPreparedStatement("UPDATE offers SET amount=:a, pricen=:n, "
@@ -441,8 +443,10 @@ OfferFrame::storeChange(LedgerDelta& delta, Database& db) const
 }
 
 void
-OfferFrame::storeAdd(LedgerDelta& delta, Database& db) const
+OfferFrame::storeAdd(LedgerDelta& delta, Database& db)
 {
+    touch(delta);
+
     std::string actIDStrKey = PubKeyUtils::toStrKey(mOffer.sellerID);
     auto timer = db.getInsertTimer("offer");
 

--- a/src/ledger/OfferFrame.h
+++ b/src/ledger/OfferFrame.h
@@ -73,8 +73,8 @@ class OfferFrame : public EntryFrame
 
     // Instance-based overrides of EntryFrame.
     void storeDelete(LedgerDelta& delta, Database& db) const override;
-    void storeChange(LedgerDelta& delta, Database& db) const override;
-    void storeAdd(LedgerDelta& delta, Database& db) const override;
+    void storeChange(LedgerDelta& delta, Database& db) override;
+    void storeAdd(LedgerDelta& delta, Database& db) override;
 
     // Static helpers that don't assume an instance.
     static void storeDelete(LedgerDelta& delta, Database& db,

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -34,12 +34,14 @@ const char* TrustFrame::kSQLCreateStatement2 =
     "CREATE INDEX accountlines ON trustlines (accountid);";
 
 TrustFrame::TrustFrame()
-    : EntryFrame(TRUSTLINE), mTrustLine(mEntry.trustLine()), mIsIssuer(false)
+    : EntryFrame(TRUSTLINE)
+    , mTrustLine(mEntry.data.trustLine())
+    , mIsIssuer(false)
 {
 }
 
 TrustFrame::TrustFrame(LedgerEntry const& from)
-    : EntryFrame(from), mTrustLine(mEntry.trustLine()), mIsIssuer(false)
+    : EntryFrame(from), mTrustLine(mEntry.data.trustLine()), mIsIssuer(false)
 {
     assert(isValid());
 }
@@ -305,7 +307,7 @@ TrustFrame::createIssuerFrame(Asset const& issuer)
 {
     pointer res = make_shared<TrustFrame>();
     res->mIsIssuer = true;
-    TrustLineEntry& tl = res->mEntry.trustLine();
+    TrustLineEntry& tl = res->mEntry.data.trustLine();
 
     if (issuer.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
     {
@@ -427,9 +429,9 @@ TrustFrame::loadLines(StatementContext& prep,
     unsigned int assetType;
 
     LedgerEntry le;
-    le.type(TRUSTLINE);
+    le.data.type(TRUSTLINE);
 
-    TrustLineEntry& tl = le.trustLine();
+    TrustLineEntry& tl = le.data.trustLine();
 
     auto& st = prep.statement();
     st.exchange(into(actIDStrKey));

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -221,7 +221,7 @@ TrustFrame::storeDelete(LedgerDelta& delta, Database& db, LedgerKey const& key)
 }
 
 void
-TrustFrame::storeChange(LedgerDelta& delta, Database& db) const
+TrustFrame::storeChange(LedgerDelta& delta, Database& db)
 {
     assert(isValid());
 
@@ -230,6 +230,8 @@ TrustFrame::storeChange(LedgerDelta& delta, Database& db) const
 
     if (mIsIssuer)
         return;
+
+    touch(delta);
 
     std::string actIDStrKey, issuerStrKey, assetCode;
     getKeyFields(key, actIDStrKey, issuerStrKey, assetCode);
@@ -260,7 +262,7 @@ TrustFrame::storeChange(LedgerDelta& delta, Database& db) const
 }
 
 void
-TrustFrame::storeAdd(LedgerDelta& delta, Database& db) const
+TrustFrame::storeAdd(LedgerDelta& delta, Database& db)
 {
     assert(isValid());
 
@@ -269,6 +271,8 @@ TrustFrame::storeAdd(LedgerDelta& delta, Database& db) const
 
     if (mIsIssuer)
         return;
+
+    touch(delta);
 
     std::string actIDStrKey, issuerStrKey, assetCode;
     unsigned int assetType = getKey().trustLine().asset.type();

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -55,8 +55,8 @@ class TrustFrame : public EntryFrame
 
     // Instance-based overrides of EntryFrame.
     void storeDelete(LedgerDelta& delta, Database& db) const override;
-    void storeChange(LedgerDelta& delta, Database& db) const override;
-    void storeAdd(LedgerDelta& delta, Database& db) const override;
+    void storeChange(LedgerDelta& delta, Database& db) override;
+    void storeAdd(LedgerDelta& delta, Database& db) override;
 
     // Static helper that don't assume an instance.
     static void storeDelete(LedgerDelta& delta, Database& db,

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -143,7 +143,7 @@ ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
         creatingNewOffer = true;
         mSellSheepOffer = OfferFrame::from(getSourceID(), mManageOffer);
         if (mPassive)
-            mSellSheepOffer->mEntry.offer().flags = PASSIVE_FLAG;
+            mSellSheepOffer->mEntry.data.offer().flags = PASSIVE_FLAG;
     }
 
     int64_t maxSheepSend = mManageOffer.amount;
@@ -314,7 +314,7 @@ ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
                     innerResult().code(MANAGE_OFFER_LOW_RESERVE);
                     return false;
                 }
-                mSellSheepOffer->mEntry.offer().offerID =
+                mSellSheepOffer->mEntry.data.offer().offerID =
                     tempDelta.getHeaderFrame().generateID();
                 innerResult().success().offer.effect(MANAGE_OFFER_CREATED);
                 mSellSheepOffer->storeAdd(tempDelta, db);

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -84,12 +84,14 @@ MergeOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
         l->storeDelete(delta, db);
     }
 
-    otherAccount->getAccount().balance += mSourceAccount->getAccount().balance;
+    int64 sourceBalance = mSourceAccount->getAccount().balance;
+    otherAccount->getAccount().balance += sourceBalance;
     otherAccount->storeChange(delta, db);
     mSourceAccount->storeDelete(delta, db);
 
     metrics.NewMeter({"op-merge", "success", "apply"}, "operation").Mark();
     innerResult().code(ACCOUNT_MERGE_SUCCESS);
+    innerResult().sourceAccountBalance() = sourceBalance;
     return true;
 }
 

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -396,6 +396,26 @@ TEST_CASE("payment", "[tx][payment]")
             checkAmounts(line->getBalance(),
                          trustLineStartingBalance - 200 * assetMultiplier);
         }
+
+        SECTION("send with path (takes own offer)")
+        {
+            // raise A1's balance by what we're trying to send
+            applyPaymentTx(app, root, a1, rootSeq++, 100 * assetMultiplier);
+
+            // offer is sell 100 USD for 100 XLM
+            applyCreateOffer(app, delta, 0, a1, usdCur, xlmCur, Price(1, 1),
+                                 100 * assetMultiplier, a1Seq++);
+
+            // A1: try to send 100 USD to B1 using XLM
+
+            std::vector<Asset> path;
+            path.push_back(xlmCur);
+
+            applyPathPaymentTx(app, a1, b1, xlmCur, 100 * assetMultiplier,
+                               usdCur, 100 * assetMultiplier, a1Seq++,
+                               PATH_PAYMENT_OFFER_CROSS_SELF);
+        }
+
         SECTION("send with path (offer participant reaching limit)")
         {
             // make it such that C can only receive 120 USD (4/5th of offerC)

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -379,8 +379,8 @@ TEST_CASE("payment", "[tx][payment]")
             REQUIRE(b1Res.offerID == offerB1);
             offer = loadOffer(b1, offerB1, app);
             OfferEntry const& oe = offer->getOffer();
-            REQUIRE(b1Res.offerOwner == b1.getPublicKey());
-            checkAmounts(b1Res.amountClaimed, 25 * assetMultiplier);
+            REQUIRE(b1Res.sellerID == b1.getPublicKey());
+            checkAmounts(b1Res.amountSold, 25 * assetMultiplier);
             checkAmounts(oe.amount, 75 * assetMultiplier);
             line = loadTrustLine(b1, idrCur, app);
             // 125 where sent, 25 were consumed by B's offer
@@ -434,8 +434,8 @@ TEST_CASE("payment", "[tx][payment]")
             REQUIRE(b1Res.offerID == offerB1);
             offer = loadOffer(b1, offerB1, app);
             OfferEntry const& oe = offer->getOffer();
-            REQUIRE(b1Res.offerOwner == b1.getPublicKey());
-            checkAmounts(b1Res.amountClaimed, 25 * assetMultiplier);
+            REQUIRE(b1Res.sellerID == b1.getPublicKey());
+            checkAmounts(b1Res.amountSold, 25 * assetMultiplier);
             checkAmounts(oe.amount, 75 * assetMultiplier);
             line = loadTrustLine(b1, idrCur, app);
             // 105 where sent, 25 were consumed by B's offer

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -650,12 +650,12 @@ TransactionFrame::dropAll(Database& db)
     db.getSession() << "DROP TABLE IF EXISTS txhistory";
 
     db.getSession() << "CREATE TABLE txhistory ("
-                       "txid          CHARACTER(64) NOT NULL,"
-                       "ledgerseq     INT NOT NULL CHECK (ledgerseq >= 0),"
-                       "txindex         INT NOT NULL,"
-                       "txbody        TEXT NOT NULL,"
-                       "txresult      TEXT NOT NULL,"
-                       "txmeta        TEXT NOT NULL,"
+                       "txid        CHARACTER(64) NOT NULL,"
+                       "ledgerseq   INT NOT NULL CHECK (ledgerseq >= 0),"
+                       "txindex     INT NOT NULL,"
+                       "txbody      TEXT NOT NULL,"
+                       "txresult    TEXT NOT NULL,"
+                       "txmeta      TEXT NOT NULL,"
                        "PRIMARY KEY (txid, ledgerseq),"
                        "UNIQUE      (ledgerseq, txindex)"
                        ")";

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -69,16 +69,17 @@ applyCheck(TransactionFramePtr tx, LedgerDelta& delta, Application& app)
 void
 checkEntry(LedgerEntry const& le, Application& app)
 {
-    switch (le.type())
+    auto& d = le.data;
+    switch (d.type())
     {
     case ACCOUNT:
-        checkAccount(le.account().accountID, app);
+        checkAccount(d.account().accountID, app);
         break;
     case TRUSTLINE:
-        checkAccount(le.trustLine().accountID, app);
+        checkAccount(d.trustLine().accountID, app);
         break;
     case OFFER:
-        checkAccount(le.offer().sellerID, app);
+        checkAccount(d.offer().sellerID, app);
     default:
         break;
     }

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -98,7 +98,7 @@ struct AccountEntry
     SequenceNumber seqNum;    // last sequence number used for this account
     uint32 numSubEntries;     // number of sub-entries this account has
                               // drives the reserve
-    AccountID* inflationDest; // Account to vote during inflation
+    AccountID* inflationDest; // Account to vote for during inflation
     uint32 flags;             // see AccountFlags
 
     string32 homeDomain; // can be used for reverse federation and memo lookup

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -187,14 +187,20 @@ struct OfferEntry
     ext;
 };
 
-union LedgerEntry switch (LedgerEntryType type)
+struct LedgerEntry
 {
-case ACCOUNT:
-    AccountEntry account;
-case TRUSTLINE:
-    TrustLineEntry trustLine;
-case OFFER:
-    OfferEntry offer;
+    uint32 lastModifiedLedgerSeq; // ledger the LedgerEntry was last changed
+
+    union switch (LedgerEntryType type)
+    {
+    case ACCOUNT:
+        AccountEntry account;
+    case TRUSTLINE:
+        TrustLineEntry trustLine;
+    case OFFER:
+        OfferEntry offer;
+    }
+    data;
 };
 
 // list of all envelope types used in the application

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -201,6 +201,14 @@ struct LedgerEntry
         OfferEntry offer;
     }
     data;
+
+    // reserved for future use
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
 };
 
 // list of all envelope types used in the application

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -316,16 +316,16 @@ struct TransactionEnvelope
 struct ClaimOfferAtom
 {
     // emited to identify the offer
-    AccountID offerOwner; // Account that owns the offer
+    AccountID sellerID; // Account that owns the offer
     uint64 offerID;
 
     // amount and asset taken from the owner
-    Asset assetClaimed;
-    int64 amountClaimed;
+    Asset assetSold;
+    int64 amountSold;
 
-    // amount and assetsent to the owner
-    Asset assetSend;
-    int64 amountSend;
+    // amount and asset sent to the owner
+    Asset assetBought;
+    int64 amountBought;
 };
 
 /******* CreateAccount Result ********/

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -556,7 +556,7 @@ enum AccountMergeResultCode
 union AccountMergeResult switch (AccountMergeResultCode code)
 {
 case ACCOUNT_MERGE_SUCCESS:
-    void;
+    int64 sourceAccountBalance; // how much got transfered from source account
 default:
     void;
 };

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -394,7 +394,8 @@ enum PathPaymentResultCode
     PATH_PAYMENT_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
     PATH_PAYMENT_LINE_FULL = -8,          // dest would go above their limit
     PATH_PAYMENT_TOO_FEW_OFFERS = -9,     // not enough offers to satisfy path
-    PATH_PAYMENT_OVER_SENDMAX = -10       // could not satisfy sendmax
+    PATH_PAYMENT_OFFER_CROSS_SELF = -10,  // would cross one of its own offers
+    PATH_PAYMENT_OVER_SENDMAX = -11       // could not satisfy sendmax
 };
 
 struct SimplePaymentResult


### PR DESCRIPTION
## Protocol changes
 * claimOfferAtom is now consistent with Offers - resolves #716
 * add last modified to ledger entries - resolves #713
 * include balance transferred in result when merging accounts - resolves #710

I did not write those protocol changes as a rev to the protocol as we didn't launch yet (and I'd like to avoid quirks in the code for v1); therefore this will require a reset of history and will break client code.

## Bug fixes
 * don't allow to cross own offers in path payment - resolves #720

## Cleanup
 * removed dead code - resolves #682
 * don't include "StellarCoreVersion.h" in headers to avoid unnecessary churn when rebuilding
