### PR TITLE
fix include required for abort

### DIFF
--- a/src/util/GlobalChecks.cpp
+++ b/src/util/GlobalChecks.cpp
@@ -7,8 +7,8 @@
 #ifdef _WIN32
 #include <Windows.h>
 #endif
-#include <cassert>
 #include <cstdio>
+#include <cstdlib>
 #include <thread>
 
 namespace stellar
@@ -27,7 +27,7 @@ dbgAbort()
 #ifdef _WIN32
     DebugBreak();
 #else
-    abort();
+    std::abort();
 #endif
 }
 
@@ -37,7 +37,7 @@ printErrorAndAbort(const char* s1)
     std::fprintf(stderr, "%s\n", s1);
     std::fflush(stderr);
     dbgAbort();
-    abort();
+    std::abort();
 }
 
 void
@@ -46,6 +46,6 @@ printErrorAndAbort(const char* s1, const char* s2)
     std::fprintf(stderr, "%s%s\n", s1, s2);
     std::fflush(stderr);
     dbgAbort();
-    abort();
+    std::abort();
 }
 }


### PR DESCRIPTION
trivial change: abort is defined in `<cstdlib>` per https://en.cppreference.com/w/cpp/utility/program/abort

(this causes problems on minimal builds on Ubuntu 16.04)