### PR TITLE
do not leave unifinished processes on failure

### DIFF
--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -230,11 +230,11 @@ Work::advance()
                             << " successful, scheduling run";
         scheduleRun();
     }
-    else if (anyChildRaiseFailure())
+    else if (anyChildRaiseFailure() && allChildrenDone())
     {
         CLOG(DEBUG, "Work") << "some of " << mChildren.size()
                             << " children of " << getUniqueName()
-                            << " successful, scheduling failure";
+                            << " failed, scheduling failure";
         scheduleFailure();
     }
 }


### PR DESCRIPTION
This one allows all wget/curl processes to finish when catchup failure
is in progress. If any wget/curl process is left to finish, then it is
possible it will finish during TmpDir cleanup which could prevent it
from finishing. It may result in throwing an exception and crashing
whole stellar-core.

Fixes #1140

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>