### PR TITLE
better handling of unfinished downloads

### DIFF
--- a/src/history/FileTransferInfo.h
+++ b/src/history/FileTransferInfo.h
@@ -72,6 +72,11 @@ class FileTransferInfo
     {
         return mLocalPath + ".gz";
     }
+    std::string
+    localPath_gz_tmp() const
+    {
+        return mLocalPath + ".gz.tmp";
+    }
 
     std::string
     baseName_nogz() const
@@ -82,6 +87,11 @@ class FileTransferInfo
     baseName_gz() const
     {
         return baseName_nogz() + ".gz";
+    }
+    std::string
+    baseName_gz_tmp() const
+    {
+        return baseName_nogz() + ".gz.tmp";
     }
 
     std::string


### PR DESCRIPTION
Change a way how files are downloaded and unzipped.

Now there is additional work item called GetAndUnzipRemoteFileWork. When unzipping fails it removes downloaded file, so it can be downloaded again in next try. Previous version did not do that, so if invalid file was downloaded or an corruption happened the GunzipWork was failing every time. Now there is a way to fix this.

Also number of retries for GunzipWork was lowered from 5 to 1, as it is highly unlikely that gunzip will work on a file that was non unzippable a moment ago.

This one should make catchup much more reliable and probably should fix issues with acceptance tests.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>