### PR TITLE
Misc perf fixes

### DIFF
--- a/lib/util/basen.h
+++ b/lib/util/basen.h
@@ -66,8 +66,8 @@ struct b16_conversion_traits
 
     static char encode(unsigned int index)
     {
-        const char* const dictionary = "0123456789ABCDEF";
-        assert(index < strlen(dictionary));
+        static const char dictionary[17] = "0123456789ABCDEF";
+        assert(index < 16);
         return dictionary[index];
     }
 
@@ -92,8 +92,8 @@ struct b32_conversion_traits
 
     static char encode(unsigned int index)
     {
-        const char * dictionary = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-        assert(index < strlen(dictionary));
+        static const char dictionary[33] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        assert(index < 32);
         return dictionary[index];
     }
 
@@ -118,8 +118,8 @@ struct b64_conversion_traits
 
     static char encode(unsigned int index)
     {
-        const char* const dictionary = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        assert(index < strlen(dictionary));
+        static const char dictionary[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        assert(index < 64);
         return dictionary[index];
     }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -263,17 +263,19 @@ HerderImpl::validateValueHelper(uint64 slotIndex, StellarValue const& b)
     }
     else if (!txSet->checkValid(mApp))
     {
-        CLOG(DEBUG, "Herder") << "HerderImpl::validateValue"
-                              << " i: " << slotIndex << " Invalid txSet:"
-                              << " " << hexAbbrev(txSet->getContentsHash());
+        if (Logging::logDebug("Herder"))
+            CLOG(DEBUG, "Herder") << "HerderImpl::validateValue"
+                                  << " i: " << slotIndex << " Invalid txSet:"
+                                  << " " << hexAbbrev(txSet->getContentsHash());
         res = SCPDriver::kInvalidValue;
     }
     else
     {
-        CLOG(DEBUG, "Herder")
-            << "HerderImpl::validateValue"
-            << " i: " << slotIndex
-            << " txSet: " << hexAbbrev(txSet->getContentsHash()) << " OK";
+        if (Logging::logDebug("Herder"))
+            CLOG(DEBUG, "Herder")
+                << "HerderImpl::validateValue"
+                << " i: " << slotIndex
+                << " txSet: " << hexAbbrev(txSet->getContentsHash()) << " OK";
         res = SCPDriver::kFullyValidatedValue;
     }
     return res;
@@ -573,8 +575,9 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
 
     Hash const& txSetHash = b.txSetHash;
 
-    CLOG(DEBUG, "Herder") << "HerderImpl::valueExternalized"
-                          << " txSet: " << hexAbbrev(txSetHash);
+    if (Logging::logDebug("Herder"))
+        CLOG(DEBUG, "Herder") << "HerderImpl::valueExternalized"
+                              << " txSet: " << hexAbbrev(txSetHash);
 
     // log information from older ledger to increase the chances that
     // all messages made it
@@ -639,8 +642,9 @@ HerderImpl::valueExternalized(uint64 slotIndex, Value const& value)
 void
 HerderImpl::nominatingValue(uint64 slotIndex, Value const& value)
 {
-    CLOG(DEBUG, "Herder") << "nominatingValue i:" << slotIndex
-                          << " v: " << getValueString(value);
+    if (Logging::logDebug("Herder"))
+        CLOG(DEBUG, "Herder") << "nominatingValue i:" << slotIndex
+                              << " v: " << getValueString(value);
 
     if (!value.empty())
     {
@@ -852,10 +856,11 @@ HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
 {
     uint64 slotIndex = envelope.statement.slotIndex;
 
-    CLOG(DEBUG, "Herder") << "emitEnvelope"
-                          << " s:" << envelope.statement.pledges.type()
-                          << " i:" << slotIndex
-                          << " a:" << mApp.getStateHuman();
+    if (Logging::logDebug("Herder"))
+        CLOG(DEBUG, "Herder") << "emitEnvelope"
+                              << " s:" << envelope.statement.pledges.type()
+                              << " i:" << slotIndex
+                              << " a:" << mApp.getStateHuman();
 
     persistSCPState(slotIndex);
 
@@ -948,8 +953,9 @@ HerderImpl::recvTransaction(TransactionFramePtr tx)
         return TX_STATUS_ERROR;
     }
 
-    CLOG(TRACE, "Herder") << "recv transaction " << hexAbbrev(txID) << " for "
-                          << PubKeyUtils::toShortString(acc);
+    if (Logging::logTrace("Herder"))
+        CLOG(TRACE, "Herder") << "recv transaction " << hexAbbrev(txID) << " for "
+                              << PubKeyUtils::toShortString(acc);
 
     auto txmap = findOrAdd(mPendingTransactions[0], acc);
     txmap->addTx(tx);
@@ -965,13 +971,14 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
         return;
     }
 
-    CLOG(DEBUG, "Herder") << "recvSCPEnvelope"
-                          << " from: "
-                          << mApp.getConfig().toShortString(
-                                 envelope.statement.nodeID)
-                          << " s:" << envelope.statement.pledges.type()
-                          << " i:" << envelope.statement.slotIndex
-                          << " a:" << mApp.getStateHuman();
+    if (Logging::logDebug("Herder"))
+        CLOG(DEBUG, "Herder") << "recvSCPEnvelope"
+                              << " from: "
+                              << mApp.getConfig().toShortString(
+                                  envelope.statement.nodeID)
+                              << " s:" << envelope.statement.pledges.type()
+                              << " i:" << envelope.statement.slotIndex
+                              << " a:" << mApp.getStateHuman();
 
     if (envelope.statement.nodeID == mSCP.getLocalNode()->getNodeID())
     {

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -158,8 +158,8 @@ TxSetFrame::surgePricingFilter(LedgerManager const& lm)
     size_t max = lm.getMaxTxSetSize();
     if (mTransactions.size() > max)
     { // surge pricing in effect!
-        CLOG(DEBUG, "Herder") << "surge pricing in effect! "
-                              << mTransactions.size();
+        CLOG(WARNING, "Herder") << "surge pricing in effect! "
+                                << mTransactions.size();
 
         // determine the fee ratio for each account
         map<AccountID, double> accountFeeMap;

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -184,10 +184,11 @@ LoadManager::PeerContext::~PeerContext()
         auto recv = Peer::getByteReadMeter(mApp).count() - mBytesRecvStart;
         auto query =
             (mApp.getDatabase().getQueryMeter().count() - mSQLQueriesStart);
-        CLOG(TRACE, "Overlay")
-            << "Debiting peer " << mApp.getConfig().toShortString(mNode)
-            << " time:" << timeMag(time.count()) << " send:" << byteMag(send)
-            << " recv:" << byteMag(recv) << " query:" << query;
+        if (Logging::logTrace("Overlay"))
+            CLOG(TRACE, "Overlay")
+                << "Debiting peer " << mApp.getConfig().toShortString(mNode)
+                << " time:" << timeMag(time.count()) << " send:" << byteMag(send)
+                << " recv:" << byteMag(recv) << " query:" << query;
         pc->mTimeSpent.Mark(time.count());
         pc->mBytesSend.Mark(send);
         pc->mBytesRecv.Mark(recv);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -324,7 +324,8 @@ Peer::sendGetTxSet(uint256 const& setID)
 void
 Peer::sendGetQuorumSet(uint256 const& setID)
 {
-    CLOG(TRACE, "Overlay") << "Get quorum set: " << hexAbbrev(setID);
+    if (Logging::logTrace("Overlay"))
+        CLOG(TRACE, "Overlay") << "Get quorum set: " << hexAbbrev(setID);
 
     StellarMessage newMsg;
     newMsg.type(GET_SCP_QUORUMSET);
@@ -380,14 +381,62 @@ Peer::sendPeers()
     sendMessage(newMsg);
 }
 
+static std::string
+msgSummary(StellarMessage const& msg)
+{
+    switch (msg.type())
+    {
+    case ERROR_MSG:
+        return "ERROR";
+    case HELLO:
+        return "HELLO";
+    case AUTH:
+        return "AUTH";
+    case DONT_HAVE:
+        return "DONTHAVE";
+    case GET_PEERS:
+        return "GETPEERS";
+    case PEERS:
+        return "PEERS";
+
+    case GET_TX_SET:
+        return "GETTXSET";
+    case TX_SET:
+        return "TXSET";
+
+    case TRANSACTION:
+        return "TRANSACTION";
+
+    case GET_SCP_QUORUMSET:
+        return "GET_SCP_QSET";
+    case SCP_QUORUMSET:
+        return "SCP_QSET";
+    case SCP_MESSAGE:
+        switch (msg.envelope().statement.pledges.type()) {
+        case SCP_ST_PREPARE:
+            return "SCP::PREPARE";
+        case SCP_ST_CONFIRM:
+            return "SCP::CONFIRM";
+        case SCP_ST_EXTERNALIZE:
+            return "SCP::EXTERNALIZE";
+        case SCP_ST_NOMINATE:
+            return "SCP::NOMINATE";
+        }
+    case GET_SCP_STATE:
+        return "GET_SCP_STATE";
+    }
+    return "UNKNOWN";
+}
+
 void
 Peer::sendMessage(StellarMessage const& msg)
 {
-    CLOG(TRACE, "Overlay") << "("
-                           << mApp.getConfig().toShortString(
-                                  mApp.getConfig().NODE_SEED.getPublicKey())
-                           << ") send: " << msg.type() << " to : "
-                           << mApp.getConfig().toShortString(mPeerID);
+    if (Logging::logTrace("Overlay"))
+        CLOG(TRACE, "Overlay") << "("
+                               << mApp.getConfig().toShortString(
+                                   mApp.getConfig().NODE_SEED.getPublicKey())
+                               << ") send: " << msgSummary(msg) << " to : "
+                               << mApp.getConfig().toShortString(mPeerID);
 
     switch (msg.type())
     {
@@ -531,11 +580,12 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
         return;
     }
 
-    CLOG(TRACE, "Overlay") << "("
-                           << mApp.getConfig().toShortString(
-                                  mApp.getConfig().NODE_SEED.getPublicKey())
-                           << ") recv: " << stellarMsg.type() << " from:"
-                           << mApp.getConfig().toShortString(mPeerID);
+    if (Logging::logTrace("Overlay"))
+        CLOG(TRACE, "Overlay") << "("
+                               << mApp.getConfig().toShortString(
+                                   mApp.getConfig().NODE_SEED.getPublicKey())
+                               << ") recv: " << msgSummary(stellarMsg) << " from:"
+                               << mApp.getConfig().toShortString(mPeerID);
 
     if (!isAuthenticated() && (stellarMsg.type() != HELLO) &&
         (stellarMsg.type() != AUTH) && (stellarMsg.type() != ERROR_MSG))
@@ -714,8 +764,9 @@ Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
     }
     else
     {
-        CLOG(TRACE, "Overlay")
-            << "No quorum set: " << hexAbbrev(msg.qSetHash());
+        if (Logging::logTrace("Overlay"))
+            CLOG(TRACE, "Overlay")
+                << "No quorum set: " << hexAbbrev(msg.qSetHash());
         sendDontHave(SCP_QUORUMSET, msg.qSetHash());
         // do we want to ask other people for it?
     }
@@ -731,9 +782,10 @@ void
 Peer::recvSCPMessage(StellarMessage const& msg)
 {
     SCPEnvelope const& envelope = msg.envelope();
-    CLOG(TRACE, "Overlay") << "recvSCPMessage node: "
-                           << mApp.getConfig().toShortString(
-                                  msg.envelope().statement.nodeID);
+    if (Logging::logTrace("Overlay"))
+        CLOG(TRACE, "Overlay") << "recvSCPMessage node: "
+                               << mApp.getConfig().toShortString(
+                                   msg.envelope().statement.nodeID);
 
     mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -94,6 +94,15 @@ Peer::Peer(Application& app, PeerRole role)
     , mRecvGetSCPStateTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "get-scp-state"}))
 
+    , mRecvSCPPrepareTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-prepare"}))
+    , mRecvSCPConfirmTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-confirm"}))
+    , mRecvSCPNominateTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-nominate"}))
+    , mRecvSCPExternalizeTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-externalize"}))
+
     , mSendErrorMeter(
           app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))
     , mSendHelloMeter(
@@ -788,6 +797,13 @@ Peer::recvSCPMessage(StellarMessage const& msg)
                                    msg.envelope().statement.nodeID);
 
     mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
+
+    auto type = msg.envelope().statement.pledges.type();
+    auto t =
+        (type == SCP_ST_PREPARE ? mRecvSCPPrepareTimer.TimeScope() :
+         (type == SCP_ST_CONFIRM ? mRecvSCPConfirmTimer.TimeScope() :
+          (type == SCP_ST_EXTERNALIZE ? mRecvSCPExternalizeTimer.TimeScope() :
+           (mRecvSCPNominateTimer.TimeScope()))));
 
     mApp.getHerder().recvSCPEnvelope(envelope);
 }

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -98,6 +98,11 @@ class Peer : public std::enable_shared_from_this<Peer>,
     medida::Timer& mRecvSCPMessageTimer;
     medida::Timer& mRecvGetSCPStateTimer;
 
+    medida::Timer& mRecvSCPPrepareTimer;
+    medida::Timer& mRecvSCPConfirmTimer;
+    medida::Timer& mRecvSCPExternalizeTimer;
+    medida::Timer& mRecvSCPNominateTimer;
+
     medida::Meter& mSendErrorMeter;
     medida::Meter& mSendHelloMeter;
     medida::Meter& mSendAuthMeter;

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -127,7 +127,8 @@ TCPPeer::getIP()
 void
 TCPPeer::sendMessage(xdr::msg_ptr&& xdrBytes)
 {
-    CLOG(TRACE, "Overlay") << "TCPPeer:sendMessage to " << toString();
+    if (Logging::logTrace("Overlay"))
+        CLOG(TRACE, "Overlay") << "TCPPeer:sendMessage to " << toString();
     assertThreadIsMain();
 
     // places the buffer to write into the write queue
@@ -232,16 +233,19 @@ TCPPeer::startRead()
     auto self = static_pointer_cast<TCPPeer>(shared_from_this());
 
     assert(self->mIncomingHeader.size() == 0);
-    CLOG(TRACE, "Overlay") << "TCPPeer::startRead to " << self->toString();
+
+    if (Logging::logTrace("Overlay"))
+        CLOG(TRACE, "Overlay") << "TCPPeer::startRead to " << self->toString();
 
     self->mIncomingHeader.resize(4);
     asio::async_read(*(self->mSocket.get()),
                      asio::buffer(self->mIncomingHeader),
                      [self](asio::error_code ec, std::size_t length)
                      {
-                         CLOG(TRACE, "Overlay")
-                             << "TCPPeer::startRead calledback " << ec
-                             << " length:" << length;
+                         if (Logging::logTrace("Overlay"))
+                             CLOG(TRACE, "Overlay")
+                                 << "TCPPeer::startRead calledback " << ec
+                                 << " length:" << length;
                          self->readHeaderHandler(ec, length);
                      });
 }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -350,9 +350,10 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
         newb.value = value;
     }
 
-    CLOG(DEBUG, "SCP") << "BallotProtocol::bumpState"
-                       << " i: " << mSlot.getSlotIndex()
-                       << " v: " << mSlot.getSCP().ballotToStr(newb);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::bumpState"
+                           << " i: " << mSlot.getSlotIndex()
+                           << " v: " << mSlot.getSCP().ballotToStr(newb);
 
     bool updated = updateCurrentValue(newb);
 
@@ -427,9 +428,10 @@ BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
 void
 BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
 {
-    CLOG(DEBUG, "SCP") << "BallotProtocol::bumpToBallot"
-                       << " i: " << mSlot.getSlotIndex()
-                       << " b: " << mSlot.getSCP().ballotToStr(ballot);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::bumpToBallot"
+                           << " i: " << mSlot.getSlotIndex()
+                           << " b: " << mSlot.getSCP().ballotToStr(ballot);
 
     // `bumpToBallot` should be never called once we committed.
     dbgAssert(mPhase != SCP_PHASE_EXTERNALIZE);
@@ -833,9 +835,10 @@ BallotProtocol::attemptPreparedAccept(SCPStatement const& hint)
 bool
 BallotProtocol::setPreparedAccept(SCPBallot const& ballot)
 {
-    CLOG(DEBUG, "SCP") << "BallotProtocol::setPreparedAccept"
-                       << " i: " << mSlot.getSlotIndex()
-                       << " b: " << mSlot.getSCP().ballotToStr(ballot);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::setPreparedAccept"
+                           << " i: " << mSlot.getSlotIndex()
+                           << " b: " << mSlot.getSCP().ballotToStr(ballot);
 
     // update our state
     bool didWork = setPrepared(ballot);
@@ -980,9 +983,10 @@ bool
 BallotProtocol::setPreparedConfirmed(SCPBallot const& newC,
                                      SCPBallot const& newH)
 {
-    CLOG(DEBUG, "SCP") << "BallotProtocol::setPreparedConfirmed"
-                       << " i: " << mSlot.getSlotIndex()
-                       << " h: " << mSlot.getSCP().ballotToStr(newH);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::setPreparedConfirmed"
+                           << " i: " << mSlot.getSlotIndex()
+                           << " h: " << mSlot.getSCP().ballotToStr(newH);
 
     bool didWork = false;
 
@@ -1229,10 +1233,11 @@ BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
 bool
 BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
 {
-    CLOG(DEBUG, "SCP") << "BallotProtocol::setAcceptCommit"
-                       << " i: " << mSlot.getSlotIndex()
-                       << " new c: " << mSlot.getSCP().ballotToStr(c)
-                       << " new h: " << mSlot.getSCP().ballotToStr(h);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::setAcceptCommit"
+                           << " i: " << mSlot.getSlotIndex()
+                           << " new c: " << mSlot.getSCP().ballotToStr(c)
+                           << " new h: " << mSlot.getSCP().ballotToStr(h);
 
     bool didWork = false;
 
@@ -1431,10 +1436,11 @@ BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
 bool
 BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
 {
-    CLOG(DEBUG, "SCP") << "BallotProtocol::setConfirmCommit"
-                       << " i: " << mSlot.getSlotIndex()
-                       << " new c: " << mSlot.getSCP().ballotToStr(c)
-                       << " new h: " << mSlot.getSCP().ballotToStr(h);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::setConfirmCommit"
+                           << " i: " << mSlot.getSlotIndex()
+                           << " new c: " << mSlot.getSCP().ballotToStr(c)
+                           << " new h: " << mSlot.getSCP().ballotToStr(h);
 
     mCommit = make_unique<SCPBallot>(c);
     mHighBallot = make_unique<SCPBallot>(h);
@@ -1760,8 +1766,9 @@ void
 BallotProtocol::advanceSlot(SCPStatement const& hint)
 {
     mCurrentMessageLevel++;
-    CLOG(DEBUG, "SCP") << "BallotProtocol::advanceSlot " << mCurrentMessageLevel
-                       << " " << getLocalState();
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::advanceSlot " << mCurrentMessageLevel
+                           << " " << getLocalState();
 
     if (mCurrentMessageLevel >= MAX_ADVANCE_SLOT_RECURSION)
     {
@@ -1828,8 +1835,9 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
         } while (didBump);
     }
 
-    CLOG(DEBUG, "SCP") << "BallotProtocol::advanceSlot " << mCurrentMessageLevel
-                       << " - exiting " << getLocalState();
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "BallotProtocol::advanceSlot " << mCurrentMessageLevel
+                           << " - exiting " << getLocalState();
 
     --mCurrentMessageLevel;
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -225,11 +225,12 @@ NominationProtocol::updateRoundLeaders()
                                }
                            });
     CLOG(DEBUG, "SCP") << "updateRoundLeaders: " << mRoundLeaders.size();
-    for (auto const& rl : mRoundLeaders)
-    {
-        CLOG(DEBUG, "SCP") << "    leader "
-                           << mSlot.getSCPDriver().toShortString(rl);
-    }
+    if (Logging::logDebug("SCP"))
+        for (auto const& rl : mRoundLeaders)
+        {
+            CLOG(DEBUG, "SCP") << "    leader "
+                               << mSlot.getSCPDriver().toShortString(rl);
+        }
 }
 
 uint64
@@ -441,8 +442,9 @@ bool
 NominationProtocol::nominate(Value const& value, Value const& previousValue,
                              bool timedout)
 {
-    CLOG(DEBUG, "SCP") << "NominationProtocol::nominate "
-                       << mSlot.getSCP().getValueString(value);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "NominationProtocol::nominate "
+                           << mSlot.getSCP().getValueString(value);
 
     bool updated = false;
 

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -74,9 +74,10 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
     }
     else
     {
-        CLOG(DEBUG, "SCP") << "Slot::setStateFromEnvelope invalid envelope"
-                           << " i: " << getSlotIndex() << " "
-                           << mSCP.envToStr(e);
+        if (Logging::logDebug("SCP"))
+            CLOG(DEBUG, "SCP") << "Slot::setStateFromEnvelope invalid envelope"
+                               << " i: " << getSlotIndex() << " "
+                               << mSCP.envToStr(e);
     }
 }
 
@@ -107,9 +108,10 @@ Slot::processEnvelope(SCPEnvelope const& envelope, bool self)
 {
     dbgAssert(envelope.statement.slotIndex == mSlotIndex);
 
-    CLOG(DEBUG, "SCP") << "Slot::processEnvelope"
-                       << " i: " << getSlotIndex() << " "
-                       << mSCP.envToStr(envelope);
+    if (Logging::logDebug("SCP"))
+        CLOG(DEBUG, "SCP") << "Slot::processEnvelope"
+                           << " i: " << getSlotIndex() << " "
+                           << mSCP.envToStr(envelope);
 
     SCP::EnvelopeState res;
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -7,6 +7,7 @@
 #include "transactions/TxTests.h"
 #include "herder/Herder.h"
 #include "ledger/LedgerManager.h"
+#include "overlay/OverlayManager.h"
 #include "util/Logging.h"
 #include "util/Math.h"
 #include "util/types.h"
@@ -58,7 +59,7 @@ LoadGenerator::LoadGenerator(Hash const& networkID)
     // 9.2*10^18, so there's room even in 62bits to do this.
     auto root = make_shared<AccountInfo>(0, txtest::getRoot(networkID),
                                          10000000ULL * LOADGEN_ACCOUNT_BALANCE,
-                                         0, *this);
+                                         0, 0, *this);
     mAccounts.push_back(root);
 }
 
@@ -141,6 +142,8 @@ LoadGenerator::maybeCreateAccount(uint32_t ledgerNum, vector<TxInfo>& txs)
             for (size_t i = 0; i < n; ++i)
             {
                 auto gw = rand_element(mGateways);
+                if (gw->canUseInLedger(ledgerNum))
+                    continue;
                 acc->establishTrust(gw);
             }
         }
@@ -150,16 +153,24 @@ LoadGenerator::maybeCreateAccount(uint32_t ledgerNum, vector<TxInfo>& txs)
         if (mGateways.size() > 2 &&
             mMarketMakers.size() < (mAccounts.size() / 100))
         {
-            acc->mBuyCredit = rand_element(mGateways);
+            auto buy = rand_element(mGateways);
+            auto sell = buy;
             do
             {
-                acc->mSellCredit = rand_element(mGateways);
-            } while (acc->mSellCredit == acc->mBuyCredit);
-            acc->mSellCredit->mSellingAccounts.push_back(acc);
-            acc->mBuyCredit->mBuyingAccounts.push_back(acc);
-            mMarketMakers.push_back(acc);
-            acc->establishTrust(acc->mBuyCredit);
-            acc->establishTrust(acc->mSellCredit);
+                sell = rand_element(mGateways);
+            } while (buy == sell);
+
+            if (buy->canUseInLedger(ledgerNum) &&
+                sell->canUseInLedger(ledgerNum))
+            {
+                acc->mBuyCredit = buy;
+                acc->mSellCredit = sell;
+                acc->mSellCredit->mSellingAccounts.push_back(acc);
+                acc->mBuyCredit->mBuyingAccounts.push_back(acc);
+                mMarketMakers.push_back(acc);
+                acc->establishTrust(acc->mBuyCredit);
+                acc->establishTrust(acc->mSellCredit);
+            }
         }
         mAccounts.push_back(acc);
         txs.push_back(acc->creationTransaction());
@@ -300,8 +311,16 @@ LoadGenerator::generateLoad(Application& app, uint32_t nAccounts, uint32_t nTxs,
         auto build = buildScope.Stop();
 
         auto recvScope = recvTimer.TimeScope();
+        auto multinode = app.getOverlayManager().getPeers().size() > 1;
         for (auto& tx : txs)
         {
+            if (multinode && tx.mFrom != mAccounts[0])
+            {
+                // Reload the from-account if we're in multinode testing;
+                // odds of sequence-number skew due seems to be high enough to
+                // make this worthwhile.
+                loadAccount(app, tx.mFrom);
+            }
             if (!tx.execute(app))
             {
                 // Hopefully the rejection was just a bad seq number.
@@ -458,7 +477,8 @@ LoadGenerator::createAccount(size_t i, uint32_t ledgerNum)
     auto accountName = "Account-" + to_string(i);
     return make_shared<AccountInfo>(
         i, txtest::getAccount(accountName.c_str()), 0,
-        (static_cast<SequenceNumber>(ledgerNum) << 32), *this);
+        (static_cast<SequenceNumber>(ledgerNum) << 32),
+        ledgerNum, *this);
 }
 
 vector<LoadGenerator::AccountInfoPtr>
@@ -550,12 +570,11 @@ LoadGenerator::createTransferCreditTransaction(
 LoadGenerator::AccountInfoPtr
 LoadGenerator::pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum)
 {
-    SequenceNumber currSeq = static_cast<SequenceNumber>(ledgerNum) << 32;
     size_t i = mAccounts.size();
     while (i-- != 0)
     {
         auto n = rand_element(mAccounts);
-        if (n->mSeq < currSeq && n != tryToAvoid)
+        if (n->canUseInLedger(ledgerNum) && n != tryToAvoid)
         {
             return n;
         }
@@ -568,8 +587,7 @@ acceptablePathExtension(LoadGenerator::AccountInfoPtr from, uint32_t ledgerNum,
                         std::vector<LoadGenerator::AccountInfoPtr> const& path,
                         LoadGenerator::AccountInfoPtr proposed)
 {
-    SequenceNumber currSeq = static_cast<SequenceNumber>(ledgerNum) << 32;
-    if (proposed->mSeq >= currSeq || from == proposed)
+    if (!proposed->canUseInLedger(ledgerNum) || from == proposed)
     {
         return false;
     }
@@ -675,11 +693,15 @@ LoadGenerator::createRandomTransaction(float alpha, uint32_t ledgerNum)
         auto to = pickRandomPath(from, ledgerNum, path);
         if (to != from && !path.empty())
         {
-            return createTransferCreditTransaction(from, to, amount, path);
+            auto tx = createTransferCreditTransaction(from, to, amount, path);
+            tx.touchAccounts(ledgerNum);
+            return tx;
         }
     }
     auto to = pickRandomAccount(from, ledgerNum);
-    return createTransferNativeTransaction(from, to, amount);
+    auto tx = createTransferNativeTransaction(from, to, amount);
+    tx.touchAccounts(ledgerNum);
+    return tx;
 }
 
 vector<LoadGenerator::TxInfo>
@@ -699,8 +721,10 @@ LoadGenerator::createRandomTransactions(size_t n, float paretoAlpha)
 
 LoadGenerator::AccountInfo::AccountInfo(size_t id, SecretKey key,
                                         int64_t balance, SequenceNumber seq,
+                                        uint32_t lastChangedLedger,
                                         LoadGenerator& loadGen)
-    : mId(id), mKey(key), mBalance(balance), mSeq(seq), mLoadGen(loadGen)
+    : mId(id), mKey(key), mBalance(balance), mSeq(seq),
+      mLastChangedLedger(lastChangedLedger), mLoadGen(loadGen)
 {
 }
 
@@ -726,6 +750,14 @@ LoadGenerator::AccountInfo::establishTrust(AccountInfoPtr a)
         TrustLineInfo{a, LOADGEN_ACCOUNT_BALANCE, LOADGEN_TRUSTLINE_LIMIT};
     mTrustLines.push_back(tl);
     a->mTrustingAccounts.push_back(shared_from_this());
+}
+
+bool
+LoadGenerator::AccountInfo::canUseInLedger(uint32_t currentLedger)
+{
+    // Leave a 3-ledger window between uses of an account, in case
+    // it gets kicked down the road a bit.
+    return (mLastChangedLedger + 3) < currentLedger;
 }
 
 //////////////////////////////////////////////////////
@@ -787,6 +819,26 @@ LoadGenerator::TxMetrics::report()
                            << mOneOfferPathPayment.one_minute_rate() << " 1p, "
                            << mTwoOfferPathPayment.one_minute_rate() << " 2p, "
                            << mManyOfferPathPayment.one_minute_rate() << " Np)";
+}
+
+void
+LoadGenerator::TxInfo::touchAccounts(uint32_t ledger)
+{
+    if (mFrom)
+    {
+        mFrom->mLastChangedLedger = ledger;
+    }
+    if (mTo)
+    {
+        mTo->mLastChangedLedger = ledger;
+    }
+    for (auto i : mPath)
+    {
+        if (i)
+        {
+            i->mLastChangedLedger = ledger;
+        }
+    }
 }
 
 bool

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -41,8 +41,8 @@ using namespace std;
 // Account amounts are expressed in ten-millionths (10^-7).
 static const uint64_t TENMILLION = 10000000;
 
-// Every loadgen account or trustline gets a 99 unit balance (10^2 - 1).
-static const uint64_t LOADGEN_ACCOUNT_BALANCE = 99 * TENMILLION;
+// Every loadgen account or trustline gets a 999 unit balance (10^3 - 1).
+static const uint64_t LOADGEN_ACCOUNT_BALANCE = 999 * TENMILLION;
 
 // Trustlines are limited to 1000x the balance.
 static const uint64_t LOADGEN_TRUSTLINE_LIMIT = 1000 * LOADGEN_ACCOUNT_BALANCE;
@@ -53,11 +53,11 @@ const uint32_t LoadGenerator::STEP_MSECS = 100;
 LoadGenerator::LoadGenerator(Hash const& networkID)
     : mMinBalance(0), mLastSecond(0)
 {
-    // Root account gets enough XLM to create 100 million (10^8) accounts, which
-    // thereby uses up 7 + 2 + 8 = 17 decimal digits. Luckily we have 2^63 =
+    // Root account gets enough XLM to create 10 million (10^7) accounts, which
+    // thereby uses up 7 + 3 + 7 = 17 decimal digits. Luckily we have 2^63 =
     // 9.2*10^18, so there's room even in 62bits to do this.
     auto root = make_shared<AccountInfo>(0, txtest::getRoot(networkID),
-                                         100000000ULL * LOADGEN_ACCOUNT_BALANCE,
+                                         10000000ULL * LOADGEN_ACCOUNT_BALANCE,
                                          0, *this);
     mAccounts.push_back(root);
 }

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -98,13 +98,16 @@ class LoadGenerator
     struct AccountInfo : public std::enable_shared_from_this<AccountInfo>
     {
         AccountInfo(size_t id, SecretKey key, int64_t balance,
-                    SequenceNumber seq, LoadGenerator& loadGen);
+                    SequenceNumber seq, uint32_t lastChangedLedger,
+                    LoadGenerator& loadGen);
         size_t mId;
         SecretKey mKey;
         int64_t mBalance;
         SequenceNumber mSeq;
+        uint32_t mLastChangedLedger;
 
         void establishTrust(AccountInfoPtr a);
+        bool canUseInLedger(uint32_t currentLedger);
 
         // Used when this account trusts some other account's credits.
         std::vector<TrustLineInfo> mTrustLines;
@@ -162,6 +165,7 @@ class LoadGenerator
         int64_t mAmount;
         std::vector<AccountInfoPtr> mPath;
 
+        void touchAccounts(uint32_t ledger);
         bool execute(Application& app);
 
         void toTransactionFrames(Hash const& networkID,

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -90,6 +90,20 @@ Logging::getLogLevel(std::string const& partition)
     return el::Level::Unknown;
 }
 
+bool
+Logging::logDebug(std::string const& partition)
+{
+    auto lev = Logging::getLogLevel(partition);
+    return lev == el::Level::Debug || lev == el::Level::Trace;
+}
+
+bool
+Logging::logTrace(std::string const& partition)
+{
+    auto lev = Logging::getLogLevel(partition);
+    return lev == el::Level::Trace;
+}
+
 // Trace < Debug < Info < Warning < Error < Fatal < None
 void
 Logging::setLogLevel(el::Level level, const char* partition)

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -26,5 +26,7 @@ class Logging
     static el::Level getLLfromString(std::string const& levelName);
     static el::Level getLogLevel(std::string const& partition);
     static std::string getStringFromLL(el::Level);
+    static bool logDebug(std::string const& partition);
+    static bool logTrace(std::string const& partition);
 };
 }


### PR DESCRIPTION
Nothing too dramatic, but this speeds up our [autoload] numbers a little, and makes them drop fewer transactions on the floor when run in multinode configuration. Combined with uncorking the surge pricing thing, multinode configs are now only a moderate bit slower than single node.