### PR TITLE
Introduce PROBATION state in overlay

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -686,6 +686,7 @@ This list is the result of both inbound connections from other peers and outboun
            "elapsed" : 6,
            "id" : "sdf1",
            "olver" : 5,
+           "probation" : false,
            "ver" : "v9.1.0"
         }
      ],
@@ -695,6 +696,7 @@ This list is the result of both inbound connections from other peers and outboun
           "elapsed" : 2303,
           "id" : "sdf2",
           "olver" : 5,
+          "probation" : false,
           "ver" : "v9.1.0"
        },
        {
@@ -702,6 +704,7 @@ This list is the result of both inbound connections from other peers and outboun
           "elapsed" : 14082,
           "id" : "sdf3",
           "olver" : 5,
+          "probation" : false,
           "ver" : "v9.1.0"
         }
      ]

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -99,7 +99,7 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
     auto& peersTold = result->second->mPeersTold;
 
     // make a copy, in case peers gets modified
-    auto peers = mApp.getOverlayManager().getAuthenticatedPeers();
+    auto peers = mApp.getOverlayManager().getAnyAuthenticatedPeers();
 
     for (auto peer : peers)
     {
@@ -123,7 +123,7 @@ Floodgate::getPeersKnows(Hash const& h)
     if (record != mFloodMap.end())
     {
         auto& ids = record->second->mPeersTold;
-        auto const& peers = mApp.getOverlayManager().getAuthenticatedPeers();
+        auto const& peers = mApp.getOverlayManager().getAnyAuthenticatedPeers();
         for (auto& p : peers)
         {
             if (ids.find(p.second->toString()) != ids.end())

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -93,13 +93,17 @@ class OverlayManager
     // called on peers in Peer::CLOSING state.
     virtual void removePeer(Peer* peer) = 0;
 
-    // Try to move peer from pending to authenticated list. If there is no room
-    // for provided peer, it is checked if it is a "preferred" peer (as
-    // specified in the config file's PREFERRED_PEERS/PREFERRED_PEER_KEYS
-    // setting) - if so, one random non-preferred peer is removed.
+    // Try to make a peer authenticated - returns true on success
+    // Function may fail if there are not enough slots available
+    // probation = true: tries to move peer to probation state
+    // probation = false: tries to move the peer to the
+    //  authenticated "stable" list
     //
-    // If moving peer to authenticated list succeeded, true is returned.
-    virtual bool acceptAuthenticatedPeer(Peer::pointer peer) = 0;
+    // For "preferred" peer (as specified in the config file's
+    // PREFERRED_PEERS/PREFERRED_PEER_KEYS setting), peers skip "probation"
+    //   if there is no room, it will evict one random non-preferred peer.
+    virtual bool acceptAuthenticatedPeer(Peer::pointer peer,
+                                         bool probation) = 0;
 
     virtual bool isPreferred(Peer* peer) const = 0;
 
@@ -117,16 +121,26 @@ class OverlayManager
     // Return number of pending peers
     virtual int getPendingPeersCount() const = 0;
 
-    // Return the current in-memory set of inbound authenticated peers.
-    virtual std::map<NodeID, Peer::pointer> const&
-    getInboundAuthenticatedPeers() const = 0;
+    // Return the current in-memory set of inbound authenticated peers
+    // (regardless of probation).
+    virtual std::map<NodeID, Peer::pointer>
+    getInboundAnyAuthenticatedPeers() const = 0;
 
-    // Return the current in-memory set of outbound authenticated peers.
-    virtual std::map<NodeID, Peer::pointer> const&
-    getOutboundAuthenticatedPeers() const = 0;
+    // Return the current in-memory set of outbound authenticated peers
+    // (regardless of probation).
+    virtual std::map<NodeID, Peer::pointer>
+    getOutboundAnyAuthenticatedPeers() const = 0;
+
+    // returns list of all authenticated peers, including probation
+    virtual std::multimap<NodeID, Peer::pointer>
+    getAnyAuthenticatedPeers() const = 0;
 
     // Return the current in-memory set of authenticated peers.
     virtual std::map<NodeID, Peer::pointer> getAuthenticatedPeers() const = 0;
+
+    // return the current in-memory set of authenticated peers in probation
+    virtual std::multimap<NodeID, Peer::pointer>
+    getAuthenticatedProbationPeers() const = 0;
 
     // Return number of authenticated peers
     virtual int getAuthenticatedPeersCount() const = 0;

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -59,9 +59,24 @@ class OverlayManagerImpl : public OverlayManager
         std::string mDirectionString;
         int mMaxAuthenticatedCount;
 
-        // connections move from pending to authenticated
+        // connection management invariant:
+        // a peer can only be connected once when authenticated permanently
+        // (regardless of direction)
+
+        // if there isn't already a permanently authenticated connection,
+        // connections proceed as mPending connections.
+        // When the initial handshake is succesful, they move from mPending to
+        // mAuthenticatedProbation.
+        // In this stage connections are still not stable so we allow
+        // bidirectional connections to co-exist in case one direction gets
+        // dropped (too many inbound connections for example).
         std::vector<Peer::pointer> mPending;
         std::map<NodeID, Peer::pointer> mAuthenticatedProbation;
+
+        // After some time, peers move from mAuthenticatedProbation to
+        // mAuthenticated which means that as soon as a connection is promoted
+        // to authenticated, we drop any other reverse connection as to preserve
+        // invariants
         std::map<NodeID, Peer::pointer> mAuthenticated;
 
         Peer::pointer byAddress(PeerBareAddress const& address) const;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -39,11 +39,12 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     enum PeerState
     {
-        CONNECTING = 0,
-        CONNECTED = 1,
-        GOT_HELLO = 2,
-        GOT_AUTH = 3,
-        CLOSING = 4
+        CLOSING = -1,
+        CONNECTING = 0,         // establishing connection
+        CONNECTED = 1,          // connection established
+        GOT_HELLO = 2,          // received HELLO
+        GOT_AUTH_PROBATION = 3, // received AUTH, connection is in probation
+        GOT_AUTH_ACTIVE = 4     // received AUTH, connection is now active
     };
 
     enum PeerRole
@@ -169,6 +170,11 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     bool isConnected() const;
     bool isAuthenticated() const;
+
+    // returns true if peer has been in probation state long enough
+    bool isPassedProbation() const;
+
+    void setAuthenticated();
 
     VirtualClock::time_point
     getCreationTime() const

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -37,6 +37,21 @@ class Peer : public std::enable_shared_from_this<Peer>,
   public:
     typedef std::shared_ptr<Peer> pointer;
 
+    /*
+      general connection flow is
+      originator                  remote
+      s=CONNECTING                -
+         \_ connect      --TCP-->          accept
+      s=CONNECTED        <-TCP---  s=CONNECTED _/
+        \_ send HELLO    -HELLO-->     s=GOT_HELLO
+      s=GOT_HELLO         <--HELLO-  send HELLO _/
+         \_ send AUTH     -AUTH-->  s=GOT_AUTH_PROBATION
+      s=GOT_AUTH_PROBATION <--AUTH-     send AUTH     _/
+
+      ...
+       Transition to GOT_AUTH_ACTIVE is managed by OverlayManager
+    */
+
     enum PeerState
     {
         CLOSING = -1,

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -277,11 +277,20 @@ PeerManager::store(PeerBareAddress const& address, PeerRecord const& peerRecord,
     }
     else
     {
+        CLOG(TRACE, "Overlay") << "Learned peer " << address.toString() << " @"
+                               << mApp.getConfig().PEER_PORT;
+
         query = "INSERT INTO peers "
                 "(nextattempt, numfailures, type, ip,  port) "
                 "VALUES "
                 "(:v1,         :v2,        :v3,  :v4, :v5)";
     }
+
+    CLOG(TRACE, "Overlay") << fmt::format(
+        "Storing peer {} n={} f={} @{}", address.toString(),
+        VirtualClock::to_time_t(
+            VirtualClock::tmToPoint(peerRecord.mNextAttempt)),
+        peerRecord.mNumFailures, mApp.getConfig().PEER_PORT);
 
     try
     {
@@ -401,9 +410,7 @@ PeerManager::ensureExists(PeerBareAddress const& address)
     auto peer = load(address);
     if (!peer.second)
     {
-        CLOG(TRACE, "Overlay") << "Learned peer " << address.toString() << " @"
-                               << mApp.getConfig().PEER_PORT;
-        store(address, peer.first, peer.second);
+        store(address, peer.first, false);
     }
 }
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -476,10 +476,10 @@ TCPPeer::drop(std::string const& reason, DropDirection dropDirection,
         return;
     }
 
-    if (mState != GOT_AUTH)
+    if (mState != GOT_AUTH_ACTIVE)
     {
         CLOG(DEBUG, "Overlay") << "TCPPeer::drop " << toString() << " in state "
-                               << mState << " we called:" << mRole;
+                               << mState << " role:" << mRole << " reason: " << reason;
     }
     else if (dropDirection == Peer::DropDirection::WE_DROPPED_REMOTE)
     {

--- a/src/overlay/test/LoadManagerTests.cpp
+++ b/src/overlay/test/LoadManagerTests.cpp
@@ -47,8 +47,9 @@ TEST_CASE("disconnect peer when overloaded", "[overlay][LoadManager]")
          (i < 1000 && clock.now() < end && clock.crank(false) > 0); ++i)
         ;
 
-    REQUIRE(!conn.getInitiator()->isConnected());
+    // only check the one end we know for sure is disconnected
     REQUIRE(!conn.getAcceptor()->isConnected());
+
     REQUIRE(conn2.getInitiator()->isConnected());
     REQUIRE(conn2.getAcceptor()->isConnected());
     REQUIRE(app2->getMetrics()

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -36,7 +36,7 @@ class PeerStub : public Peer
         : Peer(app, WE_CALLED_REMOTE)
     {
         mPeerID = SecretKey::pseudoRandomForTesting().getPublicKey();
-        mState = GOT_AUTH;
+        mState = GOT_AUTH_ACTIVE;
         mAddress = addres;
     }
     virtual std::string
@@ -75,7 +75,7 @@ class OverlayManagerStub : public OverlayManagerImpl
 
         auto peerStub = std::make_shared<PeerStub>(mApp, address);
         REQUIRE(addOutboundConnection(peerStub));
-        return acceptAuthenticatedPeer(peerStub);
+        return acceptAuthenticatedPeer(peerStub, false);
     }
 };
 

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -1013,7 +1013,7 @@ TEST_CASE("connecting to saturated nodes", "[overlay][connections][acceptance]")
     // 1 connects to h
     simulation->crankUntil(
         [&]() { return numberOfSimulationConnections() == 2; },
-        std::chrono::seconds{3}, false);
+        std::chrono::seconds{7}, false);
 
     simulation->addNode(vNode2SecretKey, qSet, &node2Cfg);
     simulation->addPendingConnection(vNode2NodeID, vHeadNodeID);


### PR DESCRIPTION
# Description

Resolves #2097 

this closes a possible race condition when peers connect to each other but one of
them is at capacity (therefore dropping the connection).

The approach is to add an intermediate state to the connection `GOT_AUTH_PROBATION` that tells overlay to allow that connection to go through *not* counting towards the total number of connections (ie, it's still counted as a "pending" connection).

When the grace period elapses, if the peer is still connected, it gets promoted to `GOT_AUTH_ACTIVE` and if there are other connections in probation in the other direction, they get dropped.

