### PR TITLE
make application "start" idempotent

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -64,6 +64,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     , mWork(std::make_unique<asio::io_service::work>(mWorkerIOService))
     , mWorkerThreads()
     , mStopSignals(clock.getIOService(), SIGINT)
+    , mStarted(false)
     , mStopping(false)
     , mStoppingTimer(*this)
     , mMetrics(std::make_unique<medida::MetricsRegistry>())
@@ -314,6 +315,13 @@ ApplicationImpl::timeNow()
 void
 ApplicationImpl::start()
 {
+    if (mStarted)
+    {
+        CLOG(INFO, "Ledger") << "Skipping application start up";
+        return;
+    }
+    CLOG(INFO, "Ledger") << "Starting up application";
+    mStarted = true;
     mDatabase->upgradeToCurrentSchema();
 
     if (mConfig.TESTING_UPGRADE_DATETIME.time_since_epoch().count() != 0)

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -159,6 +159,7 @@ class ApplicationImpl : public Application
 
     asio::signal_set mStopSignals;
 
+    bool mStarted;
     bool mStopping;
 
     VirtualTimer mStoppingTimer;


### PR DESCRIPTION
# Description

Commit ce473a1eef95308aaefa1b0b4dbe03fb3a98796d introduced a bug where "start" can be called several times (when calling "startup" several times by using both `catchup-at` and `catchup-to` on the same command line for example).

Fix I picked is to just make the application `start` idempotent: alternative would be to not call start if it's not necessary, but that doesn't seem useful.
