### PR TITLE
Move using xdr::operator statements into a separate header

### DIFF
--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -6,6 +6,7 @@
 
 #include "ledger/EntryFrame.h"
 #include "overlay/StellarXDR.h"
+#include "util/XDROperators.h"
 
 namespace stellar
 {
@@ -31,8 +32,6 @@ struct LedgerEntryIdCmp
     operator()(T const& a, U const& b) const
         -> decltype(a.type(), b.type(), bool())
     {
-        using xdr::operator<;
-
         LedgerEntryType aty = a.type();
         LedgerEntryType bty = b.type();
 

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/KeyUtils.h"
+#include "util/XDROperators.h"
 #include "xdr/Stellar-types.h"
 
 #include <array>
@@ -13,8 +14,6 @@
 
 namespace stellar
 {
-
-using xdr::operator==;
 
 class ByteSlice;
 struct SecretValue;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -9,6 +9,7 @@
 #include "herder/HerderSCPDriver.h"
 #include "herder/Upgrades.h"
 #include "util/Timer.h"
+#include "util/XDROperators.h"
 #include <deque>
 #include <memory>
 #include <unordered_map>
@@ -26,9 +27,6 @@ namespace stellar
 class Application;
 class LedgerManager;
 class HerderSCPDriver;
-
-using xdr::operator<;
-using xdr::operator==;
 
 /*
  * Is in charge of receiving transactions from the network.

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -4,6 +4,7 @@
 #include "herder/Upgrades.h"
 #include "main/Application.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include <overlay/OverlayManager.h>
 #include <xdrpp/marshal.h>
 
@@ -19,7 +20,6 @@ LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
     Value x;
     Value y(x.begin(), x.end());
 
-    using xdr::operator==;
     assert(txSet->getContentsHash() == mValue.txSetHash);
 }
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -10,6 +10,7 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include <algorithm>
 
@@ -19,9 +20,6 @@ namespace stellar
 {
 
 using namespace std;
-
-using xdr::operator==;
-using xdr::operator<;
 
 TxSetFrame::TxSetFrame(Hash const& previousLedgerHash)
     : mHashIsValid(false), mPreviousLedgerHash(previousLedgerHash)

--- a/src/history/HistoryTestsUtils.cpp
+++ b/src/history/HistoryTestsUtils.cpp
@@ -13,6 +13,7 @@
 #include "test/TestUtils.h"
 #include "test/TxTests.h"
 #include "test/test.h"
+#include "util/XDROperators.h"
 #include "work/WorkManager.h"
 
 #include <medida/metrics_registry.h>
@@ -22,8 +23,6 @@ using namespace txtest;
 
 namespace stellar
 {
-using xdr::operator==;
-
 namespace historytestutils
 {
 

--- a/src/invariant/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabaseTests.cpp
@@ -25,17 +25,13 @@
 #include "main/Application.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/XDROperators.h"
 #include "work/WorkManager.h"
 #include <random>
 #include <util/basen.h>
 
 using namespace stellar;
 using namespace std::placeholders;
-
-namespace stellar
-{
-using xdr::operator<;
-}
 
 namespace BucketListIsConsistentWithDatabaseTests
 {

--- a/src/invariant/CacheIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/CacheIsConsistentWithDatabaseTests.cpp
@@ -12,14 +12,10 @@
 #include "main/Application.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/XDROperators.h"
 #include <random>
 
 using namespace stellar;
-
-namespace stellar
-{
-using xdr::operator<;
-}
 
 static LedgerEntry
 generateRandomLedgerEntry(std::map<LedgerKey, LedgerEntry>& liveEntries,

--- a/src/ledger/AccountFrame.cpp
+++ b/src/ledger/AccountFrame.cpp
@@ -12,6 +12,7 @@
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerRange.h"
 #include "lib/util/format.h"
+#include "util/XDROperators.h"
 #include "util/basen.h"
 #include "util/types.h"
 #include <algorithm>
@@ -21,8 +22,6 @@ using namespace std;
 
 namespace stellar
 {
-using xdr::operator<;
-
 const char* AccountFrame::kSQLCreateStatement1 =
     "CREATE TABLE accounts"
     "("

--- a/src/ledger/EntryFrame.cpp
+++ b/src/ledger/EntryFrame.cpp
@@ -11,13 +11,12 @@
 #include "ledger/LedgerDelta.h"
 #include "ledger/OfferFrame.h"
 #include "ledger/TrustFrame.h"
+#include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include "xdrpp/printer.h"
 
 namespace stellar
 {
-using xdr::operator==;
-
 EntryFrame::pointer
 EntryFrame::FromXDR(LedgerEntry const& from)
 {

--- a/src/ledger/LedgerDelta.cpp
+++ b/src/ledger/LedgerDelta.cpp
@@ -7,13 +7,12 @@
 #include "main/Config.h"
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
+#include "util/XDROperators.h"
 #include "xdr/Stellar-ledger.h"
 #include "xdrpp/printer.h"
 
 namespace stellar
 {
-using xdr::operator==;
-
 LedgerDelta::LedgerDelta(LedgerDelta& outerDelta)
     : mOuterDelta(&outerDelta)
     , mHeader(&outerDelta.getHeader())

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -26,6 +26,7 @@
 #include "main/Config.h"
 #include "overlay/OverlayManager.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/format.h"
 #include "util/make_unique.h"
 
@@ -70,8 +71,6 @@ const uint32_t LedgerManager::GENESIS_LEDGER_BASE_FEE = 100;
 const uint32_t LedgerManager::GENESIS_LEDGER_BASE_RESERVE = 100000000;
 const uint32_t LedgerManager::GENESIS_LEDGER_MAX_TX_SIZE = 100;
 const int64_t LedgerManager::GENESIS_LEDGER_TOTAL_COINS = 1000000000000000000;
-
-using xdr::operator==;
 
 std::unique_ptr<LedgerManager>
 LedgerManager::create(Application& app)

--- a/src/ledger/TrustFrame.cpp
+++ b/src/ledger/TrustFrame.cpp
@@ -9,6 +9,7 @@
 #include "crypto/SecretKey.h"
 #include "database/Database.h"
 #include "ledger/LedgerRange.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 
 using namespace std;
@@ -16,8 +17,6 @@ using namespace soci;
 
 namespace stellar
 {
-using xdr::operator==;
-
 // note: the primary key omits assettype as assetcodes are non overlapping
 const char* TrustFrame::kSQLCreateStatement1 =
     "CREATE TABLE trustlines"

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -20,6 +20,7 @@
 #include "util/make_unique.h"
 
 #include "medida/reporting/json_reporter.h"
+#include "util/XDROperators.h"
 #include "util/basen.h"
 #include "xdrpp/marshal.h"
 #include "xdrpp/printer.h"
@@ -37,8 +38,6 @@ using std::placeholders::_2;
 
 namespace stellar
 {
-using xdr::operator<;
-
 CommandHandler::CommandHandler(Application& app) : mApp(app)
 {
     if (mApp.getConfig().HTTP_PORT)

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -13,6 +13,7 @@
 #include "scp/LocalNode.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 
 #include <functional>
@@ -21,8 +22,6 @@
 
 namespace stellar
 {
-using xdr::operator<;
-
 const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 10;
 
 Config::Config() : NODE_SEED(SecretKey::random())

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -2,6 +2,7 @@
 #include "crypto/SecretKey.h"
 #include "transactions/SignatureUtils.h"
 #include "util/Fs.h"
+#include "util/XDROperators.h"
 #include "util/XDRStream.h"
 #include "util/basen.h"
 #include <iostream>

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -11,13 +11,11 @@
 #include "medida/metrics_registry.h"
 #include "overlay/OverlayManager.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 
 namespace stellar
 {
-
-using xdr::operator<;
-
 Floodgate::FloodRecord::FloodRecord(StellarMessage const& msg, uint32_t ledger,
                                     Peer::pointer peer)
     : mLedgerSeq(ledger), mMessage(msg)

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -9,14 +9,13 @@
 #include "main/Config.h"
 #include "overlay/OverlayManager.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 
 #include <chrono>
 
 namespace stellar
 {
-using xdr::operator<;
-
 LoadManager::LoadManager() : mPeerCosts(128)
 {
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -12,6 +12,7 @@
 #include "overlay/PeerRecord.h"
 #include "overlay/TCPPeer.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 
 #include "medida/counter.h"
@@ -49,8 +50,6 @@ namespace stellar
 
 using namespace soci;
 using namespace std;
-
-using xdr::operator<;
 
 std::unique_ptr<OverlayManager>
 OverlayManager::create(Application& app)

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -20,6 +20,7 @@
 #include "overlay/StellarXDR.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
+
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "medida/timer.h"

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -19,7 +19,7 @@
 #include "overlay/PeerRecord.h"
 #include "overlay/StellarXDR.h"
 #include "util/Logging.h"
-
+#include "util/XDROperators.h"
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "medida/timer.h"
@@ -37,8 +37,6 @@ namespace stellar
 
 using namespace std;
 using namespace soci;
-
-using xdr::operator<;
 
 medida::Meter&
 Peer::getByteReadMeter(Application& app)
@@ -898,8 +896,6 @@ Peer::noteHandshakeSuccessInPeerRecord()
 void
 Peer::recvHello(Hello const& elo)
 {
-    using xdr::operator==;
-
     if (mState >= GOT_HELLO)
     {
         CLOG(ERROR, "Overlay") << "received unexpected HELLO";

--- a/src/overlay/PeerAuth.cpp
+++ b/src/overlay/PeerAuth.cpp
@@ -10,12 +10,11 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 
 namespace stellar
 {
-
-using xdr::operator==;
 
 // Certs expire every hour, are reissued every half hour.
 static const uint64_t expirationLimit = 3600;

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -11,6 +11,7 @@
 #include "medida/medida.h"
 #include "overlay/OverlayManager.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 
 namespace stellar
@@ -183,7 +184,6 @@ Tracker::listen(const SCPEnvelope& env)
 void
 Tracker::discard(const SCPEnvelope& env)
 {
-    using xdr::operator==;
     auto matchEnvelope = [&env](std::pair<Hash, SCPEnvelope> const& x) {
         return x.second == env;
     };

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -12,6 +12,7 @@
 #include "scp/QuorumSetUtils.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
@@ -19,8 +20,6 @@
 
 namespace stellar
 {
-using xdr::operator==;
-using xdr::operator<;
 using namespace std::placeholders;
 
 // max number of transitions that can occur from processing one message

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -10,6 +10,7 @@
 #include "lib/json/json.h"
 #include "scp/QuorumSetUtils.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
 #include <algorithm>
@@ -17,9 +18,6 @@
 
 namespace stellar
 {
-using xdr::operator==;
-using xdr::operator<;
-
 LocalNode::LocalNode(NodeID const& nodeID, bool isValidator,
                      SCPQuorumSet const& qSet, SCP* scp)
     : mNodeID(nodeID), mIsValidator(isValidator), mQSet(qSet), mSCP(scp)

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -12,6 +12,7 @@
 #include "scp/LocalNode.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
@@ -19,8 +20,6 @@
 
 namespace stellar
 {
-using xdr::operator==;
-using xdr::operator<;
 using namespace std::placeholders;
 
 NominationProtocol::NominationProtocol(Slot& slot)

--- a/src/scp/QuorumSetUtils.cpp
+++ b/src/scp/QuorumSetUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "QuorumSetUtils.h"
 
+#include "util/XDROperators.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-types.h"
 
@@ -11,8 +12,6 @@
 
 namespace stellar
 {
-
-using xdr::operator<;
 
 namespace
 {

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -9,6 +9,7 @@
 #include "scp/Slot.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 
 #include <algorithm>
@@ -16,7 +17,6 @@
 
 namespace stellar
 {
-using xdr::operator==;
 
 SCP::SCP(SCPDriver& driver, NodeID const& nodeID, bool isValidator,
          SCPQuorumSet const& qSetLocal)

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -11,15 +11,13 @@
 #include "scp/Slot.h"
 #include "simulation/Simulation.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
 #include "xdrpp/printer.h"
 
 namespace stellar
 {
-
-using xdr::operator<;
-using xdr::operator==;
 
 #define CREATE_VALUE(X) \
     static const Hash X##ValueHash = sha256("SEED_VALUE_HASH_" #X); \

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -10,6 +10,7 @@
 #include "scp/LocalNode.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
@@ -18,8 +19,6 @@
 
 namespace stellar
 {
-using xdr::operator==;
-using xdr::operator<;
 using namespace std::placeholders;
 
 Slot::Slot(uint64 slotIndex, SCP& scp)

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -14,6 +14,7 @@
 #include "simulation/LoadGenerator.h"
 #include "test/TxTests.h"
 #include "util/Timer.h"
+#include "util/XDROperators.h"
 #include "xdr/Stellar-types.h"
 
 #define SIMULATION_CREATE_NODE(N) \
@@ -23,9 +24,6 @@
 
 namespace stellar
 {
-using xdr::operator<;
-using xdr::operator==;
-
 class Simulation
 {
   public:

--- a/src/test/TestMarket.cpp
+++ b/src/test/TestMarket.cpp
@@ -6,14 +6,13 @@
 #include "lib/catch.hpp"
 #include "test/TestAccount.h"
 #include "test/TxTests.h"
+#include "util/XDROperators.h"
 #include "xdr/Stellar-ledger-entries.h"
 
 namespace stellar
 {
 
 using namespace txtest;
-using xdr::operator<;
-using xdr::operator==;
 
 bool
 operator<(OfferKey const& x, OfferKey const& y)

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -27,6 +27,7 @@
 #include "transactions/SetOptionsOpFrame.h"
 #include "transactions/TransactionFrame.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 #include "util/types.h"
 
@@ -36,8 +37,6 @@ using namespace stellar::txtest;
 typedef std::unique_ptr<Application> appPtr;
 namespace stellar
 {
-using xdr::operator==;
-
 namespace txtest
 {
 

--- a/src/transactions/BumpSequenceOpFrame.cpp
+++ b/src/transactions/BumpSequenceOpFrame.cpp
@@ -9,11 +9,10 @@
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "transactions/TransactionFrame.h"
+#include "util/XDROperators.h"
 
 namespace stellar
 {
-using xdr::operator==;
-
 BumpSequenceOpFrame::BumpSequenceOpFrame(Operation const& op,
                                          OperationResult& res,
                                          TransactionFrame& parentTx)

--- a/src/transactions/BumpSequenceTests.cpp
+++ b/src/transactions/BumpSequenceTests.cpp
@@ -15,6 +15,7 @@
 #include "transactions/TransactionFrame.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 
 using namespace stellar;
@@ -22,8 +23,6 @@ using namespace stellar::txtest;
 
 TEST_CASE("bump sequence", "[tx][bumpsequence]")
 {
-    using xdr::operator==;
-
     Config const& cfg = getTestConfig();
 
     VirtualClock clock;

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -10,6 +10,7 @@
 #include "ledger/OfferFrame.h"
 #include "ledger/TrustFrame.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include <algorithm>
 
 #include "main/Application.h"
@@ -20,7 +21,6 @@ namespace stellar
 {
 
 using namespace std;
-using xdr::operator==;
 
 CreateAccountOpFrame::CreateAccountOpFrame(Operation const& op,
                                            OperationResult& res,

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -16,6 +16,7 @@
 #include "transactions/InflationOpFrame.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
+#include "util/XDROperators.h"
 #include <functional>
 
 using namespace stellar;
@@ -164,8 +165,6 @@ doInflation(Application& app, int ledgerVersion, int nbAccounts,
             std::function<int64(int)> getBalance,
             std::function<int(int)> getVote, int expectedWinnerCount)
 {
-    using xdr::operator==;
-
     // simulate the expected inflation based off the current ledger state
     std::map<int, int64> balances;
 

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -11,13 +11,13 @@
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 
 namespace stellar
 {
 
 using namespace std;
-using xdr::operator==;
 
 ManageDataOpFrame::ManageDataOpFrame(Operation const& op, OperationResult& res,
                                      TransactionFrame& parentTx)

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -12,6 +12,7 @@
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/types.h"
 
 // convert from sheep to wheat
@@ -22,7 +23,6 @@ namespace stellar
 {
 
 using namespace std;
-using xdr::operator==;
 
 ManageOfferOpFrame::ManageOfferOpFrame(Operation const& op,
                                        OperationResult& res,

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -10,12 +10,12 @@
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 
 using namespace soci;
 
 namespace stellar
 {
-using xdr::operator==;
 
 MergeOpFrame::MergeOpFrame(Operation const& op, OperationResult& res,
                            TransactionFrame& parentTx)

--- a/src/transactions/PathPaymentOpFrame.cpp
+++ b/src/transactions/PathPaymentOpFrame.cpp
@@ -10,6 +10,7 @@
 #include "ledger/OfferFrame.h"
 #include "ledger/TrustFrame.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include <algorithm>
 
 #include "main/Application.h"
@@ -20,7 +21,6 @@ namespace stellar
 {
 
 using namespace std;
-using xdr::operator==;
 
 PathPaymentOpFrame::PathPaymentOpFrame(Operation const& op,
                                        OperationResult& res,

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -14,13 +14,13 @@
 #include "medida/metrics_registry.h"
 #include "transactions/PathPaymentOpFrame.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include <algorithm>
 
 namespace stellar
 {
 
 using namespace std;
-using xdr::operator==;
 
 PaymentOpFrame::PaymentOpFrame(Operation const& op, OperationResult& res,
                                TransactionFrame& parentTx)

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -8,10 +8,10 @@
 #include "main/Application.h"
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
+#include "util/XDROperators.h"
 
 namespace stellar
 {
-using xdr::operator==;
 
 static const uint32 allAccountFlags =
     (AUTH_REQUIRED_FLAG | AUTH_REVOCABLE_FLAG | AUTH_IMMUTABLE_FLAG);

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -14,6 +14,7 @@
 #include "transactions/TransactionFrame.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
+#include "util/XDROperators.h"
 #include "util/make_unique.h"
 
 using namespace stellar;
@@ -28,8 +29,6 @@ typedef std::unique_ptr<Application> appPtr;
 // minbalance
 TEST_CASE("set options", "[tx][setoptions]")
 {
-    using xdr::operator==;
-
     Config const& cfg = getTestConfig();
 
     VirtualClock clock;

--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -10,12 +10,10 @@
 #include "crypto/SignerKey.h"
 #include "transactions/SignatureUtils.h"
 #include "util/Algoritm.h"
+#include "util/XDROperators.h"
 
 namespace stellar
 {
-
-using xdr::operator<;
-using xdr::operator==;
 
 SignatureChecker::SignatureChecker(
     uint32_t protocolVersion, Hash const& contentsHash,

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -18,6 +18,7 @@
 #include "transactions/SignatureUtils.h"
 #include "util/Algoritm.h"
 #include "util/Logging.h"
+#include "util/XDROperators.h"
 #include "util/XDRStream.h"
 #include "util/basen.h"
 #include "xdrpp/marshal.h"
@@ -33,7 +34,6 @@ namespace stellar
 {
 
 using namespace std;
-using xdr::operator==;
 
 TransactionFramePtr
 TransactionFrame::makeTransactionFromWire(Hash const& networkID,

--- a/src/util/XDROperators.h
+++ b/src/util/XDROperators.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <xdrpp/types.h>
+
+namespace stellar
+{
+using xdr::operator==;
+using xdr::operator<;
+}

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -4,14 +4,13 @@
 
 #include "util/types.h"
 #include "lib/util/uint128_t.h"
+#include "util/XDROperators.h"
 #include <algorithm>
 #include <locale>
 
 namespace stellar
 {
 static std::locale cLocale("C");
-
-using xdr::operator==;
 
 bool
 isZero(uint256 const& b)


### PR DESCRIPTION
Following up on what #1529 says, the use of `using xdr::operator...` statements within different scopes doesn't really fix this when using a type outside of the scope it's defined in that requires those operators to be available (e.g. `std::map`).

This PR creates a new header just for XDR operators. I thought this was a good way to approach this as there doesn't seem to be a "standard XDR" header that's included throughout the code and I didn't want to pollute something like `util/types.h` as this is very specific, but I can change it otherwise.

Fixes #1529