### PR TITLE
Overlay busy fetch

### DIFF
--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -182,7 +182,9 @@ Tracker::tryNextPeer()
                            << (mLastAskedPeer ? mLastAskedPeer->toString()
                                               : "<none>");
 
-    if (mPeersToAsk.empty())
+    // if we don't have a list of peers to ask and we're not
+    // currently asking peers, build a new list
+    if (mPeersToAsk.empty() && !mLastAskedPeer)
     {
         std::set<std::shared_ptr<Peer>> peersWithEnvelope;
         for (auto const& e : mWaitingEnvelopes)
@@ -225,8 +227,9 @@ Tracker::tryNextPeer()
     std::chrono::milliseconds nextTry;
     if (!peer)
     { // we have asked all our peers
-        // clear list and try again in a bit
-        nextTry = MS_TO_WAIT_FOR_FETCH_REPLY * 2;
+        // clear mLastAskedPeer so that we rebuild a new list
+        mLastAskedPeer.reset();
+        if (mNumListRebuild > MAX_REBUILD_FETCH_LIST)
     }
     else
     {

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -45,6 +45,7 @@ class Tracker
     template <class T> friend class ItemFetcher;
     Application& mApp;
     Peer::pointer mLastAskedPeer;
+    int mNumListRebuild;
     std::deque<Peer::pointer> mPeersToAsk;
     VirtualTimer mTimer;
     bool mIsStopped = false;


### PR DESCRIPTION
in some cases nodes may ask for the same content in a busy loop, causing high CPU usage

resolves #919 
