### PR TITLE
Inhibit double merge on publish

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -12,6 +12,7 @@
 #include "bucket/BucketManager.h"
 #include "bucket/BucketOutputIterator.h"
 #include "bucket/LedgerCmp.h"
+#include "bucket/MergeKey.h"
 #include "crypto/Hex.h"
 #include "crypto/Random.h"
 #include "crypto/SHA.h"
@@ -608,6 +609,8 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
     {
         bucketManager.incrMergeCounters(mc);
     }
-    return out.getBucket(bucketManager);
+    MergeKey mk{maxProtocolVersion, keepDeadEntries, oldBucket, newBucket,
+                shadows};
+    return out.getBucket(bucketManager, &mk);
 }
 }

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -7,6 +7,7 @@
 #include "bucket/Bucket.h"
 #include "overlay/StellarXDR.h"
 #include "util/NonCopyable.h"
+#include <future>
 #include <memory>
 
 #include "medida/timer_context.h"
@@ -18,6 +19,7 @@ class Application;
 class BucketList;
 class TmpDirManager;
 struct LedgerHeader;
+struct MergeKey;
 struct HistoryArchiveState;
 
 // A fine-grained merge-operation-counter structure for tracking various
@@ -28,6 +30,9 @@ struct MergeCounters
 {
     uint64_t mPreInitEntryProtocolMerges{0};
     uint64_t mPostInitEntryProtocolMerges{0};
+
+    uint64_t mRunningMergeReattachments{0};
+    uint64_t mFinishedMergeReattachments{0};
 
     uint64_t mNewMetaEntries{0};
     uint64_t mNewInitEntries{0};
@@ -115,10 +120,33 @@ class BucketManager : NonMovableOrCopyable
     // worker threads. Very carefully.
     virtual std::shared_ptr<Bucket>
     adoptFileAsBucket(std::string const& filename, uint256 const& hash,
-                      size_t nObjects, size_t nBytes) = 0;
+                      size_t nObjects, size_t nBytes,
+                      MergeKey* mergeKey = nullptr) = 0;
 
     // Return a bucket by hash if we have it, else return nullptr.
     virtual std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) = 0;
+
+    // Get a reference to a merge-future that's either running (or finished
+    // somewhat recently) from either a map of the std::shared_futures doing the
+    // merges and/or a set of records mapping merge inputs to outputs and the
+    // set of outputs held in the BucketManager. Returns an invalid future if no
+    // such future can be found or synthesized.
+    virtual std::shared_future<std::shared_ptr<Bucket>>
+    getMergeFuture(MergeKey const& key) = 0;
+
+    // Add a reference to a merge _in progress_ (not yet adopted as a file) to
+    // the BucketManager's internal map of std::shared_futures doing merges.
+    // There is no corresponding entry-removal API: the std::shared_future will
+    // be removed from the map when the merge completes and the output file is
+    // adopted.
+    virtual void
+    putMergeFuture(MergeKey const& key,
+                   std::shared_future<std::shared_ptr<Bucket>>) = 0;
+
+#ifdef BUILD_TESTS
+    // Drop all references to merge futures in progress.
+    virtual void clearMergeFuturesForTesting() = 0;
+#endif
 
     // Forget any buckets not referenced by the current BucketList. This will
     // not immediately cause the buckets to delete themselves, if someone else

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -55,6 +55,7 @@ struct MergeCounters
     uint64_t mOutputIteratorBufferUpdates{0};
     uint64_t mOutputIteratorActualWrites{0};
     MergeCounters& operator+=(MergeCounters const& delta);
+    bool operator==(MergeCounters const& other) const;
 };
 
 /**

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -238,6 +238,45 @@ MergeCounters::operator+=(MergeCounters const& delta)
     return *this;
 }
 
+bool
+MergeCounters::operator==(MergeCounters const& other) const
+{
+    return (
+        mPreInitEntryProtocolMerges == other.mPreInitEntryProtocolMerges &&
+        mPostInitEntryProtocolMerges == other.mPostInitEntryProtocolMerges &&
+
+        mNewMetaEntries == other.mNewMetaEntries &&
+        mNewInitEntries == other.mNewInitEntries &&
+        mNewLiveEntries == other.mNewLiveEntries &&
+        mNewDeadEntries == other.mNewDeadEntries &&
+        mOldMetaEntries == other.mOldMetaEntries &&
+        mOldInitEntries == other.mOldInitEntries &&
+        mOldLiveEntries == other.mOldLiveEntries &&
+        mOldDeadEntries == other.mOldDeadEntries &&
+
+        mOldEntriesDefaultAccepted == other.mOldEntriesDefaultAccepted &&
+        mNewEntriesDefaultAccepted == other.mNewEntriesDefaultAccepted &&
+        mNewInitEntriesMergedWithOldDead ==
+            other.mNewInitEntriesMergedWithOldDead &&
+        mOldInitEntriesMergedWithNewLive ==
+            other.mOldInitEntriesMergedWithNewLive &&
+        mOldInitEntriesMergedWithNewDead ==
+            other.mOldInitEntriesMergedWithNewDead &&
+        mNewEntriesMergedWithOldNeitherInit ==
+            other.mNewEntriesMergedWithOldNeitherInit &&
+
+        mShadowScanSteps == other.mShadowScanSteps &&
+        mMetaEntryShadowElisions == other.mMetaEntryShadowElisions &&
+        mLiveEntryShadowElisions == other.mLiveEntryShadowElisions &&
+        mInitEntryShadowElisions == other.mInitEntryShadowElisions &&
+        mDeadEntryShadowElisions == other.mDeadEntryShadowElisions &&
+
+        mOutputIteratorTombstoneElisions ==
+            other.mOutputIteratorTombstoneElisions &&
+        mOutputIteratorBufferUpdates == other.mOutputIteratorBufferUpdates &&
+        mOutputIteratorActualWrites == other.mOutputIteratorActualWrites);
+}
+
 void
 BucketManagerImpl::incrMergeCounters(MergeCounters const& delta)
 {

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -322,7 +322,7 @@ BucketManagerImpl::adoptFileAsBucket(std::string const& filename,
 
         b = std::make_shared<Bucket>(canonicalName, hash);
         {
-            mSharedBuckets.insert(std::make_pair(hash, b));
+            mSharedBuckets.emplace(hash, b);
             mSharedBucketsSize.set_count(mSharedBuckets.size());
         }
     }
@@ -353,7 +353,7 @@ BucketManagerImpl::getBucketByHash(uint256 const& hash)
             << "BucketManager::getBucketByHash(" << binToHex(hash)
             << ") found no bucket, making new one";
         auto p = std::make_shared<Bucket>(canonicalName, hash);
-        mSharedBuckets.insert(std::make_pair(hash, p));
+        mSharedBuckets.emplace(hash, p);
         mSharedBucketsSize.set_count(mSharedBuckets.size());
         return p;
     }
@@ -368,13 +368,13 @@ BucketManagerImpl::getReferencedBuckets() const
     for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
     {
         auto const& level = mBucketList.getLevel(i);
-        auto rit = referenced.insert(level.getCurr()->getHash());
+        auto rit = referenced.emplace(level.getCurr()->getHash());
         if (rit.second)
         {
             CLOG(TRACE, "Bucket")
                 << binToHex(*rit.first) << " referenced by bucket list";
         }
-        rit = referenced.insert(level.getSnap()->getHash());
+        rit = referenced.emplace(level.getSnap()->getHash());
         if (rit.second)
         {
             CLOG(TRACE, "Bucket")
@@ -382,7 +382,7 @@ BucketManagerImpl::getReferencedBuckets() const
         }
         for (auto const& h : level.getNext().getHashes())
         {
-            rit = referenced.insert(hexToBin256(h));
+            rit = referenced.emplace(hexToBin256(h));
             if (rit.second)
             {
                 CLOG(TRACE, "Bucket") << h << " referenced by bucket list";
@@ -395,7 +395,7 @@ BucketManagerImpl::getReferencedBuckets() const
     auto lclBuckets = lclHas.allBuckets();
     for (auto const& h : lclBuckets)
     {
-        auto rit = referenced.insert(hexToBin256(h));
+        auto rit = referenced.emplace(hexToBin256(h));
         if (rit.second)
         {
             CLOG(TRACE, "Bucket") << h << " referenced by LCL";
@@ -407,7 +407,7 @@ BucketManagerImpl::getReferencedBuckets() const
     {
         for (auto const& h : pub)
         {
-            auto rit = referenced.insert(hexToBin256(h));
+            auto rit = referenced.emplace(hexToBin256(h));
             if (rit.second)
             {
                 CLOG(TRACE, "Bucket") << h << " referenced by publish queue";

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -478,7 +478,7 @@ BucketManagerImpl::getReferencedBuckets() const
         }
     }
     // retain any bucket referenced by the last closed ledger as recorded in the
-    // database (as merge complete, the bucket list drifts from that state)
+    // database (as merges complete, the bucket list drifts from that state)
     auto lclHas = mApp.getLedgerManager().getLastClosedLedgerHAS();
     auto lclBuckets = lclHas.allBuckets();
     for (auto const& h : lclBuckets)

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -2,6 +2,7 @@
 
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
+#include "bucket/BucketMergeMap.h"
 #include "overlay/StellarXDR.h"
 
 #include <map>
@@ -47,6 +48,21 @@ class BucketManagerImpl : public BucketManager
     medida::Counter& mSharedBucketsSize;
     MergeCounters mMergeCounters;
 
+    // Records bucket-merges that are currently _live_ in some FutureBucket, in
+    // the sense of either running, or finished (with or without the
+    // FutureBucket being resolved). Entries in this map will be cleared when
+    // the FutureBucket is _cleared_ (typically when the owning BucketList level
+    // is committed).
+    std::unordered_map<MergeKey, std::shared_future<std::shared_ptr<Bucket>>>
+        mLiveFutures;
+
+    // Records bucket-merges that are _finished_, i.e. have been adopted as
+    // (possibly redundant) bucket files. This is a "weak" (bi-multi-)map of
+    // hashes, that does not count towards std::shared_ptr refcounts, i.e. does
+    // not keep either the output bucket or any of its input buckets
+    // alive. Needs to be queried and updated on mSharedBuckets GC events.
+    BucketMergeMap mFinishedMerges;
+
     std::set<Hash> getReferencedBuckets() const;
     void cleanupStaleFiles();
     void cleanDir();
@@ -74,11 +90,19 @@ class BucketManagerImpl : public BucketManager
     MergeCounters readMergeCounters() override;
     void incrMergeCounters(MergeCounters const&) override;
     TmpDirManager& getTmpDirManager() override;
-    std::shared_ptr<Bucket> adoptFileAsBucket(std::string const& filename,
-                                              uint256 const& hash,
-                                              size_t nObjects,
-                                              size_t nBytes) override;
+    std::shared_ptr<Bucket>
+    adoptFileAsBucket(std::string const& filename, uint256 const& hash,
+                      size_t nObjects, size_t nBytes,
+                      MergeKey* mergeKey = nullptr) override;
     std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) override;
+
+    std::shared_future<std::shared_ptr<Bucket>>
+    getMergeFuture(MergeKey const& key) override;
+    void putMergeFuture(MergeKey const& key,
+                        std::shared_future<std::shared_ptr<Bucket>>) override;
+#ifdef BUILD_TESTS
+    void clearMergeFuturesForTesting() override;
+#endif
 
     void forgetUnreferencedBuckets() override;
     void addBatch(Application& app, uint32_t currLedger,

--- a/src/bucket/BucketMergeMap.cpp
+++ b/src/bucket/BucketMergeMap.cpp
@@ -1,0 +1,127 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketMergeMap.h"
+#include "crypto/Hex.h"
+#include "util/Logging.h"
+
+namespace
+{
+std::unordered_set<stellar::Hash>
+getMergeKeyHashes(stellar::MergeKey const& key)
+{
+    std::unordered_set<stellar::Hash> hashes;
+    hashes.emplace(key.mInputCurrBucket);
+    hashes.emplace(key.mInputSnapBucket);
+    for (auto const& in : key.mInputShadowBuckets)
+    {
+        hashes.emplace(in);
+    }
+    return hashes;
+}
+}
+
+namespace stellar
+{
+
+void
+BucketMergeMap::recordMerge(MergeKey const& input, Hash const& output)
+{
+    mMergeKeyToOutput.emplace(input, output);
+    mOutputToMergeKey.emplace(output, input);
+    for (auto const& in : getMergeKeyHashes(input))
+    {
+        CLOG(TRACE, "Bucket") << "BucketMergeMap retaining mapping for "
+                              << hexAbbrev(in) << " -> " << hexAbbrev(output);
+        mInputToOutput.emplace(in, output);
+    }
+}
+
+std::unordered_set<MergeKey>
+BucketMergeMap::forgetAllMergesProducing(Hash const& outputBeingDropped)
+{
+    std::unordered_set<MergeKey> ret;
+    auto mergesProducingOutput =
+        mOutputToMergeKey.equal_range(outputBeingDropped);
+    for (auto mergeProducingOutput = mergesProducingOutput.first;
+         mergeProducingOutput != mergesProducingOutput.second;
+         mergeProducingOutput = mOutputToMergeKey.erase(mergeProducingOutput))
+    {
+        auto const& output = mergeProducingOutput->first;
+        auto const& mergeKeyProducingOutput = mergeProducingOutput->second;
+        assert(output == outputBeingDropped);
+        ret.emplace(mergeKeyProducingOutput);
+
+        // It's possible for the same output to occur for multiple
+        // merge keys (eg. a+b and b+a). And the set of per-input
+        // entries should always be larger than the per-key entries.
+        if ((mOutputToMergeKey.size() > mMergeKeyToOutput.size()) ||
+            (mMergeKeyToOutput.size() > mInputToOutput.size()))
+        {
+            CLOG(WARNING, "Bucket")
+                << "BucketMergeMap inconsistent map sizes: "
+                << "out->in:" << mOutputToMergeKey.size()
+                << ", coarse in->out:" << mMergeKeyToOutput.size()
+                << ", fine in->out:" << mInputToOutput.size();
+        }
+
+        CLOG(TRACE, "Bucket")
+            << "BucketMergeMap forgetting mappings for merge "
+            << mergeKeyProducingOutput
+            << " <-> output=" << hexAbbrev(outputBeingDropped);
+
+        // We first remove all the (in,out) pairs from the decomposed
+        // mapping mInputToOutput, used for rooting the
+        // publish queue.
+        for (auto const& input : getMergeKeyHashes(mergeKeyProducingOutput))
+        {
+            auto mergesUsingInput = mInputToOutput.equal_range(input);
+            for (auto mergeUsingInput = mergesUsingInput.first;
+                 mergeUsingInput != mergesUsingInput.second; ++mergeUsingInput)
+            {
+                auto const& outputUsingInput = mergeUsingInput->second;
+                if (outputUsingInput == outputBeingDropped)
+                {
+                    CLOG(TRACE, "Bucket")
+                        << "BucketMergeMap forgetting mapping for "
+                        << hexAbbrev(input) << " -> "
+                        << hexAbbrev(outputUsingInput);
+                    mInputToOutput.erase(mergeUsingInput);
+                    break;
+                }
+            }
+        }
+        // Then we erase the forward mapping mergeKey => output;
+        // the for-loop-step erases reverse mapping output => mergeKey.
+        mMergeKeyToOutput.erase(mergeKeyProducingOutput);
+    }
+    return ret;
+}
+
+bool
+BucketMergeMap::findMergeFor(MergeKey const& input, Hash& output)
+{
+    auto i = mMergeKeyToOutput.find(input);
+    if (i != mMergeKeyToOutput.end())
+    {
+        output = i->second;
+        return true;
+    }
+    return false;
+}
+
+void
+BucketMergeMap::getOutputsUsingInput(Hash const& input,
+                                     std::set<Hash>& outputs) const
+{
+    auto pair = mInputToOutput.equal_range(input);
+    for (auto i = pair.first; i != pair.second; ++i)
+    {
+        outputs.emplace(i->second);
+        CLOG(TRACE, "Bucket")
+            << hexAbbrev(i->second) << " referenced as output of merge of "
+            << hexAbbrev(input);
+    }
+}
+}

--- a/src/bucket/BucketMergeMap.h
+++ b/src/bucket/BucketMergeMap.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "bucket/MergeKey.h"
+#include "util/HashOfHash.h"
+#include "xdr/Stellar-types.h"
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+namespace stellar
+{
+
+// Helper type for BucketManager. Stores a bi-directional (weak, multi)mapping
+// relating merge inputs and outputs, along with a decomposition of the map to a
+// finer-grained one that associates each individual input in each MergeKey with
+// all the outputs it's used by.
+class BucketMergeMap
+{
+    // Records bucket input-output relationships for any buckets in that were
+    // built from a merge during the lifetime of this BucketMergeMap (some were
+    // not -- they just showed up from catchup or state reloading). Entries in
+    // this map will be cleared when their _output_ is dropped from the owning
+    // BucketManager's mSharedBuckets, typically due to being unreferenced.
+    std::unordered_map<MergeKey, Hash> mMergeKeyToOutput;
+
+    // Unfortunately to use this correctly in the bucket GC path, we also need
+    // a different version of the same map, keyed by each input separately. And
+    // since one input may be used in _many_ merges, it has to be a multimap.
+    std::unordered_multimap<Hash, Hash> mInputToOutput;
+
+    // Finally we need _another_ map, the opposite direction, to allow us to
+    // erase entries from the previous two maps when we finally decide to drop
+    // a bucket because nobody's going to reattach to it as far as we can tell.
+    //
+    // This also has to be a multimap because the same output can be produced
+    // by multiple MergeKeys.
+    std::unordered_multimap<Hash, MergeKey> mOutputToMergeKey;
+
+  public:
+    void recordMerge(MergeKey const& input, Hash const& output);
+    std::unordered_set<MergeKey> forgetAllMergesProducing(Hash const& output);
+    bool findMergeFor(MergeKey const& input, Hash& output);
+    void getOutputsUsingInput(Hash const& input, std::set<Hash>& outputs) const;
+};
+}

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -105,7 +105,8 @@ BucketOutputIterator::put(BucketEntry const& e)
 }
 
 std::shared_ptr<Bucket>
-BucketOutputIterator::getBucket(BucketManager& bucketManager)
+BucketOutputIterator::getBucket(BucketManager& bucketManager,
+                                MergeKey* mergeKey)
 {
     if (mBuf)
     {
@@ -124,6 +125,6 @@ BucketOutputIterator::getBucket(BucketManager& bucketManager)
         return std::make_shared<Bucket>();
     }
     return bucketManager.adoptFileAsBucket(mFilename, mHasher->finish(),
-                                           mObjectsPut, mBytesPut);
+                                           mObjectsPut, mBytesPut, mergeKey);
 }
 }

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -48,6 +48,7 @@ class BucketOutputIterator
 
     void put(BucketEntry const& e);
 
-    std::shared_ptr<Bucket> getBucket(BucketManager& bucketManager);
+    std::shared_ptr<Bucket> getBucket(BucketManager& bucketManager,
+                                      MergeKey* mergeKey = nullptr);
 };
 }

--- a/src/bucket/MergeKey.cpp
+++ b/src/bucket/MergeKey.cpp
@@ -1,0 +1,85 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/MergeKey.h"
+#include "crypto/Hex.h"
+#include <sstream>
+
+namespace stellar
+{
+
+MergeKey::MergeKey(uint32_t maxProtocolVersion, bool keepDeadEntries,
+                   std::shared_ptr<Bucket> const& inputCurr,
+                   std::shared_ptr<Bucket> const& inputSnap,
+                   std::vector<std::shared_ptr<Bucket>> const& inputShadows)
+    : mMaxProtocolVersion(maxProtocolVersion)
+    , mKeepDeadEntries(keepDeadEntries)
+    , mInputCurrBucket(inputCurr->getHash())
+    , mInputSnapBucket(inputSnap->getHash())
+{
+    mInputShadowBuckets.reserve(inputShadows.size());
+    for (auto const& s : inputShadows)
+    {
+        mInputShadowBuckets.emplace_back(s->getHash());
+    }
+}
+
+MergeKey::MergeKey(uint32_t maxProtocolVersion, bool keepDeadEntries,
+                   Hash& inputCurr, Hash& inputSnap,
+                   std::vector<Hash> const& inputShadows)
+    : mMaxProtocolVersion(maxProtocolVersion)
+    , mKeepDeadEntries(keepDeadEntries)
+    , mInputCurrBucket(inputCurr)
+    , mInputSnapBucket(inputSnap)
+    , mInputShadowBuckets(inputShadows)
+{
+}
+
+bool
+MergeKey::operator==(MergeKey const& other) const
+{
+    return mMaxProtocolVersion == other.mMaxProtocolVersion &&
+           mKeepDeadEntries == other.mKeepDeadEntries &&
+           mInputCurrBucket == other.mInputCurrBucket &&
+           mInputSnapBucket == other.mInputSnapBucket &&
+           mInputShadowBuckets == other.mInputShadowBuckets;
+}
+
+std::ostream&
+operator<<(std::ostream& out, MergeKey const& b)
+{
+    out << "[curr=" << hexAbbrev(b.mInputCurrBucket)
+        << ", snap=" << hexAbbrev(b.mInputSnapBucket) << ", shadows=[";
+    bool first = true;
+    for (auto const& s : b.mInputShadowBuckets)
+    {
+        if (!first)
+        {
+            out << ", ";
+        }
+        first = false;
+        out << hexAbbrev(s);
+    }
+    out << "]]";
+    return out;
+}
+}
+
+namespace std
+{
+size_t
+hash<stellar::MergeKey>::operator()(stellar::MergeKey const& key) const noexcept
+{
+    std::ostringstream oss;
+    oss << key.mMaxProtocolVersion << ',' << key.mKeepDeadEntries << ','
+        << stellar::binToHex(key.mInputCurrBucket) << ','
+        << stellar::binToHex(key.mInputSnapBucket);
+    for (auto const& e : key.mInputShadowBuckets)
+    {
+        oss << stellar::binToHex(e) << ',';
+    }
+    std::hash<std::string> h;
+    return h(oss.str());
+}
+}

--- a/src/bucket/MergeKey.h
+++ b/src/bucket/MergeKey.h
@@ -1,0 +1,46 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+#include "bucket/Bucket.h"
+#include "xdr/Stellar-types.h"
+#include <cstdint>
+#include <iosfwd>
+#include <vector>
+
+namespace stellar
+{
+// Key type for cache of merges-in-progress. These only exist to enable
+// re-attaching a deserialized FutureBucket to a std::shared_future, or (if the
+// merge is finished and has been promoted to a live bucket) to identify which
+// _output_ was produced from a given set of _inptus_ so we can recreate a
+// pre-resolved std::shared_future containing that output.
+struct MergeKey
+{
+    MergeKey(uint32_t maxProtocolVersion, bool keepDeadEntries,
+             std::shared_ptr<Bucket> const& inputCurr,
+             std::shared_ptr<Bucket> const& inputSnap,
+             std::vector<std::shared_ptr<Bucket>> const& inputShadows);
+
+    MergeKey(uint32_t maxProtocolVersion, bool keepDeadEntries, Hash& inputCurr,
+             Hash& inputSnap, std::vector<Hash> const& inputShadows);
+
+    uint32_t mMaxProtocolVersion;
+    bool mKeepDeadEntries;
+    Hash mInputCurrBucket;
+    Hash mInputSnapBucket;
+    std::vector<Hash> mInputShadowBuckets;
+    bool operator==(MergeKey const& other) const;
+};
+
+std::ostream& operator<<(std::ostream& out, MergeKey const& b);
+}
+
+namespace std
+{
+template <> struct hash<stellar::MergeKey>
+{
+    size_t operator()(stellar::MergeKey const& k) const noexcept;
+};
+}

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -15,11 +15,13 @@
 #include "bucket/BucketManager.h"
 #include "bucket/BucketManagerImpl.h"
 #include "bucket/BucketTests.h"
+#include "history/HistoryArchiveManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/Config.h"
+#include "main/ExternalQueue.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
 #include "util/Math.h"
@@ -337,6 +339,214 @@ TEST_CASE("bucketmanager ownership", "[bucket][bucketmanager]")
     });
 }
 
+TEST_CASE("bucketmanager reattach to finished merge", "[bucket][bucketmanager]")
+{
+    VirtualClock clock;
+    Config cfg(getTestConfig(0, Config::TESTDB_IN_MEMORY_SQLITE));
+    cfg.ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = true;
+
+    for_versions_with_differing_bucket_logic(cfg, [&](Config const& cfg) {
+        Application::pointer app = createTestApplication(clock, cfg);
+
+        BucketManager& bm = app->getBucketManager();
+        BucketList& bl = bm.getBucketList();
+        auto vers = getAppLedgerVersion(app);
+
+        // Add some entries to get to a nontrivial merge-state.
+        uint32_t ledger = 0;
+        uint32_t level = 3;
+        do
+        {
+            ++ledger;
+            bl.addBatch(*app, ledger, vers, {},
+                        LedgerTestUtils::generateValidLedgerEntries(10), {});
+            bm.forgetUnreferencedBuckets();
+        } while (!BucketList::levelShouldSpill(ledger, level - 1));
+
+        // Check that the merge on level isn't committed (we're in
+        // ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING mode that does not resolve
+        // eagerly)
+        REQUIRE(bl.getLevel(level).getNext().isMerging());
+
+        // Serialize HAS.
+        HistoryArchiveState has(ledger, bl);
+        std::string serialHas = has.toString();
+
+        // Simulate level committing (and the FutureBucket clearing),
+        // followed by the typical ledger-close bucket GC event.
+        bl.getLevel(level).commit();
+        REQUIRE(!bl.getLevel(level).getNext().isMerging());
+
+        REQUIRE(bm.readMergeCounters().mFinishedMergeReattachments == 0);
+
+        // Deserialize HAS.
+        HistoryArchiveState has2;
+        has2.fromString(serialHas);
+
+        // Reattach to _finished_ merge future on level.
+        has2.currentBuckets[level].next.makeLive(
+            *app, vers, BucketList::keepDeadEntries(level));
+        REQUIRE(has2.currentBuckets[level].next.isMerging());
+
+        // Resolve reattached future.
+        has2.currentBuckets[level].next.resolve();
+
+        // Check that we reattached to a finished merge.
+        REQUIRE(bm.readMergeCounters().mFinishedMergeReattachments != 0);
+    });
+}
+
+TEST_CASE("bucketmanager reattach to running merge", "[bucket][bucketmanager]")
+{
+    VirtualClock clock;
+    Config cfg(getTestConfig(0, Config::TESTDB_IN_MEMORY_SQLITE));
+    cfg.ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = true;
+
+    for_versions_with_differing_bucket_logic(cfg, [&](Config const& cfg) {
+        Application::pointer app = createTestApplication(clock, cfg);
+
+        BucketManager& bm = app->getBucketManager();
+        BucketList& bl = bm.getBucketList();
+        auto vers = getAppLedgerVersion(app);
+
+        // This test is a race that will (if all goes well) eventually be won:
+        // we keep trying to do an immediate-reattach to a running merge and
+        // will only lose in cases of extremely short-running merges that finish
+        // before we have a chance to reattach. Once the merges are at all
+        // nontrivial in size, we'll likely win. In practice we observe the race
+        // being won within 10 ledgers.
+        //
+        // The amount of testing machinery we have to put in place to make this
+        // a non-racy test seems to be (a) extensive and (b) not worth the
+        // trouble, since it'd be testing fake circumstances anyways: the entire
+        // point of reattachment is to provide a benefit in cases where this
+        // race is won. So testing it _as_ a race seems reasonably fair.
+        //
+        // That said, nondeterminism in tests is no fun and tests that run
+        // potentially-forever are no fun. So we put a statistically-unlikely
+        // limit in here of 10,000 merges. If we consistently lose for that
+        // long, there's probably something wrong with the code, and in any case
+        // it's a better nondeterministic failure than timing out the entire
+        // testsuite with no explanation.
+        uint32_t ledger = 0;
+        uint32_t limit = 10000;
+        while (ledger < limit &&
+               bm.readMergeCounters().mRunningMergeReattachments == 0)
+        {
+            ++ledger;
+            // Merges will start on one or more levels here, starting a race
+            // between the main thread here and the background workers doing
+            // the merges.
+            bl.addBatch(*app, ledger, vers, {},
+                        LedgerTestUtils::generateValidLedgerEntries(100), {});
+
+            bm.forgetUnreferencedBuckets();
+
+            HistoryArchiveState has(ledger, bl);
+            std::string serialHas = has.toString();
+
+            // Deserialize and reactivate levels of HAS. Races with the merge
+            // workers end here. One of these reactivations should eventually
+            // reattach, winning the race (each time around this loop the
+            // merge workers will take longer to finish, so we will likely
+            // win quite shortly).
+            HistoryArchiveState has2;
+            has2.fromString(serialHas);
+            for (uint32_t level = 0; level < BucketList::kNumLevels; ++level)
+            {
+                if (has2.currentBuckets[level].next.hasHashes())
+                {
+                    has2.currentBuckets[level].next.makeLive(
+                        *app, vers, BucketList::keepDeadEntries(level));
+                }
+            }
+        }
+        CLOG(INFO, "Bucket")
+            << "reattached to running merge at or around ledger " << ledger;
+        REQUIRE(ledger < limit);
+        REQUIRE(bm.readMergeCounters().mRunningMergeReattachments != 0);
+    });
+}
+
+TEST_CASE("bucketmanager reattach HAS from publish queue to finished merge",
+          "[bucket][bucketmanager]")
+{
+    Config cfg(getTestConfig());
+    cfg.MAX_CONCURRENT_SUBPROCESSES = 1;
+    cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
+    cfg.ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = true;
+    stellar::historytestutils::TmpDirHistoryConfigurator tcfg;
+    cfg = tcfg.configure(cfg, true);
+
+    {
+        VirtualClock clock;
+        Application::pointer app = createTestApplication(clock, cfg);
+        auto vers = getAppLedgerVersion(app);
+        auto& hm = app->getHistoryManager();
+        auto& bm = app->getBucketManager();
+        auto& bl = bm.getBucketList();
+        auto& lm = app->getLedgerManager();
+        hm.setPublicationEnabled(false);
+        app->start();
+        app->getHistoryArchiveManager().initializeHistoryArchive("test");
+        while (hm.getPublishQueueCount() < 5)
+        {
+            CLOG(INFO, "Bucket")
+                << "finished-merge reattachments: "
+                << bm.readMergeCounters().mFinishedMergeReattachments;
+            bl.addBatch(*app, lm.getLastClosedLedgerNum() + 1, vers, {},
+                        LedgerTestUtils::generateValidLedgerEntries(100), {});
+            clock.crank(true);
+            bm.forgetUnreferencedBuckets();
+        }
+        // We should have published nothing and have the first
+        // checkpoint still queued.
+        REQUIRE(hm.getPublishSuccessCount() == 0);
+        REQUIRE(hm.getMinLedgerQueuedToPublish() == 7);
+
+        auto oldReattachments =
+            bm.readMergeCounters().mFinishedMergeReattachments;
+        auto HASs = hm.getPublishQueueStates();
+        REQUIRE(HASs.size() == 5);
+        for (auto& has : HASs)
+        {
+            for (uint32_t level = 0; level < BucketList::kNumLevels; ++level)
+            {
+                if (has.currentBuckets[level].next.hasHashes())
+                {
+                    has.currentBuckets[level].next.makeLive(
+                        *app, vers, BucketList::keepDeadEntries(level));
+                }
+            }
+        }
+
+        // This is the key check of the test: re-enabling the merges worked
+        // and caused a bunch of finished-merge reattachments.
+        REQUIRE(bm.readMergeCounters().mFinishedMergeReattachments !=
+                oldReattachments);
+        CLOG(INFO, "Bucket")
+            << "finished-merge reattachments: "
+            << bm.readMergeCounters().mFinishedMergeReattachments;
+
+        // Un-cork the publication process, nothing should be broken.
+        hm.setPublicationEnabled(true);
+        while (hm.getPublishSuccessCount() < 5)
+        {
+            clock.crank(true);
+
+            // Trim history after publishing whenever possible.
+            ExternalQueue ps(*app);
+            ps.deleteOldEntries(50000);
+        }
+        clock.cancelAllEvents();
+        while (clock.cancelAllEvents() ||
+               app->getProcessManager().getNumRunningProcesses() > 0)
+        {
+            clock.crank(true);
+        }
+    }
+}
+
 // Running one of these tests involves comparing three timelines with different
 // application lifecycles for identical outcomes.
 //
@@ -402,6 +612,10 @@ class StopAndRestartBucketMergesTest
                                  << mMergeCounters.mPreInitEntryProtocolMerges;
             CLOG(INFO, "Bucket") << "PostInitEntryProtocolMerges: "
                                  << mMergeCounters.mPostInitEntryProtocolMerges;
+            CLOG(INFO, "Bucket") << "RunningMergeReattachments: "
+                                 << mMergeCounters.mRunningMergeReattachments;
+            CLOG(INFO, "Bucket") << "FinishedMergeReattachments: "
+                                 << mMergeCounters.mFinishedMergeReattachments;
             CLOG(INFO, "Bucket")
                 << "NewMetaEntries: " << mMergeCounters.mNewMetaEntries;
             CLOG(INFO, "Bucket")
@@ -528,6 +742,11 @@ class StopAndRestartBucketMergesTest
                   other.mMergeCounters.mPreInitEntryProtocolMerges);
             CHECK(mMergeCounters.mPostInitEntryProtocolMerges ==
                   other.mMergeCounters.mPostInitEntryProtocolMerges);
+
+            CHECK(mMergeCounters.mRunningMergeReattachments ==
+                  other.mMergeCounters.mRunningMergeReattachments);
+            CHECK(mMergeCounters.mFinishedMergeReattachments ==
+                  other.mMergeCounters.mFinishedMergeReattachments);
 
             CHECK(mMergeCounters.mNewMetaEntries ==
                   other.mMergeCounters.mNewMetaEntries);

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -143,6 +143,9 @@ clearFutures(Application::pointer app, BucketList& bl)
         std::unique_lock<std::mutex> lock(mutex);
         cv2.wait(lock, [&] { return finished == n; });
     }
+
+    // Tell the BucketManager to forget all about the futures it knows.
+    app->getBucketManager().clearMergeFuturesForTesting();
 }
 
 static Hash

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -1,0 +1,110 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketMergeMap.h"
+#include "crypto/SecretKey.h"
+#include "lib/catch.hpp"
+
+using namespace stellar;
+
+TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
+{
+    Hash in1a = HashUtils::random();
+    Hash in1b = HashUtils::random();
+    Hash in1c = HashUtils::random();
+
+    Hash in2a = HashUtils::random();
+    Hash in2b = HashUtils::random();
+    Hash in2c = HashUtils::random();
+
+    Hash in3a = HashUtils::random();
+    Hash in3b = HashUtils::random();
+    Hash in3c = HashUtils::random();
+    Hash in3d = HashUtils::random();
+
+    Hash in4a = HashUtils::random();
+    Hash in4b = HashUtils::random();
+
+    Hash in5a = HashUtils::random();
+    Hash in5b = HashUtils::random();
+
+    Hash in6a = HashUtils::random();
+    Hash in6b = HashUtils::random();
+
+    Hash out1 = HashUtils::random();
+    Hash out2 = HashUtils::random();
+    Hash out4 = HashUtils::random();
+    Hash out6 = HashUtils::random();
+
+    BucketMergeMap bmm;
+
+    MergeKey m1{1, true, in1a, in1b, {in1c}};
+    MergeKey m2{1, true, in2a, in2b, {in2c}};
+    MergeKey m3{1, true, in3a, in3b, {in3c, in3d}};
+    MergeKey m4{1, true, in4a, in4b, {}};
+    MergeKey m5{1, true, in5a, in5b, {}};
+    MergeKey m6{1, true, in6a, in6b, {in1a}};
+
+    bmm.recordMerge(m1, out1);
+    bmm.recordMerge(m2, out2);
+    // m3 produces same as m2
+    bmm.recordMerge(m3, out2);
+    bmm.recordMerge(m4, out4);
+    // m5 isn't recorded
+    // m6 reuses an input from m1
+    bmm.recordMerge(m6, out6);
+
+    Hash t;
+    REQUIRE(bmm.findMergeFor(m1, t));
+    REQUIRE(t == out1);
+    REQUIRE(bmm.findMergeFor(m2, t));
+    REQUIRE(t == out2);
+    REQUIRE(bmm.findMergeFor(m3, t));
+    REQUIRE(t == out2);
+    REQUIRE(bmm.findMergeFor(m4, t));
+    REQUIRE(t == out4);
+    REQUIRE(!bmm.findMergeFor(m5, t));
+    REQUIRE(bmm.findMergeFor(m6, t));
+    REQUIRE(t == out6);
+
+    std::set<Hash> outs;
+    bmm.getOutputsUsingInput(in1a, outs);
+    REQUIRE(outs == std::set<Hash>{out1, out6});
+    outs.clear();
+    bmm.getOutputsUsingInput(in1b, outs);
+    REQUIRE(outs == std::set<Hash>{out1});
+    outs.clear();
+    bmm.getOutputsUsingInput(in1c, outs);
+    REQUIRE(outs == std::set<Hash>{out1});
+
+    REQUIRE(bmm.forgetAllMergesProducing(out1) ==
+            std::unordered_set<MergeKey>{m1});
+    REQUIRE(!bmm.findMergeFor(m1, t));
+    outs.clear();
+    bmm.getOutputsUsingInput(in1a, outs);
+    REQUIRE(outs == std::set<Hash>{out6});
+
+    REQUIRE(bmm.forgetAllMergesProducing(out2) ==
+            std::unordered_set<MergeKey>{m2, m3});
+    REQUIRE(!bmm.findMergeFor(m2, t));
+    REQUIRE(!bmm.findMergeFor(m3, t));
+
+    REQUIRE(bmm.forgetAllMergesProducing(out4) ==
+            std::unordered_set<MergeKey>{m4});
+    REQUIRE(!bmm.findMergeFor(m4, t));
+
+    REQUIRE(bmm.forgetAllMergesProducing(out6) ==
+            std::unordered_set<MergeKey>{m6});
+    REQUIRE(!bmm.findMergeFor(m6, t));
+    outs.clear();
+    bmm.getOutputsUsingInput(in6a, outs);
+    REQUIRE(outs == std::set<Hash>{});
+    outs.clear();
+    bmm.getOutputsUsingInput(in1a, outs);
+    REQUIRE(outs == std::set<Hash>{});
+
+    // Second forget produces empty set.
+    REQUIRE(bmm.forgetAllMergesProducing(out1) ==
+            std::unordered_set<MergeKey>{});
+}

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -271,6 +271,10 @@ class HistoryManager
     // queue.
     virtual std::vector<std::string> getBucketsReferencedByPublishQueue() = 0;
 
+    // Return the full set of HistoryArchiveStates in the persistent (DB)
+    // publish queue.
+    virtual std::vector<HistoryArchiveState> getPublishQueueStates() = 0;
+
     // Callback from Publication, indicates that a given snapshot was
     // published. The `success` parameter indicates whether _all_ the
     // configured archives published correctly; if so the snapshot
@@ -309,6 +313,12 @@ class HistoryManager
 
     // Return the number of checkpoints that failed publication.
     virtual uint64_t getPublishFailureCount() = 0;
+
+#ifdef BUILD_TESTS
+    // Enable or disable history publication, purely a testing interface.
+    // History is still queued when publication is disabled.
+    virtual void setPublicationEnabled(bool enabled) = 0;
+#endif
 
     virtual ~HistoryManager(){};
 };

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -306,6 +306,15 @@ HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 size_t
 HistoryManagerImpl::publishQueuedHistory()
 {
+#ifdef BUILD_TESTS
+    if (!mPublicationEnabled)
+    {
+        CLOG(INFO, "History")
+            << "Publication explicitly disabled, so not publishing";
+        return 0;
+    }
+#endif
+
     std::string state;
 
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -459,4 +468,14 @@ HistoryManagerImpl::getPublishFailureCount()
 {
     return mPublishFailure.count();
 }
+
+#ifdef BUILD_TESTS
+void
+HistoryManagerImpl::setPublicationEnabled(bool enabled)
+{
+    CLOG(INFO, "History") << (enabled ? "Enabling" : "Disabling")
+                          << " history publication";
+    mPublicationEnabled = enabled;
+}
+#endif
 }

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -39,6 +39,9 @@ class HistoryManagerImpl : public HistoryManager
         mEnqueueTimes;
 
     PublishQueueBuckets::BucketCount loadBucketsReferencedByPublishQueue();
+#ifdef BUILD_TESTS
+    bool mPublicationEnabled{true};
+#endif
 
   public:
     HistoryManagerImpl(Application& app);
@@ -70,7 +73,7 @@ class HistoryManagerImpl : public HistoryManager
 
     std::vector<std::string> getBucketsReferencedByPublishQueue() override;
 
-    std::vector<HistoryArchiveState> getPublishQueueStates();
+    std::vector<HistoryArchiveState> getPublishQueueStates() override;
 
     void historyPublished(uint32_t ledgerSeq,
                           std::vector<std::string> const& originalBuckets,
@@ -91,5 +94,9 @@ class HistoryManagerImpl : public HistoryManager
     uint64_t getPublishQueueCount() override;
     uint64_t getPublishSuccessCount() override;
     uint64_t getPublishFailureCount() override;
+
+#ifdef BUILD_TESTS
+    void setPublicationEnabled(bool enabled) override;
+#endif
 };
 }


### PR DESCRIPTION
# Description

Followup to #2172 to fix "the other problem" @MonsieurNicolas noted (a.k.a. bug #1482): if a merge is already running (or otherwise still has a live output) and we deserialize a FutureBucket that happens to match its input state, we will start the same merge twice when resolving that deserialized FutureBucket.

When does this happen? Unfortunately somewhat often, at least every time we do a publish. When we queue an HAS for publication, we serialize all of its FutureBuckets into the DB and then typically immediately deserialize them, duplicating any merges that were running (such as all those merges started at the ledger-close that triggered the publish).

We should (and this PR does) re-attach the deserialized FutureBucket to the running merge. It also retains a merge inputs-to-output map, to allow _resynthesizing_ a std::shared_future, should the FutureBucket expire before the merge is needed (eg. when a publish queue is so backed up that the BucketList has moved on and committed the FutureBuckets before the HAS is deserialized). This is a little convoluted but I _think_ it will work. Just needs lots of testing (which unfortunately I'm out of time for today).

I'm not sure if this should be considered a full fix for #1482, but maybe? The map here is not persistent in the DB, but I think it'll cover the main case we're concerned about.

(Still needs a test, just figured I'd post a thing to look at for early feedback.)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
