### PR TITLE
publish queued history just after node is synced

### DIFF
--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -510,7 +510,10 @@ HistoryManagerImpl::queueCurrentHistory()
 void
 HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 {
-    if (mPublishWork)
+    // we can only publish when ledger is synced
+    // if not, ResolveSnapshotWork will fail
+    if (mPublishWork ||
+        mApp.getLedgerManager().getState() != LedgerManager::LM_SYNCED_STATE)
     {
         mPublishDelay.Mark();
         return;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -148,6 +148,12 @@ LedgerManagerImpl::setState(State s)
         {
             mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
         }
+
+        if (mState == LM_SYNCED_STATE)
+        {
+            // we can now publish history again
+            mApp.getHistoryManager().publishQueuedHistory();
+        }
     }
 }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -348,12 +348,6 @@ ApplicationImpl::start()
                 maintenance();
             }
             mOverlayManager->start();
-            auto npub = mHistoryManager->publishQueuedHistory();
-            if (npub != 0)
-            {
-                CLOG(INFO, "Ledger")
-                    << "Restarted publishing " << npub << " queued snapshots";
-            }
             if (mConfig.FORCE_SCP)
             {
                 std::string flagClearedMsg = "";


### PR DESCRIPTION
Do not start publish work as soon as history entry has been added to
publishqueue table - do that after node is synced. Publish wont work
when node is not synced, it will just backoff PublishWork. It can cause
publish to be started more than hour later that it could be.

Fixes #1268