### PR TITLE
Partially validated slots, improved consensus tracking

### DIFF
--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -814,7 +814,7 @@ TEST_CASE("bucket persistence over app restart", "[bucket][bucketpersist]")
     // pick up the bucket list correctly.
     cfg1.FORCE_SCP = false;
     {
-        Application::pointer app = Application::create(clock, cfg1,false);
+        Application::pointer app = Application::create(clock, cfg1, false);
         app->start();
         BucketList& bl = app->getBucketManager().getBucketList();
 

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -9,6 +9,8 @@ std::chrono::seconds const Herder::MAX_SCP_TIMEOUT_SECONDS(240);
 std::chrono::seconds const Herder::CONSENSUS_STUCK_TIMEOUT_SECONDS(35);
 std::chrono::seconds const Herder::MAX_TIME_SLIP_SECONDS(60);
 std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
-uint32 const Herder::LEDGER_VALIDITY_BRACKET = 1000;
+// the value of LEDGER_VALIDITY_BRACKET should be in the order of
+// how many ledgers can close ahead given CONSENSUS_STUCK_TIMEOUT_SECONDS
+uint32 const Herder::LEDGER_VALIDITY_BRACKET = 100;
 uint32 const Herder::MAX_SLOTS_TO_REMEMBER = 4;
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -81,13 +81,14 @@ class Herder
     // restores SCP state based on the last messages saved on disk
     virtual void restoreSCPState() = 0;
 
-    virtual void recvSCPQuorumSet(Hash hash, SCPQuorumSet const& qset) = 0;
-    virtual void recvTxSet(Hash hash, TxSetFrame const& txset) = 0;
+    virtual void recvSCPQuorumSet(Hash const& hash,
+                                  SCPQuorumSet const& qset) = 0;
+    virtual void recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
     virtual TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, PeerPtr peer) = 0;
-    virtual TxSetFramePtr getTxSet(Hash hash) = 0;
+    virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // We are learning about a new envelope.

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -764,24 +764,30 @@ HerderImpl::combineCandidates(uint64 slotIndex,
 
     // take the txSet with the highest number of transactions,
     // highest xored hash that we have
-    Hash highest;
     TxSetFramePtr bestTxSet;
-    for (auto const& sv : candidateValues)
     {
-        TxSetFramePtr cTxSet = getTxSet(sv.txSetHash);
-
-        if (cTxSet && cTxSet->previousLedgerHash() == lcl.hash)
+        Hash highest;
+        TxSetFramePtr highestTxSet;
+        for (auto const& sv : candidateValues)
         {
-            if (!bestTxSet || (cTxSet->mTransactions.size() >
-                               bestTxSet->mTransactions.size()) ||
-                ((cTxSet->mTransactions.size() ==
-                  bestTxSet->mTransactions.size()) &&
-                 lessThanXored(highest, sv.txSetHash, candidatesHash)))
+            TxSetFramePtr cTxSet = getTxSet(sv.txSetHash);
+
+            if (cTxSet && cTxSet->previousLedgerHash() == lcl.hash)
             {
-                bestTxSet = cTxSet;
-                highest = sv.txSetHash;
+                if (!highestTxSet || (cTxSet->mTransactions.size() >
+                                      highestTxSet->mTransactions.size()) ||
+                    ((cTxSet->mTransactions.size() ==
+                      highestTxSet->mTransactions.size()) &&
+                     lessThanXored(highest, sv.txSetHash, candidatesHash)))
+                {
+                    highestTxSet = cTxSet;
+                    highest = sv.txSetHash;
+                }
             }
         }
+        // make a copy as we're about to modify it and we don't want to mess
+        // with the txSet cache
+        bestTxSet = std::make_shared<TxSetFrame>(*highestTxSet);
     }
 
     for (auto const& upgrade : upgrades)

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -868,22 +868,7 @@ HerderImpl::startRebroadcastTimer()
 void
 HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
 {
-    // this should not happen: if we're just watching consensus
-    // don't send out SCP messages
-    if (!mSCP.isValidator())
-    {
-        return;
-    }
-
     uint64 slotIndex = envelope.statement.slotIndex;
-
-    // SCP may emit envelopes as our instance changes state
-    // yet, we do not want to send those out when we don't do full validation
-    if (!isSlotCompatibleWithCurrentState(slotIndex) &&
-        (!mTrackingSCP || !mLedgerManager.isSynced()))
-    {
-        return;
-    }
 
     CLOG(DEBUG, "Herder") << "emitEnvelope"
                           << " s:" << envelope.statement.pledges.type()

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1023,6 +1023,10 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
         // when tracking, we can filter messages based on the information we got
         // from consensus for the max ledger
 
+        // note that this filtering will cause a node started with force scp
+        // to potentially drop messages outside of the bracket
+        // (so in general, nodes should not be started with force scp if
+        // their state is very old)
         maxLedgerSeq = nextConsensusLedgerIndex() + LEDGER_VALIDITY_BRACKET;
     }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -247,7 +247,7 @@ HerderImpl::validateValueHelper(uint64 slotIndex, StellarValue const& b)
         return SCPDriver::kMaybeValidValue;
     }
 
-    Hash txSetHash = b.txSetHash;
+    Hash const& txSetHash = b.txSetHash;
 
     // we are fully synced up
 
@@ -1251,13 +1251,13 @@ HerderImpl::removeReceivedTxs(std::vector<TransactionFramePtr> const& dropTxs)
 }
 
 void
-HerderImpl::recvSCPQuorumSet(Hash hash, const SCPQuorumSet& qset)
+HerderImpl::recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset)
 {
     mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
 }
 
 void
-HerderImpl::recvTxSet(Hash hash, const TxSetFrame& t)
+HerderImpl::recvTxSet(Hash const& hash, const TxSetFrame& t)
 {
     TxSetFramePtr txset(new TxSetFrame(t));
     mPendingEnvelopes.recvTxSet(hash, txset);
@@ -1271,13 +1271,13 @@ HerderImpl::peerDoesntHave(MessageType type, uint256 const& itemID,
 }
 
 TxSetFramePtr
-HerderImpl::getTxSet(Hash hash)
+HerderImpl::getTxSet(Hash const& hash)
 {
     return mPendingEnvelopes.getTxSet(hash);
 }
 
 SCPQuorumSetPtr
-HerderImpl::getQSet(const Hash& qSetHash)
+HerderImpl::getQSet(Hash const& qSetHash)
 {
     return mPendingEnvelopes.getQSet(qSetHash);
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1478,8 +1478,7 @@ HerderImpl::acceptedCommit(uint64 slotIndex, SCPBallot const& ballot)
 void
 HerderImpl::dumpInfo(Json::Value& ret)
 {
-    ret["you"] =
-        mApp.getConfig().toStrKey(mSCP.getSecretKey().getPublicKey());
+    ret["you"] = mApp.getConfig().toStrKey(mSCP.getSecretKey().getPublicKey());
 
     mSCP.dumpInfo(ret);
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -186,6 +186,10 @@ class HerderImpl : public Herder, public SCPDriver
     // reached consensus it can
     std::unique_ptr<ConsensusData> mTrackingSCP;
 
+    // last slot that was persisted into the database
+    // only keep track of the most recent slot
+    uint64 mLastSlotSaved;
+
     // Mark changes to mTrackingSCP in metrics.
     void stateChanged();
     VirtualClock::time_point mLastStateChange;
@@ -209,7 +213,7 @@ class HerderImpl : public Herder, public SCPDriver
     VirtualTimer mTrackingTimer;
 
     // saves the SCP messages that the instance sent out last
-    void persistSCPState();
+    void persistSCPState(uint64 slot);
 
     // called every time we get ledger externalized
     // ensures that if we don't hear from the network, we throw the herder into

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -61,7 +61,8 @@ class HerderImpl : public Herder, public SCPDriver
     void signEnvelope(SCPEnvelope& envelope) override;
     bool verifyEnvelope(SCPEnvelope const& envelope) override;
 
-    bool validateValue(uint64 slotIndex, Value const& value) override;
+    SCPDriver::ValidationLevel validateValue(uint64 slotIndex,
+                                             Value const& value) override;
 
     Value extractValidValue(uint64 slotIndex, Value const& value) override;
 
@@ -141,7 +142,8 @@ class HerderImpl : public Herder, public SCPDriver
     // in which case it also sets upgradeType
     bool validateUpgradeStep(uint64 slotIndex, UpgradeType const& upgrade,
                              LedgerUpgradeType& upgradeType);
-    bool validateValueHelper(uint64 slotIndex, StellarValue const& sv);
+    SCPDriver::ValidationLevel validateValueHelper(uint64 slotIndex,
+                                                   StellarValue const& sv);
 
     void startRebroadcastTimer();
     void rebroadcast();

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -101,12 +101,12 @@ class HerderImpl : public Herder, public SCPDriver
 
     void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) override;
 
-    void recvSCPQuorumSet(Hash hash, const SCPQuorumSet& qset) override;
-    void recvTxSet(Hash hash, const TxSetFrame& txset) override;
+    void recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset) override;
+    void recvTxSet(Hash const& hash, const TxSetFrame& txset) override;
     void peerDoesntHave(MessageType type, uint256 const& itemID,
                         PeerPtr peer) override;
-    TxSetFramePtr getTxSet(Hash hash) override;
-    SCPQuorumSetPtr getQSet(const Hash& qSetHash) override;
+    TxSetFramePtr getTxSet(Hash const& hash) override;
+    SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;
 
     void processSCPQueue();
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -164,10 +164,6 @@ class HerderImpl : public Herder, public SCPDriver
 
     PendingEnvelopes mPendingEnvelopes;
 
-    std::map<SCPBallot,
-             std::map<NodeID, std::vector<std::shared_ptr<VirtualTimer>>>>
-        mBallotValidationTimers;
-
     void herderOutOfSync();
 
     struct ConsensusData
@@ -257,8 +253,6 @@ class HerderImpl : public Herder, public SCPDriver
         medida::Meter& mEnvelopeSign;
         medida::Meter& mEnvelopeValidSig;
         medida::Meter& mEnvelopeInvalidSig;
-
-        medida::Counter& mBallotValidationTimersSize;
 
         // Counters for stuff in parent class (SCP)
         // that we monitor on a best-effort basis from

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -179,8 +179,12 @@ class HerderImpl : public Herder, public SCPDriver
     // if the local instance is tracking the current state of SCP
     // herder keeps track of the consensus index and ballot
     // when not set, it just means that herder will try to snap to any slot that
-    // reached consensus it can
+    // reached consensus
     std::unique_ptr<ConsensusData> mTrackingSCP;
+
+    // when losing track of consensus, records where we left off so that we
+    // ignore older ledgers (as we potentially receive old messages)
+    std::unique_ptr<ConsensusData> mLastTrackingSCP;
 
     // last slot that was persisted into the database
     // only keep track of the most recent slot

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -652,8 +652,8 @@ TEST_CASE("SCP State", "[herder]")
         // forwarded to node 2 when they connect to it
         // causing node 2 to externalize ledger #2
 
-        sim->addNode(nodeKeys[0], qSetAll, *clock, &nodeCfgs[0],false);
-        sim->addNode(nodeKeys[1], qSetAll, *clock, &nodeCfgs[1],false);
+        sim->addNode(nodeKeys[0], qSetAll, *clock, &nodeCfgs[0], false);
+        sim->addNode(nodeKeys[1], qSetAll, *clock, &nodeCfgs[1], false);
         sim->getNode(nodeIDs[0])->start();
         sim->getNode(nodeIDs[1])->start();
 

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -264,7 +264,7 @@ PendingEnvelopes::slotClosed(uint64 slotIndex)
 }
 
 TxSetFramePtr
-PendingEnvelopes::getTxSet(Hash hash)
+PendingEnvelopes::getTxSet(Hash const& hash)
 {
     if (mTxSetCache.exists(hash))
     {
@@ -275,7 +275,7 @@ PendingEnvelopes::getTxSet(Hash hash)
 }
 
 SCPQuorumSetPtr
-PendingEnvelopes::getQSet(Hash hash)
+PendingEnvelopes::getQSet(Hash const& hash)
 {
     if (mQsetCache.exists(hash))
     {

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -70,11 +70,9 @@ class PendingEnvelopes
 
     std::vector<uint64> readySlots();
 
-    bool isFutureCommitted(uint64 slotIndex);
-
     void dumpInfo(Json::Value& ret);
 
-    TxSetFramePtr getTxSet(Hash hash);
-    SCPQuorumSetPtr getQSet(Hash hash);
+    TxSetFramePtr getTxSet(Hash const& hash);
+    SCPQuorumSetPtr getQSet(Hash const& hash);
 };
 }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -25,6 +25,9 @@ class TxSetFrame
     std::vector<TransactionFramePtr> mTransactions;
 
     TxSetFrame(Hash const& previousLedgerHash);
+
+    TxSetFrame(TxSetFrame const& other) = default;
+
     // make it from the wire
     TxSetFrame(Hash const& networkID, TransactionSet const& xdrSet);
 

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -405,7 +405,7 @@ HistoryTests::catchupNewApplication(uint32_t initLedger,
         getTestConfig(static_cast<int>(mCfgs.size()) + 1, dbMode));
     Application::pointer app2 = Application::create(
         clock, mConfigurator->configure(mCfgs.back(), false));
-    
+
     app2->start();
     CHECK(catchupApplication(initLedger, resumeMode, app2) == true);
     return app2;
@@ -818,7 +818,7 @@ TEST_CASE_METHOD(HistoryTests, "Repair missing buckets via history",
         Application::create(clock, mConfigurator->configure(cfg2, false));
     app2->getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                         state);
-   
+
     app2->start();
 
     auto hash1 = appPtr->getBucketManager().getBucketList().getHash();

--- a/src/ledger/LedgerHeaderTests.cpp
+++ b/src/ledger/LedgerHeaderTests.cpp
@@ -47,7 +47,7 @@ TEST_CASE("ledgerheader", "[ledger]")
         Config cfg2(cfg);
         cfg2.FORCE_SCP = false;
         VirtualClock clock2;
-        Application::pointer app2 = Application::create(clock2, cfg2,false);
+        Application::pointer app2 = Application::create(clock2, cfg2, false);
         app2->start();
 
         REQUIRE(saved ==

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -164,14 +164,13 @@ TEST_CASE("ledger performance test", "[performance][hide]")
     qSet0.threshold = 1;
     qSet0.validators.push_back(v10NodeID);
 
-   
     cfg.DATABASE = "postgresql://host=localhost dbname=performance_test "
                    "user=test password=test";
     cfg.BUCKET_DIR_PATH = "performance-test.db.buckets";
     cfg.MANUAL_CLOSE = true;
     sim.addNode(v10SecretKey, qSet0, sim.getClock(), &cfg);
     sim.mApp = sim.getNodes().front();
-    
+
     sim.startAllNodes();
 
     Timer& ledgerTimer = sim.mApp->getMetrics().NewTimer(

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -13,7 +13,8 @@ Application::pointer
 Application::create(VirtualClock& clock, Config const& cfg, bool newDB)
 {
     Application::pointer ret = make_shared<ApplicationImpl>(clock, cfg);
-    if(newDB || cfg.DATABASE == "sqlite3://:memory:") ret->newDB();
+    if (newDB || cfg.DATABASE == "sqlite3://:memory:")
+        ret->newDB();
 
     return ret;
 }

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -239,7 +239,8 @@ class Application
 
     // Factory: create a new Application object bound to `clock`, with a local
     // copy made of `cfg`.
-    static pointer create(VirtualClock& clock, Config const& cfg,bool newDB=true);
+    static pointer create(VirtualClock& clock, Config const& cfg,
+                          bool newDB = true);
 
   protected:
     Application()

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -67,7 +67,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
 
     unsigned t = std::thread::hardware_concurrency();
     LOG(DEBUG) << "Application constructing "
-              << "(worker threads: " << t << ")";
+               << "(worker threads: " << t << ")";
     mStopSignals.async_wait([this](asio::error_code const& ec, int sig)
                             {
                                 if (!ec)
@@ -82,7 +82,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     // into App.getFoo() to get information / start up.
     mDatabase = make_unique<Database>(*this);
     mPersistentState = make_unique<PersistentState>(*this);
-   
+
     mTmpDirManager = make_unique<TmpDirManager>(cfg.TMP_DIR_PATH);
     mOverlayManager = OverlayManager::create(*this);
     mLedgerManager = LedgerManager::create(*this);
@@ -103,7 +103,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     LOG(DEBUG) << "Application constructed";
 }
 
-void 
+void
 ApplicationImpl::newDB()
 {
     mDatabase->initialize();
@@ -209,8 +209,8 @@ ApplicationImpl::start()
 {
     mDatabase->upgradeToCurrentSchema();
 
-    if(mPersistentState->getState(
-        PersistentState::kForceSCPOnNextLaunch) == "true")
+    if (mPersistentState->getState(PersistentState::kForceSCPOnNextLaunch) ==
+        "true")
     {
         mConfig.FORCE_SCP = true;
     }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -636,8 +636,8 @@ Config::validateConfig()
             {
                 LOG(ERROR)
                     << "Not enough nodes / thresholds too strict in your "
-                    "Quorum set to ensure your  desired level of "
-                    "FAILURE_SAFETY.";
+                       "Quorum set to ensure your  desired level of "
+                       "FAILURE_SAFETY.";
                 throw std::invalid_argument("SCP unsafe");
             }
 
@@ -713,7 +713,7 @@ Config::toShortString(PublicKey const& pk) const
     std::string ret = PubKeyUtils::toStrKey(pk);
     auto it = VALIDATOR_NAMES.find(ret);
     if (it == VALIDATOR_NAMES.end())
-        return ret.substr(0,5);
+        return ret.substr(0, 5);
     else
         return it->second;
 }
@@ -739,18 +739,19 @@ Config::resolveNodeID(std::string const& s, PublicKey& retKey) const
         if (s[0] == '$')
         {
             it = std::find_if(VALIDATOR_NAMES.begin(), VALIDATOR_NAMES.end(),
-                                   [&](std::pair<std::string, std::string> const& p)
-            {
-                return p.second == arg;
-            });
+                              [&](std::pair<std::string, std::string> const& p)
+                              {
+                                  return p.second == arg;
+                              });
         }
         else if (s[0] == '@')
         {
             it = std::find_if(VALIDATOR_NAMES.begin(), VALIDATOR_NAMES.end(),
                               [&](std::pair<std::string, std::string> const& p)
-            {
-                return p.first.compare(0, arg.size(), arg) == 0;
-            });
+                              {
+                                  return p.first.compare(0, arg.size(), arg) ==
+                                         0;
+                              });
         }
 
         if (it == VALIDATOR_NAMES.end())

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -134,8 +134,9 @@ ExternalQueue::process()
     // publication and the requirements of our pubsub subscribers.
     uint32_t cmin = std::min(lmin, rmin);
 
-    CLOG(DEBUG,"History") << "Trimming history <= ledger " << cmin << " (rmin=" << rmin
-              << ", qmin=" << qmin << ", lmin=" << lmin << ")";
+    CLOG(DEBUG, "History") << "Trimming history <= ledger " << cmin
+                           << " (rmin=" << rmin << ", qmin=" << qmin
+                           << ", lmin=" << lmin << ")";
 
     mApp.getLedgerManager().deleteOldEntries(mApp.getDatabase(), cmin);
 }

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -13,8 +13,8 @@ namespace stellar
 using namespace std;
 
 string PersistentState::mapping[kLastEntry] = {
-    "lastclosedledger",    "historyarchivestate", "forcescponnextlaunch",
-     "lastscpdata",         "databaseschema"};
+    "lastclosedledger", "historyarchivestate", "forcescponnextlaunch",
+    "lastscpdata", "databaseschema"};
 
 string PersistentState::kSQLCreateStatement =
     "CREATE TABLE IF NOT EXISTS storestate ("
@@ -24,7 +24,6 @@ string PersistentState::kSQLCreateStatement =
 
 PersistentState::PersistentState(Application& app) : mApp(app)
 {
-    
 }
 
 void

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -202,7 +202,7 @@ void
 loadXdr(Config const& cfg, std::string const& bucketFile)
 {
     VirtualClock clock;
-    Application::pointer app = Application::create(clock, cfg,false);
+    Application::pointer app = Application::create(clock, cfg, false);
     if (checkInitialized(app))
     {
         uint256 zero;
@@ -235,8 +235,8 @@ initializeHistories(Config& cfg, vector<string> newHistories)
 
     for (auto const& arch : newHistories)
     {
-        if(!HistoryManager::initializeHistoryArchive(*app, arch))
-                    return 1;           
+        if (!HistoryManager::initializeHistoryArchive(*app, arch))
+            return 1;
     }
     return 0;
 }
@@ -394,7 +394,8 @@ main(int argc, char* const* argv)
             s += cfgFile + " found";
             throw std::invalid_argument(s);
         }
-        Logging::setFmt(PubKeyUtils::toShortString(cfg.NODE_SEED.getPublicKey()));
+        Logging::setFmt(
+            PubKeyUtils::toShortString(cfg.NODE_SEED.getPublicKey()));
         Logging::setLogLevel(logLevel, nullptr);
 
         if (command.size())
@@ -408,7 +409,6 @@ main(int argc, char* const* argv)
             Logging::setLoggingToFile(cfg.LOG_FILE_PATH);
         Logging::setLogLevel(logLevel, nullptr);
 
-        
         cfg.REPORT_METRICS = metrics;
 
         if (forceSCP || newDB || getInfo || !loadXdrBucket.empty())

--- a/src/overlay/OverlayManagerTests.cpp
+++ b/src/overlay/OverlayManagerTests.cpp
@@ -108,7 +108,6 @@ class OverlayManagerTests
     {
         OverlayManagerStub& pm = app.getOverlayManager();
 
-
         pm.storePeerList(fourPeers);
 
         rowset<row> rs = app.getDatabase().getSession().prepare

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1430,9 +1430,15 @@ std::vector<SCPEnvelope>
 BallotProtocol::getCurrentState() const
 {
     std::vector<SCPEnvelope> res;
-    for (auto it : mLatestEnvelopes)
+    res.reserve(mLatestEnvelopes.size());
+    for (auto const& n : mLatestEnvelopes)
     {
-        res.emplace_back(it.second);
+        // only return messages for self if the slot is fully validated
+        if (!(n.first == mSlot.getSCP().getLocalNodeID()) ||
+            mSlot.isFullyValidated())
+        {
+            res.emplace_back(n.second);
+        }
     }
     return res;
 }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -588,7 +588,10 @@ BallotProtocol::emitCurrentStateStatement()
             isNewerStatement(mLastEnvelope->statement, envelope.statement))
         {
             mLastEnvelope = make_unique<SCPEnvelope>(envelope);
-            mSlot.getSCPDriver().emitEnvelope(envelope);
+            if (mSlot.isFullyValidated())
+            {
+                mSlot.getSCPDriver().emitEnvelope(envelope);
+            }
         }
     }
     else

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -164,13 +164,20 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
 
     SCPBallot wb = getWorkingBallot(statement);
 
-    if (mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), wb.value))
+    auto validationRes =
+        mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), wb.value);
+    if (validationRes != SCPDriver::kInvalidValue)
     {
         bool processed = false;
         SCPBallot tickBallot = getWorkingBallot(statement);
 
         if (mPhase != SCP_PHASE_EXTERNALIZE)
         {
+            if (validationRes == SCPDriver::kMaybeValidValue)
+            {
+                mSlot.setFullyValidated(false);
+            }
+
             switch (statement.pledges.type())
             {
             case SCPStatementType::SCP_ST_PREPARE:

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -71,7 +71,7 @@ NominationProtocol::isSubsetHelper(xdr::xvector<Value> const& p,
     return res;
 }
 
-bool
+SCPDriver::ValidationLevel
 NominationProtocol::validateValue(Value const& v)
 {
     return mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v);
@@ -274,7 +274,8 @@ NominationProtocol::getNewValueFromNomination(SCPNomination const& nom)
     applyAll(nom, [&](Value const& value)
              {
                  Value valueToNominate;
-                 if (validateValue(value))
+                 auto vl = validateValue(value);
+                 if (vl == SCPDriver::kFullyValidatedValue)
                  {
                      valueToNominate = value;
                  }
@@ -340,7 +341,8 @@ NominationProtocol::processEnvelope(SCPEnvelope const& envelope)
                                       _1),
                             mLatestNominations))
                     {
-                        if (validateValue(v))
+                        auto vl = validateValue(v);
+                        if (vl == SCPDriver::kFullyValidatedValue)
                         {
                             mAccepted.emplace(v);
                             mVotes.emplace(v);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -166,7 +166,10 @@ NominationProtocol::emitNomination()
                              st.pledges.nominate()))
         {
             mLastEnvelope = make_unique<SCPEnvelope>(envelope);
-            mSlot.getSCPDriver().emitEnvelope(envelope);
+            if (mSlot.isFullyValidated())
+            {
+                mSlot.getSCPDriver().emitEnvelope(envelope);
+            }
         }
     }
     else

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -570,9 +570,15 @@ std::vector<SCPEnvelope>
 NominationProtocol::getCurrentState() const
 {
     std::vector<SCPEnvelope> res;
-    for (auto it : mLatestNominations)
+    res.reserve(mLatestNominations.size());
+    for (auto const& n : mLatestNominations)
     {
-        res.emplace_back(it.second);
+        // only return messages for self if the slot is fully validated
+        if (!(n.first == mSlot.getSCP().getLocalNodeID()) ||
+            mSlot.isFullyValidated())
+        {
+            res.emplace_back(n.second);
+        }
     }
     return res;
 }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -49,7 +49,7 @@ class NominationProtocol
     static bool isSubsetHelper(xdr::xvector<Value> const& p,
                                xdr::xvector<Value> const& v, bool& notEqual);
 
-    bool validateValue(Value const& v);
+    SCPDriver::ValidationLevel validateValue(Value const& v);
     Value extractValidValue(Value const& value);
 
     bool isSane(SCPStatement const& st);

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -46,16 +46,27 @@ class SCPDriver
     // is done. It should be used to filter out values that are not compatible
     // with the current state of that node. Unvalidated values can never
     // externalize.
-    virtual bool
+    // If the value cannot be validated (node is missing some context) but
+    // passes
+    // the validity checks, kMaybeValidValue can be returned. This will cause
+    // the current slot to be marked as a non validating slot: the local node
+    // will abstain from emiting its position.
+    enum ValidationLevel
+    {
+        kInvalidValue,        // value is invalid for sure
+        kFullyValidatedValue, // value is valid for sure
+        kMaybeValidValue      // value may be valid
+    };
+    virtual ValidationLevel
     validateValue(uint64 slotIndex, Value const& value)
     {
-        return true;
+        return kMaybeValidValue;
     }
 
     // `extractValidValue` transforms the value, if possible to a different
-    // value that the local node would agree to.
+    // value that the local node would agree to (fully validated).
     // This is used during nomination when encountering an invalid value (ie
-    // validateValue returned `false` for this value).
+    // validateValue did not return `kFullyValidatedValue` for this value).
     // returning Value() means no valid value could be extracted
     virtual Value
     extractValidValue(uint64 slotIndex, Value const& value)

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -67,10 +67,10 @@ class TestSCP : public SCPDriver
         mQuorumSets[qSetHash] = qSet;
     }
 
-    bool
+    SCPDriver::ValidationLevel
     validateValue(uint64 slotIndex, Value const& value) override
     {
-        return true;
+        return SCPDriver::kFullyValidatedValue;
     }
 
     void

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -40,16 +40,19 @@ std::vector<SCPEnvelope>
 Slot::getLatestMessagesSend() const
 {
     std::vector<SCPEnvelope> res;
-    SCPEnvelope* e;
-    e = mNominationProtocol.getLastMessageSend();
-    if (e)
+    if (mFullyValidated)
     {
-        res.emplace_back(*e);
-    }
-    e = mBallotProtocol.getLastMessageSend();
-    if (e)
-    {
-        res.emplace_back(*e);
+        SCPEnvelope* e;
+        e = mNominationProtocol.getLastMessageSend();
+        if (e)
+        {
+            res.emplace_back(*e);
+        }
+        e = mBallotProtocol.getLastMessageSend();
+        if (e)
+        {
+            res.emplace_back(*e);
+        }
     }
     return res;
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -89,7 +89,7 @@ Slot::getCurrentState() const
 void
 Slot::recordStatement(SCPStatement const& st)
 {
-    mStatementsHistory.emplace_back(st);
+    mStatementsHistory.emplace_back(std::make_pair(st, mFullyValidated));
 }
 
 SCP::EnvelopeState
@@ -257,9 +257,11 @@ Slot::dumpInfo(Json::Value& ret)
     Json::Value& slotValue = slots[std::to_string(mSlotIndex)];
 
     int count = 0;
-    for (auto& item : mStatementsHistory)
+    for (auto const& item : mStatementsHistory)
     {
-        slotValue["statements"][count++] = envToStr(item);
+        Json::Value& v = slotValue["statements"][count++];
+        v.append(envToStr(item.first));
+        v.append(item.second);
     }
 
     slotValue["validated"] = mFullyValidated;

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -26,6 +26,7 @@ Slot::Slot(uint64 slotIndex, SCP& scp)
     , mSCP(scp)
     , mBallotProtocol(*this)
     , mNominationProtocol(*this)
+    , mFullyValidated(scp.getLocalNode()->isValidator())
 {
 }
 
@@ -148,6 +149,18 @@ Slot::nominate(Value const& value, Value const& previousValue, bool timedout)
     return mNominationProtocol.nominate(value, previousValue, timedout);
 }
 
+bool
+Slot::isFullyValidated() const
+{
+    return mFullyValidated;
+}
+
+void
+Slot::setFullyValidated(bool fullyValidated)
+{
+    mFullyValidated = fullyValidated;
+}
+
 SCPEnvelope
 Slot::createEnvelope(SCPStatement const& statement)
 {
@@ -249,6 +262,7 @@ Slot::dumpInfo(Json::Value& ret)
         slotValue["statements"][count++] = envToStr(item);
     }
 
+    slotValue["validated"] = mFullyValidated;
     mNominationProtocol.dumpInfo(slotValue);
     mBallotProtocol.dumpInfo(slotValue);
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -418,4 +418,15 @@ Slot::getLocalNode()
 {
     return mSCP.getLocalNode();
 }
+
+std::vector<SCPEnvelope>
+Slot::getEntireCurrentState()
+{
+    bool old = mFullyValidated;
+    // fake fully validated to force returning all envelopes
+    mFullyValidated = true;
+    auto r = getCurrentState();
+    mFullyValidated = old;
+    return r;
+}
 }

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -162,5 +162,9 @@ class Slot : public std::enable_shared_from_this<Slot>
         NOMINATION_TIMER = 0,
         BALLOT_PROTOCOL_TIMER = 1
     };
+
+  protected:
+    std::vector<SCPEnvelope> getEntireCurrentState();
+    friend class TestSCP;
 };
 }

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -34,6 +34,9 @@ class Slot : public std::enable_shared_from_this<Slot>
     // it is used for debugging purpose
     std::vector<SCPStatement> mStatementsHistory;
 
+    // true if the Slot was fully validated
+    bool mFullyValidated;
+
   public:
     Slot(uint64 slotIndex, SCP& SCP);
 
@@ -99,6 +102,9 @@ class Slot : public std::enable_shared_from_this<Slot>
     // attempts to nominate a value for consensus
     bool nominate(Value const& value, Value const& previousValue,
                   bool timedout);
+
+    bool isFullyValidated() const;
+    void setFullyValidated(bool fullyValidated);
 
     // ** status methods
 

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -32,7 +32,8 @@ class Slot : public std::enable_shared_from_this<Slot>
 
     // keeps track of all statements seen so far for this slot.
     // it is used for debugging purpose
-    std::vector<SCPStatement> mStatementsHistory;
+    // second: if the slot was fully validated at the time
+    std::vector<std::pair<SCPStatement, bool>> mStatementsHistory;
 
     // true if the Slot was fully validated
     bool mFullyValidated;

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -54,7 +54,7 @@ Simulation::getClock()
 
 NodeID
 Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
-                    Config const* cfg2, bool newDB )
+                    Config const* cfg2, bool newDB)
 {
     std::shared_ptr<Config> cfg;
     if (!cfg2)

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -44,7 +44,7 @@ class Simulation : public LoadGenerator
     VirtualClock& getClock();
 
     NodeID addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
-                   Config const* cfg = nullptr,bool newDB=true);
+                   Config const* cfg = nullptr, bool newDB = true);
     Application::pointer getNode(NodeID nodeID);
     std::vector<Application::pointer> getNodes();
     std::vector<NodeID> getNodeIDs();

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -28,8 +28,7 @@ Logging::setFmt(std::string const& peerID, bool timestamps)
     {
         datetime = "%datetime{%Y-%M-%dT%H:%m:%s.%g}";
     }
-    std::string shortFmt =
-        datetime + " " + peerID + " [%logger %level] %msg";
+    std::string shortFmt = datetime + " " + peerID + " [%logger %level] %msg";
     std::string longFmt = shortFmt + " [%fbase:%line]";
 
     gDefaultConf.setGlobally(el::ConfigurationType::Format, shortFmt);


### PR DESCRIPTION
This PR adds a new property to the SCP slot to distinguish between fully validated and partially validated slots (validate value now returns a `maybe valid` state).

A validator not capable of validating values will return `maybe valid` during those checks, which causes the slot to be marked as not fully validated.

When a slot is marked as such, the validator will never publish SCP statements for it (resolves #867 ).

This allows to avoid situations where invalid values confuse the system.
This likely resolves #884 (crash)

This PR also changes the way herder keeps track of consensus:
it enforces that externalize messages are strictly monotonic, even when getting in and out of sync.
This allows to better manage older slots life cyle (timers in particular).


Other misc changes:
 * include latest SCP statements (not just from last SCP round), when exchanging SCP messages at connection time
 * reduce SCP window in herder (was 1000 ledgers in the future even when in sync)
 * potential txSet corruption fix
 * cleanup, format
