### PR TITLE
improve parallel build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -102,7 +102,7 @@ See [INSTALL-Windows.md](INSTALL-Windows.md)
 - `git submodule update`
 - Type `./autogen.sh`.
 - Type `./configure`   *(If configure complains about compiler versions, try `CXX=clang-5.0 ./configure` or `CXX=g++-6 ./configure` or similar, depending on your compiler.)*
-- Type `make` or `make -j` (for aggressive parallel build)
+- Type `make` or `make -j<N>` (where `<N>` is the number of parallel builds, a number less than the number of CPU cores available, e.g. `make -j3`)
 - Type `make check` to run tests.
 - Type `make install` to install.
 


### PR DESCRIPTION
# Description

Add an explicit example of how to use `make -j` to run a parallel
builds, i.e. `make -j<N>`, or for example, `make -j3`.

The install instructions suggest using `make -j` for parallel builds but
if this command is executed without a limit being provided to the `-j`
option, it may lock up the machine it is being run on. For those not
familiar with the `-j` option it is a bit of a trap. Changing the example
command to show the use of the limit should prevent people who are
building this repo for the first time and unfamiliar with the `-j` option
from copy-pasting the command verbatim and making that mistake.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] ~Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)~
- [ ] ~Compiles~
- [ ] ~Ran all tests~
- [ ] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~