### PR TITLE
Load measurement and shedding

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -98,6 +98,14 @@ PREFERRED_PEER_KEYS=["GA22N4YGO7IJDRF2SISA5KHULGYYKDXBQGYIWUVNMSNHF5G2DNBKP3M5",
 # accept connections from PREFERRED_PEERS or PREFERRED_PEER_KEYS
 PREFERRED_PEERS_ONLY=false
 
+# Percentage, between 0 and 100, of system activity (measured in terms
+# of both event-loop cycles and database time) below-which the system
+# will consider itself "loaded" and attempt to shed load. Set this
+# number low and the system will be tolerant of overloading. Set it
+# high and the system will be intolerant. By default it is 0, meaning
+# totally insensitive to overloading.
+MINIMUM_IDLE_PERCENT=0
+
 # KNOWN_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # It will try to connect to these when it is below TARGET_PEER_CONNECTIONS.

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -66,6 +66,8 @@ Database::registerDrivers()
 
 Database::Database(Application& app)
     : mApp(app)
+    , mQueryMeter(app.getMetrics().NewMeter({"database", "query", "exec"},
+                                            "query"))
     , mStatementsSize(
           app.getMetrics().NewCounter({"database", "memory", "statements"}))
     , mEntryCache(4096)
@@ -86,6 +88,7 @@ Database::Database(Application& app)
 medida::TimerContext
 Database::getInsertTimer(std::string const& entityName)
 {
+    mQueryMeter.Mark();
     return mApp.getMetrics()
         .NewTimer({"database", "insert", entityName})
         .TimeScope();
@@ -94,6 +97,7 @@ Database::getInsertTimer(std::string const& entityName)
 medida::TimerContext
 Database::getSelectTimer(std::string const& entityName)
 {
+    mQueryMeter.Mark();
     return mApp.getMetrics()
         .NewTimer({"database", "select", entityName})
         .TimeScope();
@@ -102,6 +106,7 @@ Database::getSelectTimer(std::string const& entityName)
 medida::TimerContext
 Database::getDeleteTimer(std::string const& entityName)
 {
+    mQueryMeter.Mark();
     return mApp.getMetrics()
         .NewTimer({"database", "delete", entityName})
         .TimeScope();
@@ -110,6 +115,7 @@ Database::getDeleteTimer(std::string const& entityName)
 medida::TimerContext
 Database::getUpdateTimer(std::string const& entityName)
 {
+    mQueryMeter.Mark();
     return mApp.getMetrics()
         .NewTimer({"database", "update", entityName})
         .TimeScope();
@@ -267,4 +273,11 @@ Database::captureAndLogSQL(std::string contextName)
 {
     return make_shared<SQLLogContext>(contextName, mSession);
 }
+
+medida::Meter&
+Database::getQueryMeter()
+{
+    return mQueryMeter;
+}
+
 }

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -86,6 +86,7 @@ class StatementContext : NonCopyable
 class Database : NonMovableOrCopyable
 {
     Application& mApp;
+    medida::Meter& mQueryMeter;
     soci::session mSession;
     std::unique_ptr<soci::connection_pool> mPool;
 
@@ -102,6 +103,10 @@ class Database : NonMovableOrCopyable
     // Instantiate object and connect to app.getConfig().DATABASE;
     // if there is a connection error, this will throw.
     Database(Application& app);
+
+    // Return a crude meter of total queries to the db, for use in
+    // overlay/LoadManager.
+    medida::Meter& getQueryMeter();
 
     // Return a logging helper that will capture all SQL statements made
     // on the main connection while active, and will log those statements

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -149,6 +149,7 @@ LedgerManagerImpl::getStateHuman() const
 void
 LedgerManagerImpl::startNewLedger()
 {
+    DBTimeExcluder qtExclude(mApp);
     auto ledgerTime = mLedgerClose.TimeScope();
     SecretKey skey = SecretKey::fromSeed(mApp.getNetworkID());
 
@@ -178,6 +179,7 @@ void
 LedgerManagerImpl::loadLastKnownLedger(
     function<void(asio::error_code const& ec)> handler)
 {
+    DBTimeExcluder qtExclude(mApp);
     auto ledgerTime = mLedgerClose.TimeScope();
 
     string lastLedger =
@@ -604,6 +606,7 @@ during replays.
 void
 LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
 {
+    DBTimeExcluder qtExclude(mApp);
     CLOG(DEBUG, "Ledger") << "starting closeLedger() on ledgerSeq="
                           << mCurrentLedger->mHeader.ledgerSeq;
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -49,6 +49,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAX_PEER_CONNECTIONS = 50;
     PREFERRED_PEERS_ONLY = false;
 
+    MINIMUM_IDLE_PERCENT = 0;
+
     MAX_CONCURRENT_SUBPROCESSES = 32;
     PARANOID_MODE = false;
     NODE_IS_VALIDATOR = false;
@@ -485,6 +487,18 @@ Config::load(std::string const& filename)
                 }
                 MAX_CONCURRENT_SUBPROCESSES =
                     (size_t)item.second->as<int64_t>()->value();
+            }
+            else if (item.first == "MINIMUM_IDLE_PERCENT")
+            {
+                if (!item.second->as<int64_t>() ||
+                    item.second->as<int64_t>()->value() > 100 ||
+                    item.second->as<int64_t>()->value() < 0)
+                {
+                    throw std::invalid_argument(
+                        "invalid MINIMUM_IDLE_PERCENT");
+                }
+                MINIMUM_IDLE_PERCENT =
+                    (uint32_t)item.second->as<int64_t>()->value();
             }
             else if (item.first == "HISTORY")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -117,6 +117,14 @@ class Config : public std::enable_shared_from_this<Config>
     // Whether to exclude peers that are not preferred.
     bool PREFERRED_PEERS_ONLY;
 
+    // Percentage, between 0 and 100, of system activity (measured in terms
+    // of both event-loop cycles and database time) below-which the system
+    // will consider itself "loaded" and attempt to shed load. Set this
+    // number low and the system will be tolerant of overloading. Set it
+    // high and the system will be intolerant. By default it is 0, meaning
+    // totally insensitive to overloading.
+    uint32_t MINIMUM_IDLE_PERCENT;
+
     // process-management config
     size_t MAX_CONCURRENT_SUBPROCESSES;
 

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -1,0 +1,208 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "database/Database.h"
+#include "main/Application.h"
+#include "main/Config.h"
+#include "overlay/LoadManager.h"
+#include "overlay/OverlayManager.h"
+#include "util/Logging.h"
+#include "util/types.h"
+#include "lib/util/format.h"
+
+#include <chrono>
+
+namespace stellar
+{
+
+LoadManager::LoadManager()
+    : mPeerCosts(128)
+{
+}
+
+std::string
+byteMag(uint64_t bytes)
+{
+    static char const * sz[7] = {"B","KiB","MiB","GiB","TiB","PiB","EiB"};
+    for (int i = 6; i >= 0; --i)
+    {
+        uint64_t mag = i*10;
+        if (bytes >= (1ULL << mag))
+        {
+            return fmt::format("{:>d}{:s}", bytes>>mag, sz[i]);
+        }
+    }
+    return "0";
+}
+
+std::string
+timeMag(uint64_t nanos)
+{
+
+    static char const * sz[4] = {"ns","us","ms","s"};
+    uint64_t mag = 1000000000;
+    for (int i = 3; i >= 0; --i)
+    {
+        if (nanos >= mag)
+        {
+            return fmt::format("{:>d}{:s}", nanos/mag, sz[i]);
+        }
+        mag /= 1000;
+    }
+    return "0";
+}
+
+void
+LoadManager::reportLoads(std::vector<Peer::pointer> const& peers)
+{
+    CLOG(INFO, "Overlay") << "";
+    CLOG(INFO, "Overlay")
+        << "Cumulative peer-load costs:";
+    CLOG(INFO, "Overlay")
+        << "------------------------------------------------------";
+    CLOG(INFO, "Overlay")
+        << fmt::format("{:>10s} {:>10s} {:>10s} {:>10s} {:>10s}",
+                       "peer", "time", "send", "recv", "query");
+    for (auto const& peer : peers)
+    {
+        auto cost = getPeerCosts(peer->getPeerID());
+        CLOG(INFO, "Overlay") <<
+            fmt::format(
+                "{:>10s} {:>10s} {:>10s} {:>10s} {:>10d}",
+                PubKeyUtils::toShortString(peer->getPeerID()),
+                timeMag(static_cast<uint64_t>(cost->mTimeSpent.one_minute_rate())),
+                byteMag(static_cast<uint64_t>(cost->mBytesSend.one_minute_rate())),
+                byteMag(static_cast<uint64_t>(cost->mBytesRecv.one_minute_rate())),
+                cost->mSQLQueries.count());
+    }
+    CLOG(INFO, "Overlay") << "";
+}
+
+LoadManager::~LoadManager()
+{
+}
+
+void
+LoadManager::maybeShedExcessLoad(Application& app)
+{
+    uint32_t minIdle = app.getConfig().MINIMUM_IDLE_PERCENT;
+    uint32_t idleClock = app.getClock().recentIdleCrankPercent();
+    uint32_t idleDb = app.getDatabase().recentIdleDbPercent();
+
+    if ((idleClock < minIdle) || (idleDb < minIdle))
+    {
+        CLOG(WARNING, "Overlay") << "";
+        CLOG(WARNING, "Overlay") << "System appears to be overloaded";
+        CLOG(WARNING, "Overlay") << "Idle minimum " << minIdle << "% vs. "
+                                 << "clock " << idleClock << "%, "
+                                 << "DB " << idleDb << "%";
+        CLOG(WARNING, "Overlay") << "";
+
+        auto peers = app.getOverlayManager().getPeers();
+        reportLoads(peers);
+
+        // Look for the worst-behaved of the current peers and kick them out.
+        std::shared_ptr<Peer> victim;
+        std::shared_ptr<LoadManager::PeerCosts> victimCost;
+        for (auto peer : peers)
+        {
+            auto peerCost = getPeerCosts(peer->getPeerID());
+            if (!victim || victimCost->isLessThan(peerCost))
+            {
+                victim = peer;
+                victimCost = peerCost;
+            }
+        }
+
+        if (victim)
+        {
+            CLOG(WARNING, "Overlay")
+                << "Disconnecting suspected culprit "
+                << PubKeyUtils::toShortString(victim->getPeerID());
+
+            app.getMetrics().NewMeter(
+                {"overlay", "drop", "load-shed"}, "drop").Mark();
+
+            victim->drop();
+        }
+    }
+
+}
+
+LoadManager::PeerCosts::PeerCosts()
+    : mTimeSpent("nanoseconds")
+    , mBytesSend("byte")
+    , mBytesRecv("byte")
+    , mSQLQueries("query")
+{
+}
+
+bool
+LoadManager::PeerCosts::isLessThan(
+    std::shared_ptr<LoadManager::PeerCosts> other)
+{
+    double ownRates[4] = {
+        mTimeSpent.one_minute_rate(),
+        mBytesSend.one_minute_rate(),
+        mBytesRecv.one_minute_rate(),
+        mSQLQueries.one_minute_rate()
+    };
+    double otherRates[4] = {
+        other->mTimeSpent.one_minute_rate(),
+        other->mBytesSend.one_minute_rate(),
+        other->mBytesRecv.one_minute_rate(),
+        other->mSQLQueries.one_minute_rate()
+    };
+    return std::lexicographical_compare(ownRates, ownRates+4,
+                                        otherRates, otherRates+4);
+}
+
+std::shared_ptr<LoadManager::PeerCosts>
+LoadManager::getPeerCosts(NodeID const& node)
+{
+    if (mPeerCosts.exists(node))
+    {
+        return mPeerCosts.get(node);
+    }
+    auto p = std::make_shared<LoadManager::PeerCosts>();
+    mPeerCosts.put(node, p);
+    return p;
+}
+
+LoadManager::PeerContext::PeerContext(Application& app,
+                                      NodeID const& node)
+    : mApp(app)
+    , mNode(node)
+    , mWorkStart(app.getClock().now())
+    , mBytesSendStart(Peer::getByteWriteMeter(app).count())
+    , mBytesRecvStart(Peer::getByteReadMeter(app).count())
+    , mSQLQueriesStart(app.getDatabase().getQueryMeter().count())
+{
+}
+
+LoadManager::PeerContext::~PeerContext()
+{
+    if (!isZero(mNode.ed25519()))
+    {
+        auto pc = mApp.getOverlayManager().getLoadManager().getPeerCosts(mNode);
+        auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            mApp.getClock().now() - mWorkStart);
+        auto send = Peer::getByteWriteMeter(mApp).count() - mBytesSendStart;
+        auto recv = Peer::getByteReadMeter(mApp).count() - mBytesRecvStart;
+        auto query = (mApp.getDatabase().getQueryMeter().count() -
+                      mSQLQueriesStart);
+        CLOG(TRACE, "Overlay") << "Debiting peer "
+                               << PubKeyUtils::toShortString(mNode)
+                               << " time:" << timeMag(time.count())
+                               << " send:" << byteMag(send)
+                               << " recv:" << byteMag(recv)
+                               << " query:" << query;
+        pc->mTimeSpent.Mark(time.count());
+        pc->mBytesSend.Mark(send);
+        pc->mBytesRecv.Mark(recv);
+        pc->mSQLQueries.Mark(query);
+    }
+}
+
+}

--- a/src/overlay/LoadManager.h
+++ b/src/overlay/LoadManager.h
@@ -1,0 +1,88 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/SecretKey.h"
+#include "overlay/Peer.h"
+#include "util/lrucache.hpp"
+#include "xdr/Stellar-types.h"
+#include "util/HashOfHash.h"
+
+#include "medida/metrics_registry.h"
+#include "medida/timer.h"
+#include "medida/meter.h"
+
+#include "util/Timer.h"
+
+namespace stellar
+{
+
+class Application;
+
+class LoadManager
+{
+    // This class monitors system load, and attempts to assign blame for
+    // the origin of load to particular peers, including the transactions
+    // we inject ourselves.
+    //
+    // The purpose is ultimately to offer a diagnostic view of the peer
+    // when and if it's overloaded, as well as to support an automatic
+    // load-shedding action of disconnecting the "worst" peers and/or
+    // rejecting traffic due to load.
+    //
+    // This is all very heuristic and speculative; if it turns out not to
+    // work, or to do more harm than good, it ought to be disabled/removed.
+
+public:
+
+    LoadManager();
+    ~LoadManager();
+    void reportLoads(std::vector<Peer::pointer> const& peers);
+
+    // We track the costs incurred by each peer in a PeerCosts structure,
+    // and keep these in an LRU cache to avoid overfilling the LoadManager
+    // should we have ongoing churn in low-cost peers.
+    struct PeerCosts
+    {
+        PeerCosts();
+        bool isLessThan(std::shared_ptr<PeerCosts> other);
+        medida::Meter mTimeSpent;
+        medida::Meter mBytesSend;
+        medida::Meter mBytesRecv;
+        medida::Meter mSQLQueries;
+    };
+
+    std::shared_ptr<PeerCosts> getPeerCosts(NodeID const& peer);
+
+private:
+
+    cache::lru_cache<NodeID, std::shared_ptr<PeerCosts>> mPeerCosts;
+
+public:
+
+    // Measure recent load on the system and, if the system appears
+    // overloaded, shed one or more of the worst-behaved peers,
+    // according to our local per-peer accounting.
+    void maybeShedExcessLoad(Application& app);
+
+    // Context manager for doing work on behalf of a node, we push
+    // one of these on the stack. When destroyed it will debit the
+    // peer in question with the cost.
+    class PeerContext
+    {
+        Application& mApp;
+        NodeID mNode;
+
+        VirtualClock::time_point mWorkStart;
+        std::uint64_t mBytesSendStart;
+        std::uint64_t mBytesRecvStart;
+        std::uint64_t mSQLQueriesStart;
+    public:
+        PeerContext(Application& app, NodeID const& node);
+        ~PeerContext();
+    };
+};
+
+}

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -7,6 +7,7 @@
 #include "main/Application.h"
 #include "overlay/StellarXDR.h"
 #include "xdrpp/marshal.h"
+#include "overlay/LoadManager.h"
 #include "overlay/OverlayManager.h"
 #include "crypto/Random.h"
 #include "medida/metrics_registry.h"
@@ -178,6 +179,7 @@ LoopbackPeer::deliverOne()
                              {
                                  remote->recvMessage(std::move(*m));
                              });
+        LoadManager::PeerContext loadCtx(mApp, mPeerID);
         mLastWrite = mApp.getClock().now();
         mMessageWrite.Mark();
         mByteWrite.Mark((*m)->raw_size());

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -49,6 +49,7 @@ namespace stellar
 
 class PeerRecord;
 class PeerAuth;
+class LoadManager;
 
 class OverlayManager
 {
@@ -116,6 +117,9 @@ class OverlayManager
 
     // Return the persistent p2p authentication-key cache.
     virtual PeerAuth& getPeerAuth() = 0;
+
+    // Return the persistent peer-load-accounting cache.
+    virtual LoadManager& getLoadManager() = 0;
 
     // start up all background tasks for overlay
     virtual void start() = 0;

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -205,6 +205,9 @@ void
 OverlayManagerImpl::tick()
 {
     CLOG(TRACE, "Overlay") << "OverlayManagerImpl tick";
+
+    mLoad.maybeShedExcessLoad(mApp);
+
     if (mPeers.size() < mApp.getConfig().TARGET_PEER_CONNECTIONS)
     {
         connectToMorePeers(static_cast<int>(
@@ -390,6 +393,13 @@ OverlayManagerImpl::getPeerAuth()
 {
     return mAuth;
 }
+
+LoadManager&
+OverlayManagerImpl::getLoadManager()
+{
+    return mLoad;
+}
+
 
 void
 OverlayManagerImpl::shutdown()

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -8,6 +8,7 @@
 #include "PeerAuth.h"
 #include "PeerDoor.h"
 #include "PeerRecord.h"
+#include "LoadManager.h"
 #include "overlay/ItemFetcher.h"
 #include "overlay/Floodgate.h"
 #include <vector>
@@ -36,6 +37,7 @@ class OverlayManagerImpl : public OverlayManager
     std::vector<Peer::pointer> mPeers;
     PeerDoor mDoor;
     PeerAuth mAuth;
+    LoadManager mLoad;
     bool mShuttingDown;
 
     medida::Meter& mMessagesReceived;
@@ -82,6 +84,8 @@ class OverlayManagerImpl : public OverlayManager
     Peer::pointer getRandomPeer() override;
 
     PeerAuth& getPeerAuth() override;
+
+    LoadManager& getLoadManager() override;
 
     void start() override;
     void shutdown() override;

--- a/src/overlay/OverlayTests.cpp
+++ b/src/overlay/OverlayTests.cpp
@@ -241,3 +241,71 @@ TEST_CASE("reject peers with the same nodeid", "[overlay]")
                 .NewMeter({"overlay", "drop", "recv-hello-peerid"}, "drop")
                 .count() != 0);
 }
+
+void
+injectSendPeersAndReschedule(VirtualClock::time_point& end,
+                             VirtualClock& clock,
+                             VirtualTimer& timer,
+                             std::shared_ptr<LoopbackPeer> const& sendPeer)
+{
+    sendPeer->sendGetPeers();
+    if (clock.now() < end && sendPeer->isConnected())
+    {
+        timer.expires_from_now(std::chrono::milliseconds(10));
+        timer.async_wait(
+            [&](asio::error_code const& ec)
+            {
+                if (!ec)
+                {
+                    injectSendPeersAndReschedule(end, clock, timer, sendPeer);
+                }
+            });
+    }
+}
+
+TEST_CASE("disconnect peers when overloaded", "[overlay]")
+{
+    VirtualClock clock;
+    Config const& cfg1 = getTestConfig(0);
+    Config cfg2 = getTestConfig(1);
+    Config const& cfg3 = getTestConfig(2);
+
+    cfg2.RUN_STANDALONE = false;
+    cfg2.MINIMUM_IDLE_PERCENT = 99;
+    cfg2.TARGET_PEER_CONNECTIONS = 0;
+
+    auto app1 = Application::create(clock, cfg1);
+    auto app2 = Application::create(clock, cfg2);
+    auto app3 = Application::create(clock, cfg3);
+
+    LoopbackPeerConnection conn(*app1, *app2);
+    LoopbackPeerConnection conn2(*app3, *app2);
+
+    crankSome(clock);
+    app2->getOverlayManager().start();
+
+    // app1 and app3 are both connected to app2. app1 will hammer on the
+    // connection, app3 will do nothing. app2 should disconnect app1.
+    // but app3 should remain connected since the i/o timeout is 30s.
+    auto start = clock.now();
+    auto end = start + std::chrono::seconds(10);
+    VirtualTimer timer(clock);
+
+    injectSendPeersAndReschedule(end, clock, timer,
+                                 conn.getInitiator());
+
+    for (size_t i = 0;
+         (i < 1000 && clock.now() < end &&
+          conn.getInitiator()->isConnected() &&
+          clock.crank(false) > 0);
+         ++i)
+        ;
+
+    REQUIRE(!conn.getInitiator()->isConnected());
+    REQUIRE(!conn.getAcceptor()->isConnected());
+    REQUIRE(conn2.getInitiator()->isConnected());
+    REQUIRE(conn2.getAcceptor()->isConnected());
+    REQUIRE(app2->getMetrics().NewMeter(
+                {"overlay", "drop", "load-shed"},
+                "drop").count() != 0);
+}

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -36,6 +36,18 @@ namespace stellar
 using namespace std;
 using namespace soci;
 
+medida::Meter&
+Peer::getByteReadMeter(Application& app)
+{
+    return app.getMetrics().NewMeter({"overlay", "byte", "read"}, "byte");
+}
+
+medida::Meter&
+Peer::getByteWriteMeter(Application& app)
+{
+    return app.getMetrics().NewMeter({"overlay", "byte", "write"}, "byte");
+}
+
 Peer::Peer(Application& app, PeerRole role)
     : mApp(app)
     , mRole(role)
@@ -51,9 +63,8 @@ Peer::Peer(Application& app, PeerRole role)
           app.getMetrics().NewMeter({"overlay", "message", "read"}, "message"))
     , mMessageWrite(
           app.getMetrics().NewMeter({"overlay", "message", "write"}, "message"))
-    , mByteRead(app.getMetrics().NewMeter({"overlay", "byte", "read"}, "byte"))
-    , mByteWrite(
-          app.getMetrics().NewMeter({"overlay", "byte", "write"}, "byte"))
+    , mByteRead(getByteReadMeter(app))
+    , mByteWrite(getByteWriteMeter(app))
     , mErrorRead(
           app.getMetrics().NewMeter({"overlay", "error", "read"}, "error"))
     , mErrorWrite(

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -333,6 +333,18 @@ Peer::sendGetQuorumSet(uint256 const& setID)
 }
 
 void
+Peer::sendGetPeers()
+{
+    CLOG(TRACE, "Overlay") << "Get peers";
+
+    StellarMessage newMsg;
+    newMsg.type(GET_PEERS);
+
+    sendMessage(newMsg);
+    mSendGetPeersMeter.Mark();
+}
+
+void
 Peer::sendPeers()
 {
     // send top 50 peers we know about

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -13,6 +13,7 @@
 #include "herder/TxSetFrame.h"
 #include "main/Application.h"
 #include "main/Config.h"
+#include "overlay/LoadManager.h"
 #include "overlay/OverlayManager.h"
 #include "overlay/PeerAuth.h"
 #include "overlay/PeerRecord.h"
@@ -388,6 +389,7 @@ Peer::sendMessage(StellarMessage const& msg)
 void
 Peer::recvMessage(xdr::msg_ptr const& msg)
 {
+    LoadManager::PeerContext loadCtx(mApp, mPeerID);
     mLastRead = mApp.getClock().now();
     mMessageRead.Mark();
     mByteRead.Mark(msg->raw_size());

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -50,6 +50,9 @@ class Peer : public std::enable_shared_from_this<Peer>,
         WE_CALLED_REMOTE
     };
 
+    static medida::Meter& getByteReadMeter(Application& app);
+    static medida::Meter& getByteWriteMeter(Application& app);
+
   protected:
     Application& mApp;
 

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -115,6 +115,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     medida::Meter& mDropInRecvMessageSeqMeter;
     medida::Meter& mDropInRecvMessageMacMeter;
     medida::Meter& mDropInRecvMessageUnauthMeter;
+    medida::Meter& mDropInRecvHelloUnexpectedMeter;
     medida::Meter& mDropInRecvHelloVersionMeter;
     medida::Meter& mDropInRecvHelloSelfMeter;
     medida::Meter& mDropInRecvHelloPeerIDMeter;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -183,6 +183,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     void sendGetTxSet(uint256 const& setID);
     void sendGetQuorumSet(uint256 const& setID);
+    void sendGetPeers();
 
     void sendMessage(StellarMessage const& msg);
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -7,6 +7,7 @@
 #include "main/Application.h"
 #include "overlay/StellarXDR.h"
 #include "xdrpp/marshal.h"
+#include "overlay/LoadManager.h"
 #include "overlay/OverlayManager.h"
 #include "database/Database.h"
 #include "overlay/PeerRecord.h"
@@ -156,6 +157,7 @@ TCPPeer::writeHandler(asio::error_code const& error,
     }
     else
     {
+        LoadManager::PeerContext loadCtx(mApp, mPeerID);
         mLastWrite = mApp.getClock().now();
         mMessageWrite.Mark();
         mByteWrite.Mark(bytes_transferred);
@@ -236,6 +238,7 @@ TCPPeer::readHeaderHandler(asio::error_code const& error,
 
     if (!error)
     {
+        LoadManager::PeerContext loadCtx(mApp, mPeerID);
         mByteRead.Mark(bytes_transferred);
         mIncomingBody.resize(getIncomingMsgLength());
         auto self = static_pointer_cast<TCPPeer>(shared_from_this());
@@ -273,6 +276,7 @@ TCPPeer::readBodyHandler(asio::error_code const& error,
 
     if (!error)
     {
+        LoadManager::PeerContext loadCtx(mApp, mPeerID);
         mByteRead.Mark(bytes_transferred);
         recvMessage();
         startRead();

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -14,7 +14,13 @@ namespace stellar
 
 using namespace std;
 
-VirtualClock::VirtualClock(Mode mode) : mRealTimer(mIOService), mMode(mode)
+static const uint32_t RECENT_CRANK_WINDOW = 1024;
+
+VirtualClock::VirtualClock(Mode mode)
+    : mRealTimer(mIOService)
+    , mMode(mode)
+    , mRecentCrankCount(RECENT_CRANK_WINDOW >> 1)
+    , mRecentIdleCrankCount(RECENT_CRANK_WINDOW >> 1)
 {
     if (mMode == REAL_TIME)
     {
@@ -228,6 +234,7 @@ VirtualClock::crank(bool block)
     size_t nWorkDone = 0;
 
     nWorkDone += mIOService.poll();
+    noteCrankOccurred(nWorkDone == 0);
 
     if (mMode == REAL_TIME)
     {
@@ -251,6 +258,56 @@ VirtualClock::crank(bool block)
     }
 
     return nWorkDone;
+}
+
+void
+VirtualClock::noteCrankOccurred(bool hadIdle)
+{
+    // Record execution of a crank and, optionally, whether we had an idle
+    // poll event; this is used to estimate overall business of the system
+    // via recentIdleCrankPercent().
+    ++mRecentCrankCount;
+    if (hadIdle)
+    {
+        ++mRecentIdleCrankCount;
+    }
+
+    // Divide-out older samples once we have a suitable number of cranks to
+    // evaluate a ratio. This makes the measurement "present-biased" and
+    // the threshold (RECENT_CRANK_WINDOW) sets the size of the window (in
+    // cranks) that we consider as "the present". Using an event count
+    // rather than a time based EWMA (as in a medida::Meter) makes the
+    // ratio more precise, at the expense of accuracy of present-focus --
+    // we might accidentally consider samples from 1s, 1m or even 1h ago as
+    // "present" if the system is very lightly loaded. But since we're
+    // going to use this value to disconnect peers when overloaded, this is
+    // the preferred tradeoff.
+    if (mRecentCrankCount > RECENT_CRANK_WINDOW)
+    {
+        mRecentCrankCount >>= 1;
+        mRecentIdleCrankCount >>= 1;
+    }
+}
+
+uint32_t
+VirtualClock::recentIdleCrankPercent() const
+{
+    if (mRecentCrankCount == 0)
+    {
+        return 0;
+    }
+    uint32_t v = static_cast<uint32_t>(
+        (100ULL * static_cast<uint64_t>(mRecentIdleCrankCount)) /
+        static_cast<uint64_t>(mRecentCrankCount));
+
+    LOG(DEBUG) << "Estimated clock loop idle: " << v
+               << "% (" << mRecentIdleCrankCount
+               << "/" << mRecentCrankCount << ")";
+
+    // This should _really_ never be >100, it's a bug in our code if so.
+    assert(v <= 100);
+
+    return v;
 }
 
 asio::io_service&

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -106,6 +106,9 @@ class VirtualClock
     asio::basic_waitable_timer<std::chrono::system_clock> mRealTimer;
     Mode mMode;
 
+    uint32_t mRecentCrankCount;
+    uint32_t mRecentIdleCrankCount;
+
     size_t nRealTimerCancelEvents;
     time_point mNow;
 
@@ -133,6 +136,8 @@ class VirtualClock
     VirtualClock(Mode mode = VIRTUAL_TIME);
     ~VirtualClock();
     size_t crank(bool block = true);
+    void noteCrankOccurred(bool hadIdle);
+    uint32_t recentIdleCrankPercent() const;
     asio::io_service& getIOService();
 
     // Note: this is not a static method, which means that VirtualClock is


### PR DESCRIPTION
This PR adds a minimal facility for measuring system load, deciding if the system is overloaded, deciding which peer is likely causing it, and disconnecting the peer.

The UI is kept relatively simple: there's a single new config variable `MINIMUM_IDLE_PERCENT`, default 0, that you can raise if you want to make the system start shedding load as it runs out of idle-time. This percentage is then compared against the DB query time (excluding time spend during ledger-closes) and against the I/O clock cranks to decide if the system is loaded.

There's a new class `overlay/LoadManager` that implements inspection, reporting, per-peer statistic attribution and ultimately the decision to disconnect peers. The `OverlayManager` calls it once every 2 seconds, on its normal `tick` cycle, in order to judge load and possibly shed it.

It writes pretty explicit diagnostics to the log when it decides to disconnect a peer. Example:

~~~~
[Overlay] WARN  System appears to be overloaded
[Overlay] WARN  Idle minimum 99% vs. clock 78%, DB 100%
[Overlay] WARN  
[Overlay] INFO  
[Overlay] INFO  Cumulative peer-load costs:
[Overlay] INFO  ------------------------------------------------------
[Overlay] INFO        peer       time       send       recv      query
[Overlay] INFO      f83114          0          0          0        204
[Overlay] INFO      85c305          0          0          0          4
[Overlay] INFO  
[Overlay] WARN  Disconnecting suspected culprit f83114
[Overlay] INFO  Dropping peer f83114@127.0.0.1:11625
~~~~