### PR TITLE
Scp timeout update

### DIFF
--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -150,7 +150,6 @@ class HerderImpl : public Herder
     // indeterminate mode
     void trackingHeartBeat();
 
-    VirtualClock::time_point mLastTrigger;
     VirtualTimer mTriggerTimer;
 
     VirtualTimer mRebroadcastTimer;

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -414,8 +414,11 @@ HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
     }
     auto& timer = *it->second;
     timer.cancel();
-    timer.expires_from_now(timeout);
-    timer.async_wait(cb, &VirtualTimer::onFailureNoop);
+    if (cb)
+    {
+        timer.expires_from_now(timeout);
+        timer.async_wait(cb, &VirtualTimer::onFailureNoop);
+    }
 }
 
 // core SCP

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -28,7 +28,7 @@ static const int MAX_ADVANCE_SLOT_RECURSION = 50;
 
 BallotProtocol::BallotProtocol(Slot& slot)
     : mSlot(slot)
-    , mHeardFromQuorum(true)
+    , mHeardFromQuorum(false)
     , mPhase(SCP_PHASE_PREPARE)
     , mCurrentMessageLevel(0)
 {
@@ -392,6 +392,7 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
     {
         mSlot.getSCPDriver().startedBallotProtocol(mSlot.getSlotIndex(), newb);
         emitCurrentStateStatement();
+        checkHeardFromQuorum();
     }
 
     return updated;
@@ -474,14 +475,15 @@ BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
                   compareBallots(ballot, *mCurrentBallot) >= 0);
     }
 
-    bool gotBumped = !mCurrentBallot || !(*mCurrentBallot == ballot);
+    bool gotBumped =
+        !mCurrentBallot || (mCurrentBallot->counter != ballot.counter);
 
     mCurrentBallot = make_unique<SCPBallot>(ballot);
 
-    mHeardFromQuorum = false;
-
     if (gotBumped)
-        startBallotProtocolTimer();
+    {
+        mHeardFromQuorum = false;
+    }
 }
 
 void
@@ -497,18 +499,18 @@ BallotProtocol::startBallotProtocolTimer()
 }
 
 void
+BallotProtocol::stopBallotProtocolTimer()
+{
+    std::shared_ptr<Slot> slot = mSlot.shared_from_this();
+    mSlot.getSCPDriver().setupTimer(mSlot.getSlotIndex(),
+                                    Slot::BALLOT_PROTOCOL_TIMER,
+                                    std::chrono::seconds::zero(), nullptr);
+}
+
+void
 BallotProtocol::ballotProtocolTimerExpired()
 {
-    // don't abandon the ballot until we have heard from a slice
-    if (mHeardFromQuorum)
-    {
-        abandonBallot(0);
-    }
-    else
-    {
-        CLOG(DEBUG, "SCP") << "Waiting to hear from a slice.";
-        startBallotProtocolTimer();
-    }
+    abandonBallot(0);
 }
 
 SCPStatement
@@ -1800,12 +1802,6 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
             "maximum number of transitions reached in advanceSlot");
     }
 
-    // Check if we should call `ballotDidHearFromQuorum`
-    // we do this here so that we have a chance to evaluate it between
-    // transitions
-    // when a single message causes several
-    checkHeardFromQuorum();
-
     // attempt* methods will queue up messages, causing advanceSlot to be
     // called recursively
 
@@ -1833,6 +1829,15 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
             didBump = attemptBump();
             didWork = didBump || didWork;
         } while (didBump);
+
+        // Check if we should call `ballotDidHearFromQuorum` and set/reset the
+        // timer, we only do it if didWork is true (ie: when we changed state)
+        // this is to avoid being arbitrary delayed by messages that we
+        // don't care about
+        if (didWork)
+        {
+            checkHeardFromQuorum();
+        }
     }
 
     if (Logging::logDebug("SCP"))
@@ -2071,28 +2076,46 @@ BallotProtocol::federatedRatify(StatementPredicate voted)
 void
 BallotProtocol::checkHeardFromQuorum()
 {
-    if (!mHeardFromQuorum && mCurrentBallot)
+    if (mCurrentBallot)
     {
         if (LocalNode::isQuorum(
-            getLocalNode()->getQuorumSet(), mLatestEnvelopes,
-            std::bind(&Slot::getQuorumSetFromStatement, &mSlot, _1),
-            [&](SCPStatement const& st) {
-            bool res;
-            if (st.pledges.type() == SCP_ST_PREPARE)
-            {
-                res = mCurrentBallot->counter <=
-                    st.pledges.prepare().ballot.counter;
-            }
-            else
-            {
-                res = true;
-            }
-            return res;
-        }))
+                getLocalNode()->getQuorumSet(), mLatestEnvelopes,
+                std::bind(&Slot::getQuorumSetFromStatement, &mSlot, _1),
+                [&](SCPStatement const& st) {
+                    bool res;
+                    if (st.pledges.type() == SCP_ST_PREPARE)
+                    {
+                        res = mCurrentBallot->counter <=
+                              st.pledges.prepare().ballot.counter;
+                    }
+                    else
+                    {
+                        res = true;
+                    }
+                    return res;
+                }))
         {
+            bool oldHQ = mHeardFromQuorum;
             mHeardFromQuorum = true;
-            mSlot.getSCPDriver().ballotDidHearFromQuorum(mSlot.getSlotIndex(),
-                *mCurrentBallot);
+            if (!oldHQ)
+            {
+                // if we transition from not heard -> heard, we start the timer
+                mSlot.getSCPDriver().ballotDidHearFromQuorum(
+                    mSlot.getSlotIndex(), *mCurrentBallot);
+                if (mPhase != SCP_PHASE_EXTERNALIZE)
+                {
+                    startBallotProtocolTimer();
+                }
+            }
+            if (mPhase == SCP_PHASE_EXTERNALIZE)
+            {
+                stopBallotProtocolTimer();
+            }
+        }
+        else
+        {
+            mHeardFromQuorum = false;
+            stopBallotProtocolTimer();
         }
     }
 }

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -260,6 +260,7 @@ class BallotProtocol
     bool federatedRatify(StatementPredicate voted);
 
     void startBallotProtocolTimer();
+    void stopBallotProtocolTimer();
     void checkHeardFromQuorum();
 };
 }

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -260,5 +260,6 @@ class BallotProtocol
     bool federatedRatify(StatementPredicate voted);
 
     void startBallotProtocolTimer();
+    void checkHeardFromQuorum();
 };
 }

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -99,6 +99,7 @@ class SCPDriver
                                     std::set<Value> const& candidates) = 0;
 
     // `setupTimer`: requests to trigger 'cb' after timeout
+    // if cb is nullptr, the timer is cancelled
     virtual void setupTimer(uint64 slotIndex, int timerID,
                             std::chrono::milliseconds timeout,
                             std::function<void()> cb) = 0;


### PR DESCRIPTION
Resolves #1548 #1550 

This PR updates the SCP timeout code in the Ballot Protocol implementation to wait for a quorum (and not have a timeout if there is no quorum)

It also addresses an issue where we potentially trigger a ledger close too early