### PR TITLE
Fix for inability for nodes to reach full connectivity

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -79,14 +79,25 @@ NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
 PEER_PORT=11625
 
 # TARGET_PEER_CONNECTIONS (Integer) default 8
-# This server will send outbound connection attempts until it is at this
+# This controls how aggressively the server will connect to other peers.
+# It will send outbound connection attempts until it is at this
 #   number of peer connections.
 TARGET_PEER_CONNECTIONS=8
 
+# MAX_ADDITIONAL_PEER_CONNECTIONS (Integer) default -1
+# Numbers of peers above the target that can connect to this instance
+# This gives room for other peers to connect to this instance.
+# Setting this too low will result in peers stranded out of the network
+# -1: use TARGET_PEER_CONNECTIONS as value for this field
+MAX_ADDITIONAL_PEER_CONNECTIONS=-1
+
 # MAX_PEER_CONNECTIONS (Integer) default 12
+# ~~ being deprecated in favor of MAX_ADDITIONAL_PEER_CONNECTIONS ~~~
 # This server will start dropping peers if it is above this number of
 #  connected peers. The more peers you are connected to the higher
 #  the bandwidth requirements
+# The effective value of this field is the maximum of this setting and
+# (TARGET_PEER_CONNECTIONS + MAX_ADDITIONAL_PEER_CONNECTIONS)
 MAX_PEER_CONNECTIONS=12
 
 # MAX_PENDING_CONNECTIONS (Integer) default 5000

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -62,6 +62,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     HTTP_MAX_CLIENT = 128;
     PEER_PORT = DEFAULT_PEER_PORT;
     TARGET_PEER_CONNECTIONS = 8;
+    MAX_ADDITIONAL_PEER_CONNECTIONS = -1;
     MAX_PEER_CONNECTIONS = 12;
     MAX_PENDING_CONNECTIONS = 5000;
     PEER_AUTHENTICATION_TIMEOUT = 2;
@@ -467,6 +468,22 @@ Config::load(std::string const& filename)
                 MAX_PEER_CONNECTIONS =
                     static_cast<unsigned short>(parsedMaxPeerConnections);
             }
+            else if (item.first == "MAX_ADDITIONAL_PEER_CONNECTIONS")
+            {
+                if (!item.second->as<int64_t>())
+                {
+                    throw std::invalid_argument(
+                        "invalid MAX_ADDITIONAL_PEER_CONNECTIONS");
+                }
+                int64_t parsedMaxConn = item.second->as<int64_t>()->value();
+                if (parsedMaxConn < -1 || parsedMaxConn > UINT16_MAX)
+                {
+                    throw std::invalid_argument(
+                        "invalid MAX_ADDITIONAL_PEER_CONNECTIONS");
+                }
+                MAX_ADDITIONAL_PEER_CONNECTIONS =
+                    static_cast<int>(parsedMaxConn);
+            }
             else if (item.first == "MAX_PENDING_CONNECTIONS")
             {
                 if (!item.second->as<int64_t>())
@@ -733,6 +750,20 @@ Config::load(std::string const& filename)
                 loadQset(qset->as_group(), QUORUM_SET, 0);
             }
         }
+        if (MAX_ADDITIONAL_PEER_CONNECTIONS < 0)
+        {
+            MAX_ADDITIONAL_PEER_CONNECTIONS = TARGET_PEER_CONNECTIONS;
+        }
+        if (MAX_ADDITIONAL_PEER_CONNECTIONS >
+            (UINT16_MAX - TARGET_PEER_CONNECTIONS))
+        {
+            throw std::invalid_argument(
+                "invalid MAX_ADDITIONAL_PEER_CONNECTIONS");
+        }
+        MAX_PEER_CONNECTIONS = std::max(
+            MAX_PEER_CONNECTIONS,
+            static_cast<unsigned short>(MAX_ADDITIONAL_PEER_CONNECTIONS +
+                                        TARGET_PEER_CONNECTIONS));
 
         validateConfig();
     }

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -143,6 +143,7 @@ class Config : public std::enable_shared_from_this<Config>
     // overlay config
     unsigned short PEER_PORT;
     unsigned short TARGET_PEER_CONNECTIONS;
+    int MAX_ADDITIONAL_PEER_CONNECTIONS;
     unsigned short MAX_PEER_CONNECTIONS;
     unsigned short MAX_PENDING_CONNECTIONS;
     unsigned short PEER_AUTHENTICATION_TIMEOUT;

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -191,15 +191,28 @@ OverlayManagerImpl::storeConfigPeers()
 void
 OverlayManagerImpl::connectToMorePeers(int max)
 {
-    vector<PeerRecord> peers;
+    const int batchSize = std::max(10, max);
 
     // load best candidates from the database,
     // when PREFERRED_PEER_ONLY is set and we connect to a non
     // preferred_peer we just end up dropping & backing off
     // it during handshake (this allows for preferred_peers
-    // to work for both ip based and key based preferred mode).
-    PeerRecord::loadPeerRecords(mApp.getDatabase(), max, mApp.getClock().now(),
-                                peers);
+    // to work for both ip based and key based preferred mode)
+
+    vector<PeerRecord> peers;
+
+    PeerRecord::loadPeerRecords(mApp.getDatabase(), batchSize,
+                                mApp.getClock().now(),
+                                [&](PeerRecord const& pr) {
+                                    // skip peers that we're already connected
+                                    // to
+                                    if (!getConnectedPeer(pr.ip(), pr.port()))
+                                    {
+                                        peers.emplace_back(pr);
+                                    }
+                                    return peers.size() < max;
+                                });
+
     orderByPreferredPeers(peers);
 
     for (auto& pr : peers)
@@ -213,10 +226,7 @@ OverlayManagerImpl::connectToMorePeers(int max)
         {
             break;
         }
-        if (!getConnectedPeer(pr.ip(), pr.port()))
-        {
-            connectTo(pr);
-        }
+        connectTo(pr);
     }
 }
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -375,8 +375,16 @@ Peer::sendPeers()
 {
     // send top 50 peers we know about
     vector<PeerRecord> peerList;
-    PeerRecord::loadPeerRecords(mApp.getDatabase(), 50, mApp.getClock().now(),
-                                peerList);
+    PeerRecord::loadPeerRecords(
+        mApp.getDatabase(), 50, mApp.getClock().now(),
+        [&](PeerRecord const& pr) {
+            if (!pr.isPrivateAddress() &&
+                !pr.isSelfAddressAndPort(getIP(), mRemoteListeningPort))
+            {
+                peerList.emplace_back(pr);
+            }
+            return peerList.size() < 50;
+        });
     StellarMessage newMsg;
     newMsg.type(PEERS);
     newMsg.peers().reserve(peerList.size());

--- a/src/overlay/PeerRecord.h
+++ b/src/overlay/PeerRecord.h
@@ -54,9 +54,9 @@ class PeerRecord
      */
     static optional<PeerRecord> loadPeerRecord(Database& db, std::string ip,
                                                unsigned short port);
-    static void loadPeerRecords(Database& db, uint32_t max,
+    static void loadPeerRecords(Database& db, int batchSize,
                                 VirtualClock::time_point nextAttemptCutoff,
-                                vector<PeerRecord>& retList);
+                                std::function<bool(PeerRecord const& pr)> p);
     const std::string&
     ip() const
     {


### PR DESCRIPTION
fixes #1450 

This PR fixes a problem with the way nodes connect to other nodes.

In the current implementation, we may load from the peers table only peers that are currently connected, which causes the logic to connect to more peers to not do anything.
With this change, the node connects to the expected number of peers.

This PR also includes a change to the way `MAX_PEER_CONNECTIONS` is defined.

The setting is being replaced by a relative number `MAX_ADDITIONAL_PEER_CONNECTIONS` instead as the previous setting was quite error prone:
* people only setting `TARGET_PEER_CONNECTIONS` may not realize that `MAX_PEER_CONNECTIONS` would limit the number of connections the node could achieve
* it's a desirable property for the network to have a good margin between `TARGET_PEER_CONNECTIONS` and `MAX_PEER_CONNECTIONS` as this allows for nodes to connect to other nodes. Exposing it as `MAX_ADDITIONAL_PEER_CONNECTIONS` makes it clear that this is a buffer number.

In order to reach an appropriate buffer number, the default value for `MAX_ADDITIONAL_PEER_CONNECTIONS` may increase the effective value of `MAX_PEER_CONNECTIONS`.
