### PR TITLE
Catchup at retry fix

### DIFF
--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -198,11 +198,9 @@ CatchupWork::downloadBucketsHistoryArchiveState(uint32_t atCheckpoint)
                              "state for applying buckets at checkpoint "
                           << atCheckpoint;
 
-    uint64_t sleepSeconds =
-        mApp.getHistoryManager().nextCheckpointCatchupProbe(atCheckpoint);
     mGetBucketsHistoryArchiveStateWork = addWork<GetHistoryArchiveStateWork>(
         "get-buckets-history-archive-state", mApplyBucketsRemoteState,
-        atCheckpoint, std::chrono::seconds(sleepSeconds));
+        atCheckpoint, std::chrono::seconds(0));
 
     return true;
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -319,10 +319,8 @@ ApplicationImpl::start()
         mNtpSynchronizationChecker->start();
     }
 
-    while (!done)
-    {
-        mVirtualClock.crank(true);
-    }
+    while (!done && mVirtualClock.crank(true))
+        ;
 }
 
 void

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -251,7 +251,7 @@ checkInitialized(Application::pointer app)
 static void
 catchup(Config const& cfg, uint32_t to, uint32_t count)
 {
-    VirtualClock clock;
+    VirtualClock clock(VirtualClock::REAL_TIME);
     Application::pointer app = Application::create(clock, cfg, false);
 
     if (checkInitialized(app))

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -268,10 +268,8 @@ catchup(Config const& cfg, uint32_t to, uint32_t count)
 
                 done = true;
             });
-        while (!done)
-        {
-            clock.crank(true);
-        }
+        while (!done && clock.crank(true))
+            ;
 
         try
         {


### PR DESCRIPTION
Fixes #1343 and:

1. ctrl+c not working in some cases
2. wait times for work retry during commandline catchup was 0
3. initial wait time for HistoryArchiveState was not needed for second GetHistoryArchiveStateWork in CatchupWork