### PR TITLE
remove redundant Ballot creation

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -349,8 +349,6 @@ BallotProtocol::bumpState(Value const& value, bool force)
         return false;
     }
 
-    SCPBallot newb;
-
     n = mCurrentBallot ? (mCurrentBallot->counter + 1) : 1;
 
     return bumpState(value, n);


### PR DESCRIPTION
remove redundant Ballot creation

# Description

Remove a redundant Ballot creation in BallotProtocol.cpp, the created Ballot `newb` is not used anywhere in the enclosing function.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format`
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
