### PR TITLE
Invert set retain

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -247,8 +247,10 @@ exit /b 0
     <ClCompile Include="..\..\lib\util\easylogging++.cc" />
     <ClCompile Include="..\..\src\bucket\Bucket.cpp" />
     <ClCompile Include="..\..\src\bucket\BucketApplicator.cpp" />
+    <ClCompile Include="..\..\src\bucket\BucketInputIterator.cpp" />
     <ClCompile Include="..\..\src\bucket\BucketList.cpp" />
     <ClCompile Include="..\..\src\bucket\BucketManagerImpl.cpp" />
+    <ClCompile Include="..\..\src\bucket\BucketOutputIterator.cpp" />
     <ClCompile Include="..\..\src\bucket\BucketTests.cpp" />
     <ClCompile Include="..\..\src\bucket\FutureBucket.cpp" />
     <ClCompile Include="..\..\src\bucket\PublishQueueBuckets.cpp" />
@@ -518,9 +520,11 @@ exit /b 0
     <ClInclude Include="..\..\lib\catch.hpp" />
     <ClInclude Include="..\..\src\bucket\Bucket.h" />
     <ClInclude Include="..\..\src\bucket\BucketApplicator.h" />
+    <ClInclude Include="..\..\src\bucket\BucketInputIterator.h" />
     <ClInclude Include="..\..\src\bucket\BucketList.h" />
     <ClInclude Include="..\..\src\bucket\BucketManager.h" />
     <ClInclude Include="..\..\src\bucket\BucketManagerImpl.h" />
+    <ClInclude Include="..\..\src\bucket\BucketOutputIterator.h" />
     <ClInclude Include="..\..\src\bucket\FutureBucket.h" />
     <ClInclude Include="..\..\src\bucket\LedgerCmp.h" />
     <ClInclude Include="..\..\src\bucket\PublishQueueBuckets.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -348,6 +348,12 @@
     <ClCompile Include="..\..\src\bucket\Bucket.cpp">
       <Filter>bucket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\bucket\BucketInputIterator.cpp">
+      <Filter>bucket</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\bucket\BucketOutputIterator.cpp">
+      <Filter>bucket</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\bucket\BucketTests.cpp">
       <Filter>bucket\tests</Filter>
     </ClCompile>
@@ -1023,6 +1029,12 @@
       <Filter>util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\bucket\Bucket.h">
+      <Filter>bucket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bucket\BucketInputIterator.h">
+      <Filter>bucket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\bucket\BucketOutputIterator.h">
       <Filter>bucket</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\PeerRecord.h">

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -2,14 +2,15 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "bucket/Bucket.h"
 // ASIO is somewhat particular about when it gets included -- it wants to be the
 // first to include <windows.h> -- so we try to include it before everything
 // else.
 #include "util/asio.h"
+#include "bucket/Bucket.h"
 #include "bucket/BucketApplicator.h"
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
+#include "bucket/BucketOutputIterator.h"
 #include "bucket/LedgerCmp.h"
 #include "crypto/Hex.h"
 #include "crypto/Random.h"
@@ -35,21 +36,6 @@
 
 namespace stellar
 {
-
-static std::string
-randomBucketName(std::string const& tmpDir)
-{
-    for (;;)
-    {
-        std::string name =
-            tmpDir + "/tmp-bucket-" + binToHex(randomBytes(8)) + ".xdr";
-        std::ifstream ifile(name);
-        if (!ifile)
-        {
-            return name;
-        }
-    }
-}
 
 Bucket::Bucket(std::string const& filename, Hash const& hash)
     : mFilename(filename), mHash(hash)
@@ -93,141 +79,11 @@ Bucket::setRetain(bool r)
     mRetain = r;
 }
 
-/**
- * Helper class that reads from the file underlying a bucket, keeping the bucket
- * alive for the duration of its existence.
- */
-void
-Bucket::InputIterator::loadEntry()
-{
-    if (mIn.readOne(mEntry))
-    {
-        mEntryPtr = &mEntry;
-    }
-    else
-    {
-        mEntryPtr = nullptr;
-    }
-}
-
-Bucket::InputIterator::operator bool() const
-{
-    return mEntryPtr != nullptr;
-}
-
-BucketEntry const& Bucket::InputIterator::operator*()
-{
-    return *mEntryPtr;
-}
-
-Bucket::InputIterator::InputIterator(std::shared_ptr<Bucket const> bucket)
-    : mBucket(bucket), mEntryPtr(nullptr)
-{
-    if (!mBucket->mFilename.empty())
-    {
-        CLOG(TRACE, "Bucket") << "Bucket::InputIterator opening file to read: "
-                              << mBucket->mFilename;
-        mIn.open(mBucket->mFilename);
-        loadEntry();
-    }
-}
-
-Bucket::InputIterator::~InputIterator()
-{
-    mIn.close();
-}
-
-Bucket::InputIterator& Bucket::InputIterator::operator++()
-{
-    if (mIn)
-    {
-        loadEntry();
-    }
-    else
-    {
-        mEntryPtr = nullptr;
-    }
-    return *this;
-}
-
-/**
- * Helper class that points to an output tempfile. Absorbs BucketEntries and
- * hashes them while writing to either destination. Produces a Bucket when done.
- */
-Bucket::OutputIterator::OutputIterator(std::string const& tmpDir,
-                                       bool keepDeadEntries)
-    : mFilename(randomBucketName(tmpDir))
-    , mBuf(nullptr)
-    , mHasher(SHA256::create())
-    , mKeepDeadEntries(keepDeadEntries)
-{
-    CLOG(TRACE, "Bucket") << "Bucket::OutputIterator opening file to write: "
-                          << mFilename;
-    mOut.open(mFilename);
-}
-
-void
-Bucket::OutputIterator::put(BucketEntry const& e)
-{
-    if (!mKeepDeadEntries && e.type() == DEADENTRY)
-    {
-        return;
-    }
-
-    // Check to see if there's an existing buffered entry.
-    if (mBuf)
-    {
-        BucketEntryIdCmp cmp;
-        // cmp(e, *mBuf) means e < *mBuf; this should never be true since
-        // it would mean that we're getting entries out of order.
-        assert(!cmp(e, *mBuf));
-
-        // Check to see if the new entry should flush (greater identity), or
-        // merely replace (same identity), the buffered entry.
-        if (cmp(*mBuf, e))
-        {
-            mOut.writeOne(*mBuf, mHasher.get(), &mBytesPut);
-            mObjectsPut++;
-        }
-    }
-    else
-    {
-        mBuf = make_unique<BucketEntry>();
-    }
-
-    // In any case, replace *mBuf with e.
-    *mBuf = e;
-}
-
-std::shared_ptr<Bucket>
-Bucket::OutputIterator::getBucket(BucketManager& bucketManager)
-{
-    assert(mOut);
-    if (mBuf)
-    {
-        mOut.writeOne(*mBuf, mHasher.get(), &mBytesPut);
-        mObjectsPut++;
-        mBuf.reset();
-    }
-
-    mOut.close();
-    if (mObjectsPut == 0 || mBytesPut == 0)
-    {
-        assert(mObjectsPut == 0);
-        assert(mBytesPut == 0);
-        CLOG(DEBUG, "Bucket") << "Deleting empty bucket file " << mFilename;
-        std::remove(mFilename.c_str());
-        return std::make_shared<Bucket>();
-    }
-    return bucketManager.adoptFileAsBucket(mFilename, mHasher->finish(),
-                                           mObjectsPut, mBytesPut);
-}
-
 bool
 Bucket::containsBucketIdentity(BucketEntry const& id) const
 {
     BucketEntryIdCmp cmp;
-    Bucket::InputIterator iter(shared_from_this());
+    BucketInputIterator iter(shared_from_this());
     while (iter)
     {
         if (!(cmp(*iter, id) || cmp(id, *iter)))
@@ -243,7 +99,7 @@ std::pair<size_t, size_t>
 Bucket::countLiveAndDeadEntries() const
 {
     size_t live = 0, dead = 0;
-    Bucket::InputIterator iter(shared_from_this());
+    BucketInputIterator iter(shared_from_this());
     while (iter)
     {
         if ((*iter).type() == LIVEENTRY)
@@ -298,8 +154,8 @@ Bucket::fresh(BucketManager& bucketManager,
 
     std::sort(dead.begin(), dead.end(), BucketEntryIdCmp());
 
-    OutputIterator liveOut(bucketManager.getTmpDir(), true);
-    OutputIterator deadOut(bucketManager.getTmpDir(), true);
+    BucketOutputIterator liveOut(bucketManager.getTmpDir(), true);
+    BucketOutputIterator deadOut(bucketManager.getTmpDir(), true);
     for (auto const& e : live)
     {
         liveOut.put(e);
@@ -315,8 +171,8 @@ Bucket::fresh(BucketManager& bucketManager,
 }
 
 inline void
-maybePut(Bucket::OutputIterator& out, BucketEntry const& entry,
-         std::vector<Bucket::InputIterator>& shadowIterators)
+maybePut(BucketOutputIterator& out, BucketEntry const& entry,
+         std::vector<BucketInputIterator>& shadowIterators)
 {
     BucketEntryIdCmp cmp;
     for (auto& si : shadowIterators)
@@ -356,14 +212,14 @@ Bucket::merge(BucketManager& bucketManager,
     assert(oldBucket);
     assert(newBucket);
 
-    Bucket::InputIterator oi(oldBucket);
-    Bucket::InputIterator ni(newBucket);
+    BucketInputIterator oi(oldBucket);
+    BucketInputIterator ni(newBucket);
 
-    std::vector<Bucket::InputIterator> shadowIterators(shadows.begin(),
-                                                       shadows.end());
+    std::vector<BucketInputIterator> shadowIterators(shadows.begin(),
+                                                     shadows.end());
 
     auto timer = bucketManager.getMergeTimer().TimeScope();
-    Bucket::OutputIterator out(bucketManager.getTmpDir(), keepDeadEntries);
+    BucketOutputIterator out(bucketManager.getTmpDir(), keepDeadEntries);
 
     BucketEntryIdCmp cmp;
     while (oi || ni)
@@ -476,7 +332,7 @@ checkDBAgainstBuckets(medida::MetricsRegistry& metrics,
                                        "comparison");
         auto compareTimer =
             metrics.NewTimer({"bucket", "checkdb", "compare"}).TimeScope();
-        for (Bucket::InputIterator iter(superBucket); iter; ++iter)
+        for (BucketInputIterator iter(superBucket); iter; ++iter)
         {
             meter.Mark();
             auto& e = *iter;

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -48,15 +48,6 @@ Bucket::Bucket(std::string const& filename, Hash const& hash)
     }
 }
 
-Bucket::~Bucket()
-{
-    if (!mFilename.empty() && !mRetain)
-    {
-        CLOG(TRACE, "Bucket") << "Bucket::~Bucket removing file: " << mFilename;
-        std::remove(mFilename.c_str());
-    }
-}
-
 Bucket::Bucket()
 {
 }
@@ -71,12 +62,6 @@ std::string const&
 Bucket::getFilename() const
 {
     return mFilename;
-}
-
-void
-Bucket::setRetain(bool r)
-{
-    mRetain = r;
 }
 
 bool

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -40,16 +40,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     std::string const mFilename;
     Hash const mHash;
-    bool mRetain{false};
 
   public:
     // Create an empty bucket. The empty bucket has hash '000000...' and its
     // filename is the empty string.
     Bucket();
-
-    // Destroy a bucket, deleting its underlying file if the bucket is not
-    // 'retained'. See `setRetain`.
-    ~Bucket();
 
     // Construct a bucket with a given filename and hash. Asserts that the file
     // exists, but does not check that the hash is the bucket's hash. Caller
@@ -58,14 +53,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     Hash const& getHash() const;
     std::string const& getFilename() const;
-
-    // Sets or clears the `retain` flag on the bucket. A retained bucket will
-    // not be deleted (from the filesystem) when the Bucket object is deleted. A
-    // non-retained bucket _will_ delete the underlying file. Buckets should
-    // only be retained if you want them to survive process-exit / restart; in
-    // particular the contents of the BucketManager's current BucketList should
-    // be retained.
-    void setRetain(bool r);
 
     // Returns true if a BucketEntry that is key-wise identical to the given
     // BucketEntry exists in the bucket. For testing.

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -43,52 +43,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     bool mRetain{false};
 
   public:
-    // Helper class that reads through the entries in a bucket.
-    class InputIterator
-    {
-        std::shared_ptr<Bucket const> mBucket;
-
-        // Validity and current-value of the iterator is funneled into a
-        // pointer. If
-        // non-null, it points to mEntry.
-        BucketEntry const* mEntryPtr;
-        XDRInputFileStream mIn;
-        BucketEntry mEntry;
-
-        void loadEntry();
-
-      public:
-        operator bool() const;
-
-        BucketEntry const& operator*();
-
-        InputIterator(std::shared_ptr<Bucket const> bucket);
-
-        ~InputIterator();
-
-        InputIterator& operator++();
-    };
-
-    // Helper class that writes new elements to a file and returns a bucket
-    // when finished.
-    class OutputIterator
-    {
-        std::string mFilename;
-        XDROutputFileStream mOut;
-        std::unique_ptr<BucketEntry> mBuf;
-        std::unique_ptr<SHA256> mHasher;
-        size_t mBytesPut{0};
-        size_t mObjectsPut{0};
-        bool mKeepDeadEntries{true};
-
-      public:
-        OutputIterator(std::string const& tmpDir, bool keepDeadEntries);
-
-        void put(BucketEntry const& e);
-
-        std::shared_ptr<Bucket> getBucket(BucketManager& bucketManager);
-    };
-
     // Create an empty bucket. The empty bucket has hash '000000...' and its
     // filename is the empty string.
     Bucket();

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "bucket/Bucket.h"
+#include "bucket/BucketInputIterator.h"
 #include "database/Database.h"
 #include "util/XDRStream.h"
 #include <memory>
@@ -21,7 +22,7 @@ class Database;
 class BucketApplicator
 {
     Database& mDb;
-    Bucket::InputIterator mBucketIter;
+    BucketInputIterator mBucketIter;
     size_t mSize{0};
 
   public:

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -1,0 +1,66 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketInputIterator.h"
+#include "bucket/Bucket.h"
+
+namespace stellar
+{
+/**
+ * Helper class that reads from the file underlying a bucket, keeping the bucket
+ * alive for the duration of its existence.
+ */
+void
+BucketInputIterator::loadEntry()
+{
+    if (mIn.readOne(mEntry))
+    {
+        mEntryPtr = &mEntry;
+    }
+    else
+    {
+        mEntryPtr = nullptr;
+    }
+}
+
+BucketInputIterator::operator bool() const
+{
+    return mEntryPtr != nullptr;
+}
+
+BucketEntry const& BucketInputIterator::operator*()
+{
+    return *mEntryPtr;
+}
+
+BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket)
+    : mBucket(bucket), mEntryPtr(nullptr)
+{
+    if (!mBucket->getFilename().empty())
+    {
+        CLOG(TRACE, "Bucket") << "BucketInputIterator opening file to read: "
+                              << mBucket->getFilename();
+        mIn.open(mBucket->getFilename());
+        loadEntry();
+    }
+}
+
+BucketInputIterator::~BucketInputIterator()
+{
+    mIn.close();
+}
+
+BucketInputIterator& BucketInputIterator::operator++()
+{
+    if (mIn)
+    {
+        loadEntry();
+    }
+    else
+    {
+        mEntryPtr = nullptr;
+    }
+    return *this;
+}
+}

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/LedgerCmp.h"
+#include "util/XDRStream.h"
+#include "xdr/Stellar-ledger.h"
+
+#include <memory>
+
+namespace stellar
+{
+
+class Bucket;
+
+// Helper class that reads through the entries in a bucket.
+class BucketInputIterator
+{
+    std::shared_ptr<Bucket const> mBucket;
+
+    // Validity and current-value of the iterator is funneled into a
+    // pointer. If
+    // non-null, it points to mEntry.
+    BucketEntry const* mEntryPtr;
+    XDRInputFileStream mIn;
+    BucketEntry mEntry;
+
+    void loadEntry();
+
+  public:
+    operator bool() const;
+
+    BucketEntry const& operator*();
+
+    BucketInputIterator(std::shared_ptr<Bucket const> bucket);
+
+    ~BucketInputIterator();
+
+    BucketInputIterator& operator++();
+};
+}

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -68,29 +68,13 @@ void
 BucketLevel::setCurr(std::shared_ptr<Bucket> b)
 {
     mNextCurr.clear();
-    if (mCurr)
-    {
-        mCurr->setRetain(false);
-    }
     mCurr = b;
-    if (mCurr)
-    {
-        mCurr->setRetain(true);
-    }
 }
 
 void
 BucketLevel::setSnap(std::shared_ptr<Bucket> b)
 {
-    if (mSnap)
-    {
-        mSnap->setRetain(false);
-    }
     mSnap = b;
-    if (mSnap)
-    {
-        mSnap->setRetain(true);
-    }
 }
 
 void

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -94,9 +94,6 @@ class BucketManager : NonMovableOrCopyable
     virtual std::vector<std::string>
     checkForMissingBucketsFiles(HistoryArchiveState const& has) = 0;
 
-    // Retain all buckets from history state.
-    virtual void retainAll(HistoryArchiveState const& has) = 0;
-
     // Restart from a saved state: find and attach all buckets in `has`, set
     // current BL.
     virtual void assumeState(HistoryArchiveState const& has) = 0;

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -214,7 +214,6 @@ BucketManagerImpl::getBucketByHash(uint256 const& hash)
 void
 BucketManagerImpl::forgetUnreferencedBuckets()
 {
-
     std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
     std::set<Hash> referenced;
     for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
@@ -261,15 +260,16 @@ BucketManagerImpl::forgetUnreferencedBuckets()
         if (referenced.find(j->first) == referenced.end() &&
             j->second.use_count() == 1)
         {
+            auto filename = j->second->getFilename();
             CLOG(TRACE, "Bucket")
                 << "BucketManager::forgetUnreferencedBuckets dropping "
-                << j->second->getFilename();
-            j->second->setRetain(false);
+                << filename;
+            if (!filename.empty())
+            {
+                CLOG(TRACE, "Bucket") << "removing bucket file: " << filename;
+                std::remove(filename.c_str());
+            }
             mSharedBuckets.erase(j);
-        }
-        else
-        {
-            j->second->setRetain(true);
         }
     }
     mSharedBucketsSize.set_count(mSharedBuckets.size());
@@ -334,19 +334,6 @@ BucketManagerImpl::checkForMissingBucketsFiles(HistoryArchiveState const& has)
 }
 
 void
-BucketManagerImpl::retainAll(HistoryArchiveState const& has)
-{
-    for (auto const& bucket : has.allBuckets())
-    {
-        auto const& b = getBucketByHash(hexToBin256(bucket));
-        if (b)
-        {
-            b->setRetain(true);
-        }
-    }
-}
-
-void
 BucketManagerImpl::assumeState(HistoryArchiveState const& has)
 {
     for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
@@ -363,8 +350,6 @@ BucketManagerImpl::assumeState(HistoryArchiveState const& has)
         mBucketList.getLevel(i).setNext(has.currentBuckets.at(i).next);
     }
 
-    // we will need these buckets after restart
-    retainAll(has);
     mBucketList.restartMerges(mApp);
 }
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -71,7 +71,6 @@ class BucketManagerImpl : public BucketManager
 
     std::vector<std::string>
     checkForMissingBucketsFiles(HistoryArchiveState const& has) override;
-    void retainAll(HistoryArchiveState const& has) override;
     void assumeState(HistoryArchiveState const& has) override;
     void shutdown() override;
 };

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -1,0 +1,103 @@
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketOutputIterator.h"
+#include "bucket/Bucket.h"
+#include "bucket/BucketManager.h"
+#include "crypto/Random.h"
+#include "util/make_unique.h"
+
+namespace stellar
+{
+
+namespace
+{
+std::string
+randomBucketName(std::string const& tmpDir)
+{
+    for (;;)
+    {
+        std::string name =
+            tmpDir + "/tmp-bucket-" + binToHex(randomBytes(8)) + ".xdr";
+        std::ifstream ifile(name);
+        if (!ifile)
+        {
+            return name;
+        }
+    }
+}
+}
+
+/**
+ * Helper class that points to an output tempfile. Absorbs BucketEntries and
+ * hashes them while writing to either destination. Produces a Bucket when done.
+ */
+BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
+                                           bool keepDeadEntries)
+    : mFilename(randomBucketName(tmpDir))
+    , mBuf(nullptr)
+    , mHasher(SHA256::create())
+    , mKeepDeadEntries(keepDeadEntries)
+{
+    CLOG(TRACE, "Bucket") << "BucketOutputIterator opening file to write: "
+                          << mFilename;
+    mOut.open(mFilename);
+}
+
+void
+BucketOutputIterator::put(BucketEntry const& e)
+{
+    if (!mKeepDeadEntries && e.type() == DEADENTRY)
+    {
+        return;
+    }
+
+    // Check to see if there's an existing buffered entry.
+    if (mBuf)
+    {
+        // mCmp(e, *mBuf) means e < *mBuf; this should never be true since
+        // it would mean that we're getting entries out of order.
+        assert(!mCmp(e, *mBuf));
+
+        // Check to see if the new entry should flush (greater identity), or
+        // merely replace (same identity), the buffered entry.
+        if (mCmp(*mBuf, e))
+        {
+            mOut.writeOne(*mBuf, mHasher.get(), &mBytesPut);
+            mObjectsPut++;
+        }
+    }
+    else
+    {
+        mBuf = make_unique<BucketEntry>();
+    }
+
+    // In any case, replace *mBuf with e.
+    *mBuf = e;
+}
+
+std::shared_ptr<Bucket>
+BucketOutputIterator::getBucket(BucketManager& bucketManager)
+{
+    assert(mOut);
+    if (mBuf)
+    {
+        mOut.writeOne(*mBuf, mHasher.get(), &mBytesPut);
+        mObjectsPut++;
+        mBuf.reset();
+    }
+
+    mOut.close();
+    if (mObjectsPut == 0 || mBytesPut == 0)
+    {
+        assert(mObjectsPut == 0);
+        assert(mBytesPut == 0);
+        CLOG(DEBUG, "Bucket") << "Deleting empty bucket file " << mFilename;
+        std::remove(mFilename.c_str());
+        return std::make_shared<Bucket>();
+    }
+    return bucketManager.adoptFileAsBucket(mFilename, mHasher->finish(),
+                                           mObjectsPut, mBytesPut);
+}
+}

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Copyright 2017 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/LedgerCmp.h"
+#include "util/XDRStream.h"
+#include "xdr/Stellar-ledger.h"
+
+#include <memory>
+#include <string>
+
+namespace stellar
+{
+
+class Bucket;
+class BucketManager;
+
+// Helper class that writes new elements to a file and returns a bucket
+// when finished.
+class BucketOutputIterator
+{
+    std::string mFilename;
+    XDROutputFileStream mOut;
+    BucketEntryIdCmp mCmp;
+    std::unique_ptr<BucketEntry> mBuf;
+    std::unique_ptr<SHA256> mHasher;
+    size_t mBytesPut{0};
+    size_t mObjectsPut{0};
+    bool mKeepDeadEntries{true};
+
+  public:
+    BucketOutputIterator(std::string const& tmpDir, bool keepDeadEntries);
+
+    void put(BucketEntry const& e);
+
+    std::shared_ptr<Bucket> getBucket(BucketManager& bucketManager);
+};
+}

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -6,8 +6,8 @@
 // first to include <windows.h> -- so we try to include it before everything
 // else.
 #include "util/asio.h"
-
 #include "bucket/Bucket.h"
+#include "bucket/BucketInputIterator.h"
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketManagerImpl.h"
@@ -106,7 +106,7 @@ checkBucketSizeAndBounds(BucketList& bl, uint32_t ledgerSeq, uint32_t level,
     std::set<uint32_t> ledgers;
     uint32_t lbound = std::numeric_limits<uint32_t>::max();
     uint32_t ubound = 0;
-    for (Bucket::InputIterator iter(bucket); iter; ++iter)
+    for (BucketInputIterator iter(bucket); iter; ++iter)
     {
         auto lastModified = (*iter).liveEntry().lastModifiedLedgerSeq;
         ledgers.insert(lastModified);

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -260,15 +260,6 @@ FutureBucket::startMerge(Application& app, bool keepDeadEntries)
     assert(snap);
     assert(!mOutputBucket.valid());
 
-    // Retain all buckets while being merged. They'll be freed by the
-    // BucketManagers only after the merge is done and resolved.
-    curr->setRetain(true);
-    snap->setRetain(true);
-    for (auto b : shadows)
-    {
-        b->setRetain(true);
-    }
-
     CLOG(TRACE, "Bucket") << "Preparing merge of curr="
                           << hexAbbrev(curr->getHash())
                           << " with snap=" << hexAbbrev(snap->getHash());

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -58,23 +58,10 @@ ApplyBucketsWork::getBucketLevel(uint32_t level)
 std::shared_ptr<Bucket const>
 ApplyBucketsWork::getBucket(std::string const& hash)
 {
-    std::shared_ptr<Bucket const> b;
-    if (isZero(hexToBin256(hash)))
-    {
-        b = std::make_shared<Bucket>();
-    }
-    else
-    {
-        auto i = mBuckets.find(hash);
-        if (i != mBuckets.end())
-        {
-            b = i->second;
-        }
-        else
-        {
-            b = mApp.getBucketManager().getBucketByHash(hexToBin256(hash));
-        }
-    }
+    auto i = mBuckets.find(hash);
+    auto b = (i != mBuckets.end())
+                 ? i->second
+                 : mApp.getBucketManager().getBucketByHash(hexToBin256(hash));
     assert(b);
     return b;
 }

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -4,6 +4,7 @@
 
 #include "invariant/BucketListIsConsistentWithDatabase.h"
 #include "bucket/Bucket.h"
+#include "bucket/BucketInputIterator.h"
 #include "crypto/Hex.h"
 #include "database/Database.h"
 #include "invariant/InvariantManager.h"
@@ -46,7 +47,7 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
     uint64_t nAccounts = 0, nTrustLines = 0, nOffers = 0, nData = 0;
     bool hasPreviousEntry = false;
     BucketEntry previousEntry;
-    for (Bucket::InputIterator iter(bucket); iter; ++iter)
+    for (BucketInputIterator iter(bucket); iter; ++iter)
     {
         auto const& e = *iter;
         if (hasPreviousEntry && !BucketEntryIdCmp{}(previousEntry, e))

--- a/src/invariant/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabaseTests.cpp
@@ -5,8 +5,10 @@
 #include "util/asio.h"
 
 #include "bucket/Bucket.h"
+#include "bucket/BucketInputIterator.h"
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
+#include "bucket/BucketOutputIterator.h"
 #include "catchup/ApplyBucketsWork.h"
 #include "database/Database.h"
 #include "invariant/Invariant.h"
@@ -136,16 +138,16 @@ getHistoryArchiveState(Application::pointer appGenerate,
     {
         auto& level = blGenerate.getLevel(i);
         {
-            Bucket::OutputIterator out(bmApply.getTmpDir(), true);
-            for (Bucket::InputIterator in (level.getCurr()); in; ++in)
+            BucketOutputIterator out(bmApply.getTmpDir(), true);
+            for (BucketInputIterator in (level.getCurr()); in; ++in)
             {
                 out.put(*in);
             }
             out.getBucket(bmApply);
         }
         {
-            Bucket::OutputIterator out(bmApply.getTmpDir(), true);
-            for (Bucket::InputIterator in (level.getSnap()); in; ++in)
+            BucketOutputIterator out(bmApply.getTmpDir(), true);
+            for (BucketInputIterator in (level.getSnap()); in; ++in)
             {
                 out.put(*in);
             }
@@ -495,7 +497,7 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
 bool
 doesBucketContain(std::shared_ptr<Bucket const> bucket, const BucketEntry& be)
 {
-    for (Bucket::InputIterator iter(bucket); iter; ++iter)
+    for (BucketInputIterator iter(bucket); iter; ++iter)
     {
         if (*iter == be)
         {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -977,8 +977,6 @@ LedgerManagerImpl::storeCurrentLedger()
         has.resolveAnyReadyFutures();
     }
 
-    // we will need these buckets after restart
-    mApp.getBucketManager().retainAll(has);
     mApp.getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                        has.toString());
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -526,7 +526,6 @@ loadXdr(Config const& cfg, std::string const& bucketFile)
     {
         uint256 zero;
         Bucket bucket(bucketFile, zero);
-        bucket.setRetain(true);
         bucket.apply(app->getDatabase());
     }
     else


### PR DESCRIPTION
setRetain logic is now inverted - BucketManager checks if bucket should be retained at the only 2 places that did setRetain(true) before - in current HistoryArchiveState and in publish queue table in database.

This is much simpler solution.

Additionaly, I've moved bucket iterator classes to separate files.