### PR TITLE
Added code to implement logRotation function

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -463,6 +463,7 @@ void
 CommandHandler::logRotate(std::string const& params, std::string& retStr)
 {
     retStr = "Log rotate...";
+    Logging::rotateLogFile();
 }
 
 void

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -78,9 +78,9 @@ Logging::setLoggingToFile(std::string const& filename)
 void
 Logging::rolloutHandler(const char* filename, std::size_t size) {
     // size is there to match easylogging++ library template
-    std::stringstream ss;
-    ss << "mv " << filename << " " << filename << "." << ++logFileIndex;
-    system(ss.str().c_str());
+    std::stringstream ss_new_filename;
+    ss_new_filename << filename << "." << ++logFileIndex;
+    std::rename(filename, ss_new_filename.str().c_str());
     el::Loggers::removeFlag(el::LoggingFlag::StrictLogFileSizeCheck);
 }
 

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -17,11 +17,14 @@ namespace stellar
 class Logging
 {
     static el::Configurations gDefaultConf;
+    static int32_t logFileIndex;
 
   public:
     static void init();
     static void setFmt(std::string const& peerID, bool timestamps = true);
     static void setLoggingToFile(std::string const& filename);
+    static void rotateLogFile();
+    static void rolloutHandler(const char* filename, std::size_t size);
     static void setLogLevel(el::Level level, const char* partition);
     static el::Level getLLfromString(std::string const& levelName);
     static el::Level getLogLevel(std::string const& partition);


### PR DESCRIPTION
I did not manage to rotate the logfile since the log is not reopened when a function like 'logrotate' copies and truncates the logfile. Then I found this '/logrotate' API endpoint, but this wasn't doing anything more then giving false hope for logrotation....
As I found out an implementation was lacking, I gave it a try.

The easylogging++ library was lacking a trigger to do this directly so I created a workaround which triggers the max size log rolling function in the library, since it is not used anyway.

A GET to /logrotate triggers the function to set the logrotate flag which triggers the library function to rotate the log. It increments the logfile (logfile.log.1 ... logfile.log.2  etc) while maintaining logging in logfile.log.
