### PR TITLE
always emit previous state in meta

### DIFF
--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -262,13 +262,9 @@ LedgerDelta::addCurrentMeta(LedgerEntryChanges& changes,
     auto it = mPrevious.find(key);
     if (it != mPrevious.end())
     {
-        // if the old value is from a previous ledger we emit it
         auto const& e = it->second->mEntry;
-        if (e.lastModifiedLedgerSeq != mCurrentHeader.mHeader.ledgerSeq)
-        {
-            changes.emplace_back(LEDGER_ENTRY_STATE);
-            changes.back().state() = e;
-        }
+        changes.emplace_back(LEDGER_ENTRY_STATE);
+        changes.back().state() = e;
     }
 }
 

--- a/src/ledger/LedgerDeltaTests.cpp
+++ b/src/ledger/LedgerDeltaTests.cpp
@@ -282,7 +282,7 @@ TEST_CASE("Ledger delta", "[ledger][ledgerdelta]")
             {
                 accountsByKey = modAccounts;
                 checkChanges(delta2, 0, nbAccountsGroupSize * 2, 0,
-                             nbAccountsGroupSize, orgAccountsBeforeD2);
+                             nbAccountsGroupSize * 2, orgAccountsBeforeD2);
                 delta2.commit();
                 checkChanges(delta, nbAccountsGroupSize,
                              nbAccountsGroupSize * 2, nbAccountsGroupSize,
@@ -312,7 +312,7 @@ TEST_CASE("Ledger delta", "[ledger][ledgerdelta]")
             {
                 accountsByKey = delAccounts;
                 checkChanges(delta2, 0, 0, nbAccountsGroupSize * 2,
-                             nbAccountsGroupSize, orgAccountsBeforeD2);
+                             nbAccountsGroupSize * 2, orgAccountsBeforeD2);
                 delta2.commit();
                 // adds/mods were replaced by a delete
                 // adds+del result in no-op


### PR DESCRIPTION
this simplifies ingestion logic in consumers of the meta data; old version required to keep track of updates over transactions and operations

resolves #1420 
