### PR TITLE
Make `fullkeys` behavior consistent across endpoints

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -165,8 +165,9 @@ format.
   Clear metrics for a specified domain. If no domain specified, clear all
   metrics (for testing purposes).
 
-* **peers**
+* **peers?[&fullkeys=true]**
   Returns the list of known peers in JSON format.
+  If `fullkeys` is set, outputs unshortened public keys.
 
 * **quorum**
   `quorum?[node=NODE_ID][&compact=true][&fullkeys=true][&transitive=true]`<br>

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -879,8 +879,8 @@ Json::Value
 HerderImpl::getJsonInfo(size_t limit, bool fullKeys)
 {
     Json::Value ret;
-    ret["you"] =
-        mApp.getConfig().toStrKey(mApp.getConfig().NODE_SEED.getPublicKey());
+    ret["you"] = mApp.getConfig().toStrKey(
+        mApp.getConfig().NODE_SEED.getPublicKey(), fullKeys);
 
     ret["scp"] = getSCP().getJsonInfo(limit, fullKeys);
     ret["queue"] = mPendingEnvelopes.getJsonInfo(limit);
@@ -906,8 +906,7 @@ HerderImpl::getJsonTransitiveQuorumIntersectionInfo(bool fullKeys) const
             Json::Value jg;
             for (auto const& k : group)
             {
-                auto s = (fullKeys ? mApp.getConfig().toStrKey(k)
-                                   : mApp.getConfig().toShortString(k));
+                auto s = mApp.getConfig().toStrKey(k, fullKeys);
                 jg.append(s);
             }
             critical.append(jg);
@@ -922,14 +921,12 @@ HerderImpl::getJsonTransitiveQuorumIntersectionInfo(bool fullKeys) const
         auto const& pair = mLastQuorumMapIntersectionState.mPotentialSplit;
         for (auto const& k : pair.first)
         {
-            auto s = (fullKeys ? mApp.getConfig().toStrKey(k)
-                               : mApp.getConfig().toShortString(k));
+            auto s = mApp.getConfig().toStrKey(k, fullKeys);
             a.append(s);
         }
         for (auto const& k : pair.second)
         {
-            auto s = (fullKeys ? mApp.getConfig().toStrKey(k)
-                               : mApp.getConfig().toShortString(k));
+            auto s = mApp.getConfig().toStrKey(k, fullKeys);
             b.append(s);
         }
         split.append(a);
@@ -944,8 +941,7 @@ HerderImpl::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
                               uint64 index)
 {
     Json::Value ret;
-    ret["node"] = (fullKeys ? mApp.getConfig().toStrKey(id)
-                            : mApp.getConfig().toShortString(id));
+    ret["node"] = mApp.getConfig().toStrKey(id, fullKeys);
     ret["qset"] = getSCP().getJsonQuorumInfo(id, summary, fullKeys, index);
     bool isSelf = id == mApp.getConfig().NODE_SEED.getPublicKey();
     if (isSelf && mLastQuorumMapIntersectionState.hasAnyResults())
@@ -989,8 +985,7 @@ HerderImpl::getJsonTransitiveQuorumInfo(NodeID const& rootID, bool summary,
         {
             Json::Value cur;
             valGenID++;
-            cur["node"] = fullKeys ? mApp.getConfig().toStrKey(id)
-                                   : mApp.getConfig().toShortString(id);
+            cur["node"] = mApp.getConfig().toStrKey(id, fullKeys);
             if (!summary)
             {
                 cur["distance"] = distance;

--- a/src/history/InferredQuorum.cpp
+++ b/src/history/InferredQuorum.cpp
@@ -112,13 +112,12 @@ InferredQuorum::toString(Config const& cfg) const
 
     for (auto const& pair : mPubKeys)
     {
-        auto isAlias = false;
-        auto name = cfg.toStrKey(pair.first, isAlias);
+        auto name = cfg.toStrKey(pair.first);
         if (pair.second < thresh)
         {
             out << "# skipping unreliable "
                 << "(" << pair.second << "/" << thresh << ") node: " << '"'
-                << (isAlias ? "$" : "") << name << '"' << std::endl;
+                << name << '"' << std::endl;
         }
     }
 
@@ -131,8 +130,7 @@ InferredQuorum::toString(Config const& cfg) const
         {
             continue;
         }
-        auto isAlias = false;
-        auto name = cfg.toStrKey(pair.first, isAlias);
+        auto name = cfg.toStrKey(pair.first);
         if (first)
         {
             first = false;
@@ -141,7 +139,7 @@ InferredQuorum::toString(Config const& cfg) const
         {
             out << "," << std::endl;
         }
-        out << '"' << (isAlias ? "$" : "") << name << '"';
+        out << '"' << name << '"';
     }
     out << std::endl << "]" << std::endl;
     return out.str();

--- a/src/history/InferredQuorum.cpp
+++ b/src/history/InferredQuorum.cpp
@@ -96,7 +96,7 @@ InferredQuorum::notePubKey(PublicKey const& pk)
 }
 
 std::string
-InferredQuorum::toString(Config const& cfg) const
+InferredQuorum::toString(Config const& cfg, bool fullKeys) const
 {
     std::ostringstream out;
 
@@ -112,7 +112,7 @@ InferredQuorum::toString(Config const& cfg) const
 
     for (auto const& pair : mPubKeys)
     {
-        auto name = cfg.toStrKey(pair.first);
+        auto name = cfg.toStrKey(pair.first, fullKeys);
         if (pair.second < thresh)
         {
             out << "# skipping unreliable "
@@ -130,7 +130,7 @@ InferredQuorum::toString(Config const& cfg) const
         {
             continue;
         }
-        auto name = cfg.toStrKey(pair.first);
+        auto name = cfg.toStrKey(pair.first, fullKeys);
         if (first)
         {
             first = false;

--- a/src/history/InferredQuorum.h
+++ b/src/history/InferredQuorum.h
@@ -26,7 +26,7 @@ struct InferredQuorum
     void noteQset(SCPQuorumSet const& qset);
     void noteQsetHash(PublicKey const& pk, Hash const& hash);
     void notePubKey(PublicKey const& pk);
-    std::string toString(Config const& cfg) const;
+    std::string toString(Config const& cfg, bool fullKeys) const;
     void writeQuorumGraph(Config const& cfg, std::ostream& out) const;
     QuorumTracker::QuorumMap getQuorumMap() const;
 };

--- a/src/history/InferredQuorumUtils.cpp
+++ b/src/history/InferredQuorumUtils.cpp
@@ -58,7 +58,7 @@ inferQuorumAndWrite(Config const& cfg, uint32_t ledgerNum)
         iq = InferredQuorum(qmap);
     }
     LOG(INFO) << "Inferred quorum";
-    std::cout << iq.toString(cfg2) << std::endl;
+    std::cout << iq.toString(cfg2, true) << std::endl;
 }
 
 void

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -201,8 +201,12 @@ parseParam(std::map<std::string, std::string> const& map,
 }
 
 void
-CommandHandler::peers(std::string const&, std::string& retStr)
+CommandHandler::peers(std::string const& params, std::string& retStr)
 {
+    std::map<std::string, std::string> retMap;
+    http::server::server::parseParams(params, retMap);
+
+    bool fullKeys = retMap["fullkeys"] == "true";
     Json::Value root;
 
     auto& pendingPeers = root["pending_peers"];
@@ -232,7 +236,8 @@ CommandHandler::peers(std::string const&, std::string& retStr)
                 peerNode["address"] = peer.second->toString();
                 peerNode["ver"] = peer.second->getRemoteVersion();
                 peerNode["olver"] = (int)peer.second->getRemoteOverlayVersion();
-                peerNode["id"] = mApp.getConfig().toStrKey(peer.first);
+                peerNode["id"] =
+                    mApp.getConfig().toStrKey(peer.first, fullKeys);
             }
         };
     addAuthenticatedPeers(

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1264,27 +1264,18 @@ Config::toShortString(PublicKey const& pk) const
 }
 
 std::string
-Config::toStrKeyAuto(PublicKey const& pk, bool& isAlias) const
+Config::toStrKey(PublicKey const& pk, bool fullKey) const
 {
-    std::string ret = KeyUtils::toStrKey(pk);
-    auto it = VALIDATOR_NAMES.find(ret);
-    if (it == VALIDATOR_NAMES.end())
+    std::string res;
+    if (fullKey)
     {
-        isAlias = false;
-        return ret;
+        res = KeyUtils::toStrKey(pk);
     }
     else
     {
-        isAlias = true;
-        return it->second;
+        res = toShortString(pk);
     }
-}
-
-std::string
-Config::toStrKey(PublicKey const& pk) const
-{
-    bool isAlias;
-    return toStrKeyAuto(pk, isAlias);
+    return res;
 }
 
 bool

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1264,7 +1264,7 @@ Config::toShortString(PublicKey const& pk) const
 }
 
 std::string
-Config::toStrKey(PublicKey const& pk, bool& isAlias) const
+Config::toStrKeyAuto(PublicKey const& pk, bool& isAlias) const
 {
     std::string ret = KeyUtils::toStrKey(pk);
     auto it = VALIDATOR_NAMES.find(ret);
@@ -1284,7 +1284,7 @@ std::string
 Config::toStrKey(PublicKey const& pk) const
 {
     bool isAlias;
-    return toStrKey(pk, isAlias);
+    return toStrKeyAuto(pk, isAlias);
 }
 
 bool

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -308,8 +308,10 @@ class Config : public std::enable_shared_from_this<Config>
     void adjust();
 
     std::string toShortString(PublicKey const& pk) const;
-    std::string toStrKeyAuto(PublicKey const& pk, bool& isAlias) const;
-    std::string toStrKey(PublicKey const& pk) const;
+
+    // fullKey true => returns full StrKey corresponding to pk
+    //  otherwise, returns alias or shortString equivalent
+    std::string toStrKey(PublicKey const& pk, bool fullKey) const;
 
     bool resolveNodeID(std::string const& s, PublicKey& retKey) const;
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -308,8 +308,9 @@ class Config : public std::enable_shared_from_this<Config>
     void adjust();
 
     std::string toShortString(PublicKey const& pk) const;
-    std::string toStrKey(PublicKey const& pk, bool& isAlias) const;
+    std::string toStrKeyAuto(PublicKey const& pk, bool& isAlias) const;
     std::string toStrKey(PublicKey const& pk) const;
+
     bool resolveNodeID(std::string const& s, PublicKey& retKey) const;
 
     std::chrono::seconds getExpectedLedgerCloseTime() const;

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -781,7 +781,8 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
         if (std::find(pk.begin(), pk.end(), kstr) != pk.end())
         {
             CLOG(DEBUG, "Overlay")
-                << "Peer key " << mApp.getConfig().toStrKey(peer->getPeerID())
+                << "Peer key "
+                << mApp.getConfig().toShortString(peer->getPeerID())
                 << " is preferred";
             return true;
         }


### PR DESCRIPTION
# Description

Resolves #2191 

This PR makes the behavior of `fullkeys` consistent across the entire code base:
when specified, aliases are never returned and by default we return either aliases or short keys

This PR also adds support for `fullkeys` to the "peers" endpoint
