### PR TITLE
Improve error messages when an exception is thrown

### DIFF
--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -62,17 +62,26 @@ runWithConfig(Config cfg)
 
         app->applyCfgCommands();
     }
-    catch (std::exception& e)
+    catch (std::exception const& e)
     {
         LOG(FATAL) << "Got an exception: " << e.what();
         LOG(FATAL) << REPORT_INTERNAL_BUG;
         return 1;
     }
-    auto& io = clock.getIOContext();
-    asio::io_context::work mainWork(io);
-    while (!io.stopped())
+
+    try
     {
-        clock.crank();
+        auto& io = clock.getIOContext();
+        asio::io_context::work mainWork(io);
+        while (!io.stopped())
+        {
+            clock.crank();
+        }
+    }
+    catch (std::exception const& e)
+    {
+        LOG(FATAL) << "Got an exception: " << e.what();
+        throw; // propagate exception (core dump, etc)
     }
     return 0;
 }

--- a/src/main/ErrorMessages.h
+++ b/src/main/ErrorMessages.h
@@ -8,13 +8,14 @@ namespace stellar
 {
 
 constexpr auto const REPORT_INTERNAL_BUG =
-    "Please report this bug along with this log file";
+    "Please report this bug along with this log file if this was not expected";
 constexpr auto const POSSIBLY_CORRUPTED_HISTORY =
     "One or more of history archives may be corrupted. Update HISTORY "
     "configuration entry to only contain valid ones";
 constexpr auto const POSSIBLY_CORRUPTED_LOCAL_FS =
-    "It may be problem with local filesystem. Ensure that there is enough "
-    "space to perform that operation and that disc is behaving correctly.";
+    "There may be a problem with the local filesystem. Ensure that there is "
+    "enough space to perform that operation and that disc is behaving "
+    "correctly.";
 constexpr auto const POSSIBLY_CORRUPTED_LOCAL_DATA =
     "It is possible that your bucket storage or database is corrupted. Restore "
     "latest backup or reset this instance to fix this issue.";


### PR DESCRIPTION
# Description

Resolves #2157 

This PR adds some context when an exception is thrown in a low disk space situation (before this change: the app just crashes and gives the illusion of a problem in SCP that was externalizing a slot).
