### PR TITLE
Signer weight fix

### DIFF
--- a/src/invariant/LedgerEntryIsValid.h
+++ b/src/invariant/LedgerEntryIsValid.h
@@ -34,13 +34,14 @@ class LedgerEntryIsValid : public Invariant
 
   private:
     template <typename IterType>
-    std::string check(IterType iter, IterType const& end,
-                      uint32_t ledgerSeq) const;
+    std::string check(IterType iter, IterType const& end, uint32_t ledgerSeq,
+                      uint32 version) const;
 
-    std::string checkIsValid(LedgerEntry const& le, uint32_t ledgerSeq) const;
-    std::string checkIsValid(AccountEntry const& ae) const;
-    std::string checkIsValid(TrustLineEntry const& tl) const;
-    std::string checkIsValid(OfferEntry const& oe) const;
-    std::string checkIsValid(DataEntry const& de) const;
+    std::string checkIsValid(LedgerEntry const& le, uint32_t ledgerSeq,
+                             uint32 version) const;
+    std::string checkIsValid(AccountEntry const& ae, uint32 version) const;
+    std::string checkIsValid(TrustLineEntry const& tl, uint32 version) const;
+    std::string checkIsValid(OfferEntry const& oe, uint32 version) const;
+    std::string checkIsValid(DataEntry const& de, uint32 version) const;
 };
 }

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -293,6 +293,16 @@ SetOptionsOpFrame::doCheckValid(Application& app)
             innerResult().code(SET_OPTIONS_BAD_SIGNER);
             return false;
         }
+        if (mSetOptions.signer->weight > UINT8_MAX &&
+            app.getLedgerManager().getCurrentLedgerVersion() > 9)
+        {
+            app.getMetrics()
+                .NewMeter({"op-set-options", "invalid", "bad-signer"},
+                          "operation")
+                .Mark();
+            innerResult().code(SET_OPTIONS_BAD_SIGNER);
+            return false;
+        }
     }
 
     if (mSetOptions.homeDomain)

--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -51,7 +51,12 @@ SignatureChecker::checkSignature(AccountID const& accountID,
         if (signerKey.key.preAuthTx() == mContentsHash)
         {
             mUsedOneTimeSignerKeys[accountID].insert(signerKey.key);
-            totalWeight += signerKey.weight;
+            auto w = signerKey.weight;
+            if (mProtocolVersion > 9 && w > UINT8_MAX)
+            {
+                w = UINT8_MAX;
+            }
+            totalWeight += w;
             if (totalWeight >= neededWeight)
                 return true;
         }
@@ -70,7 +75,12 @@ SignatureChecker::checkSignature(AccountID const& accountID,
                 if (verify(sig, signerKey))
                 {
                     mUsedSignatures[i] = true;
-                    totalWeight += signerKey.weight;
+                    auto w = signerKey.weight;
+                    if (mProtocolVersion > 9 && w > UINT8_MAX)
+                    {
+                        w = UINT8_MAX;
+                    }
+                    totalWeight += w;
                     if (totalWeight >= neededWeight)
                         return true;
 

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -226,6 +226,8 @@ struct ManageDataOp
 
     increases the sequence to a given level
 
+    Threshold: low
+
     Result: BumpSequenceResult
 */
 


### PR DESCRIPTION
# Description

Resolves #1780 

This PR:
* adds checks to `SetOptions` so that weights like 256 are not allowed anymore
* ensures that we end up with a max value when computing the sum of weights
