### PR TITLE
use top level entities as the default for FAILURE_SAFETY

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -189,8 +189,9 @@ DESIRED_MAX_TX_PER_LEDGER=400
 # Typically, you will need at least 3f+1 nodes in your quorum set.
 # If you don't have enough nodes in your quorum set to tolerate the level you
 #  set here stellar-core won't run as a precaution.
-# A value of -1 indicates to use (n-1)/3 (n being the number of nodes)
-# A vale of 0 is only allowed if UNSAFE_QUORUM is set
+# A value of -1 indicates to use (n-1)/3 (n being the number of nodes
+#    and groups from the top level of your QUORUM_SET)
+# A value of 0 is only allowed if UNSAFE_QUORUM is set
 # Note: The value of 1 below is the maximum number derived from the value of
 # QUORUM_SET in this configuration file
 FAILURE_SAFETY=1

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -721,9 +721,12 @@ Config::validateConfig()
 
     if (FAILURE_SAFETY == -1)
     {
-        // calculates default value for safety assuming flat quorum
+        // calculates default value for safety giving the top level entities
+        // the same weight
         // n = 3f+1 <=> f = (n-1)/3
-        FAILURE_SAFETY = (static_cast<uint32>(nodes.size()) - 1) / 3;
+        auto topLevelCount =
+            QUORUM_SET.validators.size() + QUORUM_SET.innerSets.size();
+        FAILURE_SAFETY = (static_cast<uint32>(topLevelCount) - 1) / 3;
     }
 
     try


### PR DESCRIPTION
resolves #1371 
