### PR TITLE
remove unused appPtr typedefs

### DIFF
--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -28,8 +28,6 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-typedef std::unique_ptr<Application> appPtr;
-
 TEST_CASE("standalone", "[herder]")
 {
     SIMULATION_CREATE_NODE(0);

--- a/src/ledger/LedgerHeaderTests.cpp
+++ b/src/ledger/LedgerHeaderTests.cpp
@@ -22,8 +22,6 @@
 using namespace stellar;
 using namespace std;
 
-typedef std::unique_ptr<Application> appPtr;
-
 TEST_CASE("genesisledger", "[ledger]")
 {
     VirtualClock clock{};

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -29,8 +29,6 @@
 
 using namespace stellar;
 
-typedef std::unique_ptr<Application> appPtr;
-
 // Simulation tests. Some of the tests in this suite are long.
 // They are marked with [long][!hide]. Run the day-to-day tests with
 //

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -36,7 +36,6 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-typedef std::unique_ptr<Application> appPtr;
 namespace stellar
 {
 namespace txtest

--- a/src/transactions/SetOptionsTests.cpp
+++ b/src/transactions/SetOptionsTests.cpp
@@ -23,8 +23,6 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-typedef std::unique_ptr<Application> appPtr;
-
 // Try setting each option to make sure it works
 // try setting all at once
 // try setting high threshold ones without the correct sigs

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -31,8 +31,6 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-typedef std::unique_ptr<Application> appPtr;
-
 /*
   Tests that are testing the common envelope used in transactions.
   Things like:


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

This PR cleanups some unused typedefs.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
