### PR TITLE
fix crash when passing invalid node id to droppeer and unban

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -828,7 +828,14 @@ Config::resolveNodeID(std::string const& s, PublicKey& retKey) const
         return false;
     }
 
-    retKey = PubKeyUtils::fromStrKey(expanded);
+    try
+    {
+        retKey = PubKeyUtils::fromStrKey(expanded);
+    }
+    catch (std::invalid_argument &)
+    {
+        return false;
+    }
     return true;
 }
 
@@ -837,7 +844,7 @@ Config::expandNodeID(const std::string &s) const
 {
     if (s.length() < 2)
     {
-        throw std::invalid_argument("bad public key");
+        return s;
     }
     if (s[0] != '$' && s[0] != '@')
     {

--- a/src/main/ConfigTests.cpp
+++ b/src/main/ConfigTests.cpp
@@ -34,19 +34,19 @@ TEST_CASE("resolve node id", "[config]")
     SECTION("empty node id")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("", publicKey));
     }
 
     SECTION("@")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("@", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("@", publicKey));
     }
 
     SECTION("$")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("@", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("@", publicKey));
     }
 
     SECTION("unique uppercase abbrevated id")
@@ -105,24 +105,24 @@ TEST_CASE("resolve node id", "[config]")
     SECTION("abbrevated node id without prefix")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("GDKXE2OZMJIPOSLNA6N6F2BVCI3O7", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("GDKXE2OZMJIPOSLNA6N6F2BVCI3O7", publicKey));
     }
 
     SECTION("existing lowercase full node id")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("gdkxe2ozmjiposlna6n6f2bvci3o777i2ooc4bv7voyuehyx7rtrya7y", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("gdkxe2ozmjiposlna6n6f2bvci3o777i2ooc4bv7voyuehyx7rtrya7y", publicKey));
     }
 
     SECTION("non existing full node id")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("SDTTOKJOEJXDBLATFZNTQRVA5MSCECMPOPC7CCCGL6AE5DKA7YCBJYJQ", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("SDTTOKJOEJXDBLATFZNTQRVA5MSCECMPOPC7CCCGL6AE5DKA7YCBJYJQ", publicKey));
     }
 
     SECTION("invalid key type")
     {
         auto publicKey = PublicKey{};
-        REQUIRE_THROWS_AS(cfg.resolveNodeID("TDTTOKJOEJXDBLATFZNTQRVA5MSCECMPOPC7CCCGL6AE5DKA7YCBJYJQ", publicKey), std::invalid_argument);
+        REQUIRE(!cfg.resolveNodeID("TDTTOKJOEJXDBLATFZNTQRVA5MSCECMPOPC7CCCGL6AE5DKA7YCBJYJQ", publicKey));
     }
 }


### PR DESCRIPTION
Crash fixed by catching exception.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>