### PR TITLE
Benchmark of stellar-core

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -146,6 +146,10 @@ debugging purpose).
   `/generateload[?accounts=N&txs=M&txrate=(R|auto)]`<br>
   Artificially generate load for testing; must be used with `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
 
+* **benchmark**
+  `/benchmark[?preparebenchmark=A | txrate=R&duration=T]`<br>
+  Artificially generate load for benchmark; must be used with `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
+  
 * **manualclose**
   If MANUAL_CLOSE is set to true in the .cfg file. This will cause the current ledger to close.
 

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -40,6 +40,7 @@ class CommandHandler;
 class WorkManager;
 class BanManager;
 class StatusManager;
+class BenchmarkExecutor;
 
 class Application;
 void validateNetworkPassphrase(std::shared_ptr<Application> app);
@@ -231,6 +232,8 @@ class Application
     // against the current application.
     virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate) = 0;
+
+    virtual BenchmarkExecutor& getBenchmarkExecutor() = 0;
 
     // Access the load generator for manual operation.
     virtual LoadGenerator& getLoadGenerator() = 0;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -39,6 +39,7 @@
 #include "process/ProcessManager.h"
 #include "scp/LocalNode.h"
 #include "scp/QuorumSetUtils.h"
+#include "simulation/Benchmark.h"
 #include "simulation/LoadGenerator.h"
 #include "util/StatusManager.h"
 #include "work/WorkManager.h"
@@ -478,6 +479,16 @@ ApplicationImpl::getLoadGenerator()
         mLoadGenerator = make_unique<LoadGenerator>(getNetworkID());
     }
     return *mLoadGenerator;
+}
+
+BenchmarkExecutor&
+ApplicationImpl::getBenchmarkExecutor()
+{
+    if (!mBenchmarkExecutor)
+    {
+        mBenchmarkExecutor = make_unique<BenchmarkExecutor>();
+    }
+    return *mBenchmarkExecutor;
 }
 
 void

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -30,6 +30,7 @@ class CommandHandler;
 class Database;
 class LoadGenerator;
 class NtpSynchronizationChecker;
+class BenchmarkExecutor;
 
 class ApplicationImpl : public Application
 {
@@ -88,6 +89,8 @@ class ApplicationImpl : public Application
     virtual void generateLoad(uint32_t nAccounts, uint32_t nTxs,
                               uint32_t txRate, bool autoRate) override;
 
+    virtual BenchmarkExecutor& getBenchmarkExecutor() override;
+
     virtual LoadGenerator& getLoadGenerator() override;
 
     virtual void checkDB() override;
@@ -140,6 +143,7 @@ class ApplicationImpl : public Application
     std::shared_ptr<WorkManager> mWorkManager;
     std::unique_ptr<PersistentState> mPersistentState;
     std::unique_ptr<LoadGenerator> mLoadGenerator;
+    std::unique_ptr<BenchmarkExecutor> mBenchmarkExecutor;
     std::unique_ptr<BanManager> mBanManager;
     std::shared_ptr<NtpSynchronizationChecker> mNtpSynchronizationChecker;
     std::unique_ptr<StatusManager> mStatusManager;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -417,6 +417,7 @@ CommandHandler::benchmark(std::string const& params, std::string& retStr)
     }
 
     uint32 createAccounts = 0;
+    uint32 accounts = 0;
     uint32_t txRate = 200;
     uint32_t duration = 60;
 
@@ -454,6 +455,20 @@ CommandHandler::benchmark(std::string const& params, std::string& retStr)
         return;
     }
 
+    if (!parseNumParam(map, "accounts", accounts, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'accounts'";
+        return;
+    }
+    if (accounts > 0)
+    {
+        Benchmark::BenchmarkBuilder builder(mApp.getNetworkID());
+        auto benchmark = builder.setNumberOfInitialAccounts(accounts)
+            .loadAccounts();
+        mApp.getBenchmarkExecutor().setBenchmark(builder.createBenchmark(mApp));
+    }
+
     mApp.getMetrics().NewMeter({"benchmark", "run", "started"}, "run").Mark();
     auto stopCallback = [this](Benchmark::Metrics metrics) {
 
@@ -465,9 +480,9 @@ CommandHandler::benchmark(std::string const& params, std::string& retStr)
     mApp.getBenchmarkExecutor().executeBenchmark(
         mApp, std::chrono::seconds{duration}, txRate, stopCallback);
 
-    retStr = fmt::format("{{ \"Benchmark\": {{ \"txRate\": "
-                         "{:d}, \"seconds\": {:d} }} }}",
-                         txRate, duration);
+    retStr = fmt::format("{{ \"Benchmark\": {{ \"txRate\": {:d}, "
+                         "\"seconds\": {:d}, \"accounts\": {:d} }} }}",
+                         txRate, duration, accounts);
 }
 
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -14,6 +14,7 @@
 #include "main/Config.h"
 #include "overlay/BanManager.h"
 #include "overlay/OverlayManager.h"
+#include "simulation/Benchmark.h"
 #include "util/Logging.h"
 #include "util/StatusManager.h"
 #include "util/make_unique.h"
@@ -81,6 +82,8 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
                       std::bind(&CommandHandler::dropPeer, this, _1, _2));
     mServer->addRoute("generateload",
                       std::bind(&CommandHandler::generateLoad, this, _1, _2));
+    mServer->addRoute("benchmark",
+                      std::bind(&CommandHandler::benchmark, this, _1, _2));
     mServer->addRoute("info", std::bind(&CommandHandler::info, this, _1, _2));
     mServer->addRoute("ll", std::bind(&CommandHandler::ll, this, _1, _2));
     mServer->addRoute("logrotate",
@@ -296,9 +299,17 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "on the instance."
         "<ul><li><i>queue</i> performs deletion of queue data.See setcursor "
         "for more information</li></ul>"
-        "</p><p><h1> "
-        "/unban?node=NODE_ID</h1>"
+        "</p><p><h1> /unban?node=NODE_ID</h1>"
         "remove ban for PEER_ID"
+        "</p><p><h1> /benchmark[?preparebenchmark=N | "
+        "txrate=R&duration=T]</h1>"
+        "start benchmark of stellar-core; must be used with "
+        "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING set to true;"
+        "benchmark's parameters:<br/>"
+        "preparebenchmark=N populates database with N artificial accounts<br/>"
+        "txrate=R is number of transactions per second submitted by "
+        "benchmark<br/>"
+        "duration=T is time in seconds for benchmark's execution"
         "</p>"
 
         "<br>";
@@ -394,6 +405,71 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
                  "the stellar-core.cfg if you want this behavior";
     }
 }
+
+void
+CommandHandler::benchmark(std::string const& params, std::string& retStr)
+{
+    if (!mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
+    {
+        retStr = "Set ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true in "
+                 "the stellar-core.cfg if you want this behavior";
+        return;
+    }
+
+    uint32 createAccounts = 0;
+    uint32_t txRate = 200;
+    uint32_t duration = 60;
+
+    std::map<std::string, std::string> map;
+    http::server::server::parseParams(params, map);
+
+    if (!parseNumParam(map, "preparebenchmark", createAccounts, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'preparebenchmark'";
+        return;
+    }
+    if (createAccounts > 0)
+    {
+        Benchmark::BenchmarkBuilder builder(mApp.getNetworkID());
+        auto benchmark = builder.setNumberOfInitialAccounts(createAccounts)
+                             .populateBenchmarkData();
+        mApp.getBenchmarkExecutor().setBenchmark(builder.createBenchmark(mApp));
+
+        retStr = fmt::format("{{\"createdAccounts\": {:d}}}", createAccounts);
+        return;
+    }
+
+    if (!parseNumParam(map, "txrate", txRate, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'txrate'";
+        return;
+    }
+
+    if (!parseNumParam(map, "duration", duration, retStr,
+                       Requirement::OPTIONAL_REQ))
+    {
+        retStr = "Invalid value for the parameter 'duration'";
+        return;
+    }
+
+    mApp.getMetrics().NewMeter({"benchmark", "run", "started"}, "run").Mark();
+    auto stopCallback = [this](Benchmark::Metrics metrics) {
+
+        mApp.getMetrics()
+            .NewMeter({"benchmark", "run", "complete"}, "run")
+            .Mark();
+        reportBenchmark(metrics, mApp.getMetrics(), LOG(INFO));
+    };
+    mApp.getBenchmarkExecutor().executeBenchmark(
+        mApp, std::chrono::seconds{duration}, txRate, stopCallback);
+
+    retStr = fmt::format("{{ \"Benchmark\": {{ \"txRate\": "
+                         "{:d}, \"seconds\": {:d} }} }}",
+                         txRate, duration);
+}
+
 
 void
 CommandHandler::peers(std::string const&, std::string& retStr)

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -36,6 +36,7 @@ class CommandHandler
     void dropcursor(std::string const& params, std::string& retStr);
     void dropPeer(std::string const& params, std::string& retStr);
     void generateLoad(std::string const& params, std::string& retStr);
+    void benchmark(std::string const& params, std::string& retStr);
     void info(std::string const& params, std::string& retStr);
     void ll(std::string const& params, std::string& retStr);
     void logRotate(std::string const& params, std::string& retStr);

--- a/src/simulation/Benchmark.cpp
+++ b/src/simulation/Benchmark.cpp
@@ -1,0 +1,198 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "simulation/Benchmark.h"
+
+#include "bucket/BucketManager.h"
+#include "util/Logging.h"
+#include "util/make_unique.h"
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace stellar
+{
+
+const uint32_t Benchmark::STEP_MSECS = 100;
+
+Benchmark::Benchmark(medida::MetricsRegistry& registry, uint32_t txRate,
+                     std::unique_ptr<TxSampler> sampler)
+    : mIsRunning(false)
+    , mMetrics(Benchmark::Metrics(registry))
+    , mSampler(std::move(sampler))
+{
+    setTxRate(txRate);
+}
+
+Benchmark::~Benchmark()
+{
+    if (mIsRunning)
+    {
+        stopBenchmark();
+    }
+}
+
+void
+Benchmark::startBenchmark(Application& app)
+{
+    if (mIsRunning)
+    {
+        throw std::runtime_error{"Benchmark already started"};
+    }
+    mIsRunning = true;
+    mBenchmarkTimeContext =
+        make_unique<medida::TimerContext>(mMetrics.mBenchmarkTimer.TimeScope());
+    scheduleLoad(app, std::chrono::milliseconds{STEP_MSECS});
+}
+
+Benchmark::Metrics::Metrics(medida::MetricsRegistry& registry)
+    : mBenchmarkTimer(registry.NewTimer({"benchmark", "overall", "time"}))
+    , mTxsCount(registry.NewCounter({"benchmark", "txs", "count"}))
+{
+}
+
+Benchmark::Metrics
+Benchmark::stopBenchmark()
+{
+    LOG(INFO) << "Stopping benchmark";
+    if (!mIsRunning)
+    {
+        throw std::runtime_error{"Benchmark is already stopped"};
+    }
+    mBenchmarkTimeContext->Stop();
+    mIsRunning = false;
+    LOG(INFO) << "Benchmark stopping procedure finished";
+    return mMetrics;
+}
+
+void
+Benchmark::setTxRate(uint32_t txRate)
+{
+    mTxRate = txRate * STEP_MSECS / 1000;
+}
+
+bool
+Benchmark::generateLoadForBenchmark(Application& app)
+{
+    LOG(TRACE) << "Generating " << mTxRate << " transaction(s)";
+
+    mBenchmarkTimeContext->Stop();
+    auto txs = mSampler->createTransaction(mTxRate);
+    mBenchmarkTimeContext->Reset();
+    if (!txs->execute(app))
+    {
+        LOG(ERROR) << "Error while executing a transaction: "
+                      "transaction was rejected";
+        return false;
+    }
+    mMetrics.mTxsCount.inc(mTxRate);
+
+    LOG(TRACE) << mTxRate << " transaction(s) generated in a single step";
+
+    return true;
+}
+
+void
+Benchmark::scheduleLoad(Application& app, std::chrono::milliseconds stepTime)
+{
+    if (!mLoadTimer)
+    {
+        mLoadTimer = make_unique<VirtualTimer>(app.getClock());
+    }
+    mLoadTimer->expires_from_now(stepTime);
+    mLoadTimer->async_wait(
+        [this, &app, stepTime](asio::error_code const& error) {
+            if (error)
+            {
+                return;
+            }
+            if (generateLoadForBenchmark(app))
+            {
+                this->scheduleLoad(app, stepTime);
+            }
+            else
+            {
+                stopBenchmark();
+            }
+        });
+}
+
+TxSampler::TxSampler(Hash const& networkID) : LoadGenerator(networkID)
+{
+}
+
+bool
+TxSampler::Tx::execute(Application& app)
+{
+    for (auto& tx : mTxs)
+    {
+        if (!tx.execute(app))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::unique_ptr<TxSampler::Tx>
+TxSampler::createTransaction(size_t size)
+{
+    auto result = make_unique<TxSampler::Tx>();
+    for (size_t it = 0; it < size; ++it)
+    {
+        result->mTxs.push_back(LoadGenerator::createRandomTransaction(0.5));
+    }
+    return result;
+}
+
+std::vector<LoadGenerator::AccountInfoPtr>
+TxSampler::createAccounts(size_t batchSize, uint32_t ledgerNum)
+{
+    return LoadGenerator::createAccounts(batchSize, ledgerNum);
+}
+
+std::vector<LoadGenerator::AccountInfoPtr> const&
+TxSampler::getAccounts()
+{
+    return mAccounts;
+}
+
+void
+TxSampler::initialize(Application& app)
+{
+    LOG(INFO) << "Initializing benchmark";
+
+    mRandomIterator = shuffleAccounts(mAccounts);
+
+    LOG(INFO) << "Benchmark initialized";
+}
+
+void
+TxSampler::loadAccounts(Application& app)
+{
+    LoadGenerator::loadAccounts(app, mAccounts);
+}
+
+LoadGenerator::AccountInfoPtr
+TxSampler::pickRandomAccount(AccountInfoPtr tryToAvoid, uint32_t ledgerNum)
+{
+    if (mRandomIterator == mAccounts.end())
+    {
+        mRandomIterator = mAccounts.begin();
+    }
+    auto result = *mRandomIterator;
+    mRandomIterator++;
+    return result;
+}
+
+std::vector<LoadGenerator::AccountInfoPtr>::iterator
+TxSampler::shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts)
+{
+    auto rng = std::default_random_engine{0};
+    std::shuffle(mAccounts.begin(), mAccounts.end(), rng);
+    return mAccounts.begin();
+}
+}

--- a/src/simulation/Benchmark.cpp
+++ b/src/simulation/Benchmark.cpp
@@ -352,7 +352,9 @@ BenchmarkExecutor::executeBenchmark(
         auto stopProcedure = [this,
                               stopCallback](asio::error_code const& error) {
 
+            LOG(INFO) << "Stopping benchmark";
             auto metrics = mBenchmark->stopBenchmark();
+            LOG(INFO) << "Calling benchmark's stop callback";
             stopCallback(metrics);
 
             LOG(INFO) << "Benchmark complete";

--- a/src/simulation/Benchmark.h
+++ b/src/simulation/Benchmark.h
@@ -1,0 +1,94 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+#include "medida/counter.h"
+#include "medida/metrics_registry.h"
+#include "medida/reporting/json_reporter.h"
+#include "medida/timer.h"
+#include "simulation/LoadGenerator.h"
+#include "util/Timer.h"
+#include "xdr/Stellar-types.h"
+#include <chrono>
+#include <memory>
+#include <vector>
+
+namespace stellar
+{
+
+static const size_t MAXIMAL_NUMBER_OF_ACCOUNTS_IN_BATCH = 10000;
+
+class TxSampler;
+
+class Benchmark
+{
+    static const uint32_t STEP_MSECS;
+
+  public:
+    class BenchmarkBuilder;
+
+    struct Metrics
+    {
+        medida::Timer& mBenchmarkTimer;
+        medida::Counter& mTxsCount;
+
+      private:
+        Metrics(medida::MetricsRegistry& registry);
+        friend class Benchmark;
+    };
+
+    Benchmark(medida::MetricsRegistry& registry, uint32_t txRate,
+              std::unique_ptr<TxSampler> sampler);
+    ~Benchmark();
+    void startBenchmark(Application& app);
+    Metrics stopBenchmark();
+    void setTxRate(uint32_t txRate);
+
+  private:
+    bool generateLoadForBenchmark(Application& app);
+    void scheduleLoad(Application& app, std::chrono::milliseconds stepTime);
+
+    bool mIsRunning;
+    uint32_t mTxRate;
+    Benchmark::Metrics mMetrics;
+    std::unique_ptr<medida::TimerContext> mBenchmarkTimeContext;
+    std::unique_ptr<VirtualTimer> mLoadTimer;
+    std::unique_ptr<TxSampler> mSampler;
+};
+
+class TxSampler : private LoadGenerator
+{
+  public:
+    class Tx;
+
+    TxSampler(Hash const& networkID);
+    void initialize(Application& app);
+    void loadAccounts(Application& app);
+    std::unique_ptr<Tx> createTransaction(size_t size);
+    std::vector<LoadGenerator::AccountInfoPtr>
+    createAccounts(size_t batchSize, uint32_t ledgerNum);
+    std::vector<LoadGenerator::AccountInfoPtr> const& getAccounts();
+
+  private:
+    virtual LoadGenerator::AccountInfoPtr
+    pickRandomAccount(LoadGenerator::AccountInfoPtr tryToAvoid,
+                      uint32_t ledgerNum) override;
+    std::vector<LoadGenerator::AccountInfoPtr>::iterator
+    shuffleAccounts(std::vector<LoadGenerator::AccountInfoPtr>& accounts);
+
+    std::vector<LoadGenerator::AccountInfoPtr>::iterator mRandomIterator;
+};
+
+class TxSampler::Tx
+{
+  public:
+    bool execute(Application& app);
+
+  private:
+    std::vector<LoadGenerator::TxInfo> mTxs;
+    friend class TxSampler;
+};
+}

--- a/src/simulation/Benchmark.h
+++ b/src/simulation/Benchmark.h
@@ -149,12 +149,12 @@ reportBenchmark(Benchmark::Metrics const& metrics,
     using std::endl;
     str << endl
         << "{" << endl
-        << "\"benchmark metrics\": {" << endl
-        << "  \"time spent\": " << metrics.mBenchmarkTimer.sum() << "," << endl
-        << "  \"time unit\": "
+        << "\"benchmark_metrics\": {" << endl
+        << "  \"time_spent\": " << metrics.mBenchmarkTimer.sum() << "," << endl
+        << "  \"time_unit\": "
         << "\"milliseconds\"," << endl
-        << "  \"txs submitted\": " << metrics.mTxsCount.count() << "," << endl
-        << "  \"txs externalized\": " << txsExternalized << endl
+        << "  \"txs_submitted\": " << metrics.mTxsCount.count() << "," << endl
+        << "  \"txs_externalized\": " << txsExternalized << endl
         << "}" << endl
         << "}" << endl;
 

--- a/src/simulation/Benchmark.h
+++ b/src/simulation/Benchmark.h
@@ -91,4 +91,17 @@ class TxSampler::Tx
     std::vector<LoadGenerator::TxInfo> mTxs;
     friend class TxSampler;
 };
+
+class BenchmarkExecutor
+{
+  public:
+    void executeBenchmark(Application& app, std::chrono::seconds testDuration,
+                          uint32_t txRate,
+                          std::function<void(Benchmark::Metrics)> stopCallback);
+    void setBenchmark(std::unique_ptr<Benchmark> benchmark);
+
+  private:
+    std::unique_ptr<VirtualTimer> mLoadTimer;
+    std::unique_ptr<Benchmark> mBenchmark;
+};
 }

--- a/src/simulation/BenchmarkTests.cpp
+++ b/src/simulation/BenchmarkTests.cpp
@@ -1,0 +1,62 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "simulation/Benchmark.h"
+#include "lib/catch.hpp"
+#include "test/test.h"
+#include "util/Timer.h"
+#include "util/make_unique.h"
+#include <chrono>
+#include <memory>
+
+using namespace stellar;
+
+TEST_CASE("stellar-core benchmark's initialization",
+          "[benchmark][initialize][hide]")
+{
+    const size_t nAccounts = 1000;
+    Config const& cfg = getTestConfig();
+    VirtualClock clock(VirtualClock::REAL_TIME);
+    Application::pointer app = Application::create(clock, cfg, false);
+    app->applyCfgCommands();
+    app->start();
+
+    Benchmark::BenchmarkBuilder builder{app->getNetworkID()};
+    builder.setNumberOfInitialAccounts(nAccounts).populateBenchmarkData();
+    std::unique_ptr<TxSampler> sampler = builder.createSampler(*app);
+    auto tx = sampler->createTransaction(nAccounts);
+    REQUIRE(tx);
+    REQUIRE(tx->execute(*app));
+}
+
+TEST_CASE("stellar-core's benchmark", "[benchmark][execute][hide]")
+{
+    const std::chrono::seconds testDuration(1);
+    const size_t nAccounts = 1000;
+    const uint32_t txRate = 100;
+    const uint32_t txPerLedger = 1000;
+
+    Config cfg = getTestConfig();
+    cfg.DESIRED_MAX_TX_PER_LEDGER = txPerLedger;
+    VirtualClock clock(VirtualClock::REAL_TIME);
+    Application::pointer app = Application::create(clock, cfg, false);
+    app->applyCfgCommands();
+    app->start();
+
+    Benchmark::BenchmarkBuilder builder{app->getNetworkID()};
+    builder.setNumberOfInitialAccounts(nAccounts).populateBenchmarkData();
+    bool done = false;
+    BenchmarkExecutor executor;
+    executor.setBenchmark(builder.createBenchmark(*app));
+    executor.executeBenchmark(
+        *app, testDuration, txRate, [&done, app](Benchmark::Metrics metrics) {
+            done = true;
+            reportBenchmark(metrics, app->getMetrics(), LOG(INFO));
+        });
+    while (!done)
+    {
+        clock.crank();
+    }
+    app->gracefulStop();
+}

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -491,12 +491,12 @@ LoadGenerator::createAccount(size_t i, uint32_t ledgerNum)
 }
 
 vector<LoadGenerator::AccountInfoPtr>
-LoadGenerator::createAccounts(size_t n)
+LoadGenerator::createAccounts(size_t n, uint32_t ledgerNum)
 {
     vector<AccountInfoPtr> result;
     for (size_t i = 0; i < n; i++)
     {
-        auto account = createAccount(mAccounts.size());
+        auto account = createAccount(mAccounts.size(), ledgerNum);
         mAccounts.push_back(account);
         result.push_back(account);
     }
@@ -748,7 +748,7 @@ LoadGenerator::AccountInfo::creationTransaction()
                   TxInfo::TX_CREATE_ACCOUNT, LOADGEN_ACCOUNT_BALANCE};
 }
 
-void
+AccountFrame
 LoadGenerator::AccountInfo::createDirectly(Application& app)
 {
     AccountFrame a(mKey.getPublicKey());
@@ -761,6 +761,7 @@ LoadGenerator::AccountInfo::createDirectly(Application& app)
                       app.getDatabase());
     ;
     a.storeAdd(delta, app.getDatabase());
+    return a;
 }
 
 void

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -27,7 +27,7 @@ class LoadGenerator
 {
   public:
     LoadGenerator(Hash const& networkID);
-    ~LoadGenerator();
+    virtual ~LoadGenerator();
     void clear();
 
     struct TxInfo;
@@ -65,7 +65,9 @@ class LoadGenerator
 
     std::vector<TxInfo> accountCreationTransactions(size_t n);
     AccountInfoPtr createAccount(size_t i, uint32_t ledgerNum = 0);
-    std::vector<AccountInfoPtr> createAccounts(size_t n);
+    std::vector<AccountInfoPtr> createAccounts(size_t n,
+                                               uint32_t ledgerNum = 0);
+
     bool loadAccount(Application& app, AccountInfo& account);
     bool loadAccount(Application& app, AccountInfoPtr account);
     bool loadAccounts(Application& app, std::vector<AccountInfoPtr> accounts);
@@ -78,8 +80,8 @@ class LoadGenerator
                                     int64_t amount,
                                     std::vector<AccountInfoPtr> const& path);
 
-    AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid,
-                                     uint32_t ledgerNum);
+    virtual AccountInfoPtr pickRandomAccount(AccountInfoPtr tryToAvoid,
+                                             uint32_t ledgerNum);
 
     AccountInfoPtr pickRandomPath(AccountInfoPtr from, uint32_t ledgerNum,
                                   std::vector<AccountInfoPtr>& path);
@@ -124,7 +126,7 @@ class LoadGenerator
         AccountInfoPtr mBuyCredit;
         AccountInfoPtr mSellCredit;
 
-        void createDirectly(Application& app);
+        AccountFrame createDirectly(Application& app);
         void debitDirectly(Application& app, int64_t debitAmount);
         TxInfo creationTransaction();
 


### PR DESCRIPTION
Benchmark for stellar-core.
It consists of two steps/routines:
- accounts initialization - creates specified number of artificial accounts
- transaction generation and submission
It adds new http command for executing benchmark: /benchmark[?preparebenchmark=A | txrate=R&duration=T].
