### PR TITLE
Use FD_CLOEXEC on listening sockets and lock files (issue #1635)

### DIFF
--- a/lib/http/server.cpp
+++ b/lib/http/server.cpp
@@ -57,6 +57,12 @@ server::addRoute(const std::string& routeName, routeHandler callback)
     mRoutes[routeName] = callback;
 }
 
+asio::ip::tcp::acceptor&
+server::getAcceptor()
+{
+    return acceptor_;
+}
+
 void
 server::do_accept()
 {

--- a/lib/http/server.hpp
+++ b/lib/http/server.hpp
@@ -43,6 +43,7 @@ public:
 
     void addRoute(const std::string& routeName, routeHandler callback);
     void add404(routeHandler callback);
+    asio::ip::tcp::acceptor& getAcceptor();
 
     void handle_request(const request& req, reply& rep);
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -65,8 +65,8 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
         // by subprocesses when forking
         if (!fd::disableProcessInheritance(mServer->getAcceptor()))
         {
-            LOG(WARNING) << "Failed to disable process inheritance for "
-                         << "http endpoint file descriptor";
+            LOG(DEBUG) << "Failed to disable process inheritance for "
+                       << "HTTP endpoint's file descriptor";
         }
     }
     else

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -21,6 +21,7 @@
 
 #include "medida/reporting/json_reporter.h"
 #include "util/Decoder.h"
+#include "util/Fd.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include "xdrpp/printer.h"
@@ -59,6 +60,14 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
         mServer = stellar::make_unique<http::server::server>(
             app.getClock().getIOService(), ipStr, mApp.getConfig().HTTP_PORT,
             httpMaxClient);
+
+        // Set FD_CLOEXEC on Linux/BSD so the file descriptor isn't inherited
+        // by subprocesses when forking
+        if (!fd::disableProcessInheritance(mServer->getAcceptor()))
+        {
+            LOG(WARNING) << "Failed to disable process inheritance for "
+                         << "http endpoint file descriptor";
+        }
     }
     else
     {

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -75,6 +75,7 @@ PeerDoor::handleKnock(shared_ptr<TCPPeer::SocketType> socket)
 {
     CLOG(DEBUG, "Overlay") << "PeerDoor handleKnock() @"
                            << mApp.getConfig().PEER_PORT;
+
     Peer::pointer peer = TCPPeer::accept(mApp, socket);
     if (peer)
     {

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -32,7 +32,12 @@ PeerDoor::start()
         CLOG(DEBUG, "Overlay") << "PeerDoor binding to endpoint " << endpoint;
         mAcceptor.open(endpoint.protocol());
         mAcceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
-        fd::disableProcessInheritance(mAcceptor);
+        if (!fd::disableProcessInheritance(mAcceptor))
+        {
+            CLOG(DEBUG, "Overlay")
+                << "Failed to disable process inheritance for "
+                << "listening socket";
+        }
         mAcceptor.bind(endpoint);
         mAcceptor.listen();
         acceptNextPeer();

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -8,6 +8,7 @@
 #include "main/Config.h"
 #include "overlay/OverlayManager.h"
 #include "overlay/TCPPeer.h"
+#include "util/Fd.h"
 #include "util/Logging.h"
 #include <memory>
 
@@ -31,6 +32,7 @@ PeerDoor::start()
         CLOG(DEBUG, "Overlay") << "PeerDoor binding to endpoint " << endpoint;
         mAcceptor.open(endpoint.protocol());
         mAcceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+        fd::disableProcessInheritance(mAcceptor);
         mAcceptor.bind(endpoint);
         mAcceptor.listen();
         acceptNextPeer();

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -84,6 +84,13 @@ TCPPeer::accept(Application& app, shared_ptr<TCPPeer::SocketType> socket)
     asio::ip::tcp::no_delay nodelay(true);
     socket->next_layer().set_option(nodelay, ec);
 
+    if (!fd::disableProcessInheritance(socket->next_layer()))
+    {
+        CLOG(WARNING, "Overlay")
+            << "Failed to disable process inheritance for "
+            << "newly accepted connection's file descriptor";
+    }
+
     if (!ec)
     {
         CLOG(DEBUG, "Overlay") << "TCPPeer:accept"

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -12,6 +12,7 @@
 #include "overlay/OverlayManager.h"
 #include "overlay/PeerRecord.h"
 #include "overlay/StellarXDR.h"
+#include "util/Fd.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
@@ -54,6 +55,14 @@ TCPPeer::initiate(Application& app, PeerBareAddress const& address)
             {
                 asio::ip::tcp::no_delay nodelay(true);
                 result->mSocket->next_layer().set_option(nodelay, ec);
+                if (!fd::disableProcessInheritance(
+                        result->mSocket->next_layer()))
+                {
+                    CLOG(WARNING, "Overlay")
+                        << "TCPPeer::initiate "
+                        << "failed to disable process inheritance "
+                        << "for socket";
+                }
             }
             else
             {

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -58,7 +58,7 @@ TCPPeer::initiate(Application& app, PeerBareAddress const& address)
                 if (!fd::disableProcessInheritance(
                         result->mSocket->next_layer()))
                 {
-                    CLOG(WARNING, "Overlay")
+                    CLOG(DEBUG, "Overlay")
                         << "TCPPeer::initiate "
                         << "failed to disable process inheritance "
                         << "for socket";
@@ -86,9 +86,8 @@ TCPPeer::accept(Application& app, shared_ptr<TCPPeer::SocketType> socket)
 
     if (!fd::disableProcessInheritance(socket->next_layer()))
     {
-        CLOG(WARNING, "Overlay")
-            << "Failed to disable process inheritance for "
-            << "newly accepted connection's file descriptor";
+        CLOG(DEBUG, "Overlay") << "Failed to disable process inheritance for "
+                               << "newly accepted connection's file descriptor";
     }
 
     if (!ec)

--- a/src/util/Fd.cpp
+++ b/src/util/Fd.cpp
@@ -1,0 +1,48 @@
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "Fd.h"
+
+namespace stellar
+{
+namespace fd
+{
+
+#ifdef _WIN32
+
+// No-op on Windows
+bool
+disableProcessInheritance(asio::ip::tcp::acceptor& /*acceptor*/)
+{
+    return true;
+}
+
+bool
+disableProcessInheritance(int /*fileDescriptor*/)
+{
+    return true;
+}
+
+#else
+
+bool
+disableProcessInheritance(asio::ip::tcp::acceptor& acceptor)
+{
+    return disableProcessInheritance(acceptor.native_handle());
+}
+
+bool
+disableProcessInheritance(int fileDescriptor)
+{
+    int flags = fcntl(fileDescriptor, F_GETFD);
+    if (flags != -1)
+    {
+        return fcntl(fileDescriptor, F_SETFD, flags | FD_CLOEXEC) != -1;
+    }
+    return false;
+}
+
+#endif
+}
+}

--- a/src/util/Fd.cpp
+++ b/src/util/Fd.cpp
@@ -4,6 +4,12 @@
 
 #include "Fd.h"
 
+#ifndef _WIN32
+
+#include <fcntl.h>
+
+#endif
+
 namespace stellar
 {
 namespace fd

--- a/src/util/Fd.cpp
+++ b/src/util/Fd.cpp
@@ -19,6 +19,12 @@ disableProcessInheritance(asio::ip::tcp::acceptor& /*acceptor*/)
 }
 
 bool
+disableProcessInheritance(asio::ip::tcp::socket& /*socket*/)
+{
+    return true;
+}
+
+bool
 disableProcessInheritance(int /*fileDescriptor*/)
 {
     return true;
@@ -30,6 +36,12 @@ bool
 disableProcessInheritance(asio::ip::tcp::acceptor& acceptor)
 {
     return disableProcessInheritance(acceptor.native_handle());
+}
+
+bool
+disableProcessInheritance(asio::ip::tcp::socket& socket)
+{
+    return disableProcessInheritance(socket.native_handle());
 }
 
 bool

--- a/src/util/Fd.h
+++ b/src/util/Fd.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "util/asio.h"
+
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+namespace stellar
+{
+namespace fd
+{
+
+bool disableProcessInheritance(asio::ip::tcp::acceptor& acceptor);
+bool disableProcessInheritance(int fileDescriptor);
+}
+}

--- a/src/util/Fd.h
+++ b/src/util/Fd.h
@@ -12,6 +12,7 @@ namespace fd
 {
 
 bool disableProcessInheritance(asio::ip::tcp::acceptor& acceptor);
+bool disableProcessInheritance(asio::ip::tcp::socket& socket);
 bool disableProcessInheritance(int fileDescriptor);
 }
 }

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -5,6 +5,7 @@
 #include "util/Fs.h"
 #include "crypto/Hex.h"
 #include "lib/util/format.h"
+#include "util/Fd.h"
 #include "util/Logging.h"
 #include <map>
 #include <regex>
@@ -194,7 +195,7 @@ lockFile(std::string const& path)
         errmsg << "file is already locked by this process: " << path;
         throw std::runtime_error(errmsg.str());
     }
-    int fd = open(path.c_str(), O_RDWR | O_CREAT, S_IRWXU);
+    int fd = open(path.c_str(), O_RDWR | O_CREAT | O_CLOEXEC, S_IRWXU);
 
     if (fd == -1)
     {


### PR DESCRIPTION
This sets FD_CLOEXEC on:

* The HTTP server socket.
* The peer listening socket on `PeerDoor`.
* Accepted sockets through `PeerDoor`.
* `TCPPeer` outbound sockets.
* Lock files. This is done via O_CLOEXEC rather than `fcntl`.

I couldn't find an existing file where this would fit so I created a new one.