### PR TITLE
output DEPRECATED message in stderr to avoid confusing scripts

### DIFF
--- a/src/main/DeprecatedCommandLine.cpp
+++ b/src/main/DeprecatedCommandLine.cpp
@@ -215,8 +215,9 @@ catchupTo(Application::pointer app, uint32_t to, Json::Value& catchupInfo)
 int
 handleDeprecatedCommandLine(int argc, char* const* argv)
 {
-    std::cout << "Using DEPRECATED command-line syntax.\n";
-    std::cout << "Please refer to documentation for new syntax.\n\n";
+    std::cerr << "Using DEPRECATED command-line syntax." << std::endl;
+    std::cerr << "Please refer to documentation for new syntax." << std::endl
+              << std::endl;
 
     std::string cfgFile("stellar-core.cfg");
     std::string command;


### PR DESCRIPTION
#1732 emits warning messages when using old style command lines, but it emits those in `stdout` which breaks scripts that process what is output by stellar-core.

This PR emits those messages in stderr, which should mitigate this