### PR TITLE
Cut network from state

### DIFF
--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -373,8 +373,8 @@ TEST_CASE("bucketmanager missing buckets fail", "[bucket][bucketmanager]")
     // Check that restarting the app crashes.
     {
         VirtualClock clock;
-        Application::pointer app =
-            createTestApplication(clock, cfg, /*newDB=*/false);
+        Application::pointer app = createTestApplication(
+            clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         CHECK_THROWS_AS(app->start(), std::runtime_error);
     }
 }
@@ -1185,7 +1185,8 @@ class StopAndRestartBucketMergesTest
                     << "Restarting application at ledger " << std::dec << i;
                 clock = std::make_unique<VirtualClock>();
                 app = createTestApplication<LedgerManagerTestApplication>(
-                    *clock, cfg, false);
+                    *clock, cfg,
+                    Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
                 app->start();
                 if (BucketList::levelShouldSpill(i, mDesignatedLevel - 1))
                 {
@@ -1372,7 +1373,9 @@ TEST_CASE("bucket persistence over app restart",
         cfg1.FORCE_SCP = false;
         {
             VirtualClock clock;
-            Application::pointer app = Application::create(clock, cfg1, false);
+            Application::pointer app = Application::create(
+                clock, cfg1,
+                Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
             app->start();
             BucketList& bl = app->getBucketManager().getBucketList();
 

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -85,6 +85,7 @@ class Database : NonMovableOrCopyable
 {
     Application& mApp;
     medida::Meter& mQueryMeter;
+    bool mIsOpen{false};
     soci::session mSession;
     std::unique_ptr<soci::connection_pool> mPool;
 
@@ -104,9 +105,11 @@ class Database : NonMovableOrCopyable
     void applySchemaUpgrade(unsigned long vers);
 
   public:
-    // Instantiate object and connect to app.getConfig().DATABASE;
-    // if there is a connection error, this will throw.
     Database(Application& app);
+
+    // Connect to app.getConfig().DATABASE; if there is a connection error, this
+    // will throw.
+    void ensureOpen();
 
     // Return a crude meter of total queries to the db, for use in
     // overlay/LoadManager.

--- a/src/database/DatabaseImpl.cpp
+++ b/src/database/DatabaseImpl.cpp
@@ -196,7 +196,7 @@ DatabaseImpl::ensureOpen()
     mSession.open(mApp.getConfig().DATABASE.value);
     mIsOpen = true;
     DatabaseConfigureSessionOp op(mSession);
-    doDatabaseTypeSpecificOperation(op);
+    doDatabaseTypeSpecificOperation(op, &mSession);
 }
 
 void
@@ -418,6 +418,7 @@ DatabaseImpl::getSession()
 soci::connection_pool&
 DatabaseImpl::getPool()
 {
+    std::unique_lock<std::mutex> lock(mPoolMutex);
     if (!mPool)
     {
         auto const& c = mApp.getConfig().DATABASE;
@@ -437,7 +438,7 @@ DatabaseImpl::getPool()
             soci::session& sess = mPool->at(i);
             sess.open(c.value);
             DatabaseConfigureSessionOp op(sess);
-            doDatabaseTypeSpecificOperation(op);
+            doDatabaseTypeSpecificOperation(op, &sess);
         }
     }
     assert(mPool);

--- a/src/database/DatabaseImpl.h
+++ b/src/database/DatabaseImpl.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "database/Database.h"
+#include "util/NonCopyable.h"
+
+namespace stellar
+{
+
+class DatabaseImpl : public Database, NonMovableOrCopyable
+{
+    Application& mApp;
+    medida::Meter& mQueryMeter;
+    bool mIsOpen{false};
+    soci::session mSession;
+    std::unique_ptr<soci::connection_pool> mPool;
+
+    std::map<std::string, std::shared_ptr<soci::statement>> mStatements;
+    medida::Counter& mStatementsSize;
+
+    // Helpers for maintaining the total query time and calculating
+    // idle percentage.
+    std::set<std::string> mEntityTypes;
+    std::chrono::nanoseconds mExcludedQueryTime;
+    std::chrono::nanoseconds mExcludedTotalTime;
+    std::chrono::nanoseconds mLastIdleQueryTime;
+    VirtualClock::time_point mLastIdleTotalTime;
+
+    static bool gDriversRegistered;
+    static void registerDrivers();
+    void applySchemaUpgrade(unsigned long vers);
+
+  public:
+    DatabaseImpl(Application& app);
+
+    void ensureOpen() override;
+
+    medida::Meter& getQueryMeter() override;
+    std::chrono::nanoseconds totalQueryTime() const override;
+    void excludeTime(std::chrono::nanoseconds const& queryTime,
+                     std::chrono::nanoseconds const& totalTime) override;
+    uint32_t recentIdleDbPercent() override;
+    std::shared_ptr<SQLLogContext>
+    captureAndLogSQL(std::string contextName) override;
+    StatementContext getPreparedStatement(std::string const& query) override;
+    void clearPreparedStatementCache() override;
+
+    medida::TimerContext getInsertTimer(std::string const& entityName) override;
+    medida::TimerContext getSelectTimer(std::string const& entityName) override;
+    medida::TimerContext getDeleteTimer(std::string const& entityName) override;
+    medida::TimerContext getUpdateTimer(std::string const& entityName) override;
+    medida::TimerContext getUpsertTimer(std::string const& entityName) override;
+
+    void setCurrentTransactionReadOnly() override;
+    bool isSqlite() const override;
+    bool canUsePool() const override;
+    void initialize() override;
+    void putSchemaVersion(unsigned long vers) override;
+    unsigned long getDBSchemaVersion() override;
+    unsigned long getAppSchemaVersion() override;
+    void upgradeToCurrentSchema() override;
+    soci::session& getSession() override;
+    soci::connection_pool& getPool() override;
+};
+}

--- a/src/database/DatabaseImpl.h
+++ b/src/database/DatabaseImpl.h
@@ -6,6 +6,7 @@
 
 #include "database/Database.h"
 #include "util/NonCopyable.h"
+#include <mutex>
 
 namespace stellar
 {
@@ -16,6 +17,7 @@ class DatabaseImpl : public Database, NonMovableOrCopyable
     medida::Meter& mQueryMeter;
     bool mIsOpen{false};
     soci::session mSession;
+    std::mutex mPoolMutex;
     std::unique_ptr<soci::connection_pool> mPool;
 
     std::map<std::string, std::shared_ptr<soci::statement>> mStatements;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -106,6 +106,8 @@ class Herder
     virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
+    virtual bool checkTxSetValid(TxSetFramePtr txSet) = 0;
+
     // We are learning about a new envelope.
     virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -689,6 +689,12 @@ HerderImpl::getQSet(Hash const& qSetHash)
     return mHerderSCPDriver.getQSet(qSetHash);
 }
 
+bool
+HerderImpl::checkTxSetValid(TxSetFramePtr txSet)
+{
+    return txSet->checkValid(mApp);
+}
+
 uint32_t
 HerderImpl::getCurrentLedgerSeq() const
 {
@@ -736,7 +742,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
 
     proposedSet->surgePricingFilter(mApp);
 
-    if (!proposedSet->checkValid(mApp))
+    if (!checkTxSetValid(proposedSet))
     {
         throw std::runtime_error("wanting to emit an invalid txSet");
     }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -75,6 +75,8 @@ class HerderImpl : public Herder
     TxSetFramePtr getTxSet(Hash const& hash) override;
     SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;
 
+    bool checkTxSetValid(TxSetFramePtr txSet) override;
+
     void processSCPQueue();
 
     uint32_t getCurrentLedgerSeq() const override;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -151,13 +151,13 @@ class HerderImpl : public Herder
     VirtualClock::time_point mLastExternalize;
 
     // saves the SCP messages that the instance sent out last
-    void persistSCPState(uint64 slot);
+    virtual void persistSCPState(uint64 slot);
     // restores SCP state based on the last messages saved on disk
-    void restoreSCPState();
+    virtual void restoreSCPState();
 
     // saves upgrade parameters
-    void persistUpgrades();
-    void restoreUpgrades();
+    virtual void persistUpgrades();
+    virtual void restoreUpgrades();
 
     // called every time we get ledger externalized
     // ensures that if we don't hear from the network, we throw the herder into

--- a/src/herder/HerderPersistence.h
+++ b/src/herder/HerderPersistence.h
@@ -35,15 +35,13 @@ class HerderPersistence
                                 std::vector<SCPEnvelope> const& envs,
                                 QuorumTracker::QuorumMap const& qmap) = 0;
 
-    static size_t copySCPHistoryToStream(Database& db, soci::session& sess,
-                                         uint32_t ledgerSeq,
-                                         uint32_t ledgerCount,
-                                         XDROutputFileStream& scpHistory);
+    virtual size_t copySCPHistoryToStream(Database& db, soci::session& sess,
+                                          uint32_t ledgerSeq,
+                                          uint32_t ledgerCount,
+                                          XDROutputFileStream& scpHistory);
     // quorum information lookup
-    static optional<Hash> getNodeQuorumSet(Database& db, soci::session& sess,
-                                           NodeID const& nodeID);
-    static SCPQuorumSetPtr getQuorumSet(Database& db, soci::session& sess,
-                                        Hash const& qSetHash);
+    virtual optional<Hash> getNodeQuorumSet(Database& db, NodeID const& nodeID);
+    virtual SCPQuorumSetPtr getQuorumSet(Database& db, Hash const& qSetHash);
 
     static void dropAll(Database& db);
     static void deleteOldEntries(Database& db, uint32_t ledgerSeq,

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -295,7 +295,8 @@ HerderPersistence::getNodeQuorumSet(Database& db, NodeID const& nodeID)
 SCPQuorumSetPtr
 HerderPersistence::getQuorumSet(Database& db, Hash const& qSetHash)
 {
-    soci::session& sess = db.getSession();
+    MaybeBackgroundThreadSession mbts(db);
+    soci::session& sess = mbts.getSession();
     SCPQuorumSetPtr res;
     SCPQuorumSet qset;
     std::string qset64, qSetHashHex;

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -251,7 +251,7 @@ HerderPersistence::copySCPHistoryToStream(Database& db, soci::session& sess,
         {
             std::string qset64, qSetHashHex;
 
-            auto qset = getQuorumSet(db, sess, q);
+            auto qset = getQuorumSet(db, q);
             if (!qset)
             {
                 throw std::runtime_error(
@@ -270,9 +270,9 @@ HerderPersistence::copySCPHistoryToStream(Database& db, soci::session& sess,
 }
 
 optional<Hash>
-HerderPersistence::getNodeQuorumSet(Database& db, soci::session& sess,
-                                    NodeID const& nodeID)
+HerderPersistence::getNodeQuorumSet(Database& db, NodeID const& nodeID)
 {
+    soci::session& sess = db.getSession();
     std::string nodeIDStrKey = KeyUtils::toStrKey(nodeID);
     std::string qsethHex;
 
@@ -293,9 +293,9 @@ HerderPersistence::getNodeQuorumSet(Database& db, soci::session& sess,
 }
 
 SCPQuorumSetPtr
-HerderPersistence::getQuorumSet(Database& db, soci::session& sess,
-                                Hash const& qSetHash)
+HerderPersistence::getQuorumSet(Database& db, Hash const& qSetHash)
 {
+    soci::session& sess = db.getSession();
     SCPQuorumSetPtr res;
     SCPQuorumSet qset;
     std::string qset64, qSetHashHex;

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -311,7 +311,7 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
 
         res = SCPDriver::kInvalidValue;
     }
-    else if (!txSet->checkValid(mApp))
+    else if (!mHerder.checkTxSetValid(txSet))
     {
         if (Logging::logDebug("Herder"))
             CLOG(DEBUG, "Herder") << "HerderSCPDriver::validateValue"

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -490,7 +490,7 @@ PendingEnvelopes::getQSet(Hash const& hash)
     else
     {
         auto& db = mApp.getDatabase();
-        qset = HerderPersistence::getQuorumSet(db, db.getSession(), hash);
+        qset = mApp.getHerderPersistence().getQuorumSet(db, hash);
     }
     if (qset)
     {
@@ -557,8 +557,7 @@ PendingEnvelopes::rebuildQuorumTrackerState()
             {
                 // see if we had some information for that node
                 auto& db = mApp.getDatabase();
-                auto h = HerderPersistence::getNodeQuorumSet(
-                    db, db.getSession(), id);
+                auto h = mApp.getHerderPersistence().getNodeQuorumSet(db, id);
                 if (h)
                 {
                     res = getQSet(*h);

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -215,6 +215,10 @@ TxSetFrame::buildAccountTxQueues()
 void
 TxSetFrame::surgePricingFilter(Application& app)
 {
+    if (mTransactions.empty())
+    {
+        return;
+    }
     LedgerTxn ltx(app.getLedgerTxnRoot());
     auto header = ltx.loadHeader();
 
@@ -286,6 +290,11 @@ TxSetFrame::checkOrTrim(
     std::function<bool(std::deque<TransactionFramePtr> const&)>
         processInsufficientBalance)
 {
+    if (mTransactions.empty())
+    {
+        return true;
+    }
+
     LedgerTxn ltx(app.getLedgerTxnRoot());
 
     auto accountTxMap = buildAccountTxQueues();

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1285,8 +1285,10 @@ TEST_CASE("SCP State", "[herder][acceptance]")
         // forwarded to node 2 when they connect to it
         // causing node 2 to externalize ledger #6
 
-        sim->addNode(nodeKeys[0], qSetAll, &nodeCfgs[0], false);
-        sim->addNode(nodeKeys[1], qSetAll, &nodeCfgs[1], false);
+        sim->addNode(nodeKeys[0], qSetAll, &nodeCfgs[0],
+                     Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
+        sim->addNode(nodeKeys[1], qSetAll, &nodeCfgs[1],
+                     Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         sim->getNode(nodeIDs[0])->start();
         sim->getNode(nodeIDs[1])->start();
 

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -158,7 +158,9 @@ TEST_CASE("quorum tracker", "[quorum][herder][acceptance]")
                 clock.reset();
 
                 clock = std::make_shared<VirtualClock>();
-                app = Application::create(*clock, cfg, false);
+                app = Application::create(
+                    *clock, cfg,
+                    Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
                 app->start();
                 herder = static_cast<HerderImpl*>(&app->getHerder());
                 penEnvs = &herder->getPendingEnvelopes();

--- a/src/history/InferredQuorumUtils.cpp
+++ b/src/history/InferredQuorumUtils.cpp
@@ -37,7 +37,8 @@ checkQuorumIntersection(Config const& cfg, uint32_t ledgerNum)
     VirtualClock clock;
     Config cfg2(cfg);
     cfg2.setNoListen();
-    Application::pointer app = Application::create(clock, cfg2, false);
+    Application::pointer app = Application::create(
+        clock, cfg2, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
     LOG(INFO) << "Checking last-heard quorum from herder";
     app->start();
     auto qmap = getQuorumMapForLedger(app, ledgerNum);
@@ -53,7 +54,8 @@ inferQuorumAndWrite(Config const& cfg, uint32_t ledgerNum)
     {
         VirtualClock clock;
         cfg2.setNoListen();
-        Application::pointer app = Application::create(clock, cfg2, false);
+        Application::pointer app = Application::create(
+            clock, cfg2, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         auto qmap = getQuorumMapForLedger(app, ledgerNum);
         iq = InferredQuorum(qmap);
     }
@@ -70,7 +72,8 @@ writeQuorumGraph(Config const& cfg, std::string const& outputFile,
     {
         VirtualClock clock;
         cfg2.setNoListen();
-        Application::pointer app = Application::create(clock, cfg2, false);
+        Application::pointer app = Application::create(
+            clock, cfg2, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         auto qmap = getQuorumMapForLedger(app, ledgerNum);
         iq = InferredQuorum(qmap);
     }

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -71,11 +71,8 @@ StateSnapshot::makeLive()
 bool
 StateSnapshot::writeHistoryBlocks() const
 {
-    std::unique_ptr<soci::session> snapSess(
-        mApp.getDatabase().canUsePool()
-            ? std::make_unique<soci::session>(mApp.getDatabase().getPool())
-            : nullptr);
-    soci::session& sess(snapSess ? *snapSess : mApp.getDatabase().getSession());
+    MaybeBackgroundThreadSession mbts(mApp.getDatabase());
+    soci::session& sess = mbts.getSession();
     soci::transaction tx(sess);
 
     // The current "history block" is stored in _four_ files, one just ledger

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -119,7 +119,7 @@ StateSnapshot::writeHistoryBlocks() const
             << mTransactionSnapFile->localPath_nogz() << " and "
             << mTransactionResultSnapFile->localPath_nogz();
 
-        nbSCPMessages = HerderPersistence::copySCPHistoryToStream(
+        nbSCPMessages = mApp.getHerderPersistence().copySCPHistoryToStream(
             mApp.getDatabase(), sess, begin, count, scpHistory);
 
         CLOG(DEBUG, "History")

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -751,7 +751,8 @@ TEST_CASE("persist publish queue", "[history][publish][acceptance]")
 
     {
         VirtualClock clock;
-        Application::pointer app1 = Application::create(clock, cfg, 0);
+        Application::pointer app1 = Application::create(
+            clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         app1->getHistoryArchiveManager().initializeHistoryArchive(
             tcfg.getArchiveDirName());
         for (size_t i = 0; i < 100; ++i)

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -126,7 +126,7 @@ class LedgerManagerImpl : public LedgerManager
     uint64_t secondsSinceLastLedgerClose() const override;
     void syncMetrics() override;
 
-    void startNewLedger(LedgerHeader const& genesisLedger);
+    virtual void startNewLedger(LedgerHeader const& genesisLedger);
     void startNewLedger() override;
     void loadLastKnownLedger(
         std::function<void(asio::error_code const& ec)> handler) override;

--- a/src/ledger/test/LedgerHeaderTests.cpp
+++ b/src/ledger/test/LedgerHeaderTests.cpp
@@ -85,7 +85,8 @@ TEST_CASE("ledgerheader", "[ledger]")
         Config cfg2(cfg);
         cfg2.FORCE_SCP = false;
         VirtualClock clock2;
-        Application::pointer app2 = Application::create(clock2, cfg2, false);
+        Application::pointer app2 = Application::create(
+            clock2, cfg2, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         app2->start();
 
         REQUIRE(saved ==

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -4,6 +4,7 @@
 
 #include "Application.h"
 #include "ApplicationImpl.h"
+#include "main/PersistentState.h"
 #include "util/format.h"
 
 namespace stellar

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -37,8 +37,9 @@ validateNetworkPassphrase(Application::pointer app)
 }
 
 Application::pointer
-Application::create(VirtualClock& clock, Config const& cfg, bool newDB)
+Application::create(VirtualClock& clock, Config const& cfg,
+                    InitialDBMode initDBMode)
 {
-    return create<ApplicationImpl>(clock, cfg, newDB);
+    return create<ApplicationImpl>(clock, cfg, initDBMode);
 }
 }

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -157,9 +157,16 @@ class Application
         APP_NUM_STATE
     };
 
+    enum InitialDBMode
+    {
+        APP_DB_CREATE_NEW,
+        APP_DB_UPGRADE_EXISTING,
+        APP_DB_DONT_OPEN,
+    };
+
     virtual ~Application(){};
 
-    virtual void initialize(bool createNewDB) = 0;
+    virtual void initialize(InitialDBMode initDBMode) = 0;
 
     // Return the time in seconds since the POSIX epoch, according to the
     // VirtualClock this Application is bound to. Convenience method.
@@ -278,15 +285,20 @@ class Application
 
     // Factory: create a new Application object bound to `clock`, with a local
     // copy made of `cfg`.
-    static pointer create(VirtualClock& clock, Config const& cfg,
-                          bool newDB = true);
+    static pointer
+    create(VirtualClock& clock, Config const& cfg,
+           InitialDBMode initDBMode = InitialDBMode::APP_DB_CREATE_NEW);
     template <typename T>
     static std::shared_ptr<T>
-    create(VirtualClock& clock, Config const& cfg, bool newDB = true)
+    create(VirtualClock& clock, Config const& cfg,
+           InitialDBMode initDBMode = InitialDBMode::APP_DB_CREATE_NEW)
     {
         auto ret = std::make_shared<T>(clock, cfg);
-        ret->initialize(newDB);
-        validateNetworkPassphrase(ret);
+        ret->initialize(initDBMode);
+        if (initDBMode != InitialDBMode::APP_DB_DONT_OPEN)
+        {
+            validateNetworkPassphrase(ret);
+        }
 
         return ret;
     }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -123,7 +123,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mLedgerManager = createLedgerManager();
     mHerder = createHerder();
     mHerderPersistence = createHerderPersistence();
-    mBucketManager = BucketManager::create(*this);
+    mBucketManager = createBucketManager();
     mCatchupManager = CatchupManager::create(*this);
     mHistoryArchiveManager = std::make_unique<HistoryArchiveManager>(*this);
     mHistoryManager = HistoryManager::create(*this);
@@ -806,6 +806,12 @@ ApplicationImpl::enableInvariantsFromConfig()
     {
         mInvariantManager->enableInvariant(name);
     }
+}
+
+std::unique_ptr<BucketManager>
+ApplicationImpl::createBucketManager()
+{
+    return BucketManager::create(*this);
 }
 
 std::unique_ptr<Database>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -128,7 +128,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mHistoryArchiveManager = createHistoryArchiveManager();
     mHistoryManager = createHistoryManager();
     mInvariantManager = createInvariantManager();
-    mMaintainer = std::make_unique<Maintainer>(*this);
+    mMaintainer = createMaintainer();
     mCommandHandler = std::make_unique<CommandHandler>(*this);
     mWorkScheduler = createWorkScheduler();
     mBanManager = createBanManager();
@@ -382,7 +382,10 @@ ApplicationImpl::start()
             // set known cursors before starting maintenance job
             ExternalQueue ps(*this);
             ps.setInitialCursors(mConfig.KNOWN_CURSORS);
-            mMaintainer->start();
+            if (mMaintainer)
+            {
+                mMaintainer->start();
+            }
             mOverlayManager->start();
             auto npub = mHistoryManager->publishQueuedHistory();
             if (npub != 0)
@@ -844,6 +847,11 @@ ApplicationImpl::createInvariantManager()
     return InvariantManager::create(*this);
 }
 
+std::unique_ptr<Maintainer>
+ApplicationImpl::createMaintainer()
+{
+    return std::make_unique<Maintainer>(*this);
+}
 std::unique_ptr<OverlayManager>
 ApplicationImpl::createOverlayManager()
 {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -126,7 +126,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mBucketManager = createBucketManager();
     mCatchupManager = CatchupManager::create(*this);
     mHistoryArchiveManager = std::make_unique<HistoryArchiveManager>(*this);
-    mHistoryManager = HistoryManager::create(*this);
+    mHistoryManager = createHistoryManager();
     mInvariantManager = createInvariantManager();
     mMaintainer = std::make_unique<Maintainer>(*this);
     mCommandHandler = std::make_unique<CommandHandler>(*this);
@@ -860,6 +860,12 @@ std::unique_ptr<LedgerManager>
 ApplicationImpl::createLedgerManager()
 {
     return LedgerManager::create(*this);
+}
+
+std::unique_ptr<HistoryManager>
+ApplicationImpl::createHistoryManager()
+{
+    return HistoryManager::create(*this);
 }
 
 LedgerTxnRoot&

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -131,7 +131,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mMaintainer = std::make_unique<Maintainer>(*this);
     mCommandHandler = std::make_unique<CommandHandler>(*this);
     mWorkScheduler = WorkScheduler::create(*this);
-    mBanManager = BanManager::create(*this);
+    mBanManager = createBanManager();
     mStatusManager = std::make_unique<StatusManager>();
     mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
         *mDatabase, mConfig.ENTRY_CACHE_SIZE, mConfig.BEST_OFFERS_CACHE_SIZE,
@@ -842,6 +842,12 @@ std::unique_ptr<OverlayManager>
 ApplicationImpl::createOverlayManager()
 {
     return OverlayManager::create(*this);
+}
+
+std::unique_ptr<BanManager>
+ApplicationImpl::createBanManager()
+{
+    return BanManager::create(*this);
 }
 
 std::unique_ptr<PersistentState>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -129,7 +129,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mHistoryManager = createHistoryManager();
     mInvariantManager = createInvariantManager();
     mMaintainer = createMaintainer();
-    mCommandHandler = std::make_unique<CommandHandler>(*this);
+    mCommandHandler = createCommandHandler();
     mWorkScheduler = createWorkScheduler();
     mBanManager = createBanManager();
     mStatusManager = std::make_unique<StatusManager>();
@@ -852,6 +852,13 @@ ApplicationImpl::createMaintainer()
 {
     return std::make_unique<Maintainer>(*this);
 }
+
+std::unique_ptr<CommandHandler>
+ApplicationImpl::createCommandHandler()
+{
+    return std::make_unique<CommandHandler>(*this);
+}
+
 std::unique_ptr<OverlayManager>
 ApplicationImpl::createOverlayManager()
 {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -125,7 +125,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mHerderPersistence = createHerderPersistence();
     mBucketManager = createBucketManager();
     mCatchupManager = createCatchupManager();
-    mHistoryArchiveManager = std::make_unique<HistoryArchiveManager>(*this);
+    mHistoryArchiveManager = createHistoryArchiveManager();
     mHistoryManager = createHistoryManager();
     mInvariantManager = createInvariantManager();
     mMaintainer = std::make_unique<Maintainer>(*this);
@@ -878,6 +878,12 @@ std::unique_ptr<LedgerManager>
 ApplicationImpl::createLedgerManager()
 {
     return LedgerManager::create(*this);
+}
+
+std::unique_ptr<HistoryArchiveManager>
+ApplicationImpl::createHistoryArchiveManager()
+{
+    return std::make_unique<HistoryArchiveManager>(*this);
 }
 
 std::unique_ptr<HistoryManager>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -624,15 +624,24 @@ ApplicationImpl::syncOwnMetrics()
         .Mark(vhit + vmiss);
 
     // Similarly, flush global process-table stats.
-    mMetrics->NewCounter({"process", "memory", "handles"})
-        .set_count(mProcessManager->getNumRunningProcesses());
+    if (mProcessManager)
+    {
+        mMetrics->NewCounter({"process", "memory", "handles"})
+            .set_count(mProcessManager->getNumRunningProcesses());
+    }
 }
 
 void
 ApplicationImpl::syncAllMetrics()
 {
-    mHerder->syncMetrics();
-    mLedgerManager->syncMetrics();
+    if (mHerder)
+    {
+        mHerder->syncMetrics();
+    }
+    if (mLedgerManager)
+    {
+        mLedgerManager->syncMetrics();
+    }
     syncOwnMetrics();
 }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -116,7 +116,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
 void
 ApplicationImpl::initialize(InitialDBMode initDBMode)
 {
-    mDatabase = std::make_unique<Database>(*this);
+    mDatabase = createDatabase();
     mPersistentState = std::make_unique<PersistentState>(*this);
     mOverlayManager = createOverlayManager();
     mLedgerManager = createLedgerManager();
@@ -805,6 +805,12 @@ ApplicationImpl::enableInvariantsFromConfig()
     {
         mInvariantManager->enableInvariant(name);
     }
+}
+
+std::unique_ptr<Database>
+ApplicationImpl::createDatabase()
+{
+    return Database::create(*this);
 }
 
 std::unique_ptr<Herder>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -124,7 +124,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mHerder = createHerder();
     mHerderPersistence = createHerderPersistence();
     mBucketManager = createBucketManager();
-    mCatchupManager = CatchupManager::create(*this);
+    mCatchupManager = createCatchupManager();
     mHistoryArchiveManager = std::make_unique<HistoryArchiveManager>(*this);
     mHistoryManager = createHistoryManager();
     mInvariantManager = createInvariantManager();
@@ -812,6 +812,12 @@ std::unique_ptr<BucketManager>
 ApplicationImpl::createBucketManager()
 {
     return BucketManager::create(*this);
+}
+
+std::unique_ptr<CatchupManager>
+ApplicationImpl::createCatchupManager()
+{
+    return CatchupManager::create(*this);
 }
 
 std::unique_ptr<Database>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -29,6 +29,7 @@
 #include "main/CommandHandler.h"
 #include "main/ExternalQueue.h"
 #include "main/Maintainer.h"
+#include "main/PersistentState.h"
 #include "main/StellarCoreVersion.h"
 #include "medida/counter.h"
 #include "medida/meter.h"
@@ -117,7 +118,7 @@ void
 ApplicationImpl::initialize(InitialDBMode initDBMode)
 {
     mDatabase = createDatabase();
-    mPersistentState = std::make_unique<PersistentState>(*this);
+    mPersistentState = createPersistentState();
     mOverlayManager = createOverlayManager();
     mLedgerManager = createLedgerManager();
     mHerder = createHerder();
@@ -829,6 +830,12 @@ std::unique_ptr<OverlayManager>
 ApplicationImpl::createOverlayManager()
 {
     return OverlayManager::create(*this);
+}
+
+std::unique_ptr<PersistentState>
+ApplicationImpl::createPersistentState()
+{
+    return PersistentState::create(*this);
 }
 
 std::unique_ptr<LedgerManager>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -863,7 +863,9 @@ ApplicationImpl::createMaintainer()
 std::unique_ptr<CommandHandler>
 ApplicationImpl::createCommandHandler()
 {
-    return std::make_unique<CommandHandler>(*this);
+    auto cmd = CommandHandler::create(*this);
+    cmd->addRoutes();
+    return cmd;
 }
 
 std::unique_ptr<OverlayManager>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -168,7 +168,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     // Subtle: process manager should come to existence _after_ BucketManager
     // initialization and newDB run, as it relies on tmp dir created in the
     // constructor
-    mProcessManager = ProcessManager::create(*this);
+    mProcessManager = createProcessManager();
     LOG(DEBUG) << "Application constructed";
 }
 
@@ -860,6 +860,12 @@ std::unique_ptr<PersistentState>
 ApplicationImpl::createPersistentState()
 {
     return PersistentState::create(*this);
+}
+
+std::shared_ptr<ProcessManager>
+ApplicationImpl::createProcessManager()
+{
+    return ProcessManager::create(*this);
 }
 
 std::unique_ptr<LedgerManager>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -122,7 +122,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mOverlayManager = createOverlayManager();
     mLedgerManager = createLedgerManager();
     mHerder = createHerder();
-    mHerderPersistence = HerderPersistence::create(*this);
+    mHerderPersistence = createHerderPersistence();
     mBucketManager = BucketManager::create(*this);
     mCatchupManager = CatchupManager::create(*this);
     mHistoryArchiveManager = std::make_unique<HistoryArchiveManager>(*this);
@@ -818,6 +818,12 @@ std::unique_ptr<Herder>
 ApplicationImpl::createHerder()
 {
     return Herder::create(*this);
+}
+
+std::unique_ptr<HerderPersistence>
+ApplicationImpl::createHerderPersistence()
+{
+    return HerderPersistence::create(*this);
 }
 
 std::unique_ptr<InvariantManager>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -130,7 +130,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mInvariantManager = createInvariantManager();
     mMaintainer = std::make_unique<Maintainer>(*this);
     mCommandHandler = std::make_unique<CommandHandler>(*this);
-    mWorkScheduler = WorkScheduler::create(*this);
+    mWorkScheduler = createWorkScheduler();
     mBanManager = createBanManager();
     mStatusManager = std::make_unique<StatusManager>();
     mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
@@ -848,6 +848,12 @@ std::unique_ptr<BanManager>
 ApplicationImpl::createBanManager()
 {
     return BanManager::create(*this);
+}
+
+std::shared_ptr<WorkScheduler>
+ApplicationImpl::createWorkScheduler()
+{
+    return WorkScheduler::create(*this);
 }
 
 std::unique_ptr<PersistentState>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -133,9 +133,7 @@ ApplicationImpl::initialize(InitialDBMode initDBMode)
     mWorkScheduler = createWorkScheduler();
     mBanManager = createBanManager();
     mStatusManager = std::make_unique<StatusManager>();
-    mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
-        *mDatabase, mConfig.ENTRY_CACHE_SIZE, mConfig.BEST_OFFERS_CACHE_SIZE,
-        mConfig.PREFETCH_BATCH_SIZE);
+    mLedgerTxnRoot = createLedgerTxnRoot();
 
     BucketListIsConsistentWithDatabase::registerInvariant(*this);
     AccountSubEntriesCountIsValid::registerInvariant(*this);
@@ -869,6 +867,14 @@ std::unique_ptr<BanManager>
 ApplicationImpl::createBanManager()
 {
     return BanManager::create(*this);
+}
+
+std::unique_ptr<LedgerTxnRoot>
+ApplicationImpl::createLedgerTxnRoot()
+{
+    return std::make_unique<LedgerTxnRoot>(*mDatabase, mConfig.ENTRY_CACHE_SIZE,
+                                           mConfig.BEST_OFFERS_CACHE_SIZE,
+                                           mConfig.PREFETCH_BATCH_SIZE);
 }
 
 std::shared_ptr<WorkScheduler>

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -185,6 +185,7 @@ class ApplicationImpl : public Application
     void enableInvariantsFromConfig();
 
     virtual std::unique_ptr<BucketManager> createBucketManager();
+    virtual std::unique_ptr<CatchupManager> createCatchupManager();
     virtual std::unique_ptr<Database> createDatabase();
     virtual std::unique_ptr<Herder> createHerder();
     virtual std::unique_ptr<HerderPersistence> createHerderPersistence();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -189,6 +189,7 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<Herder> createHerder();
     virtual std::unique_ptr<HerderPersistence> createHerderPersistence();
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
+    virtual std::unique_ptr<BanManager> createBanManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
     virtual std::unique_ptr<PersistentState> createPersistentState();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -193,6 +193,8 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<BanManager> createBanManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
+    virtual std::unique_ptr<HistoryArchiveManager>
+    createHistoryArchiveManager();
     virtual std::unique_ptr<HistoryManager> createHistoryManager();
     virtual std::shared_ptr<WorkScheduler> createWorkScheduler();
     virtual std::unique_ptr<PersistentState> createPersistentState();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -193,6 +193,7 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<Maintainer> createMaintainer();
     virtual std::unique_ptr<CommandHandler> createCommandHandler();
     virtual std::unique_ptr<BanManager> createBanManager();
+    virtual std::unique_ptr<LedgerTxnRoot> createLedgerTxnRoot();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
     virtual std::unique_ptr<HistoryArchiveManager>

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -192,6 +192,7 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<BanManager> createBanManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
+    virtual std::unique_ptr<HistoryManager> createHistoryManager();
     virtual std::unique_ptr<PersistentState> createPersistentState();
 };
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -6,7 +6,6 @@
 
 #include "Application.h"
 #include "main/Config.h"
-#include "main/PersistentState.h"
 #include "medida/timer_context.h"
 #include "util/MetricResetter.h"
 #include "util/Timer.h"
@@ -31,6 +30,7 @@ class CommandHandler;
 class Database;
 class LedgerTxnRoot;
 class LoadGenerator;
+class PersistentState;
 
 class ApplicationImpl : public Application
 {
@@ -189,5 +189,6 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
+    virtual std::unique_ptr<PersistentState> createPersistentState();
 };
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -191,6 +191,7 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<HerderPersistence> createHerderPersistence();
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
     virtual std::unique_ptr<Maintainer> createMaintainer();
+    virtual std::unique_ptr<CommandHandler> createCommandHandler();
     virtual std::unique_ptr<BanManager> createBanManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -184,6 +184,7 @@ class ApplicationImpl : public Application
 
     void enableInvariantsFromConfig();
 
+    virtual std::unique_ptr<BucketManager> createBucketManager();
     virtual std::unique_ptr<Database> createDatabase();
     virtual std::unique_ptr<Herder> createHerder();
     virtual std::unique_ptr<HerderPersistence> createHerderPersistence();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -38,7 +38,7 @@ class ApplicationImpl : public Application
     ApplicationImpl(VirtualClock& clock, Config const& cfg);
     virtual ~ApplicationImpl() override;
 
-    virtual void initialize(bool newDB) override;
+    virtual void initialize(InitialDBMode initDBMode) override;
 
     virtual uint64_t timeNow() override;
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -193,6 +193,7 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
     virtual std::unique_ptr<HistoryManager> createHistoryManager();
+    virtual std::shared_ptr<WorkScheduler> createWorkScheduler();
     virtual std::unique_ptr<PersistentState> createPersistentState();
 };
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -195,5 +195,6 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<HistoryManager> createHistoryManager();
     virtual std::shared_ptr<WorkScheduler> createWorkScheduler();
     virtual std::unique_ptr<PersistentState> createPersistentState();
+    virtual std::shared_ptr<ProcessManager> createProcessManager();
 };
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -186,6 +186,7 @@ class ApplicationImpl : public Application
 
     virtual std::unique_ptr<Database> createDatabase();
     virtual std::unique_ptr<Herder> createHerder();
+    virtual std::unique_ptr<HerderPersistence> createHerderPersistence();
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -190,6 +190,7 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<Herder> createHerder();
     virtual std::unique_ptr<HerderPersistence> createHerderPersistence();
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
+    virtual std::unique_ptr<Maintainer> createMaintainer();
     virtual std::unique_ptr<BanManager> createBanManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -184,6 +184,7 @@ class ApplicationImpl : public Application
 
     void enableInvariantsFromConfig();
 
+    virtual std::unique_ptr<Database> createDatabase();
     virtual std::unique_ptr<Herder> createHerder();
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -48,7 +48,8 @@ runWithConfig(Config cfg)
     Application::pointer app;
     try
     {
-        app = Application::create(clock, cfg, false);
+        app = Application::create(
+            clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
 
         if (!app->getHistoryArchiveManager().checkSensibleConfig())
         {
@@ -140,7 +141,8 @@ setForceSCPFlag(Config cfg, bool set)
 {
     VirtualClock clock;
     cfg.setNoListen();
-    Application::pointer app = Application::create(clock, cfg, false);
+    Application::pointer app = Application::create(
+        clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
 
     app->getPersistentState().setState(PersistentState::kForceSCPOnNextLaunch,
                                        (set ? "true" : "false"));
@@ -183,7 +185,8 @@ showOfflineInfo(Config cfg)
     // needs real time to display proper stats
     VirtualClock clock(VirtualClock::REAL_TIME);
     cfg.setNoListen();
-    Application::pointer app = Application::create(clock, cfg, false);
+    Application::pointer app = Application::create(
+        clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
     app->reportInfo();
 }
 
@@ -193,7 +196,8 @@ loadXdr(Config cfg, std::string const& bucketFile)
 {
     VirtualClock clock;
     cfg.setNoListen();
-    Application::pointer app = Application::create(clock, cfg, false);
+    Application::pointer app = Application::create(
+        clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
 
     uint256 zero;
     Bucket bucket(bucketFile, zero);
@@ -205,7 +209,8 @@ rebuildLedgerFromBuckets(Config cfg)
 {
     VirtualClock clock(VirtualClock::REAL_TIME);
     cfg.setNoListen();
-    Application::pointer app = Application::create(clock, cfg, false);
+    Application::pointer app = Application::create(
+        clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
 
     auto& ps = app->getPersistentState();
     auto lcl = ps.getState(PersistentState::kLastClosedLedger);
@@ -264,7 +269,8 @@ reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile)
 {
     VirtualClock clock(VirtualClock::REAL_TIME);
     cfg.setNoListen();
-    Application::pointer app = Application::create(clock, cfg, false);
+    Application::pointer app = Application::create(
+        clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
 
     auto& wm = app->getWorkScheduler();
     auto getHistoryArchiveStateWork =
@@ -318,7 +324,8 @@ initializeHistories(Config cfg, std::vector<std::string> const& newHistories)
 {
     VirtualClock clock;
     cfg.setNoListen();
-    Application::pointer app = Application::create(clock, cfg, false);
+    Application::pointer app = Application::create(
+        clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
 
     for (auto const& arch : newHistories)
     {

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -11,6 +11,7 @@ namespace stellar
 
 class CatchupConfiguration;
 
+int runAsRelayWithConfig(Config cfg);
 int runWithConfig(Config cfg);
 void setForceSCPFlag(Config cfg, bool set);
 void initializeDatabase(Config cfg);

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -1,15 +1,10 @@
 #pragma once
 
-// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "lib/http/server.hpp"
 #include <string>
-
-/*
-handler functions for the http commands this server supports
-*/
 
 namespace stellar
 {
@@ -17,49 +12,12 @@ class Application;
 
 class CommandHandler
 {
-    typedef std::function<void(CommandHandler*, std::string const&,
-                               std::string&)>
-        HandlerRoute;
-
-    Application& mApp;
-    std::unique_ptr<http::server::server> mServer;
-
-    void addRoute(std::string const& name, HandlerRoute route);
-    void safeRouter(HandlerRoute route, std::string const& params,
-                    std::string& retStr);
-
   public:
-    CommandHandler(Application& app);
-
-    void manualCmd(std::string const& cmd);
-
-    void fileNotFound(std::string const& params, std::string& retStr);
-
-    void bans(std::string const& params, std::string& retStr);
-    void checkdb(std::string const& params, std::string& retStr);
-    void connect(std::string const& params, std::string& retStr);
-    void dropcursor(std::string const& params, std::string& retStr);
-    void dropPeer(std::string const& params, std::string& retStr);
-    void info(std::string const& params, std::string& retStr);
-    void ll(std::string const& params, std::string& retStr);
-    void logRotate(std::string const& params, std::string& retStr);
-    void maintenance(std::string const& params, std::string& retStr);
-    void manualClose(std::string const& params, std::string& retStr);
-    void metrics(std::string const& params, std::string& retStr);
-    void clearMetrics(std::string const& params, std::string& retStr);
-    void peers(std::string const& params, std::string& retStr);
-    void quorum(std::string const& params, std::string& retStr);
-    void setcursor(std::string const& params, std::string& retStr);
-    void getcursor(std::string const& params, std::string& retStr);
-    void scpInfo(std::string const& params, std::string& retStr);
-    void tx(std::string const& params, std::string& retStr);
-    void unban(std::string const& params, std::string& retStr);
-    void upgrades(std::string const& params, std::string& retStr);
-
-#ifdef BUILD_TESTS
-    void generateLoad(std::string const& params, std::string& retStr);
-    void testAcc(std::string const& params, std::string& retStr);
-    void testTx(std::string const& params, std::string& retStr);
-#endif
+    static std::unique_ptr<CommandHandler> create(Application& app);
+    virtual void addRoutes() = 0;
+    virtual void manualCmd(std::string const& cmd) = 0;
+    virtual ~CommandHandler()
+    {
+    }
 };
 }

--- a/src/main/CommandHandlerImpl.h
+++ b/src/main/CommandHandlerImpl.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// Copyright 2014 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "lib/http/server.hpp"
+#include "main/CommandHandler.h"
+
+/*
+handler functions for the http commands this server supports
+*/
+
+namespace stellar
+{
+class Application;
+
+class CommandHandlerImpl : public CommandHandler
+{
+    typedef std::function<void(CommandHandlerImpl*, std::string const&,
+                               std::string&)>
+        HandlerRoute;
+
+    Application& mApp;
+    std::unique_ptr<http::server::server> mServer;
+
+    void safeRouter(HandlerRoute route, std::string const& params,
+                    std::string& retStr);
+
+  protected:
+    void addRoute(std::string const& name, HandlerRoute route);
+
+  public:
+    CommandHandlerImpl(Application& app);
+
+    virtual void addRoutes() override;
+    void manualCmd(std::string const& cmd) override;
+
+    void fileNotFound(std::string const& params, std::string& retStr);
+
+    void bans(std::string const& params, std::string& retStr);
+    void checkdb(std::string const& params, std::string& retStr);
+    void connect(std::string const& params, std::string& retStr);
+    void dropcursor(std::string const& params, std::string& retStr);
+    void dropPeer(std::string const& params, std::string& retStr);
+    void info(std::string const& params, std::string& retStr);
+    void ll(std::string const& params, std::string& retStr);
+    void logRotate(std::string const& params, std::string& retStr);
+    void maintenance(std::string const& params, std::string& retStr);
+    void manualClose(std::string const& params, std::string& retStr);
+    void metrics(std::string const& params, std::string& retStr);
+    void clearMetrics(std::string const& params, std::string& retStr);
+    void peers(std::string const& params, std::string& retStr);
+    void quorum(std::string const& params, std::string& retStr);
+    void setcursor(std::string const& params, std::string& retStr);
+    void getcursor(std::string const& params, std::string& retStr);
+    void scpInfo(std::string const& params, std::string& retStr);
+    void tx(std::string const& params, std::string& retStr);
+    void unban(std::string const& params, std::string& retStr);
+    void upgrades(std::string const& params, std::string& retStr);
+
+#ifdef BUILD_TESTS
+    void generateLoad(std::string const& params, std::string& retStr);
+    void testAcc(std::string const& params, std::string& retStr);
+    void testTx(std::string const& params, std::string& retStr);
+#endif
+};
+}

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -489,7 +489,9 @@ runCatchup(CommandLineArgs const& args)
             }
 
             VirtualClock clock(VirtualClock::REAL_TIME);
-            auto app = Application::create(clock, config, false);
+            auto app = Application::create(
+                clock, config,
+                Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
             Json::Value catchupInfo;
             auto result =
                 catchup(app, parseCatchup(catchupString), catchupInfo);
@@ -510,7 +512,8 @@ runPublish(CommandLineArgs const& args)
         config.setNoListen();
 
         VirtualClock clock(VirtualClock::REAL_TIME);
-        auto app = Application::create(clock, config, false);
+        auto app = Application::create(
+            clock, config, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         return publish(app);
     });
 }
@@ -628,7 +631,8 @@ runUpgradeDB(CommandLineArgs const& args)
         auto cfg = configOption.getConfig();
         VirtualClock clock;
         cfg.setNoListen();
-        Application::create(clock, cfg, false);
+        Application::create(
+            clock, cfg, Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
         return 0;
     });
 }
@@ -835,7 +839,9 @@ runSimulate(CommandLineArgs const& args)
             config.setNoListen();
 
             VirtualClock clock(VirtualClock::REAL_TIME);
-            auto app = Application::create(clock, config, false);
+            auto app = Application::create(
+                clock, config,
+                Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
             app->start();
 
             LedgerRange lr{firstLedgerInclusive, lastLedgerInclusive};

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -695,6 +695,28 @@ runReportLastHistoryCheckpoint(CommandLineArgs const& args)
 }
 
 int
+runAsRelay(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    return runWithHelp(args, {configurationParser(configOption)}, [&] {
+        Config cfg;
+        try
+        {
+            cfg = configOption.getConfig();
+        }
+        catch (std::exception& e)
+        {
+            LOG(FATAL) << "Got an exception: " << e.what();
+            LOG(FATAL) << REPORT_INTERNAL_BUG;
+            return 1;
+        }
+        // run outside of catch block so that we properly
+        // capture crashes
+        return runAsRelayWithConfig(cfg);
+    });
+}
+
+int
 run(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -940,6 +962,7 @@ handleCommandLine(int argc, char* const* argv)
          {"upgrade-db", "upgade database schema to current version",
           runUpgradeDB},
 #ifdef BUILD_TESTS
+         {"run-relay", "run relay-mode stellar-core node", runAsRelay},
          {"load-xdr", "load an XDR bucket file, for testing", runLoadXDR},
          {"rebuild-ledger-from-buckets",
           "rebuild the current database ledger from the bucket list",

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
@@ -13,7 +13,7 @@ namespace stellar
 class PersistentState
 {
   public:
-    PersistentState(Application& app);
+    static std::unique_ptr<PersistentState> create(Application& app);
 
     enum Entry
     {
@@ -29,21 +29,15 @@ class PersistentState
 
     static void dropAll(Database& db);
 
-    std::string getState(Entry stateName);
-    void setState(Entry stateName, std::string const& value);
+    virtual std::string getState(Entry stateName) = 0;
+    virtual void setState(Entry stateName, std::string const& value) = 0;
 
     // Special methods for SCP state (multiple slots)
-    std::vector<std::string> getSCPStateAllSlots();
-    void setSCPStateForSlot(uint64 slot, std::string const& value);
+    virtual std::vector<std::string> getSCPStateAllSlots() = 0;
+    virtual void setSCPStateForSlot(uint64 slot, std::string const& value) = 0;
 
-  private:
-    static std::string kSQLCreateStatement;
-    static std::string mapping[kLastEntry];
-
-    Application& mApp;
-
-    std::string getStoreStateName(Entry n, uint32 subscript = 0);
-    void updateDb(std::string const& entry, std::string const& value);
-    std::string getFromDb(std::string const& entry);
+    virtual ~PersistentState()
+    {
+    }
 };
 }

--- a/src/main/PersistentStateImpl.h
+++ b/src/main/PersistentStateImpl.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/PersistentState.h"
+
+namespace stellar
+{
+
+class PersistentStateImpl : public PersistentState
+{
+  public:
+    PersistentStateImpl(Application& app);
+
+    std::string getState(Entry stateName) override;
+    void setState(Entry stateName, std::string const& value) override;
+    std::vector<std::string> getSCPStateAllSlots() override;
+    void setSCPStateForSlot(uint64 slot, std::string const& value) override;
+
+  private:
+    Application& mApp;
+
+    std::string getStoreStateName(Entry n, uint32 subscript = 0);
+    void updateDb(std::string const& entry, std::string const& value);
+    std::string getFromDb(std::string const& entry);
+};
+}

--- a/src/main/RelayApplication.cpp
+++ b/src/main/RelayApplication.cpp
@@ -1,0 +1,577 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/RelayApplication.h"
+#include "bucket/BucketManager.h"
+#include "database/DatabaseImpl.h"
+#include "herder/HerderImpl.h"
+#include "herder/HerderPersistenceImpl.h"
+#include "herder/LedgerCloseData.h"
+#include "history/HistoryArchiveManager.h"
+#include "history/HistoryManagerImpl.h"
+#include "ledger/LedgerManagerImpl.h"
+#include "ledger/LedgerTxn.h"
+#include "main/CommandHandlerImpl.h"
+#include "main/Maintainer.h"
+#include "overlay/BanManager.h"
+#include "overlay/OverlayManagerImpl.h"
+#include "overlay/PeerManagerImpl.h"
+#include "overlay/RandomPeerSource.h"
+#include "util/Math.h"
+#include "work/WorkScheduler.h"
+
+namespace
+{
+using namespace stellar;
+
+class StubError : public std::runtime_error
+{
+  public:
+    StubError() : std::runtime_error("Stub method caled")
+    {
+    }
+};
+
+class LedgerManagerStub : public LedgerManagerImpl
+{
+
+  public:
+    LedgerManagerStub(Application& app) : LedgerManagerImpl(app)
+    {
+    }
+
+    virtual void bootstrap() override{};
+    virtual State
+    getState() const override
+    {
+        return LedgerManager::State::LM_SYNCED_STATE;
+    };
+    virtual CatchupState
+    getCatchupState() const override
+    {
+        return LedgerManager::CatchupState::NONE;
+    };
+
+    virtual void
+    valueExternalized(LedgerCloseData const& ledgerData) override
+    {
+        // Produce an extremely minimal ledger chain, with no txset, bucket or
+        // history processing.
+        LedgerHeader header;
+        header.ledgerVersion = mApp.getConfig().LEDGER_PROTOCOL_VERSION;
+        header.ledgerSeq = ledgerData.getLedgerSeq();
+        header.scpValue = ledgerData.getValue();
+        header.previousLedgerHash = getLastClosedLedgerHeader().hash;
+        advanceLedgerPointers(header);
+    };
+    virtual HistoryArchiveState
+    getLastClosedLedgerHAS() override
+    {
+        return HistoryArchiveState();
+    };
+    virtual void
+    syncMetrics() override
+    {
+    }
+    virtual void
+    startNewLedger(LedgerHeader const& genesisLedger) override
+    {
+        CLOG(INFO, "Ledger") << "Established RelayApplication genesis ledger";
+        advanceLedgerPointers(genesisLedger);
+    }
+    virtual void
+    loadLastKnownLedger(
+        std::function<void(asio::error_code const& ec)> handler) override
+    {
+        handler(asio::error_code());
+    };
+    virtual void
+    startCatchup(CatchupConfiguration configuration) override
+    {
+    }
+    virtual void closeLedger(LedgerCloseData const& ledgerData) override{};
+    virtual void deleteOldEntries(Database& db, uint32_t ledgerSeq,
+                                  uint32_t count) override{};
+    virtual ~LedgerManagerStub()
+    {
+    }
+};
+
+class DatabaseStub : public DatabaseImpl
+{
+  public:
+    DatabaseStub(Application& app) : DatabaseImpl(app)
+    {
+    }
+    void
+    ensureOpen() override
+    {
+        throw StubError();
+    }
+};
+
+class CommandHandlerStub : public CommandHandlerImpl
+{
+  public:
+    CommandHandlerStub(Application& app) : CommandHandlerImpl(app)
+    {
+    }
+    void
+    addRoutes() override
+    {
+        addRoute("bans", &CommandHandlerImpl::bans);
+        addRoute("clearmetrics", &CommandHandlerImpl::clearMetrics);
+        addRoute("connect", &CommandHandlerImpl::connect);
+        addRoute("droppeer", &CommandHandlerImpl::dropPeer);
+        addRoute("info", &CommandHandlerImpl::info);
+        addRoute("ll", &CommandHandlerImpl::ll);
+        addRoute("logrotate", &CommandHandlerImpl::logRotate);
+        addRoute("manualclose", &CommandHandlerImpl::manualClose);
+        addRoute("metrics", &CommandHandlerImpl::metrics);
+        addRoute("peers", &CommandHandlerImpl::peers);
+        addRoute("quorum", &CommandHandlerImpl::quorum);
+        addRoute("scp", &CommandHandlerImpl::scpInfo);
+        addRoute("unban", &CommandHandlerImpl::unban);
+        addRoute("upgrades", &CommandHandlerImpl::upgrades);
+    }
+};
+
+class BanManagerStub : public BanManager
+{
+  public:
+    BanManagerStub()
+    {
+    }
+    void
+    banNode(NodeID nodeID) override
+    {
+    }
+    void
+    unbanNode(NodeID nodeID) override
+    {
+    }
+    bool
+    isBanned(NodeID nodeID) override
+    {
+        return false;
+    }
+    std::vector<std::string>
+    getBans() override
+    {
+        return {};
+    }
+};
+
+class PeerManagerStub : public PeerManagerImpl
+{
+    std::map<PeerBareAddress, PeerRecord> mStorage;
+
+  public:
+    PeerManagerStub(Application& app) : PeerManagerImpl(app)
+    {
+    }
+
+    std::pair<PeerRecord, bool>
+    load(PeerBareAddress const& address) override
+    {
+        std::pair<PeerRecord, bool> tmp;
+        auto i = mStorage.find(address);
+        if (i == mStorage.end())
+        {
+            tmp.first.mNextAttempt =
+                VirtualClock::pointToTm(mApp.getClock().now());
+            tmp.first.mType = static_cast<int>(PeerType::INBOUND);
+            tmp.second = false;
+        }
+        else
+        {
+            tmp.first = i->second;
+            tmp.second = true;
+        }
+        return tmp;
+    }
+
+    void
+    store(PeerBareAddress const& address, PeerRecord const& peerRecord,
+          bool inDatabase) override
+    {
+        mStorage[address] = peerRecord;
+    }
+
+    std::vector<PeerBareAddress>
+    loadRandomPeers(PeerQuery const& query, int size) override
+    {
+        auto currAttempt = mApp.getClock().now();
+        std::vector<PeerBareAddress> result;
+        // FIXME: this is linear in the size of mStorage, which is not ideal but
+        // it's in-memory and we're expecting it to be only a few hundred values
+        // at most. If it becomes a problem, store a parallel randomly-indexable
+        // structure.
+        for (auto const& pair : mStorage)
+        {
+            if (query.mUseNextAttempt)
+            {
+                if (mApp.getClock().tmToPoint(pair.second.mNextAttempt) >
+                    currAttempt)
+                {
+                    continue;
+                }
+            }
+            if (pair.second.mNumFailures > query.mMaxNumFailures)
+            {
+                continue;
+            }
+            switch (query.mTypeFilter)
+            {
+            case PeerTypeFilter::INBOUND_ONLY:
+            {
+                if (pair.second.mType != static_cast<int>(PeerType::INBOUND))
+                {
+                    continue;
+                }
+                break;
+            }
+            case PeerTypeFilter::OUTBOUND_ONLY:
+            {
+                if (pair.second.mType != static_cast<int>(PeerType::OUTBOUND))
+                {
+                    continue;
+                }
+                break;
+            }
+            case PeerTypeFilter::PREFERRED_ONLY:
+            {
+                if (pair.second.mType != static_cast<int>(PeerType::PREFERRED))
+                {
+                    continue;
+                }
+                break;
+            }
+            case PeerTypeFilter::ANY_OUTBOUND:
+            {
+                if (pair.second.mType == static_cast<int>(PeerType::INBOUND))
+                {
+                    continue;
+                }
+                break;
+            }
+            default:
+            {
+                abort();
+            }
+            }
+            result.emplace_back(pair.first);
+        }
+        std::shuffle(std::begin(result), std::end(result), gRandomEngine);
+        result.resize(std::min(result.size(), static_cast<size_t>(size)));
+        return result;
+    }
+
+    void
+    removePeersWithManyFailures(int minNumFailures,
+                                PeerBareAddress const* address) override
+    {
+    }
+};
+
+class HerderStub : public HerderImpl
+{
+  public:
+    HerderStub(Application& app) : HerderImpl(app){};
+    TransactionQueue::AddResult
+    recvTransaction(TransactionFramePtr tx) override
+    {
+        return TransactionQueue::AddResult::ADD_STATUS_PENDING;
+    }
+    void
+    persistSCPState(uint64 slot) override
+    {
+    }
+    void
+    persistUpgrades() override
+    {
+    }
+    void
+    restoreUpgrades() override
+    {
+    }
+    bool
+    checkTxSetValid(TxSetFramePtr txSet) override
+    {
+        return true;
+    }
+};
+
+class PersistentStateStub : public PersistentState
+{
+    std::string
+    getState(Entry stateName) override
+    {
+        return std::string();
+    }
+    void
+    setState(Entry stateName, std::string const& value) override
+    {
+    }
+    std::vector<std::string>
+    getSCPStateAllSlots() override
+    {
+        return {};
+    }
+    void
+    setSCPStateForSlot(uint64 slot, std::string const& value) override
+    {
+    }
+};
+
+class HerderPersistenceStub : public HerderPersistenceImpl
+{
+  public:
+    HerderPersistenceStub(Application& app) : HerderPersistenceImpl(app)
+    {
+    }
+    void
+    saveSCPHistory(uint32_t seq, std::vector<SCPEnvelope> const& envs,
+                   QuorumTracker::QuorumMap const& qmap) override
+    {
+    }
+    optional<Hash>
+    getNodeQuorumSet(Database& db, NodeID const& nodeID) override
+    {
+        return nullptr;
+    }
+    SCPQuorumSetPtr
+    getQuorumSet(Database& db, Hash const& qSetHash) override
+    {
+        return nullptr;
+    }
+};
+
+class OverlayManagerStub : public OverlayManagerImpl
+{
+  protected:
+    std::unique_ptr<PeerManager>
+    createPeerManager(Application& app) override
+    {
+        return std::make_unique<PeerManagerStub>(app);
+    }
+
+  public:
+    OverlayManagerStub(Application& app) : OverlayManagerImpl(app)
+    {
+    }
+};
+
+class HistoryManagerStub : public HistoryManagerImpl
+{
+  public:
+    HistoryManagerStub(Application& app) : HistoryManagerImpl(app)
+    {
+    }
+    size_t
+    publishQueueLength() const override
+    {
+        return 0;
+    }
+    bool
+    maybeQueueHistoryCheckpoint() override
+    {
+        return false;
+    }
+    void
+    queueCurrentHistory() override
+    {
+    }
+    uint32_t
+    getMinLedgerQueuedToPublish() override
+    {
+        return 0;
+    }
+    uint32_t
+    getMaxLedgerQueuedToPublish() override
+    {
+        return 0;
+    }
+    size_t
+    publishQueuedHistory() override
+    {
+        return 0;
+    }
+    std::vector<std::string>
+    getMissingBucketsReferencedByPublishQueue() override
+    {
+        return {};
+    }
+    std::vector<std::string>
+    getBucketsReferencedByPublishQueue() override
+    {
+        return {};
+    }
+    std::vector<HistoryArchiveState>
+    getPublishQueueStates() override
+    {
+        return {};
+    }
+
+    void
+    historyPublished(uint32_t ledgerSeq,
+                     std::vector<std::string> const& originalBuckets,
+                     bool success) override
+    {
+    }
+    HistoryArchiveState
+    getLastClosedHistoryArchiveState() const override
+    {
+        return HistoryArchiveState();
+    }
+    InferredQuorum
+    inferQuorum(uint32_t ledgerNum) override
+    {
+        throw StubError();
+    }
+    std::string const&
+    getTmpDir() override
+    {
+        throw StubError();
+    }
+    std::string
+    localFilename(std::string const& basename) override
+    {
+        throw StubError();
+    }
+    uint64_t
+    getPublishQueueCount() override
+    {
+        return 0;
+    }
+    uint64_t
+    getPublishSuccessCount() override
+    {
+        return 0;
+    }
+    uint64_t
+    getPublishFailureCount() override
+    {
+        return 0;
+    }
+};
+}
+
+namespace stellar
+{
+
+RelayApplication::RelayApplication(VirtualClock& clock, Config const& cfg)
+    : ApplicationImpl(clock, cfg)
+{
+}
+
+void
+RelayApplication::initialize(ApplicationImpl::InitialDBMode initDBMode)
+{
+    CLOG(INFO, "Ledger") << "Initializing RelayApplication";
+    ApplicationImpl::initialize(initDBMode);
+    CLOG(INFO, "Ledger") << "Starting new ledger for RelayApplication";
+    getLedgerManager().startNewLedger();
+}
+
+std::unique_ptr<LedgerManager>
+RelayApplication::createLedgerManager()
+{
+    return std::make_unique<LedgerManagerStub>(*this);
+}
+
+std::unique_ptr<OverlayManager>
+RelayApplication::createOverlayManager()
+{
+    auto ovm = std::make_unique<OverlayManagerStub>(*this);
+    ovm->initialize();
+    return ovm;
+}
+
+std::unique_ptr<HistoryArchiveManager>
+RelayApplication::createHistoryArchiveManager()
+{
+    return nullptr;
+}
+
+std::unique_ptr<HistoryManager>
+RelayApplication::createHistoryManager()
+{
+    return std::make_unique<HistoryManagerStub>(*this);
+}
+
+std::unique_ptr<Herder>
+RelayApplication::createHerder()
+{
+    return std::make_unique<HerderStub>(*this);
+}
+
+std::unique_ptr<HerderPersistence>
+RelayApplication::createHerderPersistence()
+{
+    return std::make_unique<HerderPersistenceStub>(*this);
+}
+
+std::unique_ptr<Database>
+RelayApplication::createDatabase()
+{
+    return std::make_unique<DatabaseStub>(*this);
+}
+
+std::unique_ptr<BucketManager>
+RelayApplication::createBucketManager()
+{
+    return nullptr;
+}
+
+std::unique_ptr<CatchupManager>
+RelayApplication::createCatchupManager()
+{
+    return nullptr;
+}
+
+std::unique_ptr<Maintainer>
+RelayApplication::createMaintainer()
+{
+    return nullptr;
+}
+
+std::unique_ptr<CommandHandler>
+RelayApplication::createCommandHandler()
+{
+    auto cmd = std::make_unique<CommandHandlerStub>(*this);
+    cmd->addRoutes();
+    return cmd;
+}
+
+std::unique_ptr<BanManager>
+RelayApplication::createBanManager()
+{
+    return std::make_unique<BanManagerStub>();
+}
+
+std::unique_ptr<LedgerTxnRoot>
+RelayApplication::createLedgerTxnRoot()
+{
+    return nullptr;
+}
+
+std::shared_ptr<WorkScheduler>
+RelayApplication::createWorkScheduler()
+{
+    return nullptr;
+}
+
+std::unique_ptr<PersistentState>
+RelayApplication::createPersistentState()
+{
+    return std::make_unique<PersistentStateStub>();
+}
+
+std::shared_ptr<ProcessManager>
+RelayApplication::createProcessManager()
+{
+    return nullptr;
+}
+}

--- a/src/main/RelayApplication.h
+++ b/src/main/RelayApplication.h
@@ -1,0 +1,45 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ApplicationImpl.h"
+#include "main/Config.h"
+#include "util/Timer.h"
+
+namespace stellar
+{
+
+// A special "relay-mode" application that only participates in networking:
+// it has all of its local state (database, buckets, ledger manager, etc.)
+// removed.
+
+class RelayApplication : public ApplicationImpl
+{
+  public:
+    RelayApplication(VirtualClock& clock, Config const& cfg);
+
+    virtual void initialize(InitialDBMode initDBMode) override;
+
+  private:
+    virtual std::unique_ptr<LedgerManager> createLedgerManager() override;
+    virtual std::unique_ptr<OverlayManager> createOverlayManager() override;
+    virtual std::unique_ptr<HistoryArchiveManager>
+    createHistoryArchiveManager() override;
+    virtual std::unique_ptr<HistoryManager> createHistoryManager() override;
+    virtual std::unique_ptr<Herder> createHerder() override;
+    virtual std::unique_ptr<HerderPersistence>
+    createHerderPersistence() override;
+    virtual std::unique_ptr<Database> createDatabase() override;
+    virtual std::unique_ptr<BucketManager> createBucketManager() override;
+    virtual std::unique_ptr<CatchupManager> createCatchupManager() override;
+    virtual std::unique_ptr<Maintainer> createMaintainer() override;
+    virtual std::unique_ptr<CommandHandler> createCommandHandler() override;
+    virtual std::unique_ptr<BanManager> createBanManager() override;
+    virtual std::unique_ptr<LedgerTxnRoot> createLedgerTxnRoot() override;
+    virtual std::shared_ptr<WorkScheduler> createWorkScheduler() override;
+    virtual std::unique_ptr<PersistentState> createPersistentState() override;
+    virtual std::shared_ptr<ProcessManager> createProcessManager() override;
+};
+}

--- a/src/main/test/RelayApplicationTests.cpp
+++ b/src/main/test/RelayApplicationTests.cpp
@@ -1,0 +1,78 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "database/DatabaseImpl.h"
+#include "herder/HerderImpl.h"
+#include "herder/HerderPersistenceImpl.h"
+#include "herder/LedgerCloseData.h"
+#include "history/HistoryManagerImpl.h"
+#include "ledger/LedgerManagerImpl.h"
+#include "lib/catch.hpp"
+#include "main/RelayApplication.h"
+#include "overlay/BanManager.h"
+#include "overlay/OverlayManagerImpl.h"
+#include "overlay/PeerManagerImpl.h"
+#include "overlay/RandomPeerSource.h"
+#include "overlay/test/LoopbackPeer.h"
+#include "test/TestAccount.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "test/test.h"
+#include "work/WorkScheduler.h"
+
+using namespace stellar;
+
+TEST_CASE("Relay applications in loopback mode", "[relay]")
+{
+    VirtualClock clock;
+    auto cfg0 = getTestConfig(0);
+    auto cfg1 = getTestConfig(1);
+    cfg0.HTTP_PORT = 0;
+    cfg1.HTTP_PORT = 0;
+
+    std::shared_ptr<RelayApplication> app1 =
+        Application::create<RelayApplication>(
+            clock, cfg0, Application::InitialDBMode::APP_DB_DONT_OPEN);
+
+    std::shared_ptr<RelayApplication> app2 =
+        Application::create<RelayApplication>(
+            clock, cfg1, Application::InitialDBMode::APP_DB_DONT_OPEN);
+
+    app1->start();
+    app2->start();
+
+    std::vector<std::shared_ptr<RelayApplication>> nodes{app1, app2};
+
+    LoopbackPeerConnection connection(*app1, *app2);
+    auto peer1 = connection.getInitiator();
+    auto peer2 = connection.getAcceptor();
+
+    SecretKey dest = SecretKey::pseudoRandomForTesting();
+    auto injectTransaction = [&](int i) {
+        const int64 txAmount = 10000000;
+
+        // round robin
+        auto inApp = nodes[i % nodes.size()];
+        auto account =
+            TestAccount{*inApp, SecretKey::pseudoRandomForTesting(), 1};
+        auto tx1 = account.tx(
+            {txtest::createAccount(dest.getPublicKey(), txAmount)}, 1);
+
+        // this is basically a modified version of Peer::recvTransaction
+        auto msg = tx1->toStellarMessage();
+        auto res = inApp->getHerder().recvTransaction(tx1);
+        REQUIRE(res == TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        inApp->getOverlayManager().broadcastMessage(msg);
+    };
+
+    int i = 0;
+    while (i < 100 && clock.crank(false) > 0 &&
+           !app1->getOverlayManager().isShuttingDown())
+    {
+        injectTransaction(i++);
+        clock.crank(false);
+        clock.crank(false);
+        clock.crank(false);
+    }
+}

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -59,6 +59,9 @@ class OverlayManager
     // Drop all PeerRecords from the Database
     static void dropAll(Database& db);
 
+    // Two-phase init to enable virtual construction of members.
+    virtual void initialize() = 0;
+
     // Flush all FloodGate and ItemFetcher state for ledgers older than
     // `ledger`.
     // This is called by LedgerManager when a ledger closes.

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -74,7 +74,9 @@ class OverlayManagerImpl : public OverlayManager
 
     PeersList& getPeersList(Peer* peer);
 
-    PeerManager mPeerManager;
+    virtual std::unique_ptr<PeerManager> createPeerManager(Application& app);
+    std::unique_ptr<PeerManager> mPeerManager;
+
     PeerDoor mDoor;
     PeerAuth mAuth;
     LoadManager mLoad;
@@ -98,6 +100,8 @@ class OverlayManagerImpl : public OverlayManager
   public:
     OverlayManagerImpl(Application& app);
     ~OverlayManagerImpl();
+
+    void initialize() override;
 
     void ledgerClosed(uint32_t lastClosedledgerSeq) override;
     void recvFloodedMsg(StellarMessage const& msg, Peer::pointer peer) override;

--- a/src/overlay/PeerManager.h
+++ b/src/overlay/PeerManager.h
@@ -5,9 +5,6 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/PeerBareAddress.h"
-#include "util/Timer.h"
-
-#include <functional>
 
 namespace soci
 {
@@ -79,77 +76,66 @@ class PeerManager
 
     static void dropAll(Database& db);
 
-    explicit PeerManager(Application& app);
-
     /**
      * Ensure that given peer is stored in database.
      */
-    void ensureExists(PeerBareAddress const& address);
+    virtual void ensureExists(PeerBareAddress const& address) = 0;
 
     /**
      * Update type of peer associated with given address.
      */
-    void update(PeerBareAddress const& address, TypeUpdate type);
+    virtual void update(PeerBareAddress const& address, TypeUpdate type) = 0;
 
     /**
      * Update "next try" of peer associated with given address - can reset
      * it to now or back off even further in future.
      */
-    void update(PeerBareAddress const& address, BackOffUpdate backOff);
+    virtual void update(PeerBareAddress const& address,
+                        BackOffUpdate backOff) = 0;
 
     /**
      * Update both type and "next try" of peer associated with given address.
      */
-    void update(PeerBareAddress const& address, TypeUpdate type,
-                BackOffUpdate backOff);
+    virtual void update(PeerBareAddress const& address, TypeUpdate type,
+                        BackOffUpdate backOff) = 0;
 
     /**
      * Load PeerRecord data for peer with given address. If not available in
      * database, create default one. Second value in pair is true when data
      * was loaded from database, false otherwise.
      */
-    std::pair<PeerRecord, bool> load(PeerBareAddress const& address);
+    virtual std::pair<PeerRecord, bool>
+    load(PeerBareAddress const& address) = 0;
 
     /**
      * Store PeerRecord data into database. If inDatabase is true, uses UPDATE
      * query, uses INSERT otherwise.
      */
-    void store(PeerBareAddress const& address, PeerRecord const& PeerRecord,
-               bool inDatabase);
+    virtual void store(PeerBareAddress const& address,
+                       PeerRecord const& PeerRecord, bool inDatabase) = 0;
 
     /**
      * Load size random peers matching query from database.
      */
-    std::vector<PeerBareAddress> loadRandomPeers(PeerQuery const& query,
-                                                 int size);
+    virtual std::vector<PeerBareAddress> loadRandomPeers(PeerQuery const& query,
+                                                         int size) = 0;
 
     /**
      * Remove peers that have at least minNumFailures. Can only remove peer with
      * given address.
      */
-    void removePeersWithManyFailures(int minNumFailures,
-                                     PeerBareAddress const* address = nullptr);
+    virtual void
+    removePeersWithManyFailures(int minNumFailures,
+                                PeerBareAddress const* address = nullptr) = 0;
 
     /**
      * Get list of peers to send to peer with given address.
      */
-    std::vector<PeerBareAddress> getPeersToSend(int size,
-                                                PeerBareAddress const& address);
+    virtual std::vector<PeerBareAddress>
+    getPeersToSend(int size, PeerBareAddress const& address) = 0;
 
-  private:
-    static const char* kSQLCreateStatement;
-
-    Application& mApp;
-    std::unique_ptr<RandomPeerSource> mOutboundPeersToSend;
-    std::unique_ptr<RandomPeerSource> mInboundPeersToSend;
-
-    int countPeers(std::string const& where,
-                   std::function<void(soci::statement&)> const& bind);
-    std::vector<PeerBareAddress>
-    loadPeers(int limit, int offset, std::string const& where,
-              std::function<void(soci::statement&)> const& bind);
-
-    void update(PeerRecord& peer, TypeUpdate type);
-    void update(PeerRecord& peer, BackOffUpdate backOff, Application& app);
+    virtual ~PeerManager()
+    {
+    }
 };
 }

--- a/src/overlay/PeerManagerImpl.h
+++ b/src/overlay/PeerManagerImpl.h
@@ -1,0 +1,59 @@
+#pragma once
+
+// Copyright 2015 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/PeerManager.h"
+#include "util/Timer.h"
+
+#include <functional>
+
+namespace soci
+{
+class statement;
+}
+
+namespace stellar
+{
+
+class Database;
+class RandomPeerSource;
+
+class PeerManagerImpl : public PeerManager
+{
+  public:
+    explicit PeerManagerImpl(Application& app);
+
+    void ensureExists(PeerBareAddress const& address) override;
+    void update(PeerBareAddress const& address, TypeUpdate type) override;
+    void update(PeerBareAddress const& address, BackOffUpdate backOff) override;
+    void update(PeerBareAddress const& address, TypeUpdate type,
+                BackOffUpdate backOff) override;
+    std::pair<PeerRecord, bool> load(PeerBareAddress const& address) override;
+    void store(PeerBareAddress const& address, PeerRecord const& PeerRecord,
+               bool inDatabase) override;
+    std::vector<PeerBareAddress> loadRandomPeers(PeerQuery const& query,
+                                                 int size) override;
+    void removePeersWithManyFailures(
+        int minNumFailures, PeerBareAddress const* address = nullptr) override;
+    std::vector<PeerBareAddress>
+    getPeersToSend(int size, PeerBareAddress const& address) override;
+
+  protected:
+    Application& mApp;
+
+  private:
+    std::unique_ptr<RandomPeerSource> mOutboundPeersToSend;
+    std::unique_ptr<RandomPeerSource> mInboundPeersToSend;
+
+    int countPeers(std::string const& where,
+                   std::function<void(soci::statement&)> const& bind);
+    std::vector<PeerBareAddress>
+    loadPeers(int limit, int offset, std::string const& where,
+              std::function<void(soci::statement&)> const& bind);
+
+    void update(PeerRecord& peer, TypeUpdate type);
+    void update(PeerRecord& peer, BackOffUpdate backOff, Application& app);
+};
+}

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -100,7 +100,9 @@ class OverlayManagerTests
         virtual std::unique_ptr<OverlayManager>
         createOverlayManager() override
         {
-            return std::make_unique<OverlayManagerStub>(*this);
+            auto ovm = std::make_unique<OverlayManagerStub>(*this);
+            ovm->initialize();
+            return ovm;
         }
     };
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -178,7 +178,8 @@ resilienceTest(Simulation::pointer sim)
             crankForward(nbLedgerStep, 1);
             // start the instance
             sim->addNode(victimConfig.NODE_SEED, victimConfig.QUORUM_SET,
-                         &victimConfig, false);
+                         &victimConfig,
+                         Application::InitialDBMode::APP_DB_UPGRADE_EXISTING);
             auto refreshedApp = sim->getNode(victimID);
             refreshedApp->start();
             // connect to another node

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -70,7 +70,7 @@ Simulation::setCurrentVirtualTime(VirtualClock::time_point t)
 
 Application::pointer
 Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
-                    bool newDB)
+                    Application::InitialDBMode initDBMode)
 {
     auto cfg = cfg2 ? std::make_shared<Config>(*cfg2)
                     : std::make_shared<Config>(newConfig());
@@ -96,7 +96,7 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
         clock->setCurrentVirtualTime(mClock.now());
     }
 
-    auto app = Application::create(*clock, *cfg, newDB);
+    auto app = Application::create(*clock, *cfg, initDBMode);
     mNodes.emplace(nodeKey.getPublicKey(), Node{clock, app});
 
     return app;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -44,9 +44,10 @@ class Simulation
     // updates all clocks in the simulation to the same time_point
     void setCurrentVirtualTime(VirtualClock::time_point t);
 
-    Application::pointer addNode(SecretKey nodeKey, SCPQuorumSet qSet,
-                                 Config const* cfg = nullptr,
-                                 bool newDB = true);
+    Application::pointer
+    addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg = nullptr,
+            Application::InitialDBMode initDBMode =
+                Application::InitialDBMode::APP_DB_CREATE_NEW);
     Application::pointer getNode(NodeID nodeID);
     std::vector<Application::pointer> getNodes();
     std::vector<NodeID> getNodeIDs();

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -68,11 +68,13 @@ template <typename T = TestApplication,
           typename = typename std::enable_if<
               std::is_base_of<TestApplication, T>::value>::type>
 std::shared_ptr<T>
-createTestApplication(VirtualClock& clock, Config const& cfg, bool newDB = true)
+createTestApplication(VirtualClock& clock, Config const& cfg,
+                      Application::InitialDBMode initDBMode =
+                          Application::InitialDBMode::APP_DB_CREATE_NEW)
 {
     Config c2(cfg);
     c2.adjust();
-    auto app = Application::create<T>(clock, c2, newDB);
+    auto app = Application::create<T>(clock, c2, initDBMode);
     return app;
 }
 

--- a/src/util/GlobalChecks.cpp
+++ b/src/util/GlobalChecks.cpp
@@ -15,10 +15,16 @@ namespace stellar
 {
 static std::thread::id mainThread = std::this_thread::get_id();
 
+bool
+onMainThread()
+{
+    return mainThread == std::this_thread::get_id();
+}
+
 void
 assertThreadIsMain()
 {
-    dbgAssert(mainThread == std::this_thread::get_id());
+    dbgAssert(onMainThread());
 }
 
 void

--- a/src/util/GlobalChecks.h
+++ b/src/util/GlobalChecks.h
@@ -6,6 +6,7 @@
 
 namespace stellar
 {
+bool onMainThread();
 void assertThreadIsMain();
 
 void dbgAbort();


### PR DESCRIPTION
# Description

This is a preliminary "very coarse cut" through the middle of the network/storage (more specifically herder/ledger) axis of stellar-core, attempting to produce a new `RelayApplication` subclass of `ApplicationImpl` that _only_ does networking-stuff. It has no database, bucketlist, etc.

Most of this consists of virtualizing methods and construction, and putting stubs in subclasses. Plus a little splitting or moving existing logic into shapes that support that. And making the database initialization a little lazier.

The _purpose_ of this is just testing at this point: we'd like to do some work on optimizing the networking system _alone_, and we expect it might be helpful to be able to test and experiment on it in isolation. We may also find some use for this type of not-even-watching "pure network relay" node in future network topologies, but that's speculation at this point.

Update: now passing tests, ready for review.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
