### PR TITLE
Fix build warnings

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,14 +1,14 @@
 # Hand-written file with variables common to all makefiles
 
 AM_CPPFLAGS = -DSQLITE_OMIT_LOAD_EXTENSION=1
-AM_CPPFLAGS += -I"$(top_srcdir)" -I"$(top_srcdir)/src" -I"$(top_builddir)/src"
+AM_CPPFLAGS += -isystem "$(top_srcdir)" -I"$(top_srcdir)/src" -I"$(top_builddir)/src"
 AM_CPPFLAGS += $(libsodium_CFLAGS) $(xdrpp_CFLAGS) $(libmedida_CFLAGS)	\
 	$(soci_CFLAGS) $(sqlite3_CFLAGS) $(libasio_CFLAGS)
-AM_CPPFLAGS += -I"$(top_srcdir)/lib"			\
-	-I"$(top_srcdir)/lib/autocheck/include"		\
-	-I"$(top_srcdir)/lib/cereal/include"		\
-	-I"$(top_srcdir)/lib/util"			\
-	-I"$(top_srcdir)/lib/soci/src/core"
+AM_CPPFLAGS += -isystem "$(top_srcdir)/lib"			\
+	-isystem "$(top_srcdir)/lib/autocheck/include"		\
+	-isystem "$(top_srcdir)/lib/cereal/include"		\
+	-isystem "$(top_srcdir)/lib/util"			\
+	-isystem "$(top_srcdir)/lib/soci/src/core"
 
 if USE_POSTGRES
 AM_CPPFLAGS += -DUSE_POSTGRES=1 $(libpq_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,7 @@ fi
 PKG_CHECK_MODULES(sqlite3, [sqlite3 >= 3.8.0], :, sqlite3_INTERNAL=yes)
 AM_CONDITIONAL(SQLITE3_INTERNAL, [test yes = "$sqlite3_INTERNAL"])
 if test yes = "$sqlite3_INTERNAL"; then
-   sqlite3_CFLAGS=-I'$(top_srcdir)/lib/sqlite'
+   sqlite3_CFLAGS=-isystem '$(top_srcdir)/lib/sqlite'
    sqlite3_LIBS=
 fi
 AC_SUBST(sqlite3_CFLAGS)
@@ -163,7 +163,7 @@ AC_SUBST(XDRC)
 mkdir -p src/xdr
 
 if test -s "$srcdir/lib/medida.mk"; then
-   libmedida_CFLAGS='-I$(top_srcdir)/lib/libmedida/src'
+   libmedida_CFLAGS='-isystem $(top_srcdir)/lib/libmedida/src'
    libmedida_LIBS='$(top_builddir)/lib/libmedida.a'
    libmedida_INTERNAL=yes
 else
@@ -174,13 +174,13 @@ AM_CONDITIONAL(LIBMEDIDA_INTERNAL, test -n "$libmedida_INTERNAL")
 AC_SUBST(libmedida_CFLAGS)
 AC_SUBST(libmedida_LIBS)
 
-soci_CFLAGS='-I$(top_srcdir)/lib/soci/src/core'
-soci_CFLAGS="$soci_CFLAGS "'-I$(top_srcdir)/lib/soci/src/backends/sqlite3'
+soci_CFLAGS='-isystem $(top_srcdir)/lib/soci/src/core'
+soci_CFLAGS="$soci_CFLAGS "'-isystem $(top_srcdir)/lib/soci/src/backends/sqlite3'
 soci_LIBS='$(top_builddir)/lib/libsoci.a'
 AC_SUBST(soci_CFLAGS)
 AC_SUBST(soci_LIBS)
 
-libasio_CFLAGS='-DASIO_SEPARATE_COMPILATION=1 -DASIO_STANDALONE -I$(top_srcdir)/lib/asio/asio/include'
+libasio_CFLAGS='-DASIO_SEPARATE_COMPILATION=1 -DASIO_STANDALONE -isystem $(top_srcdir)/lib/asio/asio/include'
 AC_SUBST(libasio_CFLAGS)
 
 AC_ARG_ENABLE(postgres,
@@ -194,7 +194,7 @@ if test x"$enable_postgres" != xno; then
     fi
     if test -n "$have_postgres"; then
        backend=
-       soci_CFLAGS="$soci_CFLAGS "'-I$(top_srcdir)/lib/soci/src/backends/postgresql'
+       soci_CFLAGS="$soci_CFLAGS "'-isystem $(top_srcdir)/lib/soci/src/backends/postgresql'
     fi
 fi
 AM_CONDITIONAL(USE_POSTGRES, [test -n "$have_postgres"])

--- a/m4/ax_pkgconfig_subdir.m4
+++ b/m4/ax_pkgconfig_subdir.m4
@@ -59,6 +59,7 @@ if test -n "$pcfile"; then
    pcname[]_CFLAGS=[$(sed -n \
                      -e 's|\${pcfiledir}|'"$pcfiledir"'/$1|g' \
                      -e 's|@\([a-zA-Z][a-zA-Z0-9_]*\)@|$(\1)/$1|g' \
+                     -e 's/-I/-isystem /g' \
                      -e 's/^Cflags: //p' $pcfile)]
    pcname[]_INTERNAL=yes
    AC_SUBST(pcname[]_LIBS)

--- a/src/herder/UpgradesTests.cpp
+++ b/src/herder/UpgradesTests.cpp
@@ -540,7 +540,6 @@ TEST_CASE("Ledger Manager applies upgrades properly", "[upgrades]")
 
 TEST_CASE("simulate upgrades", "[herder][upgrades]")
 {
-    auto epoch = VirtualClock::from_time_t(0);
     // no upgrade is done
     auto noUpgrade =
         LedgerUpgradeableData(LedgerManager::GENESIS_LEDGER_VERSION,

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -239,17 +239,17 @@ OverlayManagerImpl::getPeersToConnectTo(int maxNum)
 
     std::vector<PeerRecord> peers;
 
-    PeerRecord::loadPeerRecords(mApp.getDatabase(), batchSize,
-                                mApp.getClock().now(),
-                                [&](PeerRecord const& pr) {
-                                    // skip peers that we're already
-                                    // connected/connecting to
-                                    if (!getConnectedPeer(pr.getAddress()))
-                                    {
-                                        peers.emplace_back(pr);
-                                    }
-                                    return peers.size() < static_cast<size_t>(maxNum);
-                                });
+    PeerRecord::loadPeerRecords(
+        mApp.getDatabase(), batchSize, mApp.getClock().now(),
+        [&](PeerRecord const& pr) {
+            // skip peers that we're already
+            // connected/connecting to
+            if (!getConnectedPeer(pr.getAddress()))
+            {
+                peers.emplace_back(pr);
+            }
+            return peers.size() < static_cast<size_t>(maxNum);
+        });
     return peers;
 }
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -248,7 +248,7 @@ OverlayManagerImpl::getPeersToConnectTo(int maxNum)
                                     {
                                         peers.emplace_back(pr);
                                     }
-                                    return peers.size() < maxNum;
+                                    return peers.size() < static_cast<size_t>(maxNum);
                                 });
     return peers;
 }

--- a/src/transactions/TxResultsTests.cpp
+++ b/src/transactions/TxResultsTests.cpp
@@ -85,7 +85,7 @@ expectedResult(int64_t fee, size_t opsCount, TransactionResultCode code,
     }
 
     result.result.results().resize(static_cast<uint32_t>(ops.size()));
-    for (auto i = 0; i < ops.size(); i++)
+    for (size_t i = 0; i < ops.size(); i++)
     {
         auto& r = result.result.results()[i];
         auto& o = ops[i];
@@ -276,7 +276,7 @@ TEST_CASE("txresults", "[tx][txresults]")
 
             if (ledgerVersion != 7)
             {
-                for (auto i = 1; i < opSigned.size(); i++)
+                for (size_t i = 1; i < opSigned.size(); i++)
                 {
                     switch (opSigned[i])
                     {
@@ -328,7 +328,7 @@ TEST_CASE("txresults", "[tx][txresults]")
         auto opResults = std::vector<ExpectedOpResult>{};
         auto firstUnderfunded = true;
 
-        for (auto i = 0; i < opPayment.size(); i++)
+        for (size_t i = 0; i < opPayment.size(); i++)
         {
             if (ledgerVersion != 7)
             {
@@ -600,14 +600,14 @@ TEST_CASE("txresults", "[tx][txresults]")
 
     auto signSectionName = [](std::vector<Signed> const& signs) {
         auto result = std::string{"tx and op1 " + signedNames[signs[0]]};
-        for (auto i = 1; i < signs.size(); i++)
+        for (size_t i = 1; i < signs.size(); i++)
             result +=
                 ", op" + std::to_string(i + 1) + " " + signedNames[signs[i]];
         return result;
     };
     auto opSectionName = [](std::vector<PaymentValidity> const& ops) {
         auto result = std::string{"op1 " + paymentValidityNames[ops[0]]};
-        for (auto i = 1; i < ops.size(); i++)
+        for (size_t i = 1; i < ops.size(); i++)
             result += ", op" + std::to_string(i + 1) + " " +
                       paymentValidityNames[ops[i]];
         return result;
@@ -617,7 +617,7 @@ TEST_CASE("txresults", "[tx][txresults]")
     auto makeTx = [&](std::vector<Signed> const& signs,
                       std::vector<PaymentValidity> const& ops) {
         auto operations = std::vector<Operation>{};
-        for (auto i = 0; i < ops.size(); i++)
+        for (size_t i = 0; i < ops.size(); i++)
         {
             auto destination = accounts[(i + 1) % ops.size()];
             auto op = payment(*destination, amount(ops[i]));
@@ -629,7 +629,7 @@ TEST_CASE("txresults", "[tx][txresults]")
         auto tx = a.tx(operations);
         tx->getEnvelope().signatures.clear();
 
-        for (auto i = 0; i < signs.size(); i++)
+        for (size_t i = 0; i < signs.size(); i++)
         {
             sign(tx, *accounts[i], signs[i]);
         }


### PR DESCRIPTION
I found a few warnings when building this on gcc 5.4.0 (the default one on ubuntu xenial).

The main issue were some third party libraries, like asio and easylogging++, which had several warnings regarding "unused" variables/members and those were polluting the rest of the build. I used `-isystem` rather than `-I` to pull those include paths so now they're treated as an external directory and therefore they don't generate any warnings while including them on stellar-core.

Also, I noticed `common.mk` is using -I"$(top_srcdir)/src" and -I"$(top_builddir)/src" but they both map to the same directory. Maybe one of them should be removed?
