### PR TITLE
ensure all needed buckets are retained at shutdown

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -97,5 +97,8 @@ class BucketManager : NonMovableOrCopyable
     // Restart from a saved state: find and attach all buckets in `has`, set
     // current BL.
     virtual void assumeState(HistoryArchiveState const& has) = 0;
+
+    // Ensure all needed buckets are retained
+    virtual void shutdown() = 0;
 };
 }

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -352,4 +352,11 @@ BucketManagerImpl::assumeState(HistoryArchiveState const& has)
     }
     mBucketList.restartMerges(mApp, has.currentLedger);
 }
+
+void
+BucketManagerImpl::shutdown()
+{
+    // forgetUnreferencedBuckets does what we want - it retains needed buckets
+    forgetUnreferencedBuckets();
+}
 }

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -72,6 +72,7 @@ class BucketManagerImpl : public BucketManager
     std::vector<std::string>
     checkForMissingBucketsFiles(HistoryArchiveState const& has) override;
     void assumeState(HistoryArchiveState const& has) override;
+    void shutdown() override;
 };
 
 #define SKIP_1 50

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1010,6 +1010,13 @@ LedgerManagerImpl::storeCurrentLedger()
         has.resolveAnyReadyFutures();
     }
 
+    // we will need these buckets after restart
+    for (auto const& bucket : has.allBuckets())
+    {
+        mApp.getBucketManager()
+            .getBucketByHash(hexToBin256(bucket))
+            ->setRetain(true);
+    }
     mApp.getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                        has.toString());
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -351,6 +351,10 @@ ApplicationImpl::gracefulStop()
     {
         mProcessManager->shutdown();
     }
+    if (mBucketManager)
+    {
+        mBucketManager->shutdown();
+    }
 
     mStoppingTimer.expires_from_now(
         std::chrono::seconds(SHUTDOWN_DELAY_SECONDS));

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -4,6 +4,7 @@
 #include "util/asio.h"
 #include "StellarCoreVersion.h"
 #include "bucket/Bucket.h"
+#include "bucket/BucketManager.h"
 #include "catchup/CatchupConfiguration.h"
 #include "catchup/CatchupManager.h"
 #include "catchup/CatchupWork.h"


### PR DESCRIPTION
Fixes #1342
Also probably fixes some other issues where people were reporting missing buckets at starts, and these were not buckets from any snapshot (as they were not present in history archives).

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>