### PR TITLE
remove unnecessary Application parameters

### DIFF
--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -28,7 +28,7 @@ AllowTrustOpFrame::getThresholdLevel() const
 }
 
 bool
-AllowTrustOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+AllowTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     if (ltx.loadHeader().current().ledgerVersion > 2)
     {
@@ -129,7 +129,7 @@ AllowTrustOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-AllowTrustOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+AllowTrustOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mAllowTrust.asset.type() == ASSET_TYPE_NATIVE)
     {

--- a/src/transactions/AllowTrustOpFrame.h
+++ b/src/transactions/AllowTrustOpFrame.h
@@ -23,8 +23,8 @@ class AllowTrustOpFrame : public OperationFrame
     AllowTrustOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ls) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ls) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static AllowTrustResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/BumpSequenceOpFrame.cpp
+++ b/src/transactions/BumpSequenceOpFrame.cpp
@@ -33,7 +33,7 @@ BumpSequenceOpFrame::isVersionSupported(uint32_t protocolVersion) const
 }
 
 bool
-BumpSequenceOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+BumpSequenceOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     LedgerTxn ltxInner(ltx);
     auto header = ltxInner.loadHeader();
@@ -54,7 +54,7 @@ BumpSequenceOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-BumpSequenceOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+BumpSequenceOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mBumpSequenceOp.bumpTo < 0)
     {

--- a/src/transactions/BumpSequenceOpFrame.h
+++ b/src/transactions/BumpSequenceOpFrame.h
@@ -27,8 +27,8 @@ class BumpSequenceOpFrame : public OperationFrame
     BumpSequenceOpFrame(Operation const& op, OperationResult& res,
                         TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static BumpSequenceResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -24,7 +24,7 @@ ChangeTrustOpFrame::ChangeTrustOpFrame(Operation const& op,
 }
 
 bool
-ChangeTrustOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+ChangeTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     auto header = ltx.loadHeader();
     auto issuerID = getIssuer(mChangeTrust.line);
@@ -131,7 +131,7 @@ ChangeTrustOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-ChangeTrustOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+ChangeTrustOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mChangeTrust.limit < 0)
     {

--- a/src/transactions/ChangeTrustOpFrame.h
+++ b/src/transactions/ChangeTrustOpFrame.h
@@ -21,8 +21,8 @@ class ChangeTrustOpFrame : public OperationFrame
     ChangeTrustOpFrame(Operation const& op, OperationResult& res,
                        TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static ChangeTrustResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -30,7 +30,7 @@ CreateAccountOpFrame::CreateAccountOpFrame(Operation const& op,
 }
 
 bool
-CreateAccountOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+CreateAccountOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     if (!stellar::loadAccount(ltx, mCreateAccount.destination))
     {
@@ -89,7 +89,7 @@ CreateAccountOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-CreateAccountOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mCreateAccount.startingBalance <= 0)
     {

--- a/src/transactions/CreateAccountOpFrame.h
+++ b/src/transactions/CreateAccountOpFrame.h
@@ -24,8 +24,8 @@ class CreateAccountOpFrame : public OperationFrame
     CreateAccountOpFrame(Operation const& op, OperationResult& res,
                          TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static CreateAccountResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -28,7 +28,7 @@ InflationOpFrame::InflationOpFrame(Operation const& op, OperationResult& res,
 }
 
 bool
-InflationOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+InflationOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     auto header = ltx.loadHeader();
     auto& lh = header.current();
@@ -117,7 +117,7 @@ InflationOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-InflationOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+InflationOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     return true;
 }

--- a/src/transactions/InflationOpFrame.h
+++ b/src/transactions/InflationOpFrame.h
@@ -24,8 +24,8 @@ class InflationOpFrame : public OperationFrame
     InflationOpFrame(Operation const& op, OperationResult& res,
                      TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static InflationResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -27,7 +27,7 @@ ManageDataOpFrame::ManageDataOpFrame(Operation const& op, OperationResult& res,
 }
 
 bool
-ManageDataOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+ManageDataOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     auto header = ltx.loadHeader();
     if (header.current().ledgerVersion == 3)
@@ -79,7 +79,7 @@ ManageDataOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-ManageDataOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (ledgerVersion < 2)
     {

--- a/src/transactions/ManageDataOpFrame.h
+++ b/src/transactions/ManageDataOpFrame.h
@@ -25,8 +25,8 @@ class ManageDataOpFrame : public OperationFrame
     ManageDataOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static ManageDataResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ManageOfferOpFrame.cpp
+++ b/src/transactions/ManageOfferOpFrame.cpp
@@ -101,9 +101,8 @@ ManageOfferOpFrame::checkOfferValid(AbstractLedgerTxn& ltxOuter)
 
 bool
 ManageOfferOpFrame::computeOfferExchangeParameters(
-    Application& app, AbstractLedgerTxn& ltxOuter,
-    LedgerEntry const& offerEntry, bool creatingNewOffer, int64_t& maxSheepSend,
-    int64_t& maxWheatReceive)
+    AbstractLedgerTxn& ltxOuter, LedgerEntry const& offerEntry,
+    bool creatingNewOffer, int64_t& maxSheepSend, int64_t& maxWheatReceive)
 {
     LedgerTxn ltx(ltxOuter); // ltx will always be rolled back
 
@@ -182,7 +181,7 @@ ManageOfferOpFrame::computeOfferExchangeParameters(
 // see if this is modifying an old offer
 // see if this offer crosses any existing offers
 bool
-ManageOfferOpFrame::doApply(Application& app, AbstractLedgerTxn& ltxOuter)
+ManageOfferOpFrame::doApply(AbstractLedgerTxn& ltxOuter)
 {
     LedgerTxn ltx(ltxOuter);
     if (!checkOfferValid(ltx))
@@ -244,9 +243,8 @@ ManageOfferOpFrame::doApply(Application& app, AbstractLedgerTxn& ltxOuter)
                             newOffer.data.offer().price.n);
         int64_t maxSheepSend = 0;
         int64_t maxWheatReceive = 0;
-        if (!computeOfferExchangeParameters(app, ltx, newOffer,
-                                            creatingNewOffer, maxSheepSend,
-                                            maxWheatReceive))
+        if (!computeOfferExchangeParameters(ltx, newOffer, creatingNewOffer,
+                                            maxSheepSend, maxWheatReceive))
         {
             return false;
         }
@@ -425,7 +423,7 @@ ManageOfferOpFrame::doApply(Application& app, AbstractLedgerTxn& ltxOuter)
 
 // makes sure the currencies are different
 bool
-ManageOfferOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+ManageOfferOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     Asset const& sheep = mManageOffer.selling;
     Asset const& wheat = mManageOffer.buying;

--- a/src/transactions/ManageOfferOpFrame.h
+++ b/src/transactions/ManageOfferOpFrame.h
@@ -15,9 +15,11 @@ class ManageOfferOpFrame : public OperationFrame
 {
     bool checkOfferValid(AbstractLedgerTxn& lsOuter);
 
-    bool computeOfferExchangeParameters(
-        Application& app, AbstractLedgerTxn& lsOuter, LedgerEntry const& offer,
-        bool creatingNewOffer, int64_t& maxSheepSend, int64_t& maxWheatReceive);
+    bool computeOfferExchangeParameters(AbstractLedgerTxn& lsOuter,
+                                        LedgerEntry const& offer,
+                                        bool creatingNewOffer,
+                                        int64_t& maxSheepSend,
+                                        int64_t& maxWheatReceive);
 
     ManageOfferResult&
     innerResult()
@@ -37,8 +39,8 @@ class ManageOfferOpFrame : public OperationFrame
     ManageOfferOpFrame(Operation const& op, OperationResult& res,
                        TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& lsOuter) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& lsOuter) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static ManageOfferResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -35,7 +35,7 @@ MergeOpFrame::getThresholdLevel() const
 // make sure the we delete all the trustlines
 // move the XLM to the new account
 bool
-MergeOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+MergeOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     auto header = ltx.loadHeader();
 
@@ -116,7 +116,7 @@ MergeOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-MergeOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+MergeOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     // makes sure not merging into self
     if (getSourceID() == mOperation.body.destination())

--- a/src/transactions/MergeOpFrame.h
+++ b/src/transactions/MergeOpFrame.h
@@ -22,8 +22,8 @@ class MergeOpFrame : public OperationFrame
     MergeOpFrame(Operation const& op, OperationResult& res,
                  TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static AccountMergeResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -17,7 +17,6 @@ class MetricsRegistry;
 namespace stellar
 {
 class AbstractLedgerTxn;
-class Application;
 class LedgerManager;
 class LedgerTxnEntry;
 class LedgerTxnHeader;
@@ -39,8 +38,8 @@ class OperationFrame
     TransactionFrame& mParentTx;
     OperationResult& mResult;
 
-    virtual bool doCheckValid(Application& app, uint32_t ledgerVersion) = 0;
-    virtual bool doApply(Application& app, AbstractLedgerTxn& ltx) = 0;
+    virtual bool doCheckValid(uint32_t ledgerVersion) = 0;
+    virtual bool doApply(AbstractLedgerTxn& ltx) = 0;
 
     // returns the threshold this operation requires
     virtual ThresholdLevel getThresholdLevel() const;
@@ -61,7 +60,7 @@ class OperationFrame
     OperationFrame(OperationFrame const&) = delete;
     virtual ~OperationFrame() = default;
 
-    bool checkSignature(SignatureChecker& signatureChecker, Application& app,
+    bool checkSignature(SignatureChecker& signatureChecker,
                         AbstractLedgerTxn& ltx, bool forApply);
 
     AccountID const& getSourceID() const;
@@ -73,11 +72,10 @@ class OperationFrame
     }
     OperationResultCode getResultCode() const;
 
-    bool checkValid(SignatureChecker& signatureChecker, Application& app,
+    bool checkValid(SignatureChecker& signatureChecker,
                     AbstractLedgerTxn& ltxOuter, bool forApply);
 
-    bool apply(SignatureChecker& signatureChecker, Application& app,
-               AbstractLedgerTxn& ltx);
+    bool apply(SignatureChecker& signatureChecker, AbstractLedgerTxn& ltx);
 
     Operation const&
     getOperation() const

--- a/src/transactions/PathPaymentOpFrame.cpp
+++ b/src/transactions/PathPaymentOpFrame.cpp
@@ -31,7 +31,7 @@ PathPaymentOpFrame::PathPaymentOpFrame(Operation const& op,
 }
 
 bool
-PathPaymentOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+PathPaymentOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     innerResult().code(PATH_PAYMENT_SUCCESS);
 
@@ -265,7 +265,7 @@ PathPaymentOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-PathPaymentOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+PathPaymentOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mPathPayment.destAmount <= 0 || mPathPayment.sendMax <= 0)
     {

--- a/src/transactions/PathPaymentOpFrame.h
+++ b/src/transactions/PathPaymentOpFrame.h
@@ -23,8 +23,8 @@ class PathPaymentOpFrame : public OperationFrame
     PathPaymentOpFrame(Operation const& op, OperationResult& res,
                        TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static PathPaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -26,7 +26,7 @@ PaymentOpFrame::PaymentOpFrame(Operation const& op, OperationResult& res,
 }
 
 bool
-PaymentOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+PaymentOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     // if sending to self XLM directly, just mark as success, else we need at
     // least to check trustlines
@@ -60,8 +60,7 @@ PaymentOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
     opRes.tr().type(PATH_PAYMENT);
     PathPaymentOpFrame ppayment(op, opRes, mParentTx);
 
-    if (!ppayment.doCheckValid(app, ledgerVersion) ||
-        !ppayment.doApply(app, ltx))
+    if (!ppayment.doCheckValid(ledgerVersion) || !ppayment.doApply(ltx))
     {
         if (ppayment.getResultCode() != opINNER)
         {
@@ -111,7 +110,7 @@ PaymentOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-PaymentOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+PaymentOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mPayment.amount <= 0)
     {

--- a/src/transactions/PaymentOpFrame.h
+++ b/src/transactions/PaymentOpFrame.h
@@ -23,8 +23,8 @@ class PaymentOpFrame : public OperationFrame
     PaymentOpFrame(Operation const& op, OperationResult& res,
                    TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static PaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -41,7 +41,7 @@ SetOptionsOpFrame::getThresholdLevel() const
 }
 
 bool
-SetOptionsOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
+SetOptionsOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     auto header = ltx.loadHeader();
     auto sourceAccount = loadSourceAccount(ltx, header);
@@ -165,7 +165,7 @@ SetOptionsOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
 }
 
 bool
-SetOptionsOpFrame::doCheckValid(Application& app, uint32_t ledgerVersion)
+SetOptionsOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     if (mSetOptions.setFlags)
     {

--- a/src/transactions/SetOptionsOpFrame.h
+++ b/src/transactions/SetOptionsOpFrame.h
@@ -24,8 +24,8 @@ class SetOptionsOpFrame : public OperationFrame
     SetOptionsOpFrame(Operation const& op, OperationResult& res,
                       TransactionFrame& parentTx);
 
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
-    bool doCheckValid(Application& app, uint32_t ledgerVersion) override;
+    bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doCheckValid(uint32_t ledgerVersion) override;
 
     static SetOptionsResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -306,7 +306,7 @@ TransactionFrame::processSignatures(SignatureChecker& signatureChecker,
 
         for (auto& op : mOperations)
         {
-            if (!op->checkSignature(signatureChecker, app, ltx, false))
+            if (!op->checkSignature(signatureChecker, ltx, false))
             {
                 allOpsValid = false;
             }
@@ -497,7 +497,7 @@ TransactionFrame::checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
     {
         for (auto& op : mOperations)
         {
-            if (!op->checkValid(signatureChecker, app, ltx, false))
+            if (!op->checkValid(signatureChecker, ltx, false))
             {
                 // it's OK to just fast fail here and not try to call
                 // checkValid on all operations as the resulting object
@@ -559,7 +559,7 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
     {
         auto time = opTimer.TimeScope();
         LedgerTxn ltxOp(ltxTx);
-        bool txRes = op->apply(signatureChecker, app, ltxOp);
+        bool txRes = op->apply(signatureChecker, ltxOp);
 
         if (!txRes)
         {


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Remove unnecessary Application parameters from many OperationFrame classes

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
