### PR TITLE
Removing DESIRED_BASE_RESERVE option from example config file

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -138,10 +138,6 @@ NODE_IS_VALIDATOR=false
 # This is what you would prefer the base fee to be. It is in stroops.
 DESIRED_BASE_FEE=100
 
-# DESIRED_BASE_RESERVE (integer) default 100000000
-# This is what you prefer the base reserve to be. It is in stroops.
-DESIRED_BASE_RESERVE=100000000
-
 # DESIRED_MAX_TX_PER_LEDGER (integer) default 500
 # This is how many maximum transactions per ledger you would like to process.
 # Note that the actual MAX_TX_PER_LEDGER is decided during consensus and can


### PR DESCRIPTION
The option is rejected by Config.cpp as unknown, which prevents stellar-core from starting
when provided with the example configuration file. It appears that at one time this option was configurable, but is no longer the case.