### PR TITLE
Scalability benchmark tests

### DIFF
--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -218,6 +218,9 @@ class Application
     virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate) = 0;
 
+    // Access the load generator for manual operation.
+    virtual LoadGenerator& getLoadGenerator() = 0;
+
     // Run a consistency check between the database and the bucketlist.
     virtual void checkDB() = 0;
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -374,12 +374,18 @@ void
 ApplicationImpl::generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate)
 {
+    getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
+    getLoadGenerator().generateLoad(*this, nAccounts, nTxs, txRate, autoRate);
+}
+
+LoadGenerator&
+ApplicationImpl::getLoadGenerator()
+{
     if (!mLoadGenerator)
     {
         mLoadGenerator = make_unique<LoadGenerator>(getNetworkID());
     }
-    getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
-    mLoadGenerator->generateLoad(*this, nAccounts, nTxs, txRate, autoRate);
+    return *mLoadGenerator;
 }
 
 void

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -81,6 +81,8 @@ class ApplicationImpl : public Application
     virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate) override;
 
+    virtual LoadGenerator& getLoadGenerator() override;
+
     virtual void checkDB() override;
 
     virtual void maintenance() override;

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -124,6 +124,8 @@ class LoadGenerator
         AccountInfoPtr mBuyCredit;
         AccountInfoPtr mSellCredit;
 
+        void createDirectly(Application& app);
+        void debitDirectly(Application& app, int64_t debitAmount);
         TxInfo creationTransaction();
 
       private:


### PR DESCRIPTION
Adds a little framework for recording scalability of the system into CSV files, and an example test that scales up the number of accounts while measuring tx latency at each bulking step. Will try to add another test or two using same framework, in coming days.

Sorry for delay, spent a few days hunting a weird anomaly in ledgers with a lot of account-creation txs in them (there's a very minor but noticeable -- and number-skewing) slowdown when there are a lot of updates to a single root account in the same SQL txn. Finally isolated it and worked around here.