### PR TITLE
Restart nodes test and simulation improvements

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -569,7 +569,6 @@ exit /b 0
     <ClInclude Include="..\..\src\invariant\InvariantDoesNotHold.h" />
     <ClInclude Include="..\..\src\invariant\InvariantManager.h" />
     <ClInclude Include="..\..\src\invariant\InvariantManagerImpl.h" />
-    <ClInclude Include="..\..\src\invariant\Invariants.h" />
     <ClInclude Include="..\..\src\invariant\TotalCoinsEqualsBalancesPlusFeePool.h" />
     <ClInclude Include="..\..\src\ledger\CheckpointRange.h" />
     <ClInclude Include="..\..\src\ledger\DataFrame.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1226,9 +1226,6 @@
     <ClInclude Include="..\..\src\invariant\InvariantDoesNotHold.h">
       <Filter>invariant</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\invariant\Invariants.h">
-      <Filter>invariant</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\invariant\TotalCoinsEqualsBalancesPlusFeePool.h">
       <Filter>invariant</Filter>
     </ClInclude>

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -704,8 +704,6 @@ TEST_CASE("SCP State", "[herder]")
             getTestConfig(i + 1, Config::TestDbMode::TESTDB_ON_DISK_SQLITE);
     }
 
-    VirtualClock* clock = &sim->getClock();
-
     LedgerHeaderHistoryEntry lcl;
 
     auto doTest = [&](bool forceSCP) {
@@ -716,8 +714,8 @@ TEST_CASE("SCP State", "[herder]")
             qSet.validators.push_back(nodeIDs[0]);
             qSet.validators.push_back(nodeIDs[1]);
 
-            sim->addNode(nodeKeys[0], qSet, *clock, &nodeCfgs[0]);
-            sim->addNode(nodeKeys[1], qSet, *clock, &nodeCfgs[1]);
+            sim->addNode(nodeKeys[0], qSet, &nodeCfgs[0]);
+            sim->addNode(nodeKeys[1], qSet, &nodeCfgs[1]);
             sim->addPendingConnection(nodeIDs[0], nodeIDs[1]);
         }
 
@@ -750,7 +748,6 @@ TEST_CASE("SCP State", "[herder]")
 
         sim =
             std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
-        clock = &sim->getClock();
 
         // start a new node that will switch to whatever node0 & node1 says
         SCPQuorumSet qSetAll;
@@ -759,7 +756,7 @@ TEST_CASE("SCP State", "[herder]")
         {
             qSetAll.validators.push_back(nodeIDs[i]);
         }
-        sim->addNode(nodeKeys[2], qSetAll, *clock, &nodeCfgs[2]);
+        sim->addNode(nodeKeys[2], qSetAll, &nodeCfgs[2]);
         sim->getNode(nodeIDs[2])->start();
 
         // crank a bit (nothing should happen, node 2 is waiting for SCP
@@ -776,8 +773,8 @@ TEST_CASE("SCP State", "[herder]")
         // forwarded to node 2 when they connect to it
         // causing node 2 to externalize ledger #2
 
-        sim->addNode(nodeKeys[0], qSetAll, *clock, &nodeCfgs[0], false);
-        sim->addNode(nodeKeys[1], qSetAll, *clock, &nodeCfgs[1], false);
+        sim->addNode(nodeKeys[0], qSetAll, &nodeCfgs[0], false);
+        sim->addNode(nodeKeys[1], qSetAll, &nodeCfgs[1], false);
         sim->getNode(nodeIDs[0])->start();
         sim->getNode(nodeIDs[1])->start();
 
@@ -846,10 +843,8 @@ TEST_CASE("quick restart", "[herder][quickRestart]")
     qSet.threshold = 1;
     qSet.validators.push_back(validatorKey.getPublicKey());
 
-    auto validator =
-        simulation->addNode(validatorKey, qSet, simulation->getClock());
-    auto listener =
-        simulation->addNode(listenerKey, qSet, simulation->getClock());
+    auto validator = simulation->addNode(validatorKey, qSet);
+    auto listener = simulation->addNode(listenerKey, qSet);
     simulation->addPendingConnection(validatorKey.getPublicKey(),
                                      listenerKey.getPublicKey());
     simulation->startAllNodes();

--- a/src/herder/ProtocolUpgradeTests.cpp
+++ b/src/herder/ProtocolUpgradeTests.cpp
@@ -43,7 +43,7 @@ simulateLedgerUpgrade(const LedgerUpgradeSimulation& upgradeSimulation)
     auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     auto simulation =
         std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
-    simulation->getClock().setCurrentTime(VirtualClock::from_time_t(start));
+    simulation->setCurrentTime(VirtualClock::from_time_t(start));
 
     auto keys = std::vector<SecretKey>{};
     auto configs = std::vector<Config>{};
@@ -63,7 +63,7 @@ simulateLedgerUpgrade(const LedgerUpgradeSimulation& upgradeSimulation)
         qSet.threshold = nodes[i].quorumTheshold;
         for (auto j : nodes[i].quorumIndexes)
             qSet.validators.push_back(keys[j].getPublicKey());
-        simulation->addNode(keys[i], qSet, simulation->getClock(), &configs[i]);
+        simulation->addNode(keys[i], qSet, &configs[i]);
     }
 
     for (auto i = 0; i < nodes.size(); i++)

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -169,7 +169,7 @@ TEST_CASE("ledger performance test", "[performance][hide]")
                     "user=test password=test"};
     cfg.BUCKET_DIR_PATH = "performance-test.db.buckets";
     cfg.MANUAL_CLOSE = true;
-    sim.addNode(v10SecretKey, qSet0, sim.getClock(), &cfg);
+    sim.addNode(v10SecretKey, qSet0, &cfg);
     sim.mApp = sim.getNodes().front();
 
     sim.startAllNodes();

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -624,12 +624,12 @@ CommandHandler::dropPeer(std::string const& params, std::string& retStr)
         if (mApp.getHerder().resolveNodeID(peerId->second, n))
         {
             auto peers = mApp.getOverlayManager().getPeers();
-            auto peer = std::find_if(
+            auto peerit = std::find_if(
                 peers.begin(), peers.end(),
                 [&n](Peer::pointer peer) { return peer->getPeerID() == n; });
-            if (peer != peers.end())
+            if (peerit != peers.end())
             {
-                mApp.getOverlayManager().dropPeer(*peer);
+                mApp.getOverlayManager().dropPeer(peerit->get());
                 if (ban != retMap.end() && ban->second == "1")
                 {
                     retStr = "Drop and ban peer: ";

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -139,7 +139,7 @@ LoopbackPeer::deliverOne()
     // CLOG(TRACE, "Overlay") << "LoopbackPeer attempting to deliver message";
     if (mRemote.expired())
     {
-        throw std::runtime_error("LoopbackPeer missing target");
+        return;
     }
 
     if (!mOutQueue.empty() && !mCorked)

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -78,8 +78,7 @@ LoopbackPeer::drop()
     }
     mState = CLOSING;
     mIdleTimer.cancel();
-    auto self = shared_from_this();
-    getApp().getOverlayManager().dropPeer(self);
+    getApp().getOverlayManager().dropPeer(this);
 
     auto remote = mRemote.lock();
     if (remote)

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -41,6 +41,12 @@ LoopbackPeer::getAuthCert()
 void
 LoopbackPeer::sendMessage(xdr::msg_ptr&& msg)
 {
+    if (mRemote.expired())
+    {
+        drop();
+        return;
+    }
+
     // Damage authentication material.
     if (mDamageAuth)
     {

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -88,7 +88,7 @@ class OverlayManager
 
     // Forget about a peer, removing it from the in-memory set of connected
     // peers. Presumably due to it disconnecting.
-    virtual void dropPeer(Peer::pointer peer) = 0;
+    virtual void dropPeer(Peer* peer) = 0;
 
     // Returns true if there is room for the provided peer in the in-memory set
     // of connected peers without evicting an existing peer, or if the provided

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -276,13 +276,15 @@ OverlayManagerImpl::addConnectedPeer(Peer::pointer peer)
 }
 
 void
-OverlayManagerImpl::dropPeer(Peer::pointer peer)
+OverlayManagerImpl::dropPeer(Peer* peer)
 {
     mConnectionsDropped.Mark();
     CLOG(INFO, "Overlay") << "Dropping peer "
                           << mApp.getConfig().toShortString(peer->getPeerID())
                           << "@" << peer->toString();
-    auto iter = find(mPeers.begin(), mPeers.end(), peer);
+    auto iter =
+        find_if(mPeers.begin(), mPeers.end(),
+                [&](Peer::pointer const& p) { return p.get() == peer; });
     if (iter != mPeers.end())
         mPeers.erase(iter);
     else
@@ -307,7 +309,7 @@ OverlayManagerImpl::isPeerAccepted(Peer::pointer peer)
                 CLOG(INFO, "Overlay")
                     << "Evicting non-preferred peer " << victim->toString()
                     << " for preferred peer " << peer->toString();
-                dropPeer(victim);
+                dropPeer(victim.get());
                 return true;
             }
         }

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -75,7 +75,7 @@ class OverlayManagerImpl : public OverlayManager
     virtual void connectTo(PeerRecord& pr) override;
 
     void addConnectedPeer(Peer::pointer peer) override;
-    void dropPeer(Peer::pointer peer) override;
+    void dropPeer(Peer* peer) override;
     bool isPeerAccepted(Peer::pointer peer) override;
     std::vector<Peer::pointer>& getPeers() override;
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -380,7 +380,7 @@ TCPPeer::drop()
     mIdleTimer.cancel();
 
     auto self = static_pointer_cast<TCPPeer>(shared_from_this());
-    getApp().getOverlayManager().dropPeer(self);
+    getApp().getOverlayManager().dropPeer(this);
 
     // To shutdown, we first queue up our desire to shutdown in the strand,
     // behind any pending read/write calls. We'll let them issue first.

--- a/src/overlay/TCPPeerTests.cpp
+++ b/src/overlay/TCPPeerTests.cpp
@@ -28,12 +28,12 @@ TEST_CASE("TCPPeer can communicate", "[overlay]")
     SCPQuorumSet n0_qset;
     n0_qset.threshold = 1;
     n0_qset.validators.push_back(v10SecretKey.getPublicKey());
-    auto n0 = s->addNode(v10SecretKey, n0_qset, s->getClock());
+    auto n0 = s->addNode(v10SecretKey, n0_qset);
 
     SCPQuorumSet n1_qset;
     n1_qset.threshold = 1;
     n1_qset.validators.push_back(v11SecretKey.getPublicKey());
-    auto n1 = s->addNode(v11SecretKey, n1_qset, s->getClock());
+    auto n1 = s->addNode(v11SecretKey, n1_qset);
 
     s->addPendingConnection(v10SecretKey.getPublicKey(),
                             v11SecretKey.getPublicKey());

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -397,6 +397,8 @@ NominationProtocol::processEnvelope(SCPEnvelope const& envelope)
                     {
                         mVotes.emplace(newVote);
                         modified = true;
+                        mSlot.getSCPDriver().nominatingValue(
+                            mSlot.getSlotIndex(), newVote);
                     }
                 }
 
@@ -442,8 +444,8 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
                              bool timedout)
 {
     if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "NominationProtocol::nominate "
-                           << mSlot.getSCP().getValueString(value);
+        CLOG(DEBUG, "SCP") << "NominationProtocol::nominate (" << mRoundNumber
+                           << ") " << mSlot.getSCP().getValueString(value);
 
     bool updated = false;
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -215,6 +215,10 @@ TEST_CASE("resilience tests", "[resilience][simulation]")
         return c;
     };
 
+    SECTION("custom-A")
+    {
+        resilienceTest(Topologies::customA(mode, networkID, confGen, 2));
+    }
     SECTION("hierarchical")
     {
         resilienceTest(

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -87,8 +87,8 @@ TEST_CASE("3 nodes. 2 running. threshold 2", "[simulation][core3]")
             qSet.validators.push_back(k.getPublicKey());
         }
 
-        simulation->addNode(keys[0], qSet, simulation->getClock());
-        simulation->addNode(keys[1], qSet, simulation->getClock());
+        simulation->addNode(keys[0], qSet);
+        simulation->addNode(keys[1], qSet);
         simulation->addPendingConnection(keys[0].getPublicKey(),
                                          keys[1].getPublicKey());
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -150,6 +150,7 @@ static void
 hierarchicalTopoTest(int nLedgers, int nBranches, Simulation::Mode mode,
                      Hash const& networkID)
 {
+    LOG(DEBUG) << "starting topo test " << nLedgers << " : " << nBranches;
     auto tBegin = std::chrono::system_clock::now();
 
     Simulation::pointer sim =
@@ -196,6 +197,7 @@ static void
 hierarchicalSimplifiedTest(int nLedgers, int nbCore, int nbOuterNodes,
                            Simulation::Mode mode, Hash const& networkID)
 {
+    LOG(DEBUG) << "starting simplified test " << nLedgers << " : " << nbCore;
     auto tBegin = std::chrono::system_clock::now();
 
     Simulation::pointer sim = Topologies::hierarchicalQuorumSimplified(
@@ -231,16 +233,18 @@ TEST_CASE("core-nodes with outer nodes", "[simulation]")
 
 TEST_CASE("cycle4 topology", "[simulation]")
 {
+    const int nLedgers = 10;
+
     Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     Simulation::pointer simulation = Topologies::cycle4(networkID);
     simulation->startAllNodes();
 
     simulation->crankUntil(
-        [&simulation]() { return simulation->haveAllExternalized(2, 4); },
-        std::chrono::seconds(20), true);
+        [&]() { return simulation->haveAllExternalized(nLedgers + 2, 4); },
+        2 * nLedgers * Herder::EXP_LEDGER_TIMESPAN_SECONDS, true);
 
     // Still transiently does not work (quorum retrieval)
-    REQUIRE(simulation->haveAllExternalized(2, 4));
+    REQUIRE(simulation->haveAllExternalized(nLedgers, 4));
 }
 
 TEST_CASE("Stress test on 2 nodes 3 accounts 10 random transactions 10tx/sec",

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -40,6 +40,8 @@ Simulation::Simulation(Mode mode, Hash const& networkID,
 
 Simulation::~Simulation()
 {
+    // kills all connections
+    mLoopbackConnections.clear();
     // destroy all nodes first
     mNodes.clear();
 

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -210,7 +210,7 @@ Simulation::crankAllNodes(int nbTicks)
 }
 
 bool
-Simulation::haveAllExternalized(SequenceNumber num, uint32 maxSpread)
+Simulation::haveAllExternalized(uint32 num, uint32 maxSpread)
 {
     uint32_t min = UINT_MAX, max = 0;
     for (auto it = mNodes.begin(); it != mNodes.end(); ++it)

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -57,7 +57,7 @@ class Simulation : public LoadGenerator
 
     // returns true if all nodes have externalized
     // triggers and exception if a node externalized higher than num+maxSpread
-    bool haveAllExternalized(SequenceNumber num, uint32 maxSpread);
+    bool haveAllExternalized(uint32 num, uint32 maxSpread);
 
     size_t crankAllNodes(int nbTicks = 1);
     void crankForAtMost(VirtualClock::duration seconds, bool finalCrank);

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -54,6 +54,7 @@ class Simulation : public LoadGenerator
     void addPendingConnection(NodeID const& initiator, NodeID const& acceptor);
     void startAllNodes();
     void stopAllNodes();
+    void removeNode(NodeID const& id);
 
     // returns true if all nodes have externalized
     // triggers and exception if a node externalized higher than num+maxSpread
@@ -89,6 +90,7 @@ class Simulation : public LoadGenerator
     void addLoopbackConnection(NodeID initiator, NodeID acceptor);
     void dropLoopbackConnection(NodeID initiator, NodeID acceptor);
     void addTCPConnection(NodeID initiator, NodeID acception);
+    void dropAllConnections(NodeID const& id);
 
     bool mVirtualClockMode;
     VirtualClock mClock;

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -83,7 +83,7 @@ Topologies::cycle4(Hash const& networkID, std::function<Config()> confGen)
 }
 
 Simulation::pointer
-Topologies::separate(int nNodes, float quorumThresoldFraction,
+Topologies::separate(int nNodes, double quorumThresoldFraction,
                      Simulation::Mode mode, Hash const& networkID,
                      std::function<Config()> confGen)
 {
@@ -114,7 +114,7 @@ Topologies::separate(int nNodes, float quorumThresoldFraction,
 }
 
 Simulation::pointer
-Topologies::core(int nNodes, float quorumThresoldFraction,
+Topologies::core(int nNodes, double quorumThresoldFraction,
                  Simulation::Mode mode, Hash const& networkID,
                  std::function<Config()> confGen)
 {
@@ -136,7 +136,7 @@ Topologies::core(int nNodes, float quorumThresoldFraction,
 }
 
 Simulation::pointer
-Topologies::cycle(int nNodes, float quorumThresoldFraction,
+Topologies::cycle(int nNodes, double quorumThresoldFraction,
                   Simulation::Mode mode, Hash const& networkID,
                   std::function<Config()> confGen)
 {
@@ -156,7 +156,7 @@ Topologies::cycle(int nNodes, float quorumThresoldFraction,
 }
 
 Simulation::pointer
-Topologies::branchedcycle(int nNodes, float quorumThresoldFraction,
+Topologies::branchedcycle(int nNodes, double quorumThresoldFraction,
                           Simulation::Mode mode, Hash const& networkID,
                           std::function<Config()> confGen)
 {

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -24,8 +24,8 @@ Topologies::pair(Simulation::Mode mode, Hash const& networkID,
     qSet0.validators.push_back(v10NodeID);
     qSet0.validators.push_back(v11NodeID);
 
-    simulation->addNode(v10SecretKey, qSet0, simulation->getClock());
-    simulation->addNode(v11SecretKey, qSet0, simulation->getClock());
+    simulation->addNode(v10SecretKey, qSet0);
+    simulation->addNode(v11SecretKey, qSet0);
 
     simulation->addPendingConnection(v10SecretKey.getPublicKey(),
                                      v11SecretKey.getPublicKey());
@@ -60,10 +60,10 @@ Topologies::cycle4(Hash const& networkID, std::function<Config()> confGen)
     qSet3.validators.push_back(v3NodeID);
     qSet3.validators.push_back(v0NodeID);
 
-    simulation->addNode(v0SecretKey, qSet0, simulation->getClock());
-    simulation->addNode(v1SecretKey, qSet1, simulation->getClock());
-    simulation->addNode(v2SecretKey, qSet2, simulation->getClock());
-    simulation->addNode(v3SecretKey, qSet3, simulation->getClock());
+    simulation->addNode(v0SecretKey, qSet0);
+    simulation->addNode(v1SecretKey, qSet1);
+    simulation->addNode(v2SecretKey, qSet2);
+    simulation->addNode(v3SecretKey, qSet3);
 
     simulation->addPendingConnection(v0SecretKey.getPublicKey(),
                                      v1SecretKey.getPublicKey());
@@ -108,7 +108,7 @@ Topologies::separate(int nNodes, double quorumThresoldFraction,
 
     for (auto const& k : keys)
     {
-        simulation->addNode(k, qSet, simulation->getClock());
+        simulation->addNode(k, qSet);
     }
     return simulation;
 }
@@ -213,7 +213,7 @@ Simulation::pointer Topologies::hierarchicalQuorum(
             qSetHere.threshold = 2;
             qSetHere.validators.push_back(key.getPublicKey());
             qSetHere.innerSets.push_back(qSetTopTier);
-            sim->addNode(key, qSetHere, sim->getClock());
+            sim->addNode(key, qSetHere);
         }
 
         //// the leaf node
@@ -227,7 +227,7 @@ Simulation::pointer Topologies::hierarchicalQuorum(
         //{
         //    leafQSet.validators.push_back(key.getPublicKey());
         //}
-        // sim->addNode(leafKey, leafQSet, sim->getClock());
+        // sim->addNode(leafKey, leafQSet);
 
         // connections
         for (auto const& middle : middletierKeys)
@@ -269,7 +269,7 @@ Topologies::hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
             SecretKey::fromSeed(sha256("OUTER_NODE_SEED_" + to_string(i)));
         auto const& pubKey = sk.getPublicKey();
         qSetBuilder.validators.back() = pubKey;
-        sim->addNode(sk, qSetBuilder, sim->getClock());
+        sim->addNode(sk, qSetBuilder);
 
         // connect it to one of the core nodes
         sim->addPendingConnection(pubKey, coreNodeIDs[i % coreSize]);

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -283,4 +283,84 @@ Topologies::hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
 
     return sim;
 }
+
+Simulation::pointer
+Topologies::customA(Simulation::Mode mode, Hash const& networkID,
+                    std::function<Config()> confGen, int connections)
+{
+    Simulation::pointer s = make_shared<Simulation>(mode, networkID, confGen);
+
+    enum kIDs
+    {
+        A = 0,
+        B,
+        C,
+        T,
+        I,
+        E,
+        S
+    };
+    vector<SecretKey> keys;
+    for (int i = 0; i < 7; i++)
+    {
+        keys.push_back(
+            SecretKey::fromSeed(sha256("NODE_SEED_" + to_string(i))));
+    }
+    // A,B,C have the same qset, with all validators
+    {
+        SCPQuorumSet q;
+        q.threshold = 4;
+        for (auto& k : keys)
+        {
+            q.validators.emplace_back(k.getPublicKey());
+        }
+        s->addNode(keys[A], q);
+        s->addNode(keys[B], q);
+        s->addNode(keys[C], q);
+    }
+    // T
+    {
+        SCPQuorumSet q;
+        q.threshold = 4;
+        q.validators.emplace_back(keys[B].getPublicKey());
+        q.validators.emplace_back(keys[A].getPublicKey());
+        q.validators.emplace_back(keys[T].getPublicKey());
+        q.validators.emplace_back(keys[E].getPublicKey());
+        q.validators.emplace_back(keys[S].getPublicKey());
+        s->addNode(keys[T], q);
+    }
+    // E
+    {
+        SCPQuorumSet q;
+        q.threshold = 3;
+        q.validators.emplace_back(keys[E].getPublicKey());
+        q.validators.emplace_back(keys[A].getPublicKey());
+        q.validators.emplace_back(keys[B].getPublicKey());
+        q.validators.emplace_back(keys[C].getPublicKey());
+        s->addNode(keys[E], q);
+    }
+    // S
+    {
+        SCPQuorumSet q;
+        q.threshold = 4;
+        q.validators.emplace_back(keys[S].getPublicKey());
+        q.validators.emplace_back(keys[E].getPublicKey());
+        q.validators.emplace_back(keys[A].getPublicKey());
+        q.validators.emplace_back(keys[B].getPublicKey());
+        q.validators.emplace_back(keys[C].getPublicKey());
+        s->addNode(keys[S], q);
+    }
+
+    // create connections between nodes
+    auto nodes = s->getNodeIDs();
+    for (int i = 0; i < nodes.size(); i++)
+    {
+        auto from = nodes[i];
+        for (int j = 1; j <= connections; j++)
+        {
+            s->addPendingConnection(from, nodes[(i + j) % nodes.size()]);
+        }
+    }
+    return s;
+}
 }

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -206,14 +206,20 @@ Simulation::pointer Topologies::hierarchicalQuorum(
                 "NODE_SEED_" + to_string(i) + "_middle_" + to_string(j))));
         }
 
+        int curCore = 0;
         for (auto const& key : middletierKeys)
         {
             SCPQuorumSet qSetHere;
             // self + any 2 from top tier
             qSetHere.threshold = 2;
-            qSetHere.validators.push_back(key.getPublicKey());
+            auto pk = key.getPublicKey();
+            qSetHere.validators.push_back(pk);
             qSetHere.innerSets.push_back(qSetTopTier);
             sim->addNode(key, qSetHere);
+
+            // connect to one of the core nodes (round-robin)
+            curCore = (curCore + 1) % coreNodeIDs.size();
+            sim->addPendingConnection(pk, coreNodeIDs[curCore]);
         }
 
         //// the leaf node
@@ -228,16 +234,6 @@ Simulation::pointer Topologies::hierarchicalQuorum(
         //    leafQSet.validators.push_back(key.getPublicKey());
         //}
         // sim->addNode(leafKey, leafQSet);
-
-        // connections
-        for (auto const& middle : middletierKeys)
-        {
-            for (auto const& core : coreNodeIDs)
-                sim->addPendingConnection(middle.getPublicKey(), core);
-
-            // sim->addPendingConnection(leafKey.getPublicKey(),
-            // middle.getPublicKey());
-        }
     }
     return sim;
 }

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -16,32 +16,43 @@ class Topologies
                                     Hash const& networkID,
                                     std::function<Config()> confGen = nullptr);
 
+    // cyclic network - each node has a qset with a neighbor
     static Simulation::pointer
     cycle4(Hash const& networkID, std::function<Config()> confGen = nullptr);
 
+    // nNodes with same qSet - mesh network
     static Simulation::pointer core(int nNodes, double quorumThresoldFraction,
                                     Simulation::Mode mode,
                                     Hash const& networkID,
                                     std::function<Config()> confGen = nullptr);
 
+    // nNodes with same qSet - one way connection in cycle
     static Simulation::pointer cycle(int nNodes, double quorumThresoldFraction,
                                      Simulation::Mode mode,
                                      Hash const& networkID,
                                      std::function<Config()> confGen = nullptr);
 
+    // nNodes with same qSet - two way connection = cycle + alt-path
     static Simulation::pointer
     branchedcycle(int nNodes, double quorumThresoldFraction,
                   Simulation::Mode mode, Hash const& networkID,
                   std::function<Config()> confGen = nullptr);
 
+    // nNodes with same qSet - no connection created
     static Simulation::pointer
     separate(int nNodes, double quorumThresoldFraction, Simulation::Mode mode,
              Hash const& networkID, std::function<Config()> confGen = nullptr);
 
+    // multi-tier quorum (core4 + mid-tier nodes that depend on 2 nodes of
+    // core4) mid-tier connected round-robin to core4
     static Simulation::pointer
     hierarchicalQuorum(int nBranches, Simulation::Mode mode,
                        Hash const& networkID,
                        std::function<Config()> confGen = nullptr);
+
+    // 2-tier quorum with a variable size core and outer-nodes that listen to
+    // core & self outer-nodes have a single connection to one of the core nodes
+    // (round-robin)
     static Simulation::pointer
     hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
                                  Simulation::Mode mode, Hash const& networkID,

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -19,23 +19,23 @@ class Topologies
     static Simulation::pointer
     cycle4(Hash const& networkID, std::function<Config()> confGen = nullptr);
 
-    static Simulation::pointer core(int nNodes, float quorumThresoldFraction,
+    static Simulation::pointer core(int nNodes, double quorumThresoldFraction,
                                     Simulation::Mode mode,
                                     Hash const& networkID,
                                     std::function<Config()> confGen = nullptr);
 
-    static Simulation::pointer cycle(int nNodes, float quorumThresoldFraction,
+    static Simulation::pointer cycle(int nNodes, double quorumThresoldFraction,
                                      Simulation::Mode mode,
                                      Hash const& networkID,
                                      std::function<Config()> confGen = nullptr);
 
     static Simulation::pointer
-    branchedcycle(int nNodes, float quorumThresoldFraction,
+    branchedcycle(int nNodes, double quorumThresoldFraction,
                   Simulation::Mode mode, Hash const& networkID,
                   std::function<Config()> confGen = nullptr);
 
     static Simulation::pointer
-    separate(int nNodes, float quorumThresoldFraction, Simulation::Mode mode,
+    separate(int nNodes, double quorumThresoldFraction, Simulation::Mode mode,
              Hash const& networkID, std::function<Config()> confGen = nullptr);
 
     static Simulation::pointer

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -58,5 +58,10 @@ class Topologies
                                  Simulation::Mode mode, Hash const& networkID,
                                  std::function<Config()> confGen = nullptr,
                                  int connectionsToCore = 1);
+
+    // custom-A
+    static Simulation::pointer
+    customA(Simulation::Mode mode, Hash const& networkID,
+            std::function<Config()> confGen = nullptr, int connections = 1);
 };
 }

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -45,17 +45,18 @@ class Topologies
 
     // multi-tier quorum (core4 + mid-tier nodes that depend on 2 nodes of
     // core4) mid-tier connected round-robin to core4
-    static Simulation::pointer
-    hierarchicalQuorum(int nBranches, Simulation::Mode mode,
-                       Hash const& networkID,
-                       std::function<Config()> confGen = nullptr);
+    static Simulation::pointer hierarchicalQuorum(
+        int nBranches, Simulation::Mode mode, Hash const& networkID,
+        std::function<Config()> confGen = nullptr, int connectionsToCore = 1);
 
-    // 2-tier quorum with a variable size core and outer-nodes that listen to
-    // core & self outer-nodes have a single connection to one of the core nodes
+    // 2-tier quorum with a variable size core (with 0.75 threshold)
+    // and outer-nodes that listen to core & self
+    // outer-nodes have connectionsToCore connections to core nodes
     // (round-robin)
     static Simulation::pointer
     hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
                                  Simulation::Mode mode, Hash const& networkID,
-                                 std::function<Config()> confGen = nullptr);
+                                 std::function<Config()> confGen = nullptr,
+                                 int connectionsToCore = 1);
 };
 }

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -121,7 +121,6 @@ class VirtualClock
 
     bool mDestructing{false};
 
-    time_point next();
     void maybeSetRealtimer();
     size_t advanceTo(time_point n);
     size_t advanceToNext();
@@ -152,6 +151,9 @@ class VirtualClock
     // only valid with VIRTUAL_TIME: sets the current value
     // of the clock
     void setCurrentTime(time_point t);
+
+    // returns the time of the next scheduled event
+    time_point next();
 };
 
 class VirtualClockEvent : public NonMovableOrCopyable


### PR DESCRIPTION
resolves #1382 

this PR changes the way the `Simulation` class schedules work between its instances:
before this PR, a single clock was shared (among with its IOService), this PR allocates a clock and an IOService for each of the nodes.
There are many reasons why a shared IOService was bad, here are a few:
* the app destructor kills its ioservice - basically killing one app, kills all other apps
* work between apps bleeds between apps, causing all sorts of strange behaviors that would not otherwise occur (for example: a "busy" app that reposts work on the queue will end up preempting a lot of work that other nodes could be doing)

This allows in particular (also part of this PR), to restart nodes in a simulation by destroying/recreating nodes. As part of those resilience tests, I introduced a new "CustomA" simulation type that somewhat  resembles production.

Added benefit: if one day we feel adventurous enough, changing the simulation code to run on multiple threads should be fairly straightforward.

I also fixed a few bugs in the LoopbackPeer code that was causing crashes/undefined behavior, see the list of commits for more details.
