### PR TITLE
Windows: compile and stability fixes

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -315,6 +315,7 @@ exit /b 0
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\simulation\SimulationMergeOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\simulation\SimulationTransactionFrame.cpp" />
+    <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
     <ClCompile Include="..\..\src\work\BatchWork.cpp" />
     <ClCompile Include="..\..\src\historywork\DownloadBucketsWork.cpp" />
     <ClCompile Include="..\..\src\historywork\FetchRecentQsetsWork.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -312,6 +312,7 @@ exit /b 0
     <ClCompile Include="..\..\src\historywork\BatchDownloadWork.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumIntersectionCheckerImpl.cpp" />
     <ClCompile Include="..\..\src\herder\test\QuorumIntersectionTests.cpp" />
+    <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\simulation\SimulationMergeOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\simulation\SimulationTransactionFrame.cpp" />
     <ClCompile Include="..\..\src\work\BatchWork.cpp" />
@@ -618,6 +619,7 @@ exit /b 0
     <ClInclude Include="..\..\src\historywork\BatchDownloadWork.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionChecker.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionCheckerImpl.h" />
+    <ClInclude Include="..\..\src\test\FuzzerImpl.h" />
     <ClInclude Include="..\..\src\transactions\simulation\SimulationMergeOpFrame.h" />
     <ClInclude Include="..\..\src\transactions\simulation\SimulationTransactionFrame.h" />
     <ClInclude Include="..\..\src\work\BatchWork.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -978,6 +978,9 @@
     <ClCompile Include="..\..\src\transactions\simulation\SimulationTransactionFrame.cpp">
       <Filter>transactions\simulation</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\test\FuzzerImpl.cpp">
+      <Filter>test</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">
@@ -1690,6 +1693,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\transactions\simulation\SimulationTransactionFrame.h">
       <Filter>transactions\simulation</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\test\FuzzerImpl.h">
+      <Filter>test</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -981,6 +981,9 @@
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp">
       <Filter>test</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\FileSystemException.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -165,7 +165,7 @@ fileNameParser(std::string& string)
 }
 
 clara::Opt
-processIDParser(uint& num)
+processIDParser(int& num)
 {
     return clara::Opt{num, "PROCESS-ID"}["--process_id"](
         "for spawning multiple instances in fuzzing parallelization");
@@ -899,7 +899,7 @@ runFuzz(CommandLineArgs const& args)
     el::Level logLevel{el::Level::Info};
     std::vector<std::string> metrics;
     std::string fileName;
-    uint processID = 0;
+    int processID = 0;
     FuzzerMode fuzzerMode{FuzzerMode::OVERLAY};
     std::string fuzzerModeArg = "overlay";
 
@@ -920,7 +920,7 @@ runGenFuzz(CommandLineArgs const& args)
     std::string fileName;
     FuzzerMode fuzzerMode{FuzzerMode::OVERLAY};
     std::string fuzzerModeArg = "overlay";
-    uint processID = 0;
+    int processID = 0;
 
     return runWithHelp(
         args,

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -375,7 +375,7 @@ ProcessExitEvent::Impl::run()
                        cmd,     // Command line
                        nullptr, // Process handle not inheritable
                        nullptr, // Thread handle not inheritable
-                       TRUE,    // Inherit file handles
+                       FALSE,   // only inherit handles from `iH`
                        CREATE_NEW_PROCESS_GROUP | // Create a new process group
                            EXTENDED_STARTUPINFO_PRESENT, // use STARTUPINFOEX
                        nullptr, // Use parent's environment block

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -255,6 +255,8 @@ ProcessManagerImpl::ProcessManagerImpl(Application& app)
     : mMaxProcesses(app.getConfig().MAX_CONCURRENT_SUBPROCESSES)
     , mIOContext(app.getClock().getIOContext())
     , mSigChild(mIOContext)
+    , mTmpDir(
+          std::make_unique<TmpDir>(app.getTmpDirManager().tmpDir("process")))
 {
 }
 

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -19,7 +19,7 @@ struct Operation;
 class TransactionFuzzer : public Fuzzer
 {
   public:
-    TransactionFuzzer(int numAccounts, int processID)
+    TransactionFuzzer(unsigned int numAccounts, int processID)
         : mNumAccounts(numAccounts), mProcessID(processID)
     {
     }
@@ -31,14 +31,14 @@ class TransactionFuzzer : public Fuzzer
   private:
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;
-    int mNumAccounts;
+    unsigned int mNumAccounts;
     int mProcessID;
 };
 
 class OverlayFuzzer : public Fuzzer
 {
-    const uint ACCEPTOR_INDEX = 0;
-    const uint INITIATOR_INDEX = 1;
+    const int ACCEPTOR_INDEX = 0;
+    const int INITIATOR_INDEX = 1;
 
   public:
     OverlayFuzzer()

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -31,6 +31,8 @@ namespace stellar
 
 namespace FuzzUtils
 {
+unsigned int const NUMBER_OF_PREGENERATED_ACCOUNTS = 16;
+
 std::unique_ptr<Fuzzer>
 createFuzzer(int processID, FuzzerMode fuzzerMode)
 {
@@ -41,6 +43,8 @@ createFuzzer(int processID, FuzzerMode fuzzerMode)
     case FuzzerMode::TRANSACTION:
         return std::make_unique<TransactionFuzzer>(
             NUMBER_OF_PREGENERATED_ACCOUNTS, processID);
+    default:
+        abort();
     }
 }
 }
@@ -48,7 +52,7 @@ createFuzzer(int processID, FuzzerMode fuzzerMode)
 #define PERSIST_MAX 1000000
 void
 fuzz(std::string const& filename, el::Level logLevel,
-     std::vector<std::string> const& metrics, uint processID,
+     std::vector<std::string> const& metrics, int processID,
      FuzzerMode fuzzerMode)
 {
     auto fuzzer = FuzzUtils::createFuzzer(processID, fuzzerMode);

--- a/src/test/fuzz.h
+++ b/src/test/fuzz.h
@@ -19,11 +19,11 @@ enum class FuzzerMode
 
 namespace FuzzUtils
 {
-static auto const NUMBER_OF_PREGENERATED_ACCOUNTS = 16;
+extern unsigned int const NUMBER_OF_PREGENERATED_ACCOUNTS;
 std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode);
 }
 
 void fuzz(std::string const& filename, el::Level logLevel,
-          std::vector<std::string> const& metrics, uint processID,
+          std::vector<std::string> const& metrics, int processID,
           FuzzerMode fuzzerMode);
 }

--- a/src/util/FileSystemException.cpp
+++ b/src/util/FileSystemException.cpp
@@ -1,0 +1,45 @@
+#pragma once
+
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "FileSystemException.h"
+#include "util/format.h"
+
+namespace stellar
+{
+
+#ifdef _WIN32
+
+static std::string
+getLastErrorString()
+{
+    std::string res;
+
+    DWORD constexpr bufSize = 512;
+    char buf[bufSize + 1];
+    DWORD dw = ::GetLastError();
+
+    DWORD sz = ::FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
+                                    FORMAT_MESSAGE_IGNORE_INSERTS,
+                                NULL, dw, 0, (LPTSTR)buf, bufSize, NULL);
+    if (sz == 0)
+    {
+        res = fmt::format("Error code {}", dw);
+    }
+    else
+    {
+        buf[sz] = 0;
+        res = std::string(buf);
+    }
+    return res;
+}
+
+void
+FileSystemException::failWithGetLastError(std::string msg)
+{
+    failWith(msg + ", " + getLastErrorString());
+}
+#endif
+}

--- a/src/util/FileSystemException.h
+++ b/src/util/FileSystemException.h
@@ -27,11 +27,7 @@ class FileSystemException : public std::runtime_error
         failWith(msg + std::strerror(errno));
     }
 #ifdef _WIN32
-    static void
-    failWithGetLastError(std::string msg)
-    {
-        failWith(msg + ", code " + std::to_string(GetLastError()));
-    }
+    static void failWithGetLastError(std::string msg);
 #endif // _WIN32
     explicit FileSystemException(std::string const& msg)
         : std::runtime_error{msg}


### PR DESCRIPTION
# Description

This PR addresses a few Windows issues (does not effect other platforms).

* Fuzz changes didn't compile on Windows
* Fixed a crash on startup due to a missing initialization
* Handle inheritance fix from #1987 was incomplete as we were still passing a flag telling `CreateProcess` to inherit handles. This solves a race condition where core was not able to adopt buckets reliably since 2015.
* File system errors were cryptic `Error code 32` instead of `The process cannot access the file because it is being used by another process.`
