### PR TITLE
Performance fix for HerderSCPDriver::nominate method

### DIFF
--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -653,14 +653,16 @@ HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
     mCurrentValue = xdr::xdr_to_opaque(value);
     mLedgerSeqNominating = static_cast<uint32_t>(slotIndex);
 
-    auto valueHash = sha256(xdr::xdr_to_opaque(mCurrentValue));
-    CLOG(DEBUG, "Herder") << "HerderSCPDriver::triggerNextLedger"
-                          << " txSet.size: "
-                          << proposedSet->mTransactions.size()
-                          << " previousLedgerHash: "
-                          << hexAbbrev(proposedSet->previousLedgerHash())
-                          << " value: " << hexAbbrev(valueHash)
-                          << " slot: " << slotIndex;
+    if (Logging::logDebug("Herder")) {
+        auto valueHash = sha256(mCurrentValue);
+        CLOG(DEBUG, "Herder") << "HerderSCPDriver::triggerNextLedger"
+                              << " txSet.size: "
+                              << proposedSet->mTransactions.size()
+                              << " previousLedgerHash: "
+                              << hexAbbrev(proposedSet->previousLedgerHash())
+                              << " value: " << hexAbbrev(valueHash)
+                              << " slot: " << slotIndex;
+    }
 
     auto prevValue = xdr::xdr_to_opaque(previousValue);
     mSCP.nominate(slotIndex, mCurrentValue, prevValue);


### PR DESCRIPTION
- Calling sha256() is CPU-consuming task but the result of it is only for debug logging. Writing strings to debug logger stream is also useless. So they must be done when Logging::logDebug("Herder") is true.
- The valueHash for debug log must be sha256(mCurrentValue). Calling xdr::xdr_to_opaque(mCurrentValue) is wrong.