### PR TITLE
Log root seed when creating a new network

### DIFF
--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -47,7 +47,7 @@ const char* AccountFrame::kSQLCreateStatement3 =
     "CREATE INDEX signersaccount ON signers (accountid)";
 
 const char* AccountFrame::kSQLCreateStatement4 = "CREATE INDEX accountbalances "
-                                                 "ON Accounts (balance) WHERE "
+                                                 "ON accounts (balance) WHERE "
                                                  "balance >= 1000000000";
 
 AccountFrame::AccountFrame()

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -169,6 +169,7 @@ LedgerManagerImpl::startNewLedger()
 
     mCurrentLedger = make_shared<LedgerHeaderFrame>(genesisHeader);
     CLOG(INFO, "Ledger") << "Established genesis ledger, closing";
+    CLOG(INFO, "Ledger") << "Root account seed: " << skey.getStrKeySeed();
     closeLedgerHelper(delta);
 }
 

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -35,7 +35,7 @@ InflationOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
     auto& lcl = inflationDelta.getHeader();
 
     time_t closeTime = lcl.scpValue.closeTime;
-    uint32_t seq = lcl.inflationSeq;
+    uint64_t seq = lcl.inflationSeq;
 
     time_t inflationTime = (INFLATION_START_TIME + seq * INFLATION_FREQUENCY);
     if (closeTime < inflationTime)
@@ -51,7 +51,7 @@ InflationOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
 
     1. calculate tally of votes based on "inflationDest" set on each account
     2. take the top accounts (by vote) that get at least .05% of the vote
-    3. If no accounts are over this threshold then the extra goes back to the 
+    3. If no accounts are over this threshold then the extra goes back to the
        inflation pool
     */
 
@@ -87,13 +87,11 @@ InflationOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
 
     int64 leftAfterDole = amountToDole;
 
-   
     for (auto const& w : winners)
     {
         AccountFrame::pointer winner;
 
-        int64 toDoleThisWinner =
-            bigDivide(amountToDole, w.mVotes, totalVotes);
+        int64 toDoleThisWinner = bigDivide(amountToDole, w.mVotes, totalVotes);
 
         if (toDoleThisWinner == 0)
             continue;
@@ -109,10 +107,9 @@ InflationOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
             payouts.emplace_back(w.mInflationDest, toDoleThisWinner);
         }
     }
-   
+
     // put back in fee pool as unclaimed funds
     lcl.feePool += leftAfterDole;
-    
 
     inflationDelta.commit();
 


### PR DESCRIPTION
minor code updates

when creating a new network, the operator needs to know the root account seed in order to do anything with it - so we just log it