### PR TITLE
overlay: cache metrics so we don't keep looking them up.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -445,6 +445,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\ItemFetcher.cpp" />
     <ClCompile Include="..\..\src\overlay\LoadManager.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayManagerImpl.cpp" />
+    <ClCompile Include="..\..\src\overlay\OverlayMetrics.cpp" />
     <ClCompile Include="..\..\src\overlay\Peer.cpp" />
     <ClCompile Include="..\..\src\overlay\PeerAuth.cpp" />
     <ClCompile Include="..\..\src\overlay\PeerBareAddress.cpp" />
@@ -694,6 +695,7 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\LoadManager.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManager.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManagerImpl.h" />
+    <ClInclude Include="..\..\src\overlay\OverlayMetrics.h" />
     <ClInclude Include="..\..\src\overlay\Peer.h" />
     <ClInclude Include="..\..\src\overlay\PeerAuth.h" />
     <ClInclude Include="..\..\src\overlay\PeerBareAddress.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -888,6 +888,9 @@
     <ClCompile Include="..\..\src\overlay\OverlayManagerImpl.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\overlay\OverlayMetrics.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\overlay\Peer.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
@@ -1581,6 +1584,9 @@
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\OverlayManagerImpl.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\OverlayMetrics.h">
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\Peer.h">

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -8,6 +8,7 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
@@ -171,8 +172,10 @@ LoadManager::PeerContext::PeerContext(Application& app, NodeID const& node)
     : mApp(app)
     , mNode(node)
     , mWorkStart(app.getClock().now())
-    , mBytesSendStart(Peer::getByteWriteMeter(app).count())
-    , mBytesRecvStart(Peer::getByteReadMeter(app).count())
+    , mBytesSendStart(
+          app.getOverlayManager().getOverlayMetrics().mByteWrite.count())
+    , mBytesRecvStart(
+          app.getOverlayManager().getOverlayMetrics().mByteRead.count())
     , mSQLQueriesStart(app.getDatabase().getQueryMeter().count())
 {
 }
@@ -184,8 +187,12 @@ LoadManager::PeerContext::~PeerContext()
         auto pc = mApp.getOverlayManager().getLoadManager().getPeerCosts(mNode);
         auto time = std::chrono::duration_cast<std::chrono::nanoseconds>(
             mApp.getClock().now() - mWorkStart);
-        auto send = Peer::getByteWriteMeter(mApp).count() - mBytesSendStart;
-        auto recv = Peer::getByteReadMeter(mApp).count() - mBytesRecvStart;
+        auto send =
+            mApp.getOverlayManager().getOverlayMetrics().mByteWrite.count() -
+            mBytesSendStart;
+        auto recv =
+            mApp.getOverlayManager().getOverlayMetrics().mByteRead.count() -
+            mBytesRecvStart;
         auto query =
             (mApp.getDatabase().getQueryMeter().count() - mSQLQueriesStart);
         if (Logging::logTrace("Overlay"))

--- a/src/overlay/LoadManager.h
+++ b/src/overlay/LoadManager.h
@@ -71,7 +71,7 @@ class LoadManager
     class PeerContext
     {
         Application& mApp;
-        NodeID mNode;
+        NodeID const& mNode;
 
         VirtualClock::time_point mWorkStart;
         std::uint64_t mBytesSendStart;

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -137,6 +137,9 @@ class OverlayManager
     // returns the list of peers that sent us the item with hash `h`
     virtual std::set<Peer::pointer> getPeersKnows(Hash const& h) = 0;
 
+    // Return the persistent overlay metrics structure.
+    virtual OverlayMetrics& getOverlayMetrics() = 0;
+
     // Return the persistent p2p authentication-key cache.
     virtual PeerAuth& getPeerAuth() = 0;
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -9,6 +9,7 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "main/ErrorMessages.h"
+#include "overlay/OverlayMetrics.h"
 #include "overlay/PeerBareAddress.h"
 #include "overlay/PeerManager.h"
 #include "overlay/RandomPeerSource.h"
@@ -239,12 +240,7 @@ OverlayManagerImpl::OverlayManagerImpl(Application& app)
     , mDoor(mApp)
     , mAuth(mApp)
     , mShuttingDown(false)
-    , mMessagesBroadcast(app.getMetrics().NewMeter(
-          {"overlay", "message", "broadcast"}, "message"))
-    , mPendingPeersSize(
-          app.getMetrics().NewCounter({"overlay", "connection", "pending"}))
-    , mAuthenticatedPeersSize(app.getMetrics().NewCounter(
-          {"overlay", "connection", "authenticated"}))
+    , mOverlayMetrics(app)
     , mTimer(app)
     , mPeerIPTimer(app)
     , mFloodGate(app)
@@ -589,8 +585,9 @@ OverlayManagerImpl::ledgerClosed(uint32_t lastClosedledgerSeq)
 void
 OverlayManagerImpl::updateSizeCounters()
 {
-    mPendingPeersSize.set_count(getPendingPeersCount());
-    mAuthenticatedPeersSize.set_count(getAuthenticatedPeersCount());
+    mOverlayMetrics.mPendingPeersSize.set_count(getPendingPeersCount());
+    mOverlayMetrics.mAuthenticatedPeersSize.set_count(
+        getAuthenticatedPeersCount());
 }
 
 void
@@ -816,7 +813,7 @@ OverlayManagerImpl::recvFloodedMsg(StellarMessage const& msg,
 void
 OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force)
 {
-    mMessagesBroadcast.Mark();
+    mOverlayMetrics.mMessagesBroadcast.Mark();
     mFloodGate.broadcast(msg, force);
 }
 
@@ -830,6 +827,12 @@ std::set<Peer::pointer>
 OverlayManagerImpl::getPeersKnows(Hash const& h)
 {
     return mFloodGate.getPeersKnows(h);
+}
+
+OverlayMetrics&
+OverlayManagerImpl::getOverlayMetrics()
+{
+    return mOverlayMetrics;
 }
 
 PeerAuth&

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -13,6 +13,7 @@
 #include "overlay/Floodgate.h"
 #include "overlay/ItemFetcher.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
 #include "overlay/StellarXDR.h"
 #include "util/Timer.h"
 
@@ -76,9 +77,7 @@ class OverlayManagerImpl : public OverlayManager
     LoadManager mLoad;
     bool mShuttingDown;
 
-    medida::Meter& mMessagesBroadcast;
-    medida::Counter& mPendingPeersSize;
-    medida::Counter& mAuthenticatedPeersSize;
+    OverlayMetrics mOverlayMetrics;
 
     void tick();
     VirtualTimer mTimer;
@@ -124,6 +123,7 @@ class OverlayManagerImpl : public OverlayManager
 
     std::set<Peer::pointer> getPeersKnows(Hash const& h) override;
 
+    OverlayMetrics& getOverlayMetrics() override;
     PeerAuth& getPeerAuth() override;
 
     LoadManager& getLoadManager() override;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -1,0 +1,93 @@
+#include "overlay/OverlayMetrics.h"
+#include "main/Application.h"
+
+#include "medida/meter.h"
+#include "medida/metrics_registry.h"
+#include "medida/timer.h"
+
+namespace stellar
+{
+
+OverlayMetrics::OverlayMetrics(Application& app)
+    : mMessageRead(
+          app.getMetrics().NewMeter({"overlay", "message", "read"}, "message"))
+    , mMessageWrite(
+          app.getMetrics().NewMeter({"overlay", "message", "write"}, "message"))
+    , mByteRead(app.getMetrics().NewMeter({"overlay", "byte", "read"}, "byte"))
+    , mByteWrite(
+          app.getMetrics().NewMeter({"overlay", "byte", "write"}, "byte"))
+    , mErrorRead(
+          app.getMetrics().NewMeter({"overlay", "error", "read"}, "error"))
+    , mErrorWrite(
+          app.getMetrics().NewMeter({"overlay", "error", "write"}, "error"))
+    , mTimeoutIdle(
+          app.getMetrics().NewMeter({"overlay", "timeout", "idle"}, "timeout"))
+    , mTimeoutStraggler(app.getMetrics().NewMeter(
+          {"overlay", "timeout", "straggler"}, "timeout"))
+
+    , mRecvErrorTimer(app.getMetrics().NewTimer({"overlay", "recv", "error"}))
+    , mRecvHelloTimer(app.getMetrics().NewTimer({"overlay", "recv", "hello"}))
+    , mRecvAuthTimer(app.getMetrics().NewTimer({"overlay", "recv", "auth"}))
+    , mRecvDontHaveTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "dont-have"}))
+    , mRecvGetPeersTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "get-peers"}))
+    , mRecvPeersTimer(app.getMetrics().NewTimer({"overlay", "recv", "peers"}))
+    , mRecvGetTxSetTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "get-txset"}))
+    , mRecvTxSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "txset"}))
+    , mRecvTransactionTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "transaction"}))
+    , mRecvGetSCPQuorumSetTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "get-scp-qset"}))
+    , mRecvSCPQuorumSetTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-qset"}))
+    , mRecvSCPMessageTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-message"}))
+    , mRecvGetSCPStateTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "get-scp-state"}))
+
+    , mRecvSCPPrepareTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-prepare"}))
+    , mRecvSCPConfirmTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-confirm"}))
+    , mRecvSCPNominateTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-nominate"}))
+    , mRecvSCPExternalizeTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "scp-externalize"}))
+
+    , mSendErrorMeter(
+          app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))
+    , mSendHelloMeter(
+          app.getMetrics().NewMeter({"overlay", "send", "hello"}, "message"))
+    , mSendAuthMeter(
+          app.getMetrics().NewMeter({"overlay", "send", "auth"}, "message"))
+    , mSendDontHaveMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "dont-have"}, "message"))
+    , mSendGetPeersMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "get-peers"}, "message"))
+    , mSendPeersMeter(
+          app.getMetrics().NewMeter({"overlay", "send", "peers"}, "message"))
+    , mSendGetTxSetMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "get-txset"}, "message"))
+    , mSendTransactionMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "transaction"}, "message"))
+    , mSendTxSetMeter(
+          app.getMetrics().NewMeter({"overlay", "send", "txset"}, "message"))
+    , mSendGetSCPQuorumSetMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "get-scp-qset"}, "message"))
+    , mSendSCPQuorumSetMeter(
+          app.getMetrics().NewMeter({"overlay", "send", "scp-qset"}, "message"))
+    , mSendSCPMessageSetMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "scp-message"}, "message"))
+    , mSendGetSCPStateMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "get-scp-state"}, "message"))
+    , mMessagesBroadcast(app.getMetrics().NewMeter(
+          {"overlay", "message", "broadcast"}, "message"))
+    , mPendingPeersSize(
+          app.getMetrics().NewCounter({"overlay", "connection", "pending"}))
+    , mAuthenticatedPeersSize(app.getMetrics().NewCounter(
+          {"overlay", "connection", "authenticated"}))
+{
+}
+}

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -1,0 +1,73 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// This structure just exists to cache frequently-accessed, overlay-wide
+// (non-peer-specific) metrics. Some of these metrics are subsequently
+// tabulated at a per-peer level for purposes of identifying and
+// disconnecting overloading peers, see LoadManager for details.
+
+namespace medida
+{
+class Timer;
+class Meter;
+class Counter;
+}
+
+namespace stellar
+{
+
+class Application;
+
+struct OverlayMetrics
+{
+    OverlayMetrics(Application& app);
+    medida::Meter& mMessageRead;
+    medida::Meter& mMessageWrite;
+    medida::Meter& mByteRead;
+    medida::Meter& mByteWrite;
+    medida::Meter& mErrorRead;
+    medida::Meter& mErrorWrite;
+    medida::Meter& mTimeoutIdle;
+    medida::Meter& mTimeoutStraggler;
+
+    medida::Timer& mRecvErrorTimer;
+    medida::Timer& mRecvHelloTimer;
+    medida::Timer& mRecvAuthTimer;
+    medida::Timer& mRecvDontHaveTimer;
+    medida::Timer& mRecvGetPeersTimer;
+    medida::Timer& mRecvPeersTimer;
+    medida::Timer& mRecvGetTxSetTimer;
+    medida::Timer& mRecvTxSetTimer;
+    medida::Timer& mRecvTransactionTimer;
+    medida::Timer& mRecvGetSCPQuorumSetTimer;
+    medida::Timer& mRecvSCPQuorumSetTimer;
+    medida::Timer& mRecvSCPMessageTimer;
+    medida::Timer& mRecvGetSCPStateTimer;
+
+    medida::Timer& mRecvSCPPrepareTimer;
+    medida::Timer& mRecvSCPConfirmTimer;
+    medida::Timer& mRecvSCPNominateTimer;
+    medida::Timer& mRecvSCPExternalizeTimer;
+
+    medida::Meter& mSendErrorMeter;
+    medida::Meter& mSendHelloMeter;
+    medida::Meter& mSendAuthMeter;
+    medida::Meter& mSendDontHaveMeter;
+    medida::Meter& mSendGetPeersMeter;
+    medida::Meter& mSendPeersMeter;
+    medida::Meter& mSendGetTxSetMeter;
+    medida::Meter& mSendTransactionMeter;
+    medida::Meter& mSendTxSetMeter;
+    medida::Meter& mSendGetSCPQuorumSetMeter;
+    medida::Meter& mSendSCPQuorumSetMeter;
+    medida::Meter& mSendSCPMessageSetMeter;
+    medida::Meter& mSendGetSCPStateMeter;
+
+    medida::Meter& mMessagesBroadcast;
+    medida::Counter& mPendingPeersSize;
+    medida::Counter& mAuthenticatedPeersSize;
+};
+}

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -16,6 +16,7 @@
 #include "main/Config.h"
 #include "overlay/LoadManager.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
 #include "overlay/PeerAuth.h"
 #include "overlay/PeerManager.h"
 #include "overlay/StellarXDR.h"
@@ -40,18 +41,6 @@ namespace stellar
 using namespace std;
 using namespace soci;
 
-medida::Meter&
-Peer::getByteReadMeter(Application& app)
-{
-    return app.getMetrics().NewMeter({"overlay", "byte", "read"}, "byte");
-}
-
-medida::Meter&
-Peer::getByteWriteMeter(Application& app)
-{
-    return app.getMetrics().NewMeter({"overlay", "byte", "write"}, "byte");
-}
-
 Peer::Peer(Application& app, PeerRole role)
     : mApp(app)
     , mRole(role)
@@ -61,79 +50,8 @@ Peer::Peer(Application& app, PeerRole role)
     , mLastRead(app.getClock().now())
     , mLastWrite(app.getClock().now())
     , mLastEmpty(app.getClock().now())
-
-    , mMessageRead(
-          app.getMetrics().NewMeter({"overlay", "message", "read"}, "message"))
-    , mMessageWrite(
-          app.getMetrics().NewMeter({"overlay", "message", "write"}, "message"))
-    , mByteRead(getByteReadMeter(app))
-    , mByteWrite(getByteWriteMeter(app))
-    , mErrorRead(
-          app.getMetrics().NewMeter({"overlay", "error", "read"}, "error"))
-    , mErrorWrite(
-          app.getMetrics().NewMeter({"overlay", "error", "write"}, "error"))
-    , mTimeoutIdle(
-          app.getMetrics().NewMeter({"overlay", "timeout", "idle"}, "timeout"))
     , mTimeoutStraggler(app.getMetrics().NewMeter(
           {"overlay", "timeout", "straggler"}, "timeout"))
-
-    , mRecvErrorTimer(app.getMetrics().NewTimer({"overlay", "recv", "error"}))
-    , mRecvHelloTimer(app.getMetrics().NewTimer({"overlay", "recv", "hello"}))
-    , mRecvAuthTimer(app.getMetrics().NewTimer({"overlay", "recv", "auth"}))
-    , mRecvDontHaveTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "dont-have"}))
-    , mRecvGetPeersTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "get-peers"}))
-    , mRecvPeersTimer(app.getMetrics().NewTimer({"overlay", "recv", "peers"}))
-    , mRecvGetTxSetTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "get-txset"}))
-    , mRecvTxSetTimer(app.getMetrics().NewTimer({"overlay", "recv", "txset"}))
-    , mRecvTransactionTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "transaction"}))
-    , mRecvGetSCPQuorumSetTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "get-scp-qset"}))
-    , mRecvSCPQuorumSetTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "scp-qset"}))
-    , mRecvSCPMessageTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "scp-message"}))
-    , mRecvGetSCPStateTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "get-scp-state"}))
-
-    , mRecvSCPPrepareTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "scp-prepare"}))
-    , mRecvSCPConfirmTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "scp-confirm"}))
-    , mRecvSCPNominateTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "scp-nominate"}))
-    , mRecvSCPExternalizeTimer(
-          app.getMetrics().NewTimer({"overlay", "recv", "scp-externalize"}))
-
-    , mSendErrorMeter(
-          app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))
-    , mSendHelloMeter(
-          app.getMetrics().NewMeter({"overlay", "send", "hello"}, "message"))
-    , mSendAuthMeter(
-          app.getMetrics().NewMeter({"overlay", "send", "auth"}, "message"))
-    , mSendDontHaveMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "dont-have"}, "message"))
-    , mSendGetPeersMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "get-peers"}, "message"))
-    , mSendPeersMeter(
-          app.getMetrics().NewMeter({"overlay", "send", "peers"}, "message"))
-    , mSendGetTxSetMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "get-txset"}, "message"))
-    , mSendTransactionMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "transaction"}, "message"))
-    , mSendTxSetMeter(
-          app.getMetrics().NewMeter({"overlay", "send", "txset"}, "message"))
-    , mSendGetSCPQuorumSetMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "get-scp-qset"}, "message"))
-    , mSendSCPQuorumSetMeter(
-          app.getMetrics().NewMeter({"overlay", "send", "scp-qset"}, "message"))
-    , mSendSCPMessageSetMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "scp-message"}, "message"))
-    , mSendGetSCPStateMeter(app.getMetrics().NewMeter(
-          {"overlay", "send", "get-scp-state"}, "message"))
 {
     auto bytes = randomBytes(mSendNonce.size());
     std::copy(bytes.begin(), bytes.end(), mSendNonce.begin());
@@ -162,6 +80,12 @@ AuthCert
 Peer::getAuthCert()
 {
     return mApp.getOverlayManager().getPeerAuth().getAuthCert();
+}
+
+OverlayMetrics&
+Peer::getOverlayMetrics()
+{
+    return mApp.getOverlayManager().getOverlayMetrics();
 }
 
 std::chrono::seconds
@@ -193,8 +117,8 @@ Peer::receivedBytes(size_t byteCount, bool gotFullMessage)
     LoadManager::PeerContext loadCtx(mApp, mPeerID);
     mLastRead = mApp.getClock().now();
     if (gotFullMessage)
-        mMessageRead.Mark();
-    mByteRead.Mark(byteCount);
+        getOverlayMetrics().mMessageRead.Mark();
+    getOverlayMetrics().mByteRead.Mark(byteCount);
 }
 
 void
@@ -223,13 +147,13 @@ Peer::idleTimerExpired(asio::error_code const& error)
             std::chrono::seconds(mApp.getConfig().PEER_STRAGGLER_TIMEOUT);
         if (((now - mLastRead) >= timeout) && ((now - mLastWrite) >= timeout))
         {
-            mTimeoutIdle.Mark();
+            getOverlayMetrics().mTimeoutIdle.Mark();
             drop("idle timeout", Peer::DropDirection::WE_DROPPED_REMOTE,
                  Peer::DropMode::IGNORE_WRITE_QUEUE);
         }
         else if (((now - mLastEmpty) >= stragglerTimeout))
         {
-            mTimeoutStraggler.Mark();
+            getOverlayMetrics().mTimeoutStraggler.Mark();
             drop("straggling (cannot keep up)",
                  Peer::DropDirection::WE_DROPPED_REMOTE,
                  Peer::DropMode::IGNORE_WRITE_QUEUE);
@@ -440,43 +364,43 @@ Peer::sendMessage(StellarMessage const& msg)
     switch (msg.type())
     {
     case ERROR_MSG:
-        mSendErrorMeter.Mark();
+        getOverlayMetrics().mSendErrorMeter.Mark();
         break;
     case HELLO:
-        mSendHelloMeter.Mark();
+        getOverlayMetrics().mSendHelloMeter.Mark();
         break;
     case AUTH:
-        mSendAuthMeter.Mark();
+        getOverlayMetrics().mSendAuthMeter.Mark();
         break;
     case DONT_HAVE:
-        mSendDontHaveMeter.Mark();
+        getOverlayMetrics().mSendDontHaveMeter.Mark();
         break;
     case GET_PEERS:
-        mSendGetPeersMeter.Mark();
+        getOverlayMetrics().mSendGetPeersMeter.Mark();
         break;
     case PEERS:
-        mSendPeersMeter.Mark();
+        getOverlayMetrics().mSendPeersMeter.Mark();
         break;
     case GET_TX_SET:
-        mSendGetTxSetMeter.Mark();
+        getOverlayMetrics().mSendGetTxSetMeter.Mark();
         break;
     case TX_SET:
-        mSendTxSetMeter.Mark();
+        getOverlayMetrics().mSendTxSetMeter.Mark();
         break;
     case TRANSACTION:
-        mSendTransactionMeter.Mark();
+        getOverlayMetrics().mSendTransactionMeter.Mark();
         break;
     case GET_SCP_QUORUMSET:
-        mSendGetSCPQuorumSetMeter.Mark();
+        getOverlayMetrics().mSendGetSCPQuorumSetMeter.Mark();
         break;
     case SCP_QUORUMSET:
-        mSendSCPQuorumSetMeter.Mark();
+        getOverlayMetrics().mSendSCPQuorumSetMeter.Mark();
         break;
     case SCP_MESSAGE:
-        mSendSCPMessageSetMeter.Mark();
+        getOverlayMetrics().mSendSCPMessageSetMeter.Mark();
         break;
     case GET_SCP_STATE:
-        mSendGetSCPStateMeter.Mark();
+        getOverlayMetrics().mSendGetSCPStateMeter.Mark();
         break;
     };
 
@@ -603,91 +527,91 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
     {
     case ERROR_MSG:
     {
-        auto t = mRecvErrorTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvErrorTimer.TimeScope();
         recvError(stellarMsg);
     }
     break;
 
     case HELLO:
     {
-        auto t = mRecvHelloTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvHelloTimer.TimeScope();
         this->recvHello(stellarMsg.hello());
     }
     break;
 
     case AUTH:
     {
-        auto t = mRecvAuthTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvAuthTimer.TimeScope();
         this->recvAuth(stellarMsg);
     }
     break;
 
     case DONT_HAVE:
     {
-        auto t = mRecvDontHaveTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvDontHaveTimer.TimeScope();
         recvDontHave(stellarMsg);
     }
     break;
 
     case GET_PEERS:
     {
-        auto t = mRecvGetPeersTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvGetPeersTimer.TimeScope();
         recvGetPeers(stellarMsg);
     }
     break;
 
     case PEERS:
     {
-        auto t = mRecvPeersTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvPeersTimer.TimeScope();
         recvPeers(stellarMsg);
     }
     break;
 
     case GET_TX_SET:
     {
-        auto t = mRecvGetTxSetTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvGetTxSetTimer.TimeScope();
         recvGetTxSet(stellarMsg);
     }
     break;
 
     case TX_SET:
     {
-        auto t = mRecvTxSetTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvTxSetTimer.TimeScope();
         recvTxSet(stellarMsg);
     }
     break;
 
     case TRANSACTION:
     {
-        auto t = mRecvTransactionTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvTransactionTimer.TimeScope();
         recvTransaction(stellarMsg);
     }
     break;
 
     case GET_SCP_QUORUMSET:
     {
-        auto t = mRecvGetSCPQuorumSetTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvGetSCPQuorumSetTimer.TimeScope();
         recvGetSCPQuorumSet(stellarMsg);
     }
     break;
 
     case SCP_QUORUMSET:
     {
-        auto t = mRecvSCPQuorumSetTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvSCPQuorumSetTimer.TimeScope();
         recvSCPQuorumSet(stellarMsg);
     }
     break;
 
     case SCP_MESSAGE:
     {
-        auto t = mRecvSCPMessageTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvSCPMessageTimer.TimeScope();
         recvSCPMessage(stellarMsg);
     }
     break;
 
     case GET_SCP_STATE:
     {
-        auto t = mRecvGetSCPStateTimer.TimeScope();
+        auto t = getOverlayMetrics().mRecvGetSCPStateTimer.TimeScope();
         recvGetSCPState(stellarMsg);
     }
     break;
@@ -788,12 +712,14 @@ Peer::recvSCPMessage(StellarMessage const& msg)
 
     auto type = msg.envelope().statement.pledges.type();
     auto t = (type == SCP_ST_PREPARE
-                  ? mRecvSCPPrepareTimer.TimeScope()
+                  ? getOverlayMetrics().mRecvSCPPrepareTimer.TimeScope()
                   : (type == SCP_ST_CONFIRM
-                         ? mRecvSCPConfirmTimer.TimeScope()
+                         ? getOverlayMetrics().mRecvSCPConfirmTimer.TimeScope()
                          : (type == SCP_ST_EXTERNALIZE
-                                ? mRecvSCPExternalizeTimer.TimeScope()
-                                : (mRecvSCPNominateTimer.TimeScope()))));
+                                ? getOverlayMetrics()
+                                      .mRecvSCPExternalizeTimer.TimeScope()
+                                : (getOverlayMetrics()
+                                       .mRecvSCPNominateTimer.TimeScope()))));
 
     auto res = mApp.getHerder().recvSCPEnvelope(envelope);
     if (res != Herder::ENVELOPE_STATUS_DISCARDED)

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -25,6 +25,7 @@ typedef std::shared_ptr<SCPQuorumSet> SCPQuorumSetPtr;
 
 class Application;
 class LoopbackPeer;
+struct OverlayMetrics;
 
 /*
  * Another peer out there that we are connected to
@@ -63,9 +64,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
         WE_DROPPED_REMOTE
     };
 
-    static medida::Meter& getByteReadMeter(Application& app);
-    static medida::Meter& getByteWriteMeter(Application& app);
-
   protected:
     Application& mApp;
 
@@ -90,47 +88,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     VirtualClock::time_point mLastWrite;
     VirtualClock::time_point mLastEmpty;
 
-    medida::Meter& mMessageRead;
-    medida::Meter& mMessageWrite;
-    medida::Meter& mByteRead;
-    medida::Meter& mByteWrite;
-    medida::Meter& mErrorRead;
-    medida::Meter& mErrorWrite;
-    medida::Meter& mTimeoutIdle;
+    OverlayMetrics& getOverlayMetrics();
     medida::Meter& mTimeoutStraggler;
-
-    medida::Timer& mRecvErrorTimer;
-    medida::Timer& mRecvHelloTimer;
-    medida::Timer& mRecvAuthTimer;
-    medida::Timer& mRecvDontHaveTimer;
-    medida::Timer& mRecvGetPeersTimer;
-    medida::Timer& mRecvPeersTimer;
-    medida::Timer& mRecvGetTxSetTimer;
-    medida::Timer& mRecvTxSetTimer;
-    medida::Timer& mRecvTransactionTimer;
-    medida::Timer& mRecvGetSCPQuorumSetTimer;
-    medida::Timer& mRecvSCPQuorumSetTimer;
-    medida::Timer& mRecvSCPMessageTimer;
-    medida::Timer& mRecvGetSCPStateTimer;
-
-    medida::Timer& mRecvSCPPrepareTimer;
-    medida::Timer& mRecvSCPConfirmTimer;
-    medida::Timer& mRecvSCPNominateTimer;
-    medida::Timer& mRecvSCPExternalizeTimer;
-
-    medida::Meter& mSendErrorMeter;
-    medida::Meter& mSendHelloMeter;
-    medida::Meter& mSendAuthMeter;
-    medida::Meter& mSendDontHaveMeter;
-    medida::Meter& mSendGetPeersMeter;
-    medida::Meter& mSendPeersMeter;
-    medida::Meter& mSendGetTxSetMeter;
-    medida::Meter& mSendTransactionMeter;
-    medida::Meter& mSendTxSetMeter;
-    medida::Meter& mSendGetSCPQuorumSetMeter;
-    medida::Meter& mSendSCPQuorumSetMeter;
-    medida::Meter& mSendSCPMessageSetMeter;
-    medida::Meter& mSendGetSCPStateMeter;
 
     bool shouldAbort() const;
     void recvMessage(StellarMessage const& msg);

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -11,6 +11,7 @@
 #include "medida/metrics_registry.h"
 #include "overlay/LoadManager.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
 #include "overlay/PeerManager.h"
 #include "overlay/StellarXDR.h"
 #include "util/GlobalChecks.h"
@@ -288,7 +289,7 @@ TCPPeer::writeHandler(asio::error_code const& error,
         {
             // Only emit a warning if we have an error while connected;
             // errors during shutdown or connection are common/expected.
-            mErrorWrite.Mark();
+            getOverlayMetrics().mErrorWrite.Mark();
             CLOG(ERROR, "Overlay")
                 << "Error during sending message to " << toString();
         }
@@ -307,8 +308,8 @@ TCPPeer::writeHandler(asio::error_code const& error,
     else if (bytes_transferred != 0)
     {
         LoadManager::PeerContext loadCtx(mApp, mPeerID);
-        mMessageWrite.Mark();
-        mByteWrite.Mark(bytes_transferred);
+        getOverlayMetrics().mMessageWrite.Mark();
+        getOverlayMetrics().mByteWrite.Mark(bytes_transferred);
     }
 }
 
@@ -355,7 +356,7 @@ TCPPeer::getIncomingMsgLength()
         (!isAuthenticated() && (length > MAX_UNAUTH_MESSAGE_SIZE)) ||
         length > MAX_MESSAGE_SIZE)
     {
-        mErrorRead.Mark();
+        getOverlayMetrics().mErrorRead.Mark();
         CLOG(ERROR, "Overlay")
             << "TCP: message size unacceptable: " << length
             << (isAuthenticated() ? "" : " while not authenticated");
@@ -402,7 +403,7 @@ TCPPeer::readHeaderHandler(asio::error_code const& error,
         {
             // Only emit a warning if we have an error while connected;
             // errors during shutdown or connection are common/expected.
-            mErrorRead.Mark();
+            getOverlayMetrics().mErrorRead.Mark();
             CLOG(DEBUG, "Overlay")
                 << "readHeaderHandler error: " << error.message() << ": "
                 << toString();
@@ -435,7 +436,7 @@ TCPPeer::readBodyHandler(asio::error_code const& error,
         {
             // Only emit a warning if we have an error while connected;
             // errors during shutdown or connection are common/expected.
-            mErrorRead.Mark();
+            getOverlayMetrics().mErrorRead.Mark();
             CLOG(ERROR, "Overlay")
                 << "readBodyHandler error: " << error.message() << " :"
                 << toString();

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -8,6 +8,7 @@
 #include "medida/timer.h"
 #include "overlay/LoadManager.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
 #include "overlay/StellarXDR.h"
 #include "util/Logging.h"
 #include "util/Math.h"
@@ -238,8 +239,8 @@ LoopbackPeer::deliverOne()
         {
             mLastEmpty = mApp.getClock().now();
         }
-        mMessageWrite.Mark();
-        mByteWrite.Mark(nBytes);
+        getOverlayMetrics().mMessageWrite.Mark();
+        getOverlayMetrics().mByteWrite.Mark(nBytes);
 
         // CLOG(TRACE, "Overlay") << "LoopbackPeer posted message to remote";
     }


### PR DESCRIPTION
# Description

Somewhat embarrassingly, stellar-core currently looks up a metric (due to the peer load manager) once every message read, and due to medida's not-very-fast representation of metric names and their lookup, this accounts for a nontrivial amount of CPU usage when dealing with regular network load. It's not even a _different_ metric or a peer-specific one: we just look up the same one over and over and over.

This PR caches the lookup. Along the way it moves all the overlay metrics into their own helper struct that outlives any individual peer.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

```
before
======

 Performance counter stats for './src/stellar-core test Flooding' (5 runs):

       6325.809263      task-clock (msec)         #    0.597 CPUs utilized            ( +-  1.23% )
             3,771      context-switches          #    0.596 K/sec                    ( +-  1.04% )
               281      cpu-migrations            #    0.044 K/sec                    ( +-  3.29% )
            30,473      page-faults               #    0.005 M/sec                    ( +-  2.09% )
    17,987,544,025      cycles                    #    2.844 GHz                      ( +-  0.51% )
    10,770,607,881      stalled-cycles-frontend   #   59.88% frontend cycles idle     ( +-  0.92% )
    17,816,610,829      instructions              #    0.99  insn per cycle         
                                                  #    0.60  stalled cycles per insn  ( +-  0.32% )
     2,603,758,090      branches                  #  411.609 M/sec                    ( +-  0.32% )
        76,597,631      branch-misses             #    2.94% of all branches          ( +-  0.58% )

      10.594307901 seconds time elapsed                                          ( +-  0.74% )


after
=====

 Performance counter stats for './src/stellar-core test Flooding' (5 runs):

       5857.014959      task-clock (msec)         #    0.586 CPUs utilized            ( +-  3.01% )
             3,632      context-switches          #    0.620 K/sec                    ( +-  2.82% )
               315      cpu-migrations            #    0.054 K/sec                    ( +-  2.30% )
            29,182      page-faults               #    0.005 M/sec                    ( +-  2.50% )
    16,403,055,117      cycles                    #    2.801 GHz                      ( +-  1.99% )
     9,945,123,289      stalled-cycles-frontend   #   60.63% frontend cycles idle     ( +-  1.80% )
    15,904,421,871      instructions              #    0.97  insn per cycle         
                                                  #    0.63  stalled cycles per insn  ( +-  2.87% )
     2,171,237,679      branches                  #  370.707 M/sec                    ( +-  4.37% )
        68,549,465      branch-misses             #    3.16% of all branches          ( +-  1.18% )

      10.002086645 seconds time elapsed                                          ( +-  2.95% )
```