### PR TITLE
Explicitly disallow changing trust using native asset

### DIFF
--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -160,6 +160,19 @@ ChangeTrustOpFrame::doCheckValid(Application& app)
         innerResult().code(CHANGE_TRUST_MALFORMED);
         return false;
     }
+    if (app.getLedgerManager().getCurrentLedgerVersion() > 9)
+    {
+        if (mChangeTrust.line.type() == ASSET_TYPE_NATIVE)
+        {
+            app.getMetrics()
+                .NewMeter(
+                    {"op-change-trust", "invalid", "malformed-native-asset"},
+                    "operation")
+                .Mark();
+            innerResult().code(CHANGE_TRUST_MALFORMED);
+            return false;
+        }
+    }
     return true;
 }
 }

--- a/src/transactions/ChangeTrustTests.cpp
+++ b/src/transactions/ChangeTrustTests.cpp
@@ -158,4 +158,18 @@ TEST_CASE("change trust", "[tx][changetrust]")
             validateTrustLineIsConst();
         });
     }
+
+    SECTION("trustline on native asset")
+    {
+        const auto nativeAsset = makeNativeAsset();
+        for_versions_to(9, *app, [&] {
+            REQUIRE_THROWS_AS(gateway.changeTrust(nativeAsset, INT64_MAX - 1),
+                              ex_txINTERNAL_ERROR);
+        });
+
+        for_versions_from(10, *app, [&] {
+            REQUIRE_THROWS_AS(gateway.changeTrust(nativeAsset, INT64_MAX - 1),
+                              ex_CHANGE_TRUST_MALFORMED);
+        });
+    }
 }


### PR DESCRIPTION
This addresses the issue found on #1521: changing trust using native asset now returns CHANGE_TRUST_MALFORMED rather than internal error.