### PR TITLE
Update name of LiabilitiesMatchOffers invariant

### DIFF
--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -251,10 +251,7 @@ LiabilitiesMatchOffers::LiabilitiesMatchOffers() : Invariant(false)
 std::string
 LiabilitiesMatchOffers::getName() const
 {
-    // NOTE: In order for the acceptance tests to run correctly, this will
-    // currently need to read "MinimumAccountBalance". We will update this to
-    // "LiabilitiesMatchOffers" after.
-    return "MinimumAccountBalance";
+    return "LiabilitiesMatchOffers";
 }
 
 std::string

--- a/src/invariant/test/LiabilitiesMatchOffersTests.cpp
+++ b/src/invariant/test/LiabilitiesMatchOffersTests.cpp
@@ -58,7 +58,7 @@ TEST_CASE("Create account above minimum balance",
           "[invariant][liabilitiesmatchoffers]")
 {
     Config cfg = getTestConfig(0);
-    cfg.INVARIANT_CHECKS = {"MinimumAccountBalance"};
+    cfg.INVARIANT_CHECKS = {"LiabilitiesMatchOffers"};
 
     for (uint32_t i = 0; i < 10; ++i)
     {
@@ -75,7 +75,7 @@ TEST_CASE("Create account below minimum balance",
           "[invariant][liabilitiesmatchoffers]")
 {
     Config cfg = getTestConfig(0);
-    cfg.INVARIANT_CHECKS = {"MinimumAccountBalance"};
+    cfg.INVARIANT_CHECKS = {"LiabilitiesMatchOffers"};
 
     for (uint32_t i = 0; i < 10; ++i)
     {
@@ -92,7 +92,7 @@ TEST_CASE("Create account then decrease balance below minimum",
           "[invariant][liabilitiesmatchoffers]")
 {
     Config cfg = getTestConfig(0);
-    cfg.INVARIANT_CHECKS = {"MinimumAccountBalance"};
+    cfg.INVARIANT_CHECKS = {"LiabilitiesMatchOffers"};
 
     for (uint32_t i = 0; i < 10; ++i)
     {
@@ -111,7 +111,7 @@ TEST_CASE("Account below minimum balance increases but stays below minimum",
           "[invariant][liabilitiesmatchoffers]")
 {
     Config cfg = getTestConfig(0);
-    cfg.INVARIANT_CHECKS = {"MinimumAccountBalance"};
+    cfg.INVARIANT_CHECKS = {"LiabilitiesMatchOffers"};
 
     for (uint32_t i = 0; i < 10; ++i)
     {
@@ -130,7 +130,7 @@ TEST_CASE("Account below minimum balance decreases",
           "[invariant][liabilitiesmatchoffers]")
 {
     Config cfg = getTestConfig(0);
-    cfg.INVARIANT_CHECKS = {"MinimumAccountBalance"};
+    cfg.INVARIANT_CHECKS = {"LiabilitiesMatchOffers"};
 
     for (uint32_t i = 0; i < 10; ++i)
     {
@@ -275,7 +275,7 @@ generateBuyingLiabilities(LedgerEntry offer, bool excess, bool authorized)
 TEST_CASE("Invariant for liabilities", "[invariant][liabilitiesmatchoffers]")
 {
     Config cfg = getTestConfig(0);
-    cfg.INVARIANT_CHECKS = {"MinimumAccountBalance"};
+    cfg.INVARIANT_CHECKS = {"LiabilitiesMatchOffers"};
 
     VirtualClock clock;
     Application::pointer app = createTestApplication(clock, cfg);


### PR DESCRIPTION
Resolves #2264

There was a note in `LiabilitiesMatchOffers` invariant that the name needed to be updated.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
