### PR TITLE
allow VirtualClock::crank to process more of asio queue at a time

### DIFF
--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -127,6 +127,7 @@ class VirtualClock
     bool mDestructing{false};
 
     void maybeSetRealtimer();
+    bool haveEventAtOrBefore(time_point n) const;
     size_t advanceTo(time_point n);
     size_t advanceToNext();
     size_t advanceToNow();


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Try to fix big-quorum issues with changes VirtualClock::crank semantics.

This version allows to process as many items from io_service queue as possible as long as there is no timer event that should be processed or a delayed work item. As we control all-but one timers in code (the only one that is outside of our control is mRealTimer that is used only for executing timers controlled by us by using advanceToNow() calls), we can safely do that without worrying that timers will be starved.

This code also has safeguard to ensure that at least 100 queue items will be executed if queue contains more that 100 items, so from io_service perspective it is at least as good as old code.

This code can have problems when:
- io_service queue is big (which can happen now)
- there are a lot of timers firing quickly one after another (I have not noticed anything like that, we use very small amount of timers)
- there are a lot of delayed (or even non-delayed) work items posted to main thread (as before, it does not seem we do that now)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
