### PR TITLE
Test improvements

### DIFF
--- a/src/catchup/test/CatchupWorkTests.cpp
+++ b/src/catchup/test/CatchupWorkTests.cpp
@@ -8,6 +8,7 @@
 #include "ledger/CheckpointRange.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/Logging.h"
 #include "util/Timer.h"
 #include <lib/catch.hpp>
 #include <lib/util/format.h>
@@ -137,10 +138,10 @@ TEST_CASE("compute CatchupRange from CatchupConfiguration", "[catchupWork]")
         auto lastClosedLedger = test.first;
         auto configuration = test.second;
 
-        auto sectionName = fmt::format(
-            "lcl = {}, to ledger = {}, count = {}", lastClosedLedger,
-            configuration.toLedger(), configuration.count());
-        SECTION(sectionName)
+        auto name = fmt::format("lcl = {}, to ledger = {}, count = {}",
+                                lastClosedLedger, configuration.toLedger(),
+                                configuration.count());
+        LOG(DEBUG) << "Catchup configuration: " << name;
         {
             auto range = CatchupWork::makeCatchupRange(
                 lastClosedLedger, configuration, historyManager);

--- a/src/historywork/RepairMissingBucketsWork.cpp
+++ b/src/historywork/RepairMissingBucketsWork.cpp
@@ -17,7 +17,7 @@ namespace stellar
 
 RepairMissingBucketsWork::RepairMissingBucketsWork(
     Application& app, HistoryArchiveState const& localState, Handler endHandler)
-    : Work(app, "repair-buckets")
+    : Work(app, "repair-buckets", RETRY_NEVER)
     , mEndHandler(endHandler)
     , mLocalState(localState)
     , mDownloadDir(std::make_unique<TmpDir>(


### PR DESCRIPTION
Few updates to the test suite, which makes it run a few minutes faster (mostly due to not using timeout mechanism when it doesn't need to)

Also, repair missing buckets work shouldn't be retrying - individual work sequences it manages already handle retries correctly. 