### PR TITLE
Allow SCPDriver::getQSet to return `nullptr`, expand on documentation

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -246,8 +246,8 @@ BallotProtocol::processEnvelope(SCPEnvelope const& envelope, bool self)
 bool
 BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 {
-
-    bool res = isQuorumSetSane(*mSlot.getQuorumSetFromStatement(st), false);
+    auto qSet = mSlot.getQuorumSetFromStatement(st);
+    bool res = qSet != nullptr && isQuorumSetSane(*qSet, false);
     if (!res)
     {
         CLOG(DEBUG, "SCP") << "Invalid quorum set received";

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -27,8 +27,16 @@ class SCPDriver
     virtual void signEnvelope(SCPEnvelope& envelope) = 0;
     virtual bool verifyEnvelope(SCPEnvelope const& envelope) = 0;
 
-    // Delegates the retrieval of the quorum set designated by `qSetHash` to
-    // the user of SCP.
+    // Retrieves a quorum set from its hash
+    //
+    // All SCP statement (see `SCPNomination` and `SCPStatement`) include
+    // a quorum set hash.
+    // SCP does not define how quorum sets are exchanged between nodes,
+    // hence their retrieval is delegated to the user of SCP.
+    // The return value is not cached by SCP, as quorum sets are transient.
+    //
+    // `nullptr` is a valid return value which cause the statement to be
+    // considered invalid.
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // Users of the SCP library should inherit from SCPDriver and implement the


### PR DESCRIPTION
# Description

I am currently implementing my own SCPDriver, and started with a do-nothing stub, which quickly led me to a SEGV, which the first commit fixes.
After reviewing the usage of `getQSet` and the way Stellar-core currently uses it, I decided to expand on the documentation (from the PoV of someone who has read the SCP paper a few times and wants to use the code stand-alone).
If that kind of changes is welcome, I'll probably do the same for the other functions.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format`
- [x] Compiles
- [x] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)~
