### PR TITLE
Audit retries of the Work subsystem

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -26,7 +26,7 @@ ApplyBucketsWork::ApplyBucketsWork(
     Application& app,
     std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
     HistoryArchiveState const& applyState, uint32_t maxProtocolVersion)
-    : BasicWork(app, "apply-buckets", RETRY_A_FEW)
+    : BasicWork(app, "apply-buckets", BasicWork::RETRY_NEVER)
     , mBuckets(buckets)
     , mApplyState(applyState)
     , mApplying(false)

--- a/src/catchup/ApplyLedgerChainWork.cpp
+++ b/src/catchup/ApplyLedgerChainWork.cpp
@@ -26,7 +26,7 @@ namespace stellar
 ApplyLedgerChainWork::ApplyLedgerChainWork(
     Application& app, TmpDir const& downloadDir, LedgerRange range,
     LedgerHeaderHistoryEntry& lastApplied)
-    : BasicWork(app, "apply-ledger-chain", RETRY_NEVER)
+    : BasicWork(app, "apply-ledger-chain", BasicWork::RETRY_NEVER)
     , mDownloadDir(downloadDir)
     , mRange(range)
     , mLastApplied(lastApplied)

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -25,7 +25,7 @@ namespace stellar
 CatchupWork::CatchupWork(Application& app,
                          CatchupConfiguration catchupConfiguration,
                          ProgressHandler progressHandler)
-    : Work(app, "catchup", Work::RETRY_NEVER)
+    : Work(app, "catchup", BasicWork::RETRY_NEVER)
     , mLocalState{app.getHistoryManager().getLastClosedHistoryArchiveState()}
     , mDownloadDir{std::make_unique<TmpDir>(
           mApp.getTmpDirManager().tmpDir(getName()))}

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -81,7 +81,7 @@ verifyLastLedgerInCheckpoint(LedgerHeaderHistoryEntry const& ledger,
 VerifyLedgerChainWork::VerifyLedgerChainWork(
     Application& app, TmpDir const& downloadDir, LedgerRange range,
     LedgerNumHashPair const& lastClosedLedger, LedgerNumHashPair ledgerRangeEnd)
-    : BasicWork(app, "verify-ledger-chain", RETRY_NEVER)
+    : BasicWork(app, "verify-ledger-chain", BasicWork::RETRY_NEVER)
     , mDownloadDir(downloadDir)
     , mRange(range)
     , mCurrCheckpoint(

--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -13,9 +13,9 @@ namespace stellar
 
 GetAndUnzipRemoteFileWork::GetAndUnzipRemoteFileWork(
     Application& app, FileTransferInfo ft,
-    std::shared_ptr<HistoryArchive> archive, size_t maxRetries)
+    std::shared_ptr<HistoryArchive> archive)
     : Work(app, std::string("get-and-unzip-remote-file ") + ft.remoteName(),
-           maxRetries)
+           BasicWork::RETRY_A_LOT)
     , mFt(std::move(ft))
     , mArchive(archive)
     , mDownloadStart(app.getMetrics().NewMeter(
@@ -93,8 +93,8 @@ GetAndUnzipRemoteFileWork::doWork()
             {
                 return State::WORK_FAILURE;
             }
-            mGunzipFileWork =
-                addWork<GunzipFileWork>(mFt.localPath_gz(), false, RETRY_NEVER);
+            mGunzipFileWork = addWork<GunzipFileWork>(mFt.localPath_gz(), false,
+                                                      BasicWork::RETRY_NEVER);
             return State::WORK_RUNNING;
         }
         return state;
@@ -103,8 +103,9 @@ GetAndUnzipRemoteFileWork::doWork()
     {
         CLOG(DEBUG, "History")
             << "Downloading and unzipping " << mFt.remoteName();
-        mGetRemoteFileWork = addWork<GetRemoteFileWork>(
-            mFt.remoteName(), mFt.localPath_gz_tmp(), nullptr, RETRY_NEVER);
+        mGetRemoteFileWork =
+            addWork<GetRemoteFileWork>(mFt.remoteName(), mFt.localPath_gz_tmp(),
+                                       nullptr, BasicWork::RETRY_NEVER);
         mDownloadStart.Mark();
         return State::WORK_RUNNING;
     }

--- a/src/historywork/GetAndUnzipRemoteFileWork.h
+++ b/src/historywork/GetAndUnzipRemoteFileWork.h
@@ -32,9 +32,9 @@ class GetAndUnzipRemoteFileWork : public Work
     // Passing `nullptr` for the archive argument will cause the work to
     // select a new readable history archive at random each time it runs /
     // retries.
-    GetAndUnzipRemoteFileWork(Application& app, FileTransferInfo ft,
-                              std::shared_ptr<HistoryArchive> archive = nullptr,
-                              size_t maxRetries = BasicWork::RETRY_A_LOT);
+    GetAndUnzipRemoteFileWork(
+        Application& app, FileTransferInfo ft,
+        std::shared_ptr<HistoryArchive> archive = nullptr);
     ~GetAndUnzipRemoteFileWork() = default;
     std::string getStatus() const override;
 

--- a/src/historywork/GzipFileWork.cpp
+++ b/src/historywork/GzipFileWork.cpp
@@ -10,7 +10,8 @@ namespace stellar
 
 GzipFileWork::GzipFileWork(Application& app, std::string const& filenameNoGz,
                            bool keepExisting)
-    : RunCommandWork(app, std::string("gzip-file ") + filenameNoGz)
+    : RunCommandWork(app, std::string("gzip-file ") + filenameNoGz,
+                     BasicWork::RETRY_A_LOT)
     , mFilenameNoGz(filenameNoGz)
     , mKeepExisting(keepExisting)
 {

--- a/src/historywork/MakeRemoteDirWork.cpp
+++ b/src/historywork/MakeRemoteDirWork.cpp
@@ -11,7 +11,8 @@ namespace stellar
 
 MakeRemoteDirWork::MakeRemoteDirWork(Application& app, std::string const& dir,
                                      std::shared_ptr<HistoryArchive> archive)
-    : RunCommandWork(app, std::string("make-remote-dir ") + dir)
+    : RunCommandWork(app, std::string("make-remote-dir ") + dir,
+                     BasicWork::RETRY_A_LOT)
     , mDir(dir)
     , mArchive(archive)
 {

--- a/src/historywork/PublishWork.cpp
+++ b/src/historywork/PublishWork.cpp
@@ -19,7 +19,7 @@ PublishWork::PublishWork(Application& app,
     : WorkSequence(
           app,
           fmt::format("publish-{:08x}", snapshot->mLocalState.currentLedger),
-          seq)
+          seq, BasicWork::RETRY_NEVER)
     , mSnapshot(snapshot)
     , mOriginalBuckets(mSnapshot->mLocalState.allBuckets())
 {

--- a/src/historywork/PutRemoteFileWork.cpp
+++ b/src/historywork/PutRemoteFileWork.cpp
@@ -11,7 +11,8 @@ namespace stellar
 PutRemoteFileWork::PutRemoteFileWork(Application& app, std::string const& local,
                                      std::string const& remote,
                                      std::shared_ptr<HistoryArchive> archive)
-    : RunCommandWork(app, std::string("put-remote-file ") + remote)
+    : RunCommandWork(app, std::string("put-remote-file ") + remote,
+                     BasicWork::RETRY_A_LOT)
     , mLocal(local)
     , mRemote(remote)
     , mArchive(archive)

--- a/src/historywork/RepairMissingBucketsWork.cpp
+++ b/src/historywork/RepairMissingBucketsWork.cpp
@@ -17,7 +17,7 @@ namespace stellar
 
 RepairMissingBucketsWork::RepairMissingBucketsWork(
     Application& app, HistoryArchiveState const& localState, Handler endHandler)
-    : Work(app, "repair-buckets", RETRY_NEVER)
+    : Work(app, "repair-buckets", BasicWork::RETRY_NEVER)
     , mEndHandler(endHandler)
     , mLocalState(localState)
     , mDownloadDir(std::make_unique<TmpDir>(

--- a/src/historywork/ResolveSnapshotWork.cpp
+++ b/src/historywork/ResolveSnapshotWork.cpp
@@ -12,7 +12,7 @@ namespace stellar
 
 ResolveSnapshotWork::ResolveSnapshotWork(
     Application& app, std::shared_ptr<StateSnapshot> snapshot)
-    : BasicWork(app, "prepare-snapshot", Work::RETRY_NEVER)
+    : BasicWork(app, "prepare-snapshot", BasicWork::RETRY_NEVER)
     , mSnapshot(snapshot)
     , mTimer(std::make_unique<VirtualTimer>(app.getClock()))
 {

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -23,7 +23,7 @@ namespace stellar
 VerifyBucketWork::VerifyBucketWork(
     Application& app, std::map<std::string, std::shared_ptr<Bucket>>& buckets,
     std::string const& bucketFile, uint256 const& hash)
-    : BasicWork(app, "verify-bucket-hash-" + bucketFile, RETRY_NEVER)
+    : BasicWork(app, "verify-bucket-hash-" + bucketFile, BasicWork::RETRY_NEVER)
     , mBuckets(buckets)
     , mBucketFile(bucketFile)
     , mHash(hash)

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -12,9 +12,13 @@
 namespace stellar
 {
 
+// Note, WriteSnapshotWork does not have any special retry clean-up logic:
+// history items are written via XDROutputFileStream, which automatically
+// truncates any existing files.
 WriteSnapshotWork::WriteSnapshotWork(Application& app,
                                      std::shared_ptr<StateSnapshot> snapshot)
-    : BasicWork(app, "write-snapshot", Work::RETRY_A_LOT), mSnapshot(snapshot)
+    : BasicWork(app, "write-snapshot", BasicWork::RETRY_A_LOT)
+    , mSnapshot(snapshot)
 {
 }
 

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -14,7 +14,6 @@ size_t const BasicWork::RETRY_NEVER = 0;
 size_t const BasicWork::RETRY_ONCE = 1;
 size_t const BasicWork::RETRY_A_FEW = 5;
 size_t const BasicWork::RETRY_A_LOT = 32;
-size_t const BasicWork::RETRY_FOREVER = 0xffffffff;
 
 std::set<BasicWork::Transition> const BasicWork::ALLOWED_TRANSITIONS = {
     Transition(InternalState::PENDING, InternalState::RUNNING),
@@ -352,8 +351,8 @@ BasicWork::crankWork()
 VirtualClock::duration
 BasicWork::getRetryDelay() const
 {
-    // Cap to 4096sec == a little over an hour.
-    uint64_t m = 2 << std::min(uint64_t(12), uint64_t(mRetries));
+    // Cap to 512 sec or ~8 minutes
+    uint64_t m = 2 << std::min(uint64_t(8), uint64_t(mRetries));
     return std::chrono::seconds(rand_uniform<uint64_t>(1ULL, m));
 }
 

--- a/src/work/BasicWork.h
+++ b/src/work/BasicWork.h
@@ -101,7 +101,6 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
     static size_t const RETRY_ONCE;
     static size_t const RETRY_A_FEW;
     static size_t const RETRY_A_LOT;
-    static size_t const RETRY_FOREVER;
 
     // Publicly exposed state of work
     enum class State

--- a/src/work/BatchWork.cpp
+++ b/src/work/BatchWork.cpp
@@ -11,7 +11,7 @@ namespace stellar
 {
 
 BatchWork::BatchWork(Application& app, std::string name)
-    : Work(app, name, RETRY_NEVER)
+    : Work(app, name, BasicWork::RETRY_NEVER)
 {
 }
 

--- a/src/work/test/WorkTests.cpp
+++ b/src/work/test/WorkTests.cpp
@@ -35,7 +35,7 @@ class TestBasicWork : public BasicWork
     int mAbortCount{0};
 
     TestBasicWork(Application& app, std::string name, bool fail = false,
-                  int steps = 3, size_t retries = RETRY_ONCE)
+                  int steps = 3, size_t retries = BasicWork::RETRY_ONCE)
         : BasicWork(app, std::move(name), retries)
         , mShouldFail(fail)
         , mNumSteps(steps)
@@ -268,7 +268,7 @@ class TestWork : public Work
     int mRetryCount{0};
 
     TestWork(Application& app, std::string name)
-        : Work(app, std::move(name), RETRY_NEVER)
+        : Work(app, std::move(name), BasicWork::RETRY_NEVER)
     {
     }
 


### PR DESCRIPTION
tl;dr we're retrying too many times, which could cause big delays

This PR does some cleanup of work retries. The downside of retrying as we currently do is that there could be some strange edge cases where all works and its children fail, and because we use random exponential backoff for each retry, it can create pretty big delays. Some important changes:
* GetAndUnzipRemoteFile work now retries less
* A few publish-related works that manage sequences do not really need to retry, as individual sequences handle that already. 
* WriteSnapshotWork was also retrying 32 times, but I suspect the biggest cause for its failure is no disk space, so it probably only needs to retry a couple times. 

This should also resolve #1261 