### PR TITLE
Reduce libsodium dependency in ByteSliceHasher

### DIFF
--- a/src/crypto/ByteSliceHasher.cpp
+++ b/src/crypto/ByteSliceHasher.cpp
@@ -13,7 +13,7 @@ static unsigned char sKey[crypto_shorthash_KEYBYTES];
 void
 initialize()
 {
-    crypto_shorthash_keygen(sKey);
+    randombytes_buf(sKey, crypto_shorthash_KEYBYTES);
 }
 uint64_t
 computeHash(stellar::ByteSlice const& b)


### PR DESCRIPTION
```
The crypto_shorthash_keygen function was introduced in libsodium 1.0.12,
released 2017-03-17.
Unfortunately, this version is not available on the oldest Ubuntu LTS,
Xenial (16.04), and only libsodium18 (1.0.8, released 2015-12-26) is.
This minor change reduce the libsodium dependency for this file
and makes it usable on such boxes (including Travis CI).
```

Source: https://github.com/jedisct1/libsodium/blob/1.0.17/src/libsodium/crypto_shorthash/crypto_shorthash.c#L30-L34