### PR TITLE
bug 2203: verify input bucket hashes while reading for a merge.

### DIFF
--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -25,6 +25,7 @@ class BucketInputIterator
     // non-null, it points to mEntry.
     BucketEntry const* mEntryPtr{nullptr};
     XDRInputFileStream mIn;
+    std::unique_ptr<SHA256> mHasher;
     BucketEntry mEntry;
     bool mSeenMetadata{false};
     bool mSeenOtherEntries{false};
@@ -54,5 +55,6 @@ class BucketInputIterator
 
     size_t pos();
     size_t size() const;
+    void checkHash() const;
 };
 }

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -79,7 +79,7 @@ class XDRInputFileStream
 
     template <typename T>
     bool
-    readOne(T& out)
+    readOne(T& out, SHA256* hasher = nullptr)
     {
         char szBuf[4];
         if (!mIn.read(szBuf, 4))
@@ -112,6 +112,11 @@ class XDRInputFileStream
         }
         xdr::xdr_get g(mBuf.data(), mBuf.data() + sz);
         xdr::xdr_argpack_archive(g, out);
+        if (hasher)
+        {
+            hasher->add(ByteSlice(szBuf, 4));
+            hasher->add(ByteSlice(mBuf.data(), sz));
+        }
         return true;
     }
 };


### PR DESCRIPTION
# Description

Resolves #2203 

This extends the BucketInputIterator with a SHA256 instance to re-check that the bytes it's _reading_ match the purported hash (name of the bucket) it's expecting.

This is a followup to #2202 to catch data corruption in bucket files, regardless of source. It's not an instant catch -- will still lag until the next time someone reads the file for a merge -- but it tightens the window slightly (from merge-commit time back to merge-completion time) and localizes the error from an unexplained "wrong ledger hash" to a specific corrupt bucket.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

It costs an extra ~0.5% CPU during merge operations to hash while reading. I think this is tolerable for the improved error precision, but opinions may vary.