### PR TITLE
Avoid unary-neg on unsigned, makes MSVC cranky.

### DIFF
--- a/src/util/BitsetEnumerator.cpp
+++ b/src/util/BitsetEnumerator.cpp
@@ -106,13 +106,22 @@ PermutationEnumerator::operator*() const
     return bits;
 }
 
+// Simplest way of expressing unsigned unary-neg without tripping compiler
+// errors, and/or hunting for the One Right Signedness Cast agreeable to
+// all compilers / avoiding undefined behaviour.
+static inline uint64_t
+uneg(uint64_t const& n)
+{
+    return (~n) + 1;
+}
+
 void
 PermutationEnumerator::operator++()
 {
     // Next bit-permutation. See:
     // https://graphics.stanford.edu/~seander/bithacks.html#NextBitPermutation
     uint64_t t = (mCur | (mCur - 1)) + 1;
-    mCur = t | ((((t & -t) / (mCur & -mCur)) >> 1) - 1);
+    mCur = t | ((((t & -t) / (mCur & uneg(mCur))) >> 1) - 1);
 }
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
MSVC has a [warning C4146](https://msdn.microsoft.com/en-us/library/4kh09110.aspx) which we have set to error-level on our normal build; it prevents the BitsetEnumerator from compiling because it dislikes applying unary-negation to an unsigned value. This is a legit warning in most contexts and good to keep as an error. We could disable it in this file, but an even-more-explicit fix is presented here.

@MonsieurNicolas does this seem reasonable to you?