### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,7 +43,7 @@ When building on OSX, here's some dependencies you'll need:
 - brew install libtool
 - brew install automake
 - brew install pkg-config
-- brew install libpqxx
+- brew install libpqxx *(If ./configure later complains about libpq missing, try PKG_CONFIG_PATH='/usr/local/lib/pkgconfig')* 
 
 ### Windows 
 See [INSTALL-Windows.txt](INSTALL-Windows.txt)


### PR DESCRIPTION
I had some trouble with configure and pkg-config not finding libpq.  I added the /usr/local/lib/pkgconfig, but I don't think this should be necessary as the man pages for pkg-config specify that directory is parsed by default on 'most systems'.  It may just be my system configuration, but this has happened to me now on three separate systems.  Might be worth patch.  I'm sure I'm missing something silly somewhere.