### PR TITLE
Allow a non validating node to not have itself in its quorum

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -102,6 +102,10 @@ class Herder
     virtual SequenceNumber getMaxSeqInPendingTxs(AccountID const&) = 0;
 
     virtual void triggerNextLedger(uint32_t ledgerSeqToTrigger) = 0;
+
+    // returns if a nodeID's quorum set passes sanity checks
+    virtual bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet) = 0;
+
     virtual ~Herder()
     {
     }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1373,6 +1373,12 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     mSCP.nominate(slotIndex, mCurrentValue, prevValue);
 }
 
+bool
+HerderImpl::isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet)
+{
+    return mSCP.getLocalNode()->isQuorumSetSane(nodeID, qSet);
+}
+
 // Extra SCP methods overridden solely to increment metrics.
 void
 HerderImpl::updatedCandidateValue(uint64 slotIndex, Value const& value)

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -109,6 +109,8 @@ class HerderImpl : public Herder, public SCPDriver
 
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
+    bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet) override;
+
     void dumpInfo(Json::Value& ret) override;
 
     struct TxMap

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -228,7 +228,7 @@ ApplicationImpl::start()
         throw std::invalid_argument("Quorum not configured");
     }
     if (mConfig.NODE_IS_VALIDATOR &&
-        !LocalNode::isQuorumSetSane(mConfig.NODE_SEED.getPublicKey(),
+        !mHerder->isQuorumSetSane(mConfig.NODE_SEED.getPublicKey(),
                                     mConfig.QUORUM_SET))
     {
         throw std::invalid_argument(

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -248,7 +248,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
 bool
 BallotProtocol::isStatementSane(SCPStatement const& st)
 {
-    bool res = LocalNode::isQuorumSetSane(st.nodeID, *mSlot.getQuorumSetFromStatement(st));
+    bool res = mSlot.getLocalNode()->isQuorumSetSane(st.nodeID, *mSlot.getQuorumSetFromStatement(st));
     if (!res)
     {
         CLOG(DEBUG, "SCP") << "Invalid quorum set received";

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -70,7 +70,9 @@ bool
 LocalNode::isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet)
 {
     auto res = isQuorumSetSaneInternal(nodeID, qSet);
-    return res.first && res.second;
+    // it's OK for a non validating node to not have itself in its quorum set
+    return (res.first || (!mIsValidator && nodeID == mNodeID)) &&
+        res.second;
 }
 
 void

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -40,7 +40,7 @@ class LocalNode
     NodeID const& getNodeID();
 
     // returns if a nodeID's quorum set passes sanity checks
-    static bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet);
+    bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet);
 
     void updateQuorumSet(SCPQuorumSet const& qSet);
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -112,7 +112,7 @@ NominationProtocol::isSane(SCPStatement const& st)
     res = res && std::is_sorted(nom.votes.begin(), nom.votes.end());
     res = res && std::is_sorted(nom.accepted.begin(), nom.accepted.end());
 
-    res = res && LocalNode::isQuorumSetSane(
+    res = res && mSlot.getLocalNode()->isQuorumSetSane(
                      st.nodeID, *mSlot.getQuorumSetFromStatement(st));
 
     return res;


### PR DESCRIPTION
Typical non validating node are just watching other nodes on the
network by setting their quorum set to those nodes.

While this invalidates some assumptions from the paper,
it's acceptable here as no other node can rely non validators.

resolves #833 
