### PR TITLE
Remove bucketlist shadows, avoid resolving snapshots on publish 

### DIFF
--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -60,6 +60,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     // we were only supporting LIVEENTRY and DEADENTRY.
     static constexpr uint32_t
         FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY = 11;
+    static constexpr uint32_t FIRST_PROTOCOL_SHADOWS_REMOVED = 12;
 
     static void checkProtocolLegality(BucketEntry const& entry,
                                       uint32_t protocolVersion);
@@ -103,5 +104,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
           std::shared_ptr<Bucket> const& newBucket,
           std::vector<std::shared_ptr<Bucket>> const& shadows,
           bool keepDeadEntries, bool countMergeEvents, bool doFsync);
+
+    static uint32_t getBucketVersion(std::shared_ptr<Bucket> const& bucket);
 };
 }

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -404,7 +404,16 @@ class BucketList
     // merging buckets between levels. This needs to be called after forcing a
     // BucketList to adopt a new state, either at application restart or when
     // catching up from buckets loaded over the network.
-    void restartMerges(Application& app, uint32_t maxProtocolVersion);
+
+    // There are two ways to re-start a merge:
+    // 1. Use non-LIVE inputs/outputs from HAS file. This function will make
+    // these FutureBuckets LIVE (either FB_INPUT_LIVE or FB_OUTPUT_LIVE)
+    // using hashes of inputs and outputs from the HAS
+    // 2. Introduced with FIRST_PROTOCOL_SHADOWS_REMOVED: skip using
+    // input/output hashes, and restart live merges from currs and snaps of the
+    // bucketlist at that ledger.
+    void restartMerges(Application& app, uint32_t maxProtocolVersion,
+                       uint32_t ledger);
 
     // Run through the levels and check for FutureBuckets that are done merging;
     // if so, call resolve() on them, changing state from FB_LIVE_INPUTS to
@@ -412,6 +421,8 @@ class BucketList
     // avoid propagating partially-completed BucketList states to
     // HistoryArchiveStates, that can cause repeated merges when re-activated.
     void resolveAnyReadyFutures();
+
+    bool futuresAllResolved() const;
 
     // Add a batch of initial (created), live (updated) and dead entries to the
     // bucketlist, representing the entries effected by closing

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -34,6 +34,9 @@ struct MergeCounters
     uint64_t mRunningMergeReattachments{0};
     uint64_t mFinishedMergeReattachments{0};
 
+    uint64_t mPreShadowRemovalProtocolMerges{0};
+    uint64_t mPostShadowRemovalProtocolMerges{0};
+
     uint64_t mNewMetaEntries{0};
     uint64_t mNewInitEntries{0};
     uint64_t mNewLiveEntries{0};

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -212,6 +212,9 @@ MergeCounters::operator+=(MergeCounters const& delta)
     mRunningMergeReattachments += delta.mRunningMergeReattachments;
     mFinishedMergeReattachments += delta.mFinishedMergeReattachments;
 
+    mPreShadowRemovalProtocolMerges += delta.mPreShadowRemovalProtocolMerges;
+    mPostShadowRemovalProtocolMerges += delta.mPostShadowRemovalProtocolMerges;
+
     mNewMetaEntries += delta.mNewMetaEntries;
     mNewInitEntries += delta.mNewInitEntries;
     mNewLiveEntries += delta.mNewLiveEntries;
@@ -732,7 +735,7 @@ BucketManagerImpl::assumeState(HistoryArchiveState const& has,
         mBucketList.getLevel(i).setNext(has.currentBuckets.at(i).next);
     }
 
-    mBucketList.restartMerges(mApp, maxProtocolVersion);
+    mBucketList.restartMerges(mApp, maxProtocolVersion, has.currentLedger);
     cleanupStaleFiles();
 }
 

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -44,6 +44,15 @@ FutureBucket::FutureBucket(Application& app,
     assert(snap);
     mInputCurrBucketHash = binToHex(curr->getHash());
     mInputSnapBucketHash = binToHex(snap->getHash());
+    if (Bucket::getBucketVersion(snap) >=
+        Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+    {
+        if (!mInputShadowBuckets.empty())
+        {
+            throw std::runtime_error(
+                "Invalid FutureBucket: ledger version doesn't support shadows");
+        }
+    }
     for (auto const& b : mInputShadowBuckets)
     {
         mInputShadowBucketHashes.push_back(binToHex(b->getHash()));

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -205,6 +205,12 @@ FutureBucket::hasHashes() const
 }
 
 bool
+FutureBucket::isClear() const
+{
+    return mState == FB_CLEAR;
+}
+
+bool
 FutureBucket::mergeComplete() const
 {
     assert(isLive());

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -101,6 +101,9 @@ class FutureBucket
     // running).
     bool isMerging() const;
 
+    // Returns whether this object is in a FB_CLEAR state.
+    bool isClear() const;
+
     // Returns whether this object is in a FB_HASH_FOO state.
     bool hasHashes() const;
 

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -172,7 +172,7 @@ TEST_CASE("bucket list", "[bucket][bucketlist]")
     }
 }
 
-TEST_CASE("bucket list shadowing", "[bucket][bucketlist]")
+TEST_CASE("bucket list shadowing pre/post proto 12", "[bucket][bucketlist]")
 {
     VirtualClock clock;
     Config const& cfg = getTestConfig();
@@ -187,8 +187,10 @@ TEST_CASE("bucket list shadowing", "[bucket][bucketlist]")
         autocheck::generator<std::vector<LedgerKey>> deadGen;
         CLOG(DEBUG, "Bucket") << "Adding batches to bucket list";
 
+        auto totalNumEntries = 1200;
         for (uint32_t i = 1;
-             !app->getClock().getIOContext().stopped() && i < 1200; ++i)
+             !app->getClock().getIOContext().stopped() && i <= totalNumEntries;
+             ++i)
         {
             app->getClock().crank(false);
             auto liveBatch = LedgerTestUtils::generateValidLedgerEntries(5);
@@ -242,11 +244,25 @@ TEST_CASE("bucket list shadowing", "[bucket][bucketlist]")
                     bool hasBob =
                         (curr->containsBucketIdentity(BucketEntryBob) ||
                          snap->containsBucketIdentity(BucketEntryBob));
-                    CHECK(!hasAlice);
-                    CHECK(!hasBob);
+                    if (app->getConfig().LEDGER_PROTOCOL_VERSION <
+                            Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED ||
+                        j > 5)
+                    {
+                        CHECK(!hasAlice);
+                        CHECK(!hasBob);
+                    }
+                    // On the last iteration, when bucket list population is
+                    // complete, ensure that post-FIRST_PROTOCOL_SHADOWS_REMOVED
+                    // Alice and Bob appear on lower levels unshadowed.
+                    else if (i == totalNumEntries)
+                    {
+                        CHECK(hasAlice);
+                        CHECK(hasBob);
+                    }
                 }
             }
         }
+
     });
 }
 

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -25,7 +25,8 @@ namespace stellar
 ApplyBucketsWork::ApplyBucketsWork(
     Application& app,
     std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
-    HistoryArchiveState const& applyState, uint32_t maxProtocolVersion)
+    HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
+    bool resolveMerges)
     : BasicWork(app, "apply-buckets", BasicWork::RETRY_NEVER)
     , mBuckets(buckets)
     , mApplyState(applyState)
@@ -40,6 +41,7 @@ ApplyBucketsWork::ApplyBucketsWork(
     , mBucketApplyFailure(app.getMetrics().NewMeter(
           {"history", "bucket-apply", "failure"}, "event"))
     , mCounters(app.getClock().now())
+    , mResolveMerges(resolveMerges)
 {
 }
 
@@ -92,6 +94,8 @@ ApplyBucketsWork::onReset()
 
     mLevel = BucketList::kNumLevels - 1;
     mApplying = false;
+
+    mDelayTimer.reset();
     mSnapBucket.reset();
     mCurrBucket.reset();
     mSnapApplicator.reset();
@@ -145,6 +149,42 @@ ApplyBucketsWork::startLevel()
 BasicWork::State
 ApplyBucketsWork::onRun()
 {
+    if (mLevel == BucketList::kNumLevels - 1 &&
+        !mApplyState.containsValidBuckets(mApp))
+    {
+        CLOG(ERROR, "History") << "Malformed HAS: unable to apply buckets";
+        return State::WORK_FAILURE;
+    }
+
+    if (mResolveMerges && mDelayTimer)
+    {
+        CLOG(INFO, "History") << "ApplyBucketsWork: application completed; "
+                                 "waiting for merge resolution";
+        auto& bl = mApp.getBucketManager().getBucketList();
+        bl.resolveAnyReadyFutures();
+        if (bl.futuresAllResolved())
+        {
+            return State::WORK_SUCCESS;
+        }
+        else
+        {
+            std::weak_ptr<ApplyBucketsWork> weak(
+                std::static_pointer_cast<ApplyBucketsWork>(shared_from_this()));
+            auto handler = [weak](asio::error_code const& ec) {
+                auto self = weak.lock();
+                if (self)
+                {
+                    self->wakeUp();
+                }
+            };
+
+            // Check back later
+            mDelayTimer->expires_from_now(std::chrono::milliseconds(500));
+            mDelayTimer->async_wait(handler);
+            return State::WORK_WAITING;
+        }
+    }
+
     // Check if we're at the beginning of the new level
     if (isLevelComplete())
     {
@@ -192,8 +232,15 @@ ApplyBucketsWork::onRun()
         return State::WORK_RUNNING;
     }
 
-    CLOG(DEBUG, "History") << "ApplyBuckets : done, restarting merges";
+    CLOG(INFO, "History") << "ApplyBuckets : done, restarting merges";
     mApp.getBucketManager().assumeState(mApplyState, mMaxProtocolVersion);
+
+    if (mResolveMerges)
+    {
+        mDelayTimer = std::make_unique<VirtualTimer>(mApp.getClock());
+        return State::WORK_RUNNING;
+    }
+
     return State::WORK_SUCCESS;
 }
 
@@ -256,5 +303,18 @@ void
 ApplyBucketsWork::onFailureRetry()
 {
     mBucketApplyFailure.Mark();
+}
+
+void
+ApplyBucketsWork::onSuccess()
+{
+    if (mResolveMerges)
+    {
+        if (!mApp.getBucketManager().getBucketList().futuresAllResolved())
+        {
+            throw std::runtime_error(
+                "Not all futures were resolved after bucket application!");
+        }
+    }
 }
 }

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -67,6 +67,14 @@ HistoryArchiveState::futuresAllResolved() const
     return true;
 }
 
+bool
+HistoryArchiveState::futuresAllClear() const
+{
+    return std::all_of(
+        currentBuckets.begin(), currentBuckets.end(),
+        [](HistoryStateBucket const& bl) { return bl.next.isClear(); });
+}
+
 void
 HistoryArchiveState::resolveAllFutures()
 {
@@ -94,10 +102,6 @@ HistoryArchiveState::resolveAnyReadyFutures()
 void
 HistoryArchiveState::save(std::string const& outFile) const
 {
-    // We only ever write fully-resolved HASs to files, when making
-    // checkpoints. This may change in the future if we start publishing
-    // input-only HASs.
-    assert(futuresAllResolved());
     std::ofstream out(outFile);
     cereal::JSONOutputArchive ar(out);
     serialize(ar);
@@ -129,7 +133,6 @@ HistoryArchiveState::load(std::string const& inFile)
             << "Unexpected history archive state version: " << version;
         throw std::runtime_error("unexpected history archive state version");
     }
-    assert(futuresAllResolved());
 }
 
 void
@@ -138,7 +141,6 @@ HistoryArchiveState::fromString(std::string const& str)
     std::istringstream in(str);
     cereal::JSONInputArchive ar(in);
     serialize(ar);
-    assert(futuresAllResolved());
 }
 
 std::string

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -129,6 +129,9 @@ struct HistoryArchiveState
 
     std::string toString() const;
     void fromString(std::string const& str);
+
+    void prepareForPublish(Application& app);
+    bool containsValidBuckets(Application& app) const;
 };
 
 class HistoryArchive : public std::enable_shared_from_this<HistoryArchive>

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -108,6 +108,9 @@ struct HistoryArchiveState
            CEREAL_NVP(currentBuckets));
     }
 
+    // Return true if all futures are in FB_CLEAR state
+    bool futuresAllClear() const;
+
     // Return true if all futures have already been resolved, otherwise false.
     bool futuresAllResolved() const;
 

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -285,9 +285,6 @@ class HistoryManager
                      std::vector<std::string> const& originalBuckets,
                      bool success) = 0;
 
-    // Return the HistoryArchiveState of the LedgerManager's LCL
-    virtual HistoryArchiveState getLastClosedHistoryArchiveState() const = 0;
-
     // Infer a quorum set by reading SCP messages in history archives.
     virtual InferredQuorum inferQuorum(uint32_t ledgerNum) = 0;
 

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -67,7 +67,6 @@ HistoryManagerImpl::HistoryManagerImpl(Application& app)
     : mApp(app)
     , mWorkDir(nullptr)
     , mPublishWork(nullptr)
-
     , mPublishSuccess(
           app.getMetrics().NewMeter({"history", "publish", "success"}, "event"))
     , mPublishFailure(
@@ -175,14 +174,6 @@ HistoryManagerImpl::localFilename(std::string const& basename)
     return this->getTmpDir() + "/" + basename;
 }
 
-HistoryArchiveState
-HistoryManagerImpl::getLastClosedHistoryArchiveState() const
-{
-    auto seq = mApp.getLedgerManager().getLastClosedLedgerNum();
-    auto& bl = mApp.getBucketManager().getBucketList();
-    return HistoryArchiveState(seq, bl);
-}
-
 InferredQuorum
 HistoryManagerImpl::inferQuorum(uint32_t ledgerNum)
 {
@@ -251,9 +242,9 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint()
 void
 HistoryManagerImpl::queueCurrentHistory()
 {
-    auto has = getLastClosedHistoryArchiveState();
+    auto ledger = mApp.getLedgerManager().getLastClosedLedgerNum();
+    HistoryArchiveState has(ledger, mApp.getBucketManager().getBucketList());
 
-    auto ledger = has.currentLedger;
     CLOG(DEBUG, "History") << "Queueing publish state for ledger " << ledger;
     mEnqueueTimes.emplace(ledger, std::chrono::steady_clock::now());
 

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -79,8 +79,6 @@ class HistoryManagerImpl : public HistoryManager
                           std::vector<std::string> const& originalBuckets,
                           bool success) override;
 
-    HistoryArchiveState getLastClosedHistoryArchiveState() const override;
-
     InferredQuorum inferQuorum(uint32_t ledgerNum) override;
 
     std::string const& getTmpDir() override;

--- a/src/history/StateSnapshot.h
+++ b/src/history/StateSnapshot.h
@@ -28,7 +28,6 @@ struct StateSnapshot : public std::enable_shared_from_this<StateSnapshot>
     std::shared_ptr<FileTransferInfo> mSCPHistorySnapFile;
 
     StateSnapshot(Application& app, HistoryArchiveState const& state);
-    void makeLive();
     bool writeHistoryBlocks() const;
     std::vector<std::shared_ptr<FileTransferInfo>>
     differingHASFiles(HistoryArchiveState const& other);

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -541,13 +541,29 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
 }
 
 void
+CatchupSimulation::setProto12UpgradeLedger(uint32_t ledger)
+{
+    REQUIRE(mApp.getLedgerManager().getLastClosedLedgerNum() < ledger);
+    mTestProtocolShadowsRemovedLedgerSeq = ledger;
+}
+
+void
 CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger)
 {
     auto& lm = mApp.getLedgerManager();
     auto& hm = mApp.getHistoryManager();
     while (lm.getLastClosedLedgerNum() < targetLedger)
     {
-        generateRandomLedger();
+        if (lm.getLastClosedLedgerNum() + 1 ==
+            mTestProtocolShadowsRemovedLedgerSeq)
+        {
+            // Force proto 12 upgrade
+            generateRandomLedger(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED);
+        }
+        else
+        {
+            generateRandomLedger();
+        }
 
         auto seq = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
         if (seq == hm.nextCheckpointLedger(seq))

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -227,6 +227,8 @@ class CatchupSimulation
     std::vector<SequenceNumber> bobSeqs;
     std::vector<SequenceNumber> carolSeqs;
 
+    uint32_t mTestProtocolShadowsRemovedLedgerSeq{0};
+
     CatchupMetrics getCatchupMetrics(Application::pointer app);
     CatchupPerformedWork computeCatchupPerformedWork(
         uint32_t lastClosedLedger,
@@ -286,6 +288,8 @@ class CatchupSimulation
     void crankUntil(Application::pointer app,
                     std::function<bool()> const& predicate,
                     VirtualClock::duration duration);
+
+    void setProto12UpgradeLedger(uint32_t ledger);
 };
 }
 }

--- a/src/historywork/PutHistoryArchiveStateWork.cpp
+++ b/src/historywork/PutHistoryArchiveStateWork.cpp
@@ -22,6 +22,10 @@ PutHistoryArchiveStateWork::PutHistoryArchiveStateWork(
     , mArchive(archive)
     , mLocalFilename(HistoryArchiveState::localName(app, archive->getName()))
 {
+    if (!mState.containsValidBuckets(mApp))
+    {
+        throw std::runtime_error("Malformed HAS, unable to publish");
+    }
 }
 
 void

--- a/src/historywork/ResolveSnapshotWork.cpp
+++ b/src/historywork/ResolveSnapshotWork.cpp
@@ -16,6 +16,10 @@ ResolveSnapshotWork::ResolveSnapshotWork(
     , mSnapshot(snapshot)
     , mTimer(std::make_unique<VirtualTimer>(app.getClock()))
 {
+    if (!mSnapshot)
+    {
+        throw std::runtime_error("ResolveSnapshotWork: invalid snapshot");
+    }
 }
 
 BasicWork::State

--- a/src/historywork/ResolveSnapshotWork.cpp
+++ b/src/historywork/ResolveSnapshotWork.cpp
@@ -31,7 +31,7 @@ ResolveSnapshotWork::onRun()
     }
 
     mSnapshot->mLocalState.resolveAnyReadyFutures();
-    mSnapshot->makeLive();
+    mSnapshot->mLocalState.prepareForPublish(mApp);
     if ((mApp.getLedgerManager().getLastClosedLedgerNum() >
          mSnapshot->mLocalState.currentLedger) &&
         mSnapshot->mLocalState.futuresAllResolved())

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -59,10 +59,11 @@ struct BucketListGenerator
     {
         std::map<std::string, std::shared_ptr<Bucket>> buckets;
         auto has = getHistoryArchiveState();
+        has.prepareForPublish(*mAppApply);
         auto& wm = mAppApply->getWorkScheduler();
-        wm.executeWork<T>(buckets, has,
-                          mAppApply->getConfig().LEDGER_PROTOCOL_VERSION,
-                          std::forward<Args>(args)...);
+        wm.executeWork<T>(
+            buckets, has, mAppApply->getConfig().LEDGER_PROTOCOL_VERSION,
+            /* resolveMerges= */ false, std::forward<Args>(args)...);
     }
 
     void
@@ -277,8 +278,9 @@ class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
         HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        LedgerEntry const& entry)
-        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion)
+        bool resolve, LedgerEntry const& entry)
+        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion,
+                           resolve)
         , mEntry(entry)
         , mAdded{false}
     {
@@ -328,8 +330,9 @@ class ApplyBucketsWorkDeleteEntry : public ApplyBucketsWork
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
         HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        LedgerEntry const& target)
-        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion)
+        bool resolve, LedgerEntry const& target)
+        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion,
+                           resolve)
         , mKey(LedgerEntryKey(target))
         , mEntry(target)
         , mDeleted{false}
@@ -414,8 +417,9 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
         HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        LedgerEntry const& target)
-        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion)
+        bool resolve, LedgerEntry const& target)
+        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion,
+                           resolve)
         , mKey(LedgerEntryKey(target))
         , mEntry(target)
         , mModified{false}

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -235,7 +235,8 @@ rebuildLedgerFromBuckets(Config cfg)
     has.fromString(hasStr);
 
     auto applyBucketsWork = ws.executeWork<ApplyBucketsWork>(
-        localBuckets, has, Config::CURRENT_LEDGER_PROTOCOL_VERSION);
+        localBuckets, has, Config::CURRENT_LEDGER_PROTOCOL_VERSION,
+        /* resolveMerges */ false);
     auto ok = applyBucketsWork->getState() == BasicWork::State::WORK_SUCCESS;
     if (ok)
     {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -25,7 +25,7 @@
 
 namespace stellar
 {
-const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 11;
+const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 12;
 
 // Options that must only be used for testing
 static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {


### PR DESCRIPTION
This PR implements [CAP-0025](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0025.md), and makes a few changes to how we publish and catchup. Main change is shadow removal from the bucketlist, which changes how buckets are merged (and hence, producing different buckets, which affects ledger header hash). 

This change implies that on publish, it is no longer necessary to resolve future buckets. Moreover, it is not even necessary to store future buckets in half-merged state, since bucketlist can fully recover the merges by just using its currs and snaps. 

This change also implements the upgrade mechanism. Specifically, upon the upgrade (which will be properly timed), in-progress merges are dropped, and new-style merges are started. 