### PR TITLE
Improve catchup status reporting

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -181,7 +181,7 @@ UNSAFE_QUORUM=false
 # if false will catchup "minimally", using deltas to the most recent snapshot.
 CATCHUP_COMPLETE=false
 
-# MAX_CONCURRENT_SUBPROCESSES (integer) default 8
+# MAX_CONCURRENT_SUBPROCESSES (integer) default 16
 # History catchup can potentialy spawn a bunch of sub-processes.
 # This limits the number that will be active at a time.
 MAX_CONCURRENT_SUBPROCESSES=10

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -545,7 +545,7 @@ CatchupStateMachine::enterRetryingState(uint64_t nseconds)
             else if (!anchored)
             {
                 CLOG(WARNING, "History")
-                    << "Unable to anchor, restarting catchup";
+                    << "Restarting catchup after failure to anchor";
                 self->enterBeginState();
             }
             else if (!verifying)

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -230,7 +230,7 @@ CatchupStateMachine::advanceFileState(
         else
         {
             fi->setState(FILE_CATCHUP_DOWNLOADING);
-            CLOG(INFO, "History") << "Downloading " << name;
+            CLOG(DEBUG, "History") << "Downloading " << name;
             std::weak_ptr<CatchupStateMachine> weak(shared_from_this());
             hm.getFile(mArchive, fi->remoteName(), fi->localPath_gz(),
                        [weak, name](asio::error_code const& ec)
@@ -254,7 +254,7 @@ CatchupStateMachine::advanceFileState(
     case FILE_CATCHUP_DOWNLOADED:
     {
         fi->setState(FILE_CATCHUP_DECOMPRESSING);
-        CLOG(INFO, "History") << "Decompressing " << fi->localPath_gz();
+        CLOG(DEBUG, "History") << "Decompressing " << fi->localPath_gz();
         std::weak_ptr<CatchupStateMachine> weak(shared_from_this());
         hm.decompress(
             fi->localPath_gz(), [weak, name](asio::error_code const& ec)
@@ -289,7 +289,7 @@ CatchupStateMachine::advanceFileState(
         }
         else
         {
-            CLOG(INFO, "History") << "Verifying " << name;
+            CLOG(DEBUG, "History") << "Verifying " << name;
             auto filename = fi->localPath_nogz();
             std::weak_ptr<CatchupStateMachine> weak(shared_from_this());
             hm.verifyHash(
@@ -416,9 +416,9 @@ CatchupStateMachine::enterAnchoredState(HistoryArchiveState const& has)
 
             std::remove(filename_nogz.c_str());
             std::remove(filename_gz.c_str());
-            CLOG(INFO, "History") << "Retrying fetch for " << fi->remoteName()
-                                  << " from archive '" << mArchive->getName()
-                                  << "'";
+            CLOG(DEBUG, "History") << "Retrying fetch for " << fi->remoteName()
+                                   << " from archive '" << mArchive->getName()
+                                   << "'";
             fi->setState(FILE_CATCHUP_NEEDED);
         }
     }
@@ -478,9 +478,9 @@ CatchupStateMachine::enterAnchoredState(HistoryArchiveState const& has)
         auto name = fi->baseName_nogz();
         if (mFileInfos.find(name) == mFileInfos.end())
         {
-            CLOG(INFO, "History") << "Starting fetch for " << name
-                                  << " from archive '" << mArchive->getName()
-                                  << "'";
+            CLOG(DEBUG, "History") << "Starting fetch for " << name
+                                   << " from archive '" << mArchive->getName()
+                                   << "'";
             mFileInfos[name] = fi;
         }
     }
@@ -715,9 +715,9 @@ CatchupStateMachine::verifyHistoryOfSingleCheckpoint(
     auto hi = i->second;
 
     XDRInputFileStream hdrIn;
-    CLOG(INFO, "History") << "Verifying ledger headers from "
-                          << hi->localPath_nogz() << " starting from ledger "
-                          << LedgerManager::ledgerAbbrev(*prev);
+    CLOG(DEBUG, "History") << "Verifying ledger headers from "
+                           << hi->localPath_nogz() << " starting from ledger "
+                           << LedgerManager::ledgerAbbrev(*prev);
     hdrIn.open(hi->localPath_nogz());
     LedgerHeaderHistoryEntry curr;
     while (hdrIn && hdrIn.readOne(curr))
@@ -773,7 +773,7 @@ CatchupStateMachine::enterApplyingState()
         if (mMode == HistoryManager::CATCHUP_COMPLETE)
         {
             auto& lm = mApp.getLedgerManager();
-            CLOG(INFO, "History")
+            CLOG(DEBUG, "History")
                 << "Replaying contents of " << mHeaderInfos.size()
                 << " transaction-history files from LCL "
                 << LedgerManager::ledgerAbbrev(lm.getLastClosedLedgerHeader());
@@ -782,10 +782,10 @@ CatchupStateMachine::enterApplyingState()
         }
         else if (mMode == HistoryManager::CATCHUP_MINIMAL)
         {
-            CLOG(INFO, "History")
+            CLOG(DEBUG, "History")
                 << "Archive bucketListHash: "
                 << hexAbbrev(mArchiveState.getBucketListHash());
-            CLOG(INFO, "History")
+            CLOG(DEBUG, "History")
                 << "mLastClosed bucketListHash: "
                 << hexAbbrev(mLastClosed.header.bucketListHash);
         }
@@ -903,8 +903,8 @@ CatchupStateMachine::applySingleBucketLevel(bool& applying, size_t& n)
     auto& db = mApp.getDatabase();
     auto& bl = mApp.getBucketManager().getBucketList();
 
-    CLOG(INFO, "History") << "Applying buckets for level " << n << " at ledger "
-                          << mLastClosed.header.ledgerSeq;
+    CLOG(DEBUG, "History") << "Applying buckets for level " << n << " at ledger "
+                           << mLastClosed.header.ledgerSeq;
 
     // We've verified mLastClosed (in the "trusted part of history" sense) in
     // CATCHUP_VERIFY phase; we now need to check that the BucketListHash we're
@@ -998,10 +998,10 @@ CatchupStateMachine::applyHistoryOfSingleCheckpoint(uint32_t checkpoint)
     XDRInputFileStream hdrIn;
     XDRInputFileStream txIn;
 
-    CLOG(INFO, "History") << "Replaying ledger headers from "
-                          << hi->localPath_nogz();
-    CLOG(INFO, "History") << "Replaying transactions from "
-                          << ti->localPath_nogz();
+    CLOG(DEBUG, "History") << "Replaying ledger headers from "
+                           << hi->localPath_nogz();
+    CLOG(DEBUG, "History") << "Replaying transactions from "
+                           << ti->localPath_nogz();
 
     hdrIn.open(hi->localPath_nogz());
     txIn.open(ti->localPath_nogz());

--- a/src/history/CatchupStateMachine.h
+++ b/src/history/CatchupStateMachine.h
@@ -151,8 +151,10 @@ class CatchupStateMachine
     void finishVerifyingState(HistoryManager::VerifyHashStatus status);
 
     struct ApplyState;
+    std::shared_ptr<ApplyState> mApplyState;
+
     void enterApplyingState();
-    void advanceApplyingState(std::shared_ptr<ApplyState>);
+    void advanceApplyingState();
 
     void enterEndState();
 

--- a/src/history/CatchupStateMachine.h
+++ b/src/history/CatchupStateMachine.h
@@ -170,6 +170,8 @@ class CatchupStateMachine
             void(asio::error_code const& ec, HistoryManager::CatchupMode mode,
                  LedgerHeaderHistoryEntry const& lastClosed)> handler);
 
+    void logAndUpdateStatus(bool contiguous);
+
     void begin();
 
     static const std::chrono::seconds SLEEP_SECONDS_PER_LEDGER;

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -260,6 +260,10 @@ class HistoryManager
     // catchup probe.
     virtual uint64_t nextCheckpointCatchupProbe(uint32_t ledger) = 0;
 
+    // Emit a log message and call app.setExtraStateInfo() to
+    // describe current catchup state, given a network ledger-close.
+    virtual void logAndUpdateCatchupStatus(bool contiguous) = 0;
+
     // Verify that a file has a given hash.
     virtual void
     verifyHash(std::string const& filename, uint256 const& hash,

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -517,7 +517,7 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint()
     if (!hasAnyWritableHistoryArchive())
     {
         mPublishSkip.Mark();
-        CLOG(WARNING, "History")
+        CLOG(DEBUG, "History")
             << "Skipping checkpoint, no writable history archives";
         return false;
     }

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -265,6 +265,15 @@ HistoryManagerImpl::nextCheckpointCatchupProbe(uint32_t ledger)
     return (((next - ledger) + 5) * ledger_duration.count());
 }
 
+void
+HistoryManagerImpl::logAndUpdateCatchupStatus(bool contiguous)
+{
+    if (mCatchup)
+    {
+        mCatchup->logAndUpdateStatus(contiguous);
+    }
+}
+
 string const&
 HistoryManagerImpl::getTmpDir()
 {

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -47,6 +47,8 @@ class HistoryManagerImpl : public HistoryManager
     uint32_t nextCheckpointLedger(uint32_t ledger) override;
     uint64_t nextCheckpointCatchupProbe(uint32_t ledger) override;
 
+    void logAndUpdateCatchupStatus(bool contiguous) override;
+
     void verifyHash(
         std::string const& filename, uint256 const& hash,
         std::function<void(asio::error_code const&)> handler) const override;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -54,7 +54,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     MINIMUM_IDLE_PERCENT = 0;
 
-    MAX_CONCURRENT_SUBPROCESSES = 32;
+    MAX_CONCURRENT_SUBPROCESSES = 16;
     PARANOID_MODE = false;
     NODE_IS_VALIDATOR = false;
 

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -445,6 +445,12 @@ VirtualTimer::cancel()
     }
 }
 
+VirtualClock::time_point const&
+VirtualTimer::expiry_time() const
+{
+    return mExpiryTime;
+}
+
 void
 VirtualTimer::expires_at(VirtualClock::time_point t)
 {

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -187,6 +187,7 @@ class VirtualTimer : private NonMovableOrCopyable
     VirtualTimer(VirtualClock& app);
     ~VirtualTimer();
 
+    VirtualClock::time_point const& expiry_time() const;
     void expires_at(VirtualClock::time_point t);
     void expires_from_now(VirtualClock::duration d);
     template <typename R, typename P>


### PR DESCRIPTION
This makes catchup significantly less bumpy-seeming, easier to tell when it's working vs. got stuck doing something nonsensical. I also find that it (curiously) makes it much more psychologically tolerable to wait out wall-clock time. A catchup-complete (which I just ran on a laptop over starbucks wifi) takes 25 minutes end-to-end, gives the following output:
~~~~
2015-10-14T16:00:07.084 d929f3 [] [Ledger] INFO  Got consensus: [seq=128730, prev=cfdb32, tx_count=0, sv: [  txH: e3ccd6, ct: 1444863605, upgrades: [ ] ]]
2015-10-14T16:00:07.084 d929f3 [] [History] INFO  Catchup mode 'complete' awaiting checkpoint (ETA: 9 seconds)
2015-10-14T16:00:12.029 d929f3 [] [Ledger] INFO  Got consensus: [seq=128731, prev=cb82ac, tx_count=0, sv: [  txH: 888222, ct: 1444863609, upgrades: [ ] ]]
2015-10-14T16:00:12.029 d929f3 [] [History] INFO  Catchup mode 'complete' awaiting checkpoint (ETA: 4 seconds)
2015-10-14T16:00:15.085 d929f3 [] [Ledger] INFO  Got consensus: [seq=128732, prev=f01b5d, tx_count=0, sv: [  txH: a4a3f4, ct: 1444863612, upgrades: [ ] ]]
2015-10-14T16:00:15.085 d929f3 [] [History] INFO  Catchup mode 'complete' awaiting checkpoint (ETA: 1 seconds)
2015-10-14T16:00:16.807 d929f3 [] [History] WARN  Restarting catchup after failure to anchor
2015-10-14T16:00:16.807 d929f3 [] [History] INFO  Catchup BEGIN, initLedger=128676, guessed nextLedger=128704, anchor checkpoint=128703
2015-10-14T16:00:17.186 d929f3 [] [Ledger] INFO  Got consensus: [seq=128733, prev=549fe0, tx_count=0, sv: [  txH: 164dc6, ct: 1444863615, upgrades: [ ] ]]
2015-10-14T16:00:17.186 d929f3 [] [History] INFO  Catchup mode 'complete' beginning
2015-10-14T16:00:22.054 d929f3 [] [Ledger] INFO  Got consensus: [seq=128734, prev=e324d2, tx_count=0, sv: [  txH: e99e82, ct: 1444863620, upgrades: [ ] ]]
2015-10-14T16:00:22.055 d929f3 [] [History] INFO  Catchup mode 'complete', downloaded 31/4022 files
2015-10-14T16:00:25.134 d929f3 [] [Ledger] INFO  Got consensus: [seq=128735, prev=52943e, tx_count=0, sv: [  txH: 013d2e, ct: 1444863624, upgrades: [ ] ]]
2015-10-14T16:00:25.135 d929f3 [] [History] INFO  Catchup mode 'complete', downloaded 78/4022 files
2015-10-14T16:00:27.108 d929f3 [] [Ledger] INFO  Got consensus: [seq=128736, prev=381ac4, tx_count=0, sv: [  txH: da4121, ct: 1444863625, upgrades: [ ] ]]
2015-10-14T16:00:27.108 d929f3 [] [History] INFO  Catchup mode 'complete', downloaded 109/4022 files
...
2015-10-14T16:06:08.292 d929f3 [] [Ledger] INFO  Got consensus: [seq=128826, prev=c2b768, tx_count=0, sv: [  txH: df4ddd, ct: 1444863967, upgrades: [ ] ]]
2015-10-14T16:06:08.292 d929f3 [] [History] INFO  Catchup mode 'complete', downloaded 3970/4022 files
2015-10-14T16:06:21.364 d929f3 [] [History] INFO  Verifying ledger-history chain of 2011 transaction-history files from LCL [seq=1, hash=63d98f]
2015-10-14T16:06:21.482 d929f3 [] [Ledger] INFO  Got consensus: [seq=128827, prev=88cd44, tx_count=0, sv: [  txH: 7f13ee, ct: 1444863970, upgrades: [ ] ]]
2015-10-14T16:06:21.482 d929f3 [] [History] INFO  Catchup mode 'complete', verifying 2011-ledger history chain
2015-10-14T16:06:21.492 d929f3 [] [Ledger] INFO  Got consensus: [seq=128828, prev=49133f, tx_count=0, sv: [  txH: 1374f3, ct: 1444863975, upgrades: [ ] ]]
2015-10-14T16:06:21.492 d929f3 [] [History] INFO  Catchup mode 'complete', verifying 2011-ledger history chain
2015-10-14T16:06:22.234 d929f3 [] [Ledger] INFO  Got consensus: [seq=128829, prev=3ae65e, tx_count=0, sv: [  txH: dc13eb, ct: 1444863979, upgrades: [ ] ]]
2015-10-14T16:06:22.234 d929f3 [] [History] INFO  Catchup mode 'complete', verifying 2011-ledger history chain
2015-10-14T16:06:23.089 d929f3 [] [History] INFO  Catchup mode 'complete', applying ledger 63/128703
2015-10-14T16:06:23.217 d929f3 [] [History] INFO  Catchup mode 'complete', applying ledger 127/128703
2015-10-14T16:06:23.334 d929f3 [] [History] INFO  Catchup mode 'complete', applying ledger 191/128703
...
2015-10-14T16:25:29.168 d929f3 [] [History] INFO  Catchup mode 'complete', applying ledger 128575/128703
2015-10-14T16:25:29.591 d929f3 [] [History] INFO  Catchup mode 'complete', applying ledger 128639/128703
2015-10-14T16:25:29.825 d929f3 [] [History] INFO  Catchup mode 'complete', applying ledger 128703/128703
2015-10-14T16:25:30.030 d929f3 [] [Ledger] INFO  Caught up to LCL from history: [seq=128703, hash=a6b81e]
2015-10-14T16:25:30.030 d929f3 [] [Ledger] INFO  Replaying buffered ledger-close: [seq=128704, prev=a6b81e, tx_count=0, sv: [  txH: cf3bac, ct: 1444863514, upgrades: [ ] ]]
2015-10-14T16:25:30.033 d929f3 [] [Ledger] INFO  Replaying buffered ledger-close: [seq=128705, prev=d2a781, tx_count=0, sv: [  txH: 96c30b, ct: 1444863519, upgrades: [ ] ]]
2015-10-14T16:25:30.036 d929f3 [] [Ledger] INFO  Replaying buffered ledger-close: [seq=128706, prev=85f2ae, tx_count=0, sv: [  txH: 7112c4, ct: 1444863520, upgrades: [ ] ]]
2015-10-14T16:25:30.037 d929f3 [] [Ledger] INFO  Replaying buffered ledger-close: [seq=128707, prev=76bf39, tx_count=0, sv: [  txH: 2318b4, ct: 1444863524, upgrades: [ ] ]]
...
2015-10-14T16:25:30.479 d929f3 [] [Ledger] INFO  Replaying buffered ledger-close: [seq=128844, prev=6a1b60, tx_count=0, sv: [  txH: cbdfab, ct: 1444864034, upgrades: [ ] ]]
2015-10-14T16:25:30.487 d929f3 [] [Ledger] INFO  Replaying buffered ledger-close: [seq=128845, prev=4f3348, tx_count=0, sv: [  txH: b2a520, ct: 1444864039, upgrades: [ ] ]]
2015-10-14T16:25:30.490 d929f3 [] [Ledger] INFO  Caught up to LCL including recent network activity: [seq=128845, hash=45336b]
2015-10-14T16:25:30.490 d929f3 [] [Ledger] INFO  Changing state LM_CATCHING_UP_STATE -> LM_SYNCED_STATE
~~~~