### PR TITLE
Introduce Transaction Subsystem Fuzzing and Common Fuzzer Interface

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -64,16 +64,18 @@ format: always
 endif # USE_CLANG_FORMAT
 
 if USE_AFL_FUZZ
+FUZZER_MODE ?= overlay
+
 fuzz-testcases: stellar-core
 	mkdir -p fuzz-testcases
 	for i in `seq 1 10`; do \
-	    ./stellar-core gen-fuzz fuzz-testcases/fuzz$$i.xdr; \
+	    ./stellar-core gen-fuzz fuzz-testcases/fuzz$$i.xdr --mode=${FUZZER_MODE}; \
 	done
 
 fuzz: fuzz-testcases stellar-core
 	mkdir -p fuzz-findings
 	afl-fuzz -m 8000 -t 250 -i fuzz-testcases -o fuzz-findings \
-	    ./stellar-core fuzz @@
+	    ./stellar-core fuzz @@ --mode=${FUZZER_MODE}
 
 fuzz-clean: always
 	rm -Rf fuzz-testcases fuzz-findings

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1288,6 +1288,21 @@ LedgerTxnRoot::Impl::~Impl()
     }
 }
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+void
+LedgerTxnRoot::Impl::resetForFuzzer()
+{
+    mBestOffersCache.clear();
+    mEntryCache.clear();
+}
+
+void
+LedgerTxnRoot::resetForFuzzer()
+{
+    mImpl->resetForFuzzer();
+}
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
 void
 LedgerTxnRoot::addChild(AbstractLedgerTxn& child)
 {

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -577,6 +577,10 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     void dropOffers();
     void dropTrustLines();
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    void resetForFuzzer();
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
     std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
 
     std::shared_ptr<LedgerEntry const>

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -518,6 +518,10 @@ class LedgerTxnRoot::Impl
     void dropOffers();
     void dropTrustLines();
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    void resetForFuzzer();
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
     // getAllOffers has the basic exception safety guarantee. If it throws an
     // exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -12,6 +12,7 @@
 #include "main/StellarCoreVersion.h"
 #include "main/dumpxdr.h"
 #include "scp/QuorumSetUtils.h"
+#include "test/Fuzzer.h"
 #include "util/Logging.h"
 #include "util/optional.h"
 
@@ -161,6 +162,38 @@ ParserWithValidation
 fileNameParser(std::string& string)
 {
     return requiredArgParser(string, "FILE-NAME");
+}
+
+ParserWithValidation
+fuzzerModeParser(std::string& fuzzerModeArg, FuzzerMode& fuzzerMode)
+{
+    auto validateFuzzerMode = [&] {
+        if (iequals(fuzzerModeArg, "overlay"))
+        {
+            fuzzerMode = FuzzerMode::OVERLAY;
+            return "";
+        }
+
+        if (iequals(fuzzerModeArg, "tx"))
+        {
+            fuzzerMode = FuzzerMode::TRANSACTION;
+            return "";
+        }
+
+        return "Unrecognized fuzz mode. Please select a valid mode.";
+    };
+
+    return {clara::Opt{fuzzerModeArg, "FUZZER-MODE"}["--mode"](
+                "set the fuzzer mode. Expected modes: overlay, "
+                "tx. Defaults to overlay."),
+            validateFuzzerMode};
+}
+
+clara::Opt
+processIDParser(uint& num)
+{
+    return clara::Opt{num, "PROCESS-ID"}["--process_id"](
+        "for spawning multiple instances in fuzzing parallelization");
 }
 
 clara::Opt
@@ -866,12 +899,17 @@ runFuzz(CommandLineArgs const& args)
     el::Level logLevel{el::Level::Info};
     std::vector<std::string> metrics;
     std::string fileName;
+    uint processID = 0;
+    FuzzerMode fuzzerMode{FuzzerMode::OVERLAY};
+    std::string fuzzerModeArg = "overlay";
 
     return runWithHelp(args,
                        {logLevelParser(logLevel), metricsParser(metrics),
-                        fileNameParser(fileName)},
+                        fileNameParser(fileName), processIDParser(processID),
+                        fuzzerModeParser(fuzzerModeArg, fuzzerMode)},
                        [&] {
-                           fuzz(fileName, logLevel, metrics);
+                           fuzz(fileName, logLevel, metrics, processID,
+                                fuzzerMode);
                            return 0;
                        });
 }
@@ -880,11 +918,17 @@ int
 runGenFuzz(CommandLineArgs const& args)
 {
     std::string fileName;
+    FuzzerMode fuzzerMode{FuzzerMode::OVERLAY};
+    std::string fuzzerModeArg = "overlay";
+    uint processID = 0;
 
-    return runWithHelp(args, {fileNameParser(fileName)}, [&] {
-        genfuzz(fileName);
-        return 0;
-    });
+    return runWithHelp(
+        args,
+        {fileNameParser(fileName), fuzzerModeParser(fuzzerModeArg, fuzzerMode)},
+        [&] {
+            FuzzUtils::createFuzzer(processID, fuzzerMode)->genFuzz(fileName);
+            return 0;
+        });
 }
 #endif
 
@@ -955,7 +999,7 @@ handleCommandLine(int argc, char* const* argv)
     auto commandName = fmt::format("{0} {1}", exeName, command->name());
     auto args = CommandLineArgs{exeName, commandName, command->description(),
                                 adjustedCommandLine.second};
-    if (command->name() == "run")
+    if (command->name() == "run" || command->name() == "fuzz")
     {
         // run outside of catch block so that we properly capture crashes
         return command->run(args);

--- a/src/test/Fuzzer.h
+++ b/src/test/Fuzzer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <string>
+
+namespace stellar
+{
+
+class XDRInputFileStream;
+
+// Fuzzer is an encapsulation over some state that receives an
+// XDRInputFileStream and deterministically injects it, applying it to its
+// state.
+class Fuzzer
+{
+  public:
+    // inject receives an XDRInputFileStream attached to a fuzzed input file and
+    // attempts to apply it to the state according to whatever apply may mean,
+    // i.e. apply a transaction in the case of a TransactionFuzzer or send a
+    // message in case of an OverlayFuzzer
+    virtual void inject(XDRInputFileStream&) = 0;
+    virtual void initialize() = 0;
+    // genFuzz randomly generates an XDR input for the given fuzzer. For the
+    // TransactionFuzzer, this is a xdr::xvector of Operations, for the
+    // OverlayFuzzer this is a StellarMessage
+    virtual void genFuzz(std::string const& filename) = 0;
+    virtual int xdrSizeLimit() = 0;
+};
+}

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1,0 +1,164 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "test/FuzzerImpl.h"
+#include "ledger/LedgerTxn.h"
+#include "main/Application.h"
+#include "main/Config.h"
+#include "overlay/OverlayManager.h"
+#include "overlay/TCPPeer.h"
+#include "simulation/Simulation.h"
+#include "test/TestUtils.h"
+#include "test/fuzz.h"
+#include "test/test.h"
+#include "transactions/OperationFrame.h"
+#include "transactions/SignatureChecker.h"
+#include "util/Math.h"
+
+#include <xdrpp/autocheck.h>
+
+namespace stellar
+{
+
+// creates a generic configuration with settings rigged to maximize
+// determinism
+static Config
+getFuzzConfig(int instanceNumber)
+{
+    Config cfg = getTestConfig(instanceNumber);
+    cfg.MANUAL_CLOSE = true;
+    cfg.CATCHUP_COMPLETE = false;
+    cfg.CATCHUP_RECENT = 0;
+    cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
+    cfg.ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = UINT32_MAX;
+    cfg.PUBLIC_HTTP_PORT = false;
+    cfg.WORKER_THREADS = 1;
+    cfg.QUORUM_INTERSECTION_CHECKER = false;
+    cfg.PREFERRED_PEERS_ONLY = false;
+    cfg.RUN_STANDALONE = true;
+
+    return cfg;
+}
+
+bool
+isBadOverlayFuzzerInput(StellarMessage const& m)
+{
+    // HELLO, AUTH and ERROR_MSG messages cause the connection between
+    // the peers to drop. Since peer connections are only established
+    // preceding the persistent loop, a dropped peer is not only
+    // inconvenient, it also confuses the fuzzer. Consider a msg A sent
+    // before a peer is dropped and after a peer is dropped. The two,
+    // even though the same message, will take drastically different
+    // execution paths -- the fuzzer's main metric for determinism
+    // (stability) and binary coverage.
+    return m.type() == AUTH || m.type() == ERROR_MSG || m.type() == HELLO;
+}
+
+void
+OverlayFuzzer::initialize()
+{
+    auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    mSimulation = std::make_shared<Simulation>(Simulation::OVER_LOOPBACK,
+                                               networkID, getFuzzConfig);
+
+    SIMULATION_CREATE_NODE(10);
+    SIMULATION_CREATE_NODE(11);
+
+    SCPQuorumSet qSet0;
+    qSet0.threshold = 2;
+    qSet0.validators.push_back(v10NodeID);
+    qSet0.validators.push_back(v11NodeID);
+
+    mSimulation->addNode(v10SecretKey, qSet0);
+    mSimulation->addNode(v11SecretKey, qSet0);
+
+    mSimulation->addPendingConnection(v10SecretKey.getPublicKey(),
+                                      v11SecretKey.getPublicKey());
+
+    mSimulation->startAllNodes();
+
+    // crank until nodes are connected
+    mSimulation->crankUntil(
+        [&]() {
+            auto nodes = mSimulation->getNodes();
+            auto numberOfSimulationConnections =
+                nodes[ACCEPTOR_INDEX]
+                    ->getOverlayManager()
+                    .getAuthenticatedPeersCount() +
+                nodes[INITIATOR_INDEX]
+                    ->getOverlayManager()
+                    .getAuthenticatedPeersCount();
+            return numberOfSimulationConnections == 2;
+        },
+        std::chrono::milliseconds{500}, false);
+}
+
+void
+OverlayFuzzer::inject(XDRInputFileStream& in)
+{
+    // see note on TransactionFuzzer's tryRead above
+    auto tryRead = [&in](StellarMessage& m) {
+        try
+        {
+            return in.readOne(m);
+        }
+        catch (...)
+        {
+            m.type(HELLO); // we ignore HELLO messages
+            return true;
+        }
+    };
+
+    StellarMessage msg;
+    while (tryRead(msg))
+    {
+        if (isBadOverlayFuzzerInput(msg))
+        {
+            return;
+        }
+
+        auto nodeids = mSimulation->getNodeIDs();
+        auto loopbackPeerConnection = mSimulation->getLoopbackConnection(
+            nodeids[INITIATOR_INDEX], nodeids[ACCEPTOR_INDEX]);
+
+        auto initiator = loopbackPeerConnection->getInitiator();
+        auto acceptor = loopbackPeerConnection->getAcceptor();
+
+        initiator->getApp().getClock().postToCurrentCrank(
+            [initiator, msg]() { initiator->Peer::sendMessage(msg); });
+
+        mSimulation->crankForAtMost(std::chrono::milliseconds{500}, false);
+
+        // clear all queues and cancel all events
+        initiator->clearInAndOutQueues();
+        acceptor->clearInAndOutQueues();
+
+        while (initiator->getApp().getClock().cancelAllEvents())
+            ;
+        while (acceptor->getApp().getClock().cancelAllEvents())
+            ;
+    }
+}
+
+int
+OverlayFuzzer::xdrSizeLimit()
+{
+    return MAX_MESSAGE_SIZE;
+}
+
+#define FUZZER_INITIAL_CORPUS_MESSAGE_GEN_UPPERBOUND 16
+void
+OverlayFuzzer::genFuzz(std::string const& filename)
+{
+    XDROutputFileStream out(/*doFsync=*/false);
+    out.open(filename);
+    autocheck::generator<StellarMessage> gen;
+    StellarMessage m(gen(FUZZER_INITIAL_CORPUS_MESSAGE_GEN_UPPERBOUND));
+    while (isBadOverlayFuzzerInput(m))
+    {
+        m = gen(FUZZER_INITIAL_CORPUS_MESSAGE_GEN_UPPERBOUND);
+    }
+    out.writeOne(m);
+}
+}

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "test/Fuzzer.h"
+#include "xdr/Stellar-types.h"
+
+namespace stellar
+{
+
+class XDRInputFileStream;
+class Simulation;
+struct StellarMessage;
+
+class OverlayFuzzer : public Fuzzer
+{
+    const uint ACCEPTOR_INDEX = 0;
+    const uint INITIATOR_INDEX = 1;
+
+  public:
+    OverlayFuzzer()
+    {
+    }
+    void inject(XDRInputFileStream&) override;
+    void initialize() override;
+    void genFuzz(std::string const& filename) override;
+    int xdrSizeLimit() override;
+
+  private:
+    std::shared_ptr<Simulation> mSimulation;
+};
+}

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -12,7 +12,28 @@ namespace stellar
 
 class XDRInputFileStream;
 class Simulation;
+class Application;
 struct StellarMessage;
+struct Operation;
+
+class TransactionFuzzer : public Fuzzer
+{
+  public:
+    TransactionFuzzer(int numAccounts, int processID)
+        : mNumAccounts(numAccounts), mProcessID(processID)
+    {
+    }
+    void inject(XDRInputFileStream&) override;
+    void initialize() override;
+    void genFuzz(std::string const& filename) override;
+    int xdrSizeLimit() override;
+
+  private:
+    std::shared_ptr<Application> mApp;
+    PublicKey mSourceAccountID;
+    int mNumAccounts;
+    int mProcessID;
+};
 
 class OverlayFuzzer : public Fuzzer
 {

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -45,6 +45,22 @@
 namespace stellar
 {
 
+namespace FuzzUtils
+{
+std::unique_ptr<Fuzzer>
+createFuzzer(int processID, FuzzerMode fuzzerMode)
+{
+    switch (fuzzerMode)
+    {
+    case FuzzerMode::OVERLAY:
+        return std::make_unique<OverlayFuzzer>();
+    case FuzzerMode::TRANSACTION:
+        return std::make_unique<TransactionFuzzer>(
+            NUMBER_OF_PREGENERATED_ACCOUNTS, processID);
+    }
+}
+}
+
 std::string
 msgSummary(StellarMessage const& m)
 {

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -2,43 +2,27 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "util/asio.h"
-#include "crypto/Hex.h"
-#include "crypto/SHA.h"
-#include "main/Application.h"
-#include "main/Config.h"
-#include "main/StellarCoreVersion.h"
-#include "overlay/OverlayManager.h"
-#include "overlay/TCPPeer.h"
-#include "overlay/test/LoopbackPeer.h"
-#include "simulation/Simulation.h"
-#include "test/test.h"
-#include "util/Fs.h"
-#include "util/Logging.h"
-#include "util/Math.h"
-#include "util/Timer.h"
-#include "util/XDRStream.h"
-
 #include "test/fuzz.h"
+#include "test/FuzzerImpl.h"
+#include "util/XDRStream.h"
+#include "util/types.h"
 
-#include <signal.h>
 #include <xdrpp/autocheck.h>
-#include <xdrpp/printer.h>
-
 /**
  * This is a very simple fuzzer _stub_. It's intended to be run under an
- * external fuzzer with some fuzzing brains, AFL or fuzzgrind or whatever.
+ * external fuzzer with some fuzzing brains, at this time, preferably AFL.
  *
  * It has two modes:
  *
- *   - In gen-fuzz mode it spits out a small file containing a handful of
- *     random StellarMessages. This is the mode you use to generate seed data
- *     for the external fuzzer's corpus.
+ *   - In genfuzz mode it spits out a small file containing a handful of
+ *     random FuzzTransactionInputs or StellarMessages. This is the mode you use
+ *     to generate seed data for the external fuzzer's corpus.
  *
- *   - In fuzz mode it reads back a file and appplies it to a pair of of
- *     stellar-cores in loopback mode, cranking the I/O loop to simulate
- *     receiving the messages one by one. It exits when it's read the input.
- *     This is the mode the external fuzzer will run its mutant inputs through.
+ *   - In fuzz mode it reads back a file and appplies it to a stellar-core
+ *     instance, applying but not committing transactions one by one to simulate
+ *     certain transaction/overlay scenarios. It exits when it's applied the
+ *     input. This is the mode the external fuzzer will run its mutant inputs
+ *     through.
  *
  */
 
@@ -61,100 +45,14 @@ createFuzzer(int processID, FuzzerMode fuzzerMode)
 }
 }
 
-std::string
-msgSummary(StellarMessage const& m)
-{
-    xdr::detail::Printer p(0);
-    xdr::archive(p, m.type(), nullptr);
-    return p.buf_.str() + ":" + hexAbbrev(sha256(xdr::xdr_to_msg(m)));
-}
-
-bool
-tryRead(XDRInputFileStream& in, StellarMessage& m)
-{
-    try
-    {
-        return in.readOne(m);
-    }
-    catch (xdr::xdr_runtime_error& e)
-    {
-        LOG(INFO) << "Caught XDR error '" << e.what()
-                  << "' on input substituting HELLO";
-        m.type(HELLO);
-        return true;
-    }
-}
-
-void
-seedRandomness()
-{
-    srand(1);
-    gRandomEngine.seed(1);
-}
-
-#define PERSIST_MAX 10000000
-#define INITIATOR 1
-#define ACCEPTOR 0
+#define PERSIST_MAX 1000000
 void
 fuzz(std::string const& filename, el::Level logLevel,
-     std::vector<std::string> const& metrics)
+     std::vector<std::string> const& metrics, uint processID,
+     FuzzerMode fuzzerMode)
 {
-    Logging::setFmt("<fuzz>", false);
-    Logging::setLogLevel(logLevel, nullptr);
-    LOG(INFO) << "Fuzzing stellar-core " << STELLAR_CORE_VERSION;
-    LOG(INFO) << "Fuzz input is in " << filename;
-
-    seedRandomness();
-
-    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
-    auto confGen = [](int instanceNumber) {
-        Config cfg = getTestConfig(instanceNumber);
-        cfg.MANUAL_CLOSE = true;
-        cfg.CATCHUP_COMPLETE = false;
-        cfg.CATCHUP_RECENT = 0;
-        cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
-        cfg.ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = UINT32_MAX;
-        cfg.PUBLIC_HTTP_PORT = false;
-        cfg.WORKER_THREADS = 1;
-        cfg.QUORUM_INTERSECTION_CHECKER = false;
-        cfg.PREFERRED_PEERS_ONLY = false;
-        cfg.RUN_STANDALONE = true;
-
-        return cfg;
-    };
-    auto simulation = std::make_shared<Simulation>(Simulation::OVER_LOOPBACK,
-                                                   networkID, confGen);
-
-    SIMULATION_CREATE_NODE(10);
-    SIMULATION_CREATE_NODE(11);
-
-    SCPQuorumSet qSet0;
-    qSet0.threshold = 2;
-    qSet0.validators.push_back(v10NodeID);
-    qSet0.validators.push_back(v11NodeID);
-
-    simulation->addNode(v10SecretKey, qSet0);
-    simulation->addNode(v11SecretKey, qSet0);
-
-    simulation->addPendingConnection(v10SecretKey.getPublicKey(),
-                                     v11SecretKey.getPublicKey());
-
-    simulation->startAllNodes();
-
-    // crank until nodes are connected
-    simulation->crankUntil(
-        [&]() {
-            auto nodes = simulation->getNodes();
-            auto numberOfSimulationConnections =
-                nodes[ACCEPTOR]
-                    ->getOverlayManager()
-                    .getAuthenticatedPeersCount() +
-                nodes[INITIATOR]
-                    ->getOverlayManager()
-                    .getAuthenticatedPeersCount();
-            return numberOfSimulationConnections == 2;
-        },
-        std::chrono::milliseconds{500}, false);
+    auto fuzzer = FuzzUtils::createFuzzer(processID, fuzzerMode);
+    fuzzer->initialize();
 
 // "To make this work, the library and this shim need to be compiled in LLVM
 // mode using afl-clang-fast (other compiler wrappers will *not* work)."
@@ -163,84 +61,10 @@ fuzz(std::string const& filename, el::Level logLevel,
     while (__AFL_LOOP(PERSIST_MAX))
 #endif // AFL_LLVM_MODE
     {
-        XDRInputFileStream in(MAX_MESSAGE_SIZE);
+        XDRInputFileStream in(fuzzer->xdrSizeLimit());
         in.open(filename);
-        StellarMessage msg;
-        while (tryRead(in, msg))
-        {
-            // HELLO, AUTH and ERROR_MSG messages cause the connection between
-            // the peers to drop. Since peer connections are only established
-            // preceding the persistent loop, a dropped peer is not only
-            // inconvenient, it also confuses the fuzzer. Consider a msg A sent
-            // before a peer is dropped and after a peer is dropped. The two,
-            // even though the same message, will take drastically different
-            // execution paths -- the fuzzer's main metric for determinism
-            // (stability) and binary coverage.
-            if (msg.type() == HELLO || msg.type() == AUTH ||
-                msg.type() == ERROR_MSG)
-                continue;
 
-            LOG(INFO) << "Fuzzer injecting message." << msgSummary(msg);
-
-            seedRandomness();
-
-            auto nodeids = simulation->getNodeIDs();
-
-            auto loopbackPeerConnection = simulation->getLoopbackConnection(
-                nodeids[INITIATOR], nodeids[ACCEPTOR]);
-
-            // ensure connection exists
-            assert(loopbackPeerConnection);
-
-            auto initiator = loopbackPeerConnection->getInitiator();
-            auto acceptor = loopbackPeerConnection->getAcceptor();
-
-            initiator->getApp().getClock().postToCurrentCrank(
-                [initiator, msg]() { initiator->Peer::sendMessage(msg); });
-
-            simulation->crankForAtMost(std::chrono::milliseconds{500}, false);
-
-            // clear all queues and cancel all events
-            initiator->clearInAndOutQueues();
-            acceptor->clearInAndOutQueues();
-
-            while (initiator->getApp().getClock().cancelAllEvents())
-                ;
-            while (acceptor->getApp().getClock().cancelAllEvents())
-                ;
-        }
-    }
-}
-
-void
-genfuzz(std::string const& filename)
-{
-    Logging::setFmt("<fuzz>");
-    size_t n = 3;
-    LOG(INFO) << "Writing " << n << "-message random fuzz file " << filename;
-    XDROutputFileStream out(/*doFsync=*/false);
-    out.open(filename);
-    autocheck::generator<StellarMessage> gen;
-    for (size_t i = 0; i < n; ++i)
-    {
-        try
-        {
-            StellarMessage m(gen(10));
-            // As more thoroughly explained above, we filter these messages
-            // since they cause peers to drop, leading to non-deterministic
-            // message injections, confusing the fuzzer.
-            while ((m.type() == HELLO || m.type() == AUTH ||
-                    m.type() == ERROR_MSG))
-            {
-                m = gen(10);
-            }
-            out.writeOne(m);
-            LOG(INFO) << "Message " << i << ": " << msgSummary(m);
-        }
-        catch (xdr::xdr_bad_discriminant const&)
-        {
-            LOG(INFO) << "Message " << i << ": malformed, omitted";
-        }
+        fuzzer->inject(in);
     }
 }
 }

--- a/src/test/fuzz.h
+++ b/src/test/fuzz.h
@@ -24,6 +24,6 @@ std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode);
 }
 
 void fuzz(std::string const& filename, el::Level logLevel,
-          std::vector<std::string> const& metrics);
-void genfuzz(std::string const& filename);
+          std::vector<std::string> const& metrics, uint processID,
+          FuzzerMode fuzzerMode);
 }

--- a/src/test/fuzz.h
+++ b/src/test/fuzz.h
@@ -9,6 +9,20 @@
 namespace stellar
 {
 
+class Fuzzer;
+
+enum class FuzzerMode
+{
+    OVERLAY,
+    TRANSACTION
+};
+
+namespace FuzzUtils
+{
+static auto const NUMBER_OF_PREGENERATED_ACCOUNTS = 16;
+std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode);
+}
+
 void fuzz(std::string const& filename, el::Level logLevel,
           std::vector<std::string> const& metrics);
 void genfuzz(std::string const& filename);

--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -30,6 +30,10 @@ SignatureChecker::checkSignature(AccountID const& accountID,
                                  std::vector<Signer> const& signersV,
                                  int neededWeight)
 {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    return true;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
     if (mProtocolVersion == 7)
     {
         return true;
@@ -119,6 +123,10 @@ SignatureChecker::checkSignature(AccountID const& accountID,
 bool
 SignatureChecker::checkAllSignaturesUsed() const
 {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    return true;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
     if (mProtocolVersion == 7)
     {
         return true;


### PR DESCRIPTION
# Some Background

Fuzzing is a test strategy that performs automated binary executions with randomly generated/mutated inputs, monitoring for program crashes. It is useful for increasing test coverage by discovery of obscure, unthought-of, and interesting edge cases.

The basic process works as so:
```
**Input**: an initial corpus of well formed data
1. Inputs fed into a program
2. Fuzzer derives more inputs (based on some gathered metrics like unique execution path)
3. Repeat
**Output**: inputs that caused crashes
```
There are many fuzz testing tools out there such as [libFuzzer](https://llvm.org/docs/LibFuzzer.html), [AFL](http://lcamtuf.coredump.cx/afl/), and [Peach Fuzzer](https://www.peach.tech/products/peach-fuzzer/). For the time being, I have implemented a test harness to work with AFL.

# Description

This builds on #2155, introducing a transaction subsystem fuzzer.

A significant portion of the work here was integrating the introduced transaction fuzzer with [AFL's persistent mode](https://lcamtuf.blogspot.com/2015/06/new-in-afl-persistent-mode.html). Persistent mode allows for multiple executions of the binary in a single long-lived process, significantly improving executions per second since the expensive state setup can be limited to every 1,000th, or even 1,000,000th execution. Areas where determinism improved include:
* foregoing signature verification (we aren't breaking ED25519 here)
* clearing caches
* seeding randomness

This PR also defines a common interface for fuzzing various subsystems, allowing one to utilize a CLI flag to switch between `Overlay` and `Transaction` fuzzing.

Finally, this PR includes an option to specify `process_id`, allowing for easy parallelization of fuzzing (as supported by AFL). 

Further progress of #1376 

# Future Work

### Generating transactions with more operations
To demonstrate functionality, I restricted the fuzzer to a subset of operations: `ACCOUNT_MERGE` and `PAYMENT` of native assets. Running against protocol 4, the fuzzer discovered the [double merge bug described here](https://www.stellar.org/developers/stellar-core/software/security-protocol-release-notes.html#v061b-not-widely-released-2017-04-06). This set will be expanded as I extend the fuzz test harness methodically, focusing first on discovery of the rest of the [historical bugs](https://www.stellar.org/developers/stellar-core/software/security-protocol-release-notes.html#v061b-not-widely-released-2017-04-06) in chronological order.

### Improving Fuzzer Efficiency
I also spent some time thinking about how to meaningfully and unobstructively limit the *fuzz space*. For example, I use a small set of pre-generated accounts for operations. Since I do this, and cause a disconnect between what the fuzzer fuzzes and what is actually fed to Stellar-core, cpu time spent incrementing and flipping bits in the `AccountID` property of XDR's is wasted time. Thus, I feed the fuzzer an initial corpus of operations with all bytes of the `AccountID`  zero'd out except for the 32nd byte to nudge it in the right direction.

***

### Note for Reviewers

Dependent on and rebased against #2155.

# Checklist
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
