### PR TITLE
make nomination a little more strict on validation

### DIFF
--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -110,8 +110,16 @@ NominationProtocol::isSane(SCPStatement const& st)
     auto const& nom = st.pledges.nominate();
     bool res = (nom.votes.size() + nom.accepted.size()) != 0;
 
-    res = res && std::is_sorted(nom.votes.begin(), nom.votes.end());
-    res = res && std::is_sorted(nom.accepted.begin(), nom.accepted.end());
+    res = res && (std::adjacent_find(
+                      nom.votes.begin(), nom.votes.end(),
+                      [](stellar::Value const& l, stellar::Value const& r) {
+                          return !(l < r);
+                      }) == nom.votes.end());
+    res = res && (std::adjacent_find(
+                      nom.accepted.begin(), nom.accepted.end(),
+                      [](stellar::Value const& l, stellar::Value const& r) {
+                          return !(l < r);
+                      }) == nom.accepted.end());
 
     return res;
 }


### PR DESCRIPTION
note: this has no downstream effect as we use sets to compute values.

I found this after doing an audit of how we use `std::is_sorted` in the code.