### PR TITLE
Limit quorum size

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -84,9 +84,9 @@ class Herder
     // restores SCP state based on the last messages saved on disk
     virtual void restoreSCPState() = 0;
 
-    virtual void recvSCPQuorumSet(Hash const& hash,
+    virtual bool recvSCPQuorumSet(Hash const& hash,
                                   SCPQuorumSet const& qset) = 0;
-    virtual void recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
+    virtual bool recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
     virtual TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -110,11 +110,6 @@ class Herder
 
     virtual void triggerNextLedger(uint32_t ledgerSeqToTrigger) = 0;
 
-    // returns if the quorum set passes basic sanity checks
-    // if extraChecks is set, performs additional checks
-    virtual bool isQuorumSetSane(SCPQuorumSet const& qSet,
-                                 bool extraChecks) = 0;
-
     // lookup a nodeID in config and in SCP messages
     virtual bool resolveNodeID(std::string const& s, PublicKey& retKey) = 0;
 

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -72,6 +72,20 @@ class Herder
         TX_STATUS_COUNT
     };
 
+    enum EnvelopeStatus
+    {
+        // for some reason this envelope was discarded - either is was invalid,
+        // used unsane qset or was coming from node that is not in quorum
+        ENVELOPE_STATUS_DISCARDED,
+        // envelope data is currently being fetched
+        ENVELOPE_STATUS_FETCHING,
+        // current call to recvSCPEnvelope() was the first when the envelope
+        // was fully fetched so it is ready for processing
+        ENVELOPE_STATUS_READY,
+        // envelope was already processed
+        ENVELOPE_STATUS_PROCESSED,
+    };
+
     virtual State getState() const = 0;
     virtual std::string getStateHuman() const = 0;
 
@@ -95,7 +109,7 @@ class Herder
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // We are learning about a new envelope.
-    virtual void recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
+    virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
 
     // a peer needs our SCP state
     virtual void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1211,17 +1211,17 @@ HerderImpl::removeReceivedTxs(std::vector<TransactionFramePtr> const& dropTxs)
     }
 }
 
-void
+bool
 HerderImpl::recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset)
 {
-    mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
+    return mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
 }
 
-void
+bool
 HerderImpl::recvTxSet(Hash const& hash, const TxSetFrame& t)
 {
     TxSetFramePtr txset(new TxSetFrame(t));
-    mPendingEnvelopes.recvTxSet(hash, txset);
+    return mPendingEnvelopes.recvTxSet(hash, txset);
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1403,12 +1403,6 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
 }
 
 bool
-HerderImpl::isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks)
-{
-    return LocalNode::isQuorumSetSane(qSet, extraChecks);
-}
-
-bool
 HerderImpl::resolveNodeID(std::string const& s, PublicKey& retKey)
 {
     bool r = mApp.getConfig().resolveNodeID(s, retKey);

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -17,6 +17,7 @@
 #include "util/make_unique.h"
 #include "lib/json/json.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 #include "main/PersistentState.h"
 
 #include "medida/meter.h"
@@ -1214,7 +1215,10 @@ HerderImpl::removeReceivedTxs(std::vector<TransactionFramePtr> const& dropTxs)
 void
 HerderImpl::recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset)
 {
-    mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
+    if (isQuorumSetSane(qset, false))
+    {
+        mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
+    }
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -17,7 +17,6 @@
 #include "util/make_unique.h"
 #include "lib/json/json.h"
 #include "scp/LocalNode.h"
-#include "scp/QuorumSetUtils.h"
 #include "main/PersistentState.h"
 
 #include "medida/meter.h"
@@ -1215,10 +1214,7 @@ HerderImpl::removeReceivedTxs(std::vector<TransactionFramePtr> const& dropTxs)
 void
 HerderImpl::recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset)
 {
-    if (isQuorumSetSane(qset, false))
-    {
-        mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
-    }
+    mPendingEnvelopes.recvSCPQuorumSet(hash, qset);
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -946,12 +946,12 @@ HerderImpl::recvTransaction(TransactionFramePtr tx)
     return TX_STATUS_PENDING;
 }
 
-void
+Herder::EnvelopeStatus
 HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
 {
     if (mApp.getConfig().MANUAL_CLOSE)
     {
-        return;
+        return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 
     if (Logging::logDebug("Herder"))
@@ -966,7 +966,7 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
     if (envelope.statement.nodeID == mSCP.getLocalNode()->getNodeID())
     {
         CLOG(DEBUG, "Herder") << "recvSCPEnvelope: skipping own message";
-        return;
+        return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 
     mSCPMetrics.mEnvelopeReceive.Mark();
@@ -998,10 +998,10 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
         CLOG(DEBUG, "Herder") << "Ignoring SCPEnvelope outside of range: "
                               << envelope.statement.slotIndex << "( "
                               << minLedgerSeq << "," << maxLedgerSeq << ")";
-        return;
+        return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 
-    mPendingEnvelopes.recvSCPEnvelope(envelope);
+    return mPendingEnvelopes.recvSCPEnvelope(envelope);
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1001,7 +1001,12 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
         return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 
-    return mPendingEnvelopes.recvSCPEnvelope(envelope);
+    auto status = mPendingEnvelopes.recvSCPEnvelope(envelope);
+    if (status == Herder::ENVELOPE_STATUS_READY)
+    {
+        processSCPQueue();
+    }
+    return status;
 }
 
 void

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -100,8 +100,8 @@ class HerderImpl : public Herder, public SCPDriver
 
     void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) override;
 
-    void recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset) override;
-    void recvTxSet(Hash const& hash, const TxSetFrame& txset) override;
+    bool recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset) override;
+    bool recvTxSet(Hash const& hash, const TxSetFrame& txset) override;
     void peerDoesntHave(MessageType type, uint256 const& itemID,
                         PeerPtr peer) override;
     TxSetFramePtr getTxSet(Hash const& hash) override;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -115,8 +115,6 @@ class HerderImpl : public Herder, public SCPDriver
 
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
-    bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks) override;
-
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 
     void dumpInfo(Json::Value& ret, size_t limit) override;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -96,7 +96,7 @@ class HerderImpl : public Herder, public SCPDriver
 
     TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) override;
 
-    void recvSCPEnvelope(SCPEnvelope const& envelope) override;
+    EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
 
     void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) override;
 

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -254,6 +254,25 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
                           << " t:" << envelope.statement.pledges.type();
 }
 
+void
+PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
+{
+    Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
+    mQuorumSetFetcher.stopFetch(h, envelope);
+
+    std::vector<Value> vals = Slot::getStatementValues(envelope.statement);
+    for (auto const& v : vals)
+    {
+        StellarValue wb;
+        xdr::xdr_from_opaque(v, wb);
+
+        mTxSetFetcher.stopFetch(wb.txSetHash, envelope);
+    }
+
+    CLOG(TRACE, "Herder") << "StopFetch i:" << envelope.statement.slotIndex
+                          << " t:" << envelope.statement.pledges.type();
+}
+
 bool
 PendingEnvelopes::pop(uint64 slotIndex, SCPEnvelope& ret)
 {

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -228,18 +228,14 @@ PendingEnvelopes::isFullyFetched(SCPEnvelope const& envelope)
     return true;
 }
 
-// returns true if already fetched
-bool
+void
 PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
 {
-    bool ret = true;
-
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
 
     if (!mQsetCache.exists(h))
     {
         mQuorumSetFetcher.fetch(h, envelope);
-        ret = false;
     }
 
     std::vector<Value> vals = Slot::getStatementValues(envelope.statement);
@@ -251,13 +247,11 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
         if (!mTxSetCache.exists(wb.txSetHash))
         {
             mTxSetFetcher.fetch(wb.txSetHash, envelope);
-            ret = false;
         }
     }
 
     CLOG(TRACE, "Herder") << "StartFetch i:" << envelope.statement.slotIndex
                           << " t:" << envelope.statement.pledges.type();
-    return ret;
 }
 
 bool

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -66,22 +66,26 @@ PendingEnvelopes::addSCPQuorumSet(Hash hash, uint64 lastSeenSlotIndex, const SCP
     mQuorumSetFetcher.recv(hash);
 }
 
-void
+bool
 PendingEnvelopes::recvSCPQuorumSet(Hash hash, const SCPQuorumSet& q)
 {
     CLOG(TRACE, "Herder") << "Got SCPQSet " << hexAbbrev(hash);
 
     auto lastSeenSlotIndex = mQuorumSetFetcher.getLastSeenSlotIndex(hash);
-    if (lastSeenSlotIndex > 0)
+    if (lastSeenSlotIndex <= 0)
     {
-        if (isQuorumSetSane(q, false))
-        {
-            addSCPQuorumSet(hash, lastSeenSlotIndex, q);
-        }
-        else
-        {
-            discardSCPEnvelopesWithQSet(hash);
-        }
+        return false;
+    }
+
+    if (isQuorumSetSane(q, false))
+    {
+        addSCPQuorumSet(hash, lastSeenSlotIndex, q);
+        return true;
+    }
+    else
+    {
+        discardSCPEnvelopesWithQSet(hash);
+        return false;
     }
 }
 
@@ -104,16 +108,19 @@ PendingEnvelopes::addTxSet(Hash hash, uint64 lastSeenSlotIndex, TxSetFramePtr tx
     mTxSetFetcher.recv(hash);
 }
 
-void
+bool
 PendingEnvelopes::recvTxSet(Hash hash, TxSetFramePtr txset)
 {
     CLOG(TRACE, "Herder") << "Got TxSet " << hexAbbrev(hash);
 
     auto lastSeenSlotIndex = mTxSetFetcher.getLastSeenSlotIndex(hash);
-    if (lastSeenSlotIndex > 0)
+    if (lastSeenSlotIndex == 0)
     {
-        addTxSet(hash, lastSeenSlotIndex, txset);
+        return false;
     }
+
+    addTxSet(hash, lastSeenSlotIndex, txset);
+    return true;
 }
 
 bool

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -279,8 +279,6 @@ PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
 
     CLOG(TRACE, "Herder") << "Envelope ready i:" << envelope.statement.slotIndex
                           << " t:" << envelope.statement.pledges.type();
-
-    mHerder.processSCPQueue();
 }
 
 bool

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -364,6 +364,28 @@ PendingEnvelopes::eraseBelow(uint64 slotIndex)
             break;
     }
 
+    for (auto iter = mDiscardedEnvelopes.begin();
+         iter != mDiscardedEnvelopes.end();)
+    {
+        if (iter->first < slotIndex)
+        {
+            iter = mDiscardedEnvelopes.erase(iter);
+        }
+        else
+            break;
+    }
+
+    for (auto iter = mProcessedEnvelopes.begin();
+         iter != mProcessedEnvelopes.end();)
+    {
+        if (iter->first < slotIndex)
+        {
+            iter = mProcessedEnvelopes.erase(iter);
+        }
+        else
+            break;
+    }
+
     for (auto iter = mFetchingEnvelopes.begin();
          iter != mFetchingEnvelopes.end();)
     {

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -21,22 +21,25 @@ namespace stellar
 
 class HerderImpl;
 
+struct SlotEnvelopes
+{
+    // list of envelopes we have processed already
+    std::vector<SCPEnvelope> mProcessedEnvelopes;
+    // list of envelopes we have discarded already
+    std::set<SCPEnvelope> mDiscardedEnvelopes;
+    // list of envelopes we are fetching right now
+    std::set<SCPEnvelope> mFetchingEnvelopes;
+    // list of envelopes that haven't been sent to SCP yet
+    std::vector<SCPEnvelope> mPendingEnvelopes;
+};
+
 class PendingEnvelopes
 {
     Application& mApp;
     HerderImpl& mHerder;
 
-    // ledger# and list of envelopes we have processed already
-    std::map<uint64, std::vector<SCPEnvelope>> mProcessedEnvelopes;
-
-    // ledger# and list of envelopes we have discarded already
-    std::map<uint64, std::set<SCPEnvelope>> mDiscardedEnvelopes;
-
-    // ledger# and list of envelopes we are fetching right now
-    std::map<uint64, std::set<SCPEnvelope>> mFetchingEnvelopes;
-
-    // ledger# and list of envelopes that haven't been sent to SCP yet
-    std::map<uint64, std::vector<SCPEnvelope>> mPendingEnvelopes;
+    // ledger# and list of envelopes in various states
+    std::map<uint64, SlotEnvelopes> mEnvelopes;
 
     using SCPQuorumSetCacheItem = std::pair<uint64, SCPQuorumSetPtr>;
     // all the quorum sets we have learned about

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -94,8 +94,7 @@ class PendingEnvelopes
                         Peer::pointer peer);
 
     bool isFullyFetched(SCPEnvelope const& envelope);
-    // returns true if already fetched
-    bool startFetch(SCPEnvelope const& envelope);
+    void startFetch(SCPEnvelope const& envelope);
 
     void envelopeReady(SCPEnvelope const& envelope);
 

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -57,6 +57,10 @@ class PendingEnvelopes
     // returns true if we think that the node is in quorum
     bool isNodeInQuorum(NodeID const& node);
 
+    // discards all SCP envelopes thats use QSet with given hash,
+    // as it is not sane QSet
+    void discardSCPEnvelopesWithQSet(Hash hash);
+
   public:
     PendingEnvelopes(Application& app, HerderImpl& herder);
     ~PendingEnvelopes();

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -82,8 +82,10 @@ class PendingEnvelopes
      * Check if @p qset identified by @p hash was requested before from peers.
      * If not, ignores that @p qset. If it was requested, calls
      * @see addSCPQuorumSet.
+     *
+     * Return true if SCPQuorumSet is sane and useful (was asked for).
      */
-    void recvSCPQuorumSet(Hash hash, const SCPQuorumSet& qset);
+    bool recvSCPQuorumSet(Hash hash, const SCPQuorumSet& qset);
 
     /**
      * Add @p txset identified by @p hash to local cache. Notifies
@@ -97,8 +99,10 @@ class PendingEnvelopes
      * Check if @p txset identified by @p hash was requested before from peers.
      * If not, ignores that @p txset. If it was requested, calls
      * @see addTxSet.
+     *
+     * Return true if TxSet useful (was asked for).
      */
-    void recvTxSet(Hash hash, TxSetFramePtr txset);
+    bool recvTxSet(Hash hash, TxSetFramePtr txset);
     void discardSCPEnvelope(SCPEnvelope const& envelope);
 
     void peerDoesntHave(MessageType type, Hash const& itemID,

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -95,6 +95,7 @@ class PendingEnvelopes
 
     bool isFullyFetched(SCPEnvelope const& envelope);
     void startFetch(SCPEnvelope const& envelope);
+    void stopFetch(SCPEnvelope const& envelope);
 
     void envelopeReady(SCPEnvelope const& envelope);
 

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -29,8 +29,8 @@ struct SlotEnvelopes
     std::set<SCPEnvelope> mDiscardedEnvelopes;
     // list of envelopes we are fetching right now
     std::set<SCPEnvelope> mFetchingEnvelopes;
-    // list of envelopes that haven't been sent to SCP yet
-    std::vector<SCPEnvelope> mPendingEnvelopes;
+    // list of ready envelopes that haven't been sent to SCP yet
+    std::vector<SCPEnvelope> mReadyEnvelopes;
 };
 
 class PendingEnvelopes
@@ -55,7 +55,7 @@ class PendingEnvelopes
     // NodeIDs that are in quorum
     cache::lru_cache<NodeID, bool> mNodesInQuorum;
 
-    medida::Counter& mPendingEnvelopesSize;
+    medida::Counter& mReadyEnvelopesSize;
 
     // returns true if we think that the node is in quorum
     bool isNodeInQuorum(NodeID const& node);

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -29,6 +29,9 @@ class PendingEnvelopes
     // ledger# and list of envelopes we have processed already
     std::map<uint64, std::vector<SCPEnvelope>> mProcessedEnvelopes;
 
+    // ledger# and list of envelopes we have discarded already
+    std::map<uint64, std::set<SCPEnvelope>> mDiscardedEnvelopes;
+
     // ledger# and list of envelopes we are fetching right now
     std::map<uint64, std::set<SCPEnvelope>> mFetchingEnvelopes;
 
@@ -89,10 +92,12 @@ class PendingEnvelopes
      * @see addTxSet.
      */
     void recvTxSet(Hash hash, TxSetFramePtr txset);
+    void discardSCPEnvelope(SCPEnvelope const& envelope);
 
     void peerDoesntHave(MessageType type, Hash const& itemID,
                         Peer::pointer peer);
 
+    bool isDiscarded(SCPEnvelope const& envelope) const;
     bool isFullyFetched(SCPEnvelope const& envelope);
     void startFetch(SCPEnvelope const& envelope);
     void stopFetch(SCPEnvelope const& envelope);

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -6,6 +6,7 @@
 #include <util/optional.h>
 #include <set>
 #include <xdr/Stellar-SCP.h>
+#include "herder/Herder.h"
 #include "overlay/ItemFetcher.h"
 #include "lib/json/json.h"
 #include "lib/util/lrucache.hpp"
@@ -68,7 +69,12 @@ class PendingEnvelopes
     PendingEnvelopes(Application& app, HerderImpl& herder);
     ~PendingEnvelopes();
 
-    void recvSCPEnvelope(SCPEnvelope const& envelope);
+    /**
+     * Process received @p envelope.
+     *
+     * Return status of received envelope.
+     */
+    Herder::EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope);
 
     /**
      * Add @p qset identified by @p hash to local cache. Notifies

--- a/src/herder/PendingEnvelopesTests.cpp
+++ b/src/herder/PendingEnvelopesTests.cpp
@@ -1,0 +1,190 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/SHA.h"
+#include "herder/HerderImpl.h"
+#include "herder/PendingEnvelopes.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "main/test.h"
+#include "test/TestAccount.h"
+#include "test/TxTests.h"
+#include "xdrpp/marshal.h"
+
+using namespace stellar;
+using namespace stellar::txtest;
+
+TEST_CASE("PendingEnvelopes::recvSCPEnvelope", "[herder]")
+{
+    Config cfg(getTestConfig());
+    VirtualClock clock;
+    Application::pointer app = Application::create(clock, cfg);
+
+    auto const& networkID = app->getNetworkID();
+    auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
+
+    auto root = TestAccount::createRoot(*app);
+    auto a1 = getAccount("A");
+    using TxPair = std::pair<Value, TxSetFramePtr>;
+    auto makeTxPair = [](TxSetFramePtr txSet, uint64_t closeTime){
+        txSet->sortForHash();
+        auto sv = StellarValue{txSet->getContentsHash(), closeTime, emptyUpgradeSteps, 0};
+        auto v = xdr::xdr_to_opaque(sv);
+
+        return TxPair{v, txSet};
+    };
+    auto makeEnvelope = [&root](TxPair const& p, Hash qSetHash, uint64_t slotIndex){
+        // herder must want the TxSet before receiving it, so we are sending it fake envelope
+        auto envelope = SCPEnvelope{};
+        envelope.statement.slotIndex = slotIndex;
+        envelope.statement.pledges.type(SCP_ST_PREPARE);
+        envelope.statement.pledges.prepare().ballot.value = p.first;
+        envelope.statement.pledges.prepare().quorumSetHash = qSetHash;
+        envelope.signature = root.getSecretKey().sign(xdr::xdr_to_opaque(envelope.statement));
+        return envelope;
+    };
+    auto addTransactions = [&](TxSetFramePtr txSet, int n)
+    {
+        txSet->mTransactions.resize(n);
+        std::generate(std::begin(txSet->mTransactions), std::end(txSet->mTransactions),
+                      [&](){
+                          return createCreateAccountTx(networkID, root, a1, root.nextSequenceNumber(), 10000000);
+                      });
+    };
+    auto makeTransactions = [&](Hash hash, int n)
+    {
+        auto result = std::make_shared<TxSetFrame>(hash);
+        addTransactions(result, n);
+        return result;
+    };
+
+    auto makePublicKey = [](int i){
+        auto hash = sha256("NODE_SEED_" + std::to_string(i));
+        auto secretKey = SecretKey::fromSeed(hash);
+        return secretKey.getPublicKey();
+    };
+
+    auto makeSingleton = [](const PublicKey &key){
+        auto result = SCPQuorumSet{};
+        result.threshold = 1;
+        result.validators.push_back(key);
+        return result;
+    };
+
+    auto keys = std::vector<PublicKey>{};
+    for (auto i = 0; i < 1001; i++)
+    {
+        keys.push_back(makePublicKey(i));
+    }
+
+    auto saneQSet = makeSingleton(keys[0]);
+    auto saneQSetHash = sha256(xdr::xdr_to_opaque(saneQSet));
+
+    auto bigQSet = SCPQuorumSet{};
+    bigQSet.threshold = 1;
+    bigQSet.validators.push_back(keys[0]);
+    for (auto i = 0; i < 10; i++)
+    {
+        bigQSet.innerSets.push_back({});
+        bigQSet.innerSets.back().threshold = 1;
+        for (auto j = i * 100 + 1; j <= (i + 1) * 100; j++)
+            bigQSet.innerSets.back().validators.push_back(keys[j]);
+    }
+    auto bigQSetHash = sha256(xdr::xdr_to_opaque(bigQSet));
+
+    auto transactions = makeTransactions(lcl.hash, 50);
+    auto p = makeTxPair(transactions, 10);
+    auto saneEnvelope = makeEnvelope(p, saneQSetHash, lcl.header.ledgerSeq + 1);
+    auto bigEnvelope = makeEnvelope(p, bigQSetHash, lcl.header.ledgerSeq + 1);
+
+    PendingEnvelopes pendingEnvelopes{*app, static_cast<HerderImpl&>(app->getHerder())};
+
+    SECTION("return FETCHING when first receiving envelope")
+    {
+        // check if the return value change only when it was READY on previous call
+        REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+        REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+
+        SECTION("and then READY when all data came (quorum set first)")
+        {
+            REQUIRE(pendingEnvelopes.recvSCPQuorumSet(saneQSetHash, saneQSet));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+            REQUIRE(!pendingEnvelopes.recvSCPQuorumSet(saneQSetHash, saneQSet));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+
+            REQUIRE(pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+            REQUIRE(!pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_READY);
+
+            REQUIRE(!pendingEnvelopes.recvSCPQuorumSet(saneQSetHash, saneQSet));
+            REQUIRE(!pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+
+            SECTION("and then PROCESSED")
+            {
+                REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_PROCESSED);
+                REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_PROCESSED);
+            }
+        }
+
+        SECTION("and then READY when all data came (tx set first)")
+        {
+            REQUIRE(pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+            REQUIRE(!pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+
+            REQUIRE(pendingEnvelopes.recvSCPQuorumSet(saneQSetHash, saneQSet));
+            REQUIRE(!pendingEnvelopes.recvSCPQuorumSet(saneQSetHash, saneQSet));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_READY);
+
+            REQUIRE(!pendingEnvelopes.recvSCPQuorumSet(saneQSetHash, saneQSet));
+            REQUIRE(!pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+
+            SECTION("and then PROCESSED")
+            {
+                REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_PROCESSED);
+                REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_PROCESSED);
+            }
+        }
+    }
+
+    SECTION("return READY when receiving envelope with quorum set and tx that were manually added before")
+    {
+        SECTION("as not-removable")
+        {
+            pendingEnvelopes.addSCPQuorumSet(saneQSetHash, 0, saneQSet);
+            pendingEnvelopes.addTxSet(p.second->getContentsHash(), 0, p.second);
+        }
+
+        SECTION("as removable")
+        {
+            pendingEnvelopes.addSCPQuorumSet(saneQSetHash, 9, saneQSet);
+            pendingEnvelopes.addTxSet(p.second->getContentsHash(), 9, p.second);
+        }
+
+        REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_READY);
+        REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) == Herder::ENVELOPE_STATUS_PROCESSED);
+    }
+
+    SECTION("return DISCARDED when receiving envelope with too big quorum set")
+    {
+        REQUIRE(pendingEnvelopes.recvSCPEnvelope(bigEnvelope) == Herder::ENVELOPE_STATUS_FETCHING);
+
+        SECTION("quorum set first")
+        {
+            REQUIRE(!pendingEnvelopes.recvSCPQuorumSet(bigQSetHash, bigQSet));
+            REQUIRE(!pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(bigEnvelope) == Herder::ENVELOPE_STATUS_DISCARDED);
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(bigEnvelope) == Herder::ENVELOPE_STATUS_DISCARDED);
+        }
+
+        SECTION("tx set first")
+        {
+            REQUIRE(pendingEnvelopes.recvTxSet(p.second->getContentsHash(), p.second));
+            REQUIRE(!pendingEnvelopes.recvSCPQuorumSet(bigQSetHash, bigQSet));
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(bigEnvelope) == Herder::ENVELOPE_STATUS_DISCARDED);
+            REQUIRE(pendingEnvelopes.recvSCPEnvelope(bigEnvelope) == Herder::ENVELOPE_STATUS_DISCARDED);
+        }
+    }
+}

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -25,6 +25,7 @@
 #include "crypto/SecretKey.h"
 #include "crypto/SHA.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 #include "main/ExternalQueue.h"
 #include "main/NtpSynchronizationChecker.h"
 #include "medida/metrics_registry.h"
@@ -245,7 +246,7 @@ ApplicationImpl::start()
     {
         throw std::invalid_argument("Quorum not configured");
     }
-    if (!mHerder->isQuorumSetSane(mConfig.QUORUM_SET, !mConfig.UNSAFE_QUORUM))
+    if (!isQuorumSetSane(mConfig.QUORUM_SET, !mConfig.UNSAFE_QUORUM))
     {
         std::string err("Invalid QUORUM_SET: duplicate entry or bad threshold "
                         "(should be between ");

--- a/src/overlay/FloodTests.cpp
+++ b/src/overlay/FloodTests.cpp
@@ -261,8 +261,8 @@ TEST_CASE("Flooding", "[flood][overlay]")
             // inject the message
             herder.recvSCPEnvelope(envelope);
 
-            herder.recvTxSet(txSet.getContentsHash(), txSet);
-            herder.recvSCPQuorumSet(qSetHash, qset);
+            REQUIRE(herder.recvTxSet(txSet.getContentsHash(), txSet));
+            REQUIRE(herder.recvSCPQuorumSet(qSetHash, qset));
 
         };
 

--- a/src/overlay/FloodTests.cpp
+++ b/src/overlay/FloodTests.cpp
@@ -259,8 +259,7 @@ TEST_CASE("Flooding", "[flood][overlay]")
                 inApp->getNetworkID(), ENVELOPE_TYPE_SCP, st));
 
             // inject the message
-            herder.recvSCPEnvelope(envelope);
-
+            REQUIRE(herder.recvSCPEnvelope(envelope) == Herder::ENVELOPE_STATUS_FETCHING);
             REQUIRE(herder.recvTxSet(txSet.getContentsHash(), txSet));
             REQUIRE(herder.recvSCPQuorumSet(qSetHash, qset));
 

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -46,6 +46,26 @@ ItemFetcher::fetch(Hash itemHash, const SCPEnvelope& envelope)
     }
 }
 
+void
+ItemFetcher::stopFetch(Hash itemHash, const SCPEnvelope& envelope)
+{
+    CLOG(TRACE, "Overlay") << "stopFetch " << hexAbbrev(itemHash);
+    const auto& iter = mTrackers.find(itemHash);
+    if (iter != mTrackers.end())
+    {
+        auto const &tracker = iter->second;
+
+        CLOG(TRACE, "Overlay") << "stopFetch " << hexAbbrev(itemHash) << " : "
+                               << tracker->size();
+        tracker->discard(envelope);
+        if (tracker->empty())
+        {
+            // stop the timer, stop requesting the item as no one is waiting for it
+            tracker->cancel();
+        }
+    }
+}
+
 uint64
 ItemFetcher::getLastSeenSlotIndex(Hash itemHash) const
 {

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -78,6 +78,22 @@ ItemFetcher::getLastSeenSlotIndex(Hash itemHash) const
     return iter->second->getLastSeenSlotIndex();
 }
 
+std::vector<SCPEnvelope>
+ItemFetcher::fetchingFor(Hash itemHash) const
+{
+    auto result = std::vector<SCPEnvelope>{};
+    auto iter = mTrackers.find(itemHash);
+    if (iter == mTrackers.end())
+    {
+        return result;
+    }
+
+    auto const& waiting = iter->second->waitingEnvelopes();
+    std::transform(std::begin(waiting), std::end(waiting), std::back_inserter(result),
+                   [](std::pair<Hash, SCPEnvelope> const &x){ return x.second; });
+    return result;
+}
+
 void
 ItemFetcher::stopFetchingBelow(uint64 slotIndex)
 {

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -55,6 +55,13 @@ class ItemFetcher : private NonMovableOrCopyable
     void fetch(Hash itemHash, const SCPEnvelope& envelope);
 
     /**
+     * Stops fetching data identified by @p hash for @p envelope. If other
+     * envelopes requires this data, it is still being fetched, but
+     * @p envelope will not be notified about it.
+     */
+    void stopFetch(Hash itemHash, const SCPEnvelope& envelope);
+
+    /**
      * Return biggest slot index seen for given hash. If 0, then given hash
      * is not being fetched.
      */

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -68,6 +68,11 @@ class ItemFetcher : private NonMovableOrCopyable
     uint64 getLastSeenSlotIndex(Hash itemHash) const;
 
     /**
+     * Return envelopes that require data identified by @p hash.
+     */
+    std::vector<SCPEnvelope> fetchingFor(Hash itemHash) const;
+
+    /**
      * Called periodically to remove old envelopes from list (with ledger id
      * below some @p slotIndex). Can also remove @see Tracker instances when
      * non needed anymore.

--- a/src/overlay/ItemFetcherTests.cpp
+++ b/src/overlay/ItemFetcherTests.cpp
@@ -28,9 +28,10 @@ public:
     std::vector<int> received;
 
 private:
-    void recvSCPEnvelope(SCPEnvelope const& envelope) override
+    EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override
     {
         received.push_back(envelope.statement.pledges.confirm().nPrepared);
+        return Herder::ENVELOPE_STATUS_PROCESSED;
     }
 };
 

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -6,6 +6,7 @@
 
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
+#include "herder/Herder.h"
 #include "main/Application.h"
 #include "medida/medida.h"
 #include "overlay/OverlayManager.h"
@@ -34,7 +35,7 @@ Tracker::Tracker(Application& app, Hash const& hash, AskPeer &askPeer)
 
 Tracker::~Tracker()
 {
-    mTimer.cancel();
+    cancel();
 }
 
 SCPEnvelope
@@ -182,9 +183,22 @@ Tracker::listen(const SCPEnvelope& env)
 }
 
 void
+Tracker::discard(const SCPEnvelope& env)
+{
+    using xdr::operator==;
+    auto matchEnvelope = [&env](std::pair<Hash, SCPEnvelope> const& x){
+        return x.second == env;
+    };
+    mWaitingEnvelopes.erase(std::remove_if(std::begin(mWaitingEnvelopes), std::end(mWaitingEnvelopes),
+                                    matchEnvelope),
+                    std::end(mWaitingEnvelopes));
+}
+
+void
 Tracker::cancel()
 {
     mTimer.cancel();
+    mLastSeenSlotIndex = 0;
 }
 
 }

--- a/src/overlay/Tracker.h
+++ b/src/overlay/Tracker.h
@@ -88,6 +88,11 @@ class Tracker
     void listen(const SCPEnvelope& env);
 
     /**
+     * Stops tracking envelope @p env.
+     */
+    void discard(const SCPEnvelope& env);
+
+    /**
      * Stop the timer, stop requesting the item as we have it.
      */
     void cancel();

--- a/src/overlay/Tracker.h
+++ b/src/overlay/Tracker.h
@@ -64,6 +64,11 @@ class Tracker
     bool empty() const { return mWaitingEnvelopes.empty(); }
 
     /**
+     * Return list of envelopes this tracker is waiting for.
+     */
+    const std::vector<std::pair<Hash, SCPEnvelope>> & waitingEnvelopes() const { return mWaitingEnvelopes; }
+
+    /**
      * Return count of envelopes it is waiting for.
      */
     size_t size() const { return mWaitingEnvelopes.size(); }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -219,13 +219,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope, bool self)
 bool
 BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
-    bool res = isQuorumSetSane(
-        *mSlot.getQuorumSetFromStatement(st), false);
-    if (!res)
-    {
-        CLOG(DEBUG, "SCP") << "Invalid quorum set received";
-        return false;
-    }
+    auto res = true;
 
     switch (st.pledges.type())
     {

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -11,6 +11,7 @@
 #include "crypto/SHA.h"
 #include "util/Logging.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 #include "lib/json/json.h"
 #include "util/make_unique.h"
 #include "util/GlobalChecks.h"
@@ -218,7 +219,7 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope, bool self)
 bool
 BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
-    bool res = mSlot.getLocalNode()->isQuorumSetSane(
+    bool res = isQuorumSetSane(
         *mSlot.getQuorumSetFromStatement(st), false);
     if (!res)
     {

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -47,48 +47,6 @@ LocalNode::buildSingletonQSet(NodeID const& nodeID)
     return qSet;
 }
 
-bool
-LocalNode::isQuorumSetSaneInternal(SCPQuorumSet const& qSet,
-                                   std::set<NodeID>& knownNodes,
-                                   bool extraChecks)
-{
-    auto& v = qSet.validators;
-    auto& i = qSet.innerSets;
-
-    size_t totEntries = v.size() + i.size();
-
-    size_t vBlockingSize = totEntries - qSet.threshold + 1;
-
-    // threshold is within the proper range
-    if (qSet.threshold >= 1 && qSet.threshold <= totEntries &&
-        (!extraChecks || qSet.threshold >= vBlockingSize))
-    {
-        for (auto const& n : v)
-        {
-            auto r = knownNodes.insert(n);
-            if (!r.second)
-            {
-                // n was already present
-                return false;
-            }
-        }
-
-        for (auto const& iSet : i)
-        {
-            if (!isQuorumSetSaneInternal(iSet, knownNodes, extraChecks))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
 void
 LocalNode::updateQuorumSet(SCPQuorumSet const& qSet)
 {

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -31,12 +31,6 @@ class LocalNode
 
     SCP* mSCP;
 
-    // returns true if quorum set is well formed
-    // updates knownNodes as it encounters new ones
-    static bool isQuorumSetSaneInternal(SCPQuorumSet const& qSet,
-                                        std::set<NodeID>& knownNodes,
-                                        bool extraChecks);
-
   public:
     LocalNode(SecretKey const& secretKey, bool isValidator,
               SCPQuorumSet const& qSet, SCP* scp);

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -37,17 +37,11 @@ class LocalNode
                                         std::set<NodeID>& knownNodes,
                                         bool extraChecks);
 
-    // normalize quorum set
-    void normalizeQSet(SCPQuorumSet& qSet);
-
   public:
     LocalNode(SecretKey const& secretKey, bool isValidator,
               SCPQuorumSet const& qSet, SCP* scp);
 
     NodeID const& getNodeID();
-
-    // returns if a quorum set passes sanity checks
-    static bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks);
 
     void updateQuorumSet(SCPQuorumSet const& qSet);
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -11,6 +11,7 @@
 #include "crypto/SHA.h"
 #include "util/Logging.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 #include "lib/json/json.h"
 #include "util/make_unique.h"
 #include "util/GlobalChecks.h"
@@ -113,8 +114,7 @@ NominationProtocol::isSane(SCPStatement const& st)
     res = res && std::is_sorted(nom.votes.begin(), nom.votes.end());
     res = res && std::is_sorted(nom.accepted.begin(), nom.accepted.end());
 
-    res = res &&
-          mSlot.getLocalNode()->isQuorumSetSane(
+    res = res && isQuorumSetSane(
               *mSlot.getQuorumSetFromStatement(st), false);
 
     return res;

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -11,7 +11,6 @@
 #include "crypto/SHA.h"
 #include "util/Logging.h"
 #include "scp/LocalNode.h"
-#include "scp/QuorumSetUtils.h"
 #include "lib/json/json.h"
 #include "util/make_unique.h"
 #include "util/GlobalChecks.h"
@@ -113,9 +112,6 @@ NominationProtocol::isSane(SCPStatement const& st)
 
     res = res && std::is_sorted(nom.votes.begin(), nom.votes.end());
     res = res && std::is_sorted(nom.accepted.begin(), nom.accepted.end());
-
-    res = res && isQuorumSetSane(
-              *mSlot.getQuorumSetFromStatement(st), false);
 
     return res;
 }

--- a/src/scp/QuorumSetTests.cpp
+++ b/src/scp/QuorumSetTests.cpp
@@ -1,0 +1,112 @@
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "lib/catch.hpp"
+#include "scp/QuorumSetUtils.h"
+#include "simulation/Simulation.h"
+
+namespace stellar
+{
+
+TEST_CASE("sane quorum set", "[scp][quorumset]")
+{
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+    SIMULATION_CREATE_NODE(3);
+
+    auto check = [&](SCPQuorumSet const& qSetCheck, bool expected,
+                     SCPQuorumSet const& expectedSelfQSet)
+    {
+        // first, without normalization
+        {
+            SCPQuorumSet localSet;
+            localSet.threshold = 1;
+            SIMULATION_CREATE_NODE(100);
+            localSet.validators.emplace_back(v100SecretKey.getPublicKey());
+
+            REQUIRE(expected == isQuorumSetSane(qSetCheck, false));
+        }
+        // secondary test: attempts to build local node with the set
+        // (this normalizes the set)
+
+        auto normalizedQSet = qSetCheck;
+        normalizeQSet(normalizedQSet);
+        bool selfIsSane = isQuorumSetSane(normalizedQSet, false);
+
+        REQUIRE(expected == selfIsSane);
+        REQUIRE(expectedSelfQSet == normalizedQSet);
+    };
+
+    SCPQuorumSet qSet;
+
+    qSet.threshold = 0;
+    qSet.validators.push_back(v0NodeID);
+
+    // { t: 0, v0 }
+    check(qSet, false, qSet);
+
+    qSet.threshold = 2;
+    SCPQuorumSet qSetCheck2;
+    qSetCheck2 = qSet;
+    // { t: 2, v0 }
+    check(qSet, false, qSetCheck2);
+
+    qSet.threshold = 1;
+    // { t: 1, v0 }
+    check(qSet, true, qSet);
+
+    // { t: 1, v0, { t: 1, v1 } }
+    // -> { t:1, v0, v1 }
+    SCPQuorumSet qSet2;
+    qSet2 = qSet;
+    {
+        SCPQuorumSet qSetV1;
+        qSetV1.threshold = 1;
+        qSetV1.validators.push_back(v1NodeID);
+        qSet2.innerSets.push_back(qSetV1);
+    }
+
+    SCPQuorumSet qSetV0V1;
+    qSetV0V1 = qSet;
+    qSetV0V1.validators.push_back(v1NodeID);
+    check(qSet2, true, qSetV0V1);
+
+    // { t: 1, v0, { t: 1, v1 }, { t: 2, v2 } }
+    // -> { t:1, v0, v1, { t: 2, v2 } }
+    {
+        SCPQuorumSet qSet2bad;
+        SCPQuorumSet qSet2t2;
+        qSet2t2.threshold = 2;
+        qSet2t2.validators.push_back(v2NodeID);
+
+        qSet2bad = qSet2;
+        qSet2bad.innerSets.push_back(qSet2t2);
+        SCPQuorumSet qSetV0V1t2V2;
+        qSetV0V1t2V2 = qSetV0V1;
+        qSetV0V1t2V2.innerSets.push_back(qSet2t2);
+        check(qSet2bad, false, qSetV0V1t2V2);
+    }
+
+    // qSet2 { t: 1, v0, { t: 1, v1 }, { t: 1, v2, v3 } }
+    // -> qSet3 { t:1, v0, v1, { t: 1, v2, v3 } }
+    SCPQuorumSet qSetV2V3;
+    qSetV2V3.threshold = 1;
+    qSetV2V3.validators.push_back(v2NodeID);
+    qSetV2V3.validators.push_back(v3NodeID);
+    qSet2.innerSets.push_back(qSetV2V3);
+    SCPQuorumSet qSet3;
+    qSet3 = qSetV0V1;
+    qSet3.innerSets.push_back(qSetV2V3);
+    check(qSet2, true, qSet3);
+
+    // { t: 1, qSet2 }
+    // --> qSet3
+    SCPQuorumSet qSetWrapper;
+    qSetWrapper.threshold = 1;
+    qSetWrapper.innerSets.push_back(qSet2);
+    check(qSet2, true, qSet3);
+}
+
+}

--- a/src/scp/QuorumSetUtils.cpp
+++ b/src/scp/QuorumSetUtils.cpp
@@ -1,0 +1,126 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "QuorumSetUtils.h"
+
+#include "xdr/Stellar-SCP.h"
+#include "xdr/Stellar-types.h"
+
+#include <set>
+
+namespace stellar
+{
+
+using xdr::operator <;
+
+namespace
+{
+
+class QuorumSetSanityChecker
+{
+public:
+    explicit QuorumSetSanityChecker(SCPQuorumSet const& qSet, bool extraChecks);
+    bool isSane() const { return mIsSane; }
+
+private:
+    bool mExtraChecks;
+    std::set<NodeID> mKnownNodes;
+    bool mIsSane;
+
+    bool checkSanity(SCPQuorumSet const& qSet);
+};
+
+QuorumSetSanityChecker::QuorumSetSanityChecker(SCPQuorumSet const& qSet, bool extraChecks) :
+    mExtraChecks{extraChecks}
+{
+    mIsSane = checkSanity(qSet);
+}
+
+bool QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet)
+{
+    auto& v = qSet.validators;
+    auto& i = qSet.innerSets;
+
+    size_t totEntries = v.size() + i.size();
+
+    size_t vBlockingSize = totEntries - qSet.threshold + 1;
+
+    // threshold is within the proper range
+    if (qSet.threshold >= 1 && qSet.threshold <= totEntries &&
+        (!mExtraChecks || qSet.threshold >= vBlockingSize))
+    {
+        for (auto const& n : v)
+        {
+            auto r = mKnownNodes.insert(n);
+            if (!r.second)
+            {
+                // n was already present
+                return false;
+            }
+        }
+
+        for (auto const& iSet : i)
+        {
+            if (!checkSanity(iSet))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+}
+
+bool
+isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks)
+{
+    QuorumSetSanityChecker checker{qSet, extraChecks};
+    return checker.isSane();
+}
+
+// helper function that:
+//  * simplifies singleton inner set into outerset
+//      { t: n, v: { ... }, { t: 1, X }, ... }
+//        into
+//      { t: n, v: { ..., X }, .... }
+//  * simplifies singleton innersets
+//      { t:1, { innerSet } } into innerSet
+
+void
+normalizeQSet(SCPQuorumSet& qSet)
+{
+    auto& v = qSet.validators;
+    auto& i = qSet.innerSets;
+    auto it = i.begin();
+    while (it != i.end())
+    {
+        normalizeQSet(*it);
+        // merge singleton inner sets into validator list
+        if (it->threshold == 1 && it->validators.size() == 1 &&
+            it->innerSets.size() == 0)
+        {
+            v.emplace_back(it->validators.front());
+            it = i.erase(it);
+        }
+        else
+        {
+            it++;
+        }
+    }
+
+    // simplify quorum set if needed
+    if (qSet.threshold == 1 && v.size() == 0 && i.size() == 1)
+    {
+        auto t = qSet.innerSets.back();
+        qSet = t;
+    }
+}
+
+}

--- a/src/scp/QuorumSetUtils.h
+++ b/src/scp/QuorumSetUtils.h
@@ -1,0 +1,15 @@
+// Copyright 2016 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+namespace stellar
+{
+
+struct SCPQuorumSet;
+
+bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks);
+void normalizeQSet(SCPQuorumSet& qSet);
+
+}

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -14,7 +14,6 @@
 #include "util/Logging.h"
 #include "simulation/Simulation.h"
 #include "scp/LocalNode.h"
-#include "scp/QuorumSetUtils.h"
 
 namespace stellar
 {
@@ -382,106 +381,6 @@ TEST_CASE("vblocking and quorum", "[scp]")
     nodeSet.push_back(v1NodeID);
     REQUIRE(LocalNode::isQuorumSlice(qSet, nodeSet) == true);
     REQUIRE(LocalNode::isVBlocking(qSet, nodeSet) == true);
-}
-
-TEST_CASE("sane quorum set", "[scp]")
-{
-    SIMULATION_CREATE_NODE(0);
-    SIMULATION_CREATE_NODE(1);
-    SIMULATION_CREATE_NODE(2);
-    SIMULATION_CREATE_NODE(3);
-
-    auto check = [&](SCPQuorumSet const& qSetCheck, bool expected,
-                     SCPQuorumSet const& expectedSelfQSet)
-    {
-        // first, without normalization
-        {
-            SCPQuorumSet localSet;
-            localSet.threshold = 1;
-            SIMULATION_CREATE_NODE(100);
-            localSet.validators.emplace_back(v100SecretKey.getPublicKey());
-
-            REQUIRE(expected == isQuorumSetSane(qSetCheck, false));
-        }
-        // secondary test: attempts to build local node with the set
-        // (this normalizes the set)
-
-        auto normalizedQSet = qSetCheck;
-        normalizeQSet(normalizedQSet);
-        bool selfIsSane = isQuorumSetSane(normalizedQSet, false);
-
-        REQUIRE(expected == selfIsSane);
-        REQUIRE(expectedSelfQSet == normalizedQSet);
-    };
-
-    SCPQuorumSet qSet;
-
-    qSet.threshold = 0;
-    qSet.validators.push_back(v0NodeID);
-
-    // { t: 0, v0 }
-    check(qSet, false, qSet);
-
-    qSet.threshold = 2;
-    SCPQuorumSet qSetCheck2;
-    qSetCheck2 = qSet;
-    // { t: 2, v0 }
-    check(qSet, false, qSetCheck2);
-
-    qSet.threshold = 1;
-    // { t: 1, v0 }
-    check(qSet, true, qSet);
-
-    // { t: 1, v0, { t: 1, v1 } }
-    // -> { t:1, v0, v1 }
-    SCPQuorumSet qSet2;
-    qSet2 = qSet;
-    {
-        SCPQuorumSet qSetV1;
-        qSetV1.threshold = 1;
-        qSetV1.validators.push_back(v1NodeID);
-        qSet2.innerSets.push_back(qSetV1);
-    }
-
-    SCPQuorumSet qSetV0V1;
-    qSetV0V1 = qSet;
-    qSetV0V1.validators.push_back(v1NodeID);
-    check(qSet2, true, qSetV0V1);
-
-    // { t: 1, v0, { t: 1, v1 }, { t: 2, v2 } }
-    // -> { t:1, v0, v1, { t: 2, v2 } }
-    {
-        SCPQuorumSet qSet2bad;
-        SCPQuorumSet qSet2t2;
-        qSet2t2.threshold = 2;
-        qSet2t2.validators.push_back(v2NodeID);
-
-        qSet2bad = qSet2;
-        qSet2bad.innerSets.push_back(qSet2t2);
-        SCPQuorumSet qSetV0V1t2V2;
-        qSetV0V1t2V2 = qSetV0V1;
-        qSetV0V1t2V2.innerSets.push_back(qSet2t2);
-        check(qSet2bad, false, qSetV0V1t2V2);
-    }
-
-    // qSet2 { t: 1, v0, { t: 1, v1 }, { t: 1, v2, v3 } }
-    // -> qSet3 { t:1, v0, v1, { t: 1, v2, v3 } }
-    SCPQuorumSet qSetV2V3;
-    qSetV2V3.threshold = 1;
-    qSetV2V3.validators.push_back(v2NodeID);
-    qSetV2V3.validators.push_back(v3NodeID);
-    qSet2.innerSets.push_back(qSetV2V3);
-    SCPQuorumSet qSet3;
-    qSet3 = qSetV0V1;
-    qSet3.innerSets.push_back(qSetV2V3);
-    check(qSet2, true, qSet3);
-
-    // { t: 1, qSet2 }
-    // --> qSet3
-    SCPQuorumSet qSetWrapper;
-    qSetWrapper.threshold = 1;
-    qSetWrapper.innerSets.push_back(qSet2);
-    check(qSet2, true, qSet3);
 }
 
 TEST_CASE("v-blocking distance", "[scp]")

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -14,6 +14,7 @@
 #include "util/Logging.h"
 #include "simulation/Simulation.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 
 namespace stellar
 {
@@ -400,21 +401,17 @@ TEST_CASE("sane quorum set", "[scp]")
             SIMULATION_CREATE_NODE(100);
             localSet.validators.emplace_back(v100SecretKey.getPublicKey());
 
-            TestSCP scp(v100SecretKey, localSet);
-
-            REQUIRE(expected ==
-                    scp.mSCP.getLocalNode()->isQuorumSetSane(qSetCheck, false));
+            REQUIRE(expected == isQuorumSetSane(qSetCheck, false));
         }
         // secondary test: attempts to build local node with the set
         // (this normalizes the set)
-        TestSCP scp(v0SecretKey, qSetCheck);
 
-        bool selfIsSane = scp.mSCP.getLocalNode()->isQuorumSetSane(
-            scp.mSCP.getLocalNode()->getQuorumSet(), false);
+        auto normalizedQSet = qSetCheck;
+        normalizeQSet(normalizedQSet);
+        bool selfIsSane = isQuorumSetSane(normalizedQSet, false);
 
         REQUIRE(expected == selfIsSane);
-        auto actualQSet = scp.mSCP.getLocalNode()->getQuorumSet();
-        REQUIRE(expectedSelfQSet == actualQSet);
+        REQUIRE(expectedSelfQSet == normalizedQSet);
     };
 
     SCPQuorumSet qSet;


### PR DESCRIPTION
Two things changed here:
1. isQuorumSane now check for quorum deepness (it was done only in config before)
2. isQuorumSane now check for quorum size (limited to 1000 validators)

That protects against bad nodes that send too big quorums (up to 16MB or 450 000 nodes, as per message size limit).

Also quorum is added to cache only when it is sane. It means that checking for sanity was move from Ballot and Nomination classes to Herder.