### PR TITLE
Build then run tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,16 @@ branches:
  only:
  - auto
 
+stages:
+  - compile
+  - test
+
+matrix:
+  fast_finish: true
+  include:
+    - stage: compile
+      compiler: clang
+      script: ./travis-build.sh --disable-tests
+    - stage: compile
+      compiler: gcc
+      script: ./travis-build.sh --disable-tests

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -4,6 +4,20 @@
 
 set -ev
 
+WITH_TESTS=1
+
+case "$1" in
+"--disable-tests")
+        WITH_TESTS=0
+        ;;
+"")
+        ;;
+*)
+        echo Usage: $0 "[--disable-tests]"
+        exit 1
+        ;;
+esac
+
 echo $TRAVIS_PULL_REQUEST
 
 NPROCS=$(getconf _NPROCESSORS_ONLN)
@@ -37,31 +51,11 @@ clang -v
 g++ -v
 llvm-symbolizer --version || true
 
-# Create postgres databases
 if test $CXX = 'clang++'; then
     RUN_PARTITIONS=$(seq 0 $((NPROCS-1)))
 elif test $CXX = 'g++'; then
     RUN_PARTITIONS=$(seq $NPROCS $((2*NPROCS-1)))
 fi
-export PGUSER=postgres
-psql -c "create database test;"
-# we run NPROCS jobs in parallel
-for j in $(seq 0 $((NPROCS-1))); do
-    base_instance=$((j*50))
-    for i in $(seq $base_instance $((base_instance+15))); do
-        psql -c "create database test$i;"
-    done
-done
-
-committer_of(){
-    local c=$(git cat-file -p "$1" 2> /dev/null \
-    | sed -ne '/^committer \([^<]*[^ <]\)  *<.*>.*/{s//\1/p; q;}')
-    test -n "$c" -a Latobarita != "$c" && echo "$c"
-}
-committer=$(committer_of HEAD) \
-    || committer=$(committer_of HEAD^2) \
-    || committer=$(committer_of HEAD^1) \
-    || committer=Latobarita
 
 config_flags="--enable-asan --enable-extrachecks --enable-ccache --enable-sdfprefs"
 export CFLAGS="-O2 -g1"
@@ -72,7 +66,7 @@ export CXXFLAGS="-w -O2 -g1"
 # as the leak detector relies on ptrace
 export LSAN_OPTIONS=detect_leaks=0
 
-echo "committer = $committer, config_flags = $config_flags"
+echo "config_flags = $config_flags"
 
 ccache -s
 date
@@ -90,6 +84,23 @@ fi
 date
 time make -j$(($NPROCS + 1))
 ccache -s
+
+if [ $WITH_TESTS -eq 0 ] ; then
+    echo "Build done, skipping tests"
+    exit 0
+fi
+
+# Create postgres databases
+export PGUSER=postgres
+psql -c "create database test;"
+# we run NPROCS jobs in parallel
+for j in $(seq 0 $((NPROCS-1))); do
+    base_instance=$((j*50))
+    for i in $(seq $base_instance $((base_instance+15))); do
+        psql -c "create database test$i;"
+    done
+done
+
 export ALL_VERSIONS=1
 export TEMP_POSTGRES=0
 export NUM_PARTITIONS=$((NPROCS*2))

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -39,9 +39,9 @@ llvm-symbolizer --version || true
 
 # Create postgres databases
 if test $CXX = 'clang++'; then
-    RUN_PARTITIONS="0 1"
+    RUN_PARTITIONS=$(seq 0 $((NPROCS-1)))
 elif test $CXX = 'g++'; then
-    RUN_PARTITIONS="2 3"
+    RUN_PARTITIONS=$(seq $NPROCS $((2*NPROCS-1)))
 fi
 export PGUSER=postgres
 psql -c "create database test;"
@@ -92,7 +92,7 @@ time make -j$(($NPROCS + 1))
 ccache -s
 export ALL_VERSIONS=1
 export TEMP_POSTGRES=0
-export NUM_PARTITIONS=4
+export NUM_PARTITIONS=$((NPROCS*2))
 export RUN_PARTITIONS
 time make check
 


### PR DESCRIPTION
This PR separates the build stage from the stage that runs tests in travis.

While this takes a little longer to run the same tests, it allows to build and update `ccache` independently of running tests.

In master, if a changeset modifies too many things (or the cache gets deleted), we're likely to timeout as the total time compilation + running tests exceeds 50 minutes.


Information on "build stages" can be found https://docs.travis-ci.com/user/build-stages/
