### PR TITLE
fix typo in admin.m

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -280,8 +280,8 @@ The quorum here is the set of players that end up with the winning hat color.
 
 A traditional quorum has people see everybody else (placed on a circle, at
 the right distance).
-Here, each player can decide to look wherever they want. Even to look at only one
-other player, which is a risk if this other player decides to quit the game.
+Here each player can decide to look wherever they want, even if they can only see one other player (or nobody). This is risky if that player quits the game or is not following the rules.
+
 
 ## Quorum set
 

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -280,7 +280,7 @@ The quorum here is the set of players that end up with the winning hat color.
 
 A traditional quorum has people see everybody else (placed on a circle, at
 the right distance).
-Here, each player can decide to look wherever they want. Even look at only one
+Here, each player can decide to look wherever they want. Even to look at only one
 other player, which is a risk if this other player decides to quit the game.
 
 ## Quorum set


### PR DESCRIPTION
The word "to" is missing from the sentence. I had included a suggested replacement for the whole paragraph below.

It would be better to change the two sentences from:
Here, each player can decide to look wherever they want. Even look at only one
other player, which is a risk if this other player decides to quit the game.

To:
Here each player can decide to look wherever they want, even if they can only see one other player (or nobody). This is risky if that player quits the game or is not following the rules.