### PR TITLE
enable --disable-bucket-gc for publish command

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -428,15 +428,20 @@ int
 runPublish(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
+    auto disableBucketGC = false;
 
-    return runWithHelp(args, {configurationParser(configOption)}, [&] {
-        auto config = configOption.getConfig();
-        config.setNoListen();
+    return runWithHelp(args,
+                       {configurationParser(configOption),
+                        disableBucketGCParser(disableBucketGC)},
+                       [&] {
+                           auto config = configOption.getConfig();
+                           config.setNoListen();
+                           config.DISABLE_BUCKET_GC = disableBucketGC;
 
-        VirtualClock clock(VirtualClock::REAL_TIME);
-        auto app = Application::create(clock, config, false);
-        return publish(app);
-    });
+                           VirtualClock clock(VirtualClock::REAL_TIME);
+                           auto app = Application::create(clock, config, false);
+                           return publish(app);
+                       });
 }
 
 int


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

This one allows `publish` command to have `--disable-bucket-gc` option.