### PR TITLE
Fix tripped assert where ArchivePublisher tried to re-enter sending state while in end state

### DIFF
--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -192,7 +192,9 @@ ArchivePublisher::fileStateChange(asio::error_code const& ec,
         mError = ec;
     }
     mFileInfos[name]->setState(newState);
-    if (mState != PUBLISH_RETRYING)
+
+    // Only re-enter "sending" if we aren't retrying or ending.
+    if (mState == PUBLISH_OBSERVED || mState == PUBLISH_SENDING)
     {
         enterSendingState();
     }


### PR DESCRIPTION
When there's a repeatedly-failing PUT command, it's possible for the `ArchivePublisher` to enter `PUBLISH_END` state -- giving up on a publish attempt after the default 16 retries -- while there are still some straggler subprocesses running in the attempt. When this happens, and those subprocesses exit and fire the `fileStateChange` callback, which in turn tries to re-enter `PUBLISH_SENDING`, it trips an assert in `enterSendingState` and crashes the process.

There's an existing guard on that path that we're not in `PUBLISH_RETRYING` but that's too narrow, doesn't cover the `PUBLISH_END` case. This was causing a crash in production on @codeck's validators when putting through the GFW.

This PR just weakens the assert to guard in `fileStateChanged` to the same condition that the assert checks (which is adequate).