### PR TITLE
Fix quorum checks (runtime and startup) for automatically generated quorums

### DIFF
--- a/docs/stellar-core_testnet.cfg
+++ b/docs/stellar-core_testnet.cfg
@@ -6,9 +6,12 @@ NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 DATABASE="sqlite3://stellar.db"
 
 # Stellar Testnet validators
+[[HOME_DOMAINS]]
+HOME_DOMAIN="testnet.stellar.org"
+QUALITY="HIGH"
+
 [[VALIDATORS]]
 NAME="sdftest1"
-QUALITY="HIGH"
 HOME_DOMAIN="testnet.stellar.org"
 PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
 ADDRESS="core-testnet1.stellar.org"
@@ -16,7 +19,6 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{
 
 [[VALIDATORS]]
 NAME="sdftest2"
-QUALITY="HIGH"
 HOME_DOMAIN="testnet.stellar.org"
 PUBLIC_KEY="GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
 ADDRESS="core-testnet2.stellar.org"
@@ -24,7 +26,6 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{
 
 [[VALIDATORS]]
 NAME="sdftest3"
-QUALITY="HIGH"
 HOME_DOMAIN="testnet.stellar.org"
 PUBLIC_KEY="GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
 ADDRESS="core-testnet3.stellar.org"

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -352,21 +352,6 @@ ApplicationImpl::start()
     {
         throw std::invalid_argument("Quorum not configured");
     }
-    if (!isQuorumSetSane(mConfig.QUORUM_SET, !mConfig.UNSAFE_QUORUM))
-    {
-        std::string err("Invalid QUORUM_SET: duplicate entry or bad threshold "
-                        "(should be between ");
-        if (mConfig.UNSAFE_QUORUM)
-        {
-            err = err + "1";
-        }
-        else
-        {
-            err = err + "51";
-        }
-        err = err + " and 100)";
-        throw std::invalid_argument(err);
-    }
 
     mConfig.logBasicInfo();
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1181,6 +1181,15 @@ Config::validateConfig(bool mixed)
                   << " failures";
         throw;
     }
+
+    if (!isQuorumSetSane(QUORUM_SET, !UNSAFE_QUORUM))
+    {
+        LOG(FATAL) << fmt::format("Invalid QUORUM_SET: check nesting, "
+                                  "duplicate entries and thresholds (must be "
+                                  "between {} and 100)",
+                                  UNSAFE_QUORUM ? 1 : 51);
+        throw std::invalid_argument("Invalid QUORUM_SET");
+    }
 }
 
 void

--- a/src/scp/QuorumSetUtils.cpp
+++ b/src/scp/QuorumSetUtils.cpp
@@ -46,7 +46,7 @@ QuorumSetSanityChecker::QuorumSetSanityChecker(SCPQuorumSet const& qSet,
 bool
 QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth)
 {
-    if (depth > 2)
+    if (depth > 3)
         return false;
 
     if (qSet.threshold < 1)


### PR DESCRIPTION
# Description

Resolves #2209 

Turns out that the validity check was not in the right place (too late), so tests never caught this.

We do want to increase the limit here as to be able to mix all quality levels.