### PR TITLE
Bug 2226 fast replay streaming txmeta

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -316,6 +316,7 @@ exit /b 0
     <ClCompile Include="..\..\src\historywork\BatchDownloadWork.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumIntersectionCheckerImpl.cpp" />
     <ClCompile Include="..\..\src\herder\test\QuorumIntersectionTests.cpp" />
+    <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp" />
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\PathPaymentOpFrameBase.cpp" />
     <ClCompile Include="..\..\src\transactions\PathPaymentStrictReceiveOpFrame.cpp" />
@@ -379,6 +380,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerTxnOfferSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnTrustLineSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\SyncingLedgerChain.cpp" />
+    <ClCompile Include="..\..\src\ledger\InMemoryLedgerTxnRoot.cpp" />
     <ClCompile Include="..\..\lib\asio.cpp" />
     <ClCompile Include="..\..\lib\http\connection.cpp" />
     <ClCompile Include="..\..\lib\http\connection_manager.cpp" />
@@ -692,6 +694,7 @@ exit /b 0
     <ClInclude Include="..\..\src\ledger\LedgerTxnHeader.h" />
     <ClInclude Include="..\..\src\ledger\LedgerTxnImpl.h" />
     <ClInclude Include="..\..\src\ledger\SyncingLedgerChain.h" />
+    <ClInclude Include="..\..\src\ledger\InMemoryLedgerTxnRoot.h" />
     <ClInclude Include="..\..\src\ledger\test\LedgerTestUtils.h" />
     <ClInclude Include="..\..\src\ledger\TrustLineWrapper.h" />
     <ClInclude Include="..\..\src\main\Application.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1011,6 +1011,12 @@
     <ClCompile Include="..\..\src\catchup\ApplyLedgerWork.cpp">
       <Filter>catchup</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\InMemoryLedgerTxnRoot.cpp">
+      <Filter>ledger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp">
+      <Filter>ledger\tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">
@@ -1750,6 +1756,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\catchup\ApplyLedgerWork.h">
       <Filter>catchup</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ledger\InMemoryLedgerTxnRoot.h">
+      <Filter>ledger</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -384,6 +384,24 @@ DISABLE_XDR_FSYNC=false
 # set to 2 unless your downstream systems support TransactionMetaV2.
 SUPPORTED_META_VERSION=1
 
+# METADATA_OUTPUT_STREAM defaults to "", disabling it.
+# A string specifying a stream to write fine-grained metadata to for each ledger
+# close while running. This will be opened at startup and synchronously
+# streamed-to during both catchup and live ledger-closing.
+#
+# Streams may be specified either as a pathname (typically a named FIFO on POSIX
+# or a named pipe on Windows, though plain files also work) or a string of the
+# form "fd:N" for some integer N which, on POSIX, specifies the existing open
+# file descriptor N inherited by the process (for example to write to an
+# anonymous pipe).
+#
+# As a further safety check, this option is mutually exclusive with
+# NODE_IS_VALIDATOR, as its typical use writing to a pipe with a reader process
+# on the other end introduces a potentially-unbounded synchronous delay in
+# closing a ledger, and should not be used on a node participating in consensus,
+# only a passive "watcher" node.
+METADATA_OUTPUT_STREAM=""
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -85,10 +85,11 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
     }
 };
 
-class LedgerManagerTestApplication : public TestApplication
+class BucketManagerTestApplication : public TestApplication
 {
   public:
-    LedgerManagerTestApplication(VirtualClock& clock, Config const& cfg)
+    BucketManagerTestApplication(VirtualClock& clock, Config const& cfg,
+                                 Application::AppMode mode)
         : TestApplication(clock, cfg)
     {
     }
@@ -348,7 +349,7 @@ TEST_CASE("bucketmanager missing buckets fail", "[bucket][bucketmanager]")
     {
         VirtualClock clock;
         auto app =
-            createTestApplication<LedgerManagerTestApplication>(clock, cfg);
+            createTestApplication<BucketManagerTestApplication>(clock, cfg);
         app->start();
         BucketManager& bm = app->getBucketManager();
         BucketList& bl = bm.getBucketList();
@@ -523,7 +524,7 @@ TEST_CASE("bucketmanager don't leak empty-merge futures",
     cfg.LEDGER_PROTOCOL_VERSION =
         Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY - 1;
 
-    auto app = createTestApplication<LedgerManagerTestApplication>(clock, cfg);
+    auto app = createTestApplication<BucketManagerTestApplication>(clock, cfg);
     app->start();
 
     BucketManager& bm = app->getBucketManager();
@@ -1100,7 +1101,7 @@ class StopAndRestartBucketMergesTest
             << "Collecting control surveys in ledger range 2.." << std::dec
             << finalLedger << " = 0x" << std::hex << finalLedger;
         auto app =
-            createTestApplication<LedgerManagerTestApplication>(clock, cfg);
+            createTestApplication<BucketManagerTestApplication>(clock, cfg);
         app->start();
 
         std::vector<LedgerKey> allKeys;
@@ -1220,7 +1221,7 @@ class StopAndRestartBucketMergesTest
             mDesignatedLedgers.begin(), mDesignatedLedgers.size() / 2));
 
         auto app =
-            createTestApplication<LedgerManagerTestApplication>(*clock, cfg);
+            createTestApplication<BucketManagerTestApplication>(*clock, cfg);
         app->start();
         CLOG(INFO, "Bucket")
             << "Running stop/restart test in ledger range 2.." << std::dec
@@ -1280,7 +1281,7 @@ class StopAndRestartBucketMergesTest
                 CLOG(INFO, "Bucket")
                     << "Restarting application at ledger " << std::dec << i;
                 clock = std::make_unique<VirtualClock>();
-                app = createTestApplication<LedgerManagerTestApplication>(
+                app = createTestApplication<BucketManagerTestApplication>(
                     *clock, cfg, false);
                 app->start();
                 if (BucketList::levelShouldSpill(i, mDesignatedLevel - 1))

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -110,7 +110,7 @@ ApplyBucketsWork::startLevel()
 
     bool applySnap = (i.snap != binToHex(level.getSnap()->getHash()));
     bool applyCurr = (i.curr != binToHex(level.getCurr()->getHash()));
-    if (!mApplying && (applySnap || applyCurr))
+    if (!mApplying && mApp.modeHasDatabase() && (applySnap || applyCurr))
     {
         uint32_t oldestLedger = applySnap
                                     ? BucketList::oldestLedgerInSnap(

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -89,7 +89,6 @@ DownloadApplyTxsWork::yieldMoreWork()
                 }
                 res = !pqFellBehind;
             }
-
             return res;
         };
         seq.push_back(std::make_shared<ConditionalWork>(

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -560,15 +560,19 @@ Database::recentIdleDbPercent()
 
 DBTimeExcluder::DBTimeExcluder(Application& app)
     : mApp(app)
-    , mStartQueryTime(app.getDatabase().totalQueryTime())
+    , mStartQueryTime(app.modeHasDatabase() ? app.getDatabase().totalQueryTime()
+                                            : std::chrono::nanoseconds(0))
     , mStartTotalTime(app.getClock().now())
 {
 }
 
 DBTimeExcluder::~DBTimeExcluder()
 {
-    auto deltaQ = mApp.getDatabase().totalQueryTime() - mStartQueryTime;
-    auto deltaT = mApp.getClock().now() - mStartTotalTime;
-    mApp.getDatabase().excludeTime(deltaQ, deltaT);
+    if (mApp.modeHasDatabase())
+    {
+        auto deltaQ = mApp.getDatabase().totalQueryTime() - mStartQueryTime;
+        auto deltaT = mApp.getClock().now() - mStartTotalTime;
+        mApp.getDatabase().excludeTime(deltaQ, deltaT);
+    }
 }
 }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -15,6 +15,7 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "transactions/TransactionUtils.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
@@ -512,6 +513,8 @@ TxSetFrame::getTotalFees(LedgerHeader const& lh) const
 void
 TxSetFrame::toXDR(TransactionSet& txSet)
 {
+    releaseAssert(std::is_sorted(mTransactions.begin(), mTransactions.end(),
+                                 HashTxSorter));
     txSet.txs.resize(xdr::size32(mTransactions.size()));
     for (unsigned int n = 0; n < mTransactions.size(); n++)
     {

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -34,6 +34,7 @@ class AbstractTxSetFrameForApply
     virtual size_t sizeOp() const = 0;
 
     virtual std::vector<TransactionFramePtr> sortForApply() = 0;
+    virtual void toXDR(TransactionSet& set) = 0;
 };
 
 class TxSetFrame : public AbstractTxSetFrameForApply
@@ -108,6 +109,6 @@ class TxSetFrame : public AbstractTxSetFrameForApply
 
     // return the sum of all fees that this transaction set would take
     int64_t getTotalFees(LedgerHeader const& lh) const;
-    void toXDR(TransactionSet& set);
+    void toXDR(TransactionSet& set) override;
 };
 } // namespace stellar

--- a/src/herder/simulation/SimulationTxSetFrame.cpp
+++ b/src/herder/simulation/SimulationTxSetFrame.cpp
@@ -83,4 +83,18 @@ SimulationTxSetFrame::sortForApply()
     }
     return res;
 }
+
+void
+SimulationTxSetFrame::toXDR(TransactionSet& set)
+{
+    // Delegate to TxSetFrame and explicitly call sortForHash on it for now;
+    // likely this whole class will go away at some point.
+    TransactionSet txSet;
+    txSet.previousLedgerHash = mPreviousLedgerHash;
+    txSet.txs.insert(txSet.txs.end(), mTransactions.begin(),
+                     mTransactions.end());
+    TxSetFrame tf(mNetworkID, txSet);
+    tf.sortForHash();
+    tf.toXDR(set);
+}
 }

--- a/src/herder/simulation/SimulationTxSetFrame.h
+++ b/src/herder/simulation/SimulationTxSetFrame.h
@@ -33,5 +33,6 @@ class SimulationTxSetFrame : public AbstractTxSetFrameForApply
     size_t sizeOp() const override;
 
     std::vector<TransactionFramePtr> sortForApply() override;
+    void toXDR(TransactionSet& set) override;
 };
 }

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -29,6 +29,7 @@
 #include "medida/metrics_registry.h"
 #include "overlay/StellarXDR.h"
 #include "process/ProcessManager.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/Math.h"
 #include "util/StatusManager.h"
@@ -147,6 +148,11 @@ HistoryManagerImpl::logAndUpdatePublishStatus()
 size_t
 HistoryManagerImpl::publishQueueLength() const
 {
+    if (!mApp.modeHasDatabase())
+    {
+        return 0;
+    }
+
     uint32_t count;
     auto prep = mApp.getDatabase().getPreparedStatement(
         "SELECT count(ledger) FROM publishqueue;");
@@ -186,6 +192,7 @@ HistoryManagerImpl::inferQuorum(uint32_t ledgerNum)
 uint32_t
 HistoryManagerImpl::getMinLedgerQueuedToPublish()
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
     uint32_t seq;
     soci::indicator minIndicator;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -204,6 +211,7 @@ HistoryManagerImpl::getMinLedgerQueuedToPublish()
 uint32_t
 HistoryManagerImpl::getMaxLedgerQueuedToPublish()
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
     uint32_t seq;
     soci::indicator maxIndicator;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -242,6 +250,7 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint()
 void
 HistoryManagerImpl::queueCurrentHistory()
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
     auto ledger = mApp.getLedgerManager().getLastClosedLedgerNum();
     HistoryArchiveState has(ledger, mApp.getBucketManager().getBucketList());
 
@@ -273,6 +282,8 @@ HistoryManagerImpl::queueCurrentHistory()
 void
 HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
+
     if (mPublishWork)
     {
         return;
@@ -317,6 +328,11 @@ HistoryManagerImpl::publishQueuedHistory()
     }
 #endif
 
+    if (!mApp.modeHasDatabase())
+    {
+        return 0;
+    }
+
     std::string state;
 
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -341,6 +357,12 @@ std::vector<HistoryArchiveState>
 HistoryManagerImpl::getPublishQueueStates()
 {
     std::vector<HistoryArchiveState> states;
+
+    if (!mApp.modeHasDatabase())
+    {
+        return states;
+    }
+
     std::string state;
     auto prep = mApp.getDatabase().getPreparedStatement(
         "SELECT state FROM publishqueue;");
@@ -409,6 +431,8 @@ HistoryManagerImpl::historyPublished(
     uint32_t ledgerSeq, std::vector<std::string> const& originalBuckets,
     bool success)
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
+
     if (success)
     {
         auto iter = mEnqueueTimes.find(ledgerSeq);

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -1,0 +1,130 @@
+#include "ledger/InMemoryLedgerTxnRoot.h"
+#include "ledger/LedgerRange.h"
+#include "ledger/LedgerTxn.h"
+#include "util/XDROperators.h"
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdrpp/marshal.h"
+#include <algorithm>
+
+namespace stellar
+{
+
+InMemoryLedgerTxnRoot::InMemoryLedgerTxnRoot()
+    : mHeader(std::make_unique<LedgerHeader>())
+{
+}
+
+void
+InMemoryLedgerTxnRoot::addChild(AbstractLedgerTxn& child)
+{
+}
+
+void
+InMemoryLedgerTxnRoot::commitChild(EntryIterator iter,
+                                   LedgerTxnConsistency cons)
+{
+    throw std::runtime_error("committing to stub InMemoryLedgerTxnRoot");
+}
+
+void
+InMemoryLedgerTxnRoot::rollbackChild()
+{
+}
+
+std::unordered_map<LedgerKey, LedgerEntry>
+InMemoryLedgerTxnRoot::getAllOffers()
+{
+    return std::unordered_map<LedgerKey, LedgerEntry>();
+}
+
+std::shared_ptr<LedgerEntry const>
+InMemoryLedgerTxnRoot::getBestOffer(Asset const& buying, Asset const& selling)
+{
+    return nullptr;
+}
+
+std::shared_ptr<LedgerEntry const>
+InMemoryLedgerTxnRoot::getBestOffer(Asset const& buying, Asset const& selling,
+                                    OfferDescriptor const& worseThan)
+{
+    return nullptr;
+}
+
+std::unordered_map<LedgerKey, LedgerEntry>
+InMemoryLedgerTxnRoot::getOffersByAccountAndAsset(AccountID const& account,
+                                                  Asset const& asset)
+{
+    return std::unordered_map<LedgerKey, LedgerEntry>();
+}
+
+LedgerHeader const&
+InMemoryLedgerTxnRoot::getHeader() const
+{
+    return *mHeader;
+}
+
+std::vector<InflationWinner>
+InMemoryLedgerTxnRoot::getInflationWinners(size_t maxWinners,
+                                           int64_t minBalance)
+{
+    return std::vector<InflationWinner>();
+}
+
+std::shared_ptr<LedgerEntry const>
+InMemoryLedgerTxnRoot::getNewestVersion(LedgerKey const& key) const
+{
+    return nullptr;
+}
+
+uint64_t
+InMemoryLedgerTxnRoot::countObjects(LedgerEntryType let) const
+{
+    return 0;
+}
+
+uint64_t
+InMemoryLedgerTxnRoot::countObjects(LedgerEntryType let,
+                                    LedgerRange const& ledgers) const
+{
+    return 0;
+}
+
+void
+InMemoryLedgerTxnRoot::deleteObjectsModifiedOnOrAfterLedger(
+    uint32_t ledger) const
+{
+}
+
+void
+InMemoryLedgerTxnRoot::dropAccounts()
+{
+}
+
+void
+InMemoryLedgerTxnRoot::dropData()
+{
+}
+
+void
+InMemoryLedgerTxnRoot::dropOffers()
+{
+}
+
+void
+InMemoryLedgerTxnRoot::dropTrustLines()
+{
+}
+
+double
+InMemoryLedgerTxnRoot::getPrefetchHitRate() const
+{
+    return 0.0;
+}
+
+uint32_t
+InMemoryLedgerTxnRoot::prefetch(std::unordered_set<LedgerKey> const& keys)
+{
+    return 0;
+}
+}

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -1,0 +1,60 @@
+#include "ledger/LedgerTxn.h"
+#include "ledger/LedgerTxnImpl.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+// This is a stub helper class that pretends to implements a "root"
+// AbstractLedgerTxnParent like LedgerTxnRoot but returns empty/null values for
+// any query made of it, and throws if anyone ever tries to commit to it.
+//
+// This is used to anchor a live-but-never-committed LedgerTxn when doing
+// strictly-in-memory fast history replay.
+
+namespace stellar
+{
+
+class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
+{
+    std::unique_ptr<LedgerHeader> mHeader;
+
+  public:
+    InMemoryLedgerTxnRoot();
+    void addChild(AbstractLedgerTxn& child) override;
+    void commitChild(EntryIterator iter, LedgerTxnConsistency cons) override;
+    void rollbackChild() override;
+
+    std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
+    std::shared_ptr<LedgerEntry const>
+    getBestOffer(Asset const& buying, Asset const& selling) override;
+    std::shared_ptr<LedgerEntry const>
+    getBestOffer(Asset const& buying, Asset const& selling,
+                 OfferDescriptor const& worseThan) override;
+    std::unordered_map<LedgerKey, LedgerEntry>
+    getOffersByAccountAndAsset(AccountID const& account,
+                               Asset const& asset) override;
+
+    LedgerHeader const& getHeader() const override;
+
+    std::vector<InflationWinner>
+    getInflationWinners(size_t maxWinners, int64_t minBalance) override;
+
+    std::shared_ptr<LedgerEntry const>
+    getNewestVersion(LedgerKey const& key) const override;
+
+    uint64_t countObjects(LedgerEntryType let) const override;
+    uint64_t countObjects(LedgerEntryType let,
+                          LedgerRange const& ledgers) const override;
+
+    void deleteObjectsModifiedOnOrAfterLedger(uint32_t ledger) const override;
+
+    void dropAccounts() override;
+    void dropData() override;
+    void dropOffers() override;
+    void dropTrustLines() override;
+    double getPrefetchHitRate() const override;
+    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) override;
+};
+}

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -28,6 +28,7 @@
 #include "overlay/OverlayManager.h"
 #include "transactions/OperationFrame.h"
 #include "transactions/TransactionUtils.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "util/format.h"
@@ -41,6 +42,7 @@
 
 #include <chrono>
 #include <numeric>
+#include <regex>
 #include <sstream>
 
 /*
@@ -128,6 +130,7 @@ LedgerManagerImpl::LedgerManagerImpl(Application& app)
     , mState(LM_BOOTING_STATE)
 
 {
+    setupLedgerCloseMetaStream();
 }
 
 void
@@ -272,7 +275,7 @@ LedgerManagerImpl::loadLastKnownLedger(
         LOG(INFO) << "Loading last known ledger";
         Hash lastLedgerHash = hexToBin256(lastLedger);
 
-        if (Application::modeHasDatabase(mApp.getMode()))
+        if (mApp.modeHasDatabase())
         {
             auto currentLedger =
                 LedgerHeaderUtils::loadByHash(getDatabase(), lastLedgerHash);
@@ -769,6 +772,8 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     mLastClose = now;
     mLedgerAge.set_count(0);
 
+    std::shared_ptr<AbstractTxSetFrameForApply> txSet = ledgerData.getTxSet();
+
     // If we do not support ledger version, we can't apply that ledger, fail!
     if (header.current().ledgerVersion >
         mApp.getConfig().LEDGER_PROTOCOL_VERSION)
@@ -781,13 +786,12 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
                         header.current().ledgerVersion));
     }
 
-    if (ledgerData.getTxSet()->previousLedgerHash() !=
-        getLastClosedLedgerHeader().hash)
+    if (txSet->previousLedgerHash() != getLastClosedLedgerHeader().hash)
     {
         CLOG(ERROR, "Ledger")
             << "TxSet mismatch: LCD wants "
             << ledgerAbbrev(ledgerData.getLedgerSeq() - 1,
-                            ledgerData.getTxSet()->previousLedgerHash())
+                            txSet->previousLedgerHash())
             << ", LCL is " << ledgerAbbrev(getLastClosedLedgerHeader());
 
         CLOG(ERROR, "Ledger")
@@ -797,13 +801,12 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         throw std::runtime_error("txset mismatch");
     }
 
-    if (ledgerData.getTxSet()->getContentsHash() !=
-        ledgerData.getValue().txSetHash)
+    if (txSet->getContentsHash() != ledgerData.getValue().txSetHash)
     {
         CLOG(ERROR, "Ledger")
             << "Corrupt transaction set: TxSet hash is "
-            << ledgerData.getTxSet()->getContentsHash()
-            << ", SCP value reports " << ledgerData.getValue().txSetHash;
+            << txSet->getContentsHash() << ", SCP value reports "
+            << ledgerData.getValue().txSetHash;
         CLOG(ERROR, "Ledger") << POSSIBLY_CORRUPTED_QUORUM_SET;
 
         throw std::runtime_error("corrupt transaction set");
@@ -812,6 +815,18 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     auto const& sv = ledgerData.getValue();
     header.current().scpValue = sv;
 
+    // In addition to the _canonical_ LedgerResultSet hashed into the
+    // LedgerHeader, we optionally collect an even-more-fine-grained record of
+    // the ledger entries modified by each tx during tx processing in a
+    // LedgerCloseMeta, for streaming to attached clients (typically: horizon).
+    std::unique_ptr<LedgerCloseMeta> ledgerCloseMeta;
+    if (mMetaStream)
+    {
+        ledgerCloseMeta = std::make_unique<LedgerCloseMeta>();
+        ledgerCloseMeta->v0().txProcessing.reserve(txSet->sizeTx());
+        txSet->toXDR(ledgerCloseMeta->v0().txSet);
+    }
+
     // the transaction set that was agreed upon by consensus
     // was sorted by hash; we reorder it so that transactions are
     // sorted such that sequence numbers are respected
@@ -819,13 +834,12 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
 
     // first, prefetch source accounts fot txset, then charge fees
     prefetchTxSourceIds(txs);
-    processFeesSeqNums(txs, ltx,
-                       ledgerData.getTxSet()->getBaseFee(header.current()));
+    processFeesSeqNums(txs, ltx, txSet->getBaseFee(header.current()),
+                       ledgerCloseMeta);
 
     TransactionResultSet txResultSet;
     txResultSet.results.reserve(txs.size());
-
-    applyTransactions(txs, ltx, txResultSet);
+    applyTransactions(txs, ltx, txResultSet, ledgerCloseMeta);
 
     ltx.loadHeader().current().txSetResultHash =
         sha256(xdr::xdr_to_opaque(txResultSet));
@@ -857,12 +871,20 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             LedgerTxn ltxUpgrade(ltx);
             Upgrades::applyTo(lupgrade, ltxUpgrade);
 
+            auto ledgerSeq = ltxUpgrade.loadHeader().current().ledgerSeq;
             LedgerEntryChanges changes = ltxUpgrade.getChanges();
+            if (ledgerCloseMeta)
+            {
+                auto& up = ledgerCloseMeta->v0().upgradesProcessing;
+                up.emplace_back();
+                UpgradeEntryMeta& uem = up.back();
+                uem.upgrade = lupgrade;
+                uem.changes = changes;
+            }
             // Note: Index from 1 rather than 0 to match the behavior of
             // storeTransaction and storeTransactionFee.
-            if (Application::modeHasDatabase(mApp.getMode()))
+            if (mApp.modeHasDatabase())
             {
-                auto ledgerSeq = ltxUpgrade.loadHeader().current().ledgerSeq;
                 Upgrades::storeUpgradeHistory(getDatabase(), ledgerSeq,
                                               lupgrade, changes,
                                               static_cast<int>(i + 1));
@@ -880,6 +902,14 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     }
 
     ledgerClosed(ltx);
+
+    if (mMetaStream)
+    {
+        releaseAssert(ledgerCloseMeta);
+        ledgerCloseMeta->v0().ledgerHeader = mLastClosedLedger;
+        mMetaStream->writeOne(*ledgerCloseMeta);
+        mMetaStream->flush();
+    }
 
     // The next 4 steps happen in a relatively non-obvious, subtle order.
     // This is unfortunate and it would be nice if we could make it not
@@ -954,6 +984,31 @@ LedgerManagerImpl::popBufferedLedger()
 }
 
 void
+LedgerManagerImpl::setupLedgerCloseMetaStream()
+{
+    if (mMetaStream)
+    {
+        throw std::runtime_error("LedgerManagerImpl already streaming");
+    }
+    auto& cfg = mApp.getConfig();
+    if (cfg.METADATA_OUTPUT_STREAM != "")
+    {
+        mMetaStream =
+            std::make_unique<XDROutputFileStream>(/*fsyncOnClose=*/true);
+        std::regex fdrx("^fd:([0-9])+$");
+        std::smatch sm;
+        if (std::regex_match(cfg.METADATA_OUTPUT_STREAM, sm, fdrx))
+        {
+            mMetaStream->fdopen(std::stoi(sm[1]));
+        }
+        else
+        {
+            mMetaStream->open(cfg.METADATA_OUTPUT_STREAM);
+        }
+    }
+}
+
+void
 LedgerManagerImpl::advanceLedgerPointers(LedgerHeader const& header)
 {
     auto ledgerHash = sha256(xdr::xdr_to_opaque(header));
@@ -966,9 +1021,9 @@ LedgerManagerImpl::advanceLedgerPointers(LedgerHeader const& header)
 }
 
 void
-LedgerManagerImpl::processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
-                                      AbstractLedgerTxn& ltxOuter,
-                                      int64_t baseFee)
+LedgerManagerImpl::processFeesSeqNums(
+    std::vector<TransactionFramePtr>& txs, AbstractLedgerTxn& ltxOuter,
+    int64_t baseFee, std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta)
 {
     CLOG(DEBUG, "Ledger")
         << "processing fees and sequence numbers with base fee " << baseFee;
@@ -982,6 +1037,12 @@ LedgerManagerImpl::processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
             LedgerTxn ltxTx(ltx);
             tx->processFeeSeqNum(ltxTx, baseFee);
             LedgerEntryChanges changes = ltxTx.getChanges();
+            if (ledgerCloseMeta)
+            {
+                auto& tp = ledgerCloseMeta->v0().txProcessing;
+                tp.emplace_back();
+                tp.back().feeProcessing = changes;
+            }
             // Note to future: when we eliminate the txhistory and txfeehistory
             // tables, the following step can be removed.
             //
@@ -989,7 +1050,7 @@ LedgerManagerImpl::processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
             // txs counting from 1, not 0. We preserve this for the time being
             // in case anyone depends on it.
             ++index;
-            if (Application::modeHasDatabase(mApp.getMode()))
+            if (mApp.modeHasDatabase())
             {
                 tx->storeTransactionFee(mApp.getDatabase(), ledgerSeq, changes,
                                         index);
@@ -1046,9 +1107,10 @@ LedgerManagerImpl::prefetchTransactionData(
 }
 
 void
-LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
-                                     AbstractLedgerTxn& ltx,
-                                     TransactionResultSet& txResultSet)
+LedgerManagerImpl::applyTransactions(
+    std::vector<TransactionFramePtr>& txs, AbstractLedgerTxn& ltx,
+    TransactionResultSet& txResultSet,
+    std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta)
 {
     int index = 0;
 
@@ -1105,9 +1167,33 @@ LedgerManagerImpl::applyTransactions(std::vector<TransactionFramePtr>& txs,
             mInternalErrorCount.inc();
             tx->getResult().result.code(txINTERNAL_ERROR);
         }
+        TransactionResultPair results = tx->getResultPair();
+
+        // First gather the TransactionResultPair into the TxResultSet for
+        // hashing into the ledger header.
+        txResultSet.results.emplace_back(results);
+
+        // Then potentially add that TRP and its associated TransactionMeta
+        // into the associated slot of any LedgerCloseMeta we're collecting.
+        if (ledgerCloseMeta)
+        {
+            TransactionResultMeta& trm =
+                ledgerCloseMeta->v0().txProcessing.at(index);
+            trm.txApplyProcessing = tm;
+            trm.result = results;
+        }
+
+        // Then finally store the results and meta into the txhistory table.
+        // if we're running in a mode that has one.
+        //
+        // Note to future: when we eliminate the txhistory and txfeehistory
+        // tables, the following step can be removed.
+        //
+        // Also note: for historical reasons the history tables number
+        // txs counting from 1, not 0. We preserve this for the time being
+        // in case anyone depends on it.
         ++index;
-        txResultSet.results.emplace_back(tx->getResultPair());
-        if (Application::modeHasDatabase(mApp.getMode()))
+        if (mApp.modeHasDatabase())
         {
             auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
             tx->storeTransaction(mApp.getDatabase(), ledgerSeq, tm, index,
@@ -1136,7 +1222,7 @@ LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
 void
 LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header)
 {
-    if (Application::modeHasDatabase(mApp.getMode()))
+    if (mApp.modeHasDatabase())
     {
         LedgerHeaderUtils::storeInDatabase(mApp.getDatabase(), header);
     }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -10,6 +10,7 @@
 #include "ledger/SyncingLedgerChain.h"
 #include "main/PersistentState.h"
 #include "transactions/TransactionFrame.h"
+#include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
 #include <string>
 
@@ -39,6 +40,7 @@ class LedgerManagerImpl : public LedgerManager
 
   protected:
     Application& mApp;
+    std::unique_ptr<XDROutputFileStream> mMetaStream;
 
   private:
     medida::Timer& mTransactionApply;
@@ -66,12 +68,15 @@ class LedgerManagerImpl : public LedgerManager
                          LedgerHeaderHistoryEntry const& lastClosed,
                          CatchupConfiguration::Mode catchupMode);
 
-    void processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
-                            AbstractLedgerTxn& ltxOuter, int64_t baseFee);
+    void
+    processFeesSeqNums(std::vector<TransactionFramePtr>& txs,
+                       AbstractLedgerTxn& ltxOuter, int64_t baseFee,
+                       std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta);
 
-    void applyTransactions(std::vector<TransactionFramePtr>& txs,
-                           AbstractLedgerTxn& ltx,
-                           TransactionResultSet& txResultSet);
+    void
+    applyTransactions(std::vector<TransactionFramePtr>& txs,
+                      AbstractLedgerTxn& ltx, TransactionResultSet& txResultSet,
+                      std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta);
 
     void ledgerClosed(AbstractLedgerTxn& ltx);
 
@@ -145,5 +150,7 @@ class LedgerManagerImpl : public LedgerManager
 
     bool hasBufferedLedger() const override;
     LedgerCloseData popBufferedLedger() override;
+
+    void setupLedgerCloseMetaStream();
 };
 }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1495,6 +1495,73 @@ LedgerTxn::Impl::unsealHeader(LedgerTxn& self,
     f(header.current());
 }
 
+uint64_t
+LedgerTxn::countObjects(LedgerEntryType let) const
+{
+    throw std::runtime_error("called countObjects on non-root LedgerTxn");
+}
+
+uint64_t
+LedgerTxn::countObjects(LedgerEntryType let, LedgerRange const& ledgers) const
+{
+    throw std::runtime_error("called countObjects on non-root LedgerTxn");
+}
+
+void
+LedgerTxn::deleteObjectsModifiedOnOrAfterLedger(uint32_t ledger) const
+{
+    throw std::runtime_error(
+        "called deleteObjectsModifiedOnOrAfterLedger on non-root LedgerTxn");
+}
+
+void
+LedgerTxn::dropAccounts()
+{
+    throw std::runtime_error("called dropAccounts on non-root LedgerTxn");
+}
+
+void
+LedgerTxn::dropData()
+{
+    throw std::runtime_error("called dropData on non-root LedgerTxn");
+}
+
+void
+LedgerTxn::dropOffers()
+{
+    throw std::runtime_error("called dropOffers on non-root LedgerTxn");
+}
+
+void
+LedgerTxn::dropTrustLines()
+{
+    throw std::runtime_error("called dropTrustLines on non-root LedgerTxn");
+}
+
+double
+LedgerTxn::getPrefetchHitRate() const
+{
+    return getImpl()->getPrefetchHitRate();
+}
+
+double
+LedgerTxn::Impl::getPrefetchHitRate() const
+{
+    return mParent.getPrefetchHitRate();
+}
+
+uint32_t
+LedgerTxn::prefetch(std::unordered_set<LedgerKey> const& keys)
+{
+    return getImpl()->prefetch(keys);
+}
+
+uint32_t
+LedgerTxn::Impl::prefetch(std::unordered_set<LedgerKey> const& keys)
+{
+    return mParent.prefetch(keys);
+}
+
 LedgerTxn::Impl::EntryMap
 LedgerTxn::Impl::maybeUpdateLastModified() const
 {

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -391,6 +391,48 @@ class AbstractLedgerTxnParent
     // or if the corresponding LedgerEntry has been erased.
     virtual std::shared_ptr<LedgerEntry const>
     getNewestVersion(LedgerKey const& key) const = 0;
+
+    // Return the count of the number of ledger objects of type `let`. Will
+    // throw when called on anything other than a (real or stub) root LedgerTxn.
+    virtual uint64_t countObjects(LedgerEntryType let) const = 0;
+
+    // Return the count of the number of ledger objects of type `let` within
+    // range of ledgers `ledgers`. Will throw when called on anything other than
+    // a (real or stub) root LedgerTxn.
+    virtual uint64_t countObjects(LedgerEntryType let,
+                                  LedgerRange const& ledgers) const = 0;
+
+    // Delete all ledger entries modified on-or-after `ledger`. Will throw
+    // when called on anything other than a (real or stub) root LedgerTxn.
+    virtual void
+    deleteObjectsModifiedOnOrAfterLedger(uint32_t ledger) const = 0;
+
+    // Delete all account ledger entries in the database. Will throw when called
+    // on anything other than a (real or stub) root LedgerTxn.
+    virtual void dropAccounts() = 0;
+
+    // Delete all account-data ledger entries. Will throw when called on
+    // anything other than a (real or stub) root LedgerTxn.
+    virtual void dropData() = 0;
+
+    // Delete all offer ledger entries. Will throw when called on anything other
+    // than a (real or stub) root LedgerTxn.
+    virtual void dropOffers() = 0;
+
+    // Delete all trustline ledger entries. Will throw when called on anything
+    // other than a (real or stub) root LedgerTxn.
+    virtual void dropTrustLines() = 0;
+
+    // Return the current cache hit rate for prefetched ledger entries, as a
+    // fraction from 0.0 to 1.0. Will throw when called on anything other than a
+    // (real or stub) root LedgerTxn.
+    virtual double getPrefetchHitRate() const = 0;
+
+    // Prefetch a set of ledger entries into memory, anticipating their use.
+    // This is purely advisory and can be a no-op, or do any level of actual
+    // work, while still being correct. Will throw when called on anything other
+    // than a (real or stub) root LedgerTxn.
+    virtual uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) = 0;
 };
 
 // An abstraction for an object that is an AbstractLedgerTxnParent and has
@@ -616,6 +658,17 @@ class LedgerTxn final : public AbstractLedgerTxn
 
     void unsealHeader(std::function<void(LedgerHeader&)> f) override;
 
+    uint64_t countObjects(LedgerEntryType let) const override;
+    uint64_t countObjects(LedgerEntryType let,
+                          LedgerRange const& ledgers) const override;
+    void deleteObjectsModifiedOnOrAfterLedger(uint32_t ledger) const override;
+    void dropAccounts() override;
+    void dropData() override;
+    void dropOffers() override;
+    void dropTrustLines() override;
+    double getPrefetchHitRate() const override;
+    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) override;
+
 #ifdef BUILD_TESTS
     std::unordered_map<
         AssetPair,
@@ -640,16 +693,16 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     void commitChild(EntryIterator iter, LedgerTxnConsistency cons) override;
 
-    uint64_t countObjects(LedgerEntryType let) const;
+    uint64_t countObjects(LedgerEntryType let) const override;
     uint64_t countObjects(LedgerEntryType let,
-                          LedgerRange const& ledgers) const;
+                          LedgerRange const& ledgers) const override;
 
-    void deleteObjectsModifiedOnOrAfterLedger(uint32_t ledger) const;
+    void deleteObjectsModifiedOnOrAfterLedger(uint32_t ledger) const override;
 
-    void dropAccounts();
-    void dropData();
-    void dropOffers();
-    void dropTrustLines();
+    void dropAccounts() override;
+    void dropData() override;
+    void dropOffers() override;
+    void dropTrustLines() override;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     void resetForFuzzer();
@@ -677,7 +730,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     void rollbackChild() override;
 
-    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys);
-    double getPrefetchHitRate() const;
+    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) override;
+    double getPrefetchHitRate() const override;
 };
 }

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -562,6 +562,10 @@ class LedgerTxn::Impl
     // unsealHeader has the same exception safety guarantee as f
     void unsealHeader(LedgerTxn& self, std::function<void(LedgerHeader&)> f);
 
+    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys);
+
+    double getPrefetchHitRate() const;
+
 #ifdef BUILD_TESTS
     MultiOrderBook const& getOrderBook();
 #endif

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -1,0 +1,149 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/Hex.h"
+#include "crypto/Random.h"
+#include "history/HistoryArchiveManager.h"
+#include "history/test/HistoryTestsUtils.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "main/ApplicationUtils.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+#include "util/Logging.h"
+#include "util/format.h"
+#include "xdr/Stellar-ledger.h"
+#include <fstream>
+
+using namespace stellar;
+
+TEST_CASE("LedgerCloseMetaStream file descriptor - LIVE_NODE",
+          "[ledgerclosemetastreamlive]")
+{
+    // Step 1: open a writable file and pass it to config.
+    TmpDirManager tdm(std::string("streamtmp-") + binToHex(randomBytes(8)));
+    TmpDir td = tdm.tmpDir("streams");
+    std::string path = td.getName() + "/stream.xdr";
+    auto cfg = getTestConfig();
+#ifdef _WIN32
+    cfg.METADATA_OUTPUT_STREAM = path;
+#else
+    int fd = ::open(path.c_str(), O_CREAT | O_WRONLY, 0644);
+    REQUIRE(fd != -1);
+    cfg.METADATA_OUTPUT_STREAM = fmt::format("fd:{}", fd);
+#endif
+
+    // Step 2: pass it to an application and close some ledgers,
+    // streaming ledgerCloseMeta to the file descriptor.
+    VirtualClock clock;
+    auto app = createTestApplication(clock, cfg);
+    app->start();
+    while (app->getLedgerManager().getLastClosedLedgerNum() < 10)
+    {
+        clock.crank(true);
+    }
+    Hash hash = app->getLedgerManager().getLastClosedLedgerHeader().hash;
+    app.reset();
+
+    // Step 3: reopen the file as an XDR stream and read back the LCMs
+    // and check they have the expected content.
+    XDRInputFileStream stream;
+    stream.open(path);
+    LedgerCloseMeta lcm;
+    size_t nLcm = 1;
+    while (stream && stream.readOne(lcm))
+    {
+        ++nLcm;
+    }
+    REQUIRE(nLcm == 10);
+    REQUIRE(lcm.v0().ledgerHeader.hash == hash);
+}
+
+TEST_CASE("LedgerCloseMetaStream file descriptor - REPLAY_IN_MEMORY",
+          "[ledgerclosemetastreamreplay]")
+{
+    // Step 1: generate some history for replay.
+    using namespace stellar::historytestutils;
+    TmpDirHistoryConfigurator tCfg;
+    {
+        Config genCfg = getTestConfig(0);
+        VirtualClock genClock;
+        genCfg = tCfg.configure(genCfg, true);
+        auto genApp = createTestApplication(genClock, genCfg);
+        auto& genHam = genApp->getHistoryArchiveManager();
+        genHam.initializeHistoryArchive(tCfg.getArchiveDirName());
+        for (size_t i = 0; i < 100; ++i)
+        {
+            genClock.crank(false);
+        }
+        genApp->start();
+        auto& genHm = genApp->getHistoryManager();
+        while (genHm.getPublishSuccessCount() < 5)
+        {
+            genClock.crank(true);
+        }
+        while (genClock.cancelAllEvents() ||
+               genApp->getProcessManager().getNumRunningProcesses() > 0)
+        {
+            genClock.crank(false);
+        }
+    }
+
+    // Step 2: open a writable file descriptor.
+    TmpDirManager tdm(std::string("streamtmp-") + binToHex(randomBytes(8)));
+    TmpDir td = tdm.tmpDir("streams");
+    std::string path = td.getName() + "/stream.xdr";
+    auto cfg1 = getTestConfig(1);
+#ifdef _WIN32
+    cfg1.METADATA_OUTPUT_STREAM = path;
+#else
+    int fd = ::open(path.c_str(), O_CREAT | O_WRONLY, 0644);
+    REQUIRE(fd != -1);
+    cfg1.METADATA_OUTPUT_STREAM = fmt::format("fd:{}", fd);
+#endif
+
+    // Step 3: pass it to an application and have it catch up to the generated
+    // history, streaming ledgerCloseMeta to the file descriptor.
+    Hash hash;
+    {
+        auto cfg = tCfg.configure(cfg1, false);
+        cfg.NODE_IS_VALIDATOR = false;
+        cfg.FORCE_SCP = false;
+        cfg.RUN_STANDALONE = true;
+        VirtualClock clock;
+        auto app =
+            createTestApplication(clock, cfg, /*newdb=*/false,
+                                  Application::AppMode::REPLAY_IN_MEMORY);
+
+        CatchupConfiguration cc{CatchupConfiguration::CURRENT,
+                                std::numeric_limits<uint32_t>::max(),
+                                CatchupConfiguration::Mode::OFFLINE_COMPLETE};
+        Json::Value catchupInfo;
+        auto& ham = app->getHistoryArchiveManager();
+        auto& lm = app->getLedgerManager();
+        auto archive = ham.selectRandomReadableHistoryArchive();
+        int res = catchup(app, cc, catchupInfo, archive);
+        REQUIRE(res == 0);
+        hash = lm.getLastClosedLedgerHeader().hash;
+        while (clock.cancelAllEvents() ||
+               app->getProcessManager().getNumRunningProcesses() > 0)
+        {
+            clock.crank(false);
+        }
+    }
+
+    // Step 4: reopen the file as an XDR stream and read back the LCMs
+    // and check they have the expected content.
+    XDRInputFileStream stream;
+    stream.open(path);
+    LedgerCloseMeta lcm;
+    size_t nLcm = 1;
+    while (stream && stream.readOne(lcm))
+    {
+        ++nLcm;
+    }
+    // 5 checkpoints is ledger 0x13f
+    REQUIRE(nLcm == 0x13f);
+    REQUIRE(lcm.v0().ledgerHeader.hash == hash);
+}

--- a/src/ledger/test/LedgerManagerTests.cpp
+++ b/src/ledger/test/LedgerManagerTests.cpp
@@ -43,8 +43,9 @@ class LedgerManagerForTests : public LedgerManagerImpl
 class LedgerManagerTestApplication : public TestApplication
 {
   public:
-    LedgerManagerTestApplication(VirtualClock& clock, Config const& cfg)
-        : TestApplication(clock, cfg)
+    LedgerManagerTestApplication(VirtualClock& clock, Config const& cfg,
+                                 Application::AppMode mode)
+        : TestApplication(clock, cfg, mode)
     {
     }
 

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -4,6 +4,7 @@
 
 #include "Application.h"
 #include "ApplicationImpl.h"
+#include "util/GlobalChecks.h"
 #include "util/format.h"
 
 namespace stellar
@@ -37,8 +38,41 @@ validateNetworkPassphrase(Application::pointer app)
 }
 
 Application::pointer
-Application::create(VirtualClock& clock, Config const& cfg, bool newDB)
+Application::create(VirtualClock& clock, Config const& cfg, bool newDB,
+                    AppMode mode)
 {
-    return create<ApplicationImpl>(clock, cfg, newDB);
+    return create<ApplicationImpl>(clock, cfg, newDB, mode);
+}
+
+bool
+Application::modeHasOverlay(AppMode m)
+{
+    switch (m)
+    {
+    case AppMode::RUN_LIVE_NODE:
+        return true;
+    case AppMode::RELAY_LIVE_TRAFFIC:
+        return true;
+    case AppMode::REPLAY_IN_MEMORY:
+        return false;
+    default:
+        throw std::runtime_error("unhandled application mode");
+    }
+}
+
+bool
+Application::modeHasDatabase(AppMode m)
+{
+    switch (m)
+    {
+    case AppMode::RUN_LIVE_NODE:
+        return true;
+    case AppMode::RELAY_LIVE_TRAFFIC:
+        return false;
+    case AppMode::REPLAY_IN_MEMORY:
+        return false;
+    default:
+        throw std::runtime_error("unhandled application mode");
+    }
 }
 }

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -40,7 +40,7 @@ class CommandHandler;
 class WorkScheduler;
 class BanManager;
 class StatusManager;
-class LedgerTxnRoot;
+class AbstractLedgerTxnParent;
 
 #ifdef BUILD_TESTS
 class LoadGenerator;
@@ -339,7 +339,7 @@ class Application
     // instances
     virtual Hash const& getNetworkID() const = 0;
 
-    virtual LedgerTxnRoot& getLedgerTxnRoot() = 0;
+    virtual AbstractLedgerTxnParent& getLedgerTxnRoot() = 0;
 
     // Factory: create a new Application object bound to `clock`, with a local
     // copy made of `cfg`, and running in `AppMode` `mode`.

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -121,6 +121,30 @@ void validateNetworkPassphrase(std::shared_ptr<Application> app);
  * thread's io_context (held in the VirtualClock), or else deliver their results
  * to the Application through std::futures or similar standard
  * thread-synchronization primitives.
+ *
+ *
+ * Application Mode
+ * ----------------
+ *
+ * Each application has an AppMode value that causes broad variation in what the
+ * app is _doing_ while it runs. AppModes differentiate, for example, those
+ * applications that are doing network-packet relay, or in-memory history replay
+ * and metadata generation, from those applications that are connected to a live
+ * network. Different AppModes typically involve inhibiting the construction or
+ * function of one or more complete subsystems.
+ *
+ * As a general guideline, AppModes should be used when a behaviour variation is
+ * both (a) to-be-deployed in production, not just testing; and (b)
+ * significantly incompatible with the intention expressed by the 'stellar-core
+ * run' subcommand, i.e. some wholly different-seeming activity than live
+ * transaction processing.
+ *
+ * The variant functionality of AppModes could also have been accomplished by
+ * subclassing and overriding, but we decided that explicit branching on AppMode
+ * makes the set of logic variants more obvious and leads to less code churn,
+ * spurious virtual/override/factory scaffolding just to introduce variants, and
+ * less need to compare & maintain divergent replicas of logic across source
+ * files.
  */
 
 class Application
@@ -157,6 +181,42 @@ class Application
         APP_NUM_STATE
     };
 
+    enum class AppMode
+    {
+        // Application will connect to networks (unless Cfg.RUN_STANDALONE),
+        // bind to a database and bucket list, and receive and apply
+        // consensus transactions. "Normal operation".
+        RUN_LIVE_NODE,
+
+        // Application will connect to networks but _not_ establish a database
+        // of any sort, nor apply transactions or even verify them. Simply
+        // relays traffic between nodes and drives the SCP state machine.
+        RELAY_LIVE_TRAFFIC,
+
+        // Application will not connect to networks nor establish a database
+        // of any sort. Simply reads history archive content and replays
+        // transactions against _in memory_ ledger, while writing metadata
+        // stream.
+        REPLAY_IN_MEMORY
+    };
+
+    // AppModes should be accessed using either a narrow centralized query like
+    // one of the following static functions, or an exhaustive switch on the
+    // enum. These options give the least chance of missing or combining cases
+    // incorrectly.
+    static bool modeHasOverlay(AppMode m);
+    static bool modeHasDatabase(AppMode m);
+    bool
+    modeHasOverlay() const
+    {
+        return Application::modeHasOverlay(getMode());
+    }
+    bool
+    modeHasDatabase() const
+    {
+        return Application::modeHasDatabase(getMode());
+    }
+
     virtual ~Application(){};
 
     virtual void initialize(bool createNewDB) = 0;
@@ -174,6 +234,11 @@ class Application
     virtual State getState() const = 0;
     virtual std::string getStateHuman() const = 0;
     virtual bool isStopping() const = 0;
+
+    // Gets the current Application mode. This is a constant established
+    // when the Application is constructed and will not change while it
+    // runs.
+    virtual AppMode getMode() const = 0;
 
     // Get the external VirtualClock to which this Application is bound.
     virtual VirtualClock& getClock() = 0;
@@ -277,14 +342,16 @@ class Application
     virtual LedgerTxnRoot& getLedgerTxnRoot() = 0;
 
     // Factory: create a new Application object bound to `clock`, with a local
-    // copy made of `cfg`.
+    // copy made of `cfg`, and running in `AppMode` `mode`.
     static pointer create(VirtualClock& clock, Config const& cfg,
-                          bool newDB = true);
+                          bool newDB = true,
+                          AppMode mode = AppMode::RUN_LIVE_NODE);
     template <typename T>
     static std::shared_ptr<T>
-    create(VirtualClock& clock, Config const& cfg, bool newDB = true)
+    create(VirtualClock& clock, Config const& cfg, bool newDB = true,
+           AppMode mode = AppMode::RUN_LIVE_NODE)
     {
-        auto ret = std::make_shared<T>(clock, cfg);
+        auto ret = std::make_shared<T>(clock, cfg, mode);
         ret->initialize(newDB);
         validateNetworkPassphrase(ret);
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -431,6 +431,22 @@ ApplicationImpl::start()
         mConfig.FORCE_SCP = true;
     }
 
+    if (!modeHasDatabase())
+    {
+        if (mConfig.NODE_IS_VALIDATOR)
+        {
+            LOG(ERROR) << "Starting stellar-core in a non-database mode "
+                          "requires NODE_IS_VALIDATOR to be unset";
+            throw std::invalid_argument("NODE_IS_VALIDATOR is set");
+        }
+        if (getHistoryArchiveManager().hasAnyWritableHistoryArchive())
+        {
+            LOG(ERROR) << "Starting stellar-core in a non-database mode "
+                          "requires all history archives to be non-writable";
+            throw std::invalid_argument("some history archives are writable");
+        }
+    }
+
     if (mConfig.QUORUM_SET.threshold == 0)
     {
         throw std::invalid_argument("Quorum not configured");

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -126,7 +126,10 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg,
 void
 ApplicationImpl::initialize(bool createNewDB)
 {
-    mDatabase = std::make_unique<Database>(*this);
+    if (modeHasDatabase(mAppMode))
+    {
+        mDatabase = std::make_unique<Database>(*this);
+    }
     mPersistentState = std::make_unique<PersistentState>(*this);
     mOverlayManager = createOverlayManager();
     mLedgerManager = createLedgerManager();
@@ -190,8 +193,11 @@ ApplicationImpl::initialize(bool createNewDB)
 void
 ApplicationImpl::newDB()
 {
-    mDatabase->initialize();
-    mDatabase->upgradeToCurrentSchema();
+    if (modeHasDatabase(mAppMode))
+    {
+        mDatabase->initialize();
+        mDatabase->upgradeToCurrentSchema();
+    }
     mBucketManager->dropAll();
     mLedgerManager->startNewLedger();
 }
@@ -199,7 +205,10 @@ ApplicationImpl::newDB()
 void
 ApplicationImpl::upgradeDB()
 {
-    mDatabase->upgradeToCurrentSchema();
+    if (modeHasDatabase(mAppMode))
+    {
+        mDatabase->upgradeToCurrentSchema();
+    }
 }
 
 void
@@ -795,6 +804,7 @@ ApplicationImpl::getOverlayManager()
 Database&
 ApplicationImpl::getDatabase() const
 {
+    releaseAssertOrThrow(modeHasDatabase(mAppMode));
     return *mDatabase;
 }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -354,6 +354,18 @@ ApplicationImpl::~ApplicationImpl()
     reportCfgMetrics();
     shutdownMainIOContext();
     joinAllThreads();
+    if (!modeHasDatabase(mAppMode))
+    {
+        // Note: BucketManager::dropAll will delete the $BUCKETDIR/tmp which is
+        // where process and history manager write _their_ temp files to, so we
+        // make sure to tear them down first here.
+        mProcessManager = nullptr;
+        mHistoryManager = nullptr;
+        if (mBucketManager)
+        {
+            mBucketManager->dropAll();
+        }
+    }
     LOG(INFO) << "Application destroyed";
 }
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -35,7 +35,7 @@ class LoadGenerator;
 class ApplicationImpl : public Application
 {
   public:
-    ApplicationImpl(VirtualClock& clock, Config const& cfg);
+    ApplicationImpl(VirtualClock& clock, Config const& cfg, AppMode mode);
     virtual ~ApplicationImpl() override;
 
     virtual void initialize(bool newDB) override;
@@ -47,6 +47,7 @@ class ApplicationImpl : public Application
     virtual State getState() const override;
     virtual std::string getStateHuman() const override;
     virtual bool isStopping() const override;
+    virtual AppMode getMode() const override;
     virtual VirtualClock& getClock() override;
     virtual medida::MetricsRegistry& getMetrics() override;
     virtual void syncOwnMetrics() override;
@@ -122,6 +123,7 @@ class ApplicationImpl : public Application
   private:
     VirtualClock& mVirtualClock;
     Config mConfig;
+    AppMode const mAppMode;
 
     // NB: The io_context should come first, then the 'manager' sub-objects,
     // then the threads. Do not reorder these fields.

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -29,7 +29,9 @@ class HistoryManager;
 class ProcessManager;
 class CommandHandler;
 class Database;
+class LedgerTxn;
 class LedgerTxnRoot;
+class InMemoryLedgerTxnRoot;
 class LoadGenerator;
 
 class ApplicationImpl : public Application
@@ -154,7 +156,20 @@ class ApplicationImpl : public Application
     std::unique_ptr<PersistentState> mPersistentState;
     std::unique_ptr<BanManager> mBanManager;
     std::unique_ptr<StatusManager> mStatusManager;
-    std::unique_ptr<LedgerTxnRoot> mLedgerTxnRoot;
+    std::unique_ptr<AbstractLedgerTxnParent> mLedgerTxnRoot;
+
+    // This exists for use in AppMode::REPLAY_IN_MEMORY only: the
+    // mLedgerTxnRoot will be an InMemoryLedgerTxnRoot which is a _stub_
+    // AbstractLedgerTxnParent that refuses all commits and answers null to all
+    // queries; then an inner "never-committing" sub-LedgerTxn is constructed
+    // beneath it that serves as the "effective" in-memory root transaction,
+    // is returned when a client requests the root.
+    //
+    // Note that using this only works when the ledger can fit in RAM -- as it
+    // is held in the never-committing LedgerTxn in its entirety -- so if it
+    // ever grows beyond RAM-size you need to use a mode with some sort of
+    // database on secondary storage.
+    std::unique_ptr<LedgerTxn> mNeverCommittingLedgerTxn;
 
 #ifdef BUILD_TESTS
     std::unique_ptr<LoadGenerator> mLoadGenerator;

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -113,7 +113,7 @@ class ApplicationImpl : public Application
 
     virtual Hash const& getNetworkID() const override;
 
-    virtual LedgerTxnRoot& getLedgerTxnRoot() override;
+    virtual AbstractLedgerTxnParent& getLedgerTxnRoot() override;
 
   protected:
     std::unique_ptr<LedgerManager>

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -70,21 +70,25 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
 
     mServer->add404(std::bind(&CommandHandler::fileNotFound, this, _1, _2));
 
+    if (mApp.modeHasDatabase())
+    {
+        addRoute("dropcursor", &CommandHandler::dropcursor);
+        addRoute("getcursor", &CommandHandler::getcursor);
+        addRoute("setcursor", &CommandHandler::setcursor);
+        addRoute("maintenance", &CommandHandler::maintenance);
+    }
+
     addRoute("bans", &CommandHandler::bans);
     addRoute("clearmetrics", &CommandHandler::clearMetrics);
     addRoute("connect", &CommandHandler::connect);
-    addRoute("dropcursor", &CommandHandler::dropcursor);
     addRoute("droppeer", &CommandHandler::dropPeer);
-    addRoute("getcursor", &CommandHandler::getcursor);
     addRoute("info", &CommandHandler::info);
     addRoute("ll", &CommandHandler::ll);
     addRoute("logrotate", &CommandHandler::logRotate);
-    addRoute("maintenance", &CommandHandler::maintenance);
     addRoute("manualclose", &CommandHandler::manualClose);
     addRoute("metrics", &CommandHandler::metrics);
     addRoute("peers", &CommandHandler::peers);
     addRoute("quorum", &CommandHandler::quorum);
-    addRoute("setcursor", &CommandHandler::setcursor);
     addRoute("scp", &CommandHandler::scpInfo);
     addRoute("tx", &CommandHandler::tx);
     addRoute("unban", &CommandHandler::unban);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -116,6 +116,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     UNSAFE_QUORUM = false;
     DISABLE_BUCKET_GC = false;
     DISABLE_XDR_FSYNC = false;
+    METADATA_OUTPUT_STREAM = "";
 
     LOG_FILE_PATH = "stellar-core.%datetime{%Y.%M.%d-%H:%m:%s}.log";
     BUCKET_DIR_PATH = "buckets";
@@ -683,6 +684,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "DISABLE_XDR_FSYNC")
             {
                 DISABLE_XDR_FSYNC = readBool(item);
+            }
+            else if (item.first == "METADATA_OUTPUT_STREAM")
+            {
+                METADATA_OUTPUT_STREAM = readString(item);
             }
             else if (item.first == "KNOWN_CURSORS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -218,6 +218,23 @@ class Config : public std::enable_shared_from_this<Config>
     // you want to make that trade.
     bool DISABLE_XDR_FSYNC;
 
+    // A string specifying a stream to write fine-grained metadata to for each
+    // ledger close while running. This will be opened at startup and
+    // synchronously streamed-to during both catchup and live ledger-closing.
+    //
+    // Streams may be specified either as a pathname (typically a named FIFO on
+    // POSIX or a named pipe on Windows, though plain files also work) or a
+    // string of the form "fd:N" for some integer N which, on POSIX, specifies
+    // the existing open file descriptor N inherited by the process (for example
+    // to write to an anonymous pipe).
+    //
+    // As a further safety check, this option is mutually exclusive with
+    // NODE_IS_VALIDATOR, as its typical use writing to a pipe with a reader
+    // process on the other end introduces a potentially-unbounded synchronous
+    // delay in closing a ledger, and should not be used on a node participating
+    // in consensus, only a passive "watcher" node.
+    std::string METADATA_OUTPUT_STREAM;
+
     // Set of cursors added at each startup with value '1'.
     std::vector<std::string> KNOWN_CURSORS;
 

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -7,6 +7,7 @@
 #include "Application.h"
 #include "database/Database.h"
 #include "ledger/LedgerManager.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include <limits>
 #include <regex>
@@ -24,6 +25,7 @@ string ExternalQueue::kSQLCreateStatement =
 
 ExternalQueue::ExternalQueue(Application& app) : mApp(app)
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
 }
 
 void

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -5,6 +5,7 @@
 #include "main/Maintainer.h"
 #include "main/Config.h"
 #include "main/ExternalQueue.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 
 namespace stellar
@@ -12,6 +13,7 @@ namespace stellar
 
 Maintainer::Maintainer(Application& app) : mApp{app}, mTimer{mApp}
 {
+    releaseAssertOrThrow(mApp.modeHasDatabase());
 }
 
 void

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -7,6 +7,7 @@
 #include "database/Database.h"
 #include "herder/Herder.h"
 #include "ledger/LedgerManager.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 
 namespace stellar
@@ -27,6 +28,11 @@ std::string PersistentState::kSQLCreateStatement =
 
 PersistentState::PersistentState(Application& app) : mApp(app)
 {
+    if (!mApp.modeHasDatabase())
+    {
+        mNonDBState =
+            std::make_unique<std::unordered_map<std::string, std::string>>();
+    }
 }
 
 void
@@ -94,6 +100,13 @@ PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
 void
 PersistentState::updateDb(std::string const& entry, std::string const& value)
 {
+    if (!mApp.modeHasDatabase())
+    {
+        releaseAssertOrThrow(mNonDBState);
+        (*mNonDBState)[entry] = value;
+        return;
+    }
+
     auto prep = mApp.getDatabase().getPreparedStatement(
         "UPDATE storestate SET state = :v WHERE statename = :n;");
 
@@ -126,6 +139,12 @@ PersistentState::updateDb(std::string const& entry, std::string const& value)
 std::string
 PersistentState::getFromDb(std::string const& entry)
 {
+    if (!mApp.modeHasDatabase())
+    {
+        releaseAssertOrThrow(mNonDBState);
+        return (*mNonDBState)[entry];
+    }
+
     std::string res;
 
     auto& db = mApp.getDatabase();

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -5,7 +5,9 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/Application.h"
+#include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace stellar
 {
@@ -41,6 +43,12 @@ class PersistentState
     static std::string mapping[kLastEntry];
 
     Application& mApp;
+
+    // When running in a mode with !Application::modeHasDatabase() we still let
+    // subsystems write "persistent" root-state values like the LCL and LCL HAS
+    // to this object. In that case such values "persist" only across ledgers /
+    // calls to this object, not restarts of the process.
+    std::unique_ptr<std::unordered_map<std::string, std::string>> mNonDBState;
 
     std::string getStoreStateName(Entry n, uint32 subscript = 0);
     void updateDb(std::string const& entry, std::string const& value);

--- a/src/overlay/test/ItemFetcherTests.cpp
+++ b/src/overlay/test/ItemFetcherTests.cpp
@@ -40,8 +40,9 @@ class HerderStub : public HerderImpl
 class ApplicationStub : public TestApplication
 {
   public:
-    ApplicationStub(VirtualClock& clock, Config const& cfg)
-        : TestApplication(clock, cfg)
+    ApplicationStub(VirtualClock& clock, Config const& cfg,
+                    Application::AppMode mode)
+        : TestApplication(clock, cfg, mode)
     {
     }
 

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -84,7 +84,8 @@ class OverlayManagerTests
     class ApplicationStub : public TestApplication
     {
       public:
-        ApplicationStub(VirtualClock& clock, Config const& cfg)
+        ApplicationStub(VirtualClock& clock, Config const& cfg,
+                        Application::AppMode mode)
             : TestApplication(clock, cfg)
         {
         }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -80,8 +80,9 @@ TestInvariantManager::handleInvariantFailure(
     throw InvariantDoesNotHold{message};
 }
 
-TestApplication::TestApplication(VirtualClock& clock, Config const& cfg)
-    : ApplicationImpl(clock, cfg)
+TestApplication::TestApplication(VirtualClock& clock, Config const& cfg,
+                                 AppMode mode)
+    : ApplicationImpl(clock, cfg, mode)
 {
 }
 

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -58,7 +58,8 @@ class TestInvariantManager : public InvariantManagerImpl
 class TestApplication : public ApplicationImpl
 {
   public:
-    TestApplication(VirtualClock& clock, Config const& cfg);
+    TestApplication(VirtualClock& clock, Config const& cfg,
+                    AppMode mode = AppMode::RUN_LIVE_NODE);
 
   private:
     std::unique_ptr<InvariantManager> createInvariantManager() override;
@@ -68,11 +69,13 @@ template <typename T = TestApplication,
           typename = typename std::enable_if<
               std::is_base_of<TestApplication, T>::value>::type>
 std::shared_ptr<T>
-createTestApplication(VirtualClock& clock, Config const& cfg, bool newDB = true)
+createTestApplication(
+    VirtualClock& clock, Config const& cfg, bool newDB = true,
+    Application::AppMode mode = Application::AppMode::RUN_LIVE_NODE)
 {
     Config c2(cfg);
     c2.adjust();
-    auto app = Application::create<T>(clock, c2, newDB);
+    auto app = Application::create<T>(clock, c2, newDB, mode);
     return app;
 }
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -699,12 +699,10 @@ TransactionFrame::toStellarMessage() const
 
 void
 TransactionFrame::storeTransaction(Database& db, uint32_t ledgerSeq,
-                                   TransactionMeta& tm, int txindex,
-                                   TransactionResultSet& resultSet) const
+                                   TransactionMeta const& tm, int txindex,
+                                   TransactionResultSet const& resultSet) const
 {
     auto txBytes(xdr::xdr_to_opaque(mEnvelope));
-
-    resultSet.results.emplace_back(getResultPair());
     auto txResultBytes(xdr::xdr_to_opaque(resultSet.results.back()));
 
     std::string txBody;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -194,8 +194,9 @@ class TransactionFrame
                                AccountID const& accountID);
 
     // transaction history
-    void storeTransaction(Database& db, uint32_t ledgerSeq, TransactionMeta& tm,
-                          int txindex, TransactionResultSet& resultSet) const;
+    void storeTransaction(Database& db, uint32_t ledgerSeq,
+                          TransactionMeta const& tm, int txindex,
+                          TransactionResultSet const& resultSet) const;
 
     // fee history
     void storeTransactionFee(Database& db, uint32_t ledgerSeq,

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -434,7 +434,8 @@ hexStr(uint32_t checkpointNum)
 std::string
 hexDir(std::string const& hexStr)
 {
-    std::regex rx("([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2}).*");
+    static const std::regex rx(
+        "([[:xdigit:]]{2})([[:xdigit:]]{2})([[:xdigit:]]{2}).*");
     std::smatch sm;
     bool matched = std::regex_match(hexStr, sm, rx);
     assert(matched);
@@ -465,7 +466,7 @@ remoteName(std::string const& type, std::string const& hexStr,
 void
 checkGzipSuffix(std::string const& filename)
 {
-    std::string suf(".gz");
+    static const std::string suf(".gz");
     if (!(filename.size() >= suf.size() &&
           equal(suf.rbegin(), suf.rend(), filename.rbegin())))
     {
@@ -476,7 +477,7 @@ checkGzipSuffix(std::string const& filename)
 void
 checkNoGzipSuffix(std::string const& filename)
 {
-    std::string suf(".gz");
+    static const std::string suf(".gz");
     if (filename.size() >= suf.size() &&
         equal(suf.rbegin(), suf.rend(), filename.rbegin()))
     {

--- a/src/util/GlobalChecks.cpp
+++ b/src/util/GlobalChecks.cpp
@@ -9,6 +9,8 @@
 #endif
 #include <cstdio>
 #include <cstdlib>
+#include <exception>
+#include <stdexcept>
 #include <thread>
 
 namespace stellar
@@ -47,5 +49,22 @@ printErrorAndAbort(const char* s1, const char* s2)
     std::fflush(stderr);
     dbgAbort();
     std::abort();
+}
+
+void
+printAssertFailureAndAbort(const char* s1, const char* file, int line)
+{
+    std::fprintf(stderr, "%s at %s:%d\n", s1, file, line);
+    std::fflush(stderr);
+    dbgAbort();
+    std::abort();
+}
+
+void
+printAssertFailureAndThrow(const char* s1, const char* file, int line)
+{
+    std::fprintf(stderr, "%s at %s:%d\n", s1, file, line);
+    std::fflush(stderr);
+    throw std::runtime_error(s1);
 }
 }

--- a/src/util/GlobalChecks.h
+++ b/src/util/GlobalChecks.h
@@ -12,6 +12,24 @@ void dbgAbort();
 
 [[noreturn]] void printErrorAndAbort(const char* s1);
 [[noreturn]] void printErrorAndAbort(const char* s1, const char* s2);
+[[noreturn]] void printAssertFailureAndAbort(const char* s1, const char* file,
+                                             int line);
+[[noreturn]] void printAssertFailureAndThrow(const char* s1, const char* file,
+                                             int line);
+
+// This is like `assert()` but it is _not_ sensitive to the presence of
+// NDEBUG. We don't compile with NDEBUG but "compiling out important asserts" is
+// enough of a footgun that we want to avoid even the possibility.
+#define releaseAssert(e) \
+    (static_cast<bool>(e) \
+         ? void(0) \
+         : printAssertFailureAndAbort(#e, __FILE__, __LINE__))
+
+// Same as above, but throwing rather than aborting.
+#define releaseAssertOrThrow(e) \
+    (static_cast<bool>(e) \
+         ? void(0) \
+         : printAssertFailureAndThrow(#e, __FILE__, __LINE__))
 
 #ifdef NDEBUG
 

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -14,6 +14,9 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#ifdef _WIN32
+#include <io.h>
+#endif
 
 namespace stellar
 {
@@ -160,6 +163,37 @@ class XDROutputFileStream
                 "XDROutputFileStream::close() failed on fclose(): ");
         }
         mOut = nullptr;
+    }
+
+    void
+    fdopen(int fd)
+    {
+        if (mOut)
+        {
+            FileSystemException::failWith(
+                "XDROutputFileStream::fdopen() on already-open stream");
+        }
+        mOut = ::fdopen(fd, "wb");
+        if (!mOut)
+        {
+            FileSystemException::failWithErrno(
+                "XDROutputFileStream::fdopen() failed");
+        }
+    }
+
+    void
+    flush()
+    {
+        if (!mOut)
+        {
+            FileSystemException::failWith(
+                "XDROutputFileStream::flush() on non-open FILE*");
+        }
+        if (fflush(mOut) != 0)
+        {
+            FileSystemException::failWith(
+                "XDROutputFileStream::flush() failed");
+        }
     }
 
     void

--- a/src/xdr/Stellar-ledger.x
+++ b/src/xdr/Stellar-ledger.x
@@ -326,4 +326,47 @@ case 1:
 case 2:
     TransactionMetaV2 v2;
 };
+
+// This struct groups together changes on a per transaction basis
+// note however that fees and transaction application are done in separate
+// phases
+struct TransactionResultMeta
+{
+    TransactionResultPair result;
+    LedgerEntryChanges feeProcessing;
+    TransactionMeta txApplyProcessing;
+};
+
+// this represents a single upgrade that was performed as part of a ledger
+// upgrade
+struct UpgradeEntryMeta
+{
+    LedgerUpgrade upgrade;
+    LedgerEntryChanges changes;
+};
+
+struct LedgerCloseMetaV0
+{
+    LedgerHeaderHistoryEntry ledgerHeader;
+    // NB: txSet is sorted in "Hash order"
+    TransactionSet txSet;
+
+    // NB: transactions are sorted in apply order here
+    // fees for all transactions are processed first
+    // followed by applying transactions
+    TransactionResultMeta txProcessing<>;
+
+    // upgrades are applied last
+    UpgradeEntryMeta upgradesProcessing<>;
+
+    // other misc information attached to the ledger close
+    SCPHistoryEntry scpInfo<>;
+};
+
+union LedgerCloseMeta switch (int v)
+{
+case 0:
+     LedgerCloseMetaV0 v0;
+};
+
 }


### PR DESCRIPTION
# Description

First cut at #2226. This has 3 main pieces:

  - A new XDR type of high-resolution metadata called `LedgerCloseMeta` that captures a per-txn, per-ledger-entry change stream that's equivalent to / a superset of the history tables currently being written into the core database for horizon's benefit.
  - A new "application mode" field in ApplicationImpl that lets us switch-off subsystems and/or replace them with in-memory stubs when running in modes that don't use them.
  - A new catchup option `--replay-in-memory` that runs catchup in application mode `REPLAY_HISTORY_FOR_METADATA`, that has no overlay or database, and uses a "stub" `LedgerTxnRoot` that returns empty for any query, and a "never committed" pseudo-root `LedgerTxn` connected to it, that we use as the in-memory ledger.

The idea here is for horizon to write a config file that mentions a local stream and then runs stellar-core as a subprocess, in either bulk replay mode (`catchup --replay-in-memory`) during initial ingestion _or_ in `run` mode to track the ongoing changes in the network.

(cc @ire-and-curses and @bartekn)