### PR TITLE
don't exclude "self" when computing number of failures when validating config

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -630,7 +630,7 @@ Config::validateConfig()
 
     // calculates nodes that would break quorum
     auto selfID = NODE_SEED.getPublicKey();
-    auto r = LocalNode::findClosestVBlocking(QUORUM_SET, nodes, &selfID);
+    auto r = LocalNode::findClosestVBlocking(QUORUM_SET, nodes, nullptr);
 
     if (FAILURE_SAFETY == -1)
     {


### PR DESCRIPTION
Minor tweak to the way we validate configurations.

While we want to exclude "self" when computing the set for
reporting purpose (as people are normally interested in the effect of
other nodes failing);
the validation performed on the configuration should be against the
final quorum, which includes the node we're trying to add.