### PR TITLE
Scp quorum seen fix

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -397,7 +397,7 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
     return updated;
 }
 
-// updates the local state based to the specificed ballot
+// updates the local state based to the specified ballot
 // (that could be a prepared ballot) enforcing invariants
 bool
 BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
@@ -1835,14 +1835,7 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
             didWork = didBump || didWork;
         } while (didBump);
 
-        // Check if we should call `ballotDidHearFromQuorum` and set/reset the
-        // timer, we only do it if didWork is true (ie: when we changed state)
-        // this is to avoid being arbitrary delayed by messages that we
-        // don't care about
-        if (didWork)
-        {
-            checkHeardFromQuorum();
-        }
+        checkHeardFromQuorum();
     }
 
     if (Logging::logDebug("SCP"))
@@ -2081,6 +2074,12 @@ BallotProtocol::federatedRatify(StatementPredicate voted)
 void
 BallotProtocol::checkHeardFromQuorum()
 {
+    // this method is safe to call regardless of the transitions of the other
+    // nodes on the network:
+    // we guarantee that other nodes can only transition to higher counters
+    // (messages are ignored upstream)
+    // therefore the local node will not flip flop between "seen" and "not seen"
+    // for a given counter on the local node
     if (mCurrentBallot)
     {
         if (LocalNode::isQuorum(

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -597,8 +597,8 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
 
     auto recvVBlocking = std::bind(recvVBlockingChecks, _1, true);
 
-    auto recvQuorumChecks = [&](genEnvelope gen, bool withChecks,
-                                bool delayedQuorum) {
+    auto recvQuorumChecksEx = [&](genEnvelope gen, bool withChecks,
+                                  bool delayedQuorum, bool checkUpcoming) {
         SCPEnvelope e1 = gen(v1SecretKey);
         SCPEnvelope e2 = gen(v2SecretKey);
         SCPEnvelope e3 = gen(v3SecretKey);
@@ -614,14 +614,24 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
         {
             REQUIRE(scp.mEnvs.size() == i);
         }
+        if (checkUpcoming)
+        {
+            REQUIRE(scp.hasBallotTimerUpcoming());
+        }
         // nothing happens with an extra vote (unless we're in delayedQuorum)
         scp.receiveEnvelope(e4);
         if (withChecks && delayedQuorum)
         {
             REQUIRE(scp.mEnvs.size() == i);
+            if (checkUpcoming)
+            {
+                REQUIRE(scp.hasBallotTimerUpcoming());
+            }
         }
     };
-    auto recvQuorum = std::bind(recvQuorumChecks, _1, true, false);
+    auto recvQuorumChecks = std::bind(recvQuorumChecksEx, _1, _2, _3, false);
+    auto recvQuorumEx = std::bind(recvQuorumChecksEx, _1, true, false, _2);
+    auto recvQuorum = std::bind(recvQuorumEx, _1, false);
 
     auto nodesAllPledgeToCommit = [&]() {
         SCPBallot b(1, xValue);
@@ -723,11 +733,10 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
 
         SECTION("prepared A1")
         {
-            recvQuorum(makePrepareGen(qSetHash, A1));
+            recvQuorumEx(makePrepareGen(qSetHash, A1), true);
 
             REQUIRE(scp.mEnvs.size() == 2);
             verifyPrepare(scp.mEnvs[1], v0SecretKey, qSetHash0, 0, A1, &A1);
-            REQUIRE(scp.hasBallotTimerUpcoming());
 
             SECTION("bump prepared A2")
             {
@@ -739,10 +748,9 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                 verifyPrepare(scp.mEnvs[2], v0SecretKey, qSetHash0, 0, A2, &A1);
                 REQUIRE(!scp.hasBallotTimer());
 
-                recvQuorum(makePrepareGen(qSetHash, A2));
+                recvQuorumEx(makePrepareGen(qSetHash, A2), true);
                 REQUIRE(scp.mEnvs.size() == 4);
                 verifyPrepare(scp.mEnvs[3], v0SecretKey, qSetHash0, 0, A2, &A2);
-                REQUIRE(scp.hasBallotTimerUpcoming());
 
                 SECTION("Confirm prepared A2")
                 {
@@ -771,12 +779,12 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                               qSetHash0, 0, 2, A3, 2, 2);
                                 REQUIRE(!scp.hasBallotTimer());
 
-                                recvQuorum(
-                                    makePrepareGen(qSetHash, A3, &A2, 2, 2));
+                                recvQuorumEx(
+                                    makePrepareGen(qSetHash, A3, &A2, 2, 2),
+                                    true);
                                 REQUIRE(scp.mEnvs.size() == 8);
                                 verifyConfirm(scp.mEnvs[7], v0SecretKey,
                                               qSetHash0, 0, 3, A3, 2, 2);
-                                REQUIRE(scp.hasBallotTimerUpcoming());
 
                                 SECTION("Accept more commit A3")
                                 {
@@ -1020,13 +1028,12 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                           0, A3, &B2, 0, 2, &A2);
                             REQUIRE(!scp.hasBallotTimer());
 
-                            recvQuorumChecks(
+                            recvQuorumChecksEx(
                                 makePrepareGen(qSetHash, B3, &B2, 2, 2), true,
-                                true);
+                                true, true);
                             REQUIRE(scp.mEnvs.size() == 7);
                             verifyConfirm(scp.mEnvs[6], v0SecretKey, qSetHash0,
                                           0, 3, B3, 2, 2);
-                            REQUIRE(scp.hasBallotTimerUpcoming());
                         }
                     }
                 }
@@ -1164,11 +1171,10 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
 
         SECTION("prepared A1")
         {
-            recvQuorum(makePrepareGen(qSetHash, A1));
+            recvQuorumEx(makePrepareGen(qSetHash, A1), true);
 
             REQUIRE(scp.mEnvs.size() == 2);
             verifyPrepare(scp.mEnvs[1], v0SecretKey, qSetHash0, 0, A1, &A1);
-            REQUIRE(scp.hasBallotTimerUpcoming());
 
             SECTION("bump prepared A2")
             {
@@ -1180,10 +1186,9 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                 verifyPrepare(scp.mEnvs[2], v0SecretKey, qSetHash0, 0, A2, &A1);
                 REQUIRE(!scp.hasBallotTimer());
 
-                recvQuorum(makePrepareGen(qSetHash, A2));
+                recvQuorumEx(makePrepareGen(qSetHash, A2), true);
                 REQUIRE(scp.mEnvs.size() == 4);
                 verifyPrepare(scp.mEnvs[3], v0SecretKey, qSetHash0, 0, A2, &A2);
-                REQUIRE(scp.hasBallotTimerUpcoming());
 
                 SECTION("Confirm prepared A2")
                 {
@@ -1212,12 +1217,12 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                               qSetHash0, 0, 2, A3, 2, 2);
                                 REQUIRE(!scp.hasBallotTimer());
 
-                                recvQuorum(
-                                    makePrepareGen(qSetHash, A3, &A2, 2, 2));
+                                recvQuorumEx(
+                                    makePrepareGen(qSetHash, A3, &A2, 2, 2),
+                                    true);
                                 REQUIRE(scp.mEnvs.size() == 8);
                                 verifyConfirm(scp.mEnvs[7], v0SecretKey,
                                               qSetHash0, 0, 3, A3, 2, 2);
-                                REQUIRE(scp.hasBallotTimerUpcoming());
 
                                 SECTION("Accept more commit A3")
                                 {
@@ -1467,13 +1472,12 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                             // node is trying to commit A2=<2,y> but rest
                             // of its quorum is trying to commit B2
                             // we end up with a delayed quorum
-                            recvQuorumChecks(
+                            recvQuorumChecksEx(
                                 makePrepareGen(qSetHash, B3, &B2, 2, 2), true,
-                                true);
+                                true, true);
                             REQUIRE(scp.mEnvs.size() == 7);
                             verifyConfirm(scp.mEnvs[6], v0SecretKey, qSetHash0,
                                           0, 3, B3, 2, 2);
-                            REQUIRE(scp.hasBallotTimerUpcoming());
                         }
                     }
                 }

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -623,10 +623,6 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
         if (withChecks && delayedQuorum)
         {
             REQUIRE(scp.mEnvs.size() == i);
-            if (checkUpcoming)
-            {
-                REQUIRE(scp.hasBallotTimerUpcoming());
-            }
         }
     };
     auto recvQuorumChecks = std::bind(recvQuorumChecksEx, _1, _2, _3, false);
@@ -910,7 +906,9 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                     REQUIRE(scp.mEnvs.size() == 7);
                                     REQUIRE(scp.mExternalizedValues.size() ==
                                             0);
-                                    REQUIRE(!scp.hasBallotTimer());
+                                    // timer scheduled as there is a quorum
+                                    // with (2, *)
+                                    REQUIRE(scp.hasBallotTimerUpcoming());
                                 }
                                 SECTION("Network CONFIRMS other ballot")
                                 {
@@ -947,7 +945,9 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                         REQUIRE(
                                             scp.mExternalizedValues.size() ==
                                             0);
-                                        REQUIRE(!scp.hasBallotTimer());
+                                        // timer scheduled as there is a quorum
+                                        // with (3, *)
+                                        REQUIRE(scp.hasBallotTimerUpcoming());
                                     }
                                 }
                             }
@@ -1348,7 +1348,9 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                     REQUIRE(scp.mEnvs.size() == 7);
                                     REQUIRE(scp.mExternalizedValues.size() ==
                                             0);
-                                    REQUIRE(!scp.hasBallotTimer());
+                                    // timer scheduled as there is a quorum
+                                    // with (inf, *)
+                                    REQUIRE(scp.hasBallotTimerUpcoming());
                                 }
                                 SECTION("Network CONFIRMS other ballot")
                                 {
@@ -1385,7 +1387,9 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                         REQUIRE(
                                             scp.mExternalizedValues.size() ==
                                             0);
-                                        REQUIRE(!scp.hasBallotTimer());
+                                        // timer scheduled as there is a quorum
+                                        // with (3, *)
+                                        REQUIRE(scp.hasBallotTimerUpcoming());
                                     }
                                 }
                             }


### PR DESCRIPTION
we were not resetting timers properly when receiving messages not causing a state transition (typically when the local node needs to be included to form a quorum)