### PR TITLE
renamed info command line into offlineinfo

### DIFF
--- a/docs/learn/admin.md
+++ b/docs/learn/admin.md
@@ -322,7 +322,7 @@ Run:
 
 # Understanding the availability and health of your instance
 ## General info
-Run `$ stellar-core --c 'quorum'`
+Run `$ stellar-core --c 'info'`
 The output will look something like
 ```
    "info" : {

--- a/docs/learn/commands.md
+++ b/docs/learn/commands.md
@@ -25,7 +25,7 @@ forcescp doesn't change the requirements for quorum so although this node will e
 * **--fuzz FILE**: Run a single fuzz input and exit.
 * **--genfuzz FILE**:  Generate a random fuzzer input file.
 * **--genseed**: Generate and print a random public/private key and then exit.
-* **--info**: Shortcut for `--c info`
+* **--offlineinfo**: Returns an output similar to `--c info` for an offline instance
 * **--ll LEVEL**: Set the log level. It is redundant with `--c ll` but we need this form if you want to change the log level during test runs.
 * **--metric METRIC**: Report metric METRIC on exit. Used for gathering a metric cumulatively during a test run.
 * **--newdb**: Clears the local database and resets it to the genesis ledger. If you connect to the network after that it will catch up from scratch. 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -42,7 +42,7 @@ enum opttag
     OPT_GENFUZZ,
     OPT_GENSEED,
     OPT_HELP,
-    OPT_INFO,
+    OPT_OFFLINEINFO,
     OPT_LOGLEVEL,
     OPT_METRIC,
     OPT_NEWDB,
@@ -62,7 +62,7 @@ static const struct option stellar_core_options[] = {
     {"genfuzz", required_argument, nullptr, OPT_GENFUZZ},
     {"genseed", no_argument, nullptr, OPT_GENSEED},
     {"help", no_argument, nullptr, OPT_HELP},
-    {"info", no_argument, nullptr, OPT_INFO},
+    {"offlineinfo", no_argument, nullptr, OPT_OFFLINEINFO},
     {"ll", required_argument, nullptr, OPT_LOGLEVEL},
     {"metric", required_argument, nullptr, OPT_METRIC},
     {"newdb", no_argument, nullptr, OPT_NEWDB},
@@ -91,7 +91,7 @@ usage(int err = 1)
           "      --genfuzz FILE  Generate a random fuzzer input file\n "
           "      --genseed       Generate and print a random node seed\n"
           "      --help          To display this string\n"
-          "      --info          Returns some information on the instance\n"
+          "      --offlineinfo   Returns information for an offline instance\n"
           "      --ll LEVEL      Set the log level. (redundant with --c ll but "
           "you need this form for the tests.)\n"
           "                      LEVEL can be:\n"
@@ -161,7 +161,7 @@ sendCommand(std::string const& command, const std::vector<char*>& rest,
     }
 }
 
-bool
+static bool
 checkInitialized(Application::pointer app)
 {
     try
@@ -179,7 +179,7 @@ checkInitialized(Application::pointer app)
     return true;
 }
 
-void
+static void
 setForceSCPFlag(Config const& cfg, bool isOn)
 {
     VirtualClock clock;
@@ -211,8 +211,8 @@ setForceSCPFlag(Config const& cfg, bool isOn)
     }
 }
 
-void
-showInfo(Config const& cfg)
+static void
+showOfflineInfo(Config const& cfg)
 {
     // needs real time to display proper stats
     VirtualClock clock(VirtualClock::REAL_TIME);
@@ -227,7 +227,7 @@ showInfo(Config const& cfg)
     }
 }
 
-void
+static void
 loadXdr(Config const& cfg, std::string const& bucketFile)
 {
     VirtualClock clock;
@@ -245,7 +245,7 @@ loadXdr(Config const& cfg, std::string const& bucketFile)
     }
 }
 
-void
+static void
 initializeDatabase(Config& cfg)
 {
     VirtualClock clock;
@@ -256,7 +256,7 @@ initializeDatabase(Config& cfg)
     LOG(INFO) << "*";
 }
 
-int
+static int
 initializeHistories(Config& cfg, vector<string> newHistories)
 {
     VirtualClock clock;
@@ -270,7 +270,7 @@ initializeHistories(Config& cfg, vector<string> newHistories)
     return 0;
 }
 
-int
+static int
 startApp(string cfgFile, Config& cfg)
 {
     LOG(INFO) << "Starting stellar-core " << STELLAR_CORE_VERSION;
@@ -332,7 +332,7 @@ main(int argc, char* const* argv)
 
     optional<bool> forceSCP = nullptr;
     bool newDB = false;
-    bool getInfo = false;
+    bool getOfflineInfo = false;
     std::string loadXdrBucket = "";
     std::vector<std::string> newHistories;
     std::vector<std::string> metrics;
@@ -376,8 +376,8 @@ main(int argc, char* const* argv)
             std::cout << "Public: " << key.getStrKeyPublic() << std::endl;
             return 0;
         }
-        case OPT_INFO:
-            getInfo = true;
+        case OPT_OFFLINEINFO:
+            getOfflineInfo = true;
             break;
         case OPT_LOGLEVEL:
             logLevel = Logging::getLLfromString(std::string(optarg));
@@ -440,15 +440,15 @@ main(int argc, char* const* argv)
 
         cfg.REPORT_METRICS = metrics;
 
-        if (forceSCP || newDB || getInfo || !loadXdrBucket.empty())
+        if (forceSCP || newDB || getOfflineInfo || !loadXdrBucket.empty())
         {
             setNoListen(cfg);
             if (newDB)
                 initializeDatabase(cfg);
             if (forceSCP)
                 setForceSCPFlag(cfg, *forceSCP);
-            if (getInfo)
-                showInfo(cfg);
+            if (getOfflineInfo)
+                showOfflineInfo(cfg);
             if (!loadXdrBucket.empty())
                 loadXdr(cfg, loadXdrBucket);
             return 0;


### PR DESCRIPTION
"info" could be confused with the HTTP command (and was improperly documented
as a shortcut for "-c info" as a consequence)

resolves #851 
