### PR TITLE
OrderBookIsNotCrossed invariant

### DIFF
--- a/src/invariant/Invariant.h
+++ b/src/invariant/Invariant.h
@@ -59,6 +59,7 @@ class Invariant
     snapshotForFuzzer()
     {
     }
+
     virtual void
     resetForFuzzer()
     {

--- a/src/invariant/Invariant.h
+++ b/src/invariant/Invariant.h
@@ -56,6 +56,10 @@ class Invariant
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     virtual void
+    snapshotForFuzzer()
+    {
+    }
+    virtual void
     resetForFuzzer()
     {
     }

--- a/src/invariant/Invariant.h
+++ b/src/invariant/Invariant.h
@@ -53,5 +53,12 @@ class Invariant
     {
         return std::string{};
     }
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    virtual void
+    resetForFuzzer()
+    {
+    }
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 };
 }

--- a/src/invariant/InvariantManager.h
+++ b/src/invariant/InvariantManager.h
@@ -48,6 +48,11 @@ class InvariantManager
 
     virtual void enableInvariant(std::string const& name) = 0;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    virtual void snapshotForFuzzer() = 0;
+    virtual void resetForFuzzer() = 0;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
     template <typename T, typename... Args>
     std::shared_ptr<T>
     registerInvariant(Args&&... args)

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -227,4 +227,15 @@ InvariantManagerImpl::handleInvariantFailure(
         CLOG(ERROR, "Invariant") << REPORT_INTERNAL_BUG;
     }
 }
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+void
+InvariantManagerImpl::resetForFuzzer()
+{
+    for (auto invariant : mEnabled)
+    {
+        invariant->resetForFuzzer();
+    }
+}
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 }

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -232,7 +232,7 @@ InvariantManagerImpl::handleInvariantFailure(
 void
 InvariantManagerImpl::resetForFuzzer()
 {
-    for (auto invariant : mEnabled)
+    for (auto const& invariant : mEnabled)
     {
         invariant->resetForFuzzer();
     }

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -237,6 +237,7 @@ InvariantManagerImpl::snapshotForFuzzer()
         invariant->snapshotForFuzzer();
     }
 }
+
 void
 InvariantManagerImpl::resetForFuzzer()
 {

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -230,6 +230,14 @@ InvariantManagerImpl::handleInvariantFailure(
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 void
+InvariantManagerImpl::snapshotForFuzzer()
+{
+    for (auto const& invariant : mEnabled)
+    {
+        invariant->snapshotForFuzzer();
+    }
+}
+void
 InvariantManagerImpl::resetForFuzzer()
 {
     for (auto const& invariant : mEnabled)

--- a/src/invariant/InvariantManagerImpl.h
+++ b/src/invariant/InvariantManagerImpl.h
@@ -51,7 +51,8 @@ class InvariantManagerImpl : public InvariantManager
     virtual void enableInvariant(std::string const& name) override;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    void resetForFuzzer();
+    void snapshotForFuzzer() override;
+    void resetForFuzzer() override;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
   private:

--- a/src/invariant/InvariantManagerImpl.h
+++ b/src/invariant/InvariantManagerImpl.h
@@ -50,6 +50,10 @@ class InvariantManagerImpl : public InvariantManager
 
     virtual void enableInvariant(std::string const& name) override;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    void resetForFuzzer();
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
   private:
     void onInvariantFailure(std::shared_ptr<Invariant> invariant,
                             std::string const& message, uint32_t ledger);

--- a/src/invariant/OrderBookIsNotCrossed.cpp
+++ b/src/invariant/OrderBookIsNotCrossed.cpp
@@ -1,0 +1,162 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "invariant/OrderBookIsNotCrossed.h"
+#include "invariant/InvariantManager.h"
+#include "ledger/LedgerTxn.h"
+#include "lib/util/format.h"
+#include "main/Application.h"
+#include "xdr/Stellar-ledger-entries.h"
+
+#include <numeric>
+
+namespace stellar
+{
+AssetId
+getAssetID(Asset const& asset)
+{
+    auto r = std::string{};
+    switch (asset.type())
+    {
+    case stellar::ASSET_TYPE_NATIVE:
+        return std::string{"XLM-native"};
+    case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
+        assetCodeToStr(asset.alphaNum4().assetCode, r);
+        return r + "-" + KeyUtils::toStrKey(getIssuer(asset));
+    case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
+        assetCodeToStr(asset.alphaNum12().assetCode, r);
+        return r + "-" + KeyUtils::toStrKey(getIssuer(asset));
+    };
+}
+
+void
+deleteOffer(OrderBook& orderBook, OfferEntry const& oe)
+{
+    auto offerId = oe.offerID;
+    auto sellAssetId = getAssetID(oe.selling);
+    auto buyAssetId = getAssetID(oe.buying);
+    orderBook[sellAssetId][buyAssetId].erase(offerId);
+}
+
+void
+createOrModifyOffer(OrderBook& orderBook, OfferEntry const& oe)
+{
+    auto offerId = oe.offerID;
+    auto sellAssetId = getAssetID(oe.selling);
+    auto buyAssetId = getAssetID(oe.buying);
+    orderBook[sellAssetId][buyAssetId][offerId] = oe;
+}
+
+void
+updateOrderBook(LedgerTxnDelta const& ltxd, OrderBook& orderBook)
+{
+    for (auto const& entry : ltxd.entry)
+    {
+        // there are three possible "deltas" for an offer:
+        //      CREATED:  (nil)     -> LedgerKey
+        //      MODIFIED: LedgerKey -> LedgerKey
+        //      DELETED:  LedgerKey -> (nil)
+        if (entry.first.type() == OFFER)
+        {
+            if (entry.second.current)
+            {
+                createOrModifyOffer(orderBook,
+                                    entry.second.current->data.offer());
+            }
+            else
+            {
+                deleteOffer(orderBook, entry.second.previous->data.offer());
+            }
+        }
+    }
+}
+
+std::string
+check(Operation const& operation, OrderBook& orderBook)
+{
+    auto getCheckForCrossedMessage = [&](AssetId const& a, AssetId const& b) {
+        auto asks = orderBook[a][b];
+        auto bids = orderBook[b][a];
+
+        auto lowestAsk =
+            std::accumulate(asks.begin(), asks.end(), __DBL_MAX__,
+                            [](double lowestAsk, auto curEntry) {
+                                double curAsk =
+                                    double(curEntry.second.price.n) /
+                                    double(curEntry.second.price.d);
+
+                                return lowestAsk > curAsk ? curAsk : lowestAsk;
+                            });
+
+        auto highestBid = std::accumulate(
+            bids.begin(), bids.end(), 0.0,
+            [](double highestBid, auto curEntry) {
+                double curBid = 1.0 / (double(curEntry.second.price.n) /
+                                       double(curEntry.second.price.d));
+
+                return highestBid < curBid ? curBid : highestBid;
+            });
+
+        if (highestBid >= lowestAsk)
+        {
+            return fmt::format(
+                "Order book is in a crossed state for {} - {} asset pair.\nTop "
+                "of the book is:\n\tAsk price: {}\n\tBid price: {}\n\nWhere {} "
+                ">= {}!",
+                a, b, lowestAsk, highestBid, highestBid, lowestAsk);
+        }
+
+        return std::string{};
+    };
+
+    if (operation.body.type() == MANAGE_BUY_OFFER)
+    {
+        return getCheckForCrossedMessage(
+            getAssetID(operation.body.manageBuyOfferOp().buying),
+            getAssetID(operation.body.manageBuyOfferOp().selling));
+    }
+    else if (operation.body.type() == MANAGE_SELL_OFFER)
+    {
+        return getCheckForCrossedMessage(
+            getAssetID(operation.body.manageSellOfferOp().buying),
+            getAssetID(operation.body.manageSellOfferOp().selling));
+    }
+    else if (operation.body.type() == CREATE_PASSIVE_SELL_OFFER)
+    {
+        return getCheckForCrossedMessage(
+            getAssetID(operation.body.createPassiveSellOfferOp().buying),
+            getAssetID(operation.body.createPassiveSellOfferOp().selling));
+    }
+
+    return {};
+}
+
+std::shared_ptr<Invariant>
+OrderBookIsNotCrossed::registerInvariant(Application& app)
+{
+    return app.getInvariantManager().registerInvariant<OrderBookIsNotCrossed>();
+}
+std::string
+OrderBookIsNotCrossed::getName() const
+{
+    return "OrderBookIsNotCrossed";
+}
+
+std::string
+OrderBookIsNotCrossed::checkOnOperationApply(Operation const& operation,
+                                             OperationResult const& result,
+                                             LedgerTxnDelta const& ltxDelta)
+{
+    updateOrderBook(ltxDelta, mOrderBook);
+    return check(operation, mOrderBook);
+}
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+void
+OrderBookIsNotCrossed::resetForFuzzer()
+{
+    mOrderBook = {};
+};
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+}

--- a/src/invariant/OrderBookIsNotCrossed.cpp
+++ b/src/invariant/OrderBookIsNotCrossed.cpp
@@ -1,3 +1,4 @@
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
@@ -152,11 +153,10 @@ OrderBookIsNotCrossed::checkOnOperationApply(Operation const& operation,
     return check(operation, mOrderBook);
 }
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 void
 OrderBookIsNotCrossed::resetForFuzzer()
 {
     mOrderBook = {};
 };
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 }
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/invariant/OrderBookIsNotCrossed.cpp
+++ b/src/invariant/OrderBookIsNotCrossed.cpp
@@ -36,25 +36,25 @@ extractAssetPairs(Operation const& op, LedgerTxnDelta const& ltxd)
     case PATH_PAYMENT:
     {
         auto const& pp = op.body.pathPaymentOp();
-       
+
         // if no path, only have a pair between send and dest
         if (pp.path.size() == 0)
         {
             return {std::make_pair(pp.sendAsset, pp.destAsset)};
-        } 
+        }
 
         // For send, dest, {A, B} we get: {send, A}, {A, B}, {B, dest}
         std::vector<std::pair<Asset, Asset>> assets;
-        
+
         // beginning: send -> A
-        assets.emplace_back(pp.sendAsset, pp.path.front()); 
+        assets.emplace_back(pp.sendAsset, pp.path.front());
         for (int i = 1; i < pp.path.size(); ++i)
         {
             // middle: A -> B
             assets.emplace_back(pp.path[i - 1], pp.path[i]);
         }
         // end: B -> dest
-        assets.emplace_back(pp.path.back(), pp.destAsset); 
+        assets.emplace_back(pp.path.back(), pp.destAsset);
 
         return assets;
     }
@@ -223,9 +223,15 @@ OrderBookIsNotCrossed::checkOnOperationApply(Operation const& operation,
 }
 
 void
+OrderBookIsNotCrossed::snapshotForFuzzer()
+{
+    mRolledBackOrderBook = mOrderBook;
+};
+
+void
 OrderBookIsNotCrossed::resetForFuzzer()
 {
-    mOrderBook.clear();
+    mOrderBook = mRolledBackOrderBook;
 };
 }
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -26,11 +26,21 @@ struct OfferEntryCmp
     bool
     operator()(OfferEntry const& a, OfferEntry const& b) const
     {
-        auto const& price = [](OfferEntry const& offer) {
-            return double(offer.price.n) / double(offer.price.d);
-        };
+        double priceA = double(a.price.n) / double(a.price.d);
+        double priceB = double(b.price.n) / double(b.price.d);
 
-        return price(a) < price(b);
+        if (priceA < priceB)
+        {
+            return true;
+        }
+        else if (priceA == priceB)
+        {
+            return a.offerID < b.offerID;
+        }
+        else
+        {
+            return false;
+        }
     }
 };
 

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -83,7 +83,7 @@ class OrderBookIsNotCrossed : public Invariant
     void deleteFromOrderBook(OfferEntry const& oe);
     void addToOrderBook(OfferEntry const& oe);
     void updateOrderBook(LedgerTxnDelta const& ltxd);
-    std::string check(std::vector<std::pair<Asset, Asset>> assetPairs);
+    std::string check(std::set<std::pair<Asset, Asset>> assetPairs);
 };
 }
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -1,3 +1,4 @@
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 #pragma once
 
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
@@ -60,3 +61,4 @@ class OrderBookIsNotCrossed : public Invariant
     OrderBook mOrderBook;
 };
 }
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -101,6 +101,7 @@ class OrderBookIsNotCrossed : public Invariant
         return mOrderBook;
     }
 
+    void snapshotForFuzzer() override;
     void resetForFuzzer() override;
 
   private:
@@ -109,6 +110,7 @@ class OrderBookIsNotCrossed : public Invariant
     // configurable, it is likely that this invariant will be enabled with
     // pre-existing ledger and thus the mOrderBook will need a way to sync
     OrderBook mOrderBook;
+    OrderBook mRolledBackOrderBook;
     void deleteFromOrderBook(OfferEntry const& oe);
     void addToOrderBook(OfferEntry const& oe);
     void updateOrderBook(LedgerTxnDelta const& ltxd);

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -1,0 +1,62 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "invariant/Invariant.h"
+#include "xdr/Stellar-ledger-entries.h"
+
+#include <unordered_map>
+
+namespace stellar
+{
+
+class Application;
+struct LedgerTxnDelta;
+struct OfferEntry;
+
+// AssetId is defined as a concatenation of issuer and asset code:
+// ASSET_CODE | '-' | ISSUER_ACCOUNT_ID
+using AssetId = std::string;
+// Orders is a map of OfferId (int64_t) --> OfferEntry
+using Orders = std::unordered_map<int64_t, OfferEntry>;
+// AssetOrders, orders by asset, a map of AssetId --> map of Orders
+using AssetOrders = std::unordered_map<AssetId, Orders>;
+// OrderBook is a mapping of AssetId --> map of asset pair's orders
+using OrderBook = std::unordered_map<AssetId, AssetOrders>;
+
+class OrderBookIsNotCrossed : public Invariant
+{
+  public:
+    explicit OrderBookIsNotCrossed() : Invariant(false)
+    {
+    }
+
+    static std::shared_ptr<Invariant> registerInvariant(Application& app);
+
+    virtual std::string getName() const override;
+
+    virtual std::string
+    checkOnOperationApply(Operation const& operation,
+                          OperationResult const& result,
+                          LedgerTxnDelta const& ltxDelta) override;
+
+    OrderBook
+    getOrderBook()
+    {
+        return mOrderBook;
+    }
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    void resetForFuzzer() override;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+  private:
+    // as of right now, since this is only used in fuzzing, the mOrderBook will
+    // be empty to start. If used in production, since invraiants are
+    // configurable, it is likely that this invariant will be enabled with
+    // pre-existing ledger and thus the mOrderBook will need a way to sync
+    OrderBook mOrderBook;
+};
+}

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -83,7 +83,7 @@ class OrderBookIsNotCrossed : public Invariant
     void deleteFromOrderBook(OfferEntry const& oe);
     void addToOrderBook(OfferEntry const& oe);
     void updateOrderBook(LedgerTxnDelta const& ltxd);
-    std::string check(std::set<std::pair<Asset, Asset>> assetPairs);
+    std::string check(std::set<std::pair<Asset, Asset>> const& assetPairs);
 };
 }
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -7,52 +7,11 @@
 
 #include "crypto/ByteSliceHasher.h"
 #include "invariant/Invariant.h"
+#include "ledger/LedgerHashUtils.h"
 #include "xdr/Stellar-ledger.h"
 
 #include <set>
 #include <unordered_map>
-
-using namespace stellar;
-
-namespace std
-{
-template <> class hash<stellar::Asset>
-{
-  public:
-    size_t
-    operator()(stellar::Asset const& asset) const
-    {
-        size_t res = 0;
-        switch (asset.type())
-        {
-        case ASSET_TYPE_NATIVE:
-            break;
-        case ASSET_TYPE_CREDIT_ALPHANUM4:
-        {
-            auto const& tl4 = asset.alphaNum4();
-            res ^= stellar::shortHash::computeHash(
-                stellar::ByteSlice(tl4.issuer.ed25519().data(), 8));
-            res ^= stellar::shortHash::computeHash(
-                stellar::ByteSlice(tl4.assetCode));
-            break;
-        }
-        case ASSET_TYPE_CREDIT_ALPHANUM12:
-        {
-            auto const& tl12 = asset.alphaNum12();
-            res ^= stellar::shortHash::computeHash(
-                stellar::ByteSlice(tl12.issuer.ed25519().data(), 8));
-            res ^= stellar::shortHash::computeHash(
-                stellar::ByteSlice(tl12.assetCode));
-            break;
-        }
-        default:
-            abort();
-        }
-
-        return res;
-    }
-};
-}
 
 namespace stellar
 {

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -56,7 +56,7 @@ generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
 
 bool
 store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
-      OperationResult const* resPtr)
+      OperationResult const* resPtr, Operation const* opPtr)
 {
     bool shouldCommit = !ltxPtr;
     std::unique_ptr<LedgerTxn> ltxStore;
@@ -107,8 +107,12 @@ store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
     bool doInvariantsHold = true;
     try
     {
-        app.getInvariantManager().checkOnOperationApply({}, *resPtr,
-                                                        ltxPtr->getDelta());
+        if (opPtr == nullptr)
+            app.getInvariantManager().checkOnOperationApply({}, *resPtr,
+                                                            ltxPtr->getDelta());
+        else
+            app.getInvariantManager().checkOnOperationApply(*opPtr, *resPtr,
+                                                            ltxPtr->getDelta());
     }
     catch (InvariantDoesNotHold&)
     {

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -56,7 +56,7 @@ generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
 
 bool
 store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
-      OperationResult const* resPtr)
+      OperationResult const* resPtr, Operation const* opPtr)
 {
     bool shouldCommit = !ltxPtr;
     std::unique_ptr<LedgerTxn> ltxStore;
@@ -107,8 +107,16 @@ store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
     bool doInvariantsHold = true;
     try
     {
-        app.getInvariantManager().checkOnOperationApply({}, *resPtr,
-                                                        ltxPtr->getDelta());
+        if (opPtr == nullptr)
+        {
+            app.getInvariantManager().checkOnOperationApply({}, *resPtr,
+                                                            ltxPtr->getDelta());
+        }
+        else
+        {
+            app.getInvariantManager().checkOnOperationApply(*opPtr, *resPtr,
+                                                            ltxPtr->getDelta());
+        }
     }
     catch (InvariantDoesNotHold&)
     {

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -56,7 +56,7 @@ generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
 
 bool
 store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
-      OperationResult const* resPtr, Operation const* opPtr)
+      OperationResult const* resPtr)
 {
     bool shouldCommit = !ltxPtr;
     std::unique_ptr<LedgerTxn> ltxStore;
@@ -107,12 +107,8 @@ store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
     bool doInvariantsHold = true;
     try
     {
-        if (opPtr == nullptr)
-            app.getInvariantManager().checkOnOperationApply({}, *resPtr,
-                                                            ltxPtr->getDelta());
-        else
-            app.getInvariantManager().checkOnOperationApply(*opPtr, *resPtr,
-                                                            ltxPtr->getDelta());
+        app.getInvariantManager().checkOnOperationApply({}, *resPtr,
+                                                        ltxPtr->getDelta());
     }
     catch (InvariantDoesNotHold&)
     {

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -33,6 +33,27 @@ generateRandomAccount(uint32_t ledgerSeq)
     return le;
 }
 
+LedgerEntry
+generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
+              Price price)
+{
+    REQUIRE(!(selling == buying));
+    REQUIRE(amount >= 1);
+
+    LedgerEntry le;
+    le.lastModifiedLedgerSeq = 2;
+    le.data.type(OFFER);
+
+    auto offer = LedgerTestUtils::generateValidOfferEntry();
+    offer.amount = amount;
+    offer.price = price;
+    offer.selling = selling;
+    offer.buying = buying;
+
+    le.data.offer() = offer;
+    return le;
+}
+
 bool
 store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
       OperationResult const* resPtr)

--- a/src/invariant/test/InvariantTestUtils.h
+++ b/src/invariant/test/InvariantTestUtils.h
@@ -12,13 +12,18 @@ namespace stellar
 
 class Application;
 class AbstractLedgerTxn;
+struct Asset;
 struct LedgerEntry;
 struct OperationResult;
+struct Operation;
+struct Price;
 
 namespace InvariantTestUtils
 {
 
 LedgerEntry generateRandomAccount(uint32_t ledgerSeq);
+LedgerEntry generateOffer(Asset const& selling, Asset const& buying,
+                          int64_t amount, Price price);
 
 typedef std::vector<
     std::tuple<std::shared_ptr<LedgerEntry>, std::shared_ptr<LedgerEntry>>>

--- a/src/invariant/test/InvariantTestUtils.h
+++ b/src/invariant/test/InvariantTestUtils.h
@@ -31,8 +31,7 @@ typedef std::vector<
 
 bool store(Application& app, UpdateList const& apply,
            AbstractLedgerTxn* ltxPtr = nullptr,
-           OperationResult const* resPtr = nullptr,
-           Operation const* opPtr = nullptr);
+           OperationResult const* resPtr = nullptr);
 
 UpdateList makeUpdateList(std::vector<LedgerEntry> const& current,
                           std::nullptr_t previous);

--- a/src/invariant/test/InvariantTestUtils.h
+++ b/src/invariant/test/InvariantTestUtils.h
@@ -31,7 +31,8 @@ typedef std::vector<
 
 bool store(Application& app, UpdateList const& apply,
            AbstractLedgerTxn* ltxPtr = nullptr,
-           OperationResult const* resPtr = nullptr);
+           OperationResult const* resPtr = nullptr,
+           Operation const* opPtr = nullptr);
 
 UpdateList makeUpdateList(std::vector<LedgerEntry> const& current,
                           std::nullptr_t previous);

--- a/src/invariant/test/LiabilitiesMatchOffersTests.cpp
+++ b/src/invariant/test/LiabilitiesMatchOffersTests.cpp
@@ -146,27 +146,6 @@ TEST_CASE("Account below minimum balance decreases",
 }
 
 static LedgerEntry
-generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
-              Price price)
-{
-    REQUIRE(!(selling == buying));
-    REQUIRE(amount >= 1);
-
-    LedgerEntry le;
-    le.lastModifiedLedgerSeq = 2;
-    le.data.type(OFFER);
-
-    auto offer = LedgerTestUtils::generateValidOfferEntry();
-    offer.amount = amount;
-    offer.price = price;
-    offer.selling = selling;
-    offer.buying = buying;
-
-    le.data.offer() = offer;
-    return le;
-}
-
-static LedgerEntry
 generateSellingLiabilities(Application& app, LedgerEntry offer, bool excess,
                            bool authorized)
 {

--- a/src/invariant/test/OrderBookIsNotCrossedTests.cpp
+++ b/src/invariant/test/OrderBookIsNotCrossedTests.cpp
@@ -1,0 +1,274 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "invariant/InvariantDoesNotHold.h"
+#include "invariant/InvariantManager.h"
+#include "invariant/OrderBookIsNotCrossed.h"
+#include "invariant/test/InvariantTestUtils.h"
+#include "ledger/LedgerTxn.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "test/test.h"
+
+using namespace stellar;
+using namespace stellar::InvariantTestUtils;
+
+#define SHOULD_THROW false
+#define SHOULD_PASS true
+
+// XNOR's truth table is as follows:
+// | a | b | a XNOR b |
+// |---|---|----------|
+// | 0 | 0 |     1    |
+// | 0 | 1 |     0    |
+// | 1 | 0 |     0    |
+// | 1 | 1 |     1    |
+bool
+XNOR(bool a, bool b)
+{
+    return (a && b) || (!a && !b);
+}
+
+void
+genApplyCheckCreateOffer(Asset& ask, Asset& bid, int64 amount, Price price,
+                         Application& app, bool shouldPass)
+{
+    auto offer = generateOffer(ask, bid, amount, price);
+    auto op = txtest::manageOffer(offer.data.offer().offerID, ask, bid, price,
+                                  amount);
+    std::vector<LedgerEntry> current{offer};
+    auto updates = makeUpdateList(current, nullptr);
+    REQUIRE(XNOR(store(app, updates, nullptr, nullptr, &op), shouldPass));
+}
+
+void
+genApplyCheckModifyOffer(Asset& ask, Asset& bid, int64 amount, Price price,
+                         Application& app, int64 offerId, AccountID sellerId,
+                         std::vector<LedgerEntry> previous, Operation& op,
+                         bool shouldPass)
+{
+    auto offer = generateOffer(ask, bid, amount, price);
+    offer.data.offer().sellerID = sellerId;
+    offer.data.offer().offerID = offerId;
+    std::vector<LedgerEntry> current{offer};
+    auto updates = makeUpdateList(current, previous);
+    REQUIRE(XNOR(store(app, updates, nullptr, nullptr, &op), shouldPass));
+}
+
+void
+genApplyCheckDeleteOffer(Application& app, std::vector<LedgerEntry> previous,
+                         Operation& op, bool shouldPass)
+{
+    op.body.manageSellOfferOp().amount = 0;
+    auto updates = makeUpdateList(nullptr, previous);
+    REQUIRE(XNOR(store(app, updates, nullptr, nullptr, &op), shouldPass));
+}
+
+TEST_CASE("OrderBookIsNotCrossed in-memory order book is consistent with "
+          "application behaviour",
+          "[invariant][OrderBookIsNotCrossed]")
+{
+
+    Asset cur1;
+    cur1.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(cur1.alphaNum4().assetCode, "CUR1");
+    const auto cur1AssetId = "CUR1-" + KeyUtils::toStrKey(getIssuer(cur1));
+
+    Asset cur2;
+    cur2.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(cur2.alphaNum4().assetCode, "CUR2");
+    const auto cur2AssetId = "CUR2-" + KeyUtils::toStrKey(getIssuer(cur2));
+
+    Config cfg = getTestConfig(0);
+    cfg.INVARIANT_CHECKS = {"OrderBookIsNotCrossed"};
+
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+
+    auto invariant = std::make_shared<OrderBookIsNotCrossed>();
+
+    SECTION("Create offer")
+    {
+        Operation op{};
+        OperationResult opRes{};
+        auto offer1 = generateOffer(cur1, cur2, 3, Price{3, 2});
+
+        auto ltxStore = std::make_unique<LedgerTxn>(app->getLedgerTxnRoot());
+        auto ltxPtr = ltxStore.get();
+        auto entry = ltxPtr->create(offer1);
+
+        invariant->checkOnOperationApply(op, opRes, ltxPtr->getDelta());
+        auto orderbook = invariant->getOrderBook();
+        auto orders = orderbook[cur1AssetId][cur2AssetId];
+
+        REQUIRE(orders.size() == 1);
+        REQUIRE(orders.at(offer1.data.offer().offerID).amount == 3);
+        REQUIRE(orders.at(offer1.data.offer().offerID).price.n == 3);
+        REQUIRE(orders.at(offer1.data.offer().offerID).price.d == 2);
+
+        ltxPtr->commit();
+
+        SECTION("Then modify offer")
+        {
+            auto offer2 = generateOffer(cur1, cur2, 2, Price{5, 3});
+            offer2.data.offer().sellerID = offer1.data.offer().sellerID;
+            offer2.data.offer().offerID = offer1.data.offer().offerID;
+
+            auto ltxStore =
+                std::make_unique<LedgerTxn>(app->getLedgerTxnRoot());
+            auto ltxPtr = ltxStore.get();
+            auto entry = ltxPtr->load(LedgerEntryKey(offer1));
+            entry.current() = offer2;
+
+            invariant->checkOnOperationApply(op, opRes, ltxPtr->getDelta());
+            auto orderbook = invariant->getOrderBook();
+            auto orders = orderbook[cur1AssetId][cur2AssetId];
+
+            REQUIRE(orders.size() == 1);
+            REQUIRE(orders.at(offer2.data.offer().offerID).amount == 2);
+            REQUIRE(orders.at(offer2.data.offer().offerID).price.n == 5);
+            REQUIRE(orders.at(offer2.data.offer().offerID).price.d == 3);
+        }
+
+        SECTION("Then delete offer")
+        {
+            auto ltxStore =
+                std::make_unique<LedgerTxn>(app->getLedgerTxnRoot());
+            auto ltxPtr = ltxStore.get();
+            auto entry = ltxPtr->load(LedgerEntryKey(offer1));
+            entry.erase();
+
+            invariant->checkOnOperationApply(op, opRes, ltxPtr->getDelta());
+            auto orderbook = invariant->getOrderBook();
+            auto orders = orderbook[cur1AssetId][cur2AssetId];
+
+            REQUIRE(orders.size() == 0);
+        }
+    }
+}
+
+TEST_CASE("OrderBookIsNotCrossed properly throws if order book is crossed",
+          "[invariant][OrderBookIsNotCrossed]")
+{
+    Config cfg = getTestConfig(0);
+    cfg.INVARIANT_CHECKS = {"OrderBookIsNotCrossed"};
+
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+
+    Asset cur1;
+    cur1.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(cur1.alphaNum4().assetCode, "CUR1");
+
+    Asset cur2;
+    cur2.type(ASSET_TYPE_CREDIT_ALPHANUM4);
+    strToAssetCode(cur2.alphaNum4().assetCode, "CUR2");
+
+    // the initial state for the order book is:
+    //     3 A @  3/2 (B/A)
+    //     2 A @  5/3 (B/A)
+    //     4 B @  3/4 (A/B)
+    //     1 B @  4/5 (A/B)
+    // where A = cur1 and B = cur2
+    genApplyCheckCreateOffer(cur1, cur2, 3, Price{3, 2}, *app, SHOULD_PASS);
+    genApplyCheckCreateOffer(cur1, cur2, 2, Price{5, 3}, *app, SHOULD_PASS);
+    genApplyCheckCreateOffer(cur2, cur1, 4, Price{3, 4}, *app, SHOULD_PASS);
+    genApplyCheckCreateOffer(cur2, cur1, 1, Price{4, 5}, *app, SHOULD_PASS);
+
+    SECTION("Not crossed when highest bid < lowest ask")
+    {
+        SECTION("Create offer")
+        {
+            // Offer 5: 7 A @  8/5 (B/A)
+            auto offer5 = generateOffer(cur1, cur2, 7, Price{8, 5});
+            auto op5 = txtest::manageOffer(offer5.data.offer().offerID, cur1,
+                                           cur2, Price{8, 5}, 7);
+            std::vector<LedgerEntry> current5{offer5};
+            auto updates5 = makeUpdateList(current5, nullptr);
+            REQUIRE(store(*app, updates5, nullptr, nullptr, &op5));
+
+            SECTION("Then modify offer")
+            {
+                // Offer 6: 7 A @  16/11 (B/A) - MODIFY
+                genApplyCheckModifyOffer(cur1, cur2, 7, Price{16, 11}, *app,
+                                         offer5.data.offer().offerID,
+                                         offer5.data.offer().sellerID, current5,
+                                         op5, SHOULD_PASS);
+            }
+
+            SECTION("Then delete offer")
+            {
+                // Offer 6: 0 A @  8/5 (B/A) - DELETE
+                genApplyCheckDeleteOffer(*app, current5, op5, SHOULD_PASS);
+            }
+        }
+    }
+    SECTION("Crossed where highest bid = lowest ask")
+    {
+        SECTION("Create offer")
+        {
+            // Offer 5: 7 A @  4/3 (B/A)
+            auto offer5 = generateOffer(cur1, cur2, 7, Price{4, 3});
+            auto op5 = txtest::manageOffer(offer5.data.offer().offerID, cur1,
+                                           cur2, Price{4, 3}, 7);
+            std::vector<LedgerEntry> current5{offer5};
+            auto updates5 = makeUpdateList(current5, nullptr);
+            REQUIRE(!store(*app, updates5, nullptr, nullptr, &op5));
+
+            SECTION("Then modify offer")
+            {
+                // Offer 6: 3 A @ 4/3 (B/A) - MODIFY
+                genApplyCheckModifyOffer(cur1, cur2, 3, Price{4, 3}, *app,
+                                         offer5.data.offer().offerID,
+                                         offer5.data.offer().sellerID, current5,
+                                         op5, SHOULD_THROW);
+            }
+
+            SECTION("Then delete offer and create offer crossing other side of "
+                    "order book")
+            {
+                // Offer 6: 0 A @  4/3 (B/A) - DELETE
+                genApplyCheckDeleteOffer(*app, current5, op5, SHOULD_PASS);
+
+                // Offer 7: 2 B @  3/5 (A/B)
+                genApplyCheckCreateOffer(cur2, cur1, 3, Price{3, 5}, *app,
+                                         SHOULD_THROW);
+            }
+        }
+    }
+
+    SECTION("Crossed where highest bid > lowest ask")
+    {
+        SECTION("Create offer")
+        {
+            // Offer 5: 7 A @  1/1 (B/A)
+            auto offer5 = generateOffer(cur1, cur2, 7, Price{1, 1});
+            auto op5 = txtest::manageOffer(offer5.data.offer().offerID, cur1,
+                                           cur2, Price{1, 1}, 7);
+            std::vector<LedgerEntry> current5{offer5};
+            auto updates5 = makeUpdateList(current5, nullptr);
+            REQUIRE(!store(*app, updates5, nullptr, nullptr, &op5));
+
+            SECTION("Then modify offer")
+            {
+                // Offer 6: 3 A @ 100/76 (B/A) - MODIFY
+                genApplyCheckModifyOffer(cur1, cur2, 3, Price{100, 76}, *app,
+                                         offer5.data.offer().offerID,
+                                         offer5.data.offer().sellerID, current5,
+                                         op5, SHOULD_THROW);
+            }
+
+            SECTION("Then delete offer and create offer crossing other side of "
+                    "order book")
+            {
+                // Offer 6: 0 A @  1/1 (B/A) - DELETE
+                genApplyCheckDeleteOffer(*app, current5, op5, SHOULD_PASS);
+
+                // Offer 7: 2 B @  61/100 (A/B)
+                genApplyCheckCreateOffer(cur2, cur1, 2, Price{61, 100}, *app,
+                                         SHOULD_THROW);
+            }
+        }
+    }
+}

--- a/src/invariant/test/OrderBookIsNotCrossedTests.cpp
+++ b/src/invariant/test/OrderBookIsNotCrossedTests.cpp
@@ -1,3 +1,4 @@
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
@@ -272,3 +273,4 @@ TEST_CASE("OrderBookIsNotCrossed properly throws if order book is crossed",
         }
     }
 }
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -70,4 +70,42 @@ template <> class hash<stellar::LedgerKey>
         return res;
     }
 };
+
+// implements a default hasher for "Asset"
+template <> class hash<stellar::Asset>
+{
+  public:
+    size_t
+    operator()(stellar::Asset const& asset) const
+    {
+        size_t res = 0;
+        switch (asset.type())
+        {
+        case stellar::ASSET_TYPE_NATIVE:
+            break;
+        case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
+        {
+            auto const& tl4 = asset.alphaNum4();
+            res ^= stellar::shortHash::computeHash(
+                stellar::ByteSlice(tl4.issuer.ed25519().data(), 8));
+            res ^= stellar::shortHash::computeHash(
+                stellar::ByteSlice(tl4.assetCode));
+            break;
+        }
+        case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
+        {
+            auto const& tl12 = asset.alphaNum12();
+            res ^= stellar::shortHash::computeHash(
+                stellar::ByteSlice(tl12.issuer.ed25519().data(), 8));
+            res ^= stellar::shortHash::computeHash(
+                stellar::ByteSlice(tl12.assetCode));
+            break;
+        }
+        default:
+            abort();
+        }
+
+        return res;
+    }
+};
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -24,7 +24,6 @@
 #include "invariant/InvariantManager.h"
 #include "invariant/LedgerEntryIsValid.h"
 #include "invariant/LiabilitiesMatchOffers.h"
-#include "invariant/OrderBookIsNotCrossed.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "main/CommandHandler.h"
@@ -52,6 +51,10 @@
 #ifdef BUILD_TESTS
 #include "simulation/LoadGenerator.h"
 #endif
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#include "invariant/OrderBookIsNotCrossed.h"
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
 #include <set>
 #include <string>
@@ -142,7 +145,9 @@ ApplicationImpl::initialize(bool createNewDB)
     ConservationOfLumens::registerInvariant(*this);
     LedgerEntryIsValid::registerInvariant(*this);
     LiabilitiesMatchOffers::registerInvariant(*this);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     OrderBookIsNotCrossed::registerInvariant(*this);
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     enableInvariantsFromConfig();
 
     if (createNewDB || mConfig.DATABASE.value == "sqlite3://:memory:")

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -24,6 +24,7 @@
 #include "invariant/InvariantManager.h"
 #include "invariant/LedgerEntryIsValid.h"
 #include "invariant/LiabilitiesMatchOffers.h"
+#include "invariant/OrderBookIsNotCrossed.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "main/CommandHandler.h"
@@ -141,6 +142,7 @@ ApplicationImpl::initialize(bool createNewDB)
     ConservationOfLumens::registerInvariant(*this);
     LedgerEntryIsValid::registerInvariant(*this);
     LiabilitiesMatchOffers::registerInvariant(*this);
+    OrderBookIsNotCrossed::registerInvariant(*this);
     enableInvariantsFromConfig();
 
     if (createNewDB || mConfig.DATABASE.value == "sqlite3://:memory:")

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -216,8 +216,16 @@ TransactionFuzzer::inject(XDRInputFileStream& in)
             resetTxInternalState(*mApp);
             LedgerTxn ltx(mApp->getLedgerTxnRoot());
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            mApp->getInvariantManager().snapshotForFuzzer();
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
             // attempt to apply transaction
             txFramePtr->attemptApplication(*mApp, ltx);
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            mApp->getInvariantManager().resetForFuzzer();
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         }
         resetTxInternalState(*mApp);
     }


### PR DESCRIPTION
# Description

This PR introduces a new invariant, named `OrderBookIsNotCrossed`. 

## Background:
Pre-protocol 10 was allowing in some cases the order book to be in a crossed state. The example from [CAP-0004](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0004.md#motivation) reads:

> “In transaction 1, account A creates an offer selling 100 X at a price of 10 Y / 1 X.
In transaction 2, account B creates an offer selling 1 stroop Y at a price of 1 X / 10 Y.
As of protocol version 9, nothing is exchanged and the book remains crossed.” 

Put very simply, a crossed state is one such that the top of the book contains a highest bid higher than the lowest ask. 

## Implementation Overview

This invariant, unlike the previous five, requires *some state* to determine the highest bid and the lowest ask. For this, I utilize a nested map data structure to simulate an order book, which is updated upon each call of `checkOnOperationApply` based on the offer entries in `LedgerTxnDelta`.  Since this invariant will be used by the fuzzing code in #2182, which requires a reset of state between execution cycles, I have introduced a `resetForFuzzer` method to the base invariant class. 

## Open Questions
* Naming -- *IsNot* does not flow off the tongue
* Method of determining best order -- for now I just iterate through all orders for a given asset pair and take the highest/lowest (*O*(N)). This should be fine for small order books in fuzzing, but is not production ready.
* Initial in-memory order book state -- for now there is no way to initialize an order book. For fuzzing I believe this is fine, however it may be something we want (however, this in-memory structure in general is certainly not a production approach).

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
