### PR TITLE
Publish command

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -60,6 +60,9 @@ stellar-core can be controlled via the following commands.
   controls type used for printing (default: auto).<br>
   Option --base64 alters the behavior to work on base64-encoded XDR rather than
   raw XDR.
+* **publish**: Execute publish of all items remaining in publish queue without
+  connecting to network. May not publish last checkpoint if last closed ledger
+  is on checkpoint boundary.
 * **report-last-history-checkpoint**: Download and report last history
   checkpoint from a history archive.
 * **run**: Runs stellar-core service.

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -25,4 +25,5 @@ void writeCatchupInfo(Json::Value const& catchupInfo,
                       std::string const& outputFile);
 int catchup(Application::pointer app, CatchupConfiguration cc,
             Json::Value& catchupInfo);
+int publish(Application::pointer app);
 }

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -415,6 +415,21 @@ runCatchup(CommandLineArgs const& args)
 }
 
 int
+runPublish(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+
+    return runWithHelp(args, {configurationParser(configOption)}, [&] {
+        auto config = configOption.getConfig();
+        config.setNoListen();
+
+        VirtualClock clock(VirtualClock::REAL_TIME);
+        auto app = Application::create(clock, config, false);
+        return publish(app);
+    });
+}
+
+int
 runCheckQuorum(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -712,6 +727,11 @@ handleCommandLine(int argc, char* const* argv)
          {"offline-info", "return information for an offline instance",
           runOfflineInfo},
          {"print-xdr", "pretty-print one XDR envelope, then quit", runPrintXdr},
+         {"publish",
+          "execute publish of all items remaining in publish queue without "
+          "connecting to network, may not publish last checkpoint if last "
+          "closed ledger is on checkpoint boundary",
+          runPublish},
          {"report-last-history-checkpoint",
           "report information about last checkpoint available in "
           "history archives",


### PR DESCRIPTION
# Description

Resolves #1814

Add new command `publish` which publishes all (or almost all) remaining checkpoints to history archives. I may leave one unpublished in case LCL is equal to last ledger in last checkpoint, in which case we must wait for next ledger from network before progressing. Publishing of that last checkpoint is postponed to normal stellar-core run.

This PR requires #1732 to be merged first

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
