### PR TITLE
clearer command line deprecation

### DIFF
--- a/src/main/DeprecatedCommandLine.cpp
+++ b/src/main/DeprecatedCommandLine.cpp
@@ -216,7 +216,7 @@ int
 handleDeprecatedCommandLine(int argc, char* const* argv)
 {
     std::cerr << "Using DEPRECATED command-line syntax." << std::endl;
-    std::cerr << "Please refer to documentation for new syntax." << std::endl
+    std::cerr << "For new syntax: stellar-core help" << std::endl
               << std::endl;
 
     std::string cfgFile("stellar-core.cfg");


### PR DESCRIPTION
Editing command line deprecated text
fixes #1964 