### PR TITLE
don't consume the sequence number if threshold not met (protocol 10)

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -130,7 +130,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
                 bool earlyFailure =
                     (code == txMISSING_OPERATION || code == txTOO_EARLY ||
                      code == txTOO_LATE || code == txINSUFFICIENT_FEE ||
-                     code == txBAD_SEQ);
+                     code == txBAD_SEQ || code == txBAD_AUTH);
                 // verify that the sequence number changed (v10+)
                 // do not perform the check if there was a failure before
                 // or during the sequence number processing

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -320,6 +320,8 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
         }
     }
 
+    // ensure that we have enough rights to update the sequence number of the tx
+    // source account
     res = ValidationType::kInvalidUpdateSeqNum;
 
     if (!checkSignature(signatureChecker, *mSigningAccount,

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -322,8 +322,6 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
 
     // ensure that we have enough rights to update the sequence number of the tx
     // source account
-    res = ValidationType::kInvalidUpdateSeqNum;
-
     if (!checkSignature(signatureChecker, *mSigningAccount,
                         mSigningAccount->getLowThreshold()))
     {
@@ -333,6 +331,10 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
         getResult().result.code(txBAD_AUTH);
         return res;
     }
+
+    // from now on, the transaction will consume the sequence number regardless
+    // of success or failure
+    res = ValidationType::kInvalidUpdateSeqNum;
 
     // if we are in applying mode fee was already deduced from signing account
     // balance, if not, we need to check if after that deduction this account

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -740,7 +740,8 @@ enum TransactionResultCode
     txMISSING_OPERATION = -4, // no operation was specified
     txBAD_SEQ = -5,           // sequence number does not match source account
 
-    txBAD_AUTH = -6,             // too few valid signatures / wrong network
+    txBAD_AUTH =
+        -6, // too few signatures to change source account / wrong network
     txINSUFFICIENT_BALANCE = -7, // fee would bring account below reserve
     txNO_ACCOUNT = -8,           // source account not found
     txINSUFFICIENT_FEE = -9,     // fee is too small


### PR DESCRIPTION
this is a small adjustment that ensures that we're future proof when it comes to behavior:
in protocol 10 we're processing sequence numbers in the "apply transaction" phase.

One of the things that can happen is that signers get updated in one transaction, invalidating other transactions from the transaction set (the same way bumpseq can invalidate other transactions).

With this change we properly no-op (other than take the fee) when encountering those invalidated transactions - with the current behavior (not live yet) we would have consumed the transaction number even though the transaction fails with `txBAD_AUTH`
