### PR TITLE
scp info endpoint improvements

### DIFF
--- a/docs/learn/commands.md
+++ b/docs/learn/commands.md
@@ -97,7 +97,8 @@ debugging purpose).
   The actual deletion is performed by invoking the `maintenance` endpoint.
 
 * **scp**
-  Returns a JSON object with the internal state of the SCP engine.
+  `/scp?[limit=n]
+  Returns a JSON object with the internal state of the SCP engine for the last n (default 2) ledgers.
 
 * **tx**
   `/tx?blob=Base64`<br>

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -118,7 +118,7 @@ class Herder
     {
     }
 
-    virtual void dumpInfo(Json::Value& ret) = 0;
+    virtual void dumpInfo(Json::Value& ret, size_t limit) = 0;
     virtual void dumpQuorumInfo(Json::Value& ret, NodeID const& id,
                                 bool summary, uint64 index = 0) = 0;
 };

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1473,11 +1473,11 @@ HerderImpl::acceptedCommit(uint64 slotIndex, SCPBallot const& ballot)
 }
 
 void
-HerderImpl::dumpInfo(Json::Value& ret)
+HerderImpl::dumpInfo(Json::Value& ret, size_t limit)
 {
     ret["you"] = mApp.getConfig().toStrKey(mSCP.getSecretKey().getPublicKey());
 
-    mSCP.dumpInfo(ret);
+    mSCP.dumpInfo(ret, limit);
 
     mPendingEnvelopes.dumpInfo(ret);
 }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -122,7 +122,7 @@ class HerderImpl : public Herder, public SCPDriver
 
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 
-    void dumpInfo(Json::Value& ret) override;
+    void dumpInfo(Json::Value& ret, size_t limit) override;
     void dumpQuorumInfo(Json::Value& ret, NodeID const& id, bool summary,
                         uint64 index) override;
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -281,8 +281,9 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         " default). NODE_ID is either a full key (`GABCD...`), an alias "
         "(`$name`) or an abbreviated ID(`@GABCD`)."
         "If compact is set, only returns a summary version."
-        "</p><p><h1> /scp</h1>"
-        "returns a JSON object with the internal state of the SCP engine"
+        "</p><p><h1> /scp?[limit=n]</h1>"
+        "returns a JSON object with the internal state of the SCP engine for "
+        "the last n (default 2) ledgers."
         "</p><p><h1> /tx?blob=HEX</h1>"
         "submit a transaction to the network.<br>"
         "blob is a hex encoded XDR serialized 'TransactionEnvelope'<br>"
@@ -632,7 +633,21 @@ CommandHandler::scpInfo(std::string const& params, std::string& retStr)
 {
     Json::Value root;
 
-    mApp.getHerder().dumpInfo(root);
+    std::map<std::string, std::string> retMap;
+    http::server::server::parseParams(params, retMap);
+
+    size_t lim = 2;
+    std::string limStr = retMap["limit"];
+    if (!limStr.empty())
+    {
+        size_t n = strtoul(limStr.c_str(), NULL, 0);
+        if (n != 0)
+        {
+            lim = n;
+        }
+    }
+
+    mApp.getHerder().dumpInfo(root, lim);
 
     retStr = root.toStyledString();
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -126,11 +126,13 @@ SCP::getSlot(uint64 slotIndex, bool create)
 }
 
 void
-SCP::dumpInfo(Json::Value& ret)
+SCP::dumpInfo(Json::Value& ret, size_t limit)
 {
-    for (auto& item : mKnownSlots)
+    auto it = mKnownSlots.rbegin();
+    while (it != mKnownSlots.rend() && limit-- != 0)
     {
-        item.second->dumpInfo(ret);
+        it->second->dumpInfo(ret);
+        it++;
     }
 }
 

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -74,7 +74,7 @@ class SCP
     // returns the local node descriptor
     std::shared_ptr<LocalNode> getLocalNode();
 
-    void dumpInfo(Json::Value& ret);
+    void dumpInfo(Json::Value& ret, size_t limit);
 
     // summary: only return object counts
     // index = 0 for returning information for all slots


### PR DESCRIPTION
Couple of changes to the /scp endpoint.

Added a limit to change the number of slots to return (was all known slots, now defaults to 2 most recent)

Added quorum set info (to diagnose any potential quorum intersection issue):
a new section called `quorum_sets` is now added next to statements, that allows to map hashes to the quorum sets used in the `statements` section.

```
        "quorum_sets" : {
            "273af2" : {
               "t" : 2,
               "v" : [ "sdf1", "sdf2", "sdf3" ]
            }
         },
         "statements" : [
            [
               "{ENV@sdf3 |  i: 542793 | NOMINATE | D: 273af2 | X: { '[  txH: a4fd17, ct: 1446763586, upgrades: [ ] ]',} | Y: {} }",
               false
            ],
```
