### PR TITLE
Scp messages flooding fix

### DIFF
--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1021,8 +1021,19 @@ Peer::recvAuth(StellarMessage const& msg)
     }
 
     // ask for SCP state if not synced
-    // this requests data for slots lcl+1 ... latest consensus (if possible)
-    sendGetScpState(mApp.getLedgerManager().getLastClosedLedgerNum() + 1);
+    // this requests data for slots lcl-window ... latest consensus (if
+    // possible) we need to ask for older slots in case other peers need
+    // messages we didn't need ourself
+    auto low = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
+    if (low > Herder::MAX_SLOTS_TO_REMEMBER)
+    {
+        low -= Herder::MAX_SLOTS_TO_REMEMBER;
+    }
+    else
+    {
+        low = 1;
+    }
+    sendGetScpState(low);
 }
 
 void


### PR DESCRIPTION
# Description

Resolves #1489 

This PR fixes a couple issues:
* the change to only request current and future SCP messages during handshake is a bit too aggressive, while it's sufficient for the local node, it may not be enough for other nodes. This can be a problem when many connections die at the same time.
* SCP flooding tests were mixing two cases, that I separated:
   * what happens when flooding messages and some validators externalize (we need to continue flooding messages with values matching consensus) - I will open a different PR for this
   * what happens when flooding many values in a given ledger - what this PR does

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
