### PR TITLE
Remove expired upgrades

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -171,8 +171,9 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     // reflect upgrades with the ones included in this SCP round
     {
         bool updated;
-        auto newUpgrades = mUpgrades.removeUpgrades(
-            value.upgrades.begin(), value.upgrades.end(), updated);
+        auto newUpgrades = mUpgrades.removeUpgrades(value.upgrades.begin(),
+                                                    value.upgrades.end(),
+                                                    value.closeTime, updated);
         if (updated)
         {
             setUpgrades(newUpgrades);

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -50,6 +50,9 @@ load(Archive& ar, stellar::Upgrades::UpgradeParameters& o)
 
 namespace stellar
 {
+
+std::chrono::hours const Upgrades::UPDGRADE_EXPIRATION_HOURS(12);
+
 std::string
 Upgrades::UpgradeParameters::toJson() const
 {
@@ -198,10 +201,32 @@ Upgrades::toString() const
 Upgrades::UpgradeParameters
 Upgrades::removeUpgrades(std::vector<UpgradeType>::const_iterator beginUpdates,
                          std::vector<UpgradeType>::const_iterator endUpdates,
-                         bool& updated)
+                         uint64_t closeTime, bool& updated)
 {
     updated = false;
     UpgradeParameters res = mParams;
+
+    // If the upgrade time has been surpassed by more than X hours, then remove
+    // all upgrades.  This is done so nodes that come up with outdated upgrades
+    // don't attempt to change the network
+    if (res.mUpgradeTime + Upgrades::UPDGRADE_EXPIRATION_HOURS <=
+        VirtualClock::from_time_t(closeTime))
+    {
+        auto resetParamIfSet = [&](optional<uint32>& o) {
+            if (o)
+            {
+                o.reset();
+                updated = true;
+            }
+        };
+
+        resetParamIfSet(res.mProtocolVersion);
+        resetParamIfSet(res.mBaseFee);
+        resetParamIfSet(res.mMaxTxSize);
+        resetParamIfSet(res.mBaseReserve);
+
+        return res;
+    }
 
     auto resetParam = [&](optional<uint32>& o, uint32 v) {
         if (o && *o == v)

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -23,6 +23,10 @@ struct LedgerUpgrade;
 class Upgrades
 {
   public:
+    // # of hours after the scheduled upgrade time before we remove pending
+    // upgrades
+    static std::chrono::hours const UPDGRADE_EXPIRATION_HOURS;
+
     struct UpgradeParameters
     {
         UpgradeParameters()
@@ -98,7 +102,7 @@ class Upgrades
     UpgradeParameters
     removeUpgrades(std::vector<UpgradeType>::const_iterator beginUpdates,
                    std::vector<UpgradeType>::const_iterator endUpdates,
-                   bool& updated);
+                   uint64_t time, bool& updated);
 
     static void dropAll(Database& db);
 


### PR DESCRIPTION
# Description

Resolves #1661 

This change removes pending upgrades if the current ledger close time has gone past the upgrade time by 12 hours.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
