### PR TITLE
Overlay connections fix

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -225,9 +225,12 @@ ApplicationImpl::getJsonInfo()
     info["protocol_version"] = getConfig().LEDGER_PROTOCOL_VERSION;
     info["state"] = getStateHuman();
     info["ledger"]["num"] = (int)lm.getLedgerNum();
-    info["ledger"]["hash"] = binToHex(lm.getLastClosedLedgerHeader().hash);
-    info["ledger"]["closeTime"] =
-        (int)lm.getLastClosedLedgerHeader().header.scpValue.closeTime;
+    auto const& lcl = lm.getLastClosedLedgerHeader();
+    info["ledger"]["hash"] = binToHex(lcl.hash);
+    info["ledger"]["closeTime"] = (Json::UInt64)lcl.header.scpValue.closeTime;
+    info["ledger"]["version"] = lcl.header.ledgerVersion;
+    info["ledger"]["baseFee"] = lcl.header.baseFee;
+    info["ledger"]["baseReserve"] = lcl.header.baseReserve;
     info["ledger"]["age"] = (int)lm.secondsSinceLastLedgerClose();
     info["pending_peers_count"] =
         (int)getOverlayManager().getPendingPeersCount();

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -98,6 +98,8 @@ class OverlayManager
     // If moving peer to authenticated list succeeded, true is returned.
     virtual bool acceptAuthenticatedPeer(Peer::pointer peer) = 0;
 
+    virtual bool isPreferred(Peer* peer) = 0;
+
     // Return the current in-memory set of pending peers.
     virtual std::vector<Peer::pointer> const& getPendingPeers() const = 0;
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -375,7 +375,7 @@ OverlayManagerImpl::moveToAuthenticated(Peer::pointer peer)
 bool
 OverlayManagerImpl::acceptAuthenticatedPeer(Peer::pointer peer)
 {
-    if (isPeerPreferred(peer))
+    if (isPreferred(peer.get()))
     {
         if (getAuthenticatedPeersCount() <
             mApp.getConfig().MAX_PEER_CONNECTIONS)
@@ -385,7 +385,7 @@ OverlayManagerImpl::acceptAuthenticatedPeer(Peer::pointer peer)
 
         for (auto victim : mAuthenticatedPeers)
         {
-            if (!isPeerPreferred(victim.second))
+            if (!isPreferred(victim.second.get()))
             {
                 CLOG(INFO, "Overlay")
                     << "Evicting non-preferred peer "
@@ -432,7 +432,7 @@ OverlayManagerImpl::getAuthenticatedPeersCount() const
 }
 
 bool
-OverlayManagerImpl::isPeerPreferred(Peer::pointer peer)
+OverlayManagerImpl::isPreferred(Peer* peer)
 {
     std::string pstr = peer->toString();
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -137,7 +137,7 @@ OverlayManagerImpl::connectTo(PeerRecord& pr)
 
 void
 OverlayManagerImpl::storePeerList(std::vector<std::string> const& list,
-                                  bool resetBackOff)
+                                  bool resetBackOff, bool preferred)
 {
     for (auto const& peerStr : list)
     {
@@ -146,6 +146,7 @@ OverlayManagerImpl::storePeerList(std::vector<std::string> const& list,
             auto pr = PeerRecord::parseIPPort(peerStr, mApp);
             if (resetBackOff)
             {
+                pr.resetBackOff(mApp.getClock(), preferred);
                 pr.storePeerRecord(mApp.getDatabase());
             }
             else

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -60,7 +60,6 @@ class OverlayManagerImpl : public OverlayManager
     void storePeerList(std::vector<std::string> const& list,
                        bool resetBackOff = false);
     void storeConfigPeers();
-    bool isPeerPreferred(Peer::pointer peer);
 
     friend class OverlayManagerTests;
 
@@ -80,6 +79,7 @@ class OverlayManagerImpl : public OverlayManager
     void addPendingPeer(Peer::pointer peer) override;
     void dropPeer(Peer* peer) override;
     bool acceptAuthenticatedPeer(Peer::pointer peer) override;
+    bool isPreferred(Peer* peer) override;
     std::vector<Peer::pointer> const& getPendingPeers() const override;
     size_t getPendingPeersCount() const override;
     std::map<NodeID, Peer::pointer> const&

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -57,8 +57,8 @@ class OverlayManagerImpl : public OverlayManager
     void tick();
     VirtualTimer mTimer;
 
-    void storePeerList(std::vector<std::string> const& list,
-                       bool resetBackOff = false);
+    void storePeerList(std::vector<std::string> const& list, bool resetBackOff,
+                       bool preferred);
     void storeConfigPeers();
 
     friend class OverlayManagerTests;

--- a/src/overlay/OverlayManagerTests.cpp
+++ b/src/overlay/OverlayManagerTests.cpp
@@ -122,7 +122,7 @@ class OverlayManagerTests
     {
         OverlayManagerStub& pm = app->getOverlayManager();
 
-        pm.storePeerList(fourPeers);
+        pm.storePeerList(fourPeers, false, false);
 
         rowset<row> rs = app->getDatabase().getSession().prepare
                          << "SELECT ip,port FROM peers";
@@ -148,8 +148,8 @@ class OverlayManagerTests
     {
         OverlayManagerStub& pm = app->getOverlayManager();
 
-        pm.storePeerList(fourPeers);
-        pm.storePeerList(threePeers);
+        pm.storePeerList(fourPeers, false, false);
+        pm.storePeerList(threePeers, false, false);
         pm.connectToMorePeers(5);
         REQUIRE(pm.mAuthenticatedPeers.size() == 5);
         auto a = TestAccount{*app, getAccount("a")};

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -375,18 +375,21 @@ Peer::sendPeers()
 {
     // send top 50 peers we know about
     vector<PeerRecord> peerList;
-    PeerRecord::loadPeerRecords(mApp.getDatabase(), 50, mApp.getClock().now(),
-                                peerList);
+    PeerRecord::loadPeerRecords(
+        mApp.getDatabase(), 50, mApp.getClock().now(),
+        [&](PeerRecord const& pr) {
+            if (!pr.isPrivateAddress() &&
+                !pr.isSelfAddressAndPort(getIP(), mRemoteListeningPort))
+            {
+                peerList.emplace_back(pr);
+            }
+            return peerList.size() < 50;
+        });
     StellarMessage newMsg;
     newMsg.type(PEERS);
     newMsg.peers().reserve(peerList.size());
     for (auto const& pr : peerList)
     {
-        if (pr.isPrivateAddress() ||
-            pr.isSelfAddressAndPort(getIP(), mRemoteListeningPort))
-        {
-            continue;
-        }
         PeerAddress pa;
         pr.toXdr(pa);
         newMsg.peers().push_back(pa);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -874,7 +874,8 @@ Peer::noteHandshakeSuccessInPeerRecord()
                                          getRemoteListeningPort());
     if (pr)
     {
-        pr->resetBackOff(mApp.getClock());
+        pr->resetBackOff(mApp.getClock(),
+                         mApp.getOverlayManager().isPreferred(this));
     }
     else
     {

--- a/src/overlay/PeerRecord.cpp
+++ b/src/overlay/PeerRecord.cpp
@@ -336,10 +336,10 @@ PeerRecord::storePeerRecord(Database& db)
 }
 
 void
-PeerRecord::resetBackOff(VirtualClock& clock)
+PeerRecord::resetBackOff(VirtualClock& clock, bool preferred)
 {
     mNumFailures = 0;
-    mNextAttempt = clock.now();
+    mNextAttempt = preferred ? VirtualClock::time_point() : clock.now();
     CLOG(DEBUG, "Overlay") << "PeerRecord: " << toString() << " backoff reset";
 }
 

--- a/src/overlay/PeerRecord.h
+++ b/src/overlay/PeerRecord.h
@@ -79,7 +79,7 @@ class PeerRecord
     // insert or update record from database
     void storePeerRecord(Database& db);
 
-    void resetBackOff(VirtualClock& clock);
+    void resetBackOff(VirtualClock& clock, bool preferred);
     void backOff(VirtualClock& clock);
 
     void toXdr(PeerAddress& ret) const;

--- a/src/overlay/PeerRecord.h
+++ b/src/overlay/PeerRecord.h
@@ -54,9 +54,9 @@ class PeerRecord
      */
     static optional<PeerRecord> loadPeerRecord(Database& db, std::string ip,
                                                unsigned short port);
-    static void loadPeerRecords(Database& db, uint32_t max,
+    static void loadPeerRecords(Database& db, int batchSize,
                                 VirtualClock::time_point nextAttemptCutoff,
-                                vector<PeerRecord>& retList);
+                                std::function<bool(PeerRecord const& pr)> p);
     const std::string&
     ip() const
     {


### PR DESCRIPTION
resolves #1278 

This PR fixes a few problems with the overlay code:
* we were not loading enough peers from the peers table, causing the node to sometimes not attempt to make more connections
* preferred peers may get buried behind other peers, causing the previous logic to not see them

the first problem is taken care of by loading batches of peers until enough new peers are loaded from the peers table.

the second problem is solved by forcing preferred peers to have a next attempt time of 0 (epoch), which puts them at the top of the list
