### PR TITLE
Catchup improvements 3

### DIFF
--- a/src/catchup/ApplyLedgerChainWork.cpp
+++ b/src/catchup/ApplyLedgerChainWork.cpp
@@ -25,7 +25,7 @@ ApplyLedgerChainWork::ApplyLedgerChainWork(
     , mDownloadDir(downloadDir)
     , mRange(range)
     , mCurrSeq(
-          mApp.getHistoryManager().nextCheckpointLedger(mRange.first() + 1) - 1)
+          mApp.getHistoryManager().checkpointContainingLedger(mRange.first()))
     , mLastApplied(lastApplied)
     , mApplyLedgerStart(app.getMetrics().NewMeter(
           {"history", "apply-ledger", "start"}, "event"))
@@ -74,7 +74,7 @@ ApplyLedgerChainWork::onReset()
                           << LedgerManager::ledgerAbbrev(
                                  lm.getLastClosedLedgerHeader());
     mCurrSeq =
-        mApp.getHistoryManager().nextCheckpointLedger(mRange.first() + 1) - 1;
+        mApp.getHistoryManager().checkpointContainingLedger(mRange.first());
     mHdrIn.close();
     mTxIn.close();
 }

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -179,7 +179,7 @@ CatchupWork::verifyLedgers(LedgerRange const& range)
         << "Catchup verifying ledger chain for checkpointRange ["
         << range.first() << ".." << range.last() << "]";
     mVerifyLedgersWork = addWork<VerifyLedgerChainWork>(
-        *mDownloadDir, range, !mManualCatchup, mFirstVerified, mLastVerified);
+        *mDownloadDir, range, mManualCatchup, mFirstVerified, mLastVerified);
 
     return true;
 }

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -376,13 +376,6 @@ CatchupWork::onFailureRaise()
 namespace
 {
 
-uint32_t
-checkpointContainingLedger(uint32_t ledger,
-                           HistoryManager const& historyManager)
-{
-    return historyManager.nextCheckpointLedger(ledger + 1) - 1;
-}
-
 // compute first checkpoint that is not 100% finished
 // if lastClosedLedger is not last ledger in checkpoint, then first not finished
 // checkpoint is checkpoint containing lastClosedLedger
@@ -392,7 +385,7 @@ uint32_t
 firstNotFinishedCheckpoint(uint32_t lastClosedLedger,
                            HistoryManager const& historyManager)
 {
-    auto result = checkpointContainingLedger(lastClosedLedger, historyManager);
+    auto result = historyManager.checkpointContainingLedger(lastClosedLedger);
     if (lastClosedLedger < result)
     {
         return result;
@@ -426,7 +419,7 @@ computeCatchupStart(uint32_t smallestLedgerToApply,
     // checkpoint that contains smallestLedgerToApply - it is first one than
     // can be applied, it is always greater than LCL
     auto smallestCheckpointToApply =
-        checkpointContainingLedger(smallestLedgerToApply, historyManager);
+        historyManager.checkpointContainingLedger(smallestLedgerToApply);
 
     // if first ledger that should be applied is on checkpoint boundary then
     // we do an bucket-apply

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -167,7 +167,7 @@ CatchupWork::downloadLedgers(CheckpointRange const& range)
 }
 
 bool
-CatchupWork::verifyLedgers(CheckpointRange const& range)
+CatchupWork::verifyLedgers(LedgerRange const& range)
 {
     if (mVerifyLedgersWork)
     {
@@ -306,7 +306,7 @@ CatchupWork::onSuccess()
         return WORK_PENDING;
     }
 
-    if (verifyLedgers(checkpointRange))
+    if (verifyLedgers(ledgerRange))
     {
         return WORK_PENDING;
     }

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -129,7 +129,7 @@ class CatchupWork : public BucketDownloadWork
 
     bool hasAnyLedgersToCatchupTo() const;
     bool downloadLedgers(CheckpointRange const& range);
-    bool verifyLedgers(CheckpointRange const& range);
+    bool verifyLedgers(LedgerRange const& range);
     bool alreadyHaveBucketsHistoryArchiveState(uint32_t atCheckpoint) const;
     bool downloadBucketsHistoryArchiveState(uint32_t atCheckpoint);
     bool downloadBuckets();

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -51,13 +51,13 @@ verifyLedgerHistoryLink(Hash const& prev, LedgerHeaderHistoryEntry const& curr)
 
 VerifyLedgerChainWork::VerifyLedgerChainWork(
     Application& app, WorkParent& parent, TmpDir const& downloadDir,
-    CheckpointRange range, bool verifyWithBufferedLedgers,
+    LedgerRange range, bool verifyWithBufferedLedgers,
     LedgerHeaderHistoryEntry& firstVerified,
     LedgerHeaderHistoryEntry& lastVerified)
     : Work(app, parent, "verify-ledger-chain")
     , mDownloadDir(downloadDir)
     , mRange(range)
-    , mCurrSeq(
+    , mCurrCheckpoint(
           mApp.getHistoryManager().checkpointContainingLedger(mRange.first()))
     , mVerifyWithBufferedLedgers(verifyWithBufferedLedgers)
     , mFirstVerified(firstVerified)
@@ -90,7 +90,8 @@ VerifyLedgerChainWork::getStatus() const
     if (mState == WORK_RUNNING)
     {
         std::string task = "verifying checkpoint";
-        return fmtProgress(mApp, task, mRange.first(), mRange.last(), mCurrSeq);
+        return fmtProgress(mApp, task, mRange.first(), mRange.last(),
+                           mCurrCheckpoint);
     }
     return Work::getStatus();
 }
@@ -111,14 +112,15 @@ VerifyLedgerChainWork::onReset()
     {
         mLastVerified = setLedger;
     }
-    mCurrSeq =
+    mCurrCheckpoint =
         mApp.getHistoryManager().checkpointContainingLedger(mRange.first());
 }
 
 HistoryManager::VerifyHashStatus
 VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
 {
-    FileTransferInfo ft(mDownloadDir, HISTORY_FILE_TYPE_LEDGER, mCurrSeq);
+    FileTransferInfo ft(mDownloadDir, HISTORY_FILE_TYPE_LEDGER,
+                        mCurrCheckpoint);
     XDRInputFileStream hdrIn;
     hdrIn.open(ft.localPath_nogz());
 
@@ -166,20 +168,28 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
         }
         mVerifyLedgerSuccess.Mark();
         prev = curr;
+
+        if (curr.header.ledgerSeq == mRange.last())
+        {
+            break;
+        }
     }
 
-    if (curr.header.ledgerSeq != mCurrSeq)
+    if (curr.header.ledgerSeq > mCurrCheckpoint)
     {
-        CLOG(ERROR, "History") << "History chain did not end with " << mCurrSeq;
+        // If we are here the we are either trying to open non-existing file or
+        // working on an invalid file that has more entries that it should.
+        CLOG(ERROR, "History") << "History chain did not end with "
+                               << mCurrCheckpoint;
         mVerifyLedgerChainFailureEnd.Mark();
         return HistoryManager::VERIFY_HASH_BAD;
     }
 
     auto status = HistoryManager::VERIFY_HASH_OK;
-    if (mCurrSeq == mRange.last())
+    if (curr.header.ledgerSeq == mRange.last())
     {
-        CLOG(INFO, "History") << "Verifying catchup candidate " << mCurrSeq
-                              << " with LedgerManager";
+        CLOG(INFO, "History") << "Verifying catchup candidate "
+                              << curr.header.ledgerSeq << " with LedgerManager";
         status = mApp.getLedgerManager().verifyCatchupCandidate(curr);
         if ((status == HistoryManager::VERIFY_HASH_UNKNOWN_RECOVERABLE ||
              status == HistoryManager::VERIFY_HASH_UNKNOWN_UNRECOVERABLE) &&
@@ -194,7 +204,8 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
     if (status == HistoryManager::VERIFY_HASH_OK)
     {
         mVerifyLedgerChainSuccess.Mark();
-        if (mCurrSeq == mRange.first())
+        if (mCurrCheckpoint ==
+            mApp.getHistoryManager().checkpointContainingLedger(mRange.first()))
         {
             mFirstVerified = curr;
         }
@@ -213,7 +224,8 @@ VerifyLedgerChainWork::onSuccess()
 {
     mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
 
-    if (mCurrSeq > mRange.last())
+    if (mCurrCheckpoint >
+        mApp.getHistoryManager().checkpointContainingLedger(mRange.last()))
     {
         throw std::runtime_error("Verification overshot target ledger");
     }
@@ -222,14 +234,14 @@ VerifyLedgerChainWork::onSuccess()
     switch (verifyHistoryOfSingleCheckpoint())
     {
     case HistoryManager::VERIFY_HASH_OK:
-        if (mCurrSeq == mRange.last())
+        if (mLastVerified.header.ledgerSeq == mRange.last())
         {
             CLOG(INFO, "History") << "History chain [" << mRange.first() << ","
                                   << mRange.last() << "] verified";
             return WORK_SUCCESS;
         }
 
-        mCurrSeq += mApp.getHistoryManager().getCheckpointFrequency();
+        mCurrCheckpoint += mApp.getHistoryManager().getCheckpointFrequency();
         return WORK_RUNNING;
     case HistoryManager::VERIFY_HASH_UNKNOWN_RECOVERABLE:
         CLOG(WARNING, "History")

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -58,7 +58,7 @@ VerifyLedgerChainWork::VerifyLedgerChainWork(
     , mDownloadDir(downloadDir)
     , mRange(range)
     , mCurrSeq(
-          mApp.getHistoryManager().nextCheckpointLedger(mRange.first() + 1) - 1)
+          mApp.getHistoryManager().checkpointContainingLedger(mRange.first()))
     , mVerifyWithBufferedLedgers(verifyWithBufferedLedgers)
     , mFirstVerified(firstVerified)
     , mLastVerified(lastVerified)
@@ -112,7 +112,7 @@ VerifyLedgerChainWork::onReset()
         mLastVerified = setLedger;
     }
     mCurrSeq =
-        mApp.getHistoryManager().nextCheckpointLedger(mRange.first() + 1) - 1;
+        mApp.getHistoryManager().checkpointContainingLedger(mRange.first());
 }
 
 HistoryManager::VerifyHashStatus

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -236,12 +236,7 @@ VerifyLedgerChainWork::onSuccess()
 
         mCurrCheckpoint += mApp.getHistoryManager().getCheckpointFrequency();
         return WORK_RUNNING;
-    case HistoryManager::VERIFY_HASH_UNKNOWN_RECOVERABLE:
-        CLOG(WARNING, "History")
-            << "Catchup material verification inconclusive, retrying";
-        return WORK_FAILURE_RETRY;
     case HistoryManager::VERIFY_HASH_BAD:
-    case HistoryManager::VERIFY_HASH_UNKNOWN_UNRECOVERABLE:
         CLOG(ERROR, "History")
             << "Catchup material failed verification, propagating failure";
         return WORK_FAILURE_FATAL;

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -175,12 +175,15 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
         }
     }
 
-    if (curr.header.ledgerSeq > mCurrCheckpoint)
+    if (curr.header.ledgerSeq != mCurrCheckpoint &&
+        curr.header.ledgerSeq != mRange.last())
     {
-        // If we are here the we are either trying to open non-existing file or
-        // working on an invalid file that has more entries that it should.
+        // We can end at mCurrCheckpoint if history chain file was valid
+        // Or we can end at mRange.last() if history chain file was valid and we
+        // reached last ledger that we should check.
+        // Any other ledger here means that file is corrupted.
         CLOG(ERROR, "History") << "History chain did not end with "
-                               << mCurrCheckpoint;
+                               << mCurrCheckpoint << " or " << mRange.last();
         mVerifyLedgerChainFailureEnd.Mark();
         return HistoryManager::VERIFY_HASH_BAD;
     }

--- a/src/catchup/VerifyLedgerChainWork.h
+++ b/src/catchup/VerifyLedgerChainWork.h
@@ -24,7 +24,7 @@ class VerifyLedgerChainWork : public Work
     TmpDir const& mDownloadDir;
     LedgerRange mRange;
     uint32_t mCurrCheckpoint;
-    bool mVerifyWithBufferedLedgers;
+    bool mManualCatchup;
     LedgerHeaderHistoryEntry& mFirstVerified;
     LedgerHeaderHistoryEntry& mLastVerified;
 
@@ -41,7 +41,7 @@ class VerifyLedgerChainWork : public Work
   public:
     VerifyLedgerChainWork(Application& app, WorkParent& parent,
                           TmpDir const& downloadDir, LedgerRange range,
-                          bool verifyWithBufferedLedgers,
+                          bool manualCatchup,
                           LedgerHeaderHistoryEntry& firstVerified,
                           LedgerHeaderHistoryEntry& lastVerified);
     ~VerifyLedgerChainWork();

--- a/src/catchup/VerifyLedgerChainWork.h
+++ b/src/catchup/VerifyLedgerChainWork.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "history/HistoryManager.h"
-#include "ledger/CheckpointRange.h"
+#include "ledger/LedgerRange.h"
 #include "work/Work.h"
 
 namespace medida
@@ -22,8 +22,8 @@ struct LedgerHeaderHistoryEntry;
 class VerifyLedgerChainWork : public Work
 {
     TmpDir const& mDownloadDir;
-    CheckpointRange mRange;
-    uint32_t mCurrSeq;
+    LedgerRange mRange;
+    uint32_t mCurrCheckpoint;
     bool mVerifyWithBufferedLedgers;
     LedgerHeaderHistoryEntry& mFirstVerified;
     LedgerHeaderHistoryEntry& mLastVerified;
@@ -40,7 +40,7 @@ class VerifyLedgerChainWork : public Work
 
   public:
     VerifyLedgerChainWork(Application& app, WorkParent& parent,
-                          TmpDir const& downloadDir, CheckpointRange range,
+                          TmpDir const& downloadDir, LedgerRange range,
                           bool verifyWithBufferedLedgers,
                           LedgerHeaderHistoryEntry& firstVerified,
                           LedgerHeaderHistoryEntry& lastVerified);

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -238,6 +238,11 @@ class HistoryManager
     // may be different (see ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING).
     virtual uint32_t getCheckpointFrequency() const = 0;
 
+    // Return checkpoint that contains given ledger. Checkpoint is identified
+    // by last ledger in range. This does not consult the network nor take
+    // account of manual checkpoints.
+    virtual uint32_t checkpointContainingLedger(uint32_t ledger) const = 0;
+
     // Given a "current ledger" (not LCL) for a node, return the "current
     // ledger" value at which the previous scheduled checkpoint should have
     // occurred, by rounding-down to the next multiple of checkpoint

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -186,34 +186,12 @@ class HistoryManager
   public:
     static const uint32_t GENESIS_LEDGER_SEQ;
 
-    // Status code returned from LedgerManager::verifyCatchupCandidate. The
-    // HistoryManager's catchup algorithm downloads _untrusted_ history from a
-    // configured history archive, then (once it has done internal consistency
-    // checking of the chain of history it downloaded) calls
-    // verifyCatchupCandidate to check the validity of a proposed target ledger
-    // against the running consensus of the SCP protocol, thus turning untrusted
-    // history into trusted history.
-    //
-    // LedgerManager will return VERIFY_HASH_OK if the proposed ledger is
-    // definitely part of the consensus history chain (i.e. the ledger hash
-    // matches the consensus for the provided ledger number); VERIFY_HASH_BAD if
-    // the proposed ledger is definitely _not_ valid (i.e. if it has a different
-    // hash than the consensus ledger with its number);
-    // VERIFY_HASH_UNKNOWN_RECOVERABLE if the network consensus has not
-    // yet advanced to the proposed catchup target and
-    // VERIFY_HASH_UNKNOWN_UNRECOVERABLE if proposed target ledger was not
-    // received from network and next ledgers were received (so the probability
-    // of receiving it is extremaly low).
-    //
-    // In the first case, catchup will proceed; in the second it will fail (and
-    // restart, possibly against a different untrusted history archive); in the
-    // third it will pause and retry the query after a timeout.
+    // Status code returned from LedgerManager::verifyCatchupCandidate. Look
+    // there for additional documentation.
     enum VerifyHashStatus
     {
         VERIFY_HASH_OK,
-        VERIFY_HASH_BAD,
-        VERIFY_HASH_UNKNOWN_RECOVERABLE,
-        VERIFY_HASH_UNKNOWN_UNRECOVERABLE
+        VERIFY_HASH_BAD
     };
 
     // Select any readable history archive. If there are more than one,

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -249,6 +249,12 @@ HistoryManagerImpl::getCheckpointFrequency() const
 }
 
 uint32_t
+HistoryManagerImpl::checkpointContainingLedger(uint32_t ledger) const
+{
+    return nextCheckpointLedger(ledger + 1) - 1;
+}
+
+uint32_t
 HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger) const
 {
     uint32_t freq = getCheckpointFrequency();

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -45,6 +45,7 @@ class HistoryManagerImpl : public HistoryManager
     selectRandomReadableHistoryArchive() override;
 
     uint32_t getCheckpointFrequency() const override;
+    uint32_t checkpointContainingLedger(uint32_t ledger) const override;
     uint32_t prevCheckpointLedger(uint32_t ledger) const override;
     uint32_t nextCheckpointLedger(uint32_t ledger) const override;
     uint64_t nextCheckpointCatchupProbe(uint32_t ledger) const override;

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -346,8 +346,8 @@ HistoryTests::generateAndPublishInitialHistory(size_t nPublishes)
     auto& lm = mApp.getLedgerManager();
 
     // At this point LCL should be 1, current ledger should be 2
-    assert(lm.getLastClosedLedgerHeader().header.ledgerSeq == 1);
-    assert(lm.getCurrentLedgerHeader().ledgerSeq == 2);
+    REQUIRE(lm.getLastClosedLedgerHeader().header.ledgerSeq == 1);
+    REQUIRE(lm.getCurrentLedgerHeader().ledgerSeq == 2);
 
     generateAndPublishHistory(nPublishes);
 }
@@ -651,7 +651,7 @@ HistoryTests::catchupApplication(uint32_t initLedger, uint32_t count,
     uint32_t lastLedger = lm.getLastClosedLedgerNum();
     auto catchupConfiguration = CatchupConfiguration(toLedger, count);
 
-    assert(!app2->getClock().getIOService().stopped());
+    REQUIRE(!app2->getClock().getIOService().stopped());
 
     while (!app2->getWorkManager().allChildrenDone())
     {
@@ -690,7 +690,7 @@ HistoryTests::catchupApplication(uint32_t initLedger, uint32_t count,
     //
     // So cumulatively: we want to probe local history slot i = nextLedger - 3.
 
-    assert(nextLedger != 0);
+    REQUIRE(nextLedger != 0);
     if (nextLedger >= 3)
     {
         size_t i = nextLedger - 3;
@@ -1063,23 +1063,18 @@ TEST_CASE_METHOD(HistoryTests, "Publish/catchup alternation, with stall",
     // by providing 30 cranks of the event loop and assuming that failure
     // to catch up within that time means 'stalled'.
 
-    bool caughtup = false;
     initLedger = lm.getLastClosedLedgerNum();
 
-    caughtup = catchupApplication(
-        initLedger, std::numeric_limits<uint32_t>::max(), false, app2);
-    CHECK(!caughtup);
-    caughtup = catchupApplication(initLedger, 0, false, app3);
-    CHECK(!caughtup);
+    REQUIRE(!catchupApplication(
+        initLedger, std::numeric_limits<uint32_t>::max(), false, app2));
+    REQUIRE(!catchupApplication(initLedger, 0, false, app3));
 
     // Now complete this publish cycle and confirm that the stalled apps
     // will catch up.
     generateAndPublishHistory(1);
-    caughtup = catchupApplication(
-        initLedger, std::numeric_limits<uint32_t>::max(), false, app2, false);
-    CHECK(caughtup);
-    caughtup = catchupApplication(initLedger, 0, false, app3, false);
-    CHECK(caughtup);
+    REQUIRE(catchupApplication(initLedger, std::numeric_limits<uint32_t>::max(),
+                               false, app2, false));
+    REQUIRE(catchupApplication(initLedger, 0, false, app3, false));
 }
 
 TEST_CASE_METHOD(HistoryTests, "Repair missing buckets via history",
@@ -1291,14 +1286,14 @@ TEST_CASE_METHOD(HistoryTests, "too far behind / catchup restart",
     // Now generate a little more history
     generateAndPublishHistory(1);
 
-    bool caughtup = false;
     auto init = app2->getLedgerManager().getLastClosedLedgerNum() + 2;
+    REQUIRE(init == 66);
 
     // Now start a catchup on that _fails_ due to a gap
     LOG(INFO) << "Starting BROKEN catchup (with gap) from " << init;
-    caughtup = catchupApplication(init, std::numeric_limits<uint32_t>::max(),
-                                  false, app2, true, init + 10);
-    assert(!caughtup);
+    REQUIRE(!catchupApplication(init, std::numeric_limits<uint32_t>::max(),
+                                false, app2, true, init + 10));
+    REQUIRE(app2->getLedgerManager().getLastClosedLedgerNum() == 64);
 
     app2->getWorkManager().clearChildren();
 
@@ -1307,9 +1302,9 @@ TEST_CASE_METHOD(HistoryTests, "too far behind / catchup restart",
 
     // And catchup successfully
     init = mApp.getLedgerManager().getLastClosedLedgerNum();
-    caughtup = catchupApplication(init, std::numeric_limits<uint32_t>::max(),
-                                  false, app2);
-    assert(caughtup);
+    REQUIRE(catchupApplication(init, std::numeric_limits<uint32_t>::max(),
+                               false, app2));
+    REQUIRE(app2->getLedgerManager().getLastClosedLedgerNum() == 192);
 }
 
 /*

--- a/src/ledger/CheckpointRange.cpp
+++ b/src/ledger/CheckpointRange.cpp
@@ -22,8 +22,8 @@ CheckpointRange::CheckpointRange(uint32_t first, uint32_t last,
 
 CheckpointRange::CheckpointRange(LedgerRange const& ledgerRange,
                                  HistoryManager const& historyManager)
-    : mFirst{historyManager.nextCheckpointLedger(ledgerRange.first() + 1) - 1}
-    , mLast{historyManager.nextCheckpointLedger(ledgerRange.last() + 1) - 1}
+    : mFirst{historyManager.checkpointContainingLedger(ledgerRange.first())}
+    , mLast{historyManager.checkpointContainingLedger(ledgerRange.last())}
     , mFrequency{historyManager.getCheckpointFrequency()}
 {
     assert(mFirst > 0);

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -154,8 +154,12 @@ class LedgerManager
     // sequence number but _different_ hash; and VERIFY_HASH_UNKNOWN if no
     // ledger has been received from SCP yet with the proposed ledger sequence
     // number.
+    //
+    // If manualCatchup is true it returns VERIFY_HASH_OK instead of
+    // VERIFY_HASH_UNKNOWN.
     virtual HistoryManager::VerifyHashStatus
-    verifyCatchupCandidate(LedgerHeaderHistoryEntry const&) const = 0;
+    verifyCatchupCandidate(LedgerHeaderHistoryEntry const&,
+                           bool manualCatchup) const = 0;
 
     // Forcibly close the current ledger, applying `ledgerData` as the consensus
     // changes.  This is normally done automatically as part of

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -145,20 +145,21 @@ class LedgerManager
 
     // Called by the history subsystem during catchup: this method asks the
     // LedgerManager whether or not the HistoryManager should trust (thus: begin
-    // applying history that terminates in) a candidate LCL.
+    // applying history that terminates in) a candidate LCL. Trust is based on
+    // local buffer in which LedgerManager accumulates SCP consensus results
+    // during catchup
     //
-    // The LedgerManager consults a local buffer in which it accumulates SCP
-    // consensus results during catchup, and returns VERIFY_HASH_OK if the
-    // proposed ledger is a (trusted) member of that consensus buffer;
-    // VERIFY_HASH_BAD if a buffered consensus ledger exists with the same
-    // sequence number but _different_ hash; and VERIFY_HASH_UNKNOWN if no
-    // ledger has been received from SCP yet with the proposed ledger sequence
-    // number.
+    // If catchup is manual then that buffer is empty, and VERIFY_HASH_OK is
+    // returned.
     //
-    // If manualCatchup is true it returns VERIFY_HASH_OK instead of
-    // VERIFY_HASH_UNKNOWN.
+    // Otherwise LedgerManager returns VERIFY_HASH_OK if the proposed ledger is
+    // a first member of that buffer (and has matching hash). VERIFY_HASH_BAD
+    // is returned otherwise.
+    //
+    // If first member of consensus buffer has different sequnce than candidate
+    // then we have error in code and stellar-core is aborted.
     virtual HistoryManager::VerifyHashStatus
-    verifyCatchupCandidate(LedgerHeaderHistoryEntry const&,
+    verifyCatchupCandidate(LedgerHeaderHistoryEntry const& candidate,
                            bool manualCatchup) const = 0;
 
     // Forcibly close the current ledger, applying `ledgerData` as the consensus

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -472,7 +472,7 @@ LedgerManagerImpl::startCatchUp(CatchupConfiguration configuration,
 
 HistoryManager::VerifyHashStatus
 LedgerManagerImpl::verifyCatchupCandidate(
-    LedgerHeaderHistoryEntry const& candidate) const
+    LedgerHeaderHistoryEntry const& candidate, bool manualCatchup) const
 {
     // This is a callback from CatchupStateMachine when it's considering whether
     // to treat a retrieved history block as legitimate. It asks
@@ -512,6 +512,12 @@ LedgerManagerImpl::verifyCatchupCandidate(
                      });
     if (matchingSequenceId == std::end(infos))
     {
+        if (manualCatchup)
+        {
+            CLOG(WARNING, "History")
+                << "Accepting unknown-hash ledger due to manual catchup";
+            return HistoryManager::VERIFY_HASH_OK;
+        }
         if (mSyncingLedgers.hadTooNew())
         {
             return HistoryManager::VERIFY_HASH_UNKNOWN_UNRECOVERABLE;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -474,6 +474,17 @@ HistoryManager::VerifyHashStatus
 LedgerManagerImpl::verifyCatchupCandidate(
     LedgerHeaderHistoryEntry const& candidate, bool manualCatchup) const
 {
+    if (manualCatchup)
+    {
+        assert(mSyncingLedgers.empty());
+    }
+    else
+    {
+        assert(!mSyncingLedgers.empty());
+        assert(mSyncingLedgers.front().getLedgerSeq() + 1 ==
+               candidate.header.ledgerSeq);
+    }
+
     // This is a callback from CatchupStateMachine when it's considering whether
     // to treat a retrieved history block as legitimate. It asks
     // LedgerManagerImpl

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -103,7 +103,8 @@ class LedgerManagerImpl : public LedgerManager
                       bool manualCatchup) override;
 
     HistoryManager::VerifyHashStatus
-    verifyCatchupCandidate(LedgerHeaderHistoryEntry const&) const override;
+    verifyCatchupCandidate(LedgerHeaderHistoryEntry const&,
+                           bool manualCatchup) const override;
     void closeLedger(LedgerCloseData const& ledgerData) override;
     void deleteOldEntries(Database& db, uint32_t ledgerSeq) override;
     void checkDbState() override;

--- a/src/ledger/SyncingLedgerChain.cpp
+++ b/src/ledger/SyncingLedgerChain.cpp
@@ -27,14 +27,7 @@ SyncingLedgerChain::add(LedgerCloseData lcd)
         return SyncingLedgerChainAddResult::TOO_OLD;
     }
 
-    mHadTooNew = true;
     return SyncingLedgerChainAddResult::TOO_NEW;
-}
-
-bool
-SyncingLedgerChain::hadTooNew() const
-{
-    return mHadTooNew;
 }
 
 LedgerCloseData const&

--- a/src/ledger/SyncingLedgerChain.cpp
+++ b/src/ledger/SyncingLedgerChain.cpp
@@ -38,9 +38,21 @@ SyncingLedgerChain::hadTooNew() const
 }
 
 LedgerCloseData const&
+SyncingLedgerChain::front() const
+{
+    return mChain.front();
+}
+
+LedgerCloseData const&
 SyncingLedgerChain::back() const
 {
     return mChain.back();
+}
+
+bool
+SyncingLedgerChain::empty() const
+{
+    return mChain.empty();
 }
 
 SyncingLedgerChain::size_type

--- a/src/ledger/SyncingLedgerChain.h
+++ b/src/ledger/SyncingLedgerChain.h
@@ -30,7 +30,6 @@ class SyncingLedgerChain final
     ~SyncingLedgerChain();
 
     SyncingLedgerChainAddResult add(LedgerCloseData lcd);
-    bool hadTooNew() const;
 
     LedgerCloseData const& front() const;
     LedgerCloseData const& back() const;
@@ -41,6 +40,5 @@ class SyncingLedgerChain final
 
   private:
     storage mChain;
-    bool mHadTooNew{false};
 };
 }

--- a/src/ledger/SyncingLedgerChain.h
+++ b/src/ledger/SyncingLedgerChain.h
@@ -32,7 +32,9 @@ class SyncingLedgerChain final
     SyncingLedgerChainAddResult add(LedgerCloseData lcd);
     bool hadTooNew() const;
 
+    LedgerCloseData const& front() const;
     LedgerCloseData const& back() const;
+    bool empty() const;
     size_type size() const;
     const_iterator begin() const;
     const_iterator end() const;

--- a/src/ledger/SyncingLedgerChainTests.cpp
+++ b/src/ledger/SyncingLedgerChainTests.cpp
@@ -2,9 +2,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "ledger/SyncingLedgerChain.h"
 #include "crypto/SHA.h"
 #include "herder/LedgerCloseData.h"
-#include "ledger/SyncingLedgerChain.h"
 #include "lib/catch.hpp"
 
 #include <memory>
@@ -24,13 +24,6 @@ makeLedgerCloseData(uint32_t ledgerSeq)
 }
 }
 
-TEST_CASE("empty syncing ledger had not 'TOO_NEW'", "[ledger][ledgerchain]")
-{
-    auto ledgerChain = SyncingLedgerChain{};
-    REQUIRE(ledgerChain.size() == 0);
-    REQUIRE(!ledgerChain.hadTooNew());
-}
-
 TEST_CASE("empty syncing ledger chain accepts anything",
           "[ledger][ledgerchain]")
 {
@@ -38,7 +31,6 @@ TEST_CASE("empty syncing ledger chain accepts anything",
     REQUIRE(ledgerChain.add(makeLedgerCloseData(1)) ==
             SyncingLedgerChainAddResult::CONTIGUOUS);
     REQUIRE(ledgerChain.size() == 1);
-    REQUIRE(!ledgerChain.hadTooNew());
     REQUIRE(ledgerChain.back().getLedgerSeq() == 1);
 }
 
@@ -50,7 +42,6 @@ TEST_CASE("not empty syncing ledger chain accepts next ledger",
     REQUIRE(ledgerChain.add(makeLedgerCloseData(2)) ==
             SyncingLedgerChainAddResult::CONTIGUOUS);
     REQUIRE(ledgerChain.size() == 2);
-    REQUIRE(!ledgerChain.hadTooNew());
     REQUIRE(ledgerChain.back().getLedgerSeq() == 2);
 }
 
@@ -62,7 +53,6 @@ TEST_CASE("not empty syncing ledger chain do not accept after-next ledger",
     REQUIRE(ledgerChain.add(makeLedgerCloseData(3)) ==
             SyncingLedgerChainAddResult::TOO_NEW);
     REQUIRE(ledgerChain.size() == 1);
-    REQUIRE(ledgerChain.hadTooNew());
     REQUIRE(ledgerChain.back().getLedgerSeq() == 1);
 }
 
@@ -74,7 +64,6 @@ TEST_CASE("not empty syncing ledger chain do not accept duplicate",
     REQUIRE(ledgerChain.add(makeLedgerCloseData(1)) ==
             SyncingLedgerChainAddResult::TOO_OLD);
     REQUIRE(ledgerChain.size() == 1);
-    REQUIRE(!ledgerChain.hadTooNew());
     REQUIRE(ledgerChain.back().getLedgerSeq() == 1);
 }
 
@@ -86,7 +75,6 @@ TEST_CASE("not empty syncing ledger chain do not accept previous ledger",
     REQUIRE(ledgerChain.add(makeLedgerCloseData(1)) ==
             SyncingLedgerChainAddResult::TOO_OLD);
     REQUIRE(ledgerChain.size() == 1);
-    REQUIRE(!ledgerChain.hadTooNew());
     REQUIRE(ledgerChain.back().getLedgerSeq() == 2);
 }
 
@@ -99,6 +87,5 @@ TEST_CASE("not empty syncing ledger chain accepts next ledger after failure",
     REQUIRE(ledgerChain.add(makeLedgerCloseData(2)) ==
             SyncingLedgerChainAddResult::CONTIGUOUS);
     REQUIRE(ledgerChain.size() == 2);
-    REQUIRE(ledgerChain.hadTooNew());
     REQUIRE(ledgerChain.back().getLedgerSeq() == 2);
 }


### PR DESCRIPTION
Catchup ledgers are verified against first consensus that we got from network, not against last in checkpoints that contains that consensus. It makes it not possible to fail catchup if one of consensus between these values gets missing.