### PR TITLE
Scp fix for setting `h.n` in PREPARE message

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -174,9 +174,20 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     // called both here and at the end (this one is in case of an exception)
     trackingHeartBeat();
 
+    bool validated = getSCP().isSlotFullyValidated(slotIndex);
+
     if (Logging::logDebug("Herder"))
-        CLOG(DEBUG, "Herder") << "HerderSCPDriver::valueExternalized"
-                              << " txSet: " << hexAbbrev(value.txSetHash);
+        CLOG(DEBUG, "Herder") << fmt::format(
+            "HerderSCPDriver::valueExternalized index: {} txSet: {}", slotIndex,
+            hexAbbrev(value.txSetHash));
+
+    if (getSCP().isValidator() && !validated)
+    {
+        CLOG(WARNING, "Herder")
+            << fmt::format("Ledger {} ({}) closed and could NOT be fully "
+                           "validated by validator",
+                           slotIndex, hexAbbrev(value.txSetHash));
+    }
 
     TxSetFramePtr externalizedSet = mPendingEnvelopes.getTxSet(value.txSetHash);
 

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -48,6 +48,7 @@ class BallotProtocol
     std::unique_ptr<SCPBallot> mCommit;             // c
     std::map<NodeID, SCPEnvelope> mLatestEnvelopes; // M
     SCPPhase mPhase;                                // Phi
+    std::unique_ptr<Value> mValueOverride;          // z
 
     int mCurrentMessageLevel; // number of messages triggered in one run
 
@@ -164,7 +165,7 @@ class BallotProtocol
     std::set<SCPBallot> getPrepareCandidates(SCPStatement const& hint);
 
     // helper to perform step (8) from the paper
-    void updateCurrentIfNeeded();
+    bool updateCurrentIfNeeded(SCPBallot const& h);
 
     // An interval is [low,high] represented as a pair
     using Interval = std::pair<uint32, uint32>;

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -163,6 +163,20 @@ SCP::isValidator()
     return mLocalNode->isValidator();
 }
 
+bool
+SCP::isSlotFullyValidated(uint64 slotIndex)
+{
+    auto slot = getSlot(slotIndex, false);
+    if (slot)
+    {
+        return slot->isFullyValidated();
+    }
+    else
+    {
+        return false;
+    }
+}
+
 size_t
 SCP::getKnownSlotsCount() const
 {

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -90,6 +90,9 @@ class SCP
     // Returns whether the local node is a validator.
     bool isValidator();
 
+    // returns the validation state of the given slot
+    bool isSlotFullyValidated(uint64 slotIndex);
+
     // Helpers for monitoring and reporting the internal memory-usage of the SCP
     // protocol to system metric reporters.
     size_t getKnownSlotsCount() const;

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -328,7 +328,12 @@ Slot::getJsonInfo()
 Json::Value
 Slot::getJsonQuorumInfo(NodeID const& id, bool summary)
 {
-    return mBallotProtocol.getJsonQuorumInfo(id, summary);
+    Json::Value ret = mBallotProtocol.getJsonQuorumInfo(id, summary);
+    if (getLocalNode()->isValidator())
+    {
+        ret["validated"] = isFullyValidated();
+    }
+    return ret;
 }
 
 bool


### PR DESCRIPTION
# Description

Resolves #1767

This PR contains the following changes:
* SCP fix for issue above
   * There is an invariant (per the [whitepaper](https://www.stellar.org/papers/stellar-consensus-protocol.pdf) ) that `h.value == b.value` (see page 23 for what the `PREPARE` message contains) - yet rule `2` (see page 24 for the 9 rules that drive state changes) implies that `h` should be updated even though `b` may not be updated  by rule `8` if `b > h`.
   * the fix here is to NOT set `h` if it would lead to `h.value != b.value` (we still calculate the value of `h candidate`).
   * This is slightly different than what the corrected version of the internet draft does: in the draft, `h` is set but the `PREPARE` message does not set `h.n` if `b.value != h.value`. The problem with that approach is that this makes reconstructing the internal state of the SCP state machine impossible from just the last `PREPARE` message, which could lead to undefined behavior when restarting a node.
* better logging and status of the validation state (a validator could silently not be validating)
  * I had to add an entirely new test to trigger this bug. What makes this possible is to receive a message that triggers both v-blocking and quorum conditions at once: for example, in a 2 out of 3 setup, 2 nodes can be both v-blocking and form a quorum for some interesting value.


