### PR TITLE
do not check for existence of .xdr file before work item is finished

### DIFF
--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -57,6 +57,11 @@ GetAndUnzipRemoteFileWork::onSuccess()
 {
     if (mGunzipFileWork)
     {
+        if (mGunzipFileWork->getState() != WORK_SUCCESS)
+        {
+            return WORK_PENDING;
+        }
+
         if (!fs::exists(mFt.localPath_nogz()))
         {
             CLOG(ERROR, "History") << "Downloading and unzipping "


### PR DESCRIPTION
This will get rid of many of catchup errors.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>