### PR TITLE
Fix error in bulk loads for offers

### DIFF
--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -800,14 +800,21 @@ class BulkLoadOffersOperation
         std::vector<LedgerEntry> res;
         while (st.got_data())
         {
+            // Exclude offers where sellerID in LedgerKey doesn't match sellerID
+            // in LedgerEntry
+            auto pubKey = KeyUtils::fromStrKey<PublicKey>(sellerID);
+            if (mSellerIDsByOfferID[offerID] == pubKey)
+            {
+                continue;
+            }
+
             res.emplace_back();
             auto& le = res.back();
             le.data.type(OFFER);
             auto& oe = le.data.offer();
 
-            oe.sellerID = KeyUtils::fromStrKey<PublicKey>(sellerID);
+            oe.sellerID = pubKey;
             oe.offerID = offerID;
-            assert(mSellerIDsByOfferID[oe.offerID] == oe.sellerID);
 
             processAsset(oe.selling, (AssetType)sellingAssetType, sellingIssuer,
                          sellingIssuerIndicator, sellingAssetCode,


### PR DESCRIPTION
Attempting to bulk load an offer keyed by (sid, oid) should not assert if an offer keyed by (sid', oid) exists. Instead it should just not return that offer.