### PR TITLE
Preserve buckets referenced by the Last Closed Ledger

### DIFF
--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -104,6 +104,10 @@ class LedgerManager
     virtual LedgerHeaderHistoryEntry const&
     getLastClosedLedgerHeader() const = 0;
 
+    // return the HAS that corresponds to the last closed ledger as persisted in
+    // the database
+    virtual HistoryArchiveState getLastClosedLedgerHAS() = 0;
+
     // Return the sequence number of the LCL.
     virtual uint32_t getLastClosedLedgerNum() const = 0;
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -261,10 +261,7 @@ LedgerManagerImpl::loadLastKnownLedger(
 
         if (handler)
         {
-            string hasString = mApp.getPersistentState().getState(
-                PersistentState::kHistoryArchiveState);
-            HistoryArchiveState has;
-            has.fromString(hasString);
+            HistoryArchiveState has = getLastClosedLedgerHAS();
 
             auto continuation = [this, handler,
                                  has](asio::error_code const& ec) {
@@ -352,6 +349,16 @@ LedgerHeaderHistoryEntry const&
 LedgerManagerImpl::getLastClosedLedgerHeader() const
 {
     return mLastClosedLedger;
+}
+
+HistoryArchiveState
+LedgerManagerImpl::getLastClosedLedgerHAS()
+{
+    string hasString = mApp.getPersistentState().getState(
+        PersistentState::kHistoryArchiveState);
+    HistoryArchiveState has;
+    has.fromString(hasString);
+    return has;
 }
 
 uint32_t

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -113,6 +113,8 @@ class LedgerManagerImpl : public LedgerManager
 
     LedgerHeaderHistoryEntry const& getLastClosedLedgerHeader() const override;
 
+    HistoryArchiveState getLastClosedLedgerHAS() override;
+
     Database& getDatabase() override;
 
     void startCatchup(CatchupConfiguration configuration,


### PR DESCRIPTION
# Description

Resolves #1518 

This PR adds the buckets referenced by the "last closed ledger" as saved in the database.

Previously, we were only using the state of the last closed ledger *after* resuming merges, which can, depending on the machine, result in different buckets referenced in memory (as a merge in progress results in a different list than a completed merge).

I changed the logging for this particular area to "trace" level as it can get pretty verbose (if there is a backlog in the publish queue in particular), I also changed logging to log when a bucket is added to the white list.

I could not repro the actual deletion on my machine, but with tracing enabled, I can see that some buckets are indeed added to the white list some of the time.
