### PR TITLE
Fix Travis ccache integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
     - libpq5
     - libstdc++6
     - libtool
+    - llvm-5.0
     - pkg-config
     - clang-format-5.0
     - pandoc
@@ -35,7 +36,6 @@ script: ./travis-build.sh
 cache:
   directories:
   - $HOME/.ccache
-  - .libs
 
 notifications:
   email: false
@@ -59,3 +59,4 @@ matrix:
     - stage: compile
       compiler: gcc
       script: ./travis-build.sh --disable-tests
+

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -784,6 +784,9 @@ exit /b 0
     <ClInclude Include="src\generated\xdr\Stellar-types.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\.github\ISSUE_TEMPLATE\bug-report.md" />
+    <None Include="..\..\.github\ISSUE_TEMPLATE\documentation.md" />
+    <None Include="..\..\.github\ISSUE_TEMPLATE\feature-request.md" />
     <None Include="..\..\AUTHORS" />
     <None Include="..\..\autogen.sh" />
     <None Include="..\..\ChangeLog" />
@@ -814,7 +817,6 @@ exit /b 0
     <None Include="..\..\INSTALL.md" />
     <None Include="..\..\Makefile.am" />
     <None Include="..\..\NEWS" />
-    <None Include="..\..\.github\ISSUE_TEMPLATE.md" />
     <None Include="..\..\.github\PULL_REQUEST_TEMPLATE.md" />
     <None Include="..\..\performance-eval\performance-eval.md" />
     <None Include="..\..\README" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -139,6 +139,9 @@
     <Filter Include="util\tests">
       <UniqueIdentifier>{856b0ad5-10a9-49a4-a36e-e98d7840bc83}</UniqueIdentifier>
     </Filter>
+    <Filter Include="github">
+      <UniqueIdentifier>{2f5780ba-6cc8-45ba-b70b-aa50af3af3ce}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\lib\util\getopt_long.c">
@@ -1696,8 +1699,6 @@
     <None Include="..\..\CONTRIBUTING.md" />
     <None Include="..\..\README" />
     <None Include="..\..\travis-build.sh" />
-    <None Include="..\..\.github\ISSUE_TEMPLATE.md" />
-    <None Include="..\..\.github\PULL_REQUEST_TEMPLATE.md" />
     <None Include="..\..\src\history\serialize-tests\stellar-history.livenet.15686975.json">
       <Filter>history\tests\serialize-tests</Filter>
     </None>
@@ -1743,6 +1744,18 @@
     </None>
     <None Include="..\..\docs\stellar-core_example_validators.cfg">
       <Filter>docs</Filter>
+    </None>
+    <None Include="..\..\.github\ISSUE_TEMPLATE\bug-report.md">
+      <Filter>github</Filter>
+    </None>
+    <None Include="..\..\.github\ISSUE_TEMPLATE\documentation.md">
+      <Filter>github</Filter>
+    </None>
+    <None Include="..\..\.github\ISSUE_TEMPLATE\feature-request.md">
+      <Filter>github</Filter>
+    </None>
+    <None Include="..\..\.github\PULL_REQUEST_TEMPLATE.md">
+      <Filter>github</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -39,15 +39,24 @@ fi
 
 # Try to ensure we're using the real g++ and clang++ versions we want
 mkdir bin
+which gcc-6
 ln -s `which gcc-6` bin/gcc
+which g++-6
 ln -s `which g++-6` bin/g++
+which clang-5.0
 ln -s `which clang-5.0` bin/clang
+which clang++-5.0
 ln -s `which clang++-5.0` bin/clang++
+which llvm-symbolizer-5.0
 ln -s `which llvm-symbolizer-5.0` bin/llvm-symbolizer
 
 export PATH=`pwd`/bin:$PATH
+echo "PATH is $PATH"
+
 hash -r
+
 clang -v
+which g++
 g++ -v
 llvm-symbolizer --version || true
 
@@ -81,8 +90,10 @@ then
     exit 1
 fi
 
+ccache -p
 date
 time make -j$(($NPROCS + 1))
+
 ccache -s
 
 if [ $WITH_TESTS -eq 0 ] ; then


### PR DESCRIPTION
Looks like Travis run don't cache enough (lots of cache misses).

Logs show that `tar` is failing, pointing to a misconfiguration.

This PR switches to using the "built-in" ccache defaults.
