### PR TITLE
better use of floodmap (lower memory footprint)

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -80,6 +80,8 @@ class Herder
         // for some reason this envelope was discarded - either is was invalid,
         // used unsane qset or was coming from node that is not in quorum
         ENVELOPE_STATUS_DISCARDED,
+        // envelope was skipped as it's from this validator
+        ENVELOPE_STATUS_SKIPPED_SELF,
         // envelope data is currently being fetched
         ENVELOPE_STATUS_FETCHING,
         // current call to recvSCPEnvelope() was the first when the envelope

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -377,12 +377,6 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
             << " i:" << envelope.statement.slotIndex
             << " a:" << mApp.getStateHuman();
 
-    if (envelope.statement.nodeID == getSCP().getLocalNode()->getNodeID())
-    {
-        CLOG(DEBUG, "Herder") << "recvSCPEnvelope: skipping own message";
-        return Herder::ENVELOPE_STATUS_DISCARDED;
-    }
-
     mSCPMetrics.mEnvelopeReceive.Mark();
 
     uint32_t minLedgerSeq = getCurrentLedgerSeq();
@@ -414,6 +408,12 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
                               << envelope.statement.slotIndex << "( "
                               << minLedgerSeq << "," << maxLedgerSeq << ")";
         return Herder::ENVELOPE_STATUS_DISCARDED;
+    }
+
+    if (envelope.statement.nodeID == getSCP().getLocalNode()->getNodeID())
+    {
+        CLOG(DEBUG, "Herder") << "recvSCPEnvelope: skipping own message";
+        return Herder::ENVELOPE_STATUS_SKIPPED_SELF;
     }
 
     auto status = mPendingEnvelopes.recvSCPEnvelope(envelope);

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -38,7 +38,7 @@ class Floodgate
 
         uint32_t mLedgerSeq;
         StellarMessage mMessage;
-        std::set<Peer::pointer> mPeersTold;
+        std::set<std::string> mPeersTold;
 
         FloodRecord(StellarMessage const& msg, uint32_t ledger,
                     Peer::pointer peer);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -767,8 +767,6 @@ Peer::recvSCPMessage(StellarMessage const& msg)
             << "recvSCPMessage node: "
             << mApp.getConfig().toShortString(msg.envelope().statement.nodeID);
 
-    mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
-
     auto type = msg.envelope().statement.pledges.type();
     auto t = (type == SCP_ST_PREPARE
                   ? mRecvSCPPrepareTimer.TimeScope()
@@ -778,7 +776,11 @@ Peer::recvSCPMessage(StellarMessage const& msg)
                                 ? mRecvSCPExternalizeTimer.TimeScope()
                                 : (mRecvSCPNominateTimer.TimeScope()))));
 
-    mApp.getHerder().recvSCPEnvelope(envelope);
+    auto res = mApp.getHerder().recvSCPEnvelope(envelope);
+    if (res != Herder::ENVELOPE_STATUS_DISCARDED)
+    {
+        mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
+    }
 }
 
 void

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1020,10 +1020,8 @@ Peer::recvAuth(StellarMessage const& msg)
         return;
     }
 
-    // send SCP State
-    // remove when all known peers implements the next line
-    mApp.getHerder().sendSCPStateToPeer(0, self);
     // ask for SCP state if not synced
+    // this requests data for slots lcl+1 ... latest consensus (if possible)
     sendGetScpState(mApp.getLedgerManager().getLastClosedLedgerNum() + 1);
 }
 


### PR DESCRIPTION
This PR prioritizes keeping in the floodmap messages for the current SCP validity bracket