### PR TITLE
Improve logging and metrics for transaction subsystem

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -57,6 +57,7 @@ history.verify-<X>.failure        | meter     | verification of <X> failed
 invariant.does-not-hold.count.<X> | counter   | number of times invariant <X> failed
 ledger.transaction.apply          | timer     | time to apply one transaction
 ledger.transaction.count          | histogram | number of transactions per ledger
+ledger.operation.count            | histogram | number of operations per ledger
 ledger.ledger.close               | timer     | time to close a ledger (excluding consensus)
 ledger.age.closed                 | timer     | time between ledgers
 ledger.age.current-seconds        | counter   | gap between last close ledger time and current time

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -59,6 +59,7 @@ ledger.transaction.apply          | timer     | time to apply one transaction
 ledger.transaction.count          | histogram | number of transactions per ledger
 ledger.transaction.internal-error | counter   | number of internal errors since start
 ledger.operation.count            | histogram | number of operations per ledger
+ledger.operation.apply            | timer     | time applying an operation
 ledger.ledger.close               | timer     | time to close a ledger (excluding consensus)
 ledger.age.closed                 | timer     | time between ledgers
 ledger.age.current-seconds        | counter   | gap between last close ledger time and current time
@@ -91,5 +92,3 @@ loadgen.payment.native            | meter     | loadgenerator: native payment su
 loadgen.txn.attempted             | meter     | loadgenerator: transaction submitted
 loadgen.txn.rejected              | meter     | loadgenerator: transaction rejected
 loadgen.txn.bytes                 | meter     | loadgenerator: size of transactions submitted
-transaction.op.apply              | timer     | time applying an operation
-

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,7 +54,7 @@ history.download-<X>.success      | meter     | download of <X> completed succes
 history.download-<X>.failure      | meter     | download of <X> failed
 history.verify-<X>.success        | meter     | verification of <X> succeeded
 history.verify-<X>.failure        | meter     | verification of <X> failed
-invariant.does-not-hold.count.<X> | counter   | number of times invariant <X> failed
+ledger.invariant.failure          | counter   | number of times invariants failed
 ledger.transaction.apply          | timer     | time to apply one transaction
 ledger.transaction.count          | histogram | number of transactions per ledger
 ledger.transaction.internal-error | counter   | number of internal errors since start

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -57,6 +57,7 @@ history.verify-<X>.failure        | meter     | verification of <X> failed
 invariant.does-not-hold.count.<X> | counter   | number of times invariant <X> failed
 ledger.transaction.apply          | timer     | time to apply one transaction
 ledger.transaction.count          | histogram | number of transactions per ledger
+ledger.transaction.internal-error | counter   | number of internal errors since start
 ledger.operation.count            | histogram | number of operations per ledger
 ledger.ledger.close               | timer     | time to close a ledger (excluding consensus)
 ledger.age.closed                 | timer     | time between ledgers

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -90,9 +90,5 @@ loadgen.payment.native            | meter     | loadgenerator: native payment su
 loadgen.txn.attempted             | meter     | loadgenerator: transaction submitted
 loadgen.txn.rejected              | meter     | loadgenerator: transaction rejected
 loadgen.txn.bytes                 | meter     | loadgenerator: size of transactions submitted
-op-<NAME>.success.apply           | meter     | operation <NAME> succeeded
-op-<NAME>.failure.<ERR>           | meter     | operation <NAME> failed for reason <ERR>
-operation.failure.<ERR>           | meter     | common operation failure for reason <ERR>
-transaction.failure.<ERR>         | meter     | common transaction failure for reason <ERR>
 transaction.op.apply              | timer     | time applying an operation
 

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -32,7 +32,8 @@ InvariantManager::create(Application& app)
 }
 
 InvariantManagerImpl::InvariantManagerImpl(medida::MetricsRegistry& registry)
-    : mMetricsRegistry(registry)
+    : mInvariantFailureCount(
+          registry.NewCounter({"ledger", "invariant", "failure"}))
 {
 }
 
@@ -40,19 +41,17 @@ Json::Value
 InvariantManagerImpl::getJsonInfo()
 {
     Json::Value failures;
-    for (auto const& invariant : mInvariants)
-    {
-        auto& counter = mMetricsRegistry.NewCounter(
-            {"invariant", "does-not-hold", "count", invariant.first});
-        if (counter.count() > 0)
-        {
-            auto const& info = mFailureInformation.at(invariant.first);
 
-            auto& fail = failures[invariant.first];
-            fail["count"] = (Json::Int64)counter.count();
-            fail["last_failed_on_ledger"] = info.lastFailedOnLedger;
-            fail["last_failed_with_message"] = info.lastFailedWithMessage;
-        }
+    for (auto const& fi : mFailureInformation)
+    {
+        auto& fail = failures[fi.first];
+        auto& info = fi.second;
+        fail["last_failed_on_ledger"] = info.lastFailedOnLedger;
+        fail["last_failed_with_message"] = info.lastFailedWithMessage;
+    }
+    if (!failures.empty())
+    {
+        failures["count"] = (Json::Int64)mInvariantFailureCount.count();
     }
     return failures;
 }
@@ -131,8 +130,6 @@ InvariantManagerImpl::registerInvariant(std::shared_ptr<Invariant> invariant)
     if (iter == mInvariants.end())
     {
         mInvariants[name] = invariant;
-        mMetricsRegistry.NewCounter(
-            {"invariant", "does-not-hold", "count", invariant->getName()});
     }
     else
     {
@@ -208,12 +205,8 @@ InvariantManagerImpl::onInvariantFailure(std::shared_ptr<Invariant> invariant,
                                          std::string const& message,
                                          uint32_t ledger)
 {
-    mMetricsRegistry
-        .NewCounter(
-            {"invariant", "does-not-hold", "count", invariant->getName()})
-        .inc();
-    mFailureInformation[invariant->getName()].lastFailedOnLedger = ledger;
-    mFailureInformation[invariant->getName()].lastFailedWithMessage = message;
+    mInvariantFailureCount.inc();
+    mFailureInformation[invariant->getName()] = {ledger, message};
     handleInvariantFailure(invariant, message);
 }
 

--- a/src/invariant/InvariantManagerImpl.h
+++ b/src/invariant/InvariantManagerImpl.h
@@ -11,6 +11,7 @@
 namespace medida
 {
 class MetricsRegistry;
+class Counter;
 }
 
 namespace stellar
@@ -20,7 +21,7 @@ class InvariantManagerImpl : public InvariantManager
 {
     std::map<std::string, std::shared_ptr<Invariant>> mInvariants;
     std::vector<std::shared_ptr<Invariant>> mEnabled;
-    medida::MetricsRegistry& mMetricsRegistry;
+    medida::Counter& mInvariantFailureCount;
 
     struct InvariantFailureInformation
     {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -998,6 +998,7 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
         {
             CLOG(DEBUG, "Tx")
                 << " tx#" << index << " = " << hexAbbrev(tx->getFullHash())
+                << " ops=" << tx->getOperations().size()
                 << " txseq=" << tx->getSeqNum() << " (@ "
                 << mApp.getConfig().toShortString(tx->getSourceID()) << ")";
             tx->apply(mApp, ls, tm.v1());

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1007,6 +1007,9 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
         }
         catch (InvariantDoesNotHold&)
         {
+            CLOG(ERROR, "Ledger")
+                << "Invariant failure during tx->apply for tx "
+                << tx->getFullHash();
             throw;
         }
         catch (std::runtime_error& e)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1009,12 +1009,15 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
         }
         catch (std::runtime_error& e)
         {
-            CLOG(ERROR, "Ledger") << "Exception during tx->apply: " << e.what();
+            CLOG(ERROR, "Ledger") << "Exception during tx->apply for tx "
+                                  << tx->getFullHash() << " : " << e.what();
             tx->getResult().result.code(txINTERNAL_ERROR);
         }
         catch (...)
         {
-            CLOG(ERROR, "Ledger") << "Unknown exception during tx->apply";
+            CLOG(ERROR, "Ledger")
+                << "Unknown exception during tx->apply for tx "
+                << tx->getFullHash();
             tx->getResult().result.code(txINTERNAL_ERROR);
         }
         auto ledgerSeq = ls.loadHeader().current().ledgerSeq;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -41,6 +41,7 @@ class LedgerManagerImpl : public LedgerManager
     medida::Timer& mTransactionApply;
     medida::Histogram& mTransactionCount;
     medida::Histogram& mOperationCount;
+    medida::Counter& mInternalErrorCount;
     medida::Timer& mLedgerClose;
     medida::Timer& mLedgerAgeClosed;
     medida::Counter& mLedgerAge;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -40,6 +40,7 @@ class LedgerManagerImpl : public LedgerManager
     Application& mApp;
     medida::Timer& mTransactionApply;
     medida::Histogram& mTransactionCount;
+    medida::Histogram& mOperationCount;
     medida::Timer& mLedgerClose;
     medida::Timer& mLedgerAgeClosed;
     medida::Counter& mLedgerAge;

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -498,7 +498,7 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
     auto& app = *appPtr;
 
     auto& lg = app.getLoadGenerator();
-    auto& txtime = app.getMetrics().NewTimer({"transaction", "op", "apply"});
+    auto& txtime = app.getMetrics().NewTimer({"ledger", "operation", "apply"});
     uint32_t numItems = 500000;
 
     // Create accounts

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -402,7 +402,7 @@ LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer, bool isCreate,
 
     auto& m = mApp.getMetrics();
     auto& applyTx = m.NewTimer({"ledger", "transaction", "apply"});
-    auto& applyOp = m.NewTimer({"transaction", "op", "apply"});
+    auto& applyOp = m.NewTimer({"ledger", "operation", "apply"});
 
     auto submitSteps = duration_cast<milliseconds>(submitTimer).count();
 

--- a/src/transactions/BumpSequenceOpFrame.cpp
+++ b/src/transactions/BumpSequenceOpFrame.cpp
@@ -6,8 +6,6 @@
 #include "crypto/SignerKey.h"
 #include "database/Database.h"
 #include "main/Application.h"
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
 #include "transactions/TransactionFrame.h"
 #include "util/XDROperators.h"
 
@@ -52,9 +50,6 @@ BumpSequenceOpFrame::doApply(Application& app, AbstractLedgerState& ls)
 
     // Return successful results
     innerResult().code(BUMP_SEQUENCE_SUCCESS);
-    app.getMetrics()
-        .NewMeter({"op-bump-sequence", "success", "apply"}, "operation")
-        .Mark();
     return true;
 }
 
@@ -63,9 +58,6 @@ BumpSequenceOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
 {
     if (mBumpSequenceOp.bumpTo < 0)
     {
-        app.getMetrics()
-            .NewMeter({"op-bump-sequence", "invalid", "bad-seq"}, "operation")
-            .Mark();
         innerResult().code(BUMP_SEQUENCE_BAD_SEQ);
         return false;
     }

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -8,8 +8,6 @@
 #include "ledger/LedgerStateEntry.h"
 #include "ledger/LedgerStateHeader.h"
 #include "main/Application.h"
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionUtils.h"
 
@@ -40,9 +38,6 @@ InflationOpFrame::doApply(Application& app, AbstractLedgerState& ls)
     time_t inflationTime = (INFLATION_START_TIME + seq * INFLATION_FREQUENCY);
     if (closeTime < inflationTime)
     {
-        app.getMetrics()
-            .NewMeter({"op-inflation", "failure", "not-time"}, "operation")
-            .Mark();
         innerResult().code(INFLATION_NOT_TIME);
         return false;
     }
@@ -118,9 +113,6 @@ InflationOpFrame::doApply(Application& app, AbstractLedgerState& ls)
         lh.totalCoins += inflationAmount;
     }
 
-    app.getMetrics()
-        .NewMeter({"op-inflation", "success", "apply"}, "operation")
-        .Mark();
     return true;
 }
 

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -9,8 +9,6 @@
 #include "ledger/LedgerStateEntry.h"
 #include "ledger/LedgerStateHeader.h"
 #include "main/Application.h"
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
@@ -46,10 +44,6 @@ ManageDataOpFrame::doApply(Application& app, AbstractLedgerState& ls)
             auto sourceAccount = loadSourceAccount(ls, header);
             if (!addNumEntries(header, sourceAccount, 1))
             {
-                app.getMetrics()
-                    .NewMeter({"op-manage-data", "invalid", "low reserve"},
-                              "operation")
-                    .Mark();
                 innerResult().code(MANAGE_DATA_LOW_RESERVE);
                 return false;
             }
@@ -71,10 +65,6 @@ ManageDataOpFrame::doApply(Application& app, AbstractLedgerState& ls)
     { // delete an existing piece of data
         if (!data)
         {
-            app.getMetrics()
-                .NewMeter({"op-manage-data", "invalid", "not-found"},
-                          "operation")
-                .Mark();
             innerResult().code(MANAGE_DATA_NAME_NOT_FOUND);
             return false;
         }
@@ -85,9 +75,6 @@ ManageDataOpFrame::doApply(Application& app, AbstractLedgerState& ls)
 
     innerResult().code(MANAGE_DATA_SUCCESS);
 
-    app.getMetrics()
-        .NewMeter({"op-manage-data", "success", "apply"}, "operation")
-        .Mark();
     return true;
 }
 
@@ -96,11 +83,6 @@ ManageDataOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
 {
     if (ledgerVersion < 2)
     {
-        app.getMetrics()
-            .NewMeter(
-                {"op-set-options", "invalid", "invalid-data-old-protocol"},
-                "operation")
-            .Mark();
         innerResult().code(MANAGE_DATA_NOT_SUPPORTED_YET);
         return false;
     }
@@ -108,10 +90,6 @@ ManageDataOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     if ((mManageData.dataName.size() < 1) ||
         (!isString32Valid(mManageData.dataName)))
     {
-        app.getMetrics()
-            .NewMeter({"op-set-options", "invalid", "invalid-data-name"},
-                      "operation")
-            .Mark();
         innerResult().code(MANAGE_DATA_INVALID_NAME);
         return false;
     }

--- a/src/transactions/ManageOfferOpFrame.h
+++ b/src/transactions/ManageOfferOpFrame.h
@@ -13,8 +13,7 @@ class AbstractLedgerState;
 
 class ManageOfferOpFrame : public OperationFrame
 {
-    bool checkOfferValid(medida::MetricsRegistry& metrics,
-                         AbstractLedgerState& lsOuter);
+    bool checkOfferValid(AbstractLedgerState& lsOuter);
 
     bool computeOfferExchangeParameters(Application& app,
                                         AbstractLedgerState& lsOuter,

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -25,6 +25,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
+#include "xdrpp/printer.h"
 #include <string>
 
 #include "medida/meter.h"
@@ -100,10 +101,19 @@ OperationFrame::apply(SignatureChecker& signatureChecker, Application& app,
                       AbstractLedgerState& ls)
 {
     bool res;
+    if (Logging::logTrace("Tx"))
+    {
+        CLOG(TRACE, "Tx") << "Operation: " << xdr::xdr_to_string(mOperation);
+    }
     res = checkValid(signatureChecker, app, ls, true);
     if (res)
     {
         res = doApply(app, ls);
+        if (Logging::logTrace("Tx"))
+        {
+            CLOG(TRACE, "Tx")
+                << "Operation result: " << xdr::xdr_to_string(mResult);
+        }
     }
 
     return res;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -28,9 +28,6 @@
 #include "xdrpp/printer.h"
 #include <string>
 
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
-
 namespace stellar
 {
 
@@ -144,9 +141,6 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
         if (!mParentTx.checkSignature(signatureChecker, sourceAccount,
                                       neededThreshold))
         {
-            app.getMetrics()
-                .NewMeter({"operation", "failure", "bad-auth"}, "operation")
-                .Mark();
             mResult.code(opBAD_AUTH);
             return false;
         }
@@ -155,9 +149,6 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
     {
         if (forApply || !mOperation.sourceAccount)
         {
-            app.getMetrics()
-                .NewMeter({"operation", "failure", "no-account"}, "operation")
-                .Mark();
             mResult.code(opNO_ACCOUNT);
             return false;
         }
@@ -165,9 +156,6 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
         if (!mParentTx.checkSignatureNoAccount(signatureChecker,
                                                *mOperation.sourceAccount))
         {
-            app.getMetrics()
-                .NewMeter({"operation", "failure", "bad-auth"}, "operation")
-                .Mark();
             mResult.code(opBAD_AUTH);
             return false;
         }
@@ -202,9 +190,6 @@ OperationFrame::checkValid(SignatureChecker& signatureChecker, Application& app,
     auto ledgerVersion = ls.loadHeader().current().ledgerVersion;
     if (!isVersionSupported(ledgerVersion))
     {
-        app.getMetrics()
-            .NewMeter({"operation", "failure", "not-supported"}, "operation")
-            .Mark();
         mResult.code(opNOT_SUPPORTED);
         return false;
     }
@@ -222,9 +207,6 @@ OperationFrame::checkValid(SignatureChecker& signatureChecker, Application& app,
         // previous versions it is done in checkSignature call
         if (!loadSourceAccount(ls, ls.loadHeader()))
         {
-            app.getMetrics()
-                .NewMeter({"operation", "failure", "no-account"}, "operation")
-                .Mark();
             mResult.code(opNO_ACCOUNT);
             return false;
         }

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -9,8 +9,6 @@
 #include "ledger/LedgerState.h"
 #include "ledger/LedgerStateHeader.h"
 #include "main/Application.h"
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
 #include "transactions/PathPaymentOpFrame.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
@@ -40,9 +38,6 @@ PaymentOpFrame::doApply(Application& app, AbstractLedgerState& ls)
                               : mPayment.destination == getSourceID();
     if (instantSuccess)
     {
-        app.getMetrics()
-            .NewMeter({"op-payment", "success", "apply"}, "operation")
-            .Mark();
         innerResult().code(PAYMENT_SUCCESS);
         return true;
     }
@@ -77,55 +72,27 @@ PaymentOpFrame::doApply(Application& app, AbstractLedgerState& ls)
         switch (PathPaymentOpFrame::getInnerCode(ppayment.getResult()))
         {
         case PATH_PAYMENT_UNDERFUNDED:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "underfunded"}, "operation")
-                .Mark();
             res = PAYMENT_UNDERFUNDED;
             break;
         case PATH_PAYMENT_SRC_NOT_AUTHORIZED:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "src-not-authorized"},
-                          "operation")
-                .Mark();
             res = PAYMENT_SRC_NOT_AUTHORIZED;
             break;
         case PATH_PAYMENT_SRC_NO_TRUST:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "src-no-trust"},
-                          "operation")
-                .Mark();
             res = PAYMENT_SRC_NO_TRUST;
             break;
         case PATH_PAYMENT_NO_DESTINATION:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "no-destination"},
-                          "operation")
-                .Mark();
             res = PAYMENT_NO_DESTINATION;
             break;
         case PATH_PAYMENT_NO_TRUST:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "no-trust"}, "operation")
-                .Mark();
             res = PAYMENT_NO_TRUST;
             break;
         case PATH_PAYMENT_NOT_AUTHORIZED:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "not-authorized"},
-                          "operation")
-                .Mark();
             res = PAYMENT_NOT_AUTHORIZED;
             break;
         case PATH_PAYMENT_LINE_FULL:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "line-full"}, "operation")
-                .Mark();
             res = PAYMENT_LINE_FULL;
             break;
         case PATH_PAYMENT_NO_ISSUER:
-            app.getMetrics()
-                .NewMeter({"op-payment", "failure", "no-issuer"}, "operation")
-                .Mark();
             res = PAYMENT_NO_ISSUER;
             break;
         default:
@@ -138,9 +105,6 @@ PaymentOpFrame::doApply(Application& app, AbstractLedgerState& ls)
     assert(PathPaymentOpFrame::getInnerCode(ppayment.getResult()) ==
            PATH_PAYMENT_SUCCESS);
 
-    app.getMetrics()
-        .NewMeter({"op-payment", "success", "apply"}, "operation")
-        .Mark();
     innerResult().code(PAYMENT_SUCCESS);
 
     return true;
@@ -151,19 +115,11 @@ PaymentOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
 {
     if (mPayment.amount <= 0)
     {
-        app.getMetrics()
-            .NewMeter({"op-payment", "invalid", "malformed-negative-amount"},
-                      "operation")
-            .Mark();
         innerResult().code(PAYMENT_MALFORMED);
         return false;
     }
     if (!isAssetValid(mPayment.asset))
     {
-        app.getMetrics()
-            .NewMeter({"op-payment", "invalid", "malformed-invalid-asset"},
-                      "operation")
-            .Mark();
         innerResult().code(PAYMENT_MALFORMED);
         return false;
     }

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -9,8 +9,6 @@
 #include "ledger/LedgerStateEntry.h"
 #include "ledger/LedgerStateHeader.h"
 #include "main/Application.h"
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
 #include "transactions/TransactionUtils.h"
 #include "util/XDROperators.h"
 
@@ -55,11 +53,6 @@ SetOptionsOpFrame::doApply(Application& app, AbstractLedgerState& ls)
         {
             if (!stellar::loadAccountWithoutRecord(ls, inflationID))
             {
-                app.getMetrics()
-                    .NewMeter(
-                        {"op-set-options", "failure", "invalid-inflation"},
-                        "operation")
-                    .Mark();
                 innerResult().code(SET_OPTIONS_INVALID_INFLATION);
                 return false;
             }
@@ -72,10 +65,6 @@ SetOptionsOpFrame::doApply(Application& app, AbstractLedgerState& ls)
         if ((*mSetOptions.clearFlags & allAccountAuthFlags) &&
             isImmutableAuth(sourceAccount))
         {
-            app.getMetrics()
-                .NewMeter({"op-set-options", "failure", "cant-change"},
-                          "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_CANT_CHANGE);
             return false;
         }
@@ -87,10 +76,6 @@ SetOptionsOpFrame::doApply(Application& app, AbstractLedgerState& ls)
         if ((*mSetOptions.setFlags & allAccountAuthFlags) &&
             isImmutableAuth(sourceAccount))
         {
-            app.getMetrics()
-                .NewMeter({"op-set-options", "failure", "cant-change"},
-                          "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_CANT_CHANGE);
             return false;
         }
@@ -144,20 +129,11 @@ SetOptionsOpFrame::doApply(Application& app, AbstractLedgerState& ls)
             {
                 if (signers.size() == signers.max_size())
                 {
-                    app.getMetrics()
-                        .NewMeter(
-                            {"op-set-options", "failure", "too-many-signers"},
-                            "operation")
-                        .Mark();
                     innerResult().code(SET_OPTIONS_TOO_MANY_SIGNERS);
                     return false;
                 }
                 if (!addNumEntries(header, sourceAccount, 1))
                 {
-                    app.getMetrics()
-                        .NewMeter({"op-set-options", "failure", "low-reserve"},
-                                  "operation")
-                        .Mark();
                     innerResult().code(SET_OPTIONS_LOW_RESERVE);
                     return false;
                 }
@@ -184,9 +160,6 @@ SetOptionsOpFrame::doApply(Application& app, AbstractLedgerState& ls)
         normalizeSigners(sourceAccount);
     }
 
-    app.getMetrics()
-        .NewMeter({"op-set-options", "success", "apply"}, "operation")
-        .Mark();
     innerResult().code(SET_OPTIONS_SUCCESS);
     return true;
 }
@@ -216,10 +189,6 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     {
         if ((*mSetOptions.setFlags & *mSetOptions.clearFlags) != 0)
         {
-            app.getMetrics()
-                .NewMeter({"op-set-options", "invalid", "bad-flags"},
-                          "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_BAD_FLAGS);
             return false;
         }
@@ -229,11 +198,6 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     {
         if (*mSetOptions.masterWeight > UINT8_MAX)
         {
-            app.getMetrics()
-                .NewMeter(
-                    {"op-set-options", "invalid", "threshold-out-of-range"},
-                    "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_THRESHOLD_OUT_OF_RANGE);
             return false;
         }
@@ -243,11 +207,6 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     {
         if (*mSetOptions.lowThreshold > UINT8_MAX)
         {
-            app.getMetrics()
-                .NewMeter(
-                    {"op-set-options", "invalid", "threshold-out-of-range"},
-                    "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_THRESHOLD_OUT_OF_RANGE);
             return false;
         }
@@ -257,11 +216,6 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     {
         if (*mSetOptions.medThreshold > UINT8_MAX)
         {
-            app.getMetrics()
-                .NewMeter(
-                    {"op-set-options", "invalid", "threshold-out-of-range"},
-                    "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_THRESHOLD_OUT_OF_RANGE);
             return false;
         }
@@ -271,11 +225,6 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     {
         if (*mSetOptions.highThreshold > UINT8_MAX)
         {
-            app.getMetrics()
-                .NewMeter(
-                    {"op-set-options", "invalid", "threshold-out-of-range"},
-                    "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_THRESHOLD_OUT_OF_RANGE);
             return false;
         }
@@ -289,19 +238,11 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
             KeyUtils::canConvert<PublicKey>(mSetOptions.signer->key);
         if (isSelf || (!isPublicKey && ledgerVersion < 3))
         {
-            app.getMetrics()
-                .NewMeter({"op-set-options", "invalid", "bad-signer"},
-                          "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_BAD_SIGNER);
             return false;
         }
         if (mSetOptions.signer->weight > UINT8_MAX && ledgerVersion > 9)
         {
-            app.getMetrics()
-                .NewMeter({"op-set-options", "invalid", "bad-signer"},
-                          "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_BAD_SIGNER);
             return false;
         }
@@ -311,10 +252,6 @@ SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
     {
         if (!isString32Valid(*mSetOptions.homeDomain))
         {
-            app.getMetrics()
-                .NewMeter({"op-set-options", "invalid", "invalid-home-domain"},
-                          "operation")
-                .Mark();
             innerResult().code(SET_OPTIONS_INVALID_HOME_DOMAIN);
             return false;
         }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -240,10 +240,6 @@ TransactionFrame::commonValidPreSeqNum(Application& app,
 
     if (mOperations.size() == 0)
     {
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "missing-operation"},
-                      "transaction")
-            .Mark();
         getResult().result.code(txMISSING_OPERATION);
         return false;
     }
@@ -254,19 +250,12 @@ TransactionFrame::commonValidPreSeqNum(Application& app,
         uint64 closeTime = header.current().scpValue.closeTime;
         if (mEnvelope.tx.timeBounds->minTime > closeTime)
         {
-            app.getMetrics()
-                .NewMeter({"transaction", "failure", "too-early"},
-                          "transaction")
-                .Mark();
             getResult().result.code(txTOO_EARLY);
             return false;
         }
         if (mEnvelope.tx.timeBounds->maxTime &&
             (mEnvelope.tx.timeBounds->maxTime < closeTime))
         {
-            app.getMetrics()
-                .NewMeter({"transaction", "failure", "too-late"}, "transaction")
-                .Mark();
             getResult().result.code(txTOO_LATE);
             return false;
         }
@@ -274,19 +263,12 @@ TransactionFrame::commonValidPreSeqNum(Application& app,
 
     if (mEnvelope.tx.fee < getMinFee(header))
     {
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "insufficient-fee"},
-                      "transaction")
-            .Mark();
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;
     }
 
     if (!loadSourceAccount(ls, header))
     {
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "no-account"}, "transaction")
-            .Mark();
         getResult().result.code(txNO_ACCOUNT);
         return false;
     }
@@ -335,9 +317,6 @@ TransactionFrame::processSignatures(SignatureChecker& signatureChecker,
 
     if (!allOpsValid)
     {
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "invalid-op"}, "transaction")
-            .Mark();
         markResultFailed();
         return false;
     }
@@ -345,10 +324,6 @@ TransactionFrame::processSignatures(SignatureChecker& signatureChecker,
     if (!signatureChecker.checkAllSignaturesUsed())
     {
         getResult().result.code(txBAD_AUTH_EXTRA);
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "bad-auth-extra"},
-                      "transaction")
-            .Mark();
         return false;
     }
 
@@ -381,9 +356,6 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
         }
         if (current == INT64_MAX || current + 1 != mEnvelope.tx.seqNum)
         {
-            app.getMetrics()
-                .NewMeter({"transaction", "failure", "bad-seq"}, "transaction")
-                .Mark();
             getResult().result.code(txBAD_SEQ);
             return res;
         }
@@ -395,9 +367,6 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
             signatureChecker, sourceAccount,
             sourceAccount.current().data.account().thresholds[THRESHOLD_LOW]))
     {
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "bad-auth"}, "transaction")
-            .Mark();
         getResult().result.code(txBAD_AUTH);
         return res;
     }
@@ -414,10 +383,6 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
     // liabilities
     if (getAvailableBalance(header, sourceAccount) < feeToPay)
     {
-        app.getMetrics()
-            .NewMeter({"transaction", "failure", "insufficient-balance"},
-                      "transaction")
-            .Mark();
         getResult().result.code(txINSUFFICIENT_BALANCE);
         return res;
     }
@@ -537,10 +502,6 @@ TransactionFrame::checkValid(Application& app, AbstractLedgerState& lsOuter,
                 // it's OK to just fast fail here and not try to call
                 // checkValid on all operations as the resulting object
                 // is only used by applications
-                app.getMetrics()
-                    .NewMeter({"transaction", "failure", "invalid-op"},
-                              "transaction")
-                    .Mark();
                 markResultFailed();
                 return false;
             }
@@ -550,10 +511,6 @@ TransactionFrame::checkValid(Application& app, AbstractLedgerState& lsOuter,
         {
             res = false;
             getResult().result.code(txBAD_AUTH_EXTRA);
-            app.getMetrics()
-                .NewMeter({"transaction", "failure", "bad-auth-extra"},
-                          "transaction")
-                .Mark();
         }
     }
     return res;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -554,7 +554,7 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
 
     // shield outer scope of any side effects with LedgerState
     LedgerState lsTx(ls);
-    auto& opTimer = app.getMetrics().NewTimer({"transaction", "op", "apply"});
+    auto& opTimer = app.getMetrics().NewTimer({"ledger", "operation", "apply"});
     for (auto& op : mOperations)
     {
         auto time = opTimer.TimeScope();


### PR DESCRIPTION
# Description

Resolves #1879 #1878 

This PR replaces the use of metrics by better logging in the transaction subsystem and makes it easier to stop "abnormal" failures with metrics.
