### PR TITLE
Update commands.md

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -166,7 +166,9 @@ debugging purpose).
   * `/upgrades?mode=clear`<br>
   clears any upgrade settings<br>
   * `/upgrades?mode=set&upgradetime=DATETIME&[basefee=NUM]&[basereserve=NUM]&[maxtxsize=NUM]&[protocolversion=NUM]`<br>
-  upgradetime is a required date (UTC) in the form 1970-01-01T00:00:00Z.<br>
+    * upgradetime is a required date (UTC) in the form `1970-01-01T00:00:00Z`. 
+        It is the time the upgrade will be scheduled for. If it is in the past,
+        the upgrade will occur immediately.<br>
     * fee (uint32) This is what you would prefer the base fee to be. It is
         in stroops<br>
     * basereserve (uint32) This is what you would prefer the base reserve 


### PR DESCRIPTION
Clarification on purpose of `upgradetime` param. 
Q: It is specified as UTC, but includes the TZ offset in the date pattern. What happens if the user specifies a different offset?

# Description

Resolves #X

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](../CONTRIBUTING.md) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format`
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](../performance-eval.md)
