### PR TITLE
add command flag `fullkeys` to show full nodeIDs on /quorum and /scp

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -146,8 +146,9 @@ class Herder
     {
     }
 
-    virtual Json::Value getJsonInfo(size_t limit) = 0;
+    virtual Json::Value getJsonInfo(size_t limit, bool fullKeys = false) = 0;
     virtual Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
+                                          bool fullKeys = false,
                                           uint64 index = 0) = 0;
 };
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -866,23 +866,24 @@ HerderImpl::resolveNodeID(std::string const& s, PublicKey& retKey)
 }
 
 Json::Value
-HerderImpl::getJsonInfo(size_t limit)
+HerderImpl::getJsonInfo(size_t limit, bool fullKeys)
 {
     Json::Value ret;
     ret["you"] =
         mApp.getConfig().toStrKey(mApp.getConfig().NODE_SEED.getPublicKey());
 
-    ret["scp"] = getSCP().getJsonInfo(limit);
+    ret["scp"] = getSCP().getJsonInfo(limit, fullKeys);
     ret["queue"] = mPendingEnvelopes.getJsonInfo(limit);
     return ret;
 }
 
 Json::Value
-HerderImpl::getJsonQuorumInfo(NodeID const& id, bool summary, uint64 index)
+HerderImpl::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
+                              uint64 index)
 {
     Json::Value ret;
     ret["node"] = mApp.getConfig().toStrKey(id);
-    ret["slots"] = getSCP().getJsonQuorumInfo(id, summary, index);
+    ret["slots"] = getSCP().getJsonQuorumInfo(id, summary, fullKeys, index);
     return ret;
 }
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -86,9 +86,10 @@ class HerderImpl : public Herder
 
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 
-    Json::Value getJsonInfo(size_t limit) override;
+    Json::Value getJsonInfo(size_t limit, bool fullKeys = false) override;
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
-                                  uint64 index) override;
+                                  bool fullKeys = false,
+                                  uint64 index = 0) override;
 
     struct TxMap
     {

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -700,8 +700,8 @@ void
 HerderSCPDriver::logQuorumInformation(uint64_t index)
 {
     std::string res;
-    auto v =
-        mApp.getHerder().getJsonQuorumInfo(mSCP.getLocalNodeID(), true, index);
+    auto v = mApp.getHerder().getJsonQuorumInfo(mSCP.getLocalNodeID(), true,
+                                                false, index);
     auto slots = v.get("slots", "");
     if (!slots.empty())
     {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -246,8 +246,9 @@ ApplicationImpl::getJsonInfo()
     }
 
     auto& herder = getHerder();
-    auto q = herder.getJsonQuorumInfo(getConfig().NODE_SEED.getPublicKey(),
-                                      true, herder.getCurrentLedgerSeq());
+    auto q =
+        herder.getJsonQuorumInfo(getConfig().NODE_SEED.getPublicKey(), true,
+                                 false, herder.getCurrentLedgerSeq());
     if (q["slots"].size() != 0)
     {
         info["quorum"] = q["slots"];

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -291,14 +291,16 @@ CommandHandler::fileNotFound(std::string const& params, std::string& retStr)
         "clear all metrics (for testing purposes)"
         "</p><p><h1> /peers</h1>"
         "returns the list of known peers in JSON format"
-        "</p><p><h1> /quorum?[node=NODE_ID][&compact=true]</h1>"
+        "</p><p><h1> /quorum?[node=NODE_ID][&compact=true][&fullkeys=true]</h1>"
         "returns information about the quorum for node NODE_ID (this node by"
         " default). NODE_ID is either a full key (`GABCD...`), an alias "
         "(`$name`) or an abbreviated ID(`@GABCD`)."
         "If compact is set, only returns a summary version."
-        "</p><p><h1> /scp?[limit=n]</h1>"
+        "Outputs unshortened public keys if fullkeys is set."
+        "</p><p><h1> /scp?[limit=n][&fullkeys=true]</h1>"
         "returns a JSON object with the internal state of the SCP engine for "
         "the last n (default 2) ledgers."
+        "Outputs unshortened public keys if fullkeys is set."
         "</p><p><h1> /tx?blob=BASE64</h1>"
         "submit a transaction to the network.<br>"
         "blob is a base64 encoded XDR serialized 'TransactionEnvelope'<br>"
@@ -789,8 +791,8 @@ CommandHandler::quorum(std::string const& params, std::string& retStr)
         }
     }
 
-    auto root =
-        mApp.getHerder().getJsonQuorumInfo(n, retMap["compact"] == "true");
+    auto root = mApp.getHerder().getJsonQuorumInfo(
+        n, retMap["compact"] == "true", retMap["fullkeys"] == "true");
     retStr = root.toStyledString();
 }
 
@@ -799,11 +801,10 @@ CommandHandler::scpInfo(std::string const& params, std::string& retStr)
 {
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
-
     size_t lim = 2;
     maybeParseParam(retMap, "limit", lim);
 
-    auto root = mApp.getHerder().getJsonInfo(lim);
+    auto root = mApp.getHerder().getJsonInfo(lim, retMap["fullkeys"] == "true");
     retStr = root.toStyledString();
 }
 

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1962,7 +1962,7 @@ BallotProtocol::getJsonInfo()
 }
 
 Json::Value
-BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary)
+BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
 {
     Json::Value ret;
     auto& phase = ret["phase"];
@@ -2077,9 +2077,12 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary)
         auto& f_ex = ret["fail_with"];
         for (auto const& n : f)
         {
-            f_ex.append(mSlot.getSCPDriver().toShortString(n));
+            std::string nodeID = fullKeys
+                                     ? mSlot.getSCPDriver().toStrKey(n)
+                                     : mSlot.getSCPDriver().toShortString(n);
+            f_ex.append(nodeID);
         }
-        ret["value"] = getLocalNode()->toJson(*qSet);
+        ret["value"] = getLocalNode()->toJson(*qSet, fullKeys);
     }
 
     ret["hash"] = hexAbbrev(qSetHash);

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -88,7 +88,8 @@ class BallotProtocol
     Json::Value getJsonInfo();
 
     // returns information about the quorum for a given node
-    Json::Value getJsonQuorumInfo(NodeID const& id, bool summary);
+    Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
+                                  bool fullKeys = false);
 
     // returns the hash of the QuorumSet that should be downloaded
     // with the statement.

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -362,18 +362,20 @@ LocalNode::findClosestVBlocking(SCPQuorumSet const& qset,
 }
 
 Json::Value
-LocalNode::toJson(SCPQuorumSet const& qSet) const
+LocalNode::toJson(SCPQuorumSet const& qSet, bool fullKeys) const
 {
     Json::Value ret;
     ret["t"] = qSet.threshold;
     auto& entries = ret["v"];
     for (auto const& v : qSet.validators)
     {
-        entries.append(mSCP->getDriver().toShortString(v));
+        std::string nodeID = fullKeys ? mSCP->getDriver().toStrKey(v)
+                                      : mSCP->getDriver().toShortString(v);
+        entries.append(nodeID);
     }
     for (auto const& s : qSet.innerSets)
     {
-        entries.append(toJson(s));
+        entries.append(toJson(s, fullKeys));
     }
     return ret;
 }
@@ -382,7 +384,7 @@ std::string
 LocalNode::to_string(SCPQuorumSet const& qSet) const
 {
     Json::FastWriter fw;
-    return fw.write(toJson(qSet));
+    return fw.write(toJson(qSet, false));
 }
 
 NodeID const&

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -98,7 +98,7 @@ class LocalNode
             [](SCPStatement const&) { return true; },
         NodeID const* excluded = nullptr);
 
-    Json::Value toJson(SCPQuorumSet const& qSet) const;
+    Json::Value toJson(SCPQuorumSet const& qSet, bool fullKeys) const;
     std::string to_string(SCPQuorumSet const& qSet) const;
 
   protected:

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -76,12 +76,12 @@ class SCP
     // returns the local node descriptor
     std::shared_ptr<LocalNode> getLocalNode();
 
-    Json::Value getJsonInfo(size_t limit);
+    Json::Value getJsonInfo(size_t limit, bool fullKeys = false);
 
     // summary: only return object counts
     // index = 0 for returning information for all slots
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
-                                  uint64 index = 0);
+                                  bool fullKeys = false, uint64 index = 0);
 
     // Purges all data relative to all the slots whose slotIndex is smaller
     // than the specified `maxSlotIndex`.
@@ -130,8 +130,9 @@ class SCP
     std::string getValueString(Value const& v) const;
     std::string ballotToStr(SCPBallot const& ballot) const;
     std::string ballotToStr(std::unique_ptr<SCPBallot> const& ballot) const;
-    std::string envToStr(SCPEnvelope const& envelope) const;
-    std::string envToStr(SCPStatement const& st) const;
+    std::string envToStr(SCPEnvelope const& envelope,
+                         bool fullKeys = false) const;
+    std::string envToStr(SCPStatement const& st, bool fullKeys = false) const;
 
   protected:
     std::shared_ptr<LocalNode> mLocalNode;

--- a/src/scp/SCPDriver.cpp
+++ b/src/scp/SCPDriver.cpp
@@ -24,6 +24,12 @@ SCPDriver::getValueString(Value const& v) const
 }
 
 std::string
+SCPDriver::toStrKey(PublicKey const& pk) const
+{
+    return KeyUtils::toStrKey(pk);
+}
+
+std::string
 SCPDriver::toShortString(PublicKey const& pk) const
 {
     return KeyUtils::toShortString(pk);

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -87,6 +87,9 @@ class SCPDriver
     // default implementation is the hash of the value
     virtual std::string getValueString(Value const& v) const;
 
+    // `toStrKey` returns StrKey encoded string representation
+    virtual std::string toStrKey(PublicKey const& pk) const;
+
     // `toShortString` converts to the common name of a key if found
     virtual std::string toShortString(PublicKey const& pk) const;
 

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -289,7 +289,7 @@ Slot::getQuorumSetFromStatement(SCPStatement const& st)
 }
 
 Json::Value
-Slot::getJsonInfo()
+Slot::getJsonInfo(bool fullKeys)
 {
     Json::Value ret;
     std::map<Hash, SCPQuorumSetPtr> qSetsUsed;
@@ -299,7 +299,7 @@ Slot::getJsonInfo()
     {
         Json::Value& v = ret["statements"][count++];
         v.append((Json::UInt64)item.mWhen);
-        v.append(mSCP.envToStr(item.mStatement));
+        v.append(mSCP.envToStr(item.mStatement, fullKeys));
         v.append(item.mValidated);
 
         Hash const& qSetHash =
@@ -314,7 +314,7 @@ Slot::getJsonInfo()
     auto& qSets = ret["quorum_sets"];
     for (auto const& q : qSetsUsed)
     {
-        qSets[hexAbbrev(q.first)] = getLocalNode()->toJson(*q.second);
+        qSets[hexAbbrev(q.first)] = getLocalNode()->toJson(*q.second, fullKeys);
     }
 
     ret["validated"] = mFullyValidated;
@@ -325,9 +325,9 @@ Slot::getJsonInfo()
 }
 
 Json::Value
-Slot::getJsonQuorumInfo(NodeID const& id, bool summary)
+Slot::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
 {
-    Json::Value ret = mBallotProtocol.getJsonQuorumInfo(id, summary);
+    Json::Value ret = mBallotProtocol.getJsonQuorumInfo(id, summary, fullKeys);
     if (getLocalNode()->isValidator())
     {
         ret["validated"] = isFullyValidated();

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -133,10 +133,11 @@ class Slot : public std::enable_shared_from_this<Slot>
 
     // returns information about the local state in JSON format
     // including historical statements if available
-    Json::Value getJsonInfo();
+    Json::Value getJsonInfo(bool fullKeys = false);
 
     // returns information about the quorum for a given node
-    Json::Value getJsonQuorumInfo(NodeID const& id, bool summary);
+    Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
+                                  bool fullKeys = false);
 
     // returns the hash of the QuorumSet that should be downloaded
     // with the statement.


### PR DESCRIPTION
# Description

Resolves #1721 

Abstract: Show full public keys with `/quorum?fullkeys=true` or `/scp?fullkeys=true` output

I'm new to cpp development (any advice is welcome) and thought that would be a tiny task but somehow I ended up modifying lots of files, passing the flag through various layers. It would be probably better to combine `summary` and `fullkeys` to a new `options` associative array parameter or use a global fullkeys flag in config instead of GET params? Btw: what is the reason to shorten the keys in the first place?

# Checklist
- [X] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [X] Rebased on top of master (no merge commits)
- [X] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [X] Compiles
- [X] Ran all tests
- [X] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
