### PR TITLE
quorum information

### DIFF
--- a/docs/learn/commands.md
+++ b/docs/learn/commands.md
@@ -84,7 +84,8 @@ debugging purpose).
 
 * **quorum**
   `/quorum[&node=NODE_ID]`<br>
-  returns information about the quorum for node NODE_ID (this node by default)
+  returns information about the quorum for node NODE_ID (this node by default).
+  NODE_ID is either a full key (`GABCD...`) or an alias (`$name`)
 
 * **setcursor**
  `/setcursor?id=ID&cursor=N`<br>

--- a/docs/learn/commands.md
+++ b/docs/learn/commands.md
@@ -82,6 +82,10 @@ debugging purpose).
 * **peers**
   Returns the list of known peers in JSON format.
 
+* **quorum**
+  `/quorum[&node=NODE_ID]`<br>
+  returns information about the quorum for node NODE_ID (this node by default)
+
 * **setcursor**
  `/setcursor?id=ID&cursor=N`<br>
   sets or creates a cursor identified by `ID` with value `N`. ID is an uppercase AlphaNum, N is an uint32 that represents the last ledger sequence number that the instance ID processed.

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -296,15 +296,24 @@ mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
 
 
 # QUORUM_SET (object see below) default is empty
-# This is how you specify this server's quorom set.
-# It can be nested 2 levels: (A,B,C,(D,E,F),(G,H,(I,J,K,L)))
-# The THRESHOLD_PERCENT is how many have to agree. The sets are treated 
+# This is how you specify this server's quorum set.
+#
+# It can be nested 2 levels: {A,B,C,{D,E,F},{G,H,{I,J,K,L}}}
+# The THRESHOLD_PERCENT is how many have to agree (1-100%). The sets are treated
 # as one vote. So for example in the above there are 5 things that can vote: 
-# individual validators: A,B,C and sets (D,E,F) and set (G,H with subset (I,J,K,L))
+# individual validators: A,B,C, and the sets {D,E,F} and {G,H with subset {I,J,K,L}}
 # the sets each have their own threshold.
-# This allows you to for example, treat 3 servers of some entity as one vote 
-#  but you only need to hear from 2 of them.
-# THRESHOLD_PERCENT defaults to 67.
+# For example with {100% G,H with subset (50% I,J,K,L}}
+#   means that quorum will be met with G, H and any 2 (50%) of {I, J, K, L}
+#
+# a [QUORUM_SET.path] section is constructed as
+# THRESHOLD_PERCENT: how many have to agree, defaults to 67.
+# VALIDATORS: array of node IDs
+# additional subsets [QUORUM_SET.path.item_number]
+# a QUORUM_SET
+#  must not contain duplicate entries {{A,B},{A,C}} is invalid for example
+#  must contain the validator key (for validators)
+#
 # The following setup is equivalent to the example given above.
 #
 # Note on naming: you can add common names to the NAMED_NODES list here as 
@@ -318,18 +327,18 @@ VALIDATORS=[
 [QUORUM_SET.1]
 THRESHOLD_PERCENT=67
 VALIDATORS=[
-"$self",
-"GDXJAZZJ3H5MJGR6PDQX3JHRREAVYNCVM7FJYGLZJKEHQV2ZXEUO5SX2",
-"GB6GK3WWTZYY2JXWM6C5LRKLQ2X7INQ7IYTSECCG3SMZFYOZNEZR4SO5"]
+"$self", # 'D' from above is this node
+"GDXJAZZJ3H5MJGR6PDQX3JHRREAVYNCVM7FJYGLZJKEHQV2ZXEUO5SX2 E_from_above",
+"GB6GK3WWTZYY2JXWM6C5LRKLQ2X7INQ7IYTSECCG3SMZFYOZNEZR4SO5 F_from_above"]
 [QUORUM_SET.2]
 THRESHOLD_PERCENT=100
 VALIDATORS=[
-"GCTAIXWDDBM3HBDHGSAOLY223QZHPS2EDROF7YUBB3GNYXLOCPV5PXUK",
-"GCJ6UBAOXNQFN3HGLCVQBWGEZO6IABSMNE2OCQC4FJAZXJA5AIE7WSPW"]
+"GCTAIXWDDBM3HBDHGSAOLY223QZHPS2EDROF7YUBB3GNYXLOCPV5PXUK G_from_above",
+"GCJ6UBAOXNQFN3HGLCVQBWGEZO6IABSMNE2OCQC4FJAZXJA5AIE7WSPW H_from_above"]
 [QUORUM_SET.2.1]
 THRESHOLD_PERCENT=50
 VALIDATORS=[
-"GC4X65TQJVI3OWAS4DTA2EN2VNZ5ZRJD646H5WKEJHO5ZHURDRAX2OTH",
-"GAXSWUO4RBELRQT5WMDLIKTRIKC722GGXX2GIGEYQZDQDLOTINQ4DX6F",
-"GAWOEMG7DQDWHCFDTPJEBYWRKUUZTX2M2HLMNABM42G7C7IAPU54GL6X",
-"GDZAJNUUDJFKTZX3YWZSOAS4S4NGCJ5RQAY7JPYBG5CUFL3JZ5C3ECOH"]
+"GC4X65TQJVI3OWAS4DTA2EN2VNZ5ZRJD646H5WKEJHO5ZHURDRAX2OTH I_from_above",
+"GAXSWUO4RBELRQT5WMDLIKTRIKC722GGXX2GIGEYQZDQDLOTINQ4DX6F J_from_above",
+"GAWOEMG7DQDWHCFDTPJEBYWRKUUZTX2M2HLMNABM42G7C7IAPU54GL6X K_from_above",
+"GDZAJNUUDJFKTZX3YWZSOAS4S4NGCJ5RQAY7JPYBG5CUFL3JZ5C3ECOH L_from_above"]

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -308,7 +308,7 @@ PubKeyUtils::fromStrKey(std::string const& s)
         (k.size() != crypto_sign_PUBLICKEYBYTES) ||
         (s.size() != strKey::getStrKeySize(crypto_sign_PUBLICKEYBYTES)))
     {
-        throw std::runtime_error("bad public key");
+        throw std::invalid_argument("bad public key");
     }
     std::copy(k.begin(), k.end(), pk.ed25519().begin());
     return pk;

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -10,4 +10,5 @@ std::chrono::seconds const Herder::CONSENSUS_STUCK_TIMEOUT_SECONDS(35);
 std::chrono::seconds const Herder::MAX_TIME_SLIP_SECONDS(60);
 std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 uint32 const Herder::LEDGER_VALIDITY_BRACKET = 1000;
+uint32 const Herder::MAX_SLOTS_TO_REMEMBER = 4;
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -112,5 +112,6 @@ class Herder
     }
 
     virtual void dumpInfo(Json::Value& ret) = 0;
+    virtual void dumpQuorumInfo(Json::Value& ret, NodeID const& id) = 0;
 };
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -46,8 +46,11 @@ class Herder
     // How many seconds of inactivity before evicting a node.
     static std::chrono::seconds const NODE_EXPIRATION_SECONDS;
 
-    // How many ledger in past/future we consider an envelope viable.
+    // How many ledger in the future we consider an envelope viable.
     static uint32 const LEDGER_VALIDITY_BRACKET;
+
+    // How many ledgers in the past we keep track of
+    static uint32 const MAX_SLOTS_TO_REMEMBER;
 
     static std::unique_ptr<Herder> create(Application& app);
 

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -115,6 +115,7 @@ class Herder
     }
 
     virtual void dumpInfo(Json::Value& ret) = 0;
-    virtual void dumpQuorumInfo(Json::Value& ret, NodeID const& id) = 0;
+    virtual void dumpQuorumInfo(Json::Value& ret, NodeID const& id,
+                                bool summary, uint64 index = 0) = 0;
 };
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1449,6 +1449,14 @@ HerderImpl::dumpInfo(Json::Value& ret)
 }
 
 void
+HerderImpl::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
+{
+    ret["node"] = mApp.getConfig().toShortString(id);
+
+    mSCP.dumpQuorumInfo(ret["slots"], id);
+}
+
+void
 HerderImpl::persistSCPState()
 {
     // saves SCP messages and related data (transaction sets, quorum sets)

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -27,8 +27,6 @@
 
 #include <ctime>
 
-#define MAX_SLOTS_TO_REMEMBER 4
-
 using namespace std;
 
 namespace stellar

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -520,8 +520,9 @@ findOrAdd(HerderImpl::AccountTxMap& acc, AccountID const& aid)
 void
 HerderImpl::logQuorumInformation(uint64 index)
 {
+    std::string res;
     Json::Value v;
-    dumpQuorumInfo(v, mSCP.getLocalNodeID());
+    dumpQuorumInfo(v, mSCP.getLocalNodeID(), true, index);
     auto slots = v.get("slots", "");
     if (!slots.empty())
     {
@@ -564,7 +565,10 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
 
     // log information from older ledger to increase the chances that
     // all messages made it
-    logQuorumInformation(slotIndex - 2);
+    if (slotIndex > 2)
+    {
+        logQuorumInformation(slotIndex - 2);
+    }
 
     // current value is not valid anymore
     mCurrentValue.clear();
@@ -1483,11 +1487,12 @@ HerderImpl::dumpInfo(Json::Value& ret)
 }
 
 void
-HerderImpl::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
+HerderImpl::dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary,
+                           uint64 index)
 {
     ret["node"] = mApp.getConfig().toShortString(id);
 
-    mSCP.dumpQuorumInfo(ret["slots"], id);
+    mSCP.dumpQuorumInfo(ret["slots"], id, summary, index);
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -573,6 +573,12 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
     {
         stateChanged();
     }
+    else if (slotIndex <= mTrackingSCP->mConsensusIndex)
+    {
+        // don't do anything for older slots
+        return;
+    }
+
     mTrackingSCP = make_unique<ConsensusData>(slotIndex, b);
     trackingHeartBeat();
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -119,7 +119,8 @@ class HerderImpl : public Herder, public SCPDriver
                          SCPQuorumSet const& qSet) override;
 
     void dumpInfo(Json::Value& ret) override;
-    void dumpQuorumInfo(Json::Value& ret, NodeID const& id) override;
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary,
+                        uint64 index) override;
 
     struct TxMap
     {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -148,7 +148,7 @@ class HerderImpl : public Herder, public SCPDriver
 
     void updateSCPCounters();
 
-    void processSCPQueueAtIndex(uint64 slotIndex);
+    void processSCPQueueUpToIndex(uint64 slotIndex);
 
     // returns true if the local instance is in a state compatible with
     // this slot

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -132,6 +132,7 @@ class HerderImpl : public Herder, public SCPDriver
     typedef std::unordered_map<AccountID, std::shared_ptr<TxMap>> AccountTxMap;
 
   private:
+    void logQuorumInformation(uint64 index);
     void ledgerClosed();
     void removeReceivedTxs(std::vector<TransactionFramePtr> const& txs);
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -119,6 +119,7 @@ class HerderImpl : public Herder, public SCPDriver
                          SCPQuorumSet const& qSet) override;
 
     void dumpInfo(Json::Value& ret) override;
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id) override;
 
     struct TxMap
     {

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -190,19 +190,20 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
 bool
 PendingEnvelopes::pop(uint64 slotIndex, SCPEnvelope& ret)
 {
-    if (mPendingEnvelopes.find(slotIndex) == mPendingEnvelopes.end())
+    auto it = mPendingEnvelopes.begin();
+    while (it != mPendingEnvelopes.end() && slotIndex >= it->first)
     {
-        return false;
-    }
-    else
-    {
-        if (!mPendingEnvelopes[slotIndex].size())
-            return false;
-        ret = mPendingEnvelopes[slotIndex].back();
-        mPendingEnvelopes[slotIndex].pop_back();
+        auto& v = it->second;
+        if (v.size() != 0)
+        {
+            ret = v.back();
+            v.pop_back();
 
-        return true;
+            return true;
+        }
+        it++;
     }
+    return false;
 }
 
 vector<uint64>
@@ -246,14 +247,20 @@ PendingEnvelopes::eraseBelow(uint64 slotIndex)
 void
 PendingEnvelopes::slotClosed(uint64 slotIndex)
 {
-    mPendingEnvelopes.erase(slotIndex);
+    // stop processing envelopes & downloads for the slot falling off the
+    // window
+    if (slotIndex > Herder::MAX_SLOTS_TO_REMEMBER)
+    {
+        slotIndex -= Herder::MAX_SLOTS_TO_REMEMBER;
 
-    // keep the last few ledgers worth of messages around to give to people
-    mProcessedEnvelopes.erase(slotIndex - 10);
-    mFetchingEnvelopes.erase(slotIndex);
+        mPendingEnvelopes.erase(slotIndex);
 
-    mTxSetFetcher.stopFetchingBelow(slotIndex + 1);
-    mQuorumSetFetcher.stopFetchingBelow(slotIndex + 1);
+        mProcessedEnvelopes.erase(slotIndex);
+        mFetchingEnvelopes.erase(slotIndex);
+
+        mTxSetFetcher.stopFetchingBelow(slotIndex + 1);
+        mQuorumSetFetcher.stopFetchingBelow(slotIndex + 1);
+    }
 }
 
 TxSetFramePtr

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -235,8 +235,9 @@ ApplicationImpl::start()
         !mHerder->isQuorumSetSane(mConfig.NODE_SEED.getPublicKey(),
                                   mConfig.QUORUM_SET))
     {
-        throw std::invalid_argument(
-            "Invalid QUORUM_SET: bad threshold or validator is not a member");
+        throw std::invalid_argument("Invalid QUORUM_SET: bad threshold, "
+                                    "validator is not a member or duplicate "
+                                    "entry");
     }
 
     if (mPersistentState->getState(PersistentState::kDatabaseInitialized) !=

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -278,7 +278,8 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "returns the list of known peers in JSON format"
         "</p><p><h1> /quorum[?node=NODE_ID]</h1>"
         "returns information about the quorum for node NODE_ID (this node by"
-        " default)"
+        " default). NODE_ID is either a full key (`GABCD...`) or an alias "
+        "(`$name)`"
         "</p><p><h1> /scp</h1>"
         "returns a JSON object with the internal state of the SCP engine"
         "</p><p><h1> /tx?blob=HEX</h1>"
@@ -594,8 +595,12 @@ CommandHandler::quorum(std::string const& params, std::string& retStr)
         }
         else
         {
-            n = PubKeyUtils::fromStrKey(nID);
+            if (!mApp.getConfig().resolveNodeID(nID, n))
+            {
+                throw std::invalid_argument("unknown name");
+            }
         }
+
         mApp.getHerder().dumpQuorumInfo(root, n);
 
         retStr = root.toStyledString();

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -403,7 +403,7 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
         root["peers"][counter]["port"] = (int)peer->getRemoteListeningPort();
         root["peers"][counter]["ver"] = peer->getRemoteVersion();
         root["peers"][counter]["olver"] = (int)peer->getRemoteOverlayVersion();
-        root["peers"][counter]["id"] = 
+        root["peers"][counter]["id"] =
             mApp.getConfig().toStrKey(peer->getPeerID());
 
         counter++;

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -41,6 +41,7 @@ class CommandHandler
     void manualClose(std::string const& params, std::string& retStr);
     void metrics(std::string const& params, std::string& retStr);
     void peers(std::string const& params, std::string& retStr);
+    void quorum(std::string const& params, std::string& retStr);
     void setcursor(std::string const& params, std::string& retStr);
     void scpInfo(std::string const& params, std::string& retStr);
     void tx(std::string const& params, std::string& retStr);

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -172,5 +172,6 @@ class Config : public std::enable_shared_from_this<Config>
 
     std::string toShortString(PublicKey const& pk) const;
     std::string toStrKey(PublicKey const& pk) const;
+    bool resolveNodeID(std::string const& s, PublicKey& retKey) const;
 };
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -338,8 +338,9 @@ OverlayManagerImpl::isPeerPreferred(Peer::pointer peer)
             mApp.getConfig().PREFERRED_PEER_KEYS;
         if (std::find(pk.begin(), pk.end(), kstr) != pk.end())
         {
-            CLOG(DEBUG, "Overlay") << "Peer key " << 
-                mApp.getConfig().toStrKey(peer->getPeerID()) << " is preferred";
+            CLOG(DEBUG, "Overlay")
+                << "Peer key " << mApp.getConfig().toStrKey(peer->getPeerID())
+                << " is preferred";
             return true;
         }
     }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1596,6 +1596,19 @@ BallotProtocol::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
                     disagree.append(mSlot.getSCPDriver().toShortString(n));
                 }
             });
+        auto f = LocalNode::findClosestVBlocking(
+            *qSet, mLatestEnvelopes, [&](SCPStatement const& st)
+            {
+                return areBallotsCompatible(getWorkingBallot(st), b);
+            });
+        ret["fail_at"] = f.size();
+
+        auto& f_ex = ret["fail_with"];
+        for (auto const& n : f)
+        {
+            f_ex.append(mSlot.getSCPDriver().toShortString(n));
+        }
+
         ret["agree"] = agree;
     }
 }

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -79,6 +79,9 @@ class BallotProtocol
     // including historical statements if available
     void dumpInfo(Json::Value& ret);
 
+    // returns information about the quorum for a given node
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id);
+
     // returns the hash of the QuorumSet that should be downloaded
     // with the statement.
     // note: the companion hash for an EXTERNALIZE statement does

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -80,7 +80,7 @@ class BallotProtocol
     void dumpInfo(Json::Value& ret);
 
     // returns information about the quorum for a given node
-    void dumpQuorumInfo(Json::Value& ret, NodeID const& id);
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary);
 
     // returns the hash of the QuorumSet that should be downloaded
     // with the statement.

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -99,6 +99,18 @@ class LocalNode
                  return true;
              });
 
+    // computes the distance to the set of v-blocking sets given a set of nodes
+    static std::vector<NodeID>
+    findClosestVBlocking(SCPQuorumSet const& qset,
+                         std::set<NodeID> const& nodes);
+    static std::vector<NodeID> findClosestVBlocking(
+        SCPQuorumSet const& qset, std::map<NodeID, SCPEnvelope> const& map,
+        std::function<bool(SCPStatement const&)> const& filter =
+            [](SCPStatement const&)
+        {
+            return true;
+        });
+
   protected:
     // returns a quorum set {{ nodeID }}
     static SCPQuorumSet buildSingletonQSet(NodeID const& nodeID);

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -31,9 +31,10 @@ class LocalNode
 
     SCP* mSCP;
 
-    // first: nodeID found, second: quorum set well formed
-    static std::pair<bool, bool>
-    isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSet);
+    // returns true if quorum set is well formed
+    // updates knownNodes as it encounters new ones
+    bool isQuorumSetSaneInternal(NodeID const& nodeID, SCPQuorumSet const& qSet,
+                                 std::set<NodeID>& knownNodes);
 
   public:
     LocalNode(SecretKey const& secretKey, bool isValidator,

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -124,6 +124,15 @@ SCP::dumpInfo(Json::Value& ret)
     }
 }
 
+void
+SCP::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
+{
+    for (auto& item : mKnownSlots)
+    {
+        item.second->dumpQuorumInfo(ret, id);
+    }
+}
+
 SecretKey const&
 SCP::getSecretKey()
 {

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -125,11 +125,23 @@ SCP::dumpInfo(Json::Value& ret)
 }
 
 void
-SCP::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
+SCP::dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary,
+                    uint64 index)
 {
-    for (auto& item : mKnownSlots)
+    if (index == 0)
     {
-        item.second->dumpQuorumInfo(ret, id);
+        for (auto& item : mKnownSlots)
+        {
+            item.second->dumpQuorumInfo(ret, id, summary);
+        }
+    }
+    else
+    {
+        auto s = getSlot(index, false);
+        if (s)
+        {
+            s->dumpQuorumInfo(ret, id, summary);
+        }
     }
 }
 

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -73,6 +73,8 @@ class SCP
 
     void dumpInfo(Json::Value& ret);
 
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id);
+
     // Purges all data relative to all the slots whose slotIndex is smaller
     // than the specified `maxSlotIndex`.
     void purgeSlots(uint64 maxSlotIndex);

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -73,7 +73,10 @@ class SCP
 
     void dumpInfo(Json::Value& ret);
 
-    void dumpQuorumInfo(Json::Value& ret, NodeID const& id);
+    // summary: only return object counts
+    // index = 0 for returning information for all slots
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary,
+                        uint64 index = 0);
 
     // Purges all data relative to all the slots whose slotIndex is smaller
     // than the specified `maxSlotIndex`.

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -254,10 +254,10 @@ Slot::dumpInfo(Json::Value& ret)
 }
 
 void
-Slot::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
+Slot::dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary)
 {
     std::string i = std::to_string(static_cast<uint32>(mSlotIndex));
-    mBallotProtocol.dumpQuorumInfo(ret[i], id);
+    mBallotProtocol.dumpQuorumInfo(ret[i], id, summary);
 }
 
 std::string

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -239,8 +239,9 @@ Slot::getQuorumSetFromStatement(SCPStatement const& st)
 void
 Slot::dumpInfo(Json::Value& ret)
 {
-    Json::Value slotValue;
-    slotValue["index"] = static_cast<int>(mSlotIndex);
+    auto& slots = ret["slots"];
+
+    Json::Value& slotValue = slots[std::to_string(mSlotIndex)];
 
     int count = 0;
     for (auto& item : mStatementsHistory)
@@ -250,8 +251,6 @@ Slot::dumpInfo(Json::Value& ret)
 
     mNominationProtocol.dumpInfo(slotValue);
     mBallotProtocol.dumpInfo(slotValue);
-
-    ret["slot"].append(slotValue);
 }
 
 void

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -254,6 +254,13 @@ Slot::dumpInfo(Json::Value& ret)
     ret["slot"].append(slotValue);
 }
 
+void
+Slot::dumpQuorumInfo(Json::Value& ret, NodeID const& id)
+{
+    std::string i = std::to_string(static_cast<uint32>(mSlotIndex));
+    mBallotProtocol.dumpQuorumInfo(ret[i], id);
+}
+
 std::string
 Slot::getValueString(Value const& v) const
 {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -112,6 +112,9 @@ class Slot : public std::enable_shared_from_this<Slot>
     // including historical statements if available
     void dumpInfo(Json::Value& ret);
 
+    // returns information about the quorum for a given node
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id);
+
     // returns the hash of the QuorumSet that should be downloaded
     // with the statement.
     // note: the companion hash for an EXTERNALIZE statement does

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -113,7 +113,7 @@ class Slot : public std::enable_shared_from_this<Slot>
     void dumpInfo(Json::Value& ret);
 
     // returns information about the quorum for a given node
-    void dumpQuorumInfo(Json::Value& ret, NodeID const& id);
+    void dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary);
 
     // returns the hash of the QuorumSet that should be downloaded
     // with the statement.


### PR DESCRIPTION
This PR adds a new endpoint `quorum` to give some insight on the health of a given node (self by default resolves #856 ).
It also adds a summary version of the local node's health information to the `info` endpoint (resolves #855 )
