### PR TITLE
Actually kill subprocesses (issue #1636)

### DIFF
--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -99,15 +99,15 @@ ProcessManagerImpl::getNumRunningProcesses()
 ProcessManagerImpl::~ProcessManagerImpl()
 {
     const auto killProcess = [&](ProcessExitEvent::Impl& impl) {
-		const int pid = impl.getProcessId();
+        const int pid = impl.getProcessId();
         auto ec = asio::error_code(1, asio::system_category());
         impl.cancel(ec);
 #ifdef _WIN32
-		if (!TerminateProcess(impl.mProcessHandle.native_handle(), 1))
-		{
-			CLOG(WARNING, "Process")
-				<< "failed to terminate process with pid " << pid;
-		}
+        if (!TerminateProcess(impl.mProcessHandle.native_handle(), 1))
+        {
+            CLOG(WARNING, "Process")
+                << "failed to terminate process with pid " << pid;
+        }
         impl.mProcessHandle.cancel(ec);
 #else
         int result = kill(pid, SIGKILL);

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -132,6 +132,14 @@ ProcessManagerImpl::shutdown()
             pair.second->cancel(ec);
 #ifdef _WIN32
             pair.second->mProcessHandle.cancel(ec);
+#else
+            const int pid = pair.second->getProcessId();
+            int result = kill(pid, SIGINT);
+            if (result != 0)
+            {
+                CLOG(WARNING, "Process")
+                    << "kill failed for pid " << pid << ": " << result;
+            }
 #endif
         }
         mImpls.clear();

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -50,6 +50,8 @@ class ProcessManagerImpl : public ProcessManager
     void startSignalWait();
     void handleSignalWait();
     void handleProcessTermination(int pid, int status);
+    void cleanShutdown(ProcessExitEvent::Impl& impl);
+    void forceShutdown(ProcessExitEvent::Impl& impl);
 
     friend class ProcessExitEvent::Impl;
 

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -41,6 +41,7 @@ class ProcessManagerImpl : public ProcessManager
     asio::io_service& mIOService;
 
     std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mPendingImpls;
+    std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mKillableImpls;
     void maybeRunPendingProcesses();
     void registerManager();
 

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -49,7 +49,7 @@ class ProcessManagerImpl : public ProcessManager
     asio::signal_set mSigChild;
     void startSignalWait();
     void handleSignalWait();
-    bool handleProcessTermination(int pid, int status);
+    void handleProcessTermination(int pid, int status);
 
     friend class ProcessExitEvent::Impl;
 

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -20,13 +20,6 @@ namespace stellar
 
 class ProcessManagerImpl : public ProcessManager
 {
-    // Subprocess callbacks are process-wide, owing to the process-wide
-    // receipt of SIGCHLD, at least on POSIX. The list of all active
-    // process mangers is kept globally so as to dispatch the child
-    // process stop signal accordingly
-    static std::recursive_mutex gManagersMutex;
-    static std::vector<ProcessManagerImpl*> gManagers;
-
     // On windows we use a simple global counter to throttle the
     // number of processes we run at once.
     static std::atomic<size_t> gNumProcessesActive;
@@ -43,7 +36,6 @@ class ProcessManagerImpl : public ProcessManager
     std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mPendingImpls;
     std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mKillableImpls;
     void maybeRunPendingProcesses();
-    void registerManager();
 
     // These are only used on POSIX, but they're harmless here.
     asio::signal_set mSigChild;

--- a/src/process/ProcessTests.cpp
+++ b/src/process/ProcessTests.cpp
@@ -178,7 +178,7 @@ TEST_CASE("shutdown while process running", "[process]")
             CLOG(DEBUG, "Process") << "error code: " << ec.message();
         }
         failed = !!ec;
-        exited = true; 
+        exited = true;
         errorCode = ec;
     });
 

--- a/src/process/ProcessTests.cpp
+++ b/src/process/ProcessTests.cpp
@@ -14,7 +14,9 @@
 #include "util/Logging.h"
 #include "util/Timer.h"
 #include "xdrpp/autocheck.h"
+#include <chrono>
 #include <future>
+#include <thread>
 
 using namespace stellar;
 
@@ -186,6 +188,9 @@ TEST_CASE("shutdown while process running", "[process]")
             errorCodes.push_back(ec);
         });
     }
+
+    // Wait, just in case the processes haven't started yet
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     // Shutdown so we force the command execution to fail
     app1->getProcessManager().shutdown();

--- a/src/process/ProcessTests.cpp
+++ b/src/process/ProcessTests.cpp
@@ -163,7 +163,7 @@ TEST_CASE("shutdown while process running", "[process]")
     Config const& cfg = getTestConfig();
     Application::pointer app = createTestApplication(clock, cfg);
 #ifdef _WIN32
-    std::string command = "timeout 10";
+    std::string command = "waitfor /T 10 pause";
 #else
     std::string command = "sleep 10";
 #endif
@@ -178,7 +178,7 @@ TEST_CASE("shutdown while process running", "[process]")
             CLOG(DEBUG, "Process") << "error code: " << ec.message();
         }
         failed = !!ec;
-        exited = true;
+        exited = true; 
         errorCode = ec;
     });
 


### PR DESCRIPTION
This fixes #1636. I had to make a few changes for this to work, following @MonsieurNicolas's comments on the ticket. The list of changes implemented here are:

* Now instead of sharing the map of subprocesses globally, those are kept in a per instance basis. Since there's still a need for forwarding signals properly to all `ProcessManager` instances, the instances themselves are registered globally so that whoever gets the signal can forward it to all of them. I had to use raw pointers here as there's no easy way to register instances on their constructor otherwise. I'm not a fan of this but it works.
* On Linux, `ProcessManager::shutdown` will send `SIGINT` to all subprocesses. Once the destructor is hit, then `SIGKILL` will be sent, regardless of whether `SIGINT` was already sent or not.
* On Windows, `TerminateProcess` is called on the destructor. I'm not sure what to do on shutdown as, as far as I can see, there's no `SIGINT` equivalent on that OS. Maybe it's worth calling `TerminateProcess` on shutdown and only do that on the destructor for cases when shutdown isn't initially called?
* I fixed a circular `shared_ptr` dependency between the `ProcessManagerImpl` and its subprocesses. Basically they both had a `shared_ptr` to each other so if any subprocesses were kept alive, then the process manager would never be destructed.
* I moved `gNumProcessesActive` to be an `atomic`. This is only really needed when decrementing the value in the `async_wait` callback on the Windows implementation of `ProcessExitEvent::Impl::run` as the rest of the accesses are protected by the `mImplsMutex` mutex. This could be replaced by a lock and a counter but I didn't want to introduce another global lock just for that.
* As for tests, on Linux it's simple: run `sleep 10` and then kill it right away. I made sure the process is actually dead after `stellar-core` stops running. On Windows I had to use `waitfor /T 10 pause` instead. The other alternatives I tried (e.g. `timeout`) fail because the process can't read from stdin, hence it aborts right away. I also made sure the process actually exits while testing this. 