### PR TITLE
Remove publish snapshot race condition 

### DIFF
--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -271,7 +271,6 @@ HistoryManagerImpl::queueCurrentHistory()
 
     mPublishQueued++;
     mPublishQueueBuckets.addBuckets(has.allBuckets());
-    takeSnapshotAndPublish(has);
 }
 
 void


### PR DESCRIPTION
partially resolves #1750 by always publishing snapshots from the publish queue. 