### PR TITLE
Windows handle fix part 3

### DIFF
--- a/src/util/FileSystemException.cpp
+++ b/src/util/FileSystemException.cpp
@@ -24,15 +24,8 @@ FileSystemException::getLastErrorString()
     DWORD sz = ::FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM |
                                     FORMAT_MESSAGE_IGNORE_INSERTS,
                                 NULL, dw, 0, (LPTSTR)buf, bufSize, NULL);
-    if (sz == 0)
-    {
-        res = fmt::format("Error code {}", dw);
-    }
-    else
-    {
-        buf[sz] = 0;
-        res = std::string(buf);
-    }
+    buf[sz] = 0;
+    res = fmt::format("Error {:#X} - {}", dw, buf);
     return res;
 }
 

--- a/src/util/FileSystemException.cpp
+++ b/src/util/FileSystemException.cpp
@@ -12,8 +12,8 @@ namespace stellar
 
 #ifdef _WIN32
 
-static std::string
-getLastErrorString()
+std::string
+FileSystemException::getLastErrorString()
 {
     std::string res;
 

--- a/src/util/FileSystemException.h
+++ b/src/util/FileSystemException.h
@@ -27,6 +27,7 @@ class FileSystemException : public std::runtime_error
         failWith(msg + std::strerror(errno));
     }
 #ifdef _WIN32
+    static std::string getLastErrorString();
     static void failWithGetLastError(std::string msg);
 #endif // _WIN32
     explicit FileSystemException(std::string const& msg)


### PR DESCRIPTION
# Description

This PR is the latest attempt at fixing a race condition when spawning processes in Windows.

Previous attempts were #2253 and #1987

Third time should do it:

using `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` requires to set `bInheritHandles =TRUE` in `CreateProcess` (so #2253 was wrong, and the pieces that were working were by pure luck) 
https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-updateprocthreadattribute

the problem was actually that #1987 didn't set `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` when redirecting `stdout`, this was causing all inheritable handles to be inherited.
