### PR TITLE
Improved logging of SCP messages and invariants

### DIFF
--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -157,6 +157,7 @@ InvariantManagerImpl::enableInvariant(std::string const& name)
     if (iter == mEnabled.end())
     {
         mEnabled.push_back(registryIter->second);
+        CLOG(INFO, "Invariant") << "Enabled invariant '" << name << "'";
     }
     else
     {

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -13,6 +13,7 @@
 #include "util/make_unique.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
+#include <ctime>
 #include <functional>
 
 namespace stellar
@@ -100,7 +101,8 @@ Slot::getExternalizingState() const
 void
 Slot::recordStatement(SCPStatement const& st)
 {
-    mStatementsHistory.emplace_back(HistoricalStatement{st, mFullyValidated});
+    mStatementsHistory.emplace_back(
+        HistoricalStatement{std::time(nullptr), st, mFullyValidated});
 }
 
 SCP::EnvelopeState
@@ -305,6 +307,7 @@ Slot::dumpInfo(Json::Value& ret)
     for (auto const& item : mStatementsHistory)
     {
         Json::Value& v = slotValue["statements"][count++];
+        v.append((Json::UInt64)item.mWhen);
         v.append(mSCP.envToStr(item.mStatement));
         v.append(item.mValidated);
 

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -100,7 +100,7 @@ Slot::getExternalizingState() const
 void
 Slot::recordStatement(SCPStatement const& st)
 {
-    mStatementsHistory.emplace_back(std::make_pair(st, mFullyValidated));
+    mStatementsHistory.emplace_back(HistoricalStatement{st, mFullyValidated});
 }
 
 SCP::EnvelopeState
@@ -190,8 +190,8 @@ Slot::isNodeInQuorum(NodeID const& node)
     // statements for each protocol
     for (auto const& e : mStatementsHistory)
     {
-        auto& n = m[e.first.nodeID];
-        n.emplace_back(&e.first);
+        auto& n = m[e.mStatement.nodeID];
+        n.emplace_back(&e.mStatement);
     }
     return mSCP.getLocalNode()->isNodeInQuorum(
         node,
@@ -305,11 +305,11 @@ Slot::dumpInfo(Json::Value& ret)
     for (auto const& item : mStatementsHistory)
     {
         Json::Value& v = slotValue["statements"][count++];
-        v.append(mSCP.envToStr(item.first));
-        v.append(item.second);
+        v.append(mSCP.envToStr(item.mStatement));
+        v.append(item.mValidated);
 
         Hash const& qSetHash =
-            getCompanionQuorumSetHashFromStatement(item.first);
+            getCompanionQuorumSetHashFromStatement(item.mStatement);
         auto qSet = getSCPDriver().getQSet(qSetHash);
         if (qSet)
         {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -35,6 +35,7 @@ class Slot : public std::enable_shared_from_this<Slot>
     // it is used for debugging purpose
     struct HistoricalStatement
     {
+        time_t mWhen;
         SCPStatement mStatement;
         bool mValidated;
     };

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -33,8 +33,13 @@ class Slot : public std::enable_shared_from_this<Slot>
 
     // keeps track of all statements seen so far for this slot.
     // it is used for debugging purpose
-    // second: if the slot was fully validated at the time
-    std::vector<std::pair<SCPStatement, bool>> mStatementsHistory;
+    struct HistoricalStatement
+    {
+        SCPStatement mStatement;
+        bool mValidated;
+    };
+
+    std::vector<HistoricalStatement> mStatementsHistory;
 
     // true if the Slot was fully validated
     bool mFullyValidated;


### PR DESCRIPTION
This PR makes it easier to debug timing of various SCP messages as perceived by the local node.
It also adds log entries on startup of which invariants are enabled