### PR TITLE
Initial version of a benchmark of stellar-core

### DIFF
--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -39,6 +39,7 @@ class CommandHandler;
 class WorkManager;
 class BanManager;
 class StatusManager;
+class BenchmarkExecutor;
 
 class Application;
 void validateNetworkPassphrase(std::shared_ptr<Application> app);
@@ -230,6 +231,8 @@ class Application
     // against the current application.
     virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate) = 0;
+
+    virtual BenchmarkExecutor& getBenchmarkExecutor() = 0;
 
     // Access the load generator for manual operation.
     virtual LoadGenerator& getLoadGenerator() = 0;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -37,6 +37,7 @@
 #include "process/ProcessManager.h"
 #include "scp/LocalNode.h"
 #include "scp/QuorumSetUtils.h"
+#include "simulation/Benchmark.h"
 #include "simulation/LoadGenerator.h"
 #include "util/StatusManager.h"
 #include "work/WorkManager.h"
@@ -424,6 +425,16 @@ ApplicationImpl::getLoadGenerator()
         mLoadGenerator = make_unique<LoadGenerator>(getNetworkID());
     }
     return *mLoadGenerator;
+}
+
+BenchmarkExecutor&
+ApplicationImpl::getBenchmarkExecutor()
+{
+    if (!mBenchmarkExecutor)
+    {
+        mBenchmarkExecutor = make_unique<BenchmarkExecutor>();
+    }
+    return *mBenchmarkExecutor;
 }
 
 void

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -30,6 +30,7 @@ class CommandHandler;
 class Database;
 class LoadGenerator;
 class NtpSynchronizationChecker;
+class BenchmarkExecutor;
 
 class ApplicationImpl : public Application
 {
@@ -88,6 +89,8 @@ class ApplicationImpl : public Application
     virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate) override;
 
+    virtual BenchmarkExecutor& getBenchmarkExecutor() override;
+
     virtual LoadGenerator& getLoadGenerator() override;
 
     virtual void checkDB() override;
@@ -138,6 +141,7 @@ class ApplicationImpl : public Application
     std::shared_ptr<WorkManager> mWorkManager;
     std::unique_ptr<PersistentState> mPersistentState;
     std::unique_ptr<LoadGenerator> mLoadGenerator;
+    std::unique_ptr<BenchmarkExecutor> mBenchmarkExecutor;
     std::unique_ptr<BanManager> mBanManager;
     std::shared_ptr<NtpSynchronizationChecker> mNtpSynchronizationChecker;
     std::unique_ptr<StatusManager> mStatusManager;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -16,7 +16,6 @@
 #include "overlay/BanManager.h"
 #include "overlay/OverlayManager.h"
 #include "simulation/Benchmark.h"
-#include "simulation/BenchmarkExecutor.h"
 #include "util/Logging.h"
 #include "util/StatusManager.h"
 #include "util/make_unique.h"
@@ -30,6 +29,8 @@
 
 #include "test/TestAccount.h"
 #include "test/TxTests.h"
+#include <functional>
+#include <memory>
 #include <regex>
 
 using namespace stellar::txtest;
@@ -84,6 +85,8 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
                       std::bind(&CommandHandler::dropPeer, this, _1, _2));
     mServer->addRoute("generateload",
                       std::bind(&CommandHandler::generateLoad, this, _1, _2));
+    mServer->addRoute("benchmark",
+                      std::bind(&CommandHandler::benchmark, this, _1, _2));
     mServer->addRoute("info", std::bind(&CommandHandler::info, this, _1, _2));
     mServer->addRoute("ll", std::bind(&CommandHandler::ll, this, _1, _2));
     mServer->addRoute("logrotate",
@@ -299,9 +302,12 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "on the instance."
         "<ul><li><i>queue</i> performs deletion of queue data.See setcursor "
         "for more information</li></ul>"
-        "</p><p><h1> "
-        "/unban?node=NODE_ID</h1>"
+        "</p><p><h1> /unban?node=NODE_ID</h1>"
         "remove ban for PEER_ID"
+        "</p><p><h1> /benchmark[?createaccounts=N | "
+        "accounts=N&txrate=R&duration=T]</h1>"
+        "start benchmark of stellar-core; must be used with "
+        "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING set to true"
         "</p>"
 
         "<br>";
@@ -401,48 +407,81 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
 void
 CommandHandler::benchmark(std::string const& params, std::string& retStr)
 {
-    if (mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
-    {
-        uint32_t nAccounts = 1000000;
-        uint32_t txRate = 1000;
-        uint32_t duration = 60 * 10;
-
-        std::map<std::string, std::string> map;
-        http::server::server::parseParams(params, map);
-
-        if (!parseNumParam(map, "accounts", nAccounts, retStr,
-                           Requirement::OPTIONAL_REQ))
-        {
-            retStr = "Invalid value for the parameter 'accounts'";
-            return;
-        }
-
-        if (!parseNumParam(map, "txrate", txRate, retStr,
-                           Requirement::OPTIONAL_REQ))
-        {
-            retStr = "Invalid value for the parameter 'txrate'";
-            return;
-        }
-
-        if (!parseNumParam(map, "duration", duration, retStr, Requirement::OPTIONAL_REQ))
-        {
-            retStr = "Invalid value for the parameter 'duration'";
-            return;
-        }
-
-        auto benchmark = std::make_shared<Benchmark>(mApp.getNetworkID(), nAccounts, txRate);
-        BenchmarkExecutor executor;
-        executor.executeBenchmark(mApp, benchmark, std::chrono::seconds(duration));
-
-        retStr = fmt::format(
-            "Benchmark of stellar-core: {:d} accounts, {:d} txrate, {:d} minutes",
-            nAccounts, txRate, duration);
-    }
-    else
+    if (!mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
     {
         retStr = "Set ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true in "
-            "the stellar-core.cfg if you want this behavior";
+                 "the stellar-core.cfg if you want this behavior";
+        return;
     }
+
+    uint32 createAccounts = 0;
+    uint32_t nAccounts = 1000000;
+    uint32_t txRate = 1000;
+    uint32_t duration = 60 * 10;
+
+    std::map<std::string, std::string> map;
+    http::server::server::parseParams(params, map);
+
+    if (!parseNumParam(map, "createaccounts", createAccounts, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'createaccounts'";
+        return;
+    }
+
+    if (createAccounts > 0)
+    {
+        Benchmark::BenchmarkBuilder builder(mApp.getNetworkID());
+        builder.setNumberOfInitialAccounts(createAccounts)
+            .populateBenchmarkData()
+            .createBenchmark(mApp);
+
+        retStr = fmt::format("{{\"createdAccounts\": {:d}}}", createAccounts);
+        return;
+    }
+
+    if (!parseNumParam(map, "accounts", nAccounts, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'accounts'";
+        return;
+    }
+
+    if (!parseNumParam(map, "txrate", txRate, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'txrate'";
+        return;
+    }
+
+    if (!parseNumParam(map, "duration", duration, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'duration'";
+        return;
+    }
+
+    Benchmark::BenchmarkBuilder builder(mApp.getNetworkID());
+    builder.setNumberOfInitialAccounts(nAccounts)
+        .setTxRate(txRate)
+        .initializeBenchmark();
+
+    mApp.getMetrics().NewMeter({"benchmark", "run", "started"}, "run").Mark();
+
+    auto stopCallback = [this](Benchmark::Metrics metrics) {
+
+        mApp.getMetrics()
+            .NewMeter({"benchmark", "run", "complete"}, "run")
+            .Mark();
+        BenchmarkReporter().reportBenchmark(metrics, mApp.getMetrics(),
+                                            LOG(INFO));
+    };
+    mApp.getBenchmarkExecutor().executeBenchmark(
+        mApp, builder, std::chrono::seconds{duration}, stopCallback);
+
+    retStr = fmt::format("{{ \"Benchmark\": {{ \"accounts\": {:d}, \"txRate\": "
+                         "{:d}, \"seconds\": {:d} }} }}",
+                         nAccounts, txRate, duration);
 }
 
 void

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -36,6 +36,7 @@ class CommandHandler
     void dropcursor(std::string const& params, std::string& retStr);
     void dropPeer(std::string const& params, std::string& retStr);
     void generateLoad(std::string const& params, std::string& retStr);
+    void benchmark(std::string const& params, std::string& retStr);
     void info(std::string const& params, std::string& retStr);
     void ll(std::string const& params, std::string& retStr);
     void logRotate(std::string const& params, std::string& retStr);

--- a/src/simulation/Benchmark.cpp
+++ b/src/simulation/Benchmark.cpp
@@ -6,10 +6,12 @@
 
 #include "bucket/BucketManager.h"
 #include "database/Database.h"
+#include "herder/Herder.h"
 #include "ledger/LedgerDelta.h"
 #include "util/Logging.h"
 #include "util/make_unique.h"
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <random>
@@ -22,54 +24,55 @@ const char* Benchmark::LOGGER_ID = "Benchmark";
 
 size_t Benchmark::MAXIMAL_NUMBER_OF_TXS_PER_LEDGER = 1000;
 
-Benchmark::Benchmark(Hash const& networkID)
-    : Benchmark(networkID, 1000000, MAXIMAL_NUMBER_OF_TXS_PER_LEDGER)
-{
-}
-
-Benchmark::Benchmark(Hash const& networkID, size_t numberOfInitialAccounts,
-                     uint32_t txRate)
-    : LoadGenerator(networkID)
-    , mIsRunning(false)
-    , mNumberOfInitialAccounts(numberOfInitialAccounts)
+Benchmark::Benchmark(medida::MetricsRegistry& registry, uint32_t txRate,
+                     std::unique_ptr<TxSampler> sampler)
+    : mIsRunning(false)
     , mTxRate(txRate)
+    , mMetrics(initializeMetrics(registry))
+    , mSampler(std::move(sampler))
 {
 }
 
-std::shared_ptr<Benchmark::Metrics>
+Benchmark::~Benchmark()
+{
+    if (mIsRunning)
+    {
+        stopBenchmark();
+    }
+}
+
+void
 Benchmark::startBenchmark(Application& app)
 {
+    if (mIsRunning)
+    {
+        throw std::runtime_error{"Benchmark already started"};
+    }
     mIsRunning = true;
     using namespace std;
-    shared_ptr<Benchmark::Metrics> metrics{initializeMetrics(app.getMetrics())};
-    auto lastLedgerNum = app.getLedgerManager().getLedgerNum();
-    lastLedgerNum = lastLedgerNum == 0 ? 0 : lastLedgerNum - 1;
-    std::function<bool()> load = [this, &app, metrics,
-                                  lastLedgerNum]() mutable {
+    size_t txPerStep = (mTxRate * LoadGenerator::STEP_MSECS / 1000);
+    txPerStep = max(txPerStep, size_t(1));
+    function<bool()> load = [this, &app, txPerStep]() {
         if (!this->mIsRunning)
         {
             return false;
         }
-        if (lastLedgerNum < app.getLedgerManager().getLedgerNum())
-        {
-            generateLoadForBenchmark(app, this->mTxRate, *metrics);
-            lastLedgerNum = app.getLedgerManager().getLedgerNum();
-        }
+
+        generateLoadForBenchmark(app, txPerStep, mMetrics);
 
         return true;
     };
-    metrics->benchmarkTimeContext =
-        make_unique<medida::TimerContext>(metrics->benchmarkTimer.TimeScope());
+    mBenchmarkTimeContext =
+        make_unique<medida::TimerContext>(mMetrics.benchmarkTimer.TimeScope());
     load();
-    scheduleLoad(app, load);
-
-    return metrics;
+    scheduleLoad(app, load,
+                 std::chrono::milliseconds{LoadGenerator::STEP_MSECS});
 }
 
-std::unique_ptr<Benchmark::Metrics>
+Benchmark::Metrics
 Benchmark::initializeMetrics(medida::MetricsRegistry& registry)
 {
-    return make_unique<Benchmark::Metrics>(Benchmark::Metrics(registry));
+    return Benchmark::Metrics(registry);
 }
 
 Benchmark::Metrics::Metrics(medida::MetricsRegistry& registry)
@@ -78,122 +81,211 @@ Benchmark::Metrics::Metrics(medida::MetricsRegistry& registry)
 {
 }
 
-std::shared_ptr<Benchmark::Metrics>
-Benchmark::stopBenchmark(std::shared_ptr<Benchmark::Metrics> metrics)
+Benchmark::Metrics
+Benchmark::stopBenchmark()
 {
+    CLOG(INFO, LOGGER_ID) << "Stopping benchmark";
+    if (!mIsRunning)
+    {
+        throw std::runtime_error{"Benchmark is already stopped"};
+    }
+    mBenchmarkTimeContext->Stop();
     mIsRunning = false;
-    metrics->timeSpent = metrics->benchmarkTimeContext->Stop();
-    return metrics;
+    CLOG(INFO, LOGGER_ID) << "Benchmark stopped";
+    return mMetrics;
+}
+
+Benchmark::Metrics
+Benchmark::getMetrics()
+{
+    return mMetrics;
 }
 
 bool
 Benchmark::generateLoadForBenchmark(Application& app, uint32_t txRate,
                                     Metrics& metrics)
 {
-    updateMinBalance(app);
-
-    if (txRate == 0)
-    {
-        txRate = 1;
-    }
-
     CLOG(TRACE, LOGGER_ID) << "Generating " << txRate
-                           << "transactions per step";
+                           << " transaction(s) per step";
 
-    uint32_t ledgerNum = app.getLedgerManager().getLedgerNum();
-    std::vector<LoadGenerator::TxInfo> txs;
+    mBenchmarkTimeContext->Stop();
+
     for (uint32_t it = 0; it < txRate; ++it)
     {
-        txs.push_back(createRandomTransaction(0.5, ledgerNum));
-    }
+        uint32_t ledgerNum = app.getLedgerManager().getLedgerNum();
+        auto tx = mSampler->createTransaction();
 
-    for (auto& tx : txs)
-    {
-        if (!tx.execute(app))
+        mBenchmarkTimeContext->Reset();
+
+        if (!tx->execute(app))
         {
-            CLOG(ERROR, LOGGER_ID)
-                << "Error while executing a transaction: transaction rejected";
+            CLOG(ERROR, LOGGER_ID) << "Error while executing a transaction: "
+                                      "transaction was rejected";
             return false;
         }
+        mBenchmarkTimeContext->Stop();
+        metrics.txsCount.inc();
     }
 
-    metrics.txsCount.inc(txs.size());
+    mBenchmarkTimeContext->Reset();
 
     CLOG(TRACE, LOGGER_ID) << txRate
-                           << " transactions generated in single step";
+                           << " transaction(s) generated in a single step";
 
     return true;
 }
 
 void
-Benchmark::createAccountsUsingLedgerManager(Application& app, size_t n)
+Benchmark::scheduleLoad(Application& app, std::function<bool()> loadGenerator,
+                        std::chrono::milliseconds stepTime)
 {
-    auto accountsLeft = mNumberOfInitialAccounts;
-    TxMetrics txm(app.getMetrics());
-    LedgerManager& ledger = app.getLedgerManager();
+    VirtualTimer& timer = getTimer(app.getClock());
+    timer.expires_from_now(stepTime);
+    timer.async_wait(
+        [this, &app, loadGenerator, stepTime](asio::error_code const& error) {
+            if (error)
+            {
+                return;
+            }
+            if (loadGenerator())
+            {
+                this->scheduleLoad(app, loadGenerator, stepTime);
+            }
+        });
+}
+
+VirtualTimer&
+Benchmark::getTimer(VirtualClock& clock)
+{
+    if (!mLoadTimer)
+    {
+        mLoadTimer = make_unique<VirtualTimer>(clock);
+    }
+    return *mLoadTimer;
+}
+
+Benchmark::BenchmarkBuilder::BenchmarkBuilder(Hash const& networkID)
+    : mInitialize(false)
+    , mPopulate(false)
+    , mTxRate(0)
+    , mAccounts(0)
+    , mNetworkID(networkID)
+{
+}
+
+Benchmark::BenchmarkBuilder&
+Benchmark::BenchmarkBuilder::setNumberOfInitialAccounts(uint32_t accounts)
+{
+    mAccounts = accounts;
+    return *this;
+}
+
+Benchmark::BenchmarkBuilder&
+Benchmark::BenchmarkBuilder::setTxRate(uint32_t txRate)
+{
+    mTxRate = txRate;
+    return *this;
+}
+
+Benchmark::BenchmarkBuilder&
+Benchmark::BenchmarkBuilder::initializeBenchmark()
+{
+    mInitialize = true;
+    return *this;
+}
+
+Benchmark::BenchmarkBuilder&
+Benchmark::BenchmarkBuilder::populateBenchmarkData()
+{
+    mPopulate = true;
+    return *this;
+}
+
+std::unique_ptr<Benchmark>
+Benchmark::BenchmarkBuilder::createBenchmark(Application& app) const
+{
+    auto sampler = make_unique<ShuffleLoadGenerator>(mNetworkID);
+    if (mPopulate)
+    {
+        prepareBenchmark(app, *sampler);
+    }
+    if (mInitialize)
+    {
+        sampler->initialize(app, mAccounts);
+    }
+    setMaxTxSize(app.getLedgerManager(), MAXIMAL_NUMBER_OF_TXS_PER_LEDGER);
+    app.getHerder().triggerNextLedger(app.getLedgerManager().getLedgerNum());
+    app.getHistoryManager().queueCurrentHistory();
+
+    class BenchmarkExt : public Benchmark
+    {
+      public:
+        BenchmarkExt(medida::MetricsRegistry& registry, uint32_t txRate,
+                     std::unique_ptr<TxSampler> sampler)
+            : Benchmark(registry, txRate, std::move(sampler))
+        {
+        }
+    };
+    return make_unique<BenchmarkExt>(
+        app.getMetrics(), mTxRate,
+        std::unique_ptr<TxSampler>(sampler.release()));
+}
+
+void
+Benchmark::BenchmarkBuilder::prepareBenchmark(
+    Application& app, ShuffleLoadGenerator& sampler) const
+{
+    populateAccounts(app, mAccounts, sampler);
+}
+
+void
+Benchmark::BenchmarkBuilder::populateAccounts(
+    Application& app, size_t size, ShuffleLoadGenerator& sampler) const
+{
+    for (size_t accountsLeft = size, batchSize = size; accountsLeft > 0;
+         accountsLeft -= batchSize)
+    {
+        batchSize = std::min(accountsLeft, MAXIMAL_NUMBER_OF_TXS_PER_LEDGER);
+        auto newAccounts = sampler.createAccounts(batchSize);
+        createAccountsDirectly(app, newAccounts);
+    }
+}
+
+void
+Benchmark::BenchmarkBuilder::setMaxTxSize(LedgerManager& ledger,
+                                          uint32_t maxTxSetSize) const
+{
+    StellarValue sv(ledger.getLastClosedLedgerHeader().hash,
+                    ledger.getLedgerNum(), emptyUpgradeSteps, 0);
+    {
+        LedgerUpgrade up(LEDGER_UPGRADE_MAX_TX_SET_SIZE);
+        up.newMaxTxSetSize() = maxTxSetSize;
+        Value v(xdr::xdr_to_opaque(up));
+        sv.upgrades.emplace_back(v.begin(), v.end());
+    }
+    LedgerCloseData ledgerData = createData(ledger, sv);
+    ledger.closeLedger(ledgerData);
+}
+
+LedgerCloseData
+Benchmark::BenchmarkBuilder::createData(LedgerManager& ledger,
+                                        StellarValue& value) const
+{
     auto ledgerNum = ledger.getLedgerNum();
-    StellarValue value(ledger.getLastClosedLedgerHeader().hash, ledgerNum,
-                       emptyUpgradeSteps, 0);
-
-    while (accountsLeft > 0)
-    {
-        auto ledgerNum = ledger.getLedgerNum();
-        TxSetFramePtr txSet = std::make_shared<TxSetFrame>(
-            ledger.getLastClosedLedgerHeader().hash);
-
-        std::vector<TransactionFramePtr> txFrames;
-        auto batchSize =
-            std::min(accountsLeft, MAXIMAL_NUMBER_OF_TXS_PER_LEDGER);
-
-        std::vector<LoadGenerator::AccountInfoPtr> newAccounts =
-            LoadGenerator::createAccounts(batchSize, ledgerNum);
-
-        for (AccountInfoPtr& account : newAccounts)
-        {
-            TxInfo tx = account->creationTransaction();
-            tx.toTransactionFrames(app, txFrames, txm);
-            tx.recordExecution(app.getConfig().DESIRED_BASE_FEE);
-        }
-
-        for (TransactionFramePtr txFrame : txFrames)
-        {
-            txSet->add(txFrame);
-        }
-
-        StellarValue value(txSet->getContentsHash(), ledgerNum,
-                           emptyUpgradeSteps, 0);
-        auto closeData = LedgerCloseData{ledgerNum, txSet, value};
-        app.getLedgerManager().valueExternalized(closeData);
-
-        accountsLeft -= batchSize;
-    }
+    TxSetFramePtr txSet =
+        std::make_shared<TxSetFrame>(ledger.getLastClosedLedgerHeader().hash);
+    value.txSetHash = txSet->getContentsHash();
+    return LedgerCloseData{ledgerNum, txSet, value};
 }
 
 void
-Benchmark::createAccountsUsingTransactions(Application& app, size_t n)
-{
-    auto ledgerNum = app.getLedgerManager().getLedgerNum();
-    std::vector<LoadGenerator::AccountInfoPtr> newAccounts =
-        LoadGenerator::createAccounts(n, ledgerNum);
-    for (LoadGenerator::AccountInfoPtr account : newAccounts)
-    {
-        LoadGenerator::TxInfo tx = account->creationTransaction();
-        if (!tx.execute(app))
-        {
-            CLOG(ERROR, LOGGER_ID)
-                << "Error while executing CREATE_ACCOUNT transaction";
-        }
-    }
-}
-
-void
-Benchmark::createAccountsDirectly(Application& app, size_t n)
+Benchmark::BenchmarkBuilder::createAccountsDirectly(
+    Application& app,
+    std::vector<LoadGenerator::AccountInfoPtr>& createdAccounts) const
 {
     soci::transaction sqlTx(app.getDatabase().getSession());
 
     auto ledger = app.getLedgerManager().getLedgerNum();
-    std::vector<LoadGenerator::AccountInfoPtr> createdAccounts =
-        LoadGenerator::createAccounts(mNumberOfInitialAccounts, ledger);
 
     int64_t balanceDiff = 0;
     std::vector<LedgerEntry> live;
@@ -225,75 +317,60 @@ Benchmark::createAccountsDirectly(Application& app, size_t n)
                     ledger, emptyUpgradeSteps, 0);
     LedgerCloseData ledgerData = createData(app.getLedgerManager(), sv);
     app.getLedgerManager().closeLedger(ledgerData);
-
-    mAccounts = createdAccounts;
 }
 
-void
-Benchmark::setMaxTxSize(LedgerManager& ledger, uint32_t maxTxSetSize)
+ShuffleLoadGenerator::ShuffleLoadGenerator(Hash const& networkID)
+    : LoadGenerator(networkID)
 {
-    StellarValue sv(ledger.getLastClosedLedgerHeader().hash,
-                    ledger.getLedgerNum(), emptyUpgradeSteps, 0);
+}
+
+std::unique_ptr<TxSampler::Tx>
+ShuffleLoadGenerator::createTransaction()
+{
+    class LoadGeneratorTx : public TxSampler::Tx
     {
-        LedgerUpgrade up(LEDGER_UPGRADE_MAX_TX_SET_SIZE);
-        up.newMaxTxSetSize() = maxTxSetSize;
-        Value v(xdr::xdr_to_opaque(up));
-        sv.upgrades.emplace_back(v.begin(), v.end());
+      public:
+        LoadGeneratorTx(TxInfo tx) : mTx(tx)
+        {
+        }
+
+        virtual bool
+        execute(Application& app) override
+        {
+            return mTx.execute(app);
+        }
+
+      private:
+        LoadGenerator::TxInfo mTx;
+    };
+    return make_unique<LoadGeneratorTx>(
+        LoadGenerator::createRandomTransaction(0.5));
+}
+
+std::vector<LoadGenerator::AccountInfoPtr>
+ShuffleLoadGenerator::createAccounts(size_t batchSize)
+{
+    return LoadGenerator::createAccounts(batchSize);
+}
+
+void
+ShuffleLoadGenerator::initialize(Application& app, size_t numberOfAccounts)
+{
+    CLOG(INFO, Benchmark::LOGGER_ID) << "Initializing benchmark";
+
+    if (mAccounts.empty())
+    {
+        mAccounts = LoadGenerator::createAccounts(numberOfAccounts);
+        loadAccounts(app, mAccounts);
     }
-    LedgerCloseData ledgerData = createData(ledger, sv);
-    ledger.closeLedger(ledgerData);
-}
-
-LedgerCloseData
-Benchmark::createData(LedgerManager& ledger, StellarValue& value)
-{
-    auto ledgerNum = ledger.getLedgerNum();
-    TxSetFramePtr txSet =
-        std::make_shared<TxSetFrame>(ledger.getLastClosedLedgerHeader().hash);
-    value.txSetHash = txSet->getContentsHash();
-    return LedgerCloseData{ledgerNum, txSet, value};
-}
-
-void
-Benchmark::prepareBenchmark(Application& app)
-{
-    CLOG(INFO, LOGGER_ID) << "Preparing data for benchmark";
-
-    initializeMetrics(app.getMetrics());
-
-    app.newDB();
-
-    setMaxTxSize(app.getLedgerManager(), MAXIMAL_NUMBER_OF_TXS_PER_LEDGER);
-
-    auto ledger = app.getLedgerManager().getLedgerNum();
-
-    createAccountsDirectly(app, mNumberOfInitialAccounts);
-    // createAccounts(app, mNumberOfInitialAccounts);
-    // createAccountsUsingTransactions(app, mNumberOfInitialAccounts);
-
-    app.getHistoryManager().queueCurrentHistory();
-
-    CLOG(INFO, LOGGER_ID) << "Data for benchmark prepared";
-}
-
-void
-Benchmark::initializeBenchmark(Application& app, uint32_t ledgerNum)
-{
-    mAccounts =
-        LoadGenerator::createAccounts(mNumberOfInitialAccounts, ledgerNum);
     mRandomIterator = shuffleAccounts(mAccounts);
-}
 
-std::vector<LoadGenerator::AccountInfoPtr>::iterator
-Benchmark::shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts)
-{
-    auto rng = std::default_random_engine{0};
-    std::shuffle(mAccounts.begin(), mAccounts.end(), rng);
-    return mAccounts.begin();
+    CLOG(INFO, Benchmark::LOGGER_ID) << "Benchmark initialized";
 }
 
 LoadGenerator::AccountInfoPtr
-Benchmark::pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum)
+ShuffleLoadGenerator::pickRandomAccount(AccountInfoPtr tryToAvoid,
+                                        uint32_t ledgerNum)
 {
     if (mRandomIterator == mAccounts.end())
     {
@@ -302,5 +379,53 @@ Benchmark::pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum)
     auto result = *mRandomIterator;
     mRandomIterator++;
     return result;
+}
+
+std::vector<LoadGenerator::AccountInfoPtr>::iterator
+ShuffleLoadGenerator::shuffleAccounts(
+    std::vector<LoadGenerator::AccountInfoPtr>& accounts)
+{
+    auto rng = std::default_random_engine{0};
+    std::shuffle(mAccounts.begin(), mAccounts.end(), rng);
+    return mAccounts.begin();
+}
+
+void
+BenchmarkExecutor::executeBenchmark(
+    Application& app, Benchmark::BenchmarkBuilder& benchmarkBuilder,
+    std::chrono::seconds testDuration,
+    std::function<void(Benchmark::Metrics)> stopCallback)
+{
+    VirtualTimer& timer = getTimer(app.getClock());
+    timer.expires_from_now(std::chrono::milliseconds{1});
+    timer.async_wait([this, &app, benchmarkBuilder, testDuration, &timer,
+                      stopCallback](asio::error_code const& error) {
+
+        std::shared_ptr<Benchmark> benchmark{
+            benchmarkBuilder.createBenchmark(app)};
+        benchmark->startBenchmark(app);
+
+        auto stopProcedure = [benchmark,
+                              stopCallback](asio::error_code const& error) {
+
+            auto metrics = benchmark->stopBenchmark();
+            stopCallback(metrics);
+
+            CLOG(INFO, Benchmark::LOGGER_ID) << "Benchmark complete.";
+        };
+
+        timer.expires_from_now(testDuration);
+        timer.async_wait(stopProcedure);
+    });
+}
+
+VirtualTimer&
+BenchmarkExecutor::getTimer(VirtualClock& clock)
+{
+    if (!mLoadTimer)
+    {
+        mLoadTimer = make_unique<VirtualTimer>(clock);
+    }
+    return *mLoadTimer;
 }
 }

--- a/src/simulation/Benchmark.cpp
+++ b/src/simulation/Benchmark.cpp
@@ -1,0 +1,306 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "simulation/Benchmark.h"
+
+#include "bucket/BucketManager.h"
+#include "database/Database.h"
+#include "ledger/LedgerDelta.h"
+#include "util/Logging.h"
+#include "util/make_unique.h"
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace stellar
+{
+
+const char* Benchmark::LOGGER_ID = "Benchmark";
+
+size_t Benchmark::MAXIMAL_NUMBER_OF_TXS_PER_LEDGER = 1000;
+
+Benchmark::Benchmark(Hash const& networkID)
+    : Benchmark(networkID, 1000000, MAXIMAL_NUMBER_OF_TXS_PER_LEDGER)
+{
+}
+
+Benchmark::Benchmark(Hash const& networkID, size_t numberOfInitialAccounts,
+                     uint32_t txRate)
+    : LoadGenerator(networkID)
+    , mIsRunning(false)
+    , mNumberOfInitialAccounts(numberOfInitialAccounts)
+    , mTxRate(txRate)
+{
+}
+
+std::shared_ptr<Benchmark::Metrics>
+Benchmark::startBenchmark(Application& app)
+{
+    mIsRunning = true;
+    using namespace std;
+    shared_ptr<Benchmark::Metrics> metrics{initializeMetrics(app.getMetrics())};
+    auto lastLedgerNum = app.getLedgerManager().getLedgerNum();
+    lastLedgerNum = lastLedgerNum == 0 ? 0 : lastLedgerNum - 1;
+    std::function<bool()> load = [this, &app, metrics,
+                                  lastLedgerNum]() mutable {
+        if (!this->mIsRunning)
+        {
+            return false;
+        }
+        if (lastLedgerNum < app.getLedgerManager().getLedgerNum())
+        {
+            generateLoadForBenchmark(app, this->mTxRate, *metrics);
+            lastLedgerNum = app.getLedgerManager().getLedgerNum();
+        }
+
+        return true;
+    };
+    metrics->benchmarkTimeContext =
+        make_unique<medida::TimerContext>(metrics->benchmarkTimer.TimeScope());
+    load();
+    scheduleLoad(app, load);
+
+    return metrics;
+}
+
+std::unique_ptr<Benchmark::Metrics>
+Benchmark::initializeMetrics(medida::MetricsRegistry& registry)
+{
+    return make_unique<Benchmark::Metrics>(Benchmark::Metrics(registry));
+}
+
+Benchmark::Metrics::Metrics(medida::MetricsRegistry& registry)
+    : benchmarkTimer(registry.NewTimer({"benchmark", "overall", "time"}))
+    , txsCount(registry.NewCounter({"benchmark", "txs", "count"}))
+{
+}
+
+std::shared_ptr<Benchmark::Metrics>
+Benchmark::stopBenchmark(std::shared_ptr<Benchmark::Metrics> metrics)
+{
+    mIsRunning = false;
+    metrics->timeSpent = metrics->benchmarkTimeContext->Stop();
+    return metrics;
+}
+
+bool
+Benchmark::generateLoadForBenchmark(Application& app, uint32_t txRate,
+                                    Metrics& metrics)
+{
+    updateMinBalance(app);
+
+    if (txRate == 0)
+    {
+        txRate = 1;
+    }
+
+    CLOG(TRACE, LOGGER_ID) << "Generating " << txRate
+                           << "transactions per step";
+
+    uint32_t ledgerNum = app.getLedgerManager().getLedgerNum();
+    std::vector<LoadGenerator::TxInfo> txs;
+    for (uint32_t it = 0; it < txRate; ++it)
+    {
+        txs.push_back(createRandomTransaction(0.5, ledgerNum));
+    }
+
+    for (auto& tx : txs)
+    {
+        if (!tx.execute(app))
+        {
+            CLOG(ERROR, LOGGER_ID)
+                << "Error while executing a transaction: transaction rejected";
+            return false;
+        }
+    }
+
+    metrics.txsCount.inc(txs.size());
+
+    CLOG(TRACE, LOGGER_ID) << txRate
+                           << " transactions generated in single step";
+
+    return true;
+}
+
+void
+Benchmark::createAccountsUsingLedgerManager(Application& app, size_t n)
+{
+    auto accountsLeft = mNumberOfInitialAccounts;
+    TxMetrics txm(app.getMetrics());
+    LedgerManager& ledger = app.getLedgerManager();
+    auto ledgerNum = ledger.getLedgerNum();
+    StellarValue value(ledger.getLastClosedLedgerHeader().hash, ledgerNum,
+                       emptyUpgradeSteps, 0);
+
+    while (accountsLeft > 0)
+    {
+        auto ledgerNum = ledger.getLedgerNum();
+        TxSetFramePtr txSet = std::make_shared<TxSetFrame>(
+            ledger.getLastClosedLedgerHeader().hash);
+
+        std::vector<TransactionFramePtr> txFrames;
+        auto batchSize =
+            std::min(accountsLeft, MAXIMAL_NUMBER_OF_TXS_PER_LEDGER);
+
+        std::vector<LoadGenerator::AccountInfoPtr> newAccounts =
+            LoadGenerator::createAccounts(batchSize, ledgerNum);
+
+        for (AccountInfoPtr& account : newAccounts)
+        {
+            TxInfo tx = account->creationTransaction();
+            tx.toTransactionFrames(app, txFrames, txm);
+            tx.recordExecution(app.getConfig().DESIRED_BASE_FEE);
+        }
+
+        for (TransactionFramePtr txFrame : txFrames)
+        {
+            txSet->add(txFrame);
+        }
+
+        StellarValue value(txSet->getContentsHash(), ledgerNum,
+                           emptyUpgradeSteps, 0);
+        auto closeData = LedgerCloseData{ledgerNum, txSet, value};
+        app.getLedgerManager().valueExternalized(closeData);
+
+        accountsLeft -= batchSize;
+    }
+}
+
+void
+Benchmark::createAccountsUsingTransactions(Application& app, size_t n)
+{
+    auto ledgerNum = app.getLedgerManager().getLedgerNum();
+    std::vector<LoadGenerator::AccountInfoPtr> newAccounts =
+        LoadGenerator::createAccounts(n, ledgerNum);
+    for (LoadGenerator::AccountInfoPtr account : newAccounts)
+    {
+        LoadGenerator::TxInfo tx = account->creationTransaction();
+        if (!tx.execute(app))
+        {
+            CLOG(ERROR, LOGGER_ID)
+                << "Error while executing CREATE_ACCOUNT transaction";
+        }
+    }
+}
+
+void
+Benchmark::createAccountsDirectly(Application& app, size_t n)
+{
+    soci::transaction sqlTx(app.getDatabase().getSession());
+
+    auto ledger = app.getLedgerManager().getLedgerNum();
+    std::vector<LoadGenerator::AccountInfoPtr> createdAccounts =
+        LoadGenerator::createAccounts(mNumberOfInitialAccounts, ledger);
+
+    int64_t balanceDiff = 0;
+    std::vector<LedgerEntry> live;
+    std::transform(
+        createdAccounts.begin(), createdAccounts.end(),
+        std::back_inserter(live),
+        [&app, &balanceDiff](LoadGenerator::AccountInfoPtr const& account) {
+            AccountFrame aFrame = account->createDirectly(app);
+            balanceDiff += aFrame.getBalance();
+            return aFrame.mEntry;
+        });
+
+    SecretKey skey = SecretKey::fromSeed(app.getNetworkID());
+    AccountFrame::pointer masterAccount =
+        AccountFrame::loadAccount(skey.getPublicKey(), app.getDatabase());
+    LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
+                      app.getDatabase());
+    masterAccount->addBalance(-balanceDiff);
+    masterAccount->touch(ledger);
+    masterAccount->storeChange(delta, app.getDatabase());
+
+    sqlTx.commit();
+
+    auto liveEntries = delta.getLiveEntries();
+    live.insert(live.end(), liveEntries.begin(), liveEntries.end());
+    app.getBucketManager().addBatch(app, ledger, live, {});
+
+    StellarValue sv(app.getLedgerManager().getLastClosedLedgerHeader().hash,
+                    ledger, emptyUpgradeSteps, 0);
+    LedgerCloseData ledgerData = createData(app.getLedgerManager(), sv);
+    app.getLedgerManager().closeLedger(ledgerData);
+
+    mAccounts = createdAccounts;
+}
+
+void
+Benchmark::setMaxTxSize(LedgerManager& ledger, uint32_t maxTxSetSize)
+{
+    StellarValue sv(ledger.getLastClosedLedgerHeader().hash,
+                    ledger.getLedgerNum(), emptyUpgradeSteps, 0);
+    {
+        LedgerUpgrade up(LEDGER_UPGRADE_MAX_TX_SET_SIZE);
+        up.newMaxTxSetSize() = maxTxSetSize;
+        Value v(xdr::xdr_to_opaque(up));
+        sv.upgrades.emplace_back(v.begin(), v.end());
+    }
+    LedgerCloseData ledgerData = createData(ledger, sv);
+    ledger.closeLedger(ledgerData);
+}
+
+LedgerCloseData
+Benchmark::createData(LedgerManager& ledger, StellarValue& value)
+{
+    auto ledgerNum = ledger.getLedgerNum();
+    TxSetFramePtr txSet =
+        std::make_shared<TxSetFrame>(ledger.getLastClosedLedgerHeader().hash);
+    value.txSetHash = txSet->getContentsHash();
+    return LedgerCloseData{ledgerNum, txSet, value};
+}
+
+void
+Benchmark::prepareBenchmark(Application& app)
+{
+    CLOG(INFO, LOGGER_ID) << "Preparing data for benchmark";
+
+    initializeMetrics(app.getMetrics());
+
+    app.newDB();
+
+    setMaxTxSize(app.getLedgerManager(), MAXIMAL_NUMBER_OF_TXS_PER_LEDGER);
+
+    auto ledger = app.getLedgerManager().getLedgerNum();
+
+    createAccountsDirectly(app, mNumberOfInitialAccounts);
+    // createAccounts(app, mNumberOfInitialAccounts);
+    // createAccountsUsingTransactions(app, mNumberOfInitialAccounts);
+
+    app.getHistoryManager().queueCurrentHistory();
+
+    CLOG(INFO, LOGGER_ID) << "Data for benchmark prepared";
+}
+
+void
+Benchmark::initializeBenchmark(Application& app, uint32_t ledgerNum)
+{
+    mAccounts =
+        LoadGenerator::createAccounts(mNumberOfInitialAccounts, ledgerNum);
+    mRandomIterator = shuffleAccounts(mAccounts);
+}
+
+std::vector<LoadGenerator::AccountInfoPtr>::iterator
+Benchmark::shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts)
+{
+    auto rng = std::default_random_engine{0};
+    std::shuffle(mAccounts.begin(), mAccounts.end(), rng);
+    return mAccounts.begin();
+}
+
+LoadGenerator::AccountInfoPtr
+Benchmark::pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum)
+{
+    if (mRandomIterator == mAccounts.end())
+    {
+        mRandomIterator = mAccounts.begin();
+    }
+    auto result = *mRandomIterator;
+    mRandomIterator++;
+    return result;
+}
+}

--- a/src/simulation/Benchmark.h
+++ b/src/simulation/Benchmark.h
@@ -41,19 +41,16 @@ class Benchmark
     ~Benchmark();
     void startBenchmark(Application& app);
     Metrics stopBenchmark();
-    Metrics getMetrics();
 
   protected:
     Benchmark(medida::MetricsRegistry& registry, uint32_t txRate,
               std::unique_ptr<TxSampler> sampler);
 
   private:
-    bool generateLoadForBenchmark(Application& app, uint32_t txRate,
-                                  Metrics& metrics);
-    void scheduleLoad(Application& app, std::function<bool()> loadGenerator,
+    bool generateLoadForBenchmark(Application& app);
+    void scheduleLoad(Application& app,
                       std::chrono::milliseconds stepTime);
     Benchmark::Metrics initializeMetrics(medida::MetricsRegistry& registry);
-    VirtualTimer& getTimer(VirtualClock& clock);
 
     bool mIsRunning;
     uint32_t mTxRate;

--- a/src/simulation/Benchmark.h
+++ b/src/simulation/Benchmark.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+#include "medida/counter.h"
+#include "medida/metrics_registry.h"
+#include "simulation/LoadGenerator.h"
+#include <chrono>
+#include <memory>
+#include <vector>
+
+namespace medida
+{
+class MetricsRegistry;
+class Meter;
+class Counter;
+class Timer;
+}
+
+namespace stellar
+{
+
+class Benchmark : private LoadGenerator
+{
+  private:
+  public:
+    static size_t MAXIMAL_NUMBER_OF_TXS_PER_LEDGER;
+
+    struct Metrics
+    {
+        medida::Timer& benchmarkTimer;
+        std::unique_ptr<medida::TimerContext> benchmarkTimeContext;
+        medida::Counter& txsCount;
+        std::chrono::nanoseconds timeSpent;
+
+      private:
+        Metrics(medida::MetricsRegistry& registry);
+        friend class Benchmark;
+    };
+
+    Benchmark(Hash const& networkID);
+    Benchmark(Hash const& networkID, size_t numberOfInitialAccounts,
+              uint32_t txRate);
+    void prepareBenchmark(Application& app);
+    void initializeBenchmark(Application& app, uint32_t ledgerNum);
+    std::shared_ptr<Metrics> startBenchmark(Application& app);
+    std::shared_ptr<Metrics> stopBenchmark(std::shared_ptr<Metrics> metrics);
+    virtual LoadGenerator::AccountInfoPtr
+    pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum) override;
+    void createAccountsDirectly(Application& app, size_t n);
+    void createAccountsUsingLedgerManager(Application& app, size_t n);
+    void createAccountsUsingTransactions(Application& app, size_t n);
+
+  private:
+    void setMaxTxSize(LedgerManager& ledger, uint32_t maxTxSetSize);
+    bool generateLoadForBenchmark(Application& app, uint32_t txRate,
+                                  Metrics& metrics);
+    std::vector<AccountInfoPtr>::iterator
+    shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts);
+    LedgerCloseData createData(LedgerManager& ledger, StellarValue& value);
+    std::unique_ptr<Benchmark::Metrics>
+    initializeMetrics(medida::MetricsRegistry& registry);
+    bool mIsRunning;
+    size_t mNumberOfInitialAccounts;
+    uint32_t mTxRate;
+    std::vector<AccountInfoPtr>::iterator mRandomIterator;
+
+    static const char* LOGGER_ID;
+};
+}

--- a/src/simulation/Benchmark.h
+++ b/src/simulation/Benchmark.h
@@ -7,67 +7,175 @@
 #include "main/Application.h"
 #include "medida/counter.h"
 #include "medida/metrics_registry.h"
+#include "medida/reporting/json_reporter.h"
+#include "medida/timer.h"
 #include "simulation/LoadGenerator.h"
+#include "util/Timer.h"
 #include <chrono>
 #include <memory>
 #include <vector>
 
-namespace medida
-{
-class MetricsRegistry;
-class Meter;
-class Counter;
-class Timer;
-}
-
 namespace stellar
 {
 
-class Benchmark : private LoadGenerator
+class TxSampler;
+
+class Benchmark
 {
-  private:
   public:
     static size_t MAXIMAL_NUMBER_OF_TXS_PER_LEDGER;
+    static const char* LOGGER_ID;
+
+    class BenchmarkBuilder;
 
     struct Metrics
     {
         medida::Timer& benchmarkTimer;
-        std::unique_ptr<medida::TimerContext> benchmarkTimeContext;
         medida::Counter& txsCount;
-        std::chrono::nanoseconds timeSpent;
 
       private:
         Metrics(medida::MetricsRegistry& registry);
         friend class Benchmark;
     };
 
-    Benchmark(Hash const& networkID);
-    Benchmark(Hash const& networkID, size_t numberOfInitialAccounts,
-              uint32_t txRate);
-    void prepareBenchmark(Application& app);
-    void initializeBenchmark(Application& app, uint32_t ledgerNum);
-    std::shared_ptr<Metrics> startBenchmark(Application& app);
-    std::shared_ptr<Metrics> stopBenchmark(std::shared_ptr<Metrics> metrics);
-    virtual LoadGenerator::AccountInfoPtr
-    pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum) override;
-    void createAccountsDirectly(Application& app, size_t n);
-    void createAccountsUsingLedgerManager(Application& app, size_t n);
-    void createAccountsUsingTransactions(Application& app, size_t n);
+    ~Benchmark();
+    void startBenchmark(Application& app);
+    Metrics stopBenchmark();
+    Metrics getMetrics();
+
+  protected:
+    Benchmark(medida::MetricsRegistry& registry, uint32_t txRate,
+              std::unique_ptr<TxSampler> sampler);
 
   private:
-    void setMaxTxSize(LedgerManager& ledger, uint32_t maxTxSetSize);
     bool generateLoadForBenchmark(Application& app, uint32_t txRate,
                                   Metrics& metrics);
-    std::vector<AccountInfoPtr>::iterator
-    shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts);
-    LedgerCloseData createData(LedgerManager& ledger, StellarValue& value);
-    std::unique_ptr<Benchmark::Metrics>
-    initializeMetrics(medida::MetricsRegistry& registry);
-    bool mIsRunning;
-    size_t mNumberOfInitialAccounts;
-    uint32_t mTxRate;
-    std::vector<AccountInfoPtr>::iterator mRandomIterator;
+    void scheduleLoad(Application& app, std::function<bool()> loadGenerator,
+                      std::chrono::milliseconds stepTime);
+    Benchmark::Metrics initializeMetrics(medida::MetricsRegistry& registry);
+    VirtualTimer& getTimer(VirtualClock& clock);
 
-    static const char* LOGGER_ID;
+    bool mIsRunning;
+    uint32_t mTxRate;
+    Benchmark::Metrics mMetrics;
+    std::unique_ptr<medida::TimerContext> mBenchmarkTimeContext;
+    std::unique_ptr<VirtualTimer> mLoadTimer;
+    std::unique_ptr<TxSampler> mSampler;
+};
+
+class ShuffleLoadGenerator;
+
+class Benchmark::BenchmarkBuilder
+{
+  public:
+    BenchmarkBuilder(Hash const& networkID);
+    BenchmarkBuilder& setNumberOfInitialAccounts(uint32_t accounts);
+    BenchmarkBuilder& setTxRate(uint32_t txRate);
+    BenchmarkBuilder& initializeBenchmark();
+    BenchmarkBuilder& populateBenchmarkData();
+    std::unique_ptr<Benchmark> createBenchmark(Application& app) const;
+
+  private:
+    void prepareBenchmark(Application& app,
+                          ShuffleLoadGenerator& sampler) const;
+    void populateAccounts(Application& app, size_t n,
+                          ShuffleLoadGenerator& sampler) const;
+    void setMaxTxSize(LedgerManager& ledger, uint32_t maxTxSetSize) const;
+    LedgerCloseData createData(LedgerManager& ledger,
+                               StellarValue& value) const;
+    void createAccountsDirectly(
+        Application& app,
+        std::vector<LoadGenerator::AccountInfoPtr>& accounts) const;
+
+    bool mInitialize;
+    bool mPopulate;
+    uint32_t mTxRate;
+    uint32_t mAccounts;
+    Hash mNetworkID;
+};
+
+class TxSampler
+{
+  public:
+    class Tx
+    {
+      public:
+        virtual ~Tx() = default;
+        virtual bool execute(Application& app) = 0;
+    };
+
+    virtual ~TxSampler() = default;
+    virtual std::unique_ptr<Tx> createTransaction() = 0;
+};
+
+class ShuffleLoadGenerator : public LoadGenerator, public TxSampler
+{
+  public:
+    ShuffleLoadGenerator(Hash const& networkID);
+    virtual ~ShuffleLoadGenerator() = default;
+    virtual std::unique_ptr<Tx> createTransaction() override;
+    std::vector<LoadGenerator::AccountInfoPtr> createAccounts(size_t batchSize);
+    void initialize(Application& app, size_t numberOfAccounts);
+
+  protected:
+    virtual LoadGenerator::AccountInfoPtr
+    pickRandomAccount(LoadGenerator::AccountInfoPtr tryToAvoid,
+                      uint32_t ledgerNum) override;
+    std::vector<LoadGenerator::AccountInfoPtr>::iterator
+    shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts);
+
+    std::vector<LoadGenerator::AccountInfoPtr>::iterator mRandomIterator;
+};
+
+class BenchmarkExecutor
+{
+  public:
+    void executeBenchmark(Application& app,
+                          Benchmark::BenchmarkBuilder& benchmarkBuilder,
+                          std::chrono::seconds testDuration,
+                          std::function<void(Benchmark::Metrics)> stopCallback);
+
+  private:
+    VirtualTimer& getTimer(VirtualClock& clock);
+
+    std::unique_ptr<VirtualTimer> mLoadTimer;
+};
+
+struct BenchmarkReporter
+{
+    template <typename Stream>
+    void
+    reportBenchmark(Benchmark::Metrics const& metrics,
+                    medida::MetricsRegistry& metricsRegistry, Stream& str)
+    {
+        using namespace std;
+        class ReportProcessor : public medida::MetricProcessor
+        {
+          public:
+            virtual ~ReportProcessor() = default;
+            virtual void
+            Process(medida::Timer& timer)
+            {
+                count = timer.count();
+            }
+
+            std::uint64_t count;
+        };
+        auto externalizedTxs =
+            metricsRegistry.GetAllMetrics()[{"ledger", "transaction", "apply"}];
+        ReportProcessor processor;
+        externalizedTxs->Process(processor);
+        auto txsExternalized = processor.count;
+
+        str << endl
+            << "Benchmark metrics:" << endl
+            << "  time spent: " << metrics.benchmarkTimer.sum()
+            << " milliseconds" << endl
+            << "  txs submitted: " << metrics.txsCount.count() << endl
+            << "  txs externalized: " << txsExternalized << endl;
+
+        medida::reporting::JsonReporter jr(metricsRegistry);
+        str << jr.Report() << endl;
+    }
 };
 }

--- a/src/simulation/BenchmarkTests.cpp
+++ b/src/simulation/BenchmarkTests.cpp
@@ -1,0 +1,103 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "simulation/Benchmark.h"
+#include "history/HistoryArchive.h"
+#include "lib/catch.hpp"
+#include "medida/metric_processor.h"
+#include "medida/reporting/json_reporter.h"
+#include "simulation/BenchmarkExecutor.h"
+#include "test/test.h"
+#include "util/Logging.h"
+#include "util/Timer.h"
+#include "util/make_unique.h"
+#include <memory>
+
+using namespace stellar;
+
+const char* LOGGER_ID = "Benchmark";
+
+std::unique_ptr<Benchmark>
+initializeBenchmark(Application& app)
+{
+    auto benchmark = make_unique<Benchmark>(app.getNetworkID());
+    benchmark->initializeBenchmark(app,
+                                   app.getLedgerManager().getLedgerNum() - 1);
+    return benchmark;
+}
+
+void
+prepareBenchmark(Application& app)
+{
+    auto benchmark = make_unique<Benchmark>(app.getNetworkID());
+    benchmark->prepareBenchmark(app);
+}
+
+std::unique_ptr<Config>
+initializeConfig()
+{
+    std::unique_ptr<Config> cfg = make_unique<Config>(getTestConfig());
+    cfg->DATABASE = SecretValue{"postgresql://dbname=core user=stellar "
+                                "password=__PGPASS__ host=localhost"};
+    cfg->PUBLIC_HTTP_PORT = true;
+    cfg->COMMANDS.push_back("ll?level=info");
+    cfg->DESIRED_MAX_TX_PER_LEDGER =
+        Benchmark::MAXIMAL_NUMBER_OF_TXS_PER_LEDGER;
+    cfg->FORCE_SCP = true;
+    cfg->RUN_STANDALONE = false;
+    cfg->BUCKET_DIR_PATH = "buckets";
+
+    using namespace std;
+    const string historyName = "benchmark";
+    const string historyGetCmd = "cp history/vs/{0} {1}";
+    const string historyPutCmd = "cp {0} history/vs/{1}";
+    const string historyMkdirCmd = "mkdir -p history/vs/{0}";
+    cfg->HISTORY[historyName] = make_shared<HistoryArchive>(
+        historyName, historyGetCmd, historyPutCmd, historyMkdirCmd);
+
+    return cfg;
+}
+
+TEST_CASE("stellar-core benchmark's initialization", "[benchmark][initialize]")
+{
+    std::unique_ptr<Config> cfg = initializeConfig();
+    VirtualClock clock(VirtualClock::REAL_TIME);
+    Application::pointer app = Application::create(clock, *cfg, false);
+    app->applyCfgCommands();
+
+    prepareBenchmark(*app);
+}
+
+TEST_CASE("stellar-core's benchmark", "[benchmark]")
+{
+    auto testDuration = std::chrono::seconds(60 * 10);
+
+    VirtualClock clock(VirtualClock::REAL_TIME);
+    std::unique_ptr<Config> cfg = initializeConfig();
+
+    Application::pointer app = Application::create(clock, *cfg, false);
+    app->applyCfgCommands();
+    app->start();
+    auto benchmark = initializeBenchmark(*app);
+    bool done = false;
+
+    VirtualTimer timer{clock};
+    auto metrics = benchmark->startBenchmark(*app);
+    timer.expires_from_now(testDuration);
+    timer.async_wait(
+        [&benchmark, &done, app, metrics](asio::error_code const& error) {
+            auto stopMetrics = benchmark->stopBenchmark(metrics);
+            BenchmarkExecutor().reportBenchmark(*metrics, *app);
+            done = true;
+        });
+
+    while (!done)
+    {
+        clock.crank();
+    }
+    app->gracefulStop();
+
+    CLOG(INFO, LOGGER_ID) << "Benchmark complete.";
+    app->getMetrics().NewMeter({"benchmark", "run", "complete"}, "run").Mark();
+}

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "simulation/LoadGenerator.h"
+#include "bucket/BucketManager.h"
 #include "herder/Herder.h"
 #include "ledger/LedgerDelta.h"
 #include "ledger/LedgerManager.h"
@@ -116,6 +117,28 @@ LoadGenerator::scheduleLoadGeneration(Application& app, uint32_t nAccounts,
             }
         });
     }
+}
+
+void
+LoadGenerator::scheduleLoad(Application& app,
+                            std::function<bool()> loadGenerator)
+{
+    if (!mLoadTimer)
+    {
+        mLoadTimer = make_unique<VirtualTimer>(app.getClock());
+    }
+    const auto deadline = std::chrono::milliseconds(STEP_MSECS);
+    mLoadTimer->expires_from_now(deadline);
+    mLoadTimer->async_wait(
+        [this, &app, loadGenerator](asio::error_code const& error) {
+            if (!error)
+            {
+                if (loadGenerator())
+                {
+                    this->scheduleLoad(app, loadGenerator);
+                }
+            }
+        });
 }
 
 bool
@@ -479,16 +502,27 @@ LoadGenerator::createAccount(size_t i, uint32_t ledgerNum)
 }
 
 vector<LoadGenerator::AccountInfoPtr>
-LoadGenerator::createAccounts(size_t n)
+LoadGenerator::createAccounts(size_t n, uint32_t ledgerNum)
 {
     vector<AccountInfoPtr> result;
     for (size_t i = 0; i < n; i++)
     {
-        auto account = createAccount(mAccounts.size());
+        auto account = createAccount(mAccounts.size(), ledgerNum);
         mAccounts.push_back(account);
         result.push_back(account);
     }
     return result;
+}
+
+void
+LoadGenerator::createAccountsDirectly(Application& app, size_t n)
+{
+    for (size_t it = 0; it < n; it++)
+    {
+        auto acc = createAccount(mAccounts.size());
+        acc->createDirectly(app);
+        mAccounts.push_back(acc);
+    }
 }
 
 vector<LoadGenerator::TxInfo>
@@ -736,7 +770,7 @@ LoadGenerator::AccountInfo::creationTransaction()
                   TxInfo::TX_CREATE_ACCOUNT, LOADGEN_ACCOUNT_BALANCE};
 }
 
-void
+AccountFrame
 LoadGenerator::AccountInfo::createDirectly(Application& app)
 {
     AccountFrame a(mKey.getPublicKey());
@@ -747,8 +781,8 @@ LoadGenerator::AccountInfo::createDirectly(Application& app)
     a.touch(ledger);
     LedgerDelta delta(app.getLedgerManager().getCurrentLedgerHeader(),
                       app.getDatabase());
-    ;
     a.storeAdd(delta, app.getDatabase());
+    return a;
 }
 
 void

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -55,8 +55,6 @@ class LoadGenerator
     void scheduleLoadGeneration(Application& app, uint32_t nAccounts,
                                 uint32_t nTxs, uint32_t txRate, bool autoRate);
 
-    void scheduleLoad(Application& app, std::function<bool()> loadGenerator);
-
     // Generate one "step" worth of load (assuming 1 step per STEP_MSECS) at a
     // given target number of accounts and txs, and a given target tx/s rate.
     // If work remains after the current step, call scheduleLoadGeneration()
@@ -181,5 +179,8 @@ class LoadGenerator
                                  TxMetrics& metrics);
         void recordExecution(int64_t baseFee);
     };
+
+  private:
+    VirtualTimer& getTimer(VirtualClock& clock);
 };
 }

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -8,6 +8,7 @@
 #include "main/Application.h"
 #include "test/TxTests.h"
 #include "xdr/Stellar-types.h"
+#include <functional>
 #include <vector>
 
 namespace medida
@@ -27,7 +28,7 @@ class LoadGenerator
 {
   public:
     LoadGenerator(Hash const& networkID);
-    ~LoadGenerator();
+    virtual ~LoadGenerator();
     void clear();
 
     struct TxInfo;
@@ -54,6 +55,8 @@ class LoadGenerator
     void scheduleLoadGeneration(Application& app, uint32_t nAccounts,
                                 uint32_t nTxs, uint32_t txRate, bool autoRate);
 
+    void scheduleLoad(Application& app, std::function<bool()> loadGenerator);
+
     // Generate one "step" worth of load (assuming 1 step per STEP_MSECS) at a
     // given target number of accounts and txs, and a given target tx/s rate.
     // If work remains after the current step, call scheduleLoadGeneration()
@@ -65,7 +68,10 @@ class LoadGenerator
 
     std::vector<TxInfo> accountCreationTransactions(size_t n);
     AccountInfoPtr createAccount(size_t i, uint32_t ledgerNum = 0);
-    std::vector<AccountInfoPtr> createAccounts(size_t n);
+    std::vector<AccountInfoPtr> createAccounts(size_t n,
+                                               uint32_t ledgerNum = 0);
+    void createAccountsDirectly(Application& app, size_t n);
+
     bool loadAccount(Application& app, AccountInfo& account);
     bool loadAccount(Application& app, AccountInfoPtr account);
     bool loadAccounts(Application& app, std::vector<AccountInfoPtr> accounts);
@@ -78,8 +84,8 @@ class LoadGenerator
                                     int64_t amount,
                                     std::vector<AccountInfoPtr> const& path);
 
-    AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid,
-                                     uint32_t ledgerNum);
+    virtual AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid,
+                                             uint32_t ledgerNum);
 
     AccountInfoPtr pickRandomPath(AccountInfoPtr from, uint32_t ledgerNum,
                                   std::vector<AccountInfoPtr>& path);
@@ -124,7 +130,7 @@ class LoadGenerator
         AccountInfoPtr mBuyCredit;
         AccountInfoPtr mSellCredit;
 
-        void createDirectly(Application& app);
+        AccountFrame createDirectly(Application& app);
         void debitDirectly(Application& app, int64_t debitAmount);
         TxInfo creationTransaction();
 

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -23,8 +23,9 @@ namespace
 {
 
 static const std::vector<std::string> kLoggers = {
-    "Fs",      "SCP",    "Bucket", "Database", "History", "Process",  "Ledger",
-    "Overlay", "Herder", "Tx",     "LoadGen",  "Work",    "Invariant"};
+    "Fs",      "SCP",    "Bucket",    "Database", "History",
+    "Process", "Ledger", "Overlay",   "Herder",   "Tx",
+    "LoadGen", "Work",   "Invariant", "Benchmark"};
 }
 
 el::Configurations Logging::gDefaultConf;


### PR DESCRIPTION
Benchmark for stellar-core.
It consists of two steps/routines:
- accounts initialization - creates specified number of initial accounts
- transaction generation and submission
Added new http command for executing benchmark: /benchmark[?createaccounts=N | accounts=N&txrate=R&duration=T].
