### PR TITLE
Fix missing information from TransactionMeta in older protocol versions

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -378,6 +378,12 @@ MAXIMUM_LEDGER_CLOSETIME_DRIFT=50
 # you want to make that trade.
 DISABLE_XDR_FSYNC=false
 
+# SUPPORTED_META_VERSION (1 or 2) defaults to 1.
+# If set to 1, stellar-core will emit TransactionMeta as TransactionMetaV1. If
+# set to 2, stellar-core will emit TransactionMeta as TransactionMetaV2. Do not
+# set to 2 unless your downstream systems support TransactionMetaV2.
+SUPPORTED_META_VERSION=1
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1065,7 +1065,7 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
     for (auto tx : txs)
     {
         auto txTime = mTransactionApply.TimeScope();
-        TransactionMeta tm(1);
+        TransactionMeta tm(mApp.getConfig().SUPPORTED_META_VERSION);
         try
         {
             CLOG(DEBUG, "Tx")
@@ -1073,7 +1073,7 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
                 << " ops=" << tx->getOperations().size()
                 << " txseq=" << tx->getSeqNum() << " (@ "
                 << mApp.getConfig().toShortString(tx->getSourceID()) << ")";
-            tx->apply(mApp, ltx, tm.v1());
+            tx->apply(mApp, ltx, tm);
         }
         catch (InvariantDoesNotHold&)
         {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -160,6 +160,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     BEST_OFFERS_CACHE_SIZE = 64;
     PREFETCH_BATCH_SIZE = 1000;
 
+    SUPPORTED_META_VERSION = 1;
+
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
 #endif
@@ -931,6 +933,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "HOME_DOMAINS")
             {
                 domainQualityMap = parseDomainsQuality(item.second);
+            }
+            else if (item.first == "SUPPORTED_META_VERSION")
+            {
+                SUPPORTED_META_VERSION = readInt<uint32_t>(item, 1, 2);
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -319,6 +319,11 @@ class Config : public std::enable_shared_from_this<Config>
     // the entry cache
     size_t PREFETCH_BATCH_SIZE;
 
+    // The version of TransactionMeta that will be generated. Acceptable values
+    // are 1 (default) and 2. Set to 2 only if downstream systems have been
+    // updated to handle TransactionMetaV2.
+    size_t SUPPORTED_META_VERSION;
+
 #ifdef BUILD_TESTS
     // If set to true, the application will be aware this run is for a test
     // case.  This is used right now in the signal handler to exit() instead of

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -89,8 +89,8 @@ class FuzzTransactionFrame : public TransactionFrame
         // protocols < 8, this triggered buggy caching, and potentially may do
         // so in the future
         loadSourceAccount(ltx, ltx.loadHeader());
-        TransactionMeta tm(1);
-        applyOperations(signatureChecker, app, ltx, tm.v1());
+        TransactionMeta tm(2);
+        applyOperations(signatureChecker, app, ltx, tm);
     }
 };
 

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -93,7 +93,7 @@ class TransactionFrame
     void markResultFailed();
 
     bool applyOperations(SignatureChecker& checker, Application& app,
-                         AbstractLedgerTxn& ltx, TransactionMetaV1& meta);
+                         AbstractLedgerTxn& ltx, TransactionMeta& meta);
 
     void processSeqNum(AbstractLedgerTxn& ltx);
 
@@ -182,8 +182,7 @@ class TransactionFrame
 
     // apply this transaction to the current ledger
     // returns true if successfully applied
-    bool apply(Application& app, AbstractLedgerTxn& ltx,
-               TransactionMetaV1& meta);
+    bool apply(Application& app, AbstractLedgerTxn& ltx, TransactionMeta& meta);
 
     // version without meta
     bool apply(Application& app, AbstractLedgerTxn& ltx);

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -306,6 +306,15 @@ struct TransactionMetaV1
     OperationMeta operations<>;   // meta for each operation
 };
 
+struct TransactionMetaV2
+{
+    LedgerEntryChanges txChangesBefore; // tx level changes before operations
+                                        // are applied if any
+    OperationMeta operations<>;         // meta for each operation
+    LedgerEntryChanges txChangesAfter;  // tx level changes after operations are
+                                        // applied if any
+};
+
 // this is the meta produced when applying transactions
 // it does not include pre-apply updates such as fees
 union TransactionMeta switch (int v)
@@ -314,5 +323,7 @@ case 0:
     OperationMeta operations<>;
 case 1:
     TransactionMetaV1 v1;
+case 2:
+    TransactionMetaV2 v2;
 };
 }


### PR DESCRIPTION
Resolves #2217 

This PR introduces a new version (version 2) of `TransactionMeta` and allows `stellar-core` to be configured to generate either version 1 or version 2.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
