### PR TITLE
enforce that clang-format was run in travis

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -63,7 +63,16 @@ echo "committer = $committer, config_flags = $config_flags"
 ccache -s
 ./autogen.sh
 ./configure $config_flags
+make format
+d=`git diff | wc`
+if [ "$d." != "." ]
+then
+    echo "clang format must be run as part of the pull request, current diff:"
+    git diff
+    exit 1
+fi
 make -j3
 ccache -s
 export ALL_VERSIONS=1
 make check
+


### PR DESCRIPTION
resolves #1388 

like title says

this can only be committed on a clean master (so depends on #1387 as of right now)