### PR TITLE
Use std::locale::classic more places.

### DIFF
--- a/src/ledger/LedgerTestUtils.cpp
+++ b/src/ledger/LedgerTestUtils.cpp
@@ -45,7 +45,7 @@ template <typename T>
 void
 replaceControlCharacters(T& s, int minSize)
 {
-    std::locale loc("C");
+    auto& loc = std::locale::classic();
     if (static_cast<int>(s.size()) < minSize)
     {
         s.resize(minSize);
@@ -53,7 +53,7 @@ replaceControlCharacters(T& s, int minSize)
     for (auto it = s.begin(); it != s.end(); it++)
     {
         char c = static_cast<char>(*it);
-        if (c < 0 || std::iscntrl(c))
+        if (c < 0 || std::iscntrl(c, loc))
         {
             auto b = autocheck::generator<char>{}(autocheck::detail::nalnums);
             *it = b;

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -12,7 +12,6 @@
 
 namespace stellar
 {
-static std::locale cLocale("C");
 
 LedgerKey
 LedgerEntryKey(LedgerEntry const& e)
@@ -84,7 +83,7 @@ isString32Valid(std::string const& str)
 {
     for (auto c : str)
     {
-        if (c < 0 || std::iscntrl(c, cLocale))
+        if (c < 0 || std::iscntrl(c, std::locale::classic()))
         {
             return false;
         }
@@ -116,7 +115,7 @@ isAssetValid(Asset const& cur)
             }
             else
             {
-                if (b > 0x7F || !std::isalnum((char)b, cLocale))
+                if (b > 0x7F || !std::isalnum((char)b, std::locale::classic()))
                 {
                     return false;
                 }
@@ -144,7 +143,7 @@ isAssetValid(Asset const& cur)
             }
             else
             {
-                if (b > 0x7F || !std::isalnum((char)b, cLocale))
+                if (b > 0x7F || !std::isalnum((char)b, std::locale::classic()))
                 {
                     return false;
                 }


### PR DESCRIPTION
Thoroughly uninteresting change. First hunk switches us from constructing (and seemingly not even using?) a `locale("C")` object in the middle of a relatively hot loop -- hot enough to show up significantly in some testing profiles -- to using `locale::classic()` explicitly, which appears to be an identical (but static) object. Second set of hunks just uses `locale::classic()` in places where we _were_ using a static `locale("C")` object, but inexplicably using our own rather than the system-provided one.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
