### PR TITLE
update preconditions for CatchupRange constructor

### DIFF
--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -50,7 +50,7 @@ struct CatchupRange final
     /**
      * Preconditions:
      * * lastClosedLedger > 0
-     * * configuration.toLedger() >= lastClosedLedger
+     * * configuration.toLedger() > lastClosedLedger
      * * configuration.toLedger() != CatchupConfiguration::CURRENT
      */
     explicit CatchupRange(uint32_t lastClosedLedger,


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Update precondition comment for CatchupRange constructor to match its behavior.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [] Ran all tests
- [] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
