### PR TITLE
Fix FreeBSD build.

### DIFF
--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -31,7 +31,7 @@
 #include <fcntl.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
 extern char** environ;
 #endif
 


### PR DESCRIPTION
Absorbs recent medida update to fix FreeBSD build and change one ifdef of our own for the same purpose.