### PR TITLE
raport percent of completed bucket apply

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -39,6 +39,7 @@ Bucket::Bucket(std::string const& filename, Hash const& hash)
     {
         CLOG(TRACE, "Bucket")
             << "Bucket::Bucket() created, file exists : " << mFilename;
+        mSize = fs::size(filename);
     }
 }
 
@@ -56,6 +57,12 @@ std::string const&
 Bucket::getFilename() const
 {
     return mFilename;
+}
+
+size_t
+Bucket::getSize() const
+{
+    return mSize;
 }
 
 bool

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -36,6 +36,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     std::string const mFilename;
     Hash const mHash;
+    size_t mSize{0};
 
   public:
     // Create an empty bucket. The empty bucket has hash '000000...' and its
@@ -49,6 +50,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     Hash const& getHash() const;
     std::string const& getFilename() const;
+    size_t getSize() const;
 
     // Returns true if a BucketEntry that is key-wise identical to the given
     // BucketEntry exists in the bucket. For testing.

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -25,9 +25,23 @@ BucketApplicator::operator bool() const
     return (bool)mBucketIter;
 }
 
-void
+size_t
+BucketApplicator::pos()
+{
+    return mBucketIter.pos();
+}
+
+size_t
+BucketApplicator::size() const
+{
+    return mBucketIter.size();
+}
+
+size_t
 BucketApplicator::advance()
 {
+    size_t count = 0;
+
     LedgerState ls(mApp.getLedgerStateRoot(), false);
     for (; mBucketIter; ++mBucketIter)
     {
@@ -53,17 +67,15 @@ BucketApplicator::advance()
                 entry.erase();
             }
         }
-        if ((++mSize & 0xff) == 0xff)
+
+        if ((++count & 0xff) == 0xff)
         {
             break;
         }
     }
     ls.commit();
 
-    if (!mBucketIter || (mSize & 0xfff) == 0xfff)
-    {
-        CLOG(INFO, "Bucket")
-            << "Bucket-apply: committed " << mSize << " entries";
-    }
+    mCount += count;
+    return count;
 }
 }

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -22,11 +22,14 @@ class BucketApplicator
 {
     Application& mApp;
     BucketInputIterator mBucketIter;
-    size_t mSize{0};
+    size_t mCount{0};
 
   public:
     BucketApplicator(Application& app, std::shared_ptr<const Bucket> bucket);
     operator bool() const;
-    void advance();
+    size_t advance();
+
+    size_t pos();
+    size_t size() const;
 };
 }

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -24,6 +24,18 @@ BucketInputIterator::loadEntry()
     }
 }
 
+size_t
+BucketInputIterator::pos()
+{
+    return mIn.pos();
+}
+
+size_t
+BucketInputIterator::size() const
+{
+    return mIn.size();
+}
+
 BucketInputIterator::operator bool() const
 {
     return mEntryPtr != nullptr;

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -39,5 +39,8 @@ class BucketInputIterator
     ~BucketInputIterator();
 
     BucketInputIterator& operator++();
+
+    size_t pos();
+    size_t size() const;
 };
 }

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -30,6 +30,7 @@ ApplyBucketsWork::ApplyBucketsWork(
     , mBuckets(buckets)
     , mApplyState(applyState)
     , mApplying(false)
+    , mTotalSize(0)
     , mLevel(BucketList::kNumLevels - 1)
     , mBucketApplyStart(app.getMetrics().NewMeter(
           {"history", "bucket-apply", "start"}, "event"))
@@ -65,6 +66,28 @@ ApplyBucketsWork::getBucket(std::string const& hash)
 void
 ApplyBucketsWork::onReset()
 {
+    mTotalBuckets = 0;
+    mAppliedBuckets = 0;
+    mAppliedEntries = 0;
+    mTotalSize = 0;
+    mAppliedSize = 0;
+    mLastAppliedSizeMb = 0;
+    mLastPos = 0;
+
+    auto addBucket = [this](std::shared_ptr<Bucket const> const& bucket) {
+        if (bucket->getSize() > 0)
+        {
+            mTotalBuckets++;
+            mTotalSize += bucket->getSize();
+        }
+    };
+
+    for (auto const& hsb : mApplyState.currentBuckets)
+    {
+        addBucket(getBucket(hsb.snap));
+        addBucket(getBucket(hsb.curr));
+    }
+
     mLevel = BucketList::kNumLevels - 1;
     mApplying = false;
     mSnapBucket.reset();
@@ -123,19 +146,55 @@ ApplyBucketsWork::onRun()
     //    if there is nothing to be applied.
     if (mSnapApplicator)
     {
-        if (*mSnapApplicator)
-        {
-            mSnapApplicator->advance();
-        }
+        advance(*mSnapApplicator);
     }
     else if (mCurrApplicator)
     {
-        if (*mCurrApplicator)
-        {
-            mCurrApplicator->advance();
-        }
+        advance(*mCurrApplicator);
     }
     scheduleSuccess();
+}
+
+void
+ApplyBucketsWork::advance(BucketApplicator& applicator)
+{
+    if (!applicator)
+    {
+        return;
+    }
+
+    assert(mTotalSize != 0);
+    mAppliedEntries += applicator.advance();
+
+    auto log = false;
+    if (applicator)
+    {
+        mAppliedSize += (applicator.pos() - mLastPos);
+        mLastPos = applicator.pos();
+    }
+    else
+    {
+        mAppliedSize += (applicator.size() - mLastPos);
+        mAppliedBuckets++;
+        mLastPos = 0;
+        log = true;
+    }
+
+    auto appliedSizeMb = mAppliedSize / 1024 / 1024;
+    if (appliedSizeMb > mLastAppliedSizeMb)
+    {
+        log = true;
+        mLastAppliedSizeMb = appliedSizeMb;
+    }
+
+    if (log)
+    {
+        CLOG(INFO, "Bucket")
+            << "Bucket-apply: " << mAppliedEntries << " entries in "
+            << formatSize(mAppliedSize) << "/" << formatSize(mTotalSize)
+            << " in " << mAppliedBuckets << "/" << mTotalBuckets << " files ("
+            << (100 * mAppliedSize / mTotalSize) << "%)";
+    }
 }
 
 Work::State

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -27,6 +27,13 @@ class ApplyBucketsWork : public Work
     const HistoryArchiveState& mApplyState;
 
     bool mApplying;
+    size_t mTotalBuckets;
+    size_t mAppliedBuckets;
+    size_t mAppliedEntries;
+    size_t mTotalSize;
+    size_t mAppliedSize;
+    size_t mLastAppliedSizeMb;
+    size_t mLastPos;
     uint32_t mLevel;
     std::shared_ptr<Bucket const> mSnapBucket;
     std::shared_ptr<Bucket const> mCurrBucket;
@@ -39,6 +46,7 @@ class ApplyBucketsWork : public Work
 
     std::shared_ptr<Bucket const> getBucket(std::string const& bucketHash);
     BucketLevel& getBucketLevel(uint32_t level);
+    void advance(BucketApplicator& applicator);
 
   public:
     ApplyBucketsWork(

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -442,6 +442,33 @@ checkNoGzipSuffix(std::string const& filename)
     }
 }
 
+size_t
+size(std::ifstream& ifs)
+{
+    assert(ifs.is_open());
+
+    ifs.seekg(0, ifs.end);
+    auto result = ifs.tellg();
+    ifs.seekg(0, ifs.beg);
+
+    return std::max(decltype(result){0}, result);
+}
+
+size_t
+size(std::string const& filename)
+{
+    std::ifstream ifs;
+    ifs.open(filename, std::ifstream::binary);
+    if (ifs)
+    {
+        return size(ifs);
+    }
+    else
+    {
+        return 0;
+    }
+}
+
 #ifdef _WIN32
 
 int

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -48,6 +48,10 @@ std::vector<std::string>
 findfiles(std::string const& path,
           std::function<bool(std::string const& name)> predicate);
 
+size_t size(std::ifstream& ifs);
+
+size_t size(std::string const& path);
+
 class PathSplitter
 {
   public:

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -6,8 +6,10 @@
 
 #include "crypto/ByteSlice.h"
 #include "crypto/SHA.h"
+#include "util/Fs.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
+
 #include <fstream>
 #include <string>
 #include <vector>
@@ -23,7 +25,8 @@ class XDRInputFileStream
 {
     std::ifstream mIn;
     std::vector<char> mBuf;
-    unsigned int mSizeLimit;
+    size_t mSizeLimit;
+    size_t mSize;
 
   public:
     XDRInputFileStream(unsigned int sizeLimit = 0) : mSizeLimit{sizeLimit}
@@ -49,11 +52,27 @@ class XDRInputFileStream
             CLOG(ERROR, "Fs") << msg;
             throw std::runtime_error(msg);
         }
+
+        mSize = fs::size(mIn);
     }
 
     operator bool() const
     {
         return mIn.good();
+    }
+
+    size_t
+    size() const
+    {
+        return mSize;
+    }
+
+    size_t
+    pos()
+    {
+        assert(!mIn.fail());
+
+        return mIn.tellg();
     }
 
     template <typename T>

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -3,8 +3,10 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "util/types.h"
+#include "lib/util/format.h"
 #include "lib/util/uint128_t.h"
 #include "util/XDROperators.h"
+
 #include <algorithm>
 #include <locale>
 
@@ -185,6 +187,22 @@ compareAsset(Asset const& first, Asset const& second)
             return true;
     }
     return false;
+}
+
+std::string
+formatSize(size_t size)
+{
+    const std::vector<std::string> suffixes = {"B", "KB", "MB", "GB"};
+    double dsize = size;
+
+    auto i = 0;
+    while (dsize >= 1024 && i < suffixes.size() - 1)
+    {
+        dsize /= 1024;
+        i++;
+    }
+
+    return fmt::format("{:.2f}{}", dsize, suffixes[i]);
 }
 
 bool

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -36,6 +36,8 @@ AccountID getIssuer(Asset const& asset);
 // returns true if the currencies are the same
 bool compareAsset(Asset const& first, Asset const& second);
 
+std::string formatSize(size_t size);
+
 template <uint32_t N>
 void
 assetCodeToStr(xdr::opaque_array<N> const& code, std::string& retStr)


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Resolves #1633

Display number of bytes applied, number of buckets applied and percentage instead of only number of entries applied in apply-bucket phase of catchup.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
