### PR TITLE
Add support for a getcursor command

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -409,6 +409,7 @@ exit /b 0
     <ClCompile Include="..\..\src\main\NtpSynchronizationChecker.cpp" />
     <ClCompile Include="..\..\src\main\PersistentState.cpp" />
     <ClCompile Include="..\..\src\main\ExternalQueue.cpp" />
+    <ClCompile Include="..\..\src\main\ExternalQueueTests.cpp" />
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp" />
     <ClCompile Include="..\..\src\overlay\FloodTests.cpp" />
     <ClCompile Include="..\..\src\overlay\ItemFetcherTests.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -630,6 +630,9 @@
     <ClCompile Include="..\..\src\main\ConfigTests.cpp">
       <Filter>main\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\ExternalQueueTests.cpp">
+      <Filter>main\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\catchup\ApplyBucketsWork.cpp">
       <Filter>catchup</Filter>
     </ClCompile>

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -125,6 +125,10 @@ debugging purpose).
   The actual deletion is performed by invoking the `maintenance` endpoint or on startup.
   See also `dropcursor`.
 
+* **getcursor**
+ `/getcursor?[id=ID]`<br>
+ gets the cursor identified by `ID`. If ID is not defined then all cursors will be returned.
+
 * **scp**
   `/scp?[limit=n]
   Returns a JSON object with the internal state of the SCP engine for the last n (default 2) ledgers.

--- a/docs/stellar-core.1.in
+++ b/docs/stellar-core.1.in
@@ -209,6 +209,10 @@ The actual deletion is performed by invoking the \f[C]maintenance\f[]
 endpoint or on startup.
 See also \f[C]dropcursor\f[].
 .IP \[bu] 2
+\f[B]getcursor\f[] \f[C]/getcursor?[id=ID]\f[] gets the cursor
+identified by \f[C]ID\f[]. If ID is not defined then all cursors will 
+be returned.
+.IP \[bu] 2
 \f[B]scp\f[] `/scp?[limit=n] Returns a JSON object with the internal
 state of the SCP engine for the last n (default 2) ledgers.
 .IP \[bu] 2

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -51,6 +51,7 @@ class CommandHandler
     void peers(std::string const& params, std::string& retStr);
     void quorum(std::string const& params, std::string& retStr);
     void setcursor(std::string const& params, std::string& retStr);
+    void getcursor(std::string const& params, std::string& retStr);
     void scpInfo(std::string const& params, std::string& retStr);
     void tx(std::string const& params, std::string& retStr);
     void testAcc(std::string const& params, std::string& retStr);

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -81,6 +81,46 @@ ExternalQueue::setCursorForResource(std::string const& resid, uint32 cursor)
 }
 
 void
+ExternalQueue::getCursorForResource(std::string const& resid,
+                                    std::map<std::string, uint32>& curMap)
+{
+    // no resid set, get all cursors
+    if (resid.empty())
+    {
+        std::string n;
+        uint32_t v;
+
+        auto& db = mApp.getDatabase();
+        auto prep =
+            db.getPreparedStatement("SELECT resid, lastread FROM pubsub;");
+        auto& st = prep.statement();
+        st.exchange(soci::into(n));
+        st.exchange(soci::into(v));
+        st.define_and_bind();
+        {
+            auto timer = db.getSelectTimer("pubsub");
+            st.execute(true);
+        }
+
+        while (st.got_data())
+        {
+            curMap[n] = v;
+            st.fetch();
+        }
+    }
+    else
+    {
+        // if resid is set attempt to look up the cursor
+        // and add it to the map if anything is found
+        std::string cursor = getCursor(resid);
+        if (!cursor.empty())
+        {
+            curMap[resid] = strtoul(cursor.c_str(), NULL, 0);
+        }
+    }
+}
+
+void
 ExternalQueue::deleteCursor(std::string const& resid)
 {
     checkID(resid);

--- a/src/main/ExternalQueue.h
+++ b/src/main/ExternalQueue.h
@@ -23,6 +23,9 @@ class ExternalQueue
 
     // sets the cursor of a given resource
     void setCursorForResource(std::string const& resid, uint32 cursor);
+    // gets the cursor of a given resource, gets all cursors of resid is empty
+    void getCursorForResource(std::string const& resid,
+                              std::map<std::string, uint32>& curMap);
     // deletes the subscription for the resource
     void deleteCursor(std::string const& resid);
 

--- a/src/main/ExternalQueueTests.cpp
+++ b/src/main/ExternalQueueTests.cpp
@@ -1,0 +1,45 @@
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+#include "main/CommandHandler.h"
+#include "main/Config.h"
+#include "main/ExternalQueue.h"
+#include "simulation/Simulation.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+
+using namespace stellar;
+
+TEST_CASE("cursors", "[externalqueue]")
+{
+    VirtualClock clock;
+    Config const& cfg = getTestConfig();
+    Application::pointer app = createTestApplication(clock, cfg);
+
+    app->start();
+
+    ExternalQueue ps(*app);
+    std::map<std::string, uint32> curMap;
+    app->getCommandHandler().manualCmd("setcursor?id=FOO&cursor=123");
+    app->getCommandHandler().manualCmd("setcursor?id=BAR&cursor=456");
+
+    SECTION("get non-existent cursor")
+    {
+        ps.getCursorForResource("NONEXISTENT", curMap);
+        REQUIRE(curMap.size() == 0);
+    }
+
+    SECTION("get single cursor")
+    {
+        ps.getCursorForResource("FOO", curMap);
+        REQUIRE(curMap.size() == 1);
+    }
+
+    SECTION("get all cursors")
+    {
+        ps.getCursorForResource("", curMap);
+        REQUIRE(curMap.size() == 2);
+    }
+}


### PR DESCRIPTION
Add support for a getcursor command so cursor state can be checked without hitting the backend directly.

Examples:
**get all cursors**
$ ./stellar-core --c 'getcursor'
Content-Length: 220
Content-Type: application/json

```
2018-01-21T10:39:08.452 GDZH6 [default INFO] {
   "cursors" : [
      {
         "cursor" : 456,
         "id" : "BAR"
      },
      {
         "cursor" : 123,
         "id" : "FOO"
      },
      {
         "cursor" : 12345,
         "id" : "FOO2"
      }
   ]
}
```

**get a single cursor**
$ ./stellar-core --c 'getcursor?id=FOO'
Content-Length: 89
Content-Type: application/json

```
2018-01-21T10:41:05.701 GBDT6 [default INFO] {
   "cursors" : [
      {
         "cursor" : 123,
         "id" : "FOO"
      }
   ]
}
```

**attempt to get a non-existent cursor**
$ ./stellar-core --c 'getcursor?id=FOOBAR'
Content-Length: 28
Content-Type: application/json

```
2018-01-21T10:41:30.177 GDJHV [default INFO] {
   "cursors" : [ null ]
}
```
