### PR TITLE
Avoid empty bulk load operations

### DIFF
--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -789,8 +789,15 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadAccounts(
     std::unordered_set<LedgerKey> const& keys) const
 {
-    BulkLoadAccountsOperation op(mDatabase, keys);
-    return populateLoadedEntries(keys,
-                                 mDatabase.doDatabaseTypeSpecificOperation(op));
+    if (!keys.empty())
+    {
+        BulkLoadAccountsOperation op(mDatabase, keys);
+        return populateLoadedEntries(
+            keys, mDatabase.doDatabaseTypeSpecificOperation(op));
+    }
+    else
+    {
+        return {};
+    }
 }
 }

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -478,8 +478,15 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadData(
     std::unordered_set<LedgerKey> const& keys) const
 {
-    BulkLoadDataOperation op(mDatabase, keys);
-    return populateLoadedEntries(keys,
-                                 mDatabase.doDatabaseTypeSpecificOperation(op));
+    if (!keys.empty())
+    {
+        BulkLoadDataOperation op(mDatabase, keys);
+        return populateLoadedEntries(
+            keys, mDatabase.doDatabaseTypeSpecificOperation(op));
+    }
+    else
+    {
+        return {};
+    }
 }
 }

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -699,9 +699,16 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadOffers(
     std::unordered_set<LedgerKey> const& keys) const
 {
-    BulkLoadOffersOperation op(mDatabase, keys);
-    return populateLoadedEntries(keys,
-                                 mDatabase.doDatabaseTypeSpecificOperation(op));
+    if (!keys.empty())
+    {
+        BulkLoadOffersOperation op(mDatabase, keys);
+        return populateLoadedEntries(
+            keys, mDatabase.doDatabaseTypeSpecificOperation(op));
+    }
+    else
+    {
+        return {};
+    }
 }
 
 static void

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -606,8 +606,15 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadTrustLines(
     std::unordered_set<LedgerKey> const& keys) const
 {
-    BulkLoadTrustLinesOperation op(mDatabase, keys);
-    return populateLoadedEntries(keys,
-                                 mDatabase.doDatabaseTypeSpecificOperation(op));
+    if (!keys.empty())
+    {
+        BulkLoadTrustLinesOperation op(mDatabase, keys);
+        return populateLoadedEntries(
+            keys, mDatabase.doDatabaseTypeSpecificOperation(op));
+    }
+    else
+    {
+        return {};
+    }
 }
 }


### PR DESCRIPTION
Discovered while reviewing #1988. The implementation of the bulk load operations (#1930) didn't optimize the case where we are attempting to bulk load no keys. This is fixed such that no SQL queries are executed in this case.