### PR TITLE
Simplify best offers cache

### DIFF
--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -70,4 +70,36 @@ template <> class hash<stellar::LedgerKey>
         return res;
     }
 };
+
+template <> class hash<stellar::Asset>
+{
+  public:
+    size_t
+    operator()(stellar::Asset const& asset) const
+    {
+        size_t res = asset.type();
+        switch (asset.type())
+        {
+        case stellar::ASSET_TYPE_NATIVE:
+            break;
+        case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
+        {
+            auto& a4 = asset.alphaNum4();
+            res ^= stellar::shortHash::computeHash(
+                stellar::ByteSlice(a4.issuer.ed25519().data(), 8));
+            res ^= a4.assetCode[0];
+            break;
+        }
+        case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
+        {
+            auto& a12 = asset.alphaNum12();
+            res ^= stellar::shortHash::computeHash(
+                stellar::ByteSlice(a12.issuer.ed25519().data(), 8));
+            res ^= a12.assetCode[0];
+            break;
+        }
+        }
+        return res;
+    }
+};
 }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -52,6 +52,19 @@ populateLoadedEntries(std::unordered_set<LedgerKey> const& keys,
     return res;
 }
 
+bool
+operator==(AssetPair const& lhs, AssetPair const& rhs)
+{
+    return lhs.buying == rhs.buying && lhs.selling == rhs.selling;
+}
+
+size_t
+AssetPairHash::operator()(AssetPair const& key) const
+{
+    std::hash<Asset> hashAsset;
+    return hashAsset(key.buying) ^ (hashAsset(key.selling) << 1);
+}
+
 // Implementation of AbstractLedgerTxnParent --------------------------------
 AbstractLedgerTxnParent::~AbstractLedgerTxnParent()
 {
@@ -2007,8 +2020,7 @@ LedgerTxnRoot::Impl::getFromBestOffersCache(
 {
     try
     {
-        auto cacheKey = binToHex(xdr::xdr_to_opaque(buying)) +
-                        binToHex(xdr::xdr_to_opaque(selling));
+        BestOffersCacheKey cacheKey{buying, selling};
         if (!mBestOffersCache.exists(cacheKey))
         {
             mBestOffersCache.put(cacheKey, defaultValue);

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -420,8 +420,9 @@ class LedgerTxnRoot::Impl
         std::list<LedgerEntry> bestOffers;
         bool allLoaded;
     };
+    typedef std::shared_ptr<BestOffersCacheEntry> BestOffersCacheEntryPtr;
 
-    typedef RandomEvictionCache<BestOffersCacheKey, BestOffersCacheEntry,
+    typedef RandomEvictionCache<BestOffersCacheKey, BestOffersCacheEntryPtr,
                                 AssetPairHash>
         BestOffersCache;
 
@@ -493,9 +494,8 @@ class LedgerTxnRoot::Impl
                          std::shared_ptr<LedgerEntry const> const& entry,
                          LoadType type) const;
 
-    BestOffersCacheEntry&
-    getFromBestOffersCache(Asset const& buying, Asset const& selling,
-                           BestOffersCacheEntry& defaultValue) const;
+    BestOffersCacheEntryPtr getFromBestOffersCache(Asset const& buying,
+                                                   Asset const& selling) const;
 
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
     bulkLoadAccounts(std::unordered_set<LedgerKey> const& keys) const;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -22,6 +22,19 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 populateLoadedEntries(std::unordered_set<LedgerKey> const& keys,
                       std::vector<LedgerEntry> const& entries);
 
+struct AssetPair
+{
+    Asset buying;
+    Asset selling;
+};
+
+bool operator==(AssetPair const& lhs, AssetPair const& rhs);
+
+struct AssetPairHash
+{
+    size_t operator()(AssetPair const& key) const;
+};
+
 // A defensive heuristic to ensure prefetching stops if entry cache is filling
 // up.
 static const double ENTRY_CACHE_FILL_RATIO = 0.5;
@@ -400,13 +413,16 @@ class LedgerTxnRoot::Impl
 
     typedef RandomEvictionCache<LedgerKey, CacheEntry> EntryCache;
 
-    typedef std::string BestOffersCacheKey;
+    typedef AssetPair BestOffersCacheKey;
+
     struct BestOffersCacheEntry
     {
         std::list<LedgerEntry> bestOffers;
         bool allLoaded;
     };
-    typedef RandomEvictionCache<std::string, BestOffersCacheEntry>
+
+    typedef RandomEvictionCache<BestOffersCacheKey, BestOffersCacheEntry,
+                                AssetPairHash>
         BestOffersCache;
 
     Database& mDatabase;

--- a/src/util/RandomEvictionCache.h
+++ b/src/util/RandomEvictionCache.h
@@ -16,7 +16,7 @@ namespace stellar
 // least-recent-out-of-2-random-choices eviction. Degrades more-gracefully
 // across pathological load patterns than LRU, and also takes somewhat less
 // book-keeping.
-template <typename K, typename V>
+template <typename K, typename V, typename Hash = std::hash<K>>
 class RandomEvictionCache : public NonMovableOrCopyable
 {
   public:
@@ -43,8 +43,9 @@ class RandomEvictionCache : public NonMovableOrCopyable
     };
 
     // Cache itself is stored in a hashmap.
-    std::unordered_map<K, CacheValue> mValueMap;
-    using MapValueType = typename std::unordered_map<K, CacheValue>::value_type;
+    using MapType = std::unordered_map<K, CacheValue, Hash>;
+    using MapValueType = typename MapType::value_type;
+    MapType mValueMap;
 
     // Pointers to hashmap elements are stored redundantly here just so we can
     // randomly pick some to evict; unordered_map has no random-access iterators


### PR DESCRIPTION
# Description

This PR simplifies access to the `LedgerTxnRoot` best offers cache.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
