### PR TITLE
Add the packaging metadata to build the stellar-core snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,33 @@
+name: stellar-core
+version: master
+summary: the backbone of the Stellar network
+description: |
+  It maintains a local copy of the ledger, communicating and staying in sync
+  with other instances of stellar-core on the network. Optionally, stellar-core
+  can store historical records of the ledger and participate in consensus.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+apps:
+  stellar-core:
+    command: stellar-core
+
+parts:
+  stellar-core:
+    source: .
+    source-type: git
+    plugin: autotools
+    build-packages:
+      - build-essential
+      - pkg-config
+      - autoconf
+      - automake
+      - libtool
+      - bison
+      - flex
+      - libpq-dev
+      - clang
+      - gcc
+      - g++
+      - cpp


### PR DESCRIPTION
This package will let you publish the latest stellar-core in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.