### PR TITLE
overlay: drop peers that are not keeping up.

### DIFF
--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -82,6 +82,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     VirtualTimer mIdleTimer;
     VirtualClock::time_point mLastRead;
     VirtualClock::time_point mLastWrite;
+    VirtualClock::time_point mLastEmpty;
 
     medida::Meter& mMessageRead;
     medida::Meter& mMessageWrite;

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -229,6 +229,7 @@ TCPPeer::messageSender()
     // if nothing to do, flush and return
     if (mWriteQueue.empty())
     {
+        mLastEmpty = mApp.getClock().now();
         mSocket->async_flush([self](asio::error_code const& ec, std::size_t) {
             self->writeHandler(ec, 0);
             if (!ec)


### PR DESCRIPTION
# Description

Relative of / simpler approach to #1961 

This adds a third timestamp to each peer indicating the last time the peer's write queue was empty. This is checked at the same boundary (~30 seconds) as the idle timer. Peers that are keeping up will regularly bounce off empty-queue state: asio issues async_writes to the TCP layer and immediately fires their completion handlers until the local TCP buffers fill up, and those are typically hundreds of KB. Effectively this means that any peer that's not able to accept the traffic we're sending them gets disconnected rather than using up more memory on the sending side's write queue.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A (aside from memory usage, which it reduces) If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
