### PR TITLE
do not connect to peers that have more than 120 failures

### DIFF
--- a/src/overlay/RandomPeerSource.cpp
+++ b/src/overlay/RandomPeerSource.cpp
@@ -60,7 +60,9 @@ peerTypeToFilter(PeerType peerType)
 PeerQuery
 RandomPeerSource::nextAttemptCutoff(PeerType requireExactType)
 {
-    return {true, -1, peerTypeToFilter(requireExactType)};
+    constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
+    return {true, REALLY_DEAD_NUM_FAILURES_CUTOFF,
+            peerTypeToFilter(requireExactType)};
 }
 
 RandomPeerSource::RandomPeerSource(PeerManager& peerManager,


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Resolves #1962

This one disables connecting to peers that have numfailures bigger than 120. Threshold for sending peers to other nodes is still kept at 10.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
