### PR TITLE
bug 2234: scrub passwords from connection strings better.

### DIFF
--- a/src/database/DatabaseConnectionString.cpp
+++ b/src/database/DatabaseConnectionString.cpp
@@ -15,7 +15,7 @@ removePasswordFromConnectionString(std::string connectionString)
     std::string nonSingleQuotePat("[^']");
     std::string singleQuotedStringPat("'(?:" + nonSingleQuotePat + "|" +
                                       escapedSingleQuotePat + ")*'");
-    std::string bareWordPat("\\w+");
+    std::string bareWordPat("\\S+");
     std::string paramValPat("(?:" + bareWordPat + "|" + singleQuotedStringPat +
                             ")");
     std::string paramPat("(?:" + bareWordPat + " *= *" + paramValPat + " *)");

--- a/src/database/test/DatabaseConnectionStringTest.cpp
+++ b/src/database/test/DatabaseConnectionStringTest.cpp
@@ -152,4 +152,12 @@ TEST_CASE("remove password from database connection string",
                     R"(sqlite3://:memory:)") ==
                 R"(sqlite3://:memory:)");
     }
+
+    SECTION("Bug 2234")
+    {
+        REQUIRE(
+            removePasswordFromConnectionString(
+                R"(postgresql://dbname=stellar user=stellar password=thisshouldbesecret host=/var/run/postgresql/)") ==
+            R"(postgresql://dbname=stellar user=stellar password=******** host=/var/run/postgresql/)");
+    }
 }


### PR DESCRIPTION
# Description

Resolves #2234. We were only parsing barewords if they were `\w` class (perlRE-like) which is alnum plus `_`. Postgres allows anything non-whitespace, such as the example that contains slashes.
