### PR TITLE
Configurable count of worker threads

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -517,6 +517,7 @@ exit /b 0
     <ClCompile Include="..\..\src\util\test\TimerTests.cpp" />
     <ClCompile Include="..\..\src\util\test\Uint128Tests.cpp" />
     <ClCompile Include="..\..\src\util\test\XDRStreamTests.cpp" />
+    <ClCompile Include="..\..\src\util\Thread.cpp" />
     <ClCompile Include="..\..\src\util\TmpDir.cpp" />
     <ClCompile Include="..\..\src\util\Timer.cpp" />
     <ClCompile Include="..\..\src\util\types.cpp" />
@@ -740,6 +741,7 @@ exit /b 0
     <ClInclude Include="..\..\src\util\SecretValue.h" />
     <ClInclude Include="..\..\src\util\SociNoWarnings.h" />
     <ClInclude Include="..\..\src\util\StatusManager.h" />
+    <ClInclude Include="..\..\src\util\Thread.h" />
     <ClInclude Include="..\..\src\util\TmpDir.h" />
     <ClInclude Include="..\..\src\util\Timer.h" />
     <ClInclude Include="..\..\src\util\types.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -903,6 +903,9 @@
     <ClCompile Include="..\..\src\test\TxTests.cpp">
       <Filter>test</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\Thread.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\overlay\Floodgate.h">
@@ -1558,6 +1561,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\TxTests.h">
       <Filter>test</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\Thread.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -240,6 +240,11 @@ CATCHUP_COMPLETE=false
 # new history
 CATCHUP_RECENT=1024
 
+# WORKER_THREADS (integer) default 10
+# Number of threads available for doing long durations jobs, like bucket
+# merging and vertification.
+WORKER_THREADS=10
+
 # MAX_CONCURRENT_SUBPROCESSES (integer) default 16
 # History catchup can potentialy spawn a bunch of sub-processes.
 # This limits the number that will be active at a time.

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -255,7 +255,7 @@ TEST_CASE("bucket list", "[bucket]")
         autocheck::generator<std::vector<LedgerKey>> deadGen;
         CLOG(DEBUG, "Bucket") << "Adding batches to bucket list";
         for (uint32_t i = 1;
-             !app->getClock().getIOService().stopped() && i < 130; ++i)
+             !app->getClock().getIOContext().stopped() && i < 130; ++i)
         {
             app->getClock().crank(false);
             bl.addBatch(*app, i, LedgerTestUtils::generateValidLedgerEntries(8),
@@ -298,7 +298,7 @@ TEST_CASE("bucket list shadowing", "[bucket]")
     autocheck::generator<std::vector<LedgerKey>> deadGen;
     CLOG(DEBUG, "Bucket") << "Adding batches to bucket list";
 
-    for (uint32_t i = 1; !app->getClock().getIOService().stopped() && i < 1200;
+    for (uint32_t i = 1; !app->getClock().getIOContext().stopped() && i < 1200;
          ++i)
     {
         app->getClock().crank(false);
@@ -368,7 +368,7 @@ TEST_CASE("duplicate bucket entries", "[bucket]")
         CLOG(DEBUG, "Bucket")
             << "Adding batches with duplicates to bucket list";
         for (uint32_t i = 1;
-             !app->getClock().getIOService().stopped() && i < 130; ++i)
+             !app->getClock().getIOContext().stopped() && i < 130; ++i)
         {
             auto liveBatch = LedgerTestUtils::generateValidLedgerEntries(8);
             auto doubleLiveBatch = liveBatch;
@@ -721,7 +721,7 @@ TEST_CASE("single entry bubbling up", "[bucket][bucketbubble]")
 
         CLOG(DEBUG, "Bucket") << "Adding empty batches to bucket list";
         for (uint32_t i = 2;
-             !app->getClock().getIOService().stopped() && i < 300; ++i)
+             !app->getClock().getIOContext().stopped() && i < 300; ++i)
         {
             app->getClock().crank(false);
             bl.addBatch(*app, i, emptySetEntry, emptySet);

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -337,7 +337,7 @@ TEST_CASE("Work batching", "[batching]")
 
     auto verify = wm.addWork<TestBatchWork>("test-batch");
     wm.advanceChildren();
-    while (!clock.getIOService().stopped() && !wm.allChildrenDone())
+    while (!clock.getIOContext().stopped() && !wm.allChildrenDone())
     {
         clock.crank(true);
         REQUIRE(verify->getChildren().size() <=

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -171,7 +171,7 @@ TestBucketGenerator::generateBucket(TestBucketState state)
             mkdir->advance();
         }
 
-        while (!mApp.getClock().getIOService().stopped() &&
+        while (!mApp.getClock().getIOContext().stopped() &&
                !wm.allChildrenDone())
         {
             mApp.getClock().crank(true);
@@ -674,7 +674,7 @@ CatchupSimulation::catchupApplication(uint32_t initLedger, uint32_t count,
 
     uint32_t lastLedger = lm.getLastClosedLedgerNum();
 
-    REQUIRE(!app2->getClock().getIOService().stopped());
+    REQUIRE(!app2->getClock().getIOContext().stopped());
     crankUntil(
         app2,
         [&]() {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -100,7 +100,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
         }
     });
 
-    unsigned t = std::thread::hardware_concurrency();
+    auto t = mConfig.WORKER_THREADS;
     LOG(DEBUG) << "Application constructing "
                << "(worker threads: " << t << ")";
     while (t--)

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -178,7 +178,6 @@ class ApplicationImpl : public Application
     Hash mNetworkID;
 
     void shutdownMainIOContext();
-    void runWorkerThread(unsigned i);
 
     void enableInvariantsFromConfig();
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -70,7 +70,7 @@ class ApplicationImpl : public Application
     virtual BanManager& getBanManager() override;
     virtual StatusManager& getStatusManager() override;
 
-    virtual asio::io_service& getWorkerIOService() override;
+    virtual asio::io_context& getWorkerIOContext() override;
     virtual void postOnMainThread(std::function<void()>&& f,
                                   std::string jobName) override;
     virtual void postOnMainThreadWithDelay(std::function<void()>&& f,
@@ -82,14 +82,14 @@ class ApplicationImpl : public Application
 
     virtual void start() override;
 
-    // Stops the worker io_service, which should cause the threads to exit once
+    // Stops the worker io_context, which should cause the threads to exit once
     // they finish running any work-in-progress. If you want a more abrupt exit
     // than this, call exit() and hope for the best.
     virtual void gracefulStop() override;
 
     // Wait-on and join all the threads this application started; should only
     // return when there is no more work to do or someone has force-stopped the
-    // worker io_service. Application can be safely destroyed after this
+    // worker io_context. Application can be safely destroyed after this
     // returns.
     virtual void joinAllThreads() override;
 
@@ -124,7 +124,7 @@ class ApplicationImpl : public Application
     VirtualClock& mVirtualClock;
     Config mConfig;
 
-    // NB: The io_service should come first, then the 'manager' sub-objects,
+    // NB: The io_context should come first, then the 'manager' sub-objects,
     // then the threads. Do not reorder these fields.
     //
     // The fields must be constructed in this order, because the subsystem
@@ -135,8 +135,8 @@ class ApplicationImpl : public Application
     // threads must be joined and destroyed before we start tearing down
     // subsystems.
 
-    asio::io_service mWorkerIOService;
-    std::unique_ptr<asio::io_service::work> mWork;
+    asio::io_context mWorkerIOContext;
+    std::unique_ptr<asio::io_context::work> mWork;
 
     std::unique_ptr<Database> mDatabase;
     std::unique_ptr<OverlayManager> mOverlayManager;
@@ -177,7 +177,7 @@ class ApplicationImpl : public Application
 
     Hash mNetworkID;
 
-    void shutdownMainIOService();
+    void shutdownMainIOContext();
     void runWorkerThread(unsigned i);
 
     void enableInvariantsFromConfig();

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -87,8 +87,8 @@ runWithConfig(Config cfg)
         LOG(FATAL) << "Got an exception: " << e.what();
         return 1;
     }
-    auto& io = clock.getIOService();
-    asio::io_service::work mainWork(io);
+    auto& io = clock.getIOContext();
+    asio::io_context::work mainWork(io);
     while (!io.stopped())
     {
         clock.crank();
@@ -350,9 +350,9 @@ catchup(Application::pointer app, CatchupConfiguration cc,
     }
 
     auto& clock = app->getClock();
-    auto& io = clock.getIOService();
+    auto& io = clock.getIOContext();
     auto synced = false;
-    asio::io_service::work mainWork(io);
+    asio::io_context::work mainWork(io);
     auto done = false;
     while (!done && clock.crank(true))
     {
@@ -420,8 +420,8 @@ publish(Application::pointer app)
     app->start();
 
     auto& clock = app->getClock();
-    auto& io = clock.getIOService();
-    asio::io_service::work mainWork(io);
+    auto& io = clock.getIOContext();
+    asio::io_context::work mainWork(io);
 
     auto lcl = app->getLedgerManager().getLastClosedLedgerNum();
     auto isCheckpoint =

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -59,13 +59,13 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
         int httpMaxClient = mApp.getConfig().HTTP_MAX_CLIENT;
 
         mServer = std::make_unique<http::server::server>(
-            app.getClock().getIOService(), ipStr, mApp.getConfig().HTTP_PORT,
+            app.getClock().getIOContext(), ipStr, mApp.getConfig().HTTP_PORT,
             httpMaxClient);
     }
     else
     {
         mServer = std::make_unique<http::server::server>(
-            app.getClock().getIOService());
+            app.getClock().getIOContext());
     }
 
     mServer->add404(std::bind(&CommandHandler::fileNotFound, this, _1, _2));

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -89,6 +89,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     MINIMUM_IDLE_PERCENT = 0;
 
+    WORKER_THREADS = 10;
     MAX_CONCURRENT_SUBPROCESSES = 16;
     NODE_IS_VALIDATOR = false;
 
@@ -462,10 +463,13 @@ Config::load(std::string const& filename)
             {
                 COMMANDS = readStringArray(item);
             }
+            else if (item.first == "WORKER_THREADS")
+            {
+                WORKER_THREADS = readInt<int>(item, 1, 1000);
+            }
             else if (item.first == "MAX_CONCURRENT_SUBPROCESSES")
             {
-                MAX_CONCURRENT_SUBPROCESSES =
-                    static_cast<size_t>(readInt<int>(item, 1));
+                MAX_CONCURRENT_SUBPROCESSES = readInt<int>(item, 1);
             }
             else if (item.first == "MINIMUM_IDLE_PERCENT")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -188,8 +188,11 @@ class Config : public std::enable_shared_from_this<Config>
     // totally insensitive to overloading.
     uint32_t MINIMUM_IDLE_PERCENT;
 
+    // thread-management config
+    int WORKER_THREADS;
+
     // process-management config
-    size_t MAX_CONCURRENT_SUBPROCESSES;
+    int MAX_CONCURRENT_SUBPROCESSES;
 
     // SCP config
     SecretKey NODE_SEED;

--- a/src/overlay/PeerBareAddress.cpp
+++ b/src/overlay/PeerBareAddress.cpp
@@ -70,7 +70,7 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
         toResolve = m[2].str();
     }
 
-    asio::ip::tcp::resolver resolver(app.getWorkerIOService());
+    asio::ip::tcp::resolver resolver(app.getWorkerIOContext());
     asio::ip::tcp::resolver::query query(toResolve, "", resolveflags);
 
     asio::error_code ec;

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -18,7 +18,7 @@ using asio::ip::tcp;
 using namespace std;
 
 PeerDoor::PeerDoor(Application& app)
-    : mApp(app), mAcceptor(mApp.getClock().getIOService())
+    : mApp(app), mAcceptor(mApp.getClock().getIOContext())
 {
 }
 
@@ -58,7 +58,7 @@ PeerDoor::acceptNextPeer()
 
     CLOG(DEBUG, "Overlay") << "PeerDoor acceptNextPeer()";
     auto sock =
-        make_shared<TCPPeer::SocketType>(mApp.getClock().getIOService());
+        make_shared<TCPPeer::SocketType>(mApp.getClock().getIOContext());
     mAcceptor.async_accept(sock->next_layer(),
                            [this, sock](asio::error_code const& ec) {
                                if (ec)

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -41,7 +41,7 @@ TCPPeer::initiate(Application& app, PeerBareAddress const& address)
     CLOG(DEBUG, "Overlay") << "TCPPeer:initiate"
                            << " to " << address.toString();
     assertThreadIsMain();
-    auto socket = make_shared<SocketType>(app.getClock().getIOService());
+    auto socket = make_shared<SocketType>(app.getClock().getIOContext());
     auto result = make_shared<TCPPeer>(app, WE_CALLED_REMOTE, socket);
     result->mAddress = address;
     result->startIdleTimer();

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -221,7 +221,7 @@ LoopbackPeer::deliverOne()
 
         // Pass ownership of a serialized XDR message buffer to a recvMesage
         // callback event against the remote Peer, posted on the remote
-        // Peer's io_service.
+        // Peer's io_context.
         auto remote = mRemote.lock();
         if (remote)
         {

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -15,7 +15,7 @@ Another peer out there that we are connected to
 namespace stellar
 {
 // [testing] Peer that communicates via byte-buffer delivery events queued in
-// in-process io_services.
+// in-process io_contexts.
 //
 // NB: Do not construct one of these directly; instead, construct a connected
 // pair of them wrapped in a LoopbackPeerConnection that explicitly manages the

--- a/src/process/ProcessManager.h
+++ b/src/process/ProcessManager.h
@@ -36,7 +36,7 @@ class ProcessExitEvent
     std::shared_ptr<RealTimer> mTimer;
     std::shared_ptr<Impl> mImpl;
     std::shared_ptr<asio::error_code> mEc;
-    ProcessExitEvent(asio::io_service& io_service);
+    ProcessExitEvent(asio::io_context& io_context);
     friend class ProcessManagerImpl;
 
   public:

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -26,7 +26,7 @@ class ProcessManagerImpl : public ProcessManager
 
     bool mIsShutdown{false};
     size_t mMaxProcesses;
-    asio::io_service& mIOService;
+    asio::io_context& mIOContext;
 
     std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mPendingImpls;
     std::deque<std::shared_ptr<ProcessExitEvent::Impl>> mKillableImpls;

--- a/src/process/test/ProcessTests.cpp
+++ b/src/process/test/ProcessTests.cpp
@@ -38,7 +38,7 @@ TEST_CASE("subprocess", "[process]")
         exited = true;
     });
 
-    while (!exited && !clock.getIOService().stopped())
+    while (!exited && !clock.getIOContext().stopped())
     {
         clock.crank(true);
     }
@@ -63,7 +63,7 @@ TEST_CASE("subprocess fails", "[process]")
         exited = true;
     });
 
-    while (!exited && !clock.getIOService().stopped())
+    while (!exited && !clock.getIOContext().stopped())
     {
         clock.crank(true);
     }
@@ -88,7 +88,7 @@ TEST_CASE("subprocess redirect to file", "[process]")
         exited = true;
     });
 
-    while (!exited && !clock.getIOService().stopped())
+    while (!exited && !clock.getIOContext().stopped())
     {
         clock.crank(true);
     }
@@ -138,7 +138,7 @@ TEST_CASE("subprocess storm", "[process]")
     }
 
     size_t last = 0;
-    while (completed < n && !clock.getIOService().stopped())
+    while (completed < n && !clock.getIOContext().stopped())
     {
         clock.crank(false);
         size_t n2 = app.getProcessManager().getNumRunningProcesses();
@@ -196,7 +196,7 @@ TEST_CASE("shutdown while process running", "[process]")
     app1->getProcessManager().shutdown();
     app2->getProcessManager().shutdown();
 
-    while (exitedCount < events.size() && !clock.getIOService().stopped())
+    while (exitedCount < events.size() && !clock.getIOContext().stopped())
     {
         clock.crank(true);
     }

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -405,8 +405,8 @@ TEST_CASE("Auto calibrated single node load test", "[autoload][!hide]")
     auto appPtr = newLoadTestApp(clock);
     // Create accounts
     appPtr->generateLoad(true, 100000, 0, 0, 10, 3, true);
-    auto& io = clock.getIOService();
-    asio::io_service::work mainWork(io);
+    auto& io = clock.getIOContext();
+    asio::io_context::work mainWork(io);
     auto& complete =
         appPtr->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
     while (!io.stopped() && complete.count() == 0)
@@ -503,8 +503,8 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
     auto& complete =
         appPtr->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
 
-    auto& io = clock.getIOService();
-    asio::io_service::work mainWork(io);
+    auto& io = clock.getIOContext();
+    asio::io_context::work mainWork(io);
     while (!io.stopped() && complete.count() == 0)
     {
         clock.crank();
@@ -648,7 +648,7 @@ TEST_CASE("Bucket list entries vs write throughput", "[scalability][!hide]")
                      "mergelatencymax", "mergelatencymean"});
 
     for (uint32_t i = 1;
-         !app->getClock().getIOService().stopped() && i < 0x200000; ++i)
+         !app->getClock().getIOContext().stopped() && i < 0x200000; ++i)
     {
         app->getClock().crank(false);
         app->getBucketManager().addBatch(

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -48,8 +48,8 @@ Simulation::~Simulation()
     mNodes.clear();
 
     // tear down main app/clock
-    mClock.getIOService().poll_one();
-    mClock.getIOService().stop();
+    mClock.getIOContext().poll_one();
+    mClock.getIOContext().stop();
     while (mClock.cancelAllEvents())
         ;
 }
@@ -338,7 +338,7 @@ Simulation::crankAllNodes(int nbTicks)
         // work was performed
         // or we've triggered the next scheduled event
 
-        if (mClock.getIOService().stopped())
+        if (mClock.getIOContext().stopped())
         {
             return 0;
         }
@@ -366,7 +366,7 @@ Simulation::crankAllNodes(int nbTicks)
             for (auto& p : mNodes)
             {
                 auto clock = p.second.mClock;
-                if (clock->getIOService().stopped())
+                if (clock->getIOContext().stopped())
                 {
                     continue;
                 }

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -143,36 +143,6 @@ findfiles(std::string const& p,
     return res;
 }
 
-long
-getCurrentPid()
-{
-    return static_cast<long>(GetCurrentProcessId());
-}
-
-bool
-processExists(long pid)
-{
-    std::vector<DWORD> buffer(4096);
-    DWORD bytesWritten;
-    for (;;)
-    {
-        if (!EnumProcesses(buffer.data(),
-                           static_cast<DWORD>(buffer.size() * sizeof(DWORD)),
-                           &bytesWritten))
-        {
-            throw std::runtime_error("EnumProcess failed");
-        }
-        if (bytesWritten / sizeof(DWORD) < buffer.size())
-        {
-            auto found = std::find(buffer.begin(), buffer.end(),
-                                   static_cast<DWORD>(pid));
-            return !(found == buffer.end());
-        }
-        // Need a larger buffer to hold all the ids.
-        buffer.resize(buffer.size() * 2);
-    }
-}
-
 #else
 #include <cerrno>
 #include <fcntl.h>
@@ -326,18 +296,6 @@ findfiles(std::string const& path,
         closedir(dir);
         throw;
     }
-}
-
-long
-getCurrentPid()
-{
-    return static_cast<long>(getpid());
-}
-
-bool
-processExists(long pid)
-{
-    return (kill(pid, 0) == 0);
 }
 
 #endif

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -14,14 +14,6 @@ namespace fs
 {
 
 ////
-// Utility for manipulating process ids
-////
-
-long getCurrentPid();
-
-bool processExists(long pid);
-
-////
 // Utility functions for operating on the filesystem.
 ////
 

--- a/src/util/Thread.cpp
+++ b/src/util/Thread.cpp
@@ -1,0 +1,62 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/Thread.h"
+#include "util/Logging.h"
+
+#ifdef _WIN32
+#else
+#include <unistd.h>
+#endif
+
+namespace stellar
+{
+
+#if defined(_WIN32)
+
+void
+runCurrentThreadWithLowPriority()
+{
+    auto native = std::this_thread::get_id();
+    auto ret = SetThreadPriority(native, THREAD_PRIORITY_BELOW_NORMAL);
+
+    if (!ret)
+    {
+        CLOG(DEBUG, "Fs") << "Unable to set priority for thread: " << ret;
+    }
+}
+
+#elif defined(__linux__)
+
+void
+runCurrentThreadWithLowPriority()
+{
+    constexpr auto const LOW_PRIORITY_NICE = 5;
+
+    auto newNice = nice(LOW_PRIORITY_NICE);
+    if (newNice != LOW_PRIORITY_NICE)
+    {
+        CLOG(DEBUG, "Fs") << "Unable to run worker thread with low priority. "
+                             "Normal priority will be used.";
+    }
+}
+
+#elif defined(__APPLE__)
+
+void
+runCurrentThreadWithLowPriority()
+{
+    // probably can use thread_policy_set with THREAD_PRECEDENCE_POLICY to get
+    // desired effect
+}
+
+#else
+
+void
+runCurrentThreadWithLowPriority()
+{
+}
+
+#endif
+}

--- a/src/util/Thread.h
+++ b/src/util/Thread.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <thread>
+
+namespace stellar
+{
+
+void runCurrentThreadWithLowPriority();
+}

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -104,7 +104,7 @@ class VirtualClock
     };
 
   private:
-    asio::io_service mIOService;
+    asio::io_context mIOContext;
     Mode mMode;
 
     uint32_t mRecentCrankCount;
@@ -145,7 +145,7 @@ class VirtualClock
     void noteCrankOccurred(bool hadIdle);
     uint32_t recentIdleCrankPercent() const;
     void resetIdleCrankPercent();
-    asio::io_service& getIOService();
+    asio::io_context& getIOContext();
 
     // Note: this is not a static method, which means that VirtualClock is
     // not an implementation of the C++ `Clock` concept; there is no global
@@ -226,7 +226,7 @@ class VirtualTimer : private NonMovableOrCopyable
 class RealTimer : public asio::basic_waitable_timer<std::chrono::system_clock>
 {
   public:
-    RealTimer(asio::io_service& io)
+    RealTimer(asio::io_context& io)
         : asio::basic_waitable_timer<std::chrono::system_clock>(io)
     {
     }

--- a/src/work/WorkManager.h
+++ b/src/work/WorkManager.h
@@ -34,7 +34,7 @@ class WorkManager : public WorkParent
         auto work = addWork<T>(std::forward<Args>(args)...);
         auto& clock = mApp.getClock();
         advanceChildren();
-        while (!clock.getIOService().stopped() && !allChildrenDone())
+        while (!clock.getIOContext().stopped() && !allChildrenDone())
         {
             clock.crank(true);
         }


### PR DESCRIPTION
# Description

Should help with #1764

Increase number of worker threads, make them configurable and lower priority. Should help with starting multiple merges at the same time.

Also replace deprecated asio API with new one.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
