### PR TITLE
Charge fees first

### DIFF
--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -104,6 +104,16 @@ txbody | TEXT NOT NULL | TransactionEnvelope (XDR)
 txresult | TEXT NOT NULL | TransactionResultPair (XDR)
 txmeta | TEXT NOT NULL | TransactionMeta (XDR)
 
+## txfeehistory
+
+Defined in [`src/transactions/TransactionFrame.cpp`](../src/transactions/TransactionFrame.cpp)
+
+Field | Type | Description
+------|------|---------------
+txid | CHARACTER(64) NOT NULL | Hash of the transaction (excluding signatures) (HEX)
+ledgerseq | INT NOT NULL CHECK (ledgerseq >= 0) | Ledger this transaction got applied
+txindex | INT NOT NULL | Apply order (per ledger, 1)
+txchanges | TEXT NOT NULL | LedgerEntryChanges (XDR)
 
 ## storestate
 

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -94,10 +94,10 @@ class HistoryTests
     std::vector<uint256> mBucket0Hashes;
     std::vector<uint256> mBucket1Hashes;
 
-    std::vector<uint64_t> mRootBalances;
-    std::vector<uint64_t> mAliceBalances;
-    std::vector<uint64_t> mBobBalances;
-    std::vector<uint64_t> mCarolBalances;
+    std::vector<int64_t> mRootBalances;
+    std::vector<int64_t> mAliceBalances;
+    std::vector<int64_t> mBobBalances;
+    std::vector<int64_t> mCarolBalances;
 
     std::vector<SequenceNumber> mRootSeqs;
     std::vector<SequenceNumber> mAliceSeqs;
@@ -277,9 +277,12 @@ HistoryTests::generateRandomLedger()
     Hash const& networkID = app.getNetworkID();
 
     // Root sends to alice every tx, bob every other tx, carol every 4rd tx.
-    txSet->add(txtest::createCreateAccountTx(networkID, mRoot, mAlice, rseq++, big));
-    txSet->add(txtest::createCreateAccountTx(networkID, mRoot, mBob, rseq++, big));
-    txSet->add(txtest::createCreateAccountTx(networkID, mRoot, mCarol, rseq++, big));
+    txSet->add(
+        txtest::createCreateAccountTx(networkID, mRoot, mAlice, rseq++, big));
+    txSet->add(
+        txtest::createCreateAccountTx(networkID, mRoot, mBob, rseq++, big));
+    txSet->add(
+        txtest::createCreateAccountTx(networkID, mRoot, mCarol, rseq++, big));
     txSet->add(txtest::createPaymentTx(networkID, mRoot, mAlice, rseq++, big));
     txSet->add(txtest::createPaymentTx(networkID, mRoot, mBob, rseq++, big));
     txSet->add(txtest::createPaymentTx(networkID, mRoot, mCarol, rseq++, big));
@@ -292,25 +295,25 @@ HistoryTests::generateRandomLedger()
         SequenceNumber cseq = txtest::getAccountSeqNum(mCarol, app) + 1;
 
         if (flip())
-            txSet->add(
-                txtest::createPaymentTx(networkID, mAlice, mBob, aseq++, small));
+            txSet->add(txtest::createPaymentTx(networkID, mAlice, mBob, aseq++,
+                                               small));
         if (flip())
-            txSet->add(
-                txtest::createPaymentTx(networkID, mAlice, mCarol, aseq++, small));
+            txSet->add(txtest::createPaymentTx(networkID, mAlice, mCarol,
+                                               aseq++, small));
 
         if (flip())
-            txSet->add(
-                txtest::createPaymentTx(networkID, mBob, mAlice, bseq++, small));
+            txSet->add(txtest::createPaymentTx(networkID, mBob, mAlice, bseq++,
+                                               small));
         if (flip())
-            txSet->add(
-                txtest::createPaymentTx(networkID, mBob, mCarol, bseq++, small));
+            txSet->add(txtest::createPaymentTx(networkID, mBob, mCarol, bseq++,
+                                               small));
 
         if (flip())
-            txSet->add(
-                txtest::createPaymentTx(networkID, mCarol, mAlice, cseq++, small));
+            txSet->add(txtest::createPaymentTx(networkID, mCarol, mAlice,
+                                               cseq++, small));
         if (flip())
-            txSet->add(
-                txtest::createPaymentTx(networkID, mCarol, mBob, cseq++, small));
+            txSet->add(txtest::createPaymentTx(networkID, mCarol, mBob, cseq++,
+                                               small));
     }
 
     // Provoke sortForHash and hash-caching:

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -683,7 +683,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             CLOG(ERROR, "Ledger") << "Unknown exception during tx->apply";
             tx->getResult().result.code(txINTERNAL_ERROR);
         }
-        tx->storeTransaction(*this, delta, tm, ++index, txResultSet);
+        tx->storeTransaction(*this, tm, ++index, txResultSet);
     }
 
     ledgerDelta.getHeader().txSetResultHash =

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -771,6 +771,7 @@ LedgerManagerImpl::processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
         {
             LedgerDelta thisTxDelta(delta);
             tx->processFeeSeqNum(thisTxDelta, *this);
+            tx->storeTransactionFee(*this, thisTxDelta.getChanges(), ++index);
             thisTxDelta.commit();
         }
         sqlTx.commit();

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -53,6 +53,8 @@ class LedgerManagerImpl : public LedgerManager
                          HistoryManager::CatchupMode mode,
                          LedgerHeaderHistoryEntry const& lastClosed);
 
+    void processFeesSeqNums(std::vector<TransactionFramePtr>& txs, LedgerDelta& delta);
+
     void closeLedgerHelper(LedgerDelta const& delta);
     void advanceLedgerPointers();
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -53,7 +53,11 @@ class LedgerManagerImpl : public LedgerManager
                          HistoryManager::CatchupMode mode,
                          LedgerHeaderHistoryEntry const& lastClosed);
 
-    void processFeesSeqNums(std::vector<TransactionFramePtr>& txs, LedgerDelta& delta);
+    void processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
+                            LedgerDelta& delta);
+    void applyTransactions(std::vector<TransactionFramePtr>& txs,
+                           LedgerDelta& ledgerDelta,
+                           TransactionResultSet& txResultSet);
 
     void closeLedgerHelper(LedgerDelta const& delta);
     void advanceLedgerPointers();

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -104,9 +104,9 @@ OperationFrame::getSourceID() const
 }
 
 bool
-OperationFrame::loadAccount(Application& app)
+OperationFrame::loadAccount(Database& db)
 {
-    mSourceAccount = mParentTx.loadAccount(app, getSourceID());
+    mSourceAccount = mParentTx.loadAccount(db, getSourceID());
     return !!mSourceAccount;
 }
 
@@ -126,7 +126,7 @@ OperationFrame::getResultCode() const
 bool
 OperationFrame::checkValid(Application& app, bool forApply)
 {
-    if (!loadAccount(app))
+    if (!loadAccount(app.getDatabase()))
     {
         if (forApply || !mOperation.sourceAccount)
         {

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -66,7 +66,7 @@ class OperationFrame
 
     // load account if needed
     // returns true on success
-    bool loadAccount(Application& app);
+    bool loadAccount(Database& db);
 
     OperationResult&
     getResult() const

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -669,8 +669,9 @@ TransactionFrame::dropAll(Database& db)
                        "txbody      TEXT NOT NULL,"
                        "txresult    TEXT NOT NULL,"
                        "txmeta      TEXT NOT NULL,"
-                       "PRIMARY KEY (txid, ledgerseq),"
-                       "UNIQUE      (ledgerseq, txindex)"
+                       "PRIMARY KEY (ledgerseq, txindex)"
+                       ")";
+    db.getSession() << "CREATE INDEX histbyseq ON txhistory (ledgerseq);";
                        ")";
 }
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -166,7 +166,7 @@ TransactionFrame::checkSignature(AccountFrame& account, int32_t neededWeight)
 }
 
 AccountFrame::pointer
-TransactionFrame::loadAccount(Application& app, AccountID const& accountID)
+TransactionFrame::loadAccount(Database& db, AccountID const& accountID)
 {
     AccountFrame::pointer res;
 
@@ -176,21 +176,20 @@ TransactionFrame::loadAccount(Application& app, AccountID const& accountID)
     }
     else
     {
-        res = AccountFrame::loadAccount(accountID, app.getDatabase());
+        res = AccountFrame::loadAccount(accountID, db);
     }
     return res;
 }
 
 bool
-TransactionFrame::loadAccount(Application& app)
+TransactionFrame::loadAccount(Database& db)
 {
-    mSigningAccount = loadAccount(app, getSourceID());
+    mSigningAccount = loadAccount(db, getSourceID());
     return !!mSigningAccount;
 }
 
-bool
-TransactionFrame::checkValid(Application& app, bool applying,
-                             SequenceNumber current)
+void
+TransactionFrame::resetResults()
 {
     // pre-allocates the results for all operations
     getResult().result.code(txSUCCESS);
@@ -256,7 +255,7 @@ TransactionFrame::checkValid(Application& app, bool applying,
         return false;
     }
 
-    if (!loadAccount(app))
+    if (!loadAccount(app.getDatabase()))
     {
         app.getMetrics()
             .NewMeter({"transaction", "invalid", "no-account"}, "transaction")

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -436,7 +436,7 @@ TransactionFrame::apply(LedgerDelta& delta, Application& app)
 }
 
 bool
-TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& tm,
+TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& meta,
                         Application& app)
 {
     resetSignatureTracker();
@@ -444,9 +444,6 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& tm,
     {
         return false;
     }
-    auto& meta = tm.v0();
-
-    meta.changes = delta.getChanges();
 
     bool errorEncountered = false;
 
@@ -469,7 +466,7 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& tm,
             {
                 errorEncountered = true;
             }
-            meta.operations.emplace_back(opDelta.getChanges());
+            meta.operations().emplace_back(opDelta.getChanges());
             opDelta.commit();
         }
 
@@ -489,7 +486,7 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& tm,
 
     if (errorEncountered)
     {
-        meta.operations.clear();
+        meta.operations().clear();
         markResultFailed();
     }
 

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -47,10 +47,10 @@ class TransactionFrame
 
     std::vector<std::shared_ptr<OperationFrame>> mOperations;
 
+    bool loadAccount(Database& app);
     // collect fee, consume sequence number
     void prepareResult(LedgerDelta& delta, LedgerManager& ledgerManager);
 
-    bool loadAccount(Application& app);
     bool checkValid(Application& app, bool applying, SequenceNumber current);
 
     void resetState();
@@ -146,7 +146,7 @@ class TransactionFrame
 
     StellarMessage toStellarMessage() const;
 
-    AccountFrame::pointer loadAccount(Application& app,
+    AccountFrame::pointer loadAccount(Database& app,
                                       AccountID const& accountID);
 
     // transaction history

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -140,7 +140,7 @@ class TransactionFrame
 
     // apply this transaction to the current ledger
     // returns true if successfully applied
-    bool apply(LedgerDelta& delta, TransactionMeta& tm, Application& app);
+    bool apply(LedgerDelta& delta, TransactionMeta& meta, Application& app);
 
     // version without meta
     bool apply(LedgerDelta& delta, Application& app);
@@ -151,8 +151,7 @@ class TransactionFrame
                                       AccountID const& accountID);
 
     // transaction history
-    void storeTransaction(LedgerManager& ledgerManager,
-                          LedgerDelta const& delta, TransactionMeta& tm,
+    void storeTransaction(LedgerManager& ledgerManager, TransactionMeta& tm,
                           int txindex, TransactionResultSet& resultSet) const;
 
     /*

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -48,12 +48,10 @@ class TransactionFrame
     std::vector<std::shared_ptr<OperationFrame>> mOperations;
 
     bool loadAccount(Database& app);
-    // collect fee, consume sequence number
-    void prepareResult(LedgerDelta& delta, LedgerManager& ledgerManager);
+    bool commonValid(Application& app, bool applying, SequenceNumber current);
 
-    bool checkValid(Application& app, bool applying, SequenceNumber current);
-
-    void resetState();
+    void resetSignatureTracker();
+    void resetResults();
     bool checkAllSignaturesUsed();
     void markResultFailed();
 
@@ -136,6 +134,9 @@ class TransactionFrame
     bool checkSignature(AccountFrame& account, int32_t neededWeight);
 
     bool checkValid(Application& app, SequenceNumber current);
+
+    // collect fee, consume sequence number
+    void processFeeSeqNum(LedgerDelta& delta, LedgerManager& ledgerManager);
 
     // apply this transaction to the current ledger
     // returns true if successfully applied

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -154,6 +154,11 @@ class TransactionFrame
     void storeTransaction(LedgerManager& ledgerManager, TransactionMeta& tm,
                           int txindex, TransactionResultSet& resultSet) const;
 
+    // fee history
+    void storeTransactionFee(LedgerManager& ledgerManager,
+                             LedgerEntryChanges const& changes,
+                             int txindex) const;
+
     /*
     txOut: stream of TransactionHistoryEntry
     txResultOut: stream of TransactionHistoryResultEntry

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -159,6 +159,12 @@ class TransactionFrame
                              LedgerEntryChanges const& changes,
                              int txindex) const;
 
+    // access to history tables
+    static TransactionResultSet getTransactionHistoryMeta(Database& db,
+                                                          uint32 ledgerSeq);
+    static std::vector<LedgerEntryChanges>
+    getTransactionFeeMeta(Database& db, uint32 ledgerSeq);
+
     /*
     txOut: stream of TransactionHistoryEntry
     txResultOut: stream of TransactionHistoryResultEntry

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -43,7 +43,6 @@ TEST_CASE("txenvelope", "[tx][envelope]")
     SecretKey root = getRoot(networkID);
     SecretKey a1 = getAccount("A");
     SequenceNumber rootSeq = getAccountSeqNum(root, app) + 1;
-    ;
 
     const uint64_t paymentAmount =
         app.getLedgerManager().getCurrentLedgerHeader().baseReserve * 10;
@@ -150,7 +149,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         {
             // updating thresholds requires high
             TransactionFramePtr tx = createSetOptions(
-                networkID, a1, a1Seq, nullptr, nullptr, nullptr, &th, &sk1);
+                networkID, a1, a1Seq++, nullptr, nullptr, nullptr, &th, &sk1);
 
             // only sign with s1 (med)
             tx->getEnvelope().signatures.clear();
@@ -472,7 +471,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                 clock.setCurrentTime(ledgerTime);
 
-                txFrame = createPaymentTx(networkID, root, a1, rootSeq,
+                txFrame = createPaymentTx(networkID, root, a1, rootSeq++,
                                           paymentAmount);
                 txFrame->getEnvelope().tx.timeBounds.activate() =
                     TimeBounds(start + 1000, start + 10000);
@@ -491,7 +490,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 applyCheck(txFrame, delta, app);
                 REQUIRE(txFrame->getResultCode() == txSUCCESS);
 
-                txFrame = createPaymentTx(networkID, root, a1, rootSeq,
+                txFrame = createPaymentTx(networkID, root, a1, rootSeq++,
                                           paymentAmount);
                 txFrame->getEnvelope().tx.timeBounds.activate() =
                     TimeBounds(1000, start);

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -145,24 +145,48 @@ getTestDate(int day, int month, int year)
     return t;
 }
 
-void
+TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
               TransactionFramePtr tx)
 {
     TxSetFramePtr txSet = std::make_shared<TxSetFrame>(
         app.getLedgerManager().getLastClosedLedgerHeader().hash);
+
     if (tx)
     {
         txSet->add(tx);
         txSet->sortForHash();
     }
 
+    return closeLedgerOn(app, ledgerSeq, day, month, year, txSet);
+}
+
+TxSetResultMeta
+closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
+              TxSetFramePtr txSet)
+{
+
     StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
                     emptyUpgradeSteps, 0);
     LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 
+    auto z1 = TransactionFrame::getTransactionHistoryMeta(app.getDatabase(),
+                                                          ledgerSeq);
+    auto z2 =
+        TransactionFrame::getTransactionFeeMeta(app.getDatabase(), ledgerSeq);
+
     REQUIRE(app.getLedgerManager().getLedgerNum() == (ledgerSeq + 1));
+
+    TxSetResultMeta res;
+    std::transform(z1.results.begin(), z1.results.end(), z2.begin(),
+                   std::back_inserter(res), [](TransactionResultPair const& r1,
+                                               LedgerEntryChanges const& r2)
+                   {
+                       return std::make_pair(r1, r2);
+                   });
+
+    return std::move(res);
 }
 
 SecretKey
@@ -233,7 +257,7 @@ getAccountSeqNum(SecretKey const& k, Application& app)
     return account->getSeqNum();
 }
 
-uint64_t
+int64_t
 getAccountBalance(SecretKey const& k, Application& app)
 {
     AccountFrame::pointer account;
@@ -833,5 +857,19 @@ checkAmounts(int64_t a, int64_t b, int64_t maxd)
     REQUIRE(a >= d);
     REQUIRE(a <= b);
 }
+
+void
+checkTx(int index, TxSetResultMeta& r, TransactionResultCode expected)
+{
+    REQUIRE(r[index].first.result.result.code() == expected);
+};
+
+void
+checkTx(int index, TxSetResultMeta& r, TransactionResultCode expected,
+        OperationResultCode code)
+{
+    checkTx(index, r, expected);
+    REQUIRE(r[index].first.result.result.results()[0].code() == code);
+};
 }
 }

--- a/src/transactions/TxTests.h
+++ b/src/transactions/TxTests.h
@@ -17,8 +17,13 @@ namespace stellar
 class TransactionFrame;
 class LedgerDelta;
 class OperationFrame;
+class TxSetFrame;
+
 namespace txtest
 {
+
+typedef std::vector<std::pair<TransactionResultPair, LedgerEntryChanges>>
+    TxSetResultMeta;
 
 struct ThresholdSetter
 {
@@ -35,8 +40,12 @@ void checkAccount(AccountID const& id, Application& app);
 
 time_t getTestDate(int day, int month, int year);
 
-void closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month,
-                   int year, TransactionFramePtr tx = nullptr);
+TxSetResultMeta closeLedgerOn(Application& app, uint32 ledgerSeq, int day,
+                              int month, int year,
+                              TransactionFramePtr tx = nullptr);
+
+TxSetResultMeta closeLedgerOn(Application& app, uint32 ledgerSeq, int day,
+                              int month, int year, TxSetFramePtr txSet);
 
 SecretKey getRoot(Hash const& networkID);
 
@@ -57,7 +66,7 @@ TrustFrame::pointer loadTrustLine(SecretKey const& k, Asset const& asset,
 
 SequenceNumber getAccountSeqNum(SecretKey const& k, Application& app);
 
-uint64_t getAccountBalance(SecretKey const& k, Application& app);
+int64_t getAccountBalance(SecretKey const& k, Application& app);
 
 TransactionFramePtr createChangeTrust(Hash const& networkID, SecretKey& from,
                                       SecretKey& to, SequenceNumber seq,
@@ -183,6 +192,12 @@ void reSignTransaction(TransactionFrame& tx, SecretKey& source);
 //    * amount left in an offer should be higher than the exact calculation
 //    * amount received by a seller should be higher than the exact calculation
 void checkAmounts(int64_t a, int64_t b, int64_t maxd = 1);
+
+// methods to check results based off meta data
+void checkTx(int index, TxSetResultMeta& r, TransactionResultCode expected);
+
+void checkTx(int index, TxSetResultMeta& r, TransactionResultCode expected,
+             OperationResultCode code);
 
 } // end txtest namespace
 }

--- a/src/transactions/readme.md
+++ b/src/transactions/readme.md
@@ -44,10 +44,9 @@ A transaction is considered valid iff
  * the Source Account exists
  * the transaction is signed for the source account (see Signatures below)
  * the signatures together meet the "low" threshold
- * fee should be less than maxFee
+ * fee is less than maxFee
  * the sequence number follows the rules defined in the "Sequence Number" section
- * the current ledger sequence number must be within the [minLedger, maxLedger] 
-   range
+ * the current ledger sequence number is within the [minLedger, maxLedger]  range
 and
 (B)
  * all operations are valid
@@ -64,17 +63,12 @@ transaction; therefore this is really a best effort implementation specific.
 
 ##Applying a transaction
 
-When SCP externalizes the transaction set to apply to the last closed ledger, 
-the set of transaction is applied one by one.
+When SCP externalizes the transaction set to apply to the last closed ledger:
+Source Accounts for transactions are charged a fee and their sequence number
+is updated. 
+Then, the transactions are applied one by one.
 
 To apply a transaction, it first checks for part (A) of the validity check.
-
-If the transaction passes this test it will collect the fee and proceed to 
-applying the operations.
-If it does not pass this test, the transaction is ignored (doesn't charge a fee,
-doesn't consume a sequence number) - but is still kept in the applied 
-transaction set. This allows to preserve the mapping between SCP transaction 
-set and what is applied.
 
 If any operation fails, the transaction is rolled back entirely but marked as 
 such: the sequence number in the account is consumed, the fee is collected and 
@@ -82,7 +76,7 @@ the result set to "Failed".
 
 ##Result
 When transactions are applied (success or not), the result is saved in the 
-"txhistory" table in the database.
+"txhistory" and "txfeehistory" tables in the database.
 
 #Operations
 
@@ -143,6 +137,8 @@ side effects of the operation, in structured form.
 Results are queued in the txhistory table for other components to derive data:
 historical module for uploading it for long term storage, but also for API 
 servers to consume externally.
+The txfeehistory table is additional meta data that tracks changes to the ledger
+done before transactions are applied.
 
 ##List of operations
 See src/xdr/Stellar-transaction.x for a detailed list of all operations and results.

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -222,10 +222,6 @@ struct OperationMeta
 union TransactionMeta switch (int v)
 {
 case 0:
-    struct
-    {
-        LedgerEntryChanges changes;
-        OperationMeta operations<>;
-    } v0;
+    OperationMeta operations<>;
 };
 }


### PR DESCRIPTION
This changeset modifies the way transaction sets are applied when closing a ledger:
it ensures that fees are collected first, removing the possibility of having invalid transactions.

A new table "txfeehistory" contains the break down of the side effects to the ledger and follows the same pattern than txhistory.
I decided to take that route (as opposed to single blobs in other tables) to avoid future complications with the increase of number of transactions per ledger close.
