### PR TITLE
overlay: add config param PEER_STRAGGLER_TIMEOUT to control straggler drops

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -117,6 +117,11 @@ PEER_AUTHENTICATION_TIMEOUT=2
 # time when authenticated.
 PEER_TIMEOUT=30
 
+# PEER_STRAGGLER_TIMEOUT (Integer) default 120
+# This server will drop peer that does not drain its outgoing queue during that
+# time when authenticated.
+PEER_STRAGGLER_TIMEOUT=120
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -84,6 +84,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAX_INBOUND_PENDING_CONNECTIONS = 0;
     PEER_AUTHENTICATION_TIMEOUT = 2;
     PEER_TIMEOUT = 30;
+    PEER_STRAGGLER_TIMEOUT = 120;
     PREFERRED_PEERS_ONLY = false;
 
     MINIMUM_IDLE_PERCENT = 0;
@@ -415,6 +416,11 @@ Config::load(std::string const& filename)
             else if (item.first == "PEER_TIMEOUT")
             {
                 PEER_TIMEOUT = readInt<unsigned short>(
+                    item, 1, std::numeric_limits<unsigned short>::max());
+            }
+            else if (item.first == "PEER_STRAGGLER_TIMEOUT")
+            {
+                PEER_STRAGGLER_TIMEOUT = readInt<unsigned short>(
                     item, 1, std::numeric_limits<unsigned short>::max());
             }
             else if (item.first == "PREFERRED_PEERS")

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -167,6 +167,7 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short MAX_OUTBOUND_PENDING_CONNECTIONS;
     unsigned short PEER_AUTHENTICATION_TIMEOUT;
     unsigned short PEER_TIMEOUT;
+    unsigned short PEER_STRAGGLER_TIMEOUT;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;
 
     // Peers we will always try to stay connected to

--- a/src/overlay/LoopbackPeer.h
+++ b/src/overlay/LoopbackPeer.h
@@ -29,6 +29,7 @@ class LoopbackPeer : public Peer
     std::queue<xdr::msg_ptr> mInQueue;  // receiving queue
 
     bool mCorked{false};
+    bool mStraggling{false};
     size_t mMaxQueueDepth{0};
 
     bool mDamageCert{false};
@@ -78,6 +79,9 @@ class LoopbackPeer : public Peer
 
     bool getCorked() const;
     void setCorked(bool c);
+
+    bool getStraggling() const;
+    void setStraggling(bool s);
 
     size_t getMaxQueueDepth() const;
     void setMaxQueueDepth(size_t sz);

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -91,6 +91,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     medida::Meter& mErrorRead;
     medida::Meter& mErrorWrite;
     medida::Meter& mTimeoutIdle;
+    medida::Meter& mTimeoutStraggler;
 
     medida::Timer& mRecvErrorTimer;
     medida::Timer& mRecvHelloTimer;


### PR DESCRIPTION
# Description

This just adds a config param to control slow-peer disconnection behaviour that was introduced (in a hard-coded way) back in f4250142fce723876baf3a95963b727c7b0eb202.

It also increases the default to 120s, which is 4x the idle timeout and ought to be plenty to deal with transient conditions.

The idea here is just to give users a knob they can turn if we find too much disconnection is happening in the field, without having to run an emergency release just to change the default. _Likely_ the default value is fine, but you know: networks.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
