### PR TITLE
Remove unused import to main/Config.h

### DIFF
--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -8,7 +8,6 @@
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
 #include "lib/json/json.h"
-#include "main/Config.h"
 #include "scp/LocalNode.h"
 #include "scp/QuorumSetUtils.h"
 #include "util/GlobalChecks.h"


### PR DESCRIPTION
# Description

This import was not used. It also showed up as an obvious breach of abstraction (pulling in tons of dependencies transitively) when I attempted to isolate the SCP code in its own `.so`