### PR TITLE
check if item from cache exists before using it

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1529,11 +1529,17 @@ HerderImpl::persistSCPState(uint64 slot)
             StellarValue wb;
             xdr::xdr_from_opaque(v, wb);
             TxSetFramePtr txSet = mPendingEnvelopes.getTxSet(wb.txSetHash);
-            txSets.insert(std::make_pair(wb.txSetHash, txSet));
+            if (txSet)
+            {
+                txSets.insert(std::make_pair(wb.txSetHash, txSet));
+            }
         }
         Hash qsHash = Slot::getCompanionQuorumSetHashFromStatement(e.statement);
         SCPQuorumSetPtr qSet = mPendingEnvelopes.getQSet(qsHash);
-        quorumSets.insert(std::make_pair(qsHash, qSet));
+        if (qSet)
+        {
+            quorumSets.insert(std::make_pair(qsHash, qSet));
+        }
     }
 
     xdr::xvector<TransactionSet> latestTxSets;

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -272,8 +272,15 @@ LocalNode::isQuorum(
         std::vector<NodeID> fNodes(pNodes.size());
         auto quorumFilter = [&](NodeID nodeID) -> bool
         {
-            return isQuorumSlice(*qfun(map.find(nodeID)->second.statement),
-                                 pNodes);
+            auto qSetPtr = qfun(map.find(nodeID)->second.statement);
+            if (qSetPtr)
+            {
+                return isQuorumSlice(*qSetPtr, pNodes);
+            }
+            else
+            {
+                return false;
+            }
         };
         auto it = std::copy_if(pNodes.begin(), pNodes.end(), fNodes.begin(),
                                quorumFilter);

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -312,7 +312,10 @@ Slot::dumpInfo(Json::Value& ret)
         Hash const& qSetHash =
             getCompanionQuorumSetHashFromStatement(item.first);
         auto qSet = getSCPDriver().getQSet(qSetHash);
-        qSetsUsed.insert(std::make_pair(qSetHash, qSet));
+        if (qSet)
+        {
+            qSetsUsed.insert(std::make_pair(qSetHash, qSet));
+        }
     }
 
     auto& qSets = slotValue["quorum_sets"];


### PR DESCRIPTION
In current version we are removing old items from cache in more aggressive way so they may not be always available for "dumpInfo" call.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>