### PR TITLE
fix compile issue (vs2019)

### DIFF
--- a/src/history/HistoryArchiveManager.h
+++ b/src/history/HistoryArchiveManager.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace stellar


### PR DESCRIPTION
Small fix that addresses a compile error when building with the latest vs2019