### PR TITLE
Fix catchup variant of too-tight assert in 21855d2.

### DIFF
--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -186,7 +186,7 @@ CatchupStateMachine::fileStateChange(asio::error_code const& ec,
     }
     auto fi = mFileInfos[name];
     fi->setState(newState);
-    if (mState != CATCHUP_RETRYING)
+    if (mState == CATCHUP_ANCHORED || mState == CATCHUP_FETCHING)
     {
         enterFetchingState(fi);
     }


### PR DESCRIPTION
We re-enter the state when DONE due to straggler commands. Happens when trying to catchup sometimes.