### PR TITLE
proper fix of VirtualClock bug

### DIFF
--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -114,9 +114,9 @@ class VirtualClock
     size_t nRealTimerCancelEvents;
     time_point mNow;
 
-    bool mDelayExecution{false};
+    bool mDelayExecution{true};
+    std::recursive_mutex mDelayExecutionMutex;
     std::vector<std::function<void()>> mDelayedExecutionQueue;
-    std::mutex mDelayedExecutionQueueMutex;
 
     using PrQueue =
         std::priority_queue<std::shared_ptr<VirtualClockEvent>,

--- a/src/util/TimerTests.cpp
+++ b/src/util/TimerTests.cpp
@@ -221,3 +221,71 @@ TEST_CASE("timer cancels", "[timer]")
     REQUIRE(timerFired == 8);
     REQUIRE(timerCancelled == 2);
 }
+
+TEST_CASE("crank returns correct value", "[timer]")
+{
+    for (auto mode : {
+             std::make_pair("REAL_TIME", VirtualClock::REAL_TIME),
+             std::make_pair("VIRTUAL_TIME", VirtualClock::VIRTUAL_TIME),
+         })
+    {
+        SECTION(mode.first)
+        {
+            VirtualClock clock{mode.second};
+            auto& io = clock.getIOService();
+            asio::io_service::work mainWork(io);
+
+            auto executed = false;
+            auto execute = [&executed] { executed = true; };
+            auto executeLater = [&] { clock.postToNextCrank(execute); };
+            auto executeMuchLater = [&] {
+                clock.postToNextCrank(executeLater);
+            };
+
+            REQUIRE(clock.crank(false) == 0);
+
+            clock.postToCurrentCrank(execute);
+            REQUIRE(!executed);
+            // 1 for "execute"
+            REQUIRE(clock.crank(false) == 1);
+            REQUIRE(executed);
+            REQUIRE(clock.crank(false) == 0);
+
+            executed = false;
+            clock.postToNextCrank(execute);
+            REQUIRE(!executed);
+            // 1 for "execute"
+            REQUIRE(clock.crank(false) == 1);
+            REQUIRE(executed);
+            REQUIRE(clock.crank(false) == 0);
+
+            executed = false;
+            clock.postToCurrentCrank(executeLater);
+            REQUIRE(!executed);
+            // 1 for "executeLater"
+            // 1 for posting "execute" to io_service
+            REQUIRE(clock.crank(false) == 2);
+            REQUIRE(!executed);
+            // 1 for "execute"
+            REQUIRE(clock.crank(false) == 1);
+            REQUIRE(executed);
+            REQUIRE(clock.crank(false) == 0);
+
+            executed = false;
+            clock.postToCurrentCrank(executeMuchLater);
+            REQUIRE(!executed);
+            // 1 for "executeMuchLater"
+            // 1 for posting "executeLater" to io_service
+            REQUIRE(clock.crank(false) == 2);
+            REQUIRE(!executed);
+            // 1 for "executeLater"
+            // 1 for posting "execute" to io_service
+            REQUIRE(clock.crank(false) == 2);
+            REQUIRE(!executed);
+            // 1 for "execute"
+            REQUIRE(clock.crank(false) == 1);
+            REQUIRE(executed);
+            REQUIRE(clock.crank(false) == 0);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

This is proper fix to bug introduced in #1818, instead of #1821.
Now it is impossible that work is put to pending queue without executing any work in current crank, as only "run_one" is called outside of `mDelayExecution`.

Also `mDelayExecution` is properly set to false at the end of crank, which was missed in original PR (I must have missed that during squash/rebase phase).

I'll try to add tests to catch issues like that in the future.