### PR TITLE
fix fallout from PR1666 part two

### DIFF
--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -484,7 +484,6 @@ TEST_CASE("file-backed buckets", "[bucket][bucketbench]")
         for (auto& e : dead)
             e = deadGen(3);
         {
-            TIMED_SCOPE(timerObj2, "merge");
             b1 = Bucket::merge(
                 app->getBucketManager(), b1,
                 Bucket::fresh(app->getBucketManager(), live, dead));
@@ -1137,7 +1136,6 @@ TEST_CASE("bucket apply bench", "[bucketbench][!hide]")
     CLOG(INFO, "Bucket") << "Applying bucket with " << live.size()
                          << " live entries";
     {
-        TIMED_SCOPE(timerObj, "apply");
         soci::transaction sqltx(sess);
         birth->apply(db);
         sqltx.commit();

--- a/src/crypto/CryptoTests.cpp
+++ b/src/crypto/CryptoTests.cpp
@@ -195,7 +195,6 @@ TEST_CASE("sign and verify benchmarking", "[crypto-bench][bench][!hide]")
 
     LOG(INFO) << "Benchmarking " << n << " signatures and verifications";
     {
-        TIMED_SCOPE(timerBlkObj, "signing");
         for (auto& c : cases)
         {
             c.sign();
@@ -203,7 +202,6 @@ TEST_CASE("sign and verify benchmarking", "[crypto-bench][bench][!hide]")
     }
 
     {
-        TIMED_SCOPE(timerBlkObj, "verifying");
         for (auto& c : cases)
         {
             c.verify();

--- a/src/crypto/CryptoTests.cpp
+++ b/src/crypto/CryptoTests.cpp
@@ -34,6 +34,10 @@ TEST_CASE("random", "[crypto]")
     LOG(DEBUG) << "k1: " << k1.getStrKeySeed().value;
     LOG(DEBUG) << "k2: " << k2.getStrKeySeed().value;
     CHECK(k1.getStrKeySeed() != k2.getStrKeySeed());
+
+    SecretKey k1b = SecretKey::fromStrKeySeed(k1.getStrKeySeed().value);
+    REQUIRE(k1 == k1b);
+    REQUIRE(k1.getPublicKey() == k1b.getPublicKey());
 }
 
 TEST_CASE("hex tests", "[crypto]")

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -175,11 +175,10 @@ SecretKey::fromStrKeySeed(std::string const& strKeySeed)
         throw std::runtime_error("invalid seed");
     }
 
-    PublicKey pk;
     SecretKey sk;
     assert(sk.mKeyType == PUBLIC_KEY_TYPE_ED25519);
-    if (crypto_sign_seed_keypair(pk.ed25519().data(), sk.mSecretKey.data(),
-                                 seed.data()) != 0)
+    if (crypto_sign_seed_keypair(sk.mPublicKey.ed25519().data(),
+                                 sk.mSecretKey.data(), seed.data()) != 0)
     {
         throw std::runtime_error("error generating secret key from seed");
     }

--- a/src/database/DatabaseTests.cpp
+++ b/src/database/DatabaseTests.cpp
@@ -272,7 +272,6 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
         {
             for (int64_t i = 0; i < 10; ++i)
             {
-                TIMED_SCOPE(bulkinsert, "single large-tx insert");
                 soci::transaction sqltx(session);
                 for (int64_t j = 0; j < sz; ++j)
                 {
@@ -290,7 +289,6 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
         soci::transaction sqltx(session);
         for (int64_t i = 0; i < 10; ++i)
         {
-            TIMED_SCOPE(timerobj, "many small-tx insert");
             for (int64_t j = 0; j < sz / div; ++j)
             {
                 soci::transaction subtx(session);
@@ -305,7 +303,6 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
             }
         }
         {
-            TIMED_SCOPE(timerobj, "outer commit");
             sqltx.commit();
         }
     }

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -7,9 +7,11 @@
 #define ELPP_THREAD_SAFE
 #define ELPP_DISABLE_DEFAULT_CRASH_HANDLING
 #define ELPP_NO_DEFAULT_LOG_FILE
-#define ELPP_FEATURE_PERFORMANCE_TRACKING
 #define ELPP_NO_CHECK_MACROS
+#define ELPP_NO_DEBUG_MACROS
+#define ELPP_DISABLE_PERFORMANCE_TRACKING
 #define ELPP_WINSOCK2
+#define ELPP_DEBUG_ERRORS
 
 // NOTE: Nothing else should include easylogging directly
 //  include this file instead


### PR DESCRIPTION
Looks like PR #1666 had another broken commit: the change ce3f03f2512e6d64174a26e5b1f501cd632aa44f introduced a bug where the "public key" field was not properly set when creating a `SecretKey` from an `StrKey`. Turns out there were not tests for that, so I included one (tests rely on binary seeds instead).

I also found that logging would silently fail to log to files in some cases, so I did a pass at all Easylogging settings and disabled/enabled the ones that seem relevant.
