### PR TITLE
enforce that clang-format was run in PR from travis

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,48 +2,61 @@
 Language:        Cpp
 # BasedOnStyle:  LLVM
 AccessModifierOffset: -2
-AlignAfterOpenBracket: true
-AlignEscapedNewlinesLeft: false
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
-AlwaysBreakAfterDefinitionReturnType: true
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakAfterReturnType: AllDefinitions
 AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true
-BinPackParameters: true
-BinPackArguments: true
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
 ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
-DerivePointerAlignment: false
-ExperimentalAutoDetectBinPacking: false
-IndentCaseLabels: false
-IndentWrappedFunctionNames: false
-IndentFunctionDeclarationAfterType: false
-MaxEmptyLinesToKeep: 1
-KeepEmptyLinesAtTheStartOfBlocks: true
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakString: 1000
-PenaltyBreakFirstLessLess: 120
-PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Left
-SpacesBeforeTrailingComments: 1
+ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-Standard:        Cpp11
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
 IncludeCategories:
   - Regex:           '^"util/asio\.h'
     Priority:        -1
@@ -55,23 +68,44 @@ IncludeCategories:
     Priority:        3
   - Regex:           '.\*'
     Priority:        4
-SortIncludes: true
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
 IndentWidth:     4
-TabWidth:        8
-UseTab:          Never
-BreakBeforeBraces: Allman
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-SpacesInAngles:  false
-SpaceInEmptyParentheses: false
-SpacesInCStyleCastParentheses: false
-SpaceAfterCStyleCast: false
-SpacesInContainerLiterals: true
-SpaceBeforeAssignmentOperators: true
-ContinuationIndentWidth: 4
-CommentPragmas:  '^ IWYU pragma:'
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-SpaceBeforeParens: ControlStatements
-DisableFormat:   false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
 ...
 

--- a/INSTALL-Windows.md
+++ b/INSTALL-Windows.md
@@ -68,8 +68,8 @@ If you do not have cURL installed
 ## clang-format
 
 For making changes to the code, you should install the clang-format tool and Visual Studio extension, you can find both at http://llvm.org/builds/
-* note that the version of clang-format used currently is 3.x - and 4.0+ does not format the same way.
-* we recommend downloading 3.9.1 from http://releases.llvm.org/download.html
+* note that the version of clang-format used currently is 5.0 (other versions may not format the same way).
+* we recommend downloading 5.0.0 from http://releases.llvm.org/download.html
 
 # Build on Windows using the Windows Subsystem for Linux
 To setup the subsystem, go to https://msdn.microsoft.com/en-us/commandline/wsl/install_guide

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,7 +26,7 @@ When running a node, the best bet is to go with the latest release.
 - `bison` and `flex`
 - `libpq-devel` unless you `./configure --disable-postgres` in the build step below.
 - 64-bit system
-
+- `clang-format-5.0` (for `make format` to work)
 
 ### Ubuntu 14.04
 
@@ -34,6 +34,8 @@ When running a node, the best bet is to go with the latest release.
     # apt-get update
     # sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev clang++-3.5 gcc-4.9 g++-4.9 cpp-4.9
 
+In order to make changes, you'll need to install the proper version of clang-format (you may have to follow instructions on https://apt.llvm.org/ )
+    # sudo apt-get install clang-format-5.0
 
 See [installing gcc 4.9 on ubuntu 14.04](http://askubuntu.com/questions/428198/getting-installing-gcc-g-4-9-on-ubuntu)
 

--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,8 @@ AS_IF([test "x$enable_afl" = "xyes"], [
 ])
 AM_CONDITIONAL([USE_AFL_FUZZ], [test "x$enable_afl" == "xyes"])
 
-AC_CHECK_PROGS(CLANG_FORMAT, [clang-format clang-format-3.6])
+# prefer 5.0 as it's the one we use
+AC_CHECK_PROGS(CLANG_FORMAT, [clang-format-5.0 clang-format])
 AM_CONDITIONAL([USE_CLANG_FORMAT], [test "x$CLANG_FORMAT" != "x"])
 
 AX_VALGRIND_CHECK

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,7 +49,7 @@ endif # !USE_POSTGRES
 
 if USE_CLANG_FORMAT
 format: always
-	cd $(srcdir) && $(CLANG_FORMAT) -i $(SRC_CXX_FILES) $(SRC_H_FILES)
+	cd $(srcdir) && $(CLANG_FORMAT) -style=file -i $(SRC_CXX_FILES) $(SRC_H_FILES)
 endif # USE_CLANG_FORMAT
 
 if USE_AFL_FUZZ

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -57,8 +57,8 @@ Bucket::Bucket(std::string const& filename, Hash const& hash)
     assert(filename.empty() || fs::exists(filename));
     if (!filename.empty())
     {
-        CLOG(TRACE, "Bucket") << "Bucket::Bucket() created, file exists : "
-                              << mFilename;
+        CLOG(TRACE, "Bucket")
+            << "Bucket::Bucket() created, file exists : " << mFilename;
     }
 }
 
@@ -439,8 +439,8 @@ checkDBAgainstBuckets(medida::MetricsRegistry& metrics,
         auto& next = level.getNext();
         if (next.isLive())
         {
-            CLOG(INFO, "Bucket") << "CheckDB resolving future bucket on level "
-                                 << i;
+            CLOG(INFO, "Bucket")
+                << "CheckDB resolving future bucket on level " << i;
             buckets.push_back(next.resolve());
         }
         buckets.push_back(level.getCurr());
@@ -505,8 +505,8 @@ checkDBAgainstBuckets(medida::MetricsRegistry& metrics,
                 }
                 if (meter.count() % 100 == 0)
                 {
-                    CLOG(INFO, "Bucket") << "CheckDB compared " << meter.count()
-                                         << " objects";
+                    CLOG(INFO, "Bucket")
+                        << "CheckDB compared " << meter.count() << " objects";
                 }
             }
         }

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -53,8 +53,8 @@ BucketApplicator::advance()
 
     if (!mBucketIter || (mSize & 0xfff) == 0xfff)
     {
-        CLOG(INFO, "Bucket") << "Bucket-apply: committed " << mSize
-                             << " entries";
+        CLOG(INFO, "Bucket")
+            << "Bucket-apply: committed " << mSize << " entries";
     }
 }
 }

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -403,9 +403,10 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
     }
 
     assert(shadows.size() == 0);
-    mLevels[0].prepare(app, currLedger, Bucket::fresh(app.getBucketManager(),
-                                                      liveEntries, deadEntries),
-                       shadows);
+    mLevels[0].prepare(
+        app, currLedger,
+        Bucket::fresh(app.getBucketManager(), liveEntries, deadEntries),
+        shadows);
     mLevels[0].commit();
 }
 
@@ -421,8 +422,8 @@ BucketList::restartMerges(Application& app)
             next.makeLive(app);
             if (next.isMerging())
             {
-                CLOG(INFO, "Bucket") << "Restarted merge on BucketList level "
-                                     << i;
+                CLOG(INFO, "Bucket")
+                    << "Restarted merge on BucketList level " << i;
             }
         }
         ++i;

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -163,8 +163,8 @@ BucketManagerImpl::adoptFileAsBucket(std::string const& filename,
         mBucketObjectInsert.Mark(nObjects);
         mBucketByteInsert.Mark(nBytes);
         std::string canonicalName = bucketFilename(hash);
-        CLOG(DEBUG, "Bucket") << "Adopting bucket file " << filename << " as "
-                              << canonicalName;
+        CLOG(DEBUG, "Bucket")
+            << "Adopting bucket file " << filename << " as " << canonicalName;
         if (rename(filename.c_str(), canonicalName.c_str()) != 0)
         {
             std::string err("Failed to rename bucket :");
@@ -193,17 +193,17 @@ BucketManagerImpl::getBucketByHash(uint256 const& hash)
     auto i = mSharedBuckets.find(hash);
     if (i != mSharedBuckets.end())
     {
-        CLOG(TRACE, "Bucket") << "BucketManager::getBucketByHash("
-                              << binToHex(hash) << ") found bucket "
-                              << i->second->getFilename();
+        CLOG(TRACE, "Bucket")
+            << "BucketManager::getBucketByHash(" << binToHex(hash)
+            << ") found bucket " << i->second->getFilename();
         return i->second;
     }
     std::string canonicalName = bucketFilename(hash);
     if (fs::exists(canonicalName))
     {
-        CLOG(TRACE, "Bucket") << "BucketManager::getBucketByHash("
-                              << binToHex(hash)
-                              << ") found no bucket, making new one";
+        CLOG(TRACE, "Bucket")
+            << "BucketManager::getBucketByHash(" << binToHex(hash)
+            << ") found no bucket, making new one";
         auto p = std::make_shared<Bucket>(canonicalName, hash);
         mSharedBuckets.insert(std::make_pair(hash, p));
         mSharedBucketsSize.set_count(mSharedBuckets.size());

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -277,8 +277,8 @@ TEST_CASE("bucket list", "[bucket]")
     }
     catch (std::future_error& e)
     {
-        CLOG(DEBUG, "Bucket") << "Test caught std::future_error " << e.code()
-                              << ": " << e.what();
+        CLOG(DEBUG, "Bucket")
+            << "Test caught std::future_error " << e.code() << ": " << e.what();
         REQUIRE(false);
     }
 }
@@ -319,8 +319,8 @@ TEST_CASE("bucket list shadowing", "[bucket]")
         bl.addBatch(*app, i, liveBatch, deadGen(5));
         if (i % 100 == 0)
         {
-            CLOG(DEBUG, "Bucket") << "Added batch " << i
-                                  << ", hash=" << binToHex(bl.getHash());
+            CLOG(DEBUG, "Bucket")
+                << "Added batch " << i << ", hash=" << binToHex(bl.getHash());
             // Alice and bob should be in either curr or snap of level 0 and 1
             for (uint32_t j = 0; j < 2; ++j)
             {
@@ -392,8 +392,8 @@ TEST_CASE("duplicate bucket entries", "[bucket]")
     }
     catch (std::future_error& e)
     {
-        CLOG(DEBUG, "Bucket") << "Test caught std::future_error " << e.code()
-                              << ": " << e.what();
+        CLOG(DEBUG, "Bucket")
+            << "Test caught std::future_error " << e.code() << ": " << e.what();
         REQUIRE(false);
     }
 }
@@ -437,8 +437,8 @@ TEST_CASE("bucket tombstones expire at bottom level", "[bucket][tombstones]")
                 }
             }
             n = mergeTimer.count() - n;
-            CLOG(INFO, "Bucket") << "Added batch at ledger " << j
-                                 << ", merges provoked: " << n;
+            CLOG(INFO, "Bucket")
+                << "Added batch at ledger " << j << ", merges provoked: " << n;
             REQUIRE(n > 0);
             REQUIRE(n < 2 * BucketList::kNumLevels);
         }
@@ -563,8 +563,8 @@ TEST_CASE("merging bucket entries", "[bucket]")
             Bucket::fresh(app->getBucketManager(), live, dead);
         CHECK(countEntries(b1) == live.size());
         auto liveCount = b1->countLiveAndDeadEntries().first;
-        CLOG(DEBUG, "Bucket") << "post-merge live count: " << liveCount
-                              << " of " << live.size();
+        CLOG(DEBUG, "Bucket")
+            << "post-merge live count: " << liveCount << " of " << live.size();
         CHECK(liveCount == live.size() - dead.size());
     }
 
@@ -737,9 +737,9 @@ TEST_CASE("single entry bubbling up", "[bucket][bucketbubble]")
                 auto const& lev = bl.getLevel(j);
                 auto currSz = countEntries(lev.getCurr());
                 auto snapSz = countEntries(lev.getSnap());
-                CLOG(DEBUG, "Bucket") << "ledger " << i << ", level " << j
-                                      << " curr=" << currSz
-                                      << " snap=" << snapSz;
+                CLOG(DEBUG, "Bucket")
+                    << "ledger " << i << ", level " << j << " curr=" << currSz
+                    << " snap=" << snapSz;
 
                 if (1 > lb && 1 <= hb)
                 {
@@ -755,8 +755,8 @@ TEST_CASE("single entry bubbling up", "[bucket][bucketbubble]")
     }
     catch (std::future_error& e)
     {
-        CLOG(DEBUG, "Bucket") << "Test caught std::future_error " << e.code()
-                              << ": " << e.what();
+        CLOG(DEBUG, "Bucket")
+            << "Test caught std::future_error " << e.code() << ": " << e.what();
         REQUIRE(false);
     }
 }

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -196,8 +196,8 @@ ApplyBucketsWork::onSuccess()
     if (mLevel != 0)
     {
         --mLevel;
-        CLOG(DEBUG, "History") << "ApplyBuckets : starting next level: "
-                               << mLevel;
+        CLOG(DEBUG, "History")
+            << "ApplyBuckets : starting next level: " << mLevel;
         return WORK_PENDING;
     }
 

--- a/src/catchup/ApplyLedgerChainWork.cpp
+++ b/src/catchup/ApplyLedgerChainWork.cpp
@@ -105,8 +105,8 @@ ApplyLedgerChainWork::getCurrentTxSet()
     {
         if (mTxHistoryEntry.ledgerSeq < seq)
         {
-            CLOG(DEBUG, "History") << "Skipping txset for ledger "
-                                   << mTxHistoryEntry.ledgerSeq;
+            CLOG(DEBUG, "History")
+                << "Skipping txset for ledger " << mTxHistoryEntry.ledgerSeq;
         }
         else if (mTxHistoryEntry.ledgerSeq > seq)
         {
@@ -145,8 +145,8 @@ ApplyLedgerChainWork::applyHistoryOfSingleLedger()
     // If we are >1 before LCL, skip
     if (header.ledgerSeq + 1 < lclHeader.header.ledgerSeq)
     {
-        CLOG(DEBUG, "History") << "Catchup skipping old ledger "
-                               << header.ledgerSeq;
+        CLOG(DEBUG, "History")
+            << "Catchup skipping old ledger " << header.ledgerSeq;
         mApplyLedgerSkip.Mark();
         return true;
     }
@@ -181,8 +181,8 @@ ApplyLedgerChainWork::applyHistoryOfSingleLedger()
                             LedgerManager::ledgerAbbrev(hHeader),
                             LedgerManager::ledgerAbbrev(lclHeader)));
         }
-        CLOG(DEBUG, "History") << "Catchup at LCL=" << header.ledgerSeq
-                               << ", hash correct";
+        CLOG(DEBUG, "History")
+            << "Catchup at LCL=" << header.ledgerSeq << ", hash correct";
         mApplyLedgerSkip.Mark();
         return true;
     }

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -87,11 +87,11 @@ class CatchupWork : public BucketDownloadWork
 
   public:
     /**
-    * Preconditions:
-    * * lastClosedLedger > 0
-    * * configuration.toLedger() >= lastClosedLedger
-    * * configuration.toLedger() != CatchupConfiguration::CURRENT
-    */
+     * Preconditions:
+     * * lastClosedLedger > 0
+     * * configuration.toLedger() >= lastClosedLedger
+     * * configuration.toLedger() != CatchupConfiguration::CURRENT
+     */
     static CatchupRange
     makeCatchupRange(uint32_t lastClosedLedger,
                      CatchupConfiguration const& configuration,

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -161,8 +161,8 @@ Database::upgradeToCurrentSchema()
     while (vers < SCHEMA_VERSION)
     {
         ++vers;
-        CLOG(INFO, "Database") << "Applying DB schema upgrade to version "
-                               << vers;
+        CLOG(INFO, "Database")
+            << "Applying DB schema upgrade to version " << vers;
         applySchemaUpgrade(vers);
         putSchemaVersion(vers);
     }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -250,10 +250,10 @@ HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
     uint64 slotIndex = envelope.statement.slotIndex;
 
     if (Logging::logDebug("Herder"))
-        CLOG(DEBUG, "Herder") << "emitEnvelope"
-                              << " s:" << envelope.statement.pledges.type()
-                              << " i:" << slotIndex
-                              << " a:" << mApp.getStateHuman();
+        CLOG(DEBUG, "Herder")
+            << "emitEnvelope"
+            << " s:" << envelope.statement.pledges.type() << " i:" << slotIndex
+            << " a:" << mApp.getStateHuman();
 
     persistSCPState(slotIndex);
 
@@ -427,8 +427,8 @@ HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer)
 
         if (envelopes.size() != 0)
         {
-            CLOG(DEBUG, "Herder") << "Send state " << envelopes.size()
-                                  << " for ledger " << seq;
+            CLOG(DEBUG, "Herder")
+                << "Send state " << envelopes.size() << " for ledger " << seq;
 
             for (auto const& e : envelopes)
             {
@@ -752,10 +752,10 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
         Value v(xdr::xdr_to_opaque(upgrade));
         if (v.size() >= UpgradeType::max_size())
         {
-            CLOG(ERROR, "Herder") << "HerderImpl::triggerNextLedger"
-                                  << " exceeded size for upgrade step (got "
-                                  << v.size() << " ) for upgrade type "
-                                  << std::to_string(upgrade.type());
+            CLOG(ERROR, "Herder")
+                << "HerderImpl::triggerNextLedger"
+                << " exceeded size for upgrade step (got " << v.size()
+                << " ) for upgrade type " << std::to_string(upgrade.type());
         }
         else
         {

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -558,8 +558,9 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
 
             if (cTxSet && cTxSet->previousLedgerHash() == lcl.hash)
             {
-                if (!highestTxSet || (cTxSet->mTransactions.size() >
-                                      highestTxSet->mTransactions.size()) ||
+                if (!highestTxSet ||
+                    (cTxSet->mTransactions.size() >
+                     highestTxSet->mTransactions.size()) ||
                     ((cTxSet->mTransactions.size() ==
                       highestTxSet->mTransactions.size()) &&
                      lessThanXored(highest, sv.txSetHash, candidatesHash)))
@@ -619,8 +620,8 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
         //  * when getting back in sync (a gap potentially opened)
         // in both cases it's safe to just ignore those as we're already
         // tracking a more recent state
-        CLOG(DEBUG, "Herder") << "Ignoring old ledger externalize "
-                              << slotIndex;
+        CLOG(DEBUG, "Herder")
+            << "Ignoring old ledger externalize " << slotIndex;
         return;
     }
 
@@ -686,8 +687,8 @@ HerderSCPDriver::logQuorumInformation(uint64_t index)
         if (!i.empty())
         {
             Json::FastWriter fw;
-            CLOG(INFO, "Herder") << "Quorum information for " << index << " : "
-                                 << fw.write(i);
+            CLOG(INFO, "Herder")
+                << "Quorum information for " << index << " : " << fw.write(i);
         }
     }
 }

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -12,12 +12,12 @@ namespace stellar
 {
 
 /**
-* Helper class that describes a single ledger-to-close -- a set of transactions
-* and auxiliary values -- as decided by the Herder (and ultimately: SCP). This
-* does not include the effects of _performing_ any transactions, merely the
-* values that the network has agreed _to apply_ to the current ledger,
-* atomically, in order to produce the next ledger.
-*/
+ * Helper class that describes a single ledger-to-close -- a set of transactions
+ * and auxiliary values -- as decided by the Herder (and ultimately: SCP). This
+ * does not include the effects of _performing_ any transactions, merely the
+ * values that the network has agreed _to apply_ to the current ledger,
+ * atomically, in order to produce the next ledger.
+ */
 class LedgerCloseData
 {
   public:

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -173,9 +173,9 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
     auto const& nodeID = envelope.statement.nodeID;
     if (!isNodeInQuorum(nodeID))
     {
-        CLOG(DEBUG, "Herder") << "Dropping envelope from "
-                              << mApp.getConfig().toShortString(nodeID)
-                              << " (not in quorum)";
+        CLOG(DEBUG, "Herder")
+            << "Dropping envelope from "
+            << mApp.getConfig().toShortString(nodeID) << " (not in quorum)";
         return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -159,8 +159,8 @@ TxSetFrame::surgePricingFilter(LedgerManager const& lm)
     size_t max = lm.getMaxTxSetSize();
     if (mTransactions.size() > max)
     { // surge pricing in effect!
-        CLOG(WARNING, "Herder") << "surge pricing in effect! "
-                                << mTransactions.size();
+        CLOG(WARNING, "Herder")
+            << "surge pricing in effect! " << mTransactions.size();
 
         // determine the fee ratio for each account
         map<AccountID, double> accountFeeMap;
@@ -266,9 +266,9 @@ TxSetFrame::checkValid(Application& app) const
 
     if (mTransactions.size() > lcl.header.maxTxSetSize)
     {
-        CLOG(DEBUG, "Herder") << "Got bad txSet: too many txs "
-                              << mTransactions.size() << " > "
-                              << lcl.header.maxTxSetSize;
+        CLOG(DEBUG, "Herder")
+            << "Got bad txSet: too many txs " << mTransactions.size() << " > "
+            << lcl.header.maxTxSetSize;
         return false;
     }
 

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -116,8 +116,8 @@ HistoryArchiveState::load(std::string const& inFile)
     serialize(ar);
     if (version != HISTORY_ARCHIVE_STATE_VERSION)
     {
-        CLOG(ERROR, "History") << "unexpected history archive state version: "
-                               << version;
+        CLOG(ERROR, "History")
+            << "unexpected history archive state version: " << version;
         throw std::runtime_error("unexpected history archive state version");
     }
     assert(futuresAllResolved());

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -66,8 +66,8 @@ HistoryManager::initializeHistoryArchive(Application& app, std::string arch)
     auto i = cfg.HISTORY.find(arch);
     if (i == cfg.HISTORY.end())
     {
-        CLOG(FATAL, "History") << "Can't initialize unknown history archive '"
-                               << arch << "'";
+        CLOG(FATAL, "History")
+            << "Can't initialize unknown history archive '" << arch << "'";
         return false;
     }
 
@@ -87,8 +87,8 @@ HistoryManager::initializeHistoryArchive(Application& app, std::string arch)
     }
     if (getHas->getState() == Work::WORK_SUCCESS)
     {
-        CLOG(ERROR, "History") << "History archive '" << arch
-                               << "' already initialized!";
+        CLOG(ERROR, "History")
+            << "History archive '" << arch << "' already initialized!";
         return false;
     }
     CLOG(INFO, "History") << "History archive '" << arch
@@ -111,8 +111,8 @@ HistoryManager::initializeHistoryArchive(Application& app, std::string arch)
     }
     else
     {
-        CLOG(FATAL, "History") << "Failed to initialize history archive '"
-                               << arch << "'";
+        CLOG(FATAL, "History")
+            << "Failed to initialize history archive '" << arch << "'";
         return false;
     }
 }

--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -594,8 +594,8 @@ HistoryTests::catchupApplication(uint32_t initLedger, uint32_t count,
         // 192 (the first entry in block 4) and externalize that value, so that
         // the catchup can see a {192}.prevHash to knit up block 3 against.
 
-        CLOG(INFO, "History") << "force-starting catchup at initLedger="
-                              << initLedger;
+        CLOG(INFO, "History")
+            << "force-starting catchup at initLedger=" << initLedger;
 
         lm.startCatchUp({initLedger, count}, manual);
     }
@@ -714,15 +714,15 @@ HistoryTests::catchupApplication(uint32_t initLedger, uint32_t count,
                                    .getCurr()
                                    ->getHash();
 
-        CLOG(INFO, "History") << "Caught up: want Seq[" << i
-                              << "] = " << wantSeq;
-        CLOG(INFO, "History") << "Caught up: have Seq[" << i
-                              << "] = " << haveSeq;
+        CLOG(INFO, "History")
+            << "Caught up: want Seq[" << i << "] = " << wantSeq;
+        CLOG(INFO, "History")
+            << "Caught up: have Seq[" << i << "] = " << haveSeq;
 
-        CLOG(INFO, "History") << "Caught up: want Hash[" << i
-                              << "] = " << hexAbbrev(wantHash);
-        CLOG(INFO, "History") << "Caught up: have Hash[" << i
-                              << "] = " << hexAbbrev(haveHash);
+        CLOG(INFO, "History")
+            << "Caught up: want Hash[" << i << "] = " << hexAbbrev(wantHash);
+        CLOG(INFO, "History")
+            << "Caught up: have Hash[" << i << "] = " << hexAbbrev(haveHash);
 
         CLOG(INFO, "History") << "Caught up: want BucketListHash[" << i
                               << "] = " << hexAbbrev(wantBucketListHash);

--- a/src/history/InferredQuorum.cpp
+++ b/src/history/InferredQuorum.cpp
@@ -225,8 +225,8 @@ InferredQuorum::checkQuorumIntersection(Config const& cfg) const
     {
         if (mQsetHashes.find(pk.first) == mQsetHashes.end())
         {
-            CLOG(WARNING, "History") << "Node without qset: "
-                                     << cfg.toShortString(pk.first);
+            CLOG(WARNING, "History")
+                << "Node without qset: " << cfg.toShortString(pk.first);
         }
     }
     CLOG(INFO, "History") << "Found " << nodeNumbers.size() << " nodes total";
@@ -271,13 +271,13 @@ InferredQuorum::checkQuorumIntersection(Config const& cfg) const
         auto name = cfg.toStrKey(revNodeNumbers.at(n), isAlias);
         if (allOk)
         {
-            CLOG(INFO, "History") << "  \"" << (isAlias ? "$" : "") << name
-                                  << '"';
+            CLOG(INFO, "History")
+                << "  \"" << (isAlias ? "$" : "") << name << '"';
         }
         else
         {
-            CLOG(WARNING, "History") << "  \"" << (isAlias ? "$" : "") << name
-                                     << '"';
+            CLOG(WARNING, "History")
+                << "  \"" << (isAlias ? "$" : "") << name << '"';
         }
     }
     return allOk;

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -103,17 +103,17 @@ StateSnapshot::writeHistoryBlocks() const
             txResultOut);
         CLOG(DEBUG, "History") << "Wrote " << nHeaders << " ledger headers to "
                                << mLedgerSnapFile->localPath_nogz();
-        CLOG(DEBUG, "History") << "Wrote " << nTxs << " transactions to "
-                               << mTransactionSnapFile->localPath_nogz()
-                               << " and "
-                               << mTransactionResultSnapFile->localPath_nogz();
+        CLOG(DEBUG, "History")
+            << "Wrote " << nTxs << " transactions to "
+            << mTransactionSnapFile->localPath_nogz() << " and "
+            << mTransactionResultSnapFile->localPath_nogz();
 
         nbSCPMessages = HerderPersistence::copySCPHistoryToStream(
             mApp.getDatabase(), sess, begin, count, scpHistory);
 
-        CLOG(DEBUG, "History") << "Wrote " << nbSCPMessages
-                               << " SCP messages to "
-                               << mSCPHistorySnapFile->localPath_nogz();
+        CLOG(DEBUG, "History")
+            << "Wrote " << nbSCPMessages << " SCP messages to "
+            << mSCPHistorySnapFile->localPath_nogz();
     }
 
     if (nbSCPMessages == 0)

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -19,8 +19,9 @@ BatchDownloadWork::BatchDownloadWork(Application& app, WorkParent& parent,
                                      CheckpointRange range,
                                      std::string const& type,
                                      TmpDir const& downloadDir)
-    : Work(app, parent, fmt::format("batch-download-{:s}-{:08x}-{:08x}", type,
-                                    range.first(), range.last()))
+    : Work(app, parent,
+           fmt::format("batch-download-{:s}-{:08x}-{:08x}", type, range.first(),
+                       range.last()))
     , mRange(range)
     , mNext(mRange.first())
     , mFileType(type)
@@ -63,8 +64,8 @@ BatchDownloadWork::addNextDownloadWorker()
     FileTransferInfo ft(mDownloadDir, mFileType, mNext);
     if (fs::exists(ft.localPath_nogz()))
     {
-        CLOG(DEBUG, "History") << "already have " << mFileType
-                               << " for checkpoint " << mNext;
+        CLOG(DEBUG, "History")
+            << "already have " << mFileType << " for checkpoint " << mNext;
         mDownloadCached.Mark();
     }
     else
@@ -99,8 +100,8 @@ BatchDownloadWork::notify(std::string const& child)
     auto i = mChildren.find(child);
     if (i == mChildren.end())
     {
-        CLOG(WARNING, "Work") << "BatchDownloadWork notified by unknown child "
-                              << child;
+        CLOG(WARNING, "Work")
+            << "BatchDownloadWork notified by unknown child " << child;
         return;
     }
 

--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -76,30 +76,30 @@ GetAndUnzipRemoteFileWork::onSuccess()
 
     if (fs::exists(mFt.localPath_gz_tmp()))
     {
-        CLOG(TRACE, "History") << "Downloading and unzipping "
-                               << mFt.remoteName()
-                               << ": renaming .gz.tmp to .gz";
+        CLOG(TRACE, "History")
+            << "Downloading and unzipping " << mFt.remoteName()
+            << ": renaming .gz.tmp to .gz";
         if (fs::exists(mFt.localPath_gz()) &&
             std::remove(mFt.localPath_gz().c_str()))
         {
-            CLOG(ERROR, "History") << "Downloading and unzipping "
-                                   << mFt.remoteName()
-                                   << ": failed to remove .gz";
+            CLOG(ERROR, "History")
+                << "Downloading and unzipping " << mFt.remoteName()
+                << ": failed to remove .gz";
             return WORK_FAILURE_RETRY;
         }
 
         if (std::rename(mFt.localPath_gz_tmp().c_str(),
                         mFt.localPath_gz().c_str()))
         {
-            CLOG(ERROR, "History") << "Downloading and unzipping "
-                                   << mFt.remoteName()
-                                   << ": failed to rename .gz.tmp to .gz";
+            CLOG(ERROR, "History")
+                << "Downloading and unzipping " << mFt.remoteName()
+                << ": failed to rename .gz.tmp to .gz";
             return WORK_FAILURE_RETRY;
         }
 
-        CLOG(TRACE, "History") << "Downloading and unzipping "
-                               << mFt.remoteName()
-                               << ": renamed .gz.tmp to .gz";
+        CLOG(TRACE, "History")
+            << "Downloading and unzipping " << mFt.remoteName()
+            << ": renamed .gz.tmp to .gz";
     }
 
     if (!fs::exists(mFt.localPath_gz()))

--- a/src/historywork/PutHistoryArchiveStateWork.cpp
+++ b/src/historywork/PutHistoryArchiveStateWork.cpp
@@ -46,8 +46,8 @@ PutHistoryArchiveStateWork::onRun()
         }
         catch (std::runtime_error& e)
         {
-            CLOG(ERROR, "History") << "error loading history state: "
-                                   << e.what();
+            CLOG(ERROR, "History")
+                << "error loading history state: " << e.what();
             scheduleFailure();
         }
     }

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -67,11 +67,11 @@ VerifyBucketWork::onStart()
             }
             else
             {
-                CLOG(WARNING, "History") << "FAILED verifying hash for "
-                                         << filename;
+                CLOG(WARNING, "History")
+                    << "FAILED verifying hash for " << filename;
                 CLOG(WARNING, "History") << "expected hash: " << binToHex(hash);
-                CLOG(WARNING, "History") << "computed hash: "
-                                         << binToHex(vHash);
+                CLOG(WARNING, "History")
+                    << "computed hash: " << binToHex(vHash);
                 ec = std::make_error_code(std::errc::io_error);
             }
         }

--- a/src/invariant/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabaseTests.cpp
@@ -299,26 +299,26 @@ class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
                 switch (mType)
                 {
                 case ACCOUNT:
-                    CLOG(INFO, "Invariant") << "Added account @ "
-                                            << mFromLedgerSeq;
+                    CLOG(INFO, "Invariant")
+                        << "Added account @ " << mFromLedgerSeq;
                     entry.data.account() =
                         LedgerTestUtils::generateValidAccountEntry(5);
                     break;
                 case TRUSTLINE:
-                    CLOG(INFO, "Invariant") << "Added trustLine @ "
-                                            << mFromLedgerSeq;
+                    CLOG(INFO, "Invariant")
+                        << "Added trustLine @ " << mFromLedgerSeq;
                     entry.data.trustLine() =
                         LedgerTestUtils::generateValidTrustLineEntry(5);
                     break;
                 case OFFER:
-                    CLOG(INFO, "Invariant") << "Added offer @ "
-                                            << mFromLedgerSeq;
+                    CLOG(INFO, "Invariant")
+                        << "Added offer @ " << mFromLedgerSeq;
                     entry.data.offer() =
                         LedgerTestUtils::generateValidOfferEntry(5);
                     break;
                 case DATA:
-                    CLOG(INFO, "Invariant") << "Added data @ "
-                                            << mFromLedgerSeq;
+                    CLOG(INFO, "Invariant")
+                        << "Added data @ " << mFromLedgerSeq;
                     entry.data.data() =
                         LedgerTestUtils::generateValidDataEntry(5);
                     break;

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -9,7 +9,6 @@
 #include "invariant/CacheIsConsistentWithDatabase.h"
 #include "invariant/ChangedAccountsSubentriesCountIsValid.h"
 #include "invariant/InvariantDoesNotHold.h"
-#include "invariant/InvariantDoesNotHold.h"
 #include "invariant/TotalCoinsEqualsBalancesPlusFeePool.h"
 #include "ledger/LedgerDelta.h"
 #include "lib/util/format.h"
@@ -62,9 +61,9 @@ InvariantManagerImpl::checkOnBucketApply(std::shared_ptr<Bucket const> bucket,
     uint32_t oldestLedger = isCurr
                                 ? BucketList::oldestLedgerInCurr(ledger, level)
                                 : BucketList::oldestLedgerInSnap(ledger, level);
-    uint32_t newestLedger =
-        oldestLedger - 1 + (isCurr ? BucketList::sizeOfCurr(ledger, level)
-                                   : BucketList::sizeOfSnap(ledger, level));
+    uint32_t newestLedger = oldestLedger - 1 +
+                            (isCurr ? BucketList::sizeOfCurr(ledger, level)
+                                    : BucketList::sizeOfSnap(ledger, level));
     for (auto invariant : mEnabled)
     {
         auto result =

--- a/src/ledger/LedgerHeaderFrame.cpp
+++ b/src/ledger/LedgerHeaderFrame.cpp
@@ -230,8 +230,8 @@ LedgerHeaderFrame::copyLedgerHeadersToStream(Database& db, soci::session& sess,
         LedgerHeaderFrame::pointer lhf = decodeFromData(headerEncoded);
         lhe.hash = lhf->getHash();
         lhe.header = lhf->mHeader;
-        CLOG(DEBUG, "Ledger") << "Streaming ledger-header "
-                              << lhe.header.ledgerSeq;
+        CLOG(DEBUG, "Ledger")
+            << "Streaming ledger-header " << lhe.header.ledgerSeq;
         headersOut.writeOne(lhe);
         ++n;
         st.fetch();

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -134,8 +134,8 @@ LedgerManagerImpl::setState(State s)
         mLedgerStateChanges.Update(now - mLastStateChange);
         mLastStateChange = now;
         mApp.syncOwnMetrics();
-        CLOG(INFO, "Ledger") << "Changing state " << oldState << " -> "
-                             << getStateHuman();
+        CLOG(INFO, "Ledger")
+            << "Changing state " << oldState << " -> " << getStateHuman();
         if (mState != LM_CATCHING_UP_STATE)
         {
             mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
@@ -372,8 +372,8 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
                     setState(LM_SYNCED_STATE);
                 }
                 closeLedger(ledgerData);
-                CLOG(INFO, "Ledger") << "Closed ledger: "
-                                     << ledgerAbbrev(mLastClosedLedger);
+                CLOG(INFO, "Ledger")
+                    << "Closed ledger: " << ledgerAbbrev(mLastClosedLedger);
             }
             else
             {
@@ -386,26 +386,26 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
         else if (ledgerData.getLedgerSeq() <=
                  mLastClosedLedger.header.ledgerSeq)
         {
-            CLOG(INFO, "Ledger") << "Skipping close ledger: local state is "
-                                 << mLastClosedLedger.header.ledgerSeq
-                                 << ", more recent than "
-                                 << ledgerData.getLedgerSeq();
+            CLOG(INFO, "Ledger")
+                << "Skipping close ledger: local state is "
+                << mLastClosedLedger.header.ledgerSeq << ", more recent than "
+                << ledgerData.getLedgerSeq();
         }
         else
         {
             // Out of sync, buffer what we just heard and start catchup.
-            CLOG(INFO, "Ledger") << "Lost sync, local LCL is "
-                                 << mLastClosedLedger.header.ledgerSeq
-                                 << ", network closed ledger "
-                                 << ledgerData.getLedgerSeq();
+            CLOG(INFO, "Ledger")
+                << "Lost sync, local LCL is "
+                << mLastClosedLedger.header.ledgerSeq
+                << ", network closed ledger " << ledgerData.getLedgerSeq();
 
             assert(mSyncingLedgers.size() == 0);
             auto addResult = mSyncingLedgers.add(ledgerData);
             assert(addResult == SyncingLedgerChainAddResult::CONTIGUOUS);
             mSyncingLedgersSize.set_count(mSyncingLedgers.size());
-            CLOG(INFO, "Ledger") << "Close of ledger "
-                                 << ledgerData.getLedgerSeq()
-                                 << " buffered, starting catchup";
+            CLOG(INFO, "Ledger")
+                << "Close of ledger " << ledgerData.getLedgerSeq()
+                << " buffered, starting catchup";
 
             // catchup just before first buffered ledger
             // that way we will have a way to verify history consistency -
@@ -426,10 +426,10 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
             mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
             break;
         case SyncingLedgerChainAddResult::TOO_OLD:
-            CLOG(INFO, "Ledger") << "Skipping close ledger: latest known is "
-                                 << mSyncingLedgers.back().getLedgerSeq()
-                                 << ", more recent than "
-                                 << ledgerData.getLedgerSeq();
+            CLOG(INFO, "Ledger")
+                << "Skipping close ledger: latest known is "
+                << mSyncingLedgers.back().getLedgerSeq()
+                << ", more recent than " << ledgerData.getLedgerSeq();
             break;
         case SyncingLedgerChainAddResult::TOO_NEW:
             // Out-of-order close while catching up; timeout / network failure?
@@ -898,8 +898,8 @@ LedgerManagerImpl::processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
     }
     catch (std::exception& e)
     {
-        CLOG(FATAL, "Ledger") << "processFeesSeqNums error @ " << index << " : "
-                              << e.what();
+        CLOG(FATAL, "Ledger")
+            << "processFeesSeqNums error @ " << index << " : " << e.what();
         throw;
     }
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -21,7 +21,6 @@
 #include "invariant/CacheIsConsistentWithDatabase.h"
 #include "invariant/ChangedAccountsSubentriesCountIsValid.h"
 #include "invariant/InvariantManager.h"
-#include "invariant/InvariantManager.h"
 #include "invariant/TotalCoinsEqualsBalancesPlusFeePool.h"
 #include "ledger/LedgerManager.h"
 #include "main/CommandHandler.h"
@@ -294,8 +293,8 @@ ApplicationImpl::start()
             auto npub = mHistoryManager->publishQueuedHistory();
             if (npub != 0)
             {
-                CLOG(INFO, "Ledger") << "Restarted publishing " << npub
-                                     << " queued snapshots";
+                CLOG(INFO, "Ledger")
+                    << "Restarted publishing " << npub << " queued snapshots";
             }
             if (mConfig.FORCE_SCP)
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -909,14 +909,13 @@ Config::expandNodeID(const std::string& s) const
         std::function<bool(std::pair<std::string, std::string> const&)>;
     auto arg = s.substr(1);
     auto validatorMatcher =
-        s[0] == '$' ? validatorMatcher_t{[&](
-                          std::pair<std::string, std::string> const& p) {
-            return p.second == arg;
-        }}
-                    : validatorMatcher_t{
-                          [&](std::pair<std::string, std::string> const& p) {
-                              return p.first.compare(0, arg.size(), arg) == 0;
-                          }};
+        s[0] == '$'
+            ? validatorMatcher_t{[&](std::pair<std::string, std::string> const&
+                                         p) { return p.second == arg; }}
+            : validatorMatcher_t{
+                  [&](std::pair<std::string, std::string> const& p) {
+                      return p.first.compare(0, arg.size(), arg) == 0;
+                  }};
 
     auto it = std::find_if(VALIDATOR_NAMES.begin(), VALIDATOR_NAMES.end(),
                            validatorMatcher);

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -87,11 +87,11 @@ dumpxdr(std::string const& filename)
     }
 }
 
-#define throw_perror(msg)                                                      \
-    do                                                                         \
-    {                                                                          \
-        throw std::runtime_error(std::string(msg) + ": " +                     \
-                                 xdr_strerror(errno));                         \
+#define throw_perror(msg) \
+    do \
+    { \
+        throw std::runtime_error(std::string(msg) + ": " + \
+                                 xdr_strerror(errno)); \
     } while (0)
 
 static std::string

--- a/src/main/fuzz.cpp
+++ b/src/main/fuzz.cpp
@@ -11,11 +11,11 @@
 #include "overlay/LoopbackPeer.h"
 #include "overlay/OverlayManager.h"
 #include "overlay/TCPPeer.h"
+#include "test/test.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
 #include "util/XDRStream.h"
-#include "test/test.h"
 
 #include "main/fuzz.h"
 

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -56,8 +56,8 @@ ItemFetcher::stopFetch(Hash itemHash, const SCPEnvelope& envelope)
     {
         auto const& tracker = iter->second;
 
-        CLOG(TRACE, "Overlay") << "stopFetch " << hexAbbrev(itemHash) << " : "
-                               << tracker->size();
+        CLOG(TRACE, "Overlay")
+            << "stopFetch " << hexAbbrev(itemHash) << " : " << tracker->size();
         tracker->discard(envelope);
         if (tracker->empty())
         {
@@ -145,8 +145,8 @@ ItemFetcher::recv(Hash itemHash)
         // calling recv on the same itemHash
         auto& tracker = iter->second;
 
-        CLOG(TRACE, "Overlay") << "Recv " << hexAbbrev(itemHash) << " : "
-                               << tracker->size();
+        CLOG(TRACE, "Overlay")
+            << "Recv " << hexAbbrev(itemHash) << " : " << tracker->size();
 
         while (!tracker->empty())
         {

--- a/src/overlay/LoopbackPeer.h
+++ b/src/overlay/LoopbackPeer.h
@@ -105,9 +105,9 @@ class LoopbackPeer : public Peer
 };
 
 /**
-* Testing class for managing a simulated network connection between two
-* LoopbackPeers.
-*/
+ * Testing class for managing a simulated network connection between two
+ * LoopbackPeers.
+ */
 class LoopbackPeerConnection
 {
     std::shared_ptr<LoopbackPeer> mInitiator;

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -175,8 +175,8 @@ OverlayManagerImpl::storeConfigPeers()
         }
         catch (std::runtime_error&)
         {
-            CLOG(ERROR, "Overlay") << "Unable to add preferred peer '" << s
-                                   << "'";
+            CLOG(ERROR, "Overlay")
+                << "Unable to add preferred peer '" << s << "'";
         }
     }
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -291,8 +291,8 @@ Peer::connectHandler(asio::error_code const& error)
 {
     if (error)
     {
-        CLOG(WARNING, "Overlay") << " connectHandler error: "
-                                 << error.message();
+        CLOG(WARNING, "Overlay")
+            << " connectHandler error: " << error.message();
         mDropInConnectHandlerMeter.Mark();
         drop();
     }
@@ -606,8 +606,8 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
     if (!isAuthenticated() && (stellarMsg.type() != HELLO) &&
         (stellarMsg.type() != AUTH) && (stellarMsg.type() != ERROR_MSG))
     {
-        CLOG(WARNING, "Overlay") << "recv: " << stellarMsg.type()
-                                 << " before completed handshake";
+        CLOG(WARNING, "Overlay")
+            << "recv: " << stellarMsg.type() << " before completed handshake";
         mDropInRecvMessageUnauthMeter.Mark();
         drop();
         return;
@@ -781,8 +781,8 @@ Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
     else
     {
         if (Logging::logTrace("Overlay"))
-            CLOG(TRACE, "Overlay") << "No quorum set: "
-                                   << hexAbbrev(msg.qSetHash());
+            CLOG(TRACE, "Overlay")
+                << "No quorum set: " << hexAbbrev(msg.qSetHash());
         sendDontHave(SCP_QUORUMSET, msg.qSetHash());
         // do we want to ask other people for it?
     }
@@ -849,8 +849,8 @@ Peer::recvError(StellarMessage const& msg)
     default:
         break;
     }
-    CLOG(WARNING, "Overlay") << "Received error (" << codeStr
-                             << "): " << msg.error().msg;
+    CLOG(WARNING, "Overlay")
+        << "Received error (" << codeStr << "): " << msg.error().msg;
     mDropInRecvErrorMeter.Mark();
     drop();
 }
@@ -1067,8 +1067,8 @@ Peer::recvPeers(StellarMessage const& msg)
     {
         if (peer.port == 0 || peer.port > UINT16_MAX)
         {
-            CLOG(WARNING, "Overlay") << "ignoring received peer with bad port "
-                                     << peer.port;
+            CLOG(WARNING, "Overlay")
+                << "ignoring received peer with bad port " << peer.port;
             continue;
         }
         if (peer.ip.type() == IPv6)
@@ -1093,13 +1093,13 @@ Peer::recvPeers(StellarMessage const& msg)
 
         if (pr.isPrivateAddress())
         {
-            CLOG(WARNING, "Overlay") << "ignoring received private address "
-                                     << pr.toString();
+            CLOG(WARNING, "Overlay")
+                << "ignoring received private address " << pr.toString();
         }
         else if (pr.isSelfAddressAndPort(getIP(), mApp.getConfig().PEER_PORT))
         {
-            CLOG(WARNING, "Overlay") << "ignoring received self-address "
-                                     << pr.toString();
+            CLOG(WARNING, "Overlay")
+                << "ignoring received self-address " << pr.toString();
         }
         else if (pr.isLocalhost() &&
                  !mApp.getConfig().ALLOW_LOCALHOST_FOR_TESTING)

--- a/src/overlay/PeerAuth.cpp
+++ b/src/overlay/PeerAuth.cpp
@@ -59,9 +59,9 @@ PeerAuth::verifyRemoteAuthCert(NodeID const& remoteNode, AuthCert const& cert)
 {
     if (cert.expiration < mApp.timeNow())
     {
-        CLOG(ERROR, "Overlay") << "PeerAuth cert expired: "
-                               << "expired= " << cert.expiration
-                               << ", now=" << mApp.timeNow();
+        CLOG(ERROR, "Overlay")
+            << "PeerAuth cert expired: "
+            << "expired= " << cert.expiration << ", now=" << mApp.timeNow();
         return false;
     }
     auto hash = sha256(xdr::xdr_to_opaque(

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -87,9 +87,9 @@ TCPPeer::accept(Application& app, shared_ptr<TCPPeer::SocketType> socket)
     }
     else
     {
-        CLOG(DEBUG, "Overlay") << "TCPPeer:accept"
-                               << "@" << app.getConfig().PEER_PORT << " error "
-                               << ec.message();
+        CLOG(DEBUG, "Overlay")
+            << "TCPPeer:accept"
+            << "@" << app.getConfig().PEER_PORT << " error " << ec.message();
     }
 
     return result;
@@ -202,8 +202,8 @@ TCPPeer::writeHandler(asio::error_code const& error,
             // Only emit a warning if we have an error while connected;
             // errors during shutdown or connection are common/expected.
             mErrorWrite.Mark();
-            CLOG(ERROR, "Overlay") << "TCPPeer::writeHandler error to "
-                                   << toString();
+            CLOG(ERROR, "Overlay")
+                << "TCPPeer::writeHandler error to " << toString();
         }
         drop();
     }
@@ -402,8 +402,8 @@ TCPPeer::drop()
             asio::ip::tcp::socket::shutdown_both, ec);
         if (ec)
         {
-            CLOG(ERROR, "Overlay") << "TCPPeer::drop shutdown socket failed: "
-                                   << ec.message();
+            CLOG(ERROR, "Overlay")
+                << "TCPPeer::drop shutdown socket failed: " << ec.message();
         }
         self->getApp().getClock().getIOService().post([self]() {
             // Close fd associated with socket. Socket is already
@@ -420,8 +420,8 @@ TCPPeer::drop()
             self->mSocket->close(ec2);
             if (ec2)
             {
-                CLOG(ERROR, "Overlay") << "TCPPeer::drop close socket failed: "
-                                       << ec2.message();
+                CLOG(ERROR, "Overlay")
+                    << "TCPPeer::drop close socket failed: " << ec2.message();
             }
         });
     });

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -91,9 +91,9 @@ Tracker::tryNextPeer()
     Peer::pointer peer;
 
     CLOG(TRACE, "Overlay") << "tryNextPeer " << hexAbbrev(mItemHash)
-                           << " last: " << (mLastAskedPeer
-                                                ? mLastAskedPeer->toString()
-                                                : "<none>");
+                           << " last: "
+                           << (mLastAskedPeer ? mLastAskedPeer->toString()
+                                              : "<none>");
 
     // if we don't have a list of peers to ask and we're not
     // currently asking peers, build a new list
@@ -122,9 +122,9 @@ Tracker::tryNextPeer()
 
         mNumListRebuild++;
 
-        CLOG(TRACE, "Overlay") << "tryNextPeer " << hexAbbrev(mItemHash)
-                               << " attempt " << mNumListRebuild
-                               << " reset to #" << mPeersToAsk.size();
+        CLOG(TRACE, "Overlay")
+            << "tryNextPeer " << hexAbbrev(mItemHash) << " attempt "
+            << mNumListRebuild << " reset to #" << mPeersToAsk.size();
         mTryNextPeerReset.Mark();
     }
 

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -207,7 +207,7 @@ ProcessExitEvent::Impl::run()
                        nullptr, // Use parent's starting directory
                        &si,     // Pointer to STARTUPINFO structure
                        &pi)     // Pointer to PROCESS_INFORMATION structure
-        )
+    )
     {
         CLOG(ERROR, "Process") << "CreateProcess() failed: " << GetLastError();
         throw std::runtime_error("CreateProcess() failed");
@@ -307,15 +307,15 @@ ProcessManagerImpl::handleSignalWait()
             {
                 if (WEXITSTATUS(status) == 0)
                 {
-                    CLOG(DEBUG, "Process") << "process " << pid << " exited "
-                                           << WEXITSTATUS(status) << ": "
-                                           << impl->mCmdLine;
+                    CLOG(DEBUG, "Process")
+                        << "process " << pid << " exited "
+                        << WEXITSTATUS(status) << ": " << impl->mCmdLine;
                 }
                 else
                 {
-                    CLOG(WARNING, "Process") << "process " << pid << " exited "
-                                             << WEXITSTATUS(status) << ": "
-                                             << impl->mCmdLine;
+                    CLOG(WARNING, "Process")
+                        << "process " << pid << " exited "
+                        << WEXITSTATUS(status) << ": " << impl->mCmdLine;
                 }
 #ifdef __linux__
                 // Linux posix_spawnp does not fault on file-not-found in the
@@ -408,8 +408,8 @@ ProcessExitEvent::Impl::run()
         err = posix_spawn_file_actions_init(&fileActions);
         if (err)
         {
-            CLOG(ERROR, "Process") << "posix_spawn_file_actions_init() failed: "
-                                   << strerror(err);
+            CLOG(ERROR, "Process")
+                << "posix_spawn_file_actions_init() failed: " << strerror(err);
             throw std::runtime_error("posix_spawn_file_actions_init() failed");
         }
         err = posix_spawn_file_actions_addopen(

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -231,8 +231,8 @@ NominationProtocol::updateRoundLeaders()
     if (Logging::logDebug("SCP"))
         for (auto const& rl : mRoundLeaders)
         {
-            CLOG(DEBUG, "SCP") << "    leader "
-                               << mSlot.getSCPDriver().toShortString(rl);
+            CLOG(DEBUG, "SCP")
+                << "    leader " << mSlot.getSCPDriver().toShortString(rl);
         }
 }
 

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -21,8 +21,8 @@ namespace stellar
 using xdr::operator<;
 using xdr::operator==;
 
-#define CREATE_VALUE(X)                                                        \
-    static const Hash X##ValueHash = sha256("SEED_VALUE_HASH_" #X);            \
+#define CREATE_VALUE(X) \
+    static const Hash X##ValueHash = sha256("SEED_VALUE_HASH_" #X); \
     static const Value X##Value = xdr::xdr_to_opaque(X##ValueHash);
 
 CREATE_VALUE(x);

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -75,9 +75,9 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
     else
     {
         if (Logging::logDebug("SCP"))
-            CLOG(DEBUG, "SCP") << "Slot::setStateFromEnvelope invalid envelope"
-                               << " i: " << getSlotIndex() << " "
-                               << mSCP.envToStr(e);
+            CLOG(DEBUG, "SCP")
+                << "Slot::setStateFromEnvelope invalid envelope"
+                << " i: " << getSlotIndex() << " " << mSCP.envToStr(e);
     }
 }
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -539,8 +539,11 @@ netTopologyTest(
             app.getMetrics().NewMeter({"overlay", "byte", "write"}, "byte");
 
         r.write({
-            (double)numNodes, (double)inmsg.count(), (double)inbyte.count(),
-            (double)outmsg.count(), (double)outbyte.count(),
+            (double)numNodes,
+            (double)inmsg.count(),
+            (double)inbyte.count(),
+            (double)outmsg.count(),
+            (double)outbyte.count(),
         });
     }
 }
@@ -577,17 +580,18 @@ TEST_CASE("Cycle nodes vs. network traffic", "[scalability][hide]")
 
 TEST_CASE("Branched-cycle nodes vs. network traffic", "[scalability][hide]")
 {
-    netTopologyTest("branchedcycle", [&](int numNodes,
-                                         int& cfgCount) -> Simulation::pointer {
-        return Topologies::branchedcycle(
-            numNodes, 1.0, Simulation::OVER_LOOPBACK,
-            sha256(fmt::format("nodes-{:d}", numNodes)), [&]() -> Config {
-                Config res = getTestConfig(cfgCount++);
-                res.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
-                res.MAX_PEER_CONNECTIONS = 1000;
-                return res;
-            });
-    });
+    netTopologyTest(
+        "branchedcycle",
+        [&](int numNodes, int& cfgCount) -> Simulation::pointer {
+            return Topologies::branchedcycle(
+                numNodes, 1.0, Simulation::OVER_LOOPBACK,
+                sha256(fmt::format("nodes-{:d}", numNodes)), [&]() -> Config {
+                    Config res = getTestConfig(cfgCount++);
+                    res.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
+                    res.MAX_PEER_CONNECTIONS = 1000;
+                    return res;
+                });
+        });
 }
 
 TEST_CASE("Bucket-list entries vs. write throughput", "[scalability][hide]")

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -73,10 +73,21 @@ LoadGenerator::~LoadGenerator()
 std::string
 LoadGenerator::pickRandomAsset()
 {
-    static std::vector<std::string> const sCurrencies = {
-        "USD", "EUR", "JPY", "CNY", "GBP"
-                                    "AUD",
-        "CAD", "THB", "MXN", "DKK", "IDR", "XBT", "TRY", "PLN", "HUF"};
+    static std::vector<std::string> const sCurrencies = {"USD",
+                                                         "EUR",
+                                                         "JPY",
+                                                         "CNY",
+                                                         "GBP"
+                                                         "AUD",
+                                                         "CAD",
+                                                         "THB",
+                                                         "MXN",
+                                                         "DKK",
+                                                         "IDR",
+                                                         "XBT",
+                                                         "TRY",
+                                                         "PLN",
+                                                         "HUF"};
     return rand_element(sCurrencies);
 }
 
@@ -444,10 +455,10 @@ LoadGenerator::generateLoad(Application& app, uint32_t nAccounts, uint32_t nTxs,
                 << " Pending: " << nAccounts << " acct, " << nTxs << " tx."
                 << " ETA: " << etaHours << "h" << etaMins << "m";
 
-            CLOG(DEBUG, "LoadGen") << "Step timing: " << totalms
-                                   << "ms total = " << step1ms << "ms build, "
-                                   << step2ms << "ms recv, "
-                                   << (STEP_MSECS - totalms) << "ms spare";
+            CLOG(DEBUG, "LoadGen")
+                << "Step timing: " << totalms << "ms total = " << step1ms
+                << "ms build, " << step2ms << "ms recv, "
+                << (STEP_MSECS - totalms) << "ms spare";
 
             TxMetrics txm(app.getMetrics());
             txm.mGateways.set_count(mGateways.size());

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -16,9 +16,9 @@
 #include "util/Timer.h"
 #include "xdr/Stellar-types.h"
 
-#define SIMULATION_CREATE_NODE(N)                                              \
-    const Hash v##N##VSeed = sha256("NODE_SEED_" #N);                          \
-    const SecretKey v##N##SecretKey = SecretKey::fromSeed(v##N##VSeed);        \
+#define SIMULATION_CREATE_NODE(N) \
+    const Hash v##N##VSeed = sha256("NODE_SEED_" #N); \
+    const SecretKey v##N##SecretKey = SecretKey::fromSeed(v##N##VSeed); \
     const PublicKey v##N##NodeID = v##N##SecretKey.getPublicKey();
 
 namespace stellar

--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -255,12 +255,11 @@ TestAccount::pay(PublicKey const& destination, Asset const& sendCur,
     catch (ex_PATH_PAYMENT_NO_ISSUER&)
     {
         REQUIRE(noIssuer);
-        REQUIRE(*noIssuer ==
-                transaction->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .pathPaymentResult()
-                    .noIssuer());
+        REQUIRE(*noIssuer == transaction->getResult()
+                                 .result.results()[0]
+                                 .tr()
+                                 .pathPaymentResult()
+                                 .noIssuer());
         throw;
     }
 

--- a/src/test/TestExceptions.h
+++ b/src/test/TestExceptions.h
@@ -18,9 +18,9 @@ class ex_txException
 {
 };
 
-#define TEST_EXCEPTION(M)                                                      \
-    class M : public ex_txException                                            \
-    {                                                                          \
+#define TEST_EXCEPTION(M) \
+    class M : public ex_txException \
+    { \
     };
 
 TEST_EXCEPTION(ex_txNO_ACCOUNT)

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -155,11 +155,12 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
     REQUIRE(app.getLedgerManager().getLedgerNum() == (ledgerSeq + 1));
 
     TxSetResultMeta res;
-    std::transform(z1.results.begin(), z1.results.end(), z2.begin(),
-                   std::back_inserter(res), [](TransactionResultPair const& r1,
-                                               LedgerEntryChanges const& r2) {
-                       return std::make_pair(r1, r2);
-                   });
+    std::transform(
+        z1.results.begin(), z1.results.end(), z2.begin(),
+        std::back_inserter(res),
+        [](TransactionResultPair const& r1, LedgerEntryChanges const& r2) {
+            return std::make_pair(r1, r2);
+        });
 
     return res;
 }

--- a/src/transactions/ExchangeTests.cpp
+++ b/src/transactions/ExchangeTests.cpp
@@ -22,32 +22,32 @@ TEST_CASE("Exchange", "[exchange]")
         REQUIRE(x.numWheatReceived == y.numWheatReceived);
         REQUIRE(x.numSheepSend == y.numSheepSend);
     };
-    auto validateV2 = [&compare](
-        int64_t wheatToReceive, Price price, int64_t maxWheatReceive,
-        int64_t maxSheepSend, ExchangeResult const& expected,
-        ReducedCheckV2 reducedCheck = REDUCED_CHECK_V2_STRICT) {
-        auto actualV2 =
-            exchangeV2(wheatToReceive, price, maxWheatReceive, maxSheepSend);
-        compare(actualV2, expected);
-        REQUIRE(uint128_t{actualV2.numWheatReceived} * uint128_t{price.n} <=
-                uint128_t{expected.numSheepSend} * uint128_t{price.d});
-        REQUIRE(actualV2.numSheepSend <= maxSheepSend);
-        if (reducedCheck == REDUCED_CHECK_V2_RELAXED)
-        {
-            REQUIRE(actualV2.numWheatReceived <= wheatToReceive);
-        }
-        else
-        {
-            if (actualV2.reduced)
+    auto validateV2 =
+        [&compare](int64_t wheatToReceive, Price price, int64_t maxWheatReceive,
+                   int64_t maxSheepSend, ExchangeResult const& expected,
+                   ReducedCheckV2 reducedCheck = REDUCED_CHECK_V2_STRICT) {
+            auto actualV2 = exchangeV2(wheatToReceive, price, maxWheatReceive,
+                                       maxSheepSend);
+            compare(actualV2, expected);
+            REQUIRE(uint128_t{actualV2.numWheatReceived} * uint128_t{price.n} <=
+                    uint128_t{expected.numSheepSend} * uint128_t{price.d});
+            REQUIRE(actualV2.numSheepSend <= maxSheepSend);
+            if (reducedCheck == REDUCED_CHECK_V2_RELAXED)
             {
-                REQUIRE(actualV2.numWheatReceived < wheatToReceive);
+                REQUIRE(actualV2.numWheatReceived <= wheatToReceive);
             }
             else
             {
-                REQUIRE(actualV2.numWheatReceived == wheatToReceive);
+                if (actualV2.reduced)
+                {
+                    REQUIRE(actualV2.numWheatReceived < wheatToReceive);
+                }
+                else
+                {
+                    REQUIRE(actualV2.numWheatReceived == wheatToReceive);
+                }
             }
-        }
-    };
+        };
     auto validateV3 = [&compare](int64_t wheatToReceive, Price price,
                                  int64_t maxWheatReceive, int64_t maxSheepSend,
                                  ExchangeResult const& expected) {
@@ -67,9 +67,10 @@ TEST_CASE("Exchange", "[exchange]")
         }
     };
     auto validate = [&validateV2, &validateV3](
-        int64_t wheatToReceive, Price price, int64_t maxWheatReceive,
-        int64_t maxSheepSend, ExchangeResult const& expected,
-        ReducedCheckV2 reducedCheck = REDUCED_CHECK_V2_STRICT) {
+                        int64_t wheatToReceive, Price price,
+                        int64_t maxWheatReceive, int64_t maxSheepSend,
+                        ExchangeResult const& expected,
+                        ReducedCheckV2 reducedCheck = REDUCED_CHECK_V2_STRICT) {
         validateV2(wheatToReceive, price, maxWheatReceive, maxSheepSend,
                    expected, reducedCheck);
         validateV3(wheatToReceive, price, maxWheatReceive, maxSheepSend,

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -96,21 +96,22 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
     }
 
     // sort by votes, then by ID in descending order
-    std::sort(votesV.begin(), votesV.end(), [](std::pair<int, int64> const& l,
-                                               std::pair<int, int64> const& r) {
-        if (l.second > r.second)
-        {
-            return true;
-        }
-        else if (l.second < r.second)
-        {
-            return false;
-        }
-        else
-        {
-            return l.first > r.first;
-        }
-    });
+    std::sort(
+        votesV.begin(), votesV.end(),
+        [](std::pair<int, int64> const& l, std::pair<int, int64> const& r) {
+            if (l.second > r.second)
+            {
+                return true;
+            }
+            else if (l.second < r.second)
+            {
+                return false;
+            }
+            else
+            {
+                return l.first > r.first;
+            }
+        });
 
     std::vector<int> winners;
     int64 totVotes = totCoins;

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -83,9 +83,9 @@ TEST_CASE("merge", "[tx][merge]")
                 txFrame->getResult().result.results()[2]);
 
             REQUIRE(result == ACCOUNT_MERGE_SUCCESS);
-            REQUIRE(b1.getBalance() ==
-                    2 * a1Balance + b1Balance - createBalance -
-                        2 * txFrame->getFee());
+            REQUIRE(b1.getBalance() == 2 * a1Balance + b1Balance -
+                                           createBalance -
+                                           2 * txFrame->getFee());
             REQUIRE(!loadAccount(a1, *app, false));
         });
 

--- a/src/transactions/OfferTests.cpp
+++ b/src/transactions/OfferTests.cpp
@@ -85,9 +85,10 @@ TEST_CASE("create offer", "[tx][offers]")
                 // firstOffer is taken, new offer was not created
                 market.requireChangesWithOffer(
                     {{firstOffer.key, OfferState::DELETED}}, [&] {
-                        return market.addOffer(b1, {usd, idr, Price{99, 100},
-                                                    100, OfferType::PASSIVE},
-                                               OfferState::DELETED);
+                        return market.addOffer(
+                            b1,
+                            {usd, idr, Price{99, 100}, 100, OfferType::PASSIVE},
+                            OfferState::DELETED);
                     });
             });
         }

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -10,7 +10,6 @@
 #include "test/TestExceptions.h"
 #include "test/TestMarket.h"
 #include "test/TestUtils.h"
-#include "test/TestUtils.h"
 #include "test/TxTests.h"
 #include "test/test.h"
 #include "transactions/ChangeTrustOpFrame.h"
@@ -847,9 +846,9 @@ TEST_CASE("payment", "[tx][payment]")
             REQUIRE(loadAccount(createDestination, *app));
             REQUIRE(loadAccount(payDestination, *app));
             REQUIRE(sourceAccount.getBalance() == amount - tx->getFee());
-            REQUIRE(createSource.getBalance() ==
-                    amount + amount - create1Amount - create2Amount +
-                        payAmount);
+            REQUIRE(createSource.getBalance() == amount + amount -
+                                                     create1Amount -
+                                                     create2Amount + payAmount);
             REQUIRE(createDestination.getBalance() ==
                     create1Amount - payAmount);
             REQUIRE(payDestination.getBalance() == create2Amount);

--- a/src/transactions/SignatureUtilsTest.cpp
+++ b/src/transactions/SignatureUtilsTest.cpp
@@ -2,12 +2,12 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "transactions/SignatureUtils.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
 #include "crypto/SignerKey.h"
 #include "crypto/SignerKeyUtils.h"
 #include "lib/catch.hpp"
-#include "transactions/SignatureUtils.h"
 #include "xdr/Stellar-transaction.h"
 
 using namespace stellar;

--- a/src/transactions/TxResultsTests.cpp
+++ b/src/transactions/TxResultsTests.cpp
@@ -753,10 +753,10 @@ TEST_CASE("txresults", "[tx][txresults]")
 
         SECTION("with operation after")
         {
-            auto tx =
-                a.tx({payment(b, 1000), setOptions(nullptr, nullptr, nullptr,
-                                                   &th, nullptr, nullptr),
-                      payment(c, 1000)});
+            auto tx = a.tx(
+                {payment(b, 1000),
+                 setOptions(nullptr, nullptr, nullptr, &th, nullptr, nullptr),
+                 payment(c, 1000)});
 
             for_versions_to(6, *app, [&] {
                 validate(tx, {baseFee * 3, txSUCCESS},

--- a/src/util/BigDivideTests.cpp
+++ b/src/util/BigDivideTests.cpp
@@ -139,11 +139,11 @@ TEST_CASE("big divide", "[bigDivide]")
 #define DOWN_IS(x) H(uint128_t, uint128_t{x}),
 #define UP_IS(x) H(uint128_t, uint128_t{x})
 
-#define TEST(when, down, up)                                                   \
-    SECTION("a * b/c WHEN " #when)                                             \
-    {                                                                          \
-        signedTester.test(WHEN(when) DOWN_IS(down) UP_IS(up));                 \
-        unsignedTester.test(WHEN(when) DOWN_IS(down) UP_IS(up));               \
+#define TEST(when, down, up) \
+    SECTION("a * b/c WHEN " #when) \
+    { \
+        signedTester.test(WHEN(when) DOWN_IS(down) UP_IS(up)); \
+        unsignedTester.test(WHEN(when) DOWN_IS(down) UP_IS(up)); \
     }
 
     TEST(a == 0, 0, 0)

--- a/src/util/StatusManagerTest.cpp
+++ b/src/util/StatusManagerTest.cpp
@@ -2,8 +2,8 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "lib/catch.hpp"
 #include "util/StatusManager.h"
+#include "lib/catch.hpp"
 
 using namespace stellar;
 

--- a/src/util/Uint128Tests.cpp
+++ b/src/util/Uint128Tests.cpp
@@ -65,7 +65,7 @@ TEST_CASE("uint128_t", "[uint128]")
     autocheck::check<unsigned __int128, unsigned __int128>(
         [](unsigned __int128 x, unsigned __int128 y) {
             bool b = true;
-#define BINOP(op)                                                              \
+#define BINOP(op) \
     (b = b && ((x op y) == toNative(fromNative(x) op fromNative(y))));
             BINOP(+);
             BINOP(-);

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -313,8 +313,8 @@ Work::complete(CompleteResult result)
     {
     case WORK_SUCCESS:
         succ.Mark();
-        CLOG(DEBUG, "Work") << "notifying parent of successful "
-                            << getUniqueName();
+        CLOG(DEBUG, "Work")
+            << "notifying parent of successful " << getUniqueName();
         notifyParent();
         break;
 
@@ -399,8 +399,8 @@ Work::setState(Work::State st)
     auto maxR = getMaxRetries();
     if (st == WORK_FAILURE_RETRY && (mRetries >= maxR))
     {
-        CLOG(WARNING, "Work") << "Reached retry limit " << maxR << " for "
-                              << getUniqueName();
+        CLOG(WARNING, "Work")
+            << "Reached retry limit " << maxR << " for " << getUniqueName();
         st = WORK_FAILURE_RAISE;
     }
 

--- a/src/work/WorkManagerImpl.cpp
+++ b/src/work/WorkManagerImpl.cpp
@@ -39,8 +39,8 @@ WorkManagerImpl::notify(std::string const& child)
     auto i = mChildren.find(child);
     if (i == mChildren.end())
     {
-        CLOG(WARNING, "Work") << "WorkManager notified by unknown child "
-                              << child;
+        CLOG(WARNING, "Work")
+            << "WorkManager notified by unknown child " << child;
         return;
     }
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -63,7 +63,16 @@ echo "committer = $committer, config_flags = $config_flags"
 ccache -s
 ./autogen.sh
 ./configure $config_flags
+make format
+d=`git diff | wc -l`
+if [ $d -ne 0 ]
+then
+    echo "clang format must be run as part of the pull request, current diff:"
+    git diff
+    exit 1
+fi
 make -j3
 ccache -s
 export ALL_VERSIONS=1
 make check
+


### PR DESCRIPTION
resolves #1388

like title says

this moves to clang-5.0 (updates the config to the current schema)
and fixes a bug in the Makefile that made it that on some machines it would ignore our custom config.
