### PR TITLE
Filter old scp messages

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -354,6 +354,12 @@ ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING=0
 # as this is a security threat.
 ALLOW_LOCALHOST_FOR_TESTING=false
 
+# MAXIMUM_LEDGER_CLOSETIME_DRIFT (in seconds) defaults to 50
+# Maximum drift between the local clock and the network time.
+# When joining the network for the first time, ignore SCP messages that are
+# unlikely to be for the latest ledger.
+MAXIMUM_LEDGER_CLOSETIME_DRIFT=50
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -954,6 +954,14 @@ HerderImpl::restoreSCPState()
 {
     // setup a sufficient state that we can participate in consensus
     auto const& lcl = mLedgerManager.getLastClosedLedgerHeader();
+    if (!mApp.getConfig().FORCE_SCP &&
+        lcl.header.ledgerSeq == LedgerManager::GENESIS_LEDGER_SEQ)
+    {
+        // if we're on genesis ledger, there is no point in claiming
+        // that we're "in sync"
+        return;
+    }
+
     mHerderSCPDriver.restoreSCPState(lcl.header.ledgerSeq, lcl.header.scpValue);
 
     trackingHeartBeat();

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -109,9 +109,10 @@ class HerderImpl : public Herder
     void signStellarValue(SecretKey const& s, StellarValue& sv);
 
   private:
-    // return true if values referenced by envelope are after the minimum
-    // allowed close time
-    bool checkMinCloseTime(SCPEnvelope const& envelope);
+    // return true if values referenced by envelope have a valid close time:
+    // * it's within the allowed range (using lcl if possible)
+    // * it's recent enough (if `enforceRecent` is set)
+    bool checkCloseTime(SCPEnvelope const& envelope, bool enforceRecent);
 
     void ledgerClosed();
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -109,6 +109,10 @@ class HerderImpl : public Herder
     void signStellarValue(SecretKey const& s, StellarValue& sv);
 
   private:
+    // return true if values referenced by envelope are after the minimum
+    // allowed close time
+    bool checkMinCloseTime(SCPEnvelope const& envelope);
+
     void ledgerClosed();
 
     void startRebroadcastTimer();

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -675,6 +675,20 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
     return xdr::xdr_to_opaque(comp);
 }
 
+bool
+HerderSCPDriver::toStellarValue(Value const& v, StellarValue& sv)
+{
+    try
+    {
+        xdr::xdr_from_opaque(v, sv);
+    }
+    catch (...)
+    {
+        return false;
+    }
+    return true;
+}
+
 void
 HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
 {

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -134,6 +134,10 @@ class HerderSCPDriver : public SCPDriver
 
     optional<VirtualClock::time_point> getPrepareStart(uint64_t slotIndex);
 
+    // converts a Value into a StellarValue
+    // returns false on error
+    bool toStellarValue(Value const& v, StellarValue& sv);
+
   private:
     Application& mApp;
     HerderImpl& mHerder;

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -138,6 +138,10 @@ class HerderSCPDriver : public SCPDriver
     // returns false on error
     bool toStellarValue(Value const& v, StellarValue& sv);
 
+    // validate close time as much as possible
+    bool checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
+                        StellarValue const& b) const;
+
   private:
     Application& mApp;
     HerderImpl& mHerder;
@@ -196,9 +200,6 @@ class HerderSCPDriver : public SCPDriver
     std::unique_ptr<ConsensusData> mLastTrackingSCP;
 
     void stateChanged();
-
-    bool checkCloseTime(uint64_t slotIndex, uint64_t lastCloseTime,
-                        StellarValue const& b) const;
 
     SCPDriver::ValidationLevel validateValueHelper(uint64_t slotIndex,
                                                    StellarValue const& sv,

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -44,6 +44,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     FORCE_SCP = false;
     LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION;
 
+    MAXIMUM_LEDGER_CLOSETIME_DRIFT = 50;
+
     OVERLAY_PROTOCOL_MIN_VERSION = 7;
     OVERLAY_PROTOCOL_VERSION = 9;
 
@@ -552,6 +554,10 @@ Config::load(std::string const& filename)
             else if (item.first == "PREFETCH_BATCH_SIZE")
             {
                 PREFETCH_BATCH_SIZE = readInt<uint32_t>(item);
+            }
+            else if (item.first == "MAXIMUM_LEDGER_CLOSETIME_DRIFT")
+            {
+                MAXIMUM_LEDGER_CLOSETIME_DRIFT = readInt<int64_t>(item, 0);
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -149,6 +149,10 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t LEDGER_PROTOCOL_VERSION;
     VirtualClock::time_point TESTING_UPGRADE_DATETIME;
 
+    // maximum allowed drift for close time when joining the network for the
+    // first time
+    uint64 MAXIMUM_LEDGER_CLOSETIME_DRIFT;
+
     // note: all versions in the range
     // [OVERLAY_PROTOCOL_MIN_VERSION, OVERLAY_PROTOCOL_VERSION] must be handled
     uint32_t OVERLAY_PROTOCOL_MIN_VERSION; // min overlay version understood

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -244,10 +244,11 @@ TEST_CASE("Flooding", "[flood][overlay]")
             Hash qSetHash = sha256(xdr::xdr_to_opaque(qset));
 
             // build an SCP message for the next ledger
-
-            StellarValue sv(txSet.getContentsHash(),
-                            lcl.header.scpValue.closeTime + 1,
-                            emptyUpgradeSteps, STELLAR_VALUE_BASIC);
+            auto ct = std::max<uint64>(
+                lcl.header.scpValue.closeTime + 1,
+                VirtualClock::to_time_t(inApp->getClock().now()));
+            StellarValue sv(txSet.getContentsHash(), ct, emptyUpgradeSteps,
+                            STELLAR_VALUE_BASIC);
 
             SCPEnvelope envelope;
 


### PR DESCRIPTION
This PR performs a few improvements on how SCP messages are ignored based on the network time (close time in the ledger header).

This is especially useful on testnet where the network gets reset often.

The way we make this better is by:
1. adding a new setting `MAXIMUM_LEDGER_CLOSETIME_DRIFT` that improves the detection of what the "latest ledger" is, based on consensus data. This setting is only used when the node is started fresh (after  `new-db` is called). The heuristic here is that the latest ledger has to be relatively recent to the local's node clock.
2. when a node receives SCP messages that have a bad "close time", we fast fail (instead of failing after feeding the message to the SCP subsystem). This avoids doing work that we don't need to do (downloading transaction sets, etc), if the value is going to be considered invalid anyways.
3. when starting fresh (genesis), we don't restore the "SCP state".
   * Restoring state is only useful when a node rejoins an existing network (where there is a good chance that peers have SCP messages that can help the node move on from its current ledger).
   * on the other hand, when starting from genesis, it's better to just consume SCP messages as soon as possible (there is no need to wait 30 seconds to determine that the network is not closing the genesis ledger)
