### PR TITLE
add missing <algorithm> include

### DIFF
--- a/src/crypto/Random.cpp
+++ b/src/crypto/Random.cpp
@@ -4,6 +4,8 @@
 
 #include "crypto/Random.h"
 #include "util/Math.h"
+
+#include <algorithm>
 #include <sodium.h>
 
 #ifdef MSAN_ENABLED


### PR DESCRIPTION
# Description

#2155 missed an include for `src/crypto/Random.cpp` for `generate` in `FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION`.
