### PR TITLE
Keep cache longer

### DIFF
--- a/lib/util/lrucache.hpp
+++ b/lib/util/lrucache.hpp
@@ -68,7 +68,7 @@ namespace cache {
             }
         }
 
-        const value_t& get(const key_t& key) {
+        value_t& get(const key_t& key) {
             auto it = _cache_items_map.find(key);
             if(it == _cache_items_map.end()) {
                 throw std::range_error("There is no such key in cache");

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -6,6 +6,7 @@
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
 #include "crypto/SHA.h"
+#include "herder/HerderUtils.h"
 #include "herder/LedgerCloseData.h"
 #include "herder/TxSetFrame.h"
 #include "ledger/LedgerManager.h"
@@ -1524,15 +1525,12 @@ HerderImpl::persistSCPState(uint64 slot)
         latestEnvs.emplace_back(e);
 
         // saves transaction sets referred by the statement
-        std::vector<Value> vals = Slot::getStatementValues(e.statement);
-        for (auto const& v : vals)
+        for (auto const& h : getTxSetHashes(e))
         {
-            StellarValue wb;
-            xdr::xdr_from_opaque(v, wb);
-            TxSetFramePtr txSet = mPendingEnvelopes.getTxSet(wb.txSetHash);
+            auto txSet = mPendingEnvelopes.getTxSet(h);
             if (txSet)
             {
-                txSets.insert(std::make_pair(wb.txSetHash, txSet));
+                txSets.insert(std::make_pair(h, txSet));
             }
         }
         Hash qsHash = Slot::getCompanionQuorumSetHashFromStatement(e.statement);

--- a/src/herder/HerderUtils.cpp
+++ b/src/herder/HerderUtils.cpp
@@ -1,0 +1,44 @@
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/HerderUtils.h"
+#include "scp/Slot.h"
+#include "xdr/Stellar-SCP.h"
+#include "xdr/Stellar-ledger.h"
+#include <algorithm>
+#include <xdrpp/marshal.h>
+
+namespace stellar
+{
+
+std::vector<Hash>
+getTxSetHashes(SCPEnvelope const& envelope)
+{
+    auto values = getStellarValues(envelope.statement);
+    auto result = std::vector<Hash>{};
+    result.resize(values.size());
+
+    std::transform(std::begin(values), std::end(values), std::begin(result),
+                   [](StellarValue const& sv) { return sv.txSetHash; });
+
+    return result;
+}
+
+std::vector<StellarValue>
+getStellarValues(SCPStatement const& statement)
+{
+    auto values = Slot::getStatementValues(statement);
+    auto result = std::vector<StellarValue>{};
+    result.resize(values.size());
+
+    std::transform(std::begin(values), std::end(values), std::begin(result),
+                   [](Value const& v) {
+                       auto wb = StellarValue{};
+                       xdr::xdr_from_opaque(v, wb);
+                       return wb;
+                   });
+
+    return result;
+}
+}

--- a/src/herder/HerderUtils.h
+++ b/src/herder/HerderUtils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "xdr/Stellar-types.h"
+#include <vector>
+
+namespace stellar
+{
+
+struct SCPEnvelope;
+struct SCPStatement;
+struct StellarValue;
+
+std::vector<Hash> getTxSetHashes(SCPEnvelope const& envelope);
+std::vector<StellarValue> getStellarValues(SCPStatement const& envelope);
+}

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -319,15 +319,11 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
         mQuorumSetFetcher.fetch(h, envelope);
     }
 
-    std::vector<Value> vals = Slot::getStatementValues(envelope.statement);
-    for (auto const& v : vals)
+    for (auto const& h : getTxSetHashes(envelope))
     {
-        StellarValue wb;
-        xdr::xdr_from_opaque(v, wb);
-
-        if (!mTxSetCache.exists(wb.txSetHash))
+        if (!mTxSetCache.exists(h))
         {
-            mTxSetFetcher.fetch(wb.txSetHash, envelope);
+            mTxSetFetcher.fetch(h, envelope);
         }
     }
 

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -337,13 +337,9 @@ PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
     mQuorumSetFetcher.stopFetch(h, envelope);
 
-    std::vector<Value> vals = Slot::getStatementValues(envelope.statement);
-    for (auto const& v : vals)
+    for (auto const& h : getTxSetHashes(envelope))
     {
-        StellarValue wb;
-        xdr::xdr_from_opaque(v, wb);
-
-        mTxSetFetcher.stopFetch(wb.txSetHash, envelope);
+        mTxSetFetcher.stopFetch(h, envelope);
     }
 
     CLOG(TRACE, "Herder") << "StopFetch i:" << envelope.statement.slotIndex

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -357,15 +357,11 @@ PendingEnvelopes::touchFetchCache(SCPEnvelope const& envelope)
         item.first = std::max(item.first, envelope.statement.slotIndex);
     }
 
-    auto vals = Slot::getStatementValues(envelope.statement);
-    for (auto const& v : vals)
+    for (auto const& h : getTxSetHashes(envelope))
     {
-        StellarValue wb;
-        xdr::xdr_from_opaque(v, wb);
-
-        if (mTxSetCache.exists(wb.txSetHash))
+        if (mTxSetCache.exists(h))
         {
-            auto& item = mTxSetCache.get(wb.txSetHash);
+            auto& item = mTxSetCache.get(h);
             item.first = std::max(item.first, envelope.statement.slotIndex);
         }
     }

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -119,6 +119,7 @@ class PendingEnvelopes
     bool isFullyFetched(SCPEnvelope const& envelope);
     void startFetch(SCPEnvelope const& envelope);
     void stopFetch(SCPEnvelope const& envelope);
+    void touchFetchCache(SCPEnvelope const& envelope);
 
     void envelopeReady(SCPEnvelope const& envelope);
 


### PR DESCRIPTION
This change updates 'lastSeenSlot' of cache items when an envelope with given hash is received. This reduces number of query sets that needs to be downloaded from network. This change has no impact on txSets, as txSets do not live longer than one ledger. Quorum sets can live for a lot longer.

This fixed bug with too aggressive cache-item-discard policy.