### PR TITLE
Simplified prefetcher api

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -43,8 +43,11 @@ DATABASE="sqlite3://stellar.db"
 # - BEST_OFFERS_CACHE_SIZE controls the maximum number of Asset pairs that
 #   will be stored in the cache, although many LedgerEntry objects may be
 #   associated with a single Asset pair (default 64)
+# - PREFETCH_BATCH_SIZE determines batch size for bulk loads used for
+#   prefetching
 ENTRY_CACHE_SIZE=4096
 BEST_OFFERS_CACHE_SIZE=64
+PREFETCH_BATCH_SIZE=1000
 
 # HTTP_PORT (integer) default 11626
 # What port stellar-core listens for commands on.

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -48,6 +48,7 @@ class LedgerManagerImpl : public LedgerManager
     medida::Timer& mLedgerClose;
     medida::Timer& mLedgerAgeClosed;
     medida::Counter& mLedgerAge;
+    medida::Counter& mPrefetchHitRate;
     VirtualClock::time_point mLastClose;
 
     medida::Counter& mSyncingLedgersSize;
@@ -72,6 +73,8 @@ class LedgerManagerImpl : public LedgerManager
     void ledgerClosed(AbstractLedgerTxn& ltx);
 
     void storeCurrentLedger(LedgerHeader const& header);
+    void prefetchTransactionData(std::vector<TransactionFramePtr>& txs);
+    void prefetchTxSourceIds(std::vector<TransactionFramePtr>& txs);
 
     enum class CloseLedgerIfResult
     {
@@ -98,6 +101,8 @@ class LedgerManagerImpl : public LedgerManager
     void initializeCatchup(LedgerCloseData const& ledgerData);
     void continueCatchup(LedgerCloseData const& ledgerData);
     void finalizeCatchup(LedgerCloseData const& ledgerData);
+    void logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
+                           size_t numOps);
 
   public:
     LedgerManagerImpl(Application& app);

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1257,17 +1257,21 @@ LedgerTxn::Impl::EntryIteratorImpl::clone() const
 
 // Implementation of LedgerTxnRoot ------------------------------------------
 LedgerTxnRoot::LedgerTxnRoot(Database& db, size_t entryCacheSize,
-                             size_t bestOfferCacheSize)
-    : mImpl(std::make_unique<Impl>(db, entryCacheSize, bestOfferCacheSize))
+                             size_t bestOfferCacheSize,
+                             size_t prefetchBatchSize)
+    : mImpl(std::make_unique<Impl>(db, entryCacheSize, bestOfferCacheSize,
+                                   prefetchBatchSize))
 {
 }
 
 LedgerTxnRoot::Impl::Impl(Database& db, size_t entryCacheSize,
-                          size_t bestOfferCacheSize)
+                          size_t bestOfferCacheSize, size_t prefetchBatchSize)
     : mDatabase(db)
     , mHeader(std::make_unique<LedgerHeader>())
     , mEntryCache(entryCacheSize)
     , mBestOffersCache(bestOfferCacheSize)
+    , mMaxCacheSize(entryCacheSize)
+    , mBulkLoadBatchSize(prefetchBatchSize)
     , mChild(nullptr)
 {
 }
@@ -1442,6 +1446,7 @@ LedgerTxnRoot::Impl::commitChild(EntryIterator iter, LedgerTxnConsistency cons)
     // Clearing the cache does not throw
     mBestOffersCache.clear();
     mEntryCache.clear();
+    mPrefetchMetrics.clear();
 
     // std::unique_ptr<...>::reset does not throw
     mTransaction.reset();
@@ -1558,6 +1563,112 @@ LedgerTxnRoot::dropTrustLines()
     mImpl->dropTrustLines();
 }
 
+uint32_t
+LedgerTxnRoot::prefetch(std::unordered_set<LedgerKey> const& keys)
+{
+    return mImpl->prefetch(keys);
+}
+
+uint32_t
+LedgerTxnRoot::Impl::prefetch(std::unordered_set<LedgerKey> const& keys)
+{
+    uint32_t total = 0;
+
+    std::unordered_set<LedgerKey> accounts;
+    std::unordered_set<LedgerKey> offers;
+    std::unordered_set<LedgerKey> trustlines;
+    std::unordered_set<LedgerKey> data;
+
+    auto cacheResult =
+        [&](std::unordered_map<LedgerKey,
+                               std::shared_ptr<LedgerEntry const>> const& res) {
+            for (auto const& item : res)
+            {
+                putInEntryCache(item.first, item.second, LoadType::PREFETCH);
+                ++total;
+            }
+        };
+
+    auto insertIfNotLoaded = [&](std::unordered_set<LedgerKey>& keys,
+                                 LedgerKey const& key) {
+        if (!mEntryCache.exists(key, false))
+        {
+            keys.insert(key);
+        }
+    };
+
+    for (auto const& key : keys)
+    {
+        if ((static_cast<double>(mEntryCache.size()) / mMaxCacheSize) >=
+            ENTRY_CACHE_FILL_RATIO)
+        {
+            return total;
+        }
+
+        switch (key.type())
+        {
+        case ACCOUNT:
+            insertIfNotLoaded(accounts, key);
+            if (accounts.size() == mBulkLoadBatchSize)
+            {
+                cacheResult(bulkLoadAccounts(accounts));
+                accounts.clear();
+            }
+            break;
+        case OFFER:
+            insertIfNotLoaded(offers, key);
+            if (offers.size() == mBulkLoadBatchSize)
+            {
+                cacheResult(bulkLoadOffers(offers));
+                offers.clear();
+            }
+            break;
+        case TRUSTLINE:
+            insertIfNotLoaded(trustlines, key);
+            if (trustlines.size() == mBulkLoadBatchSize)
+            {
+                cacheResult(bulkLoadTrustLines(trustlines));
+                trustlines.clear();
+            }
+            break;
+        case DATA:
+            insertIfNotLoaded(data, key);
+            if (data.size() == mBulkLoadBatchSize)
+            {
+                cacheResult(bulkLoadData(data));
+                data.clear();
+            }
+            break;
+        }
+    }
+
+    //  Prefetch whatever is remaining
+    cacheResult(bulkLoadAccounts(accounts));
+    cacheResult(bulkLoadOffers(offers));
+    cacheResult(bulkLoadTrustLines(trustlines));
+    cacheResult(bulkLoadData(data));
+
+    return total;
+}
+
+double
+LedgerTxnRoot::getPrefetchHitRate() const
+{
+    return mImpl->getPrefetchHitRate();
+}
+
+double
+LedgerTxnRoot::Impl::getPrefetchHitRate() const
+{
+    auto totalMisses = mEntryCache.getCounters().mMisses;
+    if (totalMisses == 0 && mTotalPrefetchHits == 0)
+    {
+        return 0;
+    }
+    return static_cast<double>(mTotalPrefetchHits) /
+           (totalMisses + mTotalPrefetchHits);
+}
+
 std::unordered_map<LedgerKey, LedgerEntry>
 LedgerTxnRoot::getAllOffers()
 {
@@ -1660,7 +1771,7 @@ LedgerTxnRoot::Impl::getBestOffer(Asset const& buying, Asset const& selling,
 
     if (res)
     {
-        putInEntryCache(getEntryCacheKey(LedgerEntryKey(*res)), res);
+        putInEntryCache(LedgerEntryKey(*res), res, LoadType::IMMEDIATE);
     }
     return res;
 }
@@ -1748,10 +1859,14 @@ LedgerTxnRoot::getNewestVersion(LedgerKey const& key) const
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::getNewestVersion(LedgerKey const& key) const
 {
-    auto cacheKey = getEntryCacheKey(key);
-    if (mEntryCache.exists(cacheKey))
+    if (mEntryCache.exists(key))
     {
-        return getFromEntryCache(cacheKey);
+        return getFromEntryCache(key);
+    }
+    else
+    {
+        auto& metrics = mPrefetchMetrics[key];
+        ++metrics.misses;
     }
 
     std::shared_ptr<LedgerEntry const> entry;
@@ -1787,7 +1902,7 @@ LedgerTxnRoot::Impl::getNewestVersion(LedgerKey const& key) const
                            "LedgerTxnRoot");
     }
 
-    putInEntryCache(cacheKey, entry);
+    putInEntryCache(key, entry, LoadType::IMMEDIATE);
     return entry;
 }
 
@@ -1819,18 +1934,24 @@ LedgerTxnRoot::Impl::rollbackChild()
     mChild = nullptr;
 }
 
-LedgerTxnRoot::Impl::EntryCacheKey
-LedgerTxnRoot::Impl::getEntryCacheKey(LedgerKey const& key) const
-{
-    return binToHex(xdr::xdr_to_opaque(key));
-}
-
 std::shared_ptr<LedgerEntry const>
-LedgerTxnRoot::Impl::getFromEntryCache(EntryCacheKey const& cacheKey) const
+LedgerTxnRoot::Impl::getFromEntryCache(LedgerKey const& key) const
 {
     try
     {
-        return mEntryCache.get(cacheKey);
+        auto cached = mEntryCache.get(key);
+        if (cached.type == LoadType::PREFETCH)
+        {
+            auto metric = mPrefetchMetrics.find(key);
+            if (metric == mPrefetchMetrics.end())
+            {
+                throw std::runtime_error(
+                    "Inconsistent state when retrieving entry from cache");
+            }
+            ++metric->second.hits;
+            ++mTotalPrefetchHits;
+        }
+        return cached.entry;
     }
     catch (...)
     {
@@ -1841,12 +1962,21 @@ LedgerTxnRoot::Impl::getFromEntryCache(EntryCacheKey const& cacheKey) const
 
 void
 LedgerTxnRoot::Impl::putInEntryCache(
-    EntryCacheKey const& cacheKey,
-    std::shared_ptr<LedgerEntry const> const& entry) const
+    LedgerKey const& key, std::shared_ptr<LedgerEntry const> const& entry,
+    LoadType type) const
 {
     try
     {
-        mEntryCache.put(cacheKey, entry);
+        mEntryCache.put(key, {entry, type});
+        if (type == LoadType::PREFETCH)
+        {
+            if (mPrefetchMetrics.find(key) != mPrefetchMetrics.end())
+            {
+                throw std::runtime_error(
+                    "Inconsistent state when putting entry into cache");
+            }
+            mPrefetchMetrics.emplace(key, KeyAccesses{});
+        }
     }
     catch (...)
     {

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -557,8 +557,8 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     std::unique_ptr<Impl> const mImpl;
 
   public:
-    explicit LedgerTxnRoot(Database& db, size_t entryCacheSize = 4096,
-                           size_t bestOfferCacheSize = 64);
+    explicit LedgerTxnRoot(Database& db, size_t entryCacheSize,
+                           size_t bestOfferCacheSize, size_t prefetchBatchSize);
 
     virtual ~LedgerTxnRoot();
 
@@ -602,5 +602,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     void encodeHomeDomainsBase64();
 
     void writeOffersIntoSimplifiedOffersTable();
+    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys);
+    double getPrefetchHitRate() const;
 };
 }

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -16,11 +16,15 @@
 namespace stellar
 {
 
-// Precondition: The keys associated with entries are unique and consitute a
+// Precondition: The keys associated with entries are unique and constitute a
 // subset of keys
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 populateLoadedEntries(std::unordered_set<LedgerKey> const& keys,
                       std::vector<LedgerEntry> const& entries);
+
+// A defensive heuristic to ensure prefetching stops if entry cache is filling
+// up.
+static const double ENTRY_CACHE_FILL_RATIO = 0.5;
 
 class EntryIterator::AbstractImpl
 {
@@ -376,10 +380,25 @@ class LedgerTxn::Impl::EntryIteratorImpl : public EntryIterator::AbstractImpl
 // been lost.
 class LedgerTxnRoot::Impl
 {
-    typedef std::string EntryCacheKey;
-    typedef RandomEvictionCache<EntryCacheKey,
-                                std::shared_ptr<LedgerEntry const>>
-        EntryCache;
+    struct KeyAccesses
+    {
+        uint64_t hits{0};
+        uint64_t misses{0};
+    };
+
+    enum class LoadType
+    {
+        IMMEDIATE,
+        PREFETCH
+    };
+
+    struct CacheEntry
+    {
+        std::shared_ptr<LedgerEntry const> entry;
+        LoadType type;
+    };
+
+    typedef RandomEvictionCache<LedgerKey, CacheEntry> EntryCache;
 
     typedef std::string BestOffersCacheKey;
     struct BestOffersCacheEntry
@@ -394,6 +413,11 @@ class LedgerTxnRoot::Impl
     std::unique_ptr<LedgerHeader> mHeader;
     mutable EntryCache mEntryCache;
     mutable BestOffersCache mBestOffersCache;
+    mutable std::unordered_map<LedgerKey, KeyAccesses> mPrefetchMetrics;
+    mutable uint64_t mTotalPrefetchHits{0};
+
+    size_t mMaxCacheSize;
+    size_t mBulkLoadBatchSize;
     std::unique_ptr<soci::transaction> mTransaction;
     AbstractLedgerTxn* mChild;
 
@@ -447,11 +471,11 @@ class LedgerTxnRoot::Impl
     //  - It is therefore always kept in exact correspondence with the
     //    database for the keyset that it has entries for. It's a precise
     //    image of a subset of the database.
-    EntryCacheKey getEntryCacheKey(LedgerKey const& key) const;
     std::shared_ptr<LedgerEntry const>
-    getFromEntryCache(EntryCacheKey const& key) const;
-    void putInEntryCache(EntryCacheKey const& key,
-                         std::shared_ptr<LedgerEntry const> const& entry) const;
+    getFromEntryCache(LedgerKey const& key) const;
+    void putInEntryCache(LedgerKey const& key,
+                         std::shared_ptr<LedgerEntry const> const& entry,
+                         LoadType type) const;
 
     BestOffersCacheEntry&
     getFromBestOffersCache(Asset const& buying, Asset const& selling,
@@ -468,7 +492,8 @@ class LedgerTxnRoot::Impl
 
   public:
     // Constructor has the strong exception safety guarantee
-    Impl(Database& db, size_t entryCacheSize, size_t bestOfferCacheSize);
+    Impl(Database& db, size_t entryCacheSize, size_t bestOfferCacheSize,
+         size_t prefetchBatchSize);
 
     ~Impl();
 
@@ -562,6 +587,13 @@ class LedgerTxnRoot::Impl
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
     void writeOffersIntoSimplifiedOffersTable();
+
+    // Prefetch some or all of given keys in batches. Note that no prefetching
+    // could occur if the cache is at its fill ratio. Returns number of keys
+    // prefetched.
+    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys);
+
+    double getPrefetchHitRate() const;
 };
 
 #ifdef USE_POSTGRES

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -134,7 +134,8 @@ ApplicationImpl::initialize()
     mBanManager = BanManager::create(*this);
     mStatusManager = std::make_unique<StatusManager>();
     mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
-        *mDatabase, mConfig.ENTRY_CACHE_SIZE, mConfig.BEST_OFFERS_CACHE_SIZE);
+        *mDatabase, mConfig.ENTRY_CACHE_SIZE, mConfig.BEST_OFFERS_CACHE_SIZE,
+        mConfig.PREFETCH_BATCH_SIZE);
 
     BucketListIsConsistentWithDatabase::registerInvariant(*this);
     AccountSubEntriesCountIsValid::registerInvariant(*this);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -96,8 +96,9 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     DATABASE = SecretValue{"sqlite3://:memory:"};
 
-    ENTRY_CACHE_SIZE = 4096;
+    ENTRY_CACHE_SIZE = 100000;
     BEST_OFFERS_CACHE_SIZE = 64;
+    PREFETCH_BATCH_SIZE = 1000;
 }
 
 namespace
@@ -543,6 +544,10 @@ Config::load(std::string const& filename)
             else if (item.first == "BEST_OFFERS_CACHE_SIZE")
             {
                 BEST_OFFERS_CACHE_SIZE = readInt<uint32_t>(item);
+            }
+            else if (item.first == "PREFETCH_BATCH_SIZE")
+            {
+                PREFETCH_BATCH_SIZE = readInt<uint32_t>(item);
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -229,6 +229,12 @@ class Config : public std::enable_shared_from_this<Config>
     size_t ENTRY_CACHE_SIZE;
     size_t BEST_OFFERS_CACHE_SIZE;
 
+    // Data layer prefetcher configuration
+    // - PREFETCH_BATCH_SIZE determines how many records we'll prefetch per
+    // SQL load. Note that it should be significantly smaller than size of
+    // the entry cache
+    size_t PREFETCH_BATCH_SIZE;
+
     Config();
 
     void load(std::string const& filename);

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -105,4 +105,11 @@ CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion)
 
     return true;
 }
+
+void
+CreateAccountOpFrame::insertLedgerKeysToPrefetch(
+    std::unordered_set<LedgerKey>& keys) const
+{
+    keys.emplace(accountKey(mCreateAccount.destination));
+}
 }

--- a/src/transactions/CreateAccountOpFrame.h
+++ b/src/transactions/CreateAccountOpFrame.h
@@ -26,6 +26,8 @@ class CreateAccountOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
+    void insertLedgerKeysToPrefetch(
+        std::unordered_set<LedgerKey>& keys) const override;
 
     static CreateAccountResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ManageBuyOfferOpFrame.cpp
+++ b/src/transactions/ManageBuyOfferOpFrame.cpp
@@ -37,13 +37,13 @@ ManageBuyOfferOpFrame::isVersionSupported(uint32_t protocolVersion) const
 }
 
 bool
-ManageBuyOfferOpFrame::isAmountValid()
+ManageBuyOfferOpFrame::isAmountValid() const
 {
     return mManageBuyOffer.buyAmount >= 0;
 }
 
 bool
-ManageBuyOfferOpFrame::isDeleteOffer()
+ManageBuyOfferOpFrame::isDeleteOffer() const
 {
     return mManageBuyOffer.buyAmount == 0;
 }

--- a/src/transactions/ManageBuyOfferOpFrame.h
+++ b/src/transactions/ManageBuyOfferOpFrame.h
@@ -27,8 +27,8 @@ class ManageBuyOfferOpFrame : public ManageOfferOpFrameBase
     ManageBuyOfferOpFrame(Operation const& op, OperationResult& res,
                           TransactionFrame& parentTx);
 
-    bool isAmountValid() override;
-    bool isDeleteOffer() override;
+    bool isAmountValid() const override;
+    bool isDeleteOffer() const override;
 
     int64_t getOfferBuyingLiabilities() override;
     int64_t getOfferSellingLiabilities() override;

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -96,4 +96,11 @@ ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion)
 
     return true;
 }
+
+void
+ManageDataOpFrame::insertLedgerKeysToPrefetch(
+    std::unordered_set<LedgerKey>& keys) const
+{
+    keys.emplace(dataKey(getSourceID(), mManageData.dataName));
+}
 }

--- a/src/transactions/ManageDataOpFrame.h
+++ b/src/transactions/ManageDataOpFrame.h
@@ -27,6 +27,8 @@ class ManageDataOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
+    void insertLedgerKeysToPrefetch(
+        std::unordered_set<LedgerKey>& keys) const override;
 
     static ManageDataResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -477,4 +477,32 @@ ManageOfferOpFrameBase::doCheckValid(uint32_t ledgerVersion)
 
     return true;
 }
+
+void
+ManageOfferOpFrameBase::insertLedgerKeysToPrefetch(
+    std::unordered_set<LedgerKey>& keys) const
+{
+    if (isDeleteOffer())
+    {
+        return;
+    }
+
+    // Prefetch existing offer
+    if (mOfferID)
+    {
+        keys.emplace(offerKey(getSourceID(), mOfferID));
+    }
+
+    auto addIssuerAndTrustline = [&](Asset const& asset) {
+        if (asset.type() != ASSET_TYPE_NATIVE)
+        {
+            auto issuer = getIssuer(asset);
+            keys.emplace(accountKey(issuer));
+            keys.emplace(trustlineKey(this->getSourceID(), asset));
+        }
+    };
+
+    addIssuerAndTrustline(mSheep);
+    addIssuerAndTrustline(mWheat);
+}
 }

--- a/src/transactions/ManageOfferOpFrameBase.h
+++ b/src/transactions/ManageOfferOpFrameBase.h
@@ -38,6 +38,8 @@ class ManageOfferOpFrameBase : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     bool doApply(AbstractLedgerTxn& lsOuter) override;
+    void insertLedgerKeysToPrefetch(
+        std::unordered_set<LedgerKey>& keys) const override;
 
     virtual bool isAmountValid() = 0;
     virtual bool isDeleteOffer() = 0;

--- a/src/transactions/ManageOfferOpFrameBase.h
+++ b/src/transactions/ManageOfferOpFrameBase.h
@@ -41,8 +41,8 @@ class ManageOfferOpFrameBase : public OperationFrame
     void insertLedgerKeysToPrefetch(
         std::unordered_set<LedgerKey>& keys) const override;
 
-    virtual bool isAmountValid() = 0;
-    virtual bool isDeleteOffer() = 0;
+    virtual bool isAmountValid() const = 0;
+    virtual bool isDeleteOffer() const = 0;
 
     virtual int64_t getOfferBuyingLiabilities() = 0;
     virtual int64_t getOfferSellingLiabilities() = 0;

--- a/src/transactions/ManageSellOfferOpFrame.cpp
+++ b/src/transactions/ManageSellOfferOpFrame.cpp
@@ -46,13 +46,13 @@ ManageSellOfferOpFrame::ManageSellOfferOpFrame(Operation const& op,
 }
 
 bool
-ManageSellOfferOpFrame::isAmountValid()
+ManageSellOfferOpFrame::isAmountValid() const
 {
     return mManageSellOffer.amount >= 0;
 }
 
 bool
-ManageSellOfferOpFrame::isDeleteOffer()
+ManageSellOfferOpFrame::isDeleteOffer() const
 {
     return mManageSellOffer.amount == 0;
 }

--- a/src/transactions/ManageSellOfferOpFrame.h
+++ b/src/transactions/ManageSellOfferOpFrame.h
@@ -27,8 +27,8 @@ class ManageSellOfferOpFrame : public ManageOfferOpFrameBase
     ManageSellOfferOpFrame(Operation const& op, OperationResult& res,
                            TransactionFrame& parentTx, bool passive);
 
-    bool isAmountValid() override;
-    bool isDeleteOffer() override;
+    bool isAmountValid() const override;
+    bool isDeleteOffer() const override;
 
     int64_t getOfferBuyingLiabilities() override;
     int64_t getOfferSellingLiabilities() override;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -218,4 +218,12 @@ OperationFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
 {
     return mParentTx.loadAccount(ltx, header, getSourceID());
 }
+
+void
+OperationFrame::insertLedgerKeysToPrefetch(
+    std::unordered_set<LedgerKey>& keys) const
+{
+    // Do nothing by default
+    return;
+}
 }

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -82,5 +82,8 @@ class OperationFrame
     {
         return mOperation;
     }
+
+    virtual void
+    insertLedgerKeysToPrefetch(std::unordered_set<LedgerKey>& keys) const;
 };
 }

--- a/src/transactions/PathPaymentOpFrame.h
+++ b/src/transactions/PathPaymentOpFrame.h
@@ -25,6 +25,8 @@ class PathPaymentOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
+    void insertLedgerKeysToPrefetch(
+        std::unordered_set<LedgerKey>& keys) const override;
 
     static PathPaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/PaymentOpFrame.h
+++ b/src/transactions/PaymentOpFrame.h
@@ -25,6 +25,8 @@ class PaymentOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
+    void insertLedgerKeysToPrefetch(
+        std::unordered_set<LedgerKey>& keys) const override;
 
     static PaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -15,39 +15,64 @@
 namespace stellar
 {
 
-LedgerTxnEntry
-loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID)
+LedgerKey
+accountKey(AccountID const& accountID)
 {
     LedgerKey key(ACCOUNT);
     key.account().accountID = accountID;
-    return ltx.load(key);
+    return key;
+}
+
+LedgerKey
+trustlineKey(AccountID const& accountID, Asset const& asset)
+{
+    LedgerKey key(TRUSTLINE);
+    key.trustLine().accountID = accountID;
+    key.trustLine().asset = asset;
+    return key;
+}
+
+LedgerKey
+offerKey(AccountID const& sellerID, uint64_t offerID)
+{
+    LedgerKey key(OFFER);
+    key.offer().sellerID = sellerID;
+    key.offer().offerID = offerID;
+    return key;
+}
+
+LedgerKey
+dataKey(AccountID const& accountID, std::string const& dataName)
+{
+    LedgerKey key(DATA);
+    key.data().accountID = accountID;
+    key.data().dataName = dataName;
+    return key;
+}
+
+LedgerTxnEntry
+loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID)
+{
+    return ltx.load(accountKey(accountID));
 }
 
 ConstLedgerTxnEntry
 loadAccountWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID)
 {
-    LedgerKey key(ACCOUNT);
-    key.account().accountID = accountID;
-    return ltx.loadWithoutRecord(key);
+    return ltx.loadWithoutRecord(accountKey(accountID));
 }
 
 LedgerTxnEntry
 loadData(AbstractLedgerTxn& ltx, AccountID const& accountID,
          std::string const& dataName)
 {
-    LedgerKey key(DATA);
-    key.data().accountID = accountID;
-    key.data().dataName = dataName;
-    return ltx.load(key);
+    return ltx.load(dataKey(accountID, dataName));
 }
 
 LedgerTxnEntry
 loadOffer(AbstractLedgerTxn& ltx, AccountID const& sellerID, uint64_t offerID)
 {
-    LedgerKey key(OFFER);
-    key.offer().sellerID = sellerID;
-    key.offer().offerID = offerID;
-    return ltx.load(key);
+    return ltx.load(offerKey(sellerID, offerID));
 }
 
 TrustLineWrapper

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -15,6 +15,12 @@ class AbstractLedgerTxn;
 class LedgerTxnEntry;
 class LedgerTxnHeader;
 class TrustLineWrapper;
+struct LedgerKey;
+
+LedgerKey accountKey(AccountID const& accountID);
+LedgerKey trustlineKey(AccountID const& accountID, Asset const& asset);
+LedgerKey offerKey(AccountID const& sellerID, uint64_t offerID);
+LedgerKey dataKey(AccountID const& accountID, std::string const& dataName);
 
 LedgerTxnEntry loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID);
 


### PR DESCRIPTION
Resolves #1859 

Take 2 at the prefetcher implementation; this one is a much simpler version that avoids any queueing, and simply prefetches a set of unique keys in batches. 

I did some preliminary performance testing, and it looks like on postgres, catchup and applying ledger chain for 2000 ledgers took 175 s with prefetching and 230 without. With 5000 ledgers, same test took 548.59 with prefetching, and 650 s without. 