### PR TITLE
buckets: do not keep keepDeadEntries in FutureBucket, instead pass it…

### DIFF
--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -321,6 +321,9 @@ class BucketList
     // should spill curr->snap and start merging snap into its next level.
     static bool levelShouldSpill(uint32_t ledger, uint32_t level);
 
+    // Returns true if at given `level` dead entries should be kept.
+    static bool keepDeadEntries(uint32_t level);
+
     // Create a new BucketList with every `kNumLevels` levels, each with
     // an empty bucket in `curr` and `snap`.
     BucketList();

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -28,7 +28,6 @@ FutureBucket::FutureBucket(Application& app,
     , mInputCurrBucket(curr)
     , mInputSnapBucket(snap)
     , mInputShadowBuckets(shadows)
-    , mKeepDeadEntries(keepDeadEntries)
 {
     // Constructed with a bunch of inputs, _immediately_ commence merging
     // them; there's no valid state for have-inputs-but-not-merging, the
@@ -41,7 +40,7 @@ FutureBucket::FutureBucket(Application& app,
     {
         mInputShadowBucketHashes.push_back(binToHex(b->getHash()));
     }
-    startMerge(app);
+    startMerge(app, keepDeadEntries);
 }
 
 void
@@ -250,7 +249,7 @@ FutureBucket::getOutputHash() const
 }
 
 void
-FutureBucket::startMerge(Application& app)
+FutureBucket::startMerge(Application& app, bool keepDeadEntries)
 {
     // NB: startMerge starts with FutureBucket in a half-valid state; the inputs
     // are live but the merge is not yet running. So you can't call checkState()
@@ -261,7 +260,6 @@ FutureBucket::startMerge(Application& app)
     std::shared_ptr<Bucket> curr = mInputCurrBucket;
     std::shared_ptr<Bucket> snap = mInputSnapBucket;
     std::vector<std::shared_ptr<Bucket>> shadows = mInputShadowBuckets;
-    bool keepDeadEntries = mKeepDeadEntries;
 
     assert(curr);
     assert(snap);
@@ -304,7 +302,7 @@ FutureBucket::startMerge(Application& app)
 }
 
 void
-FutureBucket::makeLive(Application& app)
+FutureBucket::makeLive(Application& app, bool keepDeadEntries)
 {
     checkState();
     assert(!isLive());
@@ -330,7 +328,7 @@ FutureBucket::makeLive(Application& app)
             mInputShadowBuckets.push_back(b);
         }
         mState = FB_LIVE_INPUTS;
-        startMerge(app);
+        startMerge(app, keepDeadEntries);
         assert(isLive());
     }
 }

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -70,11 +70,10 @@ class FutureBucket
     std::string mInputSnapBucketHash;
     std::vector<std::string> mInputShadowBucketHashes;
     std::string mOutputBucketHash;
-    bool mKeepDeadEntries;
 
     void checkHashesMatch() const;
     void checkState() const;
-    void startMerge(Application& app);
+    void startMerge(Application& app, bool keepDeadEntries);
 
     void clearInputs();
     void clearOutput();
@@ -118,7 +117,7 @@ class FutureBucket
     std::shared_ptr<Bucket> resolve();
 
     // Precondition: !isLive(); transitions from FB_HASH_FOO to FB_LIVE_FOO
-    void makeLive(Application& app);
+    void makeLive(Application& app, bool keepDeadEntries);
 
     // Return all hashes referenced by this future.
     std::vector<std::string> getHashes() const;

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -50,11 +50,12 @@ StateSnapshot::StateSnapshot(Application& app, HistoryArchiveState const& state)
 void
 StateSnapshot::makeLive()
 {
-    for (auto& hb : mLocalState.currentBuckets)
+    for (auto i = 0; i < mLocalState.currentBuckets.size(); i++)
     {
+        auto& hb = mLocalState.currentBuckets[i];
         if (hb.next.hasHashes() && !hb.next.isLive())
         {
-            hb.next.makeLive(mApp);
+            hb.next.makeLive(mApp, BucketList::keepDeadEntries(i));
         }
     }
 }


### PR DESCRIPTION
… in makeLive

This fixes issue where bucket would store dead entries because if was
merged after deserialization.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>