### PR TITLE
Split key verification into its own file

### DIFF
--- a/src/crypto/KeyVerification.cpp
+++ b/src/crypto/KeyVerification.cpp
@@ -1,0 +1,88 @@
+// Copyright 2014-2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+
+#include "crypto/KeyVerification.h"
+#include "crypto/SHA.h"
+#include "util/HashOfHash.h"
+#include "util/RandomEvictionCache.h"
+#include <mutex>
+#include <sodium.h>
+
+namespace stellar
+{
+
+// Process-wide global Ed25519 signature-verification cache.
+//
+// This is a pure mathematical function and has no relationship
+// to the state of the process; caching its results centrally
+// makes all signature-verification in the program faster and
+// has no effect on correctness.
+
+static std::mutex gVerifySigCacheMutex;
+static RandomEvictionCache<Hash, bool> gVerifySigCache(0xffff);
+static std::unique_ptr<SHA256> gHasher = SHA256::create();
+static uint64_t gVerifyCacheHit = 0;
+static uint64_t gVerifyCacheMiss = 0;
+
+static Hash
+verifySigCacheKey(PublicKey const& key, Signature const& signature,
+                  ByteSlice const& bin)
+{
+    assert(key.type() == PUBLIC_KEY_TYPE_ED25519);
+
+    gHasher->reset();
+    gHasher->add(key.ed25519());
+    gHasher->add(signature);
+    gHasher->add(bin);
+    return gHasher->finish();
+}
+
+bool
+PubKeyUtils::verifySig(PublicKey const& key, Signature const& signature,
+                       ByteSlice const& bin)
+{
+    assert(key.type() == PUBLIC_KEY_TYPE_ED25519);
+    if (signature.size() != 64)
+    {
+        return false;
+    }
+
+    auto cacheKey = verifySigCacheKey(key, signature, bin);
+
+    {
+        std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
+        if (gVerifySigCache.exists(cacheKey))
+        {
+            ++gVerifyCacheHit;
+            return gVerifySigCache.get(cacheKey);
+        }
+    }
+
+    ++gVerifyCacheMiss;
+    bool ok =
+        (crypto_sign_verify_detached(signature.data(), bin.data(), bin.size(),
+                                     key.ed25519().data()) == 0);
+    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
+    gVerifySigCache.put(cacheKey, ok);
+    return ok;
+}
+
+void
+PubKeyUtils::clearVerifySigCache()
+{
+    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
+    gVerifySigCache.clear();
+}
+
+void
+PubKeyUtils::flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses)
+{
+    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
+    hits = gVerifyCacheHit;
+    misses = gVerifyCacheMiss;
+    gVerifyCacheHit = 0;
+    gVerifyCacheMiss = 0;
+}
+}

--- a/src/crypto/KeyVerification.h
+++ b/src/crypto/KeyVerification.h
@@ -1,0 +1,24 @@
+#pragma once
+
+// Copyright 2014-2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/ByteSlice.h"
+#include "xdr/Stellar-types.h"
+
+namespace stellar
+{
+
+// public key utility functions
+namespace PubKeyUtils
+{
+
+// Return true iff `signature` is valid for `bin` under `key`.
+bool verifySig(PublicKey const& key, Signature const& signature,
+               ByteSlice const& bin);
+
+void clearVerifySigCache();
+void flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses);
+}
+}

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -4,18 +4,10 @@
 
 #include "crypto/SecretKey.h"
 #include "crypto/Hex.h"
-#include "crypto/KeyUtils.h"
-#include "crypto/SHA.h"
 #include "crypto/StrKey.h"
-#include "main/Config.h"
-#include "transactions/SignatureUtils.h"
 #include "util/HashOfHash.h"
 #include "util/Math.h"
-#include "util/RandomEvictionCache.h"
-#include <memory>
-#include <mutex>
 #include <sodium.h>
-#include <type_traits>
 
 #ifdef MSAN_ENABLED
 #include <sanitizer/msan_interface.h>
@@ -23,32 +15,6 @@
 
 namespace stellar
 {
-
-// Process-wide global Ed25519 signature-verification cache.
-//
-// This is a pure mathematical function and has no relationship
-// to the state of the process; caching its results centrally
-// makes all signature-verification in the program faster and
-// has no effect on correctness.
-
-static std::mutex gVerifySigCacheMutex;
-static RandomEvictionCache<Hash, bool> gVerifySigCache(0xffff);
-static std::unique_ptr<SHA256> gHasher = SHA256::create();
-static uint64_t gVerifyCacheHit = 0;
-static uint64_t gVerifyCacheMiss = 0;
-
-static Hash
-verifySigCacheKey(PublicKey const& key, Signature const& signature,
-                  ByteSlice const& bin)
-{
-    assert(key.type() == PUBLIC_KEY_TYPE_ED25519);
-
-    gHasher->reset();
-    gHasher->add(key.ed25519());
-    gHasher->add(signature);
-    gHasher->add(bin);
-    return gHasher->finish();
-}
 
 SecretKey::SecretKey() : mKeyType(PUBLIC_KEY_TYPE_ED25519)
 {
@@ -223,23 +189,6 @@ SecretKey::fromStrKeySeed(std::string const& strKeySeed)
     return sk;
 }
 
-void
-PubKeyUtils::clearVerifySigCache()
-{
-    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
-    gVerifySigCache.clear();
-}
-
-void
-PubKeyUtils::flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses)
-{
-    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
-    hits = gVerifyCacheHit;
-    misses = gVerifyCacheMiss;
-    gVerifyCacheHit = 0;
-    gVerifyCacheMiss = 0;
-}
-
 std::string
 KeyFunctions<PublicKey>::getKeyTypeName()
 {
@@ -305,36 +254,6 @@ KeyFunctions<PublicKey>::getKeyValue(PublicKey const& key)
     default:
         throw std::invalid_argument("invalid public key type");
     }
-}
-
-bool
-PubKeyUtils::verifySig(PublicKey const& key, Signature const& signature,
-                       ByteSlice const& bin)
-{
-    assert(key.type() == PUBLIC_KEY_TYPE_ED25519);
-    if (signature.size() != 64)
-    {
-        return false;
-    }
-
-    auto cacheKey = verifySigCacheKey(key, signature, bin);
-
-    {
-        std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
-        if (gVerifySigCache.exists(cacheKey))
-        {
-            ++gVerifyCacheHit;
-            return gVerifySigCache.get(cacheKey);
-        }
-    }
-
-    ++gVerifyCacheMiss;
-    bool ok =
-        (crypto_sign_verify_detached(signature.data(), bin.data(), bin.size(),
-                                     key.ed25519().data()) == 0);
-    std::lock_guard<std::mutex> guard(gVerifySigCacheMutex);
-    gVerifySigCache.put(cacheKey, ok);
-    return ok;
 }
 
 PublicKey

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -110,13 +110,6 @@ template <> struct KeyFunctions<PublicKey>
 // public key utility functions
 namespace PubKeyUtils
 {
-// Return true iff `signature` is valid for `bin` under `key`.
-bool verifySig(PublicKey const& key, Signature const& signature,
-               ByteSlice const& bin);
-
-void clearVerifySigCache();
-void flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses);
-
 PublicKey random();
 }
 

--- a/src/crypto/test/CryptoTests.cpp
+++ b/src/crypto/test/CryptoTests.cpp
@@ -4,6 +4,7 @@
 
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
+#include "crypto/KeyVerification.h"
 #include "crypto/Random.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -5,6 +5,7 @@
 #include "herder/HerderImpl.h"
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
+#include "crypto/KeyVerification.h"
 #include "crypto/SHA.h"
 #include "herder/HerderPersistence.h"
 #include "herder/HerderUtils.h"

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -13,6 +13,7 @@
 #include "bucket/BucketManager.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
+#include "crypto/KeyVerification.h"
 #include "database/Database.h"
 #include "herder/Herder.h"
 #include "herder/HerderPersistence.h"

--- a/src/overlay/PeerAuth.cpp
+++ b/src/overlay/PeerAuth.cpp
@@ -7,6 +7,7 @@
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
+#include "crypto/KeyVerification.h"
 #include "main/Application.h"
 #include "main/Config.h"
 #include "util/Logging.h"

--- a/src/transactions/SignatureUtils.cpp
+++ b/src/transactions/SignatureUtils.cpp
@@ -5,6 +5,7 @@
 #include "transactions/SignatureUtils.h"
 
 #include "crypto/SHA.h"
+#include "crypto/KeyVerification.h"
 #include "crypto/SecretKey.h"
 #include "crypto/SignerKey.h"
 #include "xdr/Stellar-transaction.h"


### PR DESCRIPTION
```
Before this commit, the SCP library transitively imported some modules it did not need,
such as 'main/Config.h' or 'util/RandomEvictionCache.h' because of the dependency
on 'crypto/SecretKey.h'. Splitting the verification cache in its own module fixes that.
```

In addition, it looks like some `#include` were not needed at all (e.g. `main/Config.h`).

# Checklist
- [X] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [X] Rebased on top of master (no merge commits)
- [X] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [X] Compiles
- [X] Ran all tests
- [X] ~If change impacts performance~