### PR TITLE
Emit ledger entry in meta before modifying it

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -175,6 +175,7 @@
     <ClCompile Include="..\..\src\ledger\AccountFrame.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerDelta.cpp" />
     <ClCompile Include="..\..\src\ledger\EntryFrame.cpp" />
+    <ClCompile Include="..\..\src\ledger\LedgerDeltaTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerEntryTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderFrame.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderTests.cpp" />

--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -486,6 +486,9 @@
     <ClCompile Include="..\..\src\overlay\FloodTests.cpp">
       <Filter>overlay\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\LedgerDeltaTests.cpp">
+      <Filter>ledger\tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ledger\LedgerManager.h">

--- a/src/history/CatchupStateMachine.cpp
+++ b/src/history/CatchupStateMachine.cpp
@@ -1236,7 +1236,8 @@ CatchupStateMachine::applyHistoryOfSingleCheckpoint(uint32_t checkpoint)
 void
 CatchupStateMachine::enterEndState()
 {
-    assert(mState == CATCHUP_APPLYING || (mState == CATCHUP_RETRYING && (!!mError)));
+    assert(mState == CATCHUP_APPLYING ||
+           (mState == CATCHUP_RETRYING && (!!mError)));
     mApplyState.reset();
     mState = CATCHUP_END;
     CLOG(DEBUG, "History") << "Completed catchup from '" << mArchive->getName()

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -135,8 +135,7 @@ class HistoryTests
     bool catchupApplication(uint32_t initLedger,
                             HistoryManager::CatchupMode resumeMode,
                             Application::pointer app2, bool doStart = true,
-                            uint32_t maxCranks = 0xffffffff,
-                            uint32_t gap=0);
+                            uint32_t maxCranks = 0xffffffff, uint32_t gap = 0);
 
     bool
     flip()
@@ -416,8 +415,7 @@ bool
 HistoryTests::catchupApplication(uint32_t initLedger,
                                  HistoryManager::CatchupMode resumeMode,
                                  Application::pointer app2, bool doStart,
-                                 uint32_t maxCranks,
-                                 uint32_t gap)
+                                 uint32_t maxCranks, uint32_t gap)
 {
 
     auto& lm = app2->getLedgerManager();
@@ -949,7 +947,6 @@ TEST_CASE("persist publish queue", "[history]")
     }
 }
 
-
 // The idea with this test is that we join a network and somehow get a gap
 // in the SCP voting sequence while we're trying to catchup.  This should
 // cause catchup to fail, but that failure should itself just flush the
@@ -978,8 +975,8 @@ TEST_CASE_METHOD(HistoryTests, "too far behind / catchup restart",
 
     // Now start a catchup on that _fails_ due to a gap
     LOG(INFO) << "Starting BROKEN catchup (with gap) from " << init;
-    caughtup = catchupApplication(init, HistoryManager::CATCHUP_COMPLETE,
-                                  app2, true, 10000, init + 10);
+    caughtup = catchupApplication(init, HistoryManager::CATCHUP_COMPLETE, app2,
+                                  true, 10000, init + 10);
 
     assert(!caughtup);
 

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -196,6 +196,18 @@ AccountFrame::getLowThreshold() const
 }
 
 AccountFrame::pointer
+AccountFrame::loadAccount(LedgerDelta& delta, AccountID const& accountID,
+                          Database& db)
+{
+    auto a = loadAccount(accountID, db);
+    if (a)
+    {
+        delta.recordEntry(*a);
+    }
+    return a;
+}
+
+AccountFrame::pointer
 AccountFrame::loadAccount(AccountID const& accountID, Database& db)
 {
     LedgerKey key;

--- a/src/ledger/AccountFrame.h
+++ b/src/ledger/AccountFrame.h
@@ -121,6 +121,8 @@ class AccountFrame : public EntryFrame
     static uint64_t countObjects(soci::session& sess);
 
     // database utilities
+    static AccountFrame::pointer
+    loadAccount(LedgerDelta& delta, AccountID const& accountID, Database& db);
     static AccountFrame::pointer loadAccount(AccountID const& accountID,
                                              Database& db);
 

--- a/src/ledger/LedgerDelta.h
+++ b/src/ledger/LedgerDelta.h
@@ -33,6 +33,7 @@ class LedgerDelta
     KeyEntryMap mNew;
     KeyEntryMap mMod;
     std::set<LedgerKey, LedgerEntryIdCmp> mDelete;
+    KeyEntryMap mPrevious;
 
     Database& mDb; // Used strictly for rollback of db entry cache.
 
@@ -42,9 +43,15 @@ class LedgerDelta
     void addEntry(EntryFrame::pointer entry);
     void deleteEntry(EntryFrame::pointer entry);
     void modEntry(EntryFrame::pointer entry);
+    void recordEntry(EntryFrame::pointer entry);
 
     // merge "other" into current ledgerDelta
     void mergeEntries(LedgerDelta& other);
+
+    // helper method that adds a meta entry to "changes"
+    // with the previous value of an entry if needed
+    void addCurrentMeta(LedgerEntryChanges& changes,
+                        LedgerKey const& key) const;
 
   public:
     // keeps an internal reference to the outerDelta,
@@ -69,6 +76,7 @@ class LedgerDelta
     void deleteEntry(EntryFrame const& entry);
     void deleteEntry(LedgerKey const& key);
     void modEntry(EntryFrame const& entry);
+    void recordEntry(EntryFrame const& entry);
 
     // commits this delta into outer delta
     void commit();

--- a/src/ledger/LedgerDeltaTests.cpp
+++ b/src/ledger/LedgerDeltaTests.cpp
@@ -1,0 +1,240 @@
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/Timer.h"
+#include "main/test.h"
+#include "lib/catch.hpp"
+#include "ledger/LedgerDelta.h"
+#include "main/Application.h"
+#include "LedgerTestUtils.h"
+#include "ledger/LedgerManager.h"
+#include "ledger/AccountFrame.h"
+
+using namespace stellar;
+
+TEST_CASE("Ledger delta", "[ledger][ledgerdelta]")
+{
+    Config cfg(getTestConfig());
+    VirtualClock clock;
+    Application::pointer app = Application::create(clock, cfg);
+    app->start();
+    LedgerHeader& curHeader = app->getLedgerManager().getCurrentLedgerHeader();
+    LedgerHeader orgHeader = curHeader;
+
+    LedgerDelta delta(curHeader, app->getDatabase());
+
+    SECTION("header changes")
+    {
+        SECTION("commit top")
+        {
+            LedgerHeader expHeader = curHeader;
+            expHeader.idPool++;
+
+            SECTION("top")
+            {
+                delta.getHeader().idPool++;
+                delta.commit();
+            }
+            SECTION("nested")
+            {
+                LedgerDelta delta2(delta);
+                delta2.getHeader().idPool++;
+                SECTION("inner no op")
+                {
+                    LedgerDelta delta3(delta2);
+                }
+                SECTION("inner rollback")
+                {
+                    LedgerDelta delta3(delta2);
+                    delta3.getHeader().idPool++;
+                    delta3.rollback();
+                }
+                delta2.commit();
+                delta.commit();
+            }
+            SECTION("nested2")
+            {
+                LedgerDelta delta2(delta);
+                {
+                    LedgerDelta delta3(delta2);
+                    delta3.getHeader().idPool++;
+                    delta3.commit();
+                }
+                delta2.commit();
+                delta.commit();
+            }
+            REQUIRE(curHeader == expHeader);
+        }
+        SECTION("rollback")
+        {
+            delta.getHeader().idPool++;
+            delta.rollback();
+            REQUIRE(curHeader == orgHeader);
+        }
+    }
+
+    SECTION("delta object operations")
+    {
+        size_t const nbAccounts = 50;
+        size_t const nbAccountsGroupSize = 10;
+
+        std::vector<AccountFrame::pointer> accounts;
+        {
+            auto aEntries =
+                LedgerTestUtils::generateValidAccountEntries(nbAccounts);
+            accounts.reserve(nbAccounts);
+            for (auto a : aEntries)
+            {
+                LedgerEntry le;
+                le.data.type(ACCOUNT);
+                le.data.account() = a;
+                accounts.emplace_back(std::make_shared<AccountFrame>(le));
+            }
+        }
+
+        using MapAccounts =
+            std::map<LedgerKey, AccountFrame::pointer, LedgerEntryIdCmp>;
+
+        MapAccounts accountsByKey;
+
+        auto addEntries =
+            [&](size_t start, size_t end, LedgerDelta& d, MapAccounts& aKeys)
+        {
+            for (size_t i = start; i < end; i++)
+            {
+                auto a = accounts[i];
+                d.addEntry(*a);
+                aKeys.insert(std::make_pair(a->getKey(), a));
+            }
+        };
+
+        addEntries(0, nbAccountsGroupSize, delta, accountsByKey);
+
+        auto checkChanges = [&]()
+        {
+            auto changes = delta.getChanges();
+            for (auto const& c : changes)
+            {
+                REQUIRE(c.type() == LEDGER_ENTRY_CREATED);
+                auto const& createdEntry = c.created();
+                auto key = LedgerEntryKey(createdEntry);
+                REQUIRE(createdEntry == (accountsByKey[key]->mEntry));
+            }
+        };
+
+        checkChanges();
+
+        SECTION("add more entries")
+        {
+            SECTION("commit")
+            {
+                LedgerDelta delta2(delta);
+                addEntries(nbAccountsGroupSize, nbAccountsGroupSize * 2, delta2,
+                           accountsByKey);
+                delta2.commit();
+                REQUIRE(accountsByKey.size() == (nbAccountsGroupSize * 2));
+            }
+            SECTION("rollback")
+            {
+                LedgerDelta delta2(delta);
+                MapAccounts accountsByKey2;
+                addEntries(nbAccountsGroupSize,
+                           nbAccountsGroupSize + nbAccountsGroupSize, delta2,
+                           accountsByKey2);
+                delta2.rollback();
+                REQUIRE(accountsByKey.size() == nbAccountsGroupSize);
+            }
+            checkChanges();
+        }
+        SECTION("modified entries")
+        {
+            auto modEntries = [&](size_t start, size_t end, LedgerDelta& d,
+                                  MapAccounts& aKeys)
+            {
+                for (size_t i = start; i < end; i++)
+                {
+                    auto a = accounts[i];
+                    SequenceNumber s = a->getSeqNum() + 1;
+                    auto newA = std::make_shared<AccountFrame>(a->mEntry);
+                    newA->setSeqNum(s);
+                    d.modEntry(*newA);
+                    aKeys[newA->getKey()] = newA;
+                }
+            };
+            SECTION("commit")
+            {
+                LedgerDelta delta2(delta);
+                MapAccounts modAccounts;
+                modEntries(0, nbAccountsGroupSize / 2, delta2, modAccounts);
+
+                auto changes = delta2.getChanges();
+                REQUIRE(changes.size() == modAccounts.size());
+                for (auto const& c : changes)
+                {
+                    REQUIRE(c.type() == LEDGER_ENTRY_UPDATED);
+                    auto const& updatedEntry = c.updated();
+                    auto key = LedgerEntryKey(updatedEntry);
+                    REQUIRE(updatedEntry == (modAccounts[key]->mEntry));
+                    // update accountsByKey so that we can check that everything
+                    // is committed to the outer delta
+                    accountsByKey[key] = modAccounts[key];
+                }
+                delta2.commit();
+                REQUIRE(accountsByKey.size() == nbAccountsGroupSize);
+            }
+            SECTION("rollback")
+            {
+                LedgerDelta delta2(delta);
+                MapAccounts modAccounts;
+                modEntries(0, nbAccountsGroupSize / 2, delta2, modAccounts);
+                delta2.rollback();
+                REQUIRE(accountsByKey.size() == nbAccountsGroupSize);
+            }
+            checkChanges();
+        }
+        SECTION("deleted entries")
+        {
+            auto delEntries = [&](size_t start, size_t end, LedgerDelta& d,
+                                  MapAccounts& aKeys)
+            {
+                for (size_t i = start; i < end; i++)
+                {
+                    auto a = accounts[i];
+                    auto const& key = a->getKey();
+                    d.deleteEntry(key);
+                    aKeys[key] = nullptr;
+                }
+            };
+            SECTION("commit")
+            {
+                LedgerDelta delta2(delta);
+                MapAccounts delAccounts;
+                delEntries(0, nbAccountsGroupSize / 2, delta2, delAccounts);
+
+                auto changes = delta2.getChanges();
+                REQUIRE(changes.size() == delAccounts.size());
+                for (auto const& c : changes)
+                {
+                    REQUIRE(c.type() == LEDGER_ENTRY_REMOVED);
+                    auto const& removedEntry = c.removed();
+                    REQUIRE(delAccounts[removedEntry] == nullptr);
+                    // update accountsByKey so that we can check that everything
+                    // is committed to the outer delta
+                    accountsByKey.erase(removedEntry);
+                }
+                delta2.commit();
+                REQUIRE(accountsByKey.size() == (nbAccountsGroupSize / 2));
+            }
+            SECTION("rollback")
+            {
+                LedgerDelta delta2(delta);
+                MapAccounts delAccounts;
+                delEntries(0, nbAccountsGroupSize / 2, delta2, delAccounts);
+                delta2.rollback();
+                REQUIRE(accountsByKey.size() == nbAccountsGroupSize);
+            }
+            checkChanges();
+        }
+    }
+}

--- a/src/ledger/OfferFrame.cpp
+++ b/src/ledger/OfferFrame.cpp
@@ -128,7 +128,8 @@ OfferFrame::isValid() const
 }
 
 OfferFrame::pointer
-OfferFrame::loadOffer(AccountID const& sellerID, uint64_t offerID, Database& db)
+OfferFrame::loadOffer(AccountID const& sellerID, uint64_t offerID, Database& db,
+                      LedgerDelta* delta)
 {
     OfferFrame::pointer retOffer;
 
@@ -146,6 +147,11 @@ OfferFrame::loadOffer(AccountID const& sellerID, uint64_t offerID, Database& db)
                {
                    retOffer = make_shared<OfferFrame>(offer);
                });
+
+    if (delta && retOffer)
+    {
+        delta->recordEntry(*retOffer);
+    }
 
     return retOffer;
 }

--- a/src/ledger/OfferFrame.h
+++ b/src/ledger/OfferFrame.h
@@ -86,7 +86,7 @@ class OfferFrame : public EntryFrame
 
     // database utilities
     static pointer loadOffer(AccountID const& accountID, uint64_t offerID,
-                             Database& db);
+                             Database& db, LedgerDelta* delta = nullptr);
 
     static void loadBestOffers(size_t numOffers, size_t offset,
                                Asset const& pays, Asset const& gets,

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -338,7 +338,7 @@ TrustFrame::createIssuerFrame(Asset const& issuer)
 
 TrustFrame::pointer
 TrustFrame::loadTrustLine(AccountID const& accountID, Asset const& asset,
-                          Database& db)
+                          Database& db, LedgerDelta* delta)
 {
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
@@ -401,17 +401,22 @@ TrustFrame::loadTrustLine(AccountID const& accountID, Asset const& asset,
     {
         putCachedEntry(key, nullptr, db);
     }
+
+    if (delta && retLine)
+    {
+        delta->recordEntry(*retLine);
+    }
     return retLine;
 }
 
 std::pair<TrustFrame::pointer, AccountFrame::pointer>
 TrustFrame::loadTrustLineIssuer(AccountID const& accountID, Asset const& asset,
-                                Database& db)
+                                Database& db, LedgerDelta& delta)
 {
     std::pair<TrustFrame::pointer, AccountFrame::pointer> res;
 
-    res.first = loadTrustLine(accountID, asset, db);
-    res.second = AccountFrame::loadAccount(getIssuer(asset), db);
+    res.first = loadTrustLine(accountID, asset, db, &delta);
+    res.second = AccountFrame::loadAccount(delta, getIssuer(asset), db);
     return res;
 }
 

--- a/src/ledger/TrustFrame.h
+++ b/src/ledger/TrustFrame.h
@@ -68,12 +68,12 @@ class TrustFrame : public EntryFrame
 
     // returns the specified trustline or a generated one for issuers
     static pointer loadTrustLine(AccountID const& accountID, Asset const& asset,
-                                 Database& db);
+                                 Database& db, LedgerDelta* delta = nullptr);
 
     // overload that also returns the issuer
     static std::pair<TrustFrame::pointer, AccountFrame::pointer>
     loadTrustLineIssuer(AccountID const& accountID, Asset const& asset,
-                        Database& db);
+                        Database& db, LedgerDelta& delta);
 
     // note: only returns trust lines stored in the database
     static void loadLines(AccountID const& accountID,

--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -61,7 +61,7 @@ AllowTrustOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
 
     Database& db = ledgerManager.getDatabase();
     TrustFrame::pointer trustLine;
-    trustLine = TrustFrame::loadTrustLine(mAllowTrust.trustor, ci, db);
+    trustLine = TrustFrame::loadTrustLine(mAllowTrust.trustor, ci, db, &delta);
 
     if (!trustLine)
     {

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -26,8 +26,8 @@ ChangeTrustOpFrame::doApply(medida::MetricsRegistry& metrics,
 {
     Database& db = ledgerManager.getDatabase();
 
-    auto tlI =
-        TrustFrame::loadTrustLineIssuer(getSourceID(), mChangeTrust.line, db);
+    auto tlI = TrustFrame::loadTrustLineIssuer(getSourceID(), mChangeTrust.line,
+                                               db, delta);
 
     auto& trustLine = tlI.first;
     auto& issuer = tlI.second;

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -37,7 +37,8 @@ CreateAccountOpFrame::doApply(medida::MetricsRegistry& metrics,
 
     Database& db = ledgerManager.getDatabase();
 
-    destAccount = AccountFrame::loadAccount(mCreateAccount.destination, db);
+    destAccount =
+        AccountFrame::loadAccount(delta, mCreateAccount.destination, db);
     if (!destAccount)
     {
         if (mCreateAccount.startingBalance < ledgerManager.getMinBalance(0))

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -96,7 +96,8 @@ InflationOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
         if (toDoleThisWinner == 0)
             continue;
 
-        winner = AccountFrame::loadAccount(w.mInflationDest, db);
+        winner =
+            AccountFrame::loadAccount(inflationDelta, w.mInflationDest, db);
 
         if (winner)
         {

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -135,7 +135,8 @@ ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
 
     if (offerID)
     { // modifying an old offer
-        mSellSheepOffer = OfferFrame::loadOffer(getSourceID(), offerID, db);
+        mSellSheepOffer =
+            OfferFrame::loadOffer(getSourceID(), offerID, db, &delta);
 
         if (!mSellSheepOffer)
         {

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -35,7 +35,7 @@ ManageOfferOpFrame::ManageOfferOpFrame(Operation const& op,
 // make sure these issuers exist and you can hold the ask asset
 bool
 ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
-                                    Database& db)
+                                    Database& db, LedgerDelta& delta)
 {
     Asset const& sheep = mManageOffer.selling;
     Asset const& wheat = mManageOffer.buying;
@@ -48,7 +48,8 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
 
     if (sheep.type() != ASSET_TYPE_NATIVE)
     {
-        auto tlI = TrustFrame::loadTrustLineIssuer(getSourceID(), sheep, db);
+        auto tlI =
+            TrustFrame::loadTrustLineIssuer(getSourceID(), sheep, db, delta);
         mSheepLineA = tlI.first;
         if (!tlI.second)
         {
@@ -84,7 +85,8 @@ ManageOfferOpFrame::checkOfferValid(medida::MetricsRegistry& metrics,
 
     if (wheat.type() != ASSET_TYPE_NATIVE)
     {
-        auto tlI = TrustFrame::loadTrustLineIssuer(getSourceID(), wheat, db);
+        auto tlI =
+            TrustFrame::loadTrustLineIssuer(getSourceID(), wheat, db, delta);
         mWheatLineA = tlI.first;
         if (!tlI.second)
         {
@@ -122,7 +124,7 @@ ManageOfferOpFrame::doApply(medida::MetricsRegistry& metrics,
 {
     Database& db = ledgerManager.getDatabase();
 
-    if (!checkOfferValid(metrics, db))
+    if (!checkOfferValid(metrics, db, delta))
     {
         return false;
     }

--- a/src/transactions/ManageOfferOpFrame.h
+++ b/src/transactions/ManageOfferOpFrame.h
@@ -17,7 +17,8 @@ class ManageOfferOpFrame : public OperationFrame
 
     OfferFrame::pointer mSellSheepOffer;
 
-    bool checkOfferValid(medida::MetricsRegistry& metrics, Database& db);
+    bool checkOfferValid(medida::MetricsRegistry& metrics, Database& db,
+                         LedgerDelta& delta);
 
     ManageOfferResult&
     innerResult()

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -39,7 +39,8 @@ MergeOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
     AccountFrame::pointer otherAccount;
     Database& db = ledgerManager.getDatabase();
 
-    otherAccount = AccountFrame::loadAccount(mOperation.body.destination(), db);
+    otherAccount =
+        AccountFrame::loadAccount(delta, mOperation.body.destination(), db);
 
     if (!otherAccount)
     {

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -42,7 +42,8 @@ OfferExchange::crossOffer(OfferFrame& sellingWheatOffer,
     TrustFrame::pointer wheatLineAccountB;
     if (wheat.type() != ASSET_TYPE_NATIVE)
     {
-        wheatLineAccountB = TrustFrame::loadTrustLine(accountBID, wheat, db);
+        wheatLineAccountB =
+            TrustFrame::loadTrustLine(accountBID, wheat, db, &mDelta);
     }
 
     TrustFrame::pointer sheepLineAccountB;
@@ -53,7 +54,8 @@ OfferExchange::crossOffer(OfferFrame& sellingWheatOffer,
     }
     else
     {
-        sheepLineAccountB = TrustFrame::loadTrustLine(accountBID, sheep, db);
+        sheepLineAccountB =
+            TrustFrame::loadTrustLine(accountBID, sheep, db, &mDelta);
 
         // compute numWheatReceived based on what the account can receive
         int64_t sellerMaxSheep =

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -28,7 +28,7 @@ OfferExchange::crossOffer(OfferFrame& sellingWheatOffer,
     Database& db = mLedgerManager.getDatabase();
 
     AccountFrame::pointer accountB;
-    accountB = AccountFrame::loadAccount(accountBID, db);
+    accountB = AccountFrame::loadAccount(mDelta, accountBID, db);
     if (!accountB)
     {
         throw std::runtime_error(

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -7,6 +7,7 @@
 #include "ledger/TrustFrame.h"
 #include "database/Database.h"
 #include "util/Logging.h"
+#include "ledger/LedgerDelta.h"
 
 namespace stellar
 {
@@ -21,6 +22,9 @@ OfferExchange::crossOffer(OfferFrame& sellingWheatOffer,
                           int64_t maxWheatReceived, int64_t& numWheatReceived,
                           int64_t maxSheepSend, int64_t& numSheepSend)
 {
+    // we're about to make changes to the offer
+    mDelta.recordEntry(sellingWheatOffer);
+
     Asset& sheep = sellingWheatOffer.getOffer().buying;
     Asset& wheat = sellingWheatOffer.getOffer().selling;
     AccountID& accountBID = sellingWheatOffer.getOffer().sellerID;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -76,7 +76,7 @@ bool
 OperationFrame::apply(LedgerDelta& delta, Application& app)
 {
     bool res;
-    res = checkValid(app, true);
+    res = checkValid(app, &delta);
     if (res)
     {
         res = doApply(app.getMetrics(), delta, app.getLedgerManager());
@@ -105,9 +105,9 @@ OperationFrame::getSourceID() const
 }
 
 bool
-OperationFrame::loadAccount(Database& db)
+OperationFrame::loadAccount(LedgerDelta* delta, Database& db)
 {
-    mSourceAccount = mParentTx.loadAccount(db, getSourceID());
+    mSourceAccount = mParentTx.loadAccount(delta, db, getSourceID());
     return !!mSourceAccount;
 }
 
@@ -122,9 +122,10 @@ OperationFrame::getResultCode() const
 // make sure sig is correct
 // verifies that the operation is well formed (operation specific)
 bool
-OperationFrame::checkValid(Application& app, bool forApply)
+OperationFrame::checkValid(Application& app, LedgerDelta* delta)
 {
-    if (!loadAccount(app.getDatabase()))
+    bool forApply = (delta != nullptr);
+    if (!loadAccount(delta, app.getDatabase()))
     {
         if (forApply || !mOperation.sourceAccount)
         {

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -66,7 +66,7 @@ class OperationFrame
 
     // load account if needed
     // returns true on success
-    bool loadAccount(Database& db);
+    bool loadAccount(LedgerDelta* delta, Database& db);
 
     OperationResult&
     getResult() const
@@ -75,7 +75,7 @@ class OperationFrame
     }
     OperationResultCode getResultCode() const;
 
-    bool checkValid(Application& app, bool forApply = false);
+    bool checkValid(Application& app, LedgerDelta* delta = nullptr);
 
     bool apply(LedgerDelta& delta, Application& app);
 

--- a/src/transactions/PathPaymentOpFrame.cpp
+++ b/src/transactions/PathPaymentOpFrame.cpp
@@ -88,13 +88,13 @@ PathPaymentOpFrame::doApply(medida::MetricsRegistry& metrics,
 
         if (bypassIssuerCheck)
         {
-            destLine =
-                TrustFrame::loadTrustLine(mPathPayment.destination, curB, db);
+            destLine = TrustFrame::loadTrustLine(mPathPayment.destination, curB,
+                                                 db, &delta);
         }
         else
         {
             auto tlI = TrustFrame::loadTrustLineIssuer(mPathPayment.destination,
-                                                       curB, db);
+                                                       curB, db, delta);
             if (!tlI.second)
             {
                 metrics.NewMeter({"op-path-payment", "failure", "no-issuer"},
@@ -241,11 +241,12 @@ PathPaymentOpFrame::doApply(medida::MetricsRegistry& metrics,
         if (bypassIssuerCheck)
         {
             sourceLineFrame =
-                TrustFrame::loadTrustLine(getSourceID(), curB, db);
+                TrustFrame::loadTrustLine(getSourceID(), curB, db, &delta);
         }
         else
         {
-            auto tlI = TrustFrame::loadTrustLineIssuer(getSourceID(), curB, db);
+            auto tlI =
+                TrustFrame::loadTrustLineIssuer(getSourceID(), curB, db, delta);
 
             if (!tlI.second)
             {

--- a/src/transactions/PathPaymentOpFrame.cpp
+++ b/src/transactions/PathPaymentOpFrame.cpp
@@ -64,7 +64,8 @@ PathPaymentOpFrame::doApply(medida::MetricsRegistry& metrics,
 
     if (!bypassIssuerCheck)
     {
-        destination = AccountFrame::loadAccount(mPathPayment.destination, db);
+        destination =
+            AccountFrame::loadAccount(delta, mPathPayment.destination, db);
 
         if (!destination)
         {
@@ -148,7 +149,7 @@ PathPaymentOpFrame::doApply(medida::MetricsRegistry& metrics,
 
         if (curA.type() != ASSET_TYPE_NATIVE)
         {
-            if (!AccountFrame::loadAccount(getIssuer(curA), db))
+            if (!AccountFrame::loadAccount(delta, getIssuer(curA), db))
             {
                 metrics.NewMeter({"op-path-payment", "failure", "no-issuer"},
                                  "operation").Mark();

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -48,7 +48,7 @@ SetOptionsOpFrame::doApply(medida::MetricsRegistry& metrics, LedgerDelta& delta,
     {
         AccountFrame::pointer inflationAccount;
         AccountID inflationID = *mSetOptions.inflationDest;
-        inflationAccount = AccountFrame::loadAccount(inflationID, db);
+        inflationAccount = AccountFrame::loadAccount(delta, inflationID, db);
         if (!inflationAccount)
         {
             metrics.NewMeter({"op-set-options", "failure", "invalid-inflation"},

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -47,8 +47,9 @@ class TransactionFrame
 
     std::vector<std::shared_ptr<OperationFrame>> mOperations;
 
-    bool loadAccount(Database& app);
-    bool commonValid(Application& app, bool applying, SequenceNumber current);
+    bool loadAccount(LedgerDelta* delta, Database& app);
+    bool commonValid(Application& app, LedgerDelta* delta,
+                     SequenceNumber current);
 
     void resetSignatureTracker();
     void resetResults();
@@ -147,7 +148,7 @@ class TransactionFrame
 
     StellarMessage toStellarMessage() const;
 
-    AccountFrame::pointer loadAccount(Database& app,
+    AccountFrame::pointer loadAccount(LedgerDelta* delta, Database& app,
                                       AccountID const& accountID);
 
     // transaction history

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -225,11 +225,15 @@ case 0:
 
 // represents the meta in the transaction table history
 
+// STATE is emitted every time a ledger entry is modified/deleted
+// and the entry was not already modified in the current ledger
+
 enum LedgerEntryChangeType
 {
     LEDGER_ENTRY_CREATED = 0, // entry was added to the ledger
     LEDGER_ENTRY_UPDATED = 1, // entry was modified in the ledger
-    LEDGER_ENTRY_REMOVED = 2  // entry was removed from the ledger
+    LEDGER_ENTRY_REMOVED = 2, // entry was removed from the ledger
+    LEDGER_ENTRY_STATE = 3    // value of the entry
 };
 
 union LedgerEntryChange switch (LedgerEntryChangeType type)
@@ -240,6 +244,8 @@ case LEDGER_ENTRY_UPDATED:
     LedgerEntry updated;
 case LEDGER_ENTRY_REMOVED:
     LedgerKey removed;
+case LEDGER_ENTRY_STATE:
+    LedgerEntry state;
 };
 
 typedef LedgerEntryChange LedgerEntryChanges<>;

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -315,7 +315,7 @@ struct TransactionEnvelope
 /* This result is used when offers are taken during an operation */
 struct ClaimOfferAtom
 {
-    // emited to identify the offer
+    // emitted to identify the offer
     AccountID sellerID; // Account that owns the offer
     uint64 offerID;
 


### PR DESCRIPTION
This change set adds an optional LEDGER_ENTRY_STATE before LEDGER_ENTRY_UPDATED and LEDGER_ENTRY_REMOVED.
The new meta is emitted when a ledger entry is first modified in a ledger:
given a transaction set that produces a stream of meta, the very first UPDATE/REMOVE for any given ledger entry will be preceded by a STATE entry.
The idea is that a consumer of this information will load the meta for a specific ledger close, and can with the new meta know what the state before applying transactions looks like.
This resolves #719 


This should help with various scenarios tracked in issues like
not possible to determine if a signer was added or removed Resolves #711 
not possible to determine if a signer is re-enabled or updated Resolves #712 
