### PR TITLE
Improve lockFile error output

### DIFF
--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -110,12 +110,11 @@ BucketManagerImpl::getBucketDir()
 
         std::string lock = d + "/" + kLockFilename;
 
-        if (!fs::lockFile(lock))
-        {
-            std::string msg("Found existing lockfile '" + lock +
-                            "' that is already locked.");
-            throw std::runtime_error(msg);
-        }
+        // there are many reasons the lock can fail so let lockFile throw
+        // directly for more clear error messages since we end up just raising
+        // a runtime exception anyway
+        fs::lockFile(lock);
+
         mLockedBucketDir = make_unique<std::string>(d);
     }
     return *(mLockedBucketDir);

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -23,8 +23,8 @@ bool processExists(long pid);
 // Utility functions for operating on the filesystem.
 ////
 
-// returns true if the lock could be aquired
-bool lockFile(std::string const& path);
+// raises an exception if a lock file cannot be created
+void lockFile(std::string const& path);
 // unlocks a file locked with `lockFile`
 void unlockFile(std::string const& path);
 


### PR DESCRIPTION
Any failure in lockFile would simply log that the lock file was already locked, which is not true in some cases (i.e. permission denied or other open/flock failure cases).  This changes lockFile to not return a bool, and instead throw with a more descriptive message for the error.  Since this function would already throw sometimes (checked case for already locked internally, the insert could throw) it seemed sensible to standardize on that model.

**Example output for the permission denied case**

**New**
2017-12-30T12:07:42.230 GBNLJ [default FATAL] Got an exception: unable to open lock file: /tmp/buckets/stellar-core.lock (Permission denied) [main.cpp:652]

**Old**
2017-12-30T12:15:52.907 GC2GL [default FATAL] Got an exception: Found existing lockfile '/tmp/buckets/stellar-core.lock' that is already locked. [main.cpp:652]

