### PR TITLE
replace "printtx" by "printxdr" (generic)

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -34,9 +34,9 @@ forcescp doesn't change the requirements for quorum so although this node will e
 * **--metric METRIC**: Report metric METRIC on exit. Used for gathering a metric cumulatively during a test run.
 * **--newdb**: Clears the local database and resets it to the genesis ledger. If you connect to the network after that it will catch up from scratch. 
 * **--newhist ARCH**:  Initialize the named history archive ARCH. ARCH should be one of the history archives you have specified in the stellar-core.cfg. This will write a `.well-known/stellar-history.json` file in the archive root.
-* **--printtxn FILE**:  Pretty-print a binary file containing a
-  `TransactionEnvelope`.  If FILE is "-", the transaction is read from
+* **--printxdr FILE**:  Pretty-print a binary file containing an XDR object. If FILE is "-", the XDR object is read from
   standard input.
+* **--filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**: toggle for type used for printxdr (default: auto).
 * **--signtxn FILE**:  Add a digital signature to a transaction
   envelope stored in binary format in FILE, and send the result to
   standard output (which should be redirected to a file or piped

--- a/src/main/dumpxdr.h
+++ b/src/main/dumpxdr.h
@@ -10,8 +10,9 @@ namespace stellar
 {
 
 extern const char* signtxn_network_id;
-void dumpxdr(std::string const& filename);
-void printtxn(std::string const& filename, bool base64);
+void dumpXdrStream(std::string const& filename);
+void printXdr(std::string const& filename, std::string const& filetype,
+              bool base64);
 void signtxn(std::string const& filename, bool base64);
 void priv2pub();
 }


### PR DESCRIPTION
While debugging some issues, I found that we don't have good support for decoding base64 encoded XDR in core. Closest out there is to use external tools such as the laboratory, but it doesn't always support the XDR version that core understands.

I made the `printtx` command line option more generic, it can now parse types other than `TransactionEnvelope` (and we can easily add more types in the future).

Example usage and output:
```
 ./stellar-core --base64 --printxdr -
AAAAAAAAAGQAAAAAAAAAAQAAAAAAAAAGAAAAAAAAAAA=
TransactionResult = {
  feeCharged = 100,
  result = {
    code = txSUCCESS,
    results = [
      { code = opINNER,
        tr = {
          type = CHANGE_TRUST,
          changeTrustResult = {
            code = CHANGE_TRUST_SUCCESS
          }
        } }
    ]
  },
  ext = {
    v = 0
  }
}
```
