### PR TITLE
filtering fix: use companion quorum set from statements

### DIFF
--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -192,7 +192,15 @@ Slot::isNodeInQuorum(NodeID const& node)
         n.emplace_back(&e.first);
     }
     return mSCP.getLocalNode()->isNodeInQuorum(
-        node, std::bind(&Slot::getQuorumSetFromStatement, this, _1), m);
+        node,
+        [this](SCPStatement const& st)
+        {
+            // uses the companion set here as we want to consider
+            // nodes that were used up to EXTERNALIZE
+            Hash h = getCompanionQuorumSetHashFromStatement(st);
+            return getSCPDriver().getQSet(h);
+        },
+        m);
 }
 
 SCPEnvelope

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -142,7 +142,7 @@ class Slot : public std::enable_shared_from_this<Slot>
     static std::vector<Value> getStatementValues(SCPStatement const& st);
 
     // returns the QuorumSet that should be used for a node given the
-    // statement
+    // statement (singleton for externalize)
     SCPQuorumSetPtr getQuorumSetFromStatement(SCPStatement const& st);
 
     // wraps a statement in an envelope (sign it, etc)


### PR DESCRIPTION
This forces to keep messages from all nodes that were used to externalize.

resolves #960 