### PR TITLE
Small improvement in encode_b32 to reserve the correct size

### DIFF
--- a/src/util/Decoder.h
+++ b/src/util/Decoder.h
@@ -28,7 +28,7 @@ inline std::string
 encode_b32(T const& v)
 {
     std::string res;
-    res.reserve(encoded_size64(v.size() * sizeof(typename T::value_type)) + 1);
+    res.reserve(encoded_size32(v.size() * sizeof(typename T::value_type)) + 1);
     bn::encode_b32(v.begin(), v.end(), std::back_inserter(res));
     return res;
 }


### PR DESCRIPTION
Reserve the correct size for the encoded string in `encode_b32`.