### PR TITLE
Fix flaky connectivity test

### DIFF
--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -256,8 +256,11 @@ Simulation::startAllNodes()
     for (auto const& it : mNodes)
     {
         auto app = it.second.mApp;
-        app->start();
-        app->getLoadGenerator().updateMinBalance();
+        if (app->getState() == Application::APP_CREATED_STATE)
+        {
+            app->start();
+            app->getLoadGenerator().updateMinBalance();
+        }
     }
 
     for (auto const& pair : mPendingConnections)


### PR DESCRIPTION
One test was randomly failing due to a race condition between peers connecting to a central peer (in a nutshell: they would not discover other peers reliably as the list of alternate peers was non deterministic)
