### PR TITLE
Clean up .xdr.gz bucket files after publish

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -68,6 +68,8 @@ Bucket::~Bucket()
     {
         CLOG(TRACE, "Bucket") << "Bucket::~Bucket removing file: " << mFilename;
         std::remove(mFilename.c_str());
+        CLOG(TRACE, "Bucket") << "Bucket::~Bucket removing file: " << mFilename << ".gz";
+        std::remove((mFilename + ".gz").c_str());
     }
 }
 


### PR DESCRIPTION
This is first non-perfect version of code that will save a lot of space in directories used by stellar-code.

What I like about that patch:
* extremely simple
* does its job

What I don't like about it:
* removing code does not correspond with creation code (different place, different scope)

Should be good to apply for now, when progress on the real patch is being made.