### PR TITLE
Scp signed values during nomination

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -793,7 +793,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     }
 
     StellarValue newProposedValue(txSetHash, nextCloseTime, emptyUpgradeSteps,
-                                  0);
+                                  STELLAR_VALUE_BASIC);
 
     // see if we need to include some upgrades
     auto upgrades = mUpgrades.createUpgradesFor(lcl.header);

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -151,6 +151,9 @@ class HerderImpl : public Herder
     // timer that detects that we're stuck on an SCP slot
     VirtualTimer mTrackingTimer;
 
+    // tracks the last time externalize was called
+    VirtualClock::time_point mLastExternalize;
+
     // saves the SCP messages that the instance sent out last
     void persistSCPState(uint64 slot);
     // restores SCP state based on the last messages saved on disk

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -111,6 +111,11 @@ class HerderImpl : public Herder
     // helper function to sign envelopes
     void signEnvelope(SecretKey const& s, SCPEnvelope& envelope);
 
+    // helper function to verify SCPValues are signed
+    bool verifyStellarValueSignature(StellarValue const& sv);
+    // helper function to sign SCPValues
+    void signStellarValue(SecretKey const& s, StellarValue& sv);
+
   private:
     void ledgerClosed();
     void removeReceivedTxs(std::vector<TransactionFramePtr> const& txs);

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -515,7 +515,7 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
 
     Hash h;
 
-    StellarValue comp(h, 0, emptyUpgradeSteps, 0);
+    StellarValue comp(h, 0, emptyUpgradeSteps, STELLAR_VALUE_BASIC);
 
     std::map<LedgerUpgradeType, LedgerUpgrade> upgrades;
 

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -196,8 +196,9 @@ class HerderSCPDriver : public SCPDriver
     bool checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
                         StellarValue const& b) const;
 
-    SCPDriver::ValidationLevel
-    validateValueHelper(uint64_t slotIndex, StellarValue const& sv) const;
+    SCPDriver::ValidationLevel validateValueHelper(uint64_t slotIndex,
+                                                   StellarValue const& sv,
+                                                   bool nomination) const;
 
     // returns true if the local instance is in a state compatible with
     // this slot

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -24,12 +24,16 @@ LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
 }
 
 std::string
-stellarValueToString(StellarValue const& sv)
+stellarValueToString(Config const& c, StellarValue const& sv)
 {
     std::stringstream res;
 
-    res << "[ "
-        << " txH: " << hexAbbrev(sv.txSetHash) << ", ct: " << sv.closeTime
+    res << "[";
+    if (sv.ext.v() == STELLAR_VALUE_SIGNED)
+    {
+        res << " SIGNED@" << c.toShortString(sv.ext.lcValueSignature().nodeID);
+    }
+    res << " txH: " << hexAbbrev(sv.txSetHash) << ", ct: " << sv.closeTime
         << ", upgrades: [";
     for (auto const& upgrade : sv.upgrades)
     {

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "TxSetFrame.h"
+#include "main/Config.h"
 #include "overlay/StellarXDR.h"
 #include <string>
 
@@ -46,7 +47,7 @@ class LedgerCloseData
     StellarValue mValue;
 };
 
-std::string stellarValueToString(StellarValue const& sv);
+std::string stellarValueToString(Config const& c, StellarValue const& sv);
 
 #define emptyUpgradeSteps (xdr::xvector<UpgradeType, 6>(0))
 }

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -822,7 +822,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
     auto makeTxPair = [](TxSetFramePtr txSet, uint64_t closeTime) {
         txSet->sortForHash();
         auto sv = StellarValue{txSet->getContentsHash(), closeTime,
-                               emptyUpgradeSteps, 0};
+                               emptyUpgradeSteps, STELLAR_VALUE_BASIC};
         auto v = xdr::xdr_to_opaque(sv);
 
         return TxPair{v, txSet};

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -799,7 +799,7 @@ TEST_CASE("surge pricing", "[herder][txset]")
 
 static void
 testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
-              bool checkHighFee)
+              bool checkHighFee, bool withSCPsignature)
 {
     Config cfg(getTestConfig());
     cfg.LEDGER_PROTOCOL_VERSION = protocolVersion;
@@ -819,23 +819,37 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
     auto a1 = TestAccount{*app, getAccount("A")};
 
     using TxPair = std::pair<Value, TxSetFramePtr>;
-    auto makeTxPair = [](TxSetFramePtr txSet, uint64_t closeTime) {
+    auto makeTxPair = [&](HerderImpl& herder, TxSetFramePtr txSet,
+                          uint64_t closeTime, bool sig) {
         txSet->sortForHash();
-        auto sv = StellarValue{txSet->getContentsHash(), closeTime,
-                               emptyUpgradeSteps, STELLAR_VALUE_BASIC};
+        auto sv = StellarValue(txSet->getContentsHash(), closeTime,
+                               emptyUpgradeSteps, STELLAR_VALUE_BASIC);
+        if (sig)
+        {
+            herder.signStellarValue(root.getSecretKey(), sv);
+        }
         auto v = xdr::xdr_to_opaque(sv);
 
         return TxPair{v, txSet};
     };
     auto makeEnvelope = [&s](HerderImpl& herder, TxPair const& p, Hash qSetHash,
-                             uint64_t slotIndex) {
+                             uint64_t slotIndex, bool nomination) {
         // herder must want the TxSet before receiving it, so we are sending it
         // fake envelope
         auto envelope = SCPEnvelope{};
         envelope.statement.slotIndex = slotIndex;
-        envelope.statement.pledges.type(SCP_ST_PREPARE);
-        envelope.statement.pledges.prepare().ballot.value = p.first;
-        envelope.statement.pledges.prepare().quorumSetHash = qSetHash;
+        if (nomination)
+        {
+            envelope.statement.pledges.type(SCP_ST_NOMINATE);
+            envelope.statement.pledges.nominate().votes.push_back(p.first);
+            envelope.statement.pledges.nominate().quorumSetHash = qSetHash;
+        }
+        else
+        {
+            envelope.statement.pledges.type(SCP_ST_PREPARE);
+            envelope.statement.pledges.prepare().ballot.value = p.first;
+            envelope.statement.pledges.prepare().quorumSetHash = qSetHash;
+        }
         envelope.statement.nodeID = s.getPublicKey();
         herder.signEnvelope(s, envelope);
         return envelope;
@@ -867,33 +881,35 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
         auto addToCandidates = [&](TxPair const& p) {
             candidates.emplace(p.first);
             auto envelope =
-                makeEnvelope(herder, p, {}, herder.getCurrentLedgerSeq());
+                makeEnvelope(herder, p, {}, herder.getCurrentLedgerSeq(), true);
             REQUIRE(herder.recvSCPEnvelope(envelope) ==
                     Herder::ENVELOPE_STATUS_FETCHING);
             REQUIRE(herder.recvTxSet(p.second->getContentsHash(), *p.second));
         };
 
         TxSetFramePtr txSet0 = makeTransactions(lcl.hash, 0, 1, 100);
-        addToCandidates(makeTxPair(txSet0, 100));
+        addToCandidates(makeTxPair(herder, txSet0, 100, withSCPsignature));
 
         Value v;
         StellarValue sv;
 
         v = herder.getHerderSCPDriver().combineCandidates(1, candidates);
         xdr::xdr_from_opaque(v, sv);
+        REQUIRE(sv.ext.v() == STELLAR_VALUE_BASIC);
         REQUIRE(sv.closeTime == 100);
         REQUIRE(sv.txSetHash == txSet0->getContentsHash());
 
         TxSetFramePtr txSet1 = makeTransactions(lcl.hash, 10, 1, 100);
 
-        addToCandidates(makeTxPair(txSet1, 10));
+        addToCandidates(makeTxPair(herder, txSet1, 10, withSCPsignature));
         v = herder.getHerderSCPDriver().combineCandidates(1, candidates);
         xdr::xdr_from_opaque(v, sv);
+        REQUIRE(sv.ext.v() == STELLAR_VALUE_BASIC);
         REQUIRE(sv.closeTime == 100);
         REQUIRE(sv.txSetHash == txSet1->getContentsHash());
 
         TxSetFramePtr txSet2 = makeTransactions(lcl.hash, 5, 3, 100);
-        addToCandidates(makeTxPair(txSet2, 1000));
+        addToCandidates(makeTxPair(herder, txSet2, 1000, withSCPsignature));
 
         auto biggestTxSet = txSet1;
         if (biggestTxSet->size(lcl.header) < txSet2->size(lcl.header))
@@ -904,17 +920,95 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
         // picks the biggest set, highest time
         v = herder.getHerderSCPDriver().combineCandidates(1, candidates);
         xdr::xdr_from_opaque(v, sv);
+        REQUIRE(sv.ext.v() == STELLAR_VALUE_BASIC);
         REQUIRE(sv.closeTime == 1000);
         REQUIRE(sv.txSetHash == biggestTxSet->getContentsHash());
         REQUIRE(biggestTxSet->sizeOp() == expectedOps);
 
         if (checkHighFee)
         {
-            TxSetFramePtr txSet3 = makeTransactions(lcl.hash, 5, 3, 101);
-            addToCandidates(makeTxPair(txSet3, 1000));
+            TxSetFramePtr txSetL =
+                makeTransactions(lcl.hash, maxTxSize, 1, 101);
+            addToCandidates(makeTxPair(herder, txSetL, 1000, withSCPsignature));
+            TxSetFramePtr txSetL2 =
+                makeTransactions(lcl.hash, maxTxSize, 1, 1000);
+            addToCandidates(
+                makeTxPair(herder, txSetL2, 1000, withSCPsignature));
             v = herder.getHerderSCPDriver().combineCandidates(1, candidates);
             xdr::xdr_from_opaque(v, sv);
-            REQUIRE(sv.txSetHash == txSet3->getContentsHash());
+            REQUIRE(sv.ext.v() == STELLAR_VALUE_BASIC);
+            REQUIRE(sv.txSetHash == txSetL2->getContentsHash());
+        }
+    }
+
+    SECTION("validateValue signatures")
+    {
+        auto& herder = static_cast<HerderImpl&>(app->getHerder());
+        auto& scp = herder.getHerderSCPDriver();
+        auto seq = herder.getCurrentLedgerSeq() + 1;
+        auto ct = app->timeNow() + 1;
+
+        TxSetFramePtr txSet0 = makeTransactions(lcl.hash, 0, 1, 100);
+        {
+            // make sure that txSet0 is loaded
+            auto p = makeTxPair(herder, txSet0, ct, withSCPsignature);
+            auto envelope = makeEnvelope(herder, p, {}, seq, true);
+            REQUIRE(herder.recvSCPEnvelope(envelope) ==
+                    Herder::ENVELOPE_STATUS_FETCHING);
+            REQUIRE(herder.recvTxSet(txSet0->getContentsHash(), *txSet0));
+        }
+
+        SECTION("valid")
+        {
+            auto nomV = makeTxPair(herder, txSet0, ct, withSCPsignature);
+            REQUIRE(scp.validateValue(seq, nomV.first, true) ==
+                    SCPDriver::kFullyValidatedValue);
+
+            auto balV = makeTxPair(herder, txSet0, ct, false);
+            REQUIRE(scp.validateValue(seq, balV.first, false) ==
+                    SCPDriver::kFullyValidatedValue);
+        }
+        SECTION("invalid")
+        {
+            // nomination, requires signature iff withSCPsignature is true
+            auto nomV = makeTxPair(herder, txSet0, ct, !withSCPsignature);
+            REQUIRE(scp.validateValue(seq, nomV.first, true) ==
+                    SCPDriver::kInvalidValue);
+
+            // ballot protocol, with signature is never valid
+            auto balV = makeTxPair(herder, txSet0, ct, true);
+            REQUIRE(scp.validateValue(seq, balV.first, false) ==
+                    SCPDriver::kInvalidValue);
+
+            if (withSCPsignature)
+            {
+                auto p = makeTxPair(herder, txSet0, ct, withSCPsignature);
+                StellarValue sv;
+                xdr::xdr_from_opaque(p.first, sv);
+
+                auto checkInvalid = [&](StellarValue const& sv) {
+                    auto v = xdr::xdr_to_opaque(sv);
+                    REQUIRE(scp.validateValue(seq, v, true) ==
+                            SCPDriver::kInvalidValue);
+                };
+
+                // mutate in a few ways
+                SECTION("missing signature")
+                {
+                    sv.ext.lcValueSignature().signature.clear();
+                    checkInvalid(sv);
+                }
+                SECTION("wrong signature")
+                {
+                    sv.ext.lcValueSignature().signature[0] ^= 1;
+                    checkInvalid(sv);
+                }
+                SECTION("wrong signature 2")
+                {
+                    sv.ext.lcValueSignature().nodeID.ed25519()[0] ^= 1;
+                    checkInvalid(sv);
+                }
+            }
         }
     }
 
@@ -959,16 +1053,16 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
         auto& herder = static_cast<HerderImpl&>(app->getHerder());
         auto transactions1 = makeTransactions(lcl.hash, 5, 1, 100);
         auto transactions2 = makeTransactions(lcl.hash, 4, 1, 100);
-        auto p1 = makeTxPair(transactions1, 10);
-        auto p2 = makeTxPair(transactions1, 10);
-        auto saneEnvelopeQ1T1 = makeEnvelope(herder, p1, saneQSet1Hash,
-                                             herder.getCurrentLedgerSeq());
-        auto saneEnvelopeQ1T2 = makeEnvelope(herder, p2, saneQSet1Hash,
-                                             herder.getCurrentLedgerSeq());
-        auto saneEnvelopeQ2T1 = makeEnvelope(herder, p1, saneQSet2Hash,
-                                             herder.getCurrentLedgerSeq());
-        auto bigEnvelope =
-            makeEnvelope(herder, p1, bigQSetHash, herder.getCurrentLedgerSeq());
+        auto p1 = makeTxPair(herder, transactions1, 10, withSCPsignature);
+        auto p2 = makeTxPair(herder, transactions1, 10, withSCPsignature);
+        auto saneEnvelopeQ1T1 = makeEnvelope(
+            herder, p1, saneQSet1Hash, herder.getCurrentLedgerSeq(), true);
+        auto saneEnvelopeQ1T2 = makeEnvelope(
+            herder, p2, saneQSet1Hash, herder.getCurrentLedgerSeq(), true);
+        auto saneEnvelopeQ2T1 = makeEnvelope(
+            herder, p1, saneQSet2Hash, herder.getCurrentLedgerSeq(), true);
+        auto bigEnvelope = makeEnvelope(herder, p1, bigQSetHash,
+                                        herder.getCurrentLedgerSeq(), true);
 
         SECTION("return FETCHING until fetched")
         {
@@ -1088,11 +1182,12 @@ TEST_CASE("SCP Driver", "[herder]")
 {
     SECTION("protocol 10")
     {
-        testSCPDriver(10, 10, 10, false);
+        testSCPDriver(10, 10, 10, false, false);
     }
     SECTION("protocol current")
     {
-        testSCPDriver(Config::CURRENT_LEDGER_PROTOCOL_VERSION, 1000, 15, true);
+        testSCPDriver(Config::CURRENT_LEDGER_PROTOCOL_VERSION, 1000, 15, true,
+                      true);
     }
 }
 

--- a/src/herder/test/PendingEnvelopesTests.cpp
+++ b/src/herder/test/PendingEnvelopesTests.cpp
@@ -35,7 +35,7 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
     auto makeTxPair = [](TxSetFramePtr txSet, uint64_t closeTime) {
         txSet->sortForHash();
         auto sv = StellarValue{txSet->getContentsHash(), closeTime,
-                               emptyUpgradeSteps, 0};
+                               emptyUpgradeSteps, STELLAR_VALUE_BASIC};
         auto v = xdr::xdr_to_opaque(sv);
 
         return TxPair{v, txSet};

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -105,7 +105,7 @@ TEST_CASE("quorum tracker", "[quorum][herder]")
         auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
         auto sv = StellarValue{txSet->getContentsHash(),
                                lcl.header.scpValue.closeTime + i,
-                               emptyUpgradeSteps, 0};
+                               emptyUpgradeSteps, STELLAR_VALUE_BASIC};
         auto v = xdr::xdr_to_opaque(sv);
 
         return TxPair{v, txSet};

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -50,11 +50,18 @@ TEST_CASE("quorum tracker", "[quorum][herder]")
     // allow SCP messages from other slots to be processed
     herder->getHerderSCPDriver().lostSync();
 
-    using TxPair = std::pair<Value, TxSetFramePtr>;
+    auto valSigner = SecretKey::pseudoRandomForTesting();
+
+    struct ValuesTxSet
+    {
+        Value mBasicV;
+        Value mSignedV;
+        TxSetFramePtr mTxSet;
+    };
 
     auto recvEnvelope = [&](SCPEnvelope envelope, uint64 slotID,
                             SecretKey const& k, SCPQuorumSet const& qSet,
-                            std::vector<TxPair> const& pp) {
+                            std::vector<ValuesTxSet> const& pp) {
         // herder must want the TxSet before receiving it, so we are sending it
         // fake envelope
         envelope.statement.slotIndex = slotID;
@@ -66,12 +73,12 @@ TEST_CASE("quorum tracker", "[quorum][herder]")
         herder->recvSCPQuorumSet(qSetH, qSet);
         for (auto& p : pp)
         {
-            herder->recvTxSet(p.second->getContentsHash(), *p.second);
+            herder->recvTxSet(p.mTxSet->getContentsHash(), *p.mTxSet);
         }
     };
     auto recvNom = [&](uint64 slotID, SecretKey const& k,
                        SCPQuorumSet const& qSet,
-                       std::vector<TxPair> const& pp) {
+                       std::vector<ValuesTxSet> const& pp) {
         SCPEnvelope envelope;
         envelope.statement.pledges.type(SCP_ST_NOMINATE);
         auto& nom = envelope.statement.pledges.nominate();
@@ -79,7 +86,7 @@ TEST_CASE("quorum tracker", "[quorum][herder]")
         std::set<Value> values;
         for (auto& p : pp)
         {
-            values.insert(p.first);
+            values.insert(p.mSignedV);
         }
         nom.votes.insert(nom.votes.begin(), values.begin(), values.end());
         auto qSetH = sha256(xdr::xdr_to_opaque(qSet));
@@ -87,17 +94,17 @@ TEST_CASE("quorum tracker", "[quorum][herder]")
         recvEnvelope(envelope, slotID, k, qSet, pp);
     };
     auto recvExternalize = [&](uint64 slotID, SecretKey const& k,
-                               SCPQuorumSet const& qSet, TxPair const& v) {
+                               SCPQuorumSet const& qSet, ValuesTxSet const& v) {
         SCPEnvelope envelope;
         envelope.statement.pledges.type(SCP_ST_EXTERNALIZE);
         auto& ext = envelope.statement.pledges.externalize();
         ext.commit.counter = UINT32_MAX;
-        ext.commit.value = v.first;
+        ext.commit.value = v.mBasicV;
         ext.nH = UINT32_MAX;
 
         auto qSetH = sha256(xdr::xdr_to_opaque(qSet));
         ext.commitQuorumSetHash = qSetH;
-        std::vector<TxPair> pp = {v};
+        std::vector<ValuesTxSet> pp = {v};
         recvEnvelope(envelope, slotID, k, qSet, pp);
     };
     auto makeValue = [&](int i) {
@@ -107,8 +114,10 @@ TEST_CASE("quorum tracker", "[quorum][herder]")
                                lcl.header.scpValue.closeTime + i,
                                emptyUpgradeSteps, STELLAR_VALUE_BASIC};
         auto v = xdr::xdr_to_opaque(sv);
+        herder->signStellarValue(valSigner, sv);
+        auto vSigned = xdr::xdr_to_opaque(sv);
 
-        return TxPair{v, txSet};
+        return ValuesTxSet{v, vSigned, txSet};
     };
 
     auto vv = makeValue(1);

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -510,7 +510,8 @@ TEST_CASE("Ledger Manager applies upgrades properly", "[upgrades]")
             LedgerManager::GENESIS_LEDGER_BASE_RESERVE);
 
     auto executeUpgrades = [&](xdr::xvector<UpgradeType, 6> const& upgrades) {
-        StellarValue sv{txSet->getContentsHash(), 2, upgrades, 0};
+        StellarValue sv{txSet->getContentsHash(), 2, upgrades,
+                        STELLAR_VALUE_BASIC};
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
         return app->getLedgerManager().getLastClosedLedgerHeader();
@@ -589,7 +590,8 @@ TEST_CASE("upgrade to version 10", "[upgrades]")
         auto upgrades = xdr::xvector<UpgradeType, 6>{};
         upgrades.push_back(toUpgradeType(makeProtocolVersionUpgrade(10)));
 
-        StellarValue sv{txSet->getContentsHash(), 2, upgrades, 0};
+        StellarValue sv{txSet->getContentsHash(), 2, upgrades,
+                        STELLAR_VALUE_BASIC};
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
 
@@ -1446,7 +1448,8 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
             CLOG(INFO, "Ledger")
                 << "Ledger " << ledgerSeq << " upgrading to v" << newProto;
         }
-        StellarValue sv(txSet->getContentsHash(), closeTime, upgrades, 0);
+        StellarValue sv(txSet->getContentsHash(), closeTime, upgrades,
+                        STELLAR_VALUE_BASIC);
         lm.closeLedger(LedgerCloseData(ledgerSeq, txSet, sv));
         auto& bm = app->getBucketManager();
         auto mc = bm.readMergeCounters();
@@ -1546,7 +1549,8 @@ TEST_CASE("upgrade base reserve", "[upgrades]")
         auto upgrades = xdr::xvector<UpgradeType, 6>{};
         upgrades.push_back(toUpgradeType(makeBaseReserveUpgrade(newReserve)));
 
-        StellarValue sv{txSet->getContentsHash(), 2, upgrades, 0};
+        StellarValue sv{txSet->getContentsHash(), 2, upgrades,
+                        STELLAR_VALUE_BASIC};
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
 

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -619,7 +619,8 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
                 << txSet->size(lm.getLastClosedLedgerHeader().header)
                 << " txs (txhash:" << hexAbbrev(txSet->getContentsHash())
                 << ")";
-            StellarValue sv(txSet->getContentsHash(), closeTime, upgrades, 0);
+            StellarValue sv(txSet->getContentsHash(), closeTime, upgrades,
+                            STELLAR_VALUE_BASIC);
             lm.closeLedger(LedgerCloseData(ledgerSeq, txSet, sv));
         }
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -473,7 +473,8 @@ CatchupSimulation::generateRandomLedger()
                            << " with " << txSet->sizeTx() << " txs (txhash:"
                            << hexAbbrev(txSet->getContentsHash()) << ")";
 
-    StellarValue sv(txSet->getContentsHash(), closeTime, emptyUpgradeSteps, 0);
+    StellarValue sv(txSet->getContentsHash(), closeTime, emptyUpgradeSteps,
+                    STELLAR_VALUE_BASIC);
     mLedgerCloseDatas.emplace_back(ledgerSeq, txSet, sv);
     lm.closeLedger(mLedgerCloseDatas.back());
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -397,8 +397,8 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
         << "[seq=" << ledgerData.getLedgerSeq()
         << ", prev=" << hexAbbrev(ledgerData.getTxSet()->previousLedgerHash())
         << ", txs=" << ledgerData.getTxSet()->sizeTx()
-        << ", ops=" << ledgerData.getTxSet()->sizeOp()
-        << ", sv: " << stellarValueToString(ledgerData.getValue()) << "]";
+        << ", ops=" << ledgerData.getTxSet()->sizeOp() << ", sv: "
+        << stellarValueToString(mApp.getConfig(), ledgerData.getValue()) << "]";
 
     auto st = getState();
     switch (st)
@@ -733,8 +733,9 @@ LedgerManagerImpl::applyBufferedLedgers()
                 << "[seq=" << lcd.getLedgerSeq()
                 << ", prev=" << hexAbbrev(lcd.getTxSet()->previousLedgerHash())
                 << ", txs=" << lcd.getTxSet()->sizeTx()
-                << ", ops=" << lcd.getTxSet()->sizeOp()
-                << ", sv: " << stellarValueToString(lcd.getValue()) << "]";
+                << ", ops=" << lcd.getTxSet()->sizeOp() << ", sv: "
+                << stellarValueToString(mApp.getConfig(), lcd.getValue())
+                << "]";
             closeLedger(lcd);
 
             applyBufferedLedgers();

--- a/src/ledger/test/LedgerHeaderTests.cpp
+++ b/src/ledger/test/LedgerHeaderTests.cpp
@@ -72,7 +72,8 @@ TEST_CASE("ledgerheader", "[ledger]")
         TxSetFramePtr txSet = make_shared<TxSetFrame>(lastHash);
 
         // close this ledger
-        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps, 0);
+        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps,
+                        STELLAR_VALUE_BASIC);
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
 

--- a/src/ledger/test/LedgerManagerTests.cpp
+++ b/src/ledger/test/LedgerManagerTests.cpp
@@ -76,7 +76,8 @@ TEST_CASE("new ledger comes from network after last applyBufferedLedgers is "
 
     auto ledgerCloseData = [](uint32_t ledger) {
         auto txSet = std::make_shared<TxSetFrame>(Hash{});
-        StellarValue sv{txSet->getContentsHash(), 2, emptyUpgradeSteps, 0};
+        StellarValue sv{txSet->getContentsHash(), 2, emptyUpgradeSteps,
+                        STELLAR_VALUE_BASIC};
         return LedgerCloseData{ledger, txSet, sv};
     };
 

--- a/src/ledger/test/LedgerTests.cpp
+++ b/src/ledger/test/LedgerTests.cpp
@@ -21,7 +21,8 @@ TEST_CASE("cannot close ledger with unsupported ledger version", "[ledger]")
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
         auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
 
-        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps, 0);
+        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps,
+                        STELLAR_VALUE_BASIC);
         LedgerCloseData ledgerData(lcl.header.ledgerSeq + 1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
     };

--- a/src/ledger/test/SyncingLedgerChainTests.cpp
+++ b/src/ledger/test/SyncingLedgerChainTests.cpp
@@ -19,6 +19,7 @@ makeLedgerCloseData(uint32_t ledgerSeq)
 {
     auto txSet = std::make_shared<TxSetFrame>(sha256("a"), TransactionSet{});
     auto sv = StellarValue{};
+    sv.ext.v(STELLAR_VALUE_BASIC);
     sv.txSetHash = txSet->getContentsHash();
     return LedgerCloseData{ledgerSeq, txSet, sv};
 }

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -243,11 +243,11 @@ TEST_CASE("Flooding", "[flood][overlay]")
 
             Hash qSetHash = sha256(xdr::xdr_to_opaque(qset));
 
-            // build an SCP nomination message for the next ledger
+            // build an SCP message for the next ledger
 
             StellarValue sv(txSet.getContentsHash(),
                             lcl.header.scpValue.closeTime + 1,
-                            emptyUpgradeSteps, 0);
+                            emptyUpgradeSteps, STELLAR_VALUE_BASIC);
 
             SCPEnvelope envelope;
 

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -275,7 +275,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 
         if (!isOK)
         {
-            CLOG(DEBUG, "SCP") << "Malformed PREPARE message";
+            CLOG(TRACE, "SCP") << "Malformed PREPARE message";
             res = false;
         }
     }
@@ -289,7 +289,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
         res = res && (c.nCommit <= c.nH);
         if (!res)
         {
-            CLOG(DEBUG, "SCP") << "Malformed CONFIRM message";
+            CLOG(TRACE, "SCP") << "Malformed CONFIRM message";
         }
     }
     break;
@@ -302,7 +302,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 
         if (!res)
         {
-            CLOG(DEBUG, "SCP") << "Malformed EXTERNALIZE message";
+            CLOG(TRACE, "SCP") << "Malformed EXTERNALIZE message";
         }
     }
     break;
@@ -316,7 +316,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 bool
 BallotProtocol::abandonBallot(uint32 n)
 {
-    CLOG(DEBUG, "SCP") << "BallotProtocol::abandonBallot";
+    CLOG(TRACE, "SCP") << "BallotProtocol::abandonBallot";
     bool res = false;
     Value v = mSlot.getLatestCompositeCandidate();
     if (v.empty())
@@ -377,8 +377,8 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
         newb.value = value;
     }
 
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::bumpState"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::bumpState"
                            << " i: " << mSlot.getSlotIndex()
                            << " v: " << mSlot.getSCP().ballotToStr(newb);
 
@@ -455,8 +455,8 @@ BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
 void
 BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
 {
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::bumpToBallot"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::bumpToBallot"
                            << " i: " << mSlot.getSlotIndex()
                            << " b: " << mSlot.getSCP().ballotToStr(ballot);
 
@@ -878,8 +878,8 @@ BallotProtocol::attemptPreparedAccept(SCPStatement const& hint)
 bool
 BallotProtocol::setPreparedAccept(SCPBallot const& ballot)
 {
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::setPreparedAccept"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::setPreparedAccept"
                            << " i: " << mSlot.getSlotIndex()
                            << " b: " << mSlot.getSCP().ballotToStr(ballot);
 
@@ -1031,8 +1031,8 @@ bool
 BallotProtocol::setPreparedConfirmed(SCPBallot const& newC,
                                      SCPBallot const& newH)
 {
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::setPreparedConfirmed"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::setPreparedConfirmed"
                            << " i: " << mSlot.getSlotIndex()
                            << " h: " << mSlot.getSCP().ballotToStr(newH);
 
@@ -1291,8 +1291,8 @@ BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
 bool
 BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
 {
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::setAcceptCommit"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::setAcceptCommit"
                            << " i: " << mSlot.getSlotIndex()
                            << " new c: " << mSlot.getSCP().ballotToStr(c)
                            << " new h: " << mSlot.getSCP().ballotToStr(h);
@@ -1488,8 +1488,8 @@ BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
 bool
 BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
 {
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::setConfirmCommit"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::setConfirmCommit"
                            << " i: " << mSlot.getSlotIndex()
                            << " new c: " << mSlot.getSCP().ballotToStr(c)
                            << " new h: " << mSlot.getSCP().ballotToStr(h);
@@ -1839,8 +1839,8 @@ void
 BallotProtocol::advanceSlot(SCPStatement const& hint)
 {
     mCurrentMessageLevel++;
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::advanceSlot "
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::advanceSlot "
                            << mCurrentMessageLevel << " " << getLocalState();
 
     if (mCurrentMessageLevel >= MAX_ADVANCE_SLOT_RECURSION)
@@ -1880,8 +1880,8 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
         checkHeardFromQuorum();
     }
 
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "BallotProtocol::advanceSlot "
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "BallotProtocol::advanceSlot "
                            << mCurrentMessageLevel << " - exiting "
                            << getLocalState();
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -232,10 +232,10 @@ NominationProtocol::updateRoundLeaders()
     });
     // expand mRoundLeaders with the newly computed leaders
     mRoundLeaders.insert(newRoundLeaders.begin(), newRoundLeaders.end());
-    CLOG(DEBUG, "SCP") << "updateRoundLeaders: " << newRoundLeaders.size()
-                       << " -> " << mRoundLeaders.size();
     if (Logging::logDebug("SCP"))
     {
+        CLOG(DEBUG, "SCP") << "updateRoundLeaders: " << newRoundLeaders.size()
+                           << " -> " << mRoundLeaders.size();
         for (auto const& rl : mRoundLeaders)
         {
             CLOG(DEBUG, "SCP")
@@ -442,7 +442,7 @@ NominationProtocol::processEnvelope(SCPEnvelope const& envelope)
         }
         else
         {
-            CLOG(DEBUG, "SCP")
+            CLOG(TRACE, "SCP")
                 << "NominationProtocol: message didn't pass sanity check";
         }
     }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -112,6 +112,10 @@ Slot::recordStatement(SCPStatement const& st)
 {
     mStatementsHistory.emplace_back(
         HistoricalStatement{std::time(nullptr), st, mFullyValidated});
+    CLOG(DEBUG, "SCP") << "new statement: "
+                       << " i: " << getSlotIndex()
+                       << " st: " << mSCP.envToStr(st, false) << " validated: "
+                       << (mFullyValidated ? "true" : "false");
 }
 
 SCP::EnvelopeState

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -73,8 +73,8 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
     }
     else
     {
-        if (Logging::logDebug("SCP"))
-            CLOG(DEBUG, "SCP")
+        if (Logging::logTrace("SCP"))
+            CLOG(TRACE, "SCP")
                 << "Slot::setStateFromEnvelope invalid envelope"
                 << " i: " << getSlotIndex() << " " << mSCP.envToStr(e);
     }
@@ -119,8 +119,8 @@ Slot::processEnvelope(SCPEnvelope const& envelope, bool self)
 {
     dbgAssert(envelope.statement.slotIndex == mSlotIndex);
 
-    if (Logging::logDebug("SCP"))
-        CLOG(DEBUG, "SCP") << "Slot::processEnvelope"
+    if (Logging::logTrace("SCP"))
+        CLOG(TRACE, "SCP") << "Slot::processEnvelope"
                            << " i: " << getSlotIndex() << " "
                            << mSCP.envToStr(envelope);
 

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -337,7 +337,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
     REQUIRE(txSet->checkValid(app));
 
     StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
-                    emptyUpgradeSteps, 0);
+                    emptyUpgradeSteps, STELLAR_VALUE_BASIC);
     LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -1092,7 +1092,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         txSet->add(txFrame);
 
         // close this ledger
-        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps, 0);
+        StellarValue sv(txSet->getContentsHash(), 1, emptyUpgradeSteps,
+                        STELLAR_VALUE_BASIC);
         LedgerCloseData ledgerData(1, txSet, sv);
         app->getLedgerManager().closeLedger(ledgerData);
 

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -283,6 +283,7 @@ enum EnvelopeType
 {
     ENVELOPE_TYPE_SCP = 1,
     ENVELOPE_TYPE_TX = 2,
-    ENVELOPE_TYPE_AUTH = 3
+    ENVELOPE_TYPE_AUTH = 3,
+    ENVELOPE_TYPE_SCPVALUE = 4
 };
 }

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -12,7 +12,14 @@ typedef opaque UpgradeType<128>;
 
 enum StellarValueType
 {
-    STELLAR_VALUE_BASIC = 0
+    STELLAR_VALUE_BASIC = 0,
+    STELLAR_VALUE_SIGNED = 1
+};
+
+struct LedgerCloseValueSignature
+{
+    NodeID nodeID;       // which node introduced the value
+    Signature signature; // nodeID's signature
 };
 
 /* StellarValue is the value used by SCP to reach consensus on a given ledger
@@ -34,6 +41,8 @@ struct StellarValue
     {
     case STELLAR_VALUE_BASIC:
         void;
+    case STELLAR_VALUE_SIGNED:
+        LedgerCloseValueSignature lcValueSignature;
     }
     ext;
 };

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -10,11 +10,16 @@ namespace stellar
 
 typedef opaque UpgradeType<128>;
 
+enum StellarValueType
+{
+    STELLAR_VALUE_BASIC = 0
+};
+
 /* StellarValue is the value used by SCP to reach consensus on a given ledger
-*/
+ */
 struct StellarValue
 {
-    Hash txSetHash;   // transaction set to apply to previous ledger
+    Hash txSetHash;      // transaction set to apply to previous ledger
     TimePoint closeTime; // network close time
 
     // upgrades to apply to the previous ledger (usually empty)
@@ -27,7 +32,7 @@ struct StellarValue
     // reserved for future use
     union switch (int v)
     {
-    case 0:
+    case STELLAR_VALUE_BASIC:
         void;
     }
     ext;
@@ -35,7 +40,7 @@ struct StellarValue
 
 /* The LedgerHeader is the highest level structure representing the
  * state of a ledger, cryptographically linked to previous ledgers.
-*/
+ */
 struct LedgerHeader
 {
     uint32 ledgerVersion;    // the protocol version of the ledger
@@ -133,11 +138,12 @@ case DATA:
 
 enum BucketEntryType
 {
-    METAENTRY = -1, // At-and-after protocol 11: bucket metadata, should come first.
-    LIVEENTRY = 0,  // Before protocol 11: created-or-updated;
-                    // At-and-after protocol 11: only updated.
+    METAENTRY =
+        -1, // At-and-after protocol 11: bucket metadata, should come first.
+    LIVEENTRY = 0, // Before protocol 11: created-or-updated;
+                   // At-and-after protocol 11: only updated.
     DEADENTRY = 1,
-    INITENTRY = 2   // At-and-after protocol 11: only created.
+    INITENTRY = 2 // At-and-after protocol 11: only created.
 };
 
 struct BucketMetadata
@@ -288,7 +294,7 @@ struct OperationMeta
 struct TransactionMetaV1
 {
     LedgerEntryChanges txChanges; // tx level changes if any
-    OperationMeta operations<>; // meta for each operation
+    OperationMeta operations<>;   // meta for each operation
 };
 
 // this is the meta produced when applying transactions


### PR DESCRIPTION
# Description

This PR adds support for additional data attached to values during the nomination round, specifically values during nomination now include the validator identity of the validator that introduced the value to the network.

This makes it easier to understand the flow of SCP messages over the network, can be used for auditing purpose in the future (like see if specific validators are not including certain transactions on purpose for example).

This PR also adds extra logging to makes it easier to diagnose problems