### PR TITLE
Add man page

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,11 +4,34 @@ SUBDIRS = lib src
 AM_EXTRA_RECURSIVE_TARGETS = check-valgrind
 ACLOCAL_AMFLAGS = -I m4
 
+dist_doc_DATA = docs/stellar-core_example.cfg			\
+	docs/stellar-core_standalone.cfg			\
+	docs/stellar-core_testnet.cfg docs/software/admin.md	\
+	docs/software/commands.md
+
+man_MANS = docs/stellar-core.1
+
 include $(top_srcdir)/common.mk
 
 .PHONY: always
 always:
 	@:
+
+# This formats the man page, substituting the file
+# software/commands.md for the line contianing %commands%.  After
+# formatting the man page with pandoc, it substitutes $(PREFIX) for
+# the string %prefix%.  In the event that pandoc is not found, instead
+# of failing with an error, just use the last version successfully
+docs/stellar-core.1: docs/stellar-core.1.md
+	mkdir -p docs
+	sed -ne '/^#/,$$p' "$(top_srcdir)/docs/software/commands.md" \
+	    | sed -e '/^%commands%$$/{s///; r/dev/stdin' -e '}' \
+	    $(top_srcdir)/docs/stellar-core.1.md > tmp.man.md
+	-pandoc -s -f markdown -t man -o "$(top_srcdir)/$@.in~" tmp.man.md \
+	    && mv -f "$(top_srcdir)/$@.in~" "$(top_srcdir)/$@.in"
+	rm -f tmp.man.md
+	sed -e "s|%prefix%|$(prefix)|g" "$(top_srcdir)/$@.in" > "$@~" \
+	    && mv -f "$@~" "$@"
 
 if USE_CLANG_FORMAT
 format: always

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -34,6 +34,17 @@ forcescp doesn't change the requirements for quorum so although this node will e
 * **--metric METRIC**: Report metric METRIC on exit. Used for gathering a metric cumulatively during a test run.
 * **--newdb**: Clears the local database and resets it to the genesis ledger. If you connect to the network after that it will catch up from scratch. 
 * **--newhist ARCH**:  Initialize the named history archive ARCH. ARCH should be one of the history archives you have specified in the stellar-core.cfg. This will write a `.well-known/stellar-history.json` file in the archive root.
+* **--printtxn FILE**:  Pretty-print a binary file containing a
+  `TransactionEnvelope`.  If FILE is "-", the transaction is read from
+  standard input.
+* **--signtxn FILE**:  Add a digital signature to a transaction
+  envelope stored in binary format in FILE, and send the result to
+  standard output (which should be redirected to a file or piped
+  through a tool such as `base64`).  The private signing key is read
+  from standard input, unless FILE is "-" in which case the
+  transaction envelope is read from standard input and the signing key
+  is read from `/dev/tty`.  In either event, if the signing key
+  appears to be coming from a terminal, stellar-core disables echo.
 * **--test**: Run all the unit tests. For [further info](https://github.com/philsquared/Catch/blob/master/docs/command-line.md) on possible options for test. For example this will run just the "Herder" tests and stop after the first failure: `stellar-core --test -a [Herder]` 
 * **--version**: Print version info and then exit.
 

--- a/docs/stellar-core.1.in
+++ b/docs/stellar-core.1.in
@@ -1,0 +1,263 @@
+.TH "stellar\-core" "1" "" "" ""
+.SH NAME
+.PP
+stellar\-core \- Core daemon for Stellar payment network
+.SH SYNOPSYS
+.PP
+stellar\-core [OPTIONS]
+.SH DESCRIPTION
+.PP
+Stellar is a decentralized, federated peer\-to\-peer network that allows
+people to send payments in any asset anywhere in the world
+instantaneously, and with minimal fee.
+\f[C]Stellar\-core\f[] is the core component of this network.
+\f[C]Stellar\-core\f[] is a C++ implementation of the Stellar Consensus
+Protocol configured to construct a chain of ledgers that are guaranteed
+to be in agreement across all the participating nodes at all times.
+.SS Configuration file
+.PP
+In most modes of operation, stellar\-core requires a configuration file.
+By default, it looks for a file called \f[C]stellar\-core.cfg\f[] in the
+current working directory, but this default can be changed by the
+\f[C]\-\-conf\f[] command\-line option.
+The configuration file is in TOML syntax.
+The full set of supported directives can be found in
+\f[C]%prefix%/share/doc/stellar\-core_example.cfg\f[].
+.SS Command line options
+.IP \[bu] 2
+\f[B]\-\-?\f[] or \f[B]\-\-help\f[]: Print the available command line
+options and then exit..
+.IP \[bu] 2
+\f[B]\-\-c\f[] Send an HTTP command (#HTTP-Commands) to an already
+running local instance of stellar\-core and then exit.
+For example:
+.PP
+\f[C]$\ stellar\-core\ \-c\ info\f[]
+.IP \[bu] 2
+\f[B]\-\-conf FILE\f[]: Specify a config file to use.
+You can use \[aq]\-\[aq] and provide the config file via STDIN.
+\f[I]default \[aq]stellar\-core.cfg\[aq]\f[]
+.IP \[bu] 2
+\f[B]\-\-convertid ID\f[]: Will output the passed ID in all known forms
+and then exit.
+Useful for determining the public key that corresponds to a given
+private key.
+For example:
+.PP
+\f[C]$\ stellar\-core\ \-\-convertid\ SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2\f[]
+.IP \[bu] 2
+\f[B]\-\-dumpxdr FILE\f[]: Dumps the given XDR file and then exits.
+.IP \[bu] 2
+\f[B]\-\-loadxdr FILE\f[]: Load an XDR bucket file, for testing.
+.IP \[bu] 2
+\f[B]\-\-forcescp\f[]: This command is used to start a network from
+scratch or when a network has lost quorum because of failed nodes or
+otherwise.
+It sets a flag in the database.
+The next time stellar\-core is run, stellar\-core will start emitting
+SCP messages based on its last known ledger.
+Without this flag stellar\-core waits to hear a ledger close from the
+network before starting SCP. forcescp doesn\[aq]t change the
+requirements for quorum so although this node will emit SCP messages SCP
+won\[aq]t complete until there are also a quorum of other nodes also
+emitting SCP messages on this same ledger.
+.IP \[bu] 2
+\f[B]\-\-fuzz FILE\f[]: Run a single fuzz input and exit.
+.IP \[bu] 2
+\f[B]\-\-genfuzz FILE\f[]: Generate a random fuzzer input file.
+.IP \[bu] 2
+\f[B]\-\-genseed\f[]: Generate and print a random public/private key and
+then exit.
+.IP \[bu] 2
+\f[B]\-\-inferquorum\f[]: Print a potential quorum set inferred from
+history.
+.IP \[bu] 2
+\f[B]\-\-checkquorum\f[]: Check quorum intersection from history to
+ensure there is closure over all the validators in the network.
+.IP \[bu] 2
+\f[B]\-\-graphquorum\f[]: Print a quorum set graph from history.
+.IP \[bu] 2
+\f[B]\-\-offlineinfo\f[]: Returns an output similar to
+\f[C]\-\-c\ info\f[] for an offline instance
+.IP \[bu] 2
+\f[B]\-\-ll LEVEL\f[]: Set the log level.
+It is redundant with \f[C]\-\-c\ ll\f[] but we need this form if you
+want to change the log level during test runs.
+.IP \[bu] 2
+\f[B]\-\-metric METRIC\f[]: Report metric METRIC on exit.
+Used for gathering a metric cumulatively during a test run.
+.IP \[bu] 2
+\f[B]\-\-newdb\f[]: Clears the local database and resets it to the
+genesis ledger.
+If you connect to the network after that it will catch up from scratch.
+.IP \[bu] 2
+\f[B]\-\-newhist ARCH\f[]: Initialize the named history archive ARCH.
+ARCH should be one of the history archives you have specified in the
+stellar\-core.cfg.
+This will write a \f[C]\&.well\-known/stellar\-history.json\f[] file in
+the archive root.
+.IP \[bu] 2
+\f[B]\-\-printtxn FILE\f[]: Pretty\-print a binary file containing a
+\f[C]TransactionEnvelope\f[].
+If FILE is "\-", the transaction is read from standard input.
+.IP \[bu] 2
+\f[B]\-\-signtxn FILE\f[]: Add a digital signature to a transaction
+envelope stored in binary format in FILE, and send the result to
+standard output (which should be redirected to a file or piped through a
+tool such as \f[C]base64\f[]).
+The private signing key is read from standard input, unless FILE is "\-"
+in which case the transaction envelope is read from standard input and
+the signing key is read from \f[C]/dev/tty\f[].
+In either event, if the signing key appears to be coming from a
+terminal, stellar\-core disables echo.
+.IP \[bu] 2
+\f[B]\-\-test\f[]: Run all the unit tests.
+For further
+info (https://github.com/philsquared/Catch/blob/master/docs/command-line.md)
+on possible options for test.
+For example this will run just the "Herder" tests and stop after the
+first failure: \f[C]stellar\-core\ \-\-test\ \-a\ [Herder]\f[]
+.IP \[bu] 2
+\f[B]\-\-version\f[]: Print version info and then exit.
+.SS HTTP Commands
+.PP
+By default stellar\-core listens for connections from localhost on port
+11626.
+You can send commands to stellar\-core via a web browser, curl, or using
+the \-\-c command line option (see above).
+Most commands return their results in JSON format.
+.IP \[bu] 2
+\f[B]help\f[] Prints a list of currently supported commands.
+.IP \[bu] 2
+\f[B]catchup\f[] \f[C]/catchup?ledger=NNN[&mode=MODE]\f[] Triggers the
+instance to catch up to ledger NNN from history; Mode is either
+\[aq]minimal\[aq] (the default, if omitted) or \[aq]complete\[aq].
+.IP \[bu] 2
+\f[B]checkdb\f[] Triggers the instance to perform a background check of
+the database\[aq]s state.
+.IP \[bu] 2
+\f[B]checkpoint\f[] Triggers the instance to write an immediate history
+checkpoint.
+And uploads it to the archive.
+.IP \[bu] 2
+\f[B]connect\f[] \f[C]/connect?peer=NAME&port=NNN\f[] Triggers the
+instance to connect to peer NAME at port NNN.
+.IP \[bu] 2
+\f[B]dropcursor\f[]
+.PD 0
+.P
+.PD
+\f[C]/dropcursor?id=XYZ\f[] deletes the tracking cursor with identified
+by \f[C]id\f[].
+See \f[C]setcursor\f[] for more information.
+.IP \[bu] 2
+\f[B]info\f[] Returns information about the server in JSON format (sync
+state, connected peers, etc).
+.IP \[bu] 2
+\f[B]ll\f[]
+.PD 0
+.P
+.PD
+\f[C]/ll?level=L[&partition=P]\f[] Adjust the log level for partition P
+(or all if no partition is specified).
+Level is one of FATAL, ERROR, WARNING, INFO, DEBUG, VERBOSE, TRACE
+.IP \[bu] 2
+\f[B]maintenance\f[] \f[C]/maintenance?[queue=true]\f[] Performs
+maintenance tasks on the instance.
+.IP \[bu] 2
+\f[C]queue\f[] performs deletion of queue data.
+See \f[C]setcursor\f[] for more information.
+.IP \[bu] 2
+\f[B]metrics\f[] Returns a snapshot of the metrics registry (for
+monitoring and debugging purpose).
+.IP \[bu] 2
+\f[B]peers\f[] Returns the list of known peers in JSON format.
+.IP \[bu] 2
+\f[B]quorum\f[] \f[C]/quorum?[node=NODE_ID][&compact=true]\f[] returns
+information about the quorum for node NODE_ID (this node by default).
+NODE_ID is either a full key (\f[C]GABCD...\f[]), an alias
+(\f[C]$name\f[]) or an abbreviated ID (\f[C]\@GABCD\f[]).
+If compact is set, only returns a summary version.
+.IP \[bu] 2
+\f[B]setcursor\f[] \f[C]/setcursor?id=ID&cursor=N\f[] sets or creates a
+cursor identified by \f[C]ID\f[] with value \f[C]N\f[].
+ID is an uppercase AlphaNum, N is an uint32 that represents the last
+ledger sequence number that the instance ID processed.
+Cursors are used by dependent services to tell stellar\-core which data
+can be safely deleted by the instance.
+The data is historical data stored in the SQL tables such as txhistory
+or ledgerheaders.
+When all consumers processed the data for ledger sequence N the data can
+be safely removed by the instance.
+The actual deletion is performed by invoking the \f[C]maintenance\f[]
+endpoint or on startup.
+See also \f[C]dropcursor\f[].
+.IP \[bu] 2
+\f[B]scp\f[] `/scp?[limit=n] Returns a JSON object with the internal
+state of the SCP engine for the last n (default 2) ledgers.
+.IP \[bu] 2
+\f[B]tx\f[] \f[C]/tx?blob=Base64\f[] submit a
+transaction (../../learn/concepts/transactions.md) to the network.
+blob is a base64 encoded XDR serialized \[aq]TransactionEnvelope\[aq]
+returns a JSON object with the following properties status:
+.RS 2
+.IP \[bu] 2
+"PENDING" \- transaction is being considered by consensus
+.IP \[bu] 2
+"DUPLICATE" \- transaction is already PENDING
+.IP \[bu] 2
+"ERROR" \- transaction rejected by transaction engine error: set when
+status is "ERROR".
+Base64 encoded, XDR serialized \[aq]TransactionResult\[aq]
+.RE
+.SS The following HTTP commands are exposed on test instances
+.IP \[bu] 2
+\f[B]generateload\f[]
+\f[C]/generateload[?accounts=N&txs=M&txrate=(R|auto)]\f[] Artificially
+generate load for testing; must be used with
+\f[C]ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING\f[] set to true.
+.IP \[bu] 2
+\f[B]manualclose\f[] If MANUAL_CLOSE is set to true in the .cfg file.
+This will cause the current ledger to close.
+.IP \[bu] 2
+\f[B]testacc\f[] \f[C]/testacc?name=N\f[] Returns basic information
+about the account identified by name.
+Note that N is a string used as seed, but "root" can be used as well to
+specify the root account used for the test instance.
+.IP \[bu] 2
+\f[B]testtx\f[] \f[C]/testtx?from=F&to=T&amount=N&[create=true]\f[]
+Injects a payment transaction (or a create transaction if "create" is
+specified) from the account F to the account T, sending N XLM to the
+account.
+Note that F and T are seed strings but can also be specified as "root"
+as a shorthand for the root account for the test instance.
+.SH EXAMPLES
+.PP
+See \f[C]%prefix%/share/doc/*.cfg\f[] for some example stellar\-core
+configuration files
+.SH FILES
+.TP
+.B stellar\-core.cfg
+Configuration file (in current working directory by default)
+.RS
+.RE
+.SH SEE ALSO
+.TP
+.B <https://www.stellar.org/developers/stellar-core/software/admin.html>
+stellar\-core administration guide
+.RS
+.RE
+.TP
+.B <https://www.stellar.org>
+Home page of Stellar development foundation
+.RS
+.RE
+.SH BUGS
+.PP
+Please report bugs using the github issue tracker:
+.PD 0
+.P
+.PD
+<https://github.com/stellar/stellar-core/issues>
+.SH AUTHORS
+Stellar Development Foundation.

--- a/docs/stellar-core.1.md
+++ b/docs/stellar-core.1.md
@@ -1,0 +1,55 @@
+% stellar-core(1)
+% Stellar Development Foundation
+%
+
+# NAME
+
+stellar-core - Core daemon for Stellar payment network
+
+# SYNOPSYS
+
+stellar-core [OPTIONS]
+
+# DESCRIPTION
+
+Stellar is a decentralized, federated peer-to-peer network that allows
+people to send payments in any asset anywhere in the world
+instantaneously, and with minimal fee.  `Stellar-core` is the core
+component of this network. `Stellar-core` is a C++ implementation of
+the Stellar Consensus Protocol configured to construct a chain of
+ledgers that are guaranteed to be in agreement across all the
+participating nodes at all times.
+
+## Configuration file
+
+In most modes of operation, stellar-core requires a configuration
+file.  By default, it looks for a file called `stellar-core.cfg` in
+the current working directory, but this default can be changed by the
+`--conf` command-line option.  The configuration file is in TOML
+syntax.  The full set of supported directives can be found in
+`%prefix%/share/doc/stellar-core_example.cfg`.
+
+%commands%
+
+# EXAMPLES
+
+See `%prefix%/share/doc/*.cfg` for some example stellar-core
+configuration files
+
+# FILES
+
+stellar-core.cfg
+:   Configuration file (in current working directory by default)
+
+# SEE ALSO
+
+<https://www.stellar.org/developers/stellar-core/software/admin.html>
+:   stellar-core administration guide
+
+<https://www.stellar.org>
+:   Home page of Stellar development foundation
+
+# BUGS
+
+Please report bugs using the github issue tracker:\
+<https://github.com/stellar/stellar-core/issues>

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -62,6 +62,16 @@ SecretKey::SecretKey() : mKeyType(KEY_TYPE_ED25519)
                   "Unexpected signature length");
 }
 
+SecretKey::~SecretKey()
+{
+    std::memset(mSecretKey.data(), 0, mSecretKey.size());
+}
+
+SecretKey::Seed::~Seed()
+{
+    std::memset(mSeed.data(), 0, mSeed.size());
+}
+
 PublicKey
 SecretKey::getPublicKey() const
 {

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -22,20 +22,22 @@ class SecretKey
     CryptoKeyType mKeyType;
     uint512 mSecretKey;
 
-  public:
-    SecretKey();
-
     struct Seed
     {
         CryptoKeyType mKeyType;
         uint256 mSeed;
+        ~Seed();
     };
-
-    // Get the public key portion of this secret key.
-    PublicKey getPublicKey() const;
 
     // Get the seed portion of this secret key.
     Seed getSeed() const;
+
+  public:
+    SecretKey();
+    ~SecretKey();
+
+    // Get the public key portion of this secret key.
+    PublicKey getPublicKey() const;
 
     // Get the seed portion of this secret key as a StrKey string.
     std::string getStrKeySeed() const;
@@ -54,6 +56,12 @@ class SecretKey
 
     // Decode a secret key from a provided StrKey seed value.
     static SecretKey fromStrKeySeed(std::string const& strKeySeed);
+    static SecretKey fromStrKeySeed(std::string &&strKeySeed) {
+        SecretKey ret = fromStrKeySeed(strKeySeed);
+        for (std::size_t i = 0; i < strKeySeed.size(); ++i)
+            strKeySeed[i] = 0;
+        return ret;
+    }
 
     // Decode a secret key from a binary seed value.
     static SecretKey fromSeed(ByteSlice const& seed);

--- a/src/main/dumpxdr.h
+++ b/src/main/dumpxdr.h
@@ -10,4 +10,7 @@ namespace stellar
 {
 
 void dumpxdr(std::string const& filename);
+void printtxn(std::string const& filename);
+void signtxn(std::string const& filename);
+
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -50,6 +50,8 @@ enum opttag
     OPT_METRIC,
     OPT_NEWDB,
     OPT_NEWHIST,
+    OPT_PRINTTXN,
+    OPT_SIGNTXN,
     OPT_TEST,
     OPT_VERSION
 };
@@ -60,6 +62,8 @@ static const struct option stellar_core_options[] = {
     {"convertid", required_argument, nullptr, OPT_CONVERTID},
     {"checkquorum", optional_argument, nullptr, OPT_CHECKQUORUM},
     {"dumpxdr", required_argument, nullptr, OPT_DUMPXDR},
+    {"printtxn", required_argument, nullptr, OPT_PRINTTXN},
+    {"signtxn", required_argument, nullptr, OPT_SIGNTXN},
     {"loadxdr", required_argument, nullptr, OPT_LOADXDR},
     {"forcescp", optional_argument, nullptr, OPT_FORCESCP},
     {"fuzz", required_argument, nullptr, OPT_FUZZ},
@@ -94,7 +98,7 @@ usage(int err = 1)
           "with the local ledger rather than waiting to hear from the "
           "network.\n"
           "      --fuzz FILE     Run a single fuzz input and exit\n"
-          "      --genfuzz FILE  Generate a random fuzzer input file\n "
+          "      --genfuzz FILE  Generate a random fuzzer input file\n"
           "      --genseed       Generate and print a random node seed\n"
           "      --help          Display this string\n"
           "      --inferquorum   Print a quorum set inferred from history\n"
@@ -109,6 +113,12 @@ usage(int err = 1)
           "      --newdb         Creates or restores the DB to the genesis "
           "ledger\n"
           "      --newhist ARCH  Initialize the named history archive ARCH\n"
+          "      --printtxn FILE Pretty-print one transaction envelope,"
+          " then quit\n"
+          "      --signtxn FILE  Add signature to transaction envelope,"
+          " then quit\n"
+          "                      (Key is read from stdin or terminal, as"
+          " appropriate.)\n"
           "      --test          Run self-tests\n"
           "      --version       Print version information\n";
     exit(err);
@@ -404,6 +414,12 @@ main(int argc, char* const* argv)
             return 0;
         case OPT_DUMPXDR:
             dumpxdr(std::string(optarg));
+            return 0;
+        case OPT_PRINTTXN:
+            printtxn(std::string(optarg));
+            return 0;
+        case OPT_SIGNTXN:
+            signtxn(std::string(optarg));
             return 0;
         case OPT_LOADXDR:
             loadXdrBucket = std::string(optarg);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -397,14 +397,16 @@ main(int argc, char* const* argv)
     std::vector<std::string> metrics;
 
     int opt;
-    while ((opt = getopt_long_only(argc, argv, "", stellar_core_options,
+    while ((opt = getopt_long_only(argc, argv, "c:", stellar_core_options,
                                    nullptr)) != -1)
     {
         switch (opt)
         {
+        case 'c':
         case OPT_CMD:
             command = optarg;
             rest.insert(rest.begin(), argv + optind, argv + argc);
+            optind = argc;
             break;
         case OPT_CONF:
             cfgFile = std::string(optarg);
@@ -473,8 +475,9 @@ main(int argc, char* const* argv)
                         metrics);
         }
         case OPT_VERSION:
-            std::cout << STELLAR_CORE_VERSION;
+            std::cout << STELLAR_CORE_VERSION << std::endl;
             return 0;
+        case OPT_HELP:
         default:
             usage(0);
             return 0;

--- a/src/overlay/StellarXDR.h
+++ b/src/overlay/StellarXDR.h
@@ -5,3 +5,9 @@
 #include "xdr/Stellar-transaction.h"
 #include "xdr/Stellar-ledger.h"
 #include "xdr/Stellar-overlay.h"
+
+namespace stellar {
+
+std::string xdr_printer(const PublicKey &pk);
+
+}


### PR DESCRIPTION
Adds a unix manual page for stellar-core, most of which is automatically inserted from docs/software/commands.md.  Also install a few files into /$(PREFIX)/share/doc/stellar-core.  Finally cleaned up options parsing, so that something like "stellar-core --c command --version" would not immediately exit with the stellar-core version number.  Also print newline after version.