### PR TITLE
Fix formatting of issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,16 +8,19 @@ Fantastic! However, the stellar-core issues repository is meant for reporting bu
 requests related to stellar-core's implementation — if you have a question, we would recommend that
 you:
 
-* Take a look at Stellar's [developer portal](https://www.stellar.org/developers/), where you'll
-  find comprehensive documentation related to Stellar.
+* Take a look at Stellar's [developer portal][1], where you'll find comprehensive documentation
+  related to Stellar.
 * If you can't find an answer to your question, please submit a question to [Stellar's Stack
-  Exchange](https://stellar.stackexchange.com/).
-* If your question is non-developer centric, take a look at [Stellar's
-  Community](https://www.stellar.org/community).
+  Exchange][2].
+* If your question is non-developer centric, take a look at [Stellar's Community][3].
 
 In general, we close any issues that are questions best served elsewhere — we have a small
 community of people that manages issues, and we want to ensure that the issues that remain open are
 high quality (so we actually get around to implementing them!)
+
+[1]: https://www.stellar.org/developers/
+[2]: https://stellar.stackexchange.com/
+[3]: https://www.stellar.org/community
 
 ### I'm fairly certain it's a bug.
 
@@ -32,14 +35,15 @@ First, you have to ask whether what you're trying to file is an issue related to
 OR if it's related to `stellar-core`, the C++ implementation that's in this repository.
 
 Typically a request that changes how the core protocol works (such as adding a new operation,
-changing the way transactions work, etc) is best filed in the [Stellar Protocol
-repository](https://github.com/stellar/stellar-protocol/issues).
+changing the way transactions work, etc) is best filed in the [Stellar Protocol repository][4]
 
 However, if your change is related to the implementation (say you'd like to see a new command line
 flag or HTTP command added to stellar-core), this is the place.
 
 * Please check existing and closed issues in Github! You may have to remove the `is:open` filter.
 * Check the releases page to see if your request has already been added in a later release.
+
+[4]: https://github.com/stellar/stellar-protocol/issues
 
 ## Issue Type
 * Bug
@@ -57,22 +61,22 @@ flag or HTTP command added to stellar-core), this is the place.
 * Did you pass in special parameters when building the app?
 
 ## Issue description
-**Describe your bug/feature request in detail.**
+*Describe your bug/feature request in detail.*
 
 ### Bug
 
 #### Steps to Reproduce
-**List in detail the exact steps to reproduce the unexpected behavior of the software.**
+*List in detail the exact steps to reproduce the unexpected behavior of the software.*
 
 #### Expected Result
-**Explain in detail what behavior you expected to happen.**
+*Explain in detail what behavior you expected to happen.*
 
 #### Actual Result
-**Explain in detail what behavior actually happened.**
+*Explain in detail what behavior actually happened.*
 
 ### Feature Request
 
-**Explain in detail the additional functionality you would like to see in stellar-core.**
+*Explain in detail the additional functionality you would like to see in stellar-core.*
 
 Be descriptive, including the interface you'd like to see, as well as any suggestions you may have
 with regard to its implementation.


### PR DESCRIPTION
# Description

Github handles linebreaks a little bit differently in issues vs. the
normal preview window, so made the linebreaks more natural on lines with
links.

Also, H4's are basically the same as bold text, so changed the bold text
below them to italic text.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)