### PR TITLE
Install new operator handler

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -7,15 +7,30 @@
 #include "util/Logging.h"
 
 #include "crypto/ByteSliceHasher.h"
+#include <cstdlib>
 #include <sodium/core.h>
 #include <xdrpp/marshal.h>
 
 INITIALIZE_EASYLOGGINGPP
 
+namespace stellar
+{
+static void
+outOfMemory()
+{
+    std::fprintf(stderr, "Unable to allocate memory\n");
+    std::fflush(stderr);
+    std::abort();
+}
+}
+
 int
 main(int argc, char* const* argv)
 {
     using namespace stellar;
+
+    // Abort when out of memory
+    std::set_new_handler(outOfMemory);
 
     Logging::init();
     if (sodium_init() != 0)


### PR DESCRIPTION
resolves #1757; I ended up taking a slightly different route by handling failed allocation prior to `bad_alloc` being thrown. This seems nicer as we don't need to track the code for accidental out-of-memory exception handling. 