### PR TITLE
Updates to how nodes decide to trigger the next ledger

### DIFF
--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -68,19 +68,10 @@ SecretKey::Seed::~Seed()
     std::memset(mSeed.data(), 0, mSeed.size());
 }
 
-PublicKey
+PublicKey const&
 SecretKey::getPublicKey() const
 {
-    PublicKey pk;
-
-    assert(mKeyType == PUBLIC_KEY_TYPE_ED25519);
-
-    if (crypto_sign_ed25519_sk_to_pk(pk.ed25519().data(), mSecretKey.data()) !=
-        0)
-    {
-        throw std::runtime_error("error extracting public key from secret key");
-    }
-    return pk;
+    return mPublicKey;
 }
 
 SecretKey::Seed
@@ -142,20 +133,20 @@ SecretKey::sign(ByteSlice const& bin) const
 SecretKey
 SecretKey::random()
 {
-    PublicKey pk;
     SecretKey sk;
     assert(sk.mKeyType == PUBLIC_KEY_TYPE_ED25519);
-    if (crypto_sign_keypair(pk.ed25519().data(), sk.mSecretKey.data()) != 0)
+    if (crypto_sign_keypair(sk.mPublicKey.ed25519().data(),
+                            sk.mSecretKey.data()) != 0)
     {
         throw std::runtime_error("error generating random secret key");
     }
+
     return sk;
 }
 
 SecretKey
 SecretKey::fromSeed(ByteSlice const& seed)
 {
-    PublicKey pk;
     SecretKey sk;
     assert(sk.mKeyType == PUBLIC_KEY_TYPE_ED25519);
 
@@ -163,8 +154,8 @@ SecretKey::fromSeed(ByteSlice const& seed)
     {
         throw std::runtime_error("seed does not match byte size");
     }
-    if (crypto_sign_seed_keypair(pk.ed25519().data(), sk.mSecretKey.data(),
-                                 seed.data()) != 0)
+    if (crypto_sign_seed_keypair(sk.mPublicKey.ed25519().data(),
+                                 sk.mSecretKey.data(), seed.data()) != 0)
     {
         throw std::runtime_error("error generating secret key from seed");
     }

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -25,6 +25,7 @@ class SecretKey
     using uint512 = xdr::opaque_array<64>;
     PublicKeyType mKeyType;
     uint512 mSecretKey;
+    PublicKey mPublicKey;
 
     struct Seed
     {
@@ -41,7 +42,7 @@ class SecretKey
     ~SecretKey();
 
     // Get the public key portion of this secret key.
-    PublicKey getPublicKey() const;
+    PublicKey const& getPublicKey() const;
 
     // Get the seed portion of this secret key as a StrKey string.
     SecretValue getStrKeySeed() const;

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -729,6 +729,18 @@ HerderSCPDriver::acceptedCommit(uint64_t slotIndex, SCPBallot const& ballot)
     mSCPMetrics.mAcceptedCommit.Mark();
 }
 
+optional<VirtualClock::time_point>
+HerderSCPDriver::getPrepareStart(uint64_t slotIndex)
+{
+    optional<VirtualClock::time_point> res;
+    auto it = mSCPExecutionTimes.find(slotIndex);
+    if (it != mSCPExecutionTimes.end())
+    {
+        res = it->second.mPrepareStart;
+    }
+    return res;
+}
+
 void
 HerderSCPDriver::recordSCPEvent(uint64_t slotIndex, bool isNomination)
 {

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -94,6 +94,7 @@ void
 HerderSCPDriver::bootstrap()
 {
     stateChanged();
+    clearSCPExecutionEvents();
 }
 
 void
@@ -809,9 +810,15 @@ HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
 
     // Clean up timings map
     auto it = mSCPExecutionTimes.begin();
-    while (it != mSCPExecutionTimes.end() && it->first <= slotIndex)
+    while (it != mSCPExecutionTimes.end() && it->first < slotIndex)
     {
         it = mSCPExecutionTimes.erase(it);
     }
+}
+
+void
+HerderSCPDriver::clearSCPExecutionEvents()
+{
+    mSCPExecutionTimes.clear();
 }
 }

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -135,6 +135,8 @@ class HerderSCPDriver : public SCPDriver
                                  SCPBallot const& ballot) override;
     void acceptedCommit(uint64_t slotIndex, SCPBallot const& ballot) override;
 
+    optional<VirtualClock::time_point> getPrepareStart(uint64_t slotIndex);
+
   private:
     Application& mApp;
     HerderImpl& mHerder;

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -219,5 +219,7 @@ class HerderSCPDriver : public SCPDriver
     bool isSlotCompatibleWithCurrentState(uint64_t slotIndex) const;
 
     void logQuorumInformation(uint64_t index);
+
+    void clearSCPExecutionEvents();
 };
 }

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -66,10 +66,17 @@ PendingEnvelopes::addSCPQuorumSet(Hash hash, const SCPQuorumSet& q)
     CLOG(TRACE, "Herder") << "Add SCPQSet " << hexAbbrev(hash);
 
     SCPQuorumSetPtr qset(new SCPQuorumSet(q));
+    if (mQsetCache.exists(hash))
+    {
+        // force recomputation of transitive quorum information as it may change
+        // "not in quorum" into "in quorum".
+        // the "quorum -> not in quorum" is similar to the case of a new quorum
+        // set, where the only thing it can do is turn
+        // a "maybe" (true) into "no" (false) which doesn't matter within
+        // a round (clear will happens regardless when the slot is externalized)
+        mNodesInQuorum.clear();
+    }
     mQsetCache.put(hash, qset);
-
-    // force recomputation of transitive quorum information
-    mNodesInQuorum.clear();
 
     mQuorumSetFetcher.recv(hash);
 }

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -827,7 +827,7 @@ BallotProtocol::attemptPreparedAccept(SCPStatement const& hint)
 
         bool accepted = federatedAccept(
             // checks if any node is voting for this ballot
-            [&ballot, this](SCPStatement const& st) {
+            [&ballot](SCPStatement const& st) {
                 bool res;
 
                 switch (st.pledges.type())

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -110,7 +110,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
     {
         if (qsetNode == nodeID)
         {
-            bigDivide(res, UINT64_MAX, n, d, ROUND_DOWN);
+            bigDivide(res, UINT64_MAX, n, d, ROUND_UP);
             return res;
         }
     }
@@ -120,7 +120,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
         uint64 leafW = getNodeWeight(nodeID, q);
         if (leafW)
         {
-            bigDivide(res, leafW, n, d, ROUND_DOWN);
+            bigDivide(res, leafW, n, d, ROUND_UP);
             return res;
         }
     }

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -10,6 +10,7 @@
 #include "lib/json/json.h"
 #include "main/Config.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/make_unique.h"
@@ -211,11 +212,13 @@ NominationProtocol::applyAll(SCPNomination const& nom,
 void
 NominationProtocol::updateRoundLeaders()
 {
-    SCPQuorumSet const& myQSet = mSlot.getLocalNode()->getQuorumSet();
+    SCPQuorumSet myQSet = mSlot.getLocalNode()->getQuorumSet();
 
     // initialize priority with value derived from self
     mRoundLeaders.clear();
     auto localID = mSlot.getLocalNode()->getNodeID();
+    normalizeQSet(myQSet, &localID);
+
     mRoundLeaders.insert(localID);
     uint64 topPriority = getNodePriority(localID, myQSet);
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -211,9 +211,13 @@ NominationProtocol::applyAll(SCPNomination const& nom,
 void
 NominationProtocol::updateRoundLeaders()
 {
-    mRoundLeaders.clear();
-    uint64 topPriority = 0;
     SCPQuorumSet const& myQSet = mSlot.getLocalNode()->getQuorumSet();
+
+    // initialize priority with value derived from self
+    mRoundLeaders.clear();
+    auto localID = mSlot.getLocalNode()->getNodeID();
+    mRoundLeaders.insert(localID);
+    uint64 topPriority = getNodePriority(localID, myQSet);
 
     LocalNode::forAllNodes(myQSet, [&](NodeID const& cur) {
         uint64 w = getNodePriority(cur, myQSet);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -257,7 +257,17 @@ NominationProtocol::getNodePriority(NodeID const& nodeID,
                                     SCPQuorumSet const& qset)
 {
     uint64 res;
-    uint64 w = LocalNode::getNodeWeight(nodeID, qset);
+    uint64 w;
+
+    if (nodeID == mSlot.getLocalNode()->getNodeID())
+    {
+        // local node is in all quorum sets
+        w = UINT64_MAX;
+    }
+    else
+    {
+        w = LocalNode::getNodeWeight(nodeID, qset);
+    }
 
     if (hashNode(false, nodeID) < w)
     {

--- a/src/scp/QuorumSetUtils.cpp
+++ b/src/scp/QuorumSetUtils.cpp
@@ -7,6 +7,7 @@
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-types.h"
 
+#include <algorithm>
 #include <set>
 
 namespace stellar
@@ -96,6 +97,9 @@ isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks)
 }
 
 // helper function that:
+//  * removes nodeID
+//      { t: n, v: { ...BEFORE... , nodeID, ...AFTER... }, ...}
+//      { t: n-1, v: { ...BEFORE..., ...AFTER...} , ... }
 //  * simplifies singleton inner set into outerset
 //      { t: n, v: { ... }, { t: 1, X }, ... }
 //        into
@@ -104,14 +108,24 @@ isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks)
 //      { t:1, { innerSet } } into innerSet
 
 void
-normalizeQSet(SCPQuorumSet& qSet)
+normalizeQSet(SCPQuorumSet& qSet, NodeID const* idToRemove)
 {
+    using xdr::operator==;
     auto& v = qSet.validators;
+    if (idToRemove)
+    {
+        auto it_v = std::remove_if(v.begin(), v.end(), [&](NodeID const& n) {
+            return n == *idToRemove;
+        });
+        qSet.threshold -= uint32(v.end() - it_v);
+        v.erase(it_v, v.end());
+    }
+
     auto& i = qSet.innerSets;
     auto it = i.begin();
     while (it != i.end())
     {
-        normalizeQSet(*it);
+        normalizeQSet(*it, idToRemove);
         // merge singleton inner sets into validator list
         if (it->threshold == 1 && it->validators.size() == 1 &&
             it->innerSets.size() == 0)

--- a/src/scp/QuorumSetUtils.h
+++ b/src/scp/QuorumSetUtils.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include "xdr/Stellar-SCP.h"
+
 namespace stellar
 {
 
-struct SCPQuorumSet;
-
 bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks);
-void normalizeQSet(SCPQuorumSet& qSet);
+
+// normalize the quorum set, optionally removing idToRemove
+void normalizeQSet(SCPQuorumSet& qSet, NodeID const* idToRemove = nullptr);
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -346,7 +346,7 @@ Slot::federatedAccept(StatementPredicate voted, StatementPredicate accepted,
 
     // Checks if the set of nodes that accepted or voted for it form a quorum
 
-    auto ratifyFilter = [this, &voted, &accepted](SCPStatement const& st) {
+    auto ratifyFilter = [&](SCPStatement const& st) {
         bool res;
         res = accepted(st) || voted(st);
         return res;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -37,8 +37,10 @@ class Simulation
 
     using pointer = std::shared_ptr<Simulation>;
     using ConfigGen = std::function<Config(int i)>;
+    using QuorumSetAdjuster = std::function<SCPQuorumSet(SCPQuorumSet const&)>;
 
-    Simulation(Mode mode, Hash const& networkID, ConfigGen = nullptr);
+    Simulation(Mode mode, Hash const& networkID, ConfigGen = nullptr,
+               QuorumSetAdjuster = nullptr);
     ~Simulation();
 
     // updates all clocks in the simulation to the same time_point
@@ -105,6 +107,8 @@ class Simulation
     std::vector<std::shared_ptr<LoopbackPeerConnection>> mLoopbackConnections;
 
     ConfigGen mConfigGen; // config generator
+
+    QuorumSetAdjuster mQuorumSetAdjuster;
 
     std::chrono::milliseconds const quantum = std::chrono::milliseconds(100);
 };

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -11,10 +11,11 @@ using namespace std;
 
 Simulation::pointer
 Topologies::pair(Simulation::Mode mode, Hash const& networkID,
-                 Simulation::ConfigGen confGen)
+                 Simulation::ConfigGen confGen,
+                 Simulation::QuorumSetAdjuster qSetAdjust)
 {
     Simulation::pointer simulation =
-        make_shared<Simulation>(mode, networkID, confGen);
+        make_shared<Simulation>(mode, networkID, confGen, qSetAdjust);
 
     SIMULATION_CREATE_NODE(10);
     SIMULATION_CREATE_NODE(11);
@@ -33,10 +34,11 @@ Topologies::pair(Simulation::Mode mode, Hash const& networkID,
 }
 
 Simulation::pointer
-Topologies::cycle4(Hash const& networkID, Simulation::ConfigGen confGen)
+Topologies::cycle4(Hash const& networkID, Simulation::ConfigGen confGen,
+                   Simulation::QuorumSetAdjuster qSetAdjust)
 {
-    Simulation::pointer simulation =
-        make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID, confGen);
+    Simulation::pointer simulation = make_shared<Simulation>(
+        Simulation::OVER_LOOPBACK, networkID, confGen, qSetAdjust);
 
     SIMULATION_CREATE_NODE(0);
     SIMULATION_CREATE_NODE(1);
@@ -85,10 +87,11 @@ Topologies::cycle4(Hash const& networkID, Simulation::ConfigGen confGen)
 Simulation::pointer
 Topologies::separate(int nNodes, double quorumThresoldFraction,
                      Simulation::Mode mode, Hash const& networkID,
-                     Simulation::ConfigGen confGen)
+                     Simulation::ConfigGen confGen,
+                     Simulation::QuorumSetAdjuster qSetAdjust)
 {
     Simulation::pointer simulation =
-        make_shared<Simulation>(mode, networkID, confGen);
+        make_shared<Simulation>(mode, networkID, confGen, qSetAdjust);
 
     vector<SecretKey> keys;
     for (int i = 0; i < nNodes; i++)
@@ -116,10 +119,11 @@ Topologies::separate(int nNodes, double quorumThresoldFraction,
 Simulation::pointer
 Topologies::core(int nNodes, double quorumThresoldFraction,
                  Simulation::Mode mode, Hash const& networkID,
-                 Simulation::ConfigGen confGen)
+                 Simulation::ConfigGen confGen,
+                 Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
-                                           networkID, confGen);
+                                           networkID, confGen, qSetAdjust);
 
     auto nodes = simulation->getNodeIDs();
     assert(static_cast<int>(nodes.size()) == nNodes);
@@ -138,10 +142,11 @@ Topologies::core(int nNodes, double quorumThresoldFraction,
 Simulation::pointer
 Topologies::cycle(int nNodes, double quorumThresoldFraction,
                   Simulation::Mode mode, Hash const& networkID,
-                  Simulation::ConfigGen confGen)
+                  Simulation::ConfigGen confGen,
+                  Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
-                                           networkID, confGen);
+                                           networkID, confGen, qSetAdjust);
 
     auto nodes = simulation->getNodeIDs();
     assert(static_cast<int>(nodes.size()) == nNodes);
@@ -158,10 +163,11 @@ Topologies::cycle(int nNodes, double quorumThresoldFraction,
 Simulation::pointer
 Topologies::branchedcycle(int nNodes, double quorumThresoldFraction,
                           Simulation::Mode mode, Hash const& networkID,
-                          Simulation::ConfigGen confGen)
+                          Simulation::ConfigGen confGen,
+                          Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
-                                           networkID, confGen);
+                                           networkID, confGen, qSetAdjust);
 
     auto nodes = simulation->getNodeIDs();
     assert(static_cast<int>(nodes.size()) == nNodes);
@@ -178,13 +184,12 @@ Topologies::branchedcycle(int nNodes, double quorumThresoldFraction,
     return simulation;
 }
 
-Simulation::pointer
-Topologies::hierarchicalQuorum(int nBranches, Simulation::Mode mode,
-                               Hash const& networkID,
-                               Simulation::ConfigGen confGen,
-                               int connectionsToCore) // Figure 3 from the paper
+Simulation::pointer Topologies::hierarchicalQuorum(
+    int nBranches, Simulation::Mode mode, Hash const& networkID,
+    Simulation::ConfigGen confGen, int connectionsToCore,
+    Simulation::QuorumSetAdjuster qSetAdjust) // Figure 3 from the paper
 {
-    auto sim = Topologies::core(4, 0.75, mode, networkID, confGen);
+    auto sim = Topologies::core(4, 0.75, mode, networkID, confGen, qSetAdjust);
     vector<NodeID> coreNodeIDs;
     for (auto const& coreNodeID : sim->getNodeIDs())
     {
@@ -245,14 +250,14 @@ Topologies::hierarchicalQuorum(int nBranches, Simulation::Mode mode,
 }
 
 Simulation::pointer
-Topologies::hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
-                                         Simulation::Mode mode,
-                                         Hash const& networkID,
-                                         Simulation::ConfigGen confGen,
-                                         int connectionsToCore)
+Topologies::hierarchicalQuorumSimplified(
+    int coreSize, int nbOuterNodes, Simulation::Mode mode,
+    Hash const& networkID, Simulation::ConfigGen confGen, int connectionsToCore,
+    Simulation::QuorumSetAdjuster qSetAdjust)
 {
     // outer nodes are independent validators that point to a [core network]
-    auto sim = Topologies::core(coreSize, 0.75, mode, networkID, confGen);
+    auto sim =
+        Topologies::core(coreSize, 0.75, mode, networkID, confGen, qSetAdjust);
 
     // each additional node considers themselves as validator
     // with a quorum set that also includes the core
@@ -286,9 +291,11 @@ Topologies::hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
 
 Simulation::pointer
 Topologies::customA(Simulation::Mode mode, Hash const& networkID,
-                    Simulation::ConfigGen confGen, int connections)
+                    Simulation::ConfigGen confGen, int connections,
+                    Simulation::QuorumSetAdjuster qSetAdjust)
 {
-    Simulation::pointer s = make_shared<Simulation>(mode, networkID, confGen);
+    Simulation::pointer s =
+        make_shared<Simulation>(mode, networkID, confGen, qSetAdjust);
 
     enum kIDs
     {

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -12,57 +12,62 @@ namespace stellar
 class Topologies
 {
   public:
-    static Simulation::pointer pair(Simulation::Mode mode,
-                                    Hash const& networkID,
-                                    Simulation::ConfigGen confGen = nullptr);
+    static Simulation::pointer
+    pair(Simulation::Mode mode, Hash const& networkID,
+         Simulation::ConfigGen confGen = nullptr,
+         Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // cyclic network - each node has a qset with a neighbor
-    static Simulation::pointer cycle4(Hash const& networkID,
-                                      Simulation::ConfigGen confGen = nullptr);
+    static Simulation::pointer
+    cycle4(Hash const& networkID, Simulation::ConfigGen confGen = nullptr,
+           Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // nNodes with same qSet - mesh network
-    static Simulation::pointer core(int nNodes, double quorumThresoldFraction,
-                                    Simulation::Mode mode,
-                                    Hash const& networkID,
-                                    Simulation::ConfigGen confGen = nullptr);
+    static Simulation::pointer
+    core(int nNodes, double quorumThresoldFraction, Simulation::Mode mode,
+         Hash const& networkID, Simulation::ConfigGen confGen = nullptr,
+         Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // nNodes with same qSet - one way connection in cycle
-    static Simulation::pointer cycle(int nNodes, double quorumThresoldFraction,
-                                     Simulation::Mode mode,
-                                     Hash const& networkID,
-                                     Simulation::ConfigGen confGen = nullptr);
+    static Simulation::pointer
+    cycle(int nNodes, double quorumThresoldFraction, Simulation::Mode mode,
+          Hash const& networkID, Simulation::ConfigGen confGen = nullptr,
+          Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // nNodes with same qSet - two way connection = cycle + alt-path
     static Simulation::pointer
     branchedcycle(int nNodes, double quorumThresoldFraction,
                   Simulation::Mode mode, Hash const& networkID,
-                  Simulation::ConfigGen confGen = nullptr);
+                  Simulation::ConfigGen confGen = nullptr,
+                  Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // nNodes with same qSet - no connection created
     static Simulation::pointer
     separate(int nNodes, double quorumThresoldFraction, Simulation::Mode mode,
-             Hash const& networkID, Simulation::ConfigGen confGen = nullptr);
+             Hash const& networkID, Simulation::ConfigGen confGen = nullptr,
+             Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // multi-tier quorum (core4 + mid-tier nodes that depend on 2 nodes of
     // core4) mid-tier connected round-robin to core4
     static Simulation::pointer hierarchicalQuorum(
         int nBranches, Simulation::Mode mode, Hash const& networkID,
-        Simulation::ConfigGen confGen = nullptr, int connectionsToCore = 1);
+        Simulation::ConfigGen confGen = nullptr, int connectionsToCore = 1,
+        Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // 2-tier quorum with a variable size core (with 0.75 threshold)
     // and outer-nodes that listen to core & self
     // outer-nodes have connectionsToCore connections to core nodes
     // (round-robin)
-    static Simulation::pointer
-    hierarchicalQuorumSimplified(int coreSize, int nbOuterNodes,
-                                 Simulation::Mode mode, Hash const& networkID,
-                                 Simulation::ConfigGen confGen = nullptr,
-                                 int connectionsToCore = 1);
+    static Simulation::pointer hierarchicalQuorumSimplified(
+        int coreSize, int nbOuterNodes, Simulation::Mode mode,
+        Hash const& networkID, Simulation::ConfigGen confGen = nullptr,
+        int connectionsToCore = 1,
+        Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // custom-A
-    static Simulation::pointer customA(Simulation::Mode mode,
-                                       Hash const& networkID,
-                                       Simulation::ConfigGen confGen = nullptr,
-                                       int connections = 1);
+    static Simulation::pointer
+    customA(Simulation::Mode mode, Hash const& networkID,
+            Simulation::ConfigGen confGen = nullptr, int connections = 1,
+            Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 };
 }

--- a/src/util/TimerTests.cpp
+++ b/src/util/TimerTests.cpp
@@ -201,13 +201,12 @@ TEST_CASE("timer cancels", "[timer]")
     {
         timers.push_back(make_unique<VirtualTimer>(*app));
         timers.back()->expires_from_now(std::chrono::seconds(i));
-        timers.back()->async_wait(
-            [&timerFired, &timerCancelled, i](asio::error_code const& ec) {
-                if (ec)
-                    ++timerCancelled;
-                else
-                    ++timerFired;
-            });
+        timers.back()->async_wait([&](asio::error_code const& ec) {
+            if (ec)
+                ++timerCancelled;
+            else
+                ++timerFired;
+        });
     }
     timers[5]->async_wait([&](asio::error_code const& ec) {
         if (!ec)


### PR DESCRIPTION
resolve #1652 , resolve #1489

This PR has a couple changes that should help with nomination timing:
* leader weights were not always computed right during nomination, leading to some rounds with no leader
* we now align to when the ballot protocol starts for deciding when to trigger
   * while this may introduce a small delay between rounds, this implementation should in most cases allow nodes to automatically synchronize to each other (assuming a uniform time for messages to make it to various nodes)
