### PR TITLE
reappend overriden -std=c++14 for enable-afl in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,8 @@ LT_INIT([disable-shared])
 AC_SUBST(LIBTOOL_DEPS)
 
 AC_LANG(C++)
+# if modifying the following macro for a future C++ version, please update CXX
+# for enable-afl in the fuzzer configuration block below
 AX_CXX_COMPILE_STDCXX_14(noext,mandatory)
 AX_FRESH_COMPILER
 # -pthread seems to be required by -std=c++14 on some hosts
@@ -191,11 +193,17 @@ AS_IF([test "x$enable_afl" = "xyes"], [
           [clang*], [AC_CHECK_PROGS([AFL_CLANG], [afl-clang-fast])
                      AC_CHECK_PROGS([AFL_CLANGPP], [afl-clang-fast++])
                      CC="afl-clang-fast"
-                     CXX="afl-clang-fast++"],
+                     # below we hard code -std=c++14 since updates to AX_CXX_COMPILE_STDCXX circa 2015 append it to
+                     # CXX, not to CXXFLAGS and thus when setting CXX we override this. For a more detailed explanation
+                     # see: https://github.com/stellar/docker-stellar-core/pull/66#issuecomment-521886881
+                     CXX="afl-clang-fast++ -std=c++14"],
           [gcc*],   [AC_CHECK_PROGS([AFL_GCC], [afl-gcc])
                      AC_CHECK_PROGS([AFL_GPP], [afl-g++])
                      CC="afl-gcc"
-                     CXX="afl-g++"],
+                     # below we hard code -std=c++14 since updates to AX_CXX_COMPILE_STDCXX circa 2015 append it to
+                     # CXX, not to CXXFLAGS and thus when setting CXX we override this. For a more detailed explanation
+                     # see: https://github.com/stellar/docker-stellar-core/pull/66#issuecomment-521886881
+                     CXX="afl-g++ -std=c++14"],
           [AC_MSG_ERROR([Don't know how to instrument CC=$CC with AFL])])
 ])
 AM_CONDITIONAL([USE_AFL_FUZZ], [test "x$enable_afl" == "xyes"])


### PR DESCRIPTION
# Description

This is a better solution than: https://github.com/stellar/docker-stellar-core/pull/66 for fixing the fuzzer build.

For an explanation see:  https://github.com/stellar/docker-stellar-core/pull/66#issuecomment-521886881

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Compiles