### PR TITLE
remove dead peers from database

### DIFF
--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -169,6 +169,7 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short PEER_TIMEOUT;
     unsigned short PEER_STRAGGLER_TIMEOUT;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;
+    static constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 
     // Peers we will always try to stay connected to
     std::vector<std::string> PREFERRED_PEERS;

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -101,6 +101,7 @@ class OverlayManagerImpl : public OverlayManager
     bool addOutboundConnection(Peer::pointer peer) override;
     void removePeer(Peer* peer) override;
     void storeConfigPeers();
+    void purgeDeadPeers();
 
     bool acceptAuthenticatedPeer(Peer::pointer peer) override;
     bool isPreferred(Peer* peer) const override;

--- a/src/overlay/PeerManager.h
+++ b/src/overlay/PeerManager.h
@@ -124,6 +124,13 @@ class PeerManager
                                                  int size);
 
     /**
+     * Remove peers that have at least minNumFailures. Can only remove peer with
+     * given address.
+     */
+    void removePeersWithManyFailures(int minNumFailures,
+                                     PeerBareAddress const* address = nullptr);
+
+    /**
      * Get list of peers to send to peer with given address.
      */
     std::vector<PeerBareAddress> getPeersToSend(int size,

--- a/src/overlay/RandomPeerSource.cpp
+++ b/src/overlay/RandomPeerSource.cpp
@@ -60,8 +60,7 @@ peerTypeToFilter(PeerType peerType)
 PeerQuery
 RandomPeerSource::nextAttemptCutoff(PeerType requireExactType)
 {
-    constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
-    return {true, REALLY_DEAD_NUM_FAILURES_CUTOFF,
+    return {true, Config::REALLY_DEAD_NUM_FAILURES_CUTOFF,
             peerTypeToFilter(requireExactType)};
 }
 

--- a/src/overlay/test/PeerManagerTests.cpp
+++ b/src/overlay/test/PeerManagerTests.cpp
@@ -18,6 +18,12 @@ namespace stellar
 
 using namespace std;
 
+PeerBareAddress
+localhost(unsigned short port)
+{
+    return PeerBareAddress{"127.0.0.1", port};
+}
+
 TEST_CASE("toXdr", "[overlay][PeerManager]")
 {
     VirtualClock clock;
@@ -97,7 +103,7 @@ TEST_CASE("create peer rercord", "[overlay][PeerManager]")
 
     SECTION("zero port")
     {
-        REQUIRE_THROWS_AS(PeerBareAddress("127.0.0.1", 0), std::runtime_error);
+        REQUIRE_THROWS_AS(localhost(0), std::runtime_error);
     }
 
     SECTION("random string") // PeerBareAddress does not validate IP format
@@ -109,7 +115,7 @@ TEST_CASE("create peer rercord", "[overlay][PeerManager]")
 
     SECTION("valid data")
     {
-        auto pa = PeerBareAddress("127.0.0.1", 80);
+        auto pa = localhost(80);
         REQUIRE(pa.getIP() == "127.0.0.1");
         REQUIRE(pa.getPort() == 80);
     }
@@ -276,8 +282,7 @@ TEST_CASE("loadRandomPeers", "[overlay][PeerManager]")
                     PeerRecord{VirtualClock::pointToTm(time), numFailures,
                                static_cast<int>(type)};
                 peerRecords[port] = peerRecord;
-                peerManager.store(PeerBareAddress("127.0.0.1", port),
-                                  peerRecord, false);
+                peerManager.store(localhost(port), peerRecord, false);
                 port++;
             }
         }
@@ -367,23 +372,23 @@ TEST_CASE("getPeersToSend", "[overlay][PeerManager]")
         unsigned short port = 1;
         for (auto i = 0; i < normalInboundCount; i++)
         {
-            peerManager.ensureExists(PeerBareAddress("127.0.0.1", port++));
+            peerManager.ensureExists(localhost(port++));
         }
         for (auto i = 0; i < failedInboundCount; i++)
         {
             peerManager.store(
-                PeerBareAddress("127.0.0.1", port++),
+                localhost(port++),
                 PeerRecord{{}, 11, static_cast<int>(PeerType::INBOUND)}, false);
         }
         for (auto i = 0; i < normalOutboundCount; i++)
         {
-            peerManager.update(PeerBareAddress("127.0.0.1", port++),
+            peerManager.update(localhost(port++),
                                PeerManager::TypeUpdate::SET_OUTBOUND);
         }
         for (auto i = 0; i < failedOutboundCount; i++)
         {
             peerManager.store(
-                PeerBareAddress("127.0.0.1", port++),
+                localhost(port++),
                 PeerRecord{{}, 11, static_cast<int>(PeerType::OUTBOUND)},
                 false);
         }
@@ -486,25 +491,55 @@ TEST_CASE("RandomPeerSource::nextAttemptCutoff also limits maxFailures",
         peerManager, RandomPeerSource::nextAttemptCutoff(PeerType::OUTBOUND)};
 
     auto now = VirtualClock::pointToTm(clock.now());
-    peerManager.store(PeerBareAddress("127.0.0.1", 1),
+    peerManager.store(localhost(1),
                       {now, 0, static_cast<int>(PeerType::INBOUND)}, false);
-    peerManager.store(PeerBareAddress("127.0.0.1", 2),
+    peerManager.store(localhost(2),
                       {now, 0, static_cast<int>(PeerType::OUTBOUND)}, false);
-    peerManager.store(PeerBareAddress("127.0.0.1", 3),
+    peerManager.store(localhost(3),
                       {now, 120, static_cast<int>(PeerType::INBOUND)}, false);
-    peerManager.store(PeerBareAddress("127.0.0.1", 4),
+    peerManager.store(localhost(4),
                       {now, 120, static_cast<int>(PeerType::OUTBOUND)}, false);
-    peerManager.store(PeerBareAddress("127.0.0.1", 5),
+    peerManager.store(localhost(5),
                       {now, 121, static_cast<int>(PeerType::INBOUND)}, false);
-    peerManager.store(PeerBareAddress("127.0.0.1", 6),
+    peerManager.store(localhost(6),
                       {now, 121, static_cast<int>(PeerType::OUTBOUND)}, false);
 
     auto peers = randomPeerSource.getRandomPeers(
         50, [](PeerBareAddress const&) { return true; });
     REQUIRE(peers.size() == 2);
-    REQUIRE(std::find(std::begin(peers), std::end(peers),
-                      PeerBareAddress("127.0.0.1", 2)) != std::end(peers));
-    REQUIRE(std::find(std::begin(peers), std::end(peers),
-                      PeerBareAddress("127.0.0.1", 4)) != std::end(peers));
+    REQUIRE(std::find(std::begin(peers), std::end(peers), localhost(2)) !=
+            std::end(peers));
+    REQUIRE(std::find(std::begin(peers), std::end(peers), localhost(4)) !=
+            std::end(peers));
+}
+
+TEST_CASE("purge peer table", "[overlay][PeerManager]")
+{
+    VirtualClock clock;
+    auto app = createTestApplication(clock, getTestConfig());
+    auto& peerManager = app->getOverlayManager().getPeerManager();
+    auto record = [](int numFailures) {
+        return PeerRecord{{}, numFailures, static_cast<int>(PeerType::INBOUND)};
+    };
+
+    peerManager.store(localhost(1), record(1), false);
+    peerManager.store(localhost(2), record(2), false);
+    peerManager.store(localhost(3), record(3), false);
+    peerManager.store(localhost(4), record(4), false);
+    peerManager.store(localhost(5), record(5), false);
+
+    peerManager.removePeersWithManyFailures(3);
+    REQUIRE(peerManager.load(localhost(1)).second);
+    REQUIRE(peerManager.load(localhost(2)).second);
+    REQUIRE(!peerManager.load(localhost(3)).second);
+    REQUIRE(!peerManager.load(localhost(4)).second);
+    REQUIRE(!peerManager.load(localhost(5)).second);
+
+    auto localhost2 = localhost(2);
+    peerManager.removePeersWithManyFailures(3, &localhost2);
+    REQUIRE(peerManager.load(localhost(2)).second);
+
+    peerManager.removePeersWithManyFailures(2, &localhost2);
+    REQUIRE(!peerManager.load(localhost(2)).second);
 }
 }


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Resolves #1989

This PR gets rid of peers that have numFailures >= 120.
This is done in 2 parts:
1. at start of stellar-core database is purged from peers that have numFailures >= 120 (so the current tables will shrink by 90%)
2. when peer is dropped it removes it from database if numFailures >= 120 (this ensures that when making outbound connection to peer with numFailures = 119, after backoff = 120, it will not get removed until connection try is over)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
