### PR TITLE
Fix exit code issue when pandoc is not installed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -30,7 +30,7 @@ docs/stellar-core.1: docs/stellar-core.1.md docs/software/commands.md
 	-pandoc -s -f markdown -t man -o "$(top_srcdir)/$@.in~" tmp.man.md \
 	    && mv -f "$(top_srcdir)/$@.in~" "$(top_srcdir)/$@.in"
 	rm -f tmp.man.md
-	sed -e "s|%prefix%|$(prefix)|g" "$(top_srcdir)/$@.in" > "$@~" \
+	-sed -e "s|%prefix%|$(prefix)|g" "$(top_srcdir)/$@.in" > "$@~" \
 	    && mv -f "$@~" "$@"
 
 if USE_CLANG_FORMAT


### PR DESCRIPTION
# Description

If pandoc is not installed, pandoc's exit code is ignored by the `-` preceding it. However, the final `sed` command tries to reference the output file of `pandoc` and its exit code is not ignored.

Thus, this PR adds the `-` prefix to the final `sed`.

For anyone curious about `@`, `-`, and `+` prefixes: https://stackoverflow.com/questions/3477292/what-do-and-do-as-prefixes-to-recipe-lines-in-make

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Compiles
