### PR TITLE
use uint256 for all types of hash

### DIFF
--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -45,10 +45,10 @@ case SIGNER_KEY_TYPE_ED25519:
     uint256 ed25519;
 case SIGNER_KEY_TYPE_HASH_TX:
     /* Hash of Transaction structure */
-    Hash hashTx;
+    uint256 hashTx;
 case SIGNER_KEY_TYPE_HASH_X:
     /* Hash of random 256 bit preimage X */
-    Hash hashX;
+    uint256 hashX;
 };
 
 // variable size as the size depends on the signature scheme used


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>