### PR TITLE
Couple download and application of checkpoints in a single Work

### DIFF
--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -132,7 +132,7 @@ class CatchupWork : public Work
 
     CatchupWork(Application& app, CatchupConfiguration catchupConfiguration,
                 ProgressHandler progressHandler, size_t maxRetries);
-    ~CatchupWork();
+    virtual ~CatchupWork();
     std::string getStatus() const override;
 
   private:
@@ -149,10 +149,10 @@ class CatchupWork : public Work
     std::shared_ptr<BasicWork> mGetBucketStateWork;
 
     WorkSeqPtr mDownloadVerifyLedgersSeq;
-    std::shared_ptr<VerifyLedgerChainWork> mVerifyLedgers;
     WorkSeqPtr mBucketVerifyApplySeq;
-    WorkSeqPtr mTransactionsVerifyApplySeq;
     WorkSeqPtr mCatchupSeq;
+    std::shared_ptr<VerifyLedgerChainWork> mVerifyLedgers;
+    std::shared_ptr<Work> mTransactionsVerifyApplySeq;
 
     bool hasAnyLedgersToCatchupTo() const;
     bool alreadyHaveBucketsHistoryArchiveState(uint32_t atCheckpoint) const;
@@ -161,6 +161,6 @@ class CatchupWork : public Work
     void downloadVerifyLedgerChain(CatchupRange const& catchupRange,
                                    LedgerNumHashPair rangeEnd);
     WorkSeqPtr downloadApplyBuckets();
-    WorkSeqPtr downloadApplyTransactions(CatchupRange const& catchupRange);
+    void downloadApplyTransactions(CatchupRange catchupRange);
 };
 }

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -165,7 +165,7 @@ TEST_CASE("History bucket verification",
     }
 }
 
-TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
+TEST_CASE("Ledger chain verification", "[ledgerheaderverification][history]")
 {
     Config cfg(getTestConfig(0));
     VirtualClock clock;

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -40,7 +40,7 @@ BatchDownloadWork::yieldMoreWork()
 {
     if (!hasNext())
     {
-        CLOG(WARNING, "Work")
+        CLOG(ERROR, "Work")
             << getName() << " has no more children to iterate over! ";
         return nullptr;
     }
@@ -56,7 +56,7 @@ BatchDownloadWork::yieldMoreWork()
 }
 
 bool
-BatchDownloadWork::hasNext() const
+BatchDownloadWork::hasNext()
 {
     return mNext <= mRange.mLast;
 }

--- a/src/historywork/BatchDownloadWork.h
+++ b/src/historywork/BatchDownloadWork.h
@@ -30,7 +30,7 @@ class BatchDownloadWork : public BatchWork
     std::string getStatus() const override;
 
   protected:
-    bool hasNext() const override;
+    bool hasNext() override;
     std::shared_ptr<BasicWork> yieldMoreWork() override;
     void resetIter() override;
 };

--- a/src/historywork/DownloadApplyTxsWork.cpp
+++ b/src/historywork/DownloadApplyTxsWork.cpp
@@ -1,0 +1,123 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "historywork/DownloadApplyTxsWork.h"
+#include "catchup/ApplyCheckpointWork.h"
+#include "history/FileTransferInfo.h"
+#include "history/HistoryManager.h"
+#include "historywork/GetAndUnzipRemoteFileWork.h"
+#include "ledger/LedgerManager.h"
+#include "work/WorkSequence.h"
+
+namespace stellar
+{
+
+DownloadApplyTxsWork::DownloadApplyTxsWork(
+    Application& app, TmpDir const& downloadDir, LedgerRange range,
+    LedgerHeaderHistoryEntry& lastApplied)
+    : BatchWork(app, "download-apply-ledgers")
+    , mRange(range)
+    , mDownloadDir(downloadDir)
+    , mLastApplied(lastApplied)
+    , mCheckpointToQueue(
+          app.getHistoryManager().checkpointContainingLedger(range.mFirst))
+{
+}
+
+std::shared_ptr<BasicWork>
+DownloadApplyTxsWork::yieldMoreWork()
+{
+    if (!hasNext())
+    {
+        CLOG(ERROR, "Work")
+            << getName() << " has no more children to iterate over! ";
+        return nullptr;
+    }
+
+    CLOG(INFO, "History") << "Downloading, unzipping and applying "
+                          << HISTORY_FILE_TYPE_TRANSACTIONS
+                          << " for checkpoint " << mCheckpointToQueue;
+    FileTransferInfo ft(mDownloadDir, HISTORY_FILE_TYPE_TRANSACTIONS,
+                        mCheckpointToQueue);
+    auto getAndUnzip = std::make_shared<GetAndUnzipRemoteFileWork>(mApp, ft);
+    auto apply = std::make_shared<ApplyCheckpointWork>(
+        mApp, mDownloadDir, mCheckpointToQueue, mRange.mLast);
+
+    std::vector<std::shared_ptr<BasicWork>> seq{getAndUnzip, apply};
+    std::vector<ConditionFn> cond;
+
+    if (!mRunning.empty())
+    {
+        auto prevWork = mRunning.back();
+        auto predicate = [prevWork]() {
+            if (!prevWork)
+            {
+                throw std::runtime_error("Download and apply txs: related Work "
+                                         "is destroyed unexpectedly");
+            }
+            return prevWork->getState() == State::WORK_SUCCESS;
+        };
+        cond = {nullptr, predicate};
+    }
+
+    auto nextWork = std::make_shared<WorkSequence>(
+        mApp, "download-apply-" + std::to_string(mCheckpointToQueue), seq, cond,
+        RETRY_NEVER);
+    mRunning.push_back(nextWork);
+    mCheckpointToQueue += mApp.getHistoryManager().getCheckpointFrequency();
+
+    return nextWork;
+}
+
+void
+DownloadApplyTxsWork::wakeWaitingWork()
+{
+    while (!mRunning.empty())
+    {
+        auto work = mRunning.front();
+        if (work->getState() == State::WORK_SUCCESS)
+        {
+            mRunning.pop_front();
+            continue;
+        }
+
+        if (work->getState() != State::WORK_FAILURE)
+        {
+            // At this point, sequence download->apply is either:
+            // - Still downloading files, in which case `wakeUp` will have
+            // no effect, and it will simply proceed to applying when done
+            // since the condition has been met OR
+            // - Finished downloading, but is waiting for previous checkpoint
+            // to finish applying; in this case, wakeUp will put it back into
+            // RUNNING state and the sequence can proceed with applying
+            work->wakeUp();
+        }
+        break;
+    }
+}
+
+void
+DownloadApplyTxsWork::resetIter()
+{
+    mCheckpointToQueue =
+        mApp.getHistoryManager().checkpointContainingLedger(mRange.mFirst);
+    mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
+    mRunning.clear();
+}
+
+bool
+DownloadApplyTxsWork::hasNext()
+{
+    wakeWaitingWork();
+    auto last =
+        mApp.getHistoryManager().checkpointContainingLedger(mRange.mLast);
+    return mCheckpointToQueue <= last;
+}
+
+void
+DownloadApplyTxsWork::onSuccess()
+{
+    mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
+}
+}

--- a/src/historywork/DownloadApplyTxsWork.h
+++ b/src/historywork/DownloadApplyTxsWork.h
@@ -1,0 +1,48 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "herder/TxSetFrame.h"
+#include "ledger/LedgerRange.h"
+#include "util/XDRStream.h"
+#include "work/BatchWork.h"
+#include "work/Work.h"
+#include "xdr/Stellar-SCP.h"
+#include "xdr/Stellar-ledger.h"
+
+namespace medida
+{
+class Meter;
+}
+
+namespace stellar
+{
+
+class TmpDir;
+struct LedgerHeaderHistoryEntry;
+
+class DownloadApplyTxsWork : public BatchWork
+{
+    LedgerRange const mRange;
+    TmpDir const& mDownloadDir;
+    LedgerHeaderHistoryEntry& mLastApplied;
+    uint32_t mCheckpointToQueue;
+    mutable std::list<std::shared_ptr<BasicWork>> mRunning;
+
+    void wakeWaitingWork();
+
+  public:
+    DownloadApplyTxsWork(Application& app, TmpDir const& downloadDir,
+                         LedgerRange range,
+                         LedgerHeaderHistoryEntry& lastApplied);
+    virtual ~DownloadApplyTxsWork() = default;
+
+  protected:
+    bool hasNext() override;
+    std::shared_ptr<BasicWork> yieldMoreWork() override;
+    void resetIter() override;
+    void onSuccess() override;
+};
+}

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -42,7 +42,7 @@ DownloadBucketsWork::getStatus() const
 }
 
 bool
-DownloadBucketsWork::hasNext() const
+DownloadBucketsWork::hasNext()
 {
     return mNextBucketIter != mHashes.end();
 }

--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -29,7 +29,7 @@ class DownloadBucketsWork : public BatchWork
     std::string getStatus() const override;
 
   protected:
-    bool hasNext() const override;
+    bool hasNext() override;
     std::shared_ptr<BasicWork> yieldMoreWork() override;
     void resetIter() override;
 };

--- a/src/work/BasicWork.h
+++ b/src/work/BasicWork.h
@@ -143,6 +143,13 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
     // up once finished.
     void startWork(std::function<void()> notificationCallback);
 
+    // A helper method that implementers can use if they plan to utilize
+    // WAITING state. This tells the work to return to RUNNING state, and
+    // propagate the notification up to the scheduler. An example use of
+    // this would be RunCommandWork: a timer is used to async_wait for a
+    // process to exit, with a call to `wakeUp` upon completion.
+    void wakeUp(std::function<void()> innerCallback = nullptr);
+
     // Prepare work for destruction. Implementers overriding this method
     // are expected to call it on all work they might have created.
     // Note `BasicWork::shutdown` must also be called, as it changes the
@@ -184,13 +191,6 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
     virtual void onFailureRaise();
     virtual void onSuccess();
 
-    // A helper method that implementers can use if they plan to utilize
-    // WAITING state. This tells the work to return to RUNNING state, and
-    // propagate the notification up to the scheduler. An example use of
-    // this would be RunCommandWork: a timer is used to async_wait for a
-    // process to exit, with a call to `wakeUp` upon completion.
-    void wakeUp(std::function<void()> innerCallback = nullptr);
-
     // Default wakeUp callback that implementers can use
     std::function<void()>
     wakeSelfUpCallback(std::function<void()> innerCallback = nullptr);
@@ -207,7 +207,7 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
         RUNNING,
         WAITING,
         // Work is shutting down. During this stage, Work is prevented from
-        // making any furhter progress. This means that any attempts to call
+        // making any further progress. This means that any attempts to call
         // wake, add child work or invoke a callback will result in a no-op.
         ABORTING,
         ABORTED,

--- a/src/work/BatchWork.cpp
+++ b/src/work/BatchWork.cpp
@@ -45,7 +45,6 @@ BatchWork::doWork()
     }
 
     addMoreWorkIfNeeded();
-    mApp.getCatchupManager().logAndUpdateCatchupStatus(true);
 
     if (allChildrenSuccessful())
     {

--- a/src/work/BatchWork.h
+++ b/src/work/BatchWork.h
@@ -38,7 +38,7 @@ class BatchWork : public Work
 
     // Implementers aren't allowed to edit batching mechanism,
     // but instead provide iteration methods.
-    virtual bool hasNext() const = 0;
+    virtual bool hasNext() = 0;
     virtual std::shared_ptr<BasicWork> yieldMoreWork() = 0;
     virtual void resetIter() = 0;
 };

--- a/src/work/test/WorkTests.cpp
+++ b/src/work/test/WorkTests.cpp
@@ -749,7 +749,7 @@ class TestBatchWork : public BatchWork
 
   protected:
     bool
-    hasNext() const override
+    hasNext() override
     {
         return mCount < mTotalWorks;
     }


### PR DESCRIPTION
This PR changes how we replay ledgers. Instead of downloading then applying everything, this change replays history per checkpoint, cleaning up files after checkpoint application succeeded. I ended up letting the parent work (in this case, `DownloadApplyTxsWork`) control its children fully (i.e. impose conditions, and wake up children when they are ready to continue running).

I'm not married to this design, but I could not justify implementing a full DAG infrastructure, given that the only use case for "waiting" work currently (and anticipated in the future) is "sequence A-B-C is running, but some other work D needs to complete before B". I'd appreciate any feedback/ideas though! 

Also, still need to add comments on how to properly use updated WorkSequence, and add more tests.

This will also resolve #1951 