### PR TITLE
Simulate transaction application

### DIFF
--- a/src/catchup/simulation/ApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/ApplyTransactionsWork.cpp
@@ -1,0 +1,137 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "catchup/simulation/ApplyTransactionsWork.h"
+#include "herder/LedgerCloseData.h"
+#include "herder/simulation/SimulationTxSetFrame.h"
+#include "ledger/LedgerManagerImpl.h"
+#include "ledger/LedgerRange.h"
+
+namespace stellar
+{
+
+ApplyTransactionsWork::ApplyTransactionsWork(
+    Application& app, TmpDir const& downloadDir, LedgerRange const& range,
+    std::string const& networkPassphrase, uint32_t desiredOperations)
+    : BasicWork(app, "apply-transactions", RETRY_NEVER)
+    , mDownloadDir(downloadDir)
+    , mRange(range)
+    , mNetworkID(sha256(networkPassphrase))
+    , mTransactionHistory{}
+    , mTransactionIter(mTransactionHistory.txSet.txs.cend())
+    , mResultHistory{}
+    , mResultIter(mResultHistory.txResultSet.results.cend())
+    , mMaxOperations(desiredOperations)
+{
+}
+
+bool
+ApplyTransactionsWork::getNextLedgerFromHistoryArchive()
+{
+    if (mStream->getNextLedger(mHeaderHistory, mTransactionHistory,
+                               mResultHistory))
+    {
+        TxSetFrame txSet(mNetworkID, mTransactionHistory.txSet);
+        mTransactionHistory.txSet.txs.clear();
+        for (auto const& tx : txSet.sortForApply())
+        {
+            mTransactionHistory.txSet.txs.emplace_back(tx->getEnvelope());
+        }
+        mTransactionIter = mTransactionHistory.txSet.txs.cbegin();
+        mResultIter = mResultHistory.txResultSet.results.cbegin();
+        return true;
+    }
+    return false;
+}
+
+bool
+ApplyTransactionsWork::getNextLedger(
+    std::vector<TransactionEnvelope>& transactions,
+    std::vector<TransactionResultPair>& results,
+    std::vector<UpgradeType>& upgrades)
+{
+    transactions.clear();
+    results.clear();
+    upgrades.clear();
+
+    if (mTransactionIter == mTransactionHistory.txSet.txs.cend())
+    {
+        if (!getNextLedgerFromHistoryArchive())
+        {
+            return false;
+        }
+    }
+
+    uint32_t nOps = 0;
+    while (true)
+    {
+        while (mTransactionIter != mTransactionHistory.txSet.txs.cend() &&
+               nOps <= mMaxOperations)
+        {
+            transactions.emplace_back(*mTransactionIter);
+            nOps += mTransactionIter->tx.operations.size();
+            ++mTransactionIter;
+
+            results.emplace_back(*mResultIter);
+            ++mResultIter;
+        }
+
+        if (mTransactionIter != mTransactionHistory.txSet.txs.cend())
+        {
+            return true;
+        }
+
+        if (!getNextLedgerFromHistoryArchive())
+        {
+            return true;
+        }
+
+        upgrades = mHeaderHistory.header.scpValue.upgrades;
+        if (!upgrades.empty())
+        {
+            return true;
+        }
+    }
+}
+
+void
+ApplyTransactionsWork::onReset()
+{
+    mStream = std::make_unique<HistoryArchiveStream>(mDownloadDir, mRange,
+                                                     mApp.getHistoryManager());
+}
+
+BasicWork::State
+ApplyTransactionsWork::onRun()
+{
+    std::vector<TransactionEnvelope> transactions;
+    std::vector<TransactionResultPair> results;
+    std::vector<UpgradeType> upgrades;
+    if (!getNextLedger(transactions, results, upgrades))
+    {
+        return State::WORK_SUCCESS;
+    }
+
+    auto& lm = mApp.getLedgerManager();
+    auto const& lclHeader = lm.getLastClosedLedgerHeader();
+
+    auto txSet = std::make_shared<SimulationTxSetFrame>(
+        mNetworkID, lclHeader.hash, transactions, results);
+
+    StellarValue sv;
+    sv.txSetHash = txSet->getContentsHash();
+    sv.closeTime = lclHeader.header.scpValue.closeTime + 1;
+    sv.upgrades.insert(sv.upgrades.begin(), upgrades.begin(), upgrades.end());
+
+    LedgerCloseData closeData(lclHeader.header.ledgerSeq + 1, txSet, sv);
+    lm.closeLedger(closeData);
+    return State::WORK_RUNNING;
+}
+
+bool
+ApplyTransactionsWork::onAbort()
+{
+    return true;
+}
+}

--- a/src/catchup/simulation/ApplyTransactionsWork.h
+++ b/src/catchup/simulation/ApplyTransactionsWork.h
@@ -1,0 +1,49 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "catchup/simulation/HistoryArchiveStream.h"
+#include "work/Work.h"
+#include "xdr/Stellar-ledger.h"
+
+namespace stellar
+{
+struct LedgerRange;
+
+class ApplyTransactionsWork : public BasicWork
+{
+    TmpDir const& mDownloadDir;
+    LedgerRange const mRange;
+    Hash const mNetworkID;
+
+    std::unique_ptr<HistoryArchiveStream> mStream;
+    LedgerHeaderHistoryEntry mHeaderHistory;
+    TransactionHistoryEntry mTransactionHistory;
+    std::vector<TransactionEnvelope>::const_iterator mTransactionIter;
+    TransactionHistoryResultEntry mResultHistory;
+    std::vector<TransactionResultPair>::const_iterator mResultIter;
+
+    uint32_t const mMaxOperations;
+
+    bool getNextLedgerFromHistoryArchive();
+
+    bool getNextLedger(std::vector<TransactionEnvelope>& transactions,
+                       std::vector<TransactionResultPair>& results,
+                       std::vector<UpgradeType>& upgrades);
+
+  public:
+    ApplyTransactionsWork(Application& app, TmpDir const& downloadDir,
+                          LedgerRange const& range,
+                          std::string const& networkPassphrase,
+                          uint32_t desiredOperations);
+
+  protected:
+    void onReset() override;
+
+    State onRun() override;
+
+    bool onAbort() override;
+};
+}

--- a/src/catchup/simulation/HistoryArchiveStream.cpp
+++ b/src/catchup/simulation/HistoryArchiveStream.cpp
@@ -1,0 +1,209 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "catchup/simulation/HistoryArchiveStream.h"
+#include "herder/TxSetFrame.h"
+#include "history/FileTransferInfo.h"
+#include "history/HistoryManager.h"
+
+namespace stellar
+{
+
+HistoryArchiveStream::HistoryArchiveStream(TmpDir const& downloadDir,
+                                           LedgerRange const& range,
+                                           HistoryManager const& hm)
+    : mDownloadDir(downloadDir), mRange(range), mHistoryManager(hm)
+{
+    if (mRange.mFirst != 1 &&
+        mHistoryManager.nextCheckpointLedger(mRange.mFirst) != mRange.mFirst)
+    {
+        uint32_t prev = mHistoryManager.prevCheckpointLedger(mRange.mFirst);
+        readHeaderHistory(std::max<uint32_t>(1, prev));
+        readTransactionHistory();
+        readResultHistory();
+        while (mHeaderHistory.header.ledgerSeq != mRange.mFirst - 1)
+        {
+            readHeaderHistory();
+            readTransactionHistory();
+            readResultHistory();
+        }
+    }
+}
+
+LedgerHeaderHistoryEntry
+HistoryArchiveStream::readHeaderHistory(uint32_t ledgerSeq)
+{
+    LedgerHeaderHistoryEntry lhhe;
+
+    if (ledgerSeq == 1 ||
+        mHistoryManager.nextCheckpointLedger(ledgerSeq) == ledgerSeq)
+    {
+        if (mHeaderStream && mHeaderStream.readOne(lhhe))
+        {
+            throw std::runtime_error(
+                "Header stream should be exhausted at end of checkpoint");
+        }
+
+        FileTransferInfo info(
+            mDownloadDir, HISTORY_FILE_TYPE_LEDGER,
+            mHistoryManager.checkpointContainingLedger(ledgerSeq));
+        mHeaderStream.close();
+        mHeaderStream.open(info.localPath_nogz());
+    }
+
+    if (!(mHeaderStream && mHeaderStream.readOne(lhhe)))
+    {
+        throw std::runtime_error(
+            "Header stream should not be exhausted before end of checkpoint");
+    }
+    assert(lhhe.header.ledgerSeq == ledgerSeq);
+
+    mHeaderHistory = lhhe;
+    return lhhe;
+}
+
+LedgerHeaderHistoryEntry
+HistoryArchiveStream::readHeaderHistory()
+{
+    return readHeaderHistory(mHeaderHistory.header.ledgerSeq + 1);
+}
+
+TransactionHistoryEntry
+HistoryArchiveStream::makeEmptyTransactionHistory()
+{
+    TransactionHistoryEntry txhe;
+    txhe.ledgerSeq = mHeaderHistory.header.ledgerSeq + 1;
+    txhe.txSet.previousLedgerHash = mHeaderHistory.hash;
+    return txhe;
+}
+
+TransactionHistoryEntry
+HistoryArchiveStream::readTransactionHistory()
+{
+    TransactionHistoryEntry txhe;
+
+    uint32_t ledgerSeq = mHeaderHistory.header.ledgerSeq;
+    if (ledgerSeq == 1 ||
+        mHistoryManager.nextCheckpointLedger(ledgerSeq) == ledgerSeq)
+    {
+        if (mTransactionHistory.ledgerSeq >= ledgerSeq)
+        {
+            throw std::runtime_error("Buffered transaction history should not "
+                                     "be ahead at end of checkpoint");
+        }
+
+        if (mTransactionStream && mTransactionStream.readOne(txhe))
+        {
+            throw std::runtime_error(
+                "Transaction stream should be exhausted at end of checkpoint");
+        }
+
+        FileTransferInfo info(
+            mDownloadDir, HISTORY_FILE_TYPE_TRANSACTIONS,
+            mHistoryManager.checkpointContainingLedger(ledgerSeq));
+        mTransactionStream.close();
+        mTransactionStream.open(info.localPath_nogz());
+    }
+
+    if (mTransactionHistory.ledgerSeq < ledgerSeq && mTransactionStream &&
+        mTransactionStream.readOne(txhe))
+    {
+        // Checkpoint contains more transaction history, buffer next
+        mTransactionHistory = txhe;
+    }
+
+    if (mTransactionHistory.ledgerSeq == ledgerSeq)
+    {
+        // Buffer contains transaction set for current header
+        if (mTransactionHistory.txSet.previousLedgerHash !=
+            mHeaderHistory.header.previousLedgerHash)
+        {
+            throw std::runtime_error("Incorrect transaction set hash");
+        }
+        return mTransactionHistory;
+    }
+    else
+    {
+        // Buffer ahead or behind
+        return makeEmptyTransactionHistory();
+    }
+}
+
+TransactionHistoryResultEntry
+HistoryArchiveStream::makeEmptyResultHistory()
+{
+    TransactionHistoryResultEntry txre;
+    txre.ledgerSeq = mHeaderHistory.header.ledgerSeq + 1;
+    return txre;
+}
+
+TransactionHistoryResultEntry
+HistoryArchiveStream::readResultHistory()
+{
+    TransactionHistoryResultEntry txre;
+
+    uint32_t ledgerSeq = mHeaderHistory.header.ledgerSeq;
+    if (ledgerSeq == 1 ||
+        mHistoryManager.nextCheckpointLedger(ledgerSeq) == ledgerSeq)
+    {
+        if (mResultHistory.ledgerSeq >= ledgerSeq)
+        {
+            throw std::runtime_error("Buffered result history should not be "
+                                     "ahead at end of checkpoint");
+        }
+
+        if (mResultStream && mResultStream.readOne(txre))
+        {
+            throw std::runtime_error(
+                "Result stream should be exhausted at end of checkpoint");
+        }
+
+        FileTransferInfo info(
+            mDownloadDir, HISTORY_FILE_TYPE_RESULTS,
+            mHistoryManager.checkpointContainingLedger(ledgerSeq));
+        mResultStream.close();
+        mResultStream.open(info.localPath_nogz());
+    }
+
+    if (mResultHistory.ledgerSeq < ledgerSeq && mResultStream &&
+        mResultStream.readOne(txre))
+    {
+        // Checkpoint contains more result history, buffer next
+        mResultHistory = txre;
+    }
+
+    if (mResultHistory.ledgerSeq == ledgerSeq)
+    {
+        // Buffer contains transaction set for current header
+        return mResultHistory;
+    }
+    else
+    {
+        // Buffer ahead or behind
+        return makeEmptyResultHistory();
+    }
+}
+
+bool
+HistoryArchiveStream::getNextLedger(LedgerHeaderHistoryEntry& header,
+                                    TransactionHistoryEntry& transaction,
+                                    TransactionHistoryResultEntry& result)
+{
+    if (mHeaderHistory.header.ledgerSeq < mRange.mLast)
+    {
+        if (mHeaderHistory.header.ledgerSeq == 0)
+        {
+            header = readHeaderHistory(mRange.mFirst);
+        }
+        else
+        {
+            header = readHeaderHistory();
+        }
+        transaction = readTransactionHistory();
+        result = readResultHistory();
+        return true;
+    }
+    return false;
+}
+}

--- a/src/catchup/simulation/HistoryArchiveStream.h
+++ b/src/catchup/simulation/HistoryArchiveStream.h
@@ -1,0 +1,49 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "ledger/LedgerRange.h"
+#include "util/XDRStream.h"
+#include "xdr/Stellar-ledger.h"
+
+namespace stellar
+{
+
+class FileTransferInfo;
+class HistoryManager;
+class TmpDir;
+
+class HistoryArchiveStream
+{
+    TmpDir const& mDownloadDir;
+    LedgerRange const mRange;
+    XDRInputFileStream mHeaderStream;
+    XDRInputFileStream mTransactionStream;
+    XDRInputFileStream mResultStream;
+
+    HistoryManager const& mHistoryManager;
+
+    LedgerHeaderHistoryEntry mHeaderHistory;
+    TransactionHistoryEntry mTransactionHistory;
+    TransactionHistoryResultEntry mResultHistory;
+
+    LedgerHeaderHistoryEntry readHeaderHistory();
+    LedgerHeaderHistoryEntry readHeaderHistory(uint32_t ledgerSeq);
+
+    TransactionHistoryEntry makeEmptyTransactionHistory();
+    TransactionHistoryEntry readTransactionHistory();
+
+    TransactionHistoryResultEntry makeEmptyResultHistory();
+    TransactionHistoryResultEntry readResultHistory();
+
+  public:
+    HistoryArchiveStream(TmpDir const& downloadDir, LedgerRange const& range,
+                         HistoryManager const& hm);
+
+    bool getNextLedger(LedgerHeaderHistoryEntry& header,
+                       TransactionHistoryEntry& transaction,
+                       TransactionHistoryResultEntry& result);
+};
+}

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -13,8 +13,9 @@ using namespace std;
 namespace stellar
 {
 
-LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
-                                 StellarValue const& v)
+LedgerCloseData::LedgerCloseData(
+    uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
+    StellarValue const& v)
     : mLedgerSeq(ledgerSeq), mTxSet(txSet), mValue(v)
 {
     Value x;

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -22,7 +22,8 @@ namespace stellar
 class LedgerCloseData
 {
   public:
-    LedgerCloseData(uint32_t ledgerSeq, TxSetFramePtr txSet,
+    LedgerCloseData(uint32_t ledgerSeq,
+                    std::shared_ptr<AbstractTxSetFrameForApply> txSet,
                     StellarValue const& v);
 
     uint32_t
@@ -30,7 +31,7 @@ class LedgerCloseData
     {
         return mLedgerSeq;
     }
-    TxSetFramePtr
+    std::shared_ptr<AbstractTxSetFrameForApply>
     getTxSet() const
     {
         return mTxSet;
@@ -43,7 +44,7 @@ class LedgerCloseData
 
   private:
     uint32_t mLedgerSeq;
-    TxSetFramePtr mTxSet;
+    std::shared_ptr<AbstractTxSetFrameForApply> mTxSet;
     StellarValue mValue;
 };
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -419,7 +419,7 @@ TxSetFrame::removeTx(TransactionFramePtr tx)
     mHashIsValid = false;
 }
 
-Hash
+Hash const&
 TxSetFrame::getContentsHash()
 {
     if (!mHashIsValid)

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -18,7 +18,25 @@ class Application;
 class TxSetFrame;
 typedef std::shared_ptr<TxSetFrame> TxSetFramePtr;
 
-class TxSetFrame
+class AbstractTxSetFrameForApply
+{
+  public:
+    virtual ~AbstractTxSetFrameForApply(){};
+
+    virtual int64_t getBaseFee(LedgerHeader const& lh) const = 0;
+
+    virtual Hash const& getContentsHash() = 0;
+
+    virtual Hash const& previousLedgerHash() const = 0;
+
+    virtual size_t sizeTx() const = 0;
+
+    virtual size_t sizeOp() const = 0;
+
+    virtual std::vector<TransactionFramePtr> sortForApply() = 0;
+};
+
+class TxSetFrame : public AbstractTxSetFrameForApply
 {
     bool mHashIsValid;
     Hash mHash;
@@ -47,15 +65,17 @@ class TxSetFrame
     // make it from the wire
     TxSetFrame(Hash const& networkID, TransactionSet const& xdrSet);
 
+    virtual ~TxSetFrame(){};
+
     // returns the hash of this tx set
-    Hash getContentsHash();
+    Hash const& getContentsHash() override;
 
     Hash& previousLedgerHash();
-    Hash const& previousLedgerHash() const;
+    Hash const& previousLedgerHash() const override;
 
     void sortForHash();
 
-    std::vector<TransactionFramePtr> sortForApply();
+    std::vector<TransactionFramePtr> sortForApply() override;
 
     bool checkValid(Application& app);
 
@@ -76,15 +96,15 @@ class TxSetFrame
     size_t size(LedgerHeader const& lh) const;
 
     size_t
-    sizeTx() const
+    sizeTx() const override
     {
         return mTransactions.size();
     }
 
-    size_t sizeOp() const;
+    size_t sizeOp() const override;
 
     // return the base fee associated with this transaction set
-    int64_t getBaseFee(LedgerHeader const& lh) const;
+    int64_t getBaseFee(LedgerHeader const& lh) const override;
 
     // return the sum of all fees that this transaction set would take
     int64_t getTotalFees(LedgerHeader const& lh) const;

--- a/src/herder/simulation/SimulationTxSetFrame.cpp
+++ b/src/herder/simulation/SimulationTxSetFrame.cpp
@@ -37,33 +37,7 @@ SimulationTxSetFrame::SimulationTxSetFrame(
 int64_t
 SimulationTxSetFrame::getBaseFee(LedgerHeader const& lh) const
 {
-    int64_t baseFee = lh.baseFee;
-    if (lh.ledgerVersion >= 11)
-    {
-        size_t ops = 0;
-        int64_t lowBaseFee = std::numeric_limits<int64_t>::max();
-        for (auto& txEnv : mTransactions)
-        {
-            auto txOps = txEnv.tx.operations.size();
-            ops += txOps;
-            int64_t txBaseFee =
-                bigDivide(txEnv.tx.fee, 1, static_cast<int64_t>(txOps),
-                          Rounding::ROUND_UP);
-            lowBaseFee = std::min(lowBaseFee, txBaseFee);
-        }
-        // if surge pricing was in action, use the lowest base fee bid from the
-        // transaction set
-        size_t surgeOpsCutoff = 0;
-        if (lh.maxTxSetSize >= MAX_OPS_PER_TX)
-        {
-            surgeOpsCutoff = lh.maxTxSetSize - MAX_OPS_PER_TX;
-        }
-        if (ops > surgeOpsCutoff)
-        {
-            baseFee = lowBaseFee;
-        }
-    }
-    return baseFee;
+    return 0;
 }
 
 Hash const&

--- a/src/herder/simulation/SimulationTxSetFrame.cpp
+++ b/src/herder/simulation/SimulationTxSetFrame.cpp
@@ -1,0 +1,112 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "herder/simulation/SimulationTxSetFrame.h"
+#include "crypto/SHA.h"
+#include "transactions/simulation/SimulationTransactionFrame.h"
+#include "xdrpp/marshal.h"
+#include <numeric>
+
+namespace stellar
+{
+
+static Hash
+computeContentsHash(Hash const& networkID, Hash const& previousLedgerHash,
+                    std::vector<TransactionEnvelope> transactions)
+{
+    TransactionSet txSet;
+    txSet.previousLedgerHash = previousLedgerHash;
+    txSet.txs.insert(txSet.txs.end(), transactions.begin(), transactions.end());
+    return TxSetFrame(networkID, txSet).getContentsHash();
+}
+
+SimulationTxSetFrame::SimulationTxSetFrame(
+    Hash const& networkID, Hash const& previousLedgerHash,
+    std::vector<TransactionEnvelope> const& transactions,
+    std::vector<TransactionResultPair> const& results)
+    : mNetworkID(networkID)
+    , mPreviousLedgerHash(previousLedgerHash)
+    , mTransactions(transactions)
+    , mResults(results)
+    , mContentsHash(
+          computeContentsHash(mNetworkID, mPreviousLedgerHash, mTransactions))
+{
+}
+
+int64_t
+SimulationTxSetFrame::getBaseFee(LedgerHeader const& lh) const
+{
+    int64_t baseFee = lh.baseFee;
+    if (lh.ledgerVersion >= 11)
+    {
+        size_t ops = 0;
+        int64_t lowBaseFee = std::numeric_limits<int64_t>::max();
+        for (auto& txEnv : mTransactions)
+        {
+            auto txOps = txEnv.tx.operations.size();
+            ops += txOps;
+            int64_t txBaseFee =
+                bigDivide(txEnv.tx.fee, 1, static_cast<int64_t>(txOps),
+                          Rounding::ROUND_UP);
+            lowBaseFee = std::min(lowBaseFee, txBaseFee);
+        }
+        // if surge pricing was in action, use the lowest base fee bid from the
+        // transaction set
+        size_t surgeOpsCutoff = 0;
+        if (lh.maxTxSetSize >= MAX_OPS_PER_TX)
+        {
+            surgeOpsCutoff = lh.maxTxSetSize - MAX_OPS_PER_TX;
+        }
+        if (ops > surgeOpsCutoff)
+        {
+            baseFee = lowBaseFee;
+        }
+    }
+    return baseFee;
+}
+
+Hash const&
+SimulationTxSetFrame::getContentsHash()
+{
+    return mContentsHash;
+}
+
+Hash const&
+SimulationTxSetFrame::previousLedgerHash() const
+{
+    return mPreviousLedgerHash;
+}
+
+size_t
+SimulationTxSetFrame::sizeTx() const
+{
+    return mTransactions.size();
+}
+
+size_t
+SimulationTxSetFrame::sizeOp() const
+{
+    return std::accumulate(mTransactions.begin(), mTransactions.end(),
+                           size_t(0),
+                           [](size_t a, TransactionEnvelope const& txEnv) {
+                               return a + txEnv.tx.operations.size();
+                           });
+}
+
+std::vector<TransactionFramePtr>
+SimulationTxSetFrame::sortForApply()
+{
+    std::vector<TransactionFramePtr> res;
+    res.reserve(mTransactions.size());
+
+    auto resultIter = mResults.cbegin();
+    for (auto const& txEnv : mTransactions)
+    {
+        res.emplace_back(SimulationTransactionFrame::makeTransactionFromWire(
+            mNetworkID, txEnv, resultIter->result));
+        ++resultIter;
+    }
+    return res;
+}
+}

--- a/src/herder/simulation/SimulationTxSetFrame.h
+++ b/src/herder/simulation/SimulationTxSetFrame.h
@@ -1,0 +1,37 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "herder/TxSetFrame.h"
+
+namespace stellar
+{
+
+class SimulationTxSetFrame : public AbstractTxSetFrameForApply
+{
+    Hash const mNetworkID;
+    Hash const mPreviousLedgerHash;
+    std::vector<TransactionEnvelope> const mTransactions;
+    std::vector<TransactionResultPair> const mResults;
+    Hash const mContentsHash;
+
+  public:
+    SimulationTxSetFrame(Hash const& networkID, Hash const& previousLedgerHash,
+                         std::vector<TransactionEnvelope> const& transactions,
+                         std::vector<TransactionResultPair> const& results);
+
+    int64_t getBaseFee(LedgerHeader const& lh) const override;
+
+    Hash const& getContentsHash() override;
+
+    Hash const& previousLedgerHash() const override;
+
+    size_t sizeTx() const override;
+
+    size_t sizeOp() const override;
+
+    std::vector<TransactionFramePtr> sortForApply() override;
+};
+}

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -15,6 +15,10 @@
 #include "util/Logging.h"
 #include "util/optional.h"
 
+#include "catchup/simulation/ApplyTransactionsWork.h"
+#include "historywork/BatchDownloadWork.h"
+#include "work/WorkScheduler.h"
+
 #ifdef BUILD_TESTS
 #include "test/fuzz.h"
 #include "test/test.h"
@@ -793,6 +797,70 @@ runRebuildLedgerFromBuckets(CommandLineArgs const& args)
 }
 
 int
+runSimulate(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    uint32_t opsPerLedger = 0;
+    uint32_t firstLedgerInclusive = 0;
+    uint32_t lastLedgerInclusive = 0;
+    std::string historyArchiveGet;
+
+    auto validateFirstLedger = [&] {
+        if (firstLedgerInclusive == 0)
+        {
+            return "first ledger must not be 0";
+        }
+        else if (firstLedgerInclusive > lastLedgerInclusive)
+        {
+            return "last ledger must not preceed first ledger";
+        }
+        return "";
+    };
+    ParserWithValidation firstLedgerParser{
+        clara::Opt{firstLedgerInclusive, "LEDGER"}["--first-ledger-inclusive"](
+            "first ledger to read from history archive"),
+        validateFirstLedger};
+
+    return runWithHelp(
+        args,
+        {configurationParser(configOption),
+         clara::Opt{opsPerLedger, "OPS-PER-LEDGER"}["--ops-per-ledger"](
+             "desired number of operations per ledger, will never be less but "
+             "could be up to 100 more"),
+         firstLedgerParser,
+         clara::Opt{lastLedgerInclusive, "LEDGER"}["--last-ledger-inclusive"](
+             "last ledger to read from history archive")},
+        [&] {
+            auto config = configOption.getConfig();
+            config.setNoListen();
+
+            VirtualClock clock(VirtualClock::REAL_TIME);
+            auto app = Application::create(clock, config, false);
+            app->start();
+
+            LedgerRange lr{firstLedgerInclusive, lastLedgerInclusive};
+            CheckpointRange cr(lr, app->getHistoryManager());
+            TmpDir dir(app->getTmpDirManager().tmpDir("simulate"));
+
+            auto downloadLedgers = std::make_shared<BatchDownloadWork>(
+                *app, cr, HISTORY_FILE_TYPE_LEDGER, dir);
+            auto downloadTransactions = std::make_shared<BatchDownloadWork>(
+                *app, cr, HISTORY_FILE_TYPE_TRANSACTIONS, dir);
+            auto downloadResults = std::make_shared<BatchDownloadWork>(
+                *app, cr, HISTORY_FILE_TYPE_RESULTS, dir);
+            auto apply = std::make_shared<ApplyTransactionsWork>(
+                *app, dir, lr, app->getConfig().NETWORK_PASSPHRASE,
+                opsPerLedger);
+            std::vector<std::shared_ptr<BasicWork>> seq{
+                downloadLedgers, downloadTransactions, downloadResults, apply};
+
+            app->getWorkScheduler().executeWork<WorkSequence>(
+                "download-simulate-seq", seq);
+            return 0;
+        });
+}
+
+int
 runFuzz(CommandLineArgs const& args)
 {
     el::Level logLevel{el::Level::Info};
@@ -872,6 +940,7 @@ handleCommandLine(int argc, char* const* argv)
           runRebuildLedgerFromBuckets},
          {"fuzz", "run a single fuzz input and exit", runFuzz},
          {"gen-fuzz", "generate a random fuzzer input file", runGenFuzz},
+         {"simulate", "simulate applying ledgers", runSimulate},
          {"test", "execute test suite", runTest},
 #endif
          {"write-quorum", "print a quorum set graph from history",

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -29,6 +29,16 @@ MergeOpFrame::getThresholdLevel() const
     return ThresholdLevel::HIGH;
 }
 
+bool
+MergeOpFrame::isSeqnumTooFar(LedgerTxnHeader const& header,
+                             AccountEntry const& sourceAccount)
+{
+    // don't allow the account to be merged if recreating it would cause it
+    // to jump backwards
+    SequenceNumber maxSeq = getStartingSequenceNumber(header);
+    return sourceAccount.seqNum >= maxSeq;
+}
+
 // make sure the deleted Account hasn't issued credit
 // make sure we aren't holding any credit
 // make sure the we delete all the offers
@@ -90,11 +100,7 @@ MergeOpFrame::doApply(AbstractLedgerTxn& ltx)
 
     if (header.current().ledgerVersion >= 10)
     {
-        SequenceNumber maxSeq = getStartingSequenceNumber(header);
-
-        // don't allow the account to be merged if recreating it would cause it
-        // to jump backwards
-        if (sourceAccount.seqNum >= maxSeq)
+        if (isSeqnumTooFar(header, sourceAccount))
         {
             innerResult().code(ACCOUNT_MERGE_SEQNUM_TOO_FAR);
             return false;

--- a/src/transactions/MergeOpFrame.h
+++ b/src/transactions/MergeOpFrame.h
@@ -8,6 +8,9 @@
 
 namespace stellar
 {
+
+class LedgerTxnHeader;
+
 class MergeOpFrame : public OperationFrame
 {
     AccountMergeResult&
@@ -17,6 +20,9 @@ class MergeOpFrame : public OperationFrame
     }
 
     ThresholdLevel getThresholdLevel() const override;
+
+    virtual bool isSeqnumTooFar(LedgerTxnHeader const& header,
+                                AccountEntry const& sourceAccount);
 
   public:
     MergeOpFrame(Operation const& op, OperationResult& res,

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -63,11 +63,19 @@ class TransactionFrame
         kFullyValid
     };
 
+    virtual bool isTooEarly(LedgerTxnHeader const& header) const;
+    virtual bool isTooLate(LedgerTxnHeader const& header) const;
+
     bool commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool forApply);
+
+    virtual bool isBadSeq(int64_t seqNum) const;
 
     ValidationType commonValid(SignatureChecker& signatureChecker,
                                AbstractLedgerTxn& ltxOuter,
                                SequenceNumber current, bool applying);
+
+    virtual std::shared_ptr<OperationFrame>
+    makeOperation(Operation const& op, OperationResult& res, size_t index);
 
     void resetResults(LedgerHeader const& header, int64_t baseFee);
 
@@ -97,6 +105,10 @@ class TransactionFrame
                      TransactionEnvelope const& envelope);
     TransactionFrame(TransactionFrame const&) = delete;
     TransactionFrame() = delete;
+
+    virtual ~TransactionFrame()
+    {
+    }
 
     static TransactionFramePtr
     makeTransactionFromWire(Hash const& networkID,
@@ -152,7 +164,7 @@ class TransactionFrame
 
     int64_t getMinFee(LedgerHeader const& header) const;
 
-    int64_t getFee(LedgerHeader const& header, int64_t baseFee) const;
+    virtual int64_t getFee(LedgerHeader const& header, int64_t baseFee) const;
 
     void addSignature(SecretKey const& secretKey);
     void addSignature(DecoratedSignature const& signature);
@@ -166,7 +178,7 @@ class TransactionFrame
     bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current);
 
     // collect fee, consume sequence number
-    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee);
+    virtual void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee);
 
     // apply this transaction to the current ledger
     // returns true if successfully applied

--- a/src/transactions/simulation/SimulationMergeOpFrame.cpp
+++ b/src/transactions/simulation/SimulationMergeOpFrame.cpp
@@ -1,0 +1,28 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "transactions/simulation/SimulationMergeOpFrame.h"
+
+namespace stellar
+{
+
+SimulationMergeOpFrame::SimulationMergeOpFrame(
+    Operation const& op, OperationResult& res, TransactionFrame& parentTx,
+    OperationResult const& simulationResult)
+    : MergeOpFrame(op, res, parentTx), mSimulationResult(simulationResult)
+{
+}
+
+bool
+SimulationMergeOpFrame::isSeqnumTooFar(LedgerTxnHeader const& header,
+                                       AccountEntry const& sourceAccount)
+{
+    if (mSimulationResult.code() == opINNER)
+    {
+        auto code = mSimulationResult.tr().accountMergeResult().code();
+        return code == ACCOUNT_MERGE_SEQNUM_TOO_FAR;
+    }
+    return false;
+}
+}

--- a/src/transactions/simulation/SimulationMergeOpFrame.h
+++ b/src/transactions/simulation/SimulationMergeOpFrame.h
@@ -1,0 +1,24 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "transactions/MergeOpFrame.h"
+
+namespace stellar
+{
+
+class SimulationMergeOpFrame : public MergeOpFrame
+{
+    OperationResult mSimulationResult;
+
+  public:
+    SimulationMergeOpFrame(Operation const& op, OperationResult& res,
+                           TransactionFrame& parentTx,
+                           OperationResult const& simulationResult);
+
+    bool isSeqnumTooFar(LedgerTxnHeader const& header,
+                        AccountEntry const& sourceAccount) override;
+};
+}

--- a/src/transactions/simulation/SimulationTransactionFrame.cpp
+++ b/src/transactions/simulation/SimulationTransactionFrame.cpp
@@ -1,0 +1,103 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "transactions/simulation/SimulationTransactionFrame.h"
+#include "ledger/LedgerTxn.h"
+#include "transactions/OperationFrame.h"
+#include "transactions/TransactionUtils.h"
+#include "transactions/simulation/SimulationMergeOpFrame.h"
+
+namespace stellar
+{
+
+TransactionFramePtr
+SimulationTransactionFrame::makeTransactionFromWire(
+    Hash const& networkID, TransactionEnvelope const& envelope,
+    TransactionResult simulationResult)
+{
+    TransactionFramePtr res = std::make_shared<SimulationTransactionFrame>(
+        networkID, envelope, simulationResult);
+    return res;
+}
+
+SimulationTransactionFrame::SimulationTransactionFrame(
+    Hash const& networkID, TransactionEnvelope const& envelope,
+    TransactionResult simulationResult)
+    : TransactionFrame(networkID, envelope), mSimulationResult(simulationResult)
+{
+}
+
+std::shared_ptr<OperationFrame>
+SimulationTransactionFrame::makeOperation(Operation const& op,
+                                          OperationResult& res, size_t index)
+{
+    if (mEnvelope.tx.operations[index].body.type() != ACCOUNT_MERGE)
+    {
+        return OperationFrame::makeHelper(op, res, *this);
+    }
+    else
+    {
+        return std::make_shared<SimulationMergeOpFrame>(
+            op, res, *this, mSimulationResult.result.results()[index]);
+    }
+}
+
+bool
+SimulationTransactionFrame::isTooEarly(LedgerTxnHeader const& header) const
+{
+    return mSimulationResult.result.code() == txTOO_EARLY;
+}
+
+bool
+SimulationTransactionFrame::isTooLate(LedgerTxnHeader const& header) const
+{
+    return mSimulationResult.result.code() == txTOO_LATE;
+}
+
+bool
+SimulationTransactionFrame::isBadSeq(int64_t seqNum) const
+{
+    return mSimulationResult.result.code() == txBAD_SEQ;
+}
+
+int64_t
+SimulationTransactionFrame::getFee(LedgerHeader const& header,
+                                   int64_t baseFee) const
+{
+    return mSimulationResult.feeCharged;
+}
+
+void
+SimulationTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
+                                             int64_t baseFee)
+{
+    mCachedAccount.reset();
+
+    auto header = ltx.loadHeader();
+    resetResults(header.current(), baseFee);
+
+    auto sourceAccount = loadSourceAccount(ltx, header);
+    if (!sourceAccount)
+    {
+        return;
+    }
+    auto& acc = sourceAccount.current().data.account();
+
+    int64_t& fee = getResult().feeCharged;
+    if (fee > 0)
+    {
+        fee = std::min(acc.balance, fee);
+        // Note: TransactionUtil addBalance checks that reserve plus liabilities
+        // are respected. In this case, we allow it to fall below that since it
+        // will be caught later in commonValid.
+        stellar::addBalance(acc.balance, -fee);
+        header.current().feePool += fee;
+    }
+    // in v10 we update sequence numbers during apply
+    if (header.current().ledgerVersion <= 9)
+    {
+        acc.seqNum = mEnvelope.tx.seqNum;
+    }
+}
+}

--- a/src/transactions/simulation/SimulationTransactionFrame.h
+++ b/src/transactions/simulation/SimulationTransactionFrame.h
@@ -1,0 +1,46 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "transactions/TransactionFrame.h"
+
+namespace stellar
+{
+
+class SimulationTransactionFrame : public TransactionFrame
+{
+    TransactionResult mSimulationResult;
+
+  protected:
+    bool isTooEarly(LedgerTxnHeader const& header) const override;
+    bool isTooLate(LedgerTxnHeader const& header) const override;
+
+    std::shared_ptr<OperationFrame> makeOperation(Operation const& op,
+                                                  OperationResult& res,
+                                                  size_t index) override;
+
+    bool isBadSeq(int64_t seqNum) const override;
+
+    int64_t getFee(LedgerHeader const& header, int64_t baseFee) const override;
+
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
+
+  public:
+    SimulationTransactionFrame(Hash const& networkID,
+                               TransactionEnvelope const& envelope,
+                               TransactionResult simulationResult);
+    SimulationTransactionFrame(TransactionFrame const&) = delete;
+    SimulationTransactionFrame() = delete;
+
+    virtual ~SimulationTransactionFrame()
+    {
+    }
+
+    static TransactionFramePtr
+    makeTransactionFromWire(Hash const& networkID,
+                            TransactionEnvelope const& envelope,
+                            TransactionResult simulationResult);
+};
+}


### PR DESCRIPTION
This PR adds a `simulate` mode to stellar-core which permits replay of transactions from a history archive at an increased number of operations per ledger. This will be useful for testing the performance characteristics of stellar-core.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
