### PR TITLE
Ban transactions for few ledgers

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -287,9 +287,11 @@ exit /b 0
     <ClCompile Include="..\..\src\herder\HerderUtils.cpp" />
     <ClCompile Include="..\..\src\herder\LedgerCloseData.cpp" />
     <ClCompile Include="..\..\src\herder\PendingEnvelopes.cpp" />
+    <ClCompile Include="..\..\src\herder\TransactionQueue.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumTracker.cpp" />
     <ClCompile Include="..\..\src\herder\test\HerderTests.cpp" />
     <ClCompile Include="..\..\src\herder\test\PendingEnvelopesTests.cpp" />
+    <ClCompile Include="..\..\src\herder\test\TransactionQueueTests.cpp" />
     <ClCompile Include="..\..\src\herder\test\QuorumTrackerTests.cpp" />
     <ClCompile Include="..\..\src\herder\test\UpgradesTests.cpp" />
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp" />
@@ -586,6 +588,7 @@ exit /b 0
     <ClInclude Include="..\..\src\herder\HerderUtils.h" />
     <ClInclude Include="..\..\src\herder\LedgerCloseData.h" />
     <ClInclude Include="..\..\src\herder\PendingEnvelopes.h" />
+    <ClInclude Include="..\..\src\herder\TransactionQueue.h" />
     <ClInclude Include="..\..\src\herder\QuorumTracker.h" />
     <ClInclude Include="..\..\src\herder\TxSetFrame.h" />
     <ClInclude Include="..\..\src\herder\Upgrades.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -498,6 +498,9 @@
     <ClCompile Include="..\..\src\herder\PendingEnvelopes.cpp">
       <Filter>herder</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\herder\TransactionQueue.cpp">
+      <Filter>herder</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp">
       <Filter>herder</Filter>
     </ClCompile>
@@ -619,6 +622,9 @@
       <Filter>herder\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\herder\test\PendingEnvelopesTests.cpp">
+      <Filter>herder\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\herder\test\TransactionQueueTests.cpp">
       <Filter>herder\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\herder\test\UpgradesTests.cpp">
@@ -1335,6 +1341,9 @@
       <Filter>herder</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\PendingEnvelopes.h">
+      <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\herder\TransactionQueue.h">
       <Filter>herder</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\TxSetFrame.h">

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -14,7 +14,5 @@ std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 uint32 const Herder::LEDGER_VALIDITY_BRACKET = 100;
 // 12 slots give us about a minute to reconnect
 uint32 const Herder::MAX_SLOTS_TO_REMEMBER = 12;
-const char* Herder::TX_STATUS_STRING[TX_STATUS_COUNT] = {"PENDING", "DUPLICATE",
-                                                         "ERROR"};
 std::chrono::nanoseconds const Herder::TIMERS_THRESHOLD_NANOSEC(5000000);
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -6,6 +6,7 @@
 
 #include "TxSetFrame.h"
 #include "Upgrades.h"
+#include "herder/TransactionQueue.h"
 #include "lib/json/json-forwards.h"
 #include "overlay/Peer.h"
 #include "overlay/StellarXDR.h"
@@ -65,16 +66,6 @@ class Herder
         HERDER_NUM_STATE
     };
 
-    enum TransactionSubmitStatus
-    {
-        TX_STATUS_PENDING = 0,
-        TX_STATUS_DUPLICATE,
-        TX_STATUS_ERROR,
-        TX_STATUS_COUNT
-    };
-
-    static const char* TX_STATUS_STRING[TX_STATUS_COUNT];
-
     enum EnvelopeStatus
     {
         // for some reason this envelope was discarded - either is was invalid,
@@ -107,7 +98,8 @@ class Herder
                                   SCPQuorumSet const& qset) = 0;
     virtual bool recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
-    virtual TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) = 0;
+    virtual TransactionQueue::AddResult
+    recvTransaction(TransactionFramePtr tx) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;
     virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -744,8 +744,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
         }
     }
 
-    std::vector<TransactionFramePtr> removed;
-    proposedSet->trimInvalid(mApp, removed);
+    auto removed = proposedSet->trimInvalid(mApp);
     removeReceivedTxs(removed);
 
     proposedSet->surgePricingFilter(mApp);

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -42,6 +42,8 @@ using namespace std;
 namespace stellar
 {
 
+constexpr auto const TRANSACTION_QUEUE_SIZE = 4;
+
 std::unique_ptr<Herder>
 Herder::create(Application& app)
 {
@@ -56,20 +58,11 @@ HerderImpl::SCPMetrics::SCPMetrics(Application& app)
           app.getMetrics().NewMeter({"scp", "envelope", "receive"}, "envelope"))
     , mCumulativeStatements(app.getMetrics().NewCounter(
           {"scp", "memory", "cumulative-statements"}))
-
-    , mHerderPendingTxs0(
-          app.getMetrics().NewCounter({"herder", "pending-txs", "age0"}))
-    , mHerderPendingTxs1(
-          app.getMetrics().NewCounter({"herder", "pending-txs", "age1"}))
-    , mHerderPendingTxs2(
-          app.getMetrics().NewCounter({"herder", "pending-txs", "age2"}))
-    , mHerderPendingTxs3(
-          app.getMetrics().NewCounter({"herder", "pending-txs", "age3"}))
 {
 }
 
 HerderImpl::HerderImpl(Application& app)
-    : mPendingTransactions(4)
+    : mTransactionQueue(app, TRANSACTION_QUEUE_SIZE)
     , mPendingEnvelopes(app, *this)
     , mHerderSCPDriver(app, *this, mUpgrades, mPendingEnvelopes)
     , mLastSlotSaved(0)
@@ -129,34 +122,6 @@ HerderImpl::bootstrap()
     ledgerClosed();
 }
 
-static uint64_t
-countTxs(HerderImpl::AccountTxMap const& acc)
-{
-    uint64_t sz = 0;
-    for (auto const& a : acc)
-    {
-        sz += a.second->mTransactions.size();
-    }
-    return sz;
-}
-
-static std::shared_ptr<HerderImpl::TxMap>
-findOrAdd(HerderImpl::AccountTxMap& acc, AccountID const& aid)
-{
-    std::shared_ptr<HerderImpl::TxMap> txmap = nullptr;
-    auto i = acc.find(aid);
-    if (i == acc.end())
-    {
-        txmap = std::make_shared<HerderImpl::TxMap>();
-        acc.insert(std::make_pair(aid, txmap));
-    }
-    else
-    {
-        txmap = i->second;
-    }
-    return txmap;
-}
-
 void
 HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
 {
@@ -213,7 +178,7 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     mLedgerManager.valueExternalized(ledgerData);
 
     // perform cleanups
-    updatePendingTransactions(externalizedSet->mTransactions);
+    updateTransactionQueue(externalizedSet->mTransactions);
 
     // Evict slots that are outside of our ledger validity bracket
     if (slotIndex > MAX_SLOTS_TO_REMEMBER)
@@ -291,81 +256,18 @@ HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
     startRebroadcastTimer();
 }
 
-void
-HerderImpl::TxMap::addTx(TransactionFramePtr tx)
-{
-    auto const& h = tx->getFullHash();
-    if (mTransactions.find(h) != mTransactions.end())
-    {
-        return;
-    }
-    mTransactions.insert(std::make_pair(h, tx));
-    mMaxSeq = std::max(tx->getSeqNum(), mMaxSeq);
-    mTotalFees += tx->getFeeBid();
-}
-
-void
-HerderImpl::TxMap::recalculate()
-{
-    mMaxSeq = 0;
-    mTotalFees = 0;
-    for (auto const& pair : mTransactions)
-    {
-        mMaxSeq = std::max(pair.second->getSeqNum(), mMaxSeq);
-        mTotalFees += pair.second->getFeeBid();
-    }
-}
-
-Herder::TransactionSubmitStatus
+TransactionQueue::AddResult
 HerderImpl::recvTransaction(TransactionFramePtr tx)
 {
-    auto const& acc = tx->getSourceID();
-    auto const& txID = tx->getFullHash();
-
-    // determine if we have seen this tx before and if not if it has the right
-    // seq num
-    int64_t totFee = tx->getFeeBid();
-    SequenceNumber highSeq = 0;
-
-    for (auto& map : mPendingTransactions)
+    auto result = mTransactionQueue.tryAdd(tx);
+    if (result == TransactionQueue::AddResult::STATUS_PENDING)
     {
-        auto i = map.find(acc);
-        if (i != map.end())
-        {
-            auto& txmap = i->second;
-            auto j = txmap->mTransactions.find(txID);
-            if (j != txmap->mTransactions.end())
-            {
-                return TX_STATUS_DUPLICATE;
-            }
-            totFee += txmap->mTotalFees;
-            highSeq = std::max(highSeq, txmap->mMaxSeq);
-        }
+        if (Logging::logTrace("Herder"))
+            CLOG(TRACE, "Herder")
+                << "recv transaction " << hexAbbrev(tx->getFullHash())
+                << " for " << KeyUtils::toShortString(tx->getSourceID());
     }
-
-    {
-        LedgerTxn ltx(mApp.getLedgerTxnRoot());
-        if (!tx->checkValid(ltx, highSeq))
-        {
-            return TX_STATUS_ERROR;
-        }
-
-        auto sourceAccount = stellar::loadAccount(ltx, tx->getSourceID());
-        if (getAvailableBalance(ltx.loadHeader(), sourceAccount) < totFee)
-        {
-            tx->getResult().result.code(txINSUFFICIENT_BALANCE);
-            return TX_STATUS_ERROR;
-        }
-    }
-
-    if (Logging::logTrace("Herder"))
-        CLOG(TRACE, "Herder") << "recv transaction " << hexAbbrev(txID)
-                              << " for " << KeyUtils::toShortString(acc);
-
-    auto txmap = findOrAdd(mPendingTransactions[0], acc);
-    txmap->addTx(tx);
-
-    return TX_STATUS_PENDING;
+    return result;
 }
 
 Herder::EnvelopeStatus
@@ -605,49 +507,6 @@ HerderImpl::ledgerClosed()
                                  &VirtualTimer::onFailureNoop);
 }
 
-void
-HerderImpl::removeReceivedTxs(std::vector<TransactionFramePtr> const& dropTxs)
-{
-    for (auto& m : mPendingTransactions)
-    {
-        if (m.empty())
-        {
-            continue;
-        }
-
-        std::set<std::shared_ptr<TxMap>> toRecalculate;
-
-        for (auto const& tx : dropTxs)
-        {
-            auto const& acc = tx->getSourceID();
-            auto const& txID = tx->getFullHash();
-            auto i = m.find(acc);
-            if (i != m.end())
-            {
-                auto& txs = i->second->mTransactions;
-                auto j = txs.find(txID);
-                if (j != txs.end())
-                {
-                    txs.erase(j);
-                    if (txs.empty())
-                    {
-                        m.erase(i);
-                    }
-                    else
-                    {
-                        toRecalculate.insert(i->second);
-                    }
-                }
-            }
-        }
-
-        for (auto txm : toRecalculate)
-        {
-            txm->recalculate();
-        }
-    }
-}
-
 bool
 HerderImpl::recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset)
 {
@@ -703,17 +562,7 @@ HerderImpl::getCurrentLedgerSeq() const
 SequenceNumber
 HerderImpl::getMaxSeqInPendingTxs(AccountID const& acc)
 {
-    SequenceNumber highSeq = 0;
-    for (auto const& m : mPendingTransactions)
-    {
-        auto i = m.find(acc);
-        if (i == m.end())
-        {
-            continue;
-        }
-        highSeq = std::max(i->second->mMaxSeq, highSeq);
-    }
-    return highSeq;
+    return mTransactionQueue.getAccountTransactionQueueState(acc).mMaxSeq;
 }
 
 // called to take a position during the next round
@@ -731,21 +580,9 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     // our first choice for this round's set is all the tx we have collected
     // during last few ledger closes
     auto const& lcl = mLedgerManager.getLastClosedLedgerHeader();
-    auto proposedSet = std::make_shared<TxSetFrame>(lcl.hash);
-
-    for (auto const& m : mPendingTransactions)
-    {
-        for (auto const& pair : m)
-        {
-            for (auto const& tx : pair.second->mTransactions)
-            {
-                proposedSet->add(tx.second);
-            }
-        }
-    }
-
+    auto proposedSet = mTransactionQueue.toTxSet(lcl.hash);
     auto removed = proposedSet->trimInvalid(mApp);
-    removeReceivedTxs(removed);
+    mTransactionQueue.remove(removed);
 
     proposedSet->surgePricingFilter(mApp);
 
@@ -1067,44 +904,23 @@ HerderImpl::trackingHeartBeat()
 }
 
 void
-HerderImpl::updatePendingTransactions(
+HerderImpl::updateTransactionQueue(
     std::vector<TransactionFramePtr> const& applied)
 {
-    // remove all these tx from mPendingTransactions
-    removeReceivedTxs(applied);
-
-    // drop the highest level
-    mPendingTransactions.erase(--mPendingTransactions.end());
-
-    // shift entries up
-    mPendingTransactions.emplace_front();
+    // remove all these tx from mTransactionQueue
+    mTransactionQueue.remove(applied);
+    mTransactionQueue.shift();
 
     // rebroadcast entries, sorted in apply-order to maximize chances of
     // propagation
     {
-        Hash h;
-        TxSetFrame toBroadcast(h);
-        for (auto const& l : mPendingTransactions)
-        {
-            for (auto const& pair : l)
-            {
-                for (auto const& tx : pair.second->mTransactions)
-                {
-                    toBroadcast.add(tx.second);
-                }
-            }
-        }
-        for (auto tx : toBroadcast.sortForApply())
+        auto toBroadcast = mTransactionQueue.toTxSet({});
+        for (auto tx : toBroadcast->sortForApply())
         {
             auto msg = tx->toStellarMessage();
             mApp.getOverlayManager().broadcastMessage(msg);
         }
     }
-
-    mSCPMetrics.mHerderPendingTxs0.set_count(countTxs(mPendingTransactions[0]));
-    mSCPMetrics.mHerderPendingTxs1.set_count(countTxs(mPendingTransactions[1]));
-    mSCPMetrics.mHerderPendingTxs2.set_count(countTxs(mPendingTransactions[2]));
-    mSCPMetrics.mHerderPendingTxs3.set_count(countTxs(mPendingTransactions[3]));
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -729,7 +729,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     }
 
     // our first choice for this round's set is all the tx we have collected
-    // during last ledger close
+    // during last few ledger closes
     auto const& lcl = mLedgerManager.getLastClosedLedgerHeader();
     auto proposedSet = std::make_shared<TxSetFrame>(lcl.hash);
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -43,6 +43,7 @@ namespace stellar
 {
 
 constexpr auto const TRANSACTION_QUEUE_SIZE = 4;
+constexpr auto const TRANSACTION_QUEUE_BAN_SIZE = 10;
 
 std::unique_ptr<Herder>
 Herder::create(Application& app)
@@ -62,7 +63,7 @@ HerderImpl::SCPMetrics::SCPMetrics(Application& app)
 }
 
 HerderImpl::HerderImpl(Application& app)
-    : mTransactionQueue(app, TRANSACTION_QUEUE_SIZE)
+    : mTransactionQueue(app, TRANSACTION_QUEUE_SIZE, TRANSACTION_QUEUE_BAN_SIZE)
     , mPendingEnvelopes(app, *this)
     , mHerderSCPDriver(app, *this, mUpgrades, mPendingEnvelopes)
     , mLastSlotSaved(0)

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -345,7 +345,7 @@ HerderImpl::recvTransaction(TransactionFramePtr tx)
 
     {
         LedgerTxn ltx(mApp.getLedgerTxnRoot());
-        if (!tx->checkValid(mApp, ltx, highSeq))
+        if (!tx->checkValid(ltx, highSeq))
         {
             return TX_STATUS_ERROR;
         }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -4,9 +4,10 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "PendingEnvelopes.h"
 #include "herder/Herder.h"
 #include "herder/HerderSCPDriver.h"
+#include "herder/PendingEnvelopes.h"
+#include "herder/TransactionQueue.h"
 #include "herder/Upgrades.h"
 #include "util/Timer.h"
 #include "util/XDROperators.h"
@@ -57,7 +58,8 @@ class HerderImpl : public Herder
     void valueExternalized(uint64 slotIndex, StellarValue const& value);
     void emitEnvelope(SCPEnvelope const& envelope);
 
-    TransactionSubmitStatus recvTransaction(TransactionFramePtr tx) override;
+    TransactionQueue::AddResult
+    recvTransaction(TransactionFramePtr tx) override;
 
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
@@ -91,16 +93,6 @@ class HerderImpl : public Herder
                                   bool fullKeys = false,
                                   uint64 index = 0) override;
 
-    struct TxMap
-    {
-        SequenceNumber mMaxSeq{0};
-        int64_t mTotalFees{0};
-        std::unordered_map<Hash, TransactionFramePtr> mTransactions;
-        void addTx(TransactionFramePtr);
-        void recalculate();
-    };
-    typedef std::unordered_map<AccountID, std::shared_ptr<TxMap>> AccountTxMap;
-
 #ifdef BUILD_TESTS
     // used for testing
     PendingEnvelopes& getPendingEnvelopes();
@@ -108,7 +100,6 @@ class HerderImpl : public Herder
 
   private:
     void ledgerClosed();
-    void removeReceivedTxs(std::vector<TransactionFramePtr> const& txs);
 
     void startRebroadcastTimer();
     void rebroadcast();
@@ -116,14 +107,10 @@ class HerderImpl : public Herder
 
     void processSCPQueueUpToIndex(uint64 slotIndex);
 
-    // 0- tx we got during ledger close
-    // 1- one ledger ago. rebroadcast
-    // 2- two ledgers ago. rebroadcast
-    // ...
-    std::deque<AccountTxMap> mPendingTransactions;
+    TransactionQueue mTransactionQueue;
 
     void
-    updatePendingTransactions(std::vector<TransactionFramePtr> const& applied);
+    updateTransactionQueue(std::vector<TransactionFramePtr> const& applied);
 
     PendingEnvelopes mPendingEnvelopes;
     Upgrades mUpgrades;
@@ -172,12 +159,6 @@ class HerderImpl : public Herder
         // Counters for things reached-through the
         // SCP maps: Slots and Nodes
         medida::Counter& mCumulativeStatements;
-
-        // Pending tx buffer sizes
-        medida::Counter& mHerderPendingTxs0;
-        medida::Counter& mHerderPendingTxs1;
-        medida::Counter& mHerderPendingTxs2;
-        medida::Counter& mHerderPendingTxs3;
 
         SCPMetrics(Application& app);
     };

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -638,10 +638,8 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
         comp.upgrades.emplace_back(v.begin(), v.end());
     }
 
-    std::vector<TransactionFramePtr> removed;
-
     // just to be sure
-    bestTxSet->trimInvalid(mApp, removed);
+    auto removed = bestTxSet->trimInvalid(mApp);
     comp.txSetHash = bestTxSet->getContentsHash();
 
     if (removed.size() != 0)

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -1,0 +1,233 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/TransactionQueue.h"
+#include "crypto/SecretKey.h"
+#include "ledger/LedgerTxn.h"
+#include "main/Application.h"
+#include "transactions/TransactionUtils.h"
+#include "util/HashOfHash.h"
+#include "util/XDROperators.h"
+
+#include <algorithm>
+#include <lib/util/format.h>
+#include <medida/meter.h>
+#include <medida/metrics_registry.h>
+
+namespace stellar
+{
+
+static uint64_t
+countTxs(TransactionQueue::AccountTxMap const& acc)
+{
+    uint64_t sz = 0;
+    for (auto const& a : acc)
+    {
+        sz += a.second->mTransactions.size();
+    }
+    return sz;
+}
+
+static std::shared_ptr<TransactionQueue::TxMap>
+findOrAdd(TransactionQueue::AccountTxMap& acc, AccountID const& aid)
+{
+    std::shared_ptr<TransactionQueue::TxMap> txmap;
+    auto i = acc.find(aid);
+    if (i == acc.end())
+    {
+        txmap = std::make_shared<TransactionQueue::TxMap>();
+        acc.emplace(std::make_pair(aid, txmap));
+    }
+    else
+    {
+        txmap = i->second;
+    }
+    return txmap;
+}
+
+void
+TransactionQueue::TxMap::addTx(TransactionFramePtr tx)
+{
+    auto const& h = tx->getFullHash();
+    if (mTransactions.find(h) != mTransactions.end())
+    {
+        return;
+    }
+    mTransactions.emplace(std::make_pair(h, tx));
+    mCurrentState.mMaxSeq = std::max(tx->getSeqNum(), mCurrentState.mMaxSeq);
+    mCurrentState.mTotalFees += tx->getFeeBid();
+}
+
+void
+TransactionQueue::TxMap::recalculate()
+{
+    mCurrentState.mMaxSeq = 0;
+    mCurrentState.mTotalFees = 0;
+    for (auto const& pair : mTransactions)
+    {
+        mCurrentState.mMaxSeq =
+            std::max(pair.second->getSeqNum(), mCurrentState.mMaxSeq);
+        mCurrentState.mTotalFees += pair.second->getFeeBid();
+    }
+}
+
+TransactionQueue::TransactionQueue(Application& app, int pendingDepth)
+    : mApp(app), mPendingTransactions(pendingDepth)
+{
+    for (auto i = 0; i < pendingDepth; i++)
+    {
+        mSizeByAge.emplace_back(&app.getMetrics().NewCounter(
+            {"herder", "pending-txs", fmt::format("age{}", i)}));
+    }
+}
+
+TransactionQueue::AddResult
+TransactionQueue::tryAdd(TransactionFramePtr tx)
+{
+    if (contains(tx))
+    {
+        return TransactionQueue::AddResult::STATUS_DUPLICATE;
+    }
+
+    auto state = getAccountTransactionQueueState(tx->getSourceID());
+    LedgerTxn ltx(mApp.getLedgerTxnRoot());
+    if (!tx->checkValid(ltx, state.mMaxSeq))
+    {
+        return TransactionQueue::AddResult::STATUS_ERROR;
+    }
+
+    auto sourceAccount = stellar::loadAccount(ltx, tx->getSourceID());
+    if (getAvailableBalance(ltx.loadHeader(), sourceAccount) - tx->getFeeBid() <
+        state.mTotalFees)
+    {
+        tx->getResult().result.code(txINSUFFICIENT_BALANCE);
+        return TransactionQueue::AddResult::STATUS_ERROR;
+    }
+
+    auto map = findOrAdd(mPendingTransactions[0], tx->getSourceID());
+    map->addTx(tx);
+
+    return TransactionQueue::AddResult::STATUS_PENDING;
+}
+
+void
+TransactionQueue::remove(std::vector<TransactionFramePtr> const& dropTxs)
+{
+    for (auto& m : mPendingTransactions)
+    {
+        if (m.empty())
+        {
+            continue;
+        }
+
+        std::set<std::shared_ptr<TxMap>> toRecalculate;
+
+        for (auto const& tx : dropTxs)
+        {
+            auto const& acc = tx->getSourceID();
+            auto const& txID = tx->getFullHash();
+            auto i = m.find(acc);
+            if (i != m.end())
+            {
+                auto& txs = i->second->mTransactions;
+                auto j = txs.find(txID);
+                if (j != txs.end())
+                {
+                    txs.erase(j);
+                    if (txs.empty())
+                    {
+                        m.erase(i);
+                    }
+                    else
+                    {
+                        toRecalculate.insert(i->second);
+                    }
+                }
+            }
+        }
+
+        for (auto txm : toRecalculate)
+        {
+            txm->recalculate();
+        }
+    }
+}
+
+bool
+TransactionQueue::contains(TransactionFramePtr tx) const
+{
+    return std::any_of(std::begin(mPendingTransactions),
+                       std::end(mPendingTransactions),
+                       [&](AccountTxMap const& map) {
+                           auto txMap = map.find(tx->getSourceID());
+                           if (txMap == map.end())
+                           {
+                               return false;
+                           }
+
+                           auto& transactions = txMap->second->mTransactions;
+                           return transactions.find(tx->getFullHash()) !=
+                                  std::end(transactions);
+                       });
+}
+
+AccountTransactionsQueueState
+TransactionQueue::getAccountTransactionQueueState(
+    AccountID const& accountID) const
+{
+    AccountTransactionsQueueState state;
+
+    for (auto& map : mPendingTransactions)
+    {
+        auto i = map.find(accountID);
+        if (i != map.end())
+        {
+            auto& txmap = i->second;
+            state.mTotalFees += txmap->mCurrentState.mTotalFees;
+            state.mMaxSeq =
+                std::max(state.mMaxSeq, txmap->mCurrentState.mMaxSeq);
+        }
+    }
+
+    return state;
+}
+
+void
+TransactionQueue::shift()
+{
+    mPendingTransactions.pop_back();
+    mPendingTransactions.emplace_front();
+
+    for (auto i = 0; i < mPendingTransactions.size(); i++)
+    {
+        mSizeByAge[i]->set_count(countTxs(mPendingTransactions[i]));
+    }
+}
+
+std::shared_ptr<TxSetFrame>
+TransactionQueue::toTxSet(Hash const& lclHash) const
+{
+    auto result = std::make_shared<TxSetFrame>(lclHash);
+
+    for (auto const& m : mPendingTransactions)
+    {
+        for (auto const& pair : m)
+        {
+            for (auto const& tx : pair.second->mTransactions)
+            {
+                result->add(tx.second);
+            }
+        }
+    }
+
+    return result;
+}
+
+bool
+operator==(AccountTransactionsQueueState const& x,
+           AccountTransactionsQueueState const& y)
+{
+    return x.mMaxSeq == y.mMaxSeq && x.mTotalFees == y.mTotalFees;
+}
+}

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -1,0 +1,85 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/SecretKey.h"
+#include "herder/TxSetFrame.h"
+#include "transactions/TransactionFrame.h"
+#include "util/HashOfHash.h"
+#include "util/XDROperators.h"
+#include "xdr/Stellar-transaction.h"
+
+#include <deque>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace medida
+{
+class Counter;
+}
+
+namespace stellar
+{
+
+class Application;
+
+struct AccountTransactionsQueueState
+{
+    SequenceNumber mMaxSeq{0};
+    int64_t mTotalFees{0};
+
+    friend bool operator==(AccountTransactionsQueueState const& x,
+                           AccountTransactionsQueueState const& y);
+};
+
+class TransactionQueue
+{
+  public:
+    enum class AddResult
+    {
+        STATUS_PENDING = 0,
+        STATUS_DUPLICATE,
+        STATUS_ERROR,
+        STATUS_COUNT
+    };
+
+    struct TxMap
+    {
+        AccountTransactionsQueueState mCurrentState;
+        std::unordered_map<Hash, TransactionFramePtr> mTransactions;
+        void addTx(TransactionFramePtr);
+        void recalculate();
+    };
+    typedef std::unordered_map<AccountID, std::shared_ptr<TxMap>> AccountTxMap;
+
+    explicit TransactionQueue(Application& app, int pendingDepth);
+
+    AddResult tryAdd(TransactionFramePtr tx);
+    // it is responsibility of the caller to always remove such sets of
+    // transactions that remaining ones have theis sequence numbers increasing
+    // by one
+    void remove(std::vector<TransactionFramePtr> const& txs);
+    // remove oldest transactions and move all other transactions to slots older
+    // by one, this results in newest queue slot being empty
+    void shift();
+
+    AccountTransactionsQueueState
+    getAccountTransactionQueueState(AccountID const& accountID) const;
+
+    std::shared_ptr<TxSetFrame> toTxSet(Hash const& lclHash) const;
+
+  private:
+    Application& mApp;
+    std::vector<medida::Counter*> mSizeByAge;
+    std::deque<AccountTxMap> mPendingTransactions;
+
+    bool contains(TransactionFramePtr tx) const;
+};
+
+static const char* TX_STATUS_STRING[static_cast<int>(
+    TransactionQueue::AddResult::STATUS_COUNT)] = {"PENDING", "DUPLICATE",
+                                                   "ERROR"};
+}

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -338,10 +338,10 @@ TxSetFrame::checkOrTrim(
     return true;
 }
 
-void
-TxSetFrame::trimInvalid(Application& app,
-                        std::vector<TransactionFramePtr>& trimmed)
+std::vector<TransactionFramePtr>
+TxSetFrame::trimInvalid(Application& app)
 {
+    std::vector<TransactionFramePtr> trimmed;
     sortForHash();
 
     auto processInvalidTxLambda = [&](TransactionFramePtr tx,
@@ -361,6 +361,7 @@ TxSetFrame::trimInvalid(Application& app,
         };
 
     checkOrTrim(app, processInvalidTxLambda, processInsufficientBalance);
+    return trimmed;
 }
 
 // need to make sure every account that is submitting a tx has enough to pay

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -310,7 +310,7 @@ TxSetFrame::checkOrTrim(
         int64_t totFee = 0;
         for (auto& tx : item.second)
         {
-            if (!tx->checkValid(app, ltx, lastSeq))
+            if (!tx->checkValid(ltx, lastSeq))
             {
                 if (processInvalidTxLambda(tx, lastSeq))
                     continue;

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -58,8 +58,10 @@ class TxSetFrame
     std::vector<TransactionFramePtr> sortForApply();
 
     bool checkValid(Application& app);
-    void trimInvalid(Application& app,
-                     std::vector<TransactionFramePtr>& trimmed);
+
+    // remove invalid transaction from this set and return those removed
+    // transactions
+    std::vector<TransactionFramePtr> trimInvalid(Application& app);
     void surgePricingFilter(Application& app);
 
     void removeTx(TransactionFramePtr tx);

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -309,8 +309,7 @@ testTxSet(uint32 protocolVersion)
         {
             REQUIRE(txSet->checkValid(*app));
 
-            std::vector<TransactionFramePtr> removed;
-            txSet->trimInvalid(*app, removed);
+            txSet->trimInvalid(*app);
             REQUIRE(txSet->checkValid(*app));
         }
         SECTION("out of order")
@@ -318,8 +317,7 @@ testTxSet(uint32 protocolVersion)
             std::swap(txSet->mTransactions[0], txSet->mTransactions[1]);
             REQUIRE(!txSet->checkValid(*app));
 
-            std::vector<TransactionFramePtr> removed;
-            txSet->trimInvalid(*app, removed);
+            txSet->trimInvalid(*app);
             REQUIRE(txSet->checkValid(*app));
         }
     }
@@ -332,8 +330,7 @@ testTxSet(uint32 protocolVersion)
             txSet->sortForHash();
             REQUIRE(!txSet->checkValid(*app));
 
-            std::vector<TransactionFramePtr> removed;
-            txSet->trimInvalid(*app, removed);
+            txSet->trimInvalid(*app);
             REQUIRE(txSet->checkValid(*app));
         }
         SECTION("sequence gap")
@@ -346,8 +343,7 @@ testTxSet(uint32 protocolVersion)
                 txSet->sortForHash();
                 REQUIRE(!txSet->checkValid(*app));
 
-                std::vector<TransactionFramePtr> removed;
-                txSet->trimInvalid(*app, removed);
+                txSet->trimInvalid(*app);
                 REQUIRE(txSet->checkValid(*app));
             }
             SECTION("gap begin")
@@ -357,8 +353,7 @@ testTxSet(uint32 protocolVersion)
                 txSet->sortForHash();
                 REQUIRE(!txSet->checkValid(*app));
 
-                std::vector<TransactionFramePtr> removed;
-                txSet->trimInvalid(*app, removed);
+                auto removed = txSet->trimInvalid(*app);
                 REQUIRE(txSet->checkValid(*app));
                 // one of the account lost all its transactions
                 REQUIRE(removed.size() == (nbTransactions - 1));
@@ -373,8 +368,7 @@ testTxSet(uint32 protocolVersion)
                 txSet->sortForHash();
                 REQUIRE(!txSet->checkValid(*app));
 
-                std::vector<TransactionFramePtr> removed;
-                txSet->trimInvalid(*app, removed);
+                auto removed = txSet->trimInvalid(*app);
                 REQUIRE(txSet->checkValid(*app));
                 // one account has all its transactions,
                 // other, we removed all its tx
@@ -389,8 +383,7 @@ testTxSet(uint32 protocolVersion)
             txSet->sortForHash();
             REQUIRE(!txSet->checkValid(*app));
 
-            std::vector<TransactionFramePtr> removed;
-            txSet->trimInvalid(*app, removed);
+            auto removed = txSet->trimInvalid(*app);
             REQUIRE(txSet->checkValid(*app));
             REQUIRE(removed.size() == (nbTransactions + 1));
             REQUIRE(txSet->mTransactions.size() == nbTransactions);
@@ -635,8 +628,6 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
     TxSetFramePtr txSet = std::make_shared<TxSetFrame>(
         app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
-    std::vector<TransactionFramePtr> removed;
-
     auto multiPaymentTx =
         std::bind(makeMultiPayment, destAccount, _1, _2, _3, 0, 100);
 
@@ -648,7 +639,7 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
     };
 
     auto surgePricing = [&]() {
-        txSet->trimInvalid(*app, removed);
+        txSet->trimInvalid(*app);
         txSet->sortForHash();
         txSet->surgePricingFilter(*app);
     };

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -68,7 +68,7 @@ TEST_CASE("standalone", "[herder]")
 
             auto feedTx = [&](TransactionFramePtr& tx) {
                 REQUIRE(app->getHerder().recvTransaction(tx) ==
-                        Herder::TX_STATUS_PENDING);
+                        TransactionQueue::AddResult::STATUS_PENDING);
             };
 
             auto waitForExternalize = [&]() {

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1,0 +1,394 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/SecretKey.h"
+#include "herder/TransactionQueue.h"
+#include "test/TestAccount.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "test/test.h"
+#include "util/Timer.h"
+
+#include <lib/catch.hpp>
+
+using namespace stellar;
+using namespace stellar::txtest;
+
+namespace
+{
+TransactionFramePtr
+transaction(Application& app, TestAccount& account, int sequenceDelta)
+{
+    return transactionFromOperations(
+        app, account, account.getLastSequenceNumber() + sequenceDelta,
+        {payment(account.getPublicKey(), 1)});
+}
+
+TransactionFramePtr
+invalidTransaction(Application& app, TestAccount& account, int sequenceDelta)
+{
+    return transactionFromOperations(
+        app, account, account.getLastSequenceNumber() + sequenceDelta,
+        {payment(account.getPublicKey(), -1)});
+}
+
+class TransactionQueueTest
+{
+  public:
+    explicit TransactionQueueTest(Application& app) : mTransactionQueue{app, 4}
+    {
+    }
+
+    void
+    add(TransactionFramePtr const& tx, TransactionQueue::AddResult AddResult)
+    {
+        auto beforeState = mTransactionQueue.getAccountTransactionQueueState(
+            tx->getSourceID());
+        if (beforeState.mMaxSeq == 0)
+        {
+            REQUIRE(beforeState.mTotalFees == 0);
+        }
+
+        REQUIRE(mTransactionQueue.tryAdd(tx) == AddResult);
+        auto afterState = mTransactionQueue.getAccountTransactionQueueState(
+            tx->getSourceID());
+
+        if (AddResult == TransactionQueue::AddResult::STATUS_PENDING)
+        {
+            REQUIRE(afterState.mMaxSeq == tx->getSeqNum());
+            REQUIRE(afterState.mTotalFees == beforeState.mTotalFees + 100);
+        }
+        else
+        {
+            REQUIRE(afterState == beforeState);
+        }
+    }
+
+    void
+    remove(std::vector<TransactionFramePtr> const& toRemove)
+    {
+        auto size = mTransactionQueue.toTxSet({})->sizeTx();
+        mTransactionQueue.remove(toRemove);
+        REQUIRE(size - toRemove.size() ==
+                mTransactionQueue.toTxSet({})->sizeTx());
+    }
+
+    void
+    shift(std::vector<TransactionFramePtr> const& removed = {})
+    {
+        auto size = mTransactionQueue.toTxSet({})->sizeTx();
+        auto removedFrom = std::map<AccountID, int>{};
+        for (auto tx : removed)
+        {
+            removedFrom[tx->getSourceID()]++;
+        }
+
+        auto beforeStates =
+            std::map<AccountID, AccountTransactionsQueueState>{};
+        for (auto from : removedFrom)
+        {
+            beforeStates[from.first] =
+                mTransactionQueue.getAccountTransactionQueueState(from.first);
+            REQUIRE(beforeStates[from.first].mMaxSeq > 0);
+        }
+
+        mTransactionQueue.shift();
+        for (auto from : removedFrom)
+        {
+            auto afterState =
+                mTransactionQueue.getAccountTransactionQueueState(from.first);
+            if (afterState.mMaxSeq == 0)
+            {
+                REQUIRE(afterState.mTotalFees == 0);
+            }
+            else
+            {
+                REQUIRE(afterState.mMaxSeq == beforeStates[from.first].mMaxSeq);
+                REQUIRE(afterState.mTotalFees ==
+                        beforeStates[from.first].mTotalFees -
+                            from.second * 100);
+            }
+        }
+        REQUIRE(size - removed.size() ==
+                mTransactionQueue.toTxSet({})->sizeTx());
+    }
+
+    void
+    check(std::vector<TransactionFramePtr> const& expected = {})
+    {
+        auto txSet = mTransactionQueue.toTxSet({});
+        auto expectedTxSet = TxSetFrame{{}};
+        for (auto const& tx : expected)
+        {
+            expectedTxSet.add(tx);
+        }
+
+        REQUIRE(txSet->sortForApply() == expectedTxSet.sortForApply());
+    }
+
+  private:
+    TransactionQueue mTransactionQueue;
+};
+}
+
+TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
+{
+    VirtualClock clock;
+    auto app = createTestApplication(clock, getTestConfig());
+    auto const minBalance2 = app->getLedgerManager().getLastMinBalance(2);
+
+    auto root = TestAccount::createRoot(*app);
+    auto account1 = root.create("a1", minBalance2);
+    auto account2 = root.create("a2", minBalance2);
+
+    auto txSeqA1T0 = transaction(*app, account1, 0);
+    auto txSeqA1T1 = transaction(*app, account1, 1);
+    auto txSeqA1T2 = transaction(*app, account1, 2);
+    auto txSeqA1T3 = transaction(*app, account1, 3);
+    auto txSeqA1T4 = transaction(*app, account1, 4);
+    auto txSeqA2T1 = transaction(*app, account2, 1);
+    auto txSeqA2T2 = transaction(*app, account2, 2);
+
+    SECTION("small sequence number")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T0, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check();
+    }
+
+    SECTION("big sequence number")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check();
+    }
+
+    SECTION("good sequence number")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good sequence number, same twice")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_DUPLICATE);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then big sequence number")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T3, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then good sequence number")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA1T2});
+    }
+
+    SECTION("good sequence number, same twice with shift")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_DUPLICATE);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then big sequence number, with shift")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T3, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then good sequence number, with shift")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA1T2});
+    }
+
+    SECTION("good sequence number, same twice with double shift")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.shift();
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_DUPLICATE);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then big sequence number, with double shift")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.shift();
+        test.add(txSeqA1T3, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then good sequence number, with double shift")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.shift();
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA1T2});
+    }
+
+    SECTION("good sequence number, same twice with four shifts")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.shift();
+        test.shift();
+        test.shift({txSeqA1T1});
+        test.check();
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1});
+    }
+
+    SECTION("good then big sequence number, with four shifts")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.shift();
+        test.shift();
+        test.shift({txSeqA1T1});
+        test.check();
+        test.add(txSeqA1T3, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check();
+    }
+
+    SECTION("good then small sequence number, with four shifts")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.shift();
+        test.shift();
+        test.shift({txSeqA1T1});
+        test.check();
+        test.add(txSeqA1T0, TransactionQueue::AddResult::STATUS_ERROR);
+        test.check();
+    }
+
+    SECTION("invalid transaction")
+    {
+        TransactionQueueTest test{*app};
+        test.add(invalidTransaction(*app, account1, 1),
+                 TransactionQueue::AddResult::STATUS_ERROR);
+        test.check();
+    }
+
+    SECTION("multiple good sequence numbers, with four shifts")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T3, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T4, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
+        test.shift();
+        test.shift();
+        test.shift();
+        test.shift({txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
+        test.check();
+    }
+
+    SECTION("multiple good sequence numbers, with shifts between")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T3, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T4, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
+        test.shift({txSeqA1T1});
+        test.check({txSeqA1T2, txSeqA1T3, txSeqA1T4});
+        test.shift({txSeqA1T2});
+        test.check({txSeqA1T3, txSeqA1T4});
+        test.shift({txSeqA1T3});
+        test.check({txSeqA1T4});
+        test.shift({txSeqA1T4});
+        test.check();
+    }
+
+    SECTION(
+        "multiple good sequence numbers, different accounts, with four shifts")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.shift();
+        test.shift();
+        test.shift();
+        test.shift({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.check();
+    }
+
+    SECTION("multiple good sequence numbers, different accounts, with shifts "
+            "between")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA2T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.shift();
+        test.add(txSeqA2T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.shift({txSeqA1T1});
+        test.check({txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.shift({txSeqA2T1});
+        test.check({txSeqA1T2, txSeqA2T2});
+        test.shift({txSeqA1T2});
+        test.check({txSeqA2T2});
+        test.shift({txSeqA2T2});
+        test.check();
+    }
+
+    SECTION("multiple good sequence numbers, different accounts, with remove")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.remove({txSeqA1T1, txSeqA2T2});
+        test.check({txSeqA2T1, txSeqA1T2});
+        test.add(txSeqA1T1, TransactionQueue::AddResult::STATUS_ERROR);
+        test.add(txSeqA2T2, TransactionQueue::AddResult::STATUS_PENDING);
+        test.check({txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.remove({txSeqA2T1, txSeqA1T2});
+        test.check({txSeqA2T2});
+        test.remove({txSeqA2T2});
+        test.check();
+    }
+}

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -844,6 +844,9 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
             root["detail"] =
                 xdr::xdr_to_string(txFrame->getResult().result.code());
             break;
+        case TransactionQueue::AddResult::STATUS_TRY_AGAIN_LATER:
+            root["status"] = "try_again_later";
+            break;
         default:
             assert(false);
         }

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -547,10 +547,10 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
         {
             // add it to our current set
             // and make sure it is valid
-            Herder::TransactionSubmitStatus status =
+            TransactionQueue::AddResult status =
                 mApp.getHerder().recvTransaction(transaction);
 
-            if (status == Herder::TX_STATUS_PENDING)
+            if (status == TransactionQueue::AddResult::STATUS_PENDING)
             {
                 StellarMessage msg;
                 msg.type(TRANSACTION);
@@ -560,8 +560,9 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
 
             output << "{"
                    << "\"status\": "
-                   << "\"" << Herder::TX_STATUS_STRING[status] << "\"";
-            if (status == Herder::TX_STATUS_ERROR)
+                   << "\"" << TX_STATUS_STRING[static_cast<int>(status)]
+                   << "\"";
+            if (status == TransactionQueue::AddResult::STATUS_ERROR)
             {
                 std::string resultBase64;
                 auto resultBin = xdr::xdr_to_opaque(transaction->getResult());
@@ -832,13 +833,13 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
 
         switch (mApp.getHerder().recvTransaction(txFrame))
         {
-        case Herder::TX_STATUS_PENDING:
+        case TransactionQueue::AddResult::STATUS_PENDING:
             root["status"] = "pending";
             break;
-        case Herder::TX_STATUS_DUPLICATE:
+        case TransactionQueue::AddResult::STATUS_DUPLICATE:
             root["status"] = "duplicate";
             break;
-        case Herder::TX_STATUS_ERROR:
+        case TransactionQueue::AddResult::STATUS_ERROR:
             root["status"] = "error";
             root["detail"] =
                 xdr::xdr_to_string(txFrame->getResult().result.code());

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -737,13 +737,13 @@ Peer::recvTransaction(StellarMessage const& msg)
         // and make sure it is valid
         auto recvRes = mApp.getHerder().recvTransaction(transaction);
 
-        if (recvRes == Herder::TX_STATUS_PENDING ||
-            recvRes == Herder::TX_STATUS_DUPLICATE)
+        if (recvRes == TransactionQueue::AddResult::STATUS_PENDING ||
+            recvRes == TransactionQueue::AddResult::STATUS_DUPLICATE)
         {
             // record that this peer sent us this transaction
             mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
 
-            if (recvRes == Herder::TX_STATUS_PENDING)
+            if (recvRes == TransactionQueue::AddResult::STATUS_PENDING)
             {
                 // if it's a new transaction, broadcast it
                 mApp.getOverlayManager().broadcastMessage(msg);

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -145,7 +145,7 @@ TEST_CASE("Flooding", "[flood][overlay]")
             // this is basically a modified version of Peer::recvTransaction
             auto msg = tx1->toStellarMessage();
             auto res = inApp->getHerder().recvTransaction(tx1);
-            REQUIRE(res == Herder::TX_STATUS_PENDING);
+            REQUIRE(res == TransactionQueue::AddResult::STATUS_PENDING);
             inApp->getOverlayManager().broadcastMessage(msg);
         };
 

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -72,7 +72,7 @@ class LoadGenerator
                                              uint32_t ledgerNum,
                                              uint64_t sourceAccount);
     void handleFailedSubmission(TestAccountPtr sourceAccount,
-                                Herder::TransactionSubmitStatus status,
+                                TransactionQueue::AddResult status,
                                 TransactionResultCode code);
     TxInfo creationTransaction(uint64_t startAccount, uint64_t numItems,
                                uint32_t ledgerNum);
@@ -106,9 +106,9 @@ class LoadGenerator
     {
         TestAccountPtr mFrom;
         std::vector<Operation> mOps;
-        Herder::TransactionSubmitStatus execute(Application& app, bool isCreate,
-                                                TransactionResultCode& code,
-                                                int32_t batchSize);
+        TransactionQueue::AddResult execute(Application& app, bool isCreate,
+                                            TransactionResultCode& code,
+                                            int32_t batchSize);
     };
 
   protected:

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -130,7 +130,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
     AccountEntry srcAccountBefore;
     {
         LedgerTxn ltxFeeProc(ltx);
-        check = tx->checkValid(app, ltxFeeProc, 0);
+        check = tx->checkValid(ltxFeeProc, 0);
         checkResult = tx->getResult();
         REQUIRE((!check || checkResult.result.code() == txSUCCESS));
 
@@ -294,7 +294,7 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
     auto shouldValidateOk = validationResult.code == txSUCCESS;
     {
         LedgerTxn ltx(app.getLedgerTxnRoot());
-        REQUIRE(tx->checkValid(app, ltx, 0) == shouldValidateOk);
+        REQUIRE(tx->checkValid(ltx, 0) == shouldValidateOk);
     }
     REQUIRE(tx->getResult().result.code() == validationResult.code);
     REQUIRE(tx->getResult().feeCharged == validationResult.fee);

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -63,11 +63,10 @@ class TransactionFrame
         kFullyValid
     };
 
-    bool commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
-                              bool forApply);
+    bool commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool forApply);
 
     ValidationType commonValid(SignatureChecker& signatureChecker,
-                               Application& app, AbstractLedgerTxn& ltxOuter,
+                               AbstractLedgerTxn& ltxOuter,
                                SequenceNumber current, bool applying);
 
     void resetResults(LedgerHeader const& header, int64_t baseFee);
@@ -90,7 +89,7 @@ class TransactionFrame
 
     void processSeqNum(AbstractLedgerTxn& ltx);
 
-    bool processSignatures(SignatureChecker& signatureChecker, Application& app,
+    bool processSignatures(SignatureChecker& signatureChecker,
                            AbstractLedgerTxn& ltxOuter);
 
   public:
@@ -164,8 +163,7 @@ class TransactionFrame
     bool checkSignatureNoAccount(SignatureChecker& signatureChecker,
                                  AccountID const& accountID);
 
-    bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
-                    SequenceNumber current);
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current);
 
     // collect fee, consume sequence number
     void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee);

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -333,7 +333,7 @@ TEST_CASE("manage buy offer liabilities", "[tx][offers]")
 
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                tx->checkValid(*app, ltx, 0);
+                tx->checkValid(ltx, 0);
             }
 
             auto buyOp = std::static_pointer_cast<ManageBuyOfferOpFrame>(

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -408,7 +408,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             setup();
                             {
                                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                                REQUIRE(!tx->checkValid(*app, ltx, 0));
+                                REQUIRE(!tx->checkValid(ltx, 0));
                             }
                             REQUIRE(tx->getResultCode() == txBAD_SEQ);
                             REQUIRE(getAccountSigners(a1, *app).size() == 1);
@@ -868,7 +868,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(!tx->checkValid(*app, ltx, 0));
+                    REQUIRE(!tx->checkValid(ltx, 0));
                 }
 
                 applyCheck(tx, *app);
@@ -897,7 +897,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     for_versions_from({1, 2, 3, 4, 5, 6, 8}, *app, [&] {
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(!tx->checkValid(*app, ltx, 0));
+                            REQUIRE(!tx->checkValid(ltx, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txFAILED);
@@ -907,7 +907,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     for_versions({7}, *app, [&] {
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(*app, ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -921,7 +921,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(*app, ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -958,7 +958,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(!tx->checkValid(*app, ltx, 0));
+                            REQUIRE(!tx->checkValid(ltx, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -995,7 +995,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(*app, ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1031,7 +1031,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(*app, ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1118,7 +1118,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                 for_versions_to(9, *app, [&] {
                     {
                         LedgerTxn ltx(app->getLedgerTxnRoot());
-                        REQUIRE(!txFrame->checkValid(*app, ltx, 0));
+                        REQUIRE(!txFrame->checkValid(ltx, 0));
                     }
                     REQUIRE(txFrame->getResultCode() == txBAD_SEQ);
                 });
@@ -1188,7 +1188,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     txFrame->getEnvelope().tx.seqNum--;
                     {
                         LedgerTxn ltx(app->getLedgerTxnRoot());
-                        REQUIRE(!txFrame->checkValid(*app, ltx, 0));
+                        REQUIRE(!txFrame->checkValid(ltx, 0));
                     }
 
                     REQUIRE(txFrame->getResultCode() == txBAD_SEQ);


### PR DESCRIPTION
# Description

Resolves #2026

This PR extracts new class - TransactionQueue - from Herder and adds capability to ban transaction for few ledgers. It means that any transaction that does not get into ledger during 4 closes (i.e. because of surge pricing and not sufficient fee) will not be able to enter the queue again for next 10 closes.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
