### PR TITLE
overlay: strongly bias the straggler test random walk, so it should always pass.

### DIFF
--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -64,15 +64,25 @@ LoopbackPeer::sendMessage(xdr::msg_ptr&& msg)
     // Possibly flush some queued messages if queue's full.
     while (mOutQueue.size() > mMaxQueueDepth && !mCorked)
     {
-        // If our recipient is straggling, we will break off sending 50% of the
+        // If our recipient is straggling, we will break off sending 75% of the
         // time even when we have more things to send, causing the outbound
         // queue to back up gradually.
         auto remote = mRemote.lock();
-        if (remote && remote->getStraggling() && rand_flip())
+        if (remote && remote->getStraggling())
         {
-            CLOG(INFO, "Overlay") << "LoopbackPeer recipient straggling, "
-                                  << "outbound queue at " << mOutQueue.size();
-            break;
+            if (rand_flip() || rand_flip())
+            {
+                CLOG(INFO, "Overlay")
+                    << "Loopback send-to-straggler pausing, "
+                    << "outbound queue at " << mOutQueue.size();
+                break;
+            }
+            else
+            {
+                CLOG(INFO, "Overlay")
+                    << "Loopback send-to-straggler sending, "
+                    << "outbound queue at " << mOutQueue.size();
+            }
         }
         deliverOne();
     }


### PR DESCRIPTION
# Description

The straggler-timeout overlay test is pseudo-randomized and I did not set it to be sufficiently biased to ensure that it always built up an outgoing queue backlog. This changes it to be _much_ more biased, while still sending enough of a trickle of traffic to inhibit the idle timeout.

While here I fixed the timing parameters to be closer to the real ones we settled on for the feature. I have no idea why I set it the other way before. Anyway running this rebased on #2002 for a few tens of minutes of random-reseeding shows it's robust now.

Sorry for the disruption.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
