### PR TITLE
fix issues with flood tests

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -111,6 +111,11 @@ class Herder
     // We are learning about a new envelope.
     virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
 
+    // We are learning about a new fully-fetched envelope.
+    virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
+                                           const SCPQuorumSet& qset,
+                                           TxSetFrame txset) = 0;
+
     // a peer needs our SCP state
     virtual void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) = 0;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -422,6 +422,17 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
     return status;
 }
 
+Herder::EnvelopeStatus
+HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope,
+                            const SCPQuorumSet& qset, TxSetFrame txset)
+{
+    mPendingEnvelopes.addTxSet(txset.getContentsHash(),
+                               envelope.statement.slotIndex,
+                               std::make_shared<TxSetFrame>(txset));
+    mPendingEnvelopes.addSCPQuorumSet(sha256(xdr::xdr_to_opaque(qset)), qset);
+    return recvSCPEnvelope(envelope);
+}
+
 void
 HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer)
 {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -62,6 +62,9 @@ class HerderImpl : public Herder
     TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) override;
 
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
+    EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
+                                   const SCPQuorumSet& qset,
+                                   TxSetFrame txset) override;
 
     void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) override;
 

--- a/src/overlay/FloodTests.cpp
+++ b/src/overlay/FloodTests.cpp
@@ -255,10 +255,8 @@ TEST_CASE("Flooding", "[flood][overlay]")
                     inApp->getNetworkID(), ENVELOPE_TYPE_SCP, st));
 
             // inject the message
-            REQUIRE(herder.recvSCPEnvelope(envelope) ==
-                    Herder::ENVELOPE_STATUS_FETCHING);
-            REQUIRE(herder.recvTxSet(txSet.getContentsHash(), txSet));
-            REQUIRE(herder.recvSCPQuorumSet(qSetHash, qset));
+            REQUIRE(herder.recvSCPEnvelope(envelope, qset, txSet) ==
+                    Herder::ENVELOPE_STATUS_READY);
 
         };
 


### PR DESCRIPTION
There were two issues with flood tests:

1. SCP envelope was injected into node before its txSet and qSet were available on that node, now the order is inversed (txSet and qSet are added before). To achieve that PendingEnvelopes from Herder were made visible to avoid checks for envelopes that need that data in Herder class

2. GetQSet messages are sent all at once for all nodes without any intervening crank. With TCP mode it could take 1.5 or more to prepare, inject and process all SCP envelopes (this includes creating new timers and sending TCP message). This means that in the first crank a lot of new GetQSet messages could be created because of timeout, usually to nodes that do not know anything about such QSet, which could result in a flood of those messages and further problems. This version uses virtual timer even for TCP mode, which solves this problem.

Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>