### PR TITLE
Trivial fixes

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -7,6 +7,7 @@
 #include "TxSetFrame.h"
 #include "Upgrades.h"
 #include "lib/json/json-forwards.h"
+#include "overlay/Peer.h"
 #include "overlay/StellarXDR.h"
 #include "scp/SCP.h"
 #include "util/Timer.h"
@@ -17,10 +18,7 @@
 namespace stellar
 {
 class Application;
-class Peer;
 class XDROutputFileStream;
-
-typedef std::shared_ptr<Peer> PeerPtr;
 
 /*
  * Public Interface to the Herder module
@@ -109,7 +107,7 @@ class Herder
     // We are learning about a new transaction.
     virtual TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
-                                uint256 const& itemID, PeerPtr peer) = 0;
+                                uint256 const& itemID, Peer::pointer peer) = 0;
     virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
@@ -122,7 +120,7 @@ class Herder
                                            TxSetFrame txset) = 0;
 
     // a peer needs our SCP state
-    virtual void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) = 0;
+    virtual void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) = 0;
 
     // returns the latest known ledger seq using consensus information
     // and local state

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -433,7 +433,7 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope,
 }
 
 void
-HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer)
+HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer)
 {
     if (getSCP().empty())
     {
@@ -641,7 +641,7 @@ HerderImpl::recvTxSet(Hash const& hash, const TxSetFrame& t)
 
 void
 HerderImpl::peerDoesntHave(MessageType type, uint256 const& itemID,
-                           PeerPtr peer)
+                           Peer::pointer peer)
 {
     mPendingEnvelopes.peerDoesntHave(type, itemID, peer);
 }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -64,12 +64,12 @@ class HerderImpl : public Herder
                                    const SCPQuorumSet& qset,
                                    TxSetFrame txset) override;
 
-    void sendSCPStateToPeer(uint32 ledgerSeq, PeerPtr peer) override;
+    void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) override;
 
     bool recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset) override;
     bool recvTxSet(Hash const& hash, const TxSetFrame& txset) override;
     void peerDoesntHave(MessageType type, uint256 const& itemID,
-                        PeerPtr peer) override;
+                        Peer::pointer peer) override;
     TxSetFramePtr getTxSet(Hash const& hash) override;
     SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;
 

--- a/src/history/HistoryTestsUtils.h
+++ b/src/history/HistoryTestsUtils.h
@@ -29,6 +29,7 @@ struct CatchupPerformedWork;
 class HistoryConfigurator : NonCopyable
 {
   public:
+    virtual ~HistoryConfigurator() = default;
     virtual Config& configure(Config& cfg, bool writable) const = 0;
     virtual std::string getArchiveDirName() const;
 };

--- a/src/ledger/EntryFrame.h
+++ b/src/ledger/EntryFrame.h
@@ -38,6 +38,7 @@ class EntryFrame : public NonMovableOrCopyable
 
     EntryFrame(LedgerEntryType type);
     EntryFrame(LedgerEntry const& from);
+    virtual ~EntryFrame() = default;
 
     static pointer FromXDR(LedgerEntry const& from);
     static pointer storeLoad(LedgerKey const& key, Database& db);

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -56,6 +56,7 @@ class OperationFrame
     OperationFrame(Operation const& op, OperationResult& res,
                    TransactionFrame& parentTx);
     OperationFrame(OperationFrame const&) = delete;
+    virtual ~OperationFrame() = default;
 
     bool checkSignature(SignatureChecker& signatureChecker, Application& app,
                         LedgerDelta* delta);


### PR DESCRIPTION
# Description

Some trivial fixes - removal of redundant typedef and adding virtual destructors.

# Checklist
- [x] Reviewed the [contributing](../CONTRIBUTING.md) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format`
- [x] Compiles
- [ ] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](../performance-eval.md)
