### PR TITLE
Make minor changes to XDR files to support external tooling.

### DIFF
--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -12,6 +12,7 @@ typedef opaque Thresholds[4];
 typedef string string32<32>;
 typedef string string64<64>;
 typedef int64 SequenceNumber;
+typedef uint64 TimePoint;
 typedef opaque DataValue<64>;
 
 enum AssetType
@@ -105,7 +106,6 @@ const MASK_ACCOUNT_FLAGS = 0x7;
     Other ledger entries created require an account.
 
 */
-
 struct AccountEntry
 {
     AccountID accountID;      // master public key for this account

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -15,7 +15,7 @@ typedef opaque UpgradeType<128>;
 struct StellarValue
 {
     Hash txSetHash;   // transaction set to apply to previous ledger
-    uint64 closeTime; // network close time
+    TimePoint closeTime; // network close time
 
     // upgrades to apply to the previous ledger (usually empty)
     // this is a vector of encoded 'LedgerUpgrade' so that nodes can drop

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -37,7 +37,6 @@ Threshold: med
 Result: CreateAccountResult
 
 */
-
 struct CreateAccountOp
 {
     AccountID destination; // account to create
@@ -126,7 +125,6 @@ struct CreatePassiveOfferOp
 
     Result: SetOptionsResult
 */
-
 struct SetOptionsOp
 {
     AccountID* inflationDest; // sets the inflation destination
@@ -215,7 +213,6 @@ Result: InflationResult
 
     Result: ManageDataResult
 */
-
 struct ManageDataOp
 {
     string64 dataName;
@@ -230,7 +227,6 @@ struct ManageDataOp
 
     Result: BumpSequenceResult
 */
-
 struct BumpSequenceOp
 {
     SequenceNumber bumpTo;
@@ -299,8 +295,8 @@ case MEMO_RETURN:
 
 struct TimeBounds
 {
-    uint64 minTime;
-    uint64 maxTime; // 0 here means no maxTime
+    TimePoint minTime;
+    TimePoint maxTime; // 0 here means no maxTime
 };
 
 /* a transaction is a container for a set of operations
@@ -310,7 +306,6 @@ struct TimeBounds
           either all operations are applied or none are
           if any returns a failing code
 */
-
 struct Transaction
 {
     // account used to run the transaction


### PR DESCRIPTION
  - Introduce TimePoint typedef for uint64s representing unix time.

  - Delete empty line between several comments and the data structures
    they describe.

Time should be rendered significantly differently from other uint64s
in human readable formats.  Using a typedef allows tools that parse
XDR files to know when to do this automatically.

Avoiding a blank line between comments and fields potentially allows
XDR generators to preserve comments when generating code in different
languages.  This, in turn, makes compiled XDR output easier to browse
with native documentation tools of the target langauge.

These changes do not affect stellar-core, but simplify some go language tooling
I'm building for Stellar transaction manipulation.
