### PR TITLE
Fix crash in apply buffered ledgers

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -352,6 +352,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerTxnTrustLineSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTestUtils.cpp" />
+    <ClCompile Include="..\..\src\ledger\LedgerManagerTests.cpp" />
     <ClCompile Include="..\..\src\ledger\LiabilitiesTests.cpp" />
     <ClCompile Include="..\..\src\ledger\SyncingLedgerChain.cpp" />
     <ClCompile Include="..\..\src\ledger\SyncingLedgerChainTests.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -309,6 +309,9 @@
     <ClCompile Include="..\..\src\ledger\LedgerTests.cpp">
       <Filter>ledger\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\LedgerManagerTests.cpp">
+      <Filter>ledger\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\main\Application.cpp">
       <Filter>main</Filter>
     </ClCompile>

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -694,19 +694,18 @@ void
 LedgerManagerImpl::applyBufferedLedgers()
 {
     assert(mCatchupState == CatchupState::APPLYING_BUFFERED_LEDGERS);
+    if (mSyncingLedgers.empty())
+    {
+        CLOG(INFO, "Ledger")
+            << "Caught up to LCL including recent network activity: "
+            << ledgerAbbrev(mLastClosedLedger)
+            << "; waiting for closing ledger";
+        setCatchupState(CatchupState::WAITING_FOR_CLOSING_LEDGER);
+        return;
+    }
 
     mApp.postOnMainThreadWithDelay(
         [&] {
-            if (mSyncingLedgers.empty())
-            {
-                CLOG(INFO, "Ledger")
-                    << "Caught up to LCL including recent network activity: "
-                    << ledgerAbbrev(mLastClosedLedger)
-                    << "; waiting for closing ledger";
-                setCatchupState(CatchupState::WAITING_FOR_CLOSING_LEDGER);
-                return;
-            }
-
             auto lcd = mSyncingLedgers.front();
             mSyncingLedgers.pop();
             mSyncingLedgersSize.set_count(mSyncingLedgers.size());

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -536,6 +536,10 @@ LedgerManagerImpl::finalizeCatchup(LedgerCloseData const& ledgerData)
 void
 LedgerManagerImpl::addToSyncingLedgers(LedgerCloseData const& ledgerData)
 {
+    assert(mState == LM_CATCHING_UP_STATE);
+    assert(mCatchupState != CatchupState::NONE);
+    assert(mCatchupState != CatchupState::WAITING_FOR_CLOSING_LEDGER);
+
     switch (mSyncingLedgers.push(ledgerData))
     {
     case SyncingLedgerChainAddResult::CONTIGUOUS:

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -48,14 +48,9 @@ class LedgerManagerImpl : public LedgerManager
     VirtualClock::time_point mLastClose;
 
     medida::Counter& mSyncingLedgersSize;
-    SyncingLedgerChain mSyncingLedgers;
     uint32_t mCatchupTriggerLedger{0};
 
     CatchupState mCatchupState{CatchupState::NONE};
-
-    void initializeCatchup(LedgerCloseData const& ledgerData);
-    void continueCatchup(LedgerCloseData const& ledgerData);
-    void finalizeCatchup(LedgerCloseData const& ledgerData);
 
     void addToSyncingLedgers(LedgerCloseData const& ledgerData);
     void startCatchupIf(uint32_t lastReceivedLedgerSeq);
@@ -63,7 +58,6 @@ class LedgerManagerImpl : public LedgerManager
     void historyCaughtup(asio::error_code const& ec,
                          CatchupWork::ProgressState progressState,
                          LedgerHeaderHistoryEntry const& lastClosed);
-    void applyBufferedLedgers();
 
     void processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
                             AbstractLedgerTxn& ltxOuter);
@@ -75,7 +69,6 @@ class LedgerManagerImpl : public LedgerManager
     void ledgerClosed(AbstractLedgerTxn& ltx);
 
     void storeCurrentLedger(LedgerHeader const& header);
-    void advanceLedgerPointers(LedgerHeader const& header);
 
     enum class CloseLedgerIfResult
     {
@@ -87,7 +80,17 @@ class LedgerManagerImpl : public LedgerManager
 
     State mState;
     void setState(State s);
+
+  protected:
+    SyncingLedgerChain mSyncingLedgers;
+
+    void applyBufferedLedgers();
     void setCatchupState(CatchupState s);
+    void advanceLedgerPointers(LedgerHeader const& header);
+
+    void initializeCatchup(LedgerCloseData const& ledgerData);
+    void continueCatchup(LedgerCloseData const& ledgerData);
+    void finalizeCatchup(LedgerCloseData const& ledgerData);
 
   public:
     LedgerManagerImpl(Application& app);

--- a/src/ledger/LedgerManagerTests.cpp
+++ b/src/ledger/LedgerManagerTests.cpp
@@ -18,6 +18,7 @@ class LedgerManagerForTests : public LedgerManagerImpl
   public:
     using LedgerManagerImpl::applyBufferedLedgers;
     using LedgerManagerImpl::continueCatchup;
+    using LedgerManagerImpl::finalizeCatchup;
     using LedgerManagerImpl::initializeCatchup;
     using LedgerManagerImpl::setCatchupState;
 
@@ -92,14 +93,14 @@ TEST_CASE("new ledger comes from network after last applyBufferedLedgers is "
         if (ledgerManager.syncingLedgersEmpty())
         {
             REQUIRE(ledgerManager.getCatchupState() ==
-                    LedgerManager::CatchupState::APPLYING_BUFFERED_LEDGERS);
+                    LedgerManager::CatchupState::WAITING_FOR_CLOSING_LEDGER);
             break;
         }
     }
 
-    ledgerManager.continueCatchup(ledgerCloseData(5));
+    // there is gap, so new catchup is starting
+    ledgerManager.finalizeCatchup(ledgerCloseData(5));
+    REQUIRE(!ledgerManager.syncingLedgersEmpty());
     REQUIRE(ledgerManager.getCatchupState() ==
-            LedgerManager::CatchupState::APPLYING_BUFFERED_LEDGERS);
-
-    clock.crank(); // crash
+            LedgerManager::CatchupState::WAITING_FOR_TRIGGER_LEDGER);
 }

--- a/src/ledger/LedgerManagerTests.cpp
+++ b/src/ledger/LedgerManagerTests.cpp
@@ -1,0 +1,105 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerManagerImpl.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+
+#include <lib/catch.hpp>
+
+using namespace stellar;
+
+namespace stellar
+{
+
+class LedgerManagerForTests : public LedgerManagerImpl
+{
+  public:
+    using LedgerManagerImpl::applyBufferedLedgers;
+    using LedgerManagerImpl::continueCatchup;
+    using LedgerManagerImpl::initializeCatchup;
+    using LedgerManagerImpl::setCatchupState;
+
+    LedgerManagerForTests(Application& app) : LedgerManagerImpl(app)
+    {
+    }
+
+    bool
+    syncingLedgersEmpty() const
+    {
+        return mSyncingLedgers.empty();
+    }
+
+    void
+    closeLedger(LedgerCloseData const& lcd) override
+    {
+        LedgerHeader next;
+        next.ledgerSeq = lcd.getLedgerSeq();
+        advanceLedgerPointers(next);
+    }
+};
+
+class LedgerManagerTestApplication : public TestApplication
+{
+  public:
+    LedgerManagerTestApplication(VirtualClock& clock, Config const& cfg)
+        : TestApplication(clock, cfg)
+    {
+    }
+
+    virtual LedgerManagerForTests&
+    getLedgerManager() override
+    {
+        auto& overlay = ApplicationImpl::getLedgerManager();
+        return static_cast<LedgerManagerForTests&>(overlay);
+    }
+
+  private:
+    virtual std::unique_ptr<LedgerManager>
+    createLedgerManager() override
+    {
+        return std::make_unique<LedgerManagerForTests>(*this);
+    }
+};
+}
+
+TEST_CASE("new ledger comes from network after last applyBufferedLedgers is "
+          "scheduled",
+          "[ledger]")
+{
+    VirtualClock clock;
+    auto app = createTestApplication<LedgerManagerTestApplication>(
+        clock, getTestConfig());
+    app->start();
+
+    auto ledgerCloseData = [](uint32_t ledger) {
+        auto txSet = std::make_shared<TxSetFrame>(Hash{});
+        StellarValue sv{txSet->getContentsHash(), 2, emptyUpgradeSteps, 0};
+        return LedgerCloseData{ledger, txSet, sv};
+    };
+
+    auto& ledgerManager = app->getLedgerManager();
+    ledgerManager.initializeCatchup(ledgerCloseData(2));
+    ledgerManager.continueCatchup(ledgerCloseData(3));
+
+    ledgerManager.setCatchupState(
+        LedgerManager::CatchupState::APPLYING_BUFFERED_LEDGERS);
+    ledgerManager.applyBufferedLedgers();
+
+    while (clock.crank())
+    {
+        if (ledgerManager.syncingLedgersEmpty())
+        {
+            REQUIRE(ledgerManager.getCatchupState() ==
+                    LedgerManager::CatchupState::APPLYING_BUFFERED_LEDGERS);
+            break;
+        }
+    }
+
+    ledgerManager.continueCatchup(ledgerCloseData(5));
+    REQUIRE(ledgerManager.getCatchupState() ==
+            LedgerManager::CatchupState::APPLYING_BUFFERED_LEDGERS);
+
+    clock.crank(); // crash
+}

--- a/src/ledger/LedgerTests.cpp
+++ b/src/ledger/LedgerTests.cpp
@@ -2,22 +2,12 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "LedgerTestUtils.h"
-#include "database/Database.h"
-#include "herder/LedgerCloseData.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
-#include "ledger/LedgerTxnEntry.h"
-#include "ledger/LedgerTxnHeader.h"
-#include "lib/catch.hpp"
 #include "main/Application.h"
-#include "main/Config.h"
-#include "test/TestUtils.h"
 #include "test/test.h"
-#include "util/Logging.h"
-#include "util/Timer.h"
-#include "util/types.h"
-#include <xdrpp/autocheck.h>
+
+#include <lib/catch.hpp>
 
 using namespace stellar;
 

--- a/src/ledger/SyncingLedgerChain.cpp
+++ b/src/ledger/SyncingLedgerChain.cpp
@@ -33,19 +33,26 @@ SyncingLedgerChain::pop()
 SyncingLedgerChainAddResult
 SyncingLedgerChain::push(LedgerCloseData lcd)
 {
-    if (mChain.empty() ||
-        mChain.back().getLedgerSeq() + 1 == lcd.getLedgerSeq())
+    if (mLastLedgerSeq == 0 || mLastLedgerSeq + 1 == lcd.getLedgerSeq())
     {
         mChain.emplace(lcd);
+        mLastLedgerSeq = lcd.getLedgerSeq();
         return SyncingLedgerChainAddResult::CONTIGUOUS;
     }
 
-    if (lcd.getLedgerSeq() <= mChain.back().getLedgerSeq())
+    if (lcd.getLedgerSeq() <= mLastLedgerSeq)
     {
         return SyncingLedgerChainAddResult::TOO_OLD;
     }
 
     return SyncingLedgerChainAddResult::TOO_NEW;
+}
+
+void
+SyncingLedgerChain::reset()
+{
+    assert(empty());
+    mLastLedgerSeq = 0;
 }
 
 size_t

--- a/src/ledger/SyncingLedgerChain.h
+++ b/src/ledger/SyncingLedgerChain.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include <cstddef>
+#include <cstdint>
 #include <list>
 #include <queue>
 
@@ -31,11 +32,13 @@ class SyncingLedgerChain final
     LedgerCloseData const& back() const;
     void pop();
     SyncingLedgerChainAddResult push(LedgerCloseData lcd);
+    void reset();
 
     size_t size() const;
     bool empty() const;
 
   private:
     std::queue<LedgerCloseData, std::list<LedgerCloseData>> mChain;
+    uint32_t mLastLedgerSeq{0};
 };
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -111,7 +111,7 @@ ApplicationImpl::initialize()
     mDatabase = std::make_unique<Database>(*this);
     mPersistentState = std::make_unique<PersistentState>(*this);
     mOverlayManager = createOverlayManager();
-    mLedgerManager = LedgerManager::create(*this);
+    mLedgerManager = createLedgerManager();
     mHerder = createHerder();
     mHerderPersistence = HerderPersistence::create(*this);
     mBucketManager = BucketManager::create(*this);
@@ -782,6 +782,12 @@ std::unique_ptr<OverlayManager>
 ApplicationImpl::createOverlayManager()
 {
     return OverlayManager::create(*this);
+}
+
+std::unique_ptr<LedgerManager>
+ApplicationImpl::createLedgerManager()
+{
+    return LedgerManager::create(*this);
 }
 
 LedgerTxnRoot&

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -181,5 +181,6 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<Herder> createHerder();
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
+    virtual std::unique_ptr<LedgerManager> createLedgerManager();
 };
 }


### PR DESCRIPTION
# Description

Resolves #1965

Fixes race condition in applyBufferedLedgers. With new switching to WAITING_FOR_CLOSING_LEDGER is done before posting applying code to next crank, so it is no longer possible for mSyncingLedger to become empty and then non-empty again without entering that state.

Also a new condition and explicit reset method is added to SyncingLedgerChain itself to prevent such bugs in future.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
