### PR TITLE
Nomination leader updates

### DIFF
--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -95,6 +95,15 @@ LocalNode::forAllNodes(SCPQuorumSet const& qset,
     });
 }
 
+uint64
+LocalNode::computeWeight(uint64 m, uint64 total, uint64 threshold)
+{
+    uint64 res;
+    assert(threshold <= total);
+    bigDivide(res, m, threshold, total, ROUND_UP);
+    return res;
+}
+
 // if a validator is repeated multiple times its weight is only the
 // weight of the first occurrence
 uint64
@@ -108,7 +117,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
     {
         if (qsetNode == nodeID)
         {
-            bigDivide(res, UINT64_MAX, n, d, ROUND_UP);
+            res = computeWeight(UINT64_MAX, d, n);
             return res;
         }
     }
@@ -118,7 +127,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
         uint64 leafW = getNodeWeight(nodeID, q);
         if (leafW)
         {
-            bigDivide(res, leafW, n, d, ROUND_UP);
+            res = computeWeight(leafW, d, n);
             return res;
         }
     }

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -102,6 +102,8 @@ class LocalNode
     Json::Value toJson(SCPQuorumSet const& qSet) const;
     std::string to_string(SCPQuorumSet const& qSet) const;
 
+    static uint64 computeWeight(uint64 m, uint64 total, uint64 threshold);
+
   protected:
     // returns a quorum set {{ nodeID }}
     static SCPQuorumSet buildSingletonQSet(NodeID const& nodeID);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -274,7 +274,9 @@ NominationProtocol::getNodePriority(NodeID const& nodeID,
 
     w = LocalNode::getNodeWeight(nodeID, qset);
 
-    if (hashNode(false, nodeID) < w)
+    // if w > 0; w is inclusive here as
+    // 0 <= hashNode <= UINT64_MAX
+    if (w > 0 && hashNode(false, nodeID) <= w)
     {
         res = hashNode(true, nodeID);
     }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -16,6 +16,7 @@ namespace stellar
 {
 class NominationProtocol
 {
+  protected:
     Slot& mSlot;
 
     int32 mRoundNumber;

--- a/src/scp/SCPUnitTests.cpp
+++ b/src/scp/SCPUnitTests.cpp
@@ -33,7 +33,7 @@ TEST_CASE("nomination weight", "[scp]")
 
     uint64 result = LocalNode::getNodeWeight(v2NodeID, qSet);
 
-    REQUIRE(isNear(result, .75));
+    REQUIRE(isNear(result, 0.80)); // 4/5
 
     result = LocalNode::getNodeWeight(v4NodeID, qSet);
     REQUIRE(result == 0);
@@ -46,7 +46,7 @@ TEST_CASE("nomination weight", "[scp]")
 
     result = LocalNode::getNodeWeight(v4NodeID, qSet);
 
-    REQUIRE(isNear(result, .6 * .5));
+    REQUIRE(isNear(result, 0.6875 * 0.6666)); // 11/16 * 2/3
 }
 
 class TestNominationSCP : public SCPDriver

--- a/src/scp/SCPUnitTests.cpp
+++ b/src/scp/SCPUnitTests.cpp
@@ -1,6 +1,10 @@
 #include "lib/catch.hpp"
 #include "scp/LocalNode.h"
+#include "scp/SCP.h"
+#include "scp/Slot.h"
 #include "simulation/Simulation.h"
+#include "util/Logging.h"
+#include "xdrpp/marshal.h"
 
 namespace stellar
 {
@@ -43,5 +47,390 @@ TEST_CASE("nomination weight", "[scp]")
     result = LocalNode::getNodeWeight(v4NodeID, qSet);
 
     REQUIRE(isNear(result, .6 * .5));
+}
+
+class TestNominationSCP : public SCPDriver
+{
+  public:
+    SCP mSCP;
+    TestNominationSCP(NodeID const& nodeID, SCPQuorumSet const& qSetLocal)
+        : mSCP(*this, nodeID, true, qSetLocal)
+    {
+        auto localQSet =
+            std::make_shared<SCPQuorumSet>(mSCP.getLocalQuorumSet());
+        storeQuorumSet(localQSet);
+    }
+
+    void
+    signEnvelope(SCPEnvelope&) override
+    {
+    }
+
+    bool
+    verifyEnvelope(SCPEnvelope const& envelope) override
+    {
+        return true;
+    }
+
+    void
+    storeQuorumSet(SCPQuorumSetPtr qSet)
+    {
+        Hash qSetHash = sha256(xdr::xdr_to_opaque(*qSet.get()));
+        mQuorumSets[qSetHash] = qSet;
+    }
+
+    SCPDriver::ValidationLevel
+    validateValue(uint64 slotIndex, Value const& value,
+                  bool nomination) override
+    {
+        return SCPDriver::kFullyValidatedValue;
+    }
+
+    SCPQuorumSetPtr
+    getQSet(Hash const& qSetHash) override
+    {
+        if (mQuorumSets.find(qSetHash) != mQuorumSets.end())
+        {
+
+            return mQuorumSets[qSetHash];
+        }
+        return SCPQuorumSetPtr();
+    }
+
+    void
+    emitEnvelope(SCPEnvelope const& envelope) override
+    {
+    }
+
+    Value
+    combineCandidates(uint64 slotIndex,
+                      std::set<Value> const& candidates) override
+    {
+        return {};
+    }
+
+    void
+    setupTimer(uint64 slotIndex, int timerID, std::chrono::milliseconds timeout,
+               std::function<void()> cb) override
+    {
+    }
+
+    std::map<Hash, SCPQuorumSetPtr> mQuorumSets;
+
+    Value const&
+    getLatestCompositeCandidate(uint64 slotIndex)
+    {
+        return {};
+    }
+};
+
+class NominationTestHandler : public NominationProtocol
+{
+  public:
+    NominationTestHandler(Slot& s) : NominationProtocol(s)
+    {
+    }
+
+    void
+    setPreviousValue(Value const& v)
+    {
+        mPreviousValue = v;
+    }
+
+    void
+    setRoundNumber(int32 n)
+    {
+        mRoundNumber = n;
+    }
+
+    void
+    updateRoundLeaders()
+    {
+        NominationProtocol::updateRoundLeaders();
+    }
+
+    std::set<NodeID>&
+    getRoundLeaders()
+    {
+        return mRoundLeaders;
+    }
+
+    uint64
+    getNodePriority(NodeID const& nodeID, SCPQuorumSet const& qset)
+    {
+        return NominationProtocol::getNodePriority(nodeID, qset);
+    }
+};
+
+// this test case display statistical information on the priority function used
+// by nomination
+TEST_CASE("nomination weight stats", "[scp][!hide]")
+{
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+
+    SIMULATION_CREATE_NODE(3);
+    SIMULATION_CREATE_NODE(4);
+    SIMULATION_CREATE_NODE(5);
+    SIMULATION_CREATE_NODE(6);
+
+    NodeID nodeIDs[] = {v0NodeID, v1NodeID, v2NodeID, v3NodeID,
+                        v4NodeID, v5NodeID, v6NodeID};
+
+    int const totalRounds = 10000;
+
+    auto runTests = [&](SCPQuorumSet qSet) {
+        TestNominationSCP nomSCP(v0NodeID, qSet);
+        Slot slot(0, nomSCP.mSCP);
+
+        NominationTestHandler nom(slot);
+
+        std::map<NodeID, int> wins;
+
+        Value v;
+        v.emplace_back(uint8_t(1)); // anything will do as a value
+
+        nom.setPreviousValue(v);
+
+        int noLeaders = 0;
+
+        for (int i = 0; i < totalRounds; i++)
+        {
+            nom.setRoundNumber(i);
+            nom.updateRoundLeaders();
+            auto& l = nom.getRoundLeaders();
+            if (l.empty())
+            {
+                noLeaders++;
+            }
+            else
+            {
+                for (auto& w : l)
+                {
+                    wins[w]++;
+                }
+            }
+        }
+
+        REQUIRE(noLeaders == 0);
+        return wins;
+    };
+
+    auto makeQSet = [&](int threshold, int total, int offset) {
+        SCPQuorumSet qSet;
+        qSet.threshold = threshold;
+        for (int i = 0; i < total; i++)
+        {
+            qSet.validators.push_back(nodeIDs[i + offset]);
+        }
+        return qSet;
+    };
+    SECTION("flat quorum")
+    {
+        auto flatTest = [&](int threshold, int total) {
+            auto qSet = makeQSet(threshold, total, 0);
+
+            auto wins = runTests(qSet);
+
+            for (auto& w : wins)
+            {
+                double stats = double(w.second * 100) / double(totalRounds);
+                CLOG(INFO, "SCP") << "Got " << stats
+                                  << ((v0NodeID == w.first) ? " LOCAL" : "");
+            }
+        };
+
+        SECTION("3 out of 5")
+        {
+            flatTest(3, 5);
+        }
+        SECTION("2 out of 3")
+        {
+            flatTest(2, 3);
+        }
+    }
+    SECTION("hierarchy")
+    {
+        auto qSet = makeQSet(3, 4, 0);
+
+        auto qSetInner = makeQSet(2, 3, 4);
+        qSet.innerSets.emplace_back(qSetInner);
+
+        auto wins = runTests(qSet);
+
+        for (auto& w : wins)
+        {
+            double stats = double(w.second * 100) / double(totalRounds);
+            bool outer =
+                std::any_of(qSet.validators.begin(), qSet.validators.end(),
+                            [&](auto const& k) { return k == w.first; });
+            CLOG(INFO, "SCP")
+                << "Got " << stats << " "
+                << ((v0NodeID == w.first) ? "LOCAL"
+                                          : (outer ? "OUTER" : "INNER"));
+        }
+    }
+}
+
+TEST_CASE("nomination two nodes win stats", "[scp][!hide]")
+{
+    int const nbRoundsForStats = 9;
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+
+    SIMULATION_CREATE_NODE(3);
+    SIMULATION_CREATE_NODE(4);
+    SIMULATION_CREATE_NODE(5);
+    SIMULATION_CREATE_NODE(6);
+
+    NodeID nodeIDs[] = {v0NodeID, v1NodeID, v2NodeID, v3NodeID,
+                        v4NodeID, v5NodeID, v6NodeID};
+
+    int const totalIter = 10000;
+
+    // maxRounds is the number of rounds to evaluate in a row
+    // the iteration is considered successful if validators could
+    // agree on what to nominate before maxRounds is reached
+    auto nominationLeaders = [&](int maxRounds, SCPQuorumSet qSetNode0,
+                                 SCPQuorumSet qSetNode1) {
+        TestNominationSCP nomSCP0(v0NodeID, qSetNode0);
+        Slot slot0(0, nomSCP0.mSCP);
+        NominationTestHandler nom0(slot0);
+
+        TestNominationSCP nomSCP1(v1NodeID, qSetNode1);
+        Slot slot1(0, nomSCP1.mSCP);
+        NominationTestHandler nom1(slot1);
+
+        int tot = 0;
+        for (int g = 0; g < totalIter; g++)
+        {
+            Value v;
+            v.emplace_back(uint8_t(g));
+            nom0.setPreviousValue(v);
+            nom1.setPreviousValue(v);
+
+            bool res = true;
+
+            bool v0Voted = false;
+            bool v1Voted = false;
+
+            int r = 0;
+            do
+            {
+                nom0.setRoundNumber(r);
+                nom1.setRoundNumber(r);
+                nom0.updateRoundLeaders();
+                nom1.updateRoundLeaders();
+
+                auto& l0 = nom0.getRoundLeaders();
+                REQUIRE(!l0.empty());
+                auto& l1 = nom1.getRoundLeaders();
+                REQUIRE(!l1.empty());
+
+                auto updateVoted = [&](auto const& id, auto const& leaders,
+                                       bool& voted) {
+                    if (!voted)
+                    {
+                        voted = std::find(leaders.begin(), leaders.end(), id) !=
+                                leaders.end();
+                    }
+                };
+
+                // checks if id voted (any past round, including this one)
+                // AND id is a leader this round
+                auto findNode = [](auto const& id, bool idVoted,
+                                   auto const& otherLeaders) {
+                    bool r = (idVoted && std::find(otherLeaders.begin(),
+                                                   otherLeaders.end(),
+                                                   id) != otherLeaders.end());
+                    return r;
+                };
+
+                updateVoted(v0NodeID, l0, v0Voted);
+                updateVoted(v1NodeID, l1, v1Voted);
+
+                // either both vote for v0 or both vote for v1
+                res = findNode(v0NodeID, v0Voted, l1);
+                res = res || findNode(v1NodeID, v1Voted, l0);
+            } while (!res && ++r < maxRounds);
+
+            tot += res ? 1 : 0;
+        }
+        return tot;
+    };
+
+    auto makeQSet = [&](int threshold, int total, int offset) {
+        SCPQuorumSet qSet;
+        qSet.threshold = threshold;
+        for (int i = 0; i < total; i++)
+        {
+            qSet.validators.push_back(nodeIDs[i + offset]);
+        }
+        return qSet;
+    };
+    SECTION("flat quorum")
+    {
+        // test using the same quorum on all nodes
+        auto flatTest = [&](int threshold, int total) {
+            auto qSet = makeQSet(threshold, total, 0);
+
+            for (int maxRounds = 1; maxRounds <= nbRoundsForStats; maxRounds++)
+            {
+                int tot = nominationLeaders(maxRounds, qSet, qSet);
+                double stats = double(tot * 100) / double(totalIter);
+                CLOG(INFO, "SCP")
+                    << "Win rate for " << maxRounds << " : " << stats;
+            }
+        };
+
+        SECTION("3 out of 5")
+        {
+            flatTest(3, 5);
+        }
+        SECTION("2 out of 3")
+        {
+            flatTest(2, 3);
+        }
+    }
+
+    SECTION("hierarchy")
+    {
+        SECTION("same qSet")
+        {
+            auto qSet = makeQSet(3, 4, 0);
+
+            auto qSetInner = makeQSet(2, 3, 4);
+            qSet.innerSets.emplace_back(qSetInner);
+
+            for (int maxRounds = 1; maxRounds <= nbRoundsForStats; maxRounds++)
+            {
+                int tot = nominationLeaders(maxRounds, qSet, qSet);
+                double stats = double(tot * 100) / double(totalIter);
+                CLOG(INFO, "SCP")
+                    << "Win rate for " << maxRounds << " : " << stats;
+            }
+        }
+        SECTION("v0 is inner node for v1")
+        {
+            auto qSet0 = makeQSet(3, 4, 0);
+            auto qSetInner0 = makeQSet(2, 3, 4);
+            qSet0.innerSets.emplace_back(qSetInner0);
+
+            // v1's qset: we move v0 into the inner set
+            auto qSet1 = qSet0;
+            REQUIRE(qSet1.validators[0] == v0NodeID);
+            std::swap(qSet1.validators[0], qSet1.innerSets[0].validators[0]);
+
+            for (int maxRounds = 1; maxRounds <= nbRoundsForStats; maxRounds++)
+            {
+                int tot = nominationLeaders(maxRounds, qSet0, qSet1);
+                double stats = double(tot * 100) / double(totalIter);
+                CLOG(INFO, "SCP")
+                    << "Win rate for " << maxRounds << " : " << stats;
+            }
+        }
+    }
 }
 }

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -123,4 +123,28 @@ bigMultiply(int64_t a, int64_t b)
     assert((a >= 0) && (b >= 0));
     return bigMultiply((uint64_t)a, (uint64_t)b);
 }
+
+uint64_t
+safeMul(uint64_t a, uint64_t b)
+{
+    uint128_t aa(a), bb(b);
+    auto rr = aa * bb;
+    if (rr > UINT64_MAX)
+    {
+        throw std::invalid_argument("overflow");
+    }
+    return rr.lower();
+}
+
+uint64_t
+safeAdd(uint64_t a, uint64_t b)
+{
+    uint128_t aa(a), bb(b);
+    auto rr = aa + bb;
+    if (rr > UINT64_MAX)
+    {
+        throw std::invalid_argument("overflow");
+    }
+    return rr.lower();
+}
 }

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -31,4 +31,7 @@ int64_t bigDivide(uint128_t a, int64_t B, Rounding rounding);
 
 uint128_t bigMultiply(uint64_t a, uint64_t b);
 uint128_t bigMultiply(int64_t a, int64_t b);
+
+uint64_t safeAdd(uint64_t a, uint64_t b);
+uint64_t safeMul(uint64_t a, uint64_t b);
 }


### PR DESCRIPTION
# Description

This PR addresses a few issues related to the "leader" election function used during nomination, used to avoid an explosion of values to feed into the ballot protocol (described in section 6.1 of the SCP whitepaper).

* main change is to compute the weight for the local node as if it was a regular member of the top level set
* secondary change is to properly compute the weight based on size of the sets (was using thresholds instead)

See individual commit comments for more detail.

Data included: odds of winning nomination for various nodes depending on quorum set configuration.

## Before this PR

```
2018-10-30T15:46:35.453 <test> [default INFO] Testing stellar-core msvc custom
2018-10-30T15:46:35.454 <test> [default INFO] Logging to stellar0.log
2018-10-30T15:46:35.501 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 2cc575
2018-10-30T15:46:39.305 <test> [SCP INFO] Got 15.24
2018-10-30T15:46:39.305 <test> [SCP INFO] Got 38.79 LOCAL
2018-10-30T15:46:39.305 <test> [SCP INFO] Got 15.26
2018-10-30T15:46:39.305 <test> [SCP INFO] Got 15.25
2018-10-30T15:46:39.306 <test> [SCP INFO] Got 15.46
2018-10-30T15:46:39.320 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 172dcb
2018-10-30T15:46:41.711 <test> [SCP INFO] Got 57.98 LOCAL
2018-10-30T15:46:41.711 <test> [SCP INFO] Got 20.69
2018-10-30T15:46:41.711 <test> [SCP INFO] Got 21.33
2018-10-30T15:46:41.723 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: c85b05
2018-10-30T15:46:47.598 <test> [SCP INFO] Got 13.43 OUTER
2018-10-30T15:46:47.599 <test> [SCP INFO] Got 33.57 LOCAL
2018-10-30T15:46:47.599 <test> [SCP INFO] Got 13.57 OUTER
2018-10-30T15:46:47.599 <test> [SCP INFO] Got 8.57 INNER
2018-10-30T15:46:47.599 <test> [SCP INFO] Got 13.64 OUTER
2018-10-30T15:46:47.599 <test> [SCP INFO] Got 8.65 INNER
2018-10-30T15:46:47.599 <test> [SCP INFO] Got 8.57 INNER
```

## After this PR
```
2018-10-30T16:28:53.286 <test> [default INFO] Testing stellar-core msvc custom
2018-10-30T16:28:53.296 <test> [default INFO] Logging to stellar0.log
2018-10-30T16:28:53.353 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 2cc575
2018-10-30T16:29:40.069 <test> [SCP INFO] Got 20.07
2018-10-30T16:29:40.069 <test> [SCP INFO] Got 20.12 LOCAL
2018-10-30T16:29:40.069 <test> [SCP INFO] Got 19.74
2018-10-30T16:29:40.069 <test> [SCP INFO] Got 19.56
2018-10-30T16:29:40.069 <test> [SCP INFO] Got 20.51
2018-10-30T16:29:40.086 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 172dcb
2018-10-30T16:29:42.670 <test> [SCP INFO] Got 33.91 LOCAL
2018-10-30T16:29:42.670 <test> [SCP INFO] Got 33.21
2018-10-30T16:29:42.670 <test> [SCP INFO] Got 32.88
2018-10-30T16:29:46.274 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: c85b05
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 16.27 OUTER
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 16.17 LOCAL
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 16.13 OUTER
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 11.63 INNER
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 16.33 OUTER
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 12.14 INNER
2018-10-30T16:34:56.543 <test> [SCP INFO] Got 11.33 INNER
```

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
