### PR TITLE
add --all-versions options to test runs

### DIFF
--- a/src/test/selftest-nopg
+++ b/src/test/selftest-nopg
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-exec ./stellar-core -ll fatal --test -a -r simple
+if [ "$ALL_VERSIONS" != "" ]; then
+    exec ./stellar-core -ll fatal --test --all-versions -a -r simple
+else
+    exec ./stellar-core -ll fatal --test -a -r simple
+fi

--- a/src/test/selftest-pg
+++ b/src/test/selftest-pg
@@ -78,7 +78,11 @@ if test "$#" = 0; then
 	echo "Disabling PostgreSQL in most tests"
 	export STELLAR_FORCE_SQLITE=1
     fi
-    ./stellar-core -ll fatal --test -a -r simple
+    if [ "$ALL_VERSIONS" != "" ]; then
+        ./stellar-core -ll fatal --test --all-versions -a -r simple
+    else
+        ./stellar-core -ll fatal --test -a -r simple
+    fi
 else
     # You can run "./test-pg bash" to get a shell with postgreSQL set up
     setup_test

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -161,12 +161,19 @@ test(int argc, char* const* argv, el::Level ll,
 
     auto unusedTokens = session.unusedTokens();
     using namespace Clara;
-    gTestAllVersions =
-        std::find_if(std::begin(unusedTokens), std::end(unusedTokens),
-                     [](Parser::Token const& token) {
-                         return token.type == Parser::Token::LongOpt &&
-                                token.data == "all-versions";
-                     }) != std::end(unusedTokens);
+
+    for (auto const& token : unusedTokens)
+    {
+        if (token.type == Parser::Token::LongOpt &&
+            token.data == "all-versions")
+        {
+            gTestAllVersions = true;
+            continue;
+        }
+
+        session.showHelp(session.configData().processName);
+        return -1;
+    }
 
     r = session.run();
     gTestRoots.clear();

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -43,6 +43,7 @@ namespace stellar
 static std::vector<std::string> gTestMetrics;
 static std::vector<std::unique_ptr<Config>> gTestCfg[Config::TESTDB_MODES];
 static std::vector<TmpDir> gTestRoots;
+static bool gTestAllVersions{false};
 
 bool force_sqlite = (std::getenv("STELLAR_FORCE_SQLITE") != nullptr);
 
@@ -151,15 +152,30 @@ test(int argc, char* const* argv, el::Level ll,
     LOG(INFO) << "Testing stellar-core " << STELLAR_CORE_VERSION;
     LOG(INFO) << "Logging to " << cfg.LOG_FILE_PATH;
 
-    int r = Catch::Session().run(argc, argv);
+    using namespace Catch;
+    Session session{};
+    auto r =
+        session.applyCommandLine(argc, argv, Session::OnUnusedOptions::Ignore);
+    if (r != 0)
+        return r;
+
+    auto unusedTokens = session.unusedTokens();
+    using namespace Clara;
+    gTestAllVersions =
+        std::find_if(std::begin(unusedTokens), std::end(unusedTokens),
+                     [](Parser::Token const& token) {
+                         return token.type == Parser::Token::LongOpt &&
+                                token.data == "all-versions";
+                     }) != std::end(unusedTokens);
+
+    r = session.run();
     gTestRoots.clear();
     gTestCfg->clear();
     return r;
 }
 
 void
-for_versions_to(int to, Application& app,
-                std::function<void(void)> const& f)
+for_versions_to(int to, Application& app, std::function<void(void)> const& f)
 {
     for_versions(1, to, app, f);
 }
@@ -172,8 +188,7 @@ for_versions_from(int from, Application& app,
 }
 
 void
-for_versions_from(std::vector<int> const& versions,
-                  Application& app,
+for_versions_from(std::vector<int> const& versions, Application& app,
                   std::function<void(void)> const& f)
 {
     for_versions(versions, app, f);
@@ -181,8 +196,7 @@ for_versions_from(std::vector<int> const& versions,
 }
 
 void
-for_all_versions(Application& app,
-                 std::function<void(void)> const& f)
+for_all_versions(Application& app, std::function<void(void)> const& f)
 {
     for_versions(1, Config::CURRENT_LEDGER_PROTOCOL_VERSION, app, f);
 }
@@ -209,12 +223,10 @@ for_versions(std::vector<int> const& versions, Application& app,
     auto previousVersion = app.getLedgerManager().getCurrentLedgerVersion();
     for (auto v : versions)
     {
-#ifdef TEST_ONLY_CURRENT_PROTOCOL
-        if (v != Config::CURRENT_LEDGER_PROTOCOL_VERSION)
+        if (!gTestAllVersions && v != Config::CURRENT_LEDGER_PROTOCOL_VERSION)
         {
             continue;
         }
-#endif
         SECTION("protocol version " + std::to_string(v))
         {
             testutil::setCurrentLedgerVersion(app.getLedgerManager(), v);
@@ -225,8 +237,7 @@ for_versions(std::vector<int> const& versions, Application& app,
 }
 
 void
-for_all_versions_except(std::vector<int> const& versions,
-                        Application& app,
+for_all_versions_except(std::vector<int> const& versions, Application& app,
                         std::function<void(void)> const& f)
 {
     int lastExcept = 0;

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -65,4 +65,5 @@ ccache -s
 ./configure $config_flags
 make -j3
 ccache -s
+export ALL_VERSIONS=1
 make check


### PR DESCRIPTION
Now it can be selected at runtime if tests are to be run againsts all
protocol versions or only against current.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>