### PR TITLE
Bug 2267 quorum intersection max scc topological order

### DIFF
--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -8,7 +8,17 @@
 #include "util/Logging.h"
 #include "util/Math.h"
 
-namespace
+namespace stellar
+{
+std::shared_ptr<QuorumIntersectionChecker>
+QuorumIntersectionChecker::create(QuorumTracker::QuorumMap const& qmap,
+                                  Config const& cfg, bool quiet)
+{
+    using namespace quorum_intersection;
+    return std::make_shared<QuorumIntersectionCheckerImpl>(qmap, cfg, quiet);
+}
+
+namespace quorum_intersection
 {
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -834,16 +844,7 @@ groupString(Config const& cfg, std::set<PublicKey> const& group)
     out << ']';
     return out.str();
 }
-}
-
-namespace stellar
-{
-std::shared_ptr<QuorumIntersectionChecker>
-QuorumIntersectionChecker::create(QuorumTracker::QuorumMap const& qmap,
-                                  Config const& cfg, bool quiet)
-{
-    return std::make_shared<QuorumIntersectionCheckerImpl>(qmap, cfg, quiet);
-}
+} // end namespace quorum_intersection
 
 std::set<std::set<PublicKey>>
 QuorumIntersectionChecker::getIntersectionCriticalGroups(
@@ -874,6 +875,7 @@ QuorumIntersectionChecker::getIntersectionCriticalGroups(
     // that asks, but still counts as an intersecting member of any two quorums
     // it's a member of.
 
+    using namespace quorum_intersection;
     std::set<std::set<PublicKey>> candidates;
     std::set<std::set<PublicKey>> critical;
     QuorumTracker::QuorumMap test_qmap(qmap);

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -376,7 +376,8 @@ struct QBitSet
     const QGraph mInnerSets;
 
     // Union of mNodes and i.mAllSuccessors for i in mInnerSets: summarizes
-    // every node that this QBitSet directly depends on.
+    // every node that this QBitSet directly depends on. Eagerly calculated.
+    // on construction.
     const BitSet mAllSuccessors;
 
     QBitSet(uint32_t threshold, BitSet const& nodes, QGraph const& innerSets);
@@ -411,6 +412,16 @@ struct TarjanSCCCalculator
     TarjanSCCCalculator(QGraph const& graph);
     void calculateSCCs();
     void scc(size_t i);
+};
+
+struct SCCReachabilityCalculator
+{
+    std::vector<BitSet> mReachableNodes;
+    QGraph const& mNodeGraph;
+
+    SCCReachabilityCalculator(QGraph const& graph);
+    void calculateReachability();
+    bool canReach(BitSet const& a, BitSet const& b) const;
 };
 
 // A MinQuorumEnumerator is responsible to scanning the powerset of the SCC
@@ -530,6 +541,17 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
                                   stellar::Config const& cfg,
                                   bool quiet = false);
     bool networkEnjoysQuorumIntersection() const override;
+
+    QGraph const&
+    getGraph() const
+    {
+        return mGraph;
+    }
+    size_t
+    getPubkeyBitNum(stellar::PublicKey const& b)
+    {
+        return mPubKeyBitNums.at(b);
+    }
 
     std::pair<std::vector<stellar::PublicKey>, std::vector<stellar::PublicKey>>
     getPotentialSplit() const override;

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -356,7 +356,9 @@
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-types.h"
 
-namespace
+namespace stellar
+{
+namespace quorum_intersection
 {
 
 struct QBitSet;
@@ -533,4 +535,5 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     getPotentialSplit() const override;
     size_t getMaxQuorumsFound() const override;
 };
+}
 }

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -291,7 +291,7 @@ interconnectOrgs(xdr::xvector<xdr::xvector<PublicKey>> const& orgs,
             }
             if (shouldDepend(i, j))
             {
-                CLOG(DEBUG, "SCP") << "dep: org#" << i << " => org#" << j;
+                CLOG(DEBUG, "Herder") << "dep: org#" << i << " => org#" << j;
                 auto& otherOrg = orgs.at(j);
                 auto thresh = roundUpPct(otherOrg.size(), innerThreshPct);
                 depOrgs.emplace_back(thresh, otherOrg, emptySet);
@@ -764,12 +764,12 @@ debugQmap(Config const& cfg, QuorumTracker::QuorumMap const& qm)
                 LocalNode::toJson(*pair.second, [&cfg](PublicKey const& k) {
                     return cfg.toShortString(k);
                 });
-            CLOG(DEBUG, "SCP")
+            CLOG(DEBUG, "Herder")
                 << "qmap[" << cfg.toShortString(pair.first) << "] = " << str;
         }
         else
         {
-            CLOG(DEBUG, "SCP")
+            CLOG(DEBUG, "Herder")
                 << "qmap[" << cfg.toShortString(pair.first) << "] = nullptr";
         }
     }

--- a/src/util/BitSet.h
+++ b/src/util/BitSet.h
@@ -51,6 +51,12 @@ class BitSet
     BitSet& operator=(BitSet&& other) = default;
 
     bool
+    operator!=(BitSet const& other) const
+    {
+        return !((*this) == other);
+    }
+
+    bool
     operator==(BitSet const& other) const
     {
         return bitset_equal(mPtr.get(), other.mPtr.get());


### PR DESCRIPTION
# Description

Resolves #2267: (partially) order SCCs topologically / by reachability, take a maximally-reachable element in the partial order.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
