### PR TITLE
Added support for filtering transactions by operation in Herder

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -427,6 +427,15 @@ MAX_SLOTS_TO_REMEMBER=12
 # only a passive "watcher" node.
 METADATA_OUTPUT_STREAM=""
 
+# EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE (list of strings) default is empty
+# Setting this will cause the node to reject transactions that it receives if
+# they contain any operation in this list. It will not, however, stop the node
+# from voting for or applying such transactions.
+#
+# Strings specified are matched against the names of values for OperationType,
+# such as "CREATE_ACCOUNT" or "PATH_PAYMENT_STRICT_SEND".
+EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE=[]
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -66,6 +66,7 @@ class TransactionQueue
         ADD_STATUS_DUPLICATE,
         ADD_STATUS_ERROR,
         ADD_STATUS_TRY_AGAIN_LATER,
+        ADD_STATUS_FILTERED,
         ADD_STATUS_COUNT
     };
 
@@ -170,6 +171,8 @@ class TransactionQueue
     medida::Counter& mBannedTransactionsCounter;
     medida::Timer& mTransactionsDelay;
 
+    std::unordered_set<OperationType> mFilteredTypes;
+
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,
                      TimestampedTransactions::iterator& oldTxIter);
@@ -187,6 +190,8 @@ class TransactionQueue
 
     size_t maxQueueSizeOps() const;
 
+    bool isFiltered(TransactionFrameBasePtr tx) const;
+
 #ifdef BUILD_TESTS
   public:
     size_t
@@ -199,5 +204,5 @@ class TransactionQueue
 
 static const char* TX_STATUS_STRING[static_cast<int>(
     TransactionQueue::AddResult::ADD_STATUS_COUNT)] = {
-    "PENDING", "DUPLICATE", "ERROR", "TRY_AGAIN_LATER"};
+    "PENDING", "DUPLICATE", "ERROR", "TRY_AGAIN_LATER", "FILTERED"};
 }

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2551,3 +2551,54 @@ TEST_CASE("slot herder policy", "[herder]")
     REQUIRE(herder.getSCP().getKnownSlotsCount() ==
             Herder::LEDGER_VALIDITY_BRACKET);
 }
+
+TEST_CASE("exclude transactions by operation type", "[herder]")
+{
+    SECTION("operation is received when no filter")
+    {
+        VirtualClock clock;
+        auto cfg = getTestConfig();
+        Application::pointer app = createTestApplication(clock, cfg);
+        app->start();
+
+        auto root = TestAccount::createRoot(*app);
+        auto acc = getAccount("acc");
+        auto tx = root.tx({createAccount(acc.getPublicKey(), 1)});
+
+        REQUIRE(app->getHerder().recvTransaction(tx) ==
+                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+    }
+
+    SECTION("filter excludes transaction containing specified operation")
+    {
+        VirtualClock clock;
+        auto cfg = getTestConfig();
+        cfg.EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE = {CREATE_ACCOUNT};
+        Application::pointer app = createTestApplication(clock, cfg);
+        app->start();
+
+        auto root = TestAccount::createRoot(*app);
+        auto acc = getAccount("acc");
+        auto tx = root.tx({createAccount(acc.getPublicKey(), 1)});
+
+        REQUIRE(app->getHerder().recvTransaction(tx) ==
+                TransactionQueue::AddResult::ADD_STATUS_FILTERED);
+    }
+
+    SECTION("filter does not exclude transaction containing non-specified "
+            "operation")
+    {
+        VirtualClock clock;
+        auto cfg = getTestConfig();
+        cfg.EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE = {MANAGE_DATA};
+        Application::pointer app = createTestApplication(clock, cfg);
+        app->start();
+
+        auto root = TestAccount::createRoot(*app);
+        auto acc = getAccount("acc");
+        auto tx = root.tx({createAccount(acc.getPublicKey(), 1)});
+
+        REQUIRE(app->getHerder().recvTransaction(tx) ==
+                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+    }
+}

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -946,23 +946,11 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
             txFrame = fromAccount.tx({payment(toAccount, paymentAmount)});
         }
 
-        switch (mApp.getHerder().recvTransaction(txFrame))
+        auto status = mApp.getHerder().recvTransaction(txFrame);
+        root["status"] = TX_STATUS_STRING[static_cast<int>(status)];
+        if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {
-        case TransactionQueue::AddResult::ADD_STATUS_PENDING:
-            root["status"] = "pending";
-            break;
-        case TransactionQueue::AddResult::ADD_STATUS_DUPLICATE:
-            root["status"] = "duplicate";
-            break;
-        case TransactionQueue::AddResult::ADD_STATUS_ERROR:
-            root["status"] = "error";
             root["detail"] = xdr_to_string(txFrame->getResult().result.code());
-            break;
-        case TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER:
-            root["status"] = "try_again_later";
-            break;
-        default:
-            assert(false);
         }
     }
     else

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -387,6 +387,10 @@ class Config : public std::enable_shared_from_this<Config>
     bool TEST_CASES_ENABLED;
 #endif
 
+    // Any transaction that reaches the TransactionQueue will be rejected if it
+    // contains an operation in this list.
+    std::vector<OperationType> EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE;
+
     Config();
 
     void load(std::string const& filename);

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -8,6 +8,7 @@
 #include "main/Config.h"
 #include "scp/QuorumSetUtils.h"
 #include "test/test.h"
+#include "util/Math.h"
 #include <fmt/format.h>
 
 using namespace stellar;
@@ -438,5 +439,68 @@ VALIDATORS=[
             }
         }
         quorumSetNumber += ".1";
+    }
+}
+
+TEST_CASE("operation filter configuration", "[config]")
+{
+    typedef xdr::xdr_traits<OperationType> OperationTypeTraits;
+    auto toConfigStr = [](std::vector<OperationType> const& vals,
+                          std::stringstream& ss) {
+        ss << "EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE=[";
+        auto iter = vals.begin();
+        if (iter != vals.end())
+        {
+            while (iter != vals.end() - 1)
+            {
+                ss << "\"" << OperationTypeTraits::enum_name(*iter++) << "\", ";
+            }
+            ss << "\"" << OperationTypeTraits::enum_name(*iter++) << "\"";
+        }
+        ss << "]";
+        CLOG(ERROR, "Tx") << ss.str();
+    };
+
+    auto loadConfig = [&](std::vector<OperationType> const& vals) {
+        auto makePublicKey = [](int i) {
+            auto hash = sha256(fmt::format("NODE_SEED_{}", i));
+            auto secretKey = SecretKey::fromSeed(hash);
+            return secretKey.getStrKeyPublic();
+        };
+
+        std::stringstream ss;
+        ss << "UNSAFE_QUORUM=true\n";
+        toConfigStr(vals, ss);
+        ss << "\n[QUORUM_SET]\n";
+        ss << "THRESHOLD_PERCENT=100\n";
+        ss << "VALIDATORS=[\"" << makePublicKey(0) << " A\"]\n";
+
+        Config c;
+        REQUIRE_NOTHROW(c.load(ss));
+        auto const& exclude = c.EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE;
+        REQUIRE(exclude == vals);
+    };
+
+    // Test every operation type individually
+    for (auto v : OperationTypeTraits::enum_values())
+    {
+        std::vector<OperationType> vals;
+        vals.emplace_back(static_cast<OperationType>(v));
+        loadConfig(vals);
+    }
+
+    // Test random subsets that are not necessarily in the typical order
+    std::uniform_int_distribution<size_t> dist(
+        0, OperationTypeTraits::enum_values().size() - 1);
+    for (size_t i = 0; i < 5; ++i)
+    {
+        std::vector<OperationType> vals;
+        for (auto v : OperationTypeTraits::enum_values())
+        {
+            vals.emplace_back(static_cast<OperationType>(v));
+        }
+        std::shuffle(vals.begin(), vals.end(), gRandomEngine);
+        vals.resize(dist(gRandomEngine));
+        loadConfig(vals);
     }
 }


### PR DESCRIPTION
Added support for filtering transactions by operation in Herder. If Herder receives a transaction that contains any operation whose type is included in the configuration array `EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE`, then Herder will reject it with the status `TX_STATUS_FILTERED`.