### PR TITLE
re-introduce assert on double delete (ledger delta)

### DIFF
--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -134,12 +134,13 @@ LedgerDelta::deleteEntry(LedgerKey const& k)
     }
     else
     {
-        if (mDelete.find(k) == mDelete.end())
-        {
-            mDelete.insert(k);
-        } // else already being deleted
+        // double delete here means there is buggy code upstream
+        // and we cannot keep going as this may corrupt the bucket list
+        assert(mDelete.find(k) == mDelete.end());
 
+        // mod + delete -> delete
         mMod.erase(k);
+        mDelete.insert(k);
     }
 }
 

--- a/src/ledger/LedgerDelta.h
+++ b/src/ledger/LedgerDelta.h
@@ -87,6 +87,7 @@ class LedgerDelta
 
     void markMeters(Application& app) const;
 
+    // helper methods for generating data compatible with bucketlist
     std::vector<LedgerEntry> getLiveEntries() const;
     std::vector<LedgerKey> getDeadEntries() const;
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -161,6 +161,7 @@ TransactionFrame::loadAccount(int ledgerProtocolVersion, LedgerDelta* delta,
     if (ledgerProtocolVersion < 8 && mSigningAccount &&
         mSigningAccount->getID() == accountID)
     {
+        // this is buggy caching that existed in old versions of the protocol
         res = mSigningAccount;
     }
     else if (delta)
@@ -411,8 +412,8 @@ TransactionFrame::checkValid(Application& app, SequenceNumber current)
     resetSigningAccount();
     resetResults();
     SignatureChecker signatureChecker{
-        app.getLedgerManager().getCurrentLedgerVersion(),
-        getContentsHash(), mEnvelope.signatures};
+        app.getLedgerManager().getCurrentLedgerVersion(), getContentsHash(),
+        mEnvelope.signatures};
     bool res = commonValid(signatureChecker, app, nullptr, current);
     if (res)
     {
@@ -480,8 +481,8 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& meta,
 {
     resetSigningAccount();
     SignatureChecker signatureChecker{
-        app.getLedgerManager().getCurrentLedgerVersion(),
-        getContentsHash(), mEnvelope.signatures};
+        app.getLedgerManager().getCurrentLedgerVersion(), getContentsHash(),
+        mEnvelope.signatures};
     if (!commonValid(signatureChecker, app, &delta, 0))
     {
         return false;


### PR DESCRIPTION
this was removed by accident in https://github.com/stellar/stellar-core/commit/8dc10bf12e537365ad6e85d148d288842548f94b

a double delete in a ledger delta is the definite manifestation of buggy code upstream, in this case this commit would just hide the bug fixed in https://github.com/stellar/stellar-core/commit/ab8dca2e9570fb6d73fb03f7708f8b39b9a6daff