### PR TITLE
PostgreSQL 9.5 and database version checking in general

### DIFF
--- a/Builds/VisualStudio/libsoci_postgresql/libsoci_postgresql.vcxproj
+++ b/Builds/VisualStudio/libsoci_postgresql/libsoci_postgresql.vcxproj
@@ -119,7 +119,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.4\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.5\include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -129,7 +129,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.5\lib\libpq.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|Win32'">
@@ -137,7 +137,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.4\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.5\include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -147,7 +147,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.5\lib\libpq.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -155,7 +155,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.4\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.5\include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -166,7 +166,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.5\lib\libpq.lib</AdditionalDependencies>
       <TargetMachine>MachineX64</TargetMachine>
     </Lib>
   </ItemDefinitionGroup>
@@ -175,7 +175,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.4\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.5\include</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -186,7 +186,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
+      <AdditionalDependencies>C:\Program Files\PostgreSQL\9.5\lib\libpq.lib</AdditionalDependencies>
       <TargetMachine>MachineX64</TargetMachine>
     </Lib>
   </ItemDefinitionGroup>
@@ -214,7 +214,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BrowseInformation>false</BrowseInformation>
-      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.4\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\lib\soci\src\core;c:\Program Files\PostgreSQL\9.5\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -78,7 +78,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\9.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\9.5\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;USE_POSTGRES;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
@@ -93,7 +93,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;%(AdditionalDependencies);C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;%(AdditionalDependencies);C:\Program Files\PostgreSQL\9.5\lib\libpq.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>
@@ -135,7 +135,7 @@ exit /b 0
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\9.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\9.5\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
@@ -197,7 +197,7 @@ exit /b 0
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\9.4\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../..;src/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\9.5\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;USE_POSTGRES;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0501;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BrowseInformation>false</BrowseInformation>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -209,7 +209,7 @@ exit /b 0
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;%(AdditionalDependencies);C:\Program Files\PostgreSQL\9.4\lib\libpq.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;%(AdditionalDependencies);C:\Program Files\PostgreSQL\9.5\lib\libpq.lib</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
       <Command>

--- a/INSTALL-Windows.md
+++ b/INSTALL-Windows.md
@@ -18,7 +18,7 @@
 
 Note: if you do not want to use postgres you can select `DebugNoPostgres` as the build target.
 
-Get version 9.4.8 from https://www.enterprisedb.com/download-postgresql-binaries
+Get version 9.5 from https://www.enterprisedb.com/download-postgresql-binaries
 
 The default project file defines USE_POSTGRES and links against it.
 * Pick a directory for the database
@@ -26,7 +26,7 @@ The default project file defines USE_POSTGRES and links against it.
 * Accept the default port (5432)
 * Accept `default` for the locale (not clear if anything depends on this. The `default` locale will
 presumably depend on your operating system's setting might cause inconsistencies)
-* Add `c:\Program Files\PostgreSQL\9.4\bin` to your PATH (else the binary will fail to start,
+* Add `c:\Program Files\PostgreSQL\9.5\bin` to your PATH (else the binary will fail to start,
     not finding `libpq.dll`)
 * If you install postgres in a different folder, you will have to update the project file in two places:
     * "additional include locations" and

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -288,7 +288,7 @@ Database::isSqlite() const
 void
 Database::doDatabaseTypeSpecificOperation(DatabaseTypeSpecificOperation& op)
 {
-    auto b = getSession().get_backend();
+    auto b = mSession.get_backend();
     if (auto sq = dynamic_cast<soci::sqlite3_session_backend*>(b))
     {
         op.doSqliteSpecificOperation(sq);

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -57,11 +57,49 @@ bool Database::gDriversRegistered = false;
 
 static unsigned long const SCHEMA_VERSION = 9;
 
-static void
-setSerializable(soci::session& sess)
+// These should always match our compiled version precisely, since we are
+// using a bundled version to get access to carray(). But in case someone
+// overrides that or our build configuration changes, it's nicer to get a
+// more-precise version-mismatch error message than a runtime crash due
+// to using SQLite features that aren't supported on an old version.
+static int const MIN_SQLITE_MAJOR_VERSION = 3;
+static int const MIN_SQLITE_MINOR_VERSION = 26;
+static int const MIN_SQLITE_VERSION =
+    (1000000 * MIN_SQLITE_MAJOR_VERSION) + (1000 * MIN_SQLITE_MINOR_VERSION);
+
+// PostgreSQL pre-10.0 actually used its "minor number" as a major one
+// (meaning: 9.4 and 9.5 were considered different major releases, with
+// compatibility differences and so forth). After 10.0 they started doing
+// what everyone else does, where 10.0 and 10.1 were only "minor". Either
+// way though, we have a minimum minor version.
+static int const MIN_POSTGRESQL_MAJOR_VERSION = 9;
+static int const MIN_POSTGRESQL_MINOR_VERSION = 5;
+static int const MIN_POSTGRESQL_VERSION =
+    (10000 * MIN_POSTGRESQL_MAJOR_VERSION) +
+    (100 * MIN_POSTGRESQL_MINOR_VERSION);
+
+static std::string
+badPgVersion(int vers)
 {
-    sess << "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL "
-            "SERIALIZABLE";
+    std::ostringstream msg;
+    int maj = (vers / 10000);
+    int min = (vers - (maj * 10000)) / 100;
+    msg << "PostgreSQL version " << maj << '.' << min
+        << " is too old, must use at least " << MIN_POSTGRESQL_MAJOR_VERSION
+        << '.' << MIN_POSTGRESQL_MINOR_VERSION;
+    return msg.str();
+}
+
+static std::string
+badSqliteVersion(int vers)
+{
+    std::ostringstream msg;
+    int maj = (vers / 1000000);
+    int min = (vers - (maj * 1000000)) / 1000;
+    msg << "SQLite version " << maj << '.' << min
+        << " is too old, must use at least " << MIN_SQLITE_MAJOR_VERSION << '.'
+        << MIN_SQLITE_MINOR_VERSION;
+    return msg.str();
 }
 
 void
@@ -76,6 +114,49 @@ Database::registerDrivers()
         gDriversRegistered = true;
     }
 }
+
+// Helper class that confirms that we're running on a new-enough version
+// of each database type and tweaks some per-backend settings.
+class DatabaseConfigureSessionOp : public DatabaseTypeSpecificOperation
+{
+    soci::session& mSession;
+
+  public:
+    DatabaseConfigureSessionOp(soci::session& sess) : mSession(sess)
+    {
+    }
+    void
+    doSqliteSpecificOperation(soci::sqlite3_session_backend* sq) override
+    {
+        int vers = sqlite_api::sqlite3_libversion_number();
+        if (vers < MIN_SQLITE_VERSION)
+        {
+            throw std::runtime_error(badSqliteVersion(vers));
+        }
+
+        mSession << "PRAGMA journal_mode = WAL";
+        // busy_timeout gives room for external processes
+        // that may lock the database for some time
+        mSession << "PRAGMA busy_timeout = 10000";
+
+        // Register the sqlite carray() extension we use for bulk operations.
+        sqlite3_carray_init(sq->conn_, nullptr, nullptr);
+    }
+#ifdef USE_POSTGRES
+    void
+    doPostgresSpecificOperation(soci::postgresql_session_backend* pg) override
+    {
+        int vers = PQserverVersion(pg->conn_);
+        if (vers < MIN_POSTGRESQL_VERSION)
+        {
+            throw std::runtime_error(badPgVersion(vers));
+        }
+        mSession
+            << "SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL "
+               "SERIALIZABLE";
+    }
+#endif
+};
 
 Database::Database(Application& app)
     : mApp(app)
@@ -94,22 +175,8 @@ Database::Database(Application& app)
                            << removePasswordFromConnectionString(
                                   app.getConfig().DATABASE.value);
     mSession.open(app.getConfig().DATABASE.value);
-    if (isSqlite())
-    {
-        mSession << "PRAGMA journal_mode = WAL";
-        // busy_timeout gives room for external processes
-        // that may lock the database for some time
-        mSession << "PRAGMA busy_timeout = 10000";
-
-        // Register the sqlite carray() extension we use for bulk operations.
-        auto besqlite3 = dynamic_cast<soci::sqlite3_session_backend*>(
-            mSession.get_backend());
-        sqlite3_carray_init(besqlite3->conn_, nullptr, nullptr);
-    }
-    else
-    {
-        setSerializable(mSession);
-    }
+    DatabaseConfigureSessionOp op(mSession);
+    doDatabaseTypeSpecificOperation(op);
 }
 
 void
@@ -379,10 +446,8 @@ Database::getPool()
             LOG(DEBUG) << "Opening pool entry " << i;
             soci::session& sess = mPool->at(i);
             sess.open(c.value);
-            if (!isSqlite())
-            {
-                setSerializable(sess);
-            }
+            DatabaseConfigureSessionOp op(sess);
+            doDatabaseTypeSpecificOperation(op);
         }
     }
     assert(mPool);


### PR DESCRIPTION
# Description

Recent changes for bulk-writing have required UPSERT functionality in postgresql, which is only present in 9.5 and later. As it happens we moved travis to test against 9.5 a while ago, we just haven't updated everything to reflect that requirement yet. This PR does more of that sort of change: switching the MSVC path to use 9.5 and also wiring in a version check when we open a connection, so we get a nice error message.

I also added a SQLite version check, which is a little bit overkill since we're currently bundling our own in all cases, but it seems like a nice enough thing to double check / trap with a friendly error message if we can.

(I believe that being on version 9.4 was what caused the recent acceptance tests to fail; I've updated the docker image in the meantime)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] (N/A) If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
