### PR TITLE
Expand round leaders over time

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -78,6 +78,7 @@ static int const MIN_POSTGRESQL_VERSION =
     (10000 * MIN_POSTGRESQL_MAJOR_VERSION) +
     (100 * MIN_POSTGRESQL_MINOR_VERSION);
 
+#ifdef USE_POSTGRES
 static std::string
 badPgVersion(int vers)
 {
@@ -89,6 +90,7 @@ badPgVersion(int vers)
         << '.' << MIN_POSTGRESQL_MINOR_VERSION;
     return msg.str();
 }
+#endif
 
 static std::string
 badSqliteVersion(int vers)

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -758,7 +758,7 @@ class BulkLoadAccountsOperation
 
         sqlite3_reset(st);
         sqlite3_bind_pointer(st, 1, accountIDcstrs.data(), "carray", 0);
-        sqlite3_bind_int(st, 2, accountIDcstrs.size());
+        sqlite3_bind_int(st, 2, static_cast<int>(accountIDcstrs.size()));
         return executeAndFetch(prep.statement());
     }
 

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -443,9 +443,9 @@ class BulkLoadDataOperation
 
         sqlite3_reset(st);
         sqlite3_bind_pointer(st, 1, cstrAccountIDs.data(), "carray", 0);
-        sqlite3_bind_int(st, 2, cstrAccountIDs.size());
+        sqlite3_bind_int(st, 2, static_cast<int>(cstrAccountIDs.size()));
         sqlite3_bind_pointer(st, 3, cstrDataNames.data(), "carray", 0);
-        sqlite3_bind_int(st, 4, cstrDataNames.size());
+        sqlite3_bind_int(st, 4, static_cast<int>(cstrDataNames.size()));
         return executeAndFetch(prep.statement());
     }
 

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -869,7 +869,7 @@ class BulkLoadOffersOperation
 
         sqlite3_reset(st);
         sqlite3_bind_pointer(st, 1, (void*)mOfferIDs.data(), "carray", 0);
-        sqlite3_bind_int(st, 2, mOfferIDs.size());
+        sqlite3_bind_int(st, 2, static_cast<int>(mOfferIDs.size()));
         return executeAndFetch(prep.statement());
     }
 

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -565,11 +565,11 @@ class BulkLoadTrustLinesOperation
 
         sqlite3_reset(st);
         sqlite3_bind_pointer(st, 1, cstrAccountIDs.data(), "carray", 0);
-        sqlite3_bind_int(st, 2, cstrAccountIDs.size());
+        sqlite3_bind_int(st, 2, static_cast<int>(cstrAccountIDs.size()));
         sqlite3_bind_pointer(st, 3, cstrIssuers.data(), "carray", 0);
-        sqlite3_bind_int(st, 4, cstrIssuers.size());
+        sqlite3_bind_int(st, 4, static_cast<int>(cstrIssuers.size()));
         sqlite3_bind_pointer(st, 5, cstrAssetCodes.data(), "carray", 0);
-        sqlite3_bind_int(st, 6, cstrAssetCodes.size());
+        sqlite3_bind_int(st, 6, static_cast<int>(cstrAssetCodes.size()));
         return executeAndFetch(prep.statement());
     }
 

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -81,6 +81,15 @@ LocalNode::forAllNodes(SCPQuorumSet const& qset,
     }
 }
 
+uint64
+LocalNode::computeWeight(uint64 m, uint64 total, uint64 threshold)
+{
+    uint64 res;
+    assert(threshold <= total);
+    bigDivide(res, m, threshold, total, ROUND_UP);
+    return res;
+}
+
 // if a validator is repeated multiple times its weight is only the
 // weight of the first occurrence
 uint64
@@ -94,7 +103,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
     {
         if (qsetNode == nodeID)
         {
-            bigDivide(res, UINT64_MAX, n, d, ROUND_UP);
+            res = computeWeight(UINT64_MAX, d, n);
             return res;
         }
     }
@@ -104,7 +113,7 @@ LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
         uint64 leafW = getNodeWeight(nodeID, q);
         if (leafW)
         {
-            bigDivide(res, leafW, n, d, ROUND_UP);
+            res = computeWeight(leafW, d, n);
             return res;
         }
     }

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -101,6 +101,8 @@ class LocalNode
     Json::Value toJson(SCPQuorumSet const& qSet) const;
     std::string to_string(SCPQuorumSet const& qSet) const;
 
+    static uint64 computeWeight(uint64 m, uint64 total, uint64 threshold);
+
   protected:
     // returns a quorum set {{ nodeID }}
     static SCPQuorumSet buildSingletonQSet(NodeID const& nodeID);

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -272,7 +272,9 @@ NominationProtocol::getNodePriority(NodeID const& nodeID,
         w = LocalNode::getNodeWeight(nodeID, qset);
     }
 
-    if (hashNode(false, nodeID) < w)
+    // if w > 0; w is inclusive here as
+    // 0 <= hashNode <= UINT64_MAX
+    if (w > 0 && hashNode(false, nodeID) <= w)
     {
         res = hashNode(true, nodeID);
     }

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -537,6 +537,12 @@ NominationProtocol::stopNomination()
     mNominationStarted = false;
 }
 
+std::set<NodeID> const&
+NominationProtocol::getLeaders() const
+{
+    return mRoundLeaders;
+}
+
 Json::Value
 NominationProtocol::getJsonInfo()
 {

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -484,6 +484,7 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
 
     Value nominatingValue;
 
+    // if we're leader, add our value
     if (mRoundLeaders.find(mSlot.getLocalNode()->getNodeID()) !=
         mRoundLeaders.end())
     {
@@ -494,20 +495,18 @@ NominationProtocol::nominate(Value const& value, Value const& previousValue,
         }
         nominatingValue = value;
     }
-    else
+    // add a few more values from other leaders
+    for (auto const& leader : mRoundLeaders)
     {
-        for (auto const& leader : mRoundLeaders)
+        auto it = mLatestNominations.find(leader);
+        if (it != mLatestNominations.end())
         {
-            auto it = mLatestNominations.find(leader);
-            if (it != mLatestNominations.end())
+            nominatingValue = getNewValueFromNomination(
+                it->second.statement.pledges.nominate());
+            if (!nominatingValue.empty())
             {
-                nominatingValue = getNewValueFromNomination(
-                    it->second.statement.pledges.nominate());
-                if (!nominatingValue.empty())
-                {
-                    mVotes.insert(nominatingValue);
-                    updated = true;
-                }
+                mVotes.insert(nominatingValue);
+                updated = true;
             }
         }
     }

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -96,6 +96,9 @@ class NominationProtocol
     // stops the nomination protocol
     void stopNomination();
 
+    // return the current leaders
+    std::set<NodeID> const& getLeaders() const;
+
     Value const&
     getLatestCompositeCandidate() const
     {

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -16,6 +16,7 @@ namespace stellar
 {
 class NominationProtocol
 {
+  protected:
     Slot& mSlot;
 
     int32 mRoundNumber;

--- a/src/scp/SCPTests.cpp
+++ b/src/scp/SCPTests.cpp
@@ -2482,173 +2482,178 @@ TEST_CASE("nomination tests core5", "[scp][nominationprotocol]")
         uint256 qSetHash0 = scp.mSCP.getLocalNode()->getQuorumSetHash();
         scp.storeQuorumSet(std::make_shared<SCPQuorumSet>(qSet));
 
-        SECTION("others nominate what v0 says (x) -> prepare x")
+        SECTION("v0 starts to nominates xValue")
         {
             REQUIRE(scp.nominate(0, xValue, false));
 
             checkLeaders(scp, {v0SecretKey.getPublicKey()});
 
-            std::vector<Value> votes, accepted;
-            votes.emplace_back(xValue);
-
-            REQUIRE(scp.mEnvs.size() == 1);
-            verifyNominate(scp.mEnvs[0], v0SecretKey, qSetHash0, 0, votes,
-                           accepted);
-
-            SCPEnvelope nom1 =
-                makeNominate(v1SecretKey, qSetHash, 0, votes, accepted);
-            SCPEnvelope nom2 =
-                makeNominate(v2SecretKey, qSetHash, 0, votes, accepted);
-            SCPEnvelope nom3 =
-                makeNominate(v3SecretKey, qSetHash, 0, votes, accepted);
-            SCPEnvelope nom4 =
-                makeNominate(v4SecretKey, qSetHash, 0, votes, accepted);
-
-            // nothing happens yet
-            scp.receiveEnvelope(nom1);
-            scp.receiveEnvelope(nom2);
-            REQUIRE(scp.mEnvs.size() == 1);
-
-            // this causes 'x' to be accepted (quorum)
-            scp.receiveEnvelope(nom3);
-            REQUIRE(scp.mEnvs.size() == 2);
-
-            scp.mExpectedCandidates.emplace(xValue);
-            scp.mCompositeValue = xValue;
-
-            accepted.emplace_back(xValue);
-            verifyNominate(scp.mEnvs[1], v0SecretKey, qSetHash0, 0, votes,
-                           accepted);
-
-            // extra message doesn't do anything
-            scp.receiveEnvelope(nom4);
-            REQUIRE(scp.mEnvs.size() == 2);
-
-            SCPEnvelope acc1 =
-                makeNominate(v1SecretKey, qSetHash, 0, votes, accepted);
-            SCPEnvelope acc2 =
-                makeNominate(v2SecretKey, qSetHash, 0, votes, accepted);
-            SCPEnvelope acc3 =
-                makeNominate(v3SecretKey, qSetHash, 0, votes, accepted);
-            SCPEnvelope acc4 =
-                makeNominate(v4SecretKey, qSetHash, 0, votes, accepted);
-
-            // nothing happens yet
-            scp.receiveEnvelope(acc1);
-            scp.receiveEnvelope(acc2);
-            REQUIRE(scp.mEnvs.size() == 2);
-
-            scp.mCompositeValue = xValue;
-            // this causes the node to send a prepare message (quorum)
-            scp.receiveEnvelope(acc3);
-            REQUIRE(scp.mEnvs.size() == 3);
-
-            verifyPrepare(scp.mEnvs[2], v0SecretKey, qSetHash0, 0,
-                          SCPBallot(1, xValue));
-
-            scp.receiveEnvelope(acc4);
-            REQUIRE(scp.mEnvs.size() == 3);
-
-            std::vector<Value> votes2 = votes;
-            votes2.emplace_back(yValue);
-
-            SECTION("nominate x -> accept x -> prepare (x) ; others accepted y "
-                    "-> update latest to (z=x+y)")
+            SECTION("others nominate what v0 says (x) -> prepare x")
             {
-                SCPEnvelope acc1_2 =
-                    makeNominate(v1SecretKey, qSetHash, 0, votes2, votes2);
-                SCPEnvelope acc2_2 =
-                    makeNominate(v2SecretKey, qSetHash, 0, votes2, votes2);
-                SCPEnvelope acc3_2 =
-                    makeNominate(v3SecretKey, qSetHash, 0, votes2, votes2);
-                SCPEnvelope acc4_2 =
-                    makeNominate(v4SecretKey, qSetHash, 0, votes2, votes2);
+                std::vector<Value> votes, accepted;
+                votes.emplace_back(xValue);
 
-                scp.receiveEnvelope(acc1_2);
+                REQUIRE(scp.mEnvs.size() == 1);
+                verifyNominate(scp.mEnvs[0], v0SecretKey, qSetHash0, 0, votes,
+                               accepted);
+
+                SCPEnvelope nom1 =
+                    makeNominate(v1SecretKey, qSetHash, 0, votes, accepted);
+                SCPEnvelope nom2 =
+                    makeNominate(v2SecretKey, qSetHash, 0, votes, accepted);
+                SCPEnvelope nom3 =
+                    makeNominate(v3SecretKey, qSetHash, 0, votes, accepted);
+                SCPEnvelope nom4 =
+                    makeNominate(v4SecretKey, qSetHash, 0, votes, accepted);
+
+                // nothing happens yet
+                scp.receiveEnvelope(nom1);
+                scp.receiveEnvelope(nom2);
+                REQUIRE(scp.mEnvs.size() == 1);
+
+                // this causes 'x' to be accepted (quorum)
+                scp.receiveEnvelope(nom3);
+                REQUIRE(scp.mEnvs.size() == 2);
+
+                scp.mExpectedCandidates.emplace(xValue);
+                scp.mCompositeValue = xValue;
+
+                accepted.emplace_back(xValue);
+                verifyNominate(scp.mEnvs[1], v0SecretKey, qSetHash0, 0, votes,
+                               accepted);
+
+                // extra message doesn't do anything
+                scp.receiveEnvelope(nom4);
+                REQUIRE(scp.mEnvs.size() == 2);
+
+                SCPEnvelope acc1 =
+                    makeNominate(v1SecretKey, qSetHash, 0, votes, accepted);
+                SCPEnvelope acc2 =
+                    makeNominate(v2SecretKey, qSetHash, 0, votes, accepted);
+                SCPEnvelope acc3 =
+                    makeNominate(v3SecretKey, qSetHash, 0, votes, accepted);
+                SCPEnvelope acc4 =
+                    makeNominate(v4SecretKey, qSetHash, 0, votes, accepted);
+
+                // nothing happens yet
+                scp.receiveEnvelope(acc1);
+                scp.receiveEnvelope(acc2);
+                REQUIRE(scp.mEnvs.size() == 2);
+
+                scp.mCompositeValue = xValue;
+                // this causes the node to send a prepare message (quorum)
+                scp.receiveEnvelope(acc3);
                 REQUIRE(scp.mEnvs.size() == 3);
 
-                // v-blocking
-                scp.receiveEnvelope(acc2_2);
-                REQUIRE(scp.mEnvs.size() == 4);
-                verifyNominate(scp.mEnvs[3], v0SecretKey, qSetHash0, 0, votes2,
-                               votes2);
+                verifyPrepare(scp.mEnvs[2], v0SecretKey, qSetHash0, 0,
+                              SCPBallot(1, xValue));
 
-                scp.mExpectedCandidates.insert(yValue);
-                scp.mCompositeValue = kValue;
-                // this updates the composite value to use next time
-                // but does not prepare it
-                scp.receiveEnvelope(acc3_2);
-                REQUIRE(scp.mEnvs.size() == 4);
+                scp.receiveEnvelope(acc4);
+                REQUIRE(scp.mEnvs.size() == 3);
 
-                REQUIRE(scp.getLatestCompositeCandidate(0) == kValue);
+                std::vector<Value> votes2 = votes;
+                votes2.emplace_back(yValue);
 
-                scp.receiveEnvelope(acc4_2);
-                REQUIRE(scp.mEnvs.size() == 4);
-            }
-            SECTION("nomination - restored state")
-            {
-                TestSCP scp2(v0SecretKey.getPublicKey(), qSet);
-                scp2.storeQuorumSet(std::make_shared<SCPQuorumSet>(qSet));
-
-                // at this point
-                // votes = { x }
-                // accepted = { x }
-
-                // tests if nomination proceeds like normal
-                // nominates x
-                auto nominationRestore = [&]() {
-                    // restores from the previous state
-                    scp2.mSCP.setStateFromEnvelope(
-                        0, makeNominate(v0SecretKey, qSetHash0, 0, votes,
-                                        accepted));
-                    // tries to start nomination with yValue
-                    REQUIRE(scp2.nominate(0, yValue, false));
-
-                    checkLeaders(scp2, {v0SecretKey.getPublicKey()});
-
-                    REQUIRE(scp2.mEnvs.size() == 1);
-                    verifyNominate(scp2.mEnvs[0], v0SecretKey, qSetHash0, 0,
-                                   votes2, accepted);
-
-                    // other nodes vote for 'x'
-                    scp2.receiveEnvelope(nom1);
-                    scp2.receiveEnvelope(nom2);
-                    REQUIRE(scp2.mEnvs.size() == 1);
-                    // 'x' is accepted (quorum)
-                    // but because the restored state already included
-                    // 'x' in the accepted set, no new message is emitted
-                    scp2.receiveEnvelope(nom3);
-
-                    scp2.mExpectedCandidates.emplace(xValue);
-                    scp2.mCompositeValue = xValue;
-
-                    // other nodes not emit 'x' as accepted
-                    scp2.receiveEnvelope(acc1);
-                    scp2.receiveEnvelope(acc2);
-                    REQUIRE(scp2.mEnvs.size() == 1);
-
-                    scp2.mCompositeValue = xValue;
-                    // this causes the node to update its composite value to x
-                    scp2.receiveEnvelope(acc3);
-                };
-
-                SECTION("ballot protocol not started")
+                SECTION(
+                    "nominate x -> accept x -> prepare (x) ; others accepted y "
+                    "-> update latest to (z=x+y)")
                 {
-                    nominationRestore();
-                    // nomination ended up starting the ballot protocol
-                    REQUIRE(scp2.mEnvs.size() == 2);
+                    SCPEnvelope acc1_2 =
+                        makeNominate(v1SecretKey, qSetHash, 0, votes2, votes2);
+                    SCPEnvelope acc2_2 =
+                        makeNominate(v2SecretKey, qSetHash, 0, votes2, votes2);
+                    SCPEnvelope acc3_2 =
+                        makeNominate(v3SecretKey, qSetHash, 0, votes2, votes2);
+                    SCPEnvelope acc4_2 =
+                        makeNominate(v4SecretKey, qSetHash, 0, votes2, votes2);
 
-                    verifyPrepare(scp2.mEnvs[1], v0SecretKey, qSetHash0, 0,
-                                  SCPBallot(1, xValue));
+                    scp.receiveEnvelope(acc1_2);
+                    REQUIRE(scp.mEnvs.size() == 3);
+
+                    // v-blocking
+                    scp.receiveEnvelope(acc2_2);
+                    REQUIRE(scp.mEnvs.size() == 4);
+                    verifyNominate(scp.mEnvs[3], v0SecretKey, qSetHash0, 0,
+                                   votes2, votes2);
+
+                    scp.mExpectedCandidates.insert(yValue);
+                    scp.mCompositeValue = kValue;
+                    // this updates the composite value to use next time
+                    // but does not prepare it
+                    scp.receiveEnvelope(acc3_2);
+                    REQUIRE(scp.mEnvs.size() == 4);
+
+                    REQUIRE(scp.getLatestCompositeCandidate(0) == kValue);
+
+                    scp.receiveEnvelope(acc4_2);
+                    REQUIRE(scp.mEnvs.size() == 4);
                 }
-                SECTION("ballot protocol started (on value k)")
+                SECTION("nomination - restored state")
                 {
-                    scp2.mSCP.setStateFromEnvelope(
-                        0, makePrepare(v0SecretKey, qSetHash0, 0,
-                                       SCPBallot(1, kValue)));
-                    nominationRestore();
-                    // nomination didn't do anything (already working on k)
-                    REQUIRE(scp2.mEnvs.size() == 1);
+                    TestSCP scp2(v0SecretKey.getPublicKey(), qSet);
+                    scp2.storeQuorumSet(std::make_shared<SCPQuorumSet>(qSet));
+
+                    // at this point
+                    // votes = { x }
+                    // accepted = { x }
+
+                    // tests if nomination proceeds like normal
+                    // nominates x
+                    auto nominationRestore = [&]() {
+                        // restores from the previous state
+                        scp2.mSCP.setStateFromEnvelope(
+                            0, makeNominate(v0SecretKey, qSetHash0, 0, votes,
+                                            accepted));
+                        // tries to start nomination with yValue
+                        REQUIRE(scp2.nominate(0, yValue, false));
+
+                        checkLeaders(scp2, {v0SecretKey.getPublicKey()});
+
+                        REQUIRE(scp2.mEnvs.size() == 1);
+                        verifyNominate(scp2.mEnvs[0], v0SecretKey, qSetHash0, 0,
+                                       votes2, accepted);
+
+                        // other nodes vote for 'x'
+                        scp2.receiveEnvelope(nom1);
+                        scp2.receiveEnvelope(nom2);
+                        REQUIRE(scp2.mEnvs.size() == 1);
+                        // 'x' is accepted (quorum)
+                        // but because the restored state already included
+                        // 'x' in the accepted set, no new message is emitted
+                        scp2.receiveEnvelope(nom3);
+
+                        scp2.mExpectedCandidates.emplace(xValue);
+                        scp2.mCompositeValue = xValue;
+
+                        // other nodes not emit 'x' as accepted
+                        scp2.receiveEnvelope(acc1);
+                        scp2.receiveEnvelope(acc2);
+                        REQUIRE(scp2.mEnvs.size() == 1);
+
+                        scp2.mCompositeValue = xValue;
+                        // this causes the node to update its composite value to
+                        // x
+                        scp2.receiveEnvelope(acc3);
+                    };
+
+                    SECTION("ballot protocol not started")
+                    {
+                        nominationRestore();
+                        // nomination ended up starting the ballot protocol
+                        REQUIRE(scp2.mEnvs.size() == 2);
+
+                        verifyPrepare(scp2.mEnvs[1], v0SecretKey, qSetHash0, 0,
+                                      SCPBallot(1, xValue));
+                    }
+                    SECTION("ballot protocol started (on value k)")
+                    {
+                        scp2.mSCP.setStateFromEnvelope(
+                            0, makePrepare(v0SecretKey, qSetHash0, 0,
+                                           SCPBallot(1, kValue)));
+                        nominationRestore();
+                        // nomination didn't do anything (already working on k)
+                        REQUIRE(scp2.mEnvs.size() == 1);
+                    }
                 }
             }
         }

--- a/src/scp/SCPUnitTests.cpp
+++ b/src/scp/SCPUnitTests.cpp
@@ -1,6 +1,10 @@
 #include "lib/catch.hpp"
 #include "scp/LocalNode.h"
+#include "scp/SCP.h"
+#include "scp/Slot.h"
 #include "simulation/Simulation.h"
+#include "util/Logging.h"
+#include "xdrpp/marshal.h"
 
 namespace stellar
 {
@@ -43,5 +47,380 @@ TEST_CASE("nomination weight", "[scp]")
     result = LocalNode::getNodeWeight(v4NodeID, qSet);
 
     REQUIRE(isNear(result, .6 * .5));
+}
+
+class TestNominationSCP : public SCPDriver
+{
+  public:
+    SCP mSCP;
+    TestNominationSCP(NodeID const& nodeID, SCPQuorumSet const& qSetLocal)
+        : mSCP(*this, nodeID, true, qSetLocal)
+    {
+        auto localQSet =
+            std::make_shared<SCPQuorumSet>(mSCP.getLocalQuorumSet());
+        storeQuorumSet(localQSet);
+    }
+
+    void
+    signEnvelope(SCPEnvelope&) override
+    {
+    }
+
+    bool
+    verifyEnvelope(SCPEnvelope const& envelope) override
+    {
+        return true;
+    }
+
+    void
+    storeQuorumSet(SCPQuorumSetPtr qSet)
+    {
+        Hash qSetHash = sha256(xdr::xdr_to_opaque(*qSet.get()));
+        mQuorumSets[qSetHash] = qSet;
+    }
+
+    SCPDriver::ValidationLevel
+    validateValue(uint64 slotIndex, Value const& value,
+                  bool nomination) override
+    {
+        return SCPDriver::kFullyValidatedValue;
+    }
+
+    SCPQuorumSetPtr
+    getQSet(Hash const& qSetHash) override
+    {
+        if (mQuorumSets.find(qSetHash) != mQuorumSets.end())
+        {
+
+            return mQuorumSets[qSetHash];
+        }
+        return SCPQuorumSetPtr();
+    }
+
+    void
+    emitEnvelope(SCPEnvelope const& envelope) override
+    {
+    }
+
+    Value
+    combineCandidates(uint64 slotIndex,
+                      std::set<Value> const& candidates) override
+    {
+        return {};
+    }
+
+    void
+    setupTimer(uint64 slotIndex, int timerID, std::chrono::milliseconds timeout,
+               std::function<void()> cb) override
+    {
+    }
+
+    std::map<Hash, SCPQuorumSetPtr> mQuorumSets;
+
+    Value const&
+    getLatestCompositeCandidate(uint64 slotIndex)
+    {
+        return {};
+    }
+};
+
+class NominationTestHandler : public NominationProtocol
+{
+  public:
+    NominationTestHandler(Slot& s) : NominationProtocol(s)
+    {
+    }
+
+    void
+    setPreviousValue(Value const& v)
+    {
+        mPreviousValue = v;
+    }
+
+    void
+    setRoundNumber(int32 n)
+    {
+        mRoundNumber = n;
+    }
+
+    void
+    updateRoundLeaders()
+    {
+        NominationProtocol::updateRoundLeaders();
+    }
+
+    std::set<NodeID>&
+    getRoundLeaders()
+    {
+        return mRoundLeaders;
+    }
+
+    uint64
+    getNodePriority(NodeID const& nodeID, SCPQuorumSet const& qset)
+    {
+        return NominationProtocol::getNodePriority(nodeID, qset);
+    }
+};
+
+static SCPQuorumSet
+makeQSet(std::vector<NodeID> const& nodeIDs, int threshold, int total,
+         int offset)
+{
+    SCPQuorumSet qSet;
+    qSet.threshold = threshold;
+    for (int i = 0; i < total; i++)
+    {
+        qSet.validators.push_back(nodeIDs[i + offset]);
+    }
+    return qSet;
+}
+
+// this test case display statistical information on the priority function used
+// by nomination
+TEST_CASE("nomination weight stats", "[scp][!hide]")
+{
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+
+    SIMULATION_CREATE_NODE(3);
+    SIMULATION_CREATE_NODE(4);
+    SIMULATION_CREATE_NODE(5);
+    SIMULATION_CREATE_NODE(6);
+
+    std::vector<NodeID> nodeIDs = {v0NodeID, v1NodeID, v2NodeID, v3NodeID,
+                                   v4NodeID, v5NodeID, v6NodeID};
+
+    int const totalSlots = 1000;
+    int const maxRoundPerSlot = 5; // 5 -> 15 seconds
+    int const totalRounds = totalSlots * maxRoundPerSlot;
+
+    auto runTests = [&](SCPQuorumSet qSet) {
+        std::map<NodeID, int> wins;
+
+        TestNominationSCP nomSCP(v0NodeID, qSet);
+        for (int s = 0; s < totalSlots; s++)
+        {
+            Slot slot(s, nomSCP.mSCP);
+
+            NominationTestHandler nom(slot);
+
+            Value v;
+            v.emplace_back(uint8_t(s)); // anything will do as a value
+
+            nom.setPreviousValue(v);
+
+            for (int i = 0; i < maxRoundPerSlot; i++)
+            {
+                nom.setRoundNumber(i);
+                nom.updateRoundLeaders();
+                auto& l = nom.getRoundLeaders();
+                REQUIRE(!l.empty());
+                for (auto& w : l)
+                {
+                    wins[w]++;
+                }
+            }
+        }
+        return wins;
+    };
+
+    SECTION("flat quorum")
+    {
+        auto flatTest = [&](int threshold, int total) {
+            auto qSet = makeQSet(nodeIDs, threshold, total, 0);
+
+            auto wins = runTests(qSet);
+
+            for (auto& w : wins)
+            {
+                double stats = double(w.second * 100) / double(totalRounds);
+                CLOG(INFO, "SCP") << "Got " << stats
+                                  << ((v0NodeID == w.first) ? " LOCAL" : "");
+            }
+        };
+
+        SECTION("3 out of 5")
+        {
+            flatTest(3, 5);
+        }
+        SECTION("2 out of 3")
+        {
+            flatTest(2, 3);
+        }
+    }
+    SECTION("hierarchy")
+    {
+        auto qSet = makeQSet(nodeIDs, 3, 4, 0);
+
+        auto qSetInner = makeQSet(nodeIDs, 2, 3, 4);
+        qSet.innerSets.emplace_back(qSetInner);
+
+        auto wins = runTests(qSet);
+
+        for (auto& w : wins)
+        {
+            double stats = double(w.second * 100) / double(totalRounds);
+            bool outer =
+                std::any_of(qSet.validators.begin(), qSet.validators.end(),
+                            [&](auto const& k) { return k == w.first; });
+            CLOG(INFO, "SCP")
+                << "Got " << stats << " "
+                << ((v0NodeID == w.first) ? "LOCAL"
+                                          : (outer ? "OUTER" : "INNER"));
+        }
+    }
+}
+
+TEST_CASE("nomination two nodes win stats", "[scp][!hide]")
+{
+    int const nbRoundsForStats = 9;
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+
+    SIMULATION_CREATE_NODE(3);
+    SIMULATION_CREATE_NODE(4);
+    SIMULATION_CREATE_NODE(5);
+    SIMULATION_CREATE_NODE(6);
+
+    std::vector<NodeID> nodeIDs = {v0NodeID, v1NodeID, v2NodeID, v3NodeID,
+                                   v4NodeID, v5NodeID, v6NodeID};
+
+    int const totalIter = 10000;
+
+    // maxRounds is the number of rounds to evaluate in a row
+    // the iteration is considered successful if validators could
+    // agree on what to nominate before maxRounds is reached
+    auto nominationLeaders = [&](int maxRounds, SCPQuorumSet qSetNode0,
+                                 SCPQuorumSet qSetNode1) {
+        TestNominationSCP nomSCP0(v0NodeID, qSetNode0);
+        Slot slot0(0, nomSCP0.mSCP);
+        NominationTestHandler nom0(slot0);
+
+        TestNominationSCP nomSCP1(v1NodeID, qSetNode1);
+        Slot slot1(0, nomSCP1.mSCP);
+        NominationTestHandler nom1(slot1);
+
+        int tot = 0;
+        for (int g = 0; g < totalIter; g++)
+        {
+            Value v;
+            v.emplace_back(uint8_t(g));
+            nom0.setPreviousValue(v);
+            nom1.setPreviousValue(v);
+
+            bool res = true;
+
+            bool v0Voted = false;
+            bool v1Voted = false;
+
+            int r = 0;
+            do
+            {
+                nom0.setRoundNumber(r);
+                nom1.setRoundNumber(r);
+                nom0.updateRoundLeaders();
+                nom1.updateRoundLeaders();
+
+                auto& l0 = nom0.getRoundLeaders();
+                REQUIRE(!l0.empty());
+                auto& l1 = nom1.getRoundLeaders();
+                REQUIRE(!l1.empty());
+
+                auto updateVoted = [&](auto const& id, auto const& leaders,
+                                       bool& voted) {
+                    if (!voted)
+                    {
+                        voted = std::find(leaders.begin(), leaders.end(), id) !=
+                                leaders.end();
+                    }
+                };
+
+                // checks if id voted (any past round, including this one)
+                // AND id is a leader this round
+                auto findNode = [](auto const& id, bool idVoted,
+                                   auto const& otherLeaders) {
+                    bool r = (idVoted && std::find(otherLeaders.begin(),
+                                                   otherLeaders.end(),
+                                                   id) != otherLeaders.end());
+                    return r;
+                };
+
+                updateVoted(v0NodeID, l0, v0Voted);
+                updateVoted(v1NodeID, l1, v1Voted);
+
+                // either both vote for v0 or both vote for v1
+                res = findNode(v0NodeID, v0Voted, l1);
+                res = res || findNode(v1NodeID, v1Voted, l0);
+            } while (!res && ++r < maxRounds);
+
+            tot += res ? 1 : 0;
+        }
+        return tot;
+    };
+
+    SECTION("flat quorum")
+    {
+        // test using the same quorum on all nodes
+        auto flatTest = [&](int threshold, int total) {
+            auto qSet = makeQSet(nodeIDs, threshold, total, 0);
+
+            for (int maxRounds = 1; maxRounds <= nbRoundsForStats; maxRounds++)
+            {
+                int tot = nominationLeaders(maxRounds, qSet, qSet);
+                double stats = double(tot * 100) / double(totalIter);
+                CLOG(INFO, "SCP")
+                    << "Win rate for " << maxRounds << " : " << stats;
+            }
+        };
+
+        SECTION("3 out of 5")
+        {
+            flatTest(3, 5);
+        }
+        SECTION("2 out of 3")
+        {
+            flatTest(2, 3);
+        }
+    }
+
+    SECTION("hierarchy")
+    {
+        SECTION("same qSet")
+        {
+            auto qSet = makeQSet(nodeIDs, 3, 4, 0);
+
+            auto qSetInner = makeQSet(nodeIDs, 2, 3, 4);
+            qSet.innerSets.emplace_back(qSetInner);
+
+            for (int maxRounds = 1; maxRounds <= nbRoundsForStats; maxRounds++)
+            {
+                int tot = nominationLeaders(maxRounds, qSet, qSet);
+                double stats = double(tot * 100) / double(totalIter);
+                CLOG(INFO, "SCP")
+                    << "Win rate for " << maxRounds << " : " << stats;
+            }
+        }
+        SECTION("v0 is inner node for v1")
+        {
+            auto qSet0 = makeQSet(nodeIDs, 3, 4, 0);
+            auto qSetInner0 = makeQSet(nodeIDs, 2, 3, 4);
+            qSet0.innerSets.emplace_back(qSetInner0);
+
+            // v1's qset: we move v0 into the inner set
+            auto qSet1 = qSet0;
+            REQUIRE(qSet1.validators[0] == v0NodeID);
+            std::swap(qSet1.validators[0], qSet1.innerSets[0].validators[0]);
+
+            for (int maxRounds = 1; maxRounds <= nbRoundsForStats; maxRounds++)
+            {
+                int tot = nominationLeaders(maxRounds, qSet0, qSet1);
+                double stats = double(tot * 100) / double(totalIter);
+                CLOG(INFO, "SCP")
+                    << "Win rate for " << maxRounds << " : " << stats;
+            }
+        }
+    }
 }
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -165,6 +165,12 @@ Slot::stopNomination()
     mNominationProtocol.stopNomination();
 }
 
+std::set<NodeID>
+Slot::getNominationLeaders() const
+{
+    return mNominationProtocol.getLeaders();
+}
+
 bool
 Slot::isFullyValidated() const
 {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -117,6 +117,9 @@ class Slot : public std::enable_shared_from_this<Slot>
 
     void stopNomination();
 
+    // returns the current nomination leaders
+    std::set<NodeID> getNominationLeaders() const;
+
     bool isFullyValidated() const;
     void setFullyValidated(bool fullyValidated);
 


### PR DESCRIPTION
# Description

This PR addresses a couple problems in SCP's nomination protocol:
* defines round leaders not just as the high priority neighbors for the current round, but instead as the union of the high priority neighbors up to that round as described in SCP's internet draft https://tools.ietf.org/html/draft-mazieres-dinrg-scp-05#section-3.4 specifically
     > A node continues to echo votes from the highest priority neighbor in prior rounds as well as the
   current round.
* small bug in equality when comparing weights

# Observed effect in tests

The improvement increases the chances of nodes nominating something as rounds progresses with by about 2x as seen in the following comparison (numbers are percentages the node votes in various configurations).

## master
```
stellar-core test "nomination weight stats"
2019-02-26T16:46:02.549 <test> [default INFO] Testing stellar-core msvc custom
2019-02-26T16:46:02.551 <test> [default INFO] Logging to stellar0.log
2019-02-26T16:46:02.569 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 2cc575
2019-02-26T16:46:04.593 <test> [SCP INFO] Got 16.4
2019-02-26T16:46:04.594 <test> [SCP INFO] Got 37.9 LOCAL
2019-02-26T16:46:04.600 <test> [SCP INFO] Got 15.66
2019-02-26T16:46:04.612 <test> [SCP INFO] Got 15.24
2019-02-26T16:46:04.633 <test> [SCP INFO] Got 14.8
2019-02-26T16:46:04.656 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 172dcb
2019-02-26T16:46:06.012 <test> [SCP INFO] Got 57.88 LOCAL
2019-02-26T16:46:06.013 <test> [SCP INFO] Got 21.12
2019-02-26T16:46:06.031 <test> [SCP INFO] Got 21
2019-02-26T16:46:06.063 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: c85b05
2019-02-26T16:46:09.319 <test> [SCP INFO] Got 14.88 OUTER
2019-02-26T16:46:09.320 <test> [SCP INFO] Got 32.34 LOCAL
2019-02-26T16:46:09.325 <test> [SCP INFO] Got 14.08 OUTER
2019-02-26T16:46:09.326 <test> [SCP INFO] Got 8.84 INNER
2019-02-26T16:46:09.347 <test> [SCP INFO] Got 13.52 OUTER
2019-02-26T16:46:09.376 <test> [SCP INFO] Got 8.6 INNER
2019-02-26T16:46:09.380 <test> [SCP INFO] Got 7.74 INNER
===============================================================================
All tests passed (3000 assertions in 1 test case)
```

## this PR
```
stellar-core test "nomination weight stats"
2019-02-26T16:43:29.890 <test> [default INFO] Testing stellar-core msvc custom
2019-02-26T16:43:29.891 <test> [default INFO] Logging to stellar0.log
2019-02-26T16:43:29.912 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 2cc575
2019-02-26T16:43:32.023 <test> [SCP INFO] Got 39.96
2019-02-26T16:43:32.024 <test> [SCP INFO] Got 69.74 LOCAL
2019-02-26T16:43:32.033 <test> [SCP INFO] Got 37.72
2019-02-26T16:43:32.039 <test> [SCP INFO] Got 37.4
2019-02-26T16:43:32.041 <test> [SCP INFO] Got 35.9
2019-02-26T16:43:32.061 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: 172dcb
2019-02-26T16:43:33.517 <test> [SCP INFO] Got 85.34 LOCAL
2019-02-26T16:43:33.518 <test> [SCP INFO] Got 47.66
2019-02-26T16:43:33.526 <test> [SCP INFO] Got 48.12
2019-02-26T16:43:33.547 <test> [SCP INFO] LocalNode::LocalNode@GAOBN qSet: c85b05
2019-02-26T16:43:36.936 <test> [SCP INFO] Got 36.84 OUTER
2019-02-26T16:43:36.937 <test> [SCP INFO] Got 63.56 LOCAL
2019-02-26T16:43:36.962 <test> [SCP INFO] Got 34.54 OUTER
2019-02-26T16:43:36.991 <test> [SCP INFO] Got 23.16 INNER
2019-02-26T16:43:37.018 <test> [SCP INFO] Got 34.04 OUTER
2019-02-26T16:43:37.046 <test> [SCP INFO] Got 22.86 INNER
2019-02-26T16:43:37.080 <test> [SCP INFO] Got 22.46 INNER
===============================================================================
All tests passed (3000 assertions in 1 test case)
```

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
