### PR TITLE
Stop nomination when a ledger closes

### DIFF
--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -224,6 +224,8 @@ class HerderImpl : public Herder, public SCPDriver
     VirtualTimer mTriggerTimer;
 
     VirtualTimer mRebroadcastTimer;
+
+    uint32_t mLedgerSeqNominating;
     Value mCurrentValue;
 
     // timers used by SCP

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -162,14 +162,13 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
         return SCP::EnvelopeState::INVALID;
     }
 
-    SCPBallot wb = getWorkingBallot(statement);
+    SCPBallot tickBallot = getWorkingBallot(statement);
 
-    auto validationRes =
-        mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), wb.value);
+    auto validationRes = mSlot.getSCPDriver().validateValue(
+        mSlot.getSlotIndex(), tickBallot.value);
     if (validationRes != SCPDriver::kInvalidValue)
     {
         bool processed = false;
-        SCPBallot tickBallot = getWorkingBallot(statement);
 
         if (mPhase != SCP_PHASE_EXTERNALIZE)
         {
@@ -184,7 +183,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope)
             {
                 recordEnvelope(envelope);
                 processed = true;
-                advanceSlot(statement.pledges.prepare().ballot);
+                advanceSlot(tickBallot);
                 res = SCP::EnvelopeState::VALID;
             }
             break;
@@ -1188,6 +1187,8 @@ BallotProtocol::attemptConfirmCommit(SCPBallot const& acceptCommitLow,
     mPhase = SCP_PHASE_EXTERNALIZE;
 
     emitCurrentStateStatement();
+
+    mSlot.stopNomination();
 
     mSlot.getSCPDriver().valueExternalized(mSlot.getSlotIndex(),
                                            mCurrentBallot->value);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -446,6 +446,12 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
 
     bool updated = false;
 
+    if (timedout && !mNominationStarted)
+    {
+        CLOG(DEBUG, "SCP") << "NominationProtocol::nominate (TIMED OUT)";
+        return false;
+    }
+
     mNominationStarted = true;
 
     mPreviousValue = previousValue;
@@ -506,6 +512,12 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
     }
 
     return updated;
+}
+
+void
+NominationProtocol::stopNomination()
+{
+    mNominationStarted = false;
 }
 
 void

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -93,6 +93,9 @@ class NominationProtocol
     bool nominate(Value const& value, Value const& previousValue,
                   bool timedout);
 
+    // stops the nomination protocol
+    void stopNomination();
+
     Value const&
     getLatestCompositeCandidate() const
     {

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -55,6 +55,16 @@ SCP::nominate(uint64 slotIndex, Value const& value, Value const& previousValue)
 }
 
 void
+SCP::stopNomination(uint64 slotIndex)
+{
+    auto s = getSlot(slotIndex, false);
+    if (s)
+    {
+        s->stopNomination();
+    }
+}
+
+void
 SCP::updateLocalQuorumSet(SCPQuorumSet const& qSet)
 {
     mLocalNode->updateQuorumSet(qSet);

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -61,6 +61,9 @@ class SCP
     bool nominate(uint64 slotIndex, Value const& value,
                   Value const& previousValue);
 
+    // stops nomination for a slot
+    void stopNomination(uint64 slotIndex);
+
     // Local QuorumSet interface (can be dynamically updated)
     void updateLocalQuorumSet(SCPQuorumSet const& qSet);
     SCPQuorumSet const& getLocalQuorumSet();

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -152,6 +152,12 @@ Slot::nominate(Value const& value, Value const& previousValue, bool timedout)
     return mNominationProtocol.nominate(value, previousValue, timedout);
 }
 
+void
+Slot::stopNomination()
+{
+    mNominationProtocol.stopNomination();
+}
+
 bool
 Slot::isFullyValidated() const
 {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -104,6 +104,8 @@ class Slot : public std::enable_shared_from_this<Slot>
     bool nominate(Value const& value, Value const& previousValue,
                   bool timedout);
 
+    void stopNomination();
+
     bool isFullyValidated() const;
     void setFullyValidated(bool fullyValidated);
 


### PR DESCRIPTION
Nomination is started when a validator is "in sync", the problem was that it would still accept messages for nomination that potentially accept new values, the code would crash as values are invalid then (the transaction set cannot be applied to the new ledger).
resolves #889 

I also fixed an issue with the way configs are parsed, resolves #887 
