### PR TITLE
allow publishing to multiple history archives at once

### DIFF
--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -20,7 +20,7 @@ PutSnapshotFilesWork::PutSnapshotFilesWork(
     Application& app, WorkParent& parent,
     std::shared_ptr<HistoryArchive const> archive,
     std::shared_ptr<StateSnapshot> snapshot)
-    : Work(app, parent, "put-snapshot-files")
+    : Work(app, parent, "put-snapshot-files-" + archive->getName())
     , mArchive(archive)
     , mSnapshot(snapshot)
 {


### PR DESCRIPTION
Allow publishing to multiple history archives at once.

Before that change creating second and next PutSnapshotFilesWork failed because PublishWork already had a subwork with name "put-snapshot-files".

Fixes #1457