### PR TITLE
fixed intermittent crash on Windows (object lifetime issue)

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -54,6 +54,7 @@ ApplyBucketsWork::ApplyBucketsWork(
 
 ApplyBucketsWork::~ApplyBucketsWork()
 {
+    clearChildren();
 }
 
 BucketList&

--- a/src/catchup/ApplyLedgerChainWork.cpp
+++ b/src/catchup/ApplyLedgerChainWork.cpp
@@ -46,6 +46,11 @@ ApplyLedgerChainWork::ApplyLedgerChainWork(
 {
 }
 
+ApplyLedgerChainWork::~ApplyLedgerChainWork()
+{
+    clearChildren();
+}
+
 std::string
 ApplyLedgerChainWork::getStatus() const
 {

--- a/src/catchup/ApplyLedgerChainWork.h
+++ b/src/catchup/ApplyLedgerChainWork.h
@@ -69,6 +69,7 @@ class ApplyLedgerChainWork : public Work
     ApplyLedgerChainWork(Application& app, WorkParent& parent,
                          TmpDir const& downloadDir, LedgerRange range,
                          LedgerHeaderHistoryEntry& lastApplied);
+    ~ApplyLedgerChainWork();
     std::string getStatus() const override;
     void onReset() override;
     void onStart() override;

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -37,6 +37,11 @@ CatchupWork::CatchupWork(Application& app, WorkParent& parent,
 {
 }
 
+CatchupWork::~CatchupWork()
+{
+    clearChildren();
+}
+
 std::string
 CatchupWork::getStatus() const
 {

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -105,6 +105,8 @@ class CatchupWork : public BucketDownloadWork
     State onSuccess() override;
     void onFailureRaise() override;
 
+    ~CatchupWork();
+
   private:
     HistoryArchiveState mRemoteState;
     HistoryArchiveState mApplyBucketsRemoteState;

--- a/src/catchup/DownloadBucketsWork.cpp
+++ b/src/catchup/DownloadBucketsWork.cpp
@@ -30,6 +30,11 @@ DownloadBucketsWork::DownloadBucketsWork(
 {
 }
 
+DownloadBucketsWork::~DownloadBucketsWork()
+{
+    clearChildren();
+}
+
 std::string
 DownloadBucketsWork::getStatus() const
 {

--- a/src/catchup/DownloadBucketsWork.h
+++ b/src/catchup/DownloadBucketsWork.h
@@ -32,6 +32,7 @@ class DownloadBucketsWork : public Work
                         std::map<std::string, std::shared_ptr<Bucket>>& buckets,
                         std::vector<std::string> hashes,
                         TmpDir const& downloadDir);
+    ~DownloadBucketsWork();
     std::string getStatus() const override;
     void onReset() override;
     void notify(std::string const& child) override;

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -79,6 +79,11 @@ VerifyLedgerChainWork::VerifyLedgerChainWork(
 {
 }
 
+VerifyLedgerChainWork::~VerifyLedgerChainWork()
+{
+    clearChildren();
+}
+
 std::string
 VerifyLedgerChainWork::getStatus() const
 {

--- a/src/catchup/VerifyLedgerChainWork.h
+++ b/src/catchup/VerifyLedgerChainWork.h
@@ -44,6 +44,7 @@ class VerifyLedgerChainWork : public Work
                           bool verifyWithBufferedLedgers,
                           LedgerHeaderHistoryEntry& firstVerified,
                           LedgerHeaderHistoryEntry& lastVerified);
+    ~VerifyLedgerChainWork();
     std::string getStatus() const override;
     void onReset() override;
     Work::State onSuccess() override;

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -36,6 +36,11 @@ BatchDownloadWork::BatchDownloadWork(Application& app, WorkParent& parent,
 {
 }
 
+BatchDownloadWork::~BatchDownloadWork()
+{
+    clearChildren();
+}
+
 std::string
 BatchDownloadWork::getStatus() const
 {

--- a/src/historywork/BatchDownloadWork.h
+++ b/src/historywork/BatchDownloadWork.h
@@ -45,6 +45,7 @@ class BatchDownloadWork : public Work
     BatchDownloadWork(Application& app, WorkParent& parent,
                       CheckpointRange range, std::string const& type,
                       TmpDir const& downloadDir);
+    ~BatchDownloadWork();
     std::string getStatus() const override;
     void onReset() override;
     void notify(std::string const& child) override;

--- a/src/historywork/BucketDownloadWork.cpp
+++ b/src/historywork/BucketDownloadWork.cpp
@@ -23,6 +23,7 @@ BucketDownloadWork::BucketDownloadWork(Application& app, WorkParent& parent,
 
 BucketDownloadWork::~BucketDownloadWork()
 {
+    clearChildren();
 }
 
 void

--- a/src/historywork/FetchRecentQsetsWork.cpp
+++ b/src/historywork/FetchRecentQsetsWork.cpp
@@ -24,6 +24,11 @@ FetchRecentQsetsWork::FetchRecentQsetsWork(Application& app, WorkParent& parent,
 {
 }
 
+FetchRecentQsetsWork::~FetchRecentQsetsWork()
+{
+    clearChildren();
+}
+
 void
 FetchRecentQsetsWork::onReset()
 {

--- a/src/historywork/FetchRecentQsetsWork.h
+++ b/src/historywork/FetchRecentQsetsWork.h
@@ -27,6 +27,7 @@ class FetchRecentQsetsWork : public Work
   public:
     FetchRecentQsetsWork(Application& app, WorkParent& parent,
                          InferredQuorum& iq, handler endHandler);
+    ~FetchRecentQsetsWork();
     void onReset() override;
     void onFailureRaise() override;
     Work::State onSuccess() override;

--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -22,6 +22,11 @@ GetAndUnzipRemoteFileWork::GetAndUnzipRemoteFileWork(
 {
 }
 
+GetAndUnzipRemoteFileWork::~GetAndUnzipRemoteFileWork()
+{
+    clearChildren();
+}
+
 std::string
 GetAndUnzipRemoteFileWork::getStatus() const
 {

--- a/src/historywork/GetAndUnzipRemoteFileWork.h
+++ b/src/historywork/GetAndUnzipRemoteFileWork.h
@@ -29,6 +29,7 @@ class GetAndUnzipRemoteFileWork : public Work
         Application& app, WorkParent& parent, FileTransferInfo ft,
         std::shared_ptr<HistoryArchive const> archive = nullptr,
         size_t maxRetries = Work::RETRY_A_LOT);
+    ~GetAndUnzipRemoteFileWork();
     std::string getStatus() const override;
     void onReset() override;
     Work::State onSuccess() override;

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -38,6 +38,11 @@ GetHistoryArchiveStateWork::GetHistoryArchiveStateWork(
 {
 }
 
+GetHistoryArchiveStateWork::~GetHistoryArchiveStateWork()
+{
+    clearChildren();
+}
+
 std::string
 GetHistoryArchiveStateWork::getStatus() const
 {

--- a/src/historywork/GetHistoryArchiveStateWork.h
+++ b/src/historywork/GetHistoryArchiveStateWork.h
@@ -36,6 +36,7 @@ class GetHistoryArchiveStateWork : public Work
         VirtualClock::duration const& intitialDelay = std::chrono::seconds(0),
         std::shared_ptr<HistoryArchive const> archive = nullptr,
         size_t maxRetries = Work::RETRY_A_FEW);
+    ~GetHistoryArchiveStateWork();
     std::string getStatus() const override;
     VirtualClock::duration getRetryDelay() const override;
     void onReset() override;

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -22,6 +22,11 @@ GetRemoteFileWork::GetRemoteFileWork(
 {
 }
 
+GetRemoteFileWork::~GetRemoteFileWork()
+{
+    clearChildren();
+}
+
 void
 GetRemoteFileWork::getCommand(std::string& cmdLine, std::string& outFile)
 {

--- a/src/historywork/GetRemoteFileWork.h
+++ b/src/historywork/GetRemoteFileWork.h
@@ -26,6 +26,7 @@ class GetRemoteFileWork : public RunCommandWork
                       std::string const& remote, std::string const& local,
                       std::shared_ptr<HistoryArchive const> archive = nullptr,
                       size_t maxRetries = Work::RETRY_A_LOT);
+    ~GetRemoteFileWork();
     void onReset() override;
 };
 }

--- a/src/historywork/GunzipFileWork.cpp
+++ b/src/historywork/GunzipFileWork.cpp
@@ -19,6 +19,11 @@ GunzipFileWork::GunzipFileWork(Application& app, WorkParent& parent,
     fs::checkGzipSuffix(mFilenameGz);
 }
 
+GunzipFileWork::~GunzipFileWork()
+{
+    clearChildren();
+}
+
 void
 GunzipFileWork::getCommand(std::string& cmdLine, std::string& outFile)
 {

--- a/src/historywork/GunzipFileWork.h
+++ b/src/historywork/GunzipFileWork.h
@@ -19,6 +19,7 @@ class GunzipFileWork : public RunCommandWork
     GunzipFileWork(Application& app, WorkParent& parent,
                    std::string const& filenameGz, bool keepExisting = false,
                    size_t maxRetries = Work::RETRY_NEVER);
+    ~GunzipFileWork();
     void onReset() override;
 };
 }

--- a/src/historywork/GzipFileWork.cpp
+++ b/src/historywork/GzipFileWork.cpp
@@ -17,6 +17,11 @@ GzipFileWork::GzipFileWork(Application& app, WorkParent& parent,
     fs::checkNoGzipSuffix(mFilenameNoGz);
 }
 
+GzipFileWork::~GzipFileWork()
+{
+    clearChildren();
+}
+
 void
 GzipFileWork::onReset()
 {

--- a/src/historywork/GzipFileWork.h
+++ b/src/historywork/GzipFileWork.h
@@ -18,6 +18,7 @@ class GzipFileWork : public RunCommandWork
   public:
     GzipFileWork(Application& app, WorkParent& parent,
                  std::string const& filenameNoGz, bool keepExisting = false);
+    ~GzipFileWork();
     void onReset() override;
 };
 }

--- a/src/historywork/MakeRemoteDirWork.cpp
+++ b/src/historywork/MakeRemoteDirWork.cpp
@@ -18,6 +18,11 @@ MakeRemoteDirWork::MakeRemoteDirWork(
     assert(mArchive);
 }
 
+MakeRemoteDirWork::~MakeRemoteDirWork()
+{
+    clearChildren();
+}
+
 void
 MakeRemoteDirWork::getCommand(std::string& cmdLine, std::string& outFile)
 {

--- a/src/historywork/MakeRemoteDirWork.h
+++ b/src/historywork/MakeRemoteDirWork.h
@@ -21,5 +21,6 @@ class MakeRemoteDirWork : public RunCommandWork
     MakeRemoteDirWork(Application& app, WorkParent& parent,
                       std::string const& dir,
                       std::shared_ptr<HistoryArchive const> archive);
+    ~MakeRemoteDirWork();
 };
 }

--- a/src/historywork/PublishWork.cpp
+++ b/src/historywork/PublishWork.cpp
@@ -24,6 +24,11 @@ PublishWork::PublishWork(Application& app, WorkParent& parent,
 {
 }
 
+PublishWork::~PublishWork()
+{
+    clearChildren();
+}
+
 std::string
 PublishWork::getStatus() const
 {

--- a/src/historywork/PublishWork.h
+++ b/src/historywork/PublishWork.h
@@ -23,6 +23,7 @@ class PublishWork : public Work
   public:
     PublishWork(Application& app, WorkParent& parent,
                 std::shared_ptr<StateSnapshot> snapshot);
+    ~PublishWork();
     std::string getStatus() const override;
     void onReset() override;
     void onFailureRaise() override;

--- a/src/historywork/PutHistoryArchiveStateWork.cpp
+++ b/src/historywork/PutHistoryArchiveStateWork.cpp
@@ -21,6 +21,11 @@ PutHistoryArchiveStateWork::PutHistoryArchiveStateWork(
 {
 }
 
+PutHistoryArchiveStateWork::~PutHistoryArchiveStateWork()
+{
+    clearChildren();
+}
+
 void
 PutHistoryArchiveStateWork::onReset()
 {

--- a/src/historywork/PutHistoryArchiveStateWork.h
+++ b/src/historywork/PutHistoryArchiveStateWork.h
@@ -23,6 +23,7 @@ class PutHistoryArchiveStateWork : public Work
     PutHistoryArchiveStateWork(Application& app, WorkParent& parent,
                                HistoryArchiveState const& state,
                                std::shared_ptr<HistoryArchive const> archive);
+    ~PutHistoryArchiveStateWork();
     void onReset() override;
     void onRun() override;
     Work::State onSuccess() override;

--- a/src/historywork/PutRemoteFileWork.cpp
+++ b/src/historywork/PutRemoteFileWork.cpp
@@ -20,6 +20,11 @@ PutRemoteFileWork::PutRemoteFileWork(
     assert(mArchive->hasPutCmd());
 }
 
+PutRemoteFileWork::~PutRemoteFileWork()
+{
+    clearChildren();
+}
+
 void
 PutRemoteFileWork::getCommand(std::string& cmdLine, std::string& outFile)
 {

--- a/src/historywork/PutRemoteFileWork.h
+++ b/src/historywork/PutRemoteFileWork.h
@@ -22,5 +22,6 @@ class PutRemoteFileWork : public RunCommandWork
     PutRemoteFileWork(Application& app, WorkParent& parent,
                       std::string const& remote, std::string const& local,
                       std::shared_ptr<HistoryArchive const> archive);
+    ~PutRemoteFileWork();
 };
 }

--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -26,6 +26,11 @@ PutSnapshotFilesWork::PutSnapshotFilesWork(
 {
 }
 
+PutSnapshotFilesWork::~PutSnapshotFilesWork()
+{
+    clearChildren();
+}
+
 void
 PutSnapshotFilesWork::onReset()
 {

--- a/src/historywork/PutSnapshotFilesWork.h
+++ b/src/historywork/PutSnapshotFilesWork.h
@@ -26,6 +26,7 @@ class PutSnapshotFilesWork : public Work
     PutSnapshotFilesWork(Application& app, WorkParent& parent,
                          std::shared_ptr<HistoryArchive const> archive,
                          std::shared_ptr<StateSnapshot> snapshot);
+    ~PutSnapshotFilesWork();
     void onReset() override;
     Work::State onSuccess() override;
 };

--- a/src/historywork/RepairMissingBucketsWork.cpp
+++ b/src/historywork/RepairMissingBucketsWork.cpp
@@ -21,6 +21,11 @@ RepairMissingBucketsWork::RepairMissingBucketsWork(
 {
 }
 
+RepairMissingBucketsWork::~RepairMissingBucketsWork()
+{
+    clearChildren();
+}
+
 void
 RepairMissingBucketsWork::onReset()
 {

--- a/src/historywork/RepairMissingBucketsWork.h
+++ b/src/historywork/RepairMissingBucketsWork.h
@@ -21,6 +21,7 @@ class RepairMissingBucketsWork : public BucketDownloadWork
     RepairMissingBucketsWork(Application& app, WorkParent& parent,
                              HistoryArchiveState const& localState,
                              handler endHandler);
+    ~RepairMissingBucketsWork();
     void onReset() override;
     void onFailureRaise() override;
     Work::State onSuccess() override;

--- a/src/historywork/ResolveSnapshotWork.cpp
+++ b/src/historywork/ResolveSnapshotWork.cpp
@@ -18,6 +18,11 @@ ResolveSnapshotWork::ResolveSnapshotWork(
 {
 }
 
+ResolveSnapshotWork::~ResolveSnapshotWork()
+{
+    clearChildren();
+}
+
 void
 ResolveSnapshotWork::onRun()
 {

--- a/src/historywork/ResolveSnapshotWork.h
+++ b/src/historywork/ResolveSnapshotWork.h
@@ -18,6 +18,7 @@ class ResolveSnapshotWork : public Work
   public:
     ResolveSnapshotWork(Application& app, WorkParent& parent,
                         std::shared_ptr<StateSnapshot> snapshot);
+    ~ResolveSnapshotWork();
     void onRun() override;
 };
 }

--- a/src/historywork/RunCommandWork.cpp
+++ b/src/historywork/RunCommandWork.cpp
@@ -15,6 +15,11 @@ RunCommandWork::RunCommandWork(Application& app, WorkParent& parent,
 {
 }
 
+RunCommandWork::~RunCommandWork()
+{
+    clearChildren();
+}
+
 void
 RunCommandWork::onStart()
 {

--- a/src/historywork/RunCommandWork.h
+++ b/src/historywork/RunCommandWork.h
@@ -23,6 +23,7 @@ class RunCommandWork : public Work
     RunCommandWork(Application& app, WorkParent& parent,
                    std::string const& uniqueName,
                    size_t maxRetries = Work::RETRY_A_FEW);
+    ~RunCommandWork();
     void onStart() override;
     void onRun() override;
 };

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -34,6 +34,11 @@ VerifyBucketWork::VerifyBucketWork(
     fs::checkNoGzipSuffix(mBucketFile);
 }
 
+VerifyBucketWork::~VerifyBucketWork()
+{
+    clearChildren();
+}
+
 void
 VerifyBucketWork::onStart()
 {

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -30,6 +30,7 @@ class VerifyBucketWork : public Work
     VerifyBucketWork(Application& app, WorkParent& parent,
                      std::map<std::string, std::shared_ptr<Bucket>>& buckets,
                      std::string const& bucketFile, uint256 const& hash);
+    ~VerifyBucketWork();
     void onRun() override;
     void onStart() override;
     Work::State onSuccess() override;

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -20,6 +20,11 @@ WriteSnapshotWork::WriteSnapshotWork(Application& app, WorkParent& parent,
 {
 }
 
+WriteSnapshotWork::~WriteSnapshotWork()
+{
+    clearChildren();
+}
+
 void
 WriteSnapshotWork::onStart()
 {

--- a/src/historywork/WriteSnapshotWork.h
+++ b/src/historywork/WriteSnapshotWork.h
@@ -18,6 +18,7 @@ class WriteSnapshotWork : public Work
   public:
     WriteSnapshotWork(Application& app, WorkParent& parent,
                       std::shared_ptr<StateSnapshot> snapshot);
+    ~WriteSnapshotWork();
     void onStart() override;
     void onRun() override;
 };

--- a/src/main/NtpSynchronizationChecker.cpp
+++ b/src/main/NtpSynchronizationChecker.cpp
@@ -27,6 +27,7 @@ NtpSynchronizationChecker::NtpSynchronizationChecker(Application& app,
 
 NtpSynchronizationChecker::~NtpSynchronizationChecker()
 {
+    clearChildren();
 }
 
 void

--- a/src/util/NtpWork.cpp
+++ b/src/util/NtpWork.cpp
@@ -25,6 +25,7 @@ NtpWork::NtpWork(Application& app, WorkParent& parent, std::string ntpServer,
 
 NtpWork::~NtpWork()
 {
+    clearChildren();
 }
 
 void

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -36,6 +36,7 @@ Work::Work(Application& app, WorkParent& parent, std::string uniqueName,
 
 Work::~Work()
 {
+    clearChildren();
 }
 
 std::string


### PR DESCRIPTION
resolves #1354

Problem was really that `*Work` instances were keeping other `Work`
references alive via the `WorkParent` class, which defeated the
deterministic (field declaration) order of the `*Work` class.

On Windows this would create situations where resource de-allocation of
file system related objects were racing against various destructors.

This change forces all references to children to be released so that the only references left to related Work items should be member variables.
