### PR TITLE
Check validity of upgrades before applying them during closeLedger

### DIFF
--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -67,6 +67,23 @@ class Upgrades
     // convert upgrade value to string
     static std::string toString(LedgerUpgrade const& upgrade);
 
+    enum class UpgradeValidity
+    {
+        VALID,
+        XDR_INVALID,
+        INVALID
+    };
+
+    // VALID if it is safe to apply upgrade
+    // XDR_INVALID if the upgrade cannot be deserialized
+    // INVALID if it is unsafe to apply the upgrade for any other reason
+    //
+    // If the upgrade could be deserialized then lupgrade is set
+    static UpgradeValidity isValidForApply(UpgradeType const& upgrade,
+                                           LedgerUpgrade& lupgrade,
+                                           LedgerHeader const& header,
+                                           uint32_t maxLedgerVersion);
+
     // returns true if upgrade is a valid upgrade step
     // in which case it also sets upgradeType
     bool isValid(UpgradeType const& upgrade, LedgerUpgradeType& upgradeType,
@@ -96,6 +113,11 @@ class Upgrades
     UpgradeParameters mParams;
 
     bool timeForUpgrade(uint64_t time) const;
+
+    // returns true if upgrade is a valid upgrade step
+    // in which case it also sets lupgrade
+    bool isValidForNomination(LedgerUpgrade const& upgrade,
+                              LedgerHeader const& header) const;
 
     static void applyVersionUpgrade(AbstractLedgerTxn& ltx,
                                     uint32_t newVersion);

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -488,9 +488,13 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
         Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY;
     uint32_t oldProto = newProto - 1;
     auto configurator =
-        std::make_shared<ProtocolVersionTmpDirHistoryConfigurator>(oldProto);
+        std::make_shared<RealGenesisTmpDirHistoryConfigurator>();
     CatchupSimulation catchupSimulation{VirtualClock::VIRTUAL_TIME,
                                         configurator};
+
+    // Upgrade to oldProto
+    catchupSimulation.generateRandomLedger(oldProto);
+
     auto checkpointLedger = catchupSimulation.getLastCheckpointLedger(3);
     catchupSimulation.ensureOnlineCatchupPossible(checkpointLedger);
 
@@ -502,8 +506,7 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
         auto a = catchupSimulation.createCatchupApplication(
             count, Config::TESTDB_IN_MEMORY_SQLITE,
             std::string("full, ") + resumeModeName(count) + ", " +
-                dbModeName(Config::TESTDB_IN_MEMORY_SQLITE),
-            newProto);
+                dbModeName(Config::TESTDB_IN_MEMORY_SQLITE));
         REQUIRE(catchupSimulation.catchupOnline(a, checkpointLedger - 2));
 
         // Check that during catchup/replay, we did not use any INITENTRY code,

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -75,13 +75,9 @@ class TmpDirHistoryConfigurator : public HistoryConfigurator
     Config& configure(Config& cfg, bool writable) const override;
 };
 
-class ProtocolVersionTmpDirHistoryConfigurator
-    : public TmpDirHistoryConfigurator
+class RealGenesisTmpDirHistoryConfigurator : public TmpDirHistoryConfigurator
 {
-    uint32_t mProtocolVersion;
-
   public:
-    ProtocolVersionTmpDirHistoryConfigurator(uint32_t protocolVersion);
     Config& configure(Config& cfg, bool writable) const override;
 };
 
@@ -255,7 +251,7 @@ class CatchupSimulation
 
     uint32_t getLastCheckpointLedger(uint32_t checkpointIndex) const;
 
-    void generateRandomLedger();
+    void generateRandomLedger(uint32_t version = 0);
 
     void ensurePublishesComplete();
     void ensureLedgerAvailable(uint32_t targetLedger);
@@ -263,9 +259,9 @@ class CatchupSimulation
     void ensureOnlineCatchupPossible(uint32_t targetLedger,
                                      uint32_t bufferLedgers = 0);
 
-    Application::pointer createCatchupApplication(
-        uint32_t count, Config::TestDbMode dbMode, std::string const& appName,
-        uint32_t protocol = Config::CURRENT_LEDGER_PROTOCOL_VERSION);
+    Application::pointer createCatchupApplication(uint32_t count,
+                                                  Config::TestDbMode dbMode,
+                                                  std::string const& appName);
     bool catchupOffline(Application::pointer app, uint32_t toLedger);
     bool catchupOnline(Application::pointer app, uint32_t initLedger,
                        uint32_t bufferLedgers = 0, uint32_t gapLedger = 0);

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -288,7 +288,7 @@ TEST_CASE("inflation", "[tx][inflation]")
 
     // Do our setup in version 1 so that for_all_versions below does not
     // try to downgrade us from >1 to 1.
-    cfg.LEDGER_PROTOCOL_VERSION = 1;
+    cfg.USE_CONFIG_FOR_GENESIS = false;
 
     VirtualClock::time_point inflationStart;
     // inflation starts on 1-jul-2014

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -36,7 +36,7 @@ TEST_CASE("merge", "[tx][merge]")
 
     // Do our setup in version 1 so that for_all_versions below does not
     // try to downgrade us from >1 to 1.
-    cfg.LEDGER_PROTOCOL_VERSION = 1;
+    cfg.USE_CONFIG_FOR_GENESIS = false;
 
     VirtualClock clock;
     auto app = createTestApplication(clock, cfg);

--- a/src/transactions/test/PaymentTests.cpp
+++ b/src/transactions/test/PaymentTests.cpp
@@ -41,7 +41,7 @@ TEST_CASE("payment", "[tx][payment]")
 
     // Do our setup in version 1 so that for_all_versions below does not
     // try to downgrade us from >1 to 1.
-    cfg.LEDGER_PROTOCOL_VERSION = 1;
+    cfg.USE_CONFIG_FOR_GENESIS = false;
 
     VirtualClock clock;
     auto app = createTestApplication(clock, cfg);

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -44,7 +44,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
     // Do our setup in version 1 so that for_all_versions below does not
     // try to downgrade us from >1 to 1.
-    cfg.LEDGER_PROTOCOL_VERSION = 1;
+    cfg.USE_CONFIG_FOR_GENESIS = false;
 
     VirtualClock clock;
     auto app = createTestApplication(clock, cfg);


### PR DESCRIPTION
Fixes an issue introduced by me in 92d2f48be. That commit, part of the implementation of [CAP-0003](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0003.md), introduced the possibility that an upgrade can effect ledger entries. But if a node applies an upgrade without understanding what it needs to do to ledger entries, then it will not produce the same hash as a node that does understand what it needs to do to ledger entries. Now nodes will crash when trying to apply an upgrade that they don't understand.