### PR TITLE
Don't look up http command handler twice

### DIFF
--- a/lib/http/server.cpp
+++ b/lib/http/server.cpp
@@ -110,9 +110,10 @@ server::handle_request(const request& req, reply& rep)
         params = request_path.substr(pos);
     }
 
-    if (mRoutes.find(command) != mRoutes.end())
+    auto it = mRoutes.find(command);
+    if (it != mRoutes.end())
     {
-        mRoutes[command](params, rep.content);
+        it->second(params, rep.content);
 
         rep.status = reply::ok;
         rep.headers.resize(2);
@@ -123,9 +124,10 @@ server::handle_request(const request& req, reply& rep)
     }
     else
     {
-        if(mRoutes.find("404") != mRoutes.end())
+        it = mRoutes.find("404");
+        if (it != mRoutes.end())
         {
-            mRoutes["404"](params, rep.content);
+            it->second(params, rep.content);
 
             rep.status = reply::ok;
             rep.headers.resize(2);


### PR DESCRIPTION
We already did a find, so there's no need to look the command up again
with the [] operator.

# Description

Small cleanup in http::server::server::handle_request

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
