### PR TITLE
Fix bulk loads for offers

### DIFF
--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -800,33 +800,32 @@ class BulkLoadOffersOperation
         std::vector<LedgerEntry> res;
         while (st.got_data())
         {
+            auto pubKey = KeyUtils::fromStrKey<PublicKey>(sellerID);
+
             // Exclude offers where sellerID in LedgerKey doesn't match sellerID
             // in LedgerEntry
-            auto pubKey = KeyUtils::fromStrKey<PublicKey>(sellerID);
             if (mSellerIDsByOfferID[offerID] == pubKey)
             {
-                continue;
+                res.emplace_back();
+                auto& le = res.back();
+                le.data.type(OFFER);
+                auto& oe = le.data.offer();
+
+                oe.sellerID = pubKey;
+                oe.offerID = offerID;
+
+                processAsset(oe.selling, (AssetType)sellingAssetType,
+                             sellingIssuer, sellingIssuerIndicator,
+                             sellingAssetCode, sellingAssetCodeIndicator);
+                processAsset(oe.buying, (AssetType)buyingAssetType,
+                             buyingIssuer, buyingIssuerIndicator,
+                             buyingAssetCode, buyingAssetCodeIndicator);
+
+                oe.amount = amount;
+                oe.price = price;
+                oe.flags = flags;
+                le.lastModifiedLedgerSeq = lastModified;
             }
-
-            res.emplace_back();
-            auto& le = res.back();
-            le.data.type(OFFER);
-            auto& oe = le.data.offer();
-
-            oe.sellerID = pubKey;
-            oe.offerID = offerID;
-
-            processAsset(oe.selling, (AssetType)sellingAssetType, sellingIssuer,
-                         sellingIssuerIndicator, sellingAssetCode,
-                         sellingAssetCodeIndicator);
-            processAsset(oe.buying, (AssetType)buyingAssetType, buyingIssuer,
-                         buyingIssuerIndicator, buyingAssetCode,
-                         buyingAssetCodeIndicator);
-
-            oe.amount = amount;
-            oe.price = price;
-            oe.flags = flags;
-            le.lastModifiedLedgerSeq = lastModified;
 
             st.fetch();
         }


### PR DESCRIPTION
Looks like latest changes to bulk loads for offers introduced a few issues, which this PR attempts to fix:
* we should proceed to add the offer if `mSellerIDsByOfferID[offerID] == pubKey`
* using `continue` is dangerous because we have to remember to call `st.fetch()`, otherwise it's an infinite loop, so I removed it completely