### PR TITLE
do not use s3 static website directly

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -379,13 +379,13 @@ mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
 
 #The history store of the Stellar testnet
 #[HISTORY.h1]
-#get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+#get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
 
 #[HISTORY.h2]
-#get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+#get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
 
 #[HISTORY.h3]
-#get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
+#get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
 
 # QUORUM_SET is a required field
 # This is how you specify this server's quorum set.

--- a/docs/stellar-core_testnet.cfg
+++ b/docs/stellar-core_testnet.cfg
@@ -23,11 +23,11 @@ VALIDATORS=[
 
 #The history store of the Stellar testnet
 [HISTORY.h1]
-get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
 
 [HISTORY.h2]
-get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
 
 [HISTORY.h3]
-get="curl -sf http://s3-eu-west-1.amazonaws.com/history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
+get="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"
 


### PR DESCRIPTION
 * use CDN cached history.stellar.org endpoint

Documentation / configuration update - do not used s3 static site directly, instead use history.stellar.org CDN cached endpoint.