### PR TITLE
Test quick restart

### DIFF
--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -12,5 +12,6 @@ std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 // the value of LEDGER_VALIDITY_BRACKET should be in the order of
 // how many ledgers can close ahead given CONSENSUS_STUCK_TIMEOUT_SECONDS
 uint32 const Herder::LEDGER_VALIDITY_BRACKET = 100;
-uint32 const Herder::MAX_SLOTS_TO_REMEMBER = 4;
+// 12 slots give us about a minute to reconnect
+uint32 const Herder::MAX_SLOTS_TO_REMEMBER = 12;
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -406,29 +406,17 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
 void
 HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer)
 {
-    uint32 minSeq, maxSeq;
-
-    if (ledgerSeq == 0)
+    if (getSCP().empty())
     {
-        const uint32 nbLedgers = 3;
-        const uint32 minLedger = 2;
-
-        // include the most recent slot
-        maxSeq = getCurrentLedgerSeq() + 1;
-
-        if (maxSeq >= minLedger + nbLedgers)
-        {
-            minSeq = maxSeq - nbLedgers;
-        }
-        else
-        {
-            minSeq = minLedger;
-        }
+        return;
     }
-    else
-    {
-        minSeq = maxSeq = ledgerSeq;
-    }
+
+    assert(getSCP().getLowSlotIndex() <= std::numeric_limits<uint32_t>::max());
+    assert(getSCP().getHighSlotIndex() <= std::numeric_limits<uint32_t>::max());
+
+    auto minSeq =
+        std::max(ledgerSeq, static_cast<uint32_t>(getSCP().getLowSlotIndex()));
+    auto maxSeq = static_cast<uint32_t>(getSCP().getHighSlotIndex());
 
     // use uint64_t for seq to prevent overflows
     for (uint64_t seq = minSeq; seq <= maxSeq; seq++)

--- a/src/herder/PendingEnvelopesTests.cpp
+++ b/src/herder/PendingEnvelopesTests.cpp
@@ -2,9 +2,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "herder/PendingEnvelopes.h"
 #include "crypto/SHA.h"
 #include "herder/HerderImpl.h"
-#include "herder/PendingEnvelopes.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "test/TestAccount.h"
@@ -181,8 +181,11 @@ TEST_CASE("PendingEnvelopes::recvSCPEnvelope", "[herder]")
 
         SECTION("as removable")
         {
-            pendingEnvelopes.addSCPQuorumSet(saneQSetHash, 9, saneQSet);
-            pendingEnvelopes.addTxSet(p.second->getContentsHash(), 9, p.second);
+            pendingEnvelopes.addSCPQuorumSet(
+                saneQSetHash, 2 * Herder::MAX_SLOTS_TO_REMEMBER + 1, saneQSet);
+            pendingEnvelopes.addTxSet(p.second->getContentsHash(),
+                                      2 * Herder::MAX_SLOTS_TO_REMEMBER + 1,
+                                      p.second);
         }
 
         REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) ==
@@ -222,10 +225,12 @@ TEST_CASE("PendingEnvelopes::recvSCPEnvelope", "[herder]")
     SECTION("envelopes from different slots asking for the same quorum set and "
             "tx set")
     {
-        auto saneEnvelope2 =
-            makeEnvelope(p, saneQSetHash, lcl.header.ledgerSeq + 5);
-        auto saneEnvelope3 =
-            makeEnvelope(p, saneQSetHash, lcl.header.ledgerSeq + 9);
+        auto saneEnvelope2 = makeEnvelope(
+            p, saneQSetHash,
+            lcl.header.ledgerSeq + Herder::MAX_SLOTS_TO_REMEMBER + 1);
+        auto saneEnvelope3 = makeEnvelope(
+            p, saneQSetHash,
+            lcl.header.ledgerSeq + 2 * Herder::MAX_SLOTS_TO_REMEMBER + 1);
 
         REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) ==
                 Herder::ENVELOPE_STATUS_FETCHING);

--- a/src/herder/ProtocolUpgradeTests.cpp
+++ b/src/herder/ProtocolUpgradeTests.cpp
@@ -5,7 +5,6 @@
 #include "herder/Herder.h"
 #include "herder/LedgerCloseData.h"
 #include "lib/catch.hpp"
-#include "overlay/LoopbackPeer.h"
 #include "simulation/Simulation.h"
 #include "test/TestUtils.h"
 #include "test/test.h"

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1046,7 +1046,10 @@ Peer::recvAuth(StellarMessage const& msg)
     }
 
     // send SCP State
+    // remove when all known peers implements the next line
     mApp.getHerder().sendSCPStateToPeer(0, self);
+    // ask for SCP state if not synced
+    sendGetScpState(mApp.getLedgerManager().getLastClosedLedgerNum() + 1);
 }
 
 void

--- a/src/overlay/TCPPeerTests.cpp
+++ b/src/overlay/TCPPeerTests.cpp
@@ -28,12 +28,12 @@ TEST_CASE("TCPPeer can communicate", "[overlay]")
     SCPQuorumSet n0_qset;
     n0_qset.threshold = 1;
     n0_qset.validators.push_back(v10SecretKey.getPublicKey());
-    auto n0 = s->getNode(s->addNode(v10SecretKey, n0_qset, s->getClock()));
+    auto n0 = s->addNode(v10SecretKey, n0_qset, s->getClock());
 
     SCPQuorumSet n1_qset;
     n1_qset.threshold = 1;
     n1_qset.validators.push_back(v11SecretKey.getPublicKey());
-    auto n1 = s->getNode(s->addNode(v11SecretKey, n1_qset, s->getClock()));
+    auto n1 = s->addNode(v11SecretKey, n1_qset, s->getClock());
 
     s->addPendingConnection(v10SecretKey.getPublicKey(),
                             v11SecretKey.getPublicKey());

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -203,6 +203,28 @@ SCP::setStateFromEnvelope(uint64 slotIndex, SCPEnvelope const& e)
     }
 }
 
+bool
+SCP::empty() const
+{
+    return mKnownSlots.empty();
+}
+
+uint64
+SCP::getLowSlotIndex() const
+{
+    assert(!empty());
+    return mKnownSlots.begin()->first;
+}
+
+uint64
+SCP::getHighSlotIndex() const
+{
+    assert(!empty());
+    auto it = mKnownSlots.end();
+    it--;
+    return it->first;
+}
+
 std::vector<SCPEnvelope>
 SCP::getCurrentState(uint64 slotIndex)
 {

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -105,6 +105,13 @@ class SCP
     // this is used when rebuilding the state after a crash for example
     void setStateFromEnvelope(uint64 slotIndex, SCPEnvelope const& e);
 
+    // check if we are holding some slots
+    bool empty() const;
+    // return lowest slot index value
+    uint64 getLowSlotIndex() const;
+    // return highest slot index value
+    uint64 getHighSlotIndex() const;
+
     // returns all messages for the slot
     std::vector<SCPEnvelope> getCurrentState(uint64 slotIndex);
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -16,7 +16,6 @@
 #include "lib/util/format.h"
 #include "main/Application.h"
 #include "medida/stats/snapshot.h"
-#include "overlay/LoopbackPeer.h"
 #include "overlay/StellarXDR.h"
 #include "simulation/Topologies.h"
 #include "test/test.h"

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -52,29 +52,20 @@ Simulation::getClock()
     return mClock;
 }
 
-NodeID
+Application::pointer
 Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
                     Config const* cfg2, bool newDB)
 {
-    std::shared_ptr<Config> cfg;
-    if (!cfg2)
-    {
-        cfg = std::make_shared<Config>(newConfig());
-    }
-    else
-    {
-        cfg = std::make_shared<Config>(*cfg2);
-    }
+    auto cfg = cfg2 ? std::make_shared<Config>(*cfg2)
+                    : std::make_shared<Config>(newConfig());
     cfg->NODE_SEED = nodeKey;
     cfg->QUORUM_SET = qSet;
     cfg->RUN_STANDALONE = (mMode == OVER_LOOPBACK);
 
-    Application::pointer result = Application::create(clock, *cfg, newDB);
+    auto result = Application::create(clock, *cfg, newDB);
+    mNodes[nodeKey.getPublicKey()] = result;
 
-    NodeID nodeID = nodeKey.getPublicKey();
-    mNodes[nodeID] = result;
-
-    return nodeID;
+    return result;
 }
 
 Application::pointer

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -72,7 +72,6 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
     Application::pointer result = Application::create(clock, *cfg, newDB);
 
     NodeID nodeID = nodeKey.getPublicKey();
-    mConfigs[nodeID] = cfg;
     mNodes[nodeID] = result;
 
     return nodeID;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -81,10 +81,12 @@ class Simulation : public LoadGenerator
     std::string metricsSummary(std::string domain = "");
 
     void addConnection(NodeID initiator, NodeID acceptor);
+    void dropConnection(NodeID initiator, NodeID acceptor);
     Config newConfig(); // generates a new config
 
   private:
     void addLoopbackConnection(NodeID initiator, NodeID acceptor);
+    void dropLoopbackConnection(NodeID initiator, NodeID acceptor);
     void addTCPConnection(NodeID initiator, NodeID acception);
 
     VirtualClock mClock;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -89,7 +89,6 @@ class Simulation : public LoadGenerator
     Mode mMode;
     int mConfigCount;
     Application::pointer mIdleApp;
-    std::map<NodeID, Config::pointer> mConfigs;
     std::map<NodeID, Application::pointer> mNodes;
     std::vector<std::pair<NodeID, NodeID>> mPendingConnections;
     std::vector<std::shared_ptr<LoopbackPeerConnection>> mLoopbackConnections;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -43,8 +43,10 @@ class Simulation : public LoadGenerator
 
     VirtualClock& getClock();
 
-    NodeID addNode(SecretKey nodeKey, SCPQuorumSet qSet, VirtualClock& clock,
-                   Config const* cfg = nullptr, bool newDB = true);
+    Application::pointer addNode(SecretKey nodeKey, SCPQuorumSet qSet,
+                                 VirtualClock& clock,
+                                 Config const* cfg = nullptr,
+                                 bool newDB = true);
     Application::pointer getNode(NodeID nodeID);
     std::vector<Application::pointer> getNodes();
     std::vector<NodeID> getNodeIDs();

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -24,10 +24,11 @@ Topologies::pair(Simulation::Mode mode, Hash const& networkID,
     qSet0.validators.push_back(v10NodeID);
     qSet0.validators.push_back(v11NodeID);
 
-    auto n0 = simulation->addNode(v10SecretKey, qSet0, simulation->getClock());
-    auto n1 = simulation->addNode(v11SecretKey, qSet0, simulation->getClock());
+    simulation->addNode(v10SecretKey, qSet0, simulation->getClock());
+    simulation->addNode(v11SecretKey, qSet0, simulation->getClock());
 
-    simulation->addPendingConnection(n0, n1);
+    simulation->addPendingConnection(v10SecretKey.getPublicKey(),
+                                     v11SecretKey.getPublicKey());
     return simulation;
 }
 
@@ -59,18 +60,24 @@ Topologies::cycle4(Hash const& networkID, std::function<Config()> confGen)
     qSet3.validators.push_back(v3NodeID);
     qSet3.validators.push_back(v0NodeID);
 
-    auto n0 = simulation->addNode(v0SecretKey, qSet0, simulation->getClock());
-    auto n1 = simulation->addNode(v1SecretKey, qSet1, simulation->getClock());
-    auto n2 = simulation->addNode(v2SecretKey, qSet2, simulation->getClock());
-    auto n3 = simulation->addNode(v3SecretKey, qSet3, simulation->getClock());
+    simulation->addNode(v0SecretKey, qSet0, simulation->getClock());
+    simulation->addNode(v1SecretKey, qSet1, simulation->getClock());
+    simulation->addNode(v2SecretKey, qSet2, simulation->getClock());
+    simulation->addNode(v3SecretKey, qSet3, simulation->getClock());
 
-    simulation->addPendingConnection(n0, n1);
-    simulation->addPendingConnection(n1, n2);
-    simulation->addPendingConnection(n2, n3);
-    simulation->addPendingConnection(n3, n0);
+    simulation->addPendingConnection(v0SecretKey.getPublicKey(),
+                                     v1SecretKey.getPublicKey());
+    simulation->addPendingConnection(v1SecretKey.getPublicKey(),
+                                     v2SecretKey.getPublicKey());
+    simulation->addPendingConnection(v2SecretKey.getPublicKey(),
+                                     v3SecretKey.getPublicKey());
+    simulation->addPendingConnection(v3SecretKey.getPublicKey(),
+                                     v0SecretKey.getPublicKey());
 
-    simulation->addPendingConnection(n0, n2);
-    simulation->addPendingConnection(n1, n3);
+    simulation->addPendingConnection(v0SecretKey.getPublicKey(),
+                                     v2SecretKey.getPublicKey());
+    simulation->addPendingConnection(v1SecretKey.getPublicKey(),
+                                     v3SecretKey.getPublicKey());
 
     return simulation;
 }

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -10,7 +10,6 @@
 #include "ledger/LedgerDelta.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestExceptions.h"
 #include "test/TestUtils.h"
 #include "test/test.h"

--- a/src/transactions/ChangeTrustTests.cpp
+++ b/src/transactions/ChangeTrustTests.cpp
@@ -5,7 +5,6 @@
 #include "lib/catch.hpp"
 #include "lib/json/json.h"
 #include "main/Application.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestUtils.h"

--- a/src/transactions/ManageDataTests.cpp
+++ b/src/transactions/ManageDataTests.cpp
@@ -5,7 +5,6 @@
 #include "lib/catch.hpp"
 #include "lib/json/json.h"
 #include "main/Application.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestUtils.h"

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -6,7 +6,6 @@
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/Config.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestUtils.h"

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -7,7 +7,6 @@
 #include "lib/util/uint128_t.h"
 #include "main/Application.h"
 #include "main/Config.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestMarket.h"

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -6,7 +6,6 @@
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/Config.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestMarket.h"

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -6,7 +6,6 @@
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/Config.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestUtils.h"

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -9,7 +9,6 @@
 #include "lib/catch.hpp"
 #include "lib/json/json.h"
 #include "main/Application.h"
-#include "overlay/LoopbackPeer.h"
 #include "test/TestAccount.h"
 #include "test/TestExceptions.h"
 #include "test/TestUtils.h"


### PR DESCRIPTION
It seems that stellar-core can survive restart/disconnection only if the next connection comes withing 2 ledgers (about 10 seconds).

It is controlled by HerderImpl::sendSCPStateToPeer::nbLedgers constant (it is 1 more than number of missing ledgers).

Tests for: #1332