### PR TITLE
Fuzz fixes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,7 +54,7 @@ fuzz-testcases: stellar-core
 
 fuzz: fuzz-testcases stellar-core
 	mkdir -p fuzz-findings
-	afl-fuzz -m 8000 -i fuzz-testcases -o fuzz-findings \
+	afl-fuzz -m 8000 -t 250 -i fuzz-testcases -o fuzz-findings \
 	    ./stellar-core --fuzz @@
 
 fuzz-clean: always

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1031,7 +1031,8 @@ HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer)
         minSeq = maxSeq = ledgerSeq;
     }
 
-    for (uint32 seq = minSeq; seq <= maxSeq; seq++)
+    // use uint64_t for seq to prevent overflows
+    for (uint64_t seq = minSeq; seq <= maxSeq; seq++)
     {
         auto const& envelopes = mSCP.getCurrentState(seq);
 

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -451,7 +451,8 @@ HistoryTests::catchupApplication(uint32_t initLedger,
     // externalize anything we haven't yet published, of course.
     uint32_t nextBlockStart =
         app.getHistoryManager().nextCheckpointLedger(initLedger);
-    for (uint32_t n = initLedger; n <= nextBlockStart; ++n)
+    // use uint64_t for n to prevent overflows
+    for (uint64_t n = initLedger; n <= nextBlockStart; ++n)
     {
         // Remember the vectors count from 2, not 0.
         if (n - 2 >= mLedgerCloseDatas.size())

--- a/src/history/HistoryWork.cpp
+++ b/src/history/HistoryWork.cpp
@@ -1946,7 +1946,8 @@ FetchRecentQsetsWork::onSuccess()
     }
 
     // Phase 3: extract the qsets.
-    for (auto i = firstSeq; i <= lastSeq; i += step)
+    // use uint64_t for i to prevent overflows
+    for (uint64_t i = firstSeq; i <= lastSeq; i += step)
     {
         CLOG(INFO, "History") << "Scanning for QSets in checkpoint: " << i;
         XDRInputFileStream in;

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -176,7 +176,8 @@ TEST_CASE("ledger performance test", "[performance][hide]")
     Timer& ledgerTimer = sim.mApp->getMetrics().NewTimer(
         {"performance-test", "ledger", "close"});
     Timer& mergeTimer = sim.mApp->getBucketManager().getMergeTimer();
-    for (int iAccounts = 1000000; iAccounts <= nAccounts; iAccounts *= 10)
+    // use uint64_t for iAccounts to prevent overflows
+    for (uint64_t iAccounts = 1000000; iAccounts <= nAccounts; iAccounts *= 10)
     {
         ledgerTimer.Clear();
         mergeTimer.Clear();

--- a/src/main/fuzz.cpp
+++ b/src/main/fuzz.cpp
@@ -9,6 +9,7 @@
 #include "StellarCoreVersion.h"
 #include "overlay/OverlayManager.h"
 #include "overlay/LoopbackPeer.h"
+#include "overlay/TCPPeer.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
 #include "util/XDRStream.h"
@@ -129,7 +130,7 @@ restart:
         clock.crank(true);
     }
 
-    XDRInputFileStream in;
+    XDRInputFileStream in{MAX_MESSAGE_SIZE};
     in.open(filename);
     StellarMessage msg;
     size_t i = 0;

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -16,9 +16,6 @@
 #include "main/Config.h"
 #include "util/GlobalChecks.h"
 
-#define MAX_UNAUTH_MESSAGE_SIZE 0x1000
-#define MAX_MESSAGE_SIZE 0x1000000
-
 using namespace soci;
 
 namespace stellar

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -15,6 +15,10 @@ class Meter;
 
 namespace stellar
 {
+
+static auto const MAX_UNAUTH_MESSAGE_SIZE = 0x1000;
+static auto const MAX_MESSAGE_SIZE = 0x1000000;
+
 // Peer that communicates via a TCP socket.
 class TCPPeer : public Peer
 {

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -23,8 +23,11 @@ class XDRInputFileStream
 {
     std::ifstream mIn;
     std::vector<char> mBuf;
+    size_t mSizeLimit;
 
   public:
+    XDRInputFileStream(size_t sizeLimit = 0) : mSizeLimit{sizeLimit} {}
+
     void
     close()
     {
@@ -72,6 +75,10 @@ class XDRInputFileStream
         sz <<= 8;
         sz |= static_cast<uint8_t>(szBuf[3]);
 
+        if (mSizeLimit != 0 && sz > mSizeLimit)
+        {
+            return false;
+        }
         if (sz > mBuf.size())
         {
             mBuf.resize(sz);


### PR DESCRIPTION
Fixes for bugs found by AFL.

Two of the commits cope with bugs in AFL handling - too low timeout for our two-database setup and cutting off too big messages early (to avoid extremely big allocations that are to be disposed of one step later).

The only real fix is to remove overflow in for loops that use uint32_t values with <= condition - it could lead to infinite loops.