### PR TITLE
Use full pathnames for libraries rather than -l flags.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -139,6 +139,9 @@ AC_SUBST(sqlite3_CFLAGS)
 AC_SUBST(sqlite3_LIBS)
 
 AX_PKGCONFIG_SUBDIR(lib/libsodium)
+if test -n "$libsodium_INTERNAL"; then
+   libsodium_LIBS='$(top_builddir)/lib/libsodium/src/libsodium/libsodium.la'
+fi
 
 AX_PKGCONFIG_SUBDIR(lib/xdrpp)
 AC_MSG_CHECKING(for xdrc)
@@ -160,7 +163,7 @@ mkdir -p src/xdr
 
 if test -s "$srcdir/lib/medida.mk"; then
    libmedida_CFLAGS='-I$(top_srcdir)/lib/libmedida/src'
-   libmedida_LIBS=-lmedida
+   libmedida_LIBS='$(top_builddir)/lib/libmedida.a'
    libmedida_INTERNAL=yes
 else
    PKG_CHECK_MODULES(libmedida, libmedida)
@@ -172,7 +175,7 @@ AC_SUBST(libmedida_LIBS)
 
 soci_CFLAGS='-I$(top_srcdir)/lib/soci/src/core'
 soci_CFLAGS="$soci_CFLAGS "'-I$(top_srcdir)/lib/soci/src/backends/sqlite3'
-soci_LIBS='-lsoci'
+soci_LIBS='$(top_builddir)/lib/libsoci.a'
 AC_SUBST(soci_CFLAGS)
 AC_SUBST(soci_LIBS)
 

--- a/m4/ax_pkgconfig_subdir.m4
+++ b/m4/ax_pkgconfig_subdir.m4
@@ -29,7 +29,7 @@
 #           PKG_CHECK_MODULES(subproject, subproject)
 #       and return.  Otherwise...
 #
-#     - Set subproject_INTERNAL=true
+#     - Set subproject_INTERNAL=yes
 #
 #     - Call AC_CONFIG_SUBDIRS(path/to/subproject)
 #

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,9 +8,9 @@ include $(srcdir)/src.mk
 noinst_HEADERS = $(SRC_H_FILES)
 
 stellar_core_SOURCES = $(SRC_CXX_FILES)
-stellar_core_LDADD = -L$(top_builddir)/lib $(soci_LIBS)			\
-	$(libmedida_LIBS) -l3rdparty $(sqlite3_LIBS) $(libpq_LIBS)	\
-	$(xdrpp_LIBS) $(libsodium_LIBS)
+stellar_core_LDADD = $(soci_LIBS) $(libmedida_LIBS)		\
+	$(top_builddir)/lib/lib3rdparty.a $(sqlite3_LIBS)	\
+	$(libpq_LIBS) $(xdrpp_LIBS) $(libsodium_LIBS)
 
 BUILT_SOURCES = $(SRC_X_FILES:.x=.h) StellarCoreVersion.h
 


### PR DESCRIPTION
This means that when a library is modified, the makefile will re-link
stellar-core.

This should subsume PR #1005 and fix issue #832.