### PR TITLE
all testcases passed in windows

### DIFF
--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -188,7 +188,8 @@ hexDir(std::string const& hexStr)
 {
     std::regex rx("([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2}).*");
     std::smatch sm;
-    assert(std::regex_match(hexStr, sm, rx));
+    bool matched = std::regex_match(hexStr, sm, rx);
+    assert(matched);
     return (std::string(sm[1]) + "/" + std::string(sm[2]) + "/" +
             std::string(sm[3]));
 }

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -92,10 +92,8 @@ VirtualClock::to_time_t(time_point point)
 time_t
 timegm(struct tm* tm)
 {
-    time_t zero = 0;
-    time_t localEpoch = mktime(gmtime(&zero));
-    time_t local = mktime(tm);
-    return local - localEpoch;
+    //Timezone independant version
+    return _mkgmtime(tm);
 }
 #endif
 

--- a/src/util/TimerTests.cpp
+++ b/src/util/TimerTests.cpp
@@ -10,8 +10,23 @@
 #include "lib/catch.hpp"
 #include "util/Logging.h"
 #include "util/make_unique.h"
+#include <chrono>
 
 using namespace stellar;
+
+TEST_CASE("pointToTm tmToPoint stuff", "[timer]")
+{
+    VirtualClock::time_point tp;
+    tp = tp + std::chrono::seconds(12); //01/01/70 00:00:12 UTC+8 is before GMT epoch, mktime may fail.
+
+    std::tm tt = VirtualClock::pointToTm(tp);
+
+    VirtualClock::time_point tp2 = VirtualClock::tmToPoint(tt);
+
+    auto twelvesec = VirtualClock::to_time_t(tp2);
+    CHECK(twelvesec == 12);
+}
+
 
 TEST_CASE("VirtualClock::pointToISOString", "[timer]")
 {


### PR DESCRIPTION
* fixed fs::hexDir()
std::regex_match() did not run in release mode (cflag with -DNDEBUG)
*Affected*: crash when run "stellar-core --newhist"

* fixed ProcessManagerImpl::runProcess()
when active processes are equal to MAX_CONCURRENT_SUBPROCESSES, new process will be queued as pending process. pending processes had no chance to run without new runProcess() invoke in windows.
*Affected*: testcase "subprocess storm" in src/process/ProcessTests.cpp endless loop in windows;

* fixed timegm() (in src/util/Timer.cpp)\
mktime() return -1 when first N hours after epoch is inputted and timezone set to UTC+N. so VirtualClock::tmToPoint always return 0 in those hours.
*Affected*: testcase "loadPeerRecord and storePeerRecord" in src/overlay/PeerRecordTests.cpp failed in windows;
