### PR TITLE
Test debug improvements

### DIFF
--- a/src/test/TestAccount.h
+++ b/src/test/TestAccount.h
@@ -28,6 +28,7 @@ class TestAccount
     explicit TestAccount(Application& app, SecretKey sk, SequenceNumber sn = 0)
         : mApp(app), mSk{std::move(sk)}, mSn{sn}
     {
+        mAccountID = KeyUtils::toStrKey(mSk.getPublicKey());
     }
 
     TransactionFramePtr tx(std::vector<Operation> const& ops,
@@ -90,7 +91,7 @@ class TestAccount
     PublicKey
     getPublicKey() const
     {
-        return getSecretKey().getPublicKey();
+        return mSk.getPublicKey();
     }
 
     void
@@ -119,6 +120,7 @@ class TestAccount
   private:
     Application& mApp;
     SecretKey mSk;
+    std::string mAccountID;
     SequenceNumber mSn;
 
     void updateSequenceNumber();

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -5,6 +5,7 @@
 #include "TxTests.h"
 
 #include "crypto/ByteSlice.h"
+#include "database/Database.h"
 #include "invariant/InvariantManager.h"
 #include "ledger/DataFrame.h"
 #include "ledger/LedgerDelta.h"
@@ -42,6 +43,8 @@ namespace txtest
 bool
 applyCheck(TransactionFramePtr tx, Application& app)
 {
+    app.getDatabase().clearPreparedStatementCache();
+
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
 


### PR DESCRIPTION
First commit adds a new field to tests accounts so that it's easy to map a test account's `StrKey` representation (used in sql and logs) with the binary public key used in most of the code.

Second commit ensures that we cleanup the sql cache - this unlocks the database, which allows to perform writes into the database from outside of the process (sqlite) without getting a "database is locked" error message (which happens when attempting to modify it as the cache creates an implicit transaction).