### PR TITLE
Drop slow peers

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -528,6 +528,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\TransactionFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\ChangeTrustOpFrame.cpp" />
     <ClCompile Include="..\..\src\util\Logging.cpp" />
+    <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\Uint128Tests.cpp" />
     <ClCompile Include="..\..\src\work\Work.cpp" />
     <ClCompile Include="..\..\src\work\WorkManagerImpl.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -189,6 +189,9 @@
     <ClCompile Include="..\..\src\util\Logging.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\LogSlowExecution.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\util\Timer.cpp">
       <Filter>util</Filter>
     </ClCompile>

--- a/src/herder/UpgradesTests.cpp
+++ b/src/herder/UpgradesTests.cpp
@@ -60,7 +60,7 @@ simulateUpgrade(std::vector<LedgerUpgradeNode> const& nodes,
     historytestutils::TmpDirHistoryConfigurator configurator{};
     auto simulation =
         std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
-    simulation->setCurrentTime(genesis(0, 0));
+    simulation->setCurrentVirtualTime(genesis(0, 0));
 
     // configure nodes
     auto keys = std::vector<SecretKey>{};

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -725,10 +725,12 @@ void
 ApplicationImpl::postOnMainThread(std::function<void()>&& f,
                                   std::string jobName)
 {
-    LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
-                            "executed after"};
-    mVirtualClock.postToCurrentCrank([ this, f = std::move(f), isSlow ]() {
-        mPostOnMainThreadDelay.Update(isSlow.checkElapsedTime());
+    mVirtualClock.postToCurrentCrank([
+        this, f = std::move(f), start = std::chrono::system_clock::now(),
+        jobName
+    ]() {
+        mPostOnMainThreadDelay.Update(
+            logSlowExecution(start, std::move(jobName), "executed after"));
         f();
     });
 }
@@ -737,10 +739,12 @@ void
 ApplicationImpl::postOnMainThreadWithDelay(std::function<void()>&& f,
                                            std::string jobName)
 {
-    LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
-                            "executed after"};
-    mVirtualClock.postToNextCrank([ this, f = std::move(f), isSlow ]() {
-        mPostOnMainThreadWithDelayDelay.Update(isSlow.checkElapsedTime());
+    mVirtualClock.postToNextCrank([
+        this, f = std::move(f), start = std::chrono::system_clock::now(),
+        jobName
+    ]() {
+        mPostOnMainThreadWithDelayDelay.Update(
+            logSlowExecution(start, std::move(jobName), "executed after"));
         f();
     });
 }
@@ -749,10 +753,12 @@ void
 ApplicationImpl::postOnBackgroundThread(std::function<void()>&& f,
                                         std::string jobName)
 {
-    LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
-                            "executed after"};
-    getWorkerIOService().post([ this, f = std::move(f), isSlow ]() {
-        mPostOnBackgroundThreadDelay.Update(isSlow.checkElapsedTime());
+    getWorkerIOService().post([
+        this, f = std::move(f), start = std::chrono::system_clock::now(),
+        jobName
+    ]() {
+        mPostOnBackgroundThreadDelay.Update(
+            logSlowExecution(start, std::move(jobName), "executed after"));
         f();
     });
 }

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -169,7 +169,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     void startIdleTimer();
     void idleTimerExpired(asio::error_code const& error);
-    size_t getIOTimeoutSeconds() const;
+    std::chrono::seconds getIOTimeout() const;
 
     // helper method to acknownledge that some bytes were received
     void receivedBytes(size_t byteCount, bool gotFullMessage);

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -30,7 +30,10 @@ class TCPPeer : public Peer
     std::vector<uint8_t> mIncomingHeader;
     std::vector<uint8_t> mIncomingBody;
 
-    std::queue<std::shared_ptr<xdr::msg_ptr>> mWriteQueue;
+    using MessageWithTimestamp =
+        std::pair<std::shared_ptr<xdr::msg_ptr>,
+                  std::chrono::system_clock::time_point>;
+    std::queue<MessageWithTimestamp> mWriteQueue;
     bool mWriting{false};
     bool mDelayedShutdown{false};
     bool mShutdownScheduled{false};

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -55,12 +55,12 @@ Simulation::~Simulation()
 }
 
 void
-Simulation::setCurrentTime(VirtualClock::time_point t)
+Simulation::setCurrentVirtualTime(VirtualClock::time_point t)
 {
-    mClock.setCurrentTime(t);
+    mClock.setCurrentVirtualTime(t);
     for (auto& p : mNodes)
     {
-        p.second.mClock->setCurrentTime(t);
+        p.second.mClock->setCurrentVirtualTime(t);
     }
 }
 
@@ -89,7 +89,7 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
                                                     : VirtualClock::REAL_TIME);
     if (mVirtualClockMode)
     {
-        clock->setCurrentTime(mClock.now());
+        clock->setCurrentVirtualTime(mClock.now());
     }
 
     auto app = Application::create(*clock, *cfg, newDB);

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -42,7 +42,7 @@ class Simulation
     ~Simulation();
 
     // updates all clocks in the simulation to the same time_point
-    void setCurrentTime(VirtualClock::time_point t);
+    void setCurrentVirtualTime(VirtualClock::time_point t);
 
     Application::pointer addNode(SecretKey nodeKey, SCPQuorumSet qSet,
                                  Config const* cfg = nullptr,

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -292,7 +292,7 @@ TEST_CASE("inflation", "[tx][inflation]")
     inflationStart = VirtualClock::from_time_t(start);
 
     VirtualClock clock;
-    clock.setCurrentTime(inflationStart);
+    clock.setCurrentVirtualTime(inflationStart);
 
     auto app = createTestApplication(clock, cfg);
 

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -1123,7 +1123,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     time_t start = getTestDate(1, 7, 2014);
                     ledgerTime = VirtualClock::from_time_t(start);
 
-                    clock.setCurrentTime(ledgerTime);
+                    clock.setCurrentVirtualTime(ledgerTime);
 
                     SECTION("too early")
                     {

--- a/src/util/LogSlowExecution.cpp
+++ b/src/util/LogSlowExecution.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/LogSlowExecution.h"
+
+namespace stellar
+{
+
+std::chrono::milliseconds
+logSlowExecution(std::chrono::system_clock::time_point start,
+                 std::string eventName, std::string message,
+                 std::chrono::milliseconds threshold)
+{
+    auto finish = std::chrono::system_clock::now();
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(finish - start);
+    auto tooSlow = elapsed > threshold;
+
+    LOG_IF(tooSlow, INFO) << "'" << eventName << "' " << message << " "
+                          << static_cast<float>(elapsed.count()) / 1000 << " s";
+    return elapsed;
+}
+}

--- a/src/util/LogSlowExecution.h
+++ b/src/util/LogSlowExecution.h
@@ -5,52 +5,37 @@
 #pragma once
 
 #include "util/Logging.h"
+
 #include <chrono>
+
+namespace stellar
+{
+
+std::chrono::milliseconds
+logSlowExecution(std::chrono::system_clock::time_point start,
+                 std::string eventName, std::string message = "hung for",
+                 std::chrono::milliseconds threshold = std::chrono::seconds(1));
 
 class LogSlowExecution
 {
   public:
-    enum class Mode
-    {
-        AUTOMATIC_RAII,
-        MANUAL // In this mode, it is the caller's responsibility to check
-               // elapsed time
-    };
-
-    LogSlowExecution(std::string eventName, Mode mode = Mode::AUTOMATIC_RAII,
-                     std::string message = "hung for", int ms = 1000)
+    LogSlowExecution(
+        std::string eventName,
+        std::chrono::milliseconds threshold = std::chrono::seconds(1))
         : mStart(std::chrono::system_clock::now())
-        , mName(std::move(eventName))
-        , mMode(mode)
-        , mMessage(std::move(message))
-        , mThresholdInMs(ms){};
+        , mEventName(std::move(eventName))
+        , mThreshold(threshold)
+    {
+    }
 
     ~LogSlowExecution()
     {
-        if (mMode == Mode::AUTOMATIC_RAII)
-        {
-            checkElapsedTime();
-        }
-    }
-
-    std::chrono::milliseconds
-    checkElapsedTime() const
-    {
-        auto finish = std::chrono::system_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            finish - mStart);
-        auto tooSlow = elapsed.count() > mThresholdInMs;
-
-        LOG_IF(tooSlow, INFO)
-            << "'" << mName << "' " << mMessage << " "
-            << static_cast<float>(elapsed.count()) / 1000 << " s";
-        return elapsed;
+        logSlowExecution(mStart, mEventName, "hung for", mThreshold);
     }
 
   private:
     std::chrono::system_clock::time_point mStart;
-    std::string mName;
-    Mode mMode;
-    std::string mMessage;
-    int mThresholdInMs;
+    std::string mEventName;
+    std::chrono::milliseconds mThreshold;
 };
+}

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -111,7 +111,7 @@ class VirtualClock
     uint32_t mRecentIdleCrankCount;
 
     size_t nRealTimerCancelEvents;
-    time_point mNow;
+    time_point mVirtualNow;
 
     bool mDelayExecution{true};
     std::recursive_mutex mDelayExecutionMutex;
@@ -127,7 +127,6 @@ class VirtualClock
     bool mDestructing{false};
 
     void maybeSetRealtimer();
-    size_t advanceTo(time_point n);
     size_t advanceToNext();
     size_t advanceToNow();
 
@@ -159,7 +158,7 @@ class VirtualClock
 
     // only valid with VIRTUAL_TIME: sets the current value
     // of the clock
-    void setCurrentTime(time_point t);
+    void setCurrentVirtualTime(time_point t);
 
     // returns the time of the next scheduled event
     time_point next();


### PR DESCRIPTION
# Description

This PR allows dropping peer that are to slow to accept messages. If sending a message to peer occurs after more than io_timeout seconds from pushing it to send queue, peer is dropped.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
