### PR TITLE
herder: order qmap before hashing, reduce spurious recalculation.

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1072,7 +1072,8 @@ static Hash
 getQmapHash(QuorumTracker::QuorumMap const& qmap)
 {
     std::unique_ptr<SHA256> hasher = SHA256::create();
-    for (auto const& pair : qmap)
+    std::map<NodeID, SCPQuorumSetPtr> ordered_map(qmap.begin(), qmap.end());
+    for (auto const& pair : ordered_map)
     {
         hasher->add(xdr::xdr_to_opaque(pair.first));
         if (pair.second)


### PR DESCRIPTION
I can't say this strictly matters -- no tests reveal presently that it's a problem -- but it takes a bit of potential nondeterminism out of the calculation of the transitive qmap which could potentially trigger more recalculation than necessary of quorum intersection.