### PR TITLE
Fixed issue where virtual members of Application were called from its constructor

### DIFF
--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -38,11 +38,6 @@ void validateNetworkPassphrase(Application::pointer app)
 Application::pointer
 Application::create(VirtualClock& clock, Config const& cfg, bool newDB)
 {
-    Application::pointer ret = make_shared<ApplicationImpl>(clock, cfg);
-    if (newDB || cfg.DATABASE.value == "sqlite3://:memory:")
-        ret->newDB();
-    validateNetworkPassphrase(ret);
-
-    return ret;
+    return create<ApplicationImpl>(clock, cfg, newDB);
 }
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -37,6 +37,8 @@ class ApplicationImpl : public Application
     ApplicationImpl(VirtualClock& clock, Config const& cfg);
     virtual ~ApplicationImpl() override;
 
+    virtual void initialize() override;
+
     virtual uint64_t timeNow() override;
 
     virtual Config const& getConfig() override;
@@ -159,5 +161,8 @@ class ApplicationImpl : public Application
     void runWorkerThread(unsigned i);
 
     void enableInvariantsFromConfig();
+
+    virtual std::unique_ptr<Herder> createHerder();
+    virtual std::unique_ptr<OverlayManager> createOverlayManager();
 };
 }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -8,16 +8,6 @@
 namespace stellar
 {
 
-Application::pointer
-createTestApplication(VirtualClock& clock, Config const& cfg)
-{
-    auto app = Application::create(clock, cfg);
-    auto& lm = app->getLedgerManager();
-    lm.getCurrentLedgerHeader().baseFee = cfg.DESIRED_BASE_FEE;
-    testutil::setCurrentLedgerVersion(lm, cfg.LEDGER_PROTOCOL_VERSION);
-    return app;
-}
-
 void
 testutil::setCurrentLedgerVersion(LedgerManager& lm, uint32_t currentLedgerVersion)
 {

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -10,12 +10,20 @@
 namespace stellar
 {
 
-Application::pointer
-createTestApplication(VirtualClock& clock, Config const& cfg);
-
 namespace testutil
 {
 void setCurrentLedgerVersion(LedgerManager& lm, uint32_t currentLedgerVersion);
+}
+
+template <typename T = ApplicationImpl>
+std::shared_ptr<T>
+createTestApplication(VirtualClock& clock, Config const& cfg)
+{
+    auto app = Application::create<T>(clock, cfg);
+    auto& lm = app->getLedgerManager();
+    lm.getCurrentLedgerHeader().baseFee = cfg.DESIRED_BASE_FEE;
+    testutil::setCurrentLedgerVersion(lm, cfg.LEDGER_PROTOCOL_VERSION);
+    return app;
 }
 
 time_t getTestDate(int day, int month, int year);


### PR DESCRIPTION
As the subsystems of `Application` were being created in the constructor of `ApplicationImpl`, they were calling virtual functions. This issue is fixed in this PR, and some related clean-up was also done simultaneously.