### PR TITLE
fix licence from ISC to Apache in two files

### DIFF
--- a/src/transactions/AllowTrustTests.cpp
+++ b/src/transactions/AllowTrustTests.cpp
@@ -1,6 +1,6 @@
-// Copyright 2014 Stellar Development Foundation and contributors. Licensed
-// under the ISC License. See the COPYING file at the top-level directory of
-// this distribution or at http://opensource.org/licenses/ISC
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "lib/catch.hpp"
 #include "main/Application.h"

--- a/src/transactions/ChangeTrustTests.cpp
+++ b/src/transactions/ChangeTrustTests.cpp
@@ -1,6 +1,6 @@
-// Copyright 2014 Stellar Development Foundation and contributors. Licensed
-// under the ISC License. See the COPYING file at the top-level directory of
-// this distribution or at http://opensource.org/licenses/ISC
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/Application.h"
 #include "overlay/LoopbackPeer.h"


### PR DESCRIPTION
ISC licence is also used in ManageDataTests.cpp