### PR TITLE
Added clearmetrics endpoint

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -500,6 +500,7 @@ exit /b 0
     <ClCompile Include="..\..\src\util\Timer.cpp" />
     <ClCompile Include="..\..\src\util\TimerTests.cpp" />
     <ClCompile Include="..\..\src\util\types.cpp" />
+    <ClCompile Include="..\..\src\util\MetricResetter.cpp" />
     <ClCompile Include="..\..\src\main\CommandHandler.cpp" />
     <ClCompile Include="..\..\src\main\Config.cpp" />
     <ClCompile Include="..\..\src\main\main.cpp" />
@@ -718,6 +719,7 @@ exit /b 0
     <ClInclude Include="..\..\src\util\TmpDir.h" />
     <ClInclude Include="..\..\src\util\Timer.h" />
     <ClInclude Include="..\..\src\util\types.h" />
+    <ClInclude Include="..\..\src\util\MetricResetter.h" />
     <ClInclude Include="..\..\src\util\XDRStream.h" />
     <ClInclude Include="..\..\src\work\Work.h" />
     <ClInclude Include="..\..\src\work\WorkManager.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -201,6 +201,9 @@
     <ClCompile Include="..\..\src\util\types.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\MetricResetter.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\util\Logging.cpp">
       <Filter>util</Filter>
     </ClCompile>
@@ -1008,6 +1011,9 @@
       <Filter>lib\util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\Logging.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\MetricResetter.h">
       <Filter>util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\make_unique.h">

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -107,6 +107,10 @@ command line option (see above). Most commands return their results in JSON form
  Returns a snapshot of the metrics registry (for monitoring and
 debugging purpose).
 
+* **clearmetrics**
+ `/clearmetrics?[domain=DOMAIN]`<br>
+  Clear metrics for a specified domain. If no domain specified, clear all metrics (for testing purposes).
+
 * **peers**
   Returns the list of known peers in JSON format.
 

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -184,6 +184,9 @@ class Application
     // Call syncOwnMetrics on self and syncMetrics all objects owned by App.
     virtual void syncAllMetrics() = 0;
 
+    // Clear all metrics
+    virtual void clearMetrics(std::string const& domain) = 0;
+
     // Get references to each of the "subsystem" objects.
     virtual TmpDirManager& getTmpDirManager() = 0;
     virtual LedgerManager& getLedgerManager() = 0;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -612,6 +612,20 @@ ApplicationImpl::syncAllMetrics()
     syncOwnMetrics();
 }
 
+void
+ApplicationImpl::clearMetrics(std::string const& domain)
+{
+    MetricResetter resetter;
+    auto const& metrics = mMetrics->GetAllMetrics();
+    for (auto const& kv : metrics)
+    {
+        if (domain.empty() || kv.first.domain() == domain)
+        {
+            kv.second->Process(resetter);
+        }
+    }
+}
+
 TmpDirManager&
 ApplicationImpl::getTmpDirManager()
 {

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -8,6 +8,7 @@
 #include "main/Config.h"
 #include "main/PersistentState.h"
 #include "medida/timer_context.h"
+#include "util/MetricResetter.h"
 #include "util/Timer.h"
 #include <thread>
 
@@ -50,6 +51,7 @@ class ApplicationImpl : public Application
     virtual medida::MetricsRegistry& getMetrics() override;
     virtual void syncOwnMetrics() override;
     virtual void syncAllMetrics() override;
+    virtual void clearMetrics(std::string const& domain) override;
     virtual TmpDirManager& getTmpDirManager() override;
     virtual LedgerManager& getLedgerManager() override;
     virtual BucketManager& getBucketManager() override;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -83,6 +83,7 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
     addRoute("maintenance", &CommandHandler::maintenance);
     addRoute("manualclose", &CommandHandler::manualClose);
     addRoute("metrics", &CommandHandler::metrics);
+    addRoute("clearmetrics", &CommandHandler::clearMetrics);
     addRoute("peers", &CommandHandler::peers);
     addRoute("quorum", &CommandHandler::quorum);
     addRoute("setcursor", &CommandHandler::setcursor);
@@ -278,6 +279,9 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "</p><p><h1> /metrics</h1>"
         "returns a snapshot of the metrics registry (for monitoring and "
         "debugging purpose)"
+        "</p><p><h1> /clearmetrics?[domain=DOMAIN]</h1>"
+        "clear metrics for a specified domain. If no domain specified, "
+        "clear all metrics (for testing purposes)"
         "</p><p><h1> /peers</h1>"
         "returns the list of known peers in JSON format"
         "</p><p><h1> /quorum?[node=NODE_ID][&compact=true]</h1>"
@@ -982,5 +986,19 @@ CommandHandler::maintenance(std::string const& params, std::string& retStr)
     {
         retStr = "No work performed";
     }
+}
+
+void
+CommandHandler::clearMetrics(std::string const& params, std::string& retStr)
+{
+    std::map<std::string, std::string> map;
+    http::server::server::parseParams(params, map);
+
+    std::string domain;
+    maybeParseParam(map, "domain", domain);
+
+    mApp.clearMetrics(domain);
+
+    retStr = fmt::format("Cleared {} metrics!", domain);
 }
 }

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -48,6 +48,7 @@ class CommandHandler
     void maintenance(std::string const& params, std::string& retStr);
     void manualClose(std::string const& params, std::string& retStr);
     void metrics(std::string const& params, std::string& retStr);
+    void clearMetrics(std::string const& params, std::string& retStr);
     void peers(std::string const& params, std::string& retStr);
     void quorum(std::string const& params, std::string& retStr);
     void setcursor(std::string const& params, std::string& retStr);

--- a/src/util/MetricResetter.cpp
+++ b/src/util/MetricResetter.cpp
@@ -1,0 +1,33 @@
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "MetricResetter.h"
+
+namespace stellar
+{
+
+void
+MetricResetter::Process(medida::Counter& counter)
+{
+    counter.clear();
+}
+
+void
+MetricResetter::Process(medida::Meter& meter)
+{
+    // Meter has no "clear" method
+}
+
+void
+MetricResetter::Process(medida::Histogram& histogram)
+{
+    histogram.Clear();
+}
+
+void
+MetricResetter::Process(medida::Timer& timer)
+{
+    timer.Clear();
+}
+}

--- a/src/util/MetricResetter.h
+++ b/src/util/MetricResetter.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "medida/metrics_registry.h"
+
+namespace medida
+{
+class MetricsRegistry;
+class Meter;
+class Counter;
+class Timer;
+}
+
+namespace stellar
+{
+
+class MetricResetter : public medida::MetricProcessor
+{
+  public:
+    MetricResetter() = default;
+    ~MetricResetter() override = default;
+    void Process(medida::Counter& counter) override;
+    void Process(medida::Meter& meter) override;
+    void Process(medida::Histogram& histogram) override;
+    void Process(medida::Timer& timer) override;
+};
+}


### PR DESCRIPTION
* What
Endpoint to clear metrics; if `domain` param passed in, clears metrics for only that domain
* Why 
This is needed for load test. Since we don't care about account creation metrics, we'd need to refresh the metrics to record only payments data
* How 
MetricResetter class is a child class of MetricProcessor. It implements Process method for each type of metric