### PR TITLE
Add ManagerOffer test for non existing offer

### DIFF
--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -304,6 +304,16 @@ TEST_CASE("create offer", "[tx][offers]")
                 }
             }
         }
+        SECTION("negative tests (manipulation)")
+        {
+            SECTION("Delete non existant offer")
+            {
+                auto bogusOfferID = offer.offerID + 1;
+                auto r = applyCreateOfferWithResult(
+                    app, delta, bogusOfferID, a1, idrCur, usdCur, oneone, 0,
+                    a1_seq++, MANAGE_OFFER_NOT_FOUND);
+            }
+        }
         SECTION("Update price")
         {
             const Price onetwo(1, 2);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -617,7 +617,7 @@ saveTransactionHelper(Database& db, soci::session& sess, uint32 ledgerSeq,
 }
 
 TransactionResultSet
-TransactionFrame::getTransactionHistoryMeta(Database& db, uint32 ledgerSeq)
+TransactionFrame::getTransactionHistoryResults(Database& db, uint32 ledgerSeq)
 {
     TransactionResultSet res;
     std::string txresult64;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -434,6 +434,15 @@ TransactionFrame::markResultFailed()
     xdr::xvector<OperationResult> t(std::move(getResult().result.results()));
     getResult().result.code(txFAILED);
     getResult().result.results() = std::move(t);
+
+    // sanity check in case some implementations decide
+    // to not implement std::move properly
+    auto const& allResults = getResult().result.results();
+    assert(allResults.size() == mOperations.size());
+    for (size_t i = 0; i < mOperations.size(); i++)
+    {
+        assert(&mOperations[i]->getResult() == &allResults[i]);
+    }
 }
 
 bool

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -161,8 +161,8 @@ class TransactionFrame
                              int txindex) const;
 
     // access to history tables
-    static TransactionResultSet getTransactionHistoryMeta(Database& db,
-                                                          uint32 ledgerSeq);
+    static TransactionResultSet getTransactionHistoryResults(Database& db,
+                                                             uint32 ledgerSeq);
     static std::vector<LedgerEntryChanges>
     getTransactionFeeMeta(Database& db, uint32 ledgerSeq);
 

--- a/src/transactions/TxTests.cpp
+++ b/src/transactions/TxTests.cpp
@@ -174,8 +174,8 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
     LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 
-    auto z1 = TransactionFrame::getTransactionHistoryMeta(app.getDatabase(),
-                                                          ledgerSeq);
+    auto z1 = TransactionFrame::getTransactionHistoryResults(app.getDatabase(),
+                                                             ledgerSeq);
     auto z2 =
         TransactionFrame::getTransactionFeeMeta(app.getDatabase(), ledgerSeq);
 


### PR DESCRIPTION
This adds a missing test for manageOffer (we had a report of a bug ; turned out it was something else)