### PR TITLE
SCP update December

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1415,7 +1415,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
 bool
 HerderImpl::isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks)
 {
-    return LocalNode::isQuorumSetSaneSimplified(qSet, extraChecks);
+    return LocalNode::isQuorumSetSane(qSet, extraChecks);
 }
 
 bool

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -219,7 +219,7 @@ bool
 BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
     bool res = mSlot.getLocalNode()->isQuorumSetSane(
-        st.nodeID, *mSlot.getQuorumSetFromStatement(st));
+        *mSlot.getQuorumSetFromStatement(st), false);
     if (!res)
     {
         CLOG(DEBUG, "SCP") << "Invalid quorum set received";
@@ -1252,6 +1252,7 @@ BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
         {
             bumpToBallot(h, false);
         }
+        mPreparedPrime.reset();
 
         didWork = true;
     }
@@ -1411,11 +1412,6 @@ BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
 
     auto pred = [&ballot, this](Interval const& cur) -> bool
     {
-        // only look for (c,h) such that c <= h <= b
-        if (cur.second > mCurrentBallot->counter)
-        {
-            return false;
-        }
         return federatedRatify(
             std::bind(&BallotProtocol::commitPredicate, ballot, cur, _1));
     };

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -37,9 +37,8 @@ class LocalNode
                                         std::set<NodeID>& knownNodes,
                                         bool extraChecks);
 
-    void adjustQSetHelper(SCPQuorumSet& qSet);
-    // adjust qset such that self is a member of all slices
-    void adjustQSet(SCPQuorumSet& qSet);
+    // normalize quorum set
+    void normalizeQSet(SCPQuorumSet& qSet);
 
   public:
     LocalNode(SecretKey const& secretKey, bool isValidator,
@@ -47,11 +46,8 @@ class LocalNode
 
     NodeID const& getNodeID();
 
-    // returns if a nodeID's quorum set passes sanity checks
-    bool isQuorumSetSane(NodeID const& nodeID, SCPQuorumSet const& qSet);
-    // simplified sanity check (for configuration validation)
-    static bool isQuorumSetSaneSimplified(SCPQuorumSet const& qSet,
-                                          bool extraChecks);
+    // returns if a quorum set passes sanity checks
+    static bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks);
 
     void updateQuorumSet(SCPQuorumSet const& qSet);
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -115,7 +115,7 @@ NominationProtocol::isSane(SCPStatement const& st)
 
     res = res &&
           mSlot.getLocalNode()->isQuorumSetSane(
-              st.nodeID, *mSlot.getQuorumSetFromStatement(st));
+              *mSlot.getQuorumSetFromStatement(st), false);
 
     return res;
 }


### PR DESCRIPTION
note this is a *preliminary* PR: the updated SCP paper is not yet available.

In the latest paper, the definition of quorum removed the requirement for a node to be a member of its quorum slices as long as we can guarantee that it doesn't emit statements that contradict previous statements.