### PR TITLE
Command line database schema upgrade

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -100,6 +100,8 @@ Command options can only by placed after command.
   * For example this will run just the tests tagged with `[tx]` using protocol
     versions 9 and 10 and stop after the first failure:
     `stellar-core --test -a --version 9 --version 10 "[tx]"`
+* **upgrade-db**: Upgrades local database to current schema version. This is
+  usually done automatically during stellar-core run or other command.
 * **version**: Print version info and then exit.
 * **write-quorum**: Print a quorum set graph from history.
 

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -255,6 +255,7 @@ Database::upgradeToCurrentSchema()
         applySchemaUpgrade(vers);
         putSchemaVersion(vers);
     }
+    CLOG(INFO, "Database") << "DB schema is in current version";
     assert(vers == SCHEMA_VERSION);
 }
 
@@ -268,11 +269,11 @@ Database::putSchemaVersion(unsigned long vers)
 unsigned long
 Database::getDBSchemaVersion()
 {
-    auto vstr =
-        mApp.getPersistentState().getState(PersistentState::kDatabaseSchema);
     unsigned long vers = 0;
     try
     {
+        auto vstr = mApp.getPersistentState().getState(
+            PersistentState::kDatabaseSchema);
         vers = std::stoul(vstr);
     }
     catch (...)
@@ -280,7 +281,8 @@ Database::getDBSchemaVersion()
     }
     if (vers == 0)
     {
-        throw std::runtime_error("No DB schema version found, try --newdb");
+        throw std::runtime_error(
+            "No DB schema version found, try stellar-core new-db");
     }
     return vers;
 }
@@ -402,6 +404,10 @@ Database::initialize()
     mApp.getLedgerTxnRoot().dropData();
     BanManager::dropAll(*this);
     putSchemaVersion(6);
+
+    LOG(INFO) << "* ";
+    LOG(INFO) << "* The database has been initialized";
+    LOG(INFO) << "* ";
 }
 
 soci::session&

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -159,7 +159,7 @@ class Application
 
     virtual ~Application(){};
 
-    virtual void initialize() = 0;
+    virtual void initialize(bool createNewDB) = 0;
 
     // Return the time in seconds since the POSIX epoch, according to the
     // VirtualClock this Application is bound to. Convenience method.
@@ -274,8 +274,6 @@ class Application
     // instances
     virtual Hash const& getNetworkID() const = 0;
 
-    virtual void newDB() = 0;
-
     virtual LedgerTxnRoot& getLedgerTxnRoot() = 0;
 
     // Factory: create a new Application object bound to `clock`, with a local
@@ -287,9 +285,7 @@ class Application
     create(VirtualClock& clock, Config const& cfg, bool newDB = true)
     {
         auto ret = std::make_shared<T>(clock, cfg);
-        ret->initialize();
-        if (newDB || cfg.DATABASE.value == "sqlite3://:memory:")
-            ret->newDB();
+        ret->initialize(newDB);
         validateNetworkPassphrase(ret);
 
         return ret;

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -38,7 +38,7 @@ class ApplicationImpl : public Application
     ApplicationImpl(VirtualClock& clock, Config const& cfg);
     virtual ~ApplicationImpl() override;
 
-    virtual void initialize() override;
+    virtual void initialize(bool newDB) override;
 
     virtual uint64_t timeNow() override;
 
@@ -78,8 +78,6 @@ class ApplicationImpl : public Application
                                            std::string jobName) override;
     virtual void postOnBackgroundThread(std::function<void()>&& f,
                                         std::string jobName) override;
-
-    void newDB() override;
 
     virtual void start() override;
 
@@ -177,6 +175,9 @@ class ApplicationImpl : public Application
     VirtualClock::time_point mStartedOn;
 
     Hash mNetworkID;
+
+    void newDB();
+    void upgradeDB();
 
     void shutdownMainIOContext();
     void shutdownWorkScheduler();

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -610,6 +610,20 @@ runNewDB(CommandLineArgs const& args)
 }
 
 int
+runUpgradeDB(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+
+    return runWithHelp(args, {configurationParser(configOption)}, [&] {
+        auto cfg = configOption.getConfig();
+        VirtualClock clock;
+        cfg.setNoListen();
+        Application::create(clock, cfg, false);
+        return 0;
+    });
+}
+
+int
 runNewHist(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -818,6 +832,8 @@ handleCommandLine(int argc, char* const* argv)
          {"sign-transaction",
           "add signature to transaction envelope, then quit",
           runSignTransaction},
+         {"upgrade-db", "upgade database schema to current version",
+          runUpgradeDB},
 #ifdef BUILD_TESTS
          {"fuzz", "run a single fuzz input and exit", runFuzz},
          {"gen-fuzz", "generate a random fuzzer input file", runGenFuzz},


### PR DESCRIPTION
# Description

Resolves #1912 

New command is added: `stellar-core upgrade-db`. It upgraded database to current schema without running application.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
