### PR TITLE
Remove per-key prefetch metrics

### DIFF
--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -380,12 +380,6 @@ class LedgerTxn::Impl::EntryIteratorImpl : public EntryIterator::AbstractImpl
 // been lost.
 class LedgerTxnRoot::Impl
 {
-    struct KeyAccesses
-    {
-        uint64_t hits{0};
-        uint64_t misses{0};
-    };
-
     enum class LoadType
     {
         IMMEDIATE,
@@ -413,7 +407,6 @@ class LedgerTxnRoot::Impl
     std::unique_ptr<LedgerHeader> mHeader;
     mutable EntryCache mEntryCache;
     mutable BestOffersCache mBestOffersCache;
-    mutable std::unordered_map<LedgerKey, KeyAccesses> mPrefetchMetrics;
     mutable uint64_t mTotalPrefetchHits{0};
 
     size_t mMaxCacheSize;


### PR DESCRIPTION
This PR removes per-key prefetch metrics. They aren't currently accessible from any external interface, and the way they were implemented isn't compatible with incremental prefetching (coming in a future PR).

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
