### PR TITLE
Check apply-state validity only once per bucket-apply.

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -149,11 +149,14 @@ ApplyBucketsWork::startLevel()
 BasicWork::State
 ApplyBucketsWork::onRun()
 {
-    if (mLevel == BucketList::kNumLevels - 1 &&
-        !mApplyState.containsValidBuckets(mApp))
+    if (!mHaveCheckedApplyStateValidity && mLevel == BucketList::kNumLevels - 1)
     {
-        CLOG(ERROR, "History") << "Malformed HAS: unable to apply buckets";
-        return State::WORK_FAILURE;
+        if (!mApplyState.containsValidBuckets(mApp))
+        {
+            CLOG(ERROR, "History") << "Malformed HAS: unable to apply buckets";
+            return State::WORK_FAILURE;
+        }
+        mHaveCheckedApplyStateValidity = true;
     }
 
     if (mResolveMerges && mDelayTimer)

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -25,6 +25,7 @@ class ApplyBucketsWork : public BasicWork
 {
     std::map<std::string, std::shared_ptr<Bucket>> const& mBuckets;
     HistoryArchiveState const& mApplyState;
+    bool mHaveCheckedApplyStateValidity{false};
 
     bool mApplying{false};
     size_t mTotalBuckets{0};


### PR DESCRIPTION
Small change to ensure we don't re-check HAS validity on every crank while applying level 10. We discussed this last week, not a huge deal but worth fixing.