### PR TITLE
Persist externalize messages for older slots

### DIFF
--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -139,7 +139,7 @@ class HerderImpl : public Herder
     void getMoreSCPState();
 
     // last slot that was persisted into the database
-    // only keep track of the most recent slot
+    // keep track of all messages for MAX_SLOTS_TO_REMEMBER slots
     uint64 mLastSlotSaved;
 
     // timer that detects that we're stuck on an SCP slot

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -29,16 +29,21 @@ class PersistentState
 
     static void dropAll(Database& db);
 
-    std::string getStoreStateName(Entry n);
-
     std::string getState(Entry stateName);
-
     void setState(Entry stateName, std::string const& value);
+
+    // Special methods for SCP state (multiple slots)
+    std::vector<std::string> getSCPStateAllSlots();
+    void setSCPStateForSlot(uint64 slot, std::string const& value);
 
   private:
     static std::string kSQLCreateStatement;
     static std::string mapping[kLastEntry];
 
     Application& mApp;
+
+    std::string getStoreStateName(Entry n, int subscript = 0);
+    void updateDb(std::string const& entry, std::string const& value);
+    std::string getFromDb(std::string const& entry);
 };
 }


### PR DESCRIPTION
This should resolve #2107, as `EXTERNALIZE` messages for older slots are now persisted. 