### PR TITLE
Configurable passphrase

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -60,7 +60,10 @@ COMMANDS=[
 "ll?level=info&partition=Herder"
 ]
 
+###########################
+## Configure which network this instance should talk to
 
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 
 ###########################
 ## Overlay configuration

--- a/docs/stellar-core_standalone.cfg
+++ b/docs/stellar-core_standalone.cfg
@@ -5,6 +5,8 @@ HTTP_PORT=8080
 PUBLIC_HTTP_PORT=false
 RUN_STANDALONE=true
 
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
 VALIDATION_SEED="SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2"
 
 #DATABASE="postgresql://dbname=stellar user=postgres password=password host=localhost"

--- a/docs/stellar-core_testnet.cfg
+++ b/docs/stellar-core_testnet.cfg
@@ -1,6 +1,8 @@
 HTTP_PORT=11626
 PUBLIC_HTTP_PORT=false
 
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+
 KNOWN_PEERS=[
 "core-testnet1.stellar.org",
 "core-testnet2.stellar.org",

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -329,8 +329,8 @@ void
 HerderImpl::signEnvelope(SCPEnvelope& envelope)
 {
     mSCPMetrics.mEnvelopeSign.Mark();
-    envelope.signature = mSCP.getSecretKey().sign(
-        xdr::xdr_to_opaque(ENVELOPE_TYPE_SCP, envelope.statement));
+    envelope.signature = mSCP.getSecretKey().sign(xdr::xdr_to_opaque(
+        mApp.getNetworkID(), ENVELOPE_TYPE_SCP, envelope.statement));
 }
 
 bool
@@ -338,7 +338,8 @@ HerderImpl::verifyEnvelope(SCPEnvelope const& envelope)
 {
     bool b = PubKeyUtils::verifySig(
         envelope.statement.nodeID, envelope.signature,
-        xdr::xdr_to_opaque(ENVELOPE_TYPE_SCP, envelope.statement));
+        xdr::xdr_to_opaque(mApp.getNetworkID(), ENVELOPE_TYPE_SCP,
+                           envelope.statement));
     if (b)
     {
         mSCPMetrics.mEnvelopeValidSig.Mark();

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -71,10 +71,10 @@ TEST_CASE("standalone", "[herder]")
         auto setup = [&](asio::error_code const& error)
         {
             // create accounts
-            TransactionFramePtr txFrameA1 =
-                createCreateAccountTx(root, a1, rootSeq++, paymentAmount);
-            TransactionFramePtr txFrameA2 =
-                createCreateAccountTx(root, b1, rootSeq++, paymentAmount);
+            TransactionFramePtr txFrameA1 = createCreateAccountTx(
+                networkID, root, a1, rootSeq++, paymentAmount);
+            TransactionFramePtr txFrameA2 = createCreateAccountTx(
+                networkID, root, b1, rootSeq++, paymentAmount);
 
             REQUIRE(app->getHerder().recvTransaction(txFrameA1) ==
                     Herder::TX_STATUS_PENDING);
@@ -155,13 +155,15 @@ TEST_CASE("txset", "[herder]")
         {
             if (j == 0)
             {
-                transactions[i].emplace_back(createCreateAccountTx(
-                    sourceAccount, accounts[i], sourceSeq++, paymentAmount));
+                transactions[i].emplace_back(
+                    createCreateAccountTx(networkID, sourceAccount, accounts[i],
+                                          sourceSeq++, paymentAmount));
             }
             else
             {
-                transactions[i].emplace_back(createPaymentTx(
-                    sourceAccount, accounts[i], sourceSeq++, paymentAmount));
+                transactions[i].emplace_back(
+                    createPaymentTx(networkID, sourceAccount, accounts[i],
+                                    sourceSeq++, paymentAmount));
             }
         }
     }
@@ -203,7 +205,8 @@ TEST_CASE("txset", "[herder]")
     {
         SECTION("no user")
         {
-            txSet->add(createPaymentTx(accounts[0], root, 1, paymentAmount));
+            txSet->add(createPaymentTx(networkID, accounts[0], root, 1,
+                                       paymentAmount));
             txSet->sortForHash();
             REQUIRE(!txSet->checkValid(*app));
 
@@ -215,8 +218,9 @@ TEST_CASE("txset", "[herder]")
         {
             SECTION("gap after")
             {
-                txSet->add(createPaymentTx(sourceAccount, accounts[0],
-                                           sourceSeq + 5, paymentAmount));
+                txSet->add(createPaymentTx(networkID, sourceAccount,
+                                           accounts[0], sourceSeq + 5,
+                                           paymentAmount));
                 txSet->sortForHash();
                 REQUIRE(!txSet->checkValid(*app));
 
@@ -248,8 +252,8 @@ TEST_CASE("txset", "[herder]")
         SECTION("insuficient balance")
         {
             // extra transaction would push the account below the reserve
-            txSet->add(createPaymentTx(sourceAccount, accounts[0], sourceSeq++,
-                                       paymentAmount));
+            txSet->add(createPaymentTx(networkID, sourceAccount, accounts[0],
+                                       sourceSeq++, paymentAmount));
             txSet->sortForHash();
             REQUIRE(!txSet->checkValid(*app));
 
@@ -306,7 +310,8 @@ TEST_CASE("surge", "[herder]")
         // extra transaction would push the account below the reserve
         for (int n = 0; n < 10; n++)
         {
-            txSet->add(createPaymentTx(root, destAccount, rootSeq++, n + 10));
+            txSet->add(createPaymentTx(networkID, root, destAccount, rootSeq++,
+                                       n + 10));
         }
         txSet->sortForHash();
         txSet->surgePricingFilter(*app);
@@ -319,7 +324,8 @@ TEST_CASE("surge", "[herder]")
         // extra transaction would push the account below the reserve
         for (int n = 0; n < 10; n++)
         {
-            txSet->add(createPaymentTx(root, destAccount, rootSeq++, n + 10));
+            txSet->add(createPaymentTx(networkID, root, destAccount, rootSeq++,
+                                       n + 10));
         }
         random_shuffle(txSet->mTransactions.begin(),
                        txSet->mTransactions.end());
@@ -334,9 +340,10 @@ TEST_CASE("surge", "[herder]")
         // extra transaction would push the account below the reserve
         for (int n = 0; n < 10; n++)
         {
-            txSet->add(createPaymentTx(root, destAccount, rootSeq++, n + 10));
-            auto tx =
-                createPaymentTx(accountB, destAccount, accountBSeq++, n + 10);
+            txSet->add(createPaymentTx(networkID, root, destAccount, rootSeq++,
+                                       n + 10));
+            auto tx = createPaymentTx(networkID, accountB, destAccount,
+                                      accountBSeq++, n + 10);
             tx->getEnvelope().tx.fee = tx->getEnvelope().tx.fee * 2;
             txSet->add(tx);
         }
@@ -354,11 +361,13 @@ TEST_CASE("surge", "[herder]")
         // extra transaction would push the account below the reserve
         for (int n = 0; n < 10; n++)
         {
-            auto tx = createPaymentTx(root, destAccount, rootSeq++, n + 10);
+            auto tx = createPaymentTx(networkID, root, destAccount, rootSeq++,
+                                      n + 10);
             tx->getEnvelope().tx.fee = tx->getEnvelope().tx.fee * 2;
             txSet->add(tx);
 
-            tx = createPaymentTx(accountB, destAccount, accountBSeq++, n + 10);
+            tx = createPaymentTx(networkID, accountB, destAccount,
+                                 accountBSeq++, n + 10);
             if (n != 1)
                 tx->getEnvelope().tx.fee = tx->getEnvelope().tx.fee * 3;
             txSet->add(tx);
@@ -378,11 +387,13 @@ TEST_CASE("surge", "[herder]")
         // extra transaction would push the account below the reserve
         for (int n = 0; n < 10; n++)
         {
-            auto tx = createPaymentTx(root, destAccount, rootSeq++, n + 10);
+            auto tx = createPaymentTx(networkID, root, destAccount, rootSeq++,
+                                      n + 10);
             tx->getEnvelope().tx.fee = tx->getEnvelope().tx.fee * 2;
             txSet->add(tx);
 
-            tx = createPaymentTx(accountB, destAccount, accountBSeq++, n + 10);
+            tx = createPaymentTx(networkID, accountB, destAccount,
+                                 accountBSeq++, n + 10);
             if (n != 1)
                 tx->getEnvelope().tx.fee = tx->getEnvelope().tx.fee * 3;
             txSet->add(tx);
@@ -402,11 +413,12 @@ TEST_CASE("surge", "[herder]")
         // extra transaction would push the account below the reserve
         for (int n = 0; n < 30; n++)
         {
-            txSet->add(createPaymentTx(root, destAccount, rootSeq++, n + 10));
-            txSet->add(
-                createPaymentTx(accountB, destAccount, accountBSeq++, n + 10));
-            txSet->add(
-                createPaymentTx(accountC, destAccount, accountCSeq++, n + 10));
+            txSet->add(createPaymentTx(networkID, root, destAccount, rootSeq++,
+                                       n + 10));
+            txSet->add(createPaymentTx(networkID, accountB, destAccount,
+                                       accountBSeq++, n + 10));
+            txSet->add(createPaymentTx(networkID, accountC, destAccount,
+                                       accountCSeq++, n + 10));
         }
         txSet->sortForHash();
         txSet->surgePricingFilter(*app);

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -35,10 +35,12 @@ TEST_CASE("standalone", "[herder]")
     VirtualClock clock;
     Application::pointer app = Application::create(clock, cfg);
 
+    Hash const& networkID = app->getNetworkID();
+
     app->start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(networkID);
     SecretKey a1 = getAccount("A");
     SecretKey b1 = getAccount("B");
 
@@ -112,10 +114,12 @@ TEST_CASE("txset", "[herder]")
     VirtualClock clock;
     Application::pointer app = Application::create(clock, cfg);
 
+    Hash const& networkID = app->getNetworkID();
+
     app->start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(networkID);
 
     const int nbAccounts = 2;
     const int nbTransactions = 5;
@@ -269,10 +273,12 @@ TEST_CASE("surge", "[herder]")
     VirtualClock clock;
     Application::pointer app = Application::create(clock, cfg);
 
+    Hash const& networkID = app->getNetworkID();
+
     app->start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(networkID);
 
     AccountFrame::pointer rootAccount;
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -27,12 +27,13 @@ TxSetFrame::TxSetFrame(Hash const& previousLedgerHash)
 {
 }
 
-TxSetFrame::TxSetFrame(TransactionSet const& xdrSet) : mHashIsValid(false)
+TxSetFrame::TxSetFrame(Hash const& networkID, TransactionSet const& xdrSet)
+    : mHashIsValid(false)
 {
     for (auto const& txEnvelope : xdrSet.txs)
     {
         TransactionFramePtr tx =
-            TransactionFrame::makeTransactionFromWire(txEnvelope);
+            TransactionFrame::makeTransactionFromWire(networkID, txEnvelope);
         mTransactions.push_back(tx);
     }
     mPreviousLedgerHash = xdrSet.previousLedgerHash;

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -26,7 +26,7 @@ class TxSetFrame
 
     TxSetFrame(Hash const& previousLedgerHash);
     // make it from the wire
-    TxSetFrame(TransactionSet const& xdrSet);
+    TxSetFrame(Hash const& networkID, TransactionSet const& xdrSet);
 
     // returns the hash of this tx set
     Hash getContentsHash();

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -1079,7 +1079,8 @@ CatchupStateMachine::applyHistoryOfSingleCheckpoint(uint32_t checkpoint)
         {
             CLOG(DEBUG, "History") << "Preparing tx for ledger "
                                    << txHistoryEntry.ledgerSeq;
-            txset = std::make_shared<TxSetFrame>(txHistoryEntry.txSet);
+            txset = std::make_shared<TxSetFrame>(mApp.getNetworkID(),
+                                                 txHistoryEntry.txSet);
             readTxSet = txIn.readOne(txHistoryEntry);
         }
         CLOG(DEBUG, "History") << "Ledger " << header.ledgerSeq << " has "

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -274,13 +274,15 @@ HistoryTests::generateRandomLedger()
 
     SequenceNumber rseq = txtest::getAccountSeqNum(mRoot, app) + 1;
 
+    Hash const& networkID = app.getNetworkID();
+
     // Root sends to alice every tx, bob every other tx, carol every 4rd tx.
-    txSet->add(txtest::createCreateAccountTx(mRoot, mAlice, rseq++, big));
-    txSet->add(txtest::createCreateAccountTx(mRoot, mBob, rseq++, big));
-    txSet->add(txtest::createCreateAccountTx(mRoot, mCarol, rseq++, big));
-    txSet->add(txtest::createPaymentTx(mRoot, mAlice, rseq++, big));
-    txSet->add(txtest::createPaymentTx(mRoot, mBob, rseq++, big));
-    txSet->add(txtest::createPaymentTx(mRoot, mCarol, rseq++, big));
+    txSet->add(txtest::createCreateAccountTx(networkID, mRoot, mAlice, rseq++, big));
+    txSet->add(txtest::createCreateAccountTx(networkID, mRoot, mBob, rseq++, big));
+    txSet->add(txtest::createCreateAccountTx(networkID, mRoot, mCarol, rseq++, big));
+    txSet->add(txtest::createPaymentTx(networkID, mRoot, mAlice, rseq++, big));
+    txSet->add(txtest::createPaymentTx(networkID, mRoot, mBob, rseq++, big));
+    txSet->add(txtest::createPaymentTx(networkID, mRoot, mCarol, rseq++, big));
 
     // They all randomly send a little to one another every ledger after #4
     if (ledgerSeq > 4)
@@ -290,19 +292,25 @@ HistoryTests::generateRandomLedger()
         SequenceNumber cseq = txtest::getAccountSeqNum(mCarol, app) + 1;
 
         if (flip())
-            txSet->add(txtest::createPaymentTx(mAlice, mBob, aseq++, small));
+            txSet->add(
+                txtest::createPaymentTx(networkID, mAlice, mBob, aseq++, small));
         if (flip())
-            txSet->add(txtest::createPaymentTx(mAlice, mCarol, aseq++, small));
+            txSet->add(
+                txtest::createPaymentTx(networkID, mAlice, mCarol, aseq++, small));
 
         if (flip())
-            txSet->add(txtest::createPaymentTx(mBob, mAlice, bseq++, small));
+            txSet->add(
+                txtest::createPaymentTx(networkID, mBob, mAlice, bseq++, small));
         if (flip())
-            txSet->add(txtest::createPaymentTx(mBob, mCarol, bseq++, small));
+            txSet->add(
+                txtest::createPaymentTx(networkID, mBob, mCarol, bseq++, small));
 
         if (flip())
-            txSet->add(txtest::createPaymentTx(mCarol, mAlice, cseq++, small));
+            txSet->add(
+                txtest::createPaymentTx(networkID, mCarol, mAlice, cseq++, small));
         if (flip())
-            txSet->add(txtest::createPaymentTx(mCarol, mBob, cseq++, small));
+            txSet->add(
+                txtest::createPaymentTx(networkID, mCarol, mBob, cseq++, small));
     }
 
     // Provoke sortForHash and hash-caching:

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -112,7 +112,7 @@ class HistoryTests
         , appPtr(
               Application::create(clock, mConfigurator->configure(cfg, true)))
         , app(*appPtr)
-        , mRoot(txtest::getRoot())
+        , mRoot(txtest::getRoot(app.getNetworkID()))
         , mAlice(txtest::getAccount("alice"))
         , mBob(txtest::getAccount("bob"))
         , mCarol(txtest::getAccount("carol"))

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -435,7 +435,8 @@ StateSnapshot::writeHistoryBlocks() const
     size_t nHeaders = LedgerHeaderFrame::copyLedgerHeadersToStream(
         mApp.getDatabase(), sess, begin, count, ledgerOut);
     size_t nTxs = TransactionFrame::copyTransactionsToStream(
-        mApp.getDatabase(), sess, begin, count, txOut, txResultOut);
+        mApp.getNetworkID(), mApp.getDatabase(), sess, begin, count, txOut,
+        txResultOut);
     CLOG(DEBUG, "History") << "Wrote " << nHeaders << " ledger headers to "
                            << mLedgerSnapFile->localPath_nogz();
     CLOG(DEBUG, "History") << "Wrote " << nTxs << " transactions to "

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -149,8 +149,7 @@ void
 LedgerManagerImpl::startNewLedger()
 {
     auto ledgerTime = mLedgerClose.TimeScope();
-    ByteSlice bytes("allmylifemyhearthasbeensearching");
-    SecretKey skey = SecretKey::fromSeed(bytes);
+    SecretKey skey = SecretKey::fromSeed(mApp.getNetworkID());
 
     AccountFrame masterAccount(skey.getPublicKey());
     masterAccount.getAccount().balance = 100000000000000000;

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include "xdr/Stellar-types.h"
 
 namespace asio
 {
@@ -225,6 +226,10 @@ class Application
 
     // Report information about the instance to standard logging
     virtual void reportInfo() = 0;
+
+    // Returns the hash of the passphrase, used to separate various network
+    // instances
+    virtual Hash const& getNetworkID() const = 0;
 
     // Factory: create a new Application object bound to `clock`, with a local
     // copy made of `cfg`.

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -59,6 +59,8 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     mStopSignals.add(SIGTERM);
 #endif
 
+    mNetworkID = sha256(mConfig.NETWORK_PASSPHRASE);
+
     unsigned t = std::thread::hardware_concurrency();
     LOG(INFO) << "Application constructing "
               << "(worker threads: " << t << ")";
@@ -189,6 +191,12 @@ ApplicationImpl::reportInfo()
 {
     mLedgerManager->loadLastKnownLedger(nullptr);
     mCommandHandler->manualCmd("info");
+}
+
+Hash const&
+ApplicationImpl::getNetworkID() const
+{
+    return mNetworkID;
 }
 
 ApplicationImpl::~ApplicationImpl()

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -20,6 +20,7 @@
 #include "main/CommandHandler.h"
 #include "simulation/LoadGenerator.h"
 #include "crypto/SecretKey.h"
+#include "crypto/SHA.h"
 #include "medida/metrics_registry.h"
 #include "medida/reporting/console_reporter.h"
 #include "medida/meter.h"
@@ -336,7 +337,7 @@ ApplicationImpl::generateLoad(uint32_t nAccounts, uint32_t nTxs,
 {
     if (!mLoadGenerator)
     {
-        mLoadGenerator = make_unique<LoadGenerator>();
+        mLoadGenerator = make_unique<LoadGenerator>(getNetworkID());
     }
     getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
     mLoadGenerator->generateLoad(*this, nAccounts, nTxs, txRate, autoRate);

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -84,6 +84,8 @@ class ApplicationImpl : public Application
 
     virtual void reportInfo() override;
 
+    virtual Hash const& getNetworkID() const override;
+
   private:
     VirtualClock& mVirtualClock;
     Config mConfig;
@@ -126,6 +128,8 @@ class ApplicationImpl : public Application
     medida::Counter& mAppStateCurrent;
     medida::Timer& mAppStateChanges;
     VirtualClock::time_point mLastStateChange;
+
+    Hash mNetworkID;
 
     void shutdownMainIOService();
     void runWorkerThread(unsigned i);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -193,12 +193,13 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
         TransactionFramePtr txFrame;
         if (create != retMap.end() && create->second == "true")
         {
-            txFrame =
-                createCreateAccountTx(fromKey, toKey, fromSeq, paymentAmount);
+            txFrame = createCreateAccountTx(networkID, fromKey, toKey, fromSeq,
+                                            paymentAmount);
         }
         else
         {
-            txFrame = createPaymentTx(fromKey, toKey, fromSeq, paymentAmount);
+            txFrame = createPaymentTx(networkID, fromKey, toKey, fromSeq,
+                                      paymentAmount);
         }
 
         switch (mApp.getHerder().recvTransaction(txFrame))
@@ -614,7 +615,8 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
 
             xdr::xdr_from_opaque(binBlob, envelope);
             TransactionFramePtr transaction =
-                TransactionFrame::makeTransactionFromWire(envelope);
+                TransactionFrame::makeTransactionFromWire(mApp.getNetworkID(),
+                                                          envelope);
             if (transaction)
             {
                 // add it to our current set

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -123,7 +123,7 @@ CommandHandler::testAcc(std::string const& params, std::string& retStr)
         SecretKey key;
         if (accName->second == "root")
         {
-            key = getRoot();
+            key = getRoot(mApp.getNetworkID());
         }
         else
         {
@@ -156,25 +156,36 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
 
     if (to != retMap.end() && from != retMap.end() && amount != retMap.end())
     {
+        Hash const& networkID = mApp.getNetworkID();
+
         SecretKey toKey, fromKey;
         if (to->second == "root")
-            toKey = getRoot();
+        {
+            toKey = getRoot(networkID);
+        }
         else
+        {
             toKey = getAccount(to->second.c_str());
+        }
 
         if (from->second == "root")
-            fromKey = getRoot();
+        {
+            fromKey = getRoot(networkID);
+        }
         else
+        {
             fromKey = getAccount(from->second.c_str());
+        }
 
         uint64_t paymentAmount = 0;
         std::istringstream iss(amount->second);
         iss >> paymentAmount;
 
         root["from_name"] = from->second;
-        root["to_name"] = to->second ;
+        root["to_name"] = to->second;
         root["from_id"] = PubKeyUtils::toStrKey(fromKey.getPublicKey());
-        root["to_id"] = PubKeyUtils::toStrKey(toKey.getPublicKey());;
+        root["to_id"] = PubKeyUtils::toStrKey(toKey.getPublicKey());
+        ;
         root["amount"] = (Json::UInt64)paymentAmount;
 
         SequenceNumber fromSeq = getSeq(fromKey, mApp) + 1;
@@ -200,7 +211,8 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
             break;
         case Herder::TX_STATUS_ERROR:
             root["status"] = "error";
-            root["detail"] = xdr::xdr_to_string(txFrame->getResult().result.code());
+            root["detail"] =
+                xdr::xdr_to_string(txFrame->getResult().result.code());
             break;
         default:
             assert(false);
@@ -209,9 +221,8 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
     else
     {
         root["status"] = "error";
-        root["detail"] =
-            "Bad HTTP GET: try something like: "
-            "testtx?from=root&to=bob&amount=1000000000";
+        root["detail"] = "Bad HTTP GET: try something like: "
+                         "testtx?from=root&to=bob&amount=1000000000";
     }
     retStr = root.toStyledString();
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -25,6 +25,7 @@ Config::Config() : PEER_KEY(SecretKey::random())
     FORCE_SCP = false;
 
     // configurable
+    NETWORK_PASSPHRASE = "(V) (;,,;) (V)";
     FAILURE_SAFETY = 1;
     UNSAFE_QUORUM = false;
     DESIRED_BASE_FEE = 10;
@@ -453,6 +454,14 @@ Config::load(std::string const& filename)
                     throw std::invalid_argument("invalid PARANOID_MODE");
                 }
                 PARANOID_MODE = item.second->as<bool>()->value();
+            }
+            else if (item.first == "NETWORK_PASSPHRASE")
+            {
+                if (!item.second->as<std::string>())
+                {
+                    throw std::invalid_argument("invalid NETWORK_PASSPHRASE");
+                }
+                NETWORK_PASSPHRASE = item.second->as<std::string>()->value();
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -106,8 +106,9 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t DESIRED_BASE_FEE;     // in stroops
     uint32_t DESIRED_BASE_RESERVE; // in stroops
     uint32_t DESIRED_MAX_TX_PER_LEDGER;
-    unsigned short HTTP_PORT; // what port to listen for commands
-    bool PUBLIC_HTTP_PORT;    // if you accept commands from not localhost
+    unsigned short HTTP_PORT;       // what port to listen for commands
+    bool PUBLIC_HTTP_PORT;          // if you accept commands from not localhost
+    std::string NETWORK_PASSPHRASE; // identifier for the network
 
     // overlay config
     unsigned short PEER_PORT;

--- a/src/overlay/OverlayManagerTests.cpp
+++ b/src/overlay/OverlayManagerTests.cpp
@@ -145,14 +145,18 @@ class OverlayManagerTests
         SecretKey c = getAccount("c");
         SecretKey d = getAccount("d");
 
-        StellarMessage AtoC = createPaymentTx(a, b, 1, 10)->toStellarMessage();
+        Hash const& networkID = app.getNetworkID();
+
+        StellarMessage AtoC =
+            createPaymentTx(networkID, a, b, 1, 10)->toStellarMessage();
         pm.recvFloodedMsg(AtoC, *(pm.mPeers.begin() + 2));
         pm.broadcastMessage(AtoC);
         vector<int> expected{1, 1, 0, 1, 1};
         REQUIRE(sentCounts(pm) == expected);
         pm.broadcastMessage(AtoC);
         REQUIRE(sentCounts(pm) == expected);
-        StellarMessage CtoD = createPaymentTx(c, d, 1, 10)->toStellarMessage();
+        StellarMessage CtoD =
+            createPaymentTx(networkID, c, d, 1, 10)->toStellarMessage();
         pm.broadcastMessage(CtoD);
         vector<int> expectedFinal{2, 2, 1, 2, 2};
         REQUIRE(sentCounts(pm) == expectedFinal);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -324,15 +324,15 @@ Peer::recvGetTxSet(StellarMessage const& msg)
 void
 Peer::recvTxSet(StellarMessage const& msg)
 {
-    TxSetFrame frame(msg.txSet());
+    TxSetFrame frame(mApp.getNetworkID(), msg.txSet());
     mApp.getHerder().recvTxSet(frame.getContentsHash(), frame);
 }
 
 void
 Peer::recvTransaction(StellarMessage const& msg)
 {
-    TransactionFramePtr transaction =
-        TransactionFrame::makeTransactionFromWire(msg.transaction());
+    TransactionFramePtr transaction = TransactionFrame::makeTransactionFromWire(
+        mApp.getNetworkID(), msg.transaction());
     if (transaction)
     {
         // add it to our current set

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -70,6 +70,7 @@ Peer::sendHello()
     msg.hello().ledgerVersion = mApp.getConfig().LEDGER_PROTOCOL_VERSION;
     msg.hello().overlayVersion = mApp.getConfig().OVERLAY_PROTOCOL_VERSION;
     msg.hello().versionStr = mApp.getConfig().VERSION_STR;
+    msg.hello().networkID = mApp.getNetworkID();
     msg.hello().listeningPort = mApp.getConfig().PEER_PORT;
     msg.hello().peerID = mApp.getConfig().PEER_PUBLIC_KEY;
 
@@ -395,6 +396,16 @@ Peer::recvHello(StellarMessage const& msg)
     if (msg.hello().peerID == mApp.getConfig().PEER_PUBLIC_KEY)
     {
         CLOG(DEBUG, "Overlay") << "connecting to self";
+        drop();
+        return false;
+    }
+
+    if (msg.hello().networkID != mApp.getNetworkID())
+    {
+        CLOG(INFO, "Overlay") << "connection from misconfigured peer";
+        CLOG(DEBUG, "Overlay")
+            << "NetworkID = " << hexAbbrev(msg.hello().networkID)
+            << " expected: " << hexAbbrev(mApp.getNetworkID());
         drop();
         return false;
     }

--- a/src/overlay/TCPPeerTests.cpp
+++ b/src/overlay/TCPPeerTests.cpp
@@ -18,7 +18,8 @@ namespace stellar
 
 TEST_CASE("TCPPeer can communicate", "[overlay]")
 {
-    Simulation::pointer s = std::make_shared<Simulation>(Simulation::OVER_TCP);
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    Simulation::pointer s = std::make_shared<Simulation>(Simulation::OVER_TCP, networkID);
 
     auto v10SecretKey = SecretKey::fromSeed(sha256("v10"));
     auto v11SecretKey = SecretKey::fromSeed(sha256("v11"));

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -57,7 +57,9 @@ TEST_CASE("3 nodes. 2 running. threshold 2", "[simulation][core3]")
     }
 
     {
-        Simulation::pointer simulation = std::make_shared<Simulation>(mode);
+        Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+        Simulation::pointer simulation =
+            std::make_shared<Simulation>(mode, networkID);
 
         std::vector<SecretKey> keys;
         for (int i = 0; i < 3; i++)
@@ -111,11 +113,13 @@ TEST_CASE("core topology: 4 ledgers at scales 2..4", "[simulation]")
         mode = Simulation::OVER_TCP;
     }
 
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+
     for (int size = 2; size <= 4; size++)
     {
         auto tBegin = std::chrono::system_clock::now();
 
-        Simulation::pointer sim = Topologies::core(size, 1.0, mode);
+        Simulation::pointer sim = Topologies::core(size, 1.0, mode, networkID);
         sim->startAllNodes();
 
         int nLedgers = 4;
@@ -133,11 +137,13 @@ TEST_CASE("core topology: 4 ledgers at scales 2..4", "[simulation]")
 }
 
 void
-hierarchicalTopo(int nLedgers, int nBranches, Simulation::Mode mode)
+hierarchicalTopo(int nLedgers, int nBranches, Simulation::Mode mode,
+                 Hash const& networkID)
 {
     auto tBegin = std::chrono::system_clock::now();
 
-    Simulation::pointer sim = Topologies::hierarchicalQuorum(nBranches, mode);
+    Simulation::pointer sim =
+        Topologies::hierarchicalQuorum(nBranches, mode, networkID);
     sim->startAllNodes();
 
     sim->crankUntil(
@@ -178,7 +184,8 @@ TEST_CASE("hierarchical topology scales 1..3", "[simulation]")
 
 TEST_CASE("cycle4 topology", "[simulation]")
 {
-    Simulation::pointer simulation = Topologies::cycle4();
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    Simulation::pointer simulation = Topologies::cycle4(networkID);
     simulation->startAllNodes();
 
     simulation->crankUntil(
@@ -195,8 +202,9 @@ TEST_CASE("cycle4 topology", "[simulation]")
 TEST_CASE("Stress test on 2 nodes 3 accounts 10 random transactions 10tx/sec",
           "[stress100][simulation][stress][long][hide]")
 {
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     Simulation::pointer simulation =
-        Topologies::pair(Simulation::OVER_LOOPBACK);
+        Topologies::pair(Simulation::OVER_LOOPBACK, networkID);
 
     simulation->startAllNodes();
     simulation->crankUntil(

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -26,7 +26,7 @@ class VirtualTimer;
 class LoadGenerator
 {
   public:
-    LoadGenerator();
+    LoadGenerator(Hash const& networkID);
     ~LoadGenerator();
     void clear();
 
@@ -77,11 +77,6 @@ class LoadGenerator
     createTransferCreditTransaction(AccountInfoPtr from, AccountInfoPtr to,
                                     int64_t amount,
                                     std::vector<AccountInfoPtr> const& path);
-
-    TxInfo createEstablishTrustTransaction(AccountInfoPtr from,
-                                           AccountInfoPtr issuer);
-
-    TxInfo createEstablishOfferTransaction(AccountInfoPtr from);
 
     AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid,
                                      uint32_t ledgerNum);
@@ -169,7 +164,8 @@ class LoadGenerator
 
         bool execute(Application& app);
 
-        void toTransactionFrames(std::vector<TransactionFramePtr>& txs,
+        void toTransactionFrames(Hash const& networkID,
+                                 std::vector<TransactionFramePtr>& txs,
                                  TxMetrics& metrics);
         void recordExecution(int64_t baseFee);
     };

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -24,8 +24,9 @@ namespace stellar
 
 using namespace std;
 
-Simulation::Simulation(Mode mode)
-    : mClock(mode == OVER_TCP ? VirtualClock::REAL_TIME
+Simulation::Simulation(Mode mode, Hash const& networkID)
+    : LoadGenerator(networkID)
+    , mClock(mode == OVER_TCP ? VirtualClock::REAL_TIME
                               : VirtualClock::VIRTUAL_TIME)
     , mMode(mode)
     , mConfigCount(0)

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -37,7 +37,7 @@ class Simulation : public LoadGenerator
 
     typedef std::shared_ptr<Simulation> pointer;
 
-    Simulation(Mode mode);
+    Simulation(Mode mode, Hash const& networkID);
     ~Simulation();
 
     VirtualClock& getClock();

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -10,9 +10,9 @@ namespace stellar
 using namespace std;
 
 Simulation::pointer
-Topologies::pair(Simulation::Mode mode)
+Topologies::pair(Simulation::Mode mode, Hash const& networkID)
 {
-    Simulation::pointer simulation = make_shared<Simulation>(mode);
+    Simulation::pointer simulation = make_shared<Simulation>(mode, networkID);
 
     SIMULATION_CREATE_NODE(10);
     SIMULATION_CREATE_NODE(11);
@@ -30,10 +30,10 @@ Topologies::pair(Simulation::Mode mode)
 }
 
 Simulation::pointer
-Topologies::cycle4()
+Topologies::cycle4(Hash const& networkID)
 {
     Simulation::pointer simulation =
-        make_shared<Simulation>(Simulation::OVER_LOOPBACK);
+        make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
 
     SIMULATION_CREATE_NODE(0);
     SIMULATION_CREATE_NODE(1);
@@ -81,9 +81,9 @@ Topologies::cycle4()
 
 Simulation::pointer
 Topologies::core(int nNodes, float quorumThresoldFraction,
-                 Simulation::Mode mode)
+                 Simulation::Mode mode, Hash const& networkID)
 {
-    Simulation::pointer simulation = make_shared<Simulation>(mode);
+    Simulation::pointer simulation = make_shared<Simulation>(mode, networkID);
 
     vector<SecretKey> keys;
     for (int i = 0; i < nNodes; i++)
@@ -118,10 +118,10 @@ Topologies::core(int nNodes, float quorumThresoldFraction,
 }
 
 Simulation::pointer
-Topologies::hierarchicalQuorum(int nBranches,
-                               Simulation::Mode mode) // Figure 3 from the paper
+Topologies::hierarchicalQuorum(int nBranches, Simulation::Mode mode,
+                               Hash const& networkID) // Figure 3 from the paper
 {
-    auto sim = Topologies::core(4, 0.75, mode);
+    auto sim = Topologies::core(4, 0.75, mode, networkID);
     vector<NodeID> coreNodeIDs;
     for (auto const& coreNodeID : sim->getNodeIDs())
     {

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -12,11 +12,14 @@ namespace stellar
 class Topologies
 {
   public:
-    static Simulation::pointer pair(Simulation::Mode mode);
-    static Simulation::pointer cycle4();
+    static Simulation::pointer pair(Simulation::Mode mode,
+                                    Hash const& networkID);
+    static Simulation::pointer cycle4(Hash const& networkID);
     static Simulation::pointer core(int nNodes, float quorumThresoldFraction,
-                                    Simulation::Mode mode);
+                                    Simulation::Mode mode,
+                                    Hash const& networkID);
     static Simulation::pointer hierarchicalQuorum(int nBranches,
-                                                  Simulation::Mode mode);
+                                                  Simulation::Mode mode,
+                                                  Hash const& networkID);
 };
 }

--- a/src/transactions/ChangeTrustTests.cpp
+++ b/src/transactions/ChangeTrustTests.cpp
@@ -27,7 +27,7 @@ TEST_CASE("change trust", "[tx][changeTrust]")
     app.start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app.getNetworkID());
     SecretKey a1 = getAccount("A");
 
     SequenceNumber rootSeq = getAccountSeqNum(root, app) + 1;

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -220,8 +220,8 @@ doInflation(Application& app, int nbAccounts,
     std::vector<int64> expectedBalances;
 
     auto root = getRoot(app.getNetworkID());
-    TransactionFramePtr txFrame =
-        createInflation(root, getAccountSeqNum(root, app) + 1);
+    TransactionFramePtr txFrame = createInflation(
+        app.getNetworkID(), root, getAccountSeqNum(root, app) + 1);
 
     expectedFees += txFrame->getFee();
 
@@ -320,7 +320,7 @@ TEST_CASE("inflation", "[tx][inflation]")
 
         closeLedgerOn(app, 3, 1, 7, 2014);
 
-        auto txFrame = createInflation(root, rootSeq++);
+        auto txFrame = createInflation(app.getNetworkID(), root, rootSeq++);
 
         closeLedgerOn(app, 4, 7, 7, 2014, txFrame);
         REQUIRE(app.getLedgerManager().getCurrentLedgerHeader().inflationSeq ==

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -36,7 +36,7 @@ createTestAccounts(Application& app, int nbAccounts,
                    std::function<int(int)> getVote)
 {
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app.getNetworkID());
 
     SequenceNumber rootSeq = getAccountSeqNum(root, app) + 1;
 
@@ -219,7 +219,7 @@ doInflation(Application& app, int nbAccounts,
 
     std::vector<int64> expectedBalances;
 
-    auto root = getRoot();
+    auto root = getRoot(app.getNetworkID());
     TransactionFramePtr txFrame =
         createInflation(root, getAccountSeqNum(root, app) + 1);
 
@@ -304,7 +304,7 @@ TEST_CASE("inflation", "[tx][inflation]")
     Application::pointer appPtr = Application::create(clock, cfg);
     Application& app = *appPtr;
 
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app.getNetworkID());
 
     app.start();
 

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -34,7 +34,7 @@ TEST_CASE("merge", "[tx][merge]")
 
     // set up world
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app.getNetworkID());
     SecretKey a1 = getAccount("A");
     SecretKey b1 = getAccount("B");
     SecretKey gateway = getAccount("gate");

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -34,10 +34,11 @@ TEST_CASE("create offer", "[tx][offers]")
     VirtualClock clock;
     Application::pointer appPtr = Application::create(clock, cfg);
     Application& app = *appPtr;
+    Hash const& networkID = app.getNetworkID();
     app.start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(networkID);
     SecretKey a1 = getAccount("A");
     SecretKey b1 = getAccount("B");
     SecretKey c1 = getAccount("C");

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -68,7 +68,8 @@ TEST_CASE("create offer", "[tx][offers]")
 
     SECTION("account a1 does not exist")
     {
-        auto txFrame = manageOfferOp(0, a1, idrCur, usdCur, oneone, 100, 1);
+        auto txFrame =
+            manageOfferOp(networkID, 0, a1, idrCur, usdCur, oneone, 100, 1);
 
         applyCheck(txFrame, delta, app);
         REQUIRE(txFrame->getResultCode() == txNO_ACCOUNT);
@@ -97,12 +98,12 @@ TEST_CASE("create offer", "[tx][offers]")
         applyCreditPaymentTx(app, gateway, b1, idrCur, gateway_seq++, 500);
         applyCreditPaymentTx(app, gateway, b1, usdCur, gateway_seq++, 500);
 
-        auto txFrame =
-            manageOfferOp(0, a1, idrCur, usdCur, oneone, 100, a1_seq++);
+        auto txFrame = manageOfferOp(networkID, 0, a1, idrCur, usdCur, oneone,
+                                     100, a1_seq++);
         REQUIRE(applyCheck(txFrame, delta, app));
 
-        txFrame =
-            createPassiveOfferOp(b1, usdCur, idrCur, oneone, 100, b1_seq++);
+        txFrame = createPassiveOfferOp(networkID, b1, usdCur, idrCur, oneone,
+                                       100, b1_seq++);
         applyCheck(txFrame, delta, app);
 
         // same price
@@ -116,15 +117,16 @@ TEST_CASE("create offer", "[tx][offers]")
         // better price
         const Price highPrice(100, 99);
         const Price lowPrice(99, 100);
-        txFrame =
-            createPassiveOfferOp(b1, usdCur, idrCur, lowPrice, 100, b1_seq++);
+        txFrame = createPassiveOfferOp(networkID, b1, usdCur, idrCur, lowPrice,
+                                       100, b1_seq++);
         applyCheck(txFrame, delta, app);
 
         REQUIRE(!loadOffer(a1, 1, app, false));
         REQUIRE(!loadOffer(b1, 3, app, false));
 
         // modify existing passive offer
-        txFrame = manageOfferOp(0, a1, idrCur, usdCur, oneone, 200, a1_seq++);
+        txFrame = manageOfferOp(networkID, 0, a1, idrCur, usdCur, oneone, 200,
+                                a1_seq++);
         applyCheck(txFrame, delta, app);
 
         REQUIRE(!loadOffer(a1, 1, app, false));
@@ -134,8 +136,8 @@ TEST_CASE("create offer", "[tx][offers]")
         offer = loadOffer(a1, 3, app);
         REQUIRE(offer->getAmount() == 100);
 
-        txFrame =
-            createPassiveOfferOp(b1, usdCur, idrCur, highPrice, 100, b1_seq++);
+        txFrame = createPassiveOfferOp(networkID, b1, usdCur, idrCur, highPrice,
+                                       100, b1_seq++);
         REQUIRE(applyCheck(txFrame, delta, app));
 
         offer = loadOffer(a1, 3, app);
@@ -144,7 +146,8 @@ TEST_CASE("create offer", "[tx][offers]")
         offer = loadOffer(b1, 4, app);
         REQUIRE(offer->getAmount() == 100);
 
-        txFrame = manageOfferOp(4, b1, usdCur, idrCur, oneone, 100, b1_seq++);
+        txFrame = manageOfferOp(networkID, 4, b1, usdCur, idrCur, oneone, 100,
+                                b1_seq++);
         applyCheck(txFrame, delta, app);
 
         offer = loadOffer(a1, 3, app);
@@ -153,7 +156,8 @@ TEST_CASE("create offer", "[tx][offers]")
         offer = loadOffer(b1, 4, app);
         REQUIRE(offer->getAmount() == 100);
 
-        txFrame = manageOfferOp(4, b1, usdCur, idrCur, lowPrice, 100, b1_seq++);
+        txFrame = manageOfferOp(networkID, 4, b1, usdCur, idrCur, lowPrice, 100,
+                                b1_seq++);
         REQUIRE(applyCheck(txFrame, delta, app));
 
         REQUIRE(!loadOffer(a1, 3, app, false));

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("payment", "[tx][payment]")
     app.start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app.getNetworkID());
     SecretKey a1 = getAccount("A");
     SecretKey b1 = getAccount("B");
 
@@ -487,7 +487,7 @@ TEST_CASE("single create account SQL", "[singlesql][paymentsql][hide]")
         Application::create(clock, getTestConfig(0, mode));
     app->start();
 
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app->getNetworkID());
     SecretKey a1 = getAccount("A");
     int64_t txfee = app->getLedgerManager().getTxFee();
     const int64_t paymentAmount =

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -173,7 +173,7 @@ TEST_CASE("payment", "[tx][payment]")
             addReserve;
 
         // verify that the account can't do anything
-        auto tx = createPaymentTx(b1, root, b1Seq++, 1);
+        auto tx = createPaymentTx(app.getNetworkID(), b1, root, b1Seq++, 1);
         REQUIRE(!applyCheck(tx, delta, app));
         REQUIRE(tx->getResultCode() == txINSUFFICIENT_BALANCE);
 
@@ -404,7 +404,7 @@ TEST_CASE("payment", "[tx][payment]")
 
             // offer is sell 100 USD for 100 XLM
             applyCreateOffer(app, delta, 0, a1, usdCur, xlmCur, Price(1, 1),
-                                 100 * assetMultiplier, a1Seq++);
+                             100 * assetMultiplier, a1Seq++);
 
             // A1: try to send 100 USD to B1 using XLM
 

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -37,7 +37,7 @@ TEST_CASE("set options", "[tx][setoptions]")
     app.start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(app.getNetworkID());
     SecretKey a1 = getAccount("A");
 
     SequenceNumber rootSeq = getAccountSeqNum(root, app) + 1;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -41,6 +41,7 @@ class TransactionFrame
     std::vector<bool> mUsedSignatures;
 
     void clearCached();
+    Hash const& mNetworkID;     // used to change the way we compute signatures
     mutable Hash mContentsHash; // the hash of the contents
     mutable Hash mFullHash;     // the hash of the contents and the sig.
 
@@ -57,12 +58,14 @@ class TransactionFrame
     void markResultFailed();
 
   public:
-    TransactionFrame(TransactionEnvelope const& envelope);
+    TransactionFrame(Hash const& networkID,
+                     TransactionEnvelope const& envelope);
     TransactionFrame(TransactionFrame const&) = delete;
     TransactionFrame() = delete;
 
     static TransactionFramePtr
-    makeTransactionFromWire(TransactionEnvelope const& msg);
+    makeTransactionFromWire(Hash const& networkID,
+                            TransactionEnvelope const& msg);
 
     Hash const& getFullHash() const;
     Hash const& getContentsHash() const;
@@ -155,7 +158,8 @@ class TransactionFrame
     txOut: stream of TransactionHistoryEntry
     txResultOut: stream of TransactionHistoryResultEntry
     */
-    static size_t copyTransactionsToStream(Database& db, soci::session& sess,
+    static size_t copyTransactionsToStream(Hash const& networkID, Database& db,
+                                           soci::session& sess,
                                            uint32_t ledgerSeq,
                                            uint32_t ledgerCount,
                                            XDROutputFileStream& txOut,

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -36,10 +36,11 @@ TEST_CASE("txenvelope", "[tx][envelope]")
     VirtualClock clock;
     Application::pointer appPtr = Application::create(clock, cfg);
     Application& app = *appPtr;
+    Hash const& networkID = app.getNetworkID();
     app.start();
 
     // set up world
-    SecretKey root = getRoot();
+    SecretKey root = getRoot(networkID);
     SecretKey a1 = getAccount("A");
     SequenceNumber rootSeq = getAccountSeqNum(root, app) + 1;
     ;

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -141,9 +141,9 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
 }
 
 SecretKey
-getRoot()
+getRoot(Hash const& networkID)
 {
-    return SecretKey::fromSeed(ByteSlice("allmylifemyhearthasbeensearching"));
+    return SecretKey::fromSeed(networkID);
 }
 
 SecretKey

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -225,8 +225,8 @@ checkTransaction(TransactionFrame& txFrame)
 }
 
 TransactionFramePtr
-transactionFromOperation(SecretKey& from, SequenceNumber seq,
-                         Operation const& op)
+transactionFromOperation(Hash const& networkID, SecretKey& from,
+                         SequenceNumber seq, Operation const& op)
 {
     TransactionEnvelope e;
 
@@ -235,7 +235,8 @@ transactionFromOperation(SecretKey& from, SequenceNumber seq,
     e.tx.seqNum = seq;
     e.tx.operations.push_back(op);
 
-    TransactionFramePtr res = TransactionFrame::makeTransactionFromWire(e);
+    TransactionFramePtr res =
+        TransactionFrame::makeTransactionFromWire(networkID, e);
 
     res->addSignature(from);
 
@@ -243,8 +244,9 @@ transactionFromOperation(SecretKey& from, SequenceNumber seq,
 }
 
 TransactionFramePtr
-createChangeTrust(SecretKey& from, SecretKey& to, SequenceNumber seq,
-                  std::string const& assetCode, int64_t limit)
+createChangeTrust(Hash const& networkID, SecretKey& from, SecretKey& to,
+                  SequenceNumber seq, std::string const& assetCode,
+                  int64_t limit)
 {
     Operation op;
 
@@ -255,12 +257,13 @@ createChangeTrust(SecretKey& from, SecretKey& to, SequenceNumber seq,
                    assetCode);
     op.body.changeTrustOp().line.alphaNum4().issuer = to.getPublicKey();
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 TransactionFramePtr
-createAllowTrust(SecretKey& from, SecretKey& trustor, SequenceNumber seq,
-                 std::string const& assetCode, bool authorize)
+createAllowTrust(Hash const& networkID, SecretKey& from, SecretKey& trustor,
+                 SequenceNumber seq, std::string const& assetCode,
+                 bool authorize)
 {
     Operation op;
 
@@ -270,7 +273,7 @@ createAllowTrust(SecretKey& from, SecretKey& trustor, SequenceNumber seq,
     strToAssetCode(op.body.allowTrustOp().asset.assetCode4(), assetCode);
     op.body.allowTrustOp().authorize = authorize;
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 void
@@ -279,7 +282,8 @@ applyAllowTrust(Application& app, SecretKey& from, SecretKey& trustor,
                 bool authorize, AllowTrustResultCode result)
 {
     TransactionFramePtr txFrame;
-    txFrame = createAllowTrust(from, trustor, seq, assetCode, authorize);
+    txFrame = createAllowTrust(app.getNetworkID(), from, trustor, seq,
+                               assetCode, authorize);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -291,15 +295,15 @@ applyAllowTrust(Application& app, SecretKey& from, SecretKey& trustor,
 }
 
 TransactionFramePtr
-createCreateAccountTx(SecretKey& from, SecretKey& to, SequenceNumber seq,
-                      int64_t amount)
+createCreateAccountTx(Hash const& networkID, SecretKey& from, SecretKey& to,
+                      SequenceNumber seq, int64_t amount)
 {
     Operation op;
     op.body.type(CREATE_ACCOUNT);
     op.body.createAccountOp().startingBalance = amount;
     op.body.createAccountOp().destination = to.getPublicKey();
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 void
@@ -314,7 +318,7 @@ applyCreateAccountTx(Application& app, SecretKey& from, SecretKey& to,
 
     fromAccount = loadAccount(from, app);
 
-    txFrame = createCreateAccountTx(from, to, seq, amount);
+    txFrame = createCreateAccountTx(app.getNetworkID(), from, to, seq, amount);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -347,8 +351,8 @@ applyCreateAccountTx(Application& app, SecretKey& from, SecretKey& to,
 }
 
 TransactionFramePtr
-createPaymentTx(SecretKey& from, SecretKey& to, SequenceNumber seq,
-                int64_t amount)
+createPaymentTx(Hash const& networkID, SecretKey& from, SecretKey& to,
+                SequenceNumber seq, int64_t amount)
 {
     Operation op;
     op.body.type(PAYMENT);
@@ -356,7 +360,7 @@ createPaymentTx(SecretKey& from, SecretKey& to, SequenceNumber seq,
     op.body.paymentOp().destination = to.getPublicKey();
     op.body.paymentOp().asset.type(ASSET_TYPE_NATIVE);
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 void
@@ -370,7 +374,7 @@ applyPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 
     fromAccount = loadAccount(from, app);
 
-    txFrame = createPaymentTx(from, to, seq, amount);
+    txFrame = createPaymentTx(app.getNetworkID(), from, to, seq, amount);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -409,7 +413,8 @@ applyChangeTrust(Application& app, SecretKey& from, SecretKey& to,
 {
     TransactionFramePtr txFrame;
 
-    txFrame = createChangeTrust(from, to, seq, assetCode, limit);
+    txFrame =
+        createChangeTrust(app.getNetworkID(), from, to, seq, assetCode, limit);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -421,8 +426,8 @@ applyChangeTrust(Application& app, SecretKey& from, SecretKey& to,
 }
 
 TransactionFramePtr
-createCreditPaymentTx(SecretKey& from, SecretKey& to, Asset& asset,
-                      SequenceNumber seq, int64_t amount)
+createCreditPaymentTx(Hash const& networkID, SecretKey& from, SecretKey& to,
+                      Asset& asset, SequenceNumber seq, int64_t amount)
 {
     Operation op;
     op.body.type(PAYMENT);
@@ -430,7 +435,7 @@ createCreditPaymentTx(SecretKey& from, SecretKey& to, Asset& asset,
     op.body.paymentOp().asset = asset;
     op.body.paymentOp().destination = to.getPublicKey();
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 Asset
@@ -450,7 +455,8 @@ applyCreditPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 {
     TransactionFramePtr txFrame;
 
-    txFrame = createCreditPaymentTx(from, to, ci, seq, amount);
+    txFrame =
+        createCreditPaymentTx(app.getNetworkID(), from, to, ci, seq, amount);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -467,9 +473,10 @@ applyCreditPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 }
 
 TransactionFramePtr
-createPathPaymentTx(SecretKey& from, SecretKey& to, Asset const& sendCur,
-                    int64_t sendMax, Asset const& destCur, int64_t destAmount,
-                    SequenceNumber seq, std::vector<Asset>* path)
+createPathPaymentTx(Hash const& networkID, SecretKey& from, SecretKey& to,
+                    Asset const& sendCur, int64_t sendMax, Asset const& destCur,
+                    int64_t destAmount, SequenceNumber seq,
+                    std::vector<Asset>* path)
 {
     Operation op;
     op.body.type(PATH_PAYMENT);
@@ -487,7 +494,7 @@ createPathPaymentTx(SecretKey& from, SecretKey& to, Asset const& sendCur,
         }
     }
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 PathPaymentResult
@@ -498,8 +505,8 @@ applyPathPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 {
     TransactionFramePtr txFrame;
 
-    txFrame = createPathPaymentTx(from, to, sendCur, sendMax, destCur,
-                                  destAmount, seq, path);
+    txFrame = createPathPaymentTx(app.getNetworkID(), from, to, sendCur,
+                                  sendMax, destCur, destAmount, seq, path);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -516,8 +523,9 @@ applyPathPaymentTx(Application& app, SecretKey& from, SecretKey& to,
 }
 
 TransactionFramePtr
-createPassiveOfferOp(SecretKey& source, Asset& selling, Asset& buying,
-                     Price const& price, int64_t amount, SequenceNumber seq)
+createPassiveOfferOp(Hash const& networkID, SecretKey& source, Asset& selling,
+                     Asset& buying, Price const& price, int64_t amount,
+                     SequenceNumber seq)
 {
     Operation op;
     op.body.type(CREATE_PASSIVE_OFFER);
@@ -526,12 +534,13 @@ createPassiveOfferOp(SecretKey& source, Asset& selling, Asset& buying,
     op.body.createPassiveOfferOp().buying = buying;
     op.body.createPassiveOfferOp().price = price;
 
-    return transactionFromOperation(source, seq, op);
+    return transactionFromOperation(networkID, source, seq, op);
 }
 
 TransactionFramePtr
-manageOfferOp(uint64 offerId, SecretKey& source, Asset& selling, Asset& buying,
-              Price const& price, int64_t amount, SequenceNumber seq)
+manageOfferOp(Hash const& networkID, uint64 offerId, SecretKey& source,
+              Asset& selling, Asset& buying, Price const& price, int64_t amount,
+              SequenceNumber seq)
 {
     Operation op;
     op.body.type(MANAGE_OFFER);
@@ -541,7 +550,7 @@ manageOfferOp(uint64 offerId, SecretKey& source, Asset& selling, Asset& buying,
     op.body.manageOfferOp().offerID = offerId;
     op.body.manageOfferOp().price = price;
 
-    return transactionFromOperation(source, seq, op);
+    return transactionFromOperation(networkID, source, seq, op);
 }
 
 static ManageOfferResult
@@ -557,8 +566,8 @@ applyCreateOfferHelper(Application& app, LedgerDelta& delta, uint64 offerId,
 
     TransactionFramePtr txFrame;
 
-    txFrame =
-        manageOfferOp(offerId, source, selling, buying, price, amount, seq);
+    txFrame = manageOfferOp(app.getNetworkID(), offerId, source, selling,
+                            buying, price, amount, seq);
 
     applyCheck(txFrame, delta, app);
 
@@ -633,7 +642,7 @@ applyCreateOfferWithResult(Application& app, LedgerDelta& delta, uint64 offerId,
 }
 
 TransactionFramePtr
-createSetOptions(SecretKey& source, SequenceNumber seq,
+createSetOptions(Hash const& networkID, SecretKey& source, SequenceNumber seq,
                  AccountID* inflationDest, uint32_t* setFlags,
                  uint32_t* clearFlags, ThresholdSetter* thrs, Signer* signer)
 {
@@ -682,7 +691,7 @@ createSetOptions(SecretKey& source, SequenceNumber seq,
         setOp.signer.activate() = *signer;
     }
 
-    return transactionFromOperation(source, seq, op);
+    return transactionFromOperation(networkID, source, seq, op);
 }
 
 void
@@ -693,8 +702,8 @@ applySetOptions(Application& app, SecretKey& source, SequenceNumber seq,
 {
     TransactionFramePtr txFrame;
 
-    txFrame = createSetOptions(source, seq, inflationDest, setFlags, clearFlags,
-                               thrs, signer);
+    txFrame = createSetOptions(app.getNetworkID(), source, seq, inflationDest,
+                               setFlags, clearFlags, thrs, signer);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -706,19 +715,20 @@ applySetOptions(Application& app, SecretKey& source, SequenceNumber seq,
 }
 
 TransactionFramePtr
-createInflation(SecretKey& from, SequenceNumber seq)
+createInflation(Hash const& networkID, SecretKey& from, SequenceNumber seq)
 {
     Operation op;
     op.body.type(INFLATION);
 
-    return transactionFromOperation(from, seq, op);
+    return transactionFromOperation(networkID, from, seq, op);
 }
 
 OperationResult
 applyInflation(Application& app, SecretKey& from, SequenceNumber seq,
                InflationResultCode result)
 {
-    TransactionFramePtr txFrame = createInflation(from, seq);
+    TransactionFramePtr txFrame =
+        createInflation(app.getNetworkID(), from, seq);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -735,20 +745,22 @@ applyInflation(Application& app, SecretKey& from, SequenceNumber seq,
 }
 
 TransactionFramePtr
-createAccountMerge(SecretKey& source, SecretKey& dest, SequenceNumber seq)
+createAccountMerge(Hash const& networkID, SecretKey& source, SecretKey& dest,
+                   SequenceNumber seq)
 {
     Operation op;
     op.body.type(ACCOUNT_MERGE);
     op.body.destination() = dest.getPublicKey();
 
-    return transactionFromOperation(source, seq, op);
+    return transactionFromOperation(networkID, source, seq, op);
 }
 
 void
 applyAccountMerge(Application& app, SecretKey& source, SecretKey& dest,
                   SequenceNumber seq, AccountMergeResultCode result)
 {
-    TransactionFramePtr txFrame = createAccountMerge(source, dest, seq);
+    TransactionFramePtr txFrame =
+        createAccountMerge(app.getNetworkID(), source, dest, seq);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());

--- a/src/transactions/TxTests.h
+++ b/src/transactions/TxTests.h
@@ -38,7 +38,7 @@ time_t getTestDate(int day, int month, int year);
 void closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month,
                    int year, TransactionFramePtr tx = nullptr);
 
-SecretKey getRoot();
+SecretKey getRoot(Hash const& networkID);
 
 SecretKey getAccount(const char* n);
 

--- a/src/transactions/TxTests.h
+++ b/src/transactions/TxTests.h
@@ -59,8 +59,8 @@ SequenceNumber getAccountSeqNum(SecretKey const& k, Application& app);
 
 uint64_t getAccountBalance(SecretKey const& k, Application& app);
 
-TransactionFramePtr createChangeTrust(SecretKey& from, SecretKey& to,
-                                      SequenceNumber seq,
+TransactionFramePtr createChangeTrust(Hash const& networkID, SecretKey& from,
+                                      SecretKey& to, SequenceNumber seq,
                                       std::string const& assetCode,
                                       int64_t limit);
 
@@ -69,8 +69,8 @@ void applyChangeTrust(Application& app, SecretKey& from, SecretKey& to,
                       int64_t limit,
                       ChangeTrustResultCode result = CHANGE_TRUST_SUCCESS);
 
-TransactionFramePtr createAllowTrust(SecretKey& from, SecretKey& trustor,
-                                     SequenceNumber seq,
+TransactionFramePtr createAllowTrust(Hash const& networkID, SecretKey& from,
+                                     SecretKey& trustor, SequenceNumber seq,
                                      std::string const& assetCode,
                                      bool authorize);
 
@@ -79,7 +79,8 @@ void applyAllowTrust(Application& app, SecretKey& from, SecretKey& trustor,
                      bool authorize,
                      AllowTrustResultCode result = ALLOW_TRUST_SUCCESS);
 
-TransactionFramePtr createCreateAccountTx(SecretKey& from, SecretKey& to,
+TransactionFramePtr createCreateAccountTx(Hash const& networkID,
+                                          SecretKey& from, SecretKey& to,
                                           SequenceNumber seq, int64_t amount);
 
 void
@@ -87,14 +88,16 @@ applyCreateAccountTx(Application& app, SecretKey& from, SecretKey& to,
                      SequenceNumber seq, int64_t amount,
                      CreateAccountResultCode result = CREATE_ACCOUNT_SUCCESS);
 
-TransactionFramePtr createPaymentTx(SecretKey& from, SecretKey& to,
-                                    SequenceNumber seq, int64_t amount);
+TransactionFramePtr createPaymentTx(Hash const& networkID, SecretKey& from,
+                                    SecretKey& to, SequenceNumber seq,
+                                    int64_t amount);
 
 void applyPaymentTx(Application& app, SecretKey& from, SecretKey& to,
                     SequenceNumber seq, int64_t amount,
                     PaymentResultCode result = PAYMENT_SUCCESS);
 
-TransactionFramePtr createCreditPaymentTx(SecretKey& from, SecretKey& to,
+TransactionFramePtr createCreditPaymentTx(Hash const& networkID,
+                                          SecretKey& from, SecretKey& to,
                                           Asset& ci, SequenceNumber seq,
                                           int64_t amount);
 
@@ -103,9 +106,9 @@ PaymentResult applyCreditPaymentTx(Application& app, SecretKey& from,
                                    int64_t amount,
                                    PaymentResultCode result = PAYMENT_SUCCESS);
 
-TransactionFramePtr createPathPaymentTx(SecretKey& from, SecretKey& to,
-                                        Asset const& sendCur, int64_t sendMax,
-                                        Asset const& destCur,
+TransactionFramePtr createPathPaymentTx(Hash const& networkID, SecretKey& from,
+                                        SecretKey& to, Asset const& sendCur,
+                                        int64_t sendMax, Asset const& destCur,
                                         int64_t destAmount, SequenceNumber seq,
                                         std::vector<Asset>* path = nullptr);
 
@@ -116,12 +119,13 @@ applyPathPaymentTx(Application& app, SecretKey& from, SecretKey& to,
                    PathPaymentResultCode result = PATH_PAYMENT_SUCCESS,
                    std::vector<Asset>* path = nullptr);
 
-TransactionFramePtr manageOfferOp(uint64 offerId, SecretKey& source,
-                                  Asset& selling, Asset& buying,
-                                  Price const& price, int64_t amount,
-                                  SequenceNumber seq);
+TransactionFramePtr manageOfferOp(Hash const& networkID, uint64 offerId,
+                                  SecretKey& source, Asset& selling,
+                                  Asset& buying, Price const& price,
+                                  int64_t amount, SequenceNumber seq);
 
-TransactionFramePtr createPassiveOfferOp(SecretKey& source, Asset& selling,
+TransactionFramePtr createPassiveOfferOp(Hash const& networkID,
+                                         SecretKey& source, Asset& selling,
                                          Asset& buying, Price const& price,
                                          int64_t amount, SequenceNumber seq);
 
@@ -138,7 +142,8 @@ ManageOfferResult applyCreateOfferWithResult(
     Asset& selling, Asset& buying, Price const& price, int64_t amount,
     SequenceNumber seq, ManageOfferResultCode result = MANAGE_OFFER_SUCCESS);
 
-TransactionFramePtr createSetOptions(SecretKey& source, SequenceNumber seq,
+TransactionFramePtr createSetOptions(Hash const& networkID, SecretKey& source,
+                                     SequenceNumber seq,
                                      AccountID* inflationDest,
                                      uint32_t* setFlags, uint32_t* clearFlags,
                                      ThresholdSetter* thrs, Signer* signer);
@@ -149,13 +154,14 @@ void applySetOptions(Application& app, SecretKey& source, SequenceNumber seq,
                      Signer* signer,
                      SetOptionsResultCode result = SET_OPTIONS_SUCCESS);
 
-TransactionFramePtr createInflation(SecretKey& from, SequenceNumber seq);
+TransactionFramePtr createInflation(Hash const& networkID, SecretKey& from,
+                                    SequenceNumber seq);
 OperationResult applyInflation(Application& app, SecretKey& from,
                                SequenceNumber seq,
                                InflationResultCode result = INFLATION_SUCCESS);
 
-TransactionFramePtr createAccountMerge(SecretKey& source, SecretKey& dest,
-                                       SequenceNumber seq);
+TransactionFramePtr createAccountMerge(Hash const& networkID, SecretKey& source,
+                                       SecretKey& dest, SequenceNumber seq);
 
 void applyAccountMerge(Application& app, SecretKey& source, SecretKey& dest,
                        SequenceNumber seq,

--- a/src/xdr/Stellar-overlay.x
+++ b/src/xdr/Stellar-overlay.x
@@ -17,6 +17,7 @@ struct Hello
 {
     uint32 ledgerVersion;
     uint32 overlayVersion;
+    Hash networkID;
     string versionStr<100>;
     int listeningPort;
     NodeID peerID;


### PR DESCRIPTION
Configurable passphrase that controls
 * the seed of the account in the genesis ledger
 * the signatures used on the networks

This resolves #692 

Note: this is a breaking change (breaks all signatures), which will require a testnet reset and client side updates (clients have to be made aware of which network they talk to).