### PR TITLE
remove catchup HTTP command

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -112,11 +112,6 @@ format.
 * **help**
   Prints a list of currently supported commands.
 
-* **catchup** 
-  `/catchup?ledger=NNN[&mode=MODE]`<br>
-  Triggers the instance to catch up to ledger NNN from history;
-  Mode is either 'minimal' (the default, if omitted) or 'complete'.
-
 * **checkdb**
   Triggers the instance to perform a background check of the database's state.
 

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -36,7 +36,6 @@ class CommandHandler
     void fileNotFound(std::string const& params, std::string& retStr);
 
     void bans(std::string const& params, std::string& retStr);
-    void catchup(std::string const& params, std::string& retStr);
     void checkdb(std::string const& params, std::string& retStr);
     void connect(std::string const& params, std::string& retStr);
     void dropcursor(std::string const& params, std::string& retStr);


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Resolves #1993

Remove catchup HTTP command that nobody uses. It was broken for a few months and nobody noticed.

Also command-line catchup is now preferred way to do catchups directly from history without connecting to network.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
