### PR TITLE
Rebuild db and replay buckets with differing logic

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -139,6 +139,14 @@ class BucketManager : NonMovableOrCopyable
     // state of the bucket list.
     virtual void snapshotLedger(LedgerHeader& currentHeader) = 0;
 
+#ifdef BUILD_TESTS
+    // Install a fake/assumed ledger version and bucket list hash to use in next
+    // call to addBatch and snapshotLedger. This interface exists only for
+    // testing in a specific type of history replay.
+    virtual void setNextCloseVersionAndHashForTesting(uint32_t protocolVers,
+                                                      uint256 const& hash) = 0;
+#endif
+
     // Check for missing bucket files that would prevent `assumeState` from
     // succeeding
     virtual std::vector<std::string>

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -51,6 +51,12 @@ class BucketManagerImpl : public BucketManager
     void cleanupStaleFiles();
     void cleanDir();
 
+#ifdef BUILD_TESTS
+    bool mUseFakeTestValuesForNextClose{false};
+    uint32_t mFakeTestProtocolVersion;
+    uint256 mFakeTestBucketListHash;
+#endif
+
   protected:
     void calculateSkipValues(LedgerHeader& currentHeader);
     std::string bucketFilename(std::string const& bucketHexHash);
@@ -81,6 +87,14 @@ class BucketManagerImpl : public BucketManager
                   std::vector<LedgerEntry> const& liveEntries,
                   std::vector<LedgerKey> const& deadEntries) override;
     void snapshotLedger(LedgerHeader& currentHeader) override;
+
+#ifdef BUILD_TESTS
+    // Install a fake/assumed ledger version and bucket list hash to use in next
+    // call to addBatch and snapshotLedger. This interface exists only for
+    // testing in a specific type of history replay.
+    void setNextCloseVersionAndHashForTesting(uint32_t protocolVers,
+                                              uint256 const& hash) override;
+#endif
 
     std::vector<std::string>
     checkForMissingBucketsFiles(HistoryArchiveState const& has) override;

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -399,7 +399,6 @@ Database::initialize()
     LedgerHeaderUtils::dropAll(*this);
     TransactionFrame::dropAll(*this);
     HistoryManager::dropAll(*this);
-    mApp.getBucketManager().dropAll();
     HerderPersistence::dropAll(*this);
     mApp.getLedgerTxnRoot().dropData();
     BanManager::dropAll(*this);

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -162,6 +162,7 @@ ApplicationImpl::newDB()
     mDatabase->initialize();
     mDatabase->upgradeToCurrentSchema();
     mLedgerManager->startNewLedger();
+    mBucketManager->dropAll();
 }
 
 void

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -15,9 +15,12 @@ int runWithConfig(Config cfg);
 void setForceSCPFlag(Config cfg, bool set);
 void initializeDatabase(Config cfg);
 void httpCommand(std::string const& command, unsigned short port);
-void loadXdr(Config cfg, std::string const& bucketFile);
 void showOfflineInfo(Config cfg);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);
+#ifdef BUILD_TESTS
+void loadXdr(Config cfg, std::string const& bucketFile);
+int rebuildLedgerFromBuckets(Config cfg);
+#endif
 void genSeed();
 int initializeHistories(Config cfg,
                         std::vector<std::string> const& newHistories);

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -599,19 +599,6 @@ runInferQuorum(CommandLineArgs const& args)
 }
 
 int
-runLoadXDR(CommandLineArgs const& args)
-{
-    CommandLine::ConfigOption configOption;
-    std::string xdr;
-
-    return runWithHelp(
-        args, {configurationParser(configOption), fileNameParser(xdr)}, [&] {
-            loadXdr(configOption.getConfig(), xdr);
-            return 0;
-        });
-}
-
-int
 runNewDB(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -776,6 +763,30 @@ runWriteQuorum(CommandLineArgs const& args)
 
 #ifdef BUILD_TESTS
 int
+runLoadXDR(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    std::string xdr;
+
+    return runWithHelp(
+        args, {configurationParser(configOption), fileNameParser(xdr)}, [&] {
+            loadXdr(configOption.getConfig(), xdr);
+            return 0;
+        });
+}
+
+int
+runRebuildLedgerFromBuckets(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+
+    return runWithHelp(args, {configurationParser(configOption)}, [&] {
+        rebuildLedgerFromBuckets(configOption.getConfig());
+        return 0;
+    });
+}
+
+int
 runFuzz(CommandLineArgs const& args)
 {
     el::Level logLevel{el::Level::Info};
@@ -825,7 +836,6 @@ handleCommandLine(int argc, char* const* argv)
           runHttpCommand},
          {"infer-quorum", "print a quorum set inferred from history",
           runInferQuorum},
-         {"load-xdr", "load an XDR bucket file, for testing", runLoadXDR},
          {"new-db", "creates or restores the DB to the genesis ledger",
           runNewDB},
          {"new-hist", "initialize history archives", runNewHist},
@@ -850,6 +860,10 @@ handleCommandLine(int argc, char* const* argv)
          {"upgrade-db", "upgade database schema to current version",
           runUpgradeDB},
 #ifdef BUILD_TESTS
+         {"load-xdr", "load an XDR bucket file, for testing", runLoadXDR},
+         {"rebuild-ledger-from-buckets",
+          "rebuild the current database ledger from the bucket list",
+          runRebuildLedgerFromBuckets},
          {"fuzz", "run a single fuzz input and exit", runFuzz},
          {"gen-fuzz", "generate a random fuzzer input file", runGenFuzz},
          {"test", "execute test suite", runTest},

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -478,6 +478,17 @@ runCatchup(CommandLineArgs const& args)
             config.setNoListen();
             config.DISABLE_BUCKET_GC = disableBucketGC;
 
+            if (config.AUTOMATIC_MAINTENANCE_PERIOD.count() > 0 &&
+                config.AUTOMATIC_MAINTENANCE_COUNT > 0)
+            {
+                // If the user did not _disable_ maintenance, turn the dial up
+                // to be much more aggressive about running maintenance during a
+                // bulk catchup, otherwise the DB is likely to overflow with
+                // unwanted history.
+                config.AUTOMATIC_MAINTENANCE_PERIOD = std::chrono::seconds{30};
+                config.AUTOMATIC_MAINTENANCE_COUNT = 1000000;
+            }
+
             VirtualClock clock(VirtualClock::REAL_TIME);
             auto app = Application::create(clock, config, false);
             Json::Value catchupInfo;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -29,9 +29,12 @@ const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 11;
 
 // Options that must only be used for testing
 static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
-    "RUN_STANDALONE", "MANUAL_CLOSE", "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
+    "RUN_STANDALONE",
+    "MANUAL_CLOSE",
+    "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
     "ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING",
-    "ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING"};
+    "ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING",
+    "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -96,6 +99,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = 0;
     ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = false;
     ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING = false;
+    ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING = false;
     ALLOW_LOCALHOST_FOR_TESTING = false;
     USE_CONFIG_FOR_GENESIS = false;
     FAILURE_SAFETY = -1;
@@ -693,6 +697,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING =
                     readInt<uint32_t>(item, 0, UINT32_MAX - 1);
+            }
+            else if (item.first ==
+                     "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING")
+            {
+                ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING =
+                    readBool(item);
             }
             else if (item.first == "ALLOW_LOCALHOST_FOR_TESTING")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -167,6 +167,14 @@ class Config : public std::enable_shared_from_this<Config>
     // and should be false in all normal cases.
     bool ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING;
 
+    // A config parameter that forces replay to use the newest bucket logic;
+    // this implicitly means that replay will _not_ check bucket-list hashes
+    // along the way, but rather will use the stated hashes from ledger headers
+    // _in place of_ the real bucket list hash. This should only be enabled when
+    // testing since it completely defeats the state-integrity checking of the
+    // system.
+    bool ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING;
+
     // A config to allow connections to localhost
     // this should only be enabled when testing as it's a security issue
     bool ALLOW_LOCALHOST_FOR_TESTING;


### PR DESCRIPTION
# Description

This includes 3 pieces from recent bucket work. I can separate them out into separate PRs if you like, though IMO they are relatives (they all got written while I was running tests of the new INITENTRY code doing replay on old ledger history).

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
