### PR TITLE
bug 1099 - consolidate PRNG use in tests and make seedable.

### DIFF
--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -21,6 +21,7 @@
 #include "main/Config.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/Math.h"
 #include "util/Timer.h"
 #include "xdrpp/autocheck.h"
 
@@ -453,13 +454,12 @@ TEST_CASE("single entry bubbling up", "[bucket][bucketlist][bucketbubble]")
 TEST_CASE("BucketList sizeOf and oldestLedgerIn relations",
           "[bucket][bucketlist][count]")
 {
-    std::default_random_engine gen;
     std::uniform_int_distribution<uint32_t> dist;
     for (uint32_t i = 0; i < 1000; ++i)
     {
         for (uint32_t level = 0; level < BucketList::kNumLevels; ++level)
         {
-            uint32_t ledger = dist(gen);
+            uint32_t ledger = dist(gRandomEngine);
             if (BucketList::sizeOfSnap(ledger, level) > 0)
             {
                 uint32_t oldestInCurr =
@@ -485,7 +485,6 @@ TEST_CASE("BucketList sizeOf and oldestLedgerIn relations",
 
 TEST_CASE("BucketList snap reaches steady state", "[bucket][bucketlist][count]")
 {
-    std::default_random_engine gen;
     // Deliberately exclude deepest level since snap on the deepest level
     // is always empty.
     for (uint32_t level = 0; level < BucketList::kNumLevels - 1; ++level)
@@ -507,8 +506,8 @@ TEST_CASE("BucketList snap reaches steady state", "[bucket][bucketlist][count]")
         std::uniform_int_distribution<uint32_t> distHigh(boundary);
         for (uint32_t i = 0; i < 1000; ++i)
         {
-            uint32_t low = distLow(gen);
-            uint32_t high = distHigh(gen);
+            uint32_t low = distLow(gRandomEngine);
+            uint32_t high = distHigh(gRandomEngine);
             REQUIRE(BucketList::sizeOfSnap(low, level) < half);
             REQUIRE(BucketList::sizeOfSnap(high, level) == half);
         }
@@ -517,7 +516,6 @@ TEST_CASE("BucketList snap reaches steady state", "[bucket][bucketlist][count]")
 
 TEST_CASE("BucketList deepest curr accumulates", "[bucket][bucketlist][count]")
 {
-    std::default_random_engine gen;
     uint32_t const deepest = BucketList::kNumLevels - 1;
     // Use binary search to find the first ledger where the deepest curr
     // first is non-empty.
@@ -530,8 +528,8 @@ TEST_CASE("BucketList deepest curr accumulates", "[bucket][bucketlist][count]")
     std::uniform_int_distribution<uint32_t> distHigh(boundary);
     for (uint32_t i = 0; i < 1000; ++i)
     {
-        uint32_t low = distLow(gen);
-        uint32_t high = distHigh(gen);
+        uint32_t low = distLow(gRandomEngine);
+        uint32_t high = distHigh(gRandomEngine);
         REQUIRE(BucketList::sizeOfCurr(low, deepest) == 0);
         REQUIRE(BucketList::oldestLedgerInCurr(low, deepest) ==
                 std::numeric_limits<uint32_t>::max());

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -22,6 +22,7 @@
 #include "test/test.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include "util/Math.h"
 #include "util/Timer.h"
 #include "xdrpp/autocheck.h"
 
@@ -152,8 +153,6 @@ TEST_CASE("merging bucket entries", "[bucket]")
         auto& bm = app->getBucketManager();
         auto vers = getAppLedgerVersion(app);
 
-        autocheck::generator<bool> flip;
-
         auto checkDeadAnnihilatesLive = [&](LedgerEntryType let) {
             std::string entryType =
                 xdr::xdr_traits<LedgerEntryType>::enum_name(let);
@@ -206,7 +205,7 @@ TEST_CASE("merging bucket entries", "[bucket]")
             for (auto& e : live)
             {
                 e = LedgerTestUtils::generateValidLedgerEntry(10);
-                if (flip())
+                if (rand_flip())
                 {
                     dead.push_back(LedgerEntryKey(e));
                 }
@@ -240,7 +239,7 @@ TEST_CASE("merging bucket entries", "[bucket]")
             size_t liveCount = live.size();
             for (auto& e : live)
             {
-                if (flip())
+                if (rand_flip())
                 {
                     e = LedgerTestUtils::generateValidLedgerEntry(10);
                     ++liveCount;

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -10,6 +10,7 @@
 #include "main/Config.h"
 #include "transactions/SignatureUtils.h"
 #include "util/HashOfHash.h"
+#include "util/Math.h"
 #include "util/RandomEvictionCache.h"
 #include <memory>
 #include <mutex>
@@ -148,6 +149,38 @@ SecretKey::random()
 #endif
     return sk;
 }
+
+#ifdef BUILD_TESTS
+static SecretKey
+pseudoRandomForTestingFromPRNG(std::default_random_engine& engine)
+{
+    std::vector<uint8_t> bytes;
+    for (size_t i = 0; i < crypto_sign_SEEDBYTES; ++i)
+    {
+        bytes.push_back(static_cast<uint8_t>(engine()));
+    }
+    return SecretKey::fromSeed(bytes);
+}
+
+SecretKey
+SecretKey::pseudoRandomForTesting()
+{
+    // Reminder: this is not cryptographic randomness or even particularly hard
+    // to guess PRNG-ness. It's intended for _deterministic_ use, when you want
+    // "slightly random-ish" keys, for test-data generation.
+    return pseudoRandomForTestingFromPRNG(gRandomEngine);
+}
+
+SecretKey
+SecretKey::pseudoRandomForTestingFromSeed(unsigned int seed)
+{
+    // Reminder: this is not cryptographic randomness or even particularly hard
+    // to guess PRNG-ness. It's intended for _deterministic_ use, when you want
+    // "slightly random-ish" keys, for test-data generation.
+    std::default_random_engine tmpEngine(seed);
+    return pseudoRandomForTestingFromPRNG(tmpEngine);
+}
+#endif
 
 SecretKey
 SecretKey::fromSeed(ByteSlice const& seed)

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -58,6 +58,19 @@ class SecretKey
     // Create a new, random secret key.
     static SecretKey random();
 
+#ifdef BUILD_TESTS
+    // Create a new, pseudo-random secret key drawn from the global weak
+    // non-cryptographic PRNG (which itself is seeded from command-line or
+    // deterministically). Do not under any circumstances use this for non-test
+    // key generation.
+    static SecretKey pseudoRandomForTesting();
+
+    // Same as above, but use a function-local PRNG seeded from the
+    // provided number. Again: do not under any circumstances use this
+    // for non-test key generation
+    static SecretKey pseudoRandomForTestingFromSeed(unsigned int seed);
+#endif
+
     // Decode a secret key from a provided StrKey seed value.
     static SecretKey fromStrKeySeed(std::string const& strKeySeed);
     static SecretKey

--- a/src/database/test/DatabaseTests.cpp
+++ b/src/database/test/DatabaseTests.cpp
@@ -11,6 +11,7 @@
 #include "test/TestUtils.h"
 #include "test/test.h"
 #include "util/Logging.h"
+#include "util/Math.h"
 #include "util/Timer.h"
 #include "util/TmpDir.h"
 #include <random>
@@ -252,7 +253,6 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
 {
     Config cfg(getTestConfig(0, Config::TESTDB_POSTGRESQL));
     VirtualClock clock;
-    std::default_random_engine gen;
     std::uniform_int_distribution<uint64_t> dist;
 
     try
@@ -275,7 +275,7 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
                 soci::transaction sqltx(session);
                 for (int64_t j = 0; j < sz; ++j)
                 {
-                    int64_t r = dist(gen);
+                    int64_t r = dist(gRandomEngine);
                     session << "insert into txtest (a,b,c) values (:a,:b,:c)",
                         soci::use(r), soci::use(pk), soci::use(j);
                 }
@@ -294,7 +294,7 @@ TEST_CASE("postgres performance", "[db][pgperf][!hide]")
                 soci::transaction subtx(session);
                 for (int64_t k = 0; k < div; ++k)
                 {
-                    int64_t r = dist(gen);
+                    int64_t r = dist(gRandomEngine);
                     pk++;
                     session << "insert into txtest (a,b,c) values (:a,:b,:c)",
                         soci::use(r), soci::use(pk), soci::use(k);

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -18,6 +18,7 @@
 #include "test/TestUtils.h"
 #include "test/TxTests.h"
 #include "test/test.h"
+#include "util/Math.h"
 #include "util/XDROperators.h"
 #include "work/WorkManager.h"
 
@@ -452,19 +453,19 @@ CatchupSimulation::generateRandomLedger()
     // They all randomly send a little to one another every ledger after #4
     if (ledgerSeq > 4)
     {
-        if (flip())
+        if (rand_flip())
             txSet->add(alice.tx({payment(bob, small)}));
-        if (flip())
+        if (rand_flip())
             txSet->add(alice.tx({payment(carol, small)}));
 
-        if (flip())
+        if (rand_flip())
             txSet->add(bob.tx({payment(alice, small)}));
-        if (flip())
+        if (rand_flip())
             txSet->add(bob.tx({payment(carol, small)}));
 
-        if (flip())
+        if (rand_flip())
             txSet->add(carol.tx({payment(alice, small)}));
-        if (flip())
+        if (rand_flip())
             txSet->add(carol.tx({payment(bob, small)}));
     }
 

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -196,9 +196,6 @@ class CatchupSimulation
     Application& mApp;
     BucketList mBucketListAtLastPublish;
 
-    std::default_random_engine mGenerator;
-    std::bernoulli_distribution mFlip{0.5};
-
     std::vector<LedgerCloseData> mLedgerCloseDatas;
 
     std::vector<uint32_t> mLedgerSeqs;
@@ -267,12 +264,6 @@ class CatchupSimulation
     void crankUntil(Application::pointer app,
                     std::function<bool()> const& predicate,
                     VirtualClock::duration duration);
-
-    bool
-    flip()
-    {
-        return mFlip(mGenerator);
-    }
 };
 }
 }

--- a/src/history/test/InferredQuorumTests.cpp
+++ b/src/history/test/InferredQuorumTests.cpp
@@ -18,10 +18,10 @@ TEST_CASE("InferredQuorum intersection", "[history][inferredquorum]")
 {
     InferredQuorum iq;
 
-    SecretKey skA = SecretKey::random();
-    SecretKey skB = SecretKey::random();
-    SecretKey skC = SecretKey::random();
-    SecretKey skD = SecretKey::random();
+    SecretKey skA = SecretKey::pseudoRandomForTesting();
+    SecretKey skB = SecretKey::pseudoRandomForTesting();
+    SecretKey skC = SecretKey::pseudoRandomForTesting();
+    SecretKey skD = SecretKey::pseudoRandomForTesting();
 
     PublicKey pkA = skA.getPublicKey();
     PublicKey pkB = skB.getPublicKey();
@@ -63,12 +63,12 @@ TEST_CASE("InferredQuorum intersection w subquorums",
 {
     InferredQuorum iq;
 
-    SecretKey skA = SecretKey::random();
-    SecretKey skB = SecretKey::random();
-    SecretKey skC = SecretKey::random();
-    SecretKey skD = SecretKey::random();
-    SecretKey skE = SecretKey::random();
-    SecretKey skF = SecretKey::random();
+    SecretKey skA = SecretKey::pseudoRandomForTesting();
+    SecretKey skB = SecretKey::pseudoRandomForTesting();
+    SecretKey skC = SecretKey::pseudoRandomForTesting();
+    SecretKey skD = SecretKey::pseudoRandomForTesting();
+    SecretKey skE = SecretKey::pseudoRandomForTesting();
+    SecretKey skF = SecretKey::pseudoRandomForTesting();
 
     PublicKey pkA = skA.getPublicKey();
     PublicKey pkB = skB.getPublicKey();
@@ -146,12 +146,12 @@ TEST_CASE("InferredQuorum non intersection", "[history][inferredquorum]")
 {
     InferredQuorum iq;
 
-    SecretKey skA = SecretKey::random();
-    SecretKey skB = SecretKey::random();
-    SecretKey skC = SecretKey::random();
-    SecretKey skD = SecretKey::random();
-    SecretKey skE = SecretKey::random();
-    SecretKey skF = SecretKey::random();
+    SecretKey skA = SecretKey::pseudoRandomForTesting();
+    SecretKey skB = SecretKey::pseudoRandomForTesting();
+    SecretKey skC = SecretKey::pseudoRandomForTesting();
+    SecretKey skD = SecretKey::pseudoRandomForTesting();
+    SecretKey skE = SecretKey::pseudoRandomForTesting();
+    SecretKey skF = SecretKey::pseudoRandomForTesting();
 
     PublicKey pkA = skA.getPublicKey();
     PublicKey pkB = skB.getPublicKey();
@@ -211,12 +211,12 @@ TEST_CASE("InferredQuorum non intersection w subquorums",
 {
     InferredQuorum iq;
 
-    SecretKey skA = SecretKey::random();
-    SecretKey skB = SecretKey::random();
-    SecretKey skC = SecretKey::random();
-    SecretKey skD = SecretKey::random();
-    SecretKey skE = SecretKey::random();
-    SecretKey skF = SecretKey::random();
+    SecretKey skA = SecretKey::pseudoRandomForTesting();
+    SecretKey skB = SecretKey::pseudoRandomForTesting();
+    SecretKey skC = SecretKey::pseudoRandomForTesting();
+    SecretKey skD = SecretKey::pseudoRandomForTesting();
+    SecretKey skE = SecretKey::pseudoRandomForTesting();
+    SecretKey skF = SecretKey::pseudoRandomForTesting();
 
     PublicKey pkA = skA.getPublicKey();
     PublicKey pkB = skB.getPublicKey();

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -224,9 +224,8 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
             }
         }
         // On a coin flip, corrupt header content rather than previous link
-        autocheck::generator<bool> flip;
         if (i == randomIndex &&
-            state == HistoryManager::VERIFY_STATUS_ERR_BAD_HASH && flip())
+            state == HistoryManager::VERIFY_STATUS_ERR_BAD_HASH && rand_flip())
         {
             lh.hash = HashUtils::random();
         }

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -66,7 +66,7 @@ TEST_CASE("Flooding", "[flood][overlay]")
             for (int i = 0; i < nbTx; i++)
             {
                 sources.emplace_back(
-                    TestAccount{*app0, SecretKey::random(), 0});
+                    TestAccount{*app0, SecretKey::pseudoRandomForTesting(), 0});
                 gen.data.account().accountID = sources.back();
 
                 // need to create on all nodes
@@ -133,7 +133,7 @@ TEST_CASE("Flooding", "[flood][overlay]")
         auto injectTransaction = [&](int i) {
             const int64 txAmount = 10000000;
 
-            SecretKey dest = SecretKey::random();
+            SecretKey dest = SecretKey::pseudoRandomForTesting();
 
             // round robin
             auto inApp = nodes[i % nodes.size()];
@@ -210,7 +210,7 @@ TEST_CASE("Flooding", "[flood][overlay]")
         std::unordered_map<PublicKey, SecretKey> keysMap;
         for (int i = 0; i < nbTx; i++)
         {
-            keys.emplace_back(SecretKey::random());
+            keys.emplace_back(SecretKey::pseudoRandomForTesting());
             auto& k = keys.back();
             keysMap.insert(std::make_pair(k.getPublicKey(), k));
         }
@@ -218,7 +218,7 @@ TEST_CASE("Flooding", "[flood][overlay]")
         auto injectSCP = [&](int i) {
             const int64 txAmount = 10000000;
 
-            SecretKey dest = SecretKey::random();
+            SecretKey dest = SecretKey::pseudoRandomForTesting();
 
             // round robin
             auto inApp = nodes[i % nodes.size()];

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -184,7 +184,7 @@ LoopbackPeer::deliverOne()
         // CLOG(TRACE, "Overlay") << "LoopbackPeer dequeued message";
 
         // Possibly duplicate the message and requeue it at the front.
-        if (mDuplicateProb(mGenerator))
+        if (mDuplicateProb(gRandomEngine))
         {
             CLOG(INFO, "Overlay") << "LoopbackPeer duplicated message";
             mOutQueue.emplace_front(duplicateMessage(msg));
@@ -192,7 +192,7 @@ LoopbackPeer::deliverOne()
         }
 
         // Possibly requeue it at the back and return, reordering.
-        if (mReorderProb(mGenerator) && mOutQueue.size() > 0)
+        if (mReorderProb(gRandomEngine) && mOutQueue.size() > 0)
         {
             CLOG(INFO, "Overlay") << "LoopbackPeer reordered message";
             mStats.messagesReordered++;
@@ -201,15 +201,15 @@ LoopbackPeer::deliverOne()
         }
 
         // Possibly flip some bits in the message.
-        if (mDamageProb(mGenerator))
+        if (mDamageProb(gRandomEngine))
         {
             CLOG(INFO, "Overlay") << "LoopbackPeer damaged message";
-            if (damageMessage(mGenerator, msg))
+            if (damageMessage(gRandomEngine, msg))
                 mStats.messagesDamaged++;
         }
 
         // Possibly just drop the message on the floor.
-        if (mDropProb(mGenerator))
+        if (mDropProb(gRandomEngine))
         {
             CLOG(INFO, "Overlay") << "LoopbackPeer dropped message";
             mStats.messagesDropped++;

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -34,7 +34,6 @@ class LoopbackPeer : public Peer
 
     bool mDamageCert{false};
     bool mDamageAuth{false};
-    std::default_random_engine mGenerator;
     std::bernoulli_distribution mDuplicateProb{0.0};
     std::bernoulli_distribution mReorderProb{0.0};
     std::bernoulli_distribution mDamageProb{0.0};

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -35,7 +35,7 @@ class PeerStub : public Peer
     PeerStub(Application& app, PeerBareAddress const& addres)
         : Peer(app, WE_CALLED_REMOTE)
     {
-        mPeerID = SecretKey::random().getPublicKey();
+        mPeerID = SecretKey::pseudoRandomForTesting().getPublicKey();
         mState = GOT_AUTH;
         mAddress = addres;
     }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -13,6 +13,7 @@
 #include "test.h"
 #include "test/TestUtils.h"
 #include "util/Logging.h"
+#include "util/Math.h"
 #include "util/TmpDir.h"
 
 #include <cstdlib>
@@ -42,6 +43,39 @@ SimpleTestReporter::~SimpleTestReporter()
 
 namespace stellar
 {
+
+// We use a Catch event-listener to re-seed all the PRNGs we know about on every
+// test, to minimize nondeterministic bleed from one test to the next.
+struct ReseedPRNGListener : Catch::TestEventListenerBase
+{
+    using TestEventListenerBase::TestEventListenerBase;
+    static unsigned int sCommandLineSeed;
+    static void
+    reseed()
+    {
+        if (sCommandLineSeed == 0)
+        {
+            srand(1);
+            gRandomEngine.seed(gRandomEngine.default_seed);
+            Catch::rng().seed(Catch::rng().default_seed);
+        }
+        else
+        {
+            srand(sCommandLineSeed);
+            gRandomEngine.seed(sCommandLineSeed);
+            Catch::rng().seed(sCommandLineSeed);
+        }
+    }
+    virtual void
+    testCaseStarting(Catch::TestCaseInfo const& testInfo) override
+    {
+        reseed();
+    }
+};
+
+unsigned int ReseedPRNGListener::sCommandLineSeed = 0;
+
+CATCH_REGISTER_LISTENER(ReseedPRNGListener)
 
 static std::vector<std::string> gTestMetrics;
 static std::vector<std::unique_ptr<Config>> gTestCfg[Config::TESTDB_MODES];
@@ -107,8 +141,18 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
             DEFAULT_PEER_PORT + instanceNumber * 2 + 1);
 
         // We set a secret key by default as FORCE_SCP is true by
-        // default and we do need a NODE_SEED to start a new network
-        thisConfig.NODE_SEED = SecretKey::random();
+        // default and we do need a NODE_SEED to start a new network.
+        //
+        // Because test configs are built lazily and cached / persist across
+        // tests, we do _not_ use the reset-per-test global PRNG to derive their
+        // secret keys (this would produce inter-test coupling, including
+        // collisions). Instead we derive each from command-line seed and test
+        // config instance number, and try to avoid zero, one, or other default
+        // seeds the global PRNG might have been seeded with by default (which
+        // could thereby collide).
+        thisConfig.NODE_SEED = SecretKey::pseudoRandomForTestingFromSeed(
+            0xFFFF0000 +
+            (instanceNumber ^ ReseedPRNGListener::sCommandLineSeed));
         thisConfig.NODE_IS_VALIDATOR = true;
 
         // single node setup
@@ -177,7 +221,8 @@ test(int argc, char* const* argv, el::Level ll,
     auto r = session.applyCommandLine(argc, argv);
     if (r != 0)
         return r;
-
+    ReseedPRNGListener::sCommandLineSeed = session.configData().rngSeed;
+    ReseedPRNGListener::reseed();
     if (gVersionsToTest.empty())
     {
         gVersionsToTest.emplace_back(Config::CURRENT_LEDGER_PROTOCOL_VERSION);
@@ -185,6 +230,11 @@ test(int argc, char* const* argv, el::Level ll,
     r = session.run();
     gTestRoots.clear();
     gTestCfg->clear();
+    if (r != 0 && ReseedPRNGListener::sCommandLineSeed != 0)
+    {
+        LOG(FATAL) << "Nonzero test result with --rng-seed "
+                   << ReseedPRNGListener::sCommandLineSeed;
+    }
     return r;
 }
 
@@ -243,6 +293,7 @@ runTest(CommandLineArgs const& args)
     Config const& cfg = getTestConfig();
     Logging::setLoggingToFile(cfg.LOG_FILE_PATH);
     Logging::setLogLevel(logLevel, nullptr);
+    auto seed = session.configData().rngSeed;
 
     LOG(INFO) << "Testing stellar-core " << STELLAR_CORE_VERSION;
     LOG(INFO) << "Logging to " << cfg.LOG_FILE_PATH;
@@ -251,10 +302,18 @@ runTest(CommandLineArgs const& args)
     {
         gVersionsToTest.emplace_back(Config::CURRENT_LEDGER_PROTOCOL_VERSION);
     }
+    if (seed != 0)
+    {
+        stellar::gRandomEngine.seed(seed);
+    }
 
     auto r = session.run();
     gTestRoots.clear();
     gTestCfg->clear();
+    if (r != 0 && seed != 0)
+    {
+        LOG(FATAL) << "Nonzero test result with --rng-seed " << seed;
+    }
     return r;
 }
 


### PR DESCRIPTION
# Description

This switches all uses of PRNGs in testing to the single global PRNG and adds support for manual seeding on the command-line. Additionally it reports the seed at the end of a run that ends in failure, so that you can run tests in a shell while-loop passing random seeds and it will conveniently break on the first nondeterministic failure. Should help shake out tests that are only passing due to lucky configuration of the (currently default-seeded) PRNGs.

Resolves #1099 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
