### PR TITLE
Use xdr::operator< to avoid build failures on Mac

### DIFF
--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -16,6 +16,8 @@
 namespace stellar
 {
 
+using xdr::operator<;
+
 Floodgate::FloodRecord::FloodRecord(StellarMessage const& msg, uint32_t ledger,
                                     Peer::pointer peer)
     : mLedgerSeq(ledger), mMessage(msg)


### PR DESCRIPTION
resolves #1523