### PR TITLE
fix AssetCode12 to actually be up to 12 chars

### DIFF
--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -19,7 +19,7 @@ typedef opaque DataValue<64>;
 typedef opaque AssetCode4[4];
 
 // 5-12 alphanumeric characters right-padded with 0 bytes
-typedef opaque AssetCode12[4];
+typedef opaque AssetCode12[12];
 
 enum AssetType
 {


### PR DESCRIPTION
broken by dbcfb136cd2cea419b334bb61cb541e1f7ae8d0f
