### PR TITLE
display known keys when displaying short keys

### DIFF
--- a/src/scp/SCPDriver.cpp
+++ b/src/scp/SCPDriver.cpp
@@ -26,7 +26,7 @@ SCPDriver::getValueString(Value const& v) const
 std::string
 SCPDriver::toStrKey(PublicKey const& pk, bool fullKey) const
 {
-    return fullKey ? KeyUtils::toStrKey(pk) : SCPDriver::toShortString(pk);
+    return fullKey ? KeyUtils::toStrKey(pk) : toShortString(pk);
 }
 
 std::string


### PR DESCRIPTION
9356a10fe7a535156323f51a314935d1b60984d3 introduced a bug where it forces the use of the default implementation from `SCPDriver` instead of using the proper override.

