### PR TITLE
Fix downloadworker to unzip xdr.gz when it exists.

### DIFF
--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -684,10 +684,18 @@ BatchDownloadWork::addNextDownloadWorker()
     }
 
     FileTransferInfo ft(mDownloadDir, mFileType, mNext);
-    if (fs::exists(ft.localPath_gz()) || fs::exists(ft.localPath_nogz()))
+    if (fs::exists(ft.localPath_nogz()))
     {
         CLOG(DEBUG, "History") << "already have " << mFileType
-                               << " for checkpoint " << mNext;
+            << " for checkpoint " << mNext;
+    }
+    else if (fs::exists(ft.localPath_gz()))
+    {
+        CLOG(DEBUG, "History") << "Unzipping " << mFileType
+            << " for checkpoint " << mNext;
+        auto gunzip = addWork<GunzipFileWork>(ft.localPath_gz());
+        assert(mRunning.find(gunzip->getUniqueName()) == mRunning.end());
+        mRunning.insert(std::make_pair(gunzip->getUniqueName(), mNext));
     }
     else
     {


### PR DESCRIPTION
During history catch-up, I had some issues that some history decompressed files were not found while the compressed version was downloaded.  
After inspection, I traced it back to this particular code part.

I'm not sure about the of the impact of this fix on other code, but the tests are still succeeding.
