### PR TITLE
Avoid recreation of download dir after catchup error

### DIFF
--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -1120,7 +1120,10 @@ ApplyLedgerChainWork::onSuccess()
 BucketDownloadWork::BucketDownloadWork(Application& app, WorkParent& parent,
                                        std::string const& uniqueName,
                                        HistoryArchiveState const& localState)
-    : Work(app, parent, uniqueName), mLocalState(localState)
+    : Work(app, parent, uniqueName)
+    , mLocalState(localState)
+    , mDownloadDir(make_unique<TmpDir>(
+          mApp.getTmpDirManager().tmpDir(getUniqueName())))
 {
 }
 
@@ -1129,8 +1132,6 @@ BucketDownloadWork::onReset()
 {
     clearChildren();
     mBuckets.clear();
-    mDownloadDir =
-        make_unique<TmpDir>(mApp.getTmpDirManager().tmpDir(getUniqueName()));
 }
 
 void


### PR DESCRIPTION
This is a fix for issue #1031. Creation of `mDownloadDir` is moved to class constructor from `onReset` method. 

Creating new directory (and destroying old one) in `onReset` method forced `BatchDownloadWork` class to re-download all files (this applied to both ledgers and transactions) in case of a catchup restart.

After applying the change, the same download directory is used regardless of catchup work restarts. This ensures that even repeated ledger/transaction fetching errors are not able to cause restart of  batch downloads.