### PR TITLE
bug 2128: resolve any ready futures before queueing publish state.

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -411,6 +411,18 @@ BucketList::getLevel(uint32_t i)
 }
 
 void
+BucketList::resolveAnyReadyFutures()
+{
+    for (auto& level : mLevels)
+    {
+        if (level.getNext().isMerging() && level.getNext().mergeComplete())
+        {
+            level.getNext().resolve();
+        }
+    }
+}
+
+void
 BucketList::addBatch(Application& app, uint32_t currLedger,
                      uint32_t currLedgerProtocol,
                      std::vector<LedgerEntry> const& initEntries,

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -535,6 +535,19 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
                                      countMergeEvents),
                        shadows, countMergeEvents);
     mLevels[0].commit();
+
+    // We almost always want to try to resolve completed merges to single
+    // buckets, as it makes restarts less fragile: fewer saved/restored shadows,
+    // fewer buckets for the user to accidentally delete from their buckets
+    // dir. Also makes publication less likely to redo a merge that was already
+    // complete (but not resolved) when the snapshot gets taken.
+    //
+    // But we support the option of not-doing so, only for the sake of
+    // testing. Note: this is nonblocking in any case.
+    if (!app.getConfig().ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING)
+    {
+        resolveAnyReadyFutures();
+    }
 }
 
 void

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -406,6 +406,13 @@ class BucketList
     // catching up from buckets loaded over the network.
     void restartMerges(Application& app, uint32_t maxProtocolVersion);
 
+    // Run through the levels and check for FutureBuckets that are done merging;
+    // if so, call resolve() on them, changing state from FB_LIVE_INPUTS to
+    // FB_LIVE_OUTPUT. This helps eagerly release no-longer-needed inputs and
+    // avoid propagating partially-completed BucketList states to
+    // HistoryArchiveStates, that can cause repeated merges when re-activated.
+    void resolveAnyReadyFutures();
+
     // Add a batch of initial (created), live (updated) and dead entries to the
     // bucketlist, representing the entries effected by closing
     // `currLedger`. The bucketlist will incorporate these into the smallest

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -55,22 +55,6 @@ formatString(std::string const& templateString, Tokens const&... tokens)
 }
 
 bool
-HistoryArchiveState::futuresAllReady() const
-{
-    for (auto const& level : currentBuckets)
-    {
-        if (level.next.isMerging())
-        {
-            if (!level.next.mergeComplete())
-            {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-bool
 HistoryArchiveState::futuresAllResolved() const
 {
     for (auto const& level : currentBuckets)

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -94,6 +94,9 @@ HistoryArchiveState::resolveAnyReadyFutures()
 void
 HistoryArchiveState::save(std::string const& outFile) const
 {
+    // We only ever write fully-resolved HASs to files, when making
+    // checkpoints. This may change in the future if we start publishing
+    // input-only HASs.
     assert(futuresAllResolved());
     std::ofstream out(outFile);
     cereal::JSONOutputArchive ar(out);
@@ -103,6 +106,9 @@ HistoryArchiveState::save(std::string const& outFile) const
 std::string
 HistoryArchiveState::toString() const
 {
+    // We serialize-to-a-string any HAS, regardless of resolvedness, as we are
+    // usually doing this to write to the database on the main thread, just as a
+    // durability step: we don't want to block.
     std::ostringstream out;
     {
         cereal::JSONOutputArchive ar(out);

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -108,11 +108,6 @@ struct HistoryArchiveState
            CEREAL_NVP(currentBuckets));
     }
 
-    // Return true if all the 'next' bucket-futures that can be resolved are
-    // ready to be (instantaneously) resolved, or false if a merge is still
-    // in progress on one or more of them.
-    bool futuresAllReady() const;
-
     // Return true if all futures have already been resolved, otherwise false.
     bool futuresAllResolved() const;
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1119,16 +1119,6 @@ LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header)
     HistoryArchiveState has(header.ledgerSeq,
                             mApp.getBucketManager().getBucketList());
 
-    // We almost always want to try to resolve completed merges to single
-    // buckets, as it makes restarts less fragile: fewer saved/restored shadows,
-    // fewer buckets for the user to accidentally delete from their buckets
-    // dir. But we support the option of not-doing so, only for the sake of
-    // testing. Note: this is nonblocking in any case.
-    if (!mApp.getConfig().ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING)
-    {
-        has.resolveAnyReadyFutures();
-    }
-
     mApp.getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                        has.toString());
 }


### PR DESCRIPTION
# Description

Resolves #2128 -- there's a long story over there but the gist is we were queueing HASs that included a lot of `FutureBucket`s in `FB_LIVE_INPUTS` state that were actually done merging, and should be resolved to `FB_LIVE_OUTPUT` state before serializing and storing to the publish queue in the DB. This causes CPU spikes (and significantly delays publishing) by redoing merges in the dequeued-and-deserialized `FutureBucket`s before publishing.

The fix is to sink eager FutureBucket resolution into the BucketList itself -- in the `addBatch` routine -- so when anyone makes a HAS copy of it it's likely to have any finished merges (especially long-running ones) resolved.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
