### PR TITLE
improve query used to delete old entries during maintenance

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -276,6 +276,7 @@ exit /b 0
     <ClCompile Include="..\..\src\database\DatabaseConnectionString.cpp" />
     <ClCompile Include="..\..\src\database\DatabaseConnectionStringTest.cpp" />
     <ClCompile Include="..\..\src\database\DatabaseTests.cpp" />
+    <ClCompile Include="..\..\src\database\DatabaseUtils.cpp" />
     <ClCompile Include="..\..\src\herder\Herder.cpp" />
     <ClCompile Include="..\..\src\herder\HerderImpl.cpp" />
     <ClCompile Include="..\..\src\herder\HerderPersistenceImpl.cpp" />
@@ -550,6 +551,7 @@ exit /b 0
     <ClInclude Include="..\..\src\crypto\StrKey.h" />
     <ClInclude Include="..\..\src\database\Database.h" />
     <ClInclude Include="..\..\src\database\DatabaseConnectionString.h" />
+    <ClInclude Include="..\..\src\database\DatabaseUtils.h" />
     <ClInclude Include="..\..\src\herder\HerderPersistence.h" />
     <ClInclude Include="..\..\src\herder\HerderPersistenceImpl.h" />
     <ClInclude Include="..\..\src\herder\HerderSCPDriver.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -843,6 +843,9 @@
     <ClCompile Include="..\..\src\main\Maintainer.cpp">
       <Filter>main</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\database\DatabaseUtils.cpp">
+      <Filter>database</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ledger\LedgerManager.h">
@@ -1450,6 +1453,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\main\Maintainer.h">
       <Filter>main</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\database\DatabaseUtils.h">
+      <Filter>database</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/database/DatabaseUtils.cpp
+++ b/src/database/DatabaseUtils.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "DatabaseUtils.h"
+
+namespace stellar
+{
+namespace DatabaseUtils
+{
+void
+deleteOldEntriesHelper(soci::session& sess, uint32_t ledgerSeq, uint32_t count,
+                       std::string const& tableName,
+                       std::string const& ledgerSeqColumn)
+{
+    uint32_t curMin = 0;
+    soci::indicator gotMin;
+    soci::statement st = (sess.prepare << "SELECT MIN(" << ledgerSeqColumn
+                                       << ") FROM " << tableName,
+                          soci::into(curMin, gotMin));
+
+    st.execute(true);
+    if (st.got_data() && gotMin == soci::i_ok)
+    {
+        uint32 m = std::min(curMin + count, ledgerSeq);
+        sess << "DELETE FROM " << tableName << " WHERE " << ledgerSeqColumn
+             << " <= " << m;
+    }
+}
+}
+}

--- a/src/database/DatabaseUtils.h
+++ b/src/database/DatabaseUtils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "Database.h"
+
+namespace stellar
+{
+namespace DatabaseUtils
+{
+void deleteOldEntriesHelper(soci::session& sess, uint32_t ledgerSeq,
+                            uint32_t count, std::string const& tableName,
+                            std::string const& ledgerSeqColumn);
+}
+}

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -5,6 +5,7 @@
 #include "herder/HerderPersistenceImpl.h"
 #include "crypto/Hex.h"
 #include "database/Database.h"
+#include "database/DatabaseUtils.h"
 #include "herder/Herder.h"
 #include "main/Application.h"
 #include "scp/Slot.h"
@@ -269,11 +270,9 @@ void
 HerderPersistence::deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                     uint32_t count)
 {
-    db.getSession() << "DELETE FROM scphistory WHERE ledgerseq IN (SELECT "
-                       "ledgerseq FROM scphistory WHERE ledgerseq <= "
-                    << ledgerSeq << " LIMIT " << count << ")";
-    db.getSession() << "DELETE FROM scpquorums WHERE lastledgerseq IN (SELECT "
-                       "lastledgerseq FROM scpquorums WHERE lastledgerseq <= "
-                    << ledgerSeq << " LIMIT " << count << ")";
+    DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
+                                          "scphistory", "ledgerseq");
+    DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
+                                          "scpquorums", "lastledgerseq");
 }
 }

--- a/src/ledger/LedgerHeaderFrame.cpp
+++ b/src/ledger/LedgerHeaderFrame.cpp
@@ -8,6 +8,7 @@
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
 #include "database/Database.h"
+#include "database/DatabaseUtils.h"
 #include "util/Logging.h"
 #include "util/XDRStream.h"
 #include "util/format.h"
@@ -243,9 +244,8 @@ void
 LedgerHeaderFrame::deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                     uint32_t count)
 {
-    db.getSession() << "DELETE FROM ledgerheaders WHERE ledgerseq IN (SELECT "
-                       "ledgerseq FROM ledgerheaders WHERE ledgerseq <= "
-                    << ledgerSeq << " LIMIT " << count << ")";
+    DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
+                                          "ledgerheaders", "ledgerseq");
 }
 
 void

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -9,6 +9,7 @@
 #include "crypto/SHA.h"
 #include "crypto/SignerKey.h"
 #include "database/Database.h"
+#include "database/DatabaseUtils.h"
 #include "herder/TxSetFrame.h"
 #include "invariant/InvariantManager.h"
 #include "ledger/LedgerDelta.h"
@@ -841,11 +842,9 @@ void
 TransactionFrame::deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                    uint32_t count)
 {
-    db.getSession() << "DELETE FROM txhistory WHERE ledgerseq IN (SELECT "
-                       "ledgerseq FROM txhistory WHERE ledgerseq <= "
-                    << ledgerSeq << " LIMIT " << count << ")";
-    db.getSession() << "DELETE FROM txfeehistory WHERE ledgerseq IN (SELECT "
-                       "ledgerseq FROM txfeehistory WHERE ledgerseq <= "
-                    << ledgerSeq << " LIMIT " << count << ")";
+    DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
+                                          "txhistory", "ledgerseq");
+    DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
+                                          "txfeehistory", "ledgerseq");
 }
 }


### PR DESCRIPTION
#resolves #1575

The query introduced in commit https://github.com/stellar/stellar-core/pull/1512/commits/77454474fe20581e448f653bf9824006dd028f66
is very slow.

This PR replaces it with a simpler one that runs much faster.

Here is the result of query analysis that compares the two query plans (I had to replace the use of `LEAST` as it's not a standard SQL function).

```sql
stellar=# EXPLAIN DELETE FROM txhistory WHERE ledgerseq IN (SELECT ledgerseq FROM txhistory WHERE ledgerseq <= 7685619 LIMIT 50000 );
                                                       QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------
 Delete on txhistory  (cost=13309.66..174581.38 rows=550925 width=34)
   ->  Hash Join  (cost=13309.66..174581.38 rows=550925 width=34)
         Hash Cond: (txhistory.ledgerseq = "ANY_subquery".ledgerseq)
         ->  Seq Scan on txhistory  (cost=0.00..144424.26 rows=913426 width=10)
         ->  Hash  (cost=12684.66..12684.66 rows=50000 width=32)
               ->  Unique  (cost=12434.66..12684.66 rows=50000 width=32)
                     ->  Sort  (cost=12434.66..12559.66 rows=50000 width=32)
                           Sort Key: "ANY_subquery".ledgerseq
                           ->  Subquery Scan on "ANY_subquery"  (cost=0.00..8532.25 rows=50000 width=32)
                                 ->  Limit  (cost=0.00..8032.25 rows=50000 width=4)
                                       ->  Seq Scan on txhistory txhistory_1  (cost=0.00..146707.83 rows=913242 width=4)
                                             Filter: (ledgerseq <= 7685619)
(12 rows)

stellar=# explain DELETE FROM txhistory WHERE ledgerseq <= (SELECT LEAST(7685619, (SELECT MIN(ledgerseq) FROM txhistory) + 50000));
                                                             QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------
 Delete on txhistory  (cost=1.06..67593.40 rows=304478 width=6)
   InitPlan 3 (returns $2)
     ->  Result  (cost=0.63..0.64 rows=1 width=0)
           InitPlan 2 (returns $1)
             ->  Result  (cost=0.62..0.63 rows=1 width=0)
                   InitPlan 1 (returns $0)
                     ->  Limit  (cost=0.42..0.62 rows=1 width=4)
                           ->  Index Only Scan using histbyseq on txhistory txhistory_1  (cost=0.42..174962.38 rows=913433 width=4)
                                 Index Cond: (ledgerseq IS NOT NULL)
   ->  Index Scan using histbyseq on txhistory  (cost=0.42..67592.76 rows=304478 width=6)
         Index Cond: (ledgerseq <= $2)
(11 rows)
```