### PR TITLE
call cleanupStaleFiles after syncing to network

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -98,6 +98,10 @@ class BucketManager : NonMovableOrCopyable
     // current BL.
     virtual void assumeState(HistoryArchiveState const& has) = 0;
 
+    // Remove staled bucket files that are not used currently. Call after
+    // syncing to the network.
+    virtual void cleanupStaleFiles() = 0;
+
     // Ensure all needed buckets are retained
     virtual void shutdown() = 0;
 };

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -443,7 +443,6 @@ BucketManagerImpl::assumeState(HistoryArchiveState const& has)
     }
 
     mBucketList.restartMerges(mApp);
-    cleanupStaleFiles();
 }
 
 void

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -46,7 +46,6 @@ class BucketManagerImpl : public BucketManager
     medida::Counter& mSharedBucketsSize;
 
     std::set<Hash> getReferencedBuckets() const;
-    void cleanupStaleFiles();
 
   protected:
     void calculateSkipValues(LedgerHeader& currentHeader);
@@ -75,6 +74,7 @@ class BucketManagerImpl : public BucketManager
     std::vector<std::string>
     checkForMissingBucketsFiles(HistoryArchiveState const& has) override;
     void assumeState(HistoryArchiveState const& has) override;
+    void cleanupStaleFiles() override;
     void shutdown() override;
 };
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -141,6 +141,10 @@ LedgerManagerImpl::setState(State s)
             mCatchupState = CatchupState::NONE;
             mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
         }
+        if (mState == LM_SYNCED_STATE)
+        {
+            mApp.getBucketManager().cleanupStaleFiles();
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Keep all buckets until catchup is done. It can save some time as buckets needed for catchup may be already downloaded but are not required by current contents of the database.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval.md)
