### PR TITLE
External queue for data retention

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -233,6 +233,7 @@
     <ClCompile Include="..\..\src\main\dumpxdr.cpp" />
     <ClCompile Include="..\..\src\main\fuzz.cpp" />
     <ClCompile Include="..\..\src\main\PersistentState.cpp" />
+    <ClCompile Include="..\..\src\main\ExternalQueue.cpp" />
     <ClCompile Include="..\..\src\overlay\ItemFetcherTests.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayManagerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\PeerRecord.cpp" />
@@ -312,6 +313,7 @@
     <ClInclude Include="..\..\src\crypto\SecretKey.h" />
     <ClInclude Include="..\..\src\crypto\StrKey.h" />
     <ClInclude Include="..\..\src\database\Database.h" />
+    <ClInclude Include="..\..\src\main\ExternalQueue.h" />
     <ClInclude Include="..\..\src\overlay\StellarXDR.h" />
     <ClInclude Include="..\..\src\herder\HerderImpl.h" />
     <ClInclude Include="..\..\src\herder\Herder.h" />

--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -462,6 +462,9 @@
     <ClCompile Include="..\..\src\main\dumpxdr.cpp">
       <Filter>main</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\ExternalQueue.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ledger\LedgerManager.h">
@@ -803,6 +806,9 @@
     </ClInclude>
     <ClInclude Include="src\generated\xdr\Stellar-types.h">
       <Filter>xdr\generated</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\ExternalQueue.h">
+      <Filter>main</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -1,10 +1,17 @@
 # Administration
 
 Stellar Core is responsible for communicating directly with and/or maintaining 
-the Stellar peer-to-peer network. Run stellar-core if you want to:
-* Participate in validating the Stellar network
+the Stellar peer-to-peer network.
+
+## Why run a node?
+
+Run stellar-core if you want to:
 * Obtain the most up-to-date and reliable data from the Stellar network
-* Submit transactions without depending on a third party
+* Generate extended meta data on activity within the Stellar network (change tracking, etc)
+* Submit transactions and their confirmations without depending on a third party
+* Extended control on which parties to trust in the Stellar network
+* Participate in validating the Stellar network
+
 
 ## Building
 See [readme](/README.md) for build instructions.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ stellar-core can be controlled via the following commands.
 * **--c** Send an [HTTP command](#HTTP-Commands) to an already running local instance of stellar-core and then exit. For example: `> stellar-core -c info`
 * **--conf FILE**: Specify a config file to use. You can use '-' and provide the config file via STDIN. *default 'stellar-core.cfg'*
 * **--convertid ID**: Will output the passed ID in all known forms and then exit. Useful for determining the public key that corresponds to a given private key. For example:
-`> stellar-core --convertid SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2`
+`stellar-core --convertid SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2`
 * **--dumpxdr FILE**:  Dumps the given XDR file and then exits.
 * **--forcescp**: This command is used to start a network from scratch or when a network has lost quorum because of failed nodes or otherwise. It sets a flag in the database. The next time stellar-core is run, stellar-core will start emitting SCP messages based on its last known ledger rather than waiting to hear a ledger close from the network. This doesn't change the requirements for quorum so although this node will emit SCP messages SCP won't complete until there are also a quorum of other nodes also emitting SCP messages on this same ledger.
 * **--fuzz FILE**: Run a single fuzz input and exit.
@@ -36,9 +36,18 @@ command line option (see above). Most commands return their results in JSON form
 * **checkpoint**
   Triggers the instance to write an immediate history checkpoint.
 
+* **checkdb**
+  Triggers the instance to perform a background check of the database's state.
+
+* **checkpoint**
+  Forces uploading a history checkpoint to the archive.
+
 * **connect**
   `/connect?peer=NAME&port=NNN`
   Triggers the instance to connect to peer NAME at port NNN.
+
+* **dropcursor**
+  `/dropcursor?id=XYZ` deletes the tracking cursor with identified by `id`. See `setcursor` for more information.
 
 * **info**
   Returns information about the server in JSON format (sync
@@ -49,9 +58,10 @@ command line option (see above). Most commands return their results in JSON form
   Adjust the log level for partition P (or all if no partition is specified).
   Level is one of FATAL, ERROR, WARNING, INFO, DEBUG, VERBOSE, TRACE
 
-* **manualclose**
-  If MANUAL_CLOSE is set to true in the .cfg file. This is will cause the 
-  current ledger to close. Used only for testing.
+* **maintenance**
+ `/maintenance?[queue=true]`
+  Performs maintenance tasks on the instance.
+   * `queue` performs deletion of queue data. See `setcursor` for more information.
 
 * **metrics**
  Returns a snapshot of the metrics registry (for monitoring and
@@ -59,6 +69,13 @@ debugging purpose).
 
 * **peers**
   Returns the list of known peers in JSON format.
+
+* **setcursor**
+ `/setcursor?id=ID&cursor=N`
+  sets or creates a cursor identified by `ID` with value `N`. ID is an uppercase AlphaNum, N is an uint32 that represents the last ledger sequence number that the instance ID processed.
+  Cursors are used by dependent services to tell stellar-core which data can be safely deleted by the instance.
+  The data is historical data stored in the SQL tables such as txhistory or ledgerheaders. When all consumers processed the data for ledger sequence N the data can be safely removed by the instance.
+  The actual deletion is performed by invoking the `maintenance` endpoint.
 
 * **scp**
   Returns a JSON object with the internal state of the SCP engine.
@@ -74,3 +91,20 @@ debugging purpose).
     * "ERROR" - transaction rejected by transaction engine
         error: set when status is "ERROR".
             Base64 encoded, XDR serialized 'TransactionResult'
+
+### The following HTTP commands are exposed on test instances
+* **generateload**
+  `/generateload[?accounts=N&txs=M&txrate=(R|auto)]`
+  Artificially generate load for testing; must be used with `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
+
+* **manualclose**
+  If MANUAL_CLOSE is set to true in the .cfg file. This will cause the current ledger to close.
+
+* **testacc**
+ `/testacc?name=N`
+ Returns basic information about the account identified by name. Note that N is a string used as seed, but "root" can be used as well to specify the root account used for the test instance.
+
+* **testtx**
+ `/testtx?from=F&to=T&amount=N&[create=true]
+  Injects a payment transaction (or a create transaction if "create" is specified) from the account F to the account T, sending N XLM to the account.
+  Note that F and T are seed strings but can also be specified as "root" as a shorthand for the root account for the test instance.

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -10,6 +10,7 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "main/PersistentState.h"
+#include "main/ExternalQueue.h"
 #include "overlay/OverlayManager.h"
 #include "transactions/TransactionFrame.h"
 #include "util/Logging.h"
@@ -154,6 +155,7 @@ Database::initialize()
     TrustFrame::dropAll(*this);
     OverlayManager::dropAll(*this);
     PersistentState::dropAll(*this);
+    ExternalQueue::dropAll(*this);
     LedgerHeaderFrame::dropAll(*this);
     TransactionFrame::dropAll(*this);
     BucketManager::dropAll(mApp);

--- a/src/ledger/LedgerHeaderFrame.cpp
+++ b/src/ledger/LedgerHeaderFrame.cpp
@@ -214,6 +214,13 @@ LedgerHeaderFrame::copyLedgerHeadersToStream(Database& db, soci::session& sess,
 }
 
 void
+LedgerHeaderFrame::deleteOldEntries(Database& db, uint32_t ledgerSeq)
+{
+    db.getSession() << "DELETE FROM ledgerheaders WHERE ledgerseq <= "
+                    << ledgerSeq;
+}
+
+void
 LedgerHeaderFrame::dropAll(Database& db)
 {
     db.getSession() << "DROP TABLE IF EXISTS ledgerheaders;";

--- a/src/ledger/LedgerHeaderFrame.h
+++ b/src/ledger/LedgerHeaderFrame.h
@@ -54,6 +54,8 @@ class LedgerHeaderFrame
                                             uint32_t ledgerCount,
                                             XDROutputFileStream& headersOut);
 
+    static void deleteOldEntries(Database& db, uint32_t ledgerSeq);
+
     static void dropAll(Database& db);
     static const char* kSQLCreateStatement;
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -160,6 +160,9 @@ class LedgerManager
     // permit testing.
     virtual void closeLedger(LedgerCloseData const& ledgerData) = 0;
 
+    // deletes old entries stored in the database
+    virtual void deleteOldEntries(Database& db, uint32_t ledgerSeq) = 0;
+
     virtual ~LedgerManager()
     {
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -748,6 +748,13 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
 }
 
 void
+LedgerManagerImpl::deleteOldEntries(Database& db, uint32_t ledgerSeq)
+{
+    LedgerHeaderFrame::deleteOldEntries(db, ledgerSeq);
+    TransactionFrame::deleteOldEntries(db, ledgerSeq);
+}
+
+void
 LedgerManagerImpl::advanceLedgerPointers()
 {
     CLOG(DEBUG, "Ledger") << "Advancing LCL: "

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -90,5 +90,6 @@ class LedgerManagerImpl : public LedgerManager
     HistoryManager::VerifyHashStatus
     verifyCatchupCandidate(LedgerHeaderHistoryEntry const&) const override;
     void closeLedger(LedgerCloseData const& ledgerData) override;
+    void deleteOldEntries(Database& db, uint32_t ledgerSeq) override;
 };
 }

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -32,6 +32,7 @@ class OverlayManager;
 class Database;
 class PersistentState;
 class LoadGenerator;
+class CommandHandler;
 
 /*
  * State of a single instance of the stellar-core application.
@@ -181,6 +182,7 @@ class Application
     virtual OverlayManager& getOverlayManager() = 0;
     virtual Database& getDatabase() = 0;
     virtual PersistentState& getPersistentState() = 0;
+    virtual CommandHandler& getCommandHandler() = 0;
 
     // Get the worker IO service, served by background threads. Work posted to
     // this io_service will execute in parallel with the calling thread, so use

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -517,6 +517,12 @@ ApplicationImpl::getPersistentState()
     return *mPersistentState;
 }
 
+CommandHandler&
+ApplicationImpl::getCommandHandler()
+{
+    return *mCommandHandler;
+}
+
 asio::io_service&
 ApplicationImpl::getWorkerIOService()
 {

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -55,6 +55,7 @@ class ApplicationImpl : public Application
     virtual OverlayManager& getOverlayManager() override;
     virtual Database& getDatabase() override;
     virtual PersistentState& getPersistentState() override;
+    virtual CommandHandler& getCommandHandler() override;
 
     virtual asio::io_service& getWorkerIOService() override;
 

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -32,13 +32,16 @@ class CommandHandler
     void checkpoint(std::string const& params, std::string& retStr);
     void checkdb(std::string const& params, std::string& retStr);
     void connect(std::string const& params, std::string& retStr);
+    void dropcursor(std::string const& params, std::string& retStr);
     void generateLoad(std::string const& params, std::string& retStr);
     void info(std::string const& params, std::string& retStr);
     void ll(std::string const& params, std::string& retStr);
     void logRotate(std::string const& params, std::string& retStr);
+    void maintenance(std::string const& params, std::string& retStr);
     void manualClose(std::string const& params, std::string& retStr);
     void metrics(std::string const& params, std::string& retStr);
     void peers(std::string const& params, std::string& retStr);
+    void setcursor(std::string const& params, std::string& retStr);
     void scpInfo(std::string const& params, std::string& retStr);
     void tx(std::string const& params, std::string& retStr);
     void testAcc(std::string const& params, std::string& retStr);

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -1,0 +1,149 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ExternalQueue.h"
+
+#include "database/Database.h"
+#include "Application.h"
+#include "ledger/LedgerManager.h"
+#include <regex>
+
+namespace stellar
+{
+
+using namespace std;
+
+string ExternalQueue::kSQLCreateStatement =
+    "CREATE TABLE IF NOT EXISTS pubsub ("
+    "resid       CHARACTER(32) PRIMARY KEY,"
+    "lastread    INTEGER"
+    "); ";
+
+ExternalQueue::ExternalQueue(Application& app) : mApp(app)
+{
+    mApp.getDatabase().getSession() << kSQLCreateStatement;
+}
+
+void
+ExternalQueue::dropAll(Database& db)
+{
+    db.getSession() << "DROP TABLE IF EXISTS pubsub;";
+
+    soci::statement st = db.getSession().prepare << kSQLCreateStatement;
+    st.execute(true);
+}
+
+bool
+ExternalQueue::validateResourceID(std::string const& resid)
+{
+    static std::regex re("^[A-Z][A-Z0-9]{0,31}$");
+    return std::regex_match(resid, re);
+}
+
+void
+ExternalQueue::setCursorForResource(std::string const& resid, uint32 cursor)
+{
+    checkID(resid);
+
+    std::string old(getCursor(resid));
+    if (old.empty())
+    {
+        auto timer = mApp.getDatabase().getInsertTimer("pubsub");
+        auto prep = mApp.getDatabase().getPreparedStatement(
+            "INSERT INTO pubsub (resid, lastread) VALUES (:n, :v);");
+        auto& st = prep.statement();
+        st.exchange(soci::use(resid));
+        st.exchange(soci::use(cursor));
+        st.define_and_bind();
+        st.execute(true);
+        if (st.get_affected_rows() != 1)
+        {
+            throw std::runtime_error("Could not insert data in SQL");
+        }
+    }
+    else
+    {
+        auto prep = mApp.getDatabase().getPreparedStatement(
+            "UPDATE pubsub SET lastread = :v WHERE resid = :n;");
+
+        auto& st = prep.statement();
+        st.exchange(soci::use(cursor));
+        st.exchange(soci::use(resid));
+        st.define_and_bind();
+        {
+            auto timer = mApp.getDatabase().getUpdateTimer("pubsub");
+            st.execute(true);
+        }
+    }
+}
+
+void
+ExternalQueue::deleteCursor(std::string const& resid)
+{
+    checkID(resid);
+
+    auto timer = mApp.getDatabase().getInsertTimer("pubsub");
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "DELETE FROM pubsub WHERE resid = :n;");
+    auto& st = prep.statement();
+    st.exchange(soci::use(resid));
+    st.define_and_bind();
+    st.execute(true);
+}
+
+void
+ExternalQueue::process()
+{
+    auto& db = mApp.getDatabase();
+    int m;
+    soci::indicator minIndicator;
+    soci::statement st =
+        (db.getSession().prepare << "SELECT MIN(lastread) FROM pubsub",
+         soci::into(m, minIndicator));
+    {
+        auto timer = db.getSelectTimer("state");
+        st.execute(true);
+    }
+
+    if (st.got_data() && minIndicator == soci::indicator::i_ok)
+    {
+        mApp.getLedgerManager().deleteOldEntries(mApp.getDatabase(), (uint32)m);
+    }
+}
+
+void
+ExternalQueue::checkID(std::string const& resid)
+{
+    if (!validateResourceID(resid))
+    {
+        throw std::invalid_argument("invalid resource ID");
+    }
+}
+
+std::string
+ExternalQueue::getCursor(std::string const& resid)
+{
+    checkID(resid);
+    std::string res;
+
+    auto& db = mApp.getDatabase();
+    auto prep = db.getPreparedStatement(
+        "SELECT lastread FROM pubsub WHERE resid = :n;");
+    auto& st = prep.statement();
+    st.exchange(soci::into(res));
+    st.exchange(soci::use(resid));
+    st.define_and_bind();
+    {
+        auto timer = db.getSelectTimer("pubsub");
+        st.execute(true);
+    }
+
+    if (!st.got_data())
+    {
+        res.clear();
+    }
+
+    return res;
+}
+}

--- a/src/main/ExternalQueue.h
+++ b/src/main/ExternalQueue.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "xdr/Stellar-types.h"
+#include "main/Application.h"
+#include <string>
+
+namespace stellar
+{
+
+class ExternalQueue
+{
+  public:
+    ExternalQueue(Application& app);
+
+    static void dropAll(Database& db);
+
+    // checks if a given resource ID is well formed
+    static bool validateResourceID(std::string const& resid);
+
+    // sets the cursor of a given resource
+    void setCursorForResource(std::string const& resid, uint32 cursor);
+    // deletes the subscription for the resource
+    void deleteCursor(std::string const& resid);
+
+    // safely delete data
+    void process();
+
+  private:
+    void checkID(std::string const& resid);
+    std::string getCursor(std::string const& resid);
+
+    static std::string kSQLCreateStatement;
+
+    Application& mApp;
+};
+}

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -664,4 +664,10 @@ TransactionFrame::dropAll(Database& db)
                        "UNIQUE      (ledgerseq, txindex)"
                        ")";
 }
+
+void
+TransactionFrame::deleteOldEntries(Database& db, uint32_t ledgerSeq)
+{
+    db.getSession() << "DELETE FROM txhistory WHERE ledgerseq <= " << ledgerSeq;
+}
 }

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -165,5 +165,7 @@ class TransactionFrame
                                            XDROutputFileStream& txOut,
                                            XDROutputFileStream& txResultOut);
     static void dropAll(Database& db);
+
+    static void deleteOldEntries(Database& db, uint32_t ledgerSeq);
 };
 }


### PR DESCRIPTION
This change allows to properly delete data that stellar-core generates.
Resolves #186 

Approach taken is to expose 3 new endpoints that allow to do a simple pub/sub off the stellar-core data:
 * `setcursor`: sets the cursor (ledger sequence number) for a given subscriber (like "HORIZON")
 * `dropcursor`: deletes a subscriber
 * `maintenance`: runs the maintenance tasks. Right now only "queue" is implemented for the pub/sub work and it's just deleting data up to the smallest cursor.

`setcursor` is typically run directly by the subscriber.
`maintenance` is typically run on a schedule by a sys admin.