### PR TITLE
Better virtual now

### DIFF
--- a/src/herder/UpgradesTests.cpp
+++ b/src/herder/UpgradesTests.cpp
@@ -60,7 +60,7 @@ simulateUpgrade(std::vector<LedgerUpgradeNode> const& nodes,
     historytestutils::TmpDirHistoryConfigurator configurator{};
     auto simulation =
         std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
-    simulation->setCurrentTime(genesis(0, 0));
+    simulation->setCurrentVirtualTime(genesis(0, 0));
 
     // configure nodes
     auto keys = std::vector<SecretKey>{};

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -55,12 +55,12 @@ Simulation::~Simulation()
 }
 
 void
-Simulation::setCurrentTime(VirtualClock::time_point t)
+Simulation::setCurrentVirtualTime(VirtualClock::time_point t)
 {
-    mClock.setCurrentTime(t);
+    mClock.setCurrentVirtualTime(t);
     for (auto& p : mNodes)
     {
-        p.second.mClock->setCurrentTime(t);
+        p.second.mClock->setCurrentVirtualTime(t);
     }
 }
 
@@ -89,7 +89,7 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
                                                     : VirtualClock::REAL_TIME);
     if (mVirtualClockMode)
     {
-        clock->setCurrentTime(mClock.now());
+        clock->setCurrentVirtualTime(mClock.now());
     }
 
     auto app = Application::create(*clock, *cfg, newDB);

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -42,7 +42,7 @@ class Simulation
     ~Simulation();
 
     // updates all clocks in the simulation to the same time_point
-    void setCurrentTime(VirtualClock::time_point t);
+    void setCurrentVirtualTime(VirtualClock::time_point t);
 
     Application::pointer addNode(SecretKey nodeKey, SCPQuorumSet qSet,
                                  Config const* cfg = nullptr,

--- a/src/transactions/InflationTests.cpp
+++ b/src/transactions/InflationTests.cpp
@@ -292,7 +292,7 @@ TEST_CASE("inflation", "[tx][inflation]")
     inflationStart = VirtualClock::from_time_t(start);
 
     VirtualClock clock;
-    clock.setCurrentTime(inflationStart);
+    clock.setCurrentVirtualTime(inflationStart);
 
     auto app = createTestApplication(clock, cfg);
 

--- a/src/transactions/TxEnvelopeTests.cpp
+++ b/src/transactions/TxEnvelopeTests.cpp
@@ -1121,7 +1121,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     time_t start = getTestDate(1, 7, 2014);
                     ledgerTime = VirtualClock::from_time_t(start);
 
-                    clock.setCurrentTime(ledgerTime);
+                    clock.setCurrentVirtualTime(ledgerTime);
 
                     SECTION("too early")
                     {

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -17,7 +17,7 @@ using namespace std;
 
 static const uint32_t RECENT_CRANK_WINDOW = 1024;
 
-VirtualClock::VirtualClock(Mode mode) : mRealTimer(mIOService), mMode(mode)
+VirtualClock::VirtualClock(Mode mode) : mMode(mode), mRealTimer(mIOService)
 {
     resetIdleCrankPercent();
 }

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -111,7 +111,7 @@ class VirtualClock
     uint32_t mRecentIdleCrankCount;
 
     size_t nRealTimerCancelEvents;
-    time_point mNow;
+    time_point mVirtualNow;
 
     bool mDelayExecution{true};
     std::recursive_mutex mDelayExecutionMutex;
@@ -127,7 +127,6 @@ class VirtualClock
     bool mDestructing{false};
 
     void maybeSetRealtimer();
-    size_t advanceTo(time_point n);
     size_t advanceToNext();
     size_t advanceToNow();
 
@@ -159,7 +158,7 @@ class VirtualClock
 
     // only valid with VIRTUAL_TIME: sets the current value
     // of the clock
-    void setCurrentTime(time_point t);
+    void setCurrentVirtualTime(time_point t);
 
     // returns the time of the next scheduled event
     time_point next();


### PR DESCRIPTION
# Description

Only use mNow variable in VirtualClock in VIRTUAL_TIME mode
Also fixed initialization order of VirtualClock members.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
