### PR TITLE
fix pid type

### DIFF
--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -103,7 +103,7 @@ BucketManagerImpl::getBucketDir()
             std::ifstream lockfile(lock);
             std::string pidStr;
             lockfile >> pidStr;
-            auto pid = stoi(pidStr);
+            auto pid = stol(pidStr);
             if (pid == self)
             {
                 CLOG(WARNING, "Bucket") << "Ignoring stale lockfile '" << lock


### PR DESCRIPTION
fs::getCurrentPid is long, so using stol instead of stoi is preferrable;
only a makeshift