### PR TITLE
redo pending transactions

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -731,7 +731,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     auto const& lcl = mLedgerManager.getLastClosedLedgerHeader();
     auto proposedSet = mTransactionQueue.toTxSet(lcl.hash);
     auto removed = proposedSet->trimInvalid(mApp);
-    mTransactionQueue.remove(removed);
+    mTransactionQueue.ban(removed);
 
     proposedSet->surgePricingFilter(mApp);
 
@@ -1311,7 +1311,7 @@ HerderImpl::updateTransactionQueue(
     std::vector<TransactionFramePtr> const& applied)
 {
     // remove all these tx from mTransactionQueue
-    mTransactionQueue.remove(applied);
+    mTransactionQueue.removeAndReset(applied);
     mTransactionQueue.shift();
 
     // rebroadcast entries, sorted in apply-order to maximize chances of

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -11,6 +11,7 @@
 #include "util/Timer.h"
 
 #include <lib/catch.hpp>
+#include <numeric>
 
 using namespace stellar;
 using namespace stellar::txtest;
@@ -18,11 +19,12 @@ using namespace stellar::txtest;
 namespace
 {
 TransactionFramePtr
-transaction(Application& app, TestAccount& account, int sequenceDelta)
+transaction(Application& app, TestAccount& account, int sequenceDelta,
+            int amount, int fee)
 {
     return transactionFromOperations(
         app, account, account.getLastSequenceNumber() + sequenceDelta,
-        {payment(account.getPublicKey(), 1)});
+        {payment(account.getPublicKey(), amount)}, fee);
 }
 
 TransactionFramePtr
@@ -36,6 +38,25 @@ invalidTransaction(Application& app, TestAccount& account, int sequenceDelta)
 class TransactionQueueTest
 {
   public:
+    struct TransactionQueueState
+    {
+        struct AccountState
+        {
+            AccountID mAccountID;
+            int mAge;
+            std::vector<TransactionFramePtr> mAccountTransactions;
+        };
+
+        struct BannedState
+        {
+            std::vector<TransactionFramePtr> mBanned0;
+            std::vector<TransactionFramePtr> mBanned1;
+        };
+
+        std::vector<AccountState> mAccountStates;
+        BannedState mBannedState;
+    };
+
     explicit TransactionQueueTest(Application& app)
         : mTransactionQueue{app, 4, 2}
     {
@@ -44,93 +65,69 @@ class TransactionQueueTest
     void
     add(TransactionFramePtr const& tx, TransactionQueue::AddResult AddResult)
     {
-        auto beforeInfo =
-            mTransactionQueue.getAccountTransactionQueueInfo(tx->getSourceID());
-        if (beforeInfo.mMaxSeq == 0)
-        {
-            REQUIRE(beforeInfo.mTotalFees == 0);
-        }
-
         REQUIRE(mTransactionQueue.tryAdd(tx) == AddResult);
-        auto afterInfo =
-            mTransactionQueue.getAccountTransactionQueueInfo(tx->getSourceID());
-
-        if (AddResult == TransactionQueue::AddResult::ADD_STATUS_PENDING)
-        {
-            REQUIRE(afterInfo.mMaxSeq == tx->getSeqNum());
-            REQUIRE(afterInfo.mTotalFees == beforeInfo.mTotalFees + 100);
-        }
-        else
-        {
-            REQUIRE(afterInfo == beforeInfo);
-        }
     }
 
     void
-    remove(std::vector<TransactionFramePtr> const& toRemove)
+    removeAndReset(std::vector<TransactionFramePtr> const& toRemove)
     {
         auto size = mTransactionQueue.toTxSet({})->sizeTx();
-        mTransactionQueue.remove(toRemove);
-        REQUIRE(size - toRemove.size() ==
+        mTransactionQueue.removeAndReset(toRemove);
+        REQUIRE(size - toRemove.size() >=
                 mTransactionQueue.toTxSet({})->sizeTx());
     }
 
     void
-    shift(std::vector<TransactionFramePtr> const& removed = {})
+    ban(std::vector<TransactionFramePtr> const& toRemove)
     {
         auto size = mTransactionQueue.toTxSet({})->sizeTx();
-        auto removedFrom = std::map<AccountID, int>{};
-        for (auto tx : removed)
-        {
-            removedFrom[tx->getSourceID()]++;
-        }
+        mTransactionQueue.ban(toRemove);
+        REQUIRE(size - toRemove.size() >=
+                mTransactionQueue.toTxSet({})->sizeTx());
+    }
 
-        auto beforeInfo =
-            std::map<AccountID, TransactionQueue::AccountTxQueueInfo>{};
-        for (auto from : removedFrom)
-        {
-            beforeInfo[from.first] =
-                mTransactionQueue.getAccountTransactionQueueInfo(from.first);
-            REQUIRE(beforeInfo[from.first].mMaxSeq > 0);
-        }
-
+    void
+    shift()
+    {
         mTransactionQueue.shift();
-        for (auto from : removedFrom)
-        {
-            auto afterInfo =
-                mTransactionQueue.getAccountTransactionQueueInfo(from.first);
-            if (afterInfo.mMaxSeq == 0)
-            {
-                REQUIRE(afterInfo.mTotalFees == 0);
-            }
-            else
-            {
-                REQUIRE(afterInfo.mMaxSeq == beforeInfo[from.first].mMaxSeq);
-                REQUIRE(afterInfo.mTotalFees ==
-                        beforeInfo[from.first].mTotalFees - from.second * 100);
-            }
-        }
-        REQUIRE(size - removed.size() ==
-                mTransactionQueue.toTxSet({})->sizeTx());
     }
 
     void
-    check(std::vector<TransactionFramePtr> const& expected = {},
-          std::vector<TransactionFramePtr> const& banned = {})
+    check(const TransactionQueueState& state)
     {
         auto txSet = mTransactionQueue.toTxSet({});
         auto expectedTxSet = TxSetFrame{{}};
-        for (auto const& tx : expected)
+        for (auto const& accountState : state.mAccountStates)
         {
-            expectedTxSet.add(tx);
+            auto& txs = accountState.mAccountTransactions;
+            auto fees =
+                std::accumulate(std::begin(txs), std::end(txs), 0,
+                                [](int fee, TransactionFramePtr const& tx) {
+                                    return fee + tx->getFeeBid();
+                                });
+            auto seqNum = txs.empty() ? 0 : txs.back()->getSeqNum();
+            auto accountTransactionQueueInfo =
+                mTransactionQueue.getAccountTransactionQueueInfo(
+                    accountState.mAccountID);
+            REQUIRE(accountTransactionQueueInfo.mTotalFees == fees);
+            REQUIRE(accountTransactionQueueInfo.mMaxSeq == seqNum);
+            REQUIRE(accountTransactionQueueInfo.mAge == accountState.mAge);
+
+            for (auto& tx : accountState.mAccountTransactions)
+            {
+                expectedTxSet.add(tx);
+            }
         }
-
         REQUIRE(txSet->sortForApply() == expectedTxSet.sortForApply());
-
-        REQUIRE(mTransactionQueue.countBanned(0) +
-                    mTransactionQueue.countBanned(1) ==
-                banned.size());
-        for (auto const& tx : banned)
+        REQUIRE(state.mBannedState.mBanned0.size() ==
+                mTransactionQueue.countBanned(0));
+        REQUIRE(state.mBannedState.mBanned1.size() ==
+                mTransactionQueue.countBanned(1));
+        for (auto const& tx : state.mBannedState.mBanned0)
+        {
+            REQUIRE(mTransactionQueue.isBanned(tx->getFullHash()));
+        }
+        for (auto const& tx : state.mBannedState.mBanned1)
         {
             REQUIRE(mTransactionQueue.isBanned(tx->getFullHash()));
         }
@@ -151,159 +148,192 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     auto account1 = root.create("a1", minBalance2);
     auto account2 = root.create("a2", minBalance2);
 
-    auto txSeqA1T0 = transaction(*app, account1, 0);
-    auto txSeqA1T1 = transaction(*app, account1, 1);
-    auto txSeqA1T2 = transaction(*app, account1, 2);
-    auto txSeqA1T3 = transaction(*app, account1, 3);
-    auto txSeqA1T4 = transaction(*app, account1, 4);
-    auto txSeqA2T1 = transaction(*app, account2, 1);
-    auto txSeqA2T2 = transaction(*app, account2, 2);
+    auto txSeqA1T0 = transaction(*app, account1, 0, 1, 100);
+    auto txSeqA1T1 = transaction(*app, account1, 1, 1, 200);
+    auto txSeqA1T2 = transaction(*app, account1, 2, 1, 300);
+    auto txSeqA1T1V2 = transaction(*app, account1, 1, 2, 400);
+    auto txSeqA1T2V2 = transaction(*app, account1, 2, 2, 500);
+    auto txSeqA1T3 = transaction(*app, account1, 3, 1, 600);
+    auto txSeqA1T4 = transaction(*app, account1, 4, 1, 700);
+    auto txSeqA2T1 = transaction(*app, account2, 1, 1, 800);
+    auto txSeqA2T2 = transaction(*app, account2, 2, 1, 900);
 
     SECTION("small sequence number")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T0, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check();
+        test.check({{{account1}, {account2}}, {}});
     }
 
     SECTION("big sequence number")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check();
+        test.check({{{account1}, {account2}}, {}});
     }
 
     SECTION("good sequence number")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good sequence number, same twice")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then big sequence number")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then good sequence number")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA1T2});
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
     }
 
     SECTION("good sequence number, same twice with shift")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then big sequence number, with shift")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then good sequence number, with shift")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA1T2});
+        test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
     }
 
     SECTION("good sequence number, same twice with double shift")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}, {}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then big sequence number, with double shift")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
         test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
     }
 
     SECTION("good then good sequence number, with double shift")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA1T2});
+        test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}}, {account2}}});
     }
 
     SECTION("good sequence number, same twice with four shifts, then two more")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
         test.shift();
-        test.shift({txSeqA1T1});
-        test.check({}, {txSeqA1T1});
+        test.check({{{account1, 3, {txSeqA1T1}}, {account2}}});
+        test.shift();
+        test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
         test.add(txSeqA1T1,
                  TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
-        test.check({}, {txSeqA1T1});
+        test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
         test.shift();
+        test.check({{{account1}, {account2}}, {{}, {txSeqA1T1}}});
         test.shift();
-        test.check({}, {});
+        test.check({{{account1}, {account2}}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1});
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
     }
 
     SECTION("good then big sequence number, with four shifts")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
         test.shift();
-        test.shift({txSeqA1T1});
-        test.check({}, {txSeqA1T1});
+        test.check({{{account1, 3, {txSeqA1T1}}, {account2}}});
+        test.shift();
+        test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
         test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check({}, {txSeqA1T1});
+        test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
     }
 
     SECTION("good then small sequence number, with four shifts")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
         test.shift();
-        test.shift({txSeqA1T1});
-        test.check({}, {txSeqA1T1});
+        test.check({{{account1, 3, {txSeqA1T1}}, {account2}}});
+        test.shift();
+        test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
         test.add(txSeqA1T0, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check({}, {txSeqA1T1});
+        test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
     }
 
     SECTION("invalid transaction")
@@ -311,43 +341,113 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         TransactionQueueTest test{*app};
         test.add(invalidTransaction(*app, account1, 1),
                  TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.check();
+        test.check({{{account1}, {account2}}});
     }
 
     SECTION("multiple good sequence numbers, with four shifts")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}});
         test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check(
+            {{{account1, 0, {txSeqA1T1, txSeqA1T2, txSeqA1T3}}, {account2}}});
         test.add(txSeqA1T4, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
+        test.check(
+            {{{account1, 0, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
+              {account2}}});
         test.shift();
+        test.check(
+            {{{account1, 1, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
+              {account2}}});
         test.shift();
+        test.check(
+            {{{account1, 2, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
+              {account2}}});
         test.shift();
-        test.shift({txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
-        test.check({}, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
+        test.check(
+            {{{account1, 3, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
+              {account2}}});
+        test.shift();
+        test.check({{{account1}, {account2}},
+                    {{txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}}});
+        test.shift();
+        test.check({{{account1}, {account2}},
+                    {{}, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}}});
+        test.shift();
+        test.check({{{account1}, {account2}}});
+    }
+
+    SECTION("multiple good sequence numbers, with replace")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
+        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}});
+        test.shift();
+        test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}}, {account2}}});
+        test.shift();
+        test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}}, {account2}}});
+        test.shift();
+        test.check({{{account1, 3, {txSeqA1T1, txSeqA1T2}}, {account2}}});
+        test.shift();
+        test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T1,
+                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+        test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T2,
+                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+        test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T2V2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T1V2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1V2}}, {account2}},
+                    {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T1,
+                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+        test.check({{{account1, 0, {txSeqA1T1V2}}, {account2}},
+                    {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T2,
+                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+        test.check({{{account1, 0, {txSeqA1T1V2}}, {account2}},
+                    {{txSeqA1T1, txSeqA1T2}}});
+        test.add(txSeqA1T2V2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1V2, txSeqA1T2V2}}, {account2}},
+                    {{txSeqA1T1, txSeqA1T2}}});
     }
 
     SECTION("multiple good sequence numbers, with shifts between")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}}, {account2}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}}, {account2}}});
         test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check(
+            {{{account1, 2, {txSeqA1T1, txSeqA1T2, txSeqA1T3}}, {account2}}});
         test.shift();
+        test.check(
+            {{{account1, 3, {txSeqA1T1, txSeqA1T2, txSeqA1T3}}, {account2}}});
         test.add(txSeqA1T4, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4});
-        test.shift({txSeqA1T1});
-        test.check({txSeqA1T2, txSeqA1T3, txSeqA1T4}, {txSeqA1T1});
-        test.shift({txSeqA1T2});
-        test.check({txSeqA1T3, txSeqA1T4}, {txSeqA1T1, txSeqA1T2});
-        test.shift({txSeqA1T3});
-        test.check({txSeqA1T4}, {txSeqA1T2, txSeqA1T3});
-        test.shift({txSeqA1T4});
-        test.check({}, {txSeqA1T3, txSeqA1T4});
+        test.check(
+            {{{account1, 3, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
+              {account2}}});
+        test.shift();
+        test.check({{{account1}, {account2}},
+                    {{txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}}});
+        test.shift();
+        test.check({{{account1}, {account2}},
+                    {{}, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}}});
+        test.shift();
+        test.check({{{account1}, {account2}}});
     }
 
     SECTION(
@@ -355,15 +455,27 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 0, {txSeqA2T1}}}});
         test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 1, {txSeqA2T1, txSeqA2T2}}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 2, {txSeqA2T1, txSeqA2T2}}}});
         test.shift();
-        test.shift({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
-        test.check({}, {txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
+        test.check({{{account1, 3, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 3, {txSeqA2T1, txSeqA2T2}}}});
+        test.shift();
+        test.check({{{account1}, {account2}},
+                    {{txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2}}});
     }
 
     SECTION("multiple good sequence numbers, different accounts, with shifts "
@@ -371,39 +483,77 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 1, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
         test.shift();
+        test.check({{{account1, 2, {txSeqA1T1}}, {account2, 1, {txSeqA2T1}}}});
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 1, {txSeqA2T1}}}});
         test.shift();
+        test.check({{{account1, 3, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 2, {txSeqA2T1}}}});
         test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
-        test.shift({txSeqA1T1});
-        test.check({txSeqA2T1, txSeqA1T2, txSeqA2T2}, {txSeqA1T1});
-        test.shift({txSeqA2T1});
-        test.check({txSeqA1T2, txSeqA2T2}, {txSeqA1T1, txSeqA2T1});
-        test.shift({txSeqA1T2});
-        test.check({txSeqA2T2}, {txSeqA2T1, txSeqA1T2});
-        test.shift({txSeqA2T2});
-        test.check({}, {txSeqA1T2, txSeqA2T2});
+        test.check({{{account1, 3, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 2, {txSeqA2T1, txSeqA2T2}}}});
+        test.shift();
+        test.check({{{account1}, {account2, 3, {txSeqA2T1, txSeqA2T2}}},
+                    {{txSeqA1T1, txSeqA1T2}}});
+        test.shift();
+        test.check({{{account1}, {account2}},
+                    {{txSeqA2T1, txSeqA2T2}, {txSeqA1T1, txSeqA1T2}}});
+        test.shift();
+        test.check({{{account1}, {account2}}, {{}, {txSeqA2T1, txSeqA2T2}}});
+        test.shift();
+        test.check({{{account1}, {account2}}});
     }
 
     SECTION("multiple good sequence numbers, different accounts, with remove")
     {
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
+        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
+        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 0, {txSeqA2T1}}}});
+        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
+        test.shift();
+        test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}},
+                     {account2, 1, {txSeqA2T1, txSeqA2T2}}}});
+        test.removeAndReset({txSeqA1T1, txSeqA2T2});
+        test.check({{{account1}, {account2, 0, {txSeqA2T1}}}});
+        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
+        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}},
+                     {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
+        test.removeAndReset({txSeqA2T1});
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
+        test.removeAndReset({txSeqA1T1});
+        test.check({{{account1}, {account2}}});
+    }
+
+    SECTION("multiple good sequence numbers, different accounts, with ban")
+    {
+        TransactionQueueTest test{*app};
+        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA1T1, txSeqA2T1, txSeqA1T2, txSeqA2T2});
-        test.remove({txSeqA1T1, txSeqA2T2});
-        test.check({txSeqA2T1, txSeqA1T2});
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_ERROR);
-        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.check({txSeqA2T1, txSeqA1T2, txSeqA2T2});
-        test.remove({txSeqA2T1, txSeqA1T2});
-        test.check({txSeqA2T2});
-        test.remove({txSeqA2T2});
-        test.check();
+        test.shift();
+        test.ban({txSeqA1T1, txSeqA2T2});
+        test.check({{{account1}, {account2, 1, {txSeqA2T1}}},
+                    {{txSeqA1T1, txSeqA1T2, txSeqA2T2}}});
+        test.add(txSeqA1T1,
+                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+        test.check({{{account1}, {account2, 1, {txSeqA2T1}}},
+                    {{txSeqA1T1, txSeqA1T2, txSeqA2T2}}});
     }
 }

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -409,12 +409,16 @@ getAccountSigners(PublicKey const& k, Application& app)
 
 TransactionFramePtr
 transactionFromOperations(Application& app, SecretKey const& from,
-                          SequenceNumber seq, const std::vector<Operation>& ops)
+                          SequenceNumber seq, const std::vector<Operation>& ops,
+                          int fee)
 {
     auto e = TransactionEnvelope{};
     e.tx.sourceAccount = from.getPublicKey();
-    e.tx.fee = static_cast<uint32_t>(
-        (ops.size() * app.getLedgerManager().getLastTxFee()) & UINT32_MAX);
+    e.tx.fee = fee != 0
+                   ? fee
+                   : static_cast<uint32_t>(
+                         (ops.size() * app.getLedgerManager().getLastTxFee()) &
+                         UINT32_MAX);
     e.tx.seqNum = seq;
     std::copy(std::begin(ops), std::end(ops),
               std::back_inserter(e.tx.operations));

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -89,10 +89,11 @@ bool doesAccountExist(Application& app, PublicKey const& k);
 xdr::xvector<Signer, 20> getAccountSigners(PublicKey const& k,
                                            Application& app);
 
-TransactionFramePtr
-transactionFromOperations(Application& app, SecretKey const& from,
-                          SequenceNumber seq,
-                          std::vector<Operation> const& ops);
+TransactionFramePtr transactionFromOperations(Application& app,
+                                              SecretKey const& from,
+                                              SequenceNumber seq,
+                                              std::vector<Operation> const& ops,
+                                              int fee = 0);
 
 Operation changeTrust(Asset const& asset, int64_t limit);
 


### PR DESCRIPTION
Signed-off-by: Rafał Malinowski <rafal.przemyslaw.malinowski@gmail.com>

# Description

Resolves #1556

With this change each behavior of transaction queue for account changes. All transactions for one account have the same "pending depth" now, so it is no longer possible that transactions with lower seqnum is removed or banned and trasaction with higher seqnum remains in queue. That situation was buggy, because account was not able to submit more valid transaction until all of them were removed from pending queue (that usually took only one ledger, so 5 seconds).

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
