### PR TITLE
fix HistoryManagerImpl::loadBucketsReferencedByPublishQueue

### DIFF
--- a/src/bucket/PublishQueueBuckets.cpp
+++ b/src/bucket/PublishQueueBuckets.cpp
@@ -8,6 +8,12 @@ namespace stellar
 {
 
 void
+PublishQueueBuckets::setBuckets(storage const& buckets)
+{
+    mBucketUsage = buckets;
+}
+
+void
 PublishQueueBuckets::addBuckets(std::vector<std::string> const& buckets)
 {
     for (auto const& bucket : buckets)

--- a/src/bucket/PublishQueueBuckets.cpp
+++ b/src/bucket/PublishQueueBuckets.cpp
@@ -8,7 +8,7 @@ namespace stellar
 {
 
 void
-PublishQueueBuckets::setBuckets(storage const& buckets)
+PublishQueueBuckets::setBuckets(BucketCount const& buckets)
 {
     mBucketUsage = buckets;
 }

--- a/src/bucket/PublishQueueBuckets.h
+++ b/src/bucket/PublishQueueBuckets.h
@@ -14,19 +14,23 @@ namespace stellar
 class PublishQueueBuckets
 {
   public:
+    using storage = std::map<std::string, int>;
+
+    void setBuckets(storage const& buckets);
+
     void addBuckets(std::vector<std::string> const& buckets);
     void addBucket(std::string const& bucket);
 
     void removeBuckets(std::vector<std::string> const& buckets);
     void removeBucket(std::string const& bucket);
 
-    std::map<std::string, int> const&
+    storage const&
     map() const
     {
         return mBucketUsage;
     }
 
   private:
-    std::map<std::string, int> mBucketUsage;
+    storage mBucketUsage;
 };
 }

--- a/src/bucket/PublishQueueBuckets.h
+++ b/src/bucket/PublishQueueBuckets.h
@@ -14,9 +14,9 @@ namespace stellar
 class PublishQueueBuckets
 {
   public:
-    using storage = std::map<std::string, int>;
+    using BucketCount = std::map<std::string, int>;
 
-    void setBuckets(storage const& buckets);
+    void setBuckets(BucketCount const& buckets);
 
     void addBuckets(std::vector<std::string> const& buckets);
     void addBucket(std::string const& bucket);
@@ -24,13 +24,13 @@ class PublishQueueBuckets
     void removeBuckets(std::vector<std::string> const& buckets);
     void removeBucket(std::string const& bucket);
 
-    storage const&
+    BucketCount const&
     map() const
     {
         return mBucketUsage;
     }
 
   private:
-    storage mBucketUsage;
+    BucketCount mBucketUsage;
 };
 }

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -566,11 +566,11 @@ HistoryManagerImpl::getPublishQueueStates()
     return states;
 }
 
-PublishQueueBuckets::storage
+PublishQueueBuckets::BucketCount
 HistoryManagerImpl::loadBucketsReferencedByPublishQueue()
 {
     auto states = getPublishQueueStates();
-    auto result = PublishQueueBuckets::storage{};
+    PublishQueueBuckets::BucketCount result{};
     for (auto const& s : states)
     {
         auto sb = s.allBuckets();

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -566,17 +566,20 @@ HistoryManagerImpl::getPublishQueueStates()
     return states;
 }
 
-std::vector<std::string>
+PublishQueueBuckets::storage
 HistoryManagerImpl::loadBucketsReferencedByPublishQueue()
 {
     auto states = getPublishQueueStates();
-    std::set<std::string> buckets;
+    auto result = PublishQueueBuckets::storage{};
     for (auto const& s : states)
     {
         auto sb = s.allBuckets();
-        buckets.insert(sb.begin(), sb.end());
+        for (auto const& b : sb)
+        {
+            result[b]++;
+        }
     }
-    return std::vector<std::string>(buckets.begin(), buckets.end());
+    return result;
 }
 
 std::vector<std::string>
@@ -584,7 +587,7 @@ HistoryManagerImpl::getBucketsReferencedByPublishQueue()
 {
     if (!mPublishQueueBucketsFilled)
     {
-        mPublishQueueBuckets.addBuckets(loadBucketsReferencedByPublishQueue());
+        mPublishQueueBuckets.setBuckets(loadBucketsReferencedByPublishQueue());
         mPublishQueueBucketsFilled = true;
     }
 

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -35,7 +35,7 @@ class HistoryManagerImpl : public HistoryManager
     medida::Meter& mPublishSuccess;
     medida::Meter& mPublishFailure;
 
-    PublishQueueBuckets::storage loadBucketsReferencedByPublishQueue();
+    PublishQueueBuckets::BucketCount loadBucketsReferencedByPublishQueue();
 
   public:
     HistoryManagerImpl(Application& app);

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -35,7 +35,7 @@ class HistoryManagerImpl : public HistoryManager
     medida::Meter& mPublishSuccess;
     medida::Meter& mPublishFailure;
 
-    std::vector<std::string> loadBucketsReferencedByPublishQueue();
+    PublishQueueBuckets::storage loadBucketsReferencedByPublishQueue();
 
   public:
     HistoryManagerImpl(Application& app);


### PR DESCRIPTION
Before fix this implementation would return only one item per bucket
even if it occured in multiple publishqueue items. New implementations
returns one item per bucket per publishqueue item, which is consistent
with how PublishQueueBuckets works in other contexts.

It will stop crashing on assert(snap) now.

Fixes #1296
Fixes #1518