### PR TITLE
Dont adjust txrate for account creations

### DIFF
--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -47,7 +47,7 @@ class LoadGenerator
     uint64_t mLastSecond;
 
     void createRootAccount();
-    uint32_t getTxPerStep(uint32_t txRate);
+    uint32_t getTxPerStep(uint32_t txRate, bool isCreate);
 
     // Schedule a callback to generateLoad() STEP_MSECS miliseconds from now.
     void scheduleLoadGeneration(bool isCreate, uint32_t nAccounts,


### PR DESCRIPTION
An issue I noticed when running benchmark tests: looks like batching 100 account creation ops per tx (or any other high number of ops) with auto adjustment of tx per step doesn't work very well. The adjustment is based on how often steps are submitted, and in case of batching multiple ops in a tx, it looks like less steps per s are submitted (possibly because the system is more loaded dealing with these large txs?), so `tx per step` keeps snowballing.