### PR TITLE
Trustline, offers, issuers fixes and changes

### DIFF
--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -127,7 +127,11 @@ BucketManagerImpl::getBucketDir()
             std::ofstream lockfile(lock, std::ios::trunc);
             lockfile << std::to_string(self) << std::endl;
         }
-        assert(fs::exists(lock));
+        if (!fs::exists(lock))
+        {
+            throw std::runtime_error("Invalid database state (bucket folder "
+                                     "missing/corrupted) ; newdb required");
+        }
         mLockedBucketDir = make_unique<std::string>(d);
     }
     return *(mLockedBucketDir);

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -51,11 +51,11 @@ HerderImpl::SCPMetrics::SCPMetrics(Application& app)
     , mStartBallotProtocol(
           app.getMetrics().NewMeter({"scp", "ballot", "started"}, "ballot"))
     , mAcceptedBallotPrepared(app.getMetrics().NewMeter(
-          {"scp", "ballot", "acceptedprepared"}, "ballot"))
+          {"scp", "ballot", "accepted-prepared"}, "ballot"))
     , mConfirmedBallotPrepared(app.getMetrics().NewMeter(
-          {"scp", "ballot", "confirmedprepared"}, "ballot"))
+          {"scp", "ballot", "confirmed-prepared"}, "ballot"))
     , mAcceptedCommit(app.getMetrics().NewMeter(
-          {"scp", "ballot", "acceptedcommit"}, "ballot"))
+          {"scp", "ballot", "accepted-commit"}, "ballot"))
     , mBallotExpire(
           app.getMetrics().NewMeter({"scp", "ballot", "expire"}, "ballot"))
 
@@ -100,8 +100,7 @@ HerderImpl::SCPMetrics::SCPMetrics(Application& app)
 }
 
 HerderImpl::HerderImpl(Application& app)
-    : mSCP(*this, app.getConfig().NODE_SEED,
-           app.getConfig().NODE_IS_VALIDATOR,
+    : mSCP(*this, app.getConfig().NODE_SEED, app.getConfig().NODE_IS_VALIDATOR,
            app.getConfig().QUORUM_SET)
     , mReceivedTransactions(4)
     , mPendingEnvelopes(app, *this)

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -110,7 +110,13 @@ AccountFrame::isValid()
 bool
 AccountFrame::isAuthRequired() const
 {
-    return (mAccountEntry.flags & AUTH_REQUIRED_FLAG);
+    return (mAccountEntry.flags & AUTH_REQUIRED_FLAG) != 0;
+}
+
+bool
+AccountFrame::isImmutableAuth() const
+{
+    return (mAccountEntry.flags & AUTH_IMMUTABLE_FLAG) != 0;
 }
 
 int64_t

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -76,6 +76,7 @@ class AccountFrame : public EntryFrame
     bool addNumEntries(int count, LedgerManager const& lm);
 
     bool isAuthRequired() const;
+    bool isImmutableAuth() const;
     AccountID const& getID() const;
 
     uint32_t getMasterWeight() const;

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -31,9 +31,6 @@ const char* TrustFrame::kSQLCreateStatement1 =
     "PRIMARY KEY  (accountid, issuer, assetcode)"
     ");";
 
-const char* TrustFrame::kSQLCreateStatement2 =
-    "CREATE INDEX issuerslines ON trustlines (issuer);";
-
 TrustFrame::TrustFrame()
     : EntryFrame(TRUSTLINE)
     , mTrustLine(mEntry.data.trustLine())
@@ -417,31 +414,6 @@ TrustFrame::loadTrustLineIssuer(AccountID const& accountID, Asset const& asset,
     return res;
 }
 
-bool
-TrustFrame::hasIssued(AccountID const& issuerID, Database& db)
-{
-    std::string accStrKey;
-    accStrKey = PubKeyUtils::toStrKey(issuerID);
-    int balance = 0;
-
-    auto prep = db.getPreparedStatement(
-        "SELECT balance FROM trustlines WHERE issuer=:id LIMIT 1");
-    auto& st = prep.statement();
-    st.exchange(use(accStrKey));
-    st.exchange(into(balance));
-    st.define_and_bind();
-
-    {
-        auto timer = db.getSelectTimer("trust");
-        st.execute(true);
-    }
-    if (st.got_data())
-    {
-        return true;
-    }
-    return false;
-}
-
 void
 TrustFrame::loadLines(StatementContext& prep,
                       std::function<void(LedgerEntry const&)> trustProcessor)
@@ -538,6 +510,5 @@ TrustFrame::dropAll(Database& db)
 {
     db.getSession() << "DROP TABLE IF EXISTS trustlines;";
     db.getSession() << kSQLCreateStatement1;
-    db.getSession() << kSQLCreateStatement2;
 }
 }

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -330,14 +330,7 @@ TrustFrame::createIssuerFrame(Asset const& issuer)
     res->mIsIssuer = true;
     TrustLineEntry& tl = res->mEntry.data.trustLine();
 
-    if (issuer.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
-    {
-        tl.accountID = issuer.alphaNum4().issuer;
-    }
-    else if (issuer.type() == ASSET_TYPE_CREDIT_ALPHANUM12)
-    {
-        tl.accountID = issuer.alphaNum12().issuer;
-    }
+    tl.accountID = getIssuer(issuer);
 
     tl.flags |= AUTHORIZED_FLAG;
     tl.balance = INT64_MAX;
@@ -350,18 +343,17 @@ TrustFrame::pointer
 TrustFrame::loadTrustLine(AccountID const& accountID, Asset const& asset,
                           Database& db)
 {
-    if (asset.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
+    if (asset.type() == ASSET_TYPE_NATIVE)
     {
-        if (accountID == asset.alphaNum4().issuer)
-            return createIssuerFrame(asset);
-    }
-    else if (asset.type() == ASSET_TYPE_CREDIT_ALPHANUM12)
-    {
-        if (accountID == asset.alphaNum12().issuer)
-            return createIssuerFrame(asset);
+        throw std::runtime_error("XLM TrustLine?");
     }
     else
-        throw std::runtime_error("XLM TrustLine?");
+    {
+        if (accountID == getIssuer(asset))
+        {
+            return createIssuerFrame(asset);
+        }
+    }
 
     LedgerKey key;
     key.type(TRUSTLINE);

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -3,7 +3,6 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "ledger/TrustFrame.h"
-#include "ledger/AccountFrame.h"
 #include "crypto/SecretKey.h"
 #include "crypto/SHA.h"
 #include "database/Database.h"
@@ -405,6 +404,17 @@ TrustFrame::loadTrustLine(AccountID const& accountID, Asset const& asset,
         putCachedEntry(key, nullptr, db);
     }
     return retLine;
+}
+
+std::pair<TrustFrame::pointer, AccountFrame::pointer>
+TrustFrame::loadTrustLineIssuer(AccountID const& accountID, Asset const& asset,
+                                Database& db)
+{
+    std::pair<TrustFrame::pointer, AccountFrame::pointer> res;
+
+    res.first = loadTrustLine(accountID, asset, db);
+    res.second = AccountFrame::loadAccount(getIssuer(asset), db);
+    return res;
 }
 
 bool

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "ledger/EntryFrame.h"
+#include "ledger/AccountFrame.h"
 #include <functional>
 #include <unordered_map>
 
@@ -68,6 +69,11 @@ class TrustFrame : public EntryFrame
     // returns the specified trustline or a generated one for issuers
     static pointer loadTrustLine(AccountID const& accountID, Asset const& asset,
                                  Database& db);
+
+    // overload that also returns the issuer
+    static std::pair<TrustFrame::pointer, AccountFrame::pointer>
+    loadTrustLineIssuer(AccountID const& accountID, Asset const& asset,
+                        Database& db);
 
     // note: only returns trust lines stored in the database
     static void loadLines(AccountID const& accountID,

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -84,8 +84,6 @@ class TrustFrame : public EntryFrame
     static std::unordered_map<AccountID, std::vector<TrustFrame::pointer>>
     loadAllLines(Database& db);
 
-    static bool hasIssued(AccountID const& issuerID, Database& db);
-
     int64_t getBalance() const;
     bool addBalance(int64_t delta);
 

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -24,10 +24,13 @@ bool
 ChangeTrustOpFrame::doApply(medida::MetricsRegistry& metrics,
                             LedgerDelta& delta, LedgerManager& ledgerManager)
 {
-    TrustFrame::pointer trustLine;
     Database& db = ledgerManager.getDatabase();
 
-    trustLine = TrustFrame::loadTrustLine(getSourceID(), mChangeTrust.line, db);
+    auto tlI =
+        TrustFrame::loadTrustLineIssuer(getSourceID(), mChangeTrust.line, db);
+
+    auto& trustLine = tlI.first;
+    auto& issuer = tlI.second;
 
     if (trustLine)
     { // we are modifying an old trustline
@@ -61,14 +64,6 @@ ChangeTrustOpFrame::doApply(medida::MetricsRegistry& metrics,
     }
     else
     { // new trust line
-        AccountFrame::pointer issuer;
-        if (mChangeTrust.line.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
-            issuer = AccountFrame::loadAccount(
-                mChangeTrust.line.alphaNum4().issuer, db);
-        else if (mChangeTrust.line.type() == ASSET_TYPE_CREDIT_ALPHANUM12)
-            issuer = AccountFrame::loadAccount(
-                mChangeTrust.line.alphaNum12().issuer, db);
-
         if (!issuer)
         {
             metrics.NewMeter({"op-change-trust", "failure", "no-issuer"},

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -55,6 +55,13 @@ ChangeTrustOpFrame::doApply(medida::MetricsRegistry& metrics,
         }
         else
         {
+            if (!issuer)
+            {
+                metrics.NewMeter({"op-change-trust", "failure", "no-issuer"},
+                                 "operation").Mark();
+                innerResult().code(CHANGE_TRUST_NO_ISSUER);
+                return false;
+            }
             trustLine->storeChange(delta, db);
         }
         metrics.NewMeter({"op-change-trust", "success", "apply"}, "operation")

--- a/src/transactions/ChangeTrustTests.cpp
+++ b/src/transactions/ChangeTrustTests.cpp
@@ -66,7 +66,24 @@ TEST_CASE("change trust", "[tx][changetrust]")
     }
     SECTION("issuer does not exist")
     {
-        applyChangeTrust(app, root, a1, rootSeq, "USD", 100,
-                         CHANGE_TRUST_NO_ISSUER);
+        SECTION("new trust line")
+        {
+            applyChangeTrust(app, root, gateway, rootSeq, "USD", 100,
+                             CHANGE_TRUST_NO_ISSUER);
+        }
+        SECTION("edit existing")
+        {
+            const int64_t minBalance2 = app.getLedgerManager().getMinBalance(2);
+
+            applyCreateAccountTx(app, root, gateway, rootSeq++, minBalance2);
+            SequenceNumber gateway_seq = getAccountSeqNum(gateway, app) + 1;
+
+            applyChangeTrust(app, root, gateway, rootSeq++, "IDR", 100);
+            // Merge gateway back into root (the trustline still exists)
+            applyAccountMerge(app, gateway, root, gateway_seq++);
+
+            applyChangeTrust(app, root, gateway, rootSeq++, "IDR", 99,
+                             CHANGE_TRUST_NO_ISSUER);
+        }
     }
 }

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -50,9 +50,8 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
         mSheepLineA = TrustFrame::loadTrustLine(getSourceID(), sheep, db);
         if (!mSheepLineA)
         { // we don't have what we are trying to sell
-            metrics.NewMeter(
-                        {"op-manage-offer", "invalid", "underfunded-absent"},
-                        "operation").Mark();
+            metrics.NewMeter({"op-manage-offer", "invalid", "sell-no-trust"},
+                             "operation").Mark();
             innerResult().code(MANAGE_OFFER_SELL_NO_TRUST);
             return false;
         }
@@ -66,8 +65,9 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
         }
         if (!mSheepLineA->isAuthorized())
         {
-            metrics.NewMeter({"op-manage-offer", "invalid", "not-authorized"},
-                             "operation").Mark();
+            metrics.NewMeter(
+                        {"op-manage-offer", "invalid", "sell-not-authorized"},
+                        "operation").Mark();
             // we are not authorized to sell
             innerResult().code(MANAGE_OFFER_SELL_NOT_AUTHORIZED);
             return false;
@@ -79,7 +79,7 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
         mWheatLineA = TrustFrame::loadTrustLine(getSourceID(), wheat, db);
         if (!mWheatLineA)
         { // we can't hold what we are trying to buy
-            metrics.NewMeter({"op-manage-offer", "invalid", "no-trust"},
+            metrics.NewMeter({"op-manage-offer", "invalid", "buy-no-trust"},
                              "operation").Mark();
             innerResult().code(MANAGE_OFFER_BUY_NO_TRUST);
             return false;
@@ -87,8 +87,9 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
 
         if (!mWheatLineA->isAuthorized())
         { // we are not authorized to hold what we are trying to buy
-            metrics.NewMeter({"op-manage-offer", "invalid", "not-authorized"},
-                             "operation").Mark();
+            metrics.NewMeter(
+                        {"op-manage-offer", "invalid", "buy-not-authorized"},
+                        "operation").Mark();
             innerResult().code(MANAGE_OFFER_BUY_NOT_AUTHORIZED);
             return false;
         }

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -262,6 +262,8 @@ ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
 
         if (wheatReceived > 0)
         {
+            // it's OK to use mSourceAccount, mWheatLineA and mSheepLineA
+            // here as OfferExchange won't cross offers from source account
             if (wheat.type() == ASSET_TYPE_NATIVE)
             {
                 mSourceAccount->getAccount().balance += wheatReceived;
@@ -269,21 +271,13 @@ ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
             }
             else
             {
-                TrustFrame::pointer wheatLineSigningAccount;
-                wheatLineSigningAccount =
-                    TrustFrame::loadTrustLine(getSourceID(), wheat, db);
-                if (!wheatLineSigningAccount)
-                {
-                    throw std::runtime_error("invalid database state: must "
-                                             "have matching trust line");
-                }
-                if (!wheatLineSigningAccount->addBalance(wheatReceived))
+                if (!mWheatLineA->addBalance(wheatReceived))
                 {
                     // this would indicate a bug in OfferExchange
                     throw std::runtime_error("offer claimed over limit");
                 }
 
-                wheatLineSigningAccount->storeChange(delta, db);
+                mWheatLineA->storeChange(delta, db);
             }
 
             if (sheep.type() == ASSET_TYPE_NATIVE)

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -65,9 +65,8 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
         }
         if (mSheepLineA->getBalance() == 0)
         {
-            metrics.NewMeter(
-                        {"op-manage-offer", "invalid", "underfunded-absent"},
-                        "operation").Mark();
+            metrics.NewMeter({"op-manage-offer", "invalid", "underfunded"},
+                             "operation").Mark();
             innerResult().code(MANAGE_OFFER_UNDERFUNDED);
             return false;
         }

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -60,8 +60,8 @@ MergeOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
     auto const& sourceAccount = mSourceAccount->getAccount();
     if (sourceAccount.numSubEntries != sourceAccount.signers.size())
     {
-        metrics.NewMeter({"op-merge", "failure", "hassubentries"}, "operation")
-            .Mark();
+        metrics.NewMeter({"op-merge", "failure", "has-sub-entries"},
+                         "operation").Mark();
         innerResult().code(ACCOUNT_MERGE_HAS_SUB_ENTRIES);
         return false;
     }

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -49,6 +49,14 @@ MergeOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
         return false;
     }
 
+    if (mSourceAccount->isImmutableAuth())
+    {
+        metrics.NewMeter({"op-merge", "failure", "static-auth"}, "operation")
+            .Mark();
+        innerResult().code(ACCOUNT_MERGE_IMMUTABLE_SET);
+        return false;
+    }
+
     auto const& sourceAccount = mSourceAccount->getAccount();
     if (sourceAccount.numSubEntries != sourceAccount.signers.size())
     {

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -58,14 +58,6 @@ MergeOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
         return false;
     }
 
-    if (TrustFrame::hasIssued(getSourceID(), db))
-    {
-        metrics.NewMeter({"op-merge", "failure", "credit-held"}, "operation")
-            .Mark();
-        innerResult().code(ACCOUNT_MERGE_CREDIT_HELD);
-        return false;
-    }
-
     int64 sourceBalance = sourceAccount.balance;
     otherAccount->getAccount().balance += sourceBalance;
     otherAccount->storeChange(delta, db);

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -78,12 +78,6 @@ TEST_CASE("merge", "[tx][merge]")
         Asset usdCur = makeAsset(gateway, "USD");
         applyChangeTrust(app, a1, gateway, a1_seq++, "USD", trustLineLimit);
 
-        SECTION("account issued credits to somebody else")
-        {
-            applyAccountMerge(app, gateway, a1, gw_seq++,
-                              ACCOUNT_MERGE_CREDIT_HELD);
-        }
-
         SECTION("account has trust line")
         {
             applyAccountMerge(app, a1, b1, a1_seq++,

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -73,6 +73,15 @@ TEST_CASE("merge", "[tx][merge]")
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
 
+    SECTION("Account has static auth flag set")
+    {
+        uint32 flags = AUTH_IMMUTABLE_FLAG;
+        applySetOptions(app, a1, a1_seq++, nullptr, &flags, nullptr, nullptr,
+                        nullptr, nullptr);
+
+        applyAccountMerge(app, a1, b1, a1_seq++, ACCOUNT_MERGE_IMMUTABLE_SET);
+    }
+
     SECTION("With sub entries")
     {
         Asset usdCur = makeAsset(gateway, "USD");

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -178,6 +178,12 @@ TEST_CASE("create offer", "[tx][offers]")
         applyCreateOfferWithResult(app, delta, 0, a1, idrCur, usdCur, oneone,
                                    100, a1_seq++, MANAGE_OFFER_SELL_NO_TRUST);
 
+        // no issuer for selling
+        SecretKey gateway2 = getAccount("other gate");
+        Asset idrCur2 = makeAsset(gateway2, "IDR");
+        applyCreateOfferWithResult(app, delta, 0, a1, idrCur2, usdCur, oneone,
+                                   100, a1_seq++, MANAGE_OFFER_SELL_NO_ISSUER);
+
         applyChangeTrust(app, a1, gateway, a1_seq++, "IDR", trustLineLimit);
 
         // can't sell IDR if account doesn't have any
@@ -191,6 +197,11 @@ TEST_CASE("create offer", "[tx][offers]")
         // missing USD trust
         applyCreateOfferWithResult(app, delta, 0, a1, idrCur, usdCur, oneone,
                                    100, a1_seq++, MANAGE_OFFER_BUY_NO_TRUST);
+
+        // no issuer for buying
+        Asset usdCur2 = makeAsset(gateway2, "USD");
+        applyCreateOfferWithResult(app, delta, 0, a1, idrCur, usdCur2, oneone,
+                                   100, a1_seq++, MANAGE_OFFER_BUY_NO_ISSUER);
 
         applyChangeTrust(app, a1, gateway, a1_seq++, "USD", trustLineLimit);
 

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -105,6 +105,11 @@ PaymentOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
                              "operation").Mark();
             res = PAYMENT_LINE_FULL;
             break;
+        case PATH_PAYMENT_NO_ISSUER:
+            metrics.NewMeter({"op-payment", "failure", "no-issuer"},
+                             "operation").Mark();
+            res = PAYMENT_NO_ISSUER;
+            break;
         default:
             throw std::runtime_error("Unexpected error code from pathPayment");
         }

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -66,6 +66,7 @@ TEST_CASE("payment", "[tx][payment]")
     const int64_t morePayment = paymentAmount / 2;
 
     SecretKey gateway = getAccount("gate");
+    SecretKey gateway2 = getAccount("gate2");
 
     const int64_t assetMultiplier = 1000000;
 
@@ -74,12 +75,16 @@ TEST_CASE("payment", "[tx][payment]")
     int64_t trustLineStartingBalance = 20000 * assetMultiplier;
 
     Asset idrCur = makeAsset(gateway, "IDR");
-    Asset usdCur = makeAsset(gateway, "USD");
+    Asset usdCur = makeAsset(gateway2, "USD");
 
     // sets up gateway account
     const int64_t gatewayPayment = minBalance2 + morePayment;
     applyCreateAccountTx(app, root, gateway, rootSeq++, gatewayPayment);
     SequenceNumber gateway_seq = getAccountSeqNum(gateway, app) + 1;
+
+    // sets up gateway2 account
+    applyCreateAccountTx(app, root, gateway2, rootSeq++, gatewayPayment);
+    SequenceNumber gateway2_seq = getAccountSeqNum(gateway2, app) + 1;
 
     AccountFrame::pointer a1Account, rootAccount;
     rootAccount = loadAccount(root, app);
@@ -94,8 +99,8 @@ TEST_CASE("payment", "[tx][payment]")
     REQUIRE(a1Account->getLowThreshold() == 0);
     REQUIRE(a1Account->getMediumThreshold() == 0);
     // root did 2 transactions at this point
-    REQUIRE(rootAccount->getBalance() ==
-            (100000000000000000 - paymentAmount - gatewayPayment - txfee * 2));
+    REQUIRE(rootAccount->getBalance() == (100000000000000000 - paymentAmount -
+                                          gatewayPayment * 2 - txfee * 3));
 
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
@@ -317,10 +322,10 @@ TEST_CASE("payment", "[tx][payment]")
         }
 
         // setup a1
-        applyChangeTrust(app, a1, gateway, a1Seq++, "USD", trustLineLimit);
+        applyChangeTrust(app, a1, gateway2, a1Seq++, "USD", trustLineLimit);
         applyChangeTrust(app, a1, gateway, a1Seq++, "IDR", trustLineLimit);
 
-        applyCreditPaymentTx(app, gateway, a1, usdCur, gateway_seq++,
+        applyCreditPaymentTx(app, gateway2, a1, usdCur, gateway2_seq++,
                              trustLineStartingBalance);
 
         // add a couple offers in the order book
@@ -332,7 +337,7 @@ TEST_CASE("payment", "[tx][payment]")
         // offer is sell 100 IDR for 200 USD ; buy USD @ 2.0 = sell IRD @ 0.5
         applyCreateAccountTx(app, root, b1, rootSeq++, minBalance3 + 10000);
         SequenceNumber b1Seq = getAccountSeqNum(b1, app) + 1;
-        applyChangeTrust(app, b1, gateway, b1Seq++, "USD", trustLineLimit);
+        applyChangeTrust(app, b1, gateway2, b1Seq++, "USD", trustLineLimit);
         applyChangeTrust(app, b1, gateway, b1Seq++, "IDR", trustLineLimit);
 
         applyCreditPaymentTx(app, gateway, b1, idrCur, gateway_seq++,
@@ -348,7 +353,7 @@ TEST_CASE("payment", "[tx][payment]")
         applyCreateAccountTx(app, root, c1, rootSeq++, minBalance3 + 10000);
         SequenceNumber c1Seq = getAccountSeqNum(c1, app) + 1;
 
-        applyChangeTrust(app, c1, gateway, c1Seq++, "USD", trustLineLimit);
+        applyChangeTrust(app, c1, gateway2, c1Seq++, "USD", trustLineLimit);
         applyChangeTrust(app, c1, gateway, c1Seq++, "IDR", trustLineLimit);
 
         applyCreditPaymentTx(app, gateway, c1, idrCur, gateway_seq++,
@@ -378,9 +383,6 @@ TEST_CASE("payment", "[tx][payment]")
             // A1: try to send 125 IDR to B1 using USD
             // should cost 150 (C's offer taken entirely) +
             //  50 (1/4 of B's offer)=200 USD
-
-            std::vector<Asset> path;
-            path.push_back(usdCur);
 
             auto res = applyPathPaymentTx(
                 app, a1, b1, usdCur, 250 * assetMultiplier, idrCur,
@@ -425,6 +427,45 @@ TEST_CASE("payment", "[tx][payment]")
                          trustLineStartingBalance - 200 * assetMultiplier);
         }
 
+        SECTION("missing issuer")
+        {
+            SECTION("dest is standard account")
+            {
+                SECTION("last")
+                {
+                    // gateway issued idrCur
+                    applyAccountMerge(app, gateway, root, gateway_seq++);
+
+                    auto res = applyPathPaymentTx(
+                        app, a1, b1, usdCur, 250 * assetMultiplier, idrCur,
+                        125 * assetMultiplier, a1Seq++, PATH_PAYMENT_NO_ISSUER);
+                    REQUIRE(res.noIssuer() == idrCur);
+                }
+                SECTION("first")
+                {
+                    // gateway2 issued usdCur
+                    applyAccountMerge(app, gateway2, root, gateway2_seq++);
+
+                    auto res = applyPathPaymentTx(
+                        app, a1, b1, usdCur, 250 * assetMultiplier, idrCur,
+                        125 * assetMultiplier, a1Seq++, PATH_PAYMENT_NO_ISSUER);
+                    REQUIRE(res.noIssuer() == usdCur);
+                }
+                SECTION("mid")
+                {
+                    std::vector<Asset> path;
+                    SecretKey missing = getAccount("missing");
+                    Asset btcCur = makeAsset(missing, "BTC");
+                    path.emplace_back(btcCur);
+                    auto res = applyPathPaymentTx(
+                        app, a1, b1, usdCur, 250 * assetMultiplier, idrCur,
+                        125 * assetMultiplier, a1Seq++, PATH_PAYMENT_NO_ISSUER,
+                        &path);
+                    REQUIRE(res.noIssuer() == btcCur);
+                }
+            }
+        }
+
         SECTION("send with path (takes own offer)")
         {
             // raise A1's balance by what we're trying to send
@@ -436,9 +477,6 @@ TEST_CASE("payment", "[tx][payment]")
 
             // A1: try to send 100 USD to B1 using XLM
 
-            std::vector<Asset> path;
-            path.push_back(xlmCur);
-
             applyPathPaymentTx(app, a1, b1, xlmCur, 100 * assetMultiplier,
                                usdCur, 100 * assetMultiplier, a1Seq++,
                                PATH_PAYMENT_OFFER_CROSS_SELF);
@@ -447,15 +485,12 @@ TEST_CASE("payment", "[tx][payment]")
         SECTION("send with path (offer participant reaching limit)")
         {
             // make it such that C can only receive 120 USD (4/5th of offerC)
-            applyChangeTrust(app, c1, gateway, c1Seq++, "USD",
+            applyChangeTrust(app, c1, gateway2, c1Seq++, "USD",
                              120 * assetMultiplier);
 
             // A1: try to send 105 IDR to B1 using USD
             // cost 120 (C's offer maxed out at 4/5th of published amount)
             //  50 (1/4 of B's offer)=170 USD
-
-            std::vector<Asset> path;
-            path.push_back(usdCur);
 
             auto res = applyPathPaymentTx(
                 app, a1, b1, usdCur, 400 * assetMultiplier, idrCur,
@@ -508,9 +543,6 @@ TEST_CASE("payment", "[tx][payment]")
 
             auto checkBalances = [&]()
             {
-                std::vector<Asset> path;
-                path.push_back(usdCur);
-
                 auto res = applyPathPaymentTx(
                     app, a1, b1, usdCur, 200 * assetMultiplier, idrCur,
                     25 * assetMultiplier, a1Seq++, PATH_PAYMENT_SUCCESS);
@@ -564,7 +596,7 @@ TEST_CASE("payment", "[tx][payment]")
 
             SECTION("deleted buying line")
             {
-                applyChangeTrust(app, c1, gateway, c1Seq++, "USD", 0);
+                applyChangeTrust(app, c1, gateway2, c1Seq++, "USD", 0);
                 checkBalances();
             }
         }

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -131,12 +131,48 @@ TEST_CASE("set options", "[tx][setoptions]")
         }
     }
 
-    SECTION("Can't set and clear same flag")
+    SECTION("flags")
     {
-        uint32_t setFlags = AUTH_REQUIRED_FLAG;
-        uint32_t clearFlags = AUTH_REQUIRED_FLAG;
-        applySetOptions(app, a1, a1seq++, nullptr, &setFlags, &clearFlags,
-                        nullptr, nullptr, nullptr, SET_OPTIONS_BAD_FLAGS);
+        SECTION("Can't set and clear same flag")
+        {
+            uint32_t setFlags = AUTH_REQUIRED_FLAG;
+            uint32_t clearFlags = AUTH_REQUIRED_FLAG;
+            applySetOptions(app, a1, a1seq++, nullptr, &setFlags, &clearFlags,
+                            nullptr, nullptr, nullptr, SET_OPTIONS_BAD_FLAGS);
+        }
+        SECTION("auth flags")
+        {
+            uint32_t flags;
+
+            flags = AUTH_REQUIRED_FLAG;
+            applySetOptions(app, a1, a1seq++, nullptr, &flags, nullptr, nullptr,
+                            nullptr, nullptr);
+
+            flags = AUTH_REVOCABLE_FLAG;
+            applySetOptions(app, a1, a1seq++, nullptr, &flags, nullptr, nullptr,
+                            nullptr, nullptr);
+
+            // clear flag
+            applySetOptions(app, a1, a1seq++, nullptr, nullptr, &flags, nullptr,
+                            nullptr, nullptr);
+
+            flags = AUTH_IMMUTABLE_FLAG;
+            applySetOptions(app, a1, a1seq++, nullptr, &flags, nullptr, nullptr,
+                            nullptr, nullptr);
+
+            // at this point trying to change any flag should fail
+
+            applySetOptions(app, a1, a1seq++, nullptr, nullptr, &flags, nullptr,
+                            nullptr, nullptr, SET_OPTIONS_CANT_CHANGE);
+
+            flags = AUTH_REQUIRED_FLAG;
+            applySetOptions(app, a1, a1seq++, nullptr, nullptr, &flags, nullptr,
+                            nullptr, nullptr, SET_OPTIONS_CANT_CHANGE);
+
+            flags = AUTH_REVOCABLE_FLAG;
+            applySetOptions(app, a1, a1seq++, nullptr, &flags, nullptr, nullptr,
+                            nullptr, nullptr, SET_OPTIONS_CANT_CHANGE);
+        }
     }
 
     SECTION("Home domain")

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -111,6 +111,14 @@ isAssetValid(Asset const& cur)
     return false;
 }
 
+AccountID
+getIssuer(Asset const& asset)
+{
+    return (asset.type() == ASSET_TYPE_CREDIT_ALPHANUM4
+                                 ? asset.alphaNum4().issuer
+                                 : asset.alphaNum12().issuer);
+}
+
 bool
 compareAsset(Asset const& first, Asset const& second)
 {

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -22,6 +22,9 @@ bool isString32Valid(std::string const& str);
 // returns true if the Asset value is well formed
 bool isAssetValid(Asset const& cur);
 
+// returns the issuer for the given asset
+AccountID getIssuer(Asset const& asset);
+
 // returns true if the currencies are the same
 bool compareAsset(Asset const& first, Asset const& second);
 

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -74,12 +74,15 @@ struct Signer
 enum AccountFlags
 { // masks for each flag
 
-    // if set, TrustLines are created with authorized set to "false"
-    // requiring the issuer to set it for each TrustLine
+    // Flags set on issuer accounts
+    // TrustLines are created with authorized set to "false" requiring
+    // the issuer to set it for each TrustLine
     AUTH_REQUIRED_FLAG = 0x1,
-    // if set, the authorized flag in TrustLines can be cleared
+    // If set, the authorized flag in TrustLines can be cleared
     // otherwise, authorization cannot be revoked
-    AUTH_REVOCABLE_FLAG = 0x2
+    AUTH_REVOCABLE_FLAG = 0x2,
+    // Once set, causes all AUTH_* flags to be read-only
+    AUTH_IMMUTABLE_FLAG = 0x4
 };
 
 /* AccountEntry

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -430,14 +430,16 @@ enum ManageOfferResultCode
     MANAGE_OFFER_BUY_NO_TRUST = -3,  // no trust line for what we're buying
     MANAGE_OFFER_SELL_NOT_AUTHORIZED = -4, // not authorized to sell
     MANAGE_OFFER_BUY_NOT_AUTHORIZED = -5,  // not authorized to buy
-    MANAGE_OFFER_LINE_FULL = -6,   // can't receive more of what it's buying
-    MANAGE_OFFER_UNDERFUNDED = -7, // doesn't hold what it's trying to sell
-    MANAGE_OFFER_CROSS_SELF = -8,  // would cross an offer from the same user
+    MANAGE_OFFER_LINE_FULL = -6,      // can't receive more of what it's buying
+    MANAGE_OFFER_UNDERFUNDED = -7,    // doesn't hold what it's trying to sell
+    MANAGE_OFFER_CROSS_SELF = -8,     // would cross an offer from the same user
+    MANAGE_OFFER_SELL_NO_ISSUER = -9, // no issuer for what we're selling
+    MANAGE_OFFER_BUY_NO_ISSUER = -10, // no issuer for what we're buying
 
     // update errors
-    MANAGE_OFFER_NOT_FOUND = -9, // offerID does not match an existing offer
+    MANAGE_OFFER_NOT_FOUND = -11, // offerID does not match an existing offer
 
-    MANAGE_OFFER_LOW_RESERVE = -10 // not enough funds to create a new Offer
+    MANAGE_OFFER_LOW_RESERVE = -12 // not enough funds to create a new Offer
 };
 
 enum ManageOfferEffect

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -555,7 +555,8 @@ enum AccountMergeResultCode
     // codes considered as "failure" for the operation
     ACCOUNT_MERGE_MALFORMED = -1,      // can't merge onto itself
     ACCOUNT_MERGE_NO_ACCOUNT = -2,     // destination does not exist
-    ACCOUNT_MERGE_HAS_SUB_ENTRIES = -3 // account has trust lines/offers
+    ACCOUNT_MERGE_IMMUTABLE_SET = -3,  // source account has AUTH_IMMUTABLE set
+    ACCOUNT_MERGE_HAS_SUB_ENTRIES = -4 // account has trust lines/offers
 };
 
 union AccountMergeResult switch (AccountMergeResultCode code)

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -547,10 +547,9 @@ enum AccountMergeResultCode
     // codes considered as "success" for the operation
     ACCOUNT_MERGE_SUCCESS = 0,
     // codes considered as "failure" for the operation
-    ACCOUNT_MERGE_MALFORMED = -1,       // can't merge onto itself
-    ACCOUNT_MERGE_NO_ACCOUNT = -2,      // destination does not exist
-    ACCOUNT_MERGE_HAS_SUB_ENTRIES = -3, // account has trust lines/offers
-    ACCOUNT_MERGE_CREDIT_HELD = -4      // an issuer cannot be merged if used
+    ACCOUNT_MERGE_MALFORMED = -1,      // can't merge onto itself
+    ACCOUNT_MERGE_NO_ACCOUNT = -2,     // destination does not exist
+    ACCOUNT_MERGE_HAS_SUB_ENTRIES = -3 // account has trust lines/offers
 };
 
 union AccountMergeResult switch (AccountMergeResultCode code)

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -366,7 +366,8 @@ enum PaymentResultCode
     PAYMENT_NO_DESTINATION = -5,     // destination account does not exist
     PAYMENT_NO_TRUST = -6,       // destination missing a trust line for asset
     PAYMENT_NOT_AUTHORIZED = -7, // destination not authorized to hold asset
-    PAYMENT_LINE_FULL = -8       // destination would go above their limit
+    PAYMENT_LINE_FULL = -8,      // destination would go above their limit
+    PAYMENT_NO_ISSUER = -9       // missing issuer on asset
 };
 
 union PaymentResult switch (PaymentResultCode code)
@@ -393,9 +394,10 @@ enum PathPaymentResultCode
     PATH_PAYMENT_NO_TRUST = -6,           // dest missing a trust line for asset
     PATH_PAYMENT_NOT_AUTHORIZED = -7,     // dest not authorized to hold asset
     PATH_PAYMENT_LINE_FULL = -8,          // dest would go above their limit
-    PATH_PAYMENT_TOO_FEW_OFFERS = -9,     // not enough offers to satisfy path
-    PATH_PAYMENT_OFFER_CROSS_SELF = -10,  // would cross one of its own offers
-    PATH_PAYMENT_OVER_SENDMAX = -11       // could not satisfy sendmax
+    PATH_PAYMENT_NO_ISSUER = -9,          // missing issuer on one asset
+    PATH_PAYMENT_TOO_FEW_OFFERS = -10,    // not enough offers to satisfy path
+    PATH_PAYMENT_OFFER_CROSS_SELF = -11,  // would cross one of its own offers
+    PATH_PAYMENT_OVER_SENDMAX = -12       // could not satisfy sendmax
 };
 
 struct SimplePaymentResult
@@ -413,6 +415,8 @@ case PATH_PAYMENT_SUCCESS:
         ClaimOfferAtom offers<>;
         SimplePaymentResult last;
     } success;
+case PATH_PAYMENT_NO_ISSUER:
+    Asset noIssuer; // the asset that caused the error
 default:
     void;
 };


### PR DESCRIPTION
Sorry for the churn on the protocol side @nullstyle (review the issues for more detail)

This PR addresses a few issues related to how we handle offers, trust lines and issuers as objects get deleted or mutated in the ledger.

Highlights:
 * Make it possible to delete offers that don't have valid trustlines, resolves #776 
 * Ensure that offers with invalid trustlines get deleted, resolves #777 
 * Allow issuers to be merged, resolves #778 
 * Rationalized the code base wrt non existent issuers (payment, changetrust, manageoffer), resolves #783
 * Added a new flag for issuers to mark their account as "immutable" (from an auth point of view), resolves #782 

Note: some of this could be avoided by implementing some sort of cascading effects on the ledger. Like delete an issuer -> delete related trust lines -> delete related offers. This would potentially cause larger chunks of work in the ledger at once, requires additional indexes (in the case of offer cleanup after payments, quite a bit of extra logic), and has the potential for confusion from the end user point of view.
