### PR TITLE
Intersection criticality check

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -896,7 +896,24 @@ HerderImpl::getJsonTransitiveQuorumIntersectionInfo(bool fullKeys) const
         static_cast<Json::UInt64>(mLastQuorumMapIntersectionState.mNumNodes);
     ret["last_check_ledger"] = static_cast<Json::UInt64>(
         mLastQuorumMapIntersectionState.mLastCheckLedger);
-    if (!mLastQuorumMapIntersectionState.enjoysQuorunIntersection())
+    if (mLastQuorumMapIntersectionState.enjoysQuorunIntersection())
+    {
+        Json::Value critical;
+        for (auto const& group :
+             mLastQuorumMapIntersectionState.mIntersectionCriticalNodes)
+        {
+            Json::Value jg;
+            for (auto const& k : group)
+            {
+                auto s = (fullKeys ? mApp.getConfig().toStrKey(k)
+                                   : mApp.getConfig().toShortString(k));
+                jg.append(s);
+            }
+            critical.append(jg);
+        }
+        ret["critical"] = critical;
+    }
+    else
     {
         ret["last_good_ledger"] = static_cast<Json::UInt64>(
             mLastQuorumMapIntersectionState.mLastGoodLedger);
@@ -1109,16 +1126,27 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
             auto qic = QuorumIntersectionChecker::create(qmap, cfg);
             auto& hState = mLastQuorumMapIntersectionState;
             auto& app = mApp;
-            auto worker = [curr, ledger, nNodes, qic, &app, &hState] {
+            auto worker = [curr, ledger, nNodes, qic, qmap, cfg, &app,
+                           &hState] {
                 bool ok = qic->networkEnjoysQuorumIntersection();
                 auto split = qic->getPotentialSplit();
+                std::set<std::set<PublicKey>> critical;
+                if (ok)
+                {
+                    // Only bother calculating the _critical_ groups if we're
+                    // intersecting; if not intersecting we should finish ASAP
+                    // and raise an alarm.
+                    critical = QuorumIntersectionChecker::
+                        getIntersectionCriticalGroups(qmap, cfg);
+                }
                 app.postOnMainThread(
-                    [ok, curr, ledger, nNodes, split, &hState] {
+                    [ok, curr, ledger, nNodes, split, critical, &hState] {
                         hState.mRecalculating = false;
                         hState.mNumNodes = nNodes;
                         hState.mLastCheckLedger = ledger;
                         hState.mLastCheckQuorumMapHash = curr;
                         hState.mPotentialSplit = split;
+                        hState.mIntersectionCriticalNodes = critical;
                         if (ok)
                         {
                             hState.mLastGoodLedger = ledger;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -204,6 +204,7 @@ class HerderImpl : public Herder
         bool mRecalculating{false};
         std::pair<std::vector<PublicKey>, std::vector<PublicKey>>
             mPotentialSplit{};
+        std::set<std::set<PublicKey>> mIntersectionCriticalNodes{};
 
         bool
         hasAnyResults() const

--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -17,7 +17,7 @@ class QuorumIntersectionChecker
   public:
     static std::shared_ptr<QuorumIntersectionChecker>
     create(stellar::QuorumTracker::QuorumMap const& qmap,
-           stellar::Config const& cfg);
+           stellar::Config const& cfg, bool quiet = false);
 
     virtual ~QuorumIntersectionChecker(){};
     virtual bool networkEnjoysQuorumIntersection() const = 0;

--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -19,6 +19,10 @@ class QuorumIntersectionChecker
     create(stellar::QuorumTracker::QuorumMap const& qmap,
            stellar::Config const& cfg, bool quiet = false);
 
+    static std::set<std::set<PublicKey>>
+    getIntersectionCriticalGroups(stellar::QuorumTracker::QuorumMap const& qmap,
+                                  stellar::Config const& cfg);
+
     virtual ~QuorumIntersectionChecker(){};
     virtual bool networkEnjoysQuorumIntersection() const = 0;
     virtual size_t getMaxQuorumsFound() const = 0;

--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -764,6 +764,75 @@ QuorumIntersectionCheckerImpl::networkEnjoysQuorumIntersection() const
     }
     return !foundDisjoint;
 }
+
+bool
+pointsToCandidate(SCPQuorumSet const& p, PublicKey const& candidate)
+{
+    for (auto const& k : p.validators)
+    {
+        if (k == candidate)
+        {
+            return true;
+        }
+    }
+    for (auto const& i : p.innerSets)
+    {
+        if (pointsToCandidate(i, candidate))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+void
+findCriticalityCandidates(SCPQuorumSet const& p,
+                          std::set<std::set<PublicKey>>& candidates, bool root)
+{
+    // Make a singleton-set for every validator, always.
+    for (auto const& k : p.validators)
+    {
+        std::set<PublicKey> singleton{k};
+        candidates.insert(singleton);
+    }
+
+    // Not-root and no-innerSets => P is a leaf group;
+    // record it!
+    if (!root && p.innerSets.empty())
+    {
+        std::set<PublicKey> inner;
+        for (auto const& k : p.validators)
+        {
+            inner.insert(k);
+        }
+        candidates.insert(inner);
+    }
+
+    // Scan innerSets recursively.
+    for (auto const& i : p.innerSets)
+    {
+        findCriticalityCandidates(i, candidates, false);
+    }
+}
+
+std::string
+groupString(Config const& cfg, std::set<PublicKey> const& group)
+{
+    std::ostringstream out;
+    bool first = true;
+    out << '[';
+    for (auto const& k : group)
+    {
+        if (!first)
+        {
+            out << ", ";
+        }
+        first = false;
+        out << cfg.toShortString(k);
+    }
+    out << ']';
+    return out.str();
+}
 }
 
 namespace stellar
@@ -773,5 +842,127 @@ QuorumIntersectionChecker::create(QuorumTracker::QuorumMap const& qmap,
                                   Config const& cfg, bool quiet)
 {
     return std::make_shared<QuorumIntersectionCheckerImpl>(qmap, cfg, quiet);
+}
+
+std::set<std::set<PublicKey>>
+QuorumIntersectionChecker::getIntersectionCriticalGroups(
+    stellar::QuorumTracker::QuorumMap const& qmap, stellar::Config const& cfg)
+{
+    // We're going to search for "intersection-critical" groups, by considering
+    // each SCPQuorumSet S that (a) has no innerSets of its own and (b) occurs
+    // as an innerSet of anyone in the qmap, and evaluating whether the group of
+    // validators in S can cause the network to split if they're reconfigured to
+    // be "fickle". Any group whose fickleness can cause a split is considered
+    // "intersection-critical". We also consider every individual node as a
+    // singleton group, though these are typically unlikely to cause a split
+    // on their own when made-fickle.
+    //
+    // Specifically a group is "fickle" if its threshold is 2 and the set of
+    // validators it has to choose from has two innerSets: one that's the group
+    // itself, and one that contains everyone that depends on any member of the
+    // group. In other words the group will "go along with anyone". This is an
+    // overapproximation of "bad configutation": the group's still online and
+    // behaving correctly, but someone really messed up its configuration.
+    //
+    // This is a less-dramatic (and more likely) behaviour than true Byzantine
+    // failure. To model the risk of Byzantine nodes we'd remove the nodes
+    // entirely and reduce the thresholds of nodes depending on them,
+    // effectively making the Byzantine node "voting different ways in different
+    // quorums", appearing to be in two separate quorums while not counting as
+    // an intersection. A merely _fickle_ node will participate in any quorum
+    // that asks, but still counts as an intersecting member of any two quorums
+    // it's a member of.
+
+    std::set<std::set<PublicKey>> candidates;
+    std::set<std::set<PublicKey>> critical;
+    QuorumTracker::QuorumMap test_qmap(qmap);
+
+    for (auto const& k : qmap)
+    {
+        if (k.second)
+        {
+            findCriticalityCandidates(*(k.second), candidates, true);
+        }
+    }
+
+    CLOG(INFO, "SCP") << "Examininng " << candidates.size()
+                      << " node groups for intersection-criticality";
+
+    for (auto const& group : candidates)
+    {
+        // Every member of the group will share the same fickle qset.
+        auto fickleQSet = std::make_shared<SCPQuorumSet>();
+
+        // The fickle qset has 2 innerSets: self and others.
+        SCPQuorumSet groupQSet;
+        SCPQuorumSet pointsToGroupQSet;
+
+        for (auto const& k : group)
+        {
+            groupQSet.validators.emplace_back(k);
+        }
+        groupQSet.threshold = group.size();
+
+        std::set<PublicKey> pointsToGroup;
+        for (PublicKey const& candidate : group)
+        {
+            for (auto const& d : qmap)
+            {
+                if (group.find(d.first) == group.end() && d.second &&
+                    pointsToCandidate(*d.second, candidate))
+                {
+                    pointsToGroup.insert(d.first);
+                }
+            }
+        }
+        for (auto const& p : pointsToGroup)
+        {
+            pointsToGroupQSet.validators.emplace_back(p);
+        }
+        pointsToGroupQSet.threshold = 1;
+
+        fickleQSet->innerSets.emplace_back(std::move(groupQSet));
+        fickleQSet->innerSets.emplace_back(std::move(pointsToGroupQSet));
+        fickleQSet->threshold = 2;
+
+        // Install the fickle qset in every member of the group.
+        for (auto const& candidate : group)
+        {
+            test_qmap[candidate] = fickleQSet;
+        }
+
+        // Check to see if this modified config is vulnerable to splitting.
+        auto checker = QuorumIntersectionChecker::create(test_qmap, cfg,
+                                                         /*quiet=*/true);
+        if (checker->networkEnjoysQuorumIntersection())
+        {
+            CLOG(DEBUG, "SCP") << "group is not intersection-critical: "
+                               << groupString(cfg, group) << " (with "
+                               << pointsToGroup.size() << " depending nodes)";
+        }
+        else
+        {
+            CLOG(WARNING, "SCP")
+                << "Group is intersection-critical: " << groupString(cfg, group)
+                << " (with " << pointsToGroup.size() << " depending nodes)";
+            critical.insert(group);
+        }
+
+        // Restore proper qsets for all group members, for next iteration.
+        for (auto const& candidate : group)
+        {
+            test_qmap[candidate] = qmap.find(candidate)->second;
+        }
+    }
+    if (critical.empty())
+    {
+        CLOG(INFO, "SCP") << "No intersection-critical groups found";
+    }
+    else
+    {
+        CLOG(WARNING, "SCP")
+            << "Found " << critical.size() << " intersection-critical groups";
+    }
+    return critical;
 }
 }

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -486,6 +486,10 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     mutable Stats mStats;
     bool mLogTrace;
 
+    // When run as a subroutine of criticality-checking, we inhibit
+    // INFO/ERROR/WARNING level messages.
+    bool mQuiet;
+
     // State to capture a counterexample found during search, for later
     // reporting.
     mutable std::pair<std::vector<stellar::PublicKey>,
@@ -521,7 +525,8 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
 
   public:
     QuorumIntersectionCheckerImpl(stellar::QuorumTracker::QuorumMap const& qmap,
-                                  stellar::Config const& cfg);
+                                  stellar::Config const& cfg,
+                                  bool quiet = false);
     bool networkEnjoysQuorumIntersection() const override;
 
     std::pair<std::vector<stellar::PublicKey>, std::vector<stellar::PublicKey>>


### PR DESCRIPTION
Followup to #2127 : this adds a secondary check for "intersection-criticality", which is a somewhat made-up notion that attempts to capture when we're "one serious misconfiguration away" from non-intersection. The approach is described in detail in comments, but briefly:

  - We find all sets of leaf-nodes in qsets, and consider them candidate groups.
  - For each group, we run the quorum intersection checker on a modified graph in which the group's members have all been made "fickle", which is an overapproximation (for purposes of evaluating splitting risk) of "misconfiguration" that makes them willing to join (vote-for) any quorum of any node that depends on a node in the group.

This "fickleness" condition is weaker (and much more likely) than a byzantine failure: fickle nodes still model an intersecting, singly-voting node if they're a member of two quorums (i.e. we're not simulating them voting one way in one quorum and another way in another), they're just behaving as though someone set their threshold too low and/or over-connected them.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

Still probably needs another few tests (took me forever to work out one that even works) and adjustment to the docs to describe the new field in the info / quorum endpoints. But ready for initial review I think.