### PR TITLE
database: scrub passwords from connection strings with std::regex.

### DIFF
--- a/src/database/DatabaseConnectionString.cpp
+++ b/src/database/DatabaseConnectionString.cpp
@@ -4,160 +4,25 @@
 
 #include "DatabaseConnectionString.h"
 
-#include <stdexcept>
+#include <regex>
 
 namespace stellar
 {
-
-namespace
-{
-
-class ParserException : public std::runtime_error
-{
-  public:
-    explicit ParserException(std::string const& what) : std::runtime_error{what}
-    {
-    }
-};
-
-using Token = std::pair<std::string::iterator, std::string::iterator>;
-struct Parameter
-{
-    std::string name;
-    Token valueToken;
-};
-
-std::string::iterator
-takeSpaces(std::string::iterator it, std::string::iterator const& end)
-{
-    while (it != end && (*it == ' '))
-        ++it;
-    return it;
-}
-
-std::string::iterator
-takeEquals(std::string::iterator it, std::string::iterator const& end)
-{
-    it = takeSpaces(it, end);
-    if (it == end)
-        throw ParserException{"Expected '=', found end of string"};
-    if (*it != '=')
-        throw ParserException{std::string{"Expected '=', found "} + *it};
-
-    return it + 1;
-}
-
-std::string::iterator
-takeEscapedToken(std::string::iterator it, std::string::iterator const& end)
-{
-    ++it;
-    while (it != end && *it != '\'')
-    {
-        if (*it == '\\')
-        {
-            ++it;
-            if (it == end)
-            {
-                throw ParserException{
-                    "Expected any character after '\\', found end of string"};
-            }
-        }
-
-        ++it;
-        if (it == end)
-        {
-            return it;
-        }
-    }
-
-    if (it == end)
-    {
-        throw ParserException{"Expected \', found end of string"};
-    }
-
-    return it + 1;
-}
-
-std::string::iterator
-takePlainToken(std::string::iterator it, std::string::iterator const& end)
-{
-    while (it != end && *it != ' ' && *it != '=')
-    {
-        ++it;
-    }
-
-    return it;
-}
-
-Token
-nextToken(std::string::iterator it, std::string::iterator const& end)
-{
-    it = takeSpaces(it, end);
-    if (it == end)
-        return {end, end};
-
-    if (*it == '\'')
-        return {it, takeEscapedToken(it, end)};
-    else
-        return {it, takePlainToken(it, end)};
-}
-
-Parameter
-nextParameter(std::string::iterator it, std::string::iterator const& end)
-{
-    auto nameToken = nextToken(it, end);
-    if (nameToken.first == end)
-    {
-        return Parameter{"", {}};
-    }
-
-    it = takeEquals(nameToken.second, end);
-    auto valueToken = nextToken(it, end);
-
-    auto name = std::string{nameToken.first, nameToken.second};
-    return Parameter{name, valueToken};
-}
-}
-
 std::string
 removePasswordFromConnectionString(std::string connectionString)
 {
-    auto const protocolSeparator = std::string{"://"};
-    auto const p = connectionString.find(protocolSeparator);
-    if (p == std::string::npos)
-    {
-        return connectionString;
-    }
-
-    try
-    {
-        auto end = std::end(connectionString);
-        auto it = std::begin(connectionString) + p + 3;
-        auto lastPasswordEnd = it;
-        auto result = std::string{std::begin(connectionString), it};
-
-        while (true)
-        {
-            auto parameter = nextParameter(it, end);
-            it = parameter.valueToken.second;
-            if (parameter.name == "")
-            {
-                break;
-            }
-            if (parameter.name == "password")
-            {
-                result.append(lastPasswordEnd, parameter.valueToken.first);
-                result.append("********");
-                lastPasswordEnd = it;
-            }
-        }
-
-        result.append(lastPasswordEnd, end);
-        return result;
-    }
-    catch (ParserException&)
-    {
-        return connectionString;
-    }
+    std::string escapedSingleQuotePat("\\\\'");
+    std::string nonSingleQuotePat("[^']");
+    std::string singleQuotedStringPat("'(?:" + nonSingleQuotePat + "|" +
+                                      escapedSingleQuotePat + ")*'");
+    std::string bareWordPat("\\w+");
+    std::string paramValPat("(?:" + bareWordPat + "|" + singleQuotedStringPat +
+                            ")");
+    std::string paramPat("(?:" + bareWordPat + " *= *" + paramValPat + " *)");
+    std::string passwordParamPat("password( *= *)" + paramValPat);
+    std::string connPat("^(" + bareWordPat + ":// *)(" + paramPat + "*)" +
+                        passwordParamPat + "( *)(" + paramPat + "*)$");
+    return std::regex_replace(connectionString, std::regex(connPat),
+                              "$1$2password$3********$4$5");
 }
 }

--- a/src/database/test/DatabaseConnectionStringTest.cpp
+++ b/src/database/test/DatabaseConnectionStringTest.cpp
@@ -145,4 +145,11 @@ TEST_CASE("remove password from database connection string",
                     R"(dbname=name password=abc)") ==
                 R"(dbname=name password=abc)");
     }
+
+    SECTION("ignore sqlite3://:memory:")
+    {
+        REQUIRE(removePasswordFromConnectionString(
+                    R"(sqlite3://:memory:)") ==
+                R"(sqlite3://:memory:)");
+    }
 }


### PR DESCRIPTION
# Description

This replaces the parser in DatabaseConnectionString.cpp with a call to `std::regex_replace`. The main purpose here is actually to avoid having it throw on startup everytime we start with `sqlite3://:memory:` but in the meantime I figured it looked like a regular grammar so why not simplify while I"m at it.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
