### PR TITLE
Update sequence number processing

### DIFF
--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -50,47 +50,89 @@ TEST_CASE("standalone", "[herder]")
     auto a1 = TestAccount{*app, getAccount("A")};
     auto b1 = TestAccount{*app, getAccount("B")};
 
-    const int64_t paymentAmount = app->getLedgerManager().getMinBalance(0);
+    auto txfee = app->getLedgerManager().getTxFee();
+    const int64_t minBalance = app->getLedgerManager().getMinBalance(0);
+    const int64_t paymentAmount = 100;
+    const int64_t startingBalance = minBalance + (paymentAmount + txfee) * 3;
 
     SECTION("basic ledger close on valid txs")
     {
-        bool stop = false;
         VirtualTimer setupTimer(*app);
-        VirtualTimer checkTimer(*app);
 
-        auto check = [&](asio::error_code const& error) {
-            stop = true;
+        auto feedTx = [&](TransactionFramePtr& tx) {
+            REQUIRE(app->getHerder().recvTransaction(tx) ==
+                    Herder::TX_STATUS_PENDING);
+        };
 
-            REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() > 2);
+        auto waitForExternalize = [&]() {
+            VirtualTimer checkTimer(*app);
+            bool stop = false;
+            auto prev = app->getLedgerManager().getLastClosedLedgerNum();
 
-            AccountFrame::pointer a1Account, b1Account;
-            a1Account = loadAccount(a1.getPublicKey(), *app);
-            b1Account = loadAccount(b1.getPublicKey(), *app);
-            REQUIRE(a1Account->getBalance() == paymentAmount);
-            REQUIRE(b1Account->getBalance() == paymentAmount);
+            auto check = [&](asio::error_code const& error) {
+                REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() >
+                        prev);
+                stop = true;
+            };
+
+            checkTimer.expires_from_now(Herder::EXP_LEDGER_TIMESPAN_SECONDS +
+                                        std::chrono::seconds(1));
+            checkTimer.async_wait(check);
+            while (!stop)
+            {
+                app->getClock().crank(true);
+            }
         };
 
         auto setup = [&](asio::error_code const& error) {
             // create accounts
-            auto txFrameA1 = root.tx({createAccount(a1, paymentAmount)});
-            auto txFrameA2 = root.tx({createAccount(b1, paymentAmount)});
+            auto txFrameA1 = root.tx({createAccount(a1, startingBalance)});
+            auto txFrameA2 = root.tx({createAccount(b1, startingBalance)});
 
-            REQUIRE(app->getHerder().recvTransaction(txFrameA1) ==
-                    Herder::TX_STATUS_PENDING);
-            REQUIRE(app->getHerder().recvTransaction(txFrameA2) ==
-                    Herder::TX_STATUS_PENDING);
+            feedTx(txFrameA1);
+            feedTx(txFrameA2);
         };
 
         setupTimer.expires_from_now(std::chrono::seconds(0));
         setupTimer.async_wait(setup);
 
-        checkTimer.expires_from_now(Herder::EXP_LEDGER_TIMESPAN_SECONDS +
-                                    std::chrono::seconds(1));
-        checkTimer.async_wait(check);
+        waitForExternalize();
+        auto a1OldSeqNum = a1.getLastSequenceNumber();
 
-        while (!stop)
+        REQUIRE(a1.getBalance() == startingBalance);
+        REQUIRE(b1.getBalance() == startingBalance);
+
+        SECTION("txset with valid txs - but failing later")
         {
-            app->getClock().crank(true);
+            std::vector<TransactionFramePtr> txAs, txBs;
+            txAs.emplace_back(a1.tx({payment(root, paymentAmount)}));
+            txAs.emplace_back(a1.tx({payment(root, paymentAmount)}));
+            txAs.emplace_back(a1.tx({payment(root, paymentAmount)}));
+
+            txBs.emplace_back(b1.tx({payment(root, paymentAmount)}));
+            txBs.emplace_back(b1.tx({accountMerge(root)}));
+            txBs.emplace_back(b1.tx({payment(a1, paymentAmount)}));
+
+            for_all_versions(*app, [&]() {
+                for (auto a : txAs)
+                {
+                    feedTx(a);
+                }
+                for (auto b : txBs)
+                {
+                    feedTx(b);
+                }
+
+                waitForExternalize();
+
+                // all of a1's transactions went through
+                // b1's last transaction failed due to account non existant
+                int64 expectedBalance =
+                    startingBalance - 3 * paymentAmount - 3 * txfee;
+                REQUIRE(a1.getBalance() == expectedBalance);
+                REQUIRE(a1.getLastSequenceNumber() == a1OldSeqNum + 3);
+                REQUIRE(!b1.exists());
+            });
         }
 
         SECTION("Queue processing test")

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -917,7 +917,7 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
     {
         auto txTime = mTransactionApply.TimeScope();
         LedgerDelta delta(ledgerDelta);
-        TransactionMeta tm;
+        TransactionMeta tm(1);
         try
         {
             CLOG(DEBUG, "Tx")
@@ -925,7 +925,7 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
                 << " txseq=" << tx->getSeqNum() << " (@ "
                 << mApp.getConfig().toShortString(tx->getSourceID()) << ")";
 
-            if (tx->apply(delta, tm, mApp))
+            if (tx->apply(delta, tm.v1(), mApp))
             {
                 delta.commit();
             }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -916,7 +916,6 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
     for (auto tx : txs)
     {
         auto txTime = mTransactionApply.TimeScope();
-        LedgerDelta delta(ledgerDelta);
         TransactionMeta tm(1);
         try
         {
@@ -924,17 +923,7 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
                 << " tx#" << index << " = " << hexAbbrev(tx->getFullHash())
                 << " txseq=" << tx->getSeqNum() << " (@ "
                 << mApp.getConfig().toShortString(tx->getSourceID()) << ")";
-
-            if (tx->apply(delta, tm.v1(), mApp))
-            {
-                delta.commit();
-            }
-            else
-            {
-                // failure means there should be no side effects
-                assert(delta.getChanges().size() == 0);
-                assert(delta.getHeader() == ledgerDelta.getHeader());
-            }
+            tx->apply(ledgerDelta, tm.v1(), mApp);
         }
         catch (InvariantDoesNotHold& e)
         {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -20,7 +20,7 @@ namespace stellar
 {
 using xdr::operator<;
 
-const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 9;
+const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 10;
 
 Config::Config() : NODE_SEED(SecretKey::random())
 {

--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -228,7 +228,8 @@ TestAccount::pay(PublicKey const& destination, int64_t amount)
         auto toAccountAfter = loadAccount(destination, mApp, false);
         // check that the target account didn't change
         REQUIRE(!!toAccount == !!toAccountAfter);
-        if (toAccount && toAccountAfter)
+        if (toAccount && toAccountAfter &&
+            !(fromAccount->getID() == toAccount->getID()))
         {
             REQUIRE(toAccount->getAccount() == toAccountAfter->getAccount());
         }

--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -36,6 +36,12 @@ TestAccount::getBalance() const
     return loadAccount(getPublicKey(), mApp)->getBalance();
 }
 
+bool
+TestAccount::exists() const
+{
+    return loadAccount(getPublicKey(), mApp, false) != nullptr;
+}
+
 TransactionFramePtr
 TestAccount::tx(std::vector<Operation> const& ops, SequenceNumber sn)
 {

--- a/src/test/TestAccount.h
+++ b/src/test/TestAccount.h
@@ -117,6 +117,8 @@ class TestAccount
 
     int64_t getBalance() const;
 
+    bool exists() const;
+
   private:
     Application& mApp;
     SecretKey mSk;

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -34,7 +34,8 @@ struct ThresholdSetter
     optional<int> highThreshold;
 };
 
-bool applyCheck(TransactionFramePtr tx, Application& app);
+bool applyCheck(TransactionFramePtr tx, Application& app,
+                bool checkSequm = true);
 void applyTx(TransactionFramePtr const& tx, Application& app);
 
 TxSetResultMeta closeLedgerOn(Application& app, uint32 ledgerSeq, int day,

--- a/src/transactions/MergeTests.cpp
+++ b/src/transactions/MergeTests.cpp
@@ -115,7 +115,8 @@ TEST_CASE("merge", "[tx][merge]")
         txFrame->addSignature(b1.getSecretKey());
 
         for_all_versions(*app, [&] {
-            applyCheck(txFrame, *app);
+            // a1 gets re-created so we disable sequence number checks
+            applyCheck(txFrame, *app, false);
 
             auto mergeResult = txFrame->getResult()
                                    .result.results()[2]

--- a/src/transactions/PaymentTests.cpp
+++ b/src/transactions/PaymentTests.cpp
@@ -526,7 +526,9 @@ TEST_CASE("payment", "[tx][payment]")
         });
 
         for_versions_from(8, *app, [&] {
-            REQUIRE(applyCheck(tx, *app));
+            // as the account gets re-created we have to disable seqnum
+            // verification
+            REQUIRE(applyCheck(tx, *app, false));
             REQUIRE(loadAccount(sourceAccount, *app));
             REQUIRE(loadAccount(payAndMergeDestination, *app));
             REQUIRE(sourceAccount.getBalance() == createAmount);
@@ -647,7 +649,9 @@ TEST_CASE("payment", "[tx][payment]")
         });
 
         for_versions_from(8, *app, [&] {
-            REQUIRE(applyCheck(tx, *app));
+            // as the account gets re-created we have to disable seqnum
+            // verification
+            REQUIRE(applyCheck(tx, *app, false));
             REQUIRE(loadAccount(sourceAccount, *app));
             REQUIRE(loadAccount(payAndMergeDestination, *app));
             REQUIRE(sourceAccount.getBalance() == createAmount - pay2Amount);
@@ -774,7 +778,9 @@ TEST_CASE("payment", "[tx][payment]")
         });
 
         for_versions_from(8, *app, [&] {
-            REQUIRE(applyCheck(tx, *app));
+            // as the account gets re-created we have to disable seqnum
+            // verification
+            REQUIRE(applyCheck(tx, *app, false));
             REQUIRE(loadAccount(sourceAccount, *app));
             REQUIRE(loadAccount(secondSourceAccount, *app));
             REQUIRE(loadAccount(payAndMergeDestination, *app));

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -209,11 +209,10 @@ TransactionFrame::resetResults()
 }
 
 bool
-TransactionFrame::commonValid(SignatureChecker& signatureChecker,
-                              Application& app, LedgerDelta* delta,
-                              SequenceNumber current)
+TransactionFrame::commonValidPreSeqNum(Application& app, LedgerDelta* delta)
 {
-    bool applying = (delta != nullptr);
+    // this function does validations that are independent of the account state
+    //    (stay true regardless of other side effects)
 
     if (mOperations.size() == 0)
     {
@@ -269,23 +268,54 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
         return false;
     }
 
-    // when applying, the account's sequence number is updated when taking fees
-    if (!applying)
+    return true;
+}
+
+void
+TransactionFrame::processSeqNum(LedgerManager& lm, LedgerDelta& delta)
+{
+    if (lm.getCurrentLedgerVersion() >= 10)
+    {
+        mSigningAccount->setSeqNum(mEnvelope.tx.seqNum);
+        mSigningAccount->storeChange(delta, lm.getDatabase());
+    }
+}
+
+TransactionFrame::ValidationType
+TransactionFrame::commonValid(SignatureChecker& signatureChecker,
+                              Application& app, LedgerDelta* delta,
+                              SequenceNumber current)
+{
+    ValidationType res = ValidationType::kInvalid;
+
+    bool applying = (delta != nullptr);
+
+    if (!commonValidPreSeqNum(app, delta))
+    {
+        return res;
+    }
+
+    auto& lm = app.getLedgerManager();
+
+    // in older versions, the account's sequence number is updated when taking
+    // fees
+    if (lm.getCurrentLedgerVersion() >= 10 || !applying)
     {
         if (current == 0)
         {
             current = mSigningAccount->getSeqNum();
         }
-
         if (current + 1 != mEnvelope.tx.seqNum)
         {
             app.getMetrics()
                 .NewMeter({"transaction", "invalid", "bad-seq"}, "transaction")
                 .Mark();
             getResult().result.code(txBAD_SEQ);
-            return false;
+            return res;
         }
     }
+
+    res = ValidationType::kInvalidUpdateSeqNum;
 
     if (!checkSignature(signatureChecker, *mSigningAccount,
                         mSigningAccount->getLowThreshold()))
@@ -294,30 +324,29 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
             .NewMeter({"transaction", "invalid", "bad-auth"}, "transaction")
             .Mark();
         getResult().result.code(txBAD_AUTH);
-        return false;
+        return res;
     }
 
     // if we are in applying mode fee was already deduced from signing account
     // balance, if not, we need to check if after that deduction this account
     // will still have minimum balance
     auto balanceAfter =
-        (applying && (app.getLedgerManager().getCurrentLedgerVersion() > 8))
+        (applying && (lm.getCurrentLedgerVersion() > 8))
             ? mSigningAccount->getAccount().balance
             : mSigningAccount->getAccount().balance - mEnvelope.tx.fee;
 
     // don't let the account go below the reserve
-    if (balanceAfter <
-        mSigningAccount->getMinimumBalance(app.getLedgerManager()))
+    if (balanceAfter < mSigningAccount->getMinimumBalance(lm))
     {
         app.getMetrics()
             .NewMeter({"transaction", "invalid", "insufficient-balance"},
                       "transaction")
             .Mark();
         getResult().result.code(txINSUFFICIENT_BALANCE);
-        return false;
+        return res;
     }
 
-    return true;
+    return ValidationType::kFullyValid;
 }
 
 void
@@ -342,13 +371,17 @@ TransactionFrame::processFeeSeqNum(LedgerDelta& delta,
         mSigningAccount->addBalance(-fee);
         delta.getHeader().feePool += fee;
     }
-    if (mSigningAccount->getSeqNum() + 1 != mEnvelope.tx.seqNum)
+    // in v10 we update sequence numbers during apply
+    if (ledgerManager.getCurrentLedgerVersion() <= 9)
     {
-        // this should not happen as the transaction set is sanitized for
-        // sequence numbers
-        throw std::runtime_error("Unexpected account state");
+        if (mSigningAccount->getSeqNum() + 1 != mEnvelope.tx.seqNum)
+        {
+            // this should not happen as the transaction set is sanitized for
+            // sequence numbers
+            throw std::runtime_error("Unexpected account state");
+        }
+        mSigningAccount->setSeqNum(mEnvelope.tx.seqNum);
     }
-    mSigningAccount->setSeqNum(mEnvelope.tx.seqNum);
     mSigningAccount->storeChange(delta, db);
 }
 
@@ -423,7 +456,8 @@ TransactionFrame::checkValid(Application& app, SequenceNumber current)
     SignatureChecker signatureChecker{
         app.getLedgerManager().getCurrentLedgerVersion(), getContentsHash(),
         mEnvelope.signatures};
-    bool res = commonValid(signatureChecker, app, nullptr, current);
+    bool res = commonValid(signatureChecker, app, nullptr, current) ==
+               ValidationType::kFullyValid;
     if (res)
     {
         for (auto& op : mOperations)
@@ -485,25 +519,17 @@ TransactionFrame::apply(LedgerDelta& delta, Application& app)
 }
 
 bool
-TransactionFrame::apply(LedgerDelta& delta, TransactionMetaV1& meta,
-                        Application & app)
+TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
+                                  LedgerDelta& delta, TransactionMetaV1& meta,
+                                  Application& app)
 {
-    resetSigningAccount();
-    SignatureChecker signatureChecker{
-        app.getLedgerManager().getCurrentLedgerVersion(), getContentsHash(),
-        mEnvelope.signatures};
-    if (!commonValid(signatureChecker, app, &delta, 0))
-    {
-        return false;
-    }
-
     bool errorEncountered = false;
 
     {
         // shield outer scope of any side effects by using
         // a sql transaction for ledger state and LedgerDelta
         soci::transaction sqlTx(app.getDatabase().getSession());
-        LedgerDelta thisTxDelta(delta);
+        LedgerDelta thisTxOpsDelta(delta);
 
         auto& opTimer =
             app.getMetrics().NewTimer({"transaction", "op", "apply"});
@@ -511,7 +537,7 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMetaV1& meta,
         for (auto& op : mOperations)
         {
             auto time = opTimer.TimeScope();
-            LedgerDelta opDelta(thisTxDelta);
+            LedgerDelta opDelta(thisTxOpsDelta);
             bool txRes = op->apply(signatureChecker, opDelta, app);
 
             if (!txRes)
@@ -539,10 +565,10 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMetaV1& meta,
 
             // if an error occurred, it is responsibility of account's owner to
             // remove that signer
-            removeUsedOneTimeSignerKeys(signatureChecker, thisTxDelta,
+            removeUsedOneTimeSignerKeys(signatureChecker, thisTxOpsDelta,
                                         app.getLedgerManager());
             sqlTx.commit();
-            thisTxDelta.commit();
+            thisTxOpsDelta.commit();
         }
     }
 
@@ -553,6 +579,33 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMetaV1& meta,
     }
 
     return !errorEncountered;
+}
+
+bool
+TransactionFrame::apply(LedgerDelta& delta, TransactionMetaV1& meta,
+                        Application& app)
+{
+    resetSigningAccount();
+    SignatureChecker signatureChecker{
+        app.getLedgerManager().getCurrentLedgerVersion(), getContentsHash(),
+        mEnvelope.signatures};
+
+    bool valid;
+    {
+        LedgerDelta txDelta(delta);
+        // when applying, a failure during tx validation means that
+        // we'll skip trying to apply operations but we'll still
+        // process the sequence number if needed
+        auto cv = commonValid(signatureChecker, app, &txDelta, 0);
+        if (cv >= ValidationType::kInvalidUpdateSeqNum)
+        {
+            processSeqNum(app.getLedgerManager(), txDelta);
+        }
+        meta.txChanges = txDelta.getChanges();
+        txDelta.commit();
+        valid = (cv == ValidationType::kFullyValid);
+    }
+    return valid && applyOperations(signatureChecker, delta, meta, app);
 }
 
 StellarMessage

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -480,13 +480,13 @@ TransactionFrame::markResultFailed()
 bool
 TransactionFrame::apply(LedgerDelta& delta, Application& app)
 {
-    TransactionMeta tm;
-    return apply(delta, tm, app);
+    TransactionMeta tm(1);
+    return apply(delta, tm.v1(), app);
 }
 
 bool
-TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& meta,
-                        Application& app)
+TransactionFrame::apply(LedgerDelta& delta, TransactionMetaV1& meta,
+                        Application & app)
 {
     resetSigningAccount();
     SignatureChecker signatureChecker{
@@ -523,7 +523,7 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& meta,
                 app.getInvariantManager().checkOnOperationApply(
                     op->getOperation(), op->getResult(), opDelta);
             }
-            meta.operations().emplace_back(opDelta.getChanges());
+            meta.operations.emplace_back(opDelta.getChanges());
             opDelta.commit();
         }
 
@@ -548,7 +548,7 @@ TransactionFrame::apply(LedgerDelta& delta, TransactionMeta& meta,
 
     if (errorEncountered)
     {
-        meta.operations().clear();
+        meta.operations.clear();
         markResultFailed();
     }
 

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -147,7 +147,7 @@ class TransactionFrame
 
     // apply this transaction to the current ledger
     // returns true if successfully applied
-    bool apply(LedgerDelta& delta, TransactionMeta& meta, Application& app);
+    bool apply(LedgerDelta& delta, TransactionMetaV1& meta, Application& app);
 
     // version without meta
     bool apply(LedgerDelta& delta, Application& app);

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -51,8 +51,19 @@ class TransactionFrame
 
     bool loadAccount(int ledgerProtocolVersion, LedgerDelta* delta,
                      Database& app);
-    bool commonValid(SignatureChecker& signatureChecker, Application& app,
-                     LedgerDelta* delta, SequenceNumber current);
+
+    enum ValidationType
+    {
+        kInvalid,             // transaction is not valid at all
+        kInvalidUpdateSeqNum, // transaction is invalid but its sequence number
+                              // should be updated
+        kFullyValid
+    };
+
+    bool commonValidPreSeqNum(Application& app, LedgerDelta* delta);
+    ValidationType commonValid(SignatureChecker& signatureChecker,
+                               Application& app, LedgerDelta* delta,
+                               SequenceNumber current);
 
     void resetSigningAccount();
     void resetResults();
@@ -67,6 +78,11 @@ class TransactionFrame
                              const SignerKey& signerKey,
                              LedgerManager& ledgerManager) const;
     void markResultFailed();
+
+    bool applyOperations(SignatureChecker& checker, LedgerDelta& delta,
+                         TransactionMetaV1& meta, Application& app);
+
+    void processSeqNum(LedgerManager& lm, LedgerDelta& delta);
 
   public:
     TransactionFrame(Hash const& networkID,

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -982,33 +982,42 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                     clock.setCurrentTime(ledgerTime);
 
-                    txFrame =
-                        root.tx({payment(a1.getPublicKey(), paymentAmount)});
-                    txFrame->getEnvelope().tx.timeBounds.activate() =
-                        TimeBounds(start + 1000, start + 10000);
+                    SECTION("too early")
+                    {
+                        txFrame = root.tx(
+                            {payment(a1.getPublicKey(), paymentAmount)});
+                        txFrame->getEnvelope().tx.timeBounds.activate() =
+                            TimeBounds(start + 1000, start + 10000);
 
-                    closeLedgerOn(*app, 3, 1, 7, 2014);
-                    applyCheck(txFrame, *app);
+                        closeLedgerOn(*app, 3, 1, 7, 2014);
+                        applyCheck(txFrame, *app);
 
-                    REQUIRE(txFrame->getResultCode() == txTOO_EARLY);
+                        REQUIRE(txFrame->getResultCode() == txTOO_EARLY);
+                    }
 
-                    txFrame =
-                        root.tx({payment(a1.getPublicKey(), paymentAmount)});
-                    txFrame->getEnvelope().tx.timeBounds.activate() =
-                        TimeBounds(1000, start + 300000);
+                    SECTION("on time")
+                    {
+                        txFrame = root.tx(
+                            {payment(a1.getPublicKey(), paymentAmount)});
+                        txFrame->getEnvelope().tx.timeBounds.activate() =
+                            TimeBounds(1000, start + 300000);
 
-                    closeLedgerOn(*app, 4, 2, 7, 2014);
-                    applyCheck(txFrame, *app);
-                    REQUIRE(txFrame->getResultCode() == txSUCCESS);
+                        closeLedgerOn(*app, 3, 2, 7, 2014);
+                        applyCheck(txFrame, *app);
+                        REQUIRE(txFrame->getResultCode() == txSUCCESS);
+                    }
 
-                    txFrame =
-                        root.tx({payment(a1.getPublicKey(), paymentAmount)});
-                    txFrame->getEnvelope().tx.timeBounds.activate() =
-                        TimeBounds(1000, start);
+                    SECTION("too late")
+                    {
+                        txFrame = root.tx(
+                            {payment(a1.getPublicKey(), paymentAmount)});
+                        txFrame->getEnvelope().tx.timeBounds.activate() =
+                            TimeBounds(1000, start);
 
-                    closeLedgerOn(*app, 5, 3, 7, 2014);
-                    applyCheck(txFrame, *app);
-                    REQUIRE(txFrame->getResultCode() == txTOO_LATE);
+                        closeLedgerOn(*app, 3, 3, 7, 2014);
+                        applyCheck(txFrame, *app);
+                        REQUIRE(txFrame->getResultCode() == txTOO_LATE);
+                    }
                 });
             }
 

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -326,7 +326,6 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                                       ex_SET_OPTIONS_BAD_SIGNER);
                 });
 
-                testutil::setCurrentLedgerVersion(app->getLedgerManager(), 3);
                 SECTION("single signature")
                 {
                     SECTION("invalid seq nr")
@@ -676,8 +675,6 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
         SECTION("empty X")
         {
-            testutil::setCurrentLedgerVersion(app->getLedgerManager(), 3);
-
             SecretKey s1 = getAccount("S1");
             Signer sk1(KeyUtils::convertKey<SignerKey>(s1.getPublicKey()), 95);
 

--- a/src/transactions/readme.md
+++ b/src/transactions/readme.md
@@ -62,9 +62,12 @@ transaction; therefore this is really a best effort implementation specific.
 ## Applying a transaction
 
 When SCP externalizes the transaction set to apply to the last closed ledger:
-Source Accounts for transactions are charged a fee and their sequence number
-is updated. 
-Then, the transactions are applied one by one.
+1. the Source accounts for all transactions are charged a fee
+2. transactions are applied one by one, checking and updating the account's
+   sequence number.
+
+note that in earlier versions of the protocol (9 and below), the sequence
+ number was updated at the same time than when the fee was charged.
 
 To apply a transaction, it first checks for part __A__ of the validity check.
 

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -265,9 +265,19 @@ struct OperationMeta
     LedgerEntryChanges changes;
 };
 
+struct TransactionMetaV1
+{
+    LedgerEntryChanges txChanges; // tx level changes if any
+    OperationMeta operations<>; // meta for each operation
+};
+
+// this is the meta produced when applying transactions
+// it does not include pre-apply updates such as fees
 union TransactionMeta switch (int v)
 {
 case 0:
     OperationMeta operations<>;
+case 1:
+    TransactionMetaV1 v1;
 };
 }


### PR DESCRIPTION
resolves #1445 

this PR changes the way we update the sequence number in the account in preparation for the `BumpSeqOperation`:
* it moves sequence number processing from the pre-apply stage (where fees are processed) to the actual transaction apply time (protocol v10)
* it also changes the meta format for all versions. generating a "tx level side effect" meta. this field only gets updated starting at protocol 10, but I figured it was better to move to the new meta in all cases to avoid carrying over the complexity in future versions of Horizon (old meta support can be removed later)
