### PR TITLE
Merge account simplification and perf tweaks

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -294,7 +294,7 @@ Bucket::apply(Database& db) const
     {
         LedgerHeader
             lh; // buckets, by definition are independent from the header
-        LedgerDelta delta(lh, db);
+        LedgerDelta delta(lh, db, false);
         if (entry.type() == LIVEENTRY)
         {
             EntryFrame::pointer ep = EntryFrame::FromXDR(entry.liveEntry());

--- a/src/ledger/EntryFrame.cpp
+++ b/src/ledger/EntryFrame.cpp
@@ -81,6 +81,7 @@ EntryFrame::getLastModified()
 void
 EntryFrame::touch(uint32 ledgerSeq)
 {
+    assert(ledgerSeq != 0);
     getLastModified() = ledgerSeq;
 }
 
@@ -88,8 +89,7 @@ void
 EntryFrame::touch(LedgerDelta const& delta)
 {
     uint32 ledgerSeq = delta.getHeader().ledgerSeq;
-    // if we're tracking a valid header, mark the entry as modified by it
-    if (ledgerSeq != 0)
+    if (delta.updateLastModified())
     {
         touch(ledgerSeq);
     }

--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -20,15 +20,18 @@ LedgerDelta::LedgerDelta(LedgerDelta& outerDelta)
     , mCurrentHeader(outerDelta.getHeader())
     , mPreviousHeaderValue(outerDelta.getHeader())
     , mDb(outerDelta.mDb)
+    , mUpdateLastModified(outerDelta.mUpdateLastModified)
 {
 }
 
-LedgerDelta::LedgerDelta(LedgerHeader& header, Database& db)
+LedgerDelta::LedgerDelta(LedgerHeader& header, Database& db,
+                         bool updateLastModified)
     : mOuterDelta(nullptr)
     , mHeader(&header)
     , mCurrentHeader(header)
     , mPreviousHeaderValue(header)
     , mDb(db)
+    , mUpdateLastModified(updateLastModified)
 {
 }
 
@@ -272,6 +275,12 @@ LedgerDelta::getDeadEntries() const
         dead.push_back(k);
     }
     return dead;
+}
+
+bool
+LedgerDelta::updateLastModified() const
+{
+    return mUpdateLastModified;
 }
 
 void

--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -184,12 +184,13 @@ void
 LedgerDelta::commit()
 {
     checkState();
-    // checks if we're not about to override changes
-    // (commit a noop should never happen)
+    // checks if we about to override changes that were made
+    // outside of this LedgerDelta
     if (!(mPreviousHeaderValue == *mHeader))
     {
         throw std::runtime_error("unexpected header state");
     }
+
     if (mOuterDelta)
     {
         mOuterDelta->mergeEntries(*this);

--- a/src/ledger/LedgerDelta.h
+++ b/src/ledger/LedgerDelta.h
@@ -36,6 +36,8 @@ class LedgerDelta
 
     Database& mDb; // Used strictly for rollback of db entry cache.
 
+    bool mUpdateLastModified;
+
     void checkState();
     void addEntry(EntryFrame::pointer entry);
     void deleteEntry(EntryFrame::pointer entry);
@@ -52,7 +54,9 @@ class LedgerDelta
     // keeps an internal reference to ledgerHeader,
     // will apply changes to ledgerHeader on commit,
     // will clear db entry cache on rollback.
-    LedgerDelta(LedgerHeader& ledgerHeader, Database& db);
+    // updateLastModified: if true, revs the lastModified field
+    LedgerDelta(LedgerHeader& ledgerHeader, Database& db,
+                bool updateLastModified = true);
 
     ~LedgerDelta();
 
@@ -70,6 +74,8 @@ class LedgerDelta
     void commit();
     // aborts any changes pending, flush db cache entries
     void rollback();
+
+    bool updateLastModified() const;
 
     void markMeters(Application& app) const;
 

--- a/src/ledger/LedgerEntryTests.cpp
+++ b/src/ledger/LedgerEntryTests.cpp
@@ -48,7 +48,7 @@ TEST_CASE("Ledger Entry tests", "[ledgerentry]")
         }
 
         LedgerHeader lh;
-        LedgerDelta delta(lh, db);
+        LedgerDelta delta(lh, db, false);
 
         // adding accounts
         for (auto const& l : accountsMap)

--- a/src/ledger/LedgerHeaderFrame.cpp
+++ b/src/ledger/LedgerHeaderFrame.cpp
@@ -12,6 +12,7 @@
 #include "database/Database.h"
 #include "util/types.h"
 #include <util/basen.h>
+#include "util/format.h"
 
 namespace stellar
 {
@@ -166,11 +167,14 @@ LedgerHeaderFrame::loadBySequence(uint32_t seq, Database& db,
     if (sess.got_data())
     {
         lhf = decodeFromData(headerEncoded);
+        uint32_t loadedSeq = lhf->mHeader.ledgerSeq;
 
-        if (lhf->mHeader.ledgerSeq != seq)
+        if (loadedSeq != seq)
         {
-            // wrong sequence number
-            lhf.reset();
+            throw std::runtime_error(
+                fmt::format("Wrong sequence number in ledger header database: "
+                            "loaded ledger {} contains {}",
+                            seq, loadedSeq));
         }
     }
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -267,28 +267,24 @@ LedgerManagerImpl::getMinBalance(uint32_t ownerCount) const
 uint32_t
 LedgerManagerImpl::getLedgerNum() const
 {
-    assert(mCurrentLedger);
     return mCurrentLedger->mHeader.ledgerSeq;
 }
 
 uint64_t
 LedgerManagerImpl::getCloseTime() const
 {
-    assert(mCurrentLedger);
     return mCurrentLedger->mHeader.scpValue.closeTime;
 }
 
 LedgerHeader const&
 LedgerManagerImpl::getCurrentLedgerHeader() const
 {
-    assert(mCurrentLedger);
     return mCurrentLedger->mHeader;
 }
 
 LedgerHeader&
 LedgerManagerImpl::getCurrentLedgerHeader()
 {
-    assert(mCurrentLedger);
     return mCurrentLedger->mHeader;
 }
 
@@ -387,7 +383,6 @@ LedgerManagerImpl::externalizeValue(LedgerCloseData const& ledgerData)
                 << mSyncingLedgers.back().mLedgerSeq << " but network closed "
                 << ledgerData.mLedgerSeq;
             CLOG(WARNING, "Ledger") << "this round of catchup will fail.";
-            assert(!mSyncingLedgers.empty());
         }
         break;
 

--- a/src/ledger/OfferFrame.cpp
+++ b/src/ledger/OfferFrame.cpp
@@ -264,7 +264,7 @@ OfferFrame::loadBestOffers(size_t numOffers, size_t offset,
 
     if (selling.type() == ASSET_TYPE_NATIVE)
     {
-        sql += " WHERE sellingassettype = 0";
+        sql += " WHERE sellingassettype = 0 AND sellingissuer IS NULL";
     }
     else
     {
@@ -291,7 +291,7 @@ OfferFrame::loadBestOffers(size_t numOffers, size_t offset,
 
     if (buying.type() == ASSET_TYPE_NATIVE)
     {
-        sql += " AND buyingassettype = 0";
+        sql += " AND buyingassettype = 0 AND buyingissuer IS NULL";
     }
     else
     {

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -426,8 +426,7 @@ TrustFrame::hasIssued(AccountID const& issuerID, Database& db)
     int balance = 0;
 
     auto prep = db.getPreparedStatement(
-        "SELECT balance FROM trustlines WHERE issuer=:id "
-        "AND balance>0 LIMIT 1");
+        "SELECT balance FROM trustlines WHERE issuer=:id LIMIT 1");
     auto& st = prep.statement();
     st.exchange(use(accStrKey));
     st.exchange(into(balance));

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -35,6 +35,9 @@ const char* TrustFrame::kSQLCreateStatement1 =
 const char* TrustFrame::kSQLCreateStatement2 =
     "CREATE INDEX accountlines ON trustlines (accountid);";
 
+const char* TrustFrame::kSQLCreateStatement3 =
+    "CREATE INDEX issuerslines ON trustlines (issuer);";
+
 TrustFrame::TrustFrame()
     : EntryFrame(TRUSTLINE)
     , mTrustLine(mEntry.data.trustLine())
@@ -185,7 +188,7 @@ TrustFrame::exists(Database& db, LedgerKey const& key)
     auto timer = db.getSelectTimer("trust-exists");
     auto prep = db.getPreparedStatement(
         "SELECT EXISTS (SELECT NULL FROM trustlines "
-        "WHERE accountid=:v1 and issuer=:v2 and assetcode=:v3)");
+        "WHERE accountid=:v1 AND issuer=:v2 AND assetcode=:v3)");
     auto& st = prep.statement();
     st.exchange(use(actIDStrKey));
     st.exchange(use(issuerStrKey));
@@ -538,5 +541,6 @@ TrustFrame::dropAll(Database& db)
     db.getSession() << "DROP TABLE IF EXISTS trustlines;";
     db.getSession() << kSQLCreateStatement1;
     db.getSession() << kSQLCreateStatement2;
+    db.getSession() << kSQLCreateStatement3;
 }
 }

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -33,9 +33,6 @@ const char* TrustFrame::kSQLCreateStatement1 =
     ");";
 
 const char* TrustFrame::kSQLCreateStatement2 =
-    "CREATE INDEX accountlines ON trustlines (accountid);";
-
-const char* TrustFrame::kSQLCreateStatement3 =
     "CREATE INDEX issuerslines ON trustlines (issuer);";
 
 TrustFrame::TrustFrame()
@@ -540,6 +537,5 @@ TrustFrame::dropAll(Database& db)
     db.getSession() << "DROP TABLE IF EXISTS trustlines;";
     db.getSession() << kSQLCreateStatement1;
     db.getSession() << kSQLCreateStatement2;
-    db.getSession() << kSQLCreateStatement3;
 }
 }

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -106,6 +106,5 @@ class TrustFrame : public EntryFrame
     static void dropAll(Database& db);
     static const char* kSQLCreateStatement1;
     static const char* kSQLCreateStatement2;
-    static const char* kSQLCreateStatement3;
 };
 }

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -106,5 +106,6 @@ class TrustFrame : public EntryFrame
     static void dropAll(Database& db);
     static const char* kSQLCreateStatement1;
     static const char* kSQLCreateStatement2;
+    static const char* kSQLCreateStatement3;
 };
 }

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -547,10 +547,10 @@ enum AccountMergeResultCode
     // codes considered as "success" for the operation
     ACCOUNT_MERGE_SUCCESS = 0,
     // codes considered as "failure" for the operation
-    ACCOUNT_MERGE_MALFORMED = -1,  // can't merge onto itself
-    ACCOUNT_MERGE_NO_ACCOUNT = -2, // destination does not exist
-    ACCOUNT_MERGE_HAS_CREDIT = -3, // account has active trust lines
-    ACCOUNT_MERGE_CREDIT_HELD = -4 // an issuer cannot be merged if used
+    ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
+    ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
+    ACCOUNT_MERGE_HAS_SUB_ENTRIES = -3, // account has trust lines/offers
+    ACCOUNT_MERGE_CREDIT_HELD = -4      // an issuer cannot be merged if used
 };
 
 union AccountMergeResult switch (AccountMergeResultCode code)


### PR DESCRIPTION
change behavior of merge account (resolves #767)
 * simplified code to just fail if there are trustlines / offers on the user being merged. This makes future behavior changes simpler to deal with.
 * this is a protocol change, so @nullstyle  - but you will need to rev libraries etc at some point to pick up a renamed enum value
 * changed the definition of "hasIssued" to include any trustline (regardless of balance), also to future proof things.

This changeset probably does not require to reset testnet as those are edge cases.

performance tweaks:
 * new index, resolves #768 
 * removed unused indexes (were used by merge account)

cleanup items as I am doing a review of the code:
 * don't use ledger 0 as a special ledger
 * comments
