### PR TITLE
Improve merge tests

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -68,6 +68,22 @@ ExpectedOpResult::ExpectedOpResult(AccountMergeResultCode accountMergeCode)
     mOperationResult.tr().accountMergeResult().code(accountMergeCode);
 }
 
+ExpectedOpResult::ExpectedOpResult(AccountMergeResultCode accountMergeCode,
+                                   int64_t sourceAccountBalance)
+{
+    if (accountMergeCode != ACCOUNT_MERGE_SUCCESS)
+    {
+        throw std::logic_error("accountMergeCode must be ACCOUNT_MERGE_SUCCESS "
+                               "when sourceAccountBalance is passed");
+    }
+
+    mOperationResult.code(opINNER);
+    mOperationResult.tr().type(ACCOUNT_MERGE);
+    mOperationResult.tr().accountMergeResult().code(ACCOUNT_MERGE_SUCCESS);
+    mOperationResult.tr().accountMergeResult().sourceAccountBalance() =
+        sourceAccountBalance;
+}
+
 ExpectedOpResult::ExpectedOpResult(SetOptionsResultCode setOptionsResultCode)
 {
     mOperationResult.code(opINNER);
@@ -292,7 +308,6 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
 
     switch (applyResult.result.code())
     {
-    case txINTERNAL_ERROR:
     case txBAD_AUTH_EXTRA:
     case txBAD_SEQ:
         return;

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -26,12 +26,7 @@ typedef std::vector<std::pair<TransactionResultPair, LedgerEntryChanges>>
 
 struct ExpectedOpResult
 {
-    OperationResultCode code;
-    OperationType type;
-    CreateAccountResultCode createAccountCode;
-    PaymentResultCode paymentCode;
-    AccountMergeResultCode accountMergeCode;
-    SetOptionsResultCode setOptionsResultCode;
+    OperationResult mOperationResult;
 
     ExpectedOpResult(OperationResultCode code);
     ExpectedOpResult(CreateAccountResultCode createAccountCode);

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -32,6 +32,8 @@ struct ExpectedOpResult
     ExpectedOpResult(CreateAccountResultCode createAccountCode);
     ExpectedOpResult(PaymentResultCode paymentCode);
     ExpectedOpResult(AccountMergeResultCode accountMergeCode);
+    ExpectedOpResult(AccountMergeResultCode accountMergeCode,
+                     int64_t sourceAccountBalance);
     ExpectedOpResult(SetOptionsResultCode setOptionsResultCode);
 };
 

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -51,8 +51,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
     // set up world
     auto root = TestAccount::createRoot(*app);
 
-    const uint64_t paymentAmount =
-        app->getLedgerManager().getLastReserve() * 10;
+    const int64_t paymentAmount = app->getLedgerManager().getLastReserve() * 10;
 
     SECTION("outer envelope")
     {
@@ -1257,11 +1256,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 for_versions_from({7, 10}, *app, [&] {
                     auto applyResult = expectedResult(
                         baseFee * 2, 2, txSUCCESS,
-                        {SET_OPTIONS_SUCCESS, ACCOUNT_MERGE_SUCCESS});
-                    applyResult.result.results()[1]
-                        .tr()
-                        .accountMergeResult()
-                        .sourceAccountBalance() = paymentAmount - 100;
+                        {SET_OPTIONS_SUCCESS,
+                         {ACCOUNT_MERGE_SUCCESS, paymentAmount - 100}});
                     validateTxResults(tx, *app, {baseFee * 2, txSUCCESS},
                                       applyResult);
                 });
@@ -1284,11 +1280,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 for_versions_from({7, 10}, *app, [&] {
                     auto applyResult = expectedResult(
                         baseFee * 2, 2, txSUCCESS,
-                        {SET_OPTIONS_SUCCESS, ACCOUNT_MERGE_SUCCESS});
-                    applyResult.result.results()[1]
-                        .tr()
-                        .accountMergeResult()
-                        .sourceAccountBalance() = paymentAmount - 300;
+                        {SET_OPTIONS_SUCCESS,
+                         {ACCOUNT_MERGE_SUCCESS, paymentAmount - 300}});
                     validateTxResults(tx, *app, {baseFee * 2, txSUCCESS},
                                       applyResult);
                 });
@@ -1308,11 +1301,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 for_versions({7}, *app, [&] {
                     auto applyResult = expectedResult(
                         baseFee * 2, 2, txSUCCESS,
-                        {SET_OPTIONS_SUCCESS, ACCOUNT_MERGE_SUCCESS});
-                    applyResult.result.results()[1]
-                        .tr()
-                        .accountMergeResult()
-                        .sourceAccountBalance() = paymentAmount - 300;
+                        {SET_OPTIONS_SUCCESS,
+                         {ACCOUNT_MERGE_SUCCESS, paymentAmount - 300}});
                     validateTxResults(tx, *app, {baseFee * 2, txSUCCESS},
                                       applyResult);
                 });

--- a/src/transactions/TxResultsTests.cpp
+++ b/src/transactions/TxResultsTests.cpp
@@ -249,7 +249,9 @@ TEST_CASE("txresults", "[tx][txresults]")
 
         auto anyFail = std::any_of(
             std::begin(opResults), std::end(opResults), [](ExpectedOpResult o) {
-                return o.code != opINNER || o.paymentCode != PAYMENT_SUCCESS;
+                return o.mOperationResult.code() != opINNER ||
+                       o.mOperationResult.tr().paymentResult().code() !=
+                           PAYMENT_SUCCESS;
             });
         return expectedResult(fee, opPayment.size(),
                               anyFail ? txFAILED : validationResult.code,


### PR DESCRIPTION
# Description

This PR improves testing merge operations by allowing to use sourceAccountBalance value in expectedResult calls. It also fixes testing transactions that results in txINTERNAL_ERROR.

# Checklist
- [x] Reviewed the [contributing](../CONTRIBUTING.md) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format`
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](../performance-eval.md)
