### PR TITLE
Fuzzing Revival: prepwork for transaction fuzzing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,13 +67,13 @@ if USE_AFL_FUZZ
 fuzz-testcases: stellar-core
 	mkdir -p fuzz-testcases
 	for i in `seq 1 10`; do \
-	    ./stellar-core --genfuzz fuzz-testcases/fuzz$$i.xdr; \
+	    ./stellar-core gen-fuzz fuzz-testcases/fuzz$$i.xdr; \
 	done
 
 fuzz: fuzz-testcases stellar-core
 	mkdir -p fuzz-findings
 	afl-fuzz -m 8000 -t 250 -i fuzz-testcases -o fuzz-findings \
-	    ./stellar-core --fuzz @@
+	    ./stellar-core fuzz @@
 
 fuzz-clean: always
 	rm -Rf fuzz-testcases fuzz-findings

--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/Random.h"
+#include "util/Math.h"
 #include <sodium.h>
 
 #ifdef MSAN_ENABLED
@@ -13,7 +14,16 @@ std::vector<uint8_t>
 randomBytes(size_t length)
 {
     std::vector<uint8_t> vec(length);
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    std::uniform_int_distribution<unsigned short> dist(0, 255);
+    std::generate(vec.begin(), vec.end(), [&]() {
+        return static_cast<uint8_t>(dist(stellar::gRandomEngine));
+    });
+#else
     randombytes_buf(vec.data(), length);
+#endif
+
 #ifdef MSAN_ENABLED
     __msan_unpoison(out.key.data(), out.key.size());
 #endif

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -113,8 +113,7 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction, DropMode)
                                  ? Peer::DropDirection::REMOTE_DROPPED_US
                                  : Peer::DropDirection::WE_DROPPED_REMOTE,
                              Peer::DropMode::IGNORE_WRITE_QUEUE);
-
-            },
+                        },
             "LoopbackPeer: drop");
     }
 }
@@ -294,6 +293,13 @@ void
 LoopbackPeer::setCorked(bool c)
 {
     mCorked = c;
+}
+
+void
+LoopbackPeer::clearInAndOutQueues()
+{
+    mOutQueue.clear();
+    mInQueue = {};
 }
 
 bool

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -113,7 +113,7 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction, DropMode)
                                  ? Peer::DropDirection::REMOTE_DROPPED_US
                                  : Peer::DropDirection::WE_DROPPED_REMOTE,
                              Peer::DropMode::IGNORE_WRITE_QUEUE);
-                        },
+            },
             "LoopbackPeer: drop");
     }
 }
@@ -299,7 +299,7 @@ void
 LoopbackPeer::clearInAndOutQueues()
 {
     mOutQueue.clear();
-    mInQueue = {};
+    mInQueue = std::queue<xdr::msg_ptr>();
 }
 
 bool

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -102,6 +102,8 @@ class LoopbackPeer : public Peer
     double getReorderProbability() const;
     void setReorderProbability(double d);
 
+    void clearInAndOutQueues();
+
     std::string
     getDropReason() const
     {

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -212,6 +212,26 @@ Simulation::addLoopbackConnection(NodeID initiator, NodeID acceptor)
     }
 }
 
+std::shared_ptr<LoopbackPeerConnection>
+Simulation::getLoopbackConnection(NodeID const& initiator,
+                                  NodeID const& acceptor)
+{
+    auto it = std::find_if(
+        std::begin(mLoopbackConnections), std::end(mLoopbackConnections),
+        [&](std::shared_ptr<LoopbackPeerConnection> const& conn) {
+            return conn->getInitiator()
+                           ->getApp()
+                           .getConfig()
+                           .NODE_SEED.getPublicKey() == initiator &&
+                   conn->getAcceptor()
+                           ->getApp()
+                           .getConfig()
+                           .NODE_SEED.getPublicKey() == acceptor;
+        });
+
+    return it == std::end(mLoopbackConnections) ? nullptr : *it;
+}
+
 void
 Simulation::dropLoopbackConnection(NodeID initiator, NodeID acceptor)
 {

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -52,6 +52,9 @@ class Simulation
     std::vector<NodeID> getNodeIDs();
 
     void addPendingConnection(NodeID const& initiator, NodeID const& acceptor);
+    // Returns LoopbackPeerConnection given initiator, acceptor pair or nullptr
+    std::shared_ptr<LoopbackPeerConnection>
+    getLoopbackConnection(NodeID const& initiator, NodeID const& acceptor);
     void startAllNodes();
     void stopAllNodes();
     void removeNode(NodeID const& id);

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -27,7 +27,11 @@ crankSome(VirtualClock& clock)
 void
 shutdownWorkScheduler(Application& app)
 {
-    REQUIRE(!app.getClock().getIOContext().stopped());
+    if (app.getClock().getIOContext().stopped())
+    {
+        throw std::runtime_error("Work scheduler attempted to shutdown after "
+                                 "VirtualClock io context stopped.");
+    }
     app.getWorkScheduler().shutdown();
     while (app.getWorkScheduler().getState() != BasicWork::State::WORK_ABORTED)
     {

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -140,7 +140,12 @@ fuzz(std::string const& filename, el::Level logLevel,
         },
         std::chrono::milliseconds{500}, false);
 
+// "To make this work, the library and this shim need to be compiled in LLVM
+// mode using afl-clang-fast (other compiler wrappers will *not* work)."
+// -- AFL docs
+#ifdef AFL_LLVM_MODE
     while (__AFL_LOOP(PERSIST_MAX))
+#endif // AFL_LLVM_MODE
     {
         XDRInputFileStream in(MAX_MESSAGE_SIZE);
         in.open(filename);

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -69,6 +69,13 @@ tryRead(XDRInputFileStream& in, StellarMessage& m)
     }
 }
 
+void
+seedRandomness()
+{
+    srand(1);
+    gRandomEngine.seed(1);
+}
+
 #define PERSIST_MAX 10000000
 #define INITIATOR 1
 #define ACCEPTOR 0
@@ -80,6 +87,8 @@ fuzz(std::string const& filename, el::Level logLevel,
     Logging::setLogLevel(logLevel, nullptr);
     LOG(INFO) << "Fuzzing stellar-core " << STELLAR_CORE_VERSION;
     LOG(INFO) << "Fuzz input is in " << filename;
+
+    seedRandomness();
 
     Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     auto confGen = [](int instanceNumber) {
@@ -139,6 +148,8 @@ fuzz(std::string const& filename, el::Level logLevel,
         while (tryRead(in, msg))
         {
             LOG(INFO) << "Fuzzer injecting message." << msgSummary(msg);
+
+            seedRandomness();
 
             auto nodeids = simulation->getNodeIDs();
 

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -11,9 +11,11 @@
 #include "overlay/OverlayManager.h"
 #include "overlay/TCPPeer.h"
 #include "overlay/test/LoopbackPeer.h"
+#include "simulation/Simulation.h"
 #include "test/test.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include "util/Math.h"
 #include "util/Timer.h"
 #include "util/XDRStream.h"
 
@@ -43,27 +45,6 @@
 namespace stellar
 {
 
-struct CfgDirGuard
-{
-    Config const& mConfig;
-    static void
-    clean(std::string const& path)
-    {
-        if (fs::exists(path))
-        {
-            fs::deltree(path);
-        }
-    }
-    CfgDirGuard(Config const& c) : mConfig(c)
-    {
-        clean(mConfig.BUCKET_DIR_PATH);
-    }
-    ~CfgDirGuard()
-    {
-        clean(mConfig.BUCKET_DIR_PATH);
-    }
-};
-
 std::string
 msgSummary(StellarMessage const& m)
 {
@@ -88,9 +69,9 @@ tryRead(XDRInputFileStream& in, StellarMessage& m)
     }
 }
 
-#define PERSIST_MAX 1000
-static unsigned int persist_cnt = 0;
-
+#define PERSIST_MAX 10000000
+#define INITIATOR 1
+#define ACCEPTOR 0
 void
 fuzz(std::string const& filename, el::Level logLevel,
      std::vector<std::string> const& metrics)
@@ -100,71 +81,90 @@ fuzz(std::string const& filename, el::Level logLevel,
     LOG(INFO) << "Fuzzing stellar-core " << STELLAR_CORE_VERSION;
     LOG(INFO) << "Fuzz input is in " << filename;
 
-    Config cfg1, cfg2;
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    auto confGen = [](int instanceNumber) {
+        Config cfg = getTestConfig(instanceNumber);
+        cfg.MANUAL_CLOSE = true;
+        cfg.CATCHUP_COMPLETE = false;
+        cfg.CATCHUP_RECENT = 0;
+        cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
+        cfg.ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = UINT32_MAX;
+        cfg.PUBLIC_HTTP_PORT = false;
+        cfg.WORKER_THREADS = 1;
+        cfg.QUORUM_INTERSECTION_CHECKER = false;
+        cfg.PREFERRED_PEERS_ONLY = false;
+        cfg.RUN_STANDALONE = true;
 
-    cfg1 = getTestConfig(0);
-    cfg2 = getTestConfig(1);
+        return cfg;
+    };
+    auto simulation = std::make_shared<Simulation>(Simulation::OVER_LOOPBACK,
+                                                   networkID, confGen);
 
-    cfg1.HTTP_PORT = 0;
-    cfg1.PUBLIC_HTTP_PORT = false;
-    cfg1.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
-    cfg1.LOG_FILE_PATH = "fuzz-app-1.log";
-    cfg1.BUCKET_DIR_PATH = "fuzz-buckets-1";
-    cfg1.QUORUM_SET.threshold = 1;
-    cfg1.QUORUM_SET.validators.clear();
-    cfg1.QUORUM_SET.validators.push_back(
-        SecretKey::fromSeed(sha256("a")).getPublicKey());
+    SIMULATION_CREATE_NODE(10);
+    SIMULATION_CREATE_NODE(11);
 
-    cfg2.HTTP_PORT = 0;
-    cfg2.PUBLIC_HTTP_PORT = false;
-    cfg2.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
-    cfg2.LOG_FILE_PATH = "fuzz-app-2.log";
-    cfg2.BUCKET_DIR_PATH = "fuzz-buckets-2";
-    cfg2.QUORUM_SET.threshold = 1;
-    cfg2.QUORUM_SET.validators.clear();
-    cfg2.QUORUM_SET.validators.push_back(
-        SecretKey::fromSeed(sha256("b")).getPublicKey());
+    SCPQuorumSet qSet0;
+    qSet0.threshold = 2;
+    qSet0.validators.push_back(v10NodeID);
+    qSet0.validators.push_back(v11NodeID);
 
-    CfgDirGuard g1(cfg1);
-    CfgDirGuard g2(cfg2);
+    simulation->addNode(v10SecretKey, qSet0);
+    simulation->addNode(v11SecretKey, qSet0);
 
-restart:
-{
-    VirtualClock clock;
-    Application::pointer app1 = Application::create(clock, cfg1);
-    Application::pointer app2 = Application::create(clock, cfg2);
-    LoopbackPeerConnection loop(*app1, *app2);
-    while (!(loop.getInitiator()->isAuthenticated() &&
-             loop.getAcceptor()->isAuthenticated()))
+    simulation->addPendingConnection(v10SecretKey.getPublicKey(),
+                                     v11SecretKey.getPublicKey());
+
+    simulation->startAllNodes();
+
+    // crank until nodes are connected
+    simulation->crankUntil(
+        [&]() {
+            auto nodes = simulation->getNodes();
+            auto numberOfSimulationConnections =
+                nodes[ACCEPTOR]
+                    ->getOverlayManager()
+                    .getAuthenticatedPeersCount() +
+                nodes[INITIATOR]
+                    ->getOverlayManager()
+                    .getAuthenticatedPeersCount();
+            return numberOfSimulationConnections == 2;
+        },
+        std::chrono::milliseconds{500}, false);
+
+    while (__AFL_LOOP(PERSIST_MAX))
     {
-        clock.crank(true);
-    }
+        XDRInputFileStream in(MAX_MESSAGE_SIZE);
+        in.open(filename);
+        StellarMessage msg;
+        while (tryRead(in, msg))
+        {
+            LOG(INFO) << "Fuzzer injecting message." << msgSummary(msg);
 
-    XDRInputFileStream in(MAX_MESSAGE_SIZE);
-    in.open(filename);
-    StellarMessage msg;
-    size_t i = 0;
-    while (tryRead(in, msg))
-    {
-        ++i;
-        LOG(INFO) << "Fuzzer injecting message " << i << ": "
-                  << msgSummary(msg);
-        auto peer = loop.getInitiator();
-        clock.postToCurrentCrank(
-            [peer, msg]() { peer->Peer::sendMessage(msg); });
-    }
-    while (loop.getAcceptor()->isConnected())
-    {
-        clock.crank(true);
-    }
-}
+            auto nodeids = simulation->getNodeIDs();
 
-    if (getenv("AFL_PERSISTENT") && persist_cnt++ < PERSIST_MAX)
-    {
-#ifndef _WIN32
-        raise(SIGSTOP);
-#endif
-        goto restart;
+            auto loopbackPeerConnection = simulation->getLoopbackConnection(
+                nodeids[INITIATOR], nodeids[ACCEPTOR]);
+
+            // ensure connection exists
+            assert(loopbackPeerConnection);
+
+            auto initiator = loopbackPeerConnection->getInitiator();
+            auto acceptor = loopbackPeerConnection->getAcceptor();
+
+            initiator->getApp().getClock().postToCurrentCrank(
+                [initiator, msg]() { initiator->Peer::sendMessage(msg); });
+
+            simulation->crankForAtMost(std::chrono::milliseconds{500}, false);
+
+            // clear all queues and cancel all events
+            initiator->clearInAndOutQueues();
+            acceptor->clearInAndOutQueues();
+
+            while (initiator->getApp().getClock().cancelAllEvents())
+                ;
+            while (acceptor->getApp().getClock().cancelAllEvents())
+                ;
+        }
     }
 }
 


### PR DESCRIPTION
# Description

This PR lays the groundwork for future improvements and innovations to the fuzzing test suite. Specifically, these changes accomplish three things:
1. allow for deterministic `randombytes_buf` via conditional inclusion preprocessor directive: **FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION**
2. fixes existing, non-terminating overlay fuzzing via replacement of `crank`  with `crankSome` and manual `shutdown` of apps
3. moves fuzzing code from `/test` to subdirectory `/test/fuzz`

Related to #1376 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
