### PR TITLE
Fast best offers

### DIFF
--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1694,6 +1694,23 @@ LedgerTxn::Impl::getWorstBestOfferIterator()
     return WorstBestOfferIterator(std::move(iterImpl));
 }
 
+#ifdef BUILD_TESTS
+std::unordered_map<
+    AssetPair,
+    std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
+    AssetPairHash> const&
+LedgerTxn::getOrderBook()
+{
+    return getImpl()->getOrderBook();
+}
+
+LedgerTxn::Impl::MultiOrderBook const&
+LedgerTxn::Impl::getOrderBook()
+{
+    return mMultiOrderBook;
+}
+#endif
+
 // Implementation of LedgerTxn::Impl::EntryIteratorImpl ---------------------
 LedgerTxn::Impl::EntryIteratorImpl::EntryIteratorImpl(IteratorType const& begin,
                                                       IteratorType const& end)

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -222,6 +222,7 @@ struct OfferDescriptor
 bool operator==(OfferDescriptor const& lhs, OfferDescriptor const& rhs);
 
 bool isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry);
+bool isBetterOffer(OfferDescriptor const& lhs, LedgerEntry const& rhsEntry);
 bool isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs);
 
 struct IsBetterOfferComparator
@@ -340,7 +341,8 @@ class AbstractLedgerTxnParent
     virtual std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) = 0;
     virtual std::shared_ptr<LedgerEntry const>
-    getBestOffer(LedgerEntry const& worseThan) = 0;
+    getBestOffer(Asset const& buying, Asset const& selling,
+                 OfferDescriptor const& worseThan) = 0;
     virtual std::unordered_map<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,
                                Asset const& asset) = 0;
@@ -529,7 +531,8 @@ class LedgerTxn final : public AbstractLedgerTxn
     std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) override;
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(LedgerEntry const& worseThan) override;
+    getBestOffer(Asset const& buying, Asset const& selling,
+                 OfferDescriptor const& worseThan) override;
 
     LedgerEntryChanges getChanges() override;
 
@@ -614,7 +617,8 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) override;
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(LedgerEntry const& worseThan) override;
+    getBestOffer(Asset const& buying, Asset const& selling,
+                 OfferDescriptor const& worseThan) override;
 
     std::unordered_map<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -214,7 +214,33 @@ struct LedgerEntry;
 struct LedgerKey;
 struct LedgerRange;
 
+struct OfferDescriptor
+{
+    Price price;
+    int64_t offerID;
+};
+bool operator==(OfferDescriptor const& lhs, OfferDescriptor const& rhs);
+
 bool isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry);
+bool isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs);
+
+struct IsBetterOfferComparator
+{
+    bool operator()(OfferDescriptor const& lhs,
+                    OfferDescriptor const& rhs) const;
+};
+
+struct AssetPair
+{
+    Asset buying;
+    Asset selling;
+};
+bool operator==(AssetPair const& lhs, AssetPair const& rhs);
+
+struct AssetPairHash
+{
+    size_t operator()(AssetPair const& key) const;
+};
 
 class AbstractLedgerTxn;
 

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -11,6 +11,7 @@
 #include <ledger/LedgerHashUtils.h>
 #include <map>
 #include <memory>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -242,8 +243,6 @@ struct AssetPairHash
 {
     size_t operator()(AssetPair const& key) const;
 };
-
-class AbstractLedgerTxn;
 
 struct InflationWinner
 {
@@ -616,6 +615,14 @@ class LedgerTxn final : public AbstractLedgerTxn
     void rollbackChild() override;
 
     void unsealHeader(std::function<void(LedgerHeader&)> f) override;
+
+#ifdef BUILD_TESTS
+    std::unordered_map<
+        AssetPair,
+        std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
+        AssetPairHash> const&
+    getOrderBook();
+#endif
 };
 
 class LedgerTxnRoot : public AbstractLedgerTxnParent

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -338,8 +338,9 @@ class AbstractLedgerTxnParent
     //     buying or selling the specified asset.
     virtual std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() = 0;
     virtual std::shared_ptr<LedgerEntry const>
-    getBestOffer(Asset const& buying, Asset const& selling,
-                 std::unordered_set<LedgerKey>& exclude) = 0;
+    getBestOffer(Asset const& buying, Asset const& selling) = 0;
+    virtual std::shared_ptr<LedgerEntry const>
+    getBestOffer(LedgerEntry const& worseThan) = 0;
     virtual std::unordered_map<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,
                                Asset const& asset) = 0;
@@ -526,8 +527,9 @@ class LedgerTxn final : public AbstractLedgerTxn
     std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
 
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(Asset const& buying, Asset const& selling,
-                 std::unordered_set<LedgerKey>& exclude) override;
+    getBestOffer(Asset const& buying, Asset const& selling) override;
+    std::shared_ptr<LedgerEntry const>
+    getBestOffer(LedgerEntry const& worseThan) override;
 
     LedgerEntryChanges getChanges() override;
 
@@ -610,8 +612,9 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
 
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(Asset const& buying, Asset const& selling,
-                 std::unordered_set<LedgerKey>& exclude) override;
+    getBestOffer(Asset const& buying, Asset const& selling) override;
+    std::shared_ptr<LedgerEntry const>
+    getBestOffer(LedgerEntry const& worseThan) override;
 
     std::unordered_map<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -252,9 +252,10 @@ class LedgerTxn::Impl
     //   cleared
     // - the best offers cache may be, but is not guaranteed to be, modified or
     //   even cleared
+    std::shared_ptr<LedgerEntry const> getBestOffer(Asset const& buying,
+                                                    Asset const& selling);
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(Asset const& buying, Asset const& selling,
-                 std::unordered_set<LedgerKey>& exclude);
+    getBestOffer(LedgerEntry const& worseThan);
 
     // getChanges has the basic exception safety guarantee. If it throws an
     // exception, then
@@ -558,9 +559,10 @@ class LedgerTxnRoot::Impl
     //   cleared
     // - the best offers cache may be, but is not guaranteed to be, modified or
     //   even cleared
+    std::shared_ptr<LedgerEntry const> getBestOffer(Asset const& buying,
+                                                    Asset const& selling);
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(Asset const& buying, Asset const& selling,
-                 std::unordered_set<LedgerKey>& exclude);
+    getBestOffer(LedgerEntry const& worseThan);
 
     // getOffersByAccountAndAsset has the basic exception safety guarantee. If
     // it throws an exception, then

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -255,7 +255,8 @@ class LedgerTxn::Impl
     std::shared_ptr<LedgerEntry const> getBestOffer(Asset const& buying,
                                                     Asset const& selling);
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(LedgerEntry const& worseThan);
+    getBestOffer(Asset const& buying, Asset const& selling,
+                 OfferDescriptor const& worseThan);
 
     // getChanges has the basic exception safety guarantee. If it throws an
     // exception, then
@@ -562,7 +563,8 @@ class LedgerTxnRoot::Impl
     std::shared_ptr<LedgerEntry const> getBestOffer(Asset const& buying,
                                                     Asset const& selling);
     std::shared_ptr<LedgerEntry const>
-    getBestOffer(LedgerEntry const& worseThan);
+    getBestOffer(Asset const& buying, Asset const& selling,
+                 OfferDescriptor const& worseThan);
 
     // getOffersByAccountAndAsset has the basic exception safety guarantee. If
     // it throws an exception, then

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -432,6 +432,10 @@ class LedgerTxn::Impl
 
     // unsealHeader has the same exception safety guarantee as f
     void unsealHeader(LedgerTxn& self, std::function<void(LedgerHeader&)> f);
+
+#ifdef BUILD_TESTS
+    MultiOrderBook const& getOrderBook();
+#endif
 };
 
 class LedgerTxn::Impl::EntryIteratorImpl : public EntryIterator::AbstractImpl

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -112,6 +112,13 @@ isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
     }
 }
 
+bool
+isBetterOffer(OfferDescriptor const& lhs, LedgerEntry const& rhsEntry)
+{
+    auto const& rhs = rhsEntry.data.offer();
+    return isBetterOffer(lhs, {rhs.price, rhs.offerID});
+}
+
 // Note: The order induced by this function must match the order used in the
 // SQL query for loadBestOffers above.
 bool

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -93,17 +93,9 @@ LedgerTxnRoot::Impl::loadBestOffers(std::list<LedgerEntry>& offers,
     }
 }
 
-// Note: The order induced by this function must match the order used in the
-// SQL query for loadBestOffers above.
 bool
-isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry)
+isBetterOffer(OfferDescriptor const& lhs, OfferDescriptor const& rhs)
 {
-    auto const& lhs = lhsEntry.data.offer();
-    auto const& rhs = rhsEntry.data.offer();
-
-    assert(lhs.buying == rhs.buying);
-    assert(lhs.selling == rhs.selling);
-
     double lhsPrice = double(lhs.price.n) / double(lhs.price.d);
     double rhsPrice = double(rhs.price.n) / double(rhs.price.d);
     if (lhsPrice < rhsPrice)
@@ -118,6 +110,20 @@ isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry)
     {
         return false;
     }
+}
+
+// Note: The order induced by this function must match the order used in the
+// SQL query for loadBestOffers above.
+bool
+isBetterOffer(LedgerEntry const& lhsEntry, LedgerEntry const& rhsEntry)
+{
+    auto const& lhs = lhsEntry.data.offer();
+    auto const& rhs = rhsEntry.data.offer();
+
+    assert(lhs.buying == rhs.buying);
+    assert(lhs.selling == rhs.selling);
+
+    return isBetterOffer({lhs.price, lhs.offerID}, {rhs.price, rhs.offerID});
 }
 
 // Note: This function is currently only used in AllowTrustOpFrame, which means

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -2686,7 +2686,9 @@ TEST_CASE("Load best offers benchmark", "[!hide][bestoffersbench]")
         }
         for (auto& kv : sortedOffers)
         {
-            std::sort(kv.second.begin(), kv.second.end(), isBetterOffer);
+            std::sort(kv.second.begin(), kv.second.end(),
+                      (bool (*)(LedgerEntry const&,
+                                LedgerEntry const&))isBetterOffer);
         }
 
         writeEntries(*app, offers);

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -1704,6 +1704,22 @@ TEST_CASE("LedgerTxn loadBestOffer", "[ledgertxn]")
                           std::runtime_error);
     }
 
+    SECTION("fails with active entries")
+    {
+        VirtualClock clock;
+        auto app = createTestApplication(clock, getTestConfig());
+        app->start();
+
+        LedgerTxn ltx1(app->getLedgerTxnRoot());
+        auto ltxe = ltx1.create(LedgerTestUtils::generateValidLedgerEntry());
+        REQUIRE_THROWS_AS(ltx1.getBestOffer(buying, selling),
+                          std::runtime_error);
+        REQUIRE_THROWS_AS(ltx1.getBestOffer(buying, selling, {Price{1, 1}, 1}),
+                          std::runtime_error);
+        REQUIRE_THROWS_AS(ltx1.loadBestOffer(buying, selling),
+                          std::runtime_error);
+    }
+
     SECTION("empty parent")
     {
         SECTION("no offers")

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -91,7 +91,7 @@ generateLedgerEntryWithSameKey(LedgerEntry const& leBase)
     return le;
 }
 
-TEST_CASE("LedgerTxn addChild", "[ledgerstate]")
+TEST_CASE("LedgerTxn addChild", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -125,7 +125,7 @@ TEST_CASE("LedgerTxn addChild", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgerstate]")
+TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -196,7 +196,7 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgerstate]")
+TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -267,7 +267,7 @@ TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn round trip", "[ledgerstate]")
+TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
 {
     std::bernoulli_distribution shouldCommitDist;
 
@@ -418,7 +418,7 @@ TEST_CASE("LedgerTxn round trip", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn rollback and commit deactivate", "[ledgerstate]")
+TEST_CASE("LedgerTxn rollback and commit deactivate", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -471,7 +471,7 @@ TEST_CASE("LedgerTxn rollback and commit deactivate", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn create", "[ledgerstate]")
+TEST_CASE("LedgerTxn create", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -529,7 +529,7 @@ TEST_CASE("LedgerTxn create", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn createOrUpdateWithoutLoading", "[ledgerstate]")
+TEST_CASE("LedgerTxn createOrUpdateWithoutLoading", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -600,7 +600,7 @@ TEST_CASE("LedgerTxn createOrUpdateWithoutLoading", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn erase", "[ledgerstate]")
+TEST_CASE("LedgerTxn erase", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -659,7 +659,7 @@ TEST_CASE("LedgerTxn erase", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgerstate]")
+TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -843,7 +843,7 @@ testInflationWinners(
     }
 }
 
-TEST_CASE("LedgerTxn queryInflationWinners", "[ledgerstate]")
+TEST_CASE("LedgerTxn queryInflationWinners", "[ledgertxn]")
 {
     int64_t const QUERY_VOTE_MINIMUM = 1000000000;
 
@@ -1125,7 +1125,7 @@ TEST_CASE("LedgerTxn queryInflationWinners", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn loadHeader", "[ledgerstate]")
+TEST_CASE("LedgerTxn loadHeader", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -1167,7 +1167,7 @@ TEST_CASE("LedgerTxn loadHeader", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn load", "[ledgerstate]")
+TEST_CASE("LedgerTxn load", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -1224,7 +1224,7 @@ TEST_CASE("LedgerTxn load", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgerstate]")
+TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -1419,7 +1419,7 @@ testAllOffers(
     }
 }
 
-TEST_CASE("LedgerTxn loadAllOffers", "[ledgerstate]")
+TEST_CASE("LedgerTxn loadAllOffers", "[ledgertxn]")
 {
     auto a1 = LedgerTestUtils::generateValidAccountEntry().accountID;
     auto a2 = LedgerTestUtils::generateValidAccountEntry().accountID;
@@ -1671,7 +1671,7 @@ testBestOffer(
     }
 }
 
-TEST_CASE("LedgerTxn loadBestOffer", "[ledgerstate]")
+TEST_CASE("LedgerTxn loadBestOffer", "[ledgertxn]")
 {
     auto a1 = LedgerTestUtils::generateValidAccountEntry().accountID;
     auto a2 = LedgerTestUtils::generateValidAccountEntry().accountID;
@@ -1914,7 +1914,7 @@ testOffersByAccountAndAsset(
     }
 }
 
-TEST_CASE("LedgerTxn loadOffersByAccountAndAsset", "[ledgerstate]")
+TEST_CASE("LedgerTxn loadOffersByAccountAndAsset", "[ledgertxn]")
 {
     auto a1 = LedgerTestUtils::generateValidAccountEntry().accountID;
     auto a2 = LedgerTestUtils::generateValidAccountEntry().accountID;
@@ -2031,7 +2031,7 @@ TEST_CASE("LedgerTxn loadOffersByAccountAndAsset", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxn unsealHeader", "[ledgerstate]")
+TEST_CASE("LedgerTxn unsealHeader", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -2067,7 +2067,7 @@ TEST_CASE("LedgerTxn unsealHeader", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgerstate]")
+TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgertxn]")
 {
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
@@ -2159,7 +2159,7 @@ TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgerstate]")
     }
 }
 
-TEST_CASE("LedgerTxnRoot prefetch", "[ledgerstate]")
+TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
 {
     VirtualClock clock;
     auto cfg = getTestConfig();


### PR DESCRIPTION
# Description

This PR completely overhauls the implementation details of `LedgerTxn::loadBestOffer` and `LedgerTxn::getBestOffer` by leveraging an incrementally maintained in-memory order book and a newly recognized invariant satisfied by `loadBestOffer`. This is built on top of #2306, so it should not be merged until that PR is merged.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
