### PR TITLE
Allow setting upgrades at a ledger number

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -131,7 +131,7 @@ class Herder
     virtual bool resolveNodeID(std::string const& s, PublicKey& retKey) = 0;
 
     // sets the upgrades that should be applied during consensus
-    virtual void setUpgrades(Upgrades::UpgradeParameters const& upgrades) = 0;
+    virtual void setUpgrades(UpgradeParameters const& upgrades) = 0;
     // gets the upgrades that are scheduled by this node
     virtual std::string getUpgradesJson() = 0;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -810,7 +810,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
 }
 
 void
-HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
+HerderImpl::setUpgrades(UpgradeParameters const& upgrades)
 {
     mUpgrades.setParameters(upgrades, mApp.getConfig());
     persistUpgrades();
@@ -1293,7 +1293,7 @@ HerderImpl::restoreUpgrades()
         mApp.getPersistentState().getState(PersistentState::kLedgerUpgrades);
     if (!s.empty())
     {
-        Upgrades::UpgradeParameters p;
+        UpgradeParameters p;
         p.fromJson(s);
         try
         {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -83,7 +83,7 @@ class HerderImpl : public Herder
 
     void triggerNextLedger(uint32_t ledgerSeqToTrigger) override;
 
-    void setUpgrades(Upgrades::UpgradeParameters const& upgrades) override;
+    void setUpgrades(UpgradeParameters const& upgrades) override;
     std::string getUpgradesJson() override;
 
     bool resolveNodeID(std::string const& s, PublicKey& retKey) override;


### PR DESCRIPTION
This PR ensures we can upgrade at a particular ledger number. Specifically, it is useful in the context of bucketlist-related upgrades, as we can select the ledger, that is right after any large merge spills, to avoid stalling the network. 