### PR TITLE
Trivial: Update documentation to mention subclassing SCPDriver, not SCP

### DIFF
--- a/src/herder/readme.md
+++ b/src/herder/readme.md
@@ -1,10 +1,10 @@
 # Herder
 
-The [Herder](Herder.h) is a concrete implementation of the [SCP
+The [HerderSCPDriver](HerderSCPDriver.h) is a concrete implementation of the [SCP
 protocol](../scp), operating in terms of the "transaction sets" and "ledger
 numbers" that constitute the Stellar vocabulary. It is implemented as a subclass
-of the [SCP class](../scp/SCP.h), and so is most easily understood after reading
-that class and understanding where and how a subclass would make the abstract
+of the [SCPDriver class](../scp/SCPDriver.h), and so is most easily understood after
+reading that class and understanding where and how a subclass would make the abstract
 SCP protocol concrete.
 
 # key implementation details

--- a/src/scp/readme.md
+++ b/src/scp/readme.md
@@ -11,13 +11,14 @@ implementation of SCP easier to model, compare to the paper describing the
 protocol, audit for correctness, and extract for reuse in different programs at
 a later date.
 
-The central [SCP class](SCP.h) should be subclassed by any module wishing to
+The [SCPDriver class](SCPDriver.h) should be subclassed by any module wishing to
 implement consensus using the SCP protocol, implementing the necessary abstract
-methods for handling SCP-generated events, and calling SCP base-class methods to
-receive incoming messages. The messages making up the protocol are defined in
-XDR, in the file [Stellar-SCP.x](../xdr/Stellar-SCP.x)
+methods for handling SCP-generated events, and calling methods from the central
+[SCP base-class](SCP.h) methods to receive incoming messages.
+The messages making up the protocol are defined in XDR,
+in the file [Stellar-SCP.x](../xdr/Stellar-SCP.x)
 
-The `stellar-core` program has a single subclass of SCP called
+The `stellar-core` program has a single subclass of SCPDriver called
 [Herder](../herder), which gives a specific interpretation to "slot" and
 "value", and connects SCP up with a specific broadcast communication medium
 ([Overlay](../overlay)) and specific replicated state machine


### PR DESCRIPTION
This documentation became outdated when commit 473ef9cf81cfe8df480a0b39fd015fa0b3a1139e was merged.