### PR TITLE
fix travis builds

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
+AUTOMAKE_OPTIONS = serial-tests
 bin_PROGRAMS = stellar-core
 
 include $(top_srcdir)/common.mk

--- a/src/test/DotReporter.h
+++ b/src/test/DotReporter.h
@@ -1,0 +1,80 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+namespace Catch
+{
+
+struct DotReporter : public StreamingReporterBase
+{
+    DotReporter(ReporterConfig const& _config) : StreamingReporterBase(_config)
+    {
+    }
+
+    ~DotReporter();
+
+    static std::string
+    getDescription()
+    {
+        return "Reports each assertion as a dot";
+    }
+
+    ReporterPreferences
+    getPreferences() const override
+    {
+        ReporterPreferences prefs;
+        prefs.shouldRedirectStdOut = false;
+        return prefs;
+    }
+
+    void
+    noMatchingTestCases(std::string const& spec) override
+    {
+        stream << "No test cases matched '" << spec << "'" << std::endl;
+    }
+
+    void
+    assertionStarting(AssertionInfo const&) override
+    {
+        printDot();
+    }
+
+    bool
+    assertionEnded(AssertionStats const&) override
+    {
+        printDot();
+        return true;
+    }
+
+    void
+    testCaseEnded(TestCaseStats const&) override
+    {
+        printNewLine();
+    }
+
+  private:
+    int mDots{0};
+
+    void
+    printDot()
+    {
+        stream << '.';
+        mDots++;
+        if (mDots == 40)
+        {
+            printNewLine();
+        }
+    }
+
+    void
+    printNewLine()
+    {
+        stream << '\n';
+        mDots = 0;
+    }
+};
+
+INTERNAL_CATCH_REGISTER_REPORTER("dot", DotReporter)
+}

--- a/src/test/selftest-nopg
+++ b/src/test/selftest-nopg
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec ./stellar-core -ll fatal --test -a -r compact
+exec ./stellar-core -ll fatal --test -a -r dot

--- a/src/test/selftest-pg
+++ b/src/test/selftest-pg
@@ -78,7 +78,7 @@ if test "$#" = 0; then
 	echo "Disabling PostgreSQL in most tests"
 	export STELLAR_FORCE_SQLITE=1
     fi
-    ./stellar-core -ll fatal --test -a -r compact
+    ./stellar-core -ll fatal --test -a -r dot
 else
     # You can run "./test-pg bash" to get a shell with postgreSQL set up
     setup_test

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -26,6 +26,16 @@
 #define CATCH_CONFIG_RUNNER
 #include "lib/catch.hpp"
 
+#include "test/DotReporter.h"
+
+namespace Catch
+{
+
+DotReporter::~DotReporter()
+{}
+
+}
+
 namespace stellar
 {
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -51,10 +51,10 @@ committer=$(committer_of HEAD) \
 
 case $committer in
     "David Mazieres")
-        config_flags="--enable-asan --enable-ccache"
+        config_flags="--enable-asan --enable-ccache CXXFLAGS=-w"
 	;;
     *)
-	config_flags="--enable-asan --enable-ccache --enable-sdfprefs"
+	config_flags="--enable-asan --enable-ccache --enable-sdfprefs CXXFLAGS=-w"
 	;;
 esac
 


### PR DESCRIPTION
This PR fixes issues with travis-ci builds.

travis-ci requires that build creates log that is less than 4MB. Our previous -r xml output does almost exactly 4MB, so with build logs it exceeds travis-ci limits.

New `dot` reporter produces only 700kb of logs, and it can be easily made shorter at any moment, printing only every second/third/forth dot - so we can still expand out test suite.

Second requirement of travis-ci is that new items in logs appears in time intervals less than 10 minutes. With previous configuration tests were run in parallel mode, which means test logs are buffered and printed out after tests are finished. Tests for stellar-core can run for 15 or more minutes. I've switched it back to serial tests that prints logs as soon as they arrive. This with the fact that dots are printed very often keeps travis-ci safe.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>