### PR TITLE
Fix MAINTENANCE_ON_STARTUP

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -19,6 +19,9 @@
     <RootNamespace>stellar-core</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -56,16 +59,19 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\Build\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>BuildGenerateSources</CustomBuildBeforeTargets>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\Build\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>BuildGenerateSources</CustomBuildBeforeTargets>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)\Build\$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
     <CustomBuildBeforeTargets>BuildGenerateSources</CustomBuildBeforeTargets>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -89,10 +95,12 @@
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;%(AdditionalDependencies);C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>@echo Checking XDR</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>XDR</Message>
+      <Message>
+      </Message>
     </PreBuildEvent>
     <CustomBuildStep>
       <Inputs>src/generated/xdr/Stellar-overlay.h</Inputs>
@@ -112,12 +120,12 @@
       <LinkObjects>false</LinkObjects>
     </CustomBuild>
     <PostBuildEvent>
-      <Command>
-      </Command>
+      <Command>robocopy $(MSBuildProjectDirectory)\..\..\docs $(OutDir)\testdata *.cfg &gt; nul
+exit /b 0
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>
-      </Message>
+      <Message>copy testdata</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">
@@ -144,10 +152,12 @@
       </IgnoreSpecificDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>@echo Checking XDR</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>XDR</Message>
+      <Message>
+      </Message>
     </PreBuildEvent>
     <CustomBuildStep>
       <Inputs>src/generated/xdr/Stellar-overlay.h</Inputs>
@@ -168,12 +178,12 @@
       <LinkObjects>false</LinkObjects>
     </CustomBuild>
     <PostBuildEvent>
-      <Command>
-      </Command>
+      <Command>robocopy $(MSBuildProjectDirectory)\..\..\docs $(OutDir)\testdata *.cfg &gt; nul
+exit /b 0
+</Command>
     </PostBuildEvent>
     <PostBuildEvent>
-      <Message>
-      </Message>
+      <Message>copy testdata</Message>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -197,10 +207,12 @@
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;%(AdditionalDependencies);C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>@echo Checking XDR</Command>
+      <Command>
+      </Command>
     </PreBuildEvent>
     <PreBuildEvent>
-      <Message>XDR</Message>
+      <Message>
+      </Message>
     </PreBuildEvent>
     <CustomBuildStep>
       <Inputs>src/generated/xdr/Stellar-overlay.h</Inputs>
@@ -219,6 +231,14 @@
       <Message />
       <LinkObjects>false</LinkObjects>
     </CustomBuild>
+    <PostBuildEvent>
+      <Command>robocopy $(MSBuildProjectDirectory)\..\..\docs $(OutDir)\testdata *.cfg &gt; nul
+exit /b 0
+</Command>
+    </PostBuildEvent>
+    <PostBuildEvent>
+      <Message>copy testdata</Message>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\lib\util\easylogging++.cc" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -549,9 +549,6 @@
     <ClCompile Include="..\..\src\main\ApplicationTests.cpp">
       <Filter>main</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\main\ConfigTests.cpp">
-      <Filter>main</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\main\NtpSynchronizationChecker.cpp">
       <Filter>main</Filter>
     </ClCompile>
@@ -752,6 +749,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\invariant\ChangedAccountsSubentriesCountIsValid.cpp">
       <Filter>invariant</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\ConfigTests.cpp">
+      <Filter>main\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\invariant\InvariantManagerImpl.cpp">
       <Filter>invariant</Filter>

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -211,6 +211,12 @@ CATCHUP_COMPLETE=false
 # This limits the number that will be active at a time.
 MAX_CONCURRENT_SUBPROCESSES=10
 
+-# MAINTENANCE_ON_STARTUP
+-# controls the type of maintenance to perform on startup
+-# true (default): perform as much automatic maintenance as possible
+-# false: no maintenance is attempted (must be performed as a command)
+-MAINTENANCE_ON_STARTUP=true
+
 # See HISTORY table at below
 
 

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -65,10 +65,10 @@ PREFERRED_UPGRADE_DATETIME=2017-03-01T00:00:00Z
 # convenience mapping of common names to node IDs. The common names can be used
 #  in the .cfg. `$common_name`. If set, they will also appear in your logs
 #  instead of the less friendly nodeID.
-#NODE_NAMES=[
-# "GA22N4YGO7IJDRF2SISA5KHULGYYKDXBQGYIWUVNMSNHF5G2DNBKP3M5  eliza",
-# "GCDENOCHA6TQL6DFC4FS54HIH7RP7XR7VZCQZFANMGLT2WXJ7D7KGV2P  hal9000"
-#]
+NODE_NAMES=[
+ "GA22N4YGO7IJDRF2SISA5KHULGYYKDXBQGYIWUVNMSNHF5G2DNBKP3M5  eliza",
+ "GCDENOCHA6TQL6DFC4FS54HIH7RP7XR7VZCQZFANMGLT2WXJ7D7KGV2P  hal9000"
+]
 
 ###########################
 ## Configure which network this instance should talk to
@@ -103,8 +103,8 @@ PREFERRED_PEERS=["127.0.0.1:7000","127.0.0.1:8000"]
 # when connecting, similar to the PREFERRED_PEERS list.
 # can use a name already defined in the .cfg
 PREFERRED_PEER_KEYS=[
-"GCDENOCHA6TQL6DFC4FS54HIH7RP7XR7VZCQZFANMGLT2WXJ7D7KGV2P",
-"GA22N4YGO7IJDRF2SISA5KHULGYYKDXBQGYIWUVNMSNHF5G2DNBKP3M5 optional_common_name",
+"GBKXI3TVIFHD6QDSNMUOTJFDWHDYDVRRPWIHN4IM2YFXIUEWDTY7DSSI",
+"GBDOAYUPGQCPLJCP2HYJQ4W3ADODJFZISHRBQTQB7SFVR4BRUX46RYIP optional_common_name",
 "$eliza"]
 
 # PREFERRED_PEERS_ONLY (boolean) default is false
@@ -127,8 +127,6 @@ KNOWN_PEERS=[
 "core-testnet1.stellar.org",
 "core-testnet2.stellar.org",
 "core-testnet3.stellar.org"]
-
-
 
 #######################
 ##  SCP settings
@@ -175,13 +173,17 @@ DESIRED_BASE_FEE=100
 DESIRED_MAX_TX_PER_LEDGER=400
 
 # FAILURE_SAFETY (integer) default -1
-# This is the number of failures you want to be able to tolerate.
-# You will need at least 3f+1 nodes in your quorum set.
-# If you don't have enough in your quorum set to tolerate the level you
-#  set here stellar-core won't run.
+# Most people should leave this to -1
+# This is the maximum number of validator failures from your QUORUM_SET that
+# you want to be able to tolerate.
+# Typically, you will need at least 3f+1 nodes in your quorum set.
+# If you don't have enough nodes in your quorum set to tolerate the level you
+#  set here stellar-core won't run as a precaution.
 # A value of -1 indicates to use (n-1)/3 (n being the number of nodes)
 # A vale of 0 is only allowed if UNSAFE_QUORUM is set
-FAILURE_SAFETY=-1
+# Note: The value of 1 below is the maximum number derived from the value of
+# QUORUM_SET in this configuration file
+FAILURE_SAFETY=1
 
 # UNSAFE_QUORUM (true or false) default false
 # Most people should leave this to false.
@@ -195,7 +197,6 @@ FAILURE_SAFETY=-1
 # quorum sets of other nodes relate to yours when it comes to
 # quorum intersection.
 UNSAFE_QUORUM=false
-
 
 #########################
 ##  History
@@ -211,15 +212,11 @@ CATCHUP_COMPLETE=false
 # This limits the number that will be active at a time.
 MAX_CONCURRENT_SUBPROCESSES=10
 
--# MAINTENANCE_ON_STARTUP
--# controls the type of maintenance to perform on startup
--# true (default): perform as much automatic maintenance as possible
--# false: no maintenance is attempted (must be performed as a command)
--MAINTENANCE_ON_STARTUP=true
-
-# See HISTORY table at below
-
-
+# MAINTENANCE_ON_STARTUP
+# controls the type of maintenance to perform on startup
+# true (default): perform as much automatic maintenance as possible
+# false: no maintenance is attempted (must be performed as a command)
+MAINTENANCE_ON_STARTUP=true
 
 ###############################
 ## The following options should probably never be set. They are used primarily
@@ -328,14 +325,13 @@ mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
 #[HISTORY.h3]
 #get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
 
-
-
-# QUORUM_SET (object see below) default is empty
+# QUORUM_SET is a required field
 # This is how you specify this server's quorum set.
 #
-# It can be nested 2 levels: {A,B,C,{D,E,F},{G,H,{I,J,K,L}}}
-# The THRESHOLD_PERCENT is how many have to agree (1-100%). The sets are treated
-# as one vote. So for example in the above there are 5 things that can vote:
+# It can be nested up to 2 levels: {A,B,C,{D,E,F},{G,H,{I,J,K,L}}}
+# THRESHOLD_PERCENT is how many have to agree (1-100%) within a given set.
+# Each set is treated as one vote.
+# So for example in the above there are 5 things that can vote:
 # individual validators: A,B,C, and the sets {D,E,F} and {G,H with subset {I,J,K,L}}
 # the sets each have their own threshold.
 # For example with {100% G,H with subset (50% I,J,K,L}}
@@ -357,25 +353,35 @@ mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
 #  shown in the first 3 validators or use common names that have been
 #  previously defined.
 [QUORUM_SET]
+THRESHOLD_PERCENT=66
 VALIDATORS=[
-"GDQWITFJLZ5HT6JCOXYEVV5VFD6FTLAKJAUDKHAV3HKYGVJWA2DPYSQV  you_can_add",
-"GANLKVE4WOTE75MJS6FQ73CL65TSPYYMFZKC4VDEZ45LGQRCATGAIGIA  human_readable",
-"GDV46EIEF57TDL4W27UFDAUVPDDCKJNVBYB3WIV2WYUYUG753FCFU6EJ  names"]
+    "GDQWITFJLZ5HT6JCOXYEVV5VFD6FTLAKJAUDKHAV3HKYGVJWA2DPYSQV  A_from_above",
+    "GANLKVE4WOTE75MJS6FQ73CL65TSPYYMFZKC4VDEZ45LGQRCATGAIGIA  B_from_above",
+    "GDV46EIEF57TDL4W27UFDAUVPDDCKJNVBYB3WIV2WYUYUG753FCFU6EJ  C_from_above"
+]
+
 [QUORUM_SET.1]
 THRESHOLD_PERCENT=67
 VALIDATORS=[
-"$self", # 'D' from above is this node
-"GDXJAZZJ3H5MJGR6PDQX3JHRREAVYNCVM7FJYGLZJKEHQV2ZXEUO5SX2 E_from_above",
-"GB6GK3WWTZYY2JXWM6C5LRKLQ2X7INQ7IYTSECCG3SMZFYOZNEZR4SO5 F_from_above"]
+    "$self", # 'D' from above is this node
+    "GDXJAZZJ3H5MJGR6PDQX3JHRREAVYNCVM7FJYGLZJKEHQV2ZXEUO5SX2 E_from_above",
+    "GB6GK3WWTZYY2JXWM6C5LRKLQ2X7INQ7IYTSECCG3SMZFYOZNEZR4SO5 F_from_above"
+]
+
 [QUORUM_SET.2]
 THRESHOLD_PERCENT=100
 VALIDATORS=[
-"GCTAIXWDDBM3HBDHGSAOLY223QZHPS2EDROF7YUBB3GNYXLOCPV5PXUK G_from_above",
-"GCJ6UBAOXNQFN3HGLCVQBWGEZO6IABSMNE2OCQC4FJAZXJA5AIE7WSPW H_from_above"]
+    "GCTAIXWDDBM3HBDHGSAOLY223QZHPS2EDROF7YUBB3GNYXLOCPV5PXUK G_from_above",
+    "GCJ6UBAOXNQFN3HGLCVQBWGEZO6IABSMNE2OCQC4FJAZXJA5AIE7WSPW H_from_above"
+]
+
 [QUORUM_SET.2.1]
 THRESHOLD_PERCENT=50
 VALIDATORS=[
-"GC4X65TQJVI3OWAS4DTA2EN2VNZ5ZRJD646H5WKEJHO5ZHURDRAX2OTH I_from_above",
-"GAXSWUO4RBELRQT5WMDLIKTRIKC722GGXX2GIGEYQZDQDLOTINQ4DX6F J_from_above",
-"GAWOEMG7DQDWHCFDTPJEBYWRKUUZTX2M2HLMNABM42G7C7IAPU54GL6X K_from_above",
-"GDZAJNUUDJFKTZX3YWZSOAS4S4NGCJ5RQAY7JPYBG5CUFL3JZ5C3ECOH L_from_above"]
+    "GC4X65TQJVI3OWAS4DTA2EN2VNZ5ZRJD646H5WKEJHO5ZHURDRAX2OTH I_from_above",
+    "GAXSWUO4RBELRQT5WMDLIKTRIKC722GGXX2GIGEYQZDQDLOTINQ4DX6F J_from_above",
+    "GAWOEMG7DQDWHCFDTPJEBYWRKUUZTX2M2HLMNABM42G7C7IAPU54GL6X K_from_above",
+    "GDZAJNUUDJFKTZX3YWZSOAS4S4NGCJ5RQAY7JPYBG5CUFL3JZ5C3ECOH L_from_above"
+]
+
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,10 @@ stellar_core_LDADD = $(soci_LIBS) $(libmedida_LIBS)		\
 	$(top_builddir)/lib/lib3rdparty.a $(sqlite3_LIBS)	\
 	$(libpq_LIBS) $(xdrpp_LIBS) $(libsodium_LIBS)
 
-BUILT_SOURCES = $(SRC_X_FILES:.x=.h) StellarCoreVersion.h
+TESTDATA_DIR = testdata
+TEST_FILES = $(TESTDATA_DIR)/stellar-core_example.cfg $(TESTDATA_DIR)/stellar-core_standalone.cfg $(TESTDATA_DIR)/stellar-core_testnet.cfg
+
+BUILT_SOURCES = $(SRC_X_FILES:.x=.h) StellarCoreVersion.h $(TEST_FILES)
 
 SUFFIXES = .x .h
 .x.h: $(XDRC)
@@ -21,6 +24,9 @@ SUFFIXES = .x .h
 
 $(srcdir)/src.mk: $(top_srcdir)/make-mks
 	cd $(top_srcdir) && ./make-mks
+
+$(TESTDATA_DIR)/%.cfg : $(top_srcdir)/docs/%.cfg
+	mkdir -p $(@D) && cp $< $@
 
 .PHONY: always
 always:

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -341,6 +341,15 @@ Config::load(std::string const& filename)
                 }
                 ALLOW_LOCALHOST_FOR_TESTING = item.second->as<bool>()->value();
             }
+            else if (item.first == "MAINTENANCE_ON_STARTUP")
+            {
+                if (!item.second->as<bool>())
+                {
+                    throw std::invalid_argument(
+                        "invalid MAINTENANCE_ON_STARTUP");
+                }
+                MAINTENANCE_ON_STARTUP = item.second->as<bool>()->value();
+            }
             else if (item.first == "MANUAL_CLOSE")
             {
                 if (!item.second->as<bool>())

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -693,7 +693,7 @@ Config::validateConfig()
     if (FAILURE_SAFETY == -1)
     {
         // calculates default value for safety assuming flat quorum
-        // n = 3f+1
+        // n = 3f+1 <=> f = (n-1)/3
         FAILURE_SAFETY = (static_cast<uint32>(nodes.size()) - 1) / 3;
     }
 

--- a/src/main/ConfigTests.cpp
+++ b/src/main/ConfigTests.cpp
@@ -138,3 +138,20 @@ TEST_CASE("resolve node id", "[config]")
             publicKey));
     }
 }
+
+TEST_CASE("load example configs", "[config]")
+{
+    Config c;
+    std::vector<std::string> testFiles = {"stellar-core_example.cfg",
+                                          "stellar-core_standalone.cfg",
+                                          "stellar-core_testnet.cfg"};
+    for (auto const& fn : testFiles)
+    {
+        std::string fnPath = "testdata/";
+        fnPath += fn;
+        SECTION("load config " + fnPath)
+        {
+            c.load(fnPath);
+        }
+    }
+}


### PR DESCRIPTION
This change adds validations to example configs provided in our tree.

It looks like because of the lack of such validation, we missed earlier hooking up the  MAINTENANCE_ON_STARTUP config flag - this change also re-adds support for this (hidden) config flag.
