### PR TITLE
Fix link to 'transaction'

### DIFF
--- a/docs/learn/commands.md
+++ b/docs/learn/commands.md
@@ -103,7 +103,7 @@ debugging purpose).
 
 * **tx**
   `/tx?blob=Base64`<br>
-  submit a [transaction](/docs/concepts/transaction.md) to the network.
+  submit a [transaction](/docs/transaction.md) to the network.
   blob is a base64 encoded XDR serialized 'TransactionEnvelope'
   returns a JSON object with the following properties
   status:


### PR DESCRIPTION
Change /docs/concepts/transaction.md -> /docs/transaction.md as there is no concepts folder ...(?)