### PR TITLE
Fix formatting for table in db-schema.md.

### DIFF
--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -11,6 +11,7 @@ Most objects are the straight representation of the equivalent XDR object.
 See [`src/ledger/readme.md`](/src/ledger/readme.md) for a detailed description of those.
 
 Types used in the tables:
+
 Type Name | Description
 --------- | -----------
 HEX | Hex encoded binary blob


### PR DESCRIPTION
## Description

Fixes the formatting for the first table in db-schema.md in the docs, which wasn't rendering as a table properly due to a missing new line.