### PR TITLE
Guard scp processing

### DIFF
--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -125,7 +125,9 @@ class PendingEnvelopes
 
     void envelopeReady(SCPEnvelope const& envelope);
 
-    bool pop(uint64 slotIndex, SCPEnvelope& ret);
+    // returns true if it could pop a message in ready state from the lowest
+    // slot in the range [minSlotIndex, maxSlotIndex] returns false otherwise
+    bool pop(uint64 minSlotIndex, uint64 maxSlotIndex, SCPEnvelope& ret);
 
     void eraseBelow(uint64 slotIndex);
 


### PR DESCRIPTION
# Description

Resolves #1876 

This PR tries to address #1876 even though it's unclear what is the exact root cause:
* I added better logging to help diagnose the issue if we ever run into it again
* I added a guard to how we process SCP messages as to remove any assumption on how other parts of the system work: the code in master loops several times over slots which in theory can cause problems. In the issue, the node is "tracking" at ledger 21537008 yet processes a message at 21537012. A possible explanation for this is that it's actually not tracking which causes it to enter the loop https://github.com/stellar/stellar-core/blob/2b74c51da282481d1e44f660f28bbe40c59811cf/src/herder/HerderImpl.cpp#L496-L505
Later, `processSCPQueueUpToIndex` is processing all slots up to 21537012, but somehow externalizes 21537008 and continues to iterate over the ready messages, causing the exception.