### PR TITLE
print log on apply buckets and apply ledgers in commandline mode

### DIFF
--- a/src/historywork/ApplyBucketsWork.cpp
+++ b/src/historywork/ApplyBucketsWork.cpp
@@ -137,6 +137,8 @@ ApplyBucketsWork::onRun()
 Work::State
 ApplyBucketsWork::onSuccess()
 {
+    mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
+
     if ((mSnapApplicator && *mSnapApplicator) ||
         (mCurrApplicator && *mCurrApplicator))
     {

--- a/src/historywork/ApplyLedgerChainWork.cpp
+++ b/src/historywork/ApplyLedgerChainWork.cpp
@@ -241,6 +241,8 @@ ApplyLedgerChainWork::onRun()
 Work::State
 ApplyLedgerChainWork::onSuccess()
 {
+    mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
+
     if (mCurrSeq > mLastSeq)
     {
         return WORK_SUCCESS;


### PR DESCRIPTION
Force displaying log messages from CatchupManager when a bulk of buckets
or ledgers are applied.

This ensures that even in commandline mode updates are printed on
screen, when there is no 'consensus received' event that calls
logAndUpdateCatchupStatus in LedgerManagerImpl::valueExternalized.

Fixes: #1321 