### PR TITLE
Do not allow gaps in history

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -19,9 +19,12 @@ Common options can be placed at any place in the command line.
 Command options can only by placed after command.
 
 * **catchup <DESTINATION-LEDGER/LEDGER-COUNT>**: Perform catchup from history
-  archives without connecting to network. This option will catchup to
-  DESTINATION-LEDGER keeping history from DESTINATION-LEDGER-LEDGER-COUNT or
-  from the last closed ledger (whichever value is biggest).
+  archives without connecting to network. For new instances (with empty history
+  tables - only ledger 1 present in the database) it will respect LEDGER-COUNT
+  configuration and it will perform bucket application on such a checkpoint
+  that at least LEDGER-COUNT entries are present in history table afterwards.
+  For instances that already have some history entries, all ledgers since last
+  closed ledger will be replayed.
 * **check-quorum**:   Check quorum intersection from history to ensure there is
   closure over all the validators in the network.
 * **convert-id <ID>**: Will output the passed ID in all known forms and then

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -63,6 +63,8 @@ ApplyBucketsWork::getBucket(std::string const& hash)
 void
 ApplyBucketsWork::onReset()
 {
+    CLOG(INFO, "History") << "Applying buckets";
+
     mTotalBuckets = 0;
     mAppliedBuckets = 0;
     mAppliedEntries = 0;

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -322,7 +322,7 @@ dbModeName(Config::TestDbMode mode)
     }
 }
 
-TEST_CASE("History catchup", "[history][historycatchup]")
+TEST_CASE("History catchup", "[history][catchup]")
 {
     // needs REAL_TIME here, as prepare-snapshot works will fail for one of the
     // sections again and again - as it is set to RETRY_FOREVER it can generate
@@ -413,7 +413,7 @@ TEST_CASE("History catchup", "[history][historycatchup]")
     }
 }
 
-TEST_CASE("History catchup with different modes", "[history][historycatchup]")
+TEST_CASE("History catchup with different modes", "[history][catchup]")
 {
     CatchupSimulation catchupSimulation{};
 
@@ -446,7 +446,7 @@ TEST_CASE("History catchup with different modes", "[history][historycatchup]")
     }
 }
 
-TEST_CASE("History prefix catchup", "[history][historycatchup][prefixcatchup]")
+TEST_CASE("History prefix catchup", "[history][catchup][prefixcatchup]")
 {
     CatchupSimulation catchupSimulation{};
 
@@ -564,7 +564,7 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
 }
 
 TEST_CASE("Publish catchup alternation with stall",
-          "[history][historycatchup][catchupalternation]")
+          "[history][catchup][catchupalternation]")
 {
     CatchupSimulation catchupSimulation{};
     auto& lm = catchupSimulation.getApp().getLedgerManager();
@@ -742,7 +742,7 @@ TEST_CASE("persist publish queue", "[history]")
 
     {
         VirtualClock clock;
-        Application::pointer app1 = Application::create(clock, cfg, false);
+        Application::pointer app1 = Application::create(clock, cfg, 0);
         app1->getHistoryArchiveManager().initializeHistoryArchive("test");
         for (size_t i = 0; i < 100; ++i)
             clock.crank(false);
@@ -775,7 +775,7 @@ TEST_CASE("persist publish queue", "[history]")
 // The idea with this test is that we join a network and somehow get a gap
 // in the SCP voting sequence while we're trying to catchup. This will let
 // system catchup just before the gap.
-TEST_CASE("catchup with a gap", "[history][catchupstall]")
+TEST_CASE("catchup with a gap", "[history][catchup][catchupstall]")
 {
     CatchupSimulation catchupSimulation{};
     auto checkpointLedger = catchupSimulation.getLastCheckpointLedger(1);
@@ -811,7 +811,7 @@ TEST_CASE("catchup with a gap", "[history][catchupstall]")
  * Test a variety of orderings of CATCHUP_RECENT mode, to shake out boundary
  * cases.
  */
-TEST_CASE("Catchup recent", "[history][catchuprecent][!hide]")
+TEST_CASE("Catchup recent", "[history][catchup][catchuprecent][!hide]")
 {
     CatchupSimulation catchupSimulation{};
     auto checkpointLedger = catchupSimulation.getLastCheckpointLedger(3);
@@ -861,7 +861,7 @@ TEST_CASE("Catchup recent", "[history][catchuprecent][!hide]")
 /*
  * Test a variety of LCL/initLedger/count modes.
  */
-TEST_CASE("Catchup manual", "[history][catchupmanual]")
+TEST_CASE("Catchup manual", "[history][catchup][catchupmanual]")
 {
     CatchupSimulation catchupSimulation{};
     auto checkpointLedger = catchupSimulation.getLastCheckpointLedger(6);

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -16,9 +16,9 @@ BatchDownloadWork::BatchDownloadWork(Application& app, CheckpointRange range,
                                      std::string const& type,
                                      TmpDir const& downloadDir)
     : BatchWork(app, fmt::format("batch-download-{:s}-{:08x}-{:08x}", type,
-                                 range.first(), range.last()))
+                                 range.mFirst, range.mLast))
     , mRange(range)
-    , mNext(range.first())
+    , mNext(range.mFirst)
     , mFileType(type)
     , mDownloadDir(downloadDir)
 {
@@ -30,7 +30,7 @@ BatchDownloadWork::getStatus() const
     if (getState() == State::WORK_RUNNING)
     {
         auto task = fmt::format("downloading {:s} files", mFileType);
-        return fmtProgress(mApp, task, mRange.first(), mRange.last(), mNext);
+        return fmtProgress(mApp, task, mRange.mFirst, mRange.mLast, mNext);
     }
     return BatchWork::getStatus();
 }
@@ -58,12 +58,12 @@ BatchDownloadWork::yieldMoreWork()
 bool
 BatchDownloadWork::hasNext() const
 {
-    return mNext <= mRange.last();
+    return mNext <= mRange.mLast;
 }
 
 void
 BatchDownloadWork::resetIter()
 {
-    mNext = mRange.first();
+    mNext = mRange.mFirst;
 }
 }

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -63,6 +63,7 @@ GetHistoryArchiveStateWork::doWork()
     {
         auto name = mSeq == 0 ? HistoryArchiveState::wellKnownRemoteName()
                               : HistoryArchiveState::remoteName(mSeq);
+        CLOG(INFO, "History") << "Downloading history archive state: " << name;
         mGetRemoteFile = addWork<GetRemoteFileWork>(name, mLocalFilename,
                                                     mArchive, mRetries);
         return State::WORK_RUNNING;

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -10,6 +10,8 @@
 #include "main/ErrorMessages.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include "util/format.h"
+
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
 
@@ -77,6 +79,9 @@ VerifyBucketWork::spawnVerifier()
             auto hasher = SHA256::create();
             asio::error_code ec;
             {
+                CLOG(INFO, "History")
+                    << fmt::format("Verifying bucket {}", binToHex(hash));
+
                 // ensure that the stream gets its own scope to avoid race with
                 // main thread
                 std::ifstream in(filename, std::ifstream::binary);

--- a/src/ledger/CheckpointRange.cpp
+++ b/src/ledger/CheckpointRange.cpp
@@ -5,7 +5,9 @@
 #include "ledger/CheckpointRange.h"
 #include "history/HistoryManager.h"
 #include "ledger/LedgerRange.h"
+
 #include <cassert>
+#include <util/format.h>
 
 namespace stellar
 {
@@ -22,14 +24,20 @@ CheckpointRange::CheckpointRange(uint32_t first, uint32_t last,
 
 CheckpointRange::CheckpointRange(LedgerRange const& ledgerRange,
                                  HistoryManager const& historyManager)
-    : mFirst{historyManager.checkpointContainingLedger(ledgerRange.first())}
-    , mLast{historyManager.checkpointContainingLedger(ledgerRange.last())}
+    : mFirst{historyManager.checkpointContainingLedger(ledgerRange.mFirst)}
+    , mLast{historyManager.checkpointContainingLedger(ledgerRange.mLast)}
     , mFrequency{historyManager.getCheckpointFrequency()}
 {
     assert(mFirst > 0);
     assert(mLast >= mFirst);
     assert((mFirst + 1) % mFrequency == 0);
     assert((mLast + 1) % mFrequency == 0);
+}
+
+std::string
+CheckpointRange::toString() const
+{
+    return fmt::format("{}..{}", mFirst + 1 - mFrequency, mLast);
 }
 
 bool

--- a/src/ledger/CheckpointRange.h
+++ b/src/ledger/CheckpointRange.h
@@ -5,16 +5,20 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include <cstdint>
+#include <string>
 
 namespace stellar
 {
 
 class HistoryManager;
-class LedgerRange;
+struct LedgerRange;
 
-class CheckpointRange final
+struct CheckpointRange final
 {
-  public:
+    uint32_t const mFirst;
+    uint32_t const mLast;
+    uint32_t const mFrequency;
+
     CheckpointRange(uint32_t first, uint32_t last, uint32_t frequency);
     CheckpointRange(LedgerRange const& ledgerRange,
                     HistoryManager const& historyManager);
@@ -22,29 +26,11 @@ class CheckpointRange final
     friend bool operator!=(CheckpointRange const& x, CheckpointRange const& y);
 
     uint32_t
-    first() const
-    {
-        return mFirst;
-    }
-    uint32_t
-    last() const
-    {
-        return mLast;
-    }
-    uint32_t
-    frequency() const
-    {
-        return mFrequency;
-    }
-    uint32_t
     count() const
     {
-        return (last() - first()) / frequency() + 1;
+        return (mLast - mFirst) / mFrequency + 1;
     }
 
-  private:
-    uint32_t mFirst;
-    uint32_t mLast;
-    uint32_t mFrequency;
+    std::string toString() const;
 };
 }

--- a/src/ledger/LedgerRange.cpp
+++ b/src/ledger/LedgerRange.cpp
@@ -3,7 +3,9 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "ledger/LedgerRange.h"
+
 #include <cassert>
+#include <util/format.h>
 
 namespace stellar
 {
@@ -13,6 +15,12 @@ LedgerRange::LedgerRange(uint32_t first, uint32_t last)
 {
     assert(mFirst > 0);
     assert(mLast >= mFirst);
+}
+
+std::string
+LedgerRange::toString() const
+{
+    return fmt::format("{}..{}", mFirst, mLast);
 }
 
 bool

--- a/src/ledger/LedgerRange.h
+++ b/src/ledger/LedgerRange.h
@@ -14,26 +14,16 @@ namespace stellar
 // history entry, useful for catchup and ledger verification purposes.
 using LedgerNumHashPair = std::pair<uint32_t, optional<Hash>>;
 
-class LedgerRange final
+struct LedgerRange final
 {
   public:
+    uint32_t const mFirst;
+    uint32_t const mLast;
+
     LedgerRange(uint32_t first, uint32_t last);
+    std::string toString() const;
+
     friend bool operator==(LedgerRange const& x, LedgerRange const& y);
     friend bool operator!=(LedgerRange const& x, LedgerRange const& y);
-
-    uint32_t
-    first() const
-    {
-        return mFirst;
-    }
-    uint32_t
-    last() const
-    {
-        return mLast;
-    }
-
-  private:
-    uint32_t mFirst;
-    uint32_t mLast;
 };
 }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1511,8 +1511,8 @@ LedgerTxnRoot::Impl::countObjects(LedgerEntryType let,
                         tableFromLedgerEntryType(let) +
                         " WHERE lastmodified >= :v1 AND lastmodified <= :v2;";
     uint64_t count = 0;
-    int first = static_cast<int>(ledgers.first());
-    int last = static_cast<int>(ledgers.last());
+    int first = static_cast<int>(ledgers.mFirst);
+    int last = static_cast<int>(ledgers.mLast);
     mDatabase.getSession() << query, into(count), use(first), use(last);
     return count;
 }

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -212,7 +212,7 @@ class Database;
 struct InflationVotes;
 struct LedgerEntry;
 struct LedgerKey;
-class LedgerRange;
+struct LedgerRange;
 
 bool isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry);
 

--- a/src/test/TestPrinter.cpp
+++ b/src/test/TestPrinter.cpp
@@ -21,8 +21,8 @@ StringMaker<stellar::OfferState>::convert(stellar::OfferState const& os)
 std::string
 StringMaker<stellar::CatchupRange>::convert(stellar::CatchupRange const& cr)
 {
-    return fmt::format("[{}..{}], applyBuckets: {}", cr.first.first(),
-                       cr.first.last(), cr.second);
+    return fmt::format("[{}..{}], applyBuckets: {}", cr.mLedgers.mFirst,
+                       cr.getLast(), cr.getBucketApplyLedger());
 }
 
 std::string


### PR DESCRIPTION
# Description

Resolves #1913

After this PR all catchups after the initial one will be CATCHUP_COMPLETE. That means that no gaps in history are allowed past the initial one (where the only ledger in database in GENESIS_LEDGER).

This PR makes it possible to simplify catchup tests, as lot less cases needs to be addressed now.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
