### PR TITLE
buckets: add bucket applicator rate meter.

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -163,8 +163,12 @@ ApplyBucketsWork::advance(BucketApplicator& applicator)
         return;
     }
 
+    auto& meter =
+        mApp.getMetrics().NewMeter({"bucket", "apply", "entries"}, "entry");
     assert(mTotalSize != 0);
-    mAppliedEntries += applicator.advance();
+    auto sz = applicator.advance();
+    mAppliedEntries += sz;
+    meter.Mark(sz);
 
     auto log = false;
     if (applicator)
@@ -193,7 +197,8 @@ ApplyBucketsWork::advance(BucketApplicator& applicator)
             << "Bucket-apply: " << mAppliedEntries << " entries in "
             << formatSize(mAppliedSize) << "/" << formatSize(mTotalSize)
             << " in " << mAppliedBuckets << "/" << mTotalBuckets << " files ("
-            << (100 * mAppliedSize / mTotalSize) << "%)";
+            << (100 * mAppliedSize / mTotalSize) << "%, " << meter.mean_rate()
+            << " entries/sec)";
     }
 }
 


### PR DESCRIPTION
# Description

Just adds a metric for the rate of bucket entities applied per second (and includes it in the INFO progress lines during catchup). Helpful as a lightweight / easily compared "local DB performance" benchmark value.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] (NA) If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
