### PR TITLE
close the http socket

### DIFF
--- a/lib/http/connection.cpp
+++ b/lib/http/connection.cpp
@@ -93,6 +93,9 @@ connection::do_write()
         {
             connection_manager_.stop(shared_from_this());
         }
+
+        asio::error_code closeEc;
+        socket_.close(closeEc);
     });
 }
 


### PR DESCRIPTION
The HTTP socket is now properly closed, when many clients connect to the HTTP server, it sometimes replied with a tcp reset, ending up as an ECONNRESET or a EPIPE on the client side.


