### PR TITLE
Manage offer v9

### DIFF
--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -205,15 +205,15 @@ ManageOfferOpFrame::doApply(Application& app, LedgerDelta& delta,
         }
 
         // the maximum is defined by how much wheat it can receive
-        int64_t maxWheatCanSell;
+        int64_t maxWheatCanBuy;
         if (wheat.type() == ASSET_TYPE_NATIVE)
         {
-            maxWheatCanSell = INT64_MAX;
+            maxWheatCanBuy = INT64_MAX;
         }
         else
         {
-            maxWheatCanSell = mWheatLineA->getMaxAmountReceive();
-            if (maxWheatCanSell == 0)
+            maxWheatCanBuy = mWheatLineA->getMaxAmountReceive();
+            if (maxWheatCanBuy == 0)
             {
                 app.getMetrics()
                     .NewMeter({"op-manage-offer", "invalid", "line-full"},
@@ -228,7 +228,7 @@ ManageOfferOpFrame::doApply(Application& app, LedgerDelta& delta,
 
         {
             int64_t maxSheepBasedOnWheat;
-            if (!bigDivide(maxSheepBasedOnWheat, maxWheatCanSell, sheepPrice.d,
+            if (!bigDivide(maxSheepBasedOnWheat, maxWheatCanBuy, sheepPrice.d,
                            sheepPrice.n, ROUND_DOWN))
             {
                 maxSheepBasedOnWheat = INT64_MAX;
@@ -241,8 +241,7 @@ ManageOfferOpFrame::doApply(Application& app, LedgerDelta& delta,
         }
 
         // amount of sheep for sale is the lesser of amount we can sell and
-        // amount
-        // put in the offer
+        // amount put in the offer
         if (maxAmountOfSheepCanSell < maxSheepSend)
         {
             maxSheepSend = maxAmountOfSheepCanSell;
@@ -255,7 +254,7 @@ ManageOfferOpFrame::doApply(Application& app, LedgerDelta& delta,
         const Price maxWheatPrice(sheepPrice.d, sheepPrice.n);
 
         OfferExchange::ConvertResult r = oe.convertWithOffers(
-            sheep, maxSheepSend, sheepSent, wheat, maxWheatCanSell,
+            sheep, maxSheepSend, sheepSent, wheat, maxWheatCanBuy,
             wheatReceived, [this, &maxWheatPrice](OfferFrame const& o) {
                 if (o.getOfferID() == mSellSheepOffer->getOfferID())
                 {


### PR DESCRIPTION
This PR updates the way manage offer works when attempting to sell XLMs.

In v8 of the protocol, the bad scenario looks like this:
attempt to create an offer to sell XLMs for some other asset but with an XLM balance that is too low.
Internally, the offer is first run throw the order book (in case the offer can be taken right away).
The problem is that if the offer is only partially taken, a new offer needs to be created but if there was enough outstanding offers in the order book the XLM balance could be below the reserve required to create an offer - and the operation fails (meaning no XLMs were sold).

The v9 implementation instead assumes that the offer would be created, and thus limits the XLMs that can be sold like this to the ones above the larger reserve.
This causes the behavior to be deterministic (from a success/failure point of view) as the only thing that matters is that the starting balance can accommodate the creation of an offer (the same way you need to have a balance to sell other assets).

An alternative that was considered was to simply not fail on the last step (which allows to sell a few more XLMs that way) but it would break manageOffer's contract that is that the outcome of calling manageOffer to create an offer before or after different offers are created should be the same.
This would allow selling more XLMs in manageOffer than from a regular offer, creating additional incentives to not have standing offers.

resolves #1430

