### PR TITLE
hide long resilience tests by default

### DIFF
--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -202,7 +202,7 @@ resilienceTest(Simulation::pointer sim)
         }
     }
 }
-TEST_CASE("resilience tests", "[resilience][simulation]")
+TEST_CASE("resilience tests", "[resilience][simulation][long][hide]")
 {
     Simulation::Mode mode = Simulation::OVER_LOOPBACK;
 


### PR DESCRIPTION
Resilience tests took about 20 minutes to run on my machine.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>