### PR TITLE
crank returns that it's busy when dequeuing pending work

### DIFF
--- a/src/history/HistoryTests.cpp
+++ b/src/history/HistoryTests.cpp
@@ -374,10 +374,8 @@ TEST_CASE("Repair missing buckets fails", "[history][historybucketrepair]")
     app2->getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                         state);
 
-    app2->start();
-    REQUIRE_THROWS(catchupSimulation.crankUntil(
-        app2, [&]() { return app2->getWorkManager().allChildrenDone(); },
-        std::chrono::seconds(30)));
+    // will crash on startup after retrying to repair buckets a few times
+    REQUIRE_THROWS_AS(app2->start(), std::runtime_error);
 }
 
 TEST_CASE("Publish/catchup via s3", "[!hide][s3]")

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -286,6 +286,8 @@ VirtualClock::crank(bool block)
         if (!mDelayedExecutionQueue.empty())
         {
             block = false;
+            // count this as work
+            nWorkDone += 1;
         }
         for (auto&& f : mDelayedExecutionQueue)
         {

--- a/src/work/WorkTests.cpp
+++ b/src/work/WorkTests.cpp
@@ -232,8 +232,6 @@ TEST_CASE("sub-subwork items succed at the same time", "[work]")
     auto work2 = w->addWork<WorkDoNothing>("work-2");
     auto work3 = w->addWork<WorkDoNothing>("work-3");
 
-    auto i = 0;
-
     wm.advanceChildren();
     clock.crank(false);
 


### PR DESCRIPTION
# Description

#1818 introduced a change in the contract of `crank` by accident:
if for some reason crank is called without anything in IOService but something in the pending queue, it would consider that "there is no more work to do", even though work will happen the next turn of the crank.
The problem here is that this breaks:
* virtual clocks move the clock forward very aggressively (potentially timing out work that was in the pending queue)
* loops that use the return value of `crank` to know if there is no more work

The fix is very simple: just count moving items off the pending queue as actual work performed during crank.

I tested this with command line catchup that got broken by the previous commit.
