### PR TITLE
test: set PGDIRS to realpaths, not relative paths within /usr/lib/postgresql

### DIFF
--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -10,7 +10,7 @@ if [[ -z "$TEMP_POSTGRES" ]]; then
     TEMP_POSTGRES=1
 fi
 
-PGDIRS=$(exec 2>/dev/null; cd /usr/lib/postgresql && ls -1d */bin | sort -rn)
+PGDIRS=$(exec 2>/dev/null; cd /usr/lib/postgresql && ls -1d */bin | sort -rn | xargs realpath)
 
 findpg() {
     local cmd="$1"


### PR DESCRIPTION
# Description

As far as I can tell the existing code here would never have worked, as it'll set PGDIRS to just the relative paths of various bin dirs in /usr/lib/postgresql. I'm assuming people just have pg_ctl in their path and this code was dead, but apparently on my fresh new ubuntu 18.04 install it is not in path, and this code became active. So I fixed it to be absolute paths.

(Without this change, the testsuite simply fails for me.)

# Checklist
- [ x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x ] Rebased on top of master (no merge commits)
- [ x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ x] Compiles
- [ x] Ran all tests
- [ x] (N/A) If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
