### PR TITLE
install llvm's trusty based toolchain (precise is not supported anymore)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ addons:
   postgresql: "9.3"
   apt:
     sources:
-    - llvm-toolchain-precise-3.5
+    - llvm-toolchain-trusty-3.5
+    - llvm-toolchain-trusty-5.0
     - ubuntu-toolchain-r-test
     packages:
     - autoconf
@@ -23,6 +24,7 @@ addons:
     - libstdc++6
     - libtool
     - pkg-config
+    - clang-format-5.0
 
 script: ./travis-build.sh
 
@@ -39,3 +41,4 @@ notifications:
 branches:
  only:
  - auto
+

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -24,6 +24,7 @@ ln -s `which gcc-4.9` bin/gcc
 ln -s `which g++-4.9` bin/g++
 ln -s `which clang-3.5` bin/clang
 ln -s `which clang++-3.5` bin/clang++
+ln -s `which llvm-symbolizer-3.5` bin/llvm-symbolizer
 
 export PATH=`pwd`/bin:$PATH
 hash -r
@@ -67,3 +68,4 @@ make -j3
 ccache -s
 export ALL_VERSIONS=1
 make check
+


### PR DESCRIPTION
in addition:
install llvm's clang-format 5.0 to start decoupling compiler version from llvm's version
