### PR TITLE
Bug 376 and 772 track publishing in db

### DIFF
--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -326,6 +326,7 @@ FutureBucket::makeLive(Application& app)
         for (auto const& h : mInputShadowBucketHashes)
         {
             auto b = bm.getBucketByHash(hexToBin256(h));
+            assert(b);
             CLOG(DEBUG, "Bucket") << "Reconstituting shadow " << h;
             mInputShadowBuckets.push_back(b);
         }

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -170,6 +170,7 @@ Database::initialize()
     ExternalQueue::dropAll(*this);
     LedgerHeaderFrame::dropAll(*this);
     TransactionFrame::dropAll(*this);
+    HistoryManager::dropAll(*this);
     BucketManager::dropAll(mApp);
 }
 

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -102,6 +102,12 @@ TEST_CASE("standalone", "[herder]")
         {
             app->getCommandHandler().manualCmd("maintenance?queue=true");
 
+            while (app->getLedgerManager().getLastClosedLedgerNum() <
+                   (app->getHistoryManager().getCheckpointFrequency() + 5))
+            {
+                app->getClock().crank(true);
+            }
+
             app->getCommandHandler().manualCmd("setcursor?id=A1&cursor=1");
             app->getCommandHandler().manualCmd("maintenance?queue=true");
             auto& db = app->getDatabase();

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -434,6 +434,11 @@ CatchupStateMachine::enterAnchoredState(HistoryArchiveState const& has)
     {
         bucketsToFetch =
             mApp.getBucketManager().checkForMissingBucketsFiles(mLocalState);
+        auto publishBuckets =
+            mApp.getHistoryManager().getMissingBucketsReferencedByPublishQueue();
+        bucketsToFetch.insert(bucketsToFetch.end(),
+                              publishBuckets.begin(),
+                              publishBuckets.end());
     }
     else if (mMode == HistoryManager::CATCHUP_MINIMAL)
     {

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -176,6 +176,7 @@ class Application;
 class Bucket;
 class BucketList;
 class Config;
+class Database;
 class HistoryArchive;
 struct StateSnapshot;
 
@@ -230,6 +231,9 @@ class HistoryManager
     static bool checkSensibleConfig(Config const& cfg);
 
     static std::unique_ptr<HistoryManager> create(Application& app);
+
+    // Initialize DB table for persistent publishing queue.
+    static void dropAll(Database& db);
 
     // Checkpoints are made every getCheckpointFrequency() ledgers.
     // This should normally be a constant (64) but in testing cases

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -293,22 +293,39 @@ class HistoryManager
     mkdir(std::shared_ptr<HistoryArchive const> archive, std::string const& dir,
           std::function<void(asio::error_code const&)> handler) const = 0;
 
-    // Publish history if the current ledger is a multiple of
-    // getCheckpointFrequency() -- equivalently, the LCL is one _less_ than a
-    // multiple of getCheckpointFrequency() -- and no publish action is
-    // currently in
-    // progress. Returns true if checkpoint publication of the LCL was started
-    // (and the completion-handler queued), otherwise false.
-    virtual bool maybePublishHistory(
-        std::function<void(asio::error_code const&)> handler) = 0;
-
-    virtual bool hasAnyWritableHistoryArchive() = 0;
+    // Calls queueCurrentHistory() if the current ledger is a multiple of
+    // getCheckpointFrequency() -- equivalently, the LCL is one _less_ than
+    // a multiple of getCheckpointFrequency(). Returns true if checkpoint
+    // publication of the LCL was queued, otherwise false.
+    virtual bool maybeQueueHistoryCheckpoint() = 0;
 
     // Checkpoint the LCL -- both the log of history from the previous
-    // checkpoint to it, as well as the bucketlist of its state -- to all
-    // writable history archives.
-    virtual void
-    publishHistory(std::function<void(asio::error_code const&)> handler) = 0;
+    // checkpoint to it, as well as the bucketlist of its state -- to a
+    // publication-queue in the database. This should be followed shortly
+    // (typically after commit) with a call to publishQueuedHistory.
+    virtual void queueCurrentHistory() = 0;
+
+    // Returns whether or not the HistoryManager has any writable history
+    // archives (those configured with both a `get` and `put` command).
+    virtual bool hasAnyWritableHistoryArchive() = 0;
+
+    // Return the youngest ledger still in the outgoing publish queue;
+    // returns 0 if the publish queue has nothing in it.
+    virtual uint32_t getMinLedgerQueuedToPublish() = 0;
+
+    // Publish any checkpoints queued (in the database) for publication.
+    // Returns the number of publishes initiated, which is the same number
+    // as the number of times the provided handler will be called (once for
+    // each, as they complete).
+    virtual size_t
+    publishQueuedHistory(std::function<void(asio::error_code const&)>
+                         handler) = 0;
+
+    // Return the set of buckets referenced by the persistent (DB) publish
+    // queue that are not present in the BucketManager. These need to be
+    // fetched from somewhere before publishing can begin again.
+    virtual std::vector<std::string>
+    getMissingBucketsReferencedByPublishQueue() = 0;
 
     virtual void downloadMissingBuckets(
         HistoryArchiveState desiredState,

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -38,6 +38,20 @@ namespace stellar
 
 using namespace std;
 
+static string kSQLCreateStatement =
+    "CREATE TABLE IF NOT EXISTS publishqueue ("
+    "ledger   INTEGER PRIMARY KEY,"
+    "state    TEXT"
+    "); ";
+
+void
+HistoryManager::dropAll(Database& db)
+{
+    db.getSession() << "DROP TABLE IF EXISTS publishqueue;";
+    soci::statement st = db.getSession().prepare << kSQLCreateStatement;
+    st.execute(true);
+}
+
 bool
 HistoryManager::initializeHistoryArchive(Application& app, std::string arch)
 {

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -478,9 +478,26 @@ HistoryManagerImpl::hasAnyWritableHistoryArchive()
     return false;
 }
 
+uint32_t
+HistoryManagerImpl::getMinLedgerQueuedToPublish()
+{
+    uint32_t seq;
+    soci::indicator minIndicator;
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "SELECT min(ledger) FROM publishqueue;");
+    auto& st = prep.statement();
+    st.exchange(soci::into(seq, minIndicator));
+    st.define_and_bind();
+    st.execute(true);
+    if (minIndicator == soci::indicator::i_ok)
+    {
+        return seq;
+    }
+    return 0;
+}
+
 bool
-HistoryManagerImpl::maybePublishHistory(
-    std::function<void(asio::error_code const&)> handler)
+HistoryManagerImpl::maybeQueueHistoryCheckpoint()
 {
     uint32_t seq = mApp.getLedgerManager().getLedgerNum();
     if (seq != nextCheckpointLedger(seq))
@@ -496,37 +513,141 @@ HistoryManagerImpl::maybePublishHistory(
         return false;
     }
 
-    publishHistory(handler);
+    queueCurrentHistory();
     return true;
 }
 
 void
-HistoryManagerImpl::publishHistory(
+HistoryManagerImpl::queueCurrentHistory()
+{
+    auto has = getLastClosedHistoryArchiveState();
+
+    auto ledger = has.currentLedger;
+    CLOG(DEBUG, "History")
+        << "Queueing publish state for ledger " << ledger;
+    auto state = has.toString();
+    auto timer = mApp.getDatabase().getInsertTimer("publishqueue");
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "INSERT INTO publishqueue (ledger, state) VALUES (:lg, :st);");
+    auto& st = prep.statement();
+    st.exchange(soci::use(ledger));
+    st.exchange(soci::use(state));
+    st.define_and_bind();
+    st.execute(true);
+
+    // We have now written the current HAS to the database, so
+    // it's "safe" to crash (at least after the enclosing tx commits);
+    // but that HAS might have merges running and if we throw it
+    // away at this point we'll lose the merges and have to restart
+    // them. So instead we're going to insert the HAS we have in hand
+    // into the in-memory publish queue in order to preserve those
+    // merges-in-progress, avoid restarting them.
+
+    takeSnapshotAndQueue(has, [](asio::error_code const&){});
+}
+
+void
+HistoryManagerImpl::takeSnapshotAndQueue(
+    HistoryArchiveState const& has,
+    std::function<void(asio::error_code const&)> handler)
+{
+    mPublishQueue.Mark();
+    auto ledgerSeq = has.currentLedger;
+
+    CLOG(DEBUG, "History")
+        << "Activating publish for ledger " << ledgerSeq;
+
+    auto snap = PublishStateMachine::takeSnapshot(mApp, has);
+    if (mPublish->queueSnapshot(
+            snap,
+            [this, ledgerSeq, handler](asio::error_code const& ec)
+            {
+                if (ec)
+                {
+                    this->mPublishFailure.Mark();
+                }
+                else
+                {
+                    this->mPublishSuccess.Mark();
+                    this->historyPublished(ledgerSeq);
+                }
+                handler(ec);
+            }))
+    {
+        // Only bump this counter if there's a delay building up.
+        mPublishDelay.Mark();
+    }
+}
+
+size_t
+HistoryManagerImpl::publishQueuedHistory(
     std::function<void(asio::error_code const&)> handler)
 {
     if (!mPublish)
     {
         mPublish = make_unique<PublishStateMachine>(mApp);
     }
-    mPublishQueue.Mark();
-    auto snap = PublishStateMachine::takeSnapshot(mApp);
-    if (mPublish->queueSnapshot(snap,
-                                [this, handler](asio::error_code const& ec)
-                                {
-                                    if (ec)
-                                    {
-                                        this->mPublishFailure.Mark();
-                                    }
-                                    else
-                                    {
-                                        this->mPublishSuccess.Mark();
-                                    }
-                                    handler(ec);
-                                }))
+
+    // Don't re-queue anything already queued.
+    uint32_t maxLedger = mPublish->maxQueuedSnapshotLedger();
+    std::string state;
+
+    CLOG(TRACE, "History")
+        << "Max active publish " << maxLedger;
+
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "SELECT state FROM publishqueue"
+        " WHERE ledger > :maxLedger ORDER BY ledger ASC;");
+    auto& st = prep.statement();
+    st.exchange(soci::use(maxLedger));
+    st.exchange(soci::into(state));
+    st.define_and_bind();
+    st.execute(true);
+    size_t count = 0;
+    while (st.got_data())
     {
-        // Only bump this counter if there's a delay building up.
-        mPublishDelay.Mark();
+        ++count;
+        HistoryArchiveState has;
+        has.fromString(state);
+        takeSnapshotAndQueue(has, handler);
+        st.fetch();
     }
+    return count;
+}
+
+std::vector<std::string>
+HistoryManagerImpl::getMissingBucketsReferencedByPublishQueue()
+{
+    std::vector<std::string> buckets;
+    std::string state;
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "SELECT state FROM publishqueue;");
+    auto& st = prep.statement();
+    st.exchange(soci::into(state));
+    st.define_and_bind();
+    st.execute(true);
+    auto& bm = mApp.getBucketManager();
+    while (st.got_data())
+    {
+        HistoryArchiveState has;
+        has.fromString(state);
+        auto bs = bm.checkForMissingBucketsFiles(has);
+        buckets.insert(buckets.end(), bs.begin(), bs.end());
+        st.fetch();
+    }
+    return buckets;
+}
+
+void
+HistoryManagerImpl::historyPublished(uint32_t ledgerSeq)
+{
+    auto timer = mApp.getDatabase().getDeleteTimer("publishqueue");
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "DELETE FROM publishqueue WHERE ledger = :lg;");
+    auto& st = prep.statement();
+    st.exchange(soci::use(ledgerSeq));
+    st.define_and_bind();
+    st.execute(true);
 }
 
 void

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -73,13 +73,23 @@ class HistoryManagerImpl : public HistoryManager
     mkdir(std::shared_ptr<HistoryArchive const> archive, std::string const& dir,
           std::function<void(asio::error_code const&)> handler) const override;
 
-    bool maybePublishHistory(
-        std::function<void(asio::error_code const&)> handler) override;
+    bool maybeQueueHistoryCheckpoint() override;
+
+    void queueCurrentHistory() override;
+
+    void takeSnapshotAndQueue(HistoryArchiveState const& has,
+                              std::function<void(asio::error_code const&)> handler);
 
     bool hasAnyWritableHistoryArchive() override;
 
-    void publishHistory(
+    uint32_t getMinLedgerQueuedToPublish() override;
+
+    size_t publishQueuedHistory(
         std::function<void(asio::error_code const&)> handler) override;
+
+    std::vector<std::string> getMissingBucketsReferencedByPublishQueue() override;
+
+    void historyPublished(uint32_t ledgerSeq);
 
     void downloadMissingBuckets(
         HistoryArchiveState desiredState,

--- a/src/history/PublishStateMachine.h
+++ b/src/history/PublishStateMachine.h
@@ -110,7 +110,12 @@ class PublishStateMachine
 
   public:
     PublishStateMachine(Application& app);
-    static SnapshotPtr takeSnapshot(Application& app);
+    static SnapshotPtr takeSnapshot(Application& app,
+                                    HistoryArchiveState const& state);
+
+    // Returns the ledger number of the maximum currently-queued snapshot.
+    // If no ledgers are queued, returns 0.
+    uint32_t maxQueuedSnapshotLedger() const;
 
     // Returns true if delayed, false if immediately dispatched.
     bool queueSnapshot(SnapshotPtr snap, PublishCallback handler);

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -239,6 +239,13 @@ ApplicationImpl::start()
     mLedgerManager->loadLastKnownLedger(
         [this, &done](asio::error_code const& ec)
         {
+            auto npub = mHistoryManager->publishQueuedHistory(
+                [](asio::error_code const&){});
+            if (npub != 0)
+            {
+                CLOG(INFO, "Ledger") << "Restarted publishing " << npub
+                                     << " queued snapshots";
+            }
             if (mConfig.FORCE_SCP)
             {
                 std::string flagClearedMsg = "";


### PR DESCRIPTION
This changes the history subsystem to record the state of the publish queue in a database table, avoid deleting any history while it's still being published, and revive pending (not-yet-complete) publish activities when a crashed server restarts.

I'd appreciate careful review. This stuff is very fussy. Lots of edge cases around bucket lifecycles.