### PR TITLE
Remove quorum set cache

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -210,7 +210,9 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     // Evict slots that are outside of our ledger validity bracket
     if (slotIndex > MAX_SLOTS_TO_REMEMBER)
     {
-        getSCP().purgeSlots(slotIndex - MAX_SLOTS_TO_REMEMBER);
+        auto maxSlot = slotIndex - MAX_SLOTS_TO_REMEMBER;
+        getSCP().purgeSlots(maxSlot);
+        mPendingEnvelopes.eraseBelow(maxSlot);
     }
 
     ledgerClosed();
@@ -548,14 +550,6 @@ HerderImpl::processSCPQueue()
 {
     if (mHerderSCPDriver.trackingSCP())
     {
-        // drop obsolete slots
-        if (mHerderSCPDriver.nextConsensusLedgerIndex() > MAX_SLOTS_TO_REMEMBER)
-        {
-            mPendingEnvelopes.eraseBelow(
-                mHerderSCPDriver.nextConsensusLedgerIndex() -
-                MAX_SLOTS_TO_REMEMBER);
-        }
-
         processSCPQueueUpToIndex(mHerderSCPDriver.nextConsensusLedgerIndex());
     }
     else

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -521,13 +521,15 @@ HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer)
         auto seq = *itt.first;
         if (seq >= ledgerSeq)
         {
-            getSCP().processCurrentState(seq, [&](SCPEnvelope const& e) {
-                StellarMessage m;
-                m.type(SCP_MESSAGE);
-                m.envelope() = e;
-                peer->sendMessage(m);
-                return true;
-            });
+            getSCP().processCurrentState(seq,
+                                         [&](SCPEnvelope const& e) {
+                                             StellarMessage m;
+                                             m.type(SCP_MESSAGE);
+                                             m.envelope() = e;
+                                             peer->sendMessage(m);
+                                             return true;
+                                         },
+                                         false);
         }
     }
 }
@@ -841,16 +843,19 @@ HerderImpl::resolveNodeID(std::string const& s, PublicKey& retKey)
             {
                 seq--;
             }
-            getSCP().processCurrentState(seq, [&](SCPEnvelope const& e) {
-                std::string curK = KeyUtils::toStrKey(e.statement.nodeID);
-                if (curK.compare(0, arg.size(), arg) == 0)
-                {
-                    retKey = e.statement.nodeID;
-                    r = true;
-                    return false;
-                }
-                return true;
-            });
+            getSCP().processCurrentState(
+                seq,
+                [&](SCPEnvelope const& e) {
+                    std::string curK = KeyUtils::toStrKey(e.statement.nodeID);
+                    if (curK.compare(0, arg.size(), arg) == 0)
+                    {
+                        retKey = e.statement.nodeID;
+                        r = true;
+                        return false;
+                    }
+                    return true;
+                },
+                true);
         }
     }
     return r;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1254,7 +1254,7 @@ HerderImpl::restoreSCPState()
                                     "proceeding without them : "
                                  << e.what();
         }
-        mPendingEnvelopes.rebuildQuorumTrackerState();
+        mPendingEnvelopes.rebuildQuorumTrackerState(true);
     }
 
     startRebroadcastTimer();

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -83,7 +83,7 @@ PendingEnvelopes::recvSCPQuorumSet(Hash hash, const SCPQuorumSet& q)
     CLOG(TRACE, "Herder") << "Got SCPQSet " << hexAbbrev(hash);
 
     auto lastSeenSlotIndex = mQuorumSetFetcher.getLastSeenSlotIndex(hash);
-    if (lastSeenSlotIndex <= 0)
+    if (lastSeenSlotIndex == 0)
     {
         return false;
     }

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -623,10 +623,12 @@ PendingEnvelopes::DropUnrefencedQsets()
     for (; itt.first != itt.second; ++itt.first)
     {
         auto slot = *itt.first;
-        scp.processCurrentState(slot, [&](SCPEnvelope const& e) {
-            addQset(e);
-            return true;
-        });
+        scp.processCurrentState(slot,
+                                [&](SCPEnvelope const& e) {
+                                    addQset(e);
+                                    return true;
+                                },
+                                true);
     }
     // add qsets referenced by quorum
     rebuildQuorumTrackerState(false);

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -11,6 +11,7 @@
 #include <medida/medida.h>
 #include <queue>
 #include <set>
+#include <unordered_map>
 #include <util/optional.h>
 
 /*
@@ -45,7 +46,7 @@ class PendingEnvelopes
     std::map<uint64, SlotEnvelopes> mEnvelopes;
 
     // all the quorum sets we have learned about
-    cache::lru_cache<Hash, SCPQuorumSetPtr> mQsetCache;
+    std::unordered_map<Hash, SCPQuorumSetPtr> mKnownQSet;
 
     ItemFetcher mTxSetFetcher;
     ItemFetcher mQuorumSetFetcher;

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -48,6 +48,7 @@ class PendingEnvelopes
 
     // all the quorum sets we have learned about
     std::unordered_map<Hash, SCPQuorumSetPtr> mKnownQSet;
+    size_t mQSetGCThreshold; // threshold to trigger QSet GC
 
     ItemFetcher mTxSetFetcher;
     ItemFetcher mQuorumSetFetcher;
@@ -146,11 +147,14 @@ class PendingEnvelopes
     // sure
     bool isNodeDefinitelyInQuorum(NodeID const& node);
 
-    void rebuildQuorumTrackerState();
+    void rebuildQuorumTrackerState(bool force);
     QuorumTracker::QuorumMap const& getCurrentlyTrackedQuorum() const;
 
     // updates internal state when an envelope was succesfuly processed
     void envelopeProcessed(SCPEnvelope const& env);
+
+    // erases qsets not referenced anymore
+    void DropUnrefencedQsets();
 
     // queries state
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1514,7 +1514,8 @@ TEST_CASE("In quorum filtering", "[quorum][herder][acceptance]")
             HerderImpl& herder = *static_cast<HerderImpl*>(&c->getHerder());
 
             auto const& lcl = c->getLedgerManager().getLastClosedLedgerHeader();
-            herder.getSCP().processCurrentState(lcl.header.ledgerSeq, proc);
+            herder.getSCP().processCurrentState(lcl.header.ledgerSeq, proc,
+                                                true);
         }
     };
 

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -885,7 +885,7 @@ TEST_CASE("HAS in publishqueue remains in pristine state until publish",
 
             // Second, ensure `next` is in the exact same state as when it was
             // queued
-            for (int i = 0; i < BucketList::kNumLevels; i++)
+            for (uint32_t i = 0; i < BucketList::kNumLevels; i++)
             {
                 auto const& currentNext = bl.getLevel(i).getNext();
                 auto const& queuedNext = queuedHAS.currentBuckets[i].next;

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -277,13 +277,15 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
 
             HerderImpl& herder = *static_cast<HerderImpl*>(&app->getHerder());
             herder.getSCP().processCurrentState(
-                lcl.header.ledgerSeq + 1, [&](SCPEnvelope const& e) {
+                lcl.header.ledgerSeq + 1,
+                [&](SCPEnvelope const& e) {
                     if (keysMap.find(e.statement.nodeID) != keysMap.end())
                     {
                         okCount++;
                     }
                     return true;
-                });
+                },
+                true);
             bool res = okCount == sources.size();
             LOG(DEBUG) << app->getConfig().PEER_PORT
                        << (res ? " OK " : " BEHIND ") << okCount << " / "

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -276,11 +276,14 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
                 app->getLedgerManager().getLastClosedLedgerHeader();
 
             HerderImpl& herder = *static_cast<HerderImpl*>(&app->getHerder());
-            auto state =
-                herder.getSCP().getCurrentState(lcl.header.ledgerSeq + 1);
-            okCount = std::count_if(state.begin(), state.end(), [&](auto& e) {
-                return keysMap.find(e.statement.nodeID) != keysMap.end();
-            });
+            herder.getSCP().processCurrentState(
+                lcl.header.ledgerSeq + 1, [&](SCPEnvelope const& e) {
+                    if (keysMap.find(e.statement.nodeID) != keysMap.end())
+                    {
+                        okCount++;
+                    }
+                    return true;
+                });
             bool res = okCount == sources.size();
             LOG(DEBUG) << app->getConfig().PEER_PORT
                        << (res ? " OK " : " BEHIND ") << okCount << " / "

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1776,21 +1776,23 @@ BallotProtocol::setStateFromEnvelope(SCPEnvelope const& e)
     }
 }
 
-std::vector<SCPEnvelope>
-BallotProtocol::getCurrentState() const
+bool
+BallotProtocol::processCurrentState(
+    std::function<bool(SCPEnvelope const&)> const& f) const
 {
-    std::vector<SCPEnvelope> res;
-    res.reserve(mLatestEnvelopes.size());
     for (auto const& n : mLatestEnvelopes)
     {
         // only return messages for self if the slot is fully validated
         if (!(n.first == mSlot.getSCP().getLocalNodeID()) ||
             mSlot.isFullyValidated())
         {
-            res.emplace_back(n.second);
+            if (!f(n.second))
+            {
+                return false;
+            }
         }
     }
-    return res;
+    return true;
 }
 
 SCPEnvelope const*

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1778,12 +1778,12 @@ BallotProtocol::setStateFromEnvelope(SCPEnvelope const& e)
 
 bool
 BallotProtocol::processCurrentState(
-    std::function<bool(SCPEnvelope const&)> const& f) const
+    std::function<bool(SCPEnvelope const&)> const& f, bool forceSelf) const
 {
     for (auto const& n : mLatestEnvelopes)
     {
         // only return messages for self if the slot is fully validated
-        if (!(n.first == mSlot.getSCP().getLocalNodeID()) ||
+        if (forceSelf || !(n.first == mSlot.getSCP().getLocalNodeID()) ||
             mSlot.isFullyValidated())
         {
             if (!f(n.second))

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -109,8 +109,8 @@ class BallotProtocol
 
     void setStateFromEnvelope(SCPEnvelope const& e);
 
-    bool
-    processCurrentState(std::function<bool(SCPEnvelope const&)> const& f) const;
+    bool processCurrentState(std::function<bool(SCPEnvelope const&)> const& f,
+                             bool forceSelf) const;
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -109,7 +109,8 @@ class BallotProtocol
 
     void setStateFromEnvelope(SCPEnvelope const& e);
 
-    std::vector<SCPEnvelope> getCurrentState() const;
+    bool
+    processCurrentState(std::function<bool(SCPEnvelope const&)> const& f) const;
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -601,21 +601,23 @@ NominationProtocol::setStateFromEnvelope(SCPEnvelope const& e)
     mLastEnvelope = std::make_unique<SCPEnvelope>(e);
 }
 
-std::vector<SCPEnvelope>
-NominationProtocol::getCurrentState() const
+bool
+NominationProtocol::processCurrentState(
+    std::function<bool(SCPEnvelope const&)> const& f) const
 {
-    std::vector<SCPEnvelope> res;
-    res.reserve(mLatestNominations.size());
     for (auto const& n : mLatestNominations)
     {
         // only return messages for self if the slot is fully validated
         if (!(n.first == mSlot.getSCP().getLocalNodeID()) ||
             mSlot.isFullyValidated())
         {
-            res.emplace_back(n.second);
+            if (!f(n.second))
+            {
+                return false;
+            }
         }
     }
-    return res;
+    return true;
 }
 
 SCPEnvelope const*

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -603,12 +603,12 @@ NominationProtocol::setStateFromEnvelope(SCPEnvelope const& e)
 
 bool
 NominationProtocol::processCurrentState(
-    std::function<bool(SCPEnvelope const&)> const& f) const
+    std::function<bool(SCPEnvelope const&)> const& f, bool forceSelf) const
 {
     for (auto const& n : mLatestNominations)
     {
         // only return messages for self if the slot is fully validated
-        if (!(n.first == mSlot.getSCP().getLocalNodeID()) ||
+        if (forceSelf || !(n.first == mSlot.getSCP().getLocalNodeID()) ||
             mSlot.isFullyValidated())
         {
             if (!f(n.second))

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -116,8 +116,8 @@ class NominationProtocol
 
     void setStateFromEnvelope(SCPEnvelope const& e);
 
-    bool
-    processCurrentState(std::function<bool(SCPEnvelope const&)> const& f) const;
+    bool processCurrentState(std::function<bool(SCPEnvelope const&)> const& f,
+                             bool forceSelf) const;
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -116,7 +116,8 @@ class NominationProtocol
 
     void setStateFromEnvelope(SCPEnvelope const& e);
 
-    std::vector<SCPEnvelope> getCurrentState() const;
+    bool
+    processCurrentState(std::function<bool(SCPEnvelope const&)> const& f) const;
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -232,17 +232,18 @@ SCP::getHighSlotIndex() const
     return it->first;
 }
 
-std::vector<SCPEnvelope>
-SCP::getCurrentState(uint64 slotIndex)
+bool
+SCP::processCurrentState(uint64 slotIndex,
+                         std::function<bool(SCPEnvelope const&)> const& f)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
     {
-        return slot->getCurrentState();
+        return slot->processCurrentState(f);
     }
     else
     {
-        return std::vector<SCPEnvelope>();
+        return true;
     }
 }
 

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -218,12 +218,13 @@ SCP::empty() const
 
 bool
 SCP::processCurrentState(uint64 slotIndex,
-                         std::function<bool(SCPEnvelope const&)> const& f)
+                         std::function<bool(SCPEnvelope const&)> const& f,
+                         bool forceSelf)
 {
     auto slot = getSlot(slotIndex, false);
     if (slot)
     {
-        return slot->processCurrentState(f);
+        return slot->processCurrentState(f, forceSelf);
     }
     else
     {

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -216,22 +216,6 @@ SCP::empty() const
     return mKnownSlots.empty();
 }
 
-uint64
-SCP::getLowSlotIndex() const
-{
-    assert(!empty());
-    return mKnownSlots.begin()->first;
-}
-
-uint64
-SCP::getHighSlotIndex() const
-{
-    assert(!empty());
-    auto it = mKnownSlots.end();
-    it--;
-    return it->first;
-}
-
 bool
 SCP::processCurrentState(uint64 slotIndex,
                          std::function<bool(SCPEnvelope const&)> const& f)
@@ -387,5 +371,19 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
 
     oss << " }";
     return oss.str();
+}
+
+std::pair<SCP::incSlotIterator, SCP::incSlotIterator>
+SCP::ascSlots() const
+{
+    return std::make_pair(SCP::incSlotIterator(mKnownSlots.begin()),
+                          SCP::incSlotIterator(mKnownSlots.end()));
+}
+
+std::pair<SCP::decSlotIterator, SCP::decSlotIterator>
+SCP::descSlots() const
+{
+    return std::make_pair(SCP::decSlotIterator(mKnownSlots.rbegin()),
+                          SCP::decSlotIterator(mKnownSlots.rend()));
 }
 }

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -100,10 +100,6 @@ class SCP
 
     // check if we are holding some slots
     bool empty() const;
-    // return lowest slot index value
-    uint64 getLowSlotIndex() const;
-    // return highest slot index value
-    uint64 getHighSlotIndex() const;
 
     // invokes f for all latest messages
     // f returns false to stop processing, true otherwise
@@ -134,5 +130,53 @@ class SCP
     std::shared_ptr<Slot> getSlot(uint64 slotIndex, bool create);
 
     friend class TestSCP;
+
+  public:
+    template <class IT>
+    class slotIterator : public std::iterator<std::input_iterator_tag, uint64>
+    {
+        IT mCur;
+
+      public:
+        explicit slotIterator(IT it) : mCur(it)
+        {
+        }
+        iterator& operator++()
+        {
+            mCur++;
+            return *this;
+        }
+        iterator operator++(int)
+        {
+            iterator retval = *this;
+            ++(*this);
+            return retval;
+        }
+        bool
+        operator==(slotIterator const& o) const
+        {
+            return mCur == o.mCur;
+        }
+        bool
+        operator!=(slotIterator const& o) const
+        {
+            return !(*this == o);
+        }
+        uint64 operator*() const
+        {
+            return mCur->first;
+        }
+    };
+
+    using incSlotIterator =
+        slotIterator<std::map<uint64, std::shared_ptr<Slot>>::const_iterator>;
+    using decSlotIterator = slotIterator<
+        std::map<uint64, std::shared_ptr<Slot>>::const_reverse_iterator>;
+
+    // returns the begin/end pair
+    // ascending order
+    std::pair<incSlotIterator, incSlotIterator> ascSlots() const;
+    // descending order
+    std::pair<decSlotIterator, decSlotIterator> descSlots() const;
 };
 }

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -102,9 +102,11 @@ class SCP
     bool empty() const;
 
     // invokes f for all latest messages
+    // if forceSelf, return messages for self even if not fully validated
     // f returns false to stop processing, true otherwise
     bool processCurrentState(uint64 slotIndex,
-                             std::function<bool(SCPEnvelope const&)> const& f);
+                             std::function<bool(SCPEnvelope const&)> const& f,
+                             bool forceSelf);
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -105,8 +105,10 @@ class SCP
     // return highest slot index value
     uint64 getHighSlotIndex() const;
 
-    // returns all messages for the slot
-    std::vector<SCPEnvelope> getCurrentState(uint64 slotIndex);
+    // invokes f for all latest messages
+    // f returns false to stop processing, true otherwise
+    bool processCurrentState(uint64 slotIndex,
+                             std::function<bool(SCPEnvelope const&)> const& f);
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -80,14 +80,12 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
     }
 }
 
-std::vector<SCPEnvelope>
-Slot::getCurrentState() const
+bool
+Slot::processCurrentState(
+    std::function<bool(SCPEnvelope const&)> const& f) const
 {
-    std::vector<SCPEnvelope> res;
-    res = mNominationProtocol.getCurrentState();
-    auto r2 = mBallotProtocol.getCurrentState();
-    res.insert(res.end(), r2.begin(), r2.end());
-    return res;
+    return mNominationProtocol.processCurrentState(f) &&
+           mBallotProtocol.processCurrentState(f);
 }
 
 SCPEnvelope const*
@@ -386,8 +384,12 @@ Slot::getEntireCurrentState()
     bool old = mFullyValidated;
     // fake fully validated to force returning all envelopes
     mFullyValidated = true;
-    auto r = getCurrentState();
+    std::vector<SCPEnvelope> res;
+    processCurrentState([&](SCPEnvelope const& e) {
+        res.emplace_back(e);
+        return true;
+    });
     mFullyValidated = old;
-    return r;
+    return res;
 }
 }

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -81,11 +81,11 @@ Slot::setStateFromEnvelope(SCPEnvelope const& e)
 }
 
 bool
-Slot::processCurrentState(
-    std::function<bool(SCPEnvelope const&)> const& f) const
+Slot::processCurrentState(std::function<bool(SCPEnvelope const&)> const& f,
+                          bool forceSelf) const
 {
-    return mNominationProtocol.processCurrentState(f) &&
-           mBallotProtocol.processCurrentState(f);
+    return mNominationProtocol.processCurrentState(f, forceSelf) &&
+           mBallotProtocol.processCurrentState(f, forceSelf);
 }
 
 SCPEnvelope const*
@@ -381,15 +381,13 @@ Slot::getLocalNode()
 std::vector<SCPEnvelope>
 Slot::getEntireCurrentState()
 {
-    bool old = mFullyValidated;
-    // fake fully validated to force returning all envelopes
-    mFullyValidated = true;
     std::vector<SCPEnvelope> res;
-    processCurrentState([&](SCPEnvelope const& e) {
-        res.emplace_back(e);
-        return true;
-    });
-    mFullyValidated = old;
+    processCurrentState(
+        [&](SCPEnvelope const& e) {
+            res.emplace_back(e);
+            return true;
+        },
+        true);
     return res;
 }
 }

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -87,8 +87,9 @@ class Slot : public std::enable_shared_from_this<Slot>
     // this is used when rebuilding the state after a crash for example
     void setStateFromEnvelope(SCPEnvelope const& e);
 
-    // returns the latest messages known for this slot
-    std::vector<SCPEnvelope> getCurrentState() const;
+    // calls f for all latest messages
+    bool
+    processCurrentState(std::function<bool(SCPEnvelope const&)> const& f) const;
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -88,8 +88,8 @@ class Slot : public std::enable_shared_from_this<Slot>
     void setStateFromEnvelope(SCPEnvelope const& e);
 
     // calls f for all latest messages
-    bool
-    processCurrentState(std::function<bool(SCPEnvelope const&)> const& f) const;
+    bool processCurrentState(std::function<bool(SCPEnvelope const&)> const& f,
+                             bool forceSelf) const;
 
     // returns the latest message from a node
     // or nullptr if not found


### PR DESCRIPTION
# Description

Part 1 (qset) to fix #509

This PR replaces the cache used to keep track of quorum sets with a deterministic data structure.

This allows to make (close to) optimal use of memory when it comes to quorum sets.

A similar change will be done for TxSet in a subsequent PR (wanted to first test the water with QSets)