### PR TITLE
Fix computation of overlay parameters

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -123,7 +123,7 @@ export ALL_VERSIONS=1
 export TEMP_POSTGRES=0
 export NUM_PARTITIONS=$((NPROCS*2))
 export RUN_PARTITIONS
-ulimit -n 1024
+ulimit -n 256
 time make check
 
 echo All done


### PR DESCRIPTION
# Description

This PR changes the way we compute overlay's parameters (how many connections are allowed in/out and how many can be pending):
the old  behavior was overly aggressive in trying to enforce the default of 500 pending connections.

Instead, I modified the behavior to bias towards enforcing how many established connections the instance has and only reduce those numbers if limits are causing those targets to not be met