### PR TITLE
Fixed `createTestApplication` that was not using config as expected

### DIFF
--- a/src/ledger/LedgerHeaderTests.cpp
+++ b/src/ledger/LedgerHeaderTests.cpp
@@ -29,7 +29,7 @@ TEST_CASE("ledgerheader", "[ledger]")
     Hash saved;
     {
         VirtualClock clock;
-        Application::pointer app = createTestApplication(clock, cfg);
+        Application::pointer app = Application::create(clock, cfg);
         app->start();
 
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
@@ -59,7 +59,7 @@ TEST_CASE("ledgerheader", "[ledger]")
     SECTION("update")
     {
         VirtualClock clock;
-        Application::pointer app = createTestApplication(clock, cfg);
+        Application::pointer app = Application::create(clock, cfg);
         app->start();
 
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -158,8 +158,9 @@ LedgerManagerImpl::getStateHuman() const
 }
 
 void
-LedgerManagerImpl::startNewLedger(int64_t balance, uint32_t baseFee,
-                                  uint32_t baseReserve, uint32_t maxTxSetSize)
+LedgerManagerImpl::startNewLedger(uint32_t protocolVersion, int64_t balance,
+                                  uint32_t baseFee, uint32_t baseReserve,
+                                  uint32_t maxTxSetSize)
 {
     DBTimeExcluder qtExclude(mApp);
     auto ledgerTime = mLedgerClose.TimeScope();
@@ -171,6 +172,7 @@ LedgerManagerImpl::startNewLedger(int64_t balance, uint32_t baseFee,
 
     // all fields are initialized by default to 0
     // set the ones that are not 0
+    genesisHeader.ledgerVersion = protocolVersion;
     genesisHeader.baseFee = baseFee;
     genesisHeader.baseReserve = baseReserve;
     genesisHeader.maxTxSetSize = maxTxSetSize;
@@ -190,8 +192,19 @@ LedgerManagerImpl::startNewLedger(int64_t balance, uint32_t baseFee,
 void
 LedgerManagerImpl::startNewLedger()
 {
-    // 100 tx/ledger max
-    startNewLedger(1000000000000000000, 100, 100000000, 100);
+    int64 totalCoins = 1000000000000000000;
+    auto const& cfg = mApp.getConfig();
+    if (cfg.USE_CONFIG_FOR_GENESIS)
+    {
+        startNewLedger(cfg.LEDGER_PROTOCOL_VERSION, totalCoins,
+                       cfg.DESIRED_BASE_FEE, cfg.DESIRED_BASE_RESERVE,
+                       cfg.DESIRED_MAX_TX_PER_LEDGER);
+    }
+    else
+    {
+        // 100 tx/ledger max
+        startNewLedger(0, totalCoins, 100, 100000000, 100);
+    }
 }
 
 void

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -86,7 +86,8 @@ class LedgerManagerImpl : public LedgerManager
     uint64_t secondsSinceLastLedgerClose() const override;
     void syncMetrics() override;
 
-    void startNewLedger(int64_t balance, uint32_t baseFee, uint32_t baseReserve,
+    void startNewLedger(uint32_t protocolVersion, int64_t balance,
+                        uint32_t baseFee, uint32_t baseReserve,
                         uint32_t maxTxSetSize);
     void startNewLedger() override;
     void loadLastKnownLedger(

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -19,6 +19,8 @@ namespace stellar
 {
 using xdr::operator<;
 
+const int Config::CURRENT_LEDGER_PROTOCOL_VERSION = 9;
+
 Config::Config() : NODE_SEED(SecretKey::random())
 {
     // fill in defaults
@@ -44,6 +46,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = 0;
     ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = false;
     ALLOW_LOCALHOST_FOR_TESTING = false;
+    USE_CONFIG_FOR_GENESIS = false;
     FAILURE_SAFETY = -1;
     UNSAFE_QUORUM = false;
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -31,7 +31,7 @@ class Config : public std::enable_shared_from_this<Config>
     std::string expandNodeID(std::string const& s) const;
 
   public:
-    static const int CURRENT_LEDGER_PROTOCOL_VERSION = 9;
+    static const int CURRENT_LEDGER_PROTOCOL_VERSION;
 
     typedef std::shared_ptr<Config> pointer;
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -105,6 +105,10 @@ class Config : public std::enable_shared_from_this<Config>
     // this should only be enabled when testing as it's a security issue
     bool ALLOW_LOCALHOST_FOR_TESTING;
 
+    // Set to use config file values for genesis ledger
+    // not setable in config file - only tests are allowed to do this
+    bool USE_CONFIG_FOR_GENESIS;
+
     // This is the number of failures you want to be able to tolerate.
     // You will need at least 3f+1 nodes in your quorum set.
     // If you don't have enough in your quorum set to tolerate the level you

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -30,10 +30,9 @@ template <typename T = ApplicationImpl>
 std::shared_ptr<T>
 createTestApplication(VirtualClock& clock, Config const& cfg)
 {
-    auto app = Application::create<T>(clock, cfg);
-    auto& lm = app->getLedgerManager();
-    lm.getCurrentLedgerHeader().baseFee = cfg.DESIRED_BASE_FEE;
-    testutil::setCurrentLedgerVersion(lm, cfg.LEDGER_PROTOCOL_VERSION);
+    Config c2(cfg);
+    c2.USE_CONFIG_FOR_GENESIS = true;
+    auto app = Application::create<T>(clock, c2);
     return app;
 }
 


### PR DESCRIPTION
A previous change attempted to force test applications to use their configuration to update a few ledger header fields.
The problem is that this didn't work as the current ledger was created and stored in the database before updating the fields.

This PR fixes that by taking a different approach: allow changing the genesis ledger in test code to use values from the configuration.
