### PR TITLE
Don't inadvertently reset the DB

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -540,7 +540,7 @@ inferQuorumAndWrite(Config const& cfg)
     InferredQuorum iq;
     {
         VirtualClock clock;
-        Application::pointer app = Application::create(clock, cfg);
+        Application::pointer app = Application::create(clock, cfg, false);
         iq = app->getHistoryManager().inferQuorum();
     }
     LOG(INFO) << "Inferred quorum";
@@ -551,7 +551,7 @@ static void
 checkQuorumIntersection(Config const& cfg)
 {
     VirtualClock clock;
-    Application::pointer app = Application::create(clock, cfg);
+    Application::pointer app = Application::create(clock, cfg, false);
     InferredQuorum iq = app->getHistoryManager().inferQuorum();
     iq.checkQuorumIntersection(cfg);
 }
@@ -562,7 +562,7 @@ writeQuorumGraph(Config const& cfg, std::string const& outputFile)
     InferredQuorum iq;
     {
         VirtualClock clock;
-        Application::pointer app = Application::create(clock, cfg);
+        Application::pointer app = Application::create(clock, cfg, false);
         iq = app->getHistoryManager().inferQuorum();
     }
     std::string filename = outputFile.empty() ? "-" : outputFile;


### PR DESCRIPTION
## What I was trying to do

I tried to run `stellar-core --graphquorum` on a live node and it reseted the DB causing a full catchup on next "normal" run. After a bit of testing I found that `--inferquorum` and `--checkquorum` flags result in the same behaviour.

## Expected result

It should only reset the DB when started with `--newdb` flag.

## Version

I tested with `stellar-core 9.1.0 (a278e95978bdac6d1015d82f4859dad780e752d3)` but I think it affects all versions starting from `0.4.1` which [introduced quorum flags](https://github.com/stellar/stellar-core/commit/b40fd7c14c7d60536e92e7d41e2ddba43756493d).

## Config and logs

```
stellar@xlm:~$ stellar-core --conf /etc/stellar/stellar-core-bug.cfg --graphquorum
2018-02-05T07:02:34.158 XXXXX [Database INFO] Connecting to: postgresql://dbname=stellar-bug user=stellar
2018-02-05T07:02:34.166 XXXXX [SCP INFO] LocalNode::LocalNode@XXXXX qSet: 273af2
--> 2018-02-05T07:02:34.312 XXXXX [Database INFO] Applying DB schema upgrade to version 2  <--
--> 2018-02-05T07:02:34.348 XXXXX [Database INFO] Applying DB schema upgrade to version 3  <--
--> 2018-02-05T07:02:34.355 XXXXX [Database INFO] Applying DB schema upgrade to version 4  <--
--> 2018-02-05T07:02:34.364 XXXXX [Database INFO] Applying DB schema upgrade to version 5  <--
--> 2018-02-05T07:02:34.370 XXXXX [default INFO] *                                         <--
--> 2018-02-05T07:02:34.370 XXXXX [default INFO] * The database has been initialized       <--
--> 2018-02-05T07:02:34.370 XXXXX [default INFO] *                                         <--
--> 2018-02-05T07:02:34.372 XXXXX [Ledger INFO] Established genesis ledger, closing        <--
--> 2018-02-05T07:02:34.372 XXXXX [Ledger INFO] Root account seed: <XXXX>                  <--
2018-02-05T07:02:34.377 XXXXX [History INFO] Starting FetchRecentQsetsWork
2018-02-05T07:02:34.445 XXXXX [History INFO] Downloading recent SCP messages: [7138367, 7144767]
2018-02-05T07:02:36.529 XXXXX [History INFO] Scanning for QSets in checkpoint: 7138367
.....
2018-02-05T07:02:36.574 XXXXX [Work INFO] WorkManager got SUCCESS from fetch-recent-qsets
2018-02-05T07:02:36.578 XXXXX [default INFO] Application destructing
2018-02-05T07:02:36.579 XXXXX [default INFO] Application destroyed
2018-02-05T07:02:36.583 XXXXX [default INFO] *
2018-02-05T07:02:36.583 XXXXX [default INFO] * Quorum graph: digraph {
sdf1 -> sdf1;
sdf1 -> sdf2;
sdf1 -> sdf3;
sdf2 -> sdf1;
sdf2 -> sdf2;
sdf2 -> sdf3;
sdf3 -> sdf1;
sdf3 -> sdf2;
sdf3 -> sdf3;
}

2018-02-05T07:02:36.584 GBEGS [default INFO] *
```

More logs and stellar-core.cfg [here](https://gist.github.com/nebolsin/f4c3196c7a921e807025df4e7ab815b4).