### PR TITLE
Update asio library to use std::atomic_thread_fence, when available

### DIFF
--- a/lib/asio/include/asio/detail/fenced_block.hpp
+++ b/lib/asio/include/asio/detail/fenced_block.hpp
@@ -20,6 +20,8 @@
 #if !defined(ASIO_HAS_THREADS) \
   || defined(ASIO_DISABLE_FENCED_BLOCK)
 # include "asio/detail/null_fenced_block.hpp"
+#elif defined(ASIO_HAS_STD_ATOMIC)
+# include "asio/detail/std_fenced_block.hpp"
 #elif defined(__MACH__) && defined(__APPLE__)
 # include "asio/detail/macos_fenced_block.hpp"
 #elif defined(__sun)
@@ -48,6 +50,8 @@ namespace detail {
 #if !defined(ASIO_HAS_THREADS) \
   || defined(ASIO_DISABLE_FENCED_BLOCK)
 typedef null_fenced_block fenced_block;
+#elif defined(ASIO_HAS_STD_ATOMIC)
+typedef std_fenced_block fenced_block;
 #elif defined(__MACH__) && defined(__APPLE__)
 typedef macos_fenced_block fenced_block;
 #elif defined(__sun)

--- a/lib/asio/include/asio/detail/std_fenced_block.hpp
+++ b/lib/asio/include/asio/detail/std_fenced_block.hpp
@@ -1,0 +1,62 @@
+//
+// detail/std_fenced_block.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2016 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_DETAIL_STD_FENCED_BLOCK_HPP
+#define ASIO_DETAIL_STD_FENCED_BLOCK_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+
+#if defined(ASIO_HAS_STD_ATOMIC)
+
+#include <atomic>
+#include "asio/detail/noncopyable.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+namespace detail {
+
+class std_fenced_block
+  : private noncopyable
+{
+public:
+  enum half_t { half };
+  enum full_t { full };
+
+  // Constructor for a half fenced block.
+  explicit std_fenced_block(half_t)
+  {
+  }
+
+  // Constructor for a full fenced block.
+  explicit std_fenced_block(full_t)
+  {
+    std::atomic_thread_fence(std::memory_order_acquire);
+  }
+
+  // Destructor.
+  ~std_fenced_block()
+  {
+    std::atomic_thread_fence(std::memory_order_release);
+  }
+};
+
+} // namespace detail
+} // namespace asio
+
+#include "asio/detail/pop_options.hpp"
+
+#endif // defined(ASIO_HAS_STD_ATOMIC)
+
+#endif // ASIO_DETAIL_STD_FENCED_BLOCK_HPP


### PR DESCRIPTION
This issue is the same as https://github.com/otland/forgottenserver/issues/1972.

To fix this, I used changes from https://github.com/chriskohlhoff/asio/commit/ffc9dd443fc2ca1aece0bbda14f3c521ceeb7924