### PR TITLE
bug 2314: stop leaking buckets that are inputs to merges with empty outputs.

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -126,6 +126,8 @@ class BucketManager : NonMovableOrCopyable
                       size_t nObjects, size_t nBytes,
                       MergeKey* mergeKey = nullptr) = 0;
 
+    virtual void noteEmptyMergeOutput(MergeKey const& mergeKey) = 0;
+
     // Return a bucket by hash if we have it, else return nullptr.
     virtual std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) = 0;
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -95,6 +95,7 @@ class BucketManagerImpl : public BucketManager
     adoptFileAsBucket(std::string const& filename, uint256 const& hash,
                       size_t nObjects, size_t nBytes,
                       MergeKey* mergeKey = nullptr) override;
+    void noteEmptyMergeOutput(MergeKey const& mergeKey) override;
     std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) override;
 
     std::shared_future<std::shared_ptr<Bucket>>

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -123,6 +123,10 @@ BucketOutputIterator::getBucket(BucketManager& bucketManager,
         assert(mBytesPut == 0);
         CLOG(DEBUG, "Bucket") << "Deleting empty bucket file " << mFilename;
         std::remove(mFilename.c_str());
+        if (mergeKey)
+        {
+            bucketManager.noteEmptyMergeOutput(*mergeKey);
+        }
         return std::make_shared<Bucket>();
     }
     return bucketManager.adoptFileAsBucket(mFilename, mHasher->finish(),


### PR DESCRIPTION
# Description

Resolves #2314 -- the change 6bfce1985efc9058d26d4a67bafb92e2d578c69f that introduced `mLiveFutures` forgot to handle the case of a future that resolves to an empty bucket: these futures accumulate in memory endlessly, keeping a reference alive to their corresponding input buckets, which are then never GC'ed. The fix is straightforward: notice when such merges happen, and drop the futures.

Still need to add a test (working on one presently) but I figured I'd post this for a quick look by others first.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
