### PR TITLE
Simplify tx set handling during consensus

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -144,12 +144,13 @@ DESIRED_BASE_RESERVE=100000000
 
 # DESIRED_MAX_TX_PER_LEDGER (integer) default 500
 # This is how many maximum transactions per ledger you would like to process.
-# You will not nominate a transaction set with more transactions than this.
-# If this maximum is reached you will include the transactions that are paying
-#  a higher relative fee and wait to include transactions with lower fees until
-#  there is less load on the network.
-# You will still attempt to apply transaction sets that the network comes to 
-#  consensus about that conatin more transactions than this.
+# Note that the actual MAX_TX_PER_LEDGER is decided during consensus and can
+# be lower/higher by up to 30%.
+# * The instance picks the top MAX_TX_PER_LEDGER transactions locally to be
+#   considered in the next ledger. Where transactions are ordered by
+#   transaction fee (lower fee transactions are held for later).
+# * The instance will consider transaction sets coming from other peers that
+#   have more transactions invalid.
 DESIRED_MAX_TX_PER_LEDGER=400
 
 # FAILURE_SAFETY (integer) default 1

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -711,8 +711,8 @@ HerderImpl::combineCandidates(uint64 slotIndex,
 
     std::vector<TransactionFramePtr> removed;
     aggTxSet->trimInvalid(mApp, removed);
-    aggTxSet->surgePricingFilter(mApp);
 
+    aggTxSet->surgePricingFilter(mLedgerManager);
     comp.txSetHash = aggTxSet->getContentsHash();
 
     mPendingEnvelopes.recvTxSet(comp.txSetHash, aggTxSet);
@@ -1195,7 +1195,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     proposedSet->trimInvalid(mApp, removed);
     removeReceivedTxs(removed);
 
-    proposedSet->surgePricingFilter(mApp);
+    proposedSet->surgePricingFilter(mLedgerManager);
 
     if (!proposedSet->checkValid(mApp))
     {

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -17,6 +17,8 @@
 #include "main/CommandHandler.h"
 #include "ledger/LedgerHeaderFrame.h"
 
+#include "xdrpp/marshal.h"
+
 using namespace stellar;
 using namespace stellar::txtest;
 
@@ -323,6 +325,11 @@ TEST_CASE("surge", "[herder]")
 
     app->start();
 
+    auto& lm = app->getLedgerManager();
+
+    app->getLedgerManager().getCurrentLedgerHeader().maxTxSetSize =
+        cfg.DESIRED_MAX_TX_PER_LEDGER;
+
     // set up world
     SecretKey root = getRoot(networkID);
 
@@ -356,7 +363,7 @@ TEST_CASE("surge", "[herder]")
                                        n + 10));
         }
         txSet->sortForHash();
-        txSet->surgePricingFilter(*app);
+        txSet->surgePricingFilter(lm);
         REQUIRE(txSet->mTransactions.size() == 5);
         REQUIRE(txSet->checkValid(*app));
     }
@@ -372,7 +379,7 @@ TEST_CASE("surge", "[herder]")
         random_shuffle(txSet->mTransactions.begin(),
                        txSet->mTransactions.end());
         txSet->sortForHash();
-        txSet->surgePricingFilter(*app);
+        txSet->surgePricingFilter(lm);
         REQUIRE(txSet->mTransactions.size() == 5);
         REQUIRE(txSet->checkValid(*app));
     }
@@ -390,7 +397,7 @@ TEST_CASE("surge", "[herder]")
             txSet->add(tx);
         }
         txSet->sortForHash();
-        txSet->surgePricingFilter(*app);
+        txSet->surgePricingFilter(lm);
         REQUIRE(txSet->mTransactions.size() == 5);
         REQUIRE(txSet->checkValid(*app));
         for (auto& tx : txSet->mTransactions)
@@ -415,7 +422,7 @@ TEST_CASE("surge", "[herder]")
             txSet->add(tx);
         }
         txSet->sortForHash();
-        txSet->surgePricingFilter(*app);
+        txSet->surgePricingFilter(lm);
         REQUIRE(txSet->mTransactions.size() == 5);
         REQUIRE(txSet->checkValid(*app));
         for (auto& tx : txSet->mTransactions)
@@ -441,7 +448,7 @@ TEST_CASE("surge", "[herder]")
             txSet->add(tx);
         }
         txSet->sortForHash();
-        txSet->surgePricingFilter(*app);
+        txSet->surgePricingFilter(lm);
         REQUIRE(txSet->mTransactions.size() == 5);
         REQUIRE(txSet->checkValid(*app));
         for (auto& tx : txSet->mTransactions)
@@ -463,7 +470,7 @@ TEST_CASE("surge", "[herder]")
                                        accountCSeq++, n + 10));
         }
         txSet->sortForHash();
-        txSet->surgePricingFilter(*app);
+        txSet->surgePricingFilter(lm);
         REQUIRE(txSet->mTransactions.size() == 5);
         REQUIRE(txSet->checkValid(*app));
     }

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -50,6 +50,9 @@ stellarValueToString(StellarValue const& sv)
                 case LEDGER_UPGRADE_BASE_FEE:
                     res << "BASE_FEE=" << lupgrade.newBaseFee();
                     break;
+                case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
+                    res << "MAX_TX_SET_SIZE=" << lupgrade.newMaxTxSetSize();
+                    break;
                 default:
                     res << "<unsupported>";
                 }

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -31,5 +31,5 @@ class LedgerCloseData
 
 std::string stellarValueToString(StellarValue const& sv);
 
-#define emptyUpgradeSteps (xdr::xvector<UpgradeType, 4>(0))
+#define emptyUpgradeSteps (xdr::xvector<UpgradeType, 6>(0))
 }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -70,16 +70,7 @@ struct ApplyTxSorter
     {
         // need to use the hash of whole tx here since multiple txs could have
         // the same Contents
-        Hash h1 = tx1->getFullHash();
-        Hash h2 = tx2->getFullHash();
-        Hash v1, v2;
-        for (int n = 0; n < 32; n++)
-        {
-            v1[n] = mSetHash[n] ^ h1[n];
-            v2[n] = mSetHash[n] ^ h2[n];
-        }
-
-        return v1 < v2;
+        return lessThanXored(tx1->getFullHash(), tx2->getFullHash(), mSetHash);
     }
 };
 

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -41,7 +41,7 @@ class TxSetFrame
     bool checkValid(Application& app) const;
     void trimInvalid(Application& app,
                      std::vector<TransactionFramePtr>& trimmed);
-    void surgePricingFilter(Application& app);
+    void surgePricingFilter(LedgerManager const& lm);
 
     void removeTx(TransactionFramePtr tx);
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -108,6 +108,10 @@ class LedgerManager
     // arithmetic operation.
     virtual int64_t getTxFee() const = 0;
 
+    // return the maximum size of a transaction set to apply to the current
+    // ledger
+    virtual uint32_t getMaxTxSetSize() const = 0;
+
     // Return the (changing) number of seconds since the LCL closed.
     virtual uint64_t secondsSinceLastLedgerClose() const = 0;
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -160,6 +160,7 @@ LedgerManagerImpl::startNewLedger()
     // set the ones that are not 0
     genesisHeader.baseFee = 100;
     genesisHeader.baseReserve = 100000000;
+    genesisHeader.maxTxSetSize = 100; // 100 tx/ledger max
     genesisHeader.totalCoins = masterAccount.getAccount().balance;
     genesisHeader.ledgerSeq = 1;
 
@@ -257,6 +258,12 @@ int64_t
 LedgerManagerImpl::getTxFee() const
 {
     return mCurrentLedger->mHeader.baseFee;
+}
+
+uint32_t
+LedgerManagerImpl::getMaxTxSetSize() const
+{
+    return mCurrentLedger->mHeader.maxTxSetSize;
 }
 
 int64_t

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -680,6 +680,9 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         case LEDGER_UPGRADE_BASE_FEE:
             ledgerDelta.getHeader().baseFee = lupgrade.newBaseFee();
             break;
+        case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
+            ledgerDelta.getHeader().maxTxSetSize = lupgrade.newMaxTxSetSize();
+            break;
         default:
         {
             string s;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -77,6 +77,7 @@ class LedgerManagerImpl : public LedgerManager
     uint32_t getLastClosedLedgerNum() const override;
     int64_t getMinBalance(uint32_t ownerCount) const override;
     int64_t getTxFee() const override;
+    uint32_t getMaxTxSetSize() const override;
     uint64_t getCloseTime() const override;
     uint64_t secondsSinceLastLedgerClose() const override;
     void syncMetrics() override;

--- a/src/ledger/readme.md
+++ b/src/ledger/readme.md
@@ -67,8 +67,8 @@ range defined in the nodes configuration file.
 
 The reason it is done after applying the transaction set is that the
 transaction set is validated against the last closed ledger, independently of
-any upgrades. This allows to update `baseFee` (see ledger header), without
-risking invalidating transactions for the current ledger.
+any upgrades. For example, this allows to update `baseFee` (see ledger header)
+without risking invalidating transactions for the current ledger.
 
 ###Other notable fields from the ledger header
 ####Hash of the previous ledger header

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -264,6 +264,11 @@ TEST_CASE("Auto-calibrated single node load test", "[autoload][hide]")
     VirtualClock clock(VirtualClock::REAL_TIME);
     Application::pointer appPtr = Application::create(clock, cfg);
     appPtr->start();
+    // force maxTxSetSize to avoid throwing txSets on the floor during the first
+    // ledger close
+    appPtr->getLedgerManager().getCurrentLedgerHeader().maxTxSetSize =
+        cfg.DESIRED_MAX_TX_PER_LEDGER;
+
     appPtr->generateLoad(100000, 100000, 10, true);
     auto& io = clock.getIOService();
     asio::io_service::work mainWork(io);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -90,10 +90,10 @@ TransactionFrame::getEnvelope()
     return mEnvelope;
 }
 
-float
-TransactionFrame::getFeeRatio(Application& app) const
+double
+TransactionFrame::getFeeRatio(LedgerManager const& lm) const
 {
-    return ((float)getFee() / (float)getMinFee(app));
+    return ((double)getFee() / (double)getMinFee(lm));
 }
 
 int64_t
@@ -103,7 +103,7 @@ TransactionFrame::getFee() const
 }
 
 int64_t
-TransactionFrame::getMinFee(Application& app) const
+TransactionFrame::getMinFee(LedgerManager const& lm) const
 {
     size_t count = mOperations.size();
 
@@ -112,7 +112,7 @@ TransactionFrame::getMinFee(Application& app) const
         count = 1;
     }
 
-    return app.getLedgerManager().getTxFee() * count;
+    return lm.getTxFee() * count;
 }
 
 void
@@ -225,10 +225,10 @@ TransactionFrame::commonValid(Application& app, bool applying,
         return false;
     }
 
+    auto& lm = app.getLedgerManager();
     if (mEnvelope.tx.timeBounds)
     {
-        uint64 closeTime =
-            app.getLedgerManager().getCurrentLedgerHeader().scpValue.closeTime;
+        uint64 closeTime = lm.getCurrentLedgerHeader().scpValue.closeTime;
         if (mEnvelope.tx.timeBounds->minTime > closeTime)
         {
             app.getMetrics()
@@ -249,7 +249,7 @@ TransactionFrame::commonValid(Application& app, bool applying,
         }
     }
 
-    if (mEnvelope.tx.fee < getMinFee(app))
+    if (mEnvelope.tx.fee < getMinFee(lm))
     {
         app.getMetrics()
             .NewMeter({"transaction", "invalid", "insufficient-fee"},

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -125,9 +125,9 @@ class TransactionFrame
 
     int64_t getFee() const;
 
-    int64_t getMinFee(Application& app) const;
+    int64_t getMinFee(LedgerManager const& lm) const;
 
-    float getFeeRatio(Application& app) const;
+    double getFeeRatio(LedgerManager const& lm) const;
 
     void addSignature(SecretKey const& secretKey);
 

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -5,6 +5,7 @@
 #include "util/types.h"
 #include "lib/util/uint128_t.h"
 #include <locale>
+#include <algorithm>
 
 namespace stellar
 {
@@ -18,6 +19,16 @@ isZero(uint256 const& b)
             return false;
 
     return true;
+}
+
+Hash& operator^=(Hash& l, Hash const& r)
+{
+    std::transform(l.begin(), l.end(), r.begin(), l.begin(),
+                   [](uint8_t a, uint8_t b)
+                   {
+                       return a ^ b;
+                   });
+    return l;
 }
 
 bool

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -20,6 +20,19 @@ isZero(uint256 const& b)
     return true;
 }
 
+bool
+lessThanXored(Hash const& l, Hash const& r, Hash const& x)
+{
+    Hash v1, v2;
+    for (size_t i = 0; i < l.size(); i++)
+    {
+        v1[i] = x[i] ^ l[i];
+        v2[i] = x[i] ^ r[i];
+    }
+
+    return v1 < v2;
+}
+
 uint256
 makePublicKey(uint256 const& b)
 {

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -14,6 +14,9 @@ typedef std::vector<unsigned char> Blob;
 
 bool isZero(uint256 const& b);
 
+// returns true if ( l ^ x ) < ( r ^ x)
+bool lessThanXored(Hash const& l, Hash const& r, Hash const& x);
+
 uint256 makePublicKey(uint256 const& b);
 
 // returns true if the passed string32 is valid

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -14,6 +14,8 @@ typedef std::vector<unsigned char> Blob;
 
 bool isZero(uint256 const& b);
 
+Hash& operator^=(Hash& l, Hash const& r);
+
 // returns true if ( l ^ x ) < ( r ^ x)
 bool lessThanXored(Hash const& l, Hash const& r, Hash const& x);
 

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -56,6 +56,8 @@ struct LedgerHeader
     uint32 baseFee;     // base fee per operation in stroops
     uint32 baseReserve; // account base reserve in stroops
 
+    uint32 maxTxSetSize; // maximum size a transaction set can be
+
     Hash skipList[4]; // hashes of ledgers in the past. allows you to jump back
                       // in time without walking the chain back ledger by ledger
                       // each slot contains the oldest ledger that is mod of

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -21,7 +21,7 @@ struct StellarValue
     // unknown steps during consensus if needed.
     // see notes below on 'LedgerUpgrade' for more detail
     // max size is dictated by number of upgrade types (+ room for future)
-    UpgradeType upgrades<4>;
+    UpgradeType upgrades<6>;
 
     // reserved for future use
     union switch (int v)
@@ -45,7 +45,7 @@ struct LedgerHeader
 
     uint32 ledgerSeq; // sequence number of this ledger
 
-    int64 totalCoins; // total number of stroops in existence. 
+    int64 totalCoins; // total number of stroops in existence.
                       // 10,000,000 stroops in 1 XLM
 
     int64 feePool;       // fees burned since last inflation run
@@ -81,7 +81,8 @@ in ascending order
 enum LedgerUpgradeType
 {
     LEDGER_UPGRADE_VERSION = 1,
-    LEDGER_UPGRADE_BASE_FEE = 2
+    LEDGER_UPGRADE_BASE_FEE = 2,
+    LEDGER_UPGRADE_MAX_TX_SET_SIZE = 3
 };
 
 union LedgerUpgrade switch (LedgerUpgradeType type)
@@ -90,6 +91,8 @@ case LEDGER_UPGRADE_VERSION:
     uint32 newLedgerVersion; // update ledgerVersion
 case LEDGER_UPGRADE_BASE_FEE:
     uint32 newBaseFee; // update baseFee
+case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
+    uint32 newMaxTxSetSize; // update maxTxSetSize
 };
 
 /* Entries used to define the bucket list */


### PR DESCRIPTION
This change set does a bunch of things:

 * it makes the max number of transactions in a ledger something decided by validators during consensus, the same way the base fee is decided by validators. As validators are the ones with the hardware, they should control this :)
     * this allows to filter out transaction sets earlier during consensus as they are too big anyways
 * simplify the protocol by picking the transaction set with the most transactions instead of attempting  to merge transaction sets during consensus (basically a "max" implementation).
     * most of the time (low latency network), this should not change anything
     * when it happens, it leaves the implementation of how to build the largest valid transaction set open (some implementations may decide to build sets using fees as the primary way of filtering, some others may try to optimize for number of successful transactions for example).
