### PR TITLE
Scp timeout v blocking fix

### DIFF
--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -19,16 +19,16 @@
 namespace stellar
 {
 
-// x < y
+// x < y < z
 // k can be anything
-static Value xValue, yValue, kValue;
+static Value xValue, yValue, zValue, kValue;
 
 static void
 setupValues()
 {
     std::vector<Value> v;
     std::string d = fmt::format("SEED_VALUE_DATA_{}", std::rand());
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < 3; i++)
     {
         auto h = sha256(fmt::format("{}/{}", d, i));
         v.emplace_back(xdr::xdr_to_opaque(h));
@@ -36,6 +36,7 @@ setupValues()
     std::sort(v.begin(), v.end());
     xValue = v[0];
     yValue = v[1];
+    zValue = v[2];
 
     // kValue is independent
     auto kHash = sha256(d);
@@ -586,6 +587,7 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
     uint256 qSetHash0 = scp.mSCP.getLocalNode()->getQuorumSetHash();
 
     REQUIRE(xValue < yValue);
+    REQUIRE(yValue < zValue);
 
     CLOG(INFO, "SCP") << "";
     CLOG(INFO, "SCP") << "BEGIN TEST";
@@ -721,7 +723,7 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
         REQUIRE(!scp.hasBallotTimer());
 
         Value const& aValue = xValue;
-        Value const& bValue = yValue;
+        Value const& bValue = zValue;
 
         SCPBallot A1(1, aValue);
         SCPBallot B1(1, bValue);
@@ -1175,14 +1177,14 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
     }
 
     // this is the same test suite than "start <1,x>" with the exception that
-    // some transitions are not possible as x < y - so instead we verify that
+    // some transitions are not possible as x < z - so instead we verify that
     // nothing happens
-    SECTION("start <1,y>")
+    SECTION("start <1,z>")
     {
         // no timer is set
         REQUIRE(!scp.hasBallotTimer());
 
-        Value const& aValue = yValue;
+        Value const& aValue = zValue;
         Value const& bValue = xValue;
 
         SCPBallot A1(1, aValue);
@@ -1625,7 +1627,7 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
     SECTION("start from pristine")
     {
         Value const& aValue = xValue;
-        Value const& bValue = yValue;
+        Value const& bValue = zValue;
 
         SCPBallot A1(1, aValue);
         SCPBallot B1(1, bValue);
@@ -1909,7 +1911,7 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
             SCPBallot b2;
             SECTION("bumpToBallot prevented once committed (by value)")
             {
-                b2 = SCPBallot(1, yValue);
+                b2 = SCPBallot(1, zValue);
             }
             SECTION("bumpToBallot prevented once committed (by counter)")
             {
@@ -1918,7 +1920,7 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
             SECTION(
                 "bumpToBallot prevented once committed (by value and counter)")
             {
-                b2 = SCPBallot(2, yValue);
+                b2 = SCPBallot(2, zValue);
             }
 
             SCPEnvelope confirm1b2, confirm2b2, confirm3b2, confirm4b2;
@@ -2219,6 +2221,7 @@ TEST_CASE("ballot protocol core3", "[scp][ballotprotocol]")
     uint256 qSetHash0 = scp.mSCP.getLocalNode()->getQuorumSetHash();
 
     REQUIRE(xValue < yValue);
+    REQUIRE(yValue < zValue);
 
     auto recvQuorumChecksEx2 = [&](genEnvelope gen, bool withChecks,
                                    bool delayedQuorum, bool checkUpcoming,
@@ -2258,7 +2261,7 @@ TEST_CASE("ballot protocol core3", "[scp][ballotprotocol]")
     // no timer is set
     REQUIRE(!scp.hasBallotTimer());
 
-    Value const& aValue = yValue;
+    Value const& aValue = zValue;
     Value const& bValue = xValue;
 
     SCPBallot A1(1, aValue);
@@ -2354,6 +2357,7 @@ TEST_CASE("nomination tests core5", "[scp][nominationprotocol]")
     uint256 qSetHash = sha256(xdr::xdr_to_opaque(qSet));
 
     REQUIRE(xValue < yValue);
+    REQUIRE(yValue < zValue);
 
     SECTION("nomination - v0 is top")
     {

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -1693,6 +1693,12 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
             verifyPrepare(scp.mEnvs[1], v0SecretKey, qSetHash0, 0, A1, &B1);
             REQUIRE(!scp.hasBallotTimer());
         }
+        SECTION("prepare B (quorum)")
+        {
+            recvQuorumChecksEx(makePrepareGen(qSetHash, B1), true, true, true);
+            REQUIRE(scp.mEnvs.size() == 2);
+            verifyPrepare(scp.mEnvs[1], v0SecretKey, qSetHash0, 0, A1, &B1);
+        }
         SECTION("confirm (v-blocking)")
         {
             SECTION("via CONFIRM")

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -1134,6 +1134,19 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                               0, 0, &A1);
                 REQUIRE(!scp.hasBallotTimerUpcoming());
             }
+            SECTION("prepare higher counter (v-blocking)")
+            {
+                recvVBlocking(makePrepareGen(qSetHash, B2));
+                REQUIRE(scp.mEnvs.size() == 3);
+                verifyPrepare(scp.mEnvs[2], v0SecretKey, qSetHash0, 0, A2, &A1);
+                REQUIRE(!scp.hasBallotTimer());
+
+                // more timeout from vBlocking set
+                recvVBlocking(makePrepareGen(qSetHash, B3));
+                REQUIRE(scp.mEnvs.size() == 4);
+                verifyPrepare(scp.mEnvs[3], v0SecretKey, qSetHash0, 0, A3, &A1);
+                REQUIRE(!scp.hasBallotTimer());
+            }
         }
         SECTION("prepared B (v-blocking)")
         {
@@ -1585,6 +1598,19 @@ TEST_CASE("ballot protocol core5", "[scp][ballotprotocol]")
                                  false);
                 REQUIRE(scp.mEnvs.size() == 2);
                 REQUIRE(!scp.hasBallotTimerUpcoming());
+            }
+            SECTION("prepare higher counter (v-blocking)")
+            {
+                recvVBlocking(makePrepareGen(qSetHash, B2));
+                REQUIRE(scp.mEnvs.size() == 3);
+                verifyPrepare(scp.mEnvs[2], v0SecretKey, qSetHash0, 0, A2, &A1);
+                REQUIRE(!scp.hasBallotTimer());
+
+                // more timeout from vBlocking set
+                recvVBlocking(makePrepareGen(qSetHash, B3));
+                REQUIRE(scp.mEnvs.size() == 4);
+                verifyPrepare(scp.mEnvs[3], v0SecretKey, qSetHash0, 0, A3, &A1);
+                REQUIRE(!scp.hasBallotTimer());
             }
         }
         SECTION("prepared B (v-blocking)")


### PR DESCRIPTION
This PR supersedes #1786 

It adds a few comments and tests to cover updating values of `(p,p')`.
The actual code change is not necessary because of the logic at https://github.com/stellar/stellar-core/blob/b8e58b35fb9dc2d78ff46c322eb105c511270f36/src/scp/BallotProtocol.cpp#L829-L831 (also current code would crash if we ever hit that case because we check in SCP invariants that p and p' are not compatible) - but out of clarity and paranoia, it doesn't really hurt to add the condition explicitly.

While working on this, I noticed an actual bug, fixed in the "short-circuiting logic..." commit:
this relates to the rule (9) in the SCP white paper where we should be evaluating any potential counter (greater than the current counter), to see if there is no v-blocking set that is passed that counter.

The previous code was bailing out if there were any validator on a smaller counter than the current counter.
Effect was that the node would stay longer in the current state, increasing consensus time, relying on timeout instead of observation from messages from other nodes.
