### PR TITLE
configure: use -fno-omit-frame-pointer by default, as in production builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ if test -z "${WFLAGS+set}"; then
    WFLAGS="$WFLAGS -Werror=unused-result"
 fi
 
-test "${CFLAGS+set}" || CFLAGS="-g -O2"
+test "${CFLAGS+set}" || CFLAGS="-g -O2 -fno-omit-frame-pointer"
 test "${CXXFLAGS+set}" || CXXFLAGS="$CFLAGS"
 
 AC_PROG_CC([clang gcc cc])


### PR DESCRIPTION
# Description

This enables frame pointers by default. I like having them and I bet so do you! They make debugging and profiling substantially more reliable at lower cost: the tools don't have to go grovelling through hundreds of megs of DWARF to figure out where the frame is.

Perf-wise: adds 0.1% of instructions and sub-noise of time to benchmarks I run locally. Also it's already what we're building with for production .debs.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
