### PR TITLE
Proper handling of logging partitions

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -490,23 +490,10 @@ CommandHandler::ll(std::string const& params, std::string& retStr)
     std::string partition = retMap["partition"];
     if (!levelStr.size())
     {
-        root["Fs"] = Logging::getStringFromLL(Logging::getLogLevel("Fs"));
-        root["SCP"] = Logging::getStringFromLL(Logging::getLogLevel("SCP"));
-        root["Bucket"] =
-            Logging::getStringFromLL(Logging::getLogLevel("Bucket"));
-        root["Database"] =
-            Logging::getStringFromLL(Logging::getLogLevel("Database"));
-        root["History"] =
-            Logging::getStringFromLL(Logging::getLogLevel("History"));
-        root["Process"] =
-            Logging::getStringFromLL(Logging::getLogLevel("Process"));
-        root["Ledger"] =
-            Logging::getStringFromLL(Logging::getLogLevel("Ledger"));
-        root["Overlay"] =
-            Logging::getStringFromLL(Logging::getLogLevel("Overlay"));
-        root["Herder"] =
-            Logging::getStringFromLL(Logging::getLogLevel("Herder"));
-        root["Tx"] = Logging::getStringFromLL(Logging::getLogLevel("Tx"));
+        for (auto& p : Logging::kPartitionNames)
+        {
+            root[p] = Logging::getStringFromLL(Logging::getLogLevel(p));
+        }
     }
     else
     {

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -497,6 +497,7 @@ CommandHandler::ll(std::string const& params, std::string& retStr)
     }
     else
     {
+        partition = Logging::normalizePartition(partition);
         el::Level level = Logging::getLLfromString(levelStr);
         if (partition.size())
         {

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -305,4 +305,17 @@ Logging::rotate()
                                        std::to_string(prevMaxFileSize));
     }
 }
+
+std::string
+Logging::normalizePartition(std::string const& partition)
+{
+    for (auto& p : kPartitionNames)
+    {
+        if (iequals(partition, p))
+        {
+            return p;
+        }
+    }
+    throw std::invalid_argument("not a valid partition");
+}
 }

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -20,13 +20,9 @@ Levels:
 namespace stellar
 {
 
-namespace
-{
-
-static const std::vector<std::string> kLoggers = {
+std::array<std::string const, 13> const Logging::kPartitionNames = {
     "Fs",      "SCP",    "Bucket", "Database", "History", "Process",  "Ledger",
     "Overlay", "Herder", "Tx",     "LoadGen",  "Work",    "Invariant"};
-}
 
 el::Configurations Logging::gDefaultConf;
 
@@ -102,7 +98,7 @@ Logging::init()
     // el::Loggers::addFlag(el::LoggingFlag::HierarchicalLogging);
     el::Loggers::addFlag(el::LoggingFlag::DisableApplicationAbortOnFatalLog);
 
-    for (auto const& logger : kLoggers)
+    for (auto const& logger : kPartitionNames)
     {
         el::Loggers::getLogger(logger);
     }
@@ -271,7 +267,8 @@ Logging::getLLfromString(std::string const& levelName)
 void
 Logging::rotate()
 {
-    auto loggers = kLoggers;
+    std::vector<std::string> loggers(kPartitionNames.begin(),
+                                     kPartitionNames.end());
     loggers.insert(loggers.begin(), "default");
 
     // Lock the loggers while we rotate; this is needed to

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -37,6 +37,8 @@ class Logging
     static bool logDebug(std::string const& partition);
     static bool logTrace(std::string const& partition);
     static void rotate();
+    // throws if partition name is not recognized
+    static std::string normalizePartition(std::string const& partition);
 
     static std::array<std::string const, 13> const kPartitionNames;
 };

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -37,5 +37,7 @@ class Logging
     static bool logDebug(std::string const& partition);
     static bool logTrace(std::string const& partition);
     static void rotate();
+
+    static std::array<std::string const, 13> const kPartitionNames;
 };
 }


### PR DESCRIPTION
resolves #2082 

This PR makes setting logging partitions case insensitive (ie, 'll?partition=scp&level=DEBUG` will work), as well as returning a proper error when a bad partition name is passed in.
