### PR TITLE
improve links in docs; fix some whitespace

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,9 +12,9 @@ Two slightly-obscurely-named components are:
 
   - "bucketList", stored in the directory "bucket": the in-memory and on-disk
     linear history and ledger form that is hashed. A specific arrangement of
-    concatenations-of-XDR. Organized around "temporal buckets". Entries tending 
+    concatenations-of-XDR. Organized around "temporal buckets". Entries tending
 	to stay in buckets grouped by how frequently they change.
-	see [`src/bucket/readme.md`](../src/bucket/readme.md)
+	see [`src/bucket/readme.md`](/src/bucket/readme.md)
 
   - SCP -- "Stellar Consensus Protocol", the component implementing the
     [consensus algorithm](https://www.stellar.org/papers/stellar-consensus-protocol.pdf).

--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -3,12 +3,12 @@ title: DB Schema
 ---
 
 stellar-core maintains the current state of the ledger in a SQL DB. Currently
-it can be configured to use either sqlite or postgres. 
+it can be configured to use either sqlite or postgres.
 
 This database is the main way a dependent service such as Horizon can gather information on the current ledger state or transaction history.
 
 Most objects are the straight representation of the equivalent XDR object.
-See [`src/ledger/readme.md`](../src/ledger/readme.md) for a detailed description of those.
+See [`src/ledger/readme.md`](/src/ledger/readme.md) for a detailed description of those.
 
 Types used in the tables:
 Type Name | Description
@@ -16,11 +16,11 @@ Type Name | Description
 HEX | Hex encoded binary blob
 BASE64 | Base 64 encoded binary blob
 XDR | Base 64 encoded object serialized in XDR form
-STRKEY | Custom encoding for public/private keys. See [`src/crypto/readme.md`](../src/crypto/readme.md)
+STRKEY | Custom encoding for public/private keys. See [`src/crypto/readme.md`](/src/crypto/readme.md)
 
 ## ledgerheaders
 
-Defined in [`src/ledger/LedgerHeaderFrame.cpp`](../src/ledger/LedgerHeaderFrame.cpp)
+Defined in [`src/ledger/LedgerHeaderFrame.cpp`](/src/ledger/LedgerHeaderFrame.cpp)
 
 Equivalent to _LedgerHeader_
 
@@ -29,14 +29,14 @@ Field | Type | Description
 ledgerhash | CHARACTER(64) PRIMARY KEY | Hash of the ledger header (HEX)
 prevhash | CHARACTER(64) NOT NULL | previousLedgerHash (HEX)
 bucketlisthash | CHARACTER(64) NOT NULL | (HEX)
-ledgerseq | INT UNIQUE CHECK (ledgerseq >= 0) | 
+ledgerseq | INT UNIQUE CHECK (ledgerseq >= 0) |
 closetime | BIGINT NOT NULL CHECK (closetime >= 0) | scpValue.closeTime
 data | TEXT NOT NULL | Entire LedgerHeader (XDR)
 
 
 ## accounts
 
-Defined in [`src/ledger/AccountFrame.cpp`](../src/ledger/AccountFrame.cpp)
+Defined in [`src/ledger/AccountFrame.cpp`](/src/ledger/AccountFrame.cpp)
 
 Equivalent to _AccountEntry_
 
@@ -44,17 +44,17 @@ Field | Type | Description
 ------|------|---------------
 accountid | VARCHAR(56)  PRIMARY KEY | (STRKEY)
 balance | BIGINT NOT NULL CHECK (balance >= 0) |
-seqnum | BIGINT NOT NULL | 
+seqnum | BIGINT NOT NULL |
 numsubentries | INT NOT NULL CHECK (numsubentries >= 0) |
 inflationdest | VARCHAR(56) | (STRKEY)
-homedomain | VARCHAR(32) | 
+homedomain | VARCHAR(32) |
 thresholds | TEXT | (BASE64)
-flags | INT NOT NULL | 
+flags | INT NOT NULL |
 lastmodified | INT NOT NULL | lastModifiedLedgerSeq
 
 ## offers
 
-Defined in [`src/ledger/OfferFrame.cpp`](../src/ledger/OfferFrame.cpp)
+Defined in [`src/ledger/OfferFrame.cpp`](/src/ledger/OfferFrame.cpp)
 
 Equivalent to _OfferEntry_
 
@@ -78,7 +78,7 @@ lastmodified | INT NOT NULL | lastModifiedLedgerSeq
 
 ## trustlines
 
-Defined in [`src/ledger/TrustFrame.cpp`](../src/ledger/TrustFrame.cpp)
+Defined in [`src/ledger/TrustFrame.cpp`](/src/ledger/TrustFrame.cpp)
 
 Equivalent to _TrustLineEntry_
 
@@ -96,7 +96,7 @@ lastmodified | INT NOT NULL | lastModifiedLedgerSeq
 
 ## txhistory
 
-Defined in [`src/transactions/TransactionFrame.cpp`](../src/transactions/TransactionFrame.cpp)
+Defined in [`src/transactions/TransactionFrame.cpp`](/src/transactions/TransactionFrame.cpp)
 
 Field | Type | Description
 ------|------|---------------
@@ -109,7 +109,7 @@ txmeta | TEXT NOT NULL | TransactionMeta (XDR)
 
 ## txfeehistory
 
-Defined in [`src/transactions/TransactionFrame.cpp`](../src/transactions/TransactionFrame.cpp)
+Defined in [`src/transactions/TransactionFrame.cpp`](/src/transactions/TransactionFrame.cpp)
 
 Field | Type | Description
 ------|------|---------------
@@ -120,7 +120,7 @@ txchanges | TEXT NOT NULL | LedgerEntryChanges (XDR)
 
 ## storestate
 
-Defined in [`src/main/PersistantState.cpp`](../src/main/PersistantState.cpp)
+Defined in [`src/main/PersistantState.cpp`](/src/main/PersistantState.cpp)
 
 Field | Type | Description
 ------|------|---------------
@@ -130,13 +130,13 @@ state | TEXT | Value
 
 ## peers
 
-Defined in [`src/overlay/PeerRecord.cpp`](../src/overlay/PeerRecord.cpp)
+Defined in [`src/overlay/PeerRecord.cpp`](/src/overlay/PeerRecord.cpp)
 
 Field | Type | Description
 ------|------|---------------
-ip | VARCHAR(15) NOT NULL | 
-port | INT DEFAULT 0 CHECK (port > 0 AND port <= 65535) NOT NULL | 
-nextattempt | TIMESTAMP NOT NULL | 
-numfailures | INT DEFAULT 0 CHECK (numfailures >= 0) NOT NULL | 
-rank | INT DEFAULT 0 CHECK (rank >= 0) NOT NULL | 
+ip | VARCHAR(15) NOT NULL |
+port | INT DEFAULT 0 CHECK (port > 0 AND port <= 65535) NOT NULL |
+nextattempt | TIMESTAMP NOT NULL |
+numfailures | INT DEFAULT 0 CHECK (numfailures >= 0) NOT NULL |
+rank | INT DEFAULT 0 CHECK (rank >= 0) NOT NULL |
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -121,7 +121,7 @@ sequentially. Anyone wishing to audit or reconstruct the activity of stellar-cor
 history archive can simply poll the archive and consume new files as they arrive.
 
 All XDR encoding and decoding in stellar-core is done by code generated automatically from the
-associated [XDR schemas](../src/xdr); any other compliant XDR code generator should produce a
+associated [XDR schemas](/src/xdr); any other compliant XDR code generator should produce a
 deserializer that can read and write the same history. The XDR code generator used in stellar-core
 is developed independently, but [included in the source tree as a submodule](../lib/xdrpp).
 
@@ -130,7 +130,7 @@ is developed independently, but [included in the source tree as a submodule](../
 
 In addition to the considerations of interoperability and software flexibility presented above, a
 few additional, less obvious motives are at work in the design of the history system in stellar-core.
-A few reasons that the extra effort of configuring independent history archives is, in our judgment, worth its slight awkwardness: 
+A few reasons that the extra effort of configuring independent history archives is, in our judgment, worth its slight awkwardness:
 
   - Configuring independent history archives helps ensure valid backups get made. It is very easy to build a backup system that is not run
     frequently enough, only run in emergencies, or never run at all. Such systems tend to accumulate

--- a/docs/ledger.md
+++ b/docs/ledger.md
@@ -1,5 +1,5 @@
 ---
-title: Ledger 
+title: Ledger
 ---
 
 - **Ledger**: A ledger is the state of the distributed Stellar database at a
@@ -15,7 +15,7 @@ title: Ledger
 
 - **Ledger header**: The ledger's header contains meta data about the ledger,
   including the hash of the previous ledger (thus recording the chain) and its
-  own hash. (See [`src/xdr/Stellar-ledger.x`](../src/xdr/Stellar-ledger.x))
+  own hash. (See [`src/xdr/Stellar-ledger.x`](/src/xdr/Stellar-ledger.x))
 
 
 `Stellar-core` maintains the content of the latest ledger and of the ledger
@@ -27,7 +27,7 @@ performance needs.
     it possible to determine efficiently whether a newly submitted operation is
     valid. (See the `load` and `store` functions in the subclasses of
     `EntryFrame`: `AccountFrame`, `TrustFrame`, and `OfferFrame` in
-    [`src/ledger`](../src/ledger)).
+    [`src/ledger`](/src/ledger)).
 
  2. The ledger chain is represented in the the ledger headers as hashes linking
     each hedger to the previous one. The spine of the chain is lightweight data
@@ -42,7 +42,7 @@ performance needs.
     where a minority of the accounts see the majority of the operations. Second,
     it participates in providing nodes that have fallen behind with the ledger
     data they need to catch-up with the current state of the chain. (See
-    [`src/bucket/readme.md`](../src/bucket/readme.md)). While the hash computed
+    [`src/bucket/readme.md`](/src/bucket/readme.md)). While the hash computed
 	by the bucket list is functionally equivalent to a hash obtained
 	concatenating all the entries, it is not the same value since the bucket
 	list deduplicates changed entries incrementally.
@@ -53,5 +53,5 @@ performance needs.
     the full ledger chain's history, and is used to catch-up new nodes and nodes
     that have fallen far behind the rest of the network without imposing an
     undue burden on the nodes participating in the consensus protocol (See
-    [`src/history/readme.md`](../src/history/readme.md)).
+    [`src/history/readme.md`](/src/history/readme.md)).
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -12,13 +12,13 @@ of ledgers that are guaranteed to be in agreement across all the participating
 nodes at all times.
 
 For more detail on the Stellar Consensus Protocol and how it establishes this
-guarantee see [`src/scp/readme.md`](../src/scp/readme.md).
+guarantee see [`src/scp/readme.md`](/src/scp/readme.md).
 
 
 - [Building & Installing] (/INSTALL.md)
 - [Stellar-core administration] (learn/admin.md)
 - [Architecture] (architecture.md)
-- [Key Concepts] (https://www.stellar.org/developers/learn)
+- [Key Concepts] (https://www.stellar.org/developers/learn/)
 - [Major Components] (#major-components)
 - [Supporting Code Directories] (#supporting-code-directories)
 - [Contributing] (/CONTRIBUTING.md)
@@ -35,19 +35,19 @@ source directory and its own dedicated `readme.md`.
   component is fully abstracted from the rest of the system. It receives
   candidate black-box values and signals when these values have reached
   consensus by the network (called _externalizing_ a value) (See
-  [`src/scp/readme.md`](../src/scp/readme.md)).
+  [`src/scp/readme.md`](/src/scp/readme.md)).
 
 * **Herder** is responsible for interfacing between SCP and the rest of
   `stellar-core`. Herder provides SCP with concrete implementations of the
   methods SCP uses to communicate with peers, to compare values, to determine
   whether values contain valid signatures, and so forth. Herder often
   accomplishes its tasks by delegating to other components
-  (See [`src/herder/readme.md`](../src/herder/readme.md)).
+  (See [`src/herder/readme.md`](/src/herder/readme.md)).
 
 * **Overlay** connects to and keeps track of the peers this nodeis knows
   about and is connected to. It floods messages and fetches from peers the data
   that is needed to accomplish consensus (See
-  [`src/overlay/readme.md`](../src/overlay/readme.md)). All
+  [`src/overlay/readme.md`](/src/overlay/readme.md)). All
   other data downloads are handled without imposing on the SCP-nodes, see
   [`./architecture.md`](/docs/architecture.md).
 
@@ -57,21 +57,21 @@ source directory and its own dedicated `readme.md`.
   informs the overlay system to update its map of flooded messages. Ledger also
   triggers the history system's catching-up routine when it detects that this
   node has fallen behind of the rest of the network (See
-  [`src/ledger/readme.md`](../src/ledger/readme.md)).
+  [`src/ledger/readme.md`](/src/ledger/readme.md)).
 
 * **History** publishes transaction and ledger entries to off-site permanent
   storage for auditing, and as a source of catch-up data for other nodes. When
   this node falls behind, the history system fetches catch-up data and submits
   it to Ledger twice: first to verify its security, then to apply it (See
-  [`src/history/readme.md`](../src/history/readme.md)).
+  [`src/history/readme.md`](/src/history/readme.md)).
 
 * **BucketList** stores ledger entries on disk arranged for hashing and
   block-catch-up. BucketList coordinates the hashing and deduplicating of
   buckets by multiple background threads
-  (See [`src/buckets/readme.md`](../src/buckets/readme.md)).
+  (See [`src/buckets/readme.md`](/src/buckets/readme.md)).
 
 * **Transactions** implements all the various transaction types (See
-  [src/transactions/readme.md](../src/transactions/readme.md)).
+  [src/transactions/readme.md](/src/transactions/readme.md)).
 
 
 ## Supporting Code Directories
@@ -100,10 +100,3 @@ source directory and its own dedicated `readme.md`.
 
 * **src/generated** contains the wire protocol's C++ classes, generated from
   the definitions in `src/xdr`.
-
-
-
-
-
-
-


### PR DESCRIPTION
This uses root relative links so that they work everywhere (when files are moved and inside the developers site).