### PR TITLE
Remove / from http-command examples in docs

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -125,16 +125,16 @@ format.
   it to the archive.
 
 * **connect**
-  `/connect?peer=NAME&port=NNN`<br>
+  `connect?peer=NAME&port=NNN`<br>
   Triggers the instance to connect to peer NAME at port NNN.
 
 * **dropcursor**  
-  `/dropcursor?id=ID`<br>
+  `dropcursor?id=ID`<br>
   Deletes the tracking cursor identified by `id`. See `setcursor` for
   more information.
 
 * **droppeer**
-  `/droppeer?node=NODE_ID[&ban=D]`<br>
+  `droppeer?node=NODE_ID[&ban=D]`<br>
   Drops peer identified by NODE_ID, when D is 1 the peer is also banned.
 
 * **info**
@@ -142,7 +142,7 @@ format.
   peers, etc).
 
 * **ll**  
-  `/ll?level=L[&partition=P]`<br>
+  `ll?level=L[&partition=P]`<br>
   Adjust the log level for partition P where P is one of Bucket, Database, Fs,
   Herder, History, Ledger, Overlay, Process, SCP, Tx (or all if no partition is
   specified). Level is one of FATAL, ERROR, WARNING, INFO, DEBUG, VERBOSE,
@@ -152,7 +152,7 @@ format.
   Rotate log files.
 
 * **maintenance**
-  `/maintenance?[queue=true]`<br>
+  `maintenance?[queue=true]`<br>
   Performs maintenance tasks on the instance.
    * `queue` performs deletion of queue data. See `setcursor` for more information.
 
@@ -161,7 +161,7 @@ format.
   purpose).
 
 * **clearmetrics**
-  `/clearmetrics?[domain=DOMAIN]`<br>
+  `clearmetrics?[domain=DOMAIN]`<br>
   Clear metrics for a specified domain. If no domain specified, clear all
   metrics (for testing purposes).
 
@@ -169,7 +169,7 @@ format.
   Returns the list of known peers in JSON format.
 
 * **quorum**
-  `/quorum?[node=NODE_ID][&compact=true][&fullkeys=true][&transitive=true]`<br>
+  `quorum?[node=NODE_ID][&compact=true][&fullkeys=true][&transitive=true]`<br>
   Returns information about the quorum for `NODE_ID` (local node by default).
   If `transitive` is set, information is for the transitive quorum centered on `NODE_ID`, otherwise only for nodes in the quorum set of `NODE_ID`.
 
@@ -181,7 +181,7 @@ format.
   If `fullkeys` is set, outputs unshortened public keys.
 
 * **setcursor**
-  `/setcursor?id=ID&cursor=N`<br>
+  `setcursor?id=ID&cursor=N`<br>
   Sets or creates a cursor identified by `ID` with value `N`. ID is an
   uppercase AlphaNum, N is an uint32 that represents the last ledger sequence
   number that the instance ID processed. Cursors are used by dependent services
@@ -193,17 +193,17 @@ format.
   `dropcursor`.
 
 * **getcursor**
-  `/getcursor?[id=ID]`<br>
+  `getcursor?[id=ID]`<br>
   Gets the cursor identified by `ID`. If ID is not defined then all cursors
   will be returned.
 
 * **scp**
-  `/scp?[limit=n][&fullkeys=true]`<br>
+  `scp?[limit=n][&fullkeys=true]`<br>
   Returns a JSON object with the internal state of the SCP engine for the last
   n (default 2) ledgers. Outputs unshortened public keys if fullkeys is set.
 
 * **tx**
-  `/tx?blob=Base64`<br>
+  `tx?blob=Base64`<br>
   Submit a transaction to the network.
   blob is a base64 encoded XDR serialized 'TransactionEnvelope', and it
   returns a JSON object with the following properties
@@ -215,11 +215,11 @@ format.
             Base64 encoded, XDR serialized 'TransactionResult'
 
 * **upgrades**
-  * `/upgrades?mode=get`<br>
+  * `upgrades?mode=get`<br>
     Retrieves the currently configured upgrade settings.<br>
-  * `/upgrades?mode=clear`<br>
+  * `upgrades?mode=clear`<br>
     Clears any upgrade settings.<br>
-  * `/upgrades?mode=set&upgradetime=DATETIME&[basefee=NUM]&[basereserve=NUM]&[maxtxsize=NUM]&[protocolversion=NUM]`<br>
+  * `upgrades?mode=set&upgradetime=DATETIME&[basefee=NUM]&[basereserve=NUM]&[maxtxsize=NUM]&[protocolversion=NUM]`<br>
     * upgradetime is a required date (UTC) in the form `1970-01-01T00:00:00Z`. 
         It is the time the upgrade will be scheduled for. If it is in the past,
         the upgrade will occur immediately.<br>
@@ -240,7 +240,7 @@ format.
 
 ### The following HTTP commands are exposed on test instances
 * **generateload**
-  `/generateload[?mode=(create|pay)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L]`<br>
+  `generateload[?mode=(create|pay)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L]`<br>
   Artificially generate load for testing; must be used with
   `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true. Depending on the mode,
   either creates new accounts or generates payments on accounts specified
@@ -252,13 +252,13 @@ format.
   ledger to close.
 
 * **testacc**
-  `/testacc?name=N`<br>
+  `testacc?name=N`<br>
   Returns basic information about the account identified by name. Note that N
   is a string used as seed, but "root" can be used as well to specify the root
   account used for the test instance.
 
 * **testtx**
-  `/testtx?from=F&to=T&amount=N&[create=true]`<br>
+  `testtx?from=F&to=T&amount=N&[create=true]`<br>
   Injects a payment transaction (or a create transaction if "create" is
   specified) from the account F to the account T, sending N XLM to the account.
   Note that F and T are seed strings but can also be specified as "root" as


### PR DESCRIPTION
# Description

Resolves #2121 

`HTTP commands reference / for the HTTP Command reference, but for the http-command from the command line the / is not necessary.`

I went through and removed the unnecessary "/"

<!---

Remove / from http-command examples in docs

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
 [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
 [ ] Compiles
 [ ] Ran all tests
 [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
