### PR TITLE
bugfix: show fullkeys for delayed, disagree and missing validators

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -2036,7 +2036,7 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
         {
             if (!summary)
             {
-                missing.append(mSlot.getSCPDriver().toShortString(n));
+                missing.append(mSlot.getSCPDriver().toStrKey(n, fullKeys));
             }
             n_missing++;
         }
@@ -2053,7 +2053,8 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
                 {
                     if (!summary)
                     {
-                        delayed.append(mSlot.getSCPDriver().toShortString(n));
+                        delayed.append(
+                            mSlot.getSCPDriver().toStrKey(n, fullKeys));
                     }
                     n_delayed++;
                 }
@@ -2062,7 +2063,7 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
             {
                 if (!summary)
                 {
-                    disagree.append(mSlot.getSCPDriver().toShortString(n));
+                    disagree.append(mSlot.getSCPDriver().toStrKey(n, fullKeys));
                 }
                 n_disagree++;
             }
@@ -2088,10 +2089,7 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
         auto& f_ex = ret["fail_with"];
         for (auto const& n : f)
         {
-            std::string nodeID = fullKeys
-                                     ? mSlot.getSCPDriver().toStrKey(n)
-                                     : mSlot.getSCPDriver().toShortString(n);
-            f_ex.append(nodeID);
+            f_ex.append(mSlot.getSCPDriver().toStrKey(n, fullKeys));
         }
         ret["value"] = getLocalNode()->toJson(*qSet, fullKeys);
     }

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -378,9 +378,7 @@ LocalNode::toJson(SCPQuorumSet const& qSet, bool fullKeys) const
     auto& entries = ret["v"];
     for (auto const& v : qSet.validators)
     {
-        std::string nodeID = fullKeys ? mSCP->getDriver().toStrKey(v)
-                                      : mSCP->getDriver().toShortString(v);
-        entries.append(nodeID);
+        entries.append(mSCP->getDriver().toStrKey(v, fullKeys));
     }
     for (auto const& s : qSet.innerSets)
     {

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -318,8 +318,7 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
 
     Hash const& qSetHash = Slot::getCompanionQuorumSetHashFromStatement(st);
 
-    std::string nodeId = fullKeys ? mDriver.toStrKey(st.nodeID)
-                                  : mDriver.toShortString(st.nodeID);
+    std::string nodeId = mDriver.toStrKey(st.nodeID, fullKeys);
 
     oss << "{ENV@" << nodeId << " | "
         << " i: " << st.slotIndex;

--- a/src/scp/SCPDriver.cpp
+++ b/src/scp/SCPDriver.cpp
@@ -24,9 +24,9 @@ SCPDriver::getValueString(Value const& v) const
 }
 
 std::string
-SCPDriver::toStrKey(PublicKey const& pk) const
+SCPDriver::toStrKey(PublicKey const& pk, bool fullKey) const
 {
-    return KeyUtils::toStrKey(pk);
+    return fullKey ? KeyUtils::toStrKey(pk) : SCPDriver::toShortString(pk);
 }
 
 std::string

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -87,7 +87,8 @@ class SCPDriver
     virtual std::string getValueString(Value const& v) const;
 
     // `toStrKey` returns StrKey encoded string representation
-    virtual std::string toStrKey(PublicKey const& pk) const;
+    virtual std::string toStrKey(PublicKey const& pk,
+                                 bool fullKey = true) const;
 
     // `toShortString` converts to the common name of a key if found
     virtual std::string toShortString(PublicKey const& pk) const;


### PR DESCRIPTION
Fixing full keys output that I missed out for [delayed, disagree, missing] validators in /quorum?fullkeys=true.

Relates to #1721 

# Checklist
- [X] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [X] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
