### PR TITLE
reformat code base

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -300,7 +300,8 @@ Bucket::apply(Database& db) const
         {
             db.clearPreparedStatementCache();
             db.getSession().commit();
-            CLOG(INFO, "Bucket") << "Bucket-apply: committed " << i << " entries";
+            CLOG(INFO, "Bucket") << "Bucket-apply: committed " << i
+                                 << " entries";
             db.getSession().begin();
         }
         if (entry.type() == LIVEENTRY)

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -69,8 +69,8 @@ Database::registerDrivers()
 
 Database::Database(Application& app)
     : mApp(app)
-    , mQueryMeter(app.getMetrics().NewMeter({"database", "query", "exec"},
-                                            "query"))
+    , mQueryMeter(
+          app.getMetrics().NewMeter({"database", "query", "exec"}, "query"))
     , mStatementsSize(
           app.getMetrics().NewCounter({"database", "memory", "statements"}))
     , mEntryCache(4096)
@@ -112,18 +112,16 @@ Database::upgradeToCurrentSchema()
     auto vers = getDBSchemaVersion();
     if (vers > SCHEMA_VERSION)
     {
-        std::string s = ("DB schema version "
-                         + std::to_string(vers)
-                         + " is newer than application schema "
-                         + std::to_string(SCHEMA_VERSION));
+        std::string s = ("DB schema version " + std::to_string(vers) +
+                         " is newer than application schema " +
+                         std::to_string(SCHEMA_VERSION));
         throw std::runtime_error(s);
     }
     while (vers < SCHEMA_VERSION)
     {
         ++vers;
-        CLOG(INFO, "Database")
-            << "Applying DB schema upgrade to version "
-            << vers;
+        CLOG(INFO, "Database") << "Applying DB schema upgrade to version "
+                               << vers;
         applySchemaUpgrade(*this, vers);
     }
     assert(vers == SCHEMA_VERSION);
@@ -140,8 +138,8 @@ Database::putSchemaVersion(unsigned long vers)
 unsigned long
 Database::getDBSchemaVersion()
 {
-    auto vstr = mApp.getPersistentState().getState(
-        PersistentState::kDatabaseSchema);
+    auto vstr =
+        mApp.getPersistentState().getState(PersistentState::kDatabaseSchema);
     unsigned long vers = 0;
     try
     {
@@ -381,7 +379,8 @@ Database::totalQueryTime() const
         {
             auto& timer = mApp.getMetrics().NewTimer({"database", q, e});
             uint64_t sumns = static_cast<uint64_t>(
-                timer.sum() * static_cast<double>(timer.duration_unit().count()));
+                timer.sum() *
+                static_cast<double>(timer.duration_unit().count()));
             nsq += std::chrono::nanoseconds(sumns);
         }
     }
@@ -396,7 +395,6 @@ Database::excludeTime(std::chrono::nanoseconds const& queryTime,
     mExcludedTotalTime += totalTime;
 }
 
-
 uint32_t
 Database::recentIdleDbPercent()
 {
@@ -407,13 +405,13 @@ Database::recentIdleDbPercent()
     std::chrono::nanoseconds total = mApp.getClock().now() - mLastIdleTotalTime;
     total -= mExcludedTotalTime;
 
-    uint32_t queryPercent = static_cast<uint32_t>((100 * query.count()) / total.count());
+    uint32_t queryPercent =
+        static_cast<uint32_t>((100 * query.count()) / total.count());
     uint32_t idlePercent = 100 - queryPercent;
     if (idlePercent > 100)
     {
         // This should never happen, but clocks are not perfectly well behaved.
-        CLOG(WARNING, "Database") << "DB idle percent ("
-                                  << idlePercent
+        CLOG(WARNING, "Database") << "DB idle percent (" << idlePercent
                                   << ") over 100, limiting to 100";
         idlePercent = 100;
     }
@@ -429,8 +427,6 @@ Database::recentIdleDbPercent()
     return idlePercent;
 }
 
-
-
 DBTimeExcluder::DBTimeExcluder(Application& app)
     : mApp(app)
     , mStartQueryTime(app.getDatabase().totalQueryTime())
@@ -444,6 +440,4 @@ DBTimeExcluder::~DBTimeExcluder()
     auto deltaT = mApp.getClock().now() - mStartTotalTime;
     mApp.getDatabase().excludeTime(deltaQ, deltaT);
 }
-
-
 }

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -204,9 +204,9 @@ class DBTimeExcluder : NonCopyable
     Application& mApp;
     std::chrono::nanoseconds mStartQueryTime;
     VirtualClock::time_point mStartTotalTime;
-public:
+
+  public:
     DBTimeExcluder(Application& mApp);
     ~DBTimeExcluder();
 };
-
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -104,7 +104,8 @@ class Herder
     virtual void triggerNextLedger(uint32_t ledgerSeqToTrigger) = 0;
 
     // returns if a nodeID's quorum set passes sanity checks
-    virtual bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet) = 0;
+    virtual bool isQuorumSetSane(NodeID const& nodeID,
+                                 SCPQuorumSet const& qSet) = 0;
 
     virtual ~Herder()
     {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -54,7 +54,7 @@ class HerderImpl : public Herder, public SCPDriver
     SCP&
     getSCP()
     {
-        return mSCP; 
+        return mSCP;
     }
     // SCP methods
 
@@ -115,7 +115,8 @@ class HerderImpl : public Herder, public SCPDriver
 
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
-    bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet) override;
+    bool isQuorumSetSane(NodeID const& nodeID,
+                         SCPQuorumSet const& qSet) override;
 
     void dumpInfo(Json::Value& ret) override;
 

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -575,7 +575,8 @@ TEST_CASE("SCP State", "[herder]")
     {
         nodeKeys[i] = SecretKey::random();
         nodeIDs[i] = nodeKeys[i].getPublicKey();
-        nodeCfgs[i] = getTestConfig(i+1, Config::TestDbMode::TESTDB_ON_DISK_SQLITE);
+        nodeCfgs[i] =
+            getTestConfig(i + 1, Config::TestDbMode::TESTDB_ON_DISK_SQLITE);
     }
 
     VirtualClock* clock = &sim->getClock();
@@ -599,14 +600,23 @@ TEST_CASE("SCP State", "[herder]")
         sim->startAllNodes();
         // wait to close exactly once
 
-        sim->crankUntil([&]() {
-            return sim->haveAllExternalized(2, 1);
-        }, std::chrono::seconds(1), true);
+        sim->crankUntil(
+            [&]()
+            {
+                return sim->haveAllExternalized(2, 1);
+            },
+            std::chrono::seconds(1), true);
 
-        REQUIRE(sim->getNode(nodeIDs[0])->getLedgerManager().getLastClosedLedgerNum() == 2);
-        REQUIRE(sim->getNode(nodeIDs[1])->getLedgerManager().getLastClosedLedgerNum() == 2);
+        REQUIRE(sim->getNode(nodeIDs[0])
+                    ->getLedgerManager()
+                    .getLastClosedLedgerNum() == 2);
+        REQUIRE(sim->getNode(nodeIDs[1])
+                    ->getLedgerManager()
+                    .getLastClosedLedgerNum() == 2);
 
-        lcl = sim->getNode(nodeIDs[0])->getLedgerManager().getLastClosedLedgerHeader();
+        lcl = sim->getNode(nodeIDs[0])
+                  ->getLedgerManager()
+                  .getLastClosedLedgerHeader();
 
         // adjust configs for a clean restart
         for (int i = 0; i < 2; i++)
@@ -619,7 +629,8 @@ TEST_CASE("SCP State", "[herder]")
         // restart simulation
         sim.reset();
 
-        sim = std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
+        sim =
+            std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
         clock = &sim->getClock();
 
         // start a new node that will switch to whatever node0 & node1 says
@@ -632,10 +643,13 @@ TEST_CASE("SCP State", "[herder]")
         sim->addNode(nodeKeys[2], qSetAll, *clock, &nodeCfgs[2]);
         sim->getNode(nodeIDs[2])->start();
 
-        // crank a bit (nothing should happen, node 2 is waiting for SCP messages)
+        // crank a bit (nothing should happen, node 2 is waiting for SCP
+        // messages)
         sim->crankForAtLeast(std::chrono::seconds(1), false);
 
-        REQUIRE(sim->getNode(nodeIDs[2])->getLedgerManager().getLastClosedLedgerNum() == 1);
+        REQUIRE(sim->getNode(nodeIDs[2])
+                    ->getLedgerManager()
+                    .getLastClosedLedgerNum() == 1);
 
         // start up node 0 and 1 again
         // nodes 0 and 1 have lost their SCP state as they got restarted
@@ -656,15 +670,22 @@ TEST_CASE("SCP State", "[herder]")
     {
         doTest(true);
 
-        // then let the nodes run a bit more, they should all externalize the next ledger
-        sim->crankUntil([&]() {
-            return sim->haveAllExternalized(3, 2);
-        }, Herder::EXP_LEDGER_TIMESPAN_SECONDS, true);
+        // then let the nodes run a bit more, they should all externalize the
+        // next ledger
+        sim->crankUntil(
+            [&]()
+            {
+                return sim->haveAllExternalized(3, 2);
+            },
+            Herder::EXP_LEDGER_TIMESPAN_SECONDS, true);
 
         // nodes are at least on ledger 3 (some may be on 4)
         for (int i = 0; i <= 2; i++)
         {
-            auto const& actual = sim->getNode(nodeIDs[i])->getLedgerManager().getLastClosedLedgerHeader().header;
+            auto const& actual = sim->getNode(nodeIDs[i])
+                                     ->getLedgerManager()
+                                     .getLastClosedLedgerHeader()
+                                     .header;
             if (actual.ledgerSeq == 3)
             {
                 REQUIRE(actual.previousLedgerHash == lcl.hash);
@@ -678,13 +699,21 @@ TEST_CASE("SCP State", "[herder]")
         // to get stuck at ledger #2
         doTest(false);
 
-        sim->crankUntil([&]() {
-            return sim->getNode(nodeIDs[2])->getLedgerManager().getLastClosedLedgerNum() == 2;
-        }, std::chrono::seconds(1), false);
+        sim->crankUntil(
+            [&]()
+            {
+                return sim->getNode(nodeIDs[2])
+                           ->getLedgerManager()
+                           .getLastClosedLedgerNum() == 2;
+            },
+            std::chrono::seconds(1), false);
 
         for (int i = 0; i <= 2; i++)
         {
-            auto const& actual = sim->getNode(nodeIDs[i])->getLedgerManager().getLastClosedLedgerHeader().header;
+            auto const& actual = sim->getNode(nodeIDs[i])
+                                     ->getLedgerManager()
+                                     .getLastClosedLedgerHeader()
+                                     .header;
             REQUIRE(actual == lcl.header);
         }
     }

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -135,9 +135,7 @@ CatchupStateMachine::logAndUpdateStatus(bool contiguous)
                 ++nDownloaded;
             }
         }
-        stateStr << ", downloaded "
-                 << nDownloaded << "/" << nFiles
-                 << " files";
+        stateStr << ", downloaded " << nDownloaded << "/" << nFiles << " files";
     }
     break;
 
@@ -146,8 +144,8 @@ CatchupStateMachine::logAndUpdateStatus(bool contiguous)
         {
             // FIXME: give a progress count here, maybe? It usually
             // runs very quickly, even on huge history. Like disk-speed.
-            stateStr << ", verifying "
-                     << mHeaderInfos.size() << "-ledger history chain";
+            stateStr << ", verifying " << mHeaderInfos.size()
+                     << "-ledger history chain";
         }
         else
         {
@@ -159,17 +157,15 @@ CatchupStateMachine::logAndUpdateStatus(bool contiguous)
         if (mMode == HistoryManager::CATCHUP_COMPLETE)
         {
             assert(mApplyState);
-            stateStr << ", applying ledger "
-                     << mApplyState->mCheckpointNumber
+            stateStr << ", applying ledger " << mApplyState->mCheckpointNumber
                      << "/"
-                     << (mHeaderInfos.empty() ? 0 :
-                         mHeaderInfos.rbegin()->first);
+                     << (mHeaderInfos.empty() ? 0
+                                              : mHeaderInfos.rbegin()->first);
         }
         else if (mMode == HistoryManager::CATCHUP_MINIMAL)
         {
             assert(mApplyState);
-            stateStr << ", appying bucket level "
-                     << mApplyState->mBucketLevel;
+            stateStr << ", appying bucket level " << mApplyState->mBucketLevel;
         }
         break;
 
@@ -195,7 +191,6 @@ CatchupStateMachine::logAndUpdateStatus(bool contiguous)
     CLOG(INFO, "History") << stateStr.str();
     mApp.setExtraStateInfo(stateStr.str());
 }
-
 
 /**
  * Select any readable history archive. If there are more than one,
@@ -565,10 +560,9 @@ CatchupStateMachine::enterAnchoredState(HistoryArchiveState const& has)
     {
         bucketsToFetch =
             mApp.getBucketManager().checkForMissingBucketsFiles(mLocalState);
-        auto publishBuckets =
-            mApp.getHistoryManager().getMissingBucketsReferencedByPublishQueue();
-        bucketsToFetch.insert(bucketsToFetch.end(),
-                              publishBuckets.begin(),
+        auto publishBuckets = mApp.getHistoryManager()
+                                  .getMissingBucketsReferencedByPublishQueue();
+        bucketsToFetch.insert(bucketsToFetch.end(), publishBuckets.begin(),
                               publishBuckets.end());
     }
     else if (mMode == HistoryManager::CATCHUP_MINIMAL)
@@ -965,16 +959,15 @@ CatchupStateMachine::advanceApplyingState()
     if (keepGoing)
     {
         std::weak_ptr<CatchupStateMachine> weak(shared_from_this());
-        mApp.getClock().getIOService().post(
-            [weak]()
-            {
-                auto self = weak.lock();
-                if (!self)
-                {
-                    return;
-                }
-                self->advanceApplyingState();
-            });
+        mApp.getClock().getIOService().post([weak]()
+                                            {
+                                                auto self = weak.lock();
+                                                if (!self)
+                                                {
+                                                    return;
+                                                }
+                                                self->advanceApplyingState();
+                                            });
     }
     else
     {
@@ -1019,8 +1012,8 @@ CatchupStateMachine::applySingleBucketLevel(bool& applying, size_t& n)
     auto& db = mApp.getDatabase();
     auto& bl = mApp.getBucketManager().getBucketList();
 
-    CLOG(DEBUG, "History") << "Applying buckets for level " << n << " at ledger "
-                           << mLastClosed.header.ledgerSeq;
+    CLOG(DEBUG, "History") << "Applying buckets for level " << n
+                           << " at ledger " << mLastClosed.header.ledgerSeq;
 
     // We've verified mLastClosed (in the "trusted part of history" sense) in
     // CATCHUP_VERIFY phase; we now need to check that the BucketListHash we're

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -112,9 +112,9 @@ CatchupStateMachine::logAndUpdateStatus(bool contiguous)
 
     case CATCHUP_RETRYING:
     {
-        auto retry = VirtualClock::to_time_t(mRetryTimer.expiry_time());
-        auto now = mApp.timeNow();
-        auto eta = now > retry ? 0 : retry - now;
+        uint64 retry = VirtualClock::to_time_t(mRetryTimer.expiry_time());
+        uint64 now = mApp.timeNow();
+        uint64 eta = now > retry ? 0 : retry - now;
         stateStr << " awaiting checkpoint"
                  << " (ETA: " << eta << " seconds)";
     }

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -326,9 +326,8 @@ class HistoryManager
     // Returns the number of publishes initiated, which is the same number
     // as the number of times the provided handler will be called (once for
     // each, as they complete).
-    virtual size_t
-    publishQueuedHistory(std::function<void(asio::error_code const&)>
-                         handler) = 0;
+    virtual size_t publishQueuedHistory(
+        std::function<void(asio::error_code const&)> handler) = 0;
 
     // Return the set of buckets referenced by the persistent (DB) publish
     // queue that are not present in the BucketManager. These need to be

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -38,11 +38,10 @@ namespace stellar
 
 using namespace std;
 
-static string kSQLCreateStatement =
-    "CREATE TABLE IF NOT EXISTS publishqueue ("
-    "ledger   INTEGER PRIMARY KEY,"
-    "state    TEXT"
-    "); ";
+static string kSQLCreateStatement = "CREATE TABLE IF NOT EXISTS publishqueue ("
+                                    "ledger   INTEGER PRIMARY KEY,"
+                                    "state    TEXT"
+                                    "); ";
 
 void
 HistoryManager::dropAll(Database& db)
@@ -279,11 +278,8 @@ HistoryManagerImpl::logAndUpdateStatus(bool contiguous)
         if (qlen > 0)
         {
             stateStr << "Publishing " << qlen << " queued checkpoints"
-                     << " ["
-                     << mPublish->minQueuedSnapshotLedger()
-                     << "-"
-                     << mPublish->maxQueuedSnapshotLedger()
-                     << "]";
+                     << " [" << mPublish->minQueuedSnapshotLedger() << "-"
+                     << mPublish->maxQueuedSnapshotLedger() << "]";
             CLOG(INFO, "History") << stateStr.str();
         }
         else
@@ -561,8 +557,7 @@ HistoryManagerImpl::queueCurrentHistory()
     auto has = getLastClosedHistoryArchiveState();
 
     auto ledger = has.currentLedger;
-    CLOG(DEBUG, "History")
-        << "Queueing publish state for ledger " << ledger;
+    CLOG(DEBUG, "History") << "Queueing publish state for ledger " << ledger;
     auto state = has.toString();
     auto timer = mApp.getDatabase().getInsertTimer("publishqueue");
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -581,7 +576,9 @@ HistoryManagerImpl::queueCurrentHistory()
     // into the in-memory publish queue in order to preserve those
     // merges-in-progress, avoid restarting them.
 
-    takeSnapshotAndQueue(has, [](asio::error_code const&){});
+    takeSnapshotAndQueue(has, [](asio::error_code const&)
+                         {
+                         });
 }
 
 void
@@ -592,13 +589,11 @@ HistoryManagerImpl::takeSnapshotAndQueue(
     mPublishQueue.Mark();
     auto ledgerSeq = has.currentLedger;
 
-    CLOG(DEBUG, "History")
-        << "Activating publish for ledger " << ledgerSeq;
+    CLOG(DEBUG, "History") << "Activating publish for ledger " << ledgerSeq;
 
     auto snap = PublishStateMachine::takeSnapshot(mApp, has);
     if (mPublish->queueSnapshot(
-            snap,
-            [this, ledgerSeq, handler](asio::error_code const& ec)
+            snap, [this, ledgerSeq, handler](asio::error_code const& ec)
             {
                 if (ec)
                 {
@@ -630,8 +625,7 @@ HistoryManagerImpl::publishQueuedHistory(
     uint32_t maxLedger = mPublish->maxQueuedSnapshotLedger();
     std::string state;
 
-    CLOG(TRACE, "History")
-        << "Max active publish " << maxLedger;
+    CLOG(TRACE, "History") << "Max active publish " << maxLedger;
 
     auto prep = mApp.getDatabase().getPreparedStatement(
         "SELECT state FROM publishqueue"

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -81,8 +81,9 @@ class HistoryManagerImpl : public HistoryManager
 
     void queueCurrentHistory() override;
 
-    void takeSnapshotAndQueue(HistoryArchiveState const& has,
-                              std::function<void(asio::error_code const&)> handler);
+    void
+    takeSnapshotAndQueue(HistoryArchiveState const& has,
+                         std::function<void(asio::error_code const&)> handler);
 
     bool hasAnyWritableHistoryArchive() override;
 
@@ -91,7 +92,8 @@ class HistoryManagerImpl : public HistoryManager
     size_t publishQueuedHistory(
         std::function<void(asio::error_code const&)> handler) override;
 
-    std::vector<std::string> getMissingBucketsReferencedByPublishQueue() override;
+    std::vector<std::string>
+    getMissingBucketsReferencedByPublishQueue() override;
 
     void historyPublished(uint32_t ledgerSeq);
 

--- a/src/history/PublishStateMachine.cpp
+++ b/src/history/PublishStateMachine.cpp
@@ -401,8 +401,7 @@ PublishStateMachine::queueSnapshot(SnapshotPtr snap, PublishCallback handler)
     return delayed;
 }
 
-StateSnapshot::StateSnapshot(Application& app,
-                             HistoryArchiveState const& state)
+StateSnapshot::StateSnapshot(Application& app, HistoryArchiveState const& state)
     : mApp(app)
     , mLocalState(state)
     , mSnapDir(app.getTmpDirManager().tmpDir("snapshot"))
@@ -583,7 +582,8 @@ StateSnapshot::writeHistoryBlocksWithRetry()
 }
 
 std::shared_ptr<StateSnapshot>
-PublishStateMachine::takeSnapshot(Application& app, HistoryArchiveState const& state)
+PublishStateMachine::takeSnapshot(Application& app,
+                                  HistoryArchiveState const& state)
 {
     // Capture local state and _all_ the local buckets at this instant; these
     // may be expired from the bucketlist while the subsequent put-callbacks are

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -129,8 +129,8 @@ LedgerManagerImpl::setState(State s)
         mApp.syncOwnMetrics();
         CLOG(INFO, "Ledger") << "Changing state " << oldState << " -> "
                              << getStateHuman();
-        if(mState != LM_CATCHING_UP_STATE)
-        { 
+        if (mState != LM_CATCHING_UP_STATE)
+        {
             mApp.getHistoryManager().logAndUpdateStatus(true);
         }
     }
@@ -232,8 +232,8 @@ LedgerManagerImpl::loadLastKnownLedger(
 
             auto missing =
                 mApp.getBucketManager().checkForMissingBucketsFiles(has);
-            auto pubmissing =
-                mApp.getHistoryManager().getMissingBucketsReferencedByPublishQueue();
+            auto pubmissing = mApp.getHistoryManager()
+                                  .getMissingBucketsReferencedByPublishQueue();
             missing.insert(missing.end(), pubmissing.begin(), pubmissing.end());
             if (!missing.empty())
             {
@@ -725,7 +725,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     // 4. GC unreferenced buckets. Only do this once publishes are in progress.
 
     // step 1
-    auto &hm = mApp.getHistoryManager();
+    auto& hm = mApp.getHistoryManager();
     hm.maybeQueueHistoryCheckpoint();
 
     // step 2
@@ -733,7 +733,9 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     txscope.commit();
 
     // step 3
-    hm.publishQueuedHistory([](asio::error_code const&){});
+    hm.publishQueuedHistory([](asio::error_code const&)
+                            {
+                            });
     hm.logAndUpdateStatus(true);
 
     // step 4

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -233,7 +233,7 @@ ApplicationImpl::start()
     }
     if (mConfig.NODE_IS_VALIDATOR &&
         !mHerder->isQuorumSetSane(mConfig.NODE_SEED.getPublicKey(),
-                                    mConfig.QUORUM_SET))
+                                  mConfig.QUORUM_SET))
     {
         throw std::invalid_argument(
             "Invalid QUORUM_SET: bad threshold or validator is not a member");
@@ -254,7 +254,9 @@ ApplicationImpl::start()
             mHerder->restoreSCPState();
             mOverlayManager->start();
             auto npub = mHistoryManager->publishQueuedHistory(
-                [](asio::error_code const&){});
+                [](asio::error_code const&)
+                {
+                });
             if (npub != 0)
             {
                 CLOG(INFO, "Ledger") << "Restarted publishing " << npub
@@ -436,7 +438,7 @@ ApplicationImpl::getStateHuman() const
     return std::string(stateStrings[getState()]);
 }
 
-std::string 
+std::string
 ApplicationImpl::getExtraStateInfo() const
 {
     return std::string(mExtraStateInfo);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -418,7 +418,7 @@ CommandHandler::info(std::string const& params, std::string& retStr)
     root["info"]["build"] = STELLAR_CORE_VERSION;
     root["info"]["protocol_version"] = mApp.getConfig().LEDGER_PROTOCOL_VERSION;
     root["info"]["state"] = mApp.getStateHuman();
-    if(mApp.getExtraStateInfo().size())
+    if (mApp.getExtraStateInfo().size())
         root["info"]["extra"] = mApp.getExtraStateInfo();
     root["info"]["ledger"]["num"] = (int)lm.getLedgerNum();
     root["info"]["ledger"]["hash"] =

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -66,7 +66,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
 void
 Config::loadQset(std::shared_ptr<cpptoml::toml_group> group, SCPQuorumSet& qset,
-         int level)
+                 int level)
 {
     if (!group)
     {
@@ -108,7 +108,7 @@ Config::loadQset(std::shared_ptr<cpptoml::toml_group> group, SCPQuorumSet& qset,
                 {
                     throw std::invalid_argument("invalid VALIDATORS");
                 }
-                
+
                 PublicKey nodeID;
                 parseNodeID(v->as<std::string>()->value(), nodeID);
                 qset.validators.emplace_back(nodeID);
@@ -333,16 +333,15 @@ Config::load(std::string const& filename)
                 }
                 BUCKET_DIR_PATH = item.second->as<std::string>()->value();
             }
-            else if(item.first == "NODE_NAMES")
+            else if (item.first == "NODE_NAMES")
             {
-                if(!item.second->is_array())
+                if (!item.second->is_array())
                 {
-                    throw std::invalid_argument(
-                        "NODE_NAMES must be an array");
+                    throw std::invalid_argument("NODE_NAMES must be an array");
                 }
-                for(auto v : item.second->as_array()->array())
+                for (auto v : item.second->as_array()->array())
                 {
-                    if(!v->as<std::string>())
+                    if (!v->as<std::string>())
                     {
                         throw std::invalid_argument(
                             "invalid element of NODE_NAMES");
@@ -358,7 +357,7 @@ Config::load(std::string const& filename)
                 {
                     throw std::invalid_argument("invalid NODE_SEED");
                 }
-                
+
                 std::string seed = item.second->as<std::string>()->value();
                 NODE_SEED = SecretKey::fromStrKeySeed(seed);
                 VALIDATOR_NAMES[NODE_SEED.getStrKeyPublic()] = "self";
@@ -423,7 +422,8 @@ Config::load(std::string const& filename)
 
                     PublicKey nodeID;
                     parseNodeID(v->as<std::string>()->value(), nodeID);
-                    PREFERRED_PEER_KEYS.push_back(PubKeyUtils::toStrKey(nodeID));
+                    PREFERRED_PEER_KEYS.push_back(
+                        PubKeyUtils::toStrKey(nodeID));
                 }
             }
             else if (item.first == "PREFERRED_PEERS_ONLY")
@@ -615,62 +615,64 @@ Config::validateConfig()
     }
 }
 
-void 
+void
 Config::parseNodeID(std::string configStr, PublicKey& retKey)
 {
-    if(configStr.size()<2) throw std::invalid_argument("invalid key");
+    if (configStr.size() < 2)
+        throw std::invalid_argument("invalid key");
 
-    //check if configStr is a PublicKey or a common name
-    if(configStr[0] == '$')
+    // check if configStr is a PublicKey or a common name
+    if (configStr[0] == '$')
     {
         std::string commonName = configStr.substr(1);
-        for(auto& v : VALIDATOR_NAMES)
+        for (auto& v : VALIDATOR_NAMES)
         {
-            if(v.second == commonName)
+            if (v.second == commonName)
             {
-                retKey= PubKeyUtils::fromStrKey(v.first);
+                retKey = PubKeyUtils::fromStrKey(v.first);
                 return;
             }
         }
         throw std::invalid_argument("unknown key in config");
-    } else
+    }
+    else
     {
         std::istringstream iss(configStr);
         std::string nodestr;
         iss >> nodestr;
         retKey = PubKeyUtils::fromStrKey(nodestr);
 
-        if(iss)
-        {  // get any common name they have added
+        if (iss)
+        { // get any common name they have added
             std::string commonName;
             iss >> commonName;
-            if(commonName.size())
+            if (commonName.size())
             {
-                for(auto& v : VALIDATOR_NAMES)
+                for (auto& v : VALIDATOR_NAMES)
                 {
-                    if(v.second == commonName)
+                    if (v.second == commonName)
                     {
                         throw std::invalid_argument("name already used");
                     }
                 }
 
                 auto it = VALIDATOR_NAMES.find(nodestr);
-                if(it == VALIDATOR_NAMES.end())
+                if (it == VALIDATOR_NAMES.end())
                     VALIDATOR_NAMES[nodestr] = commonName;
-                else throw std::invalid_argument("naming node twice");
+                else
+                    throw std::invalid_argument("naming node twice");
             }
         }
     }
-   
 }
 
-std::string 
+std::string
 Config::toShortString(PublicKey const& pk) const
 {
-    auto it=VALIDATOR_NAMES.find(PubKeyUtils::toStrKey(pk));
-    if(it == VALIDATOR_NAMES.end())
+    auto it = VALIDATOR_NAMES.find(PubKeyUtils::toStrKey(pk));
+    if (it == VALIDATOR_NAMES.end())
         return PubKeyUtils::toShortString(pk);
-    else return it->second;
+    else
+        return it->second;
 }
-
 }

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -22,7 +22,7 @@ class Config : public std::enable_shared_from_this<Config>
     void loadQset(std::shared_ptr<cpptoml::toml_group> group,
                   SCPQuorumSet& qset, int level);
 
-    void parseNodeID(std::string configStr,PublicKey& retKey);
+    void parseNodeID(std::string configStr, PublicKey& retKey);
 
   public:
     typedef std::shared_ptr<Config> pointer;
@@ -171,6 +171,5 @@ class Config : public std::enable_shared_from_this<Config>
     void load(std::string const& filename);
 
     std::string toShortString(PublicKey const& pk) const;
-
 };
 }

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -134,11 +134,8 @@ ExternalQueue::process()
     // publication and the requirements of our pubsub subscribers.
     uint32_t cmin = std::min(lmin, rmin);
 
-    LOG(INFO) << "Trimming history <= ledger " << cmin
-              << " (rmin=" << rmin
-              << ", qmin=" << qmin
-              << ", lmin=" << lmin
-              << ")";
+    LOG(INFO) << "Trimming history <= ledger " << cmin << " (rmin=" << rmin
+              << ", qmin=" << qmin << ", lmin=" << lmin << ")";
 
     mApp.getLedgerManager().deleteOldEntries(mApp.getDatabase(), cmin);
 }

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -13,8 +13,8 @@ namespace stellar
 using namespace std;
 
 string PersistentState::mapping[kLastEntry] = {
-    "lastclosedledger", "historyarchivestate", "forcescponnextlaunch",
-    "databaseinitialized", "lastscpdata", "databaseschema"};
+    "lastclosedledger",    "historyarchivestate", "forcescponnextlaunch",
+    "databaseinitialized", "lastscpdata",         "databaseschema"};
 
 string PersistentState::kSQLCreateStatement =
     "CREATE TABLE IF NOT EXISTS storestate ("

--- a/src/main/fuzz.cpp
+++ b/src/main/fuzz.cpp
@@ -143,11 +143,10 @@ restart:
         LOG(INFO) << "Fuzzer injecting message " << i << ": "
                   << msgSummary(msg);
         auto peer = loop.getInitiator();
-        clock.getIOService().post(
-            [peer, msg]()
-            {
-                peer->Peer::sendMessage(msg);
-            });
+        clock.getIOService().post([peer, msg]()
+                                  {
+                                      peer->Peer::sendMessage(msg);
+                                  });
     }
     while (loop.getAcceptor()->isConnected())
     {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -392,8 +392,7 @@ main(int argc, char* const* argv)
             s += cfgFile + " found";
             throw std::invalid_argument(s);
         }
-        Logging::setFmt(
-            cfg.toShortString(cfg.NODE_SEED.getPublicKey()));
+        Logging::setFmt(cfg.toShortString(cfg.NODE_SEED.getPublicKey()));
         Logging::setLogLevel(logLevel, nullptr);
 
         if (command.size())

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -28,7 +28,8 @@ Floodgate::Floodgate(Application& app)
     : mApp(app)
     , mFloodMapSize(
           app.getMetrics().NewCounter({"overlay", "memory", "flood-map"}))
-    , mSendFromBroadcast(app.getMetrics().NewMeter({ "overlay", "message", "send-from-broadcast" }, "message"))
+    , mSendFromBroadcast(app.getMetrics().NewMeter(
+          {"overlay", "message", "send-from-broadcast"}, "message"))
     , mShuttingDown(false)
 {
 }
@@ -102,15 +103,15 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
 
     for (auto peer : peers)
     {
-        if (peersTold.find(peer) ==
-            peersTold.end() && peer->isAuthenticated())
+        if (peersTold.find(peer) == peersTold.end() && peer->isAuthenticated())
         {
             mSendFromBroadcast.Mark();
             peer->sendMessage(msg);
             peersTold.insert(peer);
         }
     }
-    CLOG(TRACE, "Overlay") << "broadcast " << hexAbbrev(index) << " told " << peersTold.size();
+    CLOG(TRACE, "Overlay") << "broadcast " << hexAbbrev(index) << " told "
+                           << peersTold.size();
 }
 
 std::set<Peer::pointer>

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -103,7 +103,8 @@ ItemFetcher<TrackerT>::recv(uint256 itemID)
         // calling recv on the same itemID
         auto& waiting = iter->second->mWaitingEnvelopes;
 
-        CLOG(TRACE, "Overlay") << "Recv " << hexAbbrev(itemID) << " : " << waiting.size();
+        CLOG(TRACE, "Overlay") << "Recv " << hexAbbrev(itemID) << " : "
+                               << waiting.size();
 
         while (!waiting.empty())
         {
@@ -117,16 +118,15 @@ ItemFetcher<TrackerT>::recv(uint256 itemID)
 }
 
 Tracker::Tracker(Application& app, uint256 const& id)
-    :
-    mApp(app)
-    ,mTimer(app)
-    ,mItemID(id)
-    , mTryNextPeerReset(
-        app.getMetrics().NewMeter({ "overlay", "item-fetcher", "reset-fetcher" }, "item-fetcher"))
-    ,mTryNextPeer(
-        app.getMetrics().NewMeter({ "overlay", "item-fetcher", "next-peer" }, "item-fetcher"))
-    {
-    }
+    : mApp(app)
+    , mTimer(app)
+    , mItemID(id)
+    , mTryNextPeerReset(app.getMetrics().NewMeter(
+          {"overlay", "item-fetcher", "reset-fetcher"}, "item-fetcher"))
+    , mTryNextPeer(app.getMetrics().NewMeter(
+          {"overlay", "item-fetcher", "next-peer"}, "item-fetcher"))
+{
+}
 
 Tracker::~Tracker()
 {
@@ -179,8 +179,8 @@ Tracker::tryNextPeer()
     Peer::pointer peer;
 
     CLOG(TRACE, "Overlay") << "tryNextPeer " << hexAbbrev(mItemID) << " last: "
-                          << (mLastAskedPeer ? mLastAskedPeer->toString()
-                                             : "<none>");
+                           << (mLastAskedPeer ? mLastAskedPeer->toString()
+                                              : "<none>");
 
     if (mPeersToAsk.empty())
     {
@@ -195,7 +195,7 @@ Tracker::tryNextPeer()
 
         // move the peers that have the envelope to the back,
         // to be processed first
-        for(auto const& p: mApp.getOverlayManager().getRandomPeers())
+        for (auto const& p : mApp.getOverlayManager().getRandomPeers())
         {
             if (peersWithEnvelope.find(p) != peersWithEnvelope.end())
             {
@@ -208,7 +208,7 @@ Tracker::tryNextPeer()
         }
 
         CLOG(TRACE, "Overlay") << "tryNextPeer " << hexAbbrev(mItemID)
-            << " reset to #" << mPeersToAsk.size();
+                               << " reset to #" << mPeersToAsk.size();
         mTryNextPeerReset.Mark();
     }
 
@@ -232,7 +232,7 @@ Tracker::tryNextPeer()
     {
         mLastAskedPeer = peer;
         CLOG(TRACE, "Overlay") << "Asking for " << hexAbbrev(mItemID) << " to "
-                              << peer->toString();
+                               << peer->toString();
         mTryNextPeer.Mark();
         askPeer(peer);
         nextTry = MS_TO_WAIT_FOR_FETCH_REPLY;
@@ -253,7 +253,8 @@ Tracker::listen(const SCPEnvelope& env)
     StellarMessage m;
     m.type(SCP_MESSAGE);
     m.envelope() = env;
-    mWaitingEnvelopes.push_back(std::make_pair(sha256(xdr::xdr_to_opaque(m)), env));
+    mWaitingEnvelopes.push_back(
+        std::make_pair(sha256(xdr::xdr_to_opaque(m)), env));
 }
 
 void

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -48,7 +48,7 @@ class Tracker
     std::deque<Peer::pointer> mPeersToAsk;
     VirtualTimer mTimer;
     bool mIsStopped = false;
-    std::vector<std::pair<Hash,SCPEnvelope>> mWaitingEnvelopes;
+    std::vector<std::pair<Hash, SCPEnvelope>> mWaitingEnvelopes;
     uint256 mItemID;
     medida::Meter& mTryNextPeerReset;
     medida::Meter& mTryNextPeer;

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -16,21 +16,20 @@
 namespace stellar
 {
 
-LoadManager::LoadManager()
-    : mPeerCosts(128)
+LoadManager::LoadManager() : mPeerCosts(128)
 {
 }
 
 std::string
 byteMag(uint64_t bytes)
 {
-    static char const * sz[7] = {"B","KiB","MiB","GiB","TiB","PiB","EiB"};
+    static char const* sz[7] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
     for (int i = 6; i >= 0; --i)
     {
-        uint64_t mag = i*10;
+        uint64_t mag = i * 10;
         if (bytes >= (1ULL << mag))
         {
-            return fmt::format("{:>d}{:s}", bytes>>mag, sz[i]);
+            return fmt::format("{:>d}{:s}", bytes >> mag, sz[i]);
         }
     }
     return "0";
@@ -40,13 +39,13 @@ std::string
 timeMag(uint64_t nanos)
 {
 
-    static char const * sz[4] = {"ns","us","ms","s"};
+    static char const* sz[4] = {"ns", "us", "ms", "s"};
     uint64_t mag = 1000000000;
     for (int i = 3; i >= 0; --i)
     {
         if (nanos >= mag)
         {
-            return fmt::format("{:>d}{:s}", nanos/mag, sz[i]);
+            return fmt::format("{:>d}{:s}", nanos / mag, sz[i]);
         }
         mag /= 1000;
     }
@@ -54,27 +53,26 @@ timeMag(uint64_t nanos)
 }
 
 void
-LoadManager::reportLoads(std::vector<Peer::pointer> const& peers,Application& app)
+LoadManager::reportLoads(std::vector<Peer::pointer> const& peers,
+                         Application& app)
 {
     CLOG(INFO, "Overlay") << "";
-    CLOG(INFO, "Overlay")
-        << "Cumulative peer-load costs:";
+    CLOG(INFO, "Overlay") << "Cumulative peer-load costs:";
     CLOG(INFO, "Overlay")
         << "------------------------------------------------------";
-    CLOG(INFO, "Overlay")
-        << fmt::format("{:>10s} {:>10s} {:>10s} {:>10s} {:>10s}",
-                       "peer", "time", "send", "recv", "query");
+    CLOG(INFO, "Overlay") << fmt::format(
+        "{:>10s} {:>10s} {:>10s} {:>10s} {:>10s}", "peer", "time", "send",
+        "recv", "query");
     for (auto const& peer : peers)
     {
         auto cost = getPeerCosts(peer->getPeerID());
-        CLOG(INFO, "Overlay") <<
-            fmt::format(
-                "{:>10s} {:>10s} {:>10s} {:>10s} {:>10d}",
-                app.getConfig().toShortString(peer->getPeerID()),
-                timeMag(static_cast<uint64_t>(cost->mTimeSpent.one_minute_rate())),
-                byteMag(static_cast<uint64_t>(cost->mBytesSend.one_minute_rate())),
-                byteMag(static_cast<uint64_t>(cost->mBytesRecv.one_minute_rate())),
-                cost->mSQLQueries.count());
+        CLOG(INFO, "Overlay") << fmt::format(
+            "{:>10s} {:>10s} {:>10s} {:>10s} {:>10d}",
+            app.getConfig().toShortString(peer->getPeerID()),
+            timeMag(static_cast<uint64_t>(cost->mTimeSpent.one_minute_rate())),
+            byteMag(static_cast<uint64_t>(cost->mBytesSend.one_minute_rate())),
+            byteMag(static_cast<uint64_t>(cost->mBytesRecv.one_minute_rate())),
+            cost->mSQLQueries.count());
     }
     CLOG(INFO, "Overlay") << "";
 }
@@ -100,7 +98,7 @@ LoadManager::maybeShedExcessLoad(Application& app)
         CLOG(WARNING, "Overlay") << "";
 
         auto peers = app.getOverlayManager().getPeers();
-        reportLoads(peers,app);
+        reportLoads(peers, app);
 
         // Look for the worst-behaved of the current peers and kick them out.
         std::shared_ptr<Peer> victim;
@@ -121,13 +119,13 @@ LoadManager::maybeShedExcessLoad(Application& app)
                 << "Disconnecting suspected culprit "
                 << app.getConfig().toShortString(victim->getPeerID());
 
-            app.getMetrics().NewMeter(
-                {"overlay", "drop", "load-shed"}, "drop").Mark();
+            app.getMetrics()
+                .NewMeter({"overlay", "drop", "load-shed"}, "drop")
+                .Mark();
 
             victim->drop();
         }
     }
-
 }
 
 LoadManager::PeerCosts::PeerCosts()
@@ -143,19 +141,14 @@ LoadManager::PeerCosts::isLessThan(
     std::shared_ptr<LoadManager::PeerCosts> other)
 {
     double ownRates[4] = {
-        mTimeSpent.one_minute_rate(),
-        mBytesSend.one_minute_rate(),
-        mBytesRecv.one_minute_rate(),
-        mSQLQueries.one_minute_rate()
-    };
-    double otherRates[4] = {
-        other->mTimeSpent.one_minute_rate(),
-        other->mBytesSend.one_minute_rate(),
-        other->mBytesRecv.one_minute_rate(),
-        other->mSQLQueries.one_minute_rate()
-    };
-    return std::lexicographical_compare(ownRates, ownRates+4,
-                                        otherRates, otherRates+4);
+        mTimeSpent.one_minute_rate(), mBytesSend.one_minute_rate(),
+        mBytesRecv.one_minute_rate(), mSQLQueries.one_minute_rate()};
+    double otherRates[4] = {other->mTimeSpent.one_minute_rate(),
+                            other->mBytesSend.one_minute_rate(),
+                            other->mBytesRecv.one_minute_rate(),
+                            other->mSQLQueries.one_minute_rate()};
+    return std::lexicographical_compare(ownRates, ownRates + 4, otherRates,
+                                        otherRates + 4);
 }
 
 std::shared_ptr<LoadManager::PeerCosts>
@@ -170,8 +163,7 @@ LoadManager::getPeerCosts(NodeID const& node)
     return p;
 }
 
-LoadManager::PeerContext::PeerContext(Application& app,
-                                      NodeID const& node)
+LoadManager::PeerContext::PeerContext(Application& app, NodeID const& node)
     : mApp(app)
     , mNode(node)
     , mWorkStart(app.getClock().now())
@@ -190,19 +182,16 @@ LoadManager::PeerContext::~PeerContext()
             mApp.getClock().now() - mWorkStart);
         auto send = Peer::getByteWriteMeter(mApp).count() - mBytesSendStart;
         auto recv = Peer::getByteReadMeter(mApp).count() - mBytesRecvStart;
-        auto query = (mApp.getDatabase().getQueryMeter().count() -
-                      mSQLQueriesStart);
-        CLOG(TRACE, "Overlay") << "Debiting peer "
-                               << mApp.getConfig().toShortString(mNode)
-                               << " time:" << timeMag(time.count())
-                               << " send:" << byteMag(send)
-                               << " recv:" << byteMag(recv)
-                               << " query:" << query;
+        auto query =
+            (mApp.getDatabase().getQueryMeter().count() - mSQLQueriesStart);
+        CLOG(TRACE, "Overlay")
+            << "Debiting peer " << mApp.getConfig().toShortString(mNode)
+            << " time:" << timeMag(time.count()) << " send:" << byteMag(send)
+            << " recv:" << byteMag(recv) << " query:" << query;
         pc->mTimeSpent.Mark(time.count());
         pc->mBytesSend.Mark(send);
         pc->mBytesRecv.Mark(recv);
         pc->mSQLQueries.Mark(query);
     }
 }
-
 }

--- a/src/overlay/LoadManager.h
+++ b/src/overlay/LoadManager.h
@@ -35,8 +35,7 @@ class LoadManager
     // This is all very heuristic and speculative; if it turns out not to
     // work, or to do more harm than good, it ought to be disabled/removed.
 
-public:
-
+  public:
     LoadManager();
     ~LoadManager();
     void reportLoads(std::vector<Peer::pointer> const& peers, Application& app);
@@ -56,12 +55,10 @@ public:
 
     std::shared_ptr<PeerCosts> getPeerCosts(NodeID const& peer);
 
-private:
-
+  private:
     cache::lru_cache<NodeID, std::shared_ptr<PeerCosts>> mPeerCosts;
 
-public:
-
+  public:
     // Measure recent load on the system and, if the system appears
     // overloaded, shed one or more of the worst-behaved peers,
     // according to our local per-peer accounting.
@@ -79,10 +76,10 @@ public:
         std::uint64_t mBytesSendStart;
         std::uint64_t mBytesRecvStart;
         std::uint64_t mSQLQueriesStart;
-    public:
+
+      public:
         PeerContext(Application& app, NodeID const& node);
         ~PeerContext();
     };
 };
-
 }

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -23,8 +23,7 @@ using namespace std;
 // LoopbackPeer
 ///////////////////////////////////////////////////////////////////////
 
-LoopbackPeer::LoopbackPeer(Application& app, PeerRole role)
-    : Peer(app, role)
+LoopbackPeer::LoopbackPeer(Application& app, PeerRole role) : Peer(app, role)
 {
 }
 
@@ -80,9 +79,9 @@ LoopbackPeer::drop()
     if (remote)
     {
         remote->getApp().getClock().getIOService().post([remote]()
-                              {
-                                  remote->drop();
-                              });
+                                                        {
+                                                            remote->drop();
+                                                        });
     }
 }
 
@@ -130,7 +129,10 @@ LoopbackPeer::processInQueue()
         if (!mInQueue.empty())
         {
             auto self = static_pointer_cast<LoopbackPeer>(shared_from_this());
-            mApp.getClock().getIOService().post([self]() { self->processInQueue(); });
+            mApp.getClock().getIOService().post([self]()
+                                                {
+                                                    self->processInQueue();
+                                                });
         }
     }
 }
@@ -195,10 +197,11 @@ LoopbackPeer::deliverOne()
         {
             // move msg to remote's in queue
             remote->mInQueue.emplace(std::move(msg));
-            remote->getApp().getClock().getIOService().post([remote]()
-            {
-                remote->processInQueue();
-            });
+            remote->getApp().getClock().getIOService().post(
+                [remote]()
+                {
+                    remote->processInQueue();
+                });
         }
         LoadManager::PeerContext loadCtx(mApp, mPeerID);
         mLastWrite = mApp.getClock().now();
@@ -373,10 +376,11 @@ LoopbackPeerConnection::LoopbackPeerConnection(Application& initiator,
     mAcceptor->startIdleTimer();
 
     auto init = mInitiator;
-    mInitiator->getApp().getClock().getIOService().post([init]()
-                             {
-                                 init->connectHandler(asio::error_code());
-                             });
+    mInitiator->getApp().getClock().getIOService().post(
+        [init]()
+        {
+            init->connectHandler(asio::error_code());
+        });
 }
 
 LoopbackPeerConnection::~LoopbackPeerConnection()

--- a/src/overlay/LoopbackPeer.h
+++ b/src/overlay/LoopbackPeer.h
@@ -26,7 +26,7 @@ class LoopbackPeer : public Peer
   private:
     std::weak_ptr<LoopbackPeer> mRemote;
     std::deque<xdr::msg_ptr> mOutQueue; // sending queue
-    std::queue<xdr::msg_ptr> mInQueue; // receiving queue
+    std::queue<xdr::msg_ptr> mInQueue;  // receiving queue
 
     bool mCorked{false};
     size_t mMaxQueueDepth{0};
@@ -56,6 +56,7 @@ class LoopbackPeer : public Peer
     AuthCert getAuthCert();
 
     void processInQueue();
+
   public:
     virtual ~LoopbackPeer()
     {

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -177,7 +177,8 @@ OverlayManagerImpl::connectToMorePeers(int max)
         if (PeerRecord::parseIPPort(peerStr, mApp, pr))
         {
             // see if we can get current information from the peer table
-            auto prFromDB = PeerRecord::loadPeerRecord(mApp.getDatabase(), pr.mIP, pr.mPort);
+            auto prFromDB = PeerRecord::loadPeerRecord(mApp.getDatabase(),
+                                                       pr.mIP, pr.mPort);
             if (prFromDB)
             {
                 pr = *prFromDB;
@@ -400,7 +401,6 @@ OverlayManagerImpl::getLoadManager()
 {
     return mLoad;
 }
-
 
 void
 OverlayManagerImpl::shutdown()

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -60,7 +60,6 @@ class OverlayManagerImpl : public OverlayManager
     Floodgate mFloodGate;
 
   public:
-
     OverlayManagerImpl(Application& app);
     ~OverlayManagerImpl();
 

--- a/src/overlay/OverlayTests.cpp
+++ b/src/overlay/OverlayTests.cpp
@@ -188,8 +188,8 @@ TEST_CASE("reject peers with incompatible overlay versions", "[overlay]")
         REQUIRE(!conn.getInitiator()->isConnected());
         REQUIRE(!conn.getAcceptor()->isConnected());
         REQUIRE(app2->getMetrics()
-                .NewMeter({ "overlay", "drop", "recv-hello-version" }, "drop")
-                .count() != 0);
+                    .NewMeter({"overlay", "drop", "recv-hello-version"}, "drop")
+                    .count() != 0);
     };
     SECTION("cfg2 above")
     {
@@ -255,8 +255,7 @@ TEST_CASE("reject peers with the same nodeid", "[overlay]")
 }
 
 void
-injectSendPeersAndReschedule(VirtualClock::time_point& end,
-                             VirtualClock& clock,
+injectSendPeersAndReschedule(VirtualClock::time_point& end, VirtualClock& clock,
                              VirtualTimer& timer,
                              std::shared_ptr<LoopbackPeer> const& sendPeer)
 {
@@ -264,14 +263,14 @@ injectSendPeersAndReschedule(VirtualClock::time_point& end,
     if (clock.now() < end && sendPeer->isConnected())
     {
         timer.expires_from_now(std::chrono::milliseconds(10));
-        timer.async_wait(
-            [&](asio::error_code const& ec)
-            {
-                if (!ec)
-                {
-                    injectSendPeersAndReschedule(end, clock, timer, sendPeer);
-                }
-            });
+        timer.async_wait([&](asio::error_code const& ec)
+                         {
+                             if (!ec)
+                             {
+                                 injectSendPeersAndReschedule(end, clock, timer,
+                                                              sendPeer);
+                             }
+                         });
     }
 }
 
@@ -303,12 +302,10 @@ TEST_CASE("disconnect peers when overloaded", "[overlay]")
     auto end = start + std::chrono::seconds(10);
     VirtualTimer timer(clock);
 
-    injectSendPeersAndReschedule(end, clock, timer,
-                                 conn.getInitiator());
+    injectSendPeersAndReschedule(end, clock, timer, conn.getInitiator());
 
     for (size_t i = 0;
-         (i < 1000 && clock.now() < end &&
-          conn.getInitiator()->isConnected() &&
+         (i < 1000 && clock.now() < end && conn.getInitiator()->isConnected() &&
           clock.crank(false) > 0);
          ++i)
         ;
@@ -317,7 +314,7 @@ TEST_CASE("disconnect peers when overloaded", "[overlay]")
     REQUIRE(!conn.getAcceptor()->isConnected());
     REQUIRE(conn2.getInitiator()->isConnected());
     REQUIRE(conn2.getAcceptor()->isConnected());
-    REQUIRE(app2->getMetrics().NewMeter(
-                {"overlay", "drop", "load-shed"},
-                "drop").count() != 0);
+    REQUIRE(app2->getMetrics()
+                .NewMeter({"overlay", "drop", "load-shed"}, "drop")
+                .count() != 0);
 }

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -179,6 +179,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     // helper method to acknownledge that some bytes were received
     void receivedBytes(size_t byteCount, bool gotFullMessage);
+
   public:
     Peer(Application& app, PeerRole role);
 

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -57,8 +57,10 @@ PeerDoor::acceptNextPeer()
     }
 
     CLOG(DEBUG, "Overlay") << "PeerDoor acceptNextPeer()";
-    auto sock = make_shared<TCPPeer::SocketType>(mApp.getClock().getIOService());
-    mAcceptor.async_accept(sock->next_layer(), [this, sock](asio::error_code const& ec)
+    auto sock =
+        make_shared<TCPPeer::SocketType>(mApp.getClock().getIOService());
+    mAcceptor.async_accept(sock->next_layer(),
+                           [this, sock](asio::error_code const& ec)
                            {
                                if (ec)
                                    this->acceptNextPeer();

--- a/src/overlay/PeerRecord.cpp
+++ b/src/overlay/PeerRecord.cpp
@@ -79,7 +79,8 @@ PeerRecord::parseIPPort(string const& ipPort, Application& app, PeerRecord& ret,
         asio::ip::tcp::resolver::iterator i = resolver.resolve(query, ec);
         if (ec)
         {
-            LOG(DEBUG) << "Could not resolve '" << ipPort << "' : " << ec.message();
+            LOG(DEBUG) << "Could not resolve '" << ipPort
+                       << "' : " << ec.message();
             return false;
         }
 
@@ -328,8 +329,8 @@ PeerRecord::computeBackoff(VirtualClock& clock)
     uint32 backoffCount = std::min<uint32>(MAX_BACKOFF_EXPONENT, mNumFailures);
 
     auto nsecs = std::chrono::seconds(
-        std::rand() % (static_cast<uint32>(std::pow(2, backoffCount) *
-                                           SECONDS_PER_BACKOFF)));
+        std::rand() %
+        (static_cast<uint32>(std::pow(2, backoffCount) * SECONDS_PER_BACKOFF)));
     mNextAttempt = clock.now() + nsecs;
     return nsecs;
 }

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -18,16 +18,17 @@ namespace stellar
 // Peer that communicates via a TCP socket.
 class TCPPeer : public Peer
 {
-public:
+  public:
     typedef asio::buffered_stream<asio::ip::tcp::socket> SocketType;
-private:
+
+  private:
     std::string mIP;
     std::shared_ptr<SocketType> mSocket;
     std::vector<uint8_t> mIncomingHeader;
     std::vector<uint8_t> mIncomingBody;
 
     std::queue<std::shared_ptr<xdr::msg_ptr>> mWriteQueue;
-    bool mWriting{ false };
+    bool mWriting{false};
 
     void recvMessage();
     void sendMessage(xdr::msg_ptr&& xdrBytes) override;
@@ -50,14 +51,13 @@ private:
 
     TCPPeer(Application& app, Peer::PeerRole role,
             std::shared_ptr<SocketType> socket); // hollow
-                                                            // constuctor; use
-                                                            // `initiate` or
-                                                            // `accept` instead
+                                                 // constuctor; use
+                                                 // `initiate` or
+                                                 // `accept` instead
 
     static pointer initiate(Application& app, std::string const& ip,
                             unsigned short port);
-    static pointer accept(Application& app,
-                          std::shared_ptr<SocketType> socket);
+    static pointer accept(Application& app, std::shared_ptr<SocketType> socket);
 
     virtual ~TCPPeer();
 

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -42,8 +42,9 @@ LocalNode::buildSingletonQSet(NodeID const& nodeID)
     return qSet;
 }
 
-std::pair<bool,bool>
-LocalNode::isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSet)
+std::pair<bool, bool>
+LocalNode::isQuorumSetSaneInternal(NodeID const& nodeID,
+                                   SCPQuorumSet const& qSet)
 {
     auto& v = qSet.validators;
     auto& i = qSet.innerSets;
@@ -57,7 +58,7 @@ LocalNode::isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSe
     {
         found = true;
     }
-    for(auto const& iSet: i)
+    for (auto const& iSet : i)
     {
         auto r = isQuorumSetSaneInternal(nodeID, iSet);
         found = found || r.first;
@@ -71,8 +72,7 @@ LocalNode::isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet)
 {
     auto res = isQuorumSetSaneInternal(nodeID, qSet);
     // it's OK for a non validating node to not have itself in its quorum set
-    return (res.first || (!mIsValidator && nodeID == mNodeID)) &&
-        res.second;
+    return (res.first || (!mIsValidator && nodeID == mNodeID)) && res.second;
 }
 
 void

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -32,7 +32,9 @@ class LocalNode
     SCP* mSCP;
 
     // first: nodeID found, second: quorum set well formed
-    static std::pair<bool,bool> isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSet);
+    static std::pair<bool, bool>
+    isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSet);
+
   public:
     LocalNode(SecretKey const& secretKey, bool isValidator,
               SCPQuorumSet const& qSet, SCP* scp);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -113,8 +113,9 @@ NominationProtocol::isSane(SCPStatement const& st)
     res = res && std::is_sorted(nom.votes.begin(), nom.votes.end());
     res = res && std::is_sorted(nom.accepted.begin(), nom.accepted.end());
 
-    res = res && mSlot.getLocalNode()->isQuorumSetSane(
-                     st.nodeID, *mSlot.getQuorumSetFromStatement(st));
+    res = res &&
+          mSlot.getLocalNode()->isQuorumSetSane(
+              st.nodeID, *mSlot.getQuorumSetFromStatement(st));
 
     return res;
 }
@@ -223,7 +224,8 @@ NominationProtocol::updateRoundLeaders()
     CLOG(DEBUG, "SCP") << "updateRoundLeaders: " << mRoundLeaders.size();
     for (auto const& rl : mRoundLeaders)
     {
-        CLOG(DEBUG, "SCP") << "    leader " << mSlot.getSCPDriver().toShortString(rl);
+        CLOG(DEBUG, "SCP") << "    leader "
+                           << mSlot.getSCPDriver().toShortString(rl);
     }
 }
 
@@ -532,7 +534,8 @@ NominationProtocol::dumpInfo(Json::Value& ret)
     counter = 0;
     for (auto const& v : mLatestNominations)
     {
-        nomState["N"][counter]["id"] = mSlot.getSCPDriver().toShortString(v.first);
+        nomState["N"][counter]["id"] =
+            mSlot.getSCPDriver().toShortString(v.first);
         nomState["N"][counter]["statement"] = mSlot.envToStr(v.second);
 
         counter++;
@@ -546,11 +549,12 @@ NominationProtocol::setStateFromEnvelope(SCPEnvelope const& e)
 {
     if (mNominationStarted)
     {
-        throw std::runtime_error("Cannot set state after nomination is started");
+        throw std::runtime_error(
+            "Cannot set state after nomination is started");
     }
     recordEnvelope(e);
     auto const& nom = e.statement.pledges.nominate();
-    for(auto const& a : nom.accepted)
+    for (auto const& a : nom.accepted)
     {
         mAccepted.emplace(a);
     }

--- a/src/scp/SCPDriver.cpp
+++ b/src/scp/SCPDriver.cpp
@@ -22,7 +22,7 @@ SCPDriver::getValueString(Value const& v) const
     return hexAbbrev(valueHash);
 }
 
-std::string 
+std::string
 SCPDriver::toShortString(PublicKey const& pk) const
 {
     return PubKeyUtils::toShortString(pk);

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -34,7 +34,8 @@ class TestSCP : public SCPDriver
   public:
     SCP mSCP;
 
-    TestSCP(SecretKey const& secretKey, SCPQuorumSet const& qSetLocal, bool isValidator=true)
+    TestSCP(SecretKey const& secretKey, SCPQuorumSet const& qSetLocal,
+            bool isValidator = true)
         : mSCP(*this, secretKey, isValidator, qSetLocal)
     {
         mPriorityLookup = [&](NodeID const& n)
@@ -454,7 +455,8 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
         verifyConfirm(scpNV.mEnvs[1], vNVSecretKey, qSetHash, 0, 1, b, 1);
         scpNV.receiveEnvelope(ext4);
         REQUIRE(scpNV.mEnvs.size() == 3);
-        verifyExternalize(scpNV.mEnvs[2], vNVSecretKey, qSetHash, 0, b, b.counter);
+        verifyExternalize(scpNV.mEnvs[2], vNVSecretKey, qSetHash, 0, b,
+                          b.counter);
     }
 
     SECTION("bumpState x")
@@ -1470,15 +1472,18 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
         SCPBallot b(2, xValue);
         SECTION("prepare")
         {
-            scp2.mSCP.setStateFromEnvelope(0, makePrepare(v0SecretKey, qSetHash, 0, b));
+            scp2.mSCP.setStateFromEnvelope(
+                0, makePrepare(v0SecretKey, qSetHash, 0, b));
         }
         SECTION("confirm")
         {
-            scp2.mSCP.setStateFromEnvelope(0, makeConfirm(v0SecretKey, qSetHash, 0, 2, b, 3));
+            scp2.mSCP.setStateFromEnvelope(
+                0, makeConfirm(v0SecretKey, qSetHash, 0, 2, b, 3));
         }
         SECTION("externalize")
         {
-            scp2.mSCP.setStateFromEnvelope(0, makeExternalize(v0SecretKey, qSetHash, 0, b, 3));
+            scp2.mSCP.setStateFromEnvelope(
+                0, makeExternalize(v0SecretKey, qSetHash, 0, b, 3));
         }
     }
 }
@@ -1622,14 +1627,15 @@ TEST_CASE("nomination tests core5", "[scp][nominationprotocol]")
                 auto nominationRestore = [&]()
                 {
                     // restores from the previous state
-                    scp2.mSCP.setStateFromEnvelope(0, makeNominate(v0SecretKey, qSetHash, 0, votes,
-                                                                   accepted));
+                    scp2.mSCP.setStateFromEnvelope(
+                        0, makeNominate(v0SecretKey, qSetHash, 0, votes,
+                                        accepted));
                     // tries to start nomination with yValue
                     REQUIRE(scp2.nominate(0, yValue, false));
 
                     REQUIRE(scp2.mEnvs.size() == 1);
-                    verifyNominate(scp2.mEnvs[0], v0SecretKey, qSetHash, 0, votes2,
-                                   accepted);
+                    verifyNominate(scp2.mEnvs[0], v0SecretKey, qSetHash, 0,
+                                   votes2, accepted);
 
                     // other nodes only vote for 'x'
                     scp2.receiveEnvelope(nom1);
@@ -1663,7 +1669,9 @@ TEST_CASE("nomination tests core5", "[scp][nominationprotocol]")
                 }
                 SECTION("ballot protocol started (on value y)")
                 {
-                    scp2.mSCP.setStateFromEnvelope(0, makePrepare(v0SecretKey, qSetHash, 0, SCPBallot(1, yValue)));
+                    scp2.mSCP.setStateFromEnvelope(
+                        0, makePrepare(v0SecretKey, qSetHash, 0,
+                                       SCPBallot(1, yValue)));
                     nominationRestore();
                     // nomination didn't do anything (already working on y)
                     REQUIRE(scp2.mEnvs.size() == 1);

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -59,8 +59,7 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
     if (e.statement.nodeID == getSCP().getLocalNodeID() &&
         e.statement.slotIndex == mSlotIndex)
     {
-        if (e.statement.pledges.type() ==
-            SCPStatementType::SCP_ST_NOMINATE)
+        if (e.statement.pledges.type() == SCPStatementType::SCP_ST_NOMINATE)
         {
             mNominationProtocol.setStateFromEnvelope(e);
         }
@@ -72,7 +71,7 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
     else
     {
         CLOG(DEBUG, "SCP") << "Slot::setStateFromEnvelope invalid envelope"
-            << " i: " << getSlotIndex() << " " << envToStr(e);
+                           << " i: " << getSlotIndex() << " " << envToStr(e);
     }
 }
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -138,7 +138,7 @@ TEST_CASE("core topology: 4 ledgers at scales 2..4", "[simulation]")
 
 static void
 hierarchicalTopoTest(int nLedgers, int nBranches, Simulation::Mode mode,
-                 Hash const& networkID)
+                     Hash const& networkID)
 {
     auto tBegin = std::chrono::system_clock::now();
 
@@ -182,7 +182,7 @@ TEST_CASE("hierarchical topology scales 1..3", "[simulation]")
         mode = Simulation::OVER_TCP;
         test();
     }
-    }
+}
 
 static void
 hierarchicalSimplifiedTest(int nLedgers, int nbCore, int nbOuterNodes,

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -37,7 +37,8 @@ class Simulation : public LoadGenerator
 
     typedef std::shared_ptr<Simulation> pointer;
 
-    Simulation(Mode mode, Hash const& networkID, std::function<Config()> confGen = nullptr);
+    Simulation(Mode mode, Hash const& networkID,
+               std::function<Config()> confGen = nullptr);
     ~Simulation();
 
     VirtualClock& getClock();
@@ -77,6 +78,7 @@ class Simulation : public LoadGenerator
     std::string metricsSummary(std::string domain = "");
 
     void addConnection(NodeID initiator, NodeID acceptor);
+
   private:
     void addLoopbackConnection(NodeID initiator, NodeID acceptor);
     void addTCPConnection(NodeID initiator, NodeID acception);
@@ -90,7 +92,7 @@ class Simulation : public LoadGenerator
     std::vector<std::pair<NodeID, NodeID>> mPendingConnections;
     std::vector<std::shared_ptr<LoopbackPeerConnection>> mLoopbackConnections;
 
-    Config newConfig(); // generates a new config
+    Config newConfig();                 // generates a new config
     std::function<Config()> mConfigGen; // config generator
 };
 }

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -10,9 +10,11 @@ namespace stellar
 using namespace std;
 
 Simulation::pointer
-Topologies::pair(Simulation::Mode mode, Hash const& networkID, std::function<Config()> confGen)
+Topologies::pair(Simulation::Mode mode, Hash const& networkID,
+                 std::function<Config()> confGen)
 {
-    Simulation::pointer simulation = make_shared<Simulation>(mode, networkID, confGen);
+    Simulation::pointer simulation =
+        make_shared<Simulation>(mode, networkID, confGen);
 
     SIMULATION_CREATE_NODE(10);
     SIMULATION_CREATE_NODE(11);
@@ -75,9 +77,11 @@ Topologies::cycle4(Hash const& networkID, std::function<Config()> confGen)
 
 Simulation::pointer
 Topologies::core(int nNodes, float quorumThresoldFraction,
-                 Simulation::Mode mode, Hash const& networkID, std::function<Config()> confGen)
+                 Simulation::Mode mode, Hash const& networkID,
+                 std::function<Config()> confGen)
 {
-    Simulation::pointer simulation = make_shared<Simulation>(mode, networkID, confGen);
+    Simulation::pointer simulation =
+        make_shared<Simulation>(mode, networkID, confGen);
 
     vector<SecretKey> keys;
     for (int i = 0; i < nNodes; i++)
@@ -111,9 +115,9 @@ Topologies::core(int nNodes, float quorumThresoldFraction,
     return simulation;
 }
 
-Simulation::pointer
-Topologies::hierarchicalQuorum(int nBranches, Simulation::Mode mode,
-                               Hash const& networkID, std::function<Config()> confGen) // Figure 3 from the paper
+Simulation::pointer Topologies::hierarchicalQuorum(
+    int nBranches, Simulation::Mode mode, Hash const& networkID,
+    std::function<Config()> confGen) // Figure 3 from the paper
 {
     auto sim = Topologies::core(4, 0.75, mode, networkID, confGen);
     vector<NodeID> coreNodeIDs;
@@ -178,7 +182,8 @@ Topologies::hierarchicalQuorum(int nBranches, Simulation::Mode mode,
 Simulation::pointer
 Topologies::hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
                                          Simulation::Mode mode,
-                                         Hash const& networkID, std::function<Config()> confGen)
+                                         Hash const& networkID,
+                                         std::function<Config()> confGen)
 {
     // outer nodes are independent validators that point to a [core network]
     auto sim = Topologies::core(coreSize, 0.75, mode, networkID, confGen);

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -13,16 +13,21 @@ class Topologies
 {
   public:
     static Simulation::pointer pair(Simulation::Mode mode,
-                                    Hash const& networkID, std::function<Config()> confGen=nullptr);
-    static Simulation::pointer cycle4(Hash const& networkID, std::function<Config()> confGen = nullptr);
+                                    Hash const& networkID,
+                                    std::function<Config()> confGen = nullptr);
+    static Simulation::pointer
+    cycle4(Hash const& networkID, std::function<Config()> confGen = nullptr);
     static Simulation::pointer core(int nNodes, float quorumThresoldFraction,
                                     Simulation::Mode mode,
-                                    Hash const& networkID, std::function<Config()> confGen = nullptr);
-    static Simulation::pointer hierarchicalQuorum(int nBranches,
-                                                  Simulation::Mode mode,
-                                                  Hash const& networkID, std::function<Config()> confGen = nullptr);
+                                    Hash const& networkID,
+                                    std::function<Config()> confGen = nullptr);
+    static Simulation::pointer
+    hierarchicalQuorum(int nBranches, Simulation::Mode mode,
+                       Hash const& networkID,
+                       std::function<Config()> confGen = nullptr);
     static Simulation::pointer
     hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
-                                 Simulation::Mode mode, Hash const& networkID, std::function<Config()> confGen = nullptr);
+                                 Simulation::Mode mode, Hash const& networkID,
+                                 std::function<Config()> confGen = nullptr);
 };
 }

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -48,16 +48,16 @@ VirtualClock::maybeSetRealtimer()
         {
             mRealTimer.expires_at(nextp);
             mRealTimer.async_wait([this](asio::error_code const& ec)
-            {
-                if (ec == asio::error::operation_aborted)
-                {
-                    ++this->nRealTimerCancelEvents;
-                }
-                else
-                {
-                    this->advanceToNow();
-                }
-            });
+                                  {
+                                      if (ec == asio::error::operation_aborted)
+                                      {
+                                          ++this->nRealTimerCancelEvents;
+                                      }
+                                      else
+                                      {
+                                          this->advanceToNow();
+                                      }
+                                  });
         }
     }
 }
@@ -316,9 +316,8 @@ VirtualClock::recentIdleCrankPercent() const
         (100ULL * static_cast<uint64_t>(mRecentIdleCrankCount)) /
         static_cast<uint64_t>(mRecentCrankCount));
 
-    LOG(DEBUG) << "Estimated clock loop idle: " << v
-               << "% (" << mRecentIdleCrankCount
-               << "/" << mRecentCrankCount << ")";
+    LOG(DEBUG) << "Estimated clock loop idle: " << v << "% ("
+               << mRecentIdleCrankCount << "/" << mRecentCrankCount << ")";
 
     // This should _really_ never be >100, it's a bug in our code if so.
     assert(v <= 100);


### PR DESCRIPTION
I could not clang-format on my previous PR as people have not been running clang-format themselves (it makes rebasing a pain).
This brings the code base back into a clean state