### PR TITLE
Speed up extrachecks

### DIFF
--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -10,7 +10,7 @@
 #include "main/Config.h"
 #include "transactions/SignatureUtils.h"
 #include "util/HashOfHash.h"
-#include "util/lrucache.hpp"
+#include "util/RandomEvictionCache.h"
 #include <memory>
 #include <mutex>
 #include <sodium.h>
@@ -31,7 +31,7 @@ namespace stellar
 // has no effect on correctness.
 
 static std::mutex gVerifySigCacheMutex;
-static cache::lru_cache<Hash, bool> gVerifySigCache(0xffff);
+static RandomEvictionCache<Hash, bool> gVerifySigCache(0xffff);
 static std::unique_ptr<SHA256> gHasher = SHA256::create();
 static uint64_t gVerifyCacheHit = 0;
 static uint64_t gVerifyCacheMiss = 0;


### PR DESCRIPTION
# Description

We use `--enable-extrachecks` in CI which happens to turn on iterator debugging in the C++ standard libraries. For the most part this is fine, but in a couple places it's quite pessimistic (especially in list::splice which the LRU cache uses -- winds up turning O(1) into O(n)). This just fixes the top ~two hotspots~ hotspot my profiler showed up. Wins back about 7 minutes on my workstation. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
