### PR TITLE
add --disable-bucket-gc argument for bucket recovery

### DIFF
--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -272,6 +272,11 @@ BucketManagerImpl::getReferencedBuckets() const
 void
 BucketManagerImpl::cleanupStaleFiles()
 {
+    if (mApp.getConfig().DISABLE_BUCKET_GC)
+    {
+        return;
+    }
+
     std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
     auto referenced = getReferencedBuckets();
     std::transform(std::begin(mSharedBuckets), std::end(mSharedBuckets),
@@ -324,7 +329,7 @@ BucketManagerImpl::forgetUnreferencedBuckets()
             CLOG(TRACE, "Bucket")
                 << "BucketManager::forgetUnreferencedBuckets dropping "
                 << filename;
-            if (!filename.empty())
+            if (!filename.empty() && !mApp.getConfig().DISABLE_BUCKET_GC)
             {
                 CLOG(TRACE, "Bucket") << "removing bucket file: " << filename;
                 std::remove(filename.c_str());

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -64,6 +64,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     USE_CONFIG_FOR_GENESIS = false;
     FAILURE_SAFETY = -1;
     UNSAFE_QUORUM = false;
+    DISABLE_BUCKET_GC = false;
 
     LOG_FILE_PATH = "stellar-core.%datetime{%Y.%M.%d-%H:%m:%s}.log";
     BUCKET_DIR_PATH = "buckets";

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -133,6 +133,10 @@ class Config : public std::enable_shared_from_this<Config>
     //  aren't concerned with byzantine failures.
     bool UNSAFE_QUORUM;
 
+    // If set to true, bucket GC will not be performed. It can lead to massive
+    // disk usage, but it is useful for recovering of nodes.
+    bool DISABLE_BUCKET_GC;
+
     // Set of cursors added at each startup with value '1'.
     std::vector<std::string> KNOWN_CURSORS;
 


### PR DESCRIPTION
This new option allows for bucket recovery. In case where non-checkpoint bucket is required to continue stopped stellar-core, that bucket can be recovered using command-line catchup with this new option.

Imagine a stellar-core node was stopped with last-closed ledger 123456 and it misses bucket `3e44d29cf75b2ceae1dcd58cbb18791c3ab998a89c848b231228db19bcf9c780` that is not a checkpoint-bucket (it does not gets saved to history archives).

To recover that bucket one can run second stellar-core instance and perform following commands on it:
`stellar-core --conf second-instance.conf --newdb`
`stellar-core --conf second-instance.conf --catchup-at 123400 --disable-bucket-gc`
`stellar-core --conf second-instance.conf --catchup-to 123500 --disable-bucket-gc`

Bucket directory of that second instance should now contain all missing buckets files.