### PR TITLE
remove manual checkpoint command

### DIFF
--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -36,7 +36,6 @@ class CommandHandler
 
     void bans(std::string const& params, std::string& retStr);
     void catchup(std::string const& params, std::string& retStr);
-    void checkpoint(std::string const& params, std::string& retStr);
     void checkdb(std::string const& params, std::string& retStr);
     void connect(std::string const& params, std::string& retStr);
     void dropcursor(std::string const& params, std::string& retStr);


### PR DESCRIPTION
This is now not needed. There is no way to use that checkpoint from any
other stellar-core instances, as manual catchups are now done using
normal checkpoints (every 64-ledgers ones).

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>