### PR TITLE
Add transitive quorum option to `quorum` endpoint

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -697,8 +697,9 @@ This list is the result of both inbound connections from other peers and outboun
 }
 ```
 
-### Quorum set Health
+### Quorum Health
 
+#### Quorum set diagnostics
 The `quorum` command allows to diagnose problems with the quorum set of the local node.
 
 Run
@@ -750,6 +751,80 @@ You can get a sense of the quorum set health of a different node by doing
 `$ stellar-core http-command 'quorum?node=$sdf1` or `$ stellar-core http-command 'quorum?node=@GABCDE` 
 
 Overall network health can be evaluated by walking through all nodes and looking at their health. Note that this is only an approximation as remote nodes may not have received the same messages (in particular: `missing` for other nodes is not reliable).
+
+#### Overall quorum analysis
+
+The quorum endpoint can also retrieve information for the transitive quorum.
+
+This is a easier to process format than what `scp` returns as it doesn't contain all SCP messages.
+
+`$ stellar-core http-command 'quorum?transitive=true'`
+
+The output looks something like:
+```json
+ "nodes" : [
+      {
+         "distance" : 0,
+         "heard" : 121235,
+         "node" : "GB7LI",
+         "qset" : {
+            "t" : 2,
+            "v" : [ "sdf1", "sdf2", "sdf3" ]
+         },
+         "status" : "tracking",
+         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+         "value_id" : 1
+      },
+      {
+         "distance" : 1,
+         "heard" : 121235,
+         "node" : "sdf2",
+         "qset" : {
+            "t" : 2,
+            "v" : [ "sdf1", "sdf2", "sdf3" ]
+         },
+         "status" : "tracking",
+         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+         "value_id" : 1
+      },
+      {
+         "distance" : 1,
+         "heard" : 121235,
+         "node" : "sdf3",
+         "qset" : {
+            "t" : 2,
+            "v" : [ "sdf1", "sdf2", "sdf3" ]
+         },
+         "status" : "tracking",
+         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+         "value_id" : 1
+      },
+      {
+         "distance" : 1,
+         "heard" : 121235,
+         "node" : "sdf1",
+         "qset" : {
+            "t" : 2,
+            "v" : [ "sdf1", "sdf2", "sdf3" ]
+         },
+         "status" : "tracking",
+         "value" : "[ txH: d99591, ct: 1557426183, upgrades: [ ] ]",
+         "value_id" : 1
+      }
+   ]
+```
+
+The output represents a walk of the transitive quorum centered on a given node.
+
+Fields are:
+
+* `node` : the identity of the validator
+* `distance` : how far that node is from the root node (ie. how many quorum set hops)
+* `heard` : the latest ledger sequence number that this node voted at
+* `qset` : the node's quorum set
+* `status` : one of `behind|tracking|ahead` (compared to the root node) or `missing|unknown` (when there are no recent SCP messages for that node)
+* `value_id` : a unique ID for what the node is voting for (allows to quickly tell if nodes are voting for the same thing)
+* `value` : what the node is voting for
 
 ## Validator maintenance
 

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -164,11 +164,16 @@ format.
   Returns the list of known peers in JSON format.
 
 * **quorum**
-  `/quorum?[node=NODE_ID][&compact=true][&fullkeys=true]`<br>
-  Returns information about the quorum for node NODE_ID (this node by default).
-  NODE_ID is either a full key (`GABCD...`), an alias (`$name`) or an
-  abbreviated ID (`@GABCD`). If compact is set, only returns a summary version.
-  Outputs unshortened public keys if fullkeys is set.
+  `/quorum?[node=NODE_ID][&compact=true][&fullkeys=true][&transitive=true]`<br>
+  Returns information about the quorum for `NODE_ID` (local node by default).
+  If `transitive` is set, information is for the transitive quorum centered on `NODE_ID`, otherwise only for nodes in the quorum set of `NODE_ID`.
+
+  `NODE_ID` is either a full key (`GABCD...`), an alias (`$name`) or an
+  abbreviated ID (`@GABCD`).
+
+  If `compact` is set, only returns a summary version.
+
+  If `fullkeys` is set, outputs unshortened public keys.
 
 * **setcursor**
   `/setcursor?id=ID&cursor=N`<br>

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -141,5 +141,8 @@ class Herder
     virtual Json::Value getJsonInfo(size_t limit, bool fullKeys = false) = 0;
     virtual Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
                                           bool fullKeys, uint64 index) = 0;
+    virtual Json::Value getJsonTransitiveQuorumInfo(NodeID const& id,
+                                                    bool summary,
+                                                    bool fullKeys) = 0;
 };
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -140,7 +140,6 @@ class Herder
 
     virtual Json::Value getJsonInfo(size_t limit, bool fullKeys = false) = 0;
     virtual Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
-                                          bool fullKeys = false,
-                                          uint64 index = 0) = 0;
+                                          bool fullKeys, uint64 index) = 0;
 };
 }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -91,6 +91,9 @@ class HerderImpl : public Herder
     Json::Value getJsonInfo(size_t limit, bool fullKeys = false) override;
     Json::Value getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
                                   uint64 index) override;
+    virtual Json::Value getJsonTransitiveQuorumInfo(NodeID const& id,
+                                                    bool summary,
+                                                    bool fullKeys) override;
 
 #ifdef BUILD_TESTS
     // used for testing

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -89,9 +89,8 @@ class HerderImpl : public Herder
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;
 
     Json::Value getJsonInfo(size_t limit, bool fullKeys = false) override;
-    Json::Value getJsonQuorumInfo(NodeID const& id, bool summary,
-                                  bool fullKeys = false,
-                                  uint64 index = 0) override;
+    Json::Value getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
+                                  uint64 index) override;
 
 #ifdef BUILD_TESTS
     // used for testing

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -71,6 +71,7 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
     mServer->add404(std::bind(&CommandHandler::fileNotFound, this, _1, _2));
 
     addRoute("bans", &CommandHandler::bans);
+    addRoute("clearmetrics", &CommandHandler::clearMetrics);
     addRoute("connect", &CommandHandler::connect);
     addRoute("dropcursor", &CommandHandler::dropcursor);
     addRoute("droppeer", &CommandHandler::dropPeer);
@@ -81,14 +82,13 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
     addRoute("maintenance", &CommandHandler::maintenance);
     addRoute("manualclose", &CommandHandler::manualClose);
     addRoute("metrics", &CommandHandler::metrics);
-    addRoute("clearmetrics", &CommandHandler::clearMetrics);
     addRoute("peers", &CommandHandler::peers);
     addRoute("quorum", &CommandHandler::quorum);
     addRoute("setcursor", &CommandHandler::setcursor);
     addRoute("scp", &CommandHandler::scpInfo);
     addRoute("tx", &CommandHandler::tx);
-    addRoute("upgrades", &CommandHandler::upgrades);
     addRoute("unban", &CommandHandler::unban);
+    addRoute("upgrades", &CommandHandler::upgrades);
 
 #ifdef BUILD_TESTS
     addRoute("generateload", &CommandHandler::generateLoad);
@@ -461,7 +461,7 @@ CommandHandler::quorum(std::string const& params, std::string& retStr)
     }
 
     auto root = mApp.getHerder().getJsonQuorumInfo(
-        n, retMap["compact"] == "true", retMap["fullkeys"] == "true");
+        n, retMap["compact"] == "true", retMap["fullkeys"] == "true", 0);
     retStr = root.toStyledString();
 }
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -460,8 +460,17 @@ CommandHandler::quorum(std::string const& params, std::string& retStr)
         }
     }
 
-    auto root = mApp.getHerder().getJsonQuorumInfo(
-        n, retMap["compact"] == "true", retMap["fullkeys"] == "true", 0);
+    Json::Value root;
+    if (retMap["transitive"] == "true")
+    {
+        root = mApp.getHerder().getJsonTransitiveQuorumInfo(
+            n, retMap["compact"] == "true", retMap["fullkeys"] == "true");
+    }
+    else
+    {
+        root = mApp.getHerder().getJsonQuorumInfo(
+            n, retMap["compact"] == "true", retMap["fullkeys"] == "true", 0);
+    }
     retStr = root.toStyledString();
 }
 

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -46,13 +46,6 @@ class SCP
         VALID    // the envelope is valid
     };
 
-    enum TriBool
-    {
-        TB_TRUE,
-        TB_FALSE,
-        TB_MAYBE
-    };
-
     // this is the main entry point of the SCP library
     // it processes the envelope, updates the internal state and
     // invokes the appropriate methods


### PR DESCRIPTION
This PR adds a new option to the `quorum` endpoint that provides an easy to use summary of the transitive quorum that should make it easier to write tools that analyze the health of the overall quorum (the data is an interpretation of what can be found in the `scp` endpoint for the most part).

For a preview, see the [Overall quorum analysis](https://github.com/MonsieurNicolas/stellar-core/blob/quorumTransitive/docs/software/admin.md#overall-quorum-analysis) section in the admin guide (included in this pull request).
