### PR TITLE
revert bad change that broke how commands are applied from config

### DIFF
--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -77,9 +77,9 @@ runWithConfig(Config cfg)
                              << "(for testing only)";
             }
 
-            app->applyCfgCommands();
-
             app->start();
+
+            app->applyCfgCommands();
         }
     }
     catch (std::exception& e)


### PR DESCRIPTION
# Description

Resolves #1882

3cc1f5e8a2d7a9a8e17ff3e5e054173067918e20 reintroduced a bug that was fixed a while back as part of a bad refactor

