### PR TITLE
CATCHUP_MINIMAL Cannot Move Database into Invalid State

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -152,6 +152,22 @@ BucketLevel::snap()
     return mSnap;
 }
 
+BucketListDepth::BucketListDepth(uint32_t numLevels) : mNumLevels(numLevels)
+{
+}
+
+BucketListDepth&
+BucketListDepth::operator=(uint32_t numLevels)
+{
+    mNumLevels = numLevels;
+    return *this;
+}
+
+BucketListDepth::operator uint32_t() const
+{
+    return mNumLevels;
+}
+
 uint32_t
 BucketList::levelSize(uint32_t level)
 {
@@ -430,7 +446,7 @@ BucketList::restartMerges(Application& app)
     }
 }
 
-uint32_t const BucketList::kNumLevels = 11;
+BucketListDepth BucketList::kNumLevels = 11;
 
 BucketList::BucketList()
 {

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -236,6 +236,11 @@ namespace stellar
 class Application;
 class Bucket;
 
+namespace testutil
+{
+class BucketListDepthModifier;
+}
+
 class BucketLevel
 {
     uint32_t mLevel;
@@ -260,6 +265,24 @@ class BucketLevel
     std::shared_ptr<Bucket> snap();
 };
 
+// NOTE: The access specifications for this class have been carefully chosen to
+//       make it so BucketList::kNumLevels can only be modified from
+//       BucketListDepthModifier -- not even BucketList can modify it. Please
+//       use care when modifying this class.
+class BucketListDepth
+{
+    uint32_t mNumLevels;
+
+    BucketListDepth& operator=(uint32_t numLevels);
+
+  public:
+    BucketListDepth(uint32_t numLevels);
+
+    operator uint32_t() const;
+
+    friend class testutil::BucketListDepthModifier;
+};
+
 class BucketList
 {
     // Helper for calculating `levelShouldSpill`
@@ -270,7 +293,7 @@ class BucketList
     // Number of bucket levels in the bucketlist. Every bucketlist in the system
     // will have this many levels and it effectively gets wired-in to the
     // protocol. Careful about changing it.
-    static uint32_t const kNumLevels;
+    static BucketListDepth kNumLevels;
 
     // Returns size of a given level, in ledgers.
     static uint32_t levelSize(uint32_t level);

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -8,11 +8,25 @@
 namespace stellar
 {
 
+namespace testutil
+{
+
 void
-testutil::setCurrentLedgerVersion(LedgerManager& lm,
-                                  uint32_t currentLedgerVersion)
+setCurrentLedgerVersion(LedgerManager& lm, uint32_t currentLedgerVersion)
 {
     lm.getCurrentLedgerHeader().ledgerVersion = currentLedgerVersion;
+}
+
+BucketListDepthModifier::BucketListDepthModifier(uint32_t newDepth)
+    : mPrevDepth(BucketList::kNumLevels)
+{
+    BucketList::kNumLevels = newDepth;
+}
+
+BucketListDepthModifier::~BucketListDepthModifier()
+{
+    BucketList::kNumLevels = mPrevDepth;
+}
 }
 
 time_t

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/BucketList.h"
 #include "ledger/LedgerManagerImpl.h"
 #include "main/ApplicationImpl.h"
 
@@ -13,6 +14,16 @@ namespace stellar
 namespace testutil
 {
 void setCurrentLedgerVersion(LedgerManager& lm, uint32_t currentLedgerVersion);
+
+class BucketListDepthModifier
+{
+    uint32_t const mPrevDepth;
+
+  public:
+    BucketListDepthModifier(uint32_t newDepth);
+
+    ~BucketListDepthModifier();
+};
 }
 
 template <typename T = ApplicationImpl>


### PR DESCRIPTION
Added a test showing that applying buckets before and after a DEADENTRY cancels a LIVEENTRY cannot move the database into an invalid state. The initial issue was fixed by #1318.

Resolves #1300 