### PR TITLE
set peers from config as OUTBOUND by default

### DIFF
--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -304,8 +304,9 @@ void
 OverlayManagerImpl::storePeerList(std::vector<std::string> const& list,
                                   bool setPreferred)
 {
-    auto typeUpgrade = setPreferred ? PeerManager::TypeUpdate::SET_PREFERRED
-                                    : PeerManager::TypeUpdate::KEEP;
+    auto typeUpgrade = setPreferred
+                           ? PeerManager::TypeUpdate::SET_PREFERRED
+                           : PeerManager::TypeUpdate::UPDATE_TO_OUTBOUND;
 
     for (auto const& peerStr : list)
     {

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -278,15 +278,6 @@ PeerManager::update(PeerRecord& peer, TypeUpdate type)
 {
     switch (type)
     {
-    case TypeUpdate::KEEP:
-    {
-        break;
-    }
-    case TypeUpdate::SET_INBOUND:
-    {
-        peer.mType = static_cast<int>(PeerType::INBOUND);
-        break;
-    }
     case TypeUpdate::SET_OUTBOUND:
     {
         peer.mType = static_cast<int>(PeerType::OUTBOUND);
@@ -300,6 +291,14 @@ PeerManager::update(PeerRecord& peer, TypeUpdate type)
     case TypeUpdate::REMOVE_PREFERRED:
     {
         if (peer.mType == static_cast<int>(PeerType::PREFERRED))
+        {
+            peer.mType = static_cast<int>(PeerType::OUTBOUND);
+        }
+        break;
+    }
+    case TypeUpdate::UPDATE_TO_OUTBOUND:
+    {
+        if (peer.mType == static_cast<int>(PeerType::INBOUND))
         {
             peer.mType = static_cast<int>(PeerType::OUTBOUND);
         }
@@ -333,10 +332,6 @@ PeerManager::update(PeerRecord& peer, BackOffUpdate backOff, Application& app)
 {
     switch (backOff)
     {
-    case BackOffUpdate::KEEP:
-    {
-        break;
-    }
     case BackOffUpdate::HARD_RESET:
     {
         peer.mNumFailures = 0;

--- a/src/overlay/PeerManager.h
+++ b/src/overlay/PeerManager.h
@@ -64,16 +64,14 @@ class PeerManager
   public:
     enum class TypeUpdate
     {
-        KEEP,
-        SET_INBOUND,
         SET_OUTBOUND,
         SET_PREFERRED,
-        REMOVE_PREFERRED
+        REMOVE_PREFERRED,
+        UPDATE_TO_OUTBOUND
     };
 
     enum class BackOffUpdate
     {
-        KEEP,
         HARD_RESET,
         RESET,
         INCREASE


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Set type of peers stored in configuration to be at least 'outbound'.
# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
