### PR TITLE
Align trigger close time to the close period

### DIFF
--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -110,7 +110,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
     {
         if (qsetNode == nodeID)
         {
-            bigDivide(res, UINT64_MAX, n, d, ROUND_DOWN);
+            bigDivide(res, UINT64_MAX, n, d, ROUND_UP);
             return res;
         }
     }
@@ -120,7 +120,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
         uint64 leafW = getNodeWeight(nodeID, q);
         if (leafW)
         {
-            bigDivide(res, leafW, n, d, ROUND_DOWN);
+            bigDivide(res, leafW, n, d, ROUND_UP);
             return res;
         }
     }

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -211,9 +211,13 @@ NominationProtocol::applyAll(SCPNomination const& nom,
 void
 NominationProtocol::updateRoundLeaders()
 {
-    mRoundLeaders.clear();
-    uint64 topPriority = 0;
     SCPQuorumSet const& myQSet = mSlot.getLocalNode()->getQuorumSet();
+
+    // initialize priority with value derived from self
+    mRoundLeaders.clear();
+    auto localID = mSlot.getLocalNode()->getNodeID();
+    mRoundLeaders.insert(localID);
+    uint64 topPriority = getNodePriority(localID, myQSet);
 
     LocalNode::forAllNodes(myQSet, [&](NodeID const& cur) {
         uint64 w = getNodePriority(cur, myQSet);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -257,7 +257,17 @@ NominationProtocol::getNodePriority(NodeID const& nodeID,
                                     SCPQuorumSet const& qset)
 {
     uint64 res;
-    uint64 w = LocalNode::getNodeWeight(nodeID, qset);
+    uint64 w;
+
+    if (nodeID == mSlot.getLocalNode()->getNodeID())
+    {
+        // local node is in all quorum sets
+        w = UINT64_MAX;
+    }
+    else
+    {
+        w = LocalNode::getNodeWeight(nodeID, qset);
+    }
 
     if (hashNode(false, nodeID) < w)
     {


### PR DESCRIPTION
This causes nodes to start nomination roughly at the same time on the network.

This is mostly useful in test environments as there is no guarantee that nodes on the network have synchronized clock (but in aggregate it will mostly be the case, so this should also help the production network)

resolves #1652

