### PR TITLE
async wait for required bucket list merges before closing ledger

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -427,11 +427,32 @@ BucketList::resolveAnyReadyFutures()
 }
 
 bool
-BucketList::futuresAllResolved() const
+BucketList::futuresAllResolved(uint32_t maxLevel) const
 {
-    return std::all_of(
-        mLevels.begin(), mLevels.end(),
-        [](BucketLevel const& bl) { return !bl.getNext().isMerging(); });
+    assert(maxLevel < mLevels.size());
+
+    for (uint32_t i = 0; i <= maxLevel; i++)
+    {
+        if (mLevels[i].getNext().isMerging())
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+uint32_t
+BucketList::getMaxMergeLevel(uint32_t currLedger) const
+{
+    uint32_t i = 0;
+    for (; i < static_cast<uint32_t>(mLevels.size()) - 1; ++i)
+    {
+        if (!levelShouldSpill(currLedger, i))
+        {
+            break;
+        }
+    }
+    return i;
 }
 
 void

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -422,7 +422,11 @@ class BucketList
     // HistoryArchiveStates, that can cause repeated merges when re-activated.
     void resolveAnyReadyFutures();
 
-    bool futuresAllResolved() const;
+    // returns true if levels [0, maxLevel] are resolved
+    bool futuresAllResolved(uint32_t maxLevel = kNumLevels - 1) const;
+
+    // returns the largest level that this ledger will need to merge
+    uint32_t getMaxMergeLevel(uint32_t currLedger) const;
 
     // Add a batch of initial (created), live (updated) and dead entries to the
     // bucketlist, representing the entries effected by closing

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -25,8 +25,7 @@ namespace stellar
 ApplyBucketsWork::ApplyBucketsWork(
     Application& app,
     std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
-    HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-    bool resolveMerges)
+    HistoryArchiveState const& applyState, uint32_t maxProtocolVersion)
     : BasicWork(app, "apply-buckets", BasicWork::RETRY_NEVER)
     , mBuckets(buckets)
     , mApplyState(applyState)
@@ -41,7 +40,6 @@ ApplyBucketsWork::ApplyBucketsWork(
     , mBucketApplyFailure(app.getMetrics().NewMeter(
           {"history", "bucket-apply", "failure"}, "event"))
     , mCounters(app.getClock().now())
-    , mResolveMerges(resolveMerges)
 {
 }
 
@@ -95,7 +93,6 @@ ApplyBucketsWork::onReset()
     mLevel = BucketList::kNumLevels - 1;
     mApplying = false;
 
-    mDelayTimer.reset();
     mSnapBucket.reset();
     mCurrBucket.reset();
     mSnapApplicator.reset();
@@ -159,35 +156,6 @@ ApplyBucketsWork::onRun()
         mHaveCheckedApplyStateValidity = true;
     }
 
-    if (mResolveMerges && mDelayTimer)
-    {
-        CLOG(INFO, "History") << "ApplyBucketsWork: application completed; "
-                                 "waiting for merge resolution";
-        auto& bl = mApp.getBucketManager().getBucketList();
-        bl.resolveAnyReadyFutures();
-        if (bl.futuresAllResolved())
-        {
-            return State::WORK_SUCCESS;
-        }
-        else
-        {
-            std::weak_ptr<ApplyBucketsWork> weak(
-                std::static_pointer_cast<ApplyBucketsWork>(shared_from_this()));
-            auto handler = [weak](asio::error_code const& ec) {
-                auto self = weak.lock();
-                if (self)
-                {
-                    self->wakeUp();
-                }
-            };
-
-            // Check back later
-            mDelayTimer->expires_from_now(std::chrono::milliseconds(500));
-            mDelayTimer->async_wait(handler);
-            return State::WORK_WAITING;
-        }
-    }
-
     // Check if we're at the beginning of the new level
     if (isLevelComplete())
     {
@@ -237,12 +205,6 @@ ApplyBucketsWork::onRun()
 
     CLOG(INFO, "History") << "ApplyBuckets : done, restarting merges";
     mApp.getBucketManager().assumeState(mApplyState, mMaxProtocolVersion);
-
-    if (mResolveMerges)
-    {
-        mDelayTimer = std::make_unique<VirtualTimer>(mApp.getClock());
-        return State::WORK_RUNNING;
-    }
 
     return State::WORK_SUCCESS;
 }
@@ -306,18 +268,5 @@ void
 ApplyBucketsWork::onFailureRetry()
 {
     mBucketApplyFailure.Mark();
-}
-
-void
-ApplyBucketsWork::onSuccess()
-{
-    if (mResolveMerges)
-    {
-        if (!mApp.getBucketManager().getBucketList().futuresAllResolved())
-        {
-            throw std::runtime_error(
-                "Not all futures were resolved after bucket application!");
-        }
-    }
 }
 }

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -47,25 +47,6 @@ class ApplyBucketsWork : public BasicWork
     medida::Meter& mBucketApplyFailure;
     BucketApplicator::Counters mCounters;
 
-    // With FIRST_PROTOCOL_SHADOWS_REMOVED or higher, when buckets are applied,
-    // we do not have resolved outputs before applying transactions and joining
-    // the network. If online catchup does not wait for merges to be resolved,
-    // marks a node as "in sync", and begins closing ledgers, a large (but not
-    // yet finished) merge might be needed at an applied ledger. At that point,
-    // `closeLedger` will block waiting for the merge to resolve. If the delay
-    // is long enough, node might go out of sync. Specifically, this applies to
-    // the following scenarios:
-    // - Large merge is needed during ApplyLedgerChainWork
-    // - Large merge is needed during syncing ledgers replay
-    // - Large merge is needed after successful catchup, during normal in-sync
-    // ledger close
-    // To prevent this, wait for restarted merges to resolve before proceeding.
-    // This approach conservatively waits for all merges regardless of HAS
-    // ledger number, and number of ledgers to replay.
-
-    bool const mResolveMerges;
-    std::unique_ptr<VirtualTimer> mDelayTimer;
-
     void advance(std::string const& name, BucketApplicator& applicator);
     std::shared_ptr<Bucket const> getBucket(std::string const& bucketHash);
     BucketLevel& getBucketLevel(uint32_t level);
@@ -76,8 +57,7 @@ class ApplyBucketsWork : public BasicWork
     ApplyBucketsWork(
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
-        HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        bool resolveMerges);
+        HistoryArchiveState const& applyState, uint32_t maxProtocolVersion);
     ~ApplyBucketsWork() = default;
 
   protected:
@@ -90,6 +70,5 @@ class ApplyBucketsWork : public BasicWork
     };
     void onFailureRaise() override;
     void onFailureRetry() override;
-    void onSuccess() override;
 };
 }

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -1,0 +1,75 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "catchup/ApplyBufferedLedgersWork.h"
+#include "bucket/BucketList.h"
+#include "bucket/BucketManager.h"
+#include "catchup/ApplyLedgerWork.h"
+#include "ledger/LedgerManager.h"
+#include "main/Application.h"
+
+#include <util/format.h>
+
+namespace stellar
+{
+ApplyBufferedLedgersWork::ApplyBufferedLedgersWork(Application& app)
+    : BasicWork(app, "apply-buffered-ledgers", BasicWork::RETRY_NEVER)
+{
+}
+
+void
+ApplyBufferedLedgersWork::onReset()
+{
+    mConditionalWork.reset();
+}
+
+BasicWork::State
+ApplyBufferedLedgersWork::onRun()
+{
+    if (mConditionalWork)
+    {
+        mConditionalWork->crankWork();
+        if (mConditionalWork->getState() != State::WORK_SUCCESS)
+        {
+            return mConditionalWork->getState();
+        }
+    }
+
+    auto& lm = mApp.getLedgerManager();
+    if (!lm.hasBufferedLedger())
+    {
+        return State::WORK_SUCCESS;
+    }
+
+    LedgerCloseData lcd = lm.popBufferedLedger();
+
+    CLOG(INFO, "History") << "Scheduling buffered ledger-close: "
+                          << "[seq=" << lcd.getLedgerSeq() << ", prev="
+                          << hexAbbrev(lcd.getTxSet()->previousLedgerHash())
+                          << ", txs=" << lcd.getTxSet()->sizeTx()
+                          << ", ops=" << lcd.getTxSet()->sizeOp() << ", sv: "
+                          << stellarValueToString(mApp.getConfig(),
+                                                  lcd.getValue())
+                          << "]";
+
+    auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, lcd);
+
+    auto predicate = [&]() {
+        auto& bl = mApp.getBucketManager().getBucketList();
+        bl.resolveAnyReadyFutures();
+        return bl.futuresAllResolved(
+            bl.getMaxMergeLevel(lm.getLastClosedLedgerNum() + 1));
+    };
+
+    mConditionalWork = std::make_shared<ConditionalWork>(
+        mApp,
+        fmt::format("apply-buffered-ledger-conditional ledger({})",
+                    lcd.getLedgerSeq()),
+        predicate, applyLedger, std::chrono::milliseconds(500));
+
+    mConditionalWork->startWork(wakeSelfUpCallback());
+
+    return State::WORK_RUNNING;
+}
+}

--- a/src/catchup/ApplyBufferedLedgersWork.h
+++ b/src/catchup/ApplyBufferedLedgersWork.h
@@ -1,0 +1,30 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "herder/LedgerCloseData.h"
+#include "work/BasicWork.h"
+#include "work/ConditionalWork.h"
+
+namespace stellar
+{
+
+class ApplyBufferedLedgersWork : public BasicWork
+{
+    std::shared_ptr<ConditionalWork> mConditionalWork;
+
+  public:
+    ApplyBufferedLedgersWork(Application& app);
+
+  protected:
+    void onReset() override;
+    State onRun() override;
+    bool
+    onAbort() override
+    {
+        return true;
+    };
+};
+}

--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include "herder/LedgerCloseData.h"
 #include "herder/TxSetFrame.h"
 #include "ledger/LedgerRange.h"
 #include "util/XDRStream.h"
+#include "work/ConditionalWork.h"
 #include "work/Work.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-ledger.h"
@@ -51,15 +53,19 @@ class ApplyCheckpointWork : public BasicWork
     XDRInputFileStream mHdrIn;
     XDRInputFileStream mTxIn;
     TransactionHistoryEntry mTxHistoryEntry;
+    LedgerHeaderHistoryEntry mHeaderHistoryEntry;
 
     medida::Meter& mApplyLedgerSuccess;
     medida::Meter& mApplyLedgerFailure;
 
     bool mFilesOpen{false};
 
+    std::shared_ptr<ConditionalWork> mConditionalWork;
+
     TxSetFramePtr getCurrentTxSet();
     void openInputFiles();
-    bool applyHistoryOfSingleLedger();
+
+    std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();
 
   public:
     ApplyCheckpointWork(Application& app, TmpDir const& downloadDir,

--- a/src/catchup/ApplyLedgerWork.cpp
+++ b/src/catchup/ApplyLedgerWork.cpp
@@ -1,0 +1,32 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "catchup/ApplyLedgerWork.h"
+#include "ledger/LedgerManager.h"
+#include "main/Application.h"
+
+namespace stellar
+{
+ApplyLedgerWork::ApplyLedgerWork(Application& app,
+                                 LedgerCloseData const& ledgerCloseData)
+    : BasicWork(
+          app, "apply-ledger-" + std::to_string(ledgerCloseData.getLedgerSeq()),
+          BasicWork::RETRY_NEVER)
+    , mLedgerCloseData(ledgerCloseData)
+{
+}
+
+BasicWork::State
+ApplyLedgerWork::onRun()
+{
+    mApp.getLedgerManager().closeLedger(mLedgerCloseData);
+    return BasicWork::State::WORK_SUCCESS;
+}
+
+bool
+ApplyLedgerWork::onAbort()
+{
+    return true;
+}
+}

--- a/src/catchup/ApplyLedgerWork.h
+++ b/src/catchup/ApplyLedgerWork.h
@@ -1,0 +1,24 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "herder/LedgerCloseData.h"
+#include "work/Work.h"
+
+namespace stellar
+{
+
+class ApplyLedgerWork : public BasicWork
+{
+    LedgerCloseData const mLedgerCloseData;
+
+  public:
+    ApplyLedgerWork(Application& app, LedgerCloseData const& ledgerCloseData);
+
+  protected:
+    State onRun() override;
+    bool onAbort() override;
+};
+}

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -136,15 +136,8 @@ CatchupWork::downloadApplyBuckets()
     auto getBuckets = std::make_shared<DownloadBucketsWork>(
         mApp, mBuckets, hashes, *mDownloadDir, mArchive);
 
-    // A consequence of FIRST_PROTOCOL_SHADOWS_REMOVED upgrade, inputs or
-    // outputs aren't published to the archives anymore: new-style merges are
-    // re-started from scratch. To avoid going out of sync during online
-    // catchup, allow bucket application work to wait for merges to be complete
-    // before marking itself as "successful".
-    bool waitForMerges = mCatchupConfiguration.online();
     auto applyBuckets = std::make_shared<ApplyBucketsWork>(
-        mApp, mBuckets, has, mVerifiedLedgerRangeStart.header.ledgerVersion,
-        waitForMerges);
+        mApp, mBuckets, has, mVerifiedLedgerRangeStart.header.ledgerVersion);
 
     std::vector<std::shared_ptr<BasicWork>> seq{getBuckets, applyBuckets};
     return std::make_shared<WorkSequence>(mApp, "download-verify-apply-buckets",

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -154,6 +154,7 @@ class CatchupWork : public Work
     ProgressHandler mProgressHandler;
     std::shared_ptr<HistoryArchive> mArchive;
     bool mBucketsAppliedEmitted{false};
+    bool mTransactionsVerifyEmitted{false};
 
     std::shared_ptr<GetHistoryArchiveStateWork> mGetHistoryArchiveStateWork;
     std::shared_ptr<GetHistoryArchiveStateWork> mGetBucketStateWork;
@@ -163,6 +164,7 @@ class CatchupWork : public Work
     std::shared_ptr<Work> mVerifyTxResults;
     WorkSeqPtr mBucketVerifyApplySeq;
     std::shared_ptr<Work> mTransactionsVerifyApplySeq;
+    std::shared_ptr<BasicWork> mApplyBufferedLedgersWork;
     WorkSeqPtr mCatchupSeq;
 
     bool hasAnyLedgersToCatchupTo() const;

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -61,9 +61,9 @@ struct BucketListGenerator
         auto has = getHistoryArchiveState();
         has.prepareForPublish(*mAppApply);
         auto& wm = mAppApply->getWorkScheduler();
-        wm.executeWork<T>(
-            buckets, has, mAppApply->getConfig().LEDGER_PROTOCOL_VERSION,
-            /* resolveMerges= */ false, std::forward<Args>(args)...);
+        wm.executeWork<T>(buckets, has,
+                          mAppApply->getConfig().LEDGER_PROTOCOL_VERSION,
+                          std::forward<Args>(args)...);
     }
 
     void
@@ -278,9 +278,8 @@ class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
         HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        bool resolve, LedgerEntry const& entry)
-        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion,
-                           resolve)
+        LedgerEntry const& entry)
+        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion)
         , mEntry(entry)
         , mAdded{false}
     {
@@ -330,9 +329,8 @@ class ApplyBucketsWorkDeleteEntry : public ApplyBucketsWork
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
         HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        bool resolve, LedgerEntry const& target)
-        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion,
-                           resolve)
+        LedgerEntry const& target)
+        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion)
         , mKey(LedgerEntryKey(target))
         , mEntry(target)
         , mDeleted{false}
@@ -417,9 +415,8 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
         Application& app,
         std::map<std::string, std::shared_ptr<Bucket>> const& buckets,
         HistoryArchiveState const& applyState, uint32_t maxProtocolVersion,
-        bool resolve, LedgerEntry const& target)
-        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion,
-                           resolve)
+        LedgerEntry const& target)
+        : ApplyBucketsWork(app, buckets, applyState, maxProtocolVersion)
         , mKey(LedgerEntryKey(target))
         , mEntry(target)
         , mModified{false}

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -66,7 +66,6 @@ class LedgerManager
         NONE,
         WAITING_FOR_TRIGGER_LEDGER,
         APPLYING_HISTORY,
-        APPLYING_BUFFERED_LEDGERS,
         WAITING_FOR_CLOSING_LEDGER
     };
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -161,6 +161,10 @@ class LedgerManager
     virtual void deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                   uint32_t count) = 0;
 
+    // popBufferedLedger will throw if there are no buffered ledgers
+    virtual bool hasBufferedLedger() const = 0;
+    virtual LedgerCloseData popBufferedLedger() = 0;
+
     virtual ~LedgerManager()
     {
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -957,6 +957,28 @@ LedgerManagerImpl::deleteOldEntries(Database& db, uint32_t ledgerSeq,
     txscope.commit();
 }
 
+bool
+LedgerManagerImpl::hasBufferedLedger() const
+{
+    return !mSyncingLedgers.empty();
+}
+
+LedgerCloseData
+LedgerManagerImpl::popBufferedLedger()
+{
+    if (!hasBufferedLedger())
+    {
+        throw std::runtime_error(
+            "popBufferedLedger called when mSyncingLedgers is empty!");
+    }
+
+    auto lcd = mSyncingLedgers.front();
+    mSyncingLedgers.pop();
+    mSyncingLedgersSize.set_count(mSyncingLedgers.size());
+
+    return lcd;
+}
+
 void
 LedgerManagerImpl::advanceLedgerPointers(LedgerHeader const& header)
 {

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -97,7 +97,6 @@ class LedgerManagerImpl : public LedgerManager
 
     SyncingLedgerChain mSyncingLedgers;
 
-    void applyBufferedLedgers();
     void setCatchupState(CatchupState s);
     void advanceLedgerPointers(LedgerHeader const& header);
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -143,5 +143,8 @@ class LedgerManagerImpl : public LedgerManager
     void closeLedger(LedgerCloseData const& ledgerData) override;
     void deleteOldEntries(Database& db, uint32_t ledgerSeq,
                           uint32_t count) override;
+
+    bool hasBufferedLedger() const override;
+    LedgerCloseData popBufferedLedger() override;
 };
 }

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -236,8 +236,7 @@ rebuildLedgerFromBuckets(Config cfg)
     has.prepareForPublish(*app);
 
     auto applyBucketsWork = ws.executeWork<ApplyBucketsWork>(
-        localBuckets, has, Config::CURRENT_LEDGER_PROTOCOL_VERSION,
-        /* resolveMerges */ false);
+        localBuckets, has, Config::CURRENT_LEDGER_PROTOCOL_VERSION);
     auto ok = applyBucketsWork->getState() == BasicWork::State::WORK_SUCCESS;
     if (ok)
     {

--- a/src/work/ConditionalWork.cpp
+++ b/src/work/ConditionalWork.cpp
@@ -41,6 +41,14 @@ ConditionalWork::onRun()
         return mConditionedWork->getState();
     }
 
+    if (!mStartTimer)
+    {
+        // we're only using this to check elapsed time
+        mStartTimer = std::make_unique<LogSlowExecution>(
+            "", LogSlowExecution::Mode::MANUAL, "",
+            std::chrono::milliseconds::max());
+    }
+
     // Work is not started, so check the condition
     if (!mCondition())
     {
@@ -97,5 +105,24 @@ void
 ConditionalWork::onReset()
 {
     mWorkStarted = false;
+    mStartTimer.reset();
+}
+
+std::string
+ConditionalWork::getStatus() const
+{
+    if (mWorkStarted)
+    {
+        return fmt::format("Conditioned work status = {}",
+                           mConditionedWork->getStatus());
+    }
+
+    std::chrono::milliseconds elapsed{0};
+    if (mStartTimer)
+    {
+        elapsed = mStartTimer->checkElapsedTime();
+    }
+    return fmt::format("ConditionalWork - Waiting on {} for {} milliseconds.",
+                       getName(), elapsed.count());
 }
 }

--- a/src/work/ConditionalWork.h
+++ b/src/work/ConditionalWork.h
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 #pragma once
 
+#include "util/LogSlowExecution.h"
 #include "work/BasicWork.h"
 
 namespace stellar
@@ -62,12 +63,16 @@ class ConditionalWork : public BasicWork
     std::unique_ptr<VirtualTimer> mSleepTimer;
     bool mWorkStarted{false};
 
+    std::unique_ptr<LogSlowExecution> mStartTimer;
+
   public:
     ConditionalWork(
         Application& app, std::string name, ConditionFn condition,
         std::shared_ptr<BasicWork> conditionedWork,
         std::chrono::milliseconds sleepTime = std::chrono::milliseconds(100));
     void shutdown() override;
+
+    std::string getStatus() const override;
 
   protected:
     BasicWork::State onRun() override;


### PR DESCRIPTION

# Description

Resolves #2273 

Instead of having `ApplyBucketsWork` wait for the merges to complete, the catchup process will asynchronously wait for the merges before it calls `closeLedger`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
