### PR TITLE
Remove redundant -- one might say "straggling" -- copy of straggler metric.

### DIFF
--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -50,8 +50,6 @@ Peer::Peer(Application& app, PeerRole role)
     , mLastRead(app.getClock().now())
     , mLastWrite(app.getClock().now())
     , mLastEmpty(app.getClock().now())
-    , mTimeoutStraggler(app.getMetrics().NewMeter(
-          {"overlay", "timeout", "straggler"}, "timeout"))
 {
     auto bytes = randomBytes(mSendNonce.size());
     std::copy(bytes.begin(), bytes.end(), mSendNonce.begin());

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -89,7 +89,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     VirtualClock::time_point mLastEmpty;
 
     OverlayMetrics& getOverlayMetrics();
-    medida::Meter& mTimeoutStraggler;
 
     bool shouldAbort() const;
     void recvMessage(StellarMessage const& msg);


### PR DESCRIPTION
In #2161 I made a minor merge error and left behind a stray copy of this metric. Nothing is using it.