### PR TITLE
In-memory logging

### DIFF
--- a/lib/util/easylogging++.h
+++ b/lib/util/easylogging++.h
@@ -2763,9 +2763,7 @@ extern ELPP_EXPORT base::type::StoragePointer elStorage;
 class DefaultLogDispatchCallback : public LogDispatchCallback {
  protected:
   void handle(const LogDispatchData* data);
- private:
-  const LogDispatchData* m_data;
-  void dispatch(base::type::string_t&& logLine);
+  void dispatch(base::type::string_t&& logLine, const LogDispatchData* data);
 };
 #if ELPP_ASYNC_LOGGING
 class AsyncLogDispatchCallback : public LogDispatchCallback {

--- a/lib/util/easylogging++.h
+++ b/lib/util/easylogging++.h
@@ -2207,6 +2207,7 @@ class Callback : protected base::threading::ThreadSafe {
 class LogDispatchData {
  public:
   LogDispatchData() : m_logMessage(nullptr), m_dispatchAction(base::DispatchAction::None) {}
+  LogDispatchData(LogMessage* logMessage, base::DispatchAction dispatchAction) : m_logMessage(logMessage), m_dispatchAction(dispatchAction) {}
   inline const LogMessage* logMessage(void) const {
     return m_logMessage;
   }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -586,7 +586,6 @@ main(int argc, char* const* argv)
             s += cfgFile + " found";
             throw std::invalid_argument(s);
         }
-        Logging::enableInMemoryLogging("test.log");
         Logging::setFmt(KeyUtils::toShortString(cfg.NODE_SEED.getPublicKey()));
         Logging::setLogLevel(logLevel, nullptr);
 
@@ -600,6 +599,8 @@ main(int argc, char* const* argv)
         if (cfg.LOG_FILE_PATH.size())
             Logging::setLoggingToFile(cfg.LOG_FILE_PATH);
         Logging::setLogLevel(logLevel, nullptr);
+        // TODO NOTE this must be invoked as last
+        Logging::enableInMemoryLogging(cfg.LOG_FILE_PATH, "fatal");
 
         cfg.REPORT_METRICS = metrics;
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -586,6 +586,7 @@ main(int argc, char* const* argv)
             s += cfgFile + " found";
             throw std::invalid_argument(s);
         }
+        Logging::enableInMemoryLogging("test.log");
         Logging::setFmt(KeyUtils::toShortString(cfg.NODE_SEED.getPublicKey()));
         Logging::setLogLevel(logLevel, nullptr);
 

--- a/src/util/CircularBuffer.h
+++ b/src/util/CircularBuffer.h
@@ -1,0 +1,58 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <vector>
+
+namespace stellar
+{
+
+using std::vector;
+using std::size_t;
+
+template <typename T> class CircularBuffer
+{
+  public:
+    explicit CircularBuffer(const size_t size)
+        : buffer(size), start{0}, count{0}
+    {
+    }
+
+    void
+    push(T elem)
+    {
+        size_t size = buffer.size();
+        size_t ix = (start + count) % size;
+        if (count < size)
+        {
+            count += 1;
+        }
+        else
+        {
+            start = (start + 1) % size;
+        }
+        buffer[ix] = elem;
+    }
+
+    T&
+    pop()
+    {
+        size_t size = buffer.size();
+        size_t ix = start;
+        start = (start + 1) % size;
+        count -= 1;
+        return buffer[ix];
+    }
+
+    bool
+    empty() const
+    {
+        return 0 == count;
+    }
+
+  private:
+    vector<T> buffer;
+    size_t start;
+    size_t count;
+};
+}

--- a/src/util/CircularBufferTests.cpp
+++ b/src/util/CircularBufferTests.cpp
@@ -1,0 +1,67 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/CircularBuffer.h"
+#include "lib/catch.hpp"
+
+namespace stellar
+{
+
+TEST_CASE("initially empty", "[circular_buffer]")
+{
+    auto buffer = CircularBuffer<int>(1);
+
+    REQUIRE(buffer.empty() == true);
+}
+
+TEST_CASE("not empty after push", "[circular_buffer]")
+{
+    auto buffer = CircularBuffer<int>(1);
+    buffer.push(1);
+
+    REQUIRE(buffer.empty() == false);
+}
+
+TEST_CASE("pushed element can be popped", "[circular_buffer]")
+{
+    auto buffer = CircularBuffer<int>(1);
+    buffer.push(1);
+    int pop = buffer.pop();
+
+    REQUIRE(pop == 1);
+}
+
+TEST_CASE("is first-in-first-out", "[circular_buffer]")
+{
+    auto buffer = CircularBuffer<int>(2);
+    buffer.push(1);
+    buffer.push(2);
+
+    REQUIRE(buffer.pop() == 1);
+    REQUIRE(buffer.pop() == 2);
+}
+
+TEST_CASE("is wrapping after filled", "[circular_buffer]")
+{
+    auto buffer = CircularBuffer<int>(2);
+    buffer.push(1);
+    buffer.push(2);
+    buffer.push(3);
+
+    REQUIRE(buffer.pop() == 2);
+    REQUIRE(buffer.pop() == 3);
+}
+
+TEST_CASE("empty after all elements popped", "[circular_buffer]")
+{
+    auto buffer = CircularBuffer<int>(2);
+    buffer.push(1);
+    buffer.push(2);
+
+    buffer.pop();
+    buffer.pop();
+
+    REQUIRE(buffer.empty() == true);
+}
+}

--- a/src/util/InMemoryLogHandler.cpp
+++ b/src/util/InMemoryLogHandler.cpp
@@ -1,0 +1,159 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/InMemoryLogHandler.h"
+
+namespace stellar
+{
+
+InMemoryLogHandler::InMemoryLogHandler(LogBuffer logBuffer,
+                                       LogFlushPredicate predicate)
+    : buffer{logBuffer}, flushPredicate(predicate)
+{
+    logger = el::Loggers::getLogger(Logging::inMemoryLoggerName);
+    el::Configurations* config = logger->configurations();
+    config->set(el::Level::Global, el::ConfigurationType::Enabled, "true");
+    config->setGlobally(el::ConfigurationType::ToStandardOutput, "false");
+    config->setGlobally(el::ConfigurationType::ToFile, "false");
+    logger->configure(*config);
+}
+
+InMemoryLogHandler::InMemoryLogHandler()
+    : InMemoryLogHandler(LogBuffer(100), LogFlushPredicate())
+{
+}
+
+void
+InMemoryLogHandler::handle(el::LogDispatchData const* handlePtr)
+{
+    std::string logLine = buildLogLine(*handlePtr);
+    buffer.push(logLine);
+    if (checkForPush(*handlePtr))
+    {
+        pushLogs();
+    }
+}
+
+std::string
+InMemoryLogHandler::buildLogLine(el::LogDispatchData const& data) const
+{
+    return data.logMessage()->logger()->logBuilder()->build(
+        data.logMessage(),
+        data.dispatchAction() == el::base::DispatchAction::NormalLog);
+}
+
+void
+InMemoryLogHandler::pushLogs()
+{
+    bool notEmpty = !buffer.empty();
+    if (notEmpty)
+    {
+        printToLog("<in-memory-logger>\n");
+    }
+
+    while (!buffer.empty())
+    {
+        auto logLine = buffer.pop();
+        printToLog(logLine);
+        logLine.clear();
+    }
+
+    if (notEmpty)
+    {
+        printToLog("</in-memory-logger>\n");
+    }
+}
+
+void
+InMemoryLogHandler::printToLog(std::string const& message)
+{
+    auto newMsg = el::LogMessage(el::Level::Trace, "", 0, "", 1, logger);
+    auto data =
+        el::LogDispatchData(&newMsg, el::base::DispatchAction::NormalLog);
+    dispatchCallback.dispatch(message, &data);
+}
+
+bool
+InMemoryLogHandler::checkForPush(el::LogDispatchData const& data) const
+{
+    auto level = data.logMessage()->level();
+    return flushPredicate.compareLessOrEqual(pushLevel, level);
+}
+
+void
+InMemoryLogHandler::setLogFilename(std::string const& logFilename)
+{
+    el::Configurations* config = logger->configurations();
+    config->setGlobally(el::ConfigurationType::ToFile, "true");
+    config->setGlobally(el::ConfigurationType::Filename, logFilename);
+    logger->configure(*config);
+}
+
+void
+InMemoryLogHandler::setPushLevel(std::string const& pushLevel)
+{
+    this->pushLevel = Logging::getLLfromString(pushLevel);
+}
+
+InMemoryLogHandler&
+InMemoryLogHandler::getInstance()
+{
+    static InMemoryLogHandler instance;
+    return instance;
+}
+
+void
+DispatchCallback::dispatch(std::string const& logLine,
+                           el::LogDispatchData const* data)
+{
+    el::base::DefaultLogDispatchCallback::dispatch(std::string(logLine), data);
+}
+
+void
+StaticMemoryHandler::handle(el::LogDispatchData const* handlePtr)
+{
+    InMemoryLogHandler::getInstance().handle(handlePtr);
+}
+
+void
+StaticMemoryHandler::setLogFilename(std::string const& logFilename)
+{
+    InMemoryLogHandler::getInstance().setLogFilename(logFilename);
+}
+
+void
+StaticMemoryHandler::setPushLevel(std::string const& pushLevel)
+{
+    InMemoryLogHandler::getInstance().setPushLevel(pushLevel);
+}
+
+bool
+LogFlushPredicate::compareLessOrEqual(const el::Level pushLevel,
+                                      const el::Level logLevel) const
+{
+    using el::Level;
+    switch (pushLevel)
+    {
+    case Level::Global:
+    case Level::Verbose:
+    case Level::Unknown:
+    {
+        return false;
+    }
+    case Level::Trace:
+    case Level::Debug:
+    {
+        return logLevel >= pushLevel;
+    }
+    case Level::Info:
+    case Level::Warning:
+    case Level::Error:
+    case Level::Fatal:
+    {
+        return logLevel >= Level::Fatal && logLevel <= pushLevel;
+    }
+    }
+    return false;
+}
+}

--- a/src/util/InMemoryLogHandler.h
+++ b/src/util/InMemoryLogHandler.h
@@ -1,0 +1,72 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/CircularBuffer.h"
+#include "util/Logging.h"
+#include <string>
+
+namespace stellar
+{
+
+using LogEntry = std::string;
+using LogBuffer = CircularBuffer<LogEntry>;
+
+// NOTE the only purpose of this class is to make the dispatch method of the
+// base class public.
+// After some small changes it can be used for mocking in unit tests.
+class DispatchCallback : public el::base::DefaultLogDispatchCallback
+{
+  public:
+    void dispatch(const std::string& logLine, const el::LogDispatchData* data);
+};
+
+class LogFlushPredicate
+{
+  public:
+    bool compareLessOrEqual(const el::Level pushLevel,
+                            const el::Level logLevel) const;
+};
+
+class InMemoryLogHandler
+{
+  public:
+    InMemoryLogHandler();
+
+    explicit InMemoryLogHandler(LogBuffer buffer, LogFlushPredicate predicate);
+
+    static InMemoryLogHandler& getInstance();
+
+    void handle(el::LogDispatchData const* handlePtr);
+
+    void setLogFilename(std::string const& logFilename);
+
+    void setPushLevel(std::string const& pushLevel);
+
+  private:
+    bool checkForPush(el::LogDispatchData const& data) const;
+
+    void pushLogs();
+
+    std::string buildLogLine(el::LogDispatchData const& data) const;
+
+    void printToLog(std::string const& message);
+
+    el::Level pushLevel;
+    LogBuffer buffer;
+    DispatchCallback dispatchCallback;
+    el::Logger* logger;
+    LogFlushPredicate flushPredicate;
+};
+
+class StaticMemoryHandler : public el::LogDispatchCallback
+{
+  public:
+    static void setLogFilename(std::string const& logFilename);
+
+    static void setPushLevel(std::string const& pushLevel);
+
+  protected:
+    void handle(el::LogDispatchData const* handlePtr);
+};
+}

--- a/src/util/InMemoryLogHandlerTests.cpp
+++ b/src/util/InMemoryLogHandlerTests.cpp
@@ -1,0 +1,97 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/InMemoryLogHandler.h"
+#include "lib/catch.hpp"
+
+namespace stellar
+{
+
+// Trace < Debug < Info < Warning < Error < Fatal < None
+
+TEST_CASE("returns true when given expected level", "[in_memory_log_handler]")
+{
+    using el::Level;
+    LogFlushPredicate predicate;
+    auto startLevel = el::LevelHelper::castToInt(el::Level::Trace);
+
+    el::LevelHelper::forEachLevel(
+        &startLevel, [&startLevel, &predicate]() -> bool {
+            Level thisLevel = el::LevelHelper::castFromInt(startLevel);
+            if (Level::Global == thisLevel || Level::Verbose == thisLevel ||
+                Level::Unknown == thisLevel)
+            {
+                return false;
+            }
+
+            REQUIRE(predicate.compareLessOrEqual(thisLevel, thisLevel) == true);
+
+            return false;
+        });
+}
+
+TEST_CASE("returns false when given lower level", "[in_memory_log_handler]")
+{
+    using el::Level;
+    using el::LogMessage;
+    using el::LogDispatchData;
+    using el::base::DispatchAction;
+
+    LogFlushPredicate predicate;
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Fatal, Level::Error) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Fatal, Level::Warning) ==
+            false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Fatal, Level::Info) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Fatal, Level::Debug) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Fatal, Level::Trace) == false);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Error, Level::Warning) ==
+            false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Error, Level::Info) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Error, Level::Debug) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Error, Level::Trace) == false);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Warning, Level::Info) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Warning, Level::Debug) ==
+            false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Warning, Level::Trace) ==
+            false);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Info, Level::Debug) == false);
+    REQUIRE(predicate.compareLessOrEqual(Level::Info, Level::Trace) == false);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Debug, Level::Trace) == false);
+}
+
+TEST_CASE("returns true when given higher level", "[in_memory_log_handler]")
+{
+    using el::Level;
+    using el::LogMessage;
+    using el::LogDispatchData;
+    using el::base::DispatchAction;
+
+    LogFlushPredicate predicate;
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Trace, Level::Fatal) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Trace, Level::Error) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Trace, Level::Warning) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Trace, Level::Info) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Trace, Level::Debug) == true);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Debug, Level::Fatal) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Debug, Level::Error) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Debug, Level::Warning) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Debug, Level::Info) == true);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Info, Level::Fatal) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Info, Level::Error) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Info, Level::Warning) == true);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Warning, Level::Fatal) == true);
+    REQUIRE(predicate.compareLessOrEqual(Level::Warning, Level::Error) == true);
+
+    REQUIRE(predicate.compareLessOrEqual(Level::Error, Level::Fatal) == true);
+}
+}

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -5,6 +5,7 @@
 #include "util/Logging.h"
 #include "main/Application.h"
 #include "util/types.h"
+#include "util/Fs.h"
 
 /*
 Levels:
@@ -37,8 +38,8 @@ Logging::setFmt(std::string const& peerID, bool timestamps)
     {
         datetime = "%datetime{%Y-%M-%dT%H:%m:%s.%g}";
     }
-    std::string shortFmt = datetime + " " + peerID + " [%logger %level] %msg";
-    std::string longFmt = shortFmt + " [%fbase:%line]";
+    const std::string shortFmt = datetime + " " + peerID + " [%logger %level] %msg";
+    const std::string longFmt = shortFmt + " [%fbase:%line]";
 
     gDefaultConf.setGlobally(el::ConfigurationType::Format, shortFmt);
     gDefaultConf.set(el::Level::Error, el::ConfigurationType::Format, longFmt);
@@ -228,4 +229,110 @@ Logging::rotate()
         el::Loggers::getLogger(logger)->reconfigure();
     }
 }
+
+void
+Logging::enableInMemoryLogging()
+{
+    const std::string defaultMagicLogDispatchCallback = "DefaultLogDispatchCallback";
+    const std::string inMemoryHandlerName = "InMemoryHandler";
+    el::Helpers::uninstallLogDispatchCallback<el::base::DefaultLogDispatchCallback>(defaultMagicLogDispatchCallback);
+    el::Helpers::installLogDispatchCallback<StaticMemoryHandler>(inMemoryHandlerName);
+}
+
+MemoryHandler::MemoryHandler() : start(0), size(10), count(0), pushLevel(el::Level::Fatal)
+{
+    using namespace std;
+    buffer = unique_ptr<pair<el::base::DispatchAction, unique_ptr<el::LogMessage>>[]>(new pair<el::base::DispatchAction, unique_ptr<el::LogMessage> >[size]);
+}
+
+void
+MemoryHandler::handle(const el::LogDispatchData* handlePtr)
+{
+    using namespace std;
+    el::base::DispatchAction dispatchAction = handlePtr->dispatchAction();
+    el::LogMessage* tmpMsg = const_cast<el::LogMessage*>(handlePtr->logMessage());
+    auto messageData = new el::LogMessage(tmpMsg->level(),
+                                          tmpMsg->file(),
+                                          tmpMsg->line(),
+                                          tmpMsg->func(),
+                                          tmpMsg->verboseLevel(),
+                                          tmpMsg->logger());
+    size_t ix = postIncrementIndex();
+    buffer[ix] = std::make_pair(dispatchAction, unique_ptr<el::LogMessage>(messageData));
+    if (checkForPush(*messageData))
+    {
+        push();
+        clear();
+    }
+}
+
+void
+MemoryHandler::push()
+{
+    using namespace std;
+    for (size_t i = 0; i < count; ++i) {
+        size_t ix = (start+i) % size;
+        pair< el::base::DispatchAction, unique_ptr<el::LogMessage> >& recordData = buffer[ix];
+        el::base::DispatchAction dispatchAction = recordData.first;
+        unique_ptr<el::LogMessage>& message = recordData.second;
+        el::LogDispatchData data(message.get(), dispatchAction);
+        dispatchCallback.handle(&data);
+        message.reset(nullptr);
+    }
+}
+
+void
+MemoryHandler::clear()
+{
+    start = 0;
+    count = 0;
+}
+
+
+bool
+MemoryHandler::checkForPush(el::LogMessage& message)
+{
+    if (message.level() == pushLevel)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+size_t
+MemoryHandler::postIncrementIndex()
+{
+    size_t ix = (start + count) % size;
+    if (count < size)
+    {
+        count += 1;
+    }
+    else
+    {
+        start = start+1 % size;
+    }
+    return ix;
+}
+
+MemoryHandler&
+MemoryHandler::getInstance()
+{
+    static MemoryHandler instance;
+    return instance;
+}
+
+void
+StaticMemoryHandler::handle(const el::LogDispatchData* handlePtr)
+{
+    MemoryHandler::getInstance().handle(handlePtr);
+}
+
+void DispatchCallback::handle(const el::LogDispatchData* handlePtr)
+{
+    el::base::DefaultLogDispatchCallback::handle(handlePtr);
+}
+
 }

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -12,8 +12,7 @@
 // NOTE: Nothing else should include easylogging directly
 //  include this file instead
 #include "lib/util/easylogging++.h"
-#include <memory>
-#include <utility>
+#include <string>
 
 namespace stellar
 {
@@ -32,45 +31,8 @@ class Logging
     static bool logDebug(std::string const& partition);
     static bool logTrace(std::string const& partition);
     static void rotate();
-    static void enableInMemoryLogging();
+    static void enableInMemoryLogging(const std::string& logFilename,
+                                      const std::string& pushLevel);
+    static const std::string inMemoryLoggerName;
 };
-
-class DispatchCallback : public el::base::DefaultLogDispatchCallback
-{
-public:
-    void handle(const el::LogDispatchData* handlePtr);
-};
-
-class MemoryHandler : public el::LogDispatchCallback
-{
-public:
-    MemoryHandler();
-
-    static MemoryHandler& getInstance();
-
-    void handle(const el::LogDispatchData* handlePtr);
-
-private:
-    size_t postIncrementIndex();
-
-    bool checkForPush(el::LogMessage& message);
-
-    void push();
-
-    void clear();
-
-    std::unique_ptr< std::pair< el::base::DispatchAction, std::unique_ptr<el::LogMessage> >[] > buffer;
-    size_t start;
-    size_t size;
-    size_t count;
-    el::Level pushLevel;
-    DispatchCallback dispatchCallback;
-};
-
-class StaticMemoryHandler : public el::LogDispatchCallback
-{
-protected:
-    void handle(const el::LogDispatchData* handlePtr);
-};
-
 }


### PR DESCRIPTION
Implementation of #1071.
This adds the in-memory logging feature. A new log handler constantly collects logs from all levels and stores them in memory instead of flushing to the log file. In case of an error it writes these more detailed logs, together with the error message, in the default log file. By default it stores last 100 log lines.