### PR TITLE
Fix #1647 Install fails using Mac OS X instructions during make step:…

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,7 @@ When building on OSX, here's some dependencies you'll need:
 - brew install automake
 - brew install pkg-config
 - brew install libpqxx *(If ./configure later complains about libpq missing, try PKG_CONFIG_PATH='/usr/local/lib/pkgconfig')*
+- brew install pandoc
 
 ### Windows
 See [INSTALL-Windows.md](INSTALL-Windows.md)


### PR DESCRIPTION
… make step currently fails due to missing requirement of pandoc. Installing pandoc resolves the issue so make step can complete successfully