### PR TITLE
Don't hang when spawning processes

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -186,7 +186,7 @@ debugging purpose).
 
 ### The following HTTP commands are exposed on test instances
 * **generateload**
-  `/generateload[?accounts=N&&offset=K&txs=M&txrate=(R|auto)&batchsize=L]`<br>
+  `/generateload[?mode=(create|pay)&accounts=N&offset=K&txs=M&txrate=(R|auto)&batchsize=L]`<br>
   Artificially generate load for testing; must be used with `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
   Depending on the mode, either creates new accounts or generates payments on
   accounts specified (where number of accounts can be offset).

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -661,9 +661,9 @@ startApp(string cfgFile, Config& cfg)
                              << "(for testing only)";
             }
 
-            app->applyCfgCommands();
-
             app->start();
+
+            app->applyCfgCommands();
         }
     }
     catch (std::exception& e)


### PR DESCRIPTION
# Description

Resolves #1774 

This PR fixes an issue where on some systems spawning processes would take a very long time.

I also changed how `COMMANDS` in the config are processed:
the process would crash when trying to do things that required the application to be fully setup (basically most commands other than logging)
