### PR TITLE
bucket: log one-time apply-rate when doing a direct bucket-apply.

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -110,6 +110,7 @@ Bucket::apply(Application& app) const
     {
         applicator.advance(counters);
     }
+    counters.logInfo("direct", 0, std::chrono::system_clock::now());
 }
 
 std::vector<BucketEntry>


### PR DESCRIPTION
# Description

Tiny change to report useful apply-rate stats when doing a direct Bucket::apply. This is only called in tests and a bulk-load utility path that's there pretty much just for perf measurement.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
