### PR TITLE
XDR: fsync on close (also bucket dir), with option to disable.

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -366,6 +366,18 @@ ALLOW_LOCALHOST_FOR_TESTING=false
 # unlikely to be for the latest ledger.
 MAXIMUM_LEDGER_CLOSETIME_DRIFT=50
 
+# DISABLE_XDR_FSYNC (true or false) defaults to false.
+# If set to true, writing an XDR file (a bucket or a checkpoint) will not
+# be followed by an fsync on the file. This in turn means that XDR files
+# (which hold the canonical state of the ledger) may be corrupted if the
+# operating system suddenly crashes or loses power, causing the node to
+# diverge and get stuck on restart, or potentially even publish bad
+# history. This option only exists as an escape hatch if the local
+# filesystem is so unusably slow that you prefer operating without
+# durability guarantees. Do not set it to true unless you're very certain
+# you want to make that trade.
+DISABLE_XDR_FSYNC=false
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -137,7 +137,8 @@ std::shared_ptr<Bucket>
 Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
               std::vector<LedgerEntry> const& initEntries,
               std::vector<LedgerEntry> const& liveEntries,
-              std::vector<LedgerKey> const& deadEntries, bool countMergeEvents)
+              std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
+              bool doFsync)
 {
     // When building fresh buckets after protocol version 10 (i.e. version
     // 11-or-after) we differentiate INITENTRY from LIVEENTRY. In older
@@ -151,7 +152,8 @@ Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
         convertToBucketEntry(useInit, initEntries, liveEntries, deadEntries);
 
     MergeCounters mc;
-    BucketOutputIterator out(bucketManager.getTmpDir(), true, meta, mc);
+    BucketOutputIterator out(bucketManager.getTmpDir(), true, meta, mc,
+                             doFsync);
     for (auto const& e : entries)
     {
         out.put(e);
@@ -566,7 +568,7 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
               std::shared_ptr<Bucket> const& oldBucket,
               std::shared_ptr<Bucket> const& newBucket,
               std::vector<std::shared_ptr<Bucket>> const& shadows,
-              bool keepDeadEntries, bool countMergeEvents)
+              bool keepDeadEntries, bool countMergeEvents, bool doFsync)
 {
     // This is the key operation in the scheme: merging two (read-only)
     // buckets together into a new 3rd bucket, while calculating its hash,
@@ -591,7 +593,7 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
     BucketMetadata meta;
     meta.ledgerVersion = protocolVersion;
     BucketOutputIterator out(bucketManager.getTmpDir(), keepDeadEntries, meta,
-                             mc);
+                             mc, doFsync);
 
     BucketEntryIdCmp cmp;
     while (oi || ni)

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -83,7 +83,8 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     fresh(BucketManager& bucketManager, uint32_t protocolVersion,
           std::vector<LedgerEntry> const& initEntries,
           std::vector<LedgerEntry> const& liveEntries,
-          std::vector<LedgerKey> const& deadEntries, bool countMergeEvents);
+          std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
+          bool doFsync);
 
     // Merge two buckets together, producing a fresh one. Entries in `oldBucket`
     // are overridden in the fresh bucket by keywise-equal entries in
@@ -101,6 +102,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
           std::shared_ptr<Bucket> const& oldBucket,
           std::shared_ptr<Bucket> const& newBucket,
           std::vector<std::shared_ptr<Bucket>> const& shadows,
-          bool keepDeadEntries, bool countMergeEvents);
+          bool keepDeadEntries, bool countMergeEvents, bool doFsync);
 };
 }

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -527,11 +527,12 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
     // and we are checking for an expected number of merge events on restart.
     bool countMergeEvents =
         !app.getConfig().ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING;
+    bool doFsync = !app.getConfig().DISABLE_XDR_FSYNC;
     assert(shadows.size() == 0);
     mLevels[0].prepare(app, currLedger, currLedgerProtocol,
                        Bucket::fresh(app.getBucketManager(), currLedgerProtocol,
                                      initEntries, liveEntries, deadEntries,
-                                     countMergeEvents),
+                                     countMergeEvents, doFsync),
                        shadows, countMergeEvents);
     mLevels[0].commit();
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -66,6 +66,7 @@ class BucketManagerImpl : public BucketManager
     std::set<Hash> getReferencedBuckets() const;
     void cleanupStaleFiles();
     void cleanDir();
+    bool renameBucket(std::string const& src, std::string const& dst);
 
 #ifdef BUILD_TESTS
     bool mUseFakeTestValuesForNextClose{false};

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -35,8 +35,9 @@ randomBucketName(std::string const& tmpDir)
 BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
                                            bool keepDeadEntries,
                                            BucketMetadata const& meta,
-                                           MergeCounters& mc)
+                                           MergeCounters& mc, bool doFsync)
     : mFilename(randomBucketName(tmpDir))
+    , mOut(doFsync)
     , mBuf(nullptr)
     , mHasher(SHA256::create())
     , mKeepDeadEntries(keepDeadEntries)

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -44,7 +44,8 @@ class BucketOutputIterator
     // the form of a METAENTRY; but that's not a thing the caller gets to decide
     // (or forget to do), it's handled automatically.
     BucketOutputIterator(std::string const& tmpDir, bool keepDeadEntries,
-                         BucketMetadata const& meta, MergeCounters& mc);
+                         BucketMetadata const& meta, MergeCounters& mc,
+                         bool doFsync);
 
     void put(BucketEntry const& e);
 

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -314,7 +314,6 @@ FutureBucket::startMerge(Application& app, uint32_t maxProtocolVersion,
         checkState();
         return;
     }
-
     using task_t = std::packaged_task<std::shared_ptr<Bucket>()>;
     std::shared_ptr<task_t> task = std::make_shared<task_t>(
         [curr, snap, &bm, shadows, maxProtocolVersion, countMergeEvents, level,
@@ -328,7 +327,8 @@ FutureBucket::startMerge(Application& app, uint32_t maxProtocolVersion,
             {
                 auto res = Bucket::merge(
                     bm, maxProtocolVersion, curr, snap, shadows,
-                    BucketList::keepDeadEntries(level), countMergeEvents);
+                    BucketList::keepDeadEntries(level), countMergeEvents,
+                    !app.getConfig().DISABLE_XDR_FSYNC);
 
                 CLOG(TRACE, "Bucket")
                     << "Worker finished merging curr="

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -269,11 +269,13 @@ TEST_CASE("bucket tombstones expire at bottom level",
             level.setCurr(Bucket::fresh(
                 bm, getAppLedgerVersion(app), {},
                 LedgerTestUtils::generateValidLedgerEntries(8), deadGen(8),
-                /*countMergeEvents=*/true));
+                /*countMergeEvents=*/true,
+                /*doFsync=*/true));
             level.setSnap(Bucket::fresh(
                 bm, getAppLedgerVersion(app), {},
                 LedgerTestUtils::generateValidLedgerEntries(8), deadGen(8),
-                /*countMergeEvents=*/true));
+                /*countMergeEvents=*/true,
+                /*doFsync=*/true));
         }
 
         for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -281,20 +281,20 @@ TEST_CASE("bucketmanager ownership", "[bucket][bucketmanager]")
         std::shared_ptr<Bucket> b1;
 
         {
-            std::shared_ptr<Bucket> b2 =
-                Bucket::fresh(app->getBucketManager(), getAppLedgerVersion(app),
-                              {}, live, dead, /*countMergeEvents=*/true);
+            std::shared_ptr<Bucket> b2 = Bucket::fresh(
+                app->getBucketManager(), getAppLedgerVersion(app), {}, live,
+                dead, /*countMergeEvents=*/true, /*doFsync=*/true);
             b1 = b2;
 
             // Bucket is referenced by b1, b2 and the BucketManager.
             CHECK(b1.use_count() == 3);
 
-            std::shared_ptr<Bucket> b3 =
-                Bucket::fresh(app->getBucketManager(), getAppLedgerVersion(app),
-                              {}, live, dead, /*countMergeEvents=*/true);
-            std::shared_ptr<Bucket> b4 =
-                Bucket::fresh(app->getBucketManager(), getAppLedgerVersion(app),
-                              {}, live, dead, /*countMergeEvents=*/true);
+            std::shared_ptr<Bucket> b3 = Bucket::fresh(
+                app->getBucketManager(), getAppLedgerVersion(app), {}, live,
+                dead, /*countMergeEvents=*/true, /*doFsync=*/true);
+            std::shared_ptr<Bucket> b4 = Bucket::fresh(
+                app->getBucketManager(), getAppLedgerVersion(app), {}, live,
+                dead, /*countMergeEvents=*/true, /*doFsync=*/true);
             // Bucket is referenced by b1, b2, b3, b4 and the BucketManager.
             CHECK(b1.use_count() == 5);
         }

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -87,7 +87,9 @@ StateSnapshot::writeHistoryBlocks() const
     uint32_t begin, count;
     size_t nHeaders;
     {
-        XDROutputFileStream ledgerOut, txOut, txResultOut, scpHistory;
+        bool doFsync = !mApp.getConfig().DISABLE_XDR_FSYNC;
+        XDROutputFileStream ledgerOut(doFsync), txOut(doFsync),
+            txResultOut(doFsync), scpHistory(doFsync);
         ledgerOut.open(mLedgerSnapFile->localPath_nogz());
         txOut.open(mTransactionSnapFile->localPath_nogz());
         txResultOut.open(mTransactionResultSnapFile->localPath_nogz());

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -107,7 +107,8 @@ RealGenesisTmpDirHistoryConfigurator::configure(Config& mCfg,
 BucketOutputIteratorForTesting::BucketOutputIteratorForTesting(
     std::string const& tmpDir, uint32_t protocolVersion, MergeCounters& mc)
     : BucketOutputIterator{tmpDir, true,
-                           testutil::testBucketMetadata(protocolVersion), mc}
+                           testutil::testBucketMetadata(protocolVersion), mc,
+                           /*doFsync=*/true}
 {
 }
 
@@ -212,7 +213,7 @@ TestLedgerChainGenerator::createHistoryFiles(
     uint32_t checkpoint)
 {
     FileTransferInfo ft{mTmpDir, HISTORY_FILE_TYPE_LEDGER, checkpoint};
-    XDROutputFileStream ledgerOut;
+    XDROutputFileStream ledgerOut(/*doFsync=*/true);
     ledgerOut.open(ft.localPath_nogz());
 
     for (auto& ledger : lhv)

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -162,7 +162,7 @@ struct BucketListGenerator
             auto keepDead = BucketList::keepDeadEntries(i);
             {
                 BucketOutputIterator out(bmApply.getTmpDir(), keepDead, meta,
-                                         mergeCounters);
+                                         mergeCounters, /*doFsync=*/true);
                 for (BucketInputIterator in (level.getCurr()); in; ++in)
                 {
                     out.put(*in);
@@ -171,7 +171,7 @@ struct BucketListGenerator
             }
             {
                 BucketOutputIterator out(bmApply.getTmpDir(), keepDead, meta,
-                                         mergeCounters);
+                                         mergeCounters, /*doFsync=*/true);
                 for (BucketInputIterator in (level.getSnap()); in; ++in)
                 {
                     out.put(*in);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -105,6 +105,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     FAILURE_SAFETY = -1;
     UNSAFE_QUORUM = false;
     DISABLE_BUCKET_GC = false;
+    DISABLE_XDR_FSYNC = false;
 
     LOG_FILE_PATH = "stellar-core.%datetime{%Y.%M.%d-%H:%m:%s}.log";
     BUCKET_DIR_PATH = "buckets";
@@ -660,6 +661,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "UNSAFE_QUORUM")
             {
                 UNSAFE_QUORUM = readBool(item);
+            }
+            else if (item.first == "DISABLE_XDR_FSYNC")
+            {
+                DISABLE_XDR_FSYNC = readBool(item);
             }
             else if (item.first == "KNOWN_CURSORS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -198,6 +198,17 @@ class Config : public std::enable_shared_from_this<Config>
     // disk usage, but it is useful for recovering of nodes.
     bool DISABLE_BUCKET_GC;
 
+    // If set to true, writing an XDR file (a bucket or a checkpoint) will not
+    // be followed by an fsync on the file. This in turn means that XDR files
+    // (which hold the canonical state of the ledger) may be corrupted if the
+    // operating system suddenly crashes or loses power, causing the node to
+    // diverge and get stuck on restart, or potentially even publish bad
+    // history. This option only exists as an escape hatch if the local
+    // filesystem is so unusably slow that you prefer operating without
+    // durability guarantees. Do not set it to true unless you're very certain
+    // you want to make that trade.
+    bool DISABLE_XDR_FSYNC;
+
     // Set of cursors added at each startup with value '1'.
     std::vector<std::string> KNOWN_CURSORS;
 

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -202,7 +202,7 @@ genfuzz(std::string const& filename)
     Logging::setFmt("<fuzz>");
     size_t n = 3;
     LOG(INFO) << "Writing " << n << "-message random fuzz file " << filename;
-    XDROutputFileStream out;
+    XDROutputFileStream out(/*doFsync=*/false);
     out.open(filename);
     autocheck::generator<StellarMessage> gen;
     for (size_t i = 0; i < n; ++i)

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -168,6 +168,9 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         {
         case Config::TESTDB_IN_MEMORY_SQLITE:
             dbname << "sqlite3://:memory:";
+            // When we're running on an in-memory sqlite we're
+            // probably not concerned with bucket durability.
+            thisConfig.DISABLE_XDR_FSYNC = true;
             break;
         case Config::TESTDB_ON_DISK_SQLITE:
             dbname << "sqlite3://" << rootDir << "test" << instanceNumber

--- a/src/util/FileSystemException.h
+++ b/src/util/FileSystemException.h
@@ -4,6 +4,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "util/Logging.h"
+#include <cerrno>
+#include <cstring>
 #include <stdexcept>
 
 namespace stellar
@@ -12,6 +15,24 @@ namespace stellar
 class FileSystemException : public std::runtime_error
 {
   public:
+    static void
+    failWith(std::string msg)
+    {
+        CLOG(FATAL, "Fs") << msg;
+        throw FileSystemException(msg);
+    }
+    static void
+    failWithErrno(std::string msg)
+    {
+        failWith(msg + std::strerror(errno));
+    }
+#ifdef _WIN32
+    static void
+    failWithGetLastError(std::string msg)
+    {
+        failWith(msg + ", code " + std::to_string(GetLastError()));
+    }
+#endif // _WIN32
     explicit FileSystemException(std::string const& msg)
         : std::runtime_error{msg}
     {

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -15,6 +15,7 @@
 #ifdef _WIN32
 #include <direct.h>
 #include <filesystem>
+#include <io.h>
 #else
 #include <dirent.h>
 #include <sys/resource.h>
@@ -75,6 +76,40 @@ unlockFile(std::string const& path)
     {
         throw std::runtime_error("file was not locked");
     }
+}
+
+void
+flushFileChanges(FILE* fp)
+{
+    int fd = _fileno(fp);
+    if (fd == -1)
+    {
+        FileSystemException::failWithErrno(
+            "fs::flushFileChanges() failed on _fileno(): ");
+    }
+    HANDLE fh = (HANDLE)_get_osfhandle(fd);
+    if (fh == INVALID_HANDLE_VALUE)
+    {
+        FileSystemException::failWithErrno(
+            "fs::flushFileChanges() failed on _get_osfhandle(): ");
+    }
+    if (FlushFileBuffers(fh) == FALSE)
+    {
+        FileSystemException::failWithGetLastError(
+            "fs::flushFileChanges() failed on _get_osfhandle(): ");
+    }
+}
+
+bool
+durableRename(std::string const& src, std::string const& dst,
+              std::string const& dir)
+{
+    if (MoveFileExA(src.c_str(), dst.c_str(), MOVEFILE_WRITE_THROUGH) == 0)
+    {
+        FileSystemException::failWithGetLastError(
+            "fs::durableRename() failed on MoveFileExA(): ");
+    }
+    return true;
 }
 
 bool
@@ -201,6 +236,49 @@ unlockFile(std::string const& path)
     {
         throw std::runtime_error("file was not locked");
     }
+}
+
+void
+flushFileChanges(FILE* fp)
+{
+    int fd = fileno(fp);
+    if (fd == -1)
+    {
+        FileSystemException::failWithErrno(
+            "fs::flushFileChanges() failed on fileno(): ");
+    }
+    if (fsync(fd) == -1)
+    {
+        FileSystemException::failWithErrno(
+            "fs::flushFileChanges() failed on fsync(): ");
+    }
+}
+
+bool
+durableRename(std::string const& src, std::string const& dst,
+              std::string const& dir)
+{
+    if (rename(src.c_str(), dst.c_str()) != 0)
+    {
+        return false;
+    }
+    auto dfd = open(dir.c_str(), O_RDONLY);
+    if (dfd == -1)
+    {
+        FileSystemException::failWithErrno(
+            std::string("Failed to open directory ") + dir + " :");
+    }
+    if (fsync(dfd) == -1)
+    {
+        FileSystemException::failWithErrno(
+            std::string("Failed to fsync directory ") + dir + " :");
+    }
+    if (close(dfd) == -1)
+    {
+        FileSystemException::failWithErrno(
+            std::string("Failed to close directory ") + dir + " :");
+    }
+    return true;
 }
 
 bool

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -22,6 +22,15 @@ void lockFile(std::string const& path);
 // unlocks a file locked with `lockFile`
 void unlockFile(std::string const& path);
 
+// Call fsync() on POSIX or FlushFileBuffers() on Win32.
+void flushFileChanges(FILE* fp);
+
+// On POSIX, do rename(src, dst) then open dir and fsync() it
+// too: a necessary second step for ensuring durability.
+// On Win32, do MoveFileExA with MOVEFILE_WRITE_THROUGH.
+bool durableRename(std::string const& src, std::string const& dst,
+                   std::string const& dir);
+
 // Whether a path exists
 bool exists(std::string const& path);
 

--- a/src/util/test/XDRStreamTests.cpp
+++ b/src/util/test/XDRStreamTests.cpp
@@ -5,13 +5,18 @@
 #include "bucket/Bucket.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
+#include "lib/util/format.h"
+#include "test/test.h"
+#include "util/Logging.h"
 #include "util/XDRStream.h"
+
+#include <chrono>
 
 using namespace stellar;
 
 TEST_CASE("XDROutputFileStream fail modes", "[xdrstream]")
 {
-    XDROutputFileStream out;
+    XDROutputFileStream out(/*doFsync=*/true);
     auto filename = "someFile";
 
     SECTION("open throws")
@@ -30,10 +35,59 @@ TEST_CASE("XDROutputFileStream fail modes", "[xdrstream]")
             Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
 
         REQUIRE_THROWS_AS(out.writeOne(bucketEntries[0], hasher.get(), &bytes),
-                          std::ios_base::failure);
+                          std::runtime_error);
     }
     SECTION("close throws")
     {
         REQUIRE_THROWS_AS(out.close(), std::runtime_error);
+    }
+}
+
+TEST_CASE("XDROutputFileStream fsync bench", "[!hide][xdrstream][bench]")
+{
+    Config const& cfg = getTestConfig(0);
+
+    auto hasher = SHA256::create();
+    auto ledgerEntries = LedgerTestUtils::generateValidLedgerEntries(10000000);
+    auto bucketEntries =
+        Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
+
+    fs::mkpath(cfg.BUCKET_DIR_PATH);
+
+    for (int i = 0; i < 10; ++i)
+    {
+        XDROutputFileStream outFsync(/*doFsync=*/true);
+        XDROutputFileStream outNoFsync(/*doFsync=*/false);
+
+        outFsync.open(
+            fmt::format("{}/outFsync-{}.xdr", cfg.BUCKET_DIR_PATH, i));
+        outNoFsync.open(
+            fmt::format("{}/outNoFsync-{}.xdr", cfg.BUCKET_DIR_PATH, i));
+
+        size_t bytes = 0;
+        auto start = std::chrono::system_clock::now();
+        for (auto const& e : bucketEntries)
+        {
+            outFsync.writeOne(e, hasher.get(), &bytes);
+        }
+        outFsync.close();
+        auto stop = std::chrono::system_clock::now();
+        auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+        CLOG(INFO, "Fs") << "wrote " << bytes << " bytes to fsync file in "
+                         << elapsed.count() << "ms";
+
+        bytes = 0;
+        start = std::chrono::system_clock::now();
+        for (auto const& e : bucketEntries)
+        {
+            outNoFsync.writeOne(e, hasher.get(), &bytes);
+        }
+        outNoFsync.close();
+        stop = std::chrono::system_clock::now();
+        elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(stop - start);
+        CLOG(INFO, "Fs") << "wrote " << bytes << " bytes to no-fsync file in "
+                         << elapsed.count() << "ms";
     }
 }


### PR DESCRIPTION
# Description

Resolves #2202

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

Performance is worse but not hugely. Benchmarks that hammer on the bucket system non-stop run about 10x slower wall time on local NVMe and 100x worse on a spindle. And at the _very smallest_ end of the merge times, slowdown is indeed also 10x-100x: 1ms merge becomes 10ms on NVMe or even 100ms on spindle. At level 0, the 100x case is still only taking 1-3% of allowed time for the merge -- we had a ton of headroom -- but it's worse for sure.

However, it also amortizes-away pretty smoothly as we get into bigger merges. By level 4 we're back down to 0.03% of available time and at level 5 down to 0.009%. That is: the fsync is adding a definitely-noticable 100ms to a merge running on the spindle, but it's not adding _proportionally_ much more as we scale to _somewhat_ larger buckets.

To measure whether this vanishes into the noise _completely_ when scaling up (or if, say, full buffers / actually having some real data to write changes things again), I made a synthetic 1.4gb XDR test and ran it against the spindle in a loop. This gives not super wonderful but also not super deadly results. The large files _do_ definitely show different effects that are not "constant 100ms totally vanishing into the noise":

~~~
2019-07-18T14:56:41.781 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 26094ms
2019-07-18T14:56:52.930 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 11149ms
2019-07-18T14:57:28.145 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 35214ms
2019-07-18T14:57:40.637 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 12491ms
2019-07-18T14:58:01.238 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 20600ms
2019-07-18T14:58:13.760 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 12522ms
2019-07-18T14:58:44.089 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 30328ms
2019-07-18T14:58:56.132 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 12042ms
2019-07-18T14:59:24.591 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 28458ms
2019-07-18T14:59:36.892 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 12301ms
2019-07-18T14:59:56.876 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 19983ms
2019-07-18T15:00:09.571 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 12694ms
2019-07-18T15:00:41.030 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 31459ms
2019-07-18T15:00:52.665 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 11634ms
2019-07-18T15:01:13.054 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 20388ms
2019-07-18T15:01:24.972 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 11917ms
2019-07-18T15:01:54.835 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 29863ms
2019-07-18T15:02:06.456 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 11620ms
2019-07-18T15:02:26.358 <test> [Fs INFO] wrote 1410837608 bytes to fsync file in 19901ms
2019-07-18T15:02:39.802 <test> [Fs INFO] wrote 1410837608 bytes to no-fsync file in 13444ms
~~~

I.e. varies between about 1.5x and 3x.

Back in the world of NVMe (which we certainly recommend people use for their buckets) this sort of thing is much less severe, though still measurable:

~~~
2019-07-18T15:08:01.569 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11609ms
2019-07-18T15:08:15.889 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 14319ms
2019-07-18T15:08:28.031 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 12141ms
2019-07-18T15:08:39.261 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11230ms
2019-07-18T15:08:51.141 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11880ms
2019-07-18T15:09:02.121 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 10979ms
2019-07-18T15:09:14.038 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11916ms
2019-07-18T15:09:25.084 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11045ms
2019-07-18T15:09:37.012 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11927ms
2019-07-18T15:09:48.308 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11296ms
2019-07-18T15:10:00.282 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11973ms
2019-07-18T15:10:11.388 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11105ms
2019-07-18T15:10:23.253 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11864ms
2019-07-18T15:10:34.470 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11217ms
2019-07-18T15:10:46.402 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11931ms
2019-07-18T15:10:57.530 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11127ms
2019-07-18T15:11:09.532 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 12001ms
2019-07-18T15:11:20.751 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11219ms
2019-07-18T15:11:32.724 <test> [Fs INFO] wrote 1410803760 bytes to fsync file in 11972ms
2019-07-18T15:11:44.059 <test> [Fs INFO] wrote 1410803760 bytes to no-fsync file in 11335ms
~~~