### PR TITLE
SCP: persist state and improved handshake

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -806,7 +806,6 @@
     <ClInclude Include="..\..\src\main\dumpxdr.h">
       <Filter>main</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\overlay\StellarXDR.h" />
     <ClInclude Include="src\generated\xdr\Stellar-ledger.h">
       <Filter>xdr\generated</Filter>
     </ClInclude>
@@ -841,6 +840,9 @@
       <Filter>crypto</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\LoadManager.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\StellarXDR.h">
       <Filter>overlay</Filter>
     </ClInclude>
   </ItemGroup>
@@ -943,7 +945,9 @@
     <CustomBuild Include="..\..\src\xdr\Stellar-ledger-entries.x">
       <Filter>xdr</Filter>
     </CustomBuild>
-    <CustomBuild Include="..\..\src\xdr\Stellar-SCP.x" />
+    <CustomBuild Include="..\..\src\xdr\Stellar-SCP.x">
+      <Filter>xdr</Filter>
+    </CustomBuild>
   </ItemGroup>
   <ItemGroup>
     <Text Include="..\..\INSTALL-Windows.txt" />

--- a/INSTALL-Windows.txt
+++ b/INSTALL-Windows.txt
@@ -21,14 +21,21 @@ Build Dependencies
 
 
 - In order to compile xdrc and run the binary you will need to either
-       * Download and install mingw from http://sourceforge.net/projects/mingw/files/
-          * * Add `C:\MinGW\msys\1.0\bin;C:\MinGW\bin` to the end of `%PATH%`
-          Note: while MinGW is a much smaller install than Cygwin, it's not kept up to date
-          and tends to have virtual memory address space conflict on modern versions of Windows.
-          You will run into errors like `Couldn't reserve space for mingw's heap, Win32 error 0`
+       * Download and install MinGW from http://sourceforge.net/projects/mingw/files/
+          * Add `C:\MinGW\msys\1.0\bin;C:\MinGW\bin` to the end of `%PATH%`
        * Download and install cygwin from https://cygwin.com/install.html
           * Get cygwin setup to install `Flex` and `Bison`
           * Add `c:\cygwin64\bin` to the end of `%PATH%`
+          Note: if you're going to use 'cp'and 'mkdir' from cygwin (tests do),
+                make sure that your install is correct by trying to copy a
+                file from a `cmd.exe` console (not from a cygwin terminal).
+                `cp in.txt out.txt` and then try to open *out.txt* with
+                notepad. You should not get a permission denied error.
+    Note: both MinGW and CygWin may run into virtual memory address space
+    conflicts on modern versions of Windows. You will run into errors like
+    `Couldn't reserve space for mingw's heap, Win32 error 0`.
+    A workaround is to reboot until you can run `bison.exe` from a cmd.exe
+    prompt.
 
 - For making changes to the code, you should install the clang-format tool and Visual Studio extension, you can find both at http://llvm.org/builds/
 

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -87,6 +87,9 @@ class Herder
     // We are learning about a new envelope.
     virtual void recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
 
+    // a peer needs our SCP state
+    virtual void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) = 0;
+
     // returns the latest known ledger seq using consensus information
     // and local state
     virtual uint32_t getCurrentLedgerSeq() const = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -75,6 +75,9 @@ class Herder
 
     virtual void bootstrap() = 0;
 
+    // restores SCP state based on the last messages saved on disk
+    virtual void restoreSCPState() = 0;
+
     virtual void recvSCPQuorumSet(Hash hash, SCPQuorumSet const& qset) = 0;
     virtual void recvTxSet(Hash hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -785,7 +785,8 @@ HerderImpl::setupTimer(uint64 slotIndex, int timerID,
 void
 HerderImpl::rebroadcast()
 {
-    for (auto const& e : mSCP.getLatestMessages(mLedgerManager.getLedgerNum()))
+    for (auto const& e :
+         mSCP.getLatestMessagesSend(mLedgerManager.getLedgerNum()))
     {
         broadcast(e);
     }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -89,6 +89,8 @@ class HerderImpl : public Herder, public SCPDriver
 
     void recvSCPEnvelope(SCPEnvelope const& envelope) override;
 
+    void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) override;
+
     void recvSCPQuorumSet(Hash hash, const SCPQuorumSet& qset) override;
     void recvTxSet(Hash hash, const TxSetFrame& txset) override;
     void peerDoesntHave(MessageType type, uint256 const& itemID,

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -48,6 +48,9 @@ class HerderImpl : public Herder, public SCPDriver
     // Bootstraps the HerderImpl if we're creating a new Network
     void bootstrap() override;
 
+    // restores SCP state based on the last messages saved on disk
+    void restoreSCPState() override;
+
     // SCP methods
 
     void signEnvelope(SCPEnvelope& envelope) override;
@@ -190,6 +193,9 @@ class HerderImpl : public Herder, public SCPDriver
 
     // timer that detects that we're stuck on an SCP slot
     VirtualTimer mTrackingTimer;
+
+    // saves the SCP messages that the instance sent out last
+    void persistSCPState();
 
     // called every time we get ledger externalized
     // ensures that if we don't hear from the network, we throw the herder into

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -169,7 +169,7 @@ TEST_CASE("ledger performance test", "[performance][hide]")
                    "user=test password=test";
     cfg.BUCKET_DIR_PATH = "performance-test.db.buckets";
     cfg.MANUAL_CLOSE = true;
-    sim.addNode(v10SecretKey, qSet0, sim.getClock(), make_shared<Config>(cfg));
+    sim.addNode(v10SecretKey, qSet0, sim.getClock(), &cfg);
     sim.mApp = sim.getNodes().front();
     if (sim.mApp->getPersistentState().getState(
             PersistentState::kDatabaseInitialized) != "true")

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -226,7 +226,6 @@ ApplicationImpl::start()
     {
         throw std::invalid_argument("Quorum not configured");
     }
-    mOverlayManager->start();
 
     if (mPersistentState->getState(PersistentState::kDatabaseInitialized) !=
         "true")
@@ -239,6 +238,7 @@ ApplicationImpl::start()
     mLedgerManager->loadLastKnownLedger(
         [this, &done](asio::error_code const& ec)
         {
+            mOverlayManager->start();
             auto npub = mHistoryManager->publishQueuedHistory(
                 [](asio::error_code const&){});
             if (npub != 0)

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -21,6 +21,7 @@
 #include "simulation/LoadGenerator.h"
 #include "crypto/SecretKey.h"
 #include "crypto/SHA.h"
+#include "scp/LocalNode.h"
 #include "medida/metrics_registry.h"
 #include "medida/reporting/console_reporter.h"
 #include "medida/meter.h"
@@ -225,6 +226,13 @@ ApplicationImpl::start()
     if (mConfig.QUORUM_SET.threshold == 0)
     {
         throw std::invalid_argument("Quorum not configured");
+    }
+    if (mConfig.NODE_IS_VALIDATOR &&
+        !LocalNode::isQuorumSetSane(mConfig.NODE_SEED.getPublicKey(),
+                                    mConfig.QUORUM_SET))
+    {
+        throw std::invalid_argument(
+            "Invalid QUORUM_SET: bad threshold or validator is not a member");
     }
 
     if (mPersistentState->getState(PersistentState::kDatabaseInitialized) !=

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -238,6 +238,8 @@ ApplicationImpl::start()
     mLedgerManager->loadLastKnownLedger(
         [this, &done](asio::error_code const& ec)
         {
+            // restores the SCP state before starting overlay
+            mHerder->restoreSCPState();
             mOverlayManager->start();
             auto npub = mHistoryManager->publishQueuedHistory(
                 [](asio::error_code const&){});

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -14,7 +14,7 @@ using namespace std;
 
 string PersistentState::mapping[kLastEntry] = {
     "lastclosedledger", "historyarchivestate", "forcescponnextlaunch",
-    "databaseinitialized"};
+    "databaseinitialized", "lastscpdata"};
 
 string PersistentState::kSQLCreateStatement =
     "CREATE TABLE IF NOT EXISTS storestate ("

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -21,6 +21,7 @@ class PersistentState
         kHistoryArchiveState,
         kForceSCPOnNextLaunch,
         kDatabaseInitialized,
+        kLastSCPData,
         kLastEntry
     };
 

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -30,7 +30,7 @@
  *    TRANSACTION and SCP_MESSAGE
  *
  *  - Two-way anycast messages requesting a value (by hash) or providing it:
- *    GET_TX_SET, TX_SET, GET_SCP_QUORUMSET, SCP_QUORUMSET
+ *    GET_TX_SET, TX_SET, GET_SCP_QUORUMSET, SCP_QUORUMSET, GET_SCP_STATE
  *
  * Anycasts are initiated and serviced two instances of ItemFetcher
  * (mTxSetFetcher and mQuorumSetFetcher). Anycast messages are sent to

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -836,19 +836,23 @@ Peer::recvAuth(StellarMessage const& msg)
     noteHandshakeSuccessInPeerRecord();
     mState = GOT_AUTH;
 
+    auto self = shared_from_this();
     if (mRole == REMOTE_CALLED_US)
     {
         sendAuth();
         sendPeers();
     }
 
-    if (!mApp.getOverlayManager().isPeerAccepted(shared_from_this()))
+    if (!mApp.getOverlayManager().isPeerAccepted(self))
     {
         CLOG(WARNING, "Overlay") << "New peer rejected, all slots taken";
         mDropInRecvAuthRejectMeter.Mark();
         drop(ERR_LOAD, "peer rejected");
         return;
     }
+
+    // send SCP State
+    mApp.getHerder().sendSCPStateToPeer(0, self);
 }
 
 void

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -97,6 +97,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     medida::Timer& mRecvGetSCPQuorumSetTimer;
     medida::Timer& mRecvSCPQuorumSetTimer;
     medida::Timer& mRecvSCPMessageTimer;
+    medida::Timer& mRecvGetSCPStateTimer;
 
     medida::Meter& mSendErrorMeter;
     medida::Meter& mSendHelloMeter;
@@ -108,6 +109,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     medida::Meter& mSendTxSetMeter;
     medida::Meter& mSendTransactionMeter;
     medida::Meter& mSendGetSCPQuorumSetMeter;
+    medida::Meter& mSendGetSCPStateMeter;
     medida::Meter& mSendSCPQuorumSetMeter;
 
     medida::Meter& mDropInConnectHandlerMeter;
@@ -146,6 +148,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void recvGetSCPQuorumSet(StellarMessage const& msg);
     void recvSCPQuorumSet(StellarMessage const& msg);
     void recvSCPMessage(StellarMessage const& msg);
+    void recvGetSCPState(StellarMessage const& msg);
 
     void sendHello();
     void sendAuth();
@@ -184,6 +187,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void sendGetTxSet(uint256 const& setID);
     void sendGetQuorumSet(uint256 const& setID);
     void sendGetPeers();
+    void sendGetScpState(uint32 ledgerSeq);
 
     void sendMessage(StellarMessage const& msg);
 

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -248,7 +248,12 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
 bool
 BallotProtocol::isStatementSane(SCPStatement const& st)
 {
-    bool res = true;
+    bool res = LocalNode::isQuorumSetSane(st.nodeID, *mSlot.getQuorumSetFromStatement(st));
+    if (!res)
+    {
+        CLOG(DEBUG, "SCP") << "Invalid quorum set received";
+        return false;
+    }
 
     switch (st.pledges.type())
     {

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -36,16 +36,16 @@ BallotProtocol::BallotProtocol(Slot& slot)
 bool
 BallotProtocol::isNewerStatement(NodeID const& nodeID, SCPStatement const& st)
 {
-    auto oldp = mLatestStatements.find(nodeID);
+    auto oldp = mLatestEnvelopes.find(nodeID);
     bool res = false;
 
-    if (oldp == mLatestStatements.end())
+    if (oldp == mLatestEnvelopes.end())
     {
         res = true;
     }
     else
     {
-        res = isNewerStatement(oldp->second, st);
+        res = isNewerStatement(oldp->second.statement, st);
     }
     return res;
 }
@@ -125,18 +125,19 @@ BallotProtocol::isNewerStatement(SCPStatement const& oldst,
 }
 
 void
-BallotProtocol::recordStatement(SCPStatement const& st)
+BallotProtocol::recordEnvelope(SCPEnvelope const& env)
 {
-    auto oldp = mLatestStatements.find(st.nodeID);
-    if (oldp == mLatestStatements.end())
+    auto const& st = env.statement;
+    auto oldp = mLatestEnvelopes.find(st.nodeID);
+    if (oldp == mLatestEnvelopes.end())
     {
-        mLatestStatements.insert(std::make_pair(st.nodeID, st));
+        mLatestEnvelopes.insert(std::make_pair(st.nodeID, env));
     }
     else
     {
-        oldp->second = st;
+        oldp->second = env;
     }
-    mSlot.recordStatement(st);
+    mSlot.recordStatement(env.statement);
 }
 
 SCP::EnvelopeState
@@ -174,7 +175,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
             {
             case SCPStatementType::SCP_ST_PREPARE:
             {
-                recordStatement(statement);
+                recordEnvelope(envelope);
                 processed = true;
                 advanceSlot(statement.pledges.prepare().ballot);
                 res = SCP::EnvelopeState::VALID;
@@ -186,7 +187,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
                 // we don't filter CONFIRM/EXTERNALIZE statements based on
                 // counter value as they are valid for any counter greater
                 // than the one in the statement
-                recordStatement(statement);
+                recordEnvelope(envelope);
 
                 // we trigger advance slot with our ballot counter if it's an
                 // old statement; otherwise it's newer and may trigger progress
@@ -224,7 +225,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
             if (mPhase == SCP_PHASE_EXTERNALIZE &&
                 mCommit->value == tickBallot.value)
             {
-                recordStatement(statement);
+                recordEnvelope(envelope);
                 res = SCP::EnvelopeState::VALID;
             }
             else
@@ -625,35 +626,35 @@ BallotProtocol::attemptPrepare(SCPBallot const& ballot)
     bool didWork = false;
     if (mPhase == SCP_PHASE_PREPARE)
     {
-        if (LocalNode::isVBlocking(
-                getLocalNode()->getQuorumSet(), mLatestStatements,
-                [&](SCPStatement const& st)
-                {
-                    bool res;
-                    auto const& pl = st.pledges;
-                    if (pl.type() == SCP_ST_PREPARE)
-                    {
-                        auto const& p = pl.prepare();
-                        res = !mCurrentBallot ||
-                              mCurrentBallot->counter < p.ballot.counter;
-                    }
-                    else
-                    {
-                        SCPBallot cM;
-                        if (pl.type() == SCP_ST_CONFIRM)
-                        {
-                            cM = pl.confirm().commit;
-                        }
-                        else
-                        {
-                            cM = pl.externalize().commit;
-                        }
-                        res = mConfirmedPrepared &&
-                              areBallotsLessAndCompatible(*mConfirmedPrepared,
-                                                          cM);
-                    }
-                    return res;
-                }))
+        if (LocalNode::isVBlocking(getLocalNode()->getQuorumSet(),
+                                   mLatestEnvelopes, [&](SCPStatement const& st)
+                                   {
+                                       bool res;
+                                       auto const& pl = st.pledges;
+                                       if (pl.type() == SCP_ST_PREPARE)
+                                       {
+                                           auto const& p = pl.prepare();
+                                           res = !mCurrentBallot ||
+                                                 mCurrentBallot->counter <
+                                                     p.ballot.counter;
+                                       }
+                                       else
+                                       {
+                                           SCPBallot cM;
+                                           if (pl.type() == SCP_ST_CONFIRM)
+                                           {
+                                               cM = pl.confirm().commit;
+                                           }
+                                           else
+                                           {
+                                               cM = pl.externalize().commit;
+                                           }
+                                           res = mConfirmedPrepared &&
+                                                 areBallotsLessAndCompatible(
+                                                     *mConfirmedPrepared, cM);
+                                       }
+                                       return res;
+                                   }))
         {
             didWork = abandonBallot();
         }
@@ -931,9 +932,9 @@ std::set<BallotProtocol::Interval>
 BallotProtocol::getCommitBoundariesFromStatements(SCPBallot const& ballot)
 {
     std::set<Interval> res;
-    for (auto const& stp : mLatestStatements)
+    for (auto const& env : mLatestEnvelopes)
     {
-        auto const& pl = stp.second.pledges;
+        auto const& pl = env.second.statement.pledges;
         switch (pl.type())
         {
         case SCP_ST_PREPARE:
@@ -1371,7 +1372,7 @@ BallotProtocol::advanceSlot(SCPBallot const& ballot)
     if (!mHeardFromQuorum && mCurrentBallot)
     {
         if (LocalNode::isQuorum(
-                getLocalNode()->getQuorumSet(), mLatestStatements,
+                getLocalNode()->getQuorumSet(), mLatestEnvelopes,
                 std::bind(&Slot::getQuorumSetFromStatement, &mSlot, _1),
                 [&](SCPStatement const& st)
                 {
@@ -1466,7 +1467,7 @@ BallotProtocol::getLocalState() const
         << " | p': " << mSlot.ballotToStr(mPreparedPrime)
         << " | P: " << mSlot.ballotToStr(mConfirmedPrepared)
         << " | c: " << mSlot.ballotToStr(mCommit)
-        << " | M: " << mLatestStatements.size();
+        << " | M: " << mLatestEnvelopes.size();
     return oss.str();
 }
 
@@ -1480,12 +1481,12 @@ bool
 BallotProtocol::federatedAccept(StatementPredicate voted,
                                 StatementPredicate accepted)
 {
-    return mSlot.federatedAccept(voted, accepted, mLatestStatements);
+    return mSlot.federatedAccept(voted, accepted, mLatestEnvelopes);
 }
 
 bool
 BallotProtocol::federatedRatify(StatementPredicate voted)
 {
-    return mSlot.federatedRatify(voted, mLatestStatements);
+    return mSlot.federatedRatify(voted, mLatestEnvelopes);
 }
 }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1352,6 +1352,17 @@ BallotProtocol::areBallotsLessAndCompatible(SCPBallot const& b1,
     return (compareBallots(b1, b2) <= 0) && areBallotsCompatible(b1, b2);
 }
 
+std::vector<SCPEnvelope>
+BallotProtocol::getCurrentState() const
+{
+    std::vector<SCPEnvelope> res;
+    for (auto it : mLatestEnvelopes)
+    {
+        res.emplace_back(it.second);
+    }
+    return res;
+}
+
 void
 BallotProtocol::advanceSlot(SCPBallot const& ballot)
 {

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -202,7 +202,7 @@ class BallotProtocol
                                  SCPStatement const& st);
 
     // basic sanity check on statement
-    static bool isStatementSane(SCPStatement const& st);
+    bool isStatementSane(SCPStatement const& st);
 
     // records the statement in the state machine
     void recordEnvelope(SCPEnvelope const& env);

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -95,6 +95,8 @@ class BallotProtocol
         return mLastEnvelope.get();
     }
 
+    void setStateFromEnvelope(SCPEnvelope const& e);
+
     std::vector<SCPEnvelope> getCurrentState() const;
 
   private:

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -90,7 +90,7 @@ class BallotProtocol
     static SCPBallot getWorkingBallot(SCPStatement const& st);
 
     SCPEnvelope*
-    getLastMessage() const
+    getLastMessageSend() const
     {
         return mLastEnvelope.get();
     }

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -41,13 +41,13 @@ class BallotProtocol
     // human readable names matching SCPPhase
     static const char* phaseNames[];
 
-    std::unique_ptr<SCPBallot> mCurrentBallot;        // b
-    std::unique_ptr<SCPBallot> mPrepared;             // p
-    std::unique_ptr<SCPBallot> mPreparedPrime;        // p'
-    std::unique_ptr<SCPBallot> mConfirmedPrepared;    // P
-    std::unique_ptr<SCPBallot> mCommit;               // c
-    std::map<NodeID, SCPStatement> mLatestStatements; // M
-    SCPPhase mPhase;                                  // Phi
+    std::unique_ptr<SCPBallot> mCurrentBallot;      // b
+    std::unique_ptr<SCPBallot> mPrepared;           // p
+    std::unique_ptr<SCPBallot> mPreparedPrime;      // p'
+    std::unique_ptr<SCPBallot> mConfirmedPrepared;  // P
+    std::unique_ptr<SCPBallot> mCommit;             // c
+    std::map<NodeID, SCPEnvelope> mLatestEnvelopes; // M
+    SCPPhase mPhase;                                // Phi
 
     int mCurrentMessageLevel; // number of messages triggered in one run
 
@@ -201,7 +201,7 @@ class BallotProtocol
     static bool isStatementSane(SCPStatement const& st);
 
     // records the statement in the state machine
-    void recordStatement(SCPStatement const& env);
+    void recordEnvelope(SCPEnvelope const& env);
 
     // ** State related methods
 

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -95,6 +95,8 @@ class BallotProtocol
         return mLastEnvelope.get();
     }
 
+    std::vector<SCPEnvelope> getCurrentState() const;
+
   private:
     // attempts to make progress using `ballot` as a hint
     void advanceSlot(SCPBallot const& ballot);

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -228,13 +228,13 @@ LocalNode::isVBlocking(SCPQuorumSet const& qSet,
 
 bool
 LocalNode::isVBlocking(SCPQuorumSet const& qSet,
-                       std::map<NodeID, SCPStatement> const& map,
+                       std::map<NodeID, SCPEnvelope> const& map,
                        std::function<bool(SCPStatement const&)> const& filter)
 {
     std::vector<NodeID> pNodes;
     for (auto const& it : map)
     {
-        if (filter(it.second))
+        if (filter(it.second.statement))
         {
             pNodes.push_back(it.first);
         }
@@ -245,14 +245,14 @@ LocalNode::isVBlocking(SCPQuorumSet const& qSet,
 
 bool
 LocalNode::isQuorum(
-    SCPQuorumSet const& qSet, std::map<NodeID, SCPStatement> const& map,
+    SCPQuorumSet const& qSet, std::map<NodeID, SCPEnvelope> const& map,
     std::function<SCPQuorumSetPtr(SCPStatement const&)> const& qfun,
     std::function<bool(SCPStatement const&)> const& filter)
 {
     std::vector<NodeID> pNodes;
     for (auto const& it : map)
     {
-        if (filter(it.second))
+        if (filter(it.second.statement))
         {
             pNodes.push_back(it.first);
         }
@@ -265,7 +265,8 @@ LocalNode::isQuorum(
         std::vector<NodeID> fNodes(pNodes.size());
         auto quorumFilter = [&](NodeID nodeID) -> bool
         {
-            return isQuorumSlice(*qfun(map.find(nodeID)->second), pNodes);
+            return isQuorumSlice(*qfun(map.find(nodeID)->second.statement),
+                                 pNodes);
         };
         auto it = std::copy_if(pNodes.begin(), pNodes.end(), fNodes.begin(),
                                quorumFilter);

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -70,7 +70,7 @@ class LocalNode
     // `isVBlocking` tests if the filtered nodes V are a v-blocking set for
     // this node.
     static bool isVBlocking(SCPQuorumSet const& qSet,
-                            std::map<NodeID, SCPStatement> const& map,
+                            std::map<NodeID, SCPEnvelope> const& map,
                             std::function<bool(SCPStatement const&)> const&
                                 filter = [](SCPStatement const&)
                             {
@@ -83,8 +83,7 @@ class LocalNode
     // SCPQuorumSetPtr from the SCPStatement for its associated node in map
     // (required for transitivity)
     static bool
-    isQuorum(SCPQuorumSet const& qSet,
-             std::map<NodeID, SCPStatement> const& map,
+    isQuorum(SCPQuorumSet const& qSet, std::map<NodeID, SCPEnvelope> const& map,
              std::function<SCPQuorumSetPtr(SCPStatement const&)> const& qfun,
              std::function<bool(SCPStatement const&)> const& filter =
                  [](SCPStatement const&)

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -31,11 +31,16 @@ class LocalNode
 
     SCP* mSCP;
 
+    // first: nodeID found, second: quorum set well formed
+    static std::pair<bool,bool> isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSet);
   public:
     LocalNode(SecretKey const& secretKey, bool isValidator,
               SCPQuorumSet const& qSet, SCP* scp);
 
     NodeID const& getNodeID();
+
+    // returns if a nodeID's quorum set passes sanity checks
+    static bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet);
 
     void updateQuorumSet(SCPQuorumSet const& qSet);
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -374,7 +374,7 @@ NominationProtocol::processEnvelope(SCPEnvelope const& envelope)
                     }
                 }
 
-                // only take round leader votes if we still looking for
+                // only take round leader votes if we're still looking for
                 // candidates
                 if (mCandidates.empty() &&
                     mRoundLeaders.find(st.nodeID) != mRoundLeaders.end())
@@ -530,6 +530,27 @@ NominationProtocol::dumpInfo(Json::Value& ret)
     }
 
     ret["nomination"].append(nomState);
+}
+
+void
+NominationProtocol::setStateFromEnvelope(SCPEnvelope const& e)
+{
+    if (mNominationStarted)
+    {
+        throw std::runtime_error("Cannot set state after nomination is started");
+    }
+    recordEnvelope(e);
+    auto const& nom = e.statement.pledges.nominate();
+    for(auto const& a : nom.accepted)
+    {
+        mAccepted.emplace(a);
+    }
+    for (auto const& v : nom.votes)
+    {
+        mVotes.emplace(v);
+    }
+
+    mLastEnvelope = make_unique<SCPEnvelope>(e);
 }
 
 std::vector<SCPEnvelope>

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -112,6 +112,9 @@ NominationProtocol::isSane(SCPStatement const& st)
     res = res && std::is_sorted(nom.votes.begin(), nom.votes.end());
     res = res && std::is_sorted(nom.accepted.begin(), nom.accepted.end());
 
+    res = res && LocalNode::isQuorumSetSane(
+                     st.nodeID, *mSlot.getQuorumSetFromStatement(st));
+
     return res;
 }
 
@@ -404,6 +407,11 @@ NominationProtocol::processEnvelope(SCPEnvelope const& envelope)
                     mSlot.bumpState(mLatestCompositeCandidate, false);
                 }
             }
+        }
+        else
+        {
+            CLOG(DEBUG, "SCP")
+                << "NominationProtocol: message didn't pass sanity check";
         }
     }
     return res;

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -531,4 +531,15 @@ NominationProtocol::dumpInfo(Json::Value& ret)
 
     ret["nomination"].append(nomState);
 }
+
+std::vector<SCPEnvelope>
+NominationProtocol::getCurrentState() const
+{
+    std::vector<SCPEnvelope> res;
+    for (auto it : mLatestNominations)
+    {
+        res.emplace_back(it.second);
+    }
+    return res;
+}
 }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -107,6 +107,8 @@ class NominationProtocol
         return mLastEnvelope.get();
     }
 
+    void setStateFromEnvelope(SCPEnvelope const& e);
+
     std::vector<SCPEnvelope> getCurrentState() const;
 };
 }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -102,7 +102,7 @@ class NominationProtocol
     void dumpInfo(Json::Value& ret);
 
     SCPEnvelope*
-    getLastMessage() const
+    getLastMessageSend() const
     {
         return mLastEnvelope.get();
     }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -19,10 +19,10 @@ class NominationProtocol
     Slot& mSlot;
 
     int32 mRoundNumber;
-    std::set<Value> mVotes;                            // X
-    std::set<Value> mAccepted;                         // Y
-    std::set<Value> mCandidates;                       // Z
-    std::map<NodeID, SCPStatement> mLatestNominations; // N
+    std::set<Value> mVotes;                           // X
+    std::set<Value> mAccepted;                        // Y
+    std::set<Value> mCandidates;                      // Z
+    std::map<NodeID, SCPEnvelope> mLatestNominations; // N
 
     std::unique_ptr<SCPEnvelope>
         mLastEnvelope; // last envelope emitted by this node
@@ -54,7 +54,7 @@ class NominationProtocol
 
     bool isSane(SCPStatement const& st);
 
-    void recordStatement(SCPStatement const& st);
+    void recordEnvelope(SCPEnvelope const& env);
 
     void emitNomination();
 

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -106,5 +106,7 @@ class NominationProtocol
     {
         return mLastEnvelope.get();
     }
+
+    std::vector<SCPEnvelope> getCurrentState() const;
 };
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -145,8 +145,8 @@ SCP::getCumulativeStatemtCount() const
 }
 
 std::vector<SCPEnvelope>
-SCP::getLatestMessages(uint64 slotIndex)
+SCP::getLatestMessagesSend(uint64 slotIndex)
 {
-    return getSlot(slotIndex)->getLatestMessages();
+        return slot->getLatestMessagesSend();
 }
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -166,5 +166,18 @@ SCP::getLatestMessagesSend(uint64 slotIndex)
         return std::vector<SCPEnvelope>();
     }
 }
+
+std::vector<SCPEnvelope>
+SCP::getCurrentState(uint64 slotIndex)
+{
+    auto slot = getSlot(slotIndex, false);
+    if (slot)
+    {
+        return slot->getLatestMessagesSend();
+    }
+    else
+    {
+        return std::vector<SCPEnvelope>();
+    }
 }
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -167,6 +167,16 @@ SCP::getLatestMessagesSend(uint64 slotIndex)
     }
 }
 
+void
+SCP::setStateFromEnvelope(uint64 slotIndex, SCPEnvelope const& e)
+{
+    if (mDriver.verifyEnvelope(e))
+    {
+        auto slot = getSlot(slotIndex, true);
+        slot->setStateFromEnvelope(e);
+    }
+}
+
 std::vector<SCPEnvelope>
 SCP::getCurrentState(uint64 slotIndex)
 {

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -91,6 +91,9 @@ class SCP
     // returns the latest messages sent for the given slot
     std::vector<SCPEnvelope> getLatestMessagesSend(uint64 slotIndex);
 
+    // returns all messages for the slot
+    std::vector<SCPEnvelope> getCurrentState(uint64 slotIndex);
+
   protected:
     std::shared_ptr<LocalNode> mLocalNode;
     std::map<uint64, std::shared_ptr<Slot>> mKnownSlots;

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -91,6 +91,10 @@ class SCP
     // returns the latest messages sent for the given slot
     std::vector<SCPEnvelope> getLatestMessagesSend(uint64 slotIndex);
 
+    // forces the state to match the one in the envelope
+    // this is used when rebuilding the state after a crash for example
+    void setStateFromEnvelope(uint64 slotIndex, SCPEnvelope const& e);
+
     // returns all messages for the slot
     std::vector<SCPEnvelope> getCurrentState(uint64 slotIndex);
 

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -96,7 +96,7 @@ class SCP
     std::map<uint64, std::shared_ptr<Slot>> mKnownSlots;
 
     // Slot getter
-    std::shared_ptr<Slot> getSlot(uint64 slotIndex);
+    std::shared_ptr<Slot> getSlot(uint64 slotIndex, bool create);
 
     friend class TestSCP;
 };

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -88,8 +88,8 @@ class SCP
     size_t getKnownSlotsCount() const;
     size_t getCumulativeStatemtCount() const;
 
-    // returns the latest messages for the given slot
-    std::vector<SCPEnvelope> getLatestMessages(uint64 slotIndex);
+    // returns the latest messages sent for the given slot
+    std::vector<SCPEnvelope> getLatestMessagesSend(uint64 slotIndex);
 
   protected:
     std::shared_ptr<LocalNode> mLocalNode;

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -109,13 +109,13 @@ class TestSCP : public SCPDriver
     bool
     bumpState(uint64 slotIndex, Value const& v)
     {
-        return mSCP.getSlot(slotIndex)->bumpState(v, true);
+        return mSCP.getSlot(slotIndex, true)->bumpState(v, true);
     }
 
     bool
     nominate(uint64 slotIndex, Value const& value, bool timedout)
     {
-        return mSCP.getSlot(slotIndex)->nominate(value, value, timedout);
+        return mSCP.getSlot(slotIndex, true)->nominate(value, value, timedout);
     }
 
     // only used by nomination protocol
@@ -175,7 +175,7 @@ class TestSCP : public SCPDriver
     Value const&
     getLatestCompositeCandidate(uint64 slotIndex)
     {
-        return mSCP.getSlot(slotIndex)->getLatestCompositeCandidate();
+        return mSCP.getSlot(slotIndex, true)->getLatestCompositeCandidate();
     }
 
     void

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -53,6 +53,16 @@ Slot::getLatestMessagesSend() const
     return res;
 }
 
+std::vector<SCPEnvelope>
+Slot::getCurrentState() const
+{
+    std::vector<SCPEnvelope> res;
+    res = mNominationProtocol.getCurrentState();
+    auto r2 = mBallotProtocol.getCurrentState();
+    res.insert(res.end(), r2.begin(), r2.end());
+    return res;
+}
+
 void
 Slot::recordStatement(SCPStatement const& st)
 {

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -322,12 +322,11 @@ Slot::envToStr(SCPStatement const& st) const
 
 bool
 Slot::federatedAccept(StatementPredicate voted, StatementPredicate accepted,
-                      std::map<NodeID, SCPStatement> const& statements)
+                      std::map<NodeID, SCPEnvelope> const& envs)
 {
     // Checks if the nodes that claimed to accept the statement form a
     // v-blocking set
-    if (LocalNode::isVBlocking(getLocalNode()->getQuorumSet(), statements,
-                               accepted))
+    if (LocalNode::isVBlocking(getLocalNode()->getQuorumSet(), envs, accepted))
     {
         return true;
     }
@@ -343,7 +342,7 @@ Slot::federatedAccept(StatementPredicate voted, StatementPredicate accepted,
     };
 
     if (LocalNode::isQuorum(
-            getLocalNode()->getQuorumSet(), statements,
+            getLocalNode()->getQuorumSet(), envs,
             std::bind(&Slot::getQuorumSetFromStatement, this, _1),
             ratifyFilter))
     {
@@ -355,10 +354,10 @@ Slot::federatedAccept(StatementPredicate voted, StatementPredicate accepted,
 
 bool
 Slot::federatedRatify(StatementPredicate voted,
-                      std::map<NodeID, SCPStatement> const& statements)
+                      std::map<NodeID, SCPEnvelope> const& envs)
 {
     return LocalNode::isQuorum(
-        getLocalNode()->getQuorumSet(), statements,
+        getLocalNode()->getQuorumSet(), envs,
         std::bind(&Slot::getQuorumSetFromStatement, this, _1), voted);
 }
 

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -121,7 +121,7 @@ Slot::processEnvelope(SCPEnvelope const& envelope)
 
         dumpInfo(info);
 
-        CLOG(DEBUG, "SCP") << "Exception in processEnvelope "
+        CLOG(ERROR, "SCP") << "Exception in processEnvelope "
                            << "state: " << info.toStyledString()
                            << " processing envelope: " << envToStr(envelope);
 

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -36,16 +36,16 @@ Slot::getLatestCompositeCandidate()
 }
 
 std::vector<SCPEnvelope>
-Slot::getLatestMessages() const
+Slot::getLatestMessagesSend() const
 {
     std::vector<SCPEnvelope> res;
     SCPEnvelope* e;
-    e = mNominationProtocol.getLastMessage();
+    e = mNominationProtocol.getLastMessageSend();
     if (e)
     {
         res.emplace_back(*e);
     }
-    e = mBallotProtocol.getLastMessage();
+    e = mBallotProtocol.getLastMessageSend();
     if (e)
     {
         res.emplace_back(*e);

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -53,6 +53,29 @@ Slot::getLatestMessagesSend() const
     return res;
 }
 
+void
+Slot::setStateFromEnvelope(SCPEnvelope const& e)
+{
+    if (e.statement.nodeID == getSCP().getLocalNodeID() &&
+        e.statement.slotIndex == mSlotIndex)
+    {
+        if (e.statement.pledges.type() ==
+            SCPStatementType::SCP_ST_NOMINATE)
+        {
+            mNominationProtocol.setStateFromEnvelope(e);
+        }
+        else
+        {
+            mBallotProtocol.setStateFromEnvelope(e);
+        }
+    }
+    else
+    {
+        CLOG(DEBUG, "SCP") << "Slot::setStateFromEnvelope invalid envelope"
+            << " i: " << getSlotIndex() << " " << envToStr(e);
+    }
+}
+
 std::vector<SCPEnvelope>
 Slot::getCurrentState() const
 {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -72,6 +72,10 @@ class Slot : public std::enable_shared_from_this<Slot>
     // returns the latest messages the slot emited
     std::vector<SCPEnvelope> getLatestMessagesSend() const;
 
+    // forces the state to match the one in the envelope
+    // this is used when rebuilding the state after a crash for example
+    void setStateFromEnvelope(SCPEnvelope const& e);
+
     // returns the latest messages known for this slot
     std::vector<SCPEnvelope> getCurrentState() const;
 

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -133,11 +133,11 @@ class Slot : public std::enable_shared_from_this<Slot>
     // returns true if the statement defined by voted and accepted
     // should be accepted
     bool federatedAccept(StatementPredicate voted, StatementPredicate accepted,
-                         std::map<NodeID, SCPStatement> const& statements);
+                         std::map<NodeID, SCPEnvelope> const& envs);
     // returns true if the statement defined by voted
     // is ratified
     bool federatedRatify(StatementPredicate voted,
-                         std::map<NodeID, SCPStatement> const& statements);
+                         std::map<NodeID, SCPEnvelope> const& envs);
 
     std::shared_ptr<LocalNode> getLocalNode();
 

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -72,6 +72,9 @@ class Slot : public std::enable_shared_from_this<Slot>
     // returns the latest messages the slot emited
     std::vector<SCPEnvelope> getLatestMessagesSend() const;
 
+    // returns the latest messages known for this slot
+    std::vector<SCPEnvelope> getCurrentState() const;
+
     // records the statement in the historical record for this slot
     void recordStatement(SCPStatement const& st);
 

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -70,7 +70,7 @@ class Slot : public std::enable_shared_from_this<Slot>
     Value const& getLatestCompositeCandidate();
 
     // returns the latest messages the slot emited
-    std::vector<SCPEnvelope> getLatestMessages() const;
+    std::vector<SCPEnvelope> getLatestMessagesSend() const;
 
     // records the statement in the historical record for this slot
     void recordStatement(SCPStatement const& st);

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -30,7 +30,7 @@ Simulation::Simulation(Mode mode, Hash const& networkID)
                               : VirtualClock::VIRTUAL_TIME)
     , mMode(mode)
     , mConfigCount(0)
-    , mIdleApp(Application::create(mClock, getTestConfig(++mConfigCount)))
+    , mIdleApp(Application::create(mClock, getTestConfig(mConfigCount++)))
 {
 }
 
@@ -52,17 +52,21 @@ Simulation::getClock()
 
 NodeID
 Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
-                    Config::pointer cfg)
+                    Config const* cfg2)
 {
-    if (!cfg)
+    std::shared_ptr<Config> cfg;
+    if (!cfg2)
     {
-        cfg = std::make_shared<Config>(getTestConfig(++mConfigCount));
+        cfg = std::make_shared<Config>(getTestConfig(mConfigCount++));
+        cfg->ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
+    }
+    else
+    {
+        cfg = std::make_shared<Config>(*cfg2);
     }
     cfg->NODE_SEED = nodeKey;
     cfg->QUORUM_SET = qSet;
-    cfg->FORCE_SCP = true;
     cfg->RUN_STANDALONE = (mMode == OVER_LOOPBACK);
-    cfg->ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
 
     Application::pointer result = Application::create(clock, *cfg);
 

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -278,7 +278,7 @@ Simulation::crankUntil(function<bool()> const& predicate,
             done = true;
         else
         {
-            checkTimer.expires_from_now(chrono::seconds(5));
+            checkTimer.expires_from_now(chrono::seconds(1));
             checkTimer.async_wait(checkDone, &VirtualTimer::onFailureNoop);
         }
     };
@@ -291,7 +291,7 @@ Simulation::crankUntil(function<bool()> const& predicate,
         },
         &VirtualTimer::onFailureNoop);
 
-    checkTimer.expires_from_now(chrono::seconds(5));
+    checkTimer.expires_from_now(chrono::seconds(1));
     checkTimer.async_wait(checkDone, &VirtualTimer::onFailureNoop);
 
     for (;;)

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -69,7 +69,6 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
     NodeID nodeID = nodeKey.getPublicKey();
     mConfigs[nodeID] = cfg;
     mNodes[nodeID] = result;
-    updateMinBalance(*result);
 
     return nodeID;
 }
@@ -143,6 +142,7 @@ Simulation::startAllNodes()
     for (auto const& it : mNodes)
     {
         it.second->start();
+        updateMinBalance(*it.second);
     }
 
     for (auto const& pair : mPendingConnections)

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -43,7 +43,7 @@ class Simulation : public LoadGenerator
     VirtualClock& getClock();
 
     NodeID addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
-                   Config::pointer cfg = std::shared_ptr<Config>());
+                   Config const* cfg = nullptr);
     Application::pointer getNode(NodeID nodeID);
     std::vector<Application::pointer> getNodes();
     std::vector<NodeID> getNodeIDs();

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -74,8 +74,8 @@ class Simulation : public LoadGenerator
     bool loadAccount(AccountInfo& account);
     std::string metricsSummary(std::string domain = "");
 
-  private:
     void addConnection(NodeID initiator, NodeID acceptor);
+  private:
     void addLoopbackConnection(NodeID initiator, NodeID acceptor);
     void addTCPConnection(NodeID initiator, NodeID acception);
 

--- a/src/xdr/Stellar-overlay.x
+++ b/src/xdr/Stellar-overlay.x
@@ -62,7 +62,8 @@ struct PeerAddress
         opaque ipv4[4];
     case IPv6:
         opaque ipv6[16];
-    } ip;
+    }
+    ip;
     uint32 port;
     uint32 numFailures;
 };
@@ -85,7 +86,8 @@ enum MessageType
     // SCP
     GET_SCP_QUORUMSET = 9,
     SCP_QUORUMSET = 10,
-    SCP_MESSAGE = 11
+    SCP_MESSAGE = 11,
+    GET_SCP_STATE = 12
 };
 
 struct DontHave
@@ -124,17 +126,18 @@ case SCP_QUORUMSET:
     SCPQuorumSet qSet;
 case SCP_MESSAGE:
     SCPEnvelope envelope;
+case GET_SCP_STATE:
+    uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 };
 
 union AuthenticatedMessage switch (uint32 v)
 {
 case 0:
     struct
-    {
-        uint64 sequence;
-        StellarMessage message;
-        HmacSha256Mac mac;
+{
+   uint64 sequence;
+   StellarMessage message;
+   HmacSha256Mac mac;
     } v0;
 };
-
 }


### PR DESCRIPTION
Exchange SCP messages when connecting to a new peer - Resolves #822 
Persist latest SCP messages before sending them - resolves #821 
Emit SCP message in logs when running into a bad SCP state - resolves #819 
Validate quorum sets on startup and when receiving messages - resolves #817 


Various minor changes:
 * better handling of bad messages in overlay
 * delay starting overlay until last known ledger is loaded (avoids potential crash)
 * app would crash in some bad config cases (throw from within "start")