### PR TITLE
Bug 966 catchup recent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -22,6 +22,9 @@ if test -z "${WFLAGS+set}"; then
    # output without this
    WFLAGS="$WFLAGS -Wno-unused-local-typedef"
 
+   # Also don't _further_ warn if the previous warning flag was unknown
+   WFLAGS="$WFLAGS -Wno-unknown-warning-option"
+
    # We want to consider unused MUST_USE results as errors
    WFLAGS="$WFLAGS -Werror=unused-result"
 fi

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -190,10 +190,15 @@ class HistoryManager
     // closed ledger and the catchup point. This is set by config, default is
     // CATCHUP_MINIMAL but it should be CATCHUP_COMPLETE for any server with
     // API clients. See LedgerManager::startCatchUp and its callers for uses.
+    //
+    // CATCHUP_RECENT is a hybrid mode that does a CATCHUP_MINIMAL to a point
+    // in the recent past, then runs CATCHUP_COMPLETE from there forward to
+    // the present.
     enum CatchupMode
     {
         CATCHUP_COMPLETE,
         CATCHUP_MINIMAL,
+        CATCHUP_RECENT,
         CATCHUP_BUCKET_REPAIR
     };
 

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -624,6 +624,13 @@ HistoryManagerImpl::catchupHistory(
         mCatchupWork = mApp.getWorkManager().addWork<CatchupMinimalWork>(
             initLedger, manualCatchup, handler);
     }
+    else if (mode == CATCHUP_RECENT)
+    {
+        CLOG(INFO, "History") << "Starting CatchupRecentWork";
+        mCatchupWork = mApp.getWorkManager().addWork<CatchupRecentWork>(
+            initLedger, mApp.getConfig().CATCHUP_RECENT, manualCatchup,
+            handler);
+    }
     else
     {
         assert(mode == CATCHUP_COMPLETE);

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -618,6 +618,18 @@ HistoryManagerImpl::catchupHistory(
 
     mCatchupStart.Mark();
 
+    // Avoid CATCHUP_RECENT if it's going to actually try to revert
+    // us to an earlier state of the ledger than the LCL; in that case
+    // we're close enough to the network to just run CATCHUP_COMPLETE.
+    auto lcl = mApp.getLedgerManager().getLastClosedLedgerHeader();
+    if (mode == CATCHUP_RECENT &&
+        (initLedger > lcl.header.ledgerSeq) &&
+        (initLedger - lcl.header.ledgerSeq) <= mApp.getConfig().CATCHUP_RECENT)
+    {
+        mode = HistoryManager::CATCHUP_COMPLETE;
+    }
+
+
     if (mode == CATCHUP_MINIMAL)
     {
         CLOG(INFO, "History") << "Starting CatchupMinimalWork";

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -640,8 +640,7 @@ HistoryManagerImpl::catchupHistory(
     {
         CLOG(INFO, "History") << "Starting CatchupRecentWork";
         mCatchupWork = mApp.getWorkManager().addWork<CatchupRecentWork>(
-            initLedger, mApp.getConfig().CATCHUP_RECENT, manualCatchup,
-            handler);
+            initLedger, manualCatchup, handler);
     }
     else
     {

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -1032,6 +1032,4 @@ TEST_CASE_METHOD(HistoryTests, "Catchup recent",
     {
         catchupApplication(initLedger, HistoryManager::CATCHUP_RECENT, a);
     }
-
-
 }

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -385,6 +385,10 @@ HistoryTests::catchupNewApplication(uint32_t initLedger,
 
     mCfgs.emplace_back(
         getTestConfig(static_cast<int>(mCfgs.size()) + 1, dbMode));
+    if (resumeMode == HistoryManager::CATCHUP_RECENT)
+    {
+        mCfgs.back().CATCHUP_RECENT = 80;
+    }
     Application::pointer app2 = Application::create(
         clock, mConfigurator->configure(mCfgs.back(), false));
 
@@ -601,6 +605,8 @@ resumeModeName(HistoryManager::CatchupMode mode)
         return "CATCHUP_MINIMAL";
     case HistoryManager::CATCHUP_COMPLETE:
         return "CATCHUP_COMPLETE";
+    case HistoryManager::CATCHUP_RECENT:
+        return "CATCHUP_RECENT";
     default:
         abort();
     }
@@ -634,7 +640,9 @@ TEST_CASE_METHOD(HistoryTests, "Full history catchup",
     std::vector<Application::pointer> apps;
 
     std::vector<HistoryManager::CatchupMode> resumeModes = {
-        HistoryManager::CATCHUP_MINIMAL, HistoryManager::CATCHUP_COMPLETE};
+        HistoryManager::CATCHUP_MINIMAL, HistoryManager::CATCHUP_COMPLETE,
+        HistoryManager::CATCHUP_RECENT,
+    };
 
     std::vector<Config::TestDbMode> dbModes = {Config::TESTDB_IN_MEMORY_SQLITE,
                                                Config::TESTDB_ON_DISK_SQLITE};

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -133,7 +133,7 @@ class HistoryTests
     Application::pointer
     catchupNewApplication(uint32_t initLedger, Config::TestDbMode dbMode,
                           HistoryManager::CatchupMode resumeMode,
-                          std::string const& appName);
+                          std::string const& appName, uint32_t recent = 80);
 
     bool catchupApplication(uint32_t initLedger,
                             HistoryManager::CatchupMode resumeMode,
@@ -375,7 +375,8 @@ Application::pointer
 HistoryTests::catchupNewApplication(uint32_t initLedger,
                                     Config::TestDbMode dbMode,
                                     HistoryManager::CatchupMode resumeMode,
-                                    std::string const& appName)
+                                    std::string const& appName,
+                                    uint32_t recent)
 {
 
     CLOG(INFO, "History") << "****";
@@ -387,7 +388,7 @@ HistoryTests::catchupNewApplication(uint32_t initLedger,
         getTestConfig(static_cast<int>(mCfgs.size()) + 1, dbMode));
     if (resumeMode == HistoryManager::CATCHUP_RECENT)
     {
-        mCfgs.back().CATCHUP_RECENT = 80;
+        mCfgs.back().CATCHUP_RECENT = recent;
     }
     Application::pointer app2 = Application::create(
         clock, mConfigurator->configure(mCfgs.back(), false));
@@ -974,4 +975,63 @@ TEST_CASE_METHOD(HistoryTests, "too far behind / catchup restart",
     init = app.getLedgerManager().getLastClosedLedgerNum();
     caughtup = catchupApplication(init, HistoryManager::CATCHUP_COMPLETE, app2);
     assert(caughtup);
+}
+
+/*
+ * Test a variety of orderings of CATCHUP_RECENT mode, to shake out boundary
+ * cases.
+ */
+TEST_CASE_METHOD(HistoryTests, "Catchup recent",
+                 "[history][catchuprecent]")
+{
+    auto dbMode = Config::TESTDB_IN_MEMORY_SQLITE;
+    auto catchupMode = HistoryManager::CATCHUP_RECENT;
+    std::vector<Application::pointer> apps;
+
+    generateAndPublishInitialHistory(3);
+
+    // Network has published 0x3f (63), 0x7f (127) and 0xbf (191)
+    // Network is currently sitting on ledger 0xc0 (192)
+    uint32_t initLedger = app.getLedgerManager().getLastClosedLedgerNum();
+
+    // Check that isolated catchups work at a variety of boundary
+    // conditions relative to the size of a checkpoint:
+    std::vector<uint32_t> recents =
+        {
+            0, 1, 2,
+            31, 32, 33,
+            62, 63, 64, 65, 66,
+            126, 127, 128, 129, 130,
+            190, 191, 192, 193, 194,
+            1000
+        };
+
+    for (auto r : recents)
+    {
+        auto name = std::string("catchup-recent-") + std::to_string(r);
+        apps.push_back(catchupNewApplication(initLedger, dbMode,
+                                             catchupMode, name, r));
+    }
+
+    // Now push network along a little bit and see that they can all still
+    // catch up properly.
+    generateAndPublishHistory(2);
+    initLedger = app.getLedgerManager().getLastClosedLedgerNum();
+
+    for (auto a : apps)
+    {
+        catchupApplication(initLedger, HistoryManager::CATCHUP_RECENT, a);
+    }
+
+    // Now push network along a _lot_ futher along see that they can all still
+    // catch up properly.
+    generateAndPublishHistory(25);
+    initLedger = app.getLedgerManager().getLastClosedLedgerNum();
+
+    for (auto a : apps)
+    {
+        catchupApplication(initLedger, HistoryManager::CATCHUP_RECENT, a);
+    }
+
+
 }

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -1137,10 +1137,11 @@ BucketDownloadWork::takeDownloadDir(BucketDownloadWork& other)
 ///////////////////////////////////////////////////////////////////////////
 
 CatchupWork::CatchupWork(Application& app, WorkParent& parent,
-                         uint32_t initLedger, bool manualCatchup)
+                         uint32_t initLedger, std::string const& mode,
+                         bool manualCatchup)
     : BucketDownloadWork(
-          app, parent, fmt::format("catchup-{:08x}", initLedger),
-          app.getHistoryManager().getLastClosedHistoryArchiveState())
+        app, parent, fmt::format("catchup-{:s}-{:08x}", mode, initLedger),
+        app.getHistoryManager().getLastClosedHistoryArchiveState())
     , mInitLedger(initLedger)
     , mNextLedger(manualCatchup ? initLedger
                                 : app.getHistoryManager().nextCheckpointLedger(
@@ -1166,9 +1167,8 @@ CatchupWork::onReset()
 ///////////////////////////////////////////////////////////////////////////
 
 CatchupMinimalWork::CatchupMinimalWork(Application& app, WorkParent& parent,
-                                       uint32_t initLedger, bool manualCatchup,
-                                       handler endHandler)
-    : CatchupWork(app, parent, initLedger, manualCatchup)
+                                       uint32_t initLedger, bool manualCatchup, handler endHandler)
+    : CatchupWork(app, parent, initLedger, "minimal", manualCatchup)
     , mEndHandler(endHandler)
 {
 }
@@ -1309,7 +1309,7 @@ CatchupMinimalWork::onFailureRaise()
 CatchupCompleteWork::CatchupCompleteWork(Application& app, WorkParent& parent,
                                          uint32_t initLedger,
                                          bool manualCatchup, handler endHandler)
-    : CatchupWork(app, parent, initLedger, manualCatchup)
+    : CatchupWork(app, parent, initLedger, "complete", manualCatchup)
     , mEndHandler(endHandler)
 {
 }

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -697,6 +697,7 @@ BatchDownloadWork::onReset()
     mNext = mFirst;
     mRunning.clear();
     mFinished.clear();
+    clearChildren();
     size_t nChildren = mApp.getConfig().MAX_CONCURRENT_SUBPROCESSES;
     while (mChildren.size() < nChildren && mNext <= mLast)
     {

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -915,11 +915,7 @@ ApplyLedgerChainWork::getStatus() const
 void
 ApplyLedgerChainWork::onReset()
 {
-    if (mLastApplied.header.ledgerSeq != 0)
-    {
-        mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
-    }
-
+    mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
     uint32_t step = mApp.getHistoryManager().getCheckpointFrequency();
     auto& lm = mApp.getLedgerManager();
     CLOG(INFO, "History") << "Replaying contents of "

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -678,7 +678,12 @@ BatchDownloadWork::addNextDownloadWorker()
     }
 
     FileTransferInfo ft(mDownloadDir, mFileType, mNext);
-    if (!fs::exists(ft.localPath_gz()) && !fs::exists(ft.localPath_nogz()))
+    if (fs::exists(ft.localPath_gz()) || fs::exists(ft.localPath_nogz()))
+    {
+        CLOG(DEBUG, "History") << "already have " << mFileType
+                               << " for checkpoint " << mNext;
+    }
+    else
     {
         CLOG(DEBUG, "History") << "Downloading " << mFileType
                                << " for checkpoint " << mNext;
@@ -1106,6 +1111,15 @@ BucketDownloadWork::onReset()
     mBuckets.clear();
     mDownloadDir =
         make_unique<TmpDir>(mApp.getTmpDirManager().tmpDir(getUniqueName()));
+}
+
+void
+BucketDownloadWork::takeDownloadDir(BucketDownloadWork& other)
+{
+    if (other.mDownloadDir)
+    {
+        mDownloadDir = std::move(other.mDownloadDir);
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -748,6 +748,15 @@ ApplyBucketsWork::ApplyBucketsWork(
     , mApplying(false)
     , mLevel(BucketList::kNumLevels - 1)
 {
+    // Consistency check: LCL should be in the _past_ from firstVerified,
+    // since we're about to clobber a bunch of DB state with new buckets
+    // held in firstVerified's state.
+    auto lcl = app.getLedgerManager().getLastClosedLedgerHeader();
+    if (firstVerified.header.ledgerSeq < lcl.header.ledgerSeq)
+    {
+        throw std::runtime_error(
+            "ApplyBucketsWork applying ledger earlier than local LCL");
+    }
 }
 
 BucketList&

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -1362,7 +1362,8 @@ CatchupCompleteWork::onSuccess()
     // Phase 2: download and decompress the ledgers.
     if (!mDownloadLedgersWork)
     {
-        CLOG(INFO, "History") << "Catchup COMPLETE downloading ledgers";
+        CLOG(INFO, "History") << "Catchup COMPLETE downloading ledgers ["
+                              << firstSeq << ", " << lastSeq << "]";
         mDownloadLedgersWork = addWork<BatchDownloadWork>(
             firstSeq, lastSeq, HISTORY_FILE_TYPE_LEDGER, *mDownloadDir);
         return WORK_PENDING;

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -33,16 +33,24 @@ fmtProgress(Application& app, std::string const& task, uint32_t first,
             uint32_t last, uint32_t curr)
 {
     auto step = app.getHistoryManager().getCheckpointFrequency();
+    if (curr > last)
+    {
+        curr = last;
+    }
+    if (curr < first)
+    {
+        curr = first;
+    }
     if (step == 0)
     {
         step = 1;
     }
-    auto done = (curr - first) / step;
-    auto total = (last - first) / step;
-    if (total == 0)
+    if (last < first)
     {
-        total = 1;
+        last = first;
     }
+    auto done = 1 + ((curr - first) / step);
+    auto total = 1 + ((last - first) / step);
     auto pct = (100 * done) / total;
     return fmt::format("{:s} {:d}/{:d} ({:d}%)", task, done, total, pct);
 }

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -248,7 +248,7 @@ VerifyBucketWork::VerifyBucketWork(
 }
 
 void
-VerifyBucketWork::onRun()
+VerifyBucketWork::onStart()
 {
     std::string filename = mBucketFile;
     uint256 hash = mHash;
@@ -292,6 +292,12 @@ VerifyBucketWork::onRun()
                                                    handler(ec);
                                                });
         });
+}
+
+void
+VerifyBucketWork::onRun()
+{
+    // Do nothing: we spawned the verifier in onStart().
 }
 
 Work::State
@@ -1481,7 +1487,7 @@ WriteSnapshotWork::WriteSnapshotWork(Application& app, WorkParent& parent,
 }
 
 void
-WriteSnapshotWork::onRun()
+WriteSnapshotWork::onStart()
 {
     auto handler = callComplete();
     auto snap = mSnapshot;
@@ -1508,6 +1514,12 @@ WriteSnapshotWork::onRun()
     {
         work();
     }
+}
+
+void
+WriteSnapshotWork::onRun()
+{
+    // Do nothing: we spawned the writer in onStart().
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -919,7 +919,7 @@ ApplyLedgerChainWork::onReset()
     uint32_t step = mApp.getHistoryManager().getCheckpointFrequency();
     auto& lm = mApp.getLedgerManager();
     CLOG(INFO, "History") << "Replaying contents of "
-                          << ((mLastSeq - mFirstSeq) / step)
+                          << (1 + ((mLastSeq - mFirstSeq) / step))
                           << " transaction-history files from LCL "
                           << LedgerManager::ledgerAbbrev(
                                  lm.getLastClosedLedgerHeader());
@@ -1292,7 +1292,8 @@ CatchupMinimalWork::onSuccess()
     // Phase 3: apply the buckets.
     if (!mApplyWork)
     {
-        CLOG(INFO, "History") << "Catchup MINIMAL applying buckets";
+        CLOG(INFO, "History") << "Catchup MINIMAL applying buckets for state "
+                              << LedgerManager::ledgerAbbrev(mFirstVerified);
         mApplyWork =
             addWork<ApplyBucketsWork>(mBuckets, mRemoteState, mFirstVerified);
         return WORK_PENDING;
@@ -1742,13 +1743,13 @@ CatchupRecentWork::getStatus() const
 {
     if (mState == WORK_PENDING)
     {
+        if (mCatchupCompleteWork)
+        {
+            return mCatchupCompleteWork->getStatus();
+        }
         if (mCatchupMinimalWork)
         {
             return mCatchupMinimalWork->getStatus();
-        }
-        else if (mCatchupCompleteWork)
-        {
-            return mCatchupCompleteWork->getStatus();
         }
     }
     return Work::getStatus();

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -214,7 +214,7 @@ class CatchupWork : public BucketDownloadWork
 
   public:
     CatchupWork(Application& app, WorkParent& parent, uint32_t initLedger,
-                bool manualCatchup);
+                std::string const& mode, bool manualCatchup);
     virtual void onReset() override;
 };
 

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -117,6 +117,7 @@ class VerifyBucketWork : public Work
                      std::map<std::string, std::shared_ptr<Bucket>>& buckets,
                      std::string const& bucketFile, uint256 const& hash);
     void onRun() override;
+    void onStart() override;
     Work::State onSuccess() override;
 };
 
@@ -396,6 +397,7 @@ class WriteSnapshotWork : public Work
   public:
     WriteSnapshotWork(Application& app, WorkParent& parent,
                       std::shared_ptr<StateSnapshot> snapshot);
+    void onStart() override;
     void onRun() override;
 };
 

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -220,12 +220,15 @@ class CatchupWork : public BucketDownloadWork
 
 class CatchupMinimalWork : public CatchupWork
 {
-
+  public:
     typedef std::function<void(
         asio::error_code const& ec, HistoryManager::CatchupMode mode,
         LedgerHeaderHistoryEntry const& lastClosed)> handler;
 
-    std::shared_ptr<Work> mDownloadWork;
+  protected:
+    std::shared_ptr<Work> mDownloadLedgersWork;
+    std::shared_ptr<Work> mVerifyLedgersWork;
+    std::shared_ptr<Work> mDownloadBucketsWork;
     std::shared_ptr<Work> mApplyWork;
     handler mEndHandler;
 

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -207,10 +207,13 @@ class CatchupWork : public BucketDownloadWork
     LedgerHeaderHistoryEntry mFirstVerified;
     LedgerHeaderHistoryEntry mLastVerified;
     LedgerHeaderHistoryEntry mLastApplied;
-    uint32_t mInitLedger;
-    uint32_t mNextLedger;
-    bool mManualCatchup;
+    uint32_t const mInitLedger;
+    bool const mManualCatchup;
     std::shared_ptr<Work> mGetHistoryArchiveStateWork;
+
+    uint32_t nextLedger() const;
+    virtual uint32_t firstCheckpointSeq() const = 0;
+    uint32_t lastCheckpointSeq() const;
 
   public:
     CatchupWork(Application& app, WorkParent& parent, uint32_t initLedger,
@@ -231,6 +234,7 @@ class CatchupMinimalWork : public CatchupWork
     std::shared_ptr<Work> mDownloadBucketsWork;
     std::shared_ptr<Work> mApplyWork;
     handler mEndHandler;
+    virtual uint32_t firstCheckpointSeq() const;
 
   public:
     CatchupMinimalWork(Application& app, WorkParent& parent,
@@ -283,6 +287,7 @@ class CatchupCompleteWork : public CatchupWork
     std::shared_ptr<Work> mVerifyWork;
     std::shared_ptr<Work> mApplyWork;
     handler mEndHandler;
+    virtual uint32_t firstCheckpointSeq() const;
 
   public:
     CatchupCompleteWork(Application& app, WorkParent& parent,
@@ -307,7 +312,6 @@ class CatchupRecentWork : public Work
     std::shared_ptr<Work> mCatchupMinimalWork;
     std::shared_ptr<Work> mCatchupCompleteWork;
     uint32_t mInitLedger;
-    uint32_t mNumLedgers;
     bool mManualCatchup;
     handler mEndHandler;
     LedgerHeaderHistoryEntry mFirstVerified;
@@ -317,8 +321,8 @@ class CatchupRecentWork : public Work
     handler writeLastApplied();
 
   public:
-    CatchupRecentWork(Application& app, WorkParent& parent, uint32_t initLedger,
-                      uint32_t numLedgers, bool manualCatchup,
+    CatchupRecentWork(Application& app, WorkParent& parent,
+                      uint32_t initLedger, bool manualCatchup,
                       handler endHandler);
     std::string getStatus() const override;
     void onReset() override;

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -294,6 +294,38 @@ class CatchupCompleteWork : public CatchupWork
     void onFailureRaise() override;
 };
 
+// Catchup-recent is just a catchup-minimal to (now - N),
+// followed by a catchup-complete to now.
+class CatchupRecentWork : public Work
+{
+  public:
+    typedef std::function<void(asio::error_code const& ec,
+                               HistoryManager::CatchupMode mode,
+                               LedgerHeaderHistoryEntry const& ledger)> handler;
+
+  protected:
+    std::shared_ptr<Work> mCatchupMinimalWork;
+    std::shared_ptr<Work> mCatchupCompleteWork;
+    uint32_t mInitLedger;
+    uint32_t mNumLedgers;
+    bool mManualCatchup;
+    handler mEndHandler;
+    LedgerHeaderHistoryEntry mFirstVerified;
+    LedgerHeaderHistoryEntry mLastApplied;
+
+    handler writeFirstVerified();
+    handler writeLastApplied();
+
+  public:
+    CatchupRecentWork(Application& app, WorkParent& parent, uint32_t initLedger,
+                      uint32_t numLedgers, bool manualCatchup,
+                      handler endHandler);
+    std::string getStatus() const override;
+    void onReset() override;
+    Work::State onSuccess() override;
+    void onFailureRaise() override;
+};
+
 class VerifyLedgerChainWork : public Work
 {
     TmpDir const& mDownloadDir;

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -124,7 +124,7 @@ class ApplyBucketsWork : public Work
 {
     std::map<std::string, std::shared_ptr<Bucket>>& mBuckets;
     HistoryArchiveState& mApplyState;
-    LedgerHeaderHistoryEntry& mLastVerified;
+    LedgerHeaderHistoryEntry const& mFirstVerified;
 
     bool mApplying;
     size_t mLevel;
@@ -141,7 +141,7 @@ class ApplyBucketsWork : public Work
     ApplyBucketsWork(Application& app, WorkParent& parent,
                      std::map<std::string, std::shared_ptr<Bucket>>& buckets,
                      HistoryArchiveState& applyState,
-                     LedgerHeaderHistoryEntry& lastVerified);
+                     LedgerHeaderHistoryEntry const& firstVerified);
 
     void onReset() override;
     void onStart() override;
@@ -204,6 +204,7 @@ class CatchupWork : public BucketDownloadWork
 {
   protected:
     HistoryArchiveState mRemoteState;
+    LedgerHeaderHistoryEntry mFirstVerified;
     LedgerHeaderHistoryEntry mLastVerified;
     LedgerHeaderHistoryEntry mLastApplied;
     uint32_t mInitLedger;
@@ -297,6 +298,7 @@ class VerifyLedgerChainWork : public Work
     uint32_t mCurrSeq;
     uint32_t mLastSeq;
     bool mManualCatchup;
+    LedgerHeaderHistoryEntry& mFirstVerified;
     LedgerHeaderHistoryEntry& mLastVerified;
 
     HistoryManager::VerifyHashStatus verifyHistoryOfSingleCheckpoint();
@@ -305,6 +307,7 @@ class VerifyLedgerChainWork : public Work
     VerifyLedgerChainWork(Application& app, WorkParent& parent,
                           TmpDir const& downloadDir, uint32_t firstSeq,
                           uint32_t lastSeq, bool manualCatchup,
+                          LedgerHeaderHistoryEntry& firstVerified,
                           LedgerHeaderHistoryEntry& lastVerified);
     std::string getStatus() const override;
     void onReset() override;
@@ -320,6 +323,7 @@ class ApplyLedgerChainWork : public Work
     XDRInputFileStream mHdrIn;
     XDRInputFileStream mTxIn;
     TransactionHistoryEntry mTxHistoryEntry;
+    LedgerHeaderHistoryEntry& mLastApplied;
 
     TxSetFramePtr getCurrentTxSet();
     void openCurrentInputFiles();
@@ -328,7 +332,7 @@ class ApplyLedgerChainWork : public Work
   public:
     ApplyLedgerChainWork(Application& app, WorkParent& parent,
                          TmpDir const& downloadDir, uint32_t first,
-                         uint32_t last);
+                         uint32_t last, LedgerHeaderHistoryEntry& lastApplied);
     std::string getStatus() const override;
     void onReset() override;
     void onStart() override;

--- a/src/history/HistoryWork.h
+++ b/src/history/HistoryWork.h
@@ -197,6 +197,7 @@ class BucketDownloadWork : public Work
                        std::string const& uniqueName,
                        HistoryArchiveState const& localState);
     void onReset() override;
+    void takeDownloadDir(BucketDownloadWork& other);
 };
 
 class CatchupWork : public BucketDownloadWork

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -501,9 +501,13 @@ CommandHandler::catchup(std::string const& params, std::string& retStr)
         {
             mode = HistoryManager::CATCHUP_MINIMAL;
         }
+        else if (modeP->second == std::string("recent"))
+        {
+            mode = HistoryManager::CATCHUP_RECENT;
+        }
         else
         {
-            retStr = "Mode should be either 'minimal' or 'complete'";
+            retStr = "Mode should be either 'minimal', 'recent' or 'complete'";
             return;
         }
     }
@@ -513,7 +517,9 @@ CommandHandler::catchup(std::string const& params, std::string& retStr)
               std::to_string(ledger) + std::string(" in mode ") +
               std::string(mode == HistoryManager::CATCHUP_COMPLETE
                               ? "CATCHUP_COMPLETE"
-                              : "CATCHUP_MINIMAL"));
+                              : (mode == HistoryManager::CATCHUP_RECENT
+                                     ? "CATCHUP_RECENT"
+                                     : "CATCHUP_MINIMAL")));
 }
 
 void

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -34,6 +34,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     RUN_STANDALONE = false;
     MANUAL_CLOSE = false;
     CATCHUP_COMPLETE = false;
+    CATCHUP_RECENT = 0;
     MAINTENANCE_ON_STARTUP = true;
     ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
     ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
@@ -269,6 +270,19 @@ Config::load(std::string const& filename)
                     throw std::invalid_argument("invalid CATCHUP_COMPLETE");
                 }
                 CATCHUP_COMPLETE = item.second->as<bool>()->value();
+            }
+            else if (item.first == "CATCHUP_RECENT")
+            {
+                if (!item.second->as<int64_t>())
+                {
+                    throw std::invalid_argument("invalid CATCHUP_RECENT");
+                }
+                int64_t r = item.second->as<int64_t>()->value();
+                if (r < 0 || r >= UINT32_MAX)
+                {
+                    throw std::invalid_argument("invalid CATCHUP_RECENT");
+                }
+                CATCHUP_RECENT = r;
             }
             else if (item.first == "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -64,6 +64,13 @@ class Config : public std::enable_shared_from_this<Config>
     // meaning catchup "minimally", using deltas to the most recent snapshot.
     bool CATCHUP_COMPLETE;
 
+    // Number of "recent" ledgers before the current ledger to include in a
+    // "minimal" catchup. Default is 0, and if CATCHUP_COMPLETE is set to
+    // true, this is ignored.
+    //
+    // If you want, say, a week of history, set this to 120000.
+    uint32_t CATCHUP_RECENT;
+
     // Enables or disables automatic maintenance on startup
     bool MAINTENANCE_ON_STARTUP;
 

--- a/src/test/selftest-pg
+++ b/src/test/selftest-pg
@@ -39,7 +39,7 @@ EOF
 
 setup_test() {
     runpg || return 1
-    for i in $(seq 0 8) ''; do
+    for i in $(seq 0 15) ''; do
 	psql -c "create database test$i;"
     done
 }

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -225,10 +225,16 @@ Work::advance()
     advanceChildren();
     if (allChildrenSuccessful())
     {
+        CLOG(DEBUG, "Work") << "all " << mChildren.size()
+                            << " children of " << getUniqueName()
+                            << " successful, scheduling run";
         scheduleRun();
     }
     else if (anyChildRaiseFailure())
     {
+        CLOG(DEBUG, "Work") << "some of " << mChildren.size()
+                            << " children of " << getUniqueName()
+                            << " successful, scheduling failure";
         scheduleFailure();
     }
 }
@@ -270,6 +276,8 @@ Work::complete(asio::error_code const& ec)
     {
     case WORK_SUCCESS:
         succ.Mark();
+        CLOG(DEBUG, "Work")
+            << "notifying parent of successful " << getUniqueName();
         notifyParent();
         break;
 
@@ -282,6 +290,8 @@ Work::complete(asio::error_code const& ec)
     case WORK_FAILURE_RAISE:
         fail.Mark();
         onFailureRaise();
+        CLOG(DEBUG, "Work")
+            << "notifying parent of failed " << getUniqueName();
         notifyParent();
         break;
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -34,7 +34,7 @@ llvm-symbolizer --version || true
 # Create postgres databases
 export PGUSER=postgres
 psql -c "create database test;"
-for i in $(seq 0 8)
+for i in $(seq 0 15)
 do
     psql -c "create database test$i;"
 done


### PR DESCRIPTION
This impements CATCHUP_RECENT mode, described in bug #966 

To use it, just set CATCHUP_RECENT=N to some number of ledgers in the config file. This will cause CATCHUP_MINIMAL to snap to the first checkpoint after the point N ledgers before the network ledger, and then replay checkpoints after there. This enables maintaining N ledgers of local history (say, the past week or month) at all times, without having to have _all_ of it.

If CATCHUP_COMPLETE=true is set in a config file, CATCHUP_RECENT has no effect.