### PR TITLE
re-introduced check in scp for well formed quorum set

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -638,7 +638,7 @@ exit /b 0
     <ClInclude Include="..\..\src\simulation\LoadGenerator.h" />
     <ClInclude Include="..\..\src\simulation\Simulation.h" />
     <ClInclude Include="..\..\src\simulation\Topologies.h" />
-    <ClInclude Include="..\..\src\test\DotReporter.h" />
+    <ClInclude Include="..\..\src\test\SimpleTestReporter.h" />
     <ClInclude Include="..\..\src\test\test.h" />
     <ClInclude Include="..\..\src\test\TestAccount.h" />
     <ClInclude Include="..\..\src\test\TestExceptions.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1250,9 +1250,6 @@
     <ClInclude Include="..\..\src\ledger\SyncingLedgerChain.h">
       <Filter>ledger</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\test\DotReporter.h">
-      <Filter>test</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\test\TestMarket.h">
       <Filter>test</Filter>
     </ClInclude>
@@ -1381,6 +1378,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\herder\HerderSCPDriver.h">
       <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\test\SimpleTestReporter.h">
+      <Filter>test</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -249,7 +249,13 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope, bool self)
 bool
 BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
-    auto res = true;
+
+    bool res = isQuorumSetSane(*mSlot.getQuorumSetFromStatement(st), false);
+    if (!res)
+    {
+        CLOG(DEBUG, "SCP") << "Invalid quorum set received";
+        return false;
+    }
 
     switch (st.pledges.type())
     {

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -222,7 +222,7 @@ class BallotProtocol
                                  SCPStatement const& st);
 
     // basic sanity check on statement
-    static bool isStatementSane(SCPStatement const& st, bool self);
+    bool isStatementSane(SCPStatement const& st, bool self);
 
     // records the statement in the state machine
     void recordEnvelope(SCPEnvelope const& env);

--- a/src/test/SimpleTestReporter.h
+++ b/src/test/SimpleTestReporter.h
@@ -18,7 +18,7 @@ struct SimpleTestReporter : public ConsoleReporter
     static std::string
     getDescription()
     {
-        return "Reports each assertion as a dot";
+        return "Reports minimal information on tests";
     }
 
     ReporterPreferences
@@ -30,9 +30,9 @@ struct SimpleTestReporter : public ConsoleReporter
     }
 
     void
-    noMatchingTestCases(std::string const& spec) override
+    testCaseStarting(TestCaseInfo const& ti) override
     {
-        stream << "No test cases matched '" << spec << "'" << std::endl;
+        stream << "\"" << ti.name << "\" " << ti.lineInfo << std::endl;
     }
 
     void
@@ -56,6 +56,7 @@ struct SimpleTestReporter : public ConsoleReporter
     void
     testCaseEnded(TestCaseStats const&) override
     {
+        stream << "<done>";
         printNewLine();
     }
 
@@ -69,7 +70,7 @@ struct SimpleTestReporter : public ConsoleReporter
     {
         stream << '.';
         mDots++;
-        if (mDots == 40)
+        if (mDots == 10)
         {
             printNewLine();
         }

--- a/src/test/SimpleTestReporter.h
+++ b/src/test/SimpleTestReporter.h
@@ -7,13 +7,13 @@
 namespace Catch
 {
 
-struct DotReporter : public ConsoleReporter
+struct SimpleTestReporter : public ConsoleReporter
 {
-    DotReporter(ReporterConfig const& _config) : ConsoleReporter(_config)
+    SimpleTestReporter(ReporterConfig const& _config) : ConsoleReporter(_config)
     {
     }
 
-    ~DotReporter();
+    ~SimpleTestReporter();
 
     static std::string
     getDescription()
@@ -83,5 +83,5 @@ struct DotReporter : public ConsoleReporter
     }
 };
 
-INTERNAL_CATCH_REGISTER_REPORTER("dot", DotReporter)
+INTERNAL_CATCH_REGISTER_REPORTER("simple", SimpleTestReporter)
 }

--- a/src/test/selftest-nopg
+++ b/src/test/selftest-nopg
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec ./stellar-core -ll fatal --test -a -r dot
+exec ./stellar-core -ll fatal --test -a -r simple

--- a/src/test/selftest-pg
+++ b/src/test/selftest-pg
@@ -78,7 +78,7 @@ if test "$#" = 0; then
 	echo "Disabling PostgreSQL in most tests"
 	export STELLAR_FORCE_SQLITE=1
     fi
-    ./stellar-core -ll fatal --test -a -r dot
+    ./stellar-core -ll fatal --test -a -r simple
 else
     # You can run "./test-pg bash" to get a shell with postgreSQL set up
     setup_test

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -27,12 +27,12 @@
 #include <sys/stat.h>
 #endif
 
-#include "test/DotReporter.h"
+#include "test/SimpleTestReporter.h"
 
 namespace Catch
 {
 
-DotReporter::~DotReporter()
+SimpleTestReporter::~SimpleTestReporter()
 {
 }
 }

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -63,6 +63,6 @@ echo "committer = $committer, config_flags = $config_flags"
 ccache -s
 ./autogen.sh
 ./configure $config_flags
-make
+make -j3
 ccache -s
 make check


### PR DESCRIPTION
check must be included in scp library in order to keep it as much as possible standalone
this was removed by accident in 033ab7abbd789c4b2d942e7ef2b868d62c2478be 