### PR TITLE
Typo and small edits to Bucket README.

### DIFF
--- a/src/bucket/readme.md
+++ b/src/bucket/readme.md
@@ -5,13 +5,13 @@ local SQL [database](../database) in order to query the set and apply
 transactions to it.
 
 However, for two operations the "large logical set" of entries is inconvenient
-and/or intractable in its SQL storge form:
+and/or intractable in its SQL storage form:
 
-  - Efficiently calculating a cryptographic hash of the entire set, after each
-    change to it.
+- Efficiently calculating a cryptographic hash of the entire set after each
+  change to it.
 
-  - Efficiently transmitting a minimal "delta" of changes to the set, when a peer
-    is out of sync with the current ledger state and needs to "catch up".
+- Efficiently transmitting a minimal "delta" of changes to the set when a peer
+  is out of sync with the current ledger state and needs to "catch up".
 
 In order to support these two operations, the ledger entries are *redundantly*
 stored in a secondary structure called the [BucketList](BucketList.h), which is
@@ -25,6 +25,5 @@ which is stored in the [ledger header](../xdr/Stellar-ledger.x) in order to
 unambiguously denote the set of entries that exist at each ledger-close.
 
 The individual buckets that compose each level are checkpointed to history
-storage by the [history module](../history), and a subset of them -- the
-difference from the current bucket list -- is retrieved from history and applied
-in order to perform "fast" catchup.
+storage by the [history module](../history). The difference from the current bucket list (a subset
+of the buckets) is retrieved from history and applied in order to perform "fast" catchup.


### PR DESCRIPTION
## Description 

Fixes a typo as well as some small grammatical and formatting changes to the Bucket README.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

## Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension) **N/A**
- [x] Compiles **N/A**
- [x] Ran all tests **N/A**
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md) **N/A**
