### PR TITLE
Fix mPreparedPrime ballot update bug

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1619,8 +1619,11 @@ BallotProtocol::setPrepared(SCPBallot const& ballot)
         }
         else if (comp > 0)
         {
-            // check if we should update only p'
-            if (!mPreparedPrime || compareBallots(*mPreparedPrime, ballot) < 0)
+            // check if we should update only p' with two situations:
+            // 1. p' is NULL
+            // 2. p' is smaller than ballot and p is incompatible with ballot
+            if (!mPreparedPrime || 
+                (compareBallots(*mPreparedPrime, ballot) < 0 && !areBallotsCompatible(*mPrepared, ballot)))
             {
                 mPreparedPrime = std::make_unique<SCPBallot>(ballot);
                 didWork = true;


### PR DESCRIPTION
Fix a bug that forgets to check the incompatibility of `mPrepared` ballot and new ballot before updating `mPreparedPrime`  ballot.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format`
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
