### PR TITLE
Mention Windows 64 as prerequisite

### DIFF
--- a/INSTALL-Windows.txt
+++ b/INSTALL-Windows.txt
@@ -4,6 +4,10 @@ Installation Instructions
 Build Dependencies
 ==================
 
+- Make sure you have Windows 64 bit Version 
+       * try Settings -> System -> About and look under System Type
+       * When in doubt, see http://www.tenforums.com/tutorials/4399-system-type-32-bit-x86-64-bit-x64-windows-10-a.html
+
 - Download and install `Visual Studio 2015 Update 1` (for Visual C++) ; the Community Edition is free and fully functional.
        * https://www.visualstudio.com/en-us/downloads/visual-studio-2015-downloads-vs.aspx
        * http://blogs.msdn.com/b/visualstudio/archive/2015/11/30/visual-studio-update-1-rtm.aspx


### PR DESCRIPTION
Visual Studio only accepts Windows 64 bit as compilation target, hence it's a prerequisite