### PR TITLE
Add missing dependency for running tests on mac

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -89,6 +89,7 @@ When building on OSX, here's some dependencies you'll need:
 - brew install pkg-config
 - brew install libpqxx *(If ./configure later complains about libpq missing, try PKG_CONFIG_PATH='/usr/local/lib/pkgconfig')*
 - brew install pandoc
+- brew install parallel (required for running tests)
 
 ### Windows
 See [INSTALL-Windows.md](INSTALL-Windows.md)


### PR DESCRIPTION
# Description

Readme was missing a dependency for running tests on mac, this adds `brew install parallel` so tests run correctly

Previously it was erroring out on 

```
/Users/michaelfeldstein/Source/stellar-core/src/test/selftest-parallel: line 69: parallel: command not found
FAIL: test/selftest-pg
```

# Checklist
- [x ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x ] Rebased on top of master (no merge commits)
- [n/a ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [n/a ] Compiles
- [x] Ran all tests
- [ n/a] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
