### PR TITLE
AccountEntry: signers & homeDomain fixes

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -174,6 +174,7 @@
     <ClCompile Include="..\..\src\ledger\AccountFrame.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerDelta.cpp" />
     <ClCompile Include="..\..\src\ledger\EntryFrame.cpp" />
+    <ClCompile Include="..\..\src\ledger\LedgerEntryTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderFrame.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerManagerImpl.cpp" />

--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -179,6 +179,7 @@
     <ClCompile Include="..\..\src\ledger\LedgerManagerImpl.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerPerformanceTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTests.cpp" />
+    <ClCompile Include="..\..\src\ledger\LedgerTestUtils.cpp" />
     <ClCompile Include="..\..\src\ledger\OfferFrame.cpp" />
     <ClCompile Include="..\..\src\ledger\TrustFrame.cpp" />
     <ClCompile Include="..\..\lib\asio\src\asio.cpp" />
@@ -314,6 +315,7 @@
     <ClInclude Include="..\..\src\crypto\SecretKey.h" />
     <ClInclude Include="..\..\src\crypto\StrKey.h" />
     <ClInclude Include="..\..\src\database\Database.h" />
+    <ClInclude Include="..\..\src\ledger\LedgerTestUtils.h" />
     <ClInclude Include="..\..\src\main\ExternalQueue.h" />
     <ClInclude Include="..\..\src\overlay\StellarXDR.h" />
     <ClInclude Include="..\..\src\herder\HerderImpl.h" />

--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -465,6 +465,9 @@
     <ClCompile Include="..\..\src\main\ExternalQueue.cpp">
       <Filter>main</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\LedgerEntryTests.cpp">
+      <Filter>ledger\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ledger\LedgerTestUtils.cpp">
       <Filter>ledger\tests</Filter>
     </ClCompile>

--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -465,6 +465,9 @@
     <ClCompile Include="..\..\src\main\ExternalQueue.cpp">
       <Filter>main</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\LedgerTestUtils.cpp">
+      <Filter>ledger\tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ledger\LedgerManager.h">
@@ -812,6 +815,9 @@
     </ClInclude>
     <ClInclude Include="..\..\lib\catch.hpp">
       <Filter>lib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ledger\LedgerTestUtils.h">
+      <Filter>ledger\tests</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -344,6 +344,16 @@ PubKeyUtils::hasHint(PublicKey const& pk, SignatureHint const& hint)
                   hint.size()) == 0;
 }
 
+PublicKey
+PubKeyUtils::random()
+{
+    PublicKey pk;
+    pk.type(KEY_TYPE_ED25519);
+    pk.ed25519().resize(crypto_sign_PUBLICKEYBYTES);
+    randombytes_buf(pk.ed25519().data(), pk.ed25519().size());
+    return pk;
+}
+
 static void
 logPublicKey(std::ostream& s, PublicKey const& pk)
 {

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -98,6 +98,8 @@ PublicKey fromBase58(std::string const& s);
 SignatureHint getHint(PublicKey const& pk);
 // returns true if the hint matches the key
 bool hasHint(PublicKey const& pk, SignatureHint const& hint);
+
+PublicKey random();
 }
 
 namespace StrKeyUtils

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -590,6 +590,8 @@ HistoryTests::catchupApplication(uint32_t initLedger,
     CHECK(haveAliceSeq == wantAliceSeq);
     CHECK(haveBobSeq == wantBobSeq);
     CHECK(haveCarolSeq == wantCarolSeq);
+
+    app.getLedgerManager().checkDbState();
     return true;
 }
 

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -54,13 +54,16 @@ AccountFrame::AccountFrame()
     : EntryFrame(ACCOUNT), mAccountEntry(mEntry.data.account())
 {
     mAccountEntry.thresholds[0] = 1; // by default, master key's weight is 1
-    mUpdateSigners = false;
+    mUpdateSigners = true;
 }
 
 AccountFrame::AccountFrame(LedgerEntry const& from)
     : EntryFrame(from), mAccountEntry(mEntry.data.account())
 {
-    mUpdateSigners = !mAccountEntry.signers.empty();
+    // we cannot make any assumption on mUpdateSigners:
+    // it's possible we're constructing an account with no signers
+    // but that the database's state had a previous version with signers
+    mUpdateSigners = true;
 }
 
 AccountFrame::AccountFrame(AccountFrame const& from) : AccountFrame(from.mEntry)

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -27,8 +27,8 @@ const char* AccountFrame::kSQLCreateStatement1 =
     "seqnum          BIGINT       NOT NULL,"
     "numsubentries   INT          NOT NULL CHECK (numsubentries >= 0),"
     "inflationdest   VARCHAR(56),"
-    "homedomain      VARCHAR(32),"
-    "thresholds      TEXT,"
+    "homedomain      VARCHAR(32)  NOT NULL,"
+    "thresholds      TEXT         NOT NULL,"
     "flags           INT          NOT NULL,"
     "lastmodified    INT          NOT NULL"
     ");";
@@ -201,7 +201,7 @@ AccountFrame::loadAccount(AccountID const& accountID, Database& db)
 
     std::string publicKey, inflationDest, creditAuthKey;
     std::string homeDomain, thresholds;
-    soci::indicator inflationDestInd, homeDomainInd, thresholdsInd;
+    soci::indicator inflationDestInd;
 
     AccountFrame::pointer res = make_shared<AccountFrame>(accountID);
     AccountEntry& account = res->getAccount();
@@ -216,8 +216,8 @@ AccountFrame::loadAccount(AccountID const& accountID, Database& db)
     st.exchange(into(account.seqNum));
     st.exchange(into(account.numSubEntries));
     st.exchange(into(inflationDest, inflationDestInd));
-    st.exchange(into(homeDomain, homeDomainInd));
-    st.exchange(into(thresholds, thresholdsInd));
+    st.exchange(into(homeDomain));
+    st.exchange(into(thresholds));
     st.exchange(into(account.flags));
     st.exchange(into(res->getLastModified()));
     st.exchange(use(actIDStrKey));
@@ -233,16 +233,10 @@ AccountFrame::loadAccount(AccountID const& accountID, Database& db)
         return nullptr;
     }
 
-    if (homeDomainInd == soci::i_ok)
-    {
-        account.homeDomain = homeDomain;
-    }
+    account.homeDomain = homeDomain;
 
-    if (thresholdsInd == soci::i_ok)
-    {
-        bn::decode_b64(thresholds.begin(), thresholds.end(),
-                       res->mAccountEntry.thresholds.begin());
-    }
+    bn::decode_b64(thresholds.begin(), thresholds.end(),
+                   res->mAccountEntry.thresholds.begin());
 
     if (inflationDestInd == soci::i_ok)
     {

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -387,7 +387,8 @@ AccountFrame::storeUpdate(LedgerDelta& delta, Database& db, bool insert)
         st.exchange(use(mAccountEntry.seqNum, "v2"));
         st.exchange(use(mAccountEntry.numSubEntries, "v3"));
         st.exchange(use(inflationDestStrKey, inflation_ind, "v4"));
-        st.exchange(use(string(mAccountEntry.homeDomain), "v5"));
+        string homeDomain(mAccountEntry.homeDomain);
+        st.exchange(use(homeDomain, "v5"));
         st.exchange(use(thresholds, "v6"));
         st.exchange(use(mAccountEntry.flags, "v7"));
         st.exchange(use(getLastModified(), "v8"));

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -80,14 +80,18 @@ AccountFrame::makeAuthOnlyAccount(AccountID const& id)
     return ret;
 }
 
+bool
+AccountFrame::signerCompare(Signer const& s1, Signer const& s2)
+{
+    return s1.pubKey < s2.pubKey;
+}
+
 void
 AccountFrame::normalize()
 {
     std::sort(mAccountEntry.signers.begin(), mAccountEntry.signers.end(),
-              [](Signer const& s1, Signer const& s2)
-              {
-                  return s1.pubKey < s2.pubKey;
-              });
+              &AccountFrame::signerCompare);
+}
 }
 
 bool

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -35,6 +35,8 @@ class AccountFrame : public EntryFrame
 
     bool isValid();
 
+    static std::vector<Signer> loadSigners(Database& db,
+                                           std::string const& actIDStrKey);
     void applySigners(Database& db);
 
   public:

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -32,6 +32,8 @@ class AccountFrame : public EntryFrame
 
     AccountFrame(AccountFrame const& from);
 
+    bool isValid();
+
   public:
     typedef std::shared_ptr<AccountFrame> pointer;
 

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -34,6 +34,8 @@ class AccountFrame : public EntryFrame
 
     bool isValid();
 
+    void applySigners(Database& db);
+
   public:
     typedef std::shared_ptr<AccountFrame> pointer;
 

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -116,6 +116,9 @@ class AccountFrame : public EntryFrame
     static AccountFrame::pointer loadAccount(AccountID const& accountID,
                                              Database& db);
 
+    // compare signers, ignores weight
+    static bool signerCompare(Signer const& s1, Signer const& s2);
+
     // inflation helper
 
     struct InflationVotes

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -7,6 +7,7 @@
 #include "ledger/EntryFrame.h"
 #include <functional>
 #include <map>
+#include <unordered_map>
 
 namespace soci
 {
@@ -135,6 +136,10 @@ class AccountFrame : public EntryFrame
     static void processForInflation(
         std::function<bool(InflationVotes const&)> inflationProcessor,
         int maxWinners, Database& db);
+
+    // loads all accounts from database and checks for consistency (slow!)
+    static std::unordered_map<AccountID, AccountFrame::pointer>
+    checkDB(Database& db);
 
     static void dropAll(Database& db);
     static const char* kSQLCreateStatement1;

--- a/src/ledger/LedgerEntryTests.cpp
+++ b/src/ledger/LedgerEntryTests.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/Application.h"
+#include "ledger/LedgerManager.h"
 #include "util/Timer.h"
 #include "main/test.h"
 #include "lib/catch.hpp"
@@ -13,6 +14,7 @@
 #include "xdrpp/autocheck.h"
 #include "crypto/SecretKey.h"
 #include "ledger/LedgerTestUtils.h"
+#include "database/Database.h"
 #include <utility>
 #include <memory>
 #include <unordered_map>
@@ -56,6 +58,8 @@ TEST_CASE("Account Entry tests", "[ledgerentry]")
             auto fromDb = AccountFrame::loadAccount(af->getID(), db);
             REQUIRE(af->getAccount() == fromDb->getAccount());
         }
+        app->getLedgerManager().checkDbState();
+
         // updating accounts
         for (auto& l : accountsMap)
         {
@@ -71,6 +75,7 @@ TEST_CASE("Account Entry tests", "[ledgerentry]")
             auto fromDb = AccountFrame::loadAccount(af->getID(), db);
             REQUIRE(af->getAccount() == fromDb->getAccount());
         }
+        app->getLedgerManager().checkDbState();
 
         // deleting accounts
         for (auto const& l : accountsMap)
@@ -82,6 +87,7 @@ TEST_CASE("Account Entry tests", "[ledgerentry]")
             REQUIRE(AccountFrame::loadAccount(af->getID(), db) == nullptr);
             REQUIRE(!AccountFrame::exists(db, af->getKey()));
         }
+        app->getLedgerManager().checkDbState();
     }
 }
 }

--- a/src/ledger/LedgerEntryTests.cpp
+++ b/src/ledger/LedgerEntryTests.cpp
@@ -1,0 +1,87 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+#include "util/Timer.h"
+#include "main/test.h"
+#include "lib/catch.hpp"
+#include "util/Logging.h"
+#include "AccountFrame.h"
+#include "LedgerDelta.h"
+#include "xdrpp/marshal.h"
+#include "xdrpp/autocheck.h"
+#include "crypto/SecretKey.h"
+#include "ledger/LedgerTestUtils.h"
+#include <utility>
+#include <memory>
+#include <unordered_map>
+
+using namespace stellar;
+
+namespace LedgerEntryTests
+{
+
+TEST_CASE("Account Entry tests", "[ledgerentry]")
+{
+    Config cfg(getTestConfig(0));
+
+    VirtualClock clock;
+    Application::pointer app = Application::create(clock, cfg);
+    app->start();
+    Database& db = app->getDatabase();
+
+    SECTION("round trip with database")
+    {
+        std::vector<LedgerEntry> accounts(100);
+
+        std::unordered_map<AccountID, LedgerEntry> accountsMap;
+
+        for (auto& l : accounts)
+        {
+            l.data.type(ACCOUNT);
+            auto& a = l.data.account();
+            a = LedgerTestUtils::generateValidAccountEntry(5);
+            accountsMap.insert(std::make_pair(a.accountID, l));
+        }
+
+        LedgerHeader lh;
+        LedgerDelta delta(lh, db);
+
+        // adding accounts
+        for (auto const& l : accountsMap)
+        {
+            AccountFrame::pointer af = std::make_shared<AccountFrame>(l.second);
+            af->storeAdd(delta, db);
+            auto fromDb = AccountFrame::loadAccount(af->getID(), db);
+            REQUIRE(af->getAccount() == fromDb->getAccount());
+        }
+        // updating accounts
+        for (auto& l : accountsMap)
+        {
+            AccountEntry& newA = l.second.data.account();
+            // replace by completely new object
+            newA = LedgerTestUtils::generateValidAccountEntry(5);
+
+            // preserve the accountID as it's the key
+            newA.accountID = l.first;
+
+            AccountFrame::pointer af = std::make_shared<AccountFrame>(l.second);
+            af->storeChange(delta, db);
+            auto fromDb = AccountFrame::loadAccount(af->getID(), db);
+            REQUIRE(af->getAccount() == fromDb->getAccount());
+        }
+
+        // deleting accounts
+        for (auto const& l : accountsMap)
+        {
+            AccountFrame::pointer af = std::make_shared<AccountFrame>(l.second);
+            REQUIRE(AccountFrame::loadAccount(af->getID(), db) != nullptr);
+            REQUIRE(AccountFrame::exists(db, af->getKey()));
+            af->storeDelete(delta, db);
+            REQUIRE(AccountFrame::loadAccount(af->getID(), db) == nullptr);
+            REQUIRE(!AccountFrame::exists(db, af->getKey()));
+        }
+    }
+}
+}

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -163,6 +163,9 @@ class LedgerManager
     // deletes old entries stored in the database
     virtual void deleteOldEntries(Database& db, uint32_t ledgerSeq) = 0;
 
+    // checks the database for inconsistencies between objects
+    virtual void checkDbState() = 0;
+
     virtual ~LedgerManager()
     {
     }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -97,5 +97,6 @@ class LedgerManagerImpl : public LedgerManager
     verifyCatchupCandidate(LedgerHeaderHistoryEntry const&) const override;
     void closeLedger(LedgerCloseData const& ledgerData) override;
     void deleteOldEntries(Database& db, uint32_t ledgerSeq) override;
+    void checkDbState() override;
 };
 }

--- a/src/ledger/LedgerTestUtils.cpp
+++ b/src/ledger/LedgerTestUtils.cpp
@@ -1,0 +1,211 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "LedgerTestUtils.h"
+#include "ledger/AccountFrame.h"
+#include "crypto/SecretKey.h"
+#include "util/types.h"
+#include <string>
+#include <cctype>
+#include <xdrpp/autocheck.h>
+
+namespace stellar
+{
+namespace LedgerTestUtils
+{
+
+template <typename T>
+void
+clampLow(T low, T& v)
+{
+    if (v < low)
+    {
+        v = low;
+    }
+}
+
+template <typename T>
+void
+clampHigh(T high, T& v)
+{
+    if (v > high)
+    {
+        v = high;
+    }
+}
+
+
+static void
+stripControlCharacters(std::string& s)
+{
+    std::locale loc("C");
+
+    for (auto it = s.begin(); it != s.end();)
+    {
+        char c = *it;
+        if (c < 0 || std::iscntrl((char)c))
+        {
+            it = s.erase(it);
+        }
+        else
+        {
+            it++;
+        }
+    }
+}
+
+static bool
+signerEqual(Signer const& s1, Signer const& s2)
+{
+    return s1.pubKey == s2.pubKey;
+}
+
+void
+makeValid(AccountEntry& a)
+{
+    if (a.balance < 0)
+    {
+        a.balance = -a.balance;
+    }
+
+    stripControlCharacters(a.homeDomain);
+    a.inflationDest.activate() = PubKeyUtils::random();
+
+    std::sort(a.signers.begin(), a.signers.end(), &AccountFrame::signerCompare);
+    a.signers.erase(
+        std::unique(a.signers.begin(), a.signers.end(), signerEqual),
+        a.signers.end());
+    for (auto& s : a.signers)
+    {
+        if (s.weight == 0)
+        {
+            s.weight = 100;
+        }
+    }
+    a.numSubEntries = (uint32)a.signers.size();
+}
+
+void
+makeValid(TrustLineEntry& tl)
+{
+    tl.asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(tl.asset.alphaNum4().assetCode, "USD");
+    clampLow<int64_t>(0, tl.balance);
+    clampLow<int64_t>(0, tl.limit);
+    clampHigh<int64_t>(tl.limit, tl.balance);
+}
+void
+makeValid(OfferEntry& o)
+{
+    o.selling.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(o.selling.alphaNum4().assetCode, "CAD");
+
+    o.buying.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(o.buying.alphaNum4().assetCode, "EUR");
+
+    clampLow<int64_t>(0, o.amount);
+    clampLow(0, o.price.n);
+    clampLow(1, o.price.d);
+}
+
+static auto validLedgerEntryGenerator = autocheck::map(
+    [](LedgerEntry&& le, size_t s)
+    {
+        auto& led = le.data;
+        switch (led.type())
+        {
+        case TRUSTLINE:
+            makeValid(led.trustLine());
+            break;
+
+        case OFFER:
+            makeValid(led.offer());
+            break;
+
+        case ACCOUNT:
+            makeValid(led.account());
+            break;
+        }
+
+        return le;
+    },
+    autocheck::generator<LedgerEntry>());
+
+static auto validAccountEntryGenerator = autocheck::map(
+    [](AccountEntry&& ae, size_t s)
+    {
+        makeValid(ae);
+        return ae;
+    },
+    autocheck::generator<AccountEntry>());
+
+static auto validTrustLineEntryGenerator = autocheck::map(
+    [](TrustLineEntry&& tl, size_t s)
+    {
+        makeValid(tl);
+        return tl;
+    },
+    autocheck::generator<TrustLineEntry>());
+
+static auto validOfferEntryGenerator = autocheck::map(
+    [](OfferEntry&& o, size_t s)
+    {
+        makeValid(o);
+        return o;
+    },
+    autocheck::generator<OfferEntry>());
+
+LedgerEntry
+generateValidLedgerEntry(size_t b)
+{
+    return validLedgerEntryGenerator(b);
+}
+
+std::vector<LedgerEntry>
+generateValidLedgerEntries(size_t n)
+{
+    static auto vecgen = autocheck::list_of(validLedgerEntryGenerator);
+    return vecgen(n);
+}
+
+AccountEntry
+generateValidAccountEntry(size_t b)
+{
+    return validAccountEntryGenerator(b);
+}
+
+std::vector<AccountEntry>
+generateValidAccountEntries(size_t n)
+{
+    static auto vecgen = autocheck::list_of(validAccountEntryGenerator);
+    return vecgen(n);
+}
+
+TrustLineEntry
+generateValidTrustLineEntry(size_t b)
+{
+    return validTrustLineEntryGenerator(b);
+}
+
+std::vector<TrustLineEntry>
+generateValidTrustLineEntries(size_t n)
+{
+    static auto vecgen = autocheck::list_of(validTrustLineEntryGenerator);
+    return vecgen(n);
+}
+
+OfferEntry
+generateValidOfferEntry(size_t b)
+{
+    return validOfferEntryGenerator(b);
+}
+
+std::vector<OfferEntry>
+generateValidOfferEntries(size_t n)
+{
+    static auto vecgen = autocheck::list_of(validOfferEntryGenerator);
+    return vecgen(n);
+}
+}
+}

--- a/src/ledger/LedgerTestUtils.h
+++ b/src/ledger/LedgerTestUtils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/StellarXDR.h"
+
+namespace stellar
+{
+namespace LedgerTestUtils
+{
+
+void makeValid(AccountEntry& a);
+void makeValid(TrustLineEntry& tl);
+void makeValid(OfferEntry& o);
+
+LedgerEntry generateValidLedgerEntry(size_t b = 3);
+std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
+
+AccountEntry generateValidAccountEntry(size_t b = 3);
+std::vector<AccountEntry> generateValidAccountEntries(size_t n);
+
+TrustLineEntry generateValidTrustLineEntry(size_t b = 3);
+std::vector<TrustLineEntry> generateValidTrustLineEntries(size_t n);
+
+OfferEntry generateValidOfferEntry(size_t b = 3);
+std::vector<OfferEntry> generateValidOfferEntries(size_t n);
+}
+}

--- a/src/ledger/OfferFrame.cpp
+++ b/src/ledger/OfferFrame.cpp
@@ -366,6 +366,23 @@ OfferFrame::loadOffers(AccountID const& accountID,
                });
 }
 
+std::unordered_map<AccountID, std::vector<OfferFrame::pointer>>
+OfferFrame::loadAllOffers(Database& db)
+{
+    std::unordered_map<AccountID, std::vector<OfferFrame::pointer>> retOffers;
+    std::string sql = offerColumnSelector;
+    sql += " ORDER BY sellerid";
+    auto prep = db.getPreparedStatement(sql);
+
+    auto timer = db.getSelectTimer("offer");
+    loadOffers(prep, [&retOffers](LedgerEntry const& of)
+               {
+                   auto& thisUserOffers = retOffers[of.data.offer().sellerID];
+                   thisUserOffers.emplace_back(make_shared<OfferFrame>(of));
+               });
+    return retOffers;
+}
+
 bool
 OfferFrame::exists(Database& db, LedgerKey const& key)
 {

--- a/src/ledger/OfferFrame.h
+++ b/src/ledger/OfferFrame.h
@@ -6,6 +6,7 @@
 
 #include "ledger/EntryFrame.h"
 #include <functional>
+#include <unordered_map>
 
 namespace soci
 {
@@ -95,6 +96,10 @@ class OfferFrame : public EntryFrame
     static void loadOffers(AccountID const& accountID,
                            std::vector<OfferFrame::pointer>& retOffers,
                            Database& db);
+
+    // load all offers from the database (very slow)
+    static std::unordered_map<AccountID, std::vector<OfferFrame::pointer>>
+    loadAllOffers(Database& db);
 
     static void dropAll(Database& db);
     static const char* kSQLCreateStatement1;

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -513,6 +513,25 @@ TrustFrame::loadLines(AccountID const& accountID,
               });
 }
 
+std::unordered_map<AccountID, std::vector<TrustFrame::pointer>>
+TrustFrame::loadAllLines(Database& db)
+{
+    std::unordered_map<AccountID, std::vector<TrustFrame::pointer>> retLines;
+
+    auto query = std::string(trustLineColumnSelector);
+    query += (" ORDER BY accountid");
+    auto prep = db.getPreparedStatement(query);
+
+    auto timer = db.getSelectTimer("trust");
+    loadLines(prep, [&retLines](LedgerEntry const& cur)
+              {
+                  auto& thisUserLines =
+                      retLines[cur.data.trustLine().accountID];
+                  thisUserLines.emplace_back(make_shared<TrustFrame>(cur));
+              });
+    return retLines;
+}
+
 void
 TrustFrame::dropAll(Database& db)
 {

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -6,6 +6,7 @@
 
 #include "ledger/EntryFrame.h"
 #include <functional>
+#include <unordered_map>
 
 namespace soci
 {
@@ -72,6 +73,10 @@ class TrustFrame : public EntryFrame
     static void loadLines(AccountID const& accountID,
                           std::vector<TrustFrame::pointer>& retLines,
                           Database& db);
+
+    // loads ALL trust lines from the database (very slow!)
+    static std::unordered_map<AccountID, std::vector<TrustFrame::pointer>>
+    loadAllLines(Database& db);
 
     static bool hasIssued(AccountID const& issuerID, Database& db);
 

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -838,7 +838,8 @@ TEST_CASE("create offer", "[tx][offers]")
                             AUTH_REQUIRED_FLAG | AUTH_REVOCABLE_FLAG;
 
                         applySetOptions(app, secgateway, secgw_seq++, nullptr,
-                                        &setFlags, nullptr, nullptr, nullptr);
+                                        &setFlags, nullptr, nullptr, nullptr,
+                                        nullptr);
 
                         // setup d1
                         SecretKey d1 = getAccount("D");

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -283,7 +283,7 @@ TEST_CASE("payment", "[tx][payment]")
         uint32_t setFlags = AUTH_REQUIRED_FLAG | AUTH_REVOCABLE_FLAG;
 
         applySetOptions(app, gateway, gateway_seq++, nullptr, &setFlags,
-                        nullptr, nullptr, nullptr);
+                        nullptr, nullptr, nullptr, nullptr);
 
         applyChangeTrust(app, a1, gateway, a1Seq++, "IDR", trustLineLimit);
 

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -259,6 +259,18 @@ SetOptionsOpFrame::doCheckValid(medida::MetricsRegistry& metrics)
         }
     }
 
+    if (mSetOptions.homeDomain)
+    {
+        if (!isString32Valid(*mSetOptions.homeDomain))
+        {
+            metrics.NewMeter(
+                        {"op-set-options", "invalid", "invalid-home-domain"},
+                        "operation").Mark();
+            innerResult().code(SET_OPTIONS_INVALID_HOME_DOMAIN);
+            return false;
+        }
+    }
+
     return true;
 }
 }

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -62,14 +62,14 @@ TEST_CASE("set options", "[tx][setoptions]")
         SECTION("insufficient balance")
         {
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr, &th,
-                            &sk1, SET_OPTIONS_LOW_RESERVE);
+                            &sk1, nullptr, SET_OPTIONS_LOW_RESERVE);
         }
 
         SECTION("can't use master key as alternate signer")
         {
             Signer sk(a1.getPublicKey(), 100);
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
-                            nullptr, &sk, SET_OPTIONS_BAD_SIGNER);
+                            nullptr, &sk, nullptr, SET_OPTIONS_BAD_SIGNER);
         }
 
         SECTION("multiple signers")
@@ -79,7 +79,7 @@ TEST_CASE("set options", "[tx][setoptions]")
                            app.getLedgerManager().getMinBalance(2));
 
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr, &th,
-                            &sk1);
+                            &sk1, nullptr);
 
             AccountFrame::pointer a1Account;
 
@@ -93,7 +93,7 @@ TEST_CASE("set options", "[tx][setoptions]")
             SecretKey s2 = getAccount("S2");
             Signer sk2(s2.getPublicKey(), 100);
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
-                            nullptr, &sk2);
+                            nullptr, &sk2, nullptr);
 
             a1Account = loadAccount(a1, app);
             REQUIRE(a1Account->getAccount().signers.size() == 2);
@@ -101,17 +101,17 @@ TEST_CASE("set options", "[tx][setoptions]")
             // update signer 2
             sk2.weight = 11;
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
-                            nullptr, &sk2);
+                            nullptr, &sk2, nullptr);
 
             // update signer 1
             sk1.weight = 11;
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
-                            nullptr, &sk1);
+                            nullptr, &sk1, nullptr);
 
             // remove signer 1
             sk1.weight = 0;
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
-                            nullptr, &sk1);
+                            nullptr, &sk1, nullptr);
 
             a1Account = loadAccount(a1, app);
             REQUIRE(a1Account->getAccount().signers.size() == 1);
@@ -126,7 +126,21 @@ TEST_CASE("set options", "[tx][setoptions]")
         uint32_t setFlags = AUTH_REQUIRED_FLAG;
         uint32_t clearFlags = AUTH_REQUIRED_FLAG;
         applySetOptions(app, a1, a1seq++, nullptr, &setFlags, &clearFlags,
-                        nullptr, nullptr, SET_OPTIONS_BAD_FLAGS);
+                        nullptr, nullptr, nullptr, SET_OPTIONS_BAD_FLAGS);
+    }
+
+    SECTION("Home domain")
+    {
+        SECTION("invalid home domain")
+        {
+            std::string bad[] = {"abc\r", "abc\x7F", std::string("ab\000c", 4)};
+            for (auto& s : bad)
+            {
+                applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
+                                nullptr, nullptr, &s,
+                                SET_OPTIONS_INVALID_HOME_DOMAIN);
+            }
+        }
     }
 
     // these are all tested by other tests

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -118,6 +118,14 @@ TEST_CASE("set options", "[tx][setoptions]")
             Signer& a_sk2 = a1Account->getAccount().signers[0];
             REQUIRE(a_sk2.pubKey == sk2.pubKey);
             REQUIRE(a_sk2.weight == sk2.weight);
+
+            // remove signer 2
+            sk2.weight = 0;
+            applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
+                            nullptr, &sk2, nullptr);
+
+            a1Account = loadAccount(a1, app);
+            REQUIRE(a1Account->getAccount().signers.size() == 0);
         }
     }
 

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -85,9 +85,11 @@ TEST_CASE("set options", "[tx][setoptions]")
 
             a1Account = loadAccount(a1, app);
             REQUIRE(a1Account->getAccount().signers.size() == 1);
-            Signer& a_sk1 = a1Account->getAccount().signers[0];
-            REQUIRE(a_sk1.pubKey == sk1.pubKey);
-            REQUIRE(a_sk1.weight == sk1.weight);
+            {
+                Signer& a_sk1 = a1Account->getAccount().signers[0];
+                REQUIRE(a_sk1.pubKey == sk1.pubKey);
+                REQUIRE(a_sk1.weight == sk1.weight);
+            }
 
             // add signer 2
             SecretKey s2 = getAccount("S2");
@@ -108,11 +110,11 @@ TEST_CASE("set options", "[tx][setoptions]")
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
                             nullptr, &sk1, nullptr);
 
-            // remove signer 1
             sk1.weight = 0;
             applySetOptions(app, a1, a1seq++, nullptr, nullptr, nullptr,
                             nullptr, &sk1, nullptr);
 
+            // remove signer 1
             a1Account = loadAccount(a1, app);
             REQUIRE(a1Account->getAccount().signers.size() == 1);
             Signer& a_sk2 = a1Account->getAccount().signers[0];

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -121,13 +121,14 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         th.medThreshold = make_optional<uint8_t>(50);
         th.highThreshold = make_optional<uint8_t>(100);
 
-        applySetOptions(app, a1, a1Seq++, nullptr, nullptr, nullptr, &th, &sk1);
+        applySetOptions(app, a1, a1Seq++, nullptr, nullptr, nullptr, &th, &sk1,
+                        nullptr);
 
         SecretKey s2 = getAccount("S2");
         Signer sk2(s2.getPublicKey(), 95); // med rights account
 
         applySetOptions(app, a1, a1Seq++, nullptr, nullptr, nullptr, nullptr,
-                        &sk2);
+                        &sk2, nullptr);
 
         SECTION("not enough rights (envelope)")
         {
@@ -148,8 +149,9 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         SECTION("not enough rights (operation)")
         {
             // updating thresholds requires high
-            TransactionFramePtr tx = createSetOptions(
-                networkID, a1, a1Seq++, nullptr, nullptr, nullptr, &th, &sk1);
+            TransactionFramePtr tx =
+                createSetOptions(networkID, a1, a1Seq++, nullptr, nullptr,
+                                 nullptr, &th, &sk1, nullptr);
 
             // only sign with s1 (med)
             tx->getEnvelope().signatures.clear();

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -693,7 +693,8 @@ applyCreateOfferWithResult(Application& app, LedgerDelta& delta, uint64 offerId,
 TransactionFramePtr
 createSetOptions(Hash const& networkID, SecretKey& source, SequenceNumber seq,
                  AccountID* inflationDest, uint32_t* setFlags,
-                 uint32_t* clearFlags, ThresholdSetter* thrs, Signer* signer)
+                 uint32_t* clearFlags, ThresholdSetter* thrs, Signer* signer,
+                 std::string* homeDomain)
 {
     Operation op;
     op.body.type(SET_OPTIONS);
@@ -740,6 +741,11 @@ createSetOptions(Hash const& networkID, SecretKey& source, SequenceNumber seq,
         setOp.signer.activate() = *signer;
     }
 
+    if (homeDomain)
+    {
+        setOp.homeDomain.activate() = *homeDomain;
+    }
+
     return transactionFromOperation(networkID, source, seq, op);
 }
 
@@ -747,12 +753,12 @@ void
 applySetOptions(Application& app, SecretKey& source, SequenceNumber seq,
                 AccountID* inflationDest, uint32_t* setFlags,
                 uint32_t* clearFlags, ThresholdSetter* thrs, Signer* signer,
-                SetOptionsResultCode result)
+                std::string* homeDomain, SetOptionsResultCode result)
 {
     TransactionFramePtr txFrame;
 
     txFrame = createSetOptions(app.getNetworkID(), source, seq, inflationDest,
-                               setFlags, clearFlags, thrs, signer);
+                               setFlags, clearFlags, thrs, signer, homeDomain);
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -88,6 +88,9 @@ applyCheck(TransactionFramePtr tx, LedgerDelta& delta, Application& app)
         }
     }
 
+    // validates db state
+    app.getLedgerManager().checkDbState();
+
     return res;
 }
 

--- a/src/transactions/TxTests.h
+++ b/src/transactions/TxTests.h
@@ -155,12 +155,13 @@ TransactionFramePtr createSetOptions(Hash const& networkID, SecretKey& source,
                                      SequenceNumber seq,
                                      AccountID* inflationDest,
                                      uint32_t* setFlags, uint32_t* clearFlags,
-                                     ThresholdSetter* thrs, Signer* signer);
+                                     ThresholdSetter* thrs, Signer* signer,
+                                     std::string* homeDomain);
 
 void applySetOptions(Application& app, SecretKey& source, SequenceNumber seq,
                      AccountID* inflationDest, uint32_t* setFlags,
                      uint32_t* clearFlags, ThresholdSetter* thrs,
-                     Signer* signer,
+                     Signer* signer, std::string* homeDomain,
                      SetOptionsResultCode result = SET_OPTIONS_SUCCESS);
 
 TransactionFramePtr createInflation(Hash const& networkID, SecretKey& from,

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -32,6 +32,20 @@ makePublicKey(uint256 const& b)
 }
 
 bool
+isString32Valid(std::string const& str)
+{
+    std::locale loc("C");
+    for (auto c : str)
+    {
+        if (c < 0 || std::iscntrl(c, loc))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
 isAssetValid(Asset const& cur)
 {
     if (cur.type() == ASSET_TYPE_NATIVE)
@@ -56,8 +70,7 @@ isAssetValid(Asset const& cur)
             }
             else
             {
-                char t = *(char*)&b; // safe conversion to char
-                if (!std::isalnum(t, loc))
+                if (b > 0x7F || !std::isalnum((char)b, loc))
                 {
                     return false;
                 }
@@ -86,8 +99,7 @@ isAssetValid(Asset const& cur)
             }
             else
             {
-                char t = *(char*)&b; // safe conversion to char
-                if (!std::isalnum(t, loc))
+                if (b > 0x7F || !std::isalnum((char)b, loc))
                 {
                     return false;
                 }

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -16,6 +16,9 @@ bool isZero(uint256 const& b);
 
 uint256 makePublicKey(uint256 const& b);
 
+// returns true if the passed string32 is valid
+bool isString32Valid(std::string const& str);
+
 // returns true if the Asset value is well formed
 bool isAssetValid(Asset const& cur);
 

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -485,7 +485,8 @@ enum SetOptionsResultCode
     SET_OPTIONS_CANT_CHANGE = -5,            // can no longer change this option
     SET_OPTIONS_UNKNOWN_FLAG = -6,           // can't set an unknown flag
     SET_OPTIONS_THRESHOLD_OUT_OF_RANGE = -7, // bad value for weight/threshold
-    SET_OPTIONS_BAD_SIGNER = -8              // signer cannot be masterkey
+    SET_OPTIONS_BAD_SIGNER = -8,             // signer cannot be masterkey
+    SET_OPTIONS_INVALID_HOME_DOMAIN = -9     // malformed home domain
 };
 
 union SetOptionsResult switch (SetOptionsResultCode code)


### PR DESCRIPTION
homeDomain was not validated resulting into SQL corrupting entries - resolves #758 

applying accounts with signers (while catching up) didn't work - resolves #761 

added autocheck tests for round tripping AccountEntry to the database

removing the last signer was not working - resolves #755 

added consistency check of database when performing tests

various tidying up of code
