### PR TITLE
Upgrade improvements

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -217,21 +217,21 @@ IMPORTANT:
 
 ## Network configuration
 
-The network itself has network wide settings, for example:
+The network itself has network wide settings that can be updated by validators by voting for a new value.
+
+A node can be configured to vote for upgrades using the `upgrades` endpoint . see [`commands.md`](commands.md) for more information.
+
+The network settings are:
  * the version of the protocol used to process transactions
  * the maximum number of transactions that can be included in a ledger
  * the cost (fee) associated with processing operations
 
-See the section on "Network wide settings" in the [example config](https://github.com/stellar/stellar-core/blob/master/docs/stellar-core_example.cfg)
-for more details on those parameters.
-
-When a network value is not the same as the one specified in its configuration,
-a validator will start to vote to update the network to the value specified in the
-configuration during ledgers following the date specified in `PREFERRED_UPGRADE_DATETIME`.
+When the network time is later than the upgradetime specified in
+the upgrade settings, the validator will start to vote to update the network
+to the value specified in the upgrade.
 
 When a validator is voting to change network values, the output of `info` will
-contain information about the vote. This can be useful to spot a misconfigured
-validator (if the operator didn't know about a network wide change for example).
+contain information about the vote.
 
 For a new value to be adopted, the same level of consensus between nodes needs
 to be reached than for transaction sets.
@@ -241,7 +241,7 @@ to be reached than for transaction sets.
 Changes to network wide settings have to be orchestrated properly between
 validators as well as non validating nodes:
 * a change is vetted between operators (changes can be bundled)
-* an effective date in the future is picked for the change to take effect (controlled by `PREFERRED_UPGRADE_DATETIME`)
+* an effective date in the future is picked for the change to take effect (controlled by `upgradetime`)
   * as soon as the date is decided, a best practice is to update
   the configuration file before upgrading the binaries (as updating the version of stellar core
   may trigger a vote for the new protocol version supported by that version of core)
@@ -499,6 +499,22 @@ Run:
   - to set a flag to force each node to start SCP immediatly rather than wait to hear from the network. 
 4. `$ stellar-core` 
   - on each node to start it.
+
+## Upgrading network settings
+
+Read the section on [`network-configuration`](admin.md#network-configuration) for process to follow.
+
+Example here is to upgrade the protocol version to version 9 on January-31-2018.
+
+1. `$ stellar-core -c 'upgrades?mode=set&upgradetime=2018-01-31T20:00:00Z&protocolversion=9'`
+
+2. `$ stellar-core -c info`
+At this point `info` will tell you that the node is setup to vote for this upgrade:
+```
+      "status" : [
+         "Armed with network upgrades: upgradetime=2018-01-31T20:00:00Z, protocolversion=9"
+      ]
+```
 
 # Understanding the availability and health of your instance
 ## General info

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -217,24 +217,25 @@ IMPORTANT:
 
 ## Network configuration
 
-The network itself has network wide settings that can be updated by validators by voting for a new value.
+The network itself has network wide settings that can be updated. This is done by validators voting for and agreeing to new values.
 
 A node can be configured to vote for upgrades using the `upgrades` endpoint . see [`commands.md`](commands.md) for more information.
 
 The network settings are:
  * the version of the protocol used to process transactions
- * the maximum number of transactions that can be included in a ledger
+ * the maximum number of transactions that can be included in a given ledger close
  * the cost (fee) associated with processing operations
+ * the base reserve used to calculate the lumen balance needed to store things in the ledger
 
-When the network time is later than the upgradetime specified in
-the upgrade settings, the validator will start to vote to update the network
-to the value specified in the upgrade.
+When the network time is later than the `upgradetime` specified in
+the upgrade settings, the validator will vote to update the network
+to the value specified in the upgrade setting.
 
-When a validator is voting to change network values, the output of `info` will
+When a validator is armed to change network values, the output of `info` will
 contain information about the vote.
 
 For a new value to be adopted, the same level of consensus between nodes needs
-to be reached than for transaction sets.
+to be reached as for transaction sets.
 
 ### Important notes on network wide settings
 
@@ -242,10 +243,7 @@ Changes to network wide settings have to be orchestrated properly between
 validators as well as non validating nodes:
 * a change is vetted between operators (changes can be bundled)
 * an effective date in the future is picked for the change to take effect (controlled by `upgradetime`)
-  * as soon as the date is decided, a best practice is to update
-  the configuration file before upgrading the binaries (as updating the version of stellar core
-  may trigger a vote for the new protocol version supported by that version of core)
-* if applicable, communication is sent out to consumers of the network
+* if applicable, communication is sent out to all network users
 
 An improper plan may cause issues such as:
 * nodes missing consensus (aka "getting stuck"), and having to use history to rejoin

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -141,6 +141,27 @@ debugging purpose).
         error: set when status is "ERROR".
             Base64 encoded, XDR serialized 'TransactionResult'
 
+* **upgrades**
+  * `/upgrades?mode=get`<br>
+  retrieves the currently configured upgrade settings<br>
+  * `/upgrades?mode=clear`<br>
+  clears any upgrade settings<br>
+  * `/upgrades?mode=set&upgradetime=DATETIME&[basefee=NUM]&[basereserve=NUM]&[maxtxsize=NUM]&[protocolversion=NUM]`<br>
+  upgradetime is a required date (UTC) in the form 1970-01-01T00:00:00Z.<br>
+    * fee (uint32) This is what you would prefer the base fee to be. It is
+        in stroops<br>
+    * basereserve (uint32) This is what you would prefer the base reserve 
+        to be. It is in stroops.<br>
+    * maxtxsize (uint32) This defines the maximum number of transactions 
+        to include in a ledger. When too many transactions are pending, 
+        surge pricing is applied. The instance picks the top maxtxsize
+         transactions locally to be considered in the next ledger.Where 
+        transactions are ordered by transaction fee(lower fee transactions
+         are held for later).<br>
+    * protocolversion (uint32) defines the protocol version to upgrade to.
+         When specified it must match the protocol version supported by the
+        node<br>
+
 ### The following HTTP commands are exposed on test instances
 * **generateload**
   `/generateload[?accounts=N&txs=M&txrate=(R|auto)]`<br>

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -178,9 +178,9 @@ NODE_IS_VALIDATOR=false
 # The value of the protocol version is tied to the version
 # of stellar-core used to run the validator (and cannot be set in config)
 
-# Date and Time in UTC when this node should start voting
-# for upgrades
-PREFERRED_UPGRADE_DATETIME=2017-03-01T00:00:00Z
+# Date and Time this node validates upgrades (default: 1970-01-01T00:00:00Z)
+# Field is in ISO 8601 date format (UTC)
+PREFERRED_UPGRADE_DATETIME=1970-01-01T00:00:00Z
 
 # DESIRED_BASE_FEE (integer) default 100
 # This is what you would prefer the base fee to be. It is in stroops.

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -169,37 +169,6 @@ NODE_SEED="SBI3CZU7XZEWVXU7OZLW5MMUQAP334JFOPXSLTPOH43IRTEQ2QYXU5RG self"
 NODE_IS_VALIDATOR=false
 
 ###########################
-# Network wide settings
-# Be careful when changing those value as those settings allow to
-# update network wide settings.
-# Validators will need to reach consensus before taking effect
-# In general, you need to ensure that those values match
-# the network ones to avoid voting rollbacks.
-# The value of the protocol version is tied to the version
-# of stellar-core used to run the validator (and cannot be set in config)
-
-# Date and Time this node validates upgrades (default: 1970-01-01T00:00:00Z)
-# Field is in ISO 8601 date format (UTC)
-PREFERRED_UPGRADE_DATETIME=1970-01-01T00:00:00Z
-
-# DESIRED_BASE_FEE (integer) default 100
-# This is what you would prefer the base fee to be. It is in stroops.
-DESIRED_BASE_FEE=100
-
-# DESIRED_BASE_RESERVE (integer) default 100000000
-# This is what you would prefer the base reserve to be. It is in stroops.
-DESIRED_BASE_RESERVE=100000000
-
-# DESIRED_MAX_TX_PER_LEDGER (integer) default 50
-# This defines the maximum number of transactions to include in a ledger
-# When too many transactions are pending, surge pricing is applied:
-# * The instance picks the top MAX_TX_PER_LEDGER transactions locally to be
-#   considered in the next ledger. Where transactions are ordered by
-#   transaction fee (lower fee transactions are held for later).
-
-DESIRED_MAX_TX_PER_LEDGER=50
-
-###########################
 # Consensus settings
 
 # FAILURE_SAFETY (integer) default -1

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -27,8 +27,8 @@ the SCP messages for the current ledger (ie: abstain).
 
 A node considers a step invalid either because:
 * they do not understand it, for example a new upgrade type not implemented
-* its value differs for this node configuration
-* network time is before PREFERRED_UPGRADE_DATETIME
+* its value differs for this node's scheduled upgrade setting
+* network time is before the scheduled upgrade datetime
 
 Upgrades are applied after applying the transaction set. It is done this way
 because the transaction set is validated against the last closed ledger,
@@ -37,19 +37,18 @@ without risking invalidating transactions for the current ledger.
 
 Supported upgrades are encoded using LedgerUpgradeType.
 
-Following configuration options are responsible for upgrades:
-* PREFERRED_UPGRADE_DATETIME - sets minimum time for node to accept and
+Upgrades are specified with:
+* upgradetime - the minimum time for node to accept and
   nominate upgrades
-* DESIRED_BASE_FEE - upgrades value of baseFee in ledger header, uses upgrade
+* basefee - upgrades value of baseFee in ledger header, uses upgrade
   type LEDGER_UPGRADE_BASE_FEE
-* DESIRED_MAX_TX_PER_LEDGER - upgrades value of maxTxSetSize in ledger header,
+* maxtxsize - upgrades value of maxTxSetSize in ledger header,
   uses upgrade type LEDGER_UPGRADE_MAX_TX_SET_SIZE
-* DESIRED_BASE_RESERVE - upgrades value of baseReserve in ledger header, uses
+* basereserve - upgrades value of baseReserve in ledger header, uses
   upgrade type LEDGER_UPGRADE_BASE_RESERVE
-
-Additionally nodes vote for changes to the ledgerVersion field with its
-non-configurable build-in LEDGER_PROTOCOL_VERSION field (which uses upgrade
-type LEDGER_UPGRADE_VERSION).
+* protocolversion - upgrades value of ledgerVersion in ledger header, uses
+  upgrade type LEDGER_UPGRADE_VERSION (when specified it has to match the
+  supported version number)
 
 #### Limitations of the current implementation
 There is an assumption that validator operators are either paying attention to network wide proposals

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -130,7 +130,7 @@ class Herder
     // sets the upgrades that should be applied during consensus
     virtual void setUpgrades(Upgrades::UpgradeParameters const& upgrades) = 0;
     // gets the upgrades that are scheduled by this node
-    virtual std::string getUpgrades() = 0;
+    virtual std::string getUpgradesJson() = 0;
 
     virtual ~Herder()
     {

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -95,8 +95,8 @@ class Herder
 
     virtual void bootstrap() = 0;
 
-    // restores SCP state based on the last messages saved on disk
-    virtual void restoreSCPState() = 0;
+    // restores Herder's state from disk
+    virtual void restoreState() = 0;
 
     virtual bool recvSCPQuorumSet(Hash const& hash,
                                   SCPQuorumSet const& qset) = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -129,6 +129,8 @@ class Herder
 
     // sets the upgrades that should be applied during consensus
     virtual void setUpgrades(Upgrades::UpgradeParameters const& upgrades) = 0;
+    // gets the upgrades that are scheduled by this node
+    virtual std::string getUpgrades() = 0;
 
     virtual ~Herder()
     {

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "TxSetFrame.h"
+#include "Upgrades.h"
 #include "lib/json/json-forwards.h"
 #include "overlay/StellarXDR.h"
 #include "scp/SCP.h"
@@ -125,6 +126,9 @@ class Herder
 
     // lookup a nodeID in config and in SCP messages
     virtual bool resolveNodeID(std::string const& s, PublicKey& retKey) = 0;
+
+    // sets the upgrades that should be applied during consensus
+    virtual void setUpgrades(Upgrades::UpgradeParameters const& upgrades) = 0;
 
     virtual ~Herder()
     {

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -764,22 +764,6 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
         }
     }
 
-    if (!upgrades.empty())
-    {
-        auto message = fmt::format(
-            "Proposing herder configuration upgrades: {0}; network "
-            "values for LCL are: {1}",
-            Upgrades::toString(upgrades), Upgrades::toString(lcl.header));
-        CLOG(INFO, "Herder") << message;
-        mApp.getStatusManager().setStatusMessage(
-            StatusCategory::REQUIRES_UPGRADES, message);
-    }
-    else
-    {
-        mApp.getStatusManager().removeStatusMessage(
-            StatusCategory::REQUIRES_UPGRADES);
-    }
-
     mHerderSCPDriver.nominate(slotIndex, newProposedValue, proposedSet,
                               lcl.header.scpValue);
 }
@@ -789,6 +773,21 @@ HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
 {
     mUpgrades.setParameters(upgrades, mApp.getConfig());
     persistUpgrades();
+
+    auto desc = mUpgrades.toString();
+
+    if (!desc.empty())
+    {
+        auto message = fmt::format("Armed with network upgrades: {}", desc);
+        CLOG(INFO, "Herder") << message;
+        mApp.getStatusManager().setStatusMessage(
+            StatusCategory::REQUIRES_UPGRADES, message);
+    }
+    else
+    {
+        mApp.getStatusManager().removeStatusMessage(
+            StatusCategory::REQUIRES_UPGRADES);
+    }
 }
 
 std::string

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -808,7 +808,7 @@ HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
 }
 
 std::string
-HerderImpl::getUpgrades()
+HerderImpl::getUpgradesJson()
 {
     return mUpgrades.getParameters().toJson();
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -962,6 +962,33 @@ HerderImpl::restoreSCPState()
 }
 
 void
+HerderImpl::persistUpgrades()
+{
+    auto s = mUpgrades.getParameters().toJson();
+    mApp.getPersistentState().setState(PersistentState::kLedgerUpgrades, s);
+}
+
+void
+HerderImpl::restoreUpgrades()
+{
+    std::string s =
+        mApp.getPersistentState().getState(PersistentState::kLedgerUpgrades);
+    if (!s.empty())
+    {
+        Upgrades::UpgradeParameters p;
+        p.fromJson(s);
+        mUpgrades.setParameters(p);
+    }
+}
+
+void
+HerderImpl::restoreState()
+{
+    restoreSCPState();
+    restoreUpgrades();
+}
+
+void
 HerderImpl::trackingHeartBeat()
 {
     if (mApp.getConfig().MANUAL_CLOSE)

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -72,7 +72,6 @@ HerderImpl::SCPMetrics::SCPMetrics(Application& app)
 HerderImpl::HerderImpl(Application& app)
     : mPendingTransactions(4)
     , mPendingEnvelopes(app, *this)
-    , mUpgrades(app.getConfig())
     , mHerderSCPDriver(app, *this, mUpgrades, mPendingEnvelopes)
     , mLastSlotSaved(0)
     , mTrackingTimer(app)
@@ -783,6 +782,12 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
 
     mHerderSCPDriver.nominate(slotIndex, newProposedValue, proposedSet,
                               lcl.header.scpValue);
+}
+
+void
+HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
+{
+    mUpgrades.setParameters(upgrades);
 }
 
 bool

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -787,7 +787,14 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
 void
 HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
 {
-    mUpgrades.setParameters(upgrades);
+    mUpgrades.setParameters(upgrades, mApp.getConfig());
+    persistUpgrades();
+}
+
+std::string
+HerderImpl::getUpgrades()
+{
+    return mUpgrades.getParameters().toJson();
 }
 
 bool
@@ -977,7 +984,16 @@ HerderImpl::restoreUpgrades()
     {
         Upgrades::UpgradeParameters p;
         p.fromJson(s);
-        mUpgrades.setParameters(p);
+        try
+        {
+            // use common code to set status
+            setUpgrades(p);
+        }
+        catch (std::exception e)
+        {
+            CLOG(INFO, "Herder") << "Error restoring upgrades '" << e.what()
+                                 << "' with upgrades '" << s << "'";
+        }
     }
 }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -748,7 +748,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
                                   0);
 
     // see if we need to include some upgrades
-    auto upgrades = mUpgrades.upgradesFor(lcl.header);
+    auto upgrades = mUpgrades.createUpgradesFor(lcl.header);
     for (auto const& upgrade : upgrades)
     {
         Value v(xdr::xdr_to_opaque(upgrade));

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -81,6 +81,7 @@ class HerderImpl : public Herder
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
     void setUpgrades(Upgrades::UpgradeParameters const& upgrades) override;
+    std::string getUpgrades() override;
 
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -47,8 +47,7 @@ class HerderImpl : public Herder
     // Bootstraps the HerderImpl if we're creating a new Network
     void bootstrap() override;
 
-    // restores SCP state based on the last messages saved on disk
-    void restoreSCPState() override;
+    void restoreState() override;
 
     SCP& getSCP();
     HerderSCPDriver&
@@ -135,6 +134,12 @@ class HerderImpl : public Herder
 
     // saves the SCP messages that the instance sent out last
     void persistSCPState(uint64 slot);
+    // restores SCP state based on the last messages saved on disk
+    void restoreSCPState();
+
+    // saves upgrade parameters
+    void persistUpgrades();
+    void restoreUpgrades();
 
     // called every time we get ledger externalized
     // ensures that if we don't hear from the network, we throw the herder into

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -81,7 +81,7 @@ class HerderImpl : public Herder
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
     void setUpgrades(Upgrades::UpgradeParameters const& upgrades) override;
-    std::string getUpgrades() override;
+    std::string getUpgradesJson() override;
 
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -81,6 +81,8 @@ class HerderImpl : public Herder
 
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
+    void setUpgrades(Upgrades::UpgradeParameters const& upgrades) override;
+
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 
     void dumpInfo(Json::Value& ret, size_t limit) override;

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -294,7 +294,8 @@ HerderSCPDriver::validateValue(uint64_t slotIndex, Value const& value,
         for (size_t i = 0; i < b.upgrades.size(); i++)
         {
             LedgerUpgradeType thisUpgradeType;
-            if (!mUpgrades.isValid(b.closeTime, b.upgrades[i], thisUpgradeType))
+            if (!mUpgrades.isValid(b.closeTime, b.upgrades[i], thisUpgradeType,
+                                   nomination, mApp.getConfig()))
             {
                 CLOG(TRACE, "Herder")
                     << "HerderSCPDriver::validateValue invalid step at index "
@@ -344,7 +345,8 @@ HerderSCPDriver::extractValidValue(uint64_t slotIndex, Value const& value)
         LedgerUpgradeType thisUpgradeType;
         for (auto it = b.upgrades.begin(); it != b.upgrades.end();)
         {
-            if (!mUpgrades.isValid(b.closeTime, *it, thisUpgradeType))
+            if (!mUpgrades.isValid(b.closeTime, *it, thisUpgradeType, true,
+                                   mApp.getConfig()))
             {
                 it = b.upgrades.erase(it);
             }

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -272,7 +272,8 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex,
 }
 
 SCPDriver::ValidationLevel
-HerderSCPDriver::validateValue(uint64_t slotIndex, Value const& value)
+HerderSCPDriver::validateValue(uint64_t slotIndex, Value const& value,
+                               bool nomination)
 {
     StellarValue b;
     try

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -94,7 +94,8 @@ class HerderSCPDriver : public SCPDriver
 
     // value validation
     SCPDriver::ValidationLevel validateValue(uint64_t slotIndex,
-                                             Value const& value) override;
+                                             Value const& value,
+                                             bool nomination) override;
     Value extractValidValue(uint64_t slotIndex, Value const& value) override;
 
     // value marshaling

--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -303,7 +303,7 @@ TEST_CASE("txset", "[herder]")
 TEST_CASE("surge", "[herder]")
 {
     Config cfg(getTestConfig());
-    cfg.DESIRED_MAX_TX_PER_LEDGER = 5;
+    cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER = 5;
 
     VirtualClock clock;
     Application::pointer app = createTestApplication(clock, cfg);
@@ -313,7 +313,7 @@ TEST_CASE("surge", "[herder]")
     auto& lm = app->getLedgerManager();
 
     app->getLedgerManager().getCurrentLedgerHeader().maxTxSetSize =
-        cfg.DESIRED_MAX_TX_PER_LEDGER;
+        cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER;
 
     // set up world
     auto root = TestAccount::createRoot(*app);
@@ -416,7 +416,7 @@ TEST_CASE("surge", "[herder]")
 TEST_CASE("SCP Driver", "[herder]")
 {
     Config cfg(getTestConfig());
-    cfg.DESIRED_MAX_TX_PER_LEDGER = 5;
+    cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER = 5;
 
     VirtualClock clock;
     Application::pointer app = createTestApplication(clock, cfg);
@@ -424,7 +424,7 @@ TEST_CASE("SCP Driver", "[herder]")
     app->start();
 
     app->getLedgerManager().getCurrentLedgerHeader().maxTxSetSize =
-        cfg.DESIRED_MAX_TX_PER_LEDGER;
+        cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER;
 
     auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
 

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -6,11 +6,60 @@
 #include "main/Config.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
+#include <cereal/archives/json.hpp>
+#include <cereal/cereal.hpp>
 #include <lib/util/format.h>
 #include <xdrpp/marshal.h>
 
+namespace cereal
+{
+template <class Archive>
+void
+save(Archive& ar, stellar::Upgrades::UpgradeParameters const& p)
+{
+    ar(make_nvp("time", stellar::VirtualClock::to_time_t(p.mUpgradeTime)));
+    ar(make_nvp("version", p.mProtocolVersion));
+    ar(make_nvp("fee", p.mBaseFee));
+    ar(make_nvp("maxtxsize", p.mMaxTxSize));
+    ar(make_nvp("reserve", p.mBaseReserve));
+}
+
+template <class Archive>
+void
+load(Archive& ar, stellar::Upgrades::UpgradeParameters& o)
+{
+    time_t t;
+    ar(make_nvp("time", t));
+    o.mUpgradeTime = stellar::VirtualClock::from_time_t(t);
+    ar(make_nvp("version", o.mProtocolVersion));
+    ar(make_nvp("fee", o.mBaseFee));
+    ar(make_nvp("maxtxsize", o.mMaxTxSize));
+    ar(make_nvp("reserve", o.mBaseReserve));
+}
+} // namespace cereal
+
 namespace stellar
 {
+std::string
+Upgrades::UpgradeParameters::toJson() const
+{
+    std::ostringstream out;
+    {
+        cereal::JSONOutputArchive ar(out);
+        cereal::save(ar, *this);
+    }
+    return out.str();
+}
+
+void
+Upgrades::UpgradeParameters::fromJson(std::string const& s)
+{
+    std::istringstream in(s);
+    {
+        cereal::JSONInputArchive ar(in);
+        cereal::load(ar, *this);
+    }
+}
 
 Upgrades::Upgrades(UpgradeParameters const& params) : mParams(params)
 {
@@ -20,6 +69,12 @@ void
 Upgrades::setParameters(UpgradeParameters const& params)
 {
     mParams = params;
+}
+
+Upgrades::UpgradeParameters const&
+Upgrades::getParameters() const
+{
+    return mParams;
 }
 
 std::vector<LedgerUpgrade>

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -149,46 +149,40 @@ Upgrades::toString(LedgerUpgrade const& upgrade)
     switch (upgrade.type())
     {
     case LEDGER_UPGRADE_VERSION:
-        return fmt::format("PROTOCOL_VERSION={0}", upgrade.newLedgerVersion());
+        return fmt::format("protocolversion={0}", upgrade.newLedgerVersion());
     case LEDGER_UPGRADE_BASE_FEE:
-        return fmt::format("BASE_FEE={0}", upgrade.newBaseFee());
+        return fmt::format("basefee={0}", upgrade.newBaseFee());
     case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-        return fmt::format("MAX_TX_SET_SIZE={0}", upgrade.newMaxTxSetSize());
+        return fmt::format("maxtxsetsize={0}", upgrade.newMaxTxSetSize());
     case LEDGER_UPGRADE_BASE_RESERVE:
-        return fmt::format("BASE_RESERVE={0}", upgrade.newBaseReserve());
+        return fmt::format("basereserve={0}", upgrade.newBaseReserve());
     default:
         return "<unsupported>";
     }
 }
 
 std::string
-Upgrades::toString(std::vector<LedgerUpgrade> const& upgrades)
+Upgrades::toString() const
 {
-    if (upgrades.empty())
-    {
-        return {};
-    }
+    fmt::MemoryWriter r;
 
-    auto result = std::string{};
-    for (auto const& upgrade : upgrades)
-    {
-        if (!result.empty())
+    auto appendInfo = [&](std::string const& s, optional<uint32> const& o) {
+        if (o)
         {
-            result += ", ";
+            if (!r.size())
+            {
+                r << "upgradetime="
+                  << VirtualClock::pointToISOString(mParams.mUpgradeTime);
+            }
+            r << ", " << s << "=" << *o;
         }
-        result += toString(upgrade);
-    }
+    };
+    appendInfo("protocolversion", mParams.mProtocolVersion);
+    appendInfo("basefee", mParams.mBaseFee);
+    appendInfo("basereserve", mParams.mBaseReserve);
+    appendInfo("maxtxsize", mParams.mMaxTxSize);
 
-    return fmt::format("[{0}]", result);
-}
-
-std::string
-Upgrades::toString(LedgerHeader const& header)
-{
-    return fmt::format("PROTOCOL_VERSION={0}, BASE_FEE={1}, "
-                       "MAX_TX_SET_SIZE={2}, BASE_RESERVE={3}",
-                       header.ledgerVersion, header.baseFee,
-                       header.maxTxSetSize, header.baseReserve);
+    return r.str();
 }
 
 bool

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -66,8 +66,15 @@ Upgrades::Upgrades(UpgradeParameters const& params) : mParams(params)
 }
 
 void
-Upgrades::setParameters(UpgradeParameters const& params)
+Upgrades::setParameters(UpgradeParameters const& params, Config const& cfg)
 {
+    if (params.mProtocolVersion &&
+        *params.mProtocolVersion != cfg.LEDGER_PROTOCOL_VERSION)
+    {
+        throw std::invalid_argument(
+            fmt::format("Protocol version error: supported is {}, passed is {}",
+                        cfg.LEDGER_PROTOCOL_VERSION, *params.mProtocolVersion));
+    }
     mParams = params;
 }
 

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -16,6 +16,12 @@ Upgrades::Upgrades(UpgradeParameters const& params) : mParams(params)
 {
 }
 
+void
+Upgrades::setParameters(UpgradeParameters const& params)
+{
+    mParams = params;
+}
+
 std::vector<LedgerUpgrade>
 Upgrades::createUpgradesFor(LedgerHeader const& header) const
 {

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -23,6 +23,9 @@ class Upgrades
   public:
     struct UpgradeParameters
     {
+        UpgradeParameters()
+        {
+        }
         UpgradeParameters(Config const& cfg)
         {
             mUpgradeTime = cfg.PREFERRED_UPGRADE_DATETIME;
@@ -39,7 +42,12 @@ class Upgrades
         optional<uint32> mBaseReserve;
     };
 
+    Upgrades()
+    {
+    }
     explicit Upgrades(UpgradeParameters const& params);
+
+    void setParameters(UpgradeParameters const& params);
 
     // create upgrades for given ledger
     std::vector<LedgerUpgrade>

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -73,6 +73,12 @@ class Upgrades
     // the pending upgrades
     std::string toString() const;
 
+    // sets updated to true if some upgrades were removed
+    UpgradeParameters
+    removeUpgrades(std::vector<UpgradeType>::const_iterator beginUpdates,
+                   std::vector<UpgradeType>::const_iterator endUpdates,
+                   bool& updated);
+
   private:
     UpgradeParameters mParams;
 

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -64,16 +64,14 @@ class Upgrades
     // convert upgrade value to string
     static std::string toString(LedgerUpgrade const& upgrade);
 
-    // convert upgrades vector to string
-    static std::string toString(std::vector<LedgerUpgrade> const& upgrades);
-
-    // convert upgrades from herder to string
-    static std::string toString(LedgerHeader const& header);
-
     // returns true if upgrade is a valid upgrade step
     // in which case it also sets upgradeType
     bool isValid(uint64_t closeTime, UpgradeType const& upgrade,
                  LedgerUpgradeType& upgradeType) const;
+
+    // constructs a human readable string that represents
+    // the pending upgrades
+    std::string toString() const;
 
   private:
     UpgradeParameters mParams;

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -28,12 +28,13 @@ class Upgrades
         }
         UpgradeParameters(Config const& cfg)
         {
-            mUpgradeTime = cfg.PREFERRED_UPGRADE_DATETIME;
+            mUpgradeTime = cfg.TESTING_UPGRADE_DATETIME;
             mProtocolVersion =
                 make_optional<uint32>(cfg.LEDGER_PROTOCOL_VERSION);
-            mBaseFee = make_optional<uint32>(cfg.DESIRED_BASE_FEE);
-            mMaxTxSize = make_optional<uint32>(cfg.DESIRED_MAX_TX_PER_LEDGER);
-            mBaseReserve = make_optional<uint32>(cfg.DESIRED_BASE_RESERVE);
+            mBaseFee = make_optional<uint32>(cfg.TESTING_UPGRADE_DESIRED_FEE);
+            mMaxTxSize =
+                make_optional<uint32>(cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER);
+            mBaseReserve = make_optional<uint32>(cfg.TESTING_UPGRADE_RESERVE);
         }
         VirtualClock::time_point mUpgradeTime;
         optional<uint32> mProtocolVersion;

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -40,6 +40,9 @@ class Upgrades
         optional<uint32> mBaseFee;
         optional<uint32> mMaxTxSize;
         optional<uint32> mBaseReserve;
+
+        std::string toJson() const;
+        void fromJson(std::string const& s);
     };
 
     Upgrades()
@@ -48,6 +51,8 @@ class Upgrades
     explicit Upgrades(UpgradeParameters const& params);
 
     void setParameters(UpgradeParameters const& params);
+
+    UpgradeParameters const& getParameters() const;
 
     // create upgrades for given ledger
     std::vector<LedgerUpgrade>

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -68,7 +68,8 @@ class Upgrades
     // returns true if upgrade is a valid upgrade step
     // in which case it also sets upgradeType
     bool isValid(uint64_t closeTime, UpgradeType const& upgrade,
-                 LedgerUpgradeType& upgradeType) const;
+                 LedgerUpgradeType& upgradeType, bool nomination,
+                 Config const& cfg) const;
 
     // constructs a human readable string that represents
     // the pending upgrades

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -50,7 +50,7 @@ class Upgrades
     }
     explicit Upgrades(UpgradeParameters const& params);
 
-    void setParameters(UpgradeParameters const& params);
+    void setParameters(UpgradeParameters const& params, Config const& cfg);
 
     UpgradeParameters const& getParameters() const;
 

--- a/src/herder/UpgradesTests.cpp
+++ b/src/herder/UpgradesTests.cpp
@@ -243,7 +243,7 @@ testListUpgrades(VirtualClock::time_point preferredUpgradeDatetime,
     SECTION("protocol version upgrade needed")
     {
         header.ledgerVersion--;
-        auto upgrades = Upgrades{cfg}.upgradesFor(header);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{protocolVersionUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -253,7 +253,7 @@ testListUpgrades(VirtualClock::time_point preferredUpgradeDatetime,
     SECTION("base fee upgrade needed")
     {
         header.baseFee /= 2;
-        auto upgrades = Upgrades{cfg}.upgradesFor(header);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{baseFeeUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -263,7 +263,7 @@ testListUpgrades(VirtualClock::time_point preferredUpgradeDatetime,
     SECTION("tx count upgrade needed")
     {
         header.maxTxSetSize /= 2;
-        auto upgrades = Upgrades{cfg}.upgradesFor(header);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{txCountUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -273,7 +273,7 @@ testListUpgrades(VirtualClock::time_point preferredUpgradeDatetime,
     SECTION("base reserve upgrade needed")
     {
         header.baseReserve /= 2;
-        auto upgrades = Upgrades{cfg}.upgradesFor(header);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header);
         auto expected = shouldListAny
                             ? std::vector<LedgerUpgrade>{baseReserveUpgrade}
                             : std::vector<LedgerUpgrade>{};
@@ -286,7 +286,7 @@ testListUpgrades(VirtualClock::time_point preferredUpgradeDatetime,
         header.baseFee /= 2;
         header.maxTxSetSize /= 2;
         header.baseReserve /= 2;
-        auto upgrades = Upgrades{cfg}.upgradesFor(header);
+        auto upgrades = Upgrades{cfg}.createUpgradesFor(header);
         auto expected =
             shouldListAny
                 ? std::vector<LedgerUpgrade>{protocolVersionUpgrade,

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -207,9 +207,9 @@ LedgerManagerImpl::startNewLedger()
     if (cfg.USE_CONFIG_FOR_GENESIS)
     {
         ledger.ledgerVersion = cfg.LEDGER_PROTOCOL_VERSION;
-        ledger.baseFee = cfg.DESIRED_BASE_FEE;
-        ledger.baseReserve = cfg.DESIRED_BASE_RESERVE;
-        ledger.maxTxSetSize = cfg.DESIRED_MAX_TX_PER_LEDGER;
+        ledger.baseFee = cfg.TESTING_UPGRADE_DESIRED_FEE;
+        ledger.baseReserve = cfg.TESTING_UPGRADE_RESERVE;
+        ledger.maxTxSetSize = cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER;
     }
 
     startNewLedger(std::move(ledger));

--- a/src/ledger/LedgerPerformanceTests.cpp
+++ b/src/ledger/LedgerPerformanceTests.cpp
@@ -122,7 +122,7 @@ class LedgerPerformanceTests : public Simulation
     void
     closeLedger(vector<Simulation::TxInfo> txs)
     {
-        auto baseFee = mApp->getConfig().DESIRED_BASE_FEE;
+        auto baseFee = mApp->getConfig().TESTING_UPGRADE_DESIRED_FEE;
         LoadGenerator::TxMetrics txm(mApp->getMetrics());
         TxSetFramePtr txSet = make_shared<TxSetFrame>(
             mApp->getLedgerManager().getLastClosedLedgerHeader().hash);

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -304,6 +304,8 @@ ApplicationImpl::start()
 {
     mDatabase->upgradeToCurrentSchema();
 
+    mHerder->setUpgrades(mConfig);
+
     if (mPersistentState->getState(PersistentState::kForceSCPOnNextLaunch) ==
         "true")
     {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -304,7 +304,10 @@ ApplicationImpl::start()
 {
     mDatabase->upgradeToCurrentSchema();
 
-    mHerder->setUpgrades(mConfig);
+    if (mConfig.TESTING_UPGRADE_DATETIME.time_since_epoch().count() != 0)
+    {
+        mHerder->setUpgrades(mConfig);
+    }
 
     if (mPersistentState->getState(PersistentState::kForceSCPOnNextLaunch) ==
         "true")

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -341,8 +341,8 @@ ApplicationImpl::start()
                     "Unable to restore last-known ledger state");
             }
 
-            // restores the SCP state before starting overlay
-            mHerder->restoreSCPState();
+            // restores Herder's state before starting overlay
+            mHerder->restoreState();
             // perform maintenance tasks if configured to do so
             // for now, we only perform it when CATCHUP_COMPLETE is not set
             if (mConfig.MAINTENANCE_ON_STARTUP && !mConfig.CATCHUP_COMPLETE)

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -758,7 +758,7 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
     }
     if (s == "get")
     {
-        retStr = mApp.getHerder().getUpgrades();
+        retStr = mApp.getHerder().getUpgradesJson();
     }
     else if (s == "set")
     {

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -17,7 +17,6 @@
 #include "util/Logging.h"
 #include "util/StatusManager.h"
 #include "util/make_unique.h"
-#include <iomanip>
 
 #include "medida/reporting/json_reporter.h"
 #include "util/basen.h"
@@ -766,17 +765,17 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
         Upgrades::UpgradeParameters p;
 
         auto upgradeTime = retMap["upgradetime"];
-
-        std::istringstream is(upgradeTime);
         std::tm tm;
-        is >> std::get_time(&tm, "%Y-%m-%dT%H:%M:%SZ");
-        if (is.fail())
+        try
+        {
+            tm = VirtualClock::isoStringToTm(upgradeTime);
+        }
+        catch (std::exception)
         {
             retStr =
                 fmt::format("could not parse upgradetime: '{}'", upgradeTime);
             return;
         }
-        tm.tm_isdst = false;
         p.mUpgradeTime = VirtualClock::tmToPoint(tm);
 
         auto addParam = [&](std::string const& name,
@@ -972,8 +971,8 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
     }
     else
     {
-        throw std::exception("Must specify a tx blob: tx?blob=<tx in "
-                             "xdr format>\"}");
+        throw std::invalid_argument("Must specify a tx blob: tx?blob=<tx in "
+                                    "xdr format>\"}");
     }
 
     retStr = output.str();

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -50,5 +50,6 @@ class CommandHandler
     void testAcc(std::string const& params, std::string& retStr);
     void testTx(std::string const& params, std::string& retStr);
     void unban(std::string const& params, std::string& retStr);
+    void upgrades(std::string const& params, std::string& retStr);
 };
 }

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -17,9 +17,15 @@ class Application;
 
 class CommandHandler
 {
+    typedef std::function<void(CommandHandler*, std::string const&,
+                               std::string&)>
+        HandlerRoute;
 
     Application& mApp;
     std::unique_ptr<http::server::server> mServer;
+
+    void safeRouter(HandlerRoute route, std::string const& params,
+                    std::string& retStr);
 
   public:
     CommandHandler(Application& app);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -20,7 +20,7 @@ namespace stellar
 {
 using xdr::operator<;
 
-const int Config::CURRENT_LEDGER_PROTOCOL_VERSION = 9;
+const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 9;
 
 Config::Config() : NODE_SEED(SecretKey::random())
 {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -53,9 +53,9 @@ Config::Config() : NODE_SEED(SecretKey::random())
     LOG_FILE_PATH = "stellar-core.%datetime{%Y.%M.%d-%H:%m:%s}.log";
     BUCKET_DIR_PATH = "buckets";
 
-    DESIRED_BASE_FEE = LedgerManager::GENESIS_LEDGER_BASE_FEE;
-    DESIRED_BASE_RESERVE = LedgerManager::GENESIS_LEDGER_BASE_RESERVE;
-    DESIRED_MAX_TX_PER_LEDGER = 50;
+    TESTING_UPGRADE_DESIRED_FEE = LedgerManager::GENESIS_LEDGER_BASE_FEE;
+    TESTING_UPGRADE_RESERVE = LedgerManager::GENESIS_LEDGER_BASE_RESERVE;
+    TESTING_UPGRADE_MAX_TX_PER_LEDGER = 50;
 
     HTTP_PORT = DEFAULT_PEER_PORT + 1;
     PUBLIC_HTTP_PORT = false;
@@ -225,47 +225,6 @@ Config::load(std::string const& filename)
                     throw std::invalid_argument("invalid PUBLIC_HTTP_PORT");
                 }
                 PUBLIC_HTTP_PORT = item.second->as<bool>()->value();
-            }
-            else if (item.first == "DESIRED_BASE_FEE")
-            {
-                if (!item.second->as<int64_t>())
-                {
-                    throw std::invalid_argument("invalid DESIRED_BASE_FEE");
-                }
-                int64_t f = item.second->as<int64_t>()->value();
-                if (f < 0 || f >= UINT32_MAX)
-                {
-                    throw std::invalid_argument("invalid DESIRED_BASE_FEE");
-                }
-                DESIRED_BASE_FEE = (uint32_t)f;
-            }
-            else if (item.first == "DESIRED_BASE_RESERVE")
-            {
-                if (!item.second->as<int64_t>())
-                {
-                    throw std::invalid_argument("invalid DESIRED_BASE_RESERVE");
-                }
-                int64_t f = item.second->as<int64_t>()->value();
-                if (f < 0 || f >= UINT32_MAX)
-                {
-                    throw std::invalid_argument("invalid DESIRED_BASE_RESERVE");
-                }
-                DESIRED_BASE_RESERVE = (uint32_t)f;
-            }
-            else if (item.first == "DESIRED_MAX_TX_PER_LEDGER")
-            {
-                if (!item.second->as<int64_t>())
-                {
-                    throw std::invalid_argument(
-                        "invalid DESIRED_MAX_TX_PER_LEDGER");
-                }
-                int64_t f = item.second->as<int64_t>()->value();
-                if (f <= 0 || f >= UINT32_MAX)
-                {
-                    throw std::invalid_argument(
-                        "invalid DESIRED_MAX_TX_PER_LEDGER");
-                }
-                DESIRED_MAX_TX_PER_LEDGER = (uint32_t)f;
             }
             else if (item.first == "FAILURE_SAFETY")
             {
@@ -665,16 +624,6 @@ Config::load(std::string const& filename)
                     throw std::invalid_argument("invalid NTP_SERVER");
                 }
                 NTP_SERVER = item.second->as<std::string>()->value();
-            }
-            else if (item.first == "PREFERRED_UPGRADE_DATETIME")
-            {
-                if (!item.second->as<std::tm>())
-                {
-                    throw std::invalid_argument(
-                        "invalid PREFERRED_UPGRADE_DATETIME");
-                }
-                PREFERRED_UPGRADE_DATETIME = VirtualClock::tmToPoint(
-                    item.second->as<std::tm>()->value());
             }
             else if (item.first == "INVARIANT_CHECKS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -123,7 +123,7 @@ class Config : public std::enable_shared_from_this<Config>
     bool UNSAFE_QUORUM;
 
     uint32_t LEDGER_PROTOCOL_VERSION;
-    VirtualClock::time_point PREFERRED_UPGRADE_DATETIME;
+    VirtualClock::time_point TESTING_UPGRADE_DATETIME;
 
     // note: all versions in the range
     // [OVERLAY_PROTOCOL_MIN_VERSION, OVERLAY_PROTOCOL_VERSION] must be handled
@@ -132,9 +132,9 @@ class Config : public std::enable_shared_from_this<Config>
     std::string VERSION_STR;
     std::string LOG_FILE_PATH;
     std::string BUCKET_DIR_PATH;
-    uint32_t DESIRED_BASE_FEE;     // in stroops
-    uint32_t DESIRED_BASE_RESERVE; // in stroops
-    uint32_t DESIRED_MAX_TX_PER_LEDGER;
+    uint32_t TESTING_UPGRADE_DESIRED_FEE; // in stroops
+    uint32_t TESTING_UPGRADE_RESERVE;     // in stroops
+    uint32_t TESTING_UPGRADE_MAX_TX_PER_LEDGER;
     unsigned short HTTP_PORT; // what port to listen for commands
     bool PUBLIC_HTTP_PORT;    // if you accept commands from not localhost
     int HTTP_MAX_CLIENT;      // maximum number of http clients, i.e backlog

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -32,7 +32,7 @@ class Config : public std::enable_shared_from_this<Config>
     std::string expandNodeID(std::string const& s) const;
 
   public:
-    static const int CURRENT_LEDGER_PROTOCOL_VERSION;
+    static const uint32 CURRENT_LEDGER_PROTOCOL_VERSION;
 
     typedef std::shared_ptr<Config> pointer;
 

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -14,7 +14,8 @@ using namespace std;
 
 string PersistentState::mapping[kLastEntry] = {
     "lastclosedledger", "historyarchivestate", "forcescponnextlaunch",
-    "lastscpdata",      "databaseschema",      "networkpassphrase"};
+    "lastscpdata",      "databaseschema",      "networkpassphrase",
+    "ledgerupgrades"};
 
 string PersistentState::kSQLCreateStatement =
     "CREATE TABLE IF NOT EXISTS storestate ("

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -23,6 +23,7 @@ class PersistentState
         kLastSCPData,
         kDatabaseSchema,
         kNetworkPassphrase,
+        kLedgerUpgrades,
         kLastEntry,
     };
 

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1904,7 +1904,8 @@ BallotProtocol::validateValues(SCPStatement const& st)
     SCPDriver::ValidationLevel res = SCPDriver::kFullyValidatedValue;
     for (auto const& v : values)
     {
-        auto tr = mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v);
+        auto tr =
+            mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v, false);
         if (tr != SCPDriver::kFullyValidatedValue)
         {
             if (tr == SCPDriver::kInvalidValue)

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -74,7 +74,7 @@ NominationProtocol::isSubsetHelper(xdr::xvector<Value> const& p,
 SCPDriver::ValidationLevel
 NominationProtocol::validateValue(Value const& v)
 {
-    return mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v);
+    return mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v, true);
 }
 
 Value

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -51,6 +51,7 @@ class SCPDriver
     // the validity checks, kMaybeValidValue can be returned. This will cause
     // the current slot to be marked as a non validating slot: the local node
     // will abstain from emiting its position.
+    // validation can be *more* restrictive during nomination as needed
     enum ValidationLevel
     {
         kInvalidValue,        // value is invalid for sure
@@ -58,7 +59,7 @@ class SCPDriver
         kMaybeValidValue      // value may be valid
     };
     virtual ValidationLevel
-    validateValue(uint64 slotIndex, Value const& value)
+    validateValue(uint64 slotIndex, Value const& value, bool nomination)
     {
         return kMaybeValidValue;
     }

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -68,7 +68,8 @@ class TestSCP : public SCPDriver
     }
 
     SCPDriver::ValidationLevel
-    validateValue(uint64 slotIndex, Value const& value) override
+    validateValue(uint64 slotIndex, Value const& value,
+                  bool nomination) override
     {
         return SCPDriver::kFullyValidatedValue;
     }

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -394,13 +394,13 @@ newLoadTestApp(VirtualClock& clock)
 #endif
                       getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE);
     cfg.RUN_STANDALONE = false;
-    cfg.DESIRED_MAX_TX_PER_LEDGER = 10000;
+    cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER = 10000;
     Application::pointer appPtr = Application::create(clock, cfg);
     appPtr->start();
     // force maxTxSetSize to avoid throwing txSets on the floor during the first
     // ledger close
     appPtr->getLedgerManager().getCurrentLedgerHeader().maxTxSetSize =
-        cfg.DESIRED_MAX_TX_PER_LEDGER;
+        cfg.TESTING_UPGRADE_MAX_TX_PER_LEDGER;
     return appPtr;
 }
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -919,7 +919,7 @@ LoadGenerator::TxInfo::execute(Application& app)
             return false;
         }
     }
-    recordExecution(app.getConfig().DESIRED_BASE_FEE);
+    recordExecution(app.getConfig().TESTING_UPGRADE_DESIRED_FEE);
     return true;
 }
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -188,20 +188,20 @@ test(int argc, char* const* argv, el::Level ll,
 }
 
 void
-for_versions_to(int to, Application& app, std::function<void(void)> const& f)
+for_versions_to(uint32 to, Application& app, std::function<void(void)> const& f)
 {
     for_versions(1, to, app, f);
 }
 
 void
-for_versions_from(int from, Application& app,
+for_versions_from(uint32 from, Application& app,
                   std::function<void(void)> const& f)
 {
     for_versions(from, Config::CURRENT_LEDGER_PROTOCOL_VERSION, app, f);
 }
 
 void
-for_versions_from(std::vector<int> const& versions, Application& app,
+for_versions_from(std::vector<uint32> const& versions, Application& app,
                   std::function<void(void)> const& f)
 {
     for_versions(versions, app, f);
@@ -215,14 +215,14 @@ for_all_versions(Application& app, std::function<void(void)> const& f)
 }
 
 void
-for_versions(int from, int to, Application& app,
+for_versions(uint32 from, uint32 to, Application& app,
              std::function<void(void)> const& f)
 {
     if (from > to)
     {
         return;
     }
-    auto versions = std::vector<int>{};
+    auto versions = std::vector<uint32>{};
     versions.resize(to - from + 1);
     std::iota(std::begin(versions), std::end(versions), from);
 
@@ -230,7 +230,7 @@ for_versions(int from, int to, Application& app,
 }
 
 void
-for_versions(std::vector<int> const& versions, Application& app,
+for_versions(std::vector<uint32> const& versions, Application& app,
              std::function<void(void)> const& f)
 {
     auto previousVersion = app.getLedgerManager().getCurrentLedgerVersion();
@@ -250,11 +250,11 @@ for_versions(std::vector<int> const& versions, Application& app,
 }
 
 void
-for_all_versions_except(std::vector<int> const& versions, Application& app,
+for_all_versions_except(std::vector<uint32> const& versions, Application& app,
                         std::function<void(void)> const& f)
 {
-    int lastExcept = 0;
-    for (int except : versions)
+    uint32 lastExcept = 0;
+    for (uint32 except : versions)
     {
         for_versions(lastExcept + 1, except - 1, app, f);
         lastExcept = except;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -89,6 +89,9 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
 
         thisConfig.ALLOW_LOCALHOST_FOR_TESTING = true;
 
+        // this forces to pick up any other potential upgrades
+        thisConfig.TESTING_UPGRADE_DATETIME = VirtualClock::from_time_t(1);
+
         // Tests are run in standalone by default, meaning that no external
         // listening interfaces are opened (all sockets must be manually created
         // and connected loopback sockets), no external connections are

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -21,23 +21,24 @@ int test(int argc, char* const* argv, el::Level logLevel,
 
 extern bool force_sqlite;
 
-void for_versions_to(int to, Application& app,
+void for_versions_to(uint32 to, Application& app,
                      std::function<void(void)> const& f);
 
-void for_versions_from(int from, Application& app,
+void for_versions_from(uint32 from, Application& app,
                        std::function<void(void)> const& f);
 
-void for_versions_from(std::vector<int> const& versions, Application& app,
+void for_versions_from(std::vector<uint32> const& versions, Application& app,
                        std::function<void(void)> const& f);
 
 void for_all_versions(Application& app, std::function<void(void)> const& f);
 
-void for_versions(int from, int to, Application& app,
+void for_versions(uint32 from, uint32 to, Application& app,
                   std::function<void(void)> const& f);
 
-void for_versions(std::vector<int> const& versions, Application& app,
+void for_versions(std::vector<uint32> const& versions, Application& app,
                   std::function<void(void)> const& f);
 
-void for_all_versions_except(std::vector<int> const& versions, Application& app,
+void for_all_versions_except(std::vector<uint32> const& versions,
+                             Application& app,
                              std::function<void(void)> const& f);
 }

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -1723,7 +1723,7 @@ TEST_CASE("payment fees", "[tx][payment]")
     SECTION("fee equal to base reserve")
     {
         auto cfg = getTestConfig(1);
-        cfg.DESIRED_BASE_FEE = 100000000;
+        cfg.TESTING_UPGRADE_DESIRED_FEE = 100000000;
 
         VirtualClock clock;
         auto app = createTestApplication(clock, cfg);
@@ -1833,7 +1833,7 @@ TEST_CASE("payment fees", "[tx][payment]")
     SECTION("fee bigger than base reserve")
     {
         auto cfg = getTestConfig(1);
-        cfg.DESIRED_BASE_FEE = 200000000;
+        cfg.TESTING_UPGRADE_DESIRED_FEE = 200000000;
 
         VirtualClock clock;
         auto app = createTestApplication(clock, cfg);

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -7,6 +7,7 @@
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include <chrono>
+#include <cstdio>
 #include <thread>
 
 namespace stellar
@@ -126,6 +127,28 @@ VirtualClock::tmToPoint(tm t)
 {
     time_t tt = timegm(&t);
     return VirtualClock::time_point() + std::chrono::seconds(tt);
+}
+
+std::tm
+VirtualClock::isoStringToTm(std::string const& iso)
+{
+    std::tm res;
+    int y, M, d, h, m, s;
+    if (std::sscanf(iso.c_str(), "%d-%d-%dT%d:%d:%dZ", &y, &M, &d, &h, &m,
+                    &s) != 6)
+    {
+        throw std::invalid_argument("Could not parse iso date");
+    }
+    res.tm_year = y - 1900;
+    res.tm_mon = M - 1;
+    res.tm_mday = d;
+    res.tm_hour = h;
+    res.tm_min = m;
+    res.tm_sec = s;
+    res.tm_isdst = 0;
+    res.tm_wday = 0;
+    res.tm_yday = 0;
+    return res;
 }
 
 std::string

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -92,6 +92,7 @@ class VirtualClock
     static std::tm pointToTm(time_point);
     static VirtualClock::time_point tmToPoint(tm t);
 
+    static std::tm isoStringToTm(std::string const& iso);
     static std::string tmToISOString(std::tm const& tm);
     static std::string pointToISOString(time_point point);
 

--- a/src/util/optional.h
+++ b/src/util/optional.h
@@ -4,6 +4,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "cereal/cereal.hpp"
+#include <memory>
+
 namespace stellar
 {
 template <typename T> using optional = std::shared_ptr<T>;
@@ -22,3 +25,32 @@ nullopt()
     return std::shared_ptr<T>();
 };
 }
+
+namespace cereal
+{
+template <class Archive, class T>
+void
+save(Archive& ar, stellar::optional<T> const& opt)
+{
+    ar(make_nvp("has", !!opt));
+    if (opt)
+    {
+        ar(make_nvp("val", *opt));
+    }
+}
+
+template <class Archive, class T>
+void
+load(Archive& ar, stellar::optional<T>& o)
+{
+    bool isSet;
+    o.reset();
+    ar(make_nvp("has", isSet));
+    if (isSet)
+    {
+        T v;
+        ar(make_nvp("val", v));
+        o = stellar::make_optional<T>(v);
+    }
+}
+} // namespace cereal


### PR DESCRIPTION
resolves #1453 

This PR changes the way network settings are done:
1. It replaces the config driven upgrade mechanism by a "single shot" mechanism that gets cleared when the desired upgrade is seen from SCP
2. requires node operators to specify that they want an upgrade (as opposed to guessing based on config values). This makes voting for upgrades by accident much less likely.
3. changes how upgrades are validated by allowing nodes to accept the upgrades if a v-blocking set voted for it during the ballot protocol phase yet not voting for those during nomination
