### PR TITLE
Fix windows (VS) compile errors.

### DIFF
--- a/Builds/VisualStudio2015/stellar-core.vcxproj
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj
@@ -54,7 +54,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NOMINMAX;ASIO_STANDALONE;USE_POSTGRES;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;ASIO_STANDALONE;USE_POSTGRES;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -109,7 +109,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NOMINMAX;ASIO_STANDALONE;USE_POSTGRES;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NOMINMAX;ASIO_STANDALONE;USE_POSTGRES;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BrowseInformation>false</BrowseInformation>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -238,8 +238,11 @@
     </ClCompile>
     <ClCompile Include="..\..\src\main\Application.cpp" />
     <ClCompile Include="..\..\src\main\ApplicationImpl.cpp" />
+    <ClCompile Include="..\..\src\main\ApplicationTests.cpp" />
+    <ClCompile Include="..\..\src\main\ConfigTests.cpp" />
     <ClCompile Include="..\..\src\main\dumpxdr.cpp" />
     <ClCompile Include="..\..\src\main\fuzz.cpp" />
+    <ClCompile Include="..\..\src\main\NtpSynchronizationChecker.cpp" />
     <ClCompile Include="..\..\src\main\PersistentState.cpp" />
     <ClCompile Include="..\..\src\main\ExternalQueue.cpp" />
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp" />
@@ -291,6 +294,10 @@
     <ClCompile Include="..\..\src\util\GlobalChecks.cpp" />
     <ClCompile Include="..\..\src\util\HashOfHash.cpp" />
     <ClCompile Include="..\..\src\util\Math.cpp" />
+    <ClCompile Include="..\..\src\util\NtpClient.cpp" />
+    <ClCompile Include="..\..\src\util\NtpWork.cpp" />
+    <ClCompile Include="..\..\src\util\StatusManager.cpp" />
+    <ClCompile Include="..\..\src\util\StatusManagerTest.cpp" />
     <ClCompile Include="..\..\src\util\TmpDir.cpp" />
     <ClCompile Include="..\..\src\util\Timer.cpp" />
     <ClCompile Include="..\..\src\util\TimerTests.cpp" />
@@ -341,6 +348,7 @@
     <ClInclude Include="..\..\src\history\StateSnapshot.h" />
     <ClInclude Include="..\..\src\ledger\LedgerTestUtils.h" />
     <ClInclude Include="..\..\src\main\ExternalQueue.h" />
+    <ClInclude Include="..\..\src\main\NtpSynchronizationChecker.h" />
     <ClInclude Include="..\..\src\overlay\BanManager.h" />
     <ClInclude Include="..\..\src\overlay\BanManagerImpl.h" />
     <ClInclude Include="..\..\src\overlay\LoadManager.h" />
@@ -434,7 +442,10 @@
     <ClInclude Include="..\..\src\util\Math.h" />
     <ClInclude Include="..\..\src\util\must_use.h" />
     <ClInclude Include="..\..\src\util\NonCopyable.h" />
+    <ClInclude Include="..\..\src\util\NtpClient.h" />
+    <ClInclude Include="..\..\src\util\NtpWork.h" />
     <ClInclude Include="..\..\src\util\optional.h" />
+    <ClInclude Include="..\..\src\util\StatusManager.h" />
     <ClInclude Include="..\..\src\util\TmpDir.h" />
     <ClInclude Include="..\..\src\util\Timer.h" />
     <ClInclude Include="..\..\src\util\types.h" />

--- a/Builds/VisualStudio2015/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio2015/stellar-core.vcxproj.filters
@@ -531,6 +531,27 @@
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\NtpClient.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\NtpWork.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\StatusManager.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\StatusManagerTest.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\ApplicationTests.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\ConfigTests.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\NtpSynchronizationChecker.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ledger\LedgerManager.h">
@@ -922,6 +943,18 @@
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\BanManagerImpl.h">
       <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\NtpClient.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\NtpWork.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\StatusManager.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\NtpSynchronizationChecker.h">
+      <Filter>main</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -2,6 +2,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "util/asio.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketApplicator.h"
 #include "ledger/LedgerDelta.h"

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -2,6 +2,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "util/asio.h"
 #include "bucket/BucketApplicator.h"
 #include "bucket/BucketManager.h"
 #include "crypto/Hex.h"

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -21,7 +21,10 @@ extern "C" {
 
 #if MSVC
 #include <io.h>
+#include <fcntl.h>
+#include <BaseTsd.h>
 #define isatty _isatty
+typedef SSIZE_T ssize_t;
 #endif // MSVC
 
 namespace stellar


### PR DESCRIPTION
Changed dumpxdr.cpp to conform to cpp standard instead of POSIX.
Add missing files to visual studio project file.

**Update 1:**
It seems there is some other bug too. ~The folder **stellar-core-test-798f122b4d19f20e** doesn't get created. For some tests, the folders do get created. Maybe related to a bug in the *new* `bool mkpath(const std::string &path)` implementation?~

```
$ ./stellar-core --test -a
2016-11-08T12:08:25.635 <startup> [Fs DEBUG] created dir stellar-core-test-798f122b4d19f20e
2016-11-08T12:08:25.792 <test> [default INFO ] Testing stellar-core unknown-msvc
2016-11-08T12:08:25.793 <test> [default INFO ] Logging to stellar0.log
2016-11-08T12:08:25.826 <test> [Database INFO ] Connecting to: sqlite3://:memory:

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
stellar-core.exe is a Catch v1.2.1 host application.
Run with -? for options

-------------------------------------------------------------------------------
skip list
-------------------------------------------------------------------------------
..\..\src\bucket\BucketTests.cpp(88)
...............................................................................

..\..\src\bucket\BucketTests.cpp(88): FAILED:
due to unexpected exception with message:
  error accessing path: stellar-core-test-798f122b4d19f20e/bucket/tmp

===============================================================================
test cases: 1 | 1 failed
assertions: 1 | 1 failed
```

**Update 2:** 
It seems the base test folder does get created (it just gets deleted after the test), but maybe the *bucket* or *bucket/tmp*  does not. My current best guess would be that it's related to #1063.

**Update 3:**
The *stellar-core-test-xxx/**bucket*** folder doesn't get created. When I explicitly add some code to do this, the tests successfully run. The *tmp*  folder in the *bucket* folder does get created, as long as the *bucket* folder exists. Maybe this is because *tmp* is now in *bucket*, but get's accessed earlier than *bucket* get's created?

**Update 4:**
The issue starts in `TmpDirManager`. It runs the following code:
```cpp
TmpDirManager::TmpDirManager(std::string const& root) : mRoot(root)
{
    clean();
    fs::mkpath(root);
}
```
Which calls the `clean()` function. This function tries to check if the folder exists. But this check happens **before** the `bucket` folder is created. The `fs:exists(..)` only returns false when the file is not found, but will throw an error when the path is not found (because `bucket` doesn't exist).

There are a few options I can think of:
- alter `TmpDirManager` to use a separate `fs::existsXXX` that also catches the *path not found*-error
- try to create the path before cleaning it
- alter the existing `fs:exists`, but this might have big consequences for other parts of the core