### PR TITLE
Improve close time check

### DIFF
--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -211,6 +211,9 @@ class HerderSCPDriver : public SCPDriver
 
     void stateChanged();
 
+    bool checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
+                        StellarValue const& b) const;
+
     SCPDriver::ValidationLevel
     validateValueHelper(uint64_t slotIndex, StellarValue const& sv) const;
 


### PR DESCRIPTION
This PR adds an extra check when not tracking SCP (when starting up/out of sync), that causes nodes to reject values that have invalid time stamps.

Currently we rely 100% on the fact that there is only one main branch of history (versioned with the ledger sequence number), but on test networks, this is not always the case: when resetting a network (without changing the keys), it's possible that old (before the reset) messages are still available on the network, even though they are not valid anymore.

What this PR does to deal with this kind of situation is ensure that we always compare the timestamp of the last known closed ledger (ie, compare the "network time" with the one stored locally).

The situation can be illustrated by this sequence:
1. (...) validator `A` votes for `<10000, 2018-01-01 00:01:00>`
2. reset network (ledger sequence numbers reset to genesis)
3. node `B` stopped at `<10, 2018-01-02 00:00:00>`
3. (...) validator `B` sees a vote from A `<10000, 2018-01-01 00:01:00>`
   a. currently, this would cause `B` to potentially jump to ledger 10000 from the old fork
   b. with this fix, `B` will ignore those messages as `B` already knows that the network time is at least `2018-01-02 00:00:00`

This does not help when joining the network for the first time (as the last known ledger is "genesis"), but helps nodes properly reject messages after a restart.
