### PR TITLE
Fix ioservice balance

### DIFF
--- a/src/bucket/BucketTests.cpp
+++ b/src/bucket/BucketTests.cpp
@@ -614,7 +614,7 @@ clearFutures(Application::pointer app, BucketList& bl)
     size_t waiting = 0, finished = 0;
     for (size_t i = 0; i < n; ++i)
     {
-        app->getWorkerIOService().post([&] {
+        app->postOnBackgroundThread([&] {
             std::unique_lock<std::mutex> lock(mutex);
             if (++waiting == n)
             {

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -290,7 +290,7 @@ FutureBucket::startMerge(Application& app, bool keepDeadEntries)
         });
 
     mOutputBucket = task->get_future().share();
-    app.getWorkerIOService().post(bind(&task_t::operator(), task));
+    app.postOnBackgroundThread(bind(&task_t::operator(), task));
     checkState();
 }
 

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -584,7 +584,7 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
                                 << " invalid transactions";
 
         // post to avoid triggering SCP handling code recursively
-        mApp.getClock().postToNextCrank([this, bestTxSet]() {
+        mApp.postOnMainThreadWithDelay([this, bestTxSet]() {
             mPendingEnvelopes.recvTxSet(bestTxSet->getContentsHash(),
                                         bestTxSet);
         });

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -584,7 +584,7 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
                                 << " invalid transactions";
 
         // post to avoid triggering SCP handling code recursively
-        mApp.getClock().getIOService().post([this, bestTxSet]() {
+        mApp.getClock().postToNextCrank([this, bestTxSet]() {
             mPendingEnvelopes.recvTxSet(bestTxSet->getContentsHash(),
                                         bestTxSet);
         });

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -414,7 +414,7 @@ HistoryManagerImpl::historyPublished(
         this->mPublishFailure.Mark();
     }
     mPublishWork.reset();
-    mApp.getClock().getIOService().post(
+    mApp.getClock().postToCurrentCrank(
         [this]() { this->publishQueuedHistory(); });
 }
 

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -414,8 +414,7 @@ HistoryManagerImpl::historyPublished(
         this->mPublishFailure.Mark();
     }
     mPublishWork.reset();
-    mApp.getClock().postToCurrentCrank(
-        [this]() { this->publishQueuedHistory(); });
+    mApp.postOnMainThread([this]() { this->publishQueuedHistory(); });
 }
 
 void

--- a/src/history/HistoryTestsUtils.cpp
+++ b/src/history/HistoryTestsUtils.cpp
@@ -401,6 +401,24 @@ CatchupSimulation::crankForAtMost(Application::pointer app,
     }
 }
 
+void
+CatchupSimulation::crankUntil(Application::pointer app,
+                              std::function<bool()> const& predicate,
+                              VirtualClock::duration timeout)
+{
+    auto start = std::chrono::system_clock::now();
+    while (!app->getWorkManager().allChildrenDone() || !predicate())
+    {
+        app->getClock().crank(false);
+        auto current = std::chrono::system_clock::now();
+        auto diff = current - start;
+        if (diff > timeout)
+        {
+            break;
+        }
+    }
+}
+
 bool
 CatchupSimulation::catchupApplication(uint32_t initLedger, uint32_t count,
                                       bool manual, Application::pointer app2,

--- a/src/history/HistoryTestsUtils.h
+++ b/src/history/HistoryTestsUtils.h
@@ -187,6 +187,10 @@ class CatchupSimulation
         CatchupConfiguration const& catchupConfiguration,
         HistoryManager const& historyManager);
 
+    void crankUntil(Application::pointer app,
+                    std::function<bool()> const& predicate,
+                    VirtualClock::duration duration);
+
     bool
     flip()
     {

--- a/src/history/HistoryTestsUtils.h
+++ b/src/history/HistoryTestsUtils.h
@@ -135,9 +135,6 @@ class CatchupSimulation
     std::vector<SequenceNumber> bobSeqs;
     std::vector<SequenceNumber> carolSeqs;
 
-    void crankForAtMost(Application::pointer app,
-                        VirtualClock::duration duration);
-
   public:
     explicit CatchupSimulation(
         std::shared_ptr<HistoryConfigurator> cg =

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -75,7 +75,7 @@ VerifyBucketWork::onStart()
                 ec = std::make_error_code(std::errc::io_error);
             }
         }
-        app.getClock().getIOService().post([ec, handler]() { handler(ec); });
+        app.getClock().postToCurrentCrank([ec, handler]() { handler(ec); });
     });
 }
 

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -46,7 +46,7 @@ VerifyBucketWork::onStart()
     uint256 hash = mHash;
     Application& app = this->mApp;
     auto handler = callComplete();
-    app.getWorkerIOService().post([&app, filename, handler, hash]() {
+    app.postOnBackgroundThread([&app, filename, handler, hash]() {
         auto hasher = SHA256::create();
         asio::error_code ec;
         char buf[4096];
@@ -75,7 +75,7 @@ VerifyBucketWork::onStart()
                 ec = std::make_error_code(std::errc::io_error);
             }
         }
-        app.getClock().postToCurrentCrank([ec, handler]() { handler(ec); });
+        app.postOnMainThread([ec, handler]() { handler(ec); });
     });
 }
 

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -36,7 +36,7 @@ WriteSnapshotWork::onStart()
         {
             ec = std::make_error_code(std::errc::io_error);
         }
-        snap->mApp.getClock().getIOService().post(
+        snap->mApp.getClock().postToCurrentCrank(
             [handler, ec]() { handler(ec); });
     };
 

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -36,15 +36,14 @@ WriteSnapshotWork::onStart()
         {
             ec = std::make_error_code(std::errc::io_error);
         }
-        snap->mApp.getClock().postToCurrentCrank(
-            [handler, ec]() { handler(ec); });
+        snap->mApp.postOnMainThread([handler, ec]() { handler(ec); });
     };
 
     // Throw the work over to a worker thread if we can use DB pools,
     // otherwise run on main thread.
     if (mApp.getDatabase().canUsePool())
     {
-        mApp.getWorkerIOService().post(work);
+        mApp.postOnBackgroundThread(work);
     }
     else
     {

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -67,6 +67,7 @@ class LedgerManager
         NONE,
         WAITING_FOR_TRIGGER_LEDGER,
         APPLYING_HISTORY,
+        APPLYING_BUFFERED_LEDGERS,
         WAITING_FOR_CLOSING_LEDGER
     };
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -11,7 +11,6 @@
 #include "ledger/SyncingLedgerChain.h"
 #include "main/PersistentState.h"
 #include "transactions/TransactionFrame.h"
-#include "util/Timer.h"
 #include "xdr/Stellar-ledger.h"
 #include <string>
 
@@ -51,7 +50,6 @@ class LedgerManagerImpl : public LedgerManager
     VirtualClock::time_point mLastStateChange;
 
     medida::Counter& mSyncingLedgersSize;
-
     SyncingLedgerChain mSyncingLedgers;
     uint32_t mCatchupTriggerLedger{0};
 
@@ -67,6 +65,7 @@ class LedgerManagerImpl : public LedgerManager
     void historyCaughtup(asio::error_code const& ec,
                          CatchupWork::ProgressState progressState,
                          LedgerHeaderHistoryEntry const& lastClosed);
+    void applyBufferedLedgers();
 
     void processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
                             LedgerDelta& delta);

--- a/src/ledger/SyncingLedgerChain.cpp
+++ b/src/ledger/SyncingLedgerChain.cpp
@@ -12,24 +12,6 @@ SyncingLedgerChain::SyncingLedgerChain() = default;
 SyncingLedgerChain::SyncingLedgerChain(SyncingLedgerChain const&) = default;
 SyncingLedgerChain::~SyncingLedgerChain() = default;
 
-SyncingLedgerChainAddResult
-SyncingLedgerChain::add(LedgerCloseData lcd)
-{
-    if (mChain.empty() ||
-        mChain.back().getLedgerSeq() + 1 == lcd.getLedgerSeq())
-    {
-        mChain.emplace_back(std::move(lcd));
-        return SyncingLedgerChainAddResult::CONTIGUOUS;
-    }
-
-    if (lcd.getLedgerSeq() <= mChain.back().getLedgerSeq())
-    {
-        return SyncingLedgerChainAddResult::TOO_OLD;
-    }
-
-    return SyncingLedgerChainAddResult::TOO_NEW;
-}
-
 LedgerCloseData const&
 SyncingLedgerChain::front() const
 {
@@ -42,27 +24,39 @@ SyncingLedgerChain::back() const
     return mChain.back();
 }
 
-bool
-SyncingLedgerChain::empty() const
+void
+SyncingLedgerChain::pop()
 {
-    return mChain.empty();
+    mChain.pop();
 }
 
-SyncingLedgerChain::size_type
+SyncingLedgerChainAddResult
+SyncingLedgerChain::push(LedgerCloseData lcd)
+{
+    if (mChain.empty() ||
+        mChain.back().getLedgerSeq() + 1 == lcd.getLedgerSeq())
+    {
+        mChain.emplace(lcd);
+        return SyncingLedgerChainAddResult::CONTIGUOUS;
+    }
+
+    if (lcd.getLedgerSeq() <= mChain.back().getLedgerSeq())
+    {
+        return SyncingLedgerChainAddResult::TOO_OLD;
+    }
+
+    return SyncingLedgerChainAddResult::TOO_NEW;
+}
+
+size_t
 SyncingLedgerChain::size() const
 {
     return mChain.size();
 }
 
-SyncingLedgerChain::const_iterator
-SyncingLedgerChain::begin() const
+bool
+SyncingLedgerChain::empty() const
 {
-    return std::begin(mChain);
-}
-
-SyncingLedgerChain::const_iterator
-SyncingLedgerChain::end() const
-{
-    return std::end(mChain);
+    return mChain.empty();
 }
 }

--- a/src/ledger/SyncingLedgerChain.h
+++ b/src/ledger/SyncingLedgerChain.h
@@ -4,7 +4,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include <vector>
+#include <cstddef>
+#include <list>
+#include <queue>
 
 namespace stellar
 {
@@ -21,24 +23,19 @@ enum class SyncingLedgerChainAddResult
 class SyncingLedgerChain final
 {
   public:
-    using storage = std::vector<LedgerCloseData>;
-    using const_iterator = storage::const_iterator;
-    using size_type = storage::size_type;
-
     SyncingLedgerChain();
     SyncingLedgerChain(SyncingLedgerChain const&);
     ~SyncingLedgerChain();
 
-    SyncingLedgerChainAddResult add(LedgerCloseData lcd);
-
     LedgerCloseData const& front() const;
     LedgerCloseData const& back() const;
+    void pop();
+    SyncingLedgerChainAddResult push(LedgerCloseData lcd);
+
+    size_t size() const;
     bool empty() const;
-    size_type size() const;
-    const_iterator begin() const;
-    const_iterator end() const;
 
   private:
-    storage mChain;
+    std::queue<LedgerCloseData, std::list<LedgerCloseData>> mChain;
 };
 }

--- a/src/ledger/SyncingLedgerChainTests.cpp
+++ b/src/ledger/SyncingLedgerChainTests.cpp
@@ -28,7 +28,7 @@ TEST_CASE("empty syncing ledger chain accepts anything",
           "[ledger][ledgerchain]")
 {
     auto ledgerChain = SyncingLedgerChain{};
-    REQUIRE(ledgerChain.add(makeLedgerCloseData(1)) ==
+    REQUIRE(ledgerChain.push(makeLedgerCloseData(1)) ==
             SyncingLedgerChainAddResult::CONTIGUOUS);
     REQUIRE(ledgerChain.size() == 1);
     REQUIRE(ledgerChain.back().getLedgerSeq() == 1);
@@ -38,8 +38,8 @@ TEST_CASE("not empty syncing ledger chain accepts next ledger",
           "[ledger][ledgerchain]")
 {
     auto ledgerChain = SyncingLedgerChain{};
-    ledgerChain.add(makeLedgerCloseData(1));
-    REQUIRE(ledgerChain.add(makeLedgerCloseData(2)) ==
+    ledgerChain.push(makeLedgerCloseData(1));
+    REQUIRE(ledgerChain.push(makeLedgerCloseData(2)) ==
             SyncingLedgerChainAddResult::CONTIGUOUS);
     REQUIRE(ledgerChain.size() == 2);
     REQUIRE(ledgerChain.back().getLedgerSeq() == 2);
@@ -49,8 +49,8 @@ TEST_CASE("not empty syncing ledger chain do not accept after-next ledger",
           "[ledger][ledgerchain]")
 {
     auto ledgerChain = SyncingLedgerChain{};
-    ledgerChain.add(makeLedgerCloseData(1));
-    REQUIRE(ledgerChain.add(makeLedgerCloseData(3)) ==
+    ledgerChain.push(makeLedgerCloseData(1));
+    REQUIRE(ledgerChain.push(makeLedgerCloseData(3)) ==
             SyncingLedgerChainAddResult::TOO_NEW);
     REQUIRE(ledgerChain.size() == 1);
     REQUIRE(ledgerChain.back().getLedgerSeq() == 1);
@@ -60,8 +60,8 @@ TEST_CASE("not empty syncing ledger chain do not accept duplicate",
           "[ledger][ledgerchain]")
 {
     auto ledgerChain = SyncingLedgerChain{};
-    ledgerChain.add(makeLedgerCloseData(1));
-    REQUIRE(ledgerChain.add(makeLedgerCloseData(1)) ==
+    ledgerChain.push(makeLedgerCloseData(1));
+    REQUIRE(ledgerChain.push(makeLedgerCloseData(1)) ==
             SyncingLedgerChainAddResult::TOO_OLD);
     REQUIRE(ledgerChain.size() == 1);
     REQUIRE(ledgerChain.back().getLedgerSeq() == 1);
@@ -71,8 +71,8 @@ TEST_CASE("not empty syncing ledger chain do not accept previous ledger",
           "[ledger][ledgerchain]")
 {
     auto ledgerChain = SyncingLedgerChain{};
-    ledgerChain.add(makeLedgerCloseData(2));
-    REQUIRE(ledgerChain.add(makeLedgerCloseData(1)) ==
+    ledgerChain.push(makeLedgerCloseData(2));
+    REQUIRE(ledgerChain.push(makeLedgerCloseData(1)) ==
             SyncingLedgerChainAddResult::TOO_OLD);
     REQUIRE(ledgerChain.size() == 1);
     REQUIRE(ledgerChain.back().getLedgerSeq() == 2);
@@ -82,9 +82,9 @@ TEST_CASE("not empty syncing ledger chain accepts next ledger after failure",
           "[ledger][ledgerchain]")
 {
     auto ledgerChain = SyncingLedgerChain{};
-    ledgerChain.add(makeLedgerCloseData(1));
-    ledgerChain.add(makeLedgerCloseData(3));
-    REQUIRE(ledgerChain.add(makeLedgerCloseData(2)) ==
+    ledgerChain.push(makeLedgerCloseData(1));
+    ledgerChain.push(makeLedgerCloseData(3));
+    REQUIRE(ledgerChain.push(makeLedgerCloseData(2)) ==
             SyncingLedgerChainAddResult::CONTIGUOUS);
     REQUIRE(ledgerChain.size() == 2);
     REQUIRE(ledgerChain.back().getLedgerSeq() == 2);

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -213,6 +213,10 @@ class Application
     // with caution.
     virtual asio::io_service& getWorkerIOService() = 0;
 
+    virtual void postOnMainThread(std::function<void()>&& f) = 0;
+    virtual void postOnMainThreadWithDelay(std::function<void()>&& f) = 0;
+    virtual void postOnBackgroundThread(std::function<void()>&& f) = 0;
+
     // Perform actions necessary to transition from BOOTING_STATE to other
     // states. In particular: either reload or reinitialize the database, and
     // either restart or begin reacquiring SCP consensus (as instructed by

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -747,6 +747,24 @@ ApplicationImpl::getWorkerIOService()
 }
 
 void
+ApplicationImpl::postOnMainThread(std::function<void()>&& f)
+{
+    mVirtualClock.postToCurrentCrank(std::move(f));
+}
+
+void
+ApplicationImpl::postOnMainThreadWithDelay(std::function<void()>&& f)
+{
+    mVirtualClock.postToNextCrank(std::move(f));
+}
+
+void
+ApplicationImpl::postOnBackgroundThread(std::function<void()>&& f)
+{
+    getWorkerIOService().post(std::move(f));
+}
+
+void
 ApplicationImpl::enableInvariantsFromConfig()
 {
     for (auto name : mConfig.INVARIANT_CHECKS)

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -72,8 +72,12 @@ class ApplicationImpl : public Application
     virtual StatusManager& getStatusManager() override;
 
     virtual asio::io_service& getWorkerIOService() override;
+    virtual void postOnMainThread(std::function<void()>&& f) override;
+    virtual void postOnMainThreadWithDelay(std::function<void()>&& f) override;
+    virtual void postOnBackgroundThread(std::function<void()>&& f) override;
 
     void newDB() override;
+
     virtual void start() override;
 
     // Stops the worker io_service, which should cause the threads to exit once

--- a/src/main/fuzz.cpp
+++ b/src/main/fuzz.cpp
@@ -150,7 +150,7 @@ restart:
         LOG(INFO) << "Fuzzer injecting message " << i << ": "
                   << msgSummary(msg);
         auto peer = loop.getInitiator();
-        clock.getIOService().post(
+        clock.postToCurrentCrank(
             [peer, msg]() { peer->Peer::sendMessage(msg); });
     }
     while (loop.getAcceptor()->isConnected())

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -102,7 +102,7 @@ ItemFetcher::stopFetchingBelow(uint64 slotIndex)
 {
     // only perform this cleanup from the top of the stack as it causes
     // all sorts of evil side effects
-    mApp.getClock().postToCurrentCrank(
+    mApp.postOnMainThread(
         [this, slotIndex]() { stopFetchingBelowInternal(slotIndex); });
 }
 

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -102,7 +102,7 @@ ItemFetcher::stopFetchingBelow(uint64 slotIndex)
 {
     // only perform this cleanup from the top of the stack as it causes
     // all sorts of evil side effects
-    mApp.getClock().getIOService().post(
+    mApp.getClock().postToCurrentCrank(
         [this, slotIndex]() { stopFetchingBelowInternal(slotIndex); });
 }
 

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -91,7 +91,7 @@ LoopbackPeer::drop(bool)
     auto remote = mRemote.lock();
     if (remote)
     {
-        remote->getApp().getClock().getIOService().post(
+        remote->getApp().getClock().postToCurrentCrank(
             [remote]() { remote->drop(); });
     }
 }
@@ -140,7 +140,7 @@ LoopbackPeer::processInQueue()
         if (!mInQueue.empty())
         {
             auto self = static_pointer_cast<LoopbackPeer>(shared_from_this());
-            mApp.getClock().getIOService().post(
+            mApp.getClock().postToCurrentCrank(
                 [self]() { self->processInQueue(); });
         }
     }
@@ -206,7 +206,7 @@ LoopbackPeer::deliverOne()
         {
             // move msg to remote's in queue
             remote->mInQueue.emplace(std::move(msg));
-            remote->getApp().getClock().getIOService().post(
+            remote->getApp().getClock().postToCurrentCrank(
                 [remote]() { remote->processInQueue(); });
         }
         LoadManager::PeerContext loadCtx(mApp, mPeerID);
@@ -391,7 +391,7 @@ LoopbackPeerConnection::LoopbackPeerConnection(Application& initiator,
     mAcceptor->startIdleTimer();
 
     auto init = mInitiator;
-    mInitiator->getApp().getClock().getIOService().post(
+    mInitiator->getApp().getClock().postToCurrentCrank(
         [init]() { init->connectHandler(asio::error_code()); });
 }
 

--- a/src/overlay/LoopbackPeer.cpp
+++ b/src/overlay/LoopbackPeer.cpp
@@ -91,8 +91,7 @@ LoopbackPeer::drop(bool)
     auto remote = mRemote.lock();
     if (remote)
     {
-        remote->getApp().getClock().postToCurrentCrank(
-            [remote]() { remote->drop(); });
+        remote->getApp().postOnMainThread([remote]() { remote->drop(); });
     }
 }
 
@@ -140,8 +139,7 @@ LoopbackPeer::processInQueue()
         if (!mInQueue.empty())
         {
             auto self = static_pointer_cast<LoopbackPeer>(shared_from_this());
-            mApp.getClock().postToCurrentCrank(
-                [self]() { self->processInQueue(); });
+            mApp.postOnMainThread([self]() { self->processInQueue(); });
         }
     }
 }
@@ -206,7 +204,7 @@ LoopbackPeer::deliverOne()
         {
             // move msg to remote's in queue
             remote->mInQueue.emplace(std::move(msg));
-            remote->getApp().getClock().postToCurrentCrank(
+            remote->getApp().postOnMainThread(
                 [remote]() { remote->processInQueue(); });
         }
         LoadManager::PeerContext loadCtx(mApp, mPeerID);
@@ -391,7 +389,7 @@ LoopbackPeerConnection::LoopbackPeerConnection(Application& initiator,
     mAcceptor->startIdleTimer();
 
     auto init = mInitiator;
-    mInitiator->getApp().getClock().postToCurrentCrank(
+    mInitiator->getApp().postOnMainThread(
         [init]() { init->connectHandler(asio::error_code()); });
 }
 

--- a/src/overlay/OverlayTests.cpp
+++ b/src/overlay/OverlayTests.cpp
@@ -426,7 +426,9 @@ TEST_CASE("connecting to saturated nodes", "[overlay]")
     qSet.validators.push_back(vNode2NodeID);
     qSet.validators.push_back(vNode3NodeID);
 
-    simulation->addNode(vHeadSecretKey, qSet, &headCfg);
+    auto headId = simulation->addNode(vHeadSecretKey, qSet, &headCfg)
+                      ->getConfig()
+                      .NODE_SEED.getPublicKey();
     simulation->addNode(vNode1SecretKey, qSet, &node1Cfg);
     simulation->addNode(vNode2SecretKey, qSet, &node2Cfg);
     simulation->addNode(vNode3SecretKey, qSet, &node3Cfg);
@@ -436,7 +438,10 @@ TEST_CASE("connecting to saturated nodes", "[overlay]")
     simulation->addPendingConnection(vNode3NodeID, vHeadNodeID);
 
     simulation->startAllNodes();
-    simulation->crankForAtLeast(std::chrono::seconds{30}, false);
+    simulation->crankForAtLeast(std::chrono::seconds{15}, false);
+    simulation->removeNode(headId);
+    simulation->crankForAtLeast(std::chrono::seconds{15}, false);
+
     // all three (two-way) connections are made
     REQUIRE(numberOfSimulationConnections() == 6);
     simulation->crankForAtLeast(std::chrono::seconds{1}, true);

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -174,7 +174,7 @@ TCPPeer::shutdown()
 
     // To shutdown, we first queue up our desire to shutdown in the strand,
     // behind any pending read/write calls. We'll let them issue first.
-    self->getApp().getClock().postToCurrentCrank([self]() {
+    self->getApp().postOnMainThread([self]() {
         // Gracefully shut down connection: this pushes a FIN packet into TCP
         // which, if we wanted to be really polite about, we would wait for an
         // ACK from by doing repeated reads until we get a 0-read.
@@ -195,7 +195,7 @@ TCPPeer::shutdown()
             CLOG(ERROR, "Overlay")
                 << "TCPPeer::drop shutdown socket failed: " << ec.message();
         }
-        self->getApp().getClock().postToCurrentCrank([self]() {
+        self->getApp().postOnMainThread([self]() {
             // Close fd associated with socket. Socket is already shut down, but
             // depending on platform (and apparently whether there was unread
             // data when we issued shutdown()) this call might push RST onto the

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -174,7 +174,7 @@ TCPPeer::shutdown()
 
     // To shutdown, we first queue up our desire to shutdown in the strand,
     // behind any pending read/write calls. We'll let them issue first.
-    self->getApp().getClock().getIOService().post([self]() {
+    self->getApp().getClock().postToCurrentCrank([self]() {
         // Gracefully shut down connection: this pushes a FIN packet into TCP
         // which, if we wanted to be really polite about, we would wait for an
         // ACK from by doing repeated reads until we get a 0-read.
@@ -195,7 +195,7 @@ TCPPeer::shutdown()
             CLOG(ERROR, "Overlay")
                 << "TCPPeer::drop shutdown socket failed: " << ec.message();
         }
-        self->getApp().getClock().getIOService().post([self]() {
+        self->getApp().getClock().postToCurrentCrank([self]() {
             // Close fd associated with socket. Socket is already shut down, but
             // depending on platform (and apparently whether there was unread
             // data when we issued shutdown()) this call might push RST onto the

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <queue>
 
 namespace stellar
@@ -113,6 +114,10 @@ class VirtualClock
     size_t nRealTimerCancelEvents;
     time_point mNow;
 
+    bool mDelayExecution{false};
+    std::vector<std::function<void()>> mDelayedExecutionQueue;
+    std::mutex mDelayedExecutionQueueMutex;
+
     using PrQueue =
         std::priority_queue<std::shared_ptr<VirtualClockEvent>,
                             std::vector<std::shared_ptr<VirtualClockEvent>>,
@@ -156,6 +161,9 @@ class VirtualClock
 
     // returns the time of the next scheduled event
     time_point next();
+
+    void postToCurrentCrank(std::function<void()>&& f);
+    void postToNextCrank(std::function<void()>&& f);
 };
 
 class VirtualClockEvent : public NonMovableOrCopyable

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -153,7 +153,7 @@ Work::scheduleRun()
         std::static_pointer_cast<Work>(shared_from_this()));
     CLOG(DEBUG, "Work") << "scheduling run of " << getUniqueName();
     mScheduled = true;
-    mApp.getClock().postToNextCrank([weak]() {
+    mApp.postOnMainThreadWithDelay([weak]() {
         auto self = weak.lock();
         if (!self)
         {
@@ -176,7 +176,7 @@ Work::scheduleComplete(CompleteResult result)
         std::static_pointer_cast<Work>(shared_from_this()));
     CLOG(DEBUG, "Work") << "scheduling completion of " << getUniqueName();
     mScheduled = true;
-    mApp.getClock().postToNextCrank([weak, result]() {
+    mApp.postOnMainThreadWithDelay([weak, result]() {
         auto self = weak.lock();
         if (!self)
         {

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -153,7 +153,7 @@ Work::scheduleRun()
         std::static_pointer_cast<Work>(shared_from_this()));
     CLOG(DEBUG, "Work") << "scheduling run of " << getUniqueName();
     mScheduled = true;
-    mApp.getClock().getIOService().post([weak]() {
+    mApp.getClock().postToNextCrank([weak]() {
         auto self = weak.lock();
         if (!self)
         {
@@ -176,7 +176,7 @@ Work::scheduleComplete(CompleteResult result)
         std::static_pointer_cast<Work>(shared_from_this()));
     CLOG(DEBUG, "Work") << "scheduling completion of " << getUniqueName();
     mScheduled = true;
-    mApp.getClock().getIOService().post([weak, result]() {
+    mApp.getClock().postToNextCrank([weak, result]() {
         auto self = weak.lock();
         if (!self)
         {

--- a/src/work/WorkTests.cpp
+++ b/src/work/WorkTests.cpp
@@ -235,21 +235,21 @@ TEST_CASE("sub-subwork items succed at the same time", "[work]")
     auto i = 0;
 
     wm.advanceChildren();
+    clock.crank(false);
+
+    work2->forceSuccess();
+    work1->mFirstSubwork->forceSuccess();
+    work3->forceSuccess();
+
     while (!wm.allChildrenDone())
     {
-        clock.crank(false);
-
-        switch (i++)
+        if (work1->mSecondSubwork)
         {
-        case 1:
-            work2->forceSuccess();
-            work1->mFirstSubwork->forceSuccess();
-            work3->forceSuccess();
-            break;
-        case 2:
             work1->mSecondSubwork->forceSuccess();
             break;
         }
+
+        clock.crank(false);
     }
 
     REQUIRE(!work1->mCalledSuccessWithPendingSubwork);


### PR DESCRIPTION
# Description

Resolves #1803

This PR makes two main changes:
1. buffered/syncing ledgers are now not applied all at once, but are applied one by one using io_service.post() method
2. as it was not the only reason for timeouts during catchup, a new way to handle post() jobs was implemented inside of VirtualTimer:

Previous implementation did at most 10 handlers in one crank, and that could starve socket IO, so messages would come late (up to 3 minutes late during my tests).

New implementation execute all remaining handlers in one crank, but disallows posting new handlers directly to io_service(). Instead, new handlers are added to a temporary queue which is posted to io_serivce() only after all current handlers were executed. This allows each crank() to finish in reasonable time and also fixes starving of sockets.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [?] Ran `clang-format`
- [x] Compiles
- [x] Ran all tests
- [?] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
