### PR TITLE
[HerderTests] Restart app after removal from simulation

### DIFF
--- a/src/herder/HerderTests.cpp
+++ b/src/herder/HerderTests.cpp
@@ -1073,7 +1073,8 @@ TEST_CASE("In quorum filtering", "[herder]")
         {
             qSetK[i].validators.emplace_back(extraK[1].getPublicKey());
         }
-        sim->addNode(extraK[i], qSetK[i]);
+        auto node = sim->addNode(extraK[i], qSetK[i]);
+        node->start();
         sim->addConnection(extraK[i].getPublicKey(), nodeIDs[0]);
     }
 
@@ -1123,7 +1124,9 @@ TEST_CASE("In quorum filtering", "[herder]")
     node3Config.QUORUM_SET.validators.emplace_back(extraK[2].getPublicKey());
     node3Config.QUORUM_SET.validators.emplace_back(extraK[3].getPublicKey());
 
-    sim->addNode(node3Config.NODE_SEED, node3Config.QUORUM_SET, &node3Config);
+    auto node3 = sim->addNode(node3Config.NODE_SEED, node3Config.QUORUM_SET,
+                              &node3Config);
+    node3->start();
 
     // connect it back to the core nodes
     for (int i = 0; i < 3; i++)

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -129,8 +129,8 @@ class Application
     // certain subsystem responses to IO events, timers etc.
     enum State
     {
-        // Loading state from database, not yet active. SCP is inhibited.
-        APP_BOOTING_STATE,
+        // Application created, but not started
+        APP_CREATED_STATE,
 
         // Out of sync with SCP peers
         APP_ACQUIRING_CONSENSUS_STATE,

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -505,7 +505,12 @@ Application::State
 ApplicationImpl::getState() const
 {
     State s;
-    if (mStopping)
+
+    if (!mStarted)
+    {
+        s = APP_CREATED_STATE;
+    }
+    else if (mStopping)
     {
         s = APP_STOPPING_STATE;
     }

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -281,6 +281,11 @@ Simulation::crankNode(NodeID const& id, VirtualClock::time_point timeout)
     auto p = mNodes[id];
     auto clock = p.mClock;
     auto app = p.mApp;
+    if (app->getState() == Application::APP_CREATED_STATE)
+    {
+        throw std::runtime_error("Can't crank node that is not started");
+    }
+
     size_t quantumClicks = 0;
     bool doneWithQuantum = false;
     VirtualTimer quantumTimer(*app);


### PR DESCRIPTION
Fixing the test that is currently failing on Macs. Turns out the node removed from test simulation was not properly restarted, causing it to lose track of SCP.

I also double checked similar cases where we remove and re-add the node, and they all seem to be handled correctly. 