### PR TITLE
Include algorithm in NominationProtocol.cpp

### DIFF
--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -14,6 +14,7 @@
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
+#include <algorithm>
 #include <functional>
 
 namespace stellar


### PR DESCRIPTION
```
This source file uses std::adjacent_find, std::includes, std::find, which are defined
in algorithm, but only includes functional.
```

I have no idea why it builds currently, but when I tried to build with g++-9, it errored out.
Here's the build log from a small library which I built by extracting the SCP code:
```
Build failed: /home/travis/build/source/scpp/src/scp/NominationProtocol.cpp: In static member function ‘static bool stellar::NominationProtocol::isSubsetHelper(const xdr::xvector<xdr::xvector<unsigned char, 4294967292> >&, const xdr::xvector<xdr::xvector<unsigned char, 4294967292> >&, bool&)’:
/home/travis/build/source/scpp/src/scp/NominationProtocol.cpp:53:20: error: ‘includes’ is not a member of ‘std’
   53 |         res = std::includes(v.begin(), v.end(), p.begin(), p.end());
      |                    ^~~~~~~~
/home/travis/build/source/scpp/src/scp/NominationProtocol.cpp: In member function ‘bool stellar::NominationProtocol::isSane(const stellar::SCPStatement&)’:
/home/travis/build/source/scpp/src/scp/NominationProtocol.cpp:110:24: error: ‘adjacent_find’ is not a member of ‘std’
  110 |     res = res && (std::adjacent_find(
      |                        ^~~~~~~~~~~~~
/home/travis/build/source/scpp/src/scp/NominationProtocol.cpp:115:24: error: ‘adjacent_find’ is not a member of ‘std’
  115 |     res = res && (std::adjacent_find(
      |                        ^~~~~~~~~~~~~
/home/travis/build/source/scpp/src/scp/NominationProtocol.cpp: In static member function ‘static bool stellar::NominationProtocol::acceptPredicate(const Value&, const stellar::SCPStatement&)’:
/home/travis/build/source/scpp/src/scp/NominationProtocol.cpp:189:65: error: no matching function for call to ‘find(std::vector<xdr::xvector<unsigned char, 4294967292>, std::allocator<xdr::xvector<unsigned char, 4294967292> > >::const_iterator, std::vector<xdr::xvector<unsigned char, 4294967292>, std::allocator<xdr::xvector<unsigned char, 4294967292> > >::const_iterator, const Value&)’
  189 |     res = (std::find(nom.accepted.begin(), nom.accepted.end(), v) !=
      |                                                                 ^
In file included from /usr/include/c++/9/bits/locale_facets.h:48,
                 from /usr/include/c++/9/bits/basic_ios.h:37,
                 from /usr/include/c++/9/ios:44,
                 from /usr/include/c++/9/ostream:38,
                 from /home/travis/build/source/scpp/src/crypto/SecretKey.h:13,
                 from /home/travis/build/source/scpp/src/scp/SCP.h:13,
                 from /home/travis/build/source/scpp/src/scp/NominationProtocol.h:8,
                 from /home/travis/build/source/scpp/src/scp/NominationProtocol.cpp:5:
```

# Checklist
- [X] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [X] Rebased on top of master (no merge commits)
- [X] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [X] Compiles
- [X] Ran all tests
- [X] ~If change impacts performance~