### PR TITLE
allow maximum of 10MB of incoming HTTP data per connection

### DIFF
--- a/lib/http/connection.hpp
+++ b/lib/http/connection.hpp
@@ -64,6 +64,9 @@ private:
   /// Buffer for incoming data.
   std::array<char, 8192> buffer_;
 
+  /// Size of received data
+  size_t received_count_;
+
   /// The incoming request.
   request request_;
 


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Resolves #1754

Limits data per HTTP request to 10 MB.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format`
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
