### PR TITLE
store lastmodified field in accountdata

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -119,6 +119,7 @@ Database::applySchemaUpgrade(unsigned long vers)
 
     case 4:
         BanManager::dropAll(*this);
+        DataFrame::dropAll(*this); // not and error, it changed again
         break;
 
     default:


### PR DESCRIPTION
All other EntryFrame types (account, offer, trust) store value of
lastModifiedLedgerSeq in database in lastmodified field. Now data also
stores that.

Lack of this field caused errors in stellar-core-acceptance-history-
testnet-catchup: EntryFrame::checkAgainstDatabase was loading data
from database but with lastModifiedLedgerSeq set to 0 - it was causing
"Inconsistent state between objects" exception.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>