### PR TITLE
Quorum sets are sane, take advantage of it

### DIFF
--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -66,9 +66,8 @@ PendingEnvelopes::peerDoesntHave(MessageType type, Hash const& itemID,
 void
 PendingEnvelopes::addSCPQuorumSet(Hash hash, const SCPQuorumSet& q)
 {
-    assert(isQuorumSetSane(q, false));
-
     CLOG(TRACE, "Herder") << "Add SCPQSet " << hexAbbrev(hash);
+    assert(isQuorumSetSane(q, false));
 
     auto qset = std::make_shared<SCPQuorumSet>(q);
     mNodesInQuorum.clear();

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -66,9 +66,10 @@ LocalNode::getSingletonQSet(NodeID const& nodeID)
 {
     return std::make_shared<SCPQuorumSet>(buildSingletonQSet(nodeID));
 }
+
 void
-LocalNode::forAllNodesInternal(SCPQuorumSet const& qset,
-                               std::function<void(NodeID const&)> proc)
+LocalNode::forAllNodes(SCPQuorumSet const& qset,
+                       std::function<void(NodeID const&)> proc)
 {
     for (auto const& n : qset.validators)
     {
@@ -76,23 +77,8 @@ LocalNode::forAllNodesInternal(SCPQuorumSet const& qset,
     }
     for (auto const& q : qset.innerSets)
     {
-        forAllNodesInternal(q, proc);
+        forAllNodes(q, proc);
     }
-}
-
-// runs proc over all nodes contained in qset
-void
-LocalNode::forAllNodes(SCPQuorumSet const& qset,
-                       std::function<void(NodeID const&)> proc)
-{
-    std::set<NodeID> done;
-    forAllNodesInternal(qset, [&](NodeID const& n) {
-        auto ins = done.insert(n);
-        if (ins.second)
-        {
-            proc(n);
-        }
-    });
 }
 
 // if a validator is repeated multiple times its weight is only the

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -110,7 +110,5 @@ class LocalNode
                                       std::vector<NodeID> const& nodeSet);
     static bool isVBlockingInternal(SCPQuorumSet const& qset,
                                     std::vector<NodeID> const& nodeSet);
-    static void forAllNodesInternal(SCPQuorumSet const& qset,
-                                    std::function<void(NodeID const&)> proc);
 };
 }

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -40,7 +40,6 @@ class LocalNode
 
     SCPQuorumSet const& getQuorumSet();
     Hash const& getQuorumSetHash();
-    SecretKey const& getSecretKey();
     bool isValidator();
 
     SCP::TriBool isNodeInQuorum(


### PR DESCRIPTION
# Description

As part of #1510, I noticed that a function that we use all the time uses sets even though we don't need to:

historically quorum sets were more complicated, but since late 2015 we're enforcing that nodes in a quorum set only appear once.

