### PR TITLE
change test cases to intercept signal handler and exit on SIGINT

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -96,6 +96,13 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
         if (!ec)
         {
             LOG(INFO) << "got signal " << sig << ", shutting down";
+
+#ifdef BUILD_TESTS
+            if (mConfig.TEST_CASES_ENABLED)
+            {
+                exit(1);
+            }
+#endif
             this->gracefulStop();
         }
     });

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -149,6 +149,10 @@ Config::Config() : NODE_SEED(SecretKey::random())
     ENTRY_CACHE_SIZE = 100000;
     BEST_OFFERS_CACHE_SIZE = 64;
     PREFETCH_BATCH_SIZE = 1000;
+
+#ifdef BUILD_TESTS
+    TEST_CASES_ENABLED = false;
+#endif
 }
 
 namespace

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -310,6 +310,13 @@ class Config : public std::enable_shared_from_this<Config>
     // the entry cache
     size_t PREFETCH_BATCH_SIZE;
 
+#ifdef BUILD_TESTS
+    // If set to true, the application will be aware this run is for a test
+    // case.  This is used right now in the signal handler to exit() instead of
+    // doing a graceful shutdown
+    bool TEST_CASES_ENABLED;
+#endif
+
     Config();
 
     void load(std::string const& filename);

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -135,6 +135,8 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.RUN_STANDALONE = true;
         thisConfig.FORCE_SCP = true;
 
+        thisConfig.TEST_CASES_ENABLED = true;
+
         thisConfig.PEER_PORT =
             static_cast<unsigned short>(DEFAULT_PEER_PORT + instanceNumber * 2);
         thisConfig.HTTP_PORT = static_cast<unsigned short>(


### PR DESCRIPTION
# Description

Resolves #1954 

TestApplication now registers its own handler to `exit` instead of calling `gracefulStop`. This change doesn't include any cleanup for the temp files.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
