### PR TITLE
Bucket apply fix (small change)

### DIFF
--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -26,7 +26,7 @@ void
 BucketApplicator::advance()
 {
     soci::transaction sqlTx(mDb.getSession());
-    for (; mBucketIter; ++mBucketIter)
+    while (mBucketIter)
     {
         LedgerHeader lh;
         LedgerDelta delta(lh, mDb, false);
@@ -41,6 +41,7 @@ BucketApplicator::advance()
         {
             EntryFrame::storeDelete(delta, mDb, entry.deadEntry());
         }
+        ++mBucketIter;
         // No-op, just to avoid needless rollback.
         delta.commit();
         if ((++mSize & 0xff) == 0xff)

--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -1109,36 +1109,44 @@ TEST_CASE("bucket apply", "[bucket]")
     REQUIRE(count == 1);
 }
 
-#ifdef USE_POSTGRES
 TEST_CASE("bucket apply bench", "[bucketbench][!hide]")
 {
-    VirtualClock clock;
-    Config cfg(getTestConfig(0, Config::TESTDB_POSTGRESQL));
-    Application::pointer app = createTestApplication(clock, cfg);
-    app->start();
+    auto runtest = [](Config::TestDbMode mode) {
+        VirtualClock clock;
+        Config cfg(getTestConfig(0, mode));
+        Application::pointer app = createTestApplication(clock, cfg);
+        app->start();
 
-    std::vector<LedgerEntry> live(100000);
-    std::vector<LedgerKey> noDead;
+        std::vector<LedgerEntry> live(100000);
+        std::vector<LedgerKey> noDead;
 
-    for (auto& l : live)
-    {
-        l.data.type(ACCOUNT);
-        auto& a = l.data.account();
-        a = LedgerTestUtils::generateValidAccountEntry(5);
-    }
+        for (auto& l : live)
+        {
+            l.data.type(ACCOUNT);
+            auto& a = l.data.account();
+            a = LedgerTestUtils::generateValidAccountEntry(5);
+        }
 
-    std::shared_ptr<Bucket> birth =
-        Bucket::fresh(app->getBucketManager(), live, noDead);
+        std::shared_ptr<Bucket> birth =
+            Bucket::fresh(app->getBucketManager(), live, noDead);
 
-    auto& db = app->getDatabase();
-    auto& sess = db.getSession();
+        auto& db = app->getDatabase();
 
-    CLOG(INFO, "Bucket") << "Applying bucket with " << live.size()
-                         << " live entries";
-    {
-        soci::transaction sqltx(sess);
+        CLOG(INFO, "Bucket")
+            << "Applying bucket with " << live.size() << " live entries";
+        // note: we do not wrap the `apply` call inside a transaction
+        // as bucket applicator commits to the database incrementally
         birth->apply(db);
-        sqltx.commit();
+    };
+
+    SECTION("sqlite")
+    {
+        runtest(Config::TESTDB_ON_DISK_SQLITE);
     }
-}
+#ifdef USE_POSTGRES
+    SECTION("postgresql")
+    {
+        runtest(Config::TESTDB_POSTGRESQL);
+    }
 #endif
+}


### PR DESCRIPTION
This PR fixes:
* bucket benchmark test were nested in a transaction (which is not what bucketapplicator does) and didn't work with sqlite
* bucketapplicator was processing some items twice