### PR TITLE
Remove crypto dependency from SCP

### DIFF
--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -106,6 +106,11 @@ class HerderImpl : public Herder
     PendingEnvelopes& getPendingEnvelopes();
 #endif
 
+    // helper function to verify envelopes are signed
+    bool verifyEnvelope(SCPEnvelope const& envelope);
+    // helper function to sign envelopes
+    void signEnvelope(SecretKey const& s, SCPEnvelope& envelope);
+
   private:
     void ledgerClosed();
     void removeReceivedTxs(std::vector<TransactionFramePtr> const& txs);
@@ -178,6 +183,10 @@ class HerderImpl : public Herder
         medida::Counter& mHerderPendingTxs1;
         medida::Counter& mHerderPendingTxs2;
         medida::Counter& mHerderPendingTxs3;
+
+        // envelope signature verification
+        medida::Meter& mEnvelopeValidSig;
+        medida::Meter& mEnvelopeInvalidSig;
 
         SCPMetrics(Application& app);
     };

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -26,10 +26,6 @@ namespace stellar
 HerderSCPDriver::SCPMetrics::SCPMetrics(Application& app)
     : mEnvelopeSign(
           app.getMetrics().NewMeter({"scp", "envelope", "sign"}, "envelope"))
-    , mEnvelopeValidSig(app.getMetrics().NewMeter(
-          {"scp", "envelope", "validsig"}, "envelope"))
-    , mEnvelopeInvalidSig(app.getMetrics().NewMeter(
-          {"scp", "envelope", "invalidsig"}, "envelope"))
     , mValueValid(app.getMetrics().NewMeter({"scp", "value", "valid"}, "value"))
     , mValueInvalid(
           app.getMetrics().NewMeter({"scp", "value", "invalid"}, "value"))
@@ -103,27 +99,7 @@ void
 HerderSCPDriver::signEnvelope(SCPEnvelope& envelope)
 {
     mSCPMetrics.mEnvelopeSign.Mark();
-    envelope.signature = mApp.getConfig().NODE_SEED.sign(xdr::xdr_to_opaque(
-        mApp.getNetworkID(), ENVELOPE_TYPE_SCP, envelope.statement));
-}
-
-bool
-HerderSCPDriver::verifyEnvelope(SCPEnvelope const& envelope)
-{
-    auto b = PubKeyUtils::verifySig(
-        envelope.statement.nodeID, envelope.signature,
-        xdr::xdr_to_opaque(mApp.getNetworkID(), ENVELOPE_TYPE_SCP,
-                           envelope.statement));
-    if (b)
-    {
-        mSCPMetrics.mEnvelopeValidSig.Mark();
-    }
-    else
-    {
-        mSCPMetrics.mEnvelopeInvalidSig.Mark();
-    }
-
-    return b;
+    mHerder.signEnvelope(mApp.getConfig().NODE_SEED, envelope);
 }
 
 void

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -90,7 +90,6 @@ class HerderSCPDriver : public SCPDriver
 
     // envelope handling
     void signEnvelope(SCPEnvelope& envelope) override;
-    bool verifyEnvelope(SCPEnvelope const& envelope) override;
     void emitEnvelope(SCPEnvelope const& envelope) override;
 
     // value validation
@@ -146,8 +145,6 @@ class HerderSCPDriver : public SCPDriver
     struct SCPMetrics
     {
         medida::Meter& mEnvelopeSign;
-        medida::Meter& mEnvelopeValidSig;
-        medida::Meter& mEnvelopeInvalidSig;
 
         medida::Meter& mValueValid;
         medida::Meter& mValueInvalid;

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -29,13 +29,6 @@ SCP::SCP(SCPDriver& driver, NodeID const& nodeID, bool isValidator,
 SCP::EnvelopeState
 SCP::receiveEnvelope(SCPEnvelope const& envelope)
 {
-    // If the envelope is not correctly signed, we ignore it.
-    if (!mDriver.verifyEnvelope(envelope))
-    {
-        CLOG(DEBUG, "SCP") << "SCP::receiveEnvelope invalid";
-        return SCP::EnvelopeState::INVALID;
-    }
-
     uint64 slotIndex = envelope.statement.slotIndex;
     return getSlot(slotIndex, true)->processEnvelope(envelope, false);
 }
@@ -213,11 +206,8 @@ SCP::getLatestMessagesSend(uint64 slotIndex)
 void
 SCP::setStateFromEnvelope(uint64 slotIndex, SCPEnvelope const& e)
 {
-    if (mDriver.verifyEnvelope(e))
-    {
-        auto slot = getSlot(slotIndex, true);
-        slot->setStateFromEnvelope(e);
-    }
+    auto slot = getSlot(slotIndex, true);
+    slot->setStateFromEnvelope(e);
 }
 
 bool

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -23,9 +23,8 @@ class SCPDriver
     {
     }
 
-    // Envelope signature/verification
+    // Envelope signature
     virtual void signEnvelope(SCPEnvelope& envelope) = 0;
-    virtual bool verifyEnvelope(SCPEnvelope const& envelope) = 0;
 
     // Retrieves a quorum set from its hash
     //

--- a/src/scp/test/SCPTests.cpp
+++ b/src/scp/test/SCPTests.cpp
@@ -69,12 +69,6 @@ class TestSCP : public SCPDriver
     {
     }
 
-    bool
-    verifyEnvelope(SCPEnvelope const& envelope) override
-    {
-        return true;
-    }
-
     void
     storeQuorumSet(SCPQuorumSetPtr qSet)
     {

--- a/src/scp/test/SCPUnitTests.cpp
+++ b/src/scp/test/SCPUnitTests.cpp
@@ -66,12 +66,6 @@ class TestNominationSCP : public SCPDriver
     {
     }
 
-    bool
-    verifyEnvelope(SCPEnvelope const& envelope) override
-    {
-        return true;
-    }
-
     void
     storeQuorumSet(SCPQuorumSetPtr qSet)
     {

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -328,8 +328,8 @@ TEST_CASE("manage buy offer liabilities", "[tx][offers]")
             }
 
             auto op = manageBuyOffer(0, cur1, cur2, price, buyAmount);
-            auto tx =
-                transactionFromOperations(*app, SecretKey::random(), 1, {op});
+            auto tx = transactionFromOperations(
+                *app, SecretKey::pseudoRandomForTesting(), 1, {op});
 
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());


### PR DESCRIPTION
This PR moves crypto responsibilities from SCP into the application.

This change:
* ~~allows to not sign messages that don't get sent (performance)~~ (turns out we cannot do this, so I removed this commit)
* makes it easier to use different crypto schemes (or no crypto at all for simulation)
