### PR TITLE
Reset shared_future in FutureBucket when it's ready

### DIFF
--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -59,7 +59,8 @@ class FutureBucket
     std::shared_ptr<Bucket> mInputCurrBucket;
     std::shared_ptr<Bucket> mInputSnapBucket;
     std::vector<std::shared_ptr<Bucket>> mInputShadowBuckets;
-    std::shared_future<std::shared_ptr<Bucket>> mOutputBucket;
+    std::shared_ptr<Bucket> mOutputBucket;
+    std::shared_future<std::shared_ptr<Bucket>> mOutputBucketFuture;
 
     // These strings hold the serializable (or deserialized) bucket hashes of
     // the inputs and outputs of a merge; depending on the state of the

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -271,6 +271,7 @@ CatchupWork::runCatchupStep()
                                  mVerifiedLedgerRangeStart,
                                  mCatchupConfiguration.mode());
                 mBucketsAppliedEmitted = true;
+                mBuckets.clear();
                 mLastApplied =
                     mApp.getLedgerManager().getLastClosedLedgerHeader();
             }

--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -15,7 +15,7 @@ namespace stellar
 
 class DownloadBucketsWork : public BatchWork
 {
-    std::map<std::string, std::shared_ptr<Bucket>> mBuckets;
+    std::map<std::string, std::shared_ptr<Bucket>>& mBuckets;
     std::vector<std::string> mHashes;
     std::vector<std::string>::const_iterator mNextBucketIter;
     TmpDir const& mDownloadDir;


### PR DESCRIPTION
This should resolve #2298 -- some standard library implementations (libstdc++) store task lambdas in the shared state, which we used to keep alive for a while (specifically, until level spill which could take months for low level buckets). This change explicitly resets shared_future once it's done.

The second change is a minor update to catchup, to stop referencing buckets earlier (currently we drop bucket references at the very end of a potentially long CatchupWork)