### PR TITLE
Reschedule timers for future slots when tracking

### DIFF
--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -209,5 +209,8 @@ class HerderSCPDriver : public SCPDriver
     void logQuorumInformation(uint64_t index);
 
     void clearSCPExecutionEvents();
+
+    void timerCallbackWrapper(uint64_t slotIndex, int timerID,
+                              std::function<void()> cb);
 };
 }


### PR DESCRIPTION
Resolves #1876

Prior to this fix, the following situation was possible: 
1. While Herder is not tracking, the ballot protocol timer was started for many slots
2. Herder begins tracking a slot below the highest slot for which the ballot protocol timer was started
3. The ballot protocol timer for a slot higher than the tracked slot triggers, causing the ballot to be abandoned
4. Herder tries to emit a state statement for that slot which is in the future, causing stellar-core to terminate with `moved to a bad state (ballot protocol)`

Instead of allowing timers for a slot higher than the tracked slot to trigger, we reschedule them by one second.