### PR TITLE
use stellar::shortHash for computing hashes of Hash

### DIFF
--- a/src/util/HashOfHash.cpp
+++ b/src/util/HashOfHash.cpp
@@ -1,4 +1,5 @@
 #include "HashOfHash.h"
+#include "crypto/ByteSliceHasher.h"
 
 namespace std
 {
@@ -6,10 +7,9 @@ namespace std
 size_t
 hash<stellar::uint256>::operator()(stellar::uint256 const& x) const noexcept
 {
-    size_t res = x[0];
-    res = (res << 8) | x[1];
-    res = (res << 8) | x[2];
-    res = (res << 8) | x[3];
+    size_t res =
+        stellar::shortHash::computeHash(stellar::ByteSlice(x.data(), 8));
+
     return res;
 }
 }


### PR DESCRIPTION
# Description

Minor cleanup, when I implemented https://github.com/stellar/stellar-core/pull/1871 I didn't notice that we're using a custom and not so good hash function for the "Hash" type.

This PR fixes that.
