### PR TITLE
Load generator improvements

### DIFF
--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -117,6 +117,8 @@ class LoadGenerator
 
   protected:
     Application& mApp;
+    uint32_t mLastClosedLedger;
+    uint32_t mCurrentTxsPerLedger;
     TestAccountPtr mRoot;
     // Accounts cache
     std::map<uint64_t, TestAccountPtr> mAccounts;


### PR DESCRIPTION
An attempt to reduce noise in tx submission in load generation -- instead of relying on submit step rate, check how many transactions need to be submitted per ledger, and adjust number of transactions per step based on the expected close time. Tested with sample load of 500 tx/s locally, and got 2365 txs/ledger mean and 199 std dev, which seems more stable than what we currently have. 