### PR TITLE
Catch exceptions when formatting command string templates

### DIFF
--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -35,6 +35,22 @@ namespace stellar
 
 unsigned const HistoryArchiveState::HISTORY_ARCHIVE_STATE_VERSION = 1;
 
+template <typename... Tokens>
+std::string
+formatString(std::string const& templateString, Tokens const&... tokens)
+{
+    try
+    {
+        return fmt::format(templateString, tokens...);
+    }
+    catch (fmt::FormatError const& ex)
+    {
+        CLOG(ERROR, "History") << "failed to format string \"" << templateString
+                               << "\":" << ex.what();
+        throw std::runtime_error("failed to format command string");
+    }
+}
+
 bool
 HistoryArchiveState::futuresAllReady() const
 {
@@ -320,7 +336,7 @@ HistoryArchive::getFileCmd(std::string const& remote,
 {
     if (mGetCmd.empty())
         return "";
-    return fmt::format(mGetCmd, remote, local);
+    return formatString(mGetCmd, remote, local);
 }
 
 std::string
@@ -329,7 +345,7 @@ HistoryArchive::putFileCmd(std::string const& local,
 {
     if (mPutCmd.empty())
         return "";
-    return fmt::format(mPutCmd, local, remote);
+    return formatString(mPutCmd, local, remote);
 }
 
 std::string
@@ -337,6 +353,6 @@ HistoryArchive::mkdirCmd(std::string const& remoteDir) const
 {
     if (mMkdirCmd.empty())
         return "";
-    return fmt::format(mMkdirCmd, remoteDir);
+    return formatString(mMkdirCmd, remoteDir);
 }
 }


### PR DESCRIPTION
If the configuration file being used contains any invalid format strings (e.g. `echo hello {0`) for commands, stellar-core blows up without any logging messages specifying what happened.

This PR catches exceptions when formatting strings in `HistoryArchive`, logs them and then throws again. As far as I can see, this is the only class that deals with parsing user provided format strings.