### PR TITLE
Lock TmpDir root on startup

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -16,6 +16,7 @@ namespace stellar
 
 class Application;
 class BucketList;
+class TmpDirManager;
 struct LedgerHeader;
 struct HistoryArchiveState;
 
@@ -45,12 +46,14 @@ class BucketManager : NonMovableOrCopyable
 
   public:
     static std::unique_ptr<BucketManager> create(Application&);
-    static void dropAll(Application& app);
 
     virtual ~BucketManager()
     {
     }
+    virtual void initialize() = 0;
+    virtual void dropAll() = 0;
     virtual std::string const& getTmpDir() = 0;
+    virtual TmpDirManager& getTmpDirManager() = 0;
     virtual std::string const& getBucketDir() = 0;
     virtual BucketList& getBucketList() = 0;
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -36,6 +36,7 @@ class BucketManagerImpl : public BucketManager
 
     Application& mApp;
     BucketList mBucketList;
+    std::unique_ptr<TmpDirManager> mTmpDirManager;
     std::unique_ptr<TmpDir> mWorkDir;
     std::map<Hash, std::shared_ptr<Bucket>> mSharedBuckets;
     mutable std::recursive_mutex mBucketMutex;
@@ -47,6 +48,7 @@ class BucketManagerImpl : public BucketManager
 
     std::set<Hash> getReferencedBuckets() const;
     void cleanupStaleFiles();
+    void cleanDir();
 
   protected:
     void calculateSkipValues(LedgerHeader& currentHeader);
@@ -56,10 +58,13 @@ class BucketManagerImpl : public BucketManager
   public:
     BucketManagerImpl(Application& app);
     ~BucketManagerImpl() override;
+    void initialize() override;
+    void dropAll() override;
     std::string const& getTmpDir() override;
     std::string const& getBucketDir() override;
     BucketList& getBucketList() override;
     medida::Timer& getMergeTimer() override;
+    TmpDirManager& getTmpDirManager() override;
     std::shared_ptr<Bucket> adoptFileAsBucket(std::string const& filename,
                                               uint256 const& hash,
                                               size_t nObjects,

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -311,7 +311,7 @@ Database::initialize()
     LedgerHeaderUtils::dropAll(*this);
     TransactionFrame::dropAll(*this);
     HistoryManager::dropAll(*this);
-    BucketManager::dropAll(mApp);
+    mApp.getBucketManager().dropAll();
     putSchemaVersion(1);
 }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -104,8 +104,6 @@ ApplicationImpl::initialize()
 {
     mDatabase = std::make_unique<Database>(*this);
     mPersistentState = std::make_unique<PersistentState>(*this);
-    mTmpDirManager =
-        std::make_unique<TmpDirManager>(mConfig.BUCKET_DIR_PATH + "/tmp");
     mOverlayManager = createOverlayManager();
     mLedgerManager = LedgerManager::create(*this);
     mHerder = createHerder();
@@ -630,7 +628,7 @@ ApplicationImpl::clearMetrics(std::string const& domain)
 TmpDirManager&
 ApplicationImpl::getTmpDirManager()
 {
-    return *mTmpDirManager;
+    return getBucketManager().getTmpDirManager();
 }
 
 LedgerManager&

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -136,7 +136,6 @@ class ApplicationImpl : public Application
     std::unique_ptr<asio::io_service::work> mWork;
 
     std::unique_ptr<Database> mDatabase;
-    std::unique_ptr<TmpDirManager> mTmpDirManager;
     std::unique_ptr<OverlayManager> mOverlayManager;
     std::unique_ptr<BucketManager> mBucketManager;
     std::unique_ptr<CatchupManager> mCatchupManager;


### PR DESCRIPTION
Resolves #1863 

Looks like tmp dir on startup is never locked, causing racing core instances to delete and recreate same directories. 