### PR TITLE
Throw when bucket-repair on startup fails, cc #931.

### DIFF
--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -854,6 +854,11 @@ TEST_CASE_METHOD(HistoryTests, "Repair missing buckets fails",
                                         state);
 
     REQUIRE_THROWS(app2->start());
+
+    while (app2->getProcessManager().getNumRunningProcesses() != 0)
+    {
+        app2->getClock().crank(false);
+    }
 }
 
 class S3Configurator : public Configurator

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -41,6 +41,7 @@ class Configurator : NonCopyable
 {
   public:
     virtual Config& configure(Config& cfg, bool writable) const = 0;
+    virtual std::string getArchiveDirName() const { return ""; }
 };
 
 class TmpDirConfigurator : public Configurator
@@ -51,6 +52,11 @@ class TmpDirConfigurator : public Configurator
   public:
     TmpDirConfigurator() : mArchtmp("archtmp"), mDir(mArchtmp.tmpDir("archive"))
     {
+    }
+
+    std::string getArchiveDirName() const override
+    {
+        return mDir.getName();
     }
 
     Config&
@@ -818,6 +824,36 @@ TEST_CASE_METHOD(HistoryTests, "Repair missing buckets via history",
     auto hash1 = appPtr->getBucketManager().getBucketList().getHash();
     auto hash2 = app2->getBucketManager().getBucketList().getHash();
     CHECK(hash1 == hash2);
+}
+
+TEST_CASE_METHOD(HistoryTests, "Repair missing buckets fails",
+                 "[history][historybucketrepair]")
+{
+    generateAndPublishInitialHistory(1);
+
+    // Forcibly resolve any merges in progress, so we have a calm state to
+    // repair;
+    // NB: we cannot repair lost buckets from merges-in-progress, as they're not
+    // necessarily _published_ anywhere.
+    HistoryArchiveState has(app.getLedgerManager().getLastClosedLedgerNum(),
+                            app.getBucketManager().getBucketList());
+    has.resolveAllFutures();
+    auto state = has.toString();
+
+    // Delete buckets from the archive before proceding.
+    // This means startup will fail.
+    auto dir = mConfigurator->getArchiveDirName();
+    REQUIRE(!dir.empty());
+    fs::deltree(dir + "/bucket");
+
+    auto cfg2 = getTestConfig(1);
+    cfg2.BUCKET_DIR_PATH += "2";
+    auto app2 =
+        Application::create(clock, mConfigurator->configure(cfg2, false));
+    app2->getPersistentState().setState(PersistentState::kHistoryArchiveState,
+                                        state);
+
+    REQUIRE_THROWS(app2->start());
 }
 
 class S3Configurator : public Configurator

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -195,6 +195,10 @@ ApplicationImpl::getNetworkID() const
 ApplicationImpl::~ApplicationImpl()
 {
     LOG(INFO) << "Application destructing";
+    if (mProcessManager)
+    {
+        mProcessManager->shutdown();
+    }
     reportCfgMetrics();
     shutdownMainIOService();
     joinAllThreads();
@@ -310,6 +314,10 @@ ApplicationImpl::gracefulStop()
     if (mOverlayManager)
     {
         mOverlayManager->shutdown();
+    }
+    if (mProcessManager)
+    {
+        mProcessManager->shutdown();
     }
 
     mStoppingTimer.expires_from_now(
@@ -504,6 +512,10 @@ ApplicationImpl::syncOwnMetrics()
         .Mark(vignore);
     mMetrics->NewMeter({"crypto", "verify", "total"}, "signature")
         .Mark(vhit + vmiss + vignore);
+
+    // Similarly, flush global process-table stats.
+    mMetrics->NewCounter({"process", "memory", "handles"}).set_count(
+        mProcessManager->getNumRunningProcesses());
 }
 
 void

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -246,6 +246,11 @@ ApplicationImpl::start()
     mLedgerManager->loadLastKnownLedger(
         [this, &done](asio::error_code const& ec)
         {
+            if (ec)
+            {
+                throw std::runtime_error("Unable to restore last-known ledger state");
+            }
+
             // restores the SCP state before starting overlay
             mHerder->restoreSCPState();
             // perform maintenance tasks if configured to do so

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -118,7 +118,7 @@ class ApplicationImpl : public Application
     std::unique_ptr<Herder> mHerder;
     std::unique_ptr<BucketManager> mBucketManager;
     std::unique_ptr<HistoryManager> mHistoryManager;
-    std::unique_ptr<ProcessManager> mProcessManager;
+    std::shared_ptr<ProcessManager> mProcessManager;
     std::unique_ptr<CommandHandler> mCommandHandler;
     std::shared_ptr<WorkManager> mWorkManager;
     std::unique_ptr<PersistentState> mPersistentState;

--- a/src/process/ProcessManager.h
+++ b/src/process/ProcessManager.h
@@ -44,13 +44,16 @@ class ProcessExitEvent
     void async_wait(std::function<void(asio::error_code)> const& handler);
 };
 
-class ProcessManager : public NonMovableOrCopyable
+class ProcessManager : public std::enable_shared_from_this<ProcessManager>,
+                       public NonMovableOrCopyable
 {
   public:
-    static std::unique_ptr<ProcessManager> create(Application& app);
+    static std::shared_ptr<ProcessManager> create(Application& app);
     virtual ProcessExitEvent runProcess(std::string const& cmdLine,
                                         std::string outputFile = "") = 0;
     virtual size_t getNumRunningProcesses() = 0;
+    virtual bool isShutdown() const = 0;
+    virtual void shutdown() = 0;
     virtual ~ProcessManager()
     {
     }

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -27,7 +27,9 @@ class ProcessManagerImpl : public ProcessManager
     // number of processes we run at once.
     static size_t gNumProcessesActive;
 
-    Application& mApp;
+    bool mIsShutdown{false};
+    size_t mMaxProcesses;
+    asio::io_service& mIOService;
 
     std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mPendingImpls;
     void maybeRunPendingProcesses();
@@ -37,7 +39,6 @@ class ProcessManagerImpl : public ProcessManager
     void startSignalWait();
     void handleSignalWait();
 
-    medida::Counter& mImplsSize;
     friend class ProcessExitEvent::Impl;
 
   public:
@@ -45,6 +46,10 @@ class ProcessManagerImpl : public ProcessManager
     ProcessExitEvent runProcess(std::string const& cmdLine,
                                 std::string outFile = "") override;
     size_t getNumRunningProcesses() override;
+
+    bool isShutdown() const override;
+    void shutdown() override;
+
     ~ProcessManagerImpl() override;
 };
 }


### PR DESCRIPTION
This just causes the server to throw a hard error when it fails to repair buckets on startup, as mentioned in bug #931. This shouldn't happen a lot anymore, but if it does at least it should now notice, cease retrying eventually, and hard-fail.