### PR TITLE
fix catchup current/0 error on very up-to-date databases

### DIFF
--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -52,7 +52,7 @@ CatchupManagerImpl::catchupHistory(CatchupConfiguration catchupConfiguration,
     }
 
     mCatchupWork = mApp.getWorkScheduler().scheduleWork<CatchupWork>(
-        catchupConfiguration, handler, Work::RETRY_NEVER);
+        catchupConfiguration, handler);
 }
 
 std::string

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -116,7 +116,7 @@ class CatchupWork : public Work
                      HistoryManager const& historyManager);
 
     CatchupWork(Application& app, CatchupConfiguration catchupConfiguration,
-                ProgressHandler progressHandler, size_t maxRetries);
+                ProgressHandler progressHandler);
     ~CatchupWork();
     std::string getStatus() const override;
 

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -78,7 +78,8 @@ class CatchupWork : public Work
     {
         APPLIED_BUCKETS,
         APPLIED_TRANSACTIONS,
-        FINISHED
+        FINISHED,
+        FAILED
     };
 
     // ProgressHandler is called in different phases of catchup with following
@@ -99,8 +100,7 @@ class CatchupWork : public Work
     // In case of error this callback is called with non-zero ec parameter and
     // the rest of them does not matter.
     using ProgressHandler = std::function<void(
-        asio::error_code const& ec, ProgressState progressState,
-        LedgerHeaderHistoryEntry const& lastClosed,
+        ProgressState progressState, LedgerHeaderHistoryEntry const& lastClosed,
         CatchupConfiguration::Mode catchupMode)>;
 
     /**

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -60,10 +60,6 @@ catching up to network:
     3) Replay or force-apply deltas, depending on catchup mode
 
 */
-using std::placeholders::_1;
-using std::placeholders::_2;
-using std::placeholders::_3;
-using std::placeholders::_4;
 using namespace std;
 
 namespace stellar
@@ -632,80 +628,78 @@ LedgerManagerImpl::startCatchup(CatchupConfiguration configuration)
         configuration.mode() == CatchupConfiguration::Mode::OFFLINE;
     assert(offlineCatchup == mSyncingLedgers.empty());
 
+    using namespace std::placeholders;
     mApp.getCatchupManager().catchupHistory(
         configuration,
-        std::bind(&LedgerManagerImpl::historyCaughtup, this, _1, _2, _3, _4));
+        std::bind(&LedgerManagerImpl::historyCaughtup, this, _1, _2, _3));
 }
 
 void
-LedgerManagerImpl::historyCaughtup(asio::error_code const& ec,
-                                   CatchupWork::ProgressState progressState,
+LedgerManagerImpl::historyCaughtup(CatchupWork::ProgressState progressState,
                                    LedgerHeaderHistoryEntry const& lastClosed,
                                    CatchupConfiguration::Mode catchupMode)
 {
     assert(mCatchupState == CatchupState::APPLYING_HISTORY);
 
-    if (ec)
+    switch (progressState)
     {
-        CLOG(ERROR, "Ledger") << "Error catching up: " << ec.message();
-        if (ec == std::make_error_code(std::errc::timed_out))
+    case CatchupWork::ProgressState::APPLIED_BUCKETS:
+    {
+        LedgerTxn ltx(mApp.getLedgerTxnRoot());
+        auto header = ltx.loadHeader();
+        header.current() = lastClosed.header;
+        storeCurrentLedger(header.current());
+        ltx.commit();
+
+        mLastClosedLedger = lastClosed;
+        return;
+    }
+    case CatchupWork::ProgressState::APPLIED_TRANSACTIONS:
+    {
+        // In this case we should actually have been caught-up during the
+        // replay process and, if judged successful, our LCL should be the
+        // one provided as well.
+        assert(lastClosed.hash == mLastClosedLedger.hash);
+        assert(lastClosed.header == mLastClosedLedger.header);
+        return;
+    }
+    case CatchupWork::ProgressState::FINISHED:
+    {
+        break;
+    }
+    case CatchupWork::ProgressState::FAILED:
+    {
+        if (catchupMode == CatchupConfiguration::Mode::ONLINE)
         {
             CLOG(ERROR, "Ledger") << "Catchup will restart at next close.";
         }
+
         setState(LM_BOOTING_STATE);
         mApp.getCatchupManager().historyCaughtup();
         mSyncingLedgers = {};
         mSyncingLedgersSize.set_count(mSyncingLedgers.size());
+        return;
+    }
+    default:
+    {
+        assert(false);
+    }
+    }
+
+    CLOG(INFO, "Ledger") << "Caught up to LCL from history: "
+                         << ledgerAbbrev(mLastClosedLedger);
+    mApp.getCatchupManager().historyCaughtup();
+
+    if (catchupMode == CatchupConfiguration::Mode::ONLINE)
+    {
+        CLOG(INFO, "Ledger") << "Catchup will apply buffered ledgers";
+        setCatchupState(CatchupState::APPLYING_BUFFERED_LEDGERS);
+        applyBufferedLedgers();
     }
     else
     {
-        switch (progressState)
-        {
-        case CatchupWork::ProgressState::APPLIED_BUCKETS:
-        {
-            LedgerTxn ltx(mApp.getLedgerTxnRoot());
-            auto header = ltx.loadHeader();
-            header.current() = lastClosed.header;
-            storeCurrentLedger(header.current());
-            ltx.commit();
-
-            mLastClosedLedger = lastClosed;
-            return;
-        }
-        case CatchupWork::ProgressState::APPLIED_TRANSACTIONS:
-        {
-            // In this case we should actually have been caught-up during the
-            // replay process and, if judged successful, our LCL should be the
-            // one provided as well.
-            assert(lastClosed.hash == mLastClosedLedger.hash);
-            assert(lastClosed.header == mLastClosedLedger.header);
-            return;
-        }
-        case CatchupWork::ProgressState::FINISHED:
-        {
-            break;
-        }
-        default:
-        {
-            assert(false);
-        }
-        }
-
-        CLOG(INFO, "Ledger") << "Caught up to LCL from history: "
-                             << ledgerAbbrev(mLastClosedLedger);
-        mApp.getCatchupManager().historyCaughtup();
-
-        if (catchupMode == CatchupConfiguration::Mode::ONLINE)
-        {
-            CLOG(INFO, "Ledger") << "Catchup will apply buffered ledgers";
-            setCatchupState(CatchupState::APPLYING_BUFFERED_LEDGERS);
-            applyBufferedLedgers();
-        }
-        else
-        {
-            CLOG(INFO, "Ledger") << "Catchup finished";
-            setState(LM_SYNCED_STATE);
-        }
+        CLOG(INFO, "Ledger") << "Catchup finished";
+        setState(LM_SYNCED_STATE);
     }
 }
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -648,7 +648,10 @@ LedgerManagerImpl::historyCaughtup(asio::error_code const& ec,
     if (ec)
     {
         CLOG(ERROR, "Ledger") << "Error catching up: " << ec.message();
-        CLOG(ERROR, "Ledger") << "Catchup will restart at next close.";
+        if (ec == std::make_error_code(std::errc::timed_out))
+        {
+            CLOG(ERROR, "Ledger") << "Catchup will restart at next close.";
+        }
         setState(LM_BOOTING_STATE);
         mApp.getCatchupManager().historyCaughtup();
         mSyncingLedgers = {};

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -59,8 +59,7 @@ class LedgerManagerImpl : public LedgerManager
     void addToSyncingLedgers(LedgerCloseData const& ledgerData);
     void startCatchupIf(uint32_t lastReceivedLedgerSeq);
 
-    void historyCaughtup(asio::error_code const& ec,
-                         CatchupWork::ProgressState progressState,
+    void historyCaughtup(CatchupWork::ProgressState progressState,
                          LedgerHeaderHistoryEntry const& lastClosed,
                          CatchupConfiguration::Mode catchupMode);
 

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -296,7 +296,8 @@ catchup(Application::pointer app, CatchupConfiguration cc,
     {
         LOG(INFO) << "*";
         LOG(INFO) << "* Target ledger " << cc.toLedger()
-                  << " is not newer than last closed ledger"
+                  << " is not newer than last closed ledger "
+                  << app->getLedgerManager().getLastClosedLedgerNum()
                   << " - nothing to do";
         LOG(INFO) << "* If you really want to catchup to " << cc.toLedger()
                   << " run stellar-core new-db";


### PR DESCRIPTION
# Description

Resolves #2143

Fix for edge case when doing command line catchup current/0 on databases that have at least one-past-last-network-checkpoint ledgers.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
