### PR TITLE
use std::chrono types where it makes sense

### DIFF
--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -162,20 +162,21 @@ Peer::getAuthCert()
     return mApp.getOverlayManager().getPeerAuth().getAuthCert();
 }
 
-size_t
-Peer::getIOTimeoutSeconds() const
+std::chrono::seconds
+Peer::getIOTimeout() const
 {
     if (isAuthenticated())
     {
         // Normally willing to wait 30s to hear anything
         // from an authenticated peer.
-        return mApp.getConfig().PEER_TIMEOUT;
+        return std::chrono::seconds(mApp.getConfig().PEER_TIMEOUT);
     }
     else
     {
         // We give peers much less timing leeway while
         // performing handshake.
-        return mApp.getConfig().PEER_AUTHENTICATION_TIMEOUT;
+        return std::chrono::seconds(
+            mApp.getConfig().PEER_AUTHENTICATION_TIMEOUT);
     }
 }
 
@@ -203,7 +204,7 @@ Peer::startIdleTimer()
     }
 
     auto self = shared_from_this();
-    mIdleTimer.expires_from_now(std::chrono::seconds(getIOTimeoutSeconds()));
+    mIdleTimer.expires_from_now(getIOTimeout());
     mIdleTimer.async_wait([self](asio::error_code const& error) {
         self->idleTimerExpired(error);
     });
@@ -215,7 +216,7 @@ Peer::idleTimerExpired(asio::error_code const& error)
     if (!error)
     {
         auto now = mApp.getClock().now();
-        auto timeout = std::chrono::seconds(getIOTimeoutSeconds());
+        auto timeout = getIOTimeout();
         if (((now - mLastRead) >= timeout) && ((now - mLastWrite) >= timeout))
         {
             CLOG(WARNING, "Overlay") << "idle timeout for peer " << toString();

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -170,7 +170,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     void startIdleTimer();
     void idleTimerExpired(asio::error_code const& error);
-    size_t getIOTimeoutSeconds() const;
+    std::chrono::seconds getIOTimeout() const;
 
     // helper method to acknownledge that some bytes were received
     void receivedBytes(size_t byteCount, bool gotFullMessage);

--- a/src/util/LogSlowExecution.h
+++ b/src/util/LogSlowExecution.h
@@ -17,13 +17,15 @@ class LogSlowExecution
                // elapsed time
     };
 
-    LogSlowExecution(std::string eventName, Mode mode = Mode::AUTOMATIC_RAII,
-                     std::string message = "hung for", int ms = 1000)
+    LogSlowExecution(
+        std::string eventName, Mode mode = Mode::AUTOMATIC_RAII,
+        std::string message = "hung for",
+        std::chrono::milliseconds threshold = std::chrono::seconds(1))
         : mStart(std::chrono::system_clock::now())
         , mName(std::move(eventName))
         , mMode(mode)
         , mMessage(std::move(message))
-        , mThresholdInMs(ms){};
+        , mThreshold(threshold){};
 
     ~LogSlowExecution()
     {
@@ -39,7 +41,7 @@ class LogSlowExecution
         auto finish = std::chrono::system_clock::now();
         auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
             finish - mStart);
-        auto tooSlow = elapsed.count() > mThresholdInMs;
+        auto tooSlow = elapsed > mThreshold;
 
         LOG_IF(tooSlow, INFO)
             << "'" << mName << "' " << mMessage << " "
@@ -52,5 +54,5 @@ class LogSlowExecution
     std::string mName;
     Mode mMode;
     std::string mMessage;
-    int mThresholdInMs;
+    std::chrono::milliseconds mThreshold;
 };


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Instead of using "ms" or "seconds" as part of variable names, use std::chrono::xxx types.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
