### PR TITLE
Skip tx application and validation for simulation purposes

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -389,6 +389,13 @@ MAXIMUM_LEDGER_CLOSETIME_DRIFT=50
 # you want to make that trade.
 DISABLE_XDR_FSYNC=false
 
+# MAX_SLOTS_TO_REMEMBER (in ledgers) defaults to 12
+# Most people should leave this to 12
+# Number of most recent ledgers keep in memory. Storing more ledgers allows other
+# nodes to join the network without catching up. This is useful for simulation
+# testing purposes.
+MAX_SLOTS_TO_REMEMBER=12
+
 # SUPPORTED_META_VERSION (1 or 2) defaults to 1.
 # If set to 1, stellar-core will emit TransactionMeta as TransactionMetaV1. If
 # set to 2, stellar-core will emit TransactionMeta as TransactionMetaV2. Do not

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -36,7 +36,7 @@ class BucketManagerImpl : public BucketManager
     static std::string const kLockFilename;
 
     Application& mApp;
-    BucketList mBucketList;
+    std::unique_ptr<BucketList> mBucketList;
     std::unique_ptr<TmpDirManager> mTmpDirManager;
     std::unique_ptr<TmpDir> mWorkDir;
     std::map<Hash, std::shared_ptr<Bucket>> mSharedBuckets;

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -88,8 +88,7 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
 class BucketManagerTestApplication : public TestApplication
 {
   public:
-    BucketManagerTestApplication(VirtualClock& clock, Config const& cfg,
-                                 Application::AppMode mode)
+    BucketManagerTestApplication(VirtualClock& clock, Config const& cfg)
         : TestApplication(clock, cfg)
     {
     }

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -110,7 +110,9 @@ ApplyBucketsWork::startLevel()
 
     bool applySnap = (i.snap != binToHex(level.getSnap()->getHash()));
     bool applyCurr = (i.curr != binToHex(level.getCurr()->getHash()));
-    if (!mApplying && mApp.modeHasDatabase() && (applySnap || applyCurr))
+
+    if (!mApplying && !mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER &&
+        (applySnap || applyCurr))
     {
         uint32_t oldestLedger = applySnap
                                     ? BucketList::oldestLedgerInSnap(

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -12,7 +12,5 @@ std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 // the value of LEDGER_VALIDITY_BRACKET should be in the order of
 // how many ledgers can close ahead given CONSENSUS_STUCK_TIMEOUT_SECONDS
 uint32 const Herder::LEDGER_VALIDITY_BRACKET = 100;
-// 12 slots give us about a minute to reconnect
-uint32 const Herder::MAX_SLOTS_TO_REMEMBER = 12;
 std::chrono::nanoseconds const Herder::TIMERS_THRESHOLD_NANOSEC(5000000);
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -52,9 +52,6 @@ class Herder
     // How many ledger in the future we consider an envelope viable.
     static uint32 const LEDGER_VALIDITY_BRACKET;
 
-    // How many ledgers in the past we keep track of
-    static uint32 const MAX_SLOTS_TO_REMEMBER;
-
     // Threshold used to filter out irrelevant events.
     static std::chrono::nanoseconds const TIMERS_THRESHOLD_NANOSEC;
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -163,10 +163,13 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     mTriggerTimer.cancel();
 
     // save the SCP messages in the database
-    mApp.getHerderPersistence().saveSCPHistory(
-        static_cast<uint32>(slotIndex),
-        getSCP().getExternalizingState(slotIndex),
-        mPendingEnvelopes.getCurrentlyTrackedQuorum());
+    if (mApp.getConfig().MODE_STORES_HISTORY)
+    {
+        mApp.getHerderPersistence().saveSCPHistory(
+            static_cast<uint32>(slotIndex),
+            getSCP().getExternalizingState(slotIndex),
+            mPendingEnvelopes.getCurrentlyTrackedQuorum());
+    }
 
     // reflect upgrades with the ones included in this SCP round
     {

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -211,9 +211,10 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     updateTransactionQueue(externalizedSet->mTransactions);
 
     // Evict slots that are outside of our ledger validity bracket
-    if (slotIndex > MAX_SLOTS_TO_REMEMBER)
+    auto maxSlotsToRemember = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+    if (slotIndex > maxSlotsToRemember)
     {
-        getSCP().purgeSlots(slotIndex - MAX_SLOTS_TO_REMEMBER);
+        getSCP().purgeSlots(slotIndex - maxSlotsToRemember);
     }
 
     ledgerClosed();
@@ -433,9 +434,10 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
     mSCPMetrics.mEnvelopeReceive.Mark();
 
     uint32_t minLedgerSeq = getCurrentLedgerSeq();
-    if (minLedgerSeq > MAX_SLOTS_TO_REMEMBER)
+    auto maxSlotsToRemember = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+    if (minLedgerSeq > maxSlotsToRemember)
     {
-        minLedgerSeq -= MAX_SLOTS_TO_REMEMBER;
+        minLedgerSeq -= maxSlotsToRemember;
     }
 
     uint32_t maxLedgerSeq = std::numeric_limits<uint32>::max();
@@ -552,11 +554,12 @@ HerderImpl::processSCPQueue()
     if (mHerderSCPDriver.trackingSCP())
     {
         // drop obsolete slots
-        if (mHerderSCPDriver.nextConsensusLedgerIndex() > MAX_SLOTS_TO_REMEMBER)
+        auto maxSlotsToRemember = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+        if (mHerderSCPDriver.nextConsensusLedgerIndex() > maxSlotsToRemember)
         {
             mPendingEnvelopes.eraseBelow(
                 mHerderSCPDriver.nextConsensusLedgerIndex() -
-                MAX_SLOTS_TO_REMEMBER);
+                maxSlotsToRemember);
         }
 
         processSCPQueueUpToIndex(mHerderSCPDriver.nextConsensusLedgerIndex());
@@ -1375,9 +1378,10 @@ HerderImpl::getMoreSCPState()
 {
     int const NB_PEERS_TO_ASK = 2;
     auto low = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
-    if (low > Herder::MAX_SLOTS_TO_REMEMBER)
+    auto maxSlotsToRemember = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+    if (low > maxSlotsToRemember)
     {
-        low -= Herder::MAX_SLOTS_TO_REMEMBER;
+        low -= maxSlotsToRemember;
     }
     else
     {

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -447,9 +447,10 @@ PendingEnvelopes::slotClosed(uint64 slotIndex)
 
     // stop processing envelopes & downloads for the slot falling off the
     // window
-    if (slotIndex > Herder::MAX_SLOTS_TO_REMEMBER)
+    auto maxSlots = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+    if (slotIndex > maxSlots)
     {
-        slotIndex -= Herder::MAX_SLOTS_TO_REMEMBER;
+        slotIndex -= maxSlots;
 
         mEnvelopes.erase(slotIndex);
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1406,7 +1406,8 @@ TEST_CASE("quick restart", "[herder][quickRestart]")
 
     // SMALL_GAP happens to be the maximum number of ledgers
     // that are kept in memory
-    auto static const SMALL_GAP = Herder::MAX_SLOTS_TO_REMEMBER + 1;
+    auto app = simulation->getNode(listenerKey.getPublicKey());
+    auto static const SMALL_GAP = app->getConfig().MAX_SLOTS_TO_REMEMBER + 1;
     auto static const BIG_GAP = SMALL_GAP + 1;
 
     auto beforeGap = currentLedger;

--- a/src/herder/test/PendingEnvelopesTests.cpp
+++ b/src/herder/test/PendingEnvelopesTests.cpp
@@ -186,9 +186,9 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
         SECTION("as removable")
         {
             pendingEnvelopes.addSCPQuorumSet(saneQSetHash, saneQSet);
-            pendingEnvelopes.addTxSet(p.second->getContentsHash(),
-                                      2 * Herder::MAX_SLOTS_TO_REMEMBER + 1,
-                                      p.second);
+            pendingEnvelopes.addTxSet(
+                p.second->getContentsHash(),
+                2 * app->getConfig().MAX_SLOTS_TO_REMEMBER + 1, p.second);
         }
 
         REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) ==
@@ -230,10 +230,11 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
     {
         auto saneEnvelope2 = makeEnvelope(
             p, saneQSetHash,
-            lcl.header.ledgerSeq + Herder::MAX_SLOTS_TO_REMEMBER + 1);
-        auto saneEnvelope3 = makeEnvelope(
-            p, saneQSetHash,
-            lcl.header.ledgerSeq + 2 * Herder::MAX_SLOTS_TO_REMEMBER + 1);
+            lcl.header.ledgerSeq + app->getConfig().MAX_SLOTS_TO_REMEMBER + 1);
+        auto saneEnvelope3 =
+            makeEnvelope(p, saneQSetHash,
+                         lcl.header.ledgerSeq +
+                             2 * app->getConfig().MAX_SLOTS_TO_REMEMBER + 1);
 
         REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope) ==
                 Herder::ENVELOPE_STATUS_FETCHING);
@@ -247,11 +248,11 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
                 "MAX_SLOTS_TO_REMEMBER")
         {
             pendingEnvelopes.eraseBelow(saneEnvelope2.statement.slotIndex -
-                                        Herder::MAX_SLOTS_TO_REMEMBER);
+                                        app->getConfig().MAX_SLOTS_TO_REMEMBER);
             REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope2) ==
                     Herder::ENVELOPE_STATUS_READY);
             pendingEnvelopes.eraseBelow(saneEnvelope3.statement.slotIndex -
-                                        Herder::MAX_SLOTS_TO_REMEMBER);
+                                        app->getConfig().MAX_SLOTS_TO_REMEMBER);
             REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope3) ==
                     Herder::ENVELOPE_STATUS_READY);
         }
@@ -259,7 +260,7 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
         SECTION("with slotIndex difference bigger than MAX_SLOTS_TO_REMEMBER")
         {
             pendingEnvelopes.eraseBelow(saneEnvelope3.statement.slotIndex -
-                                        Herder::MAX_SLOTS_TO_REMEMBER);
+                                        app->getConfig().MAX_SLOTS_TO_REMEMBER);
             REQUIRE(pendingEnvelopes.recvSCPEnvelope(saneEnvelope3) ==
                     Herder::ENVELOPE_STATUS_FETCHING);
         }

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -148,11 +148,6 @@ HistoryManagerImpl::logAndUpdatePublishStatus()
 size_t
 HistoryManagerImpl::publishQueueLength() const
 {
-    if (!mApp.modeHasDatabase())
-    {
-        return 0;
-    }
-
     uint32_t count;
     auto prep = mApp.getDatabase().getPreparedStatement(
         "SELECT count(ledger) FROM publishqueue;");
@@ -192,7 +187,6 @@ HistoryManagerImpl::inferQuorum(uint32_t ledgerNum)
 uint32_t
 HistoryManagerImpl::getMinLedgerQueuedToPublish()
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
     uint32_t seq;
     soci::indicator minIndicator;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -211,7 +205,6 @@ HistoryManagerImpl::getMinLedgerQueuedToPublish()
 uint32_t
 HistoryManagerImpl::getMaxLedgerQueuedToPublish()
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
     uint32_t seq;
     soci::indicator maxIndicator;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -250,7 +243,6 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint()
 void
 HistoryManagerImpl::queueCurrentHistory()
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
     auto ledger = mApp.getLedgerManager().getLastClosedLedgerNum();
     HistoryArchiveState has(ledger, mApp.getBucketManager().getBucketList());
 
@@ -282,8 +274,6 @@ HistoryManagerImpl::queueCurrentHistory()
 void
 HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
-
     if (mPublishWork)
     {
         return;
@@ -328,11 +318,6 @@ HistoryManagerImpl::publishQueuedHistory()
     }
 #endif
 
-    if (!mApp.modeHasDatabase())
-    {
-        return 0;
-    }
-
     std::string state;
 
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -357,11 +342,6 @@ std::vector<HistoryArchiveState>
 HistoryManagerImpl::getPublishQueueStates()
 {
     std::vector<HistoryArchiveState> states;
-
-    if (!mApp.modeHasDatabase())
-    {
-        return states;
-    }
 
     std::string state;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -431,8 +411,6 @@ HistoryManagerImpl::historyPublished(
     uint32_t ledgerSeq, std::vector<std::string> const& originalBuckets,
     bool success)
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
-
     if (success)
     {
         auto iter = mEnqueueTimes.find(ledgerSeq);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -29,6 +29,7 @@
 #include "transactions/OperationFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
+#include "util/LogSlowExecution.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "util/format.h"
@@ -277,7 +278,7 @@ LedgerManagerImpl::loadLastKnownLedger(
             << "Last closed ledger (LCL) hash is " << lastLedger;
         Hash lastLedgerHash = hexToBin256(lastLedger);
 
-        if (mApp.modeHasDatabase())
+        if (mApp.getConfig().MODE_STORES_HISTORY)
         {
             auto currentLedger =
                 LedgerHeaderUtils::loadByHash(getDatabase(), lastLedgerHash);
@@ -889,7 +890,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             }
             // Note: Index from 1 rather than 0 to match the behavior of
             // storeTransaction and storeTransactionFee.
-            if (mApp.modeHasDatabase())
+            if (mApp.getConfig().MODE_STORES_HISTORY)
             {
                 Upgrades::storeUpgradeHistory(getDatabase(), ledgerSeq,
                                               lupgrade, changes,
@@ -1061,7 +1062,7 @@ LedgerManagerImpl::processFeesSeqNums(
             // txs counting from 1, not 0. We preserve this for the time being
             // in case anyone depends on it.
             ++index;
-            if (mApp.modeHasDatabase())
+            if (mApp.getConfig().MODE_STORES_HISTORY)
             {
                 tx->storeTransactionFee(mApp.getDatabase(), ledgerSeq, changes,
                                         index);
@@ -1204,7 +1205,7 @@ LedgerManagerImpl::applyTransactions(
         // txs counting from 1, not 0. We preserve this for the time being
         // in case anyone depends on it.
         ++index;
-        if (mApp.modeHasDatabase())
+        if (mApp.getConfig().MODE_STORES_HISTORY)
         {
             auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
             tx->storeTransaction(mApp.getDatabase(), ledgerSeq, tm, index,
@@ -1233,7 +1234,7 @@ LedgerManagerImpl::logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
 void
 LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header)
 {
-    if (mApp.modeHasDatabase())
+    if (mApp.getConfig().MODE_STORES_HISTORY)
     {
         LedgerHeaderUtils::storeInDatabase(mApp.getDatabase(), header);
     }

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -152,10 +152,14 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - REPLAY_IN_MEMORY",
         cfg.NODE_IS_VALIDATOR = false;
         cfg.FORCE_SCP = false;
         cfg.RUN_STANDALONE = true;
+        // Replay-in-memory configs
+        cfg.DISABLE_XDR_FSYNC = true;
+        cfg.DATABASE = SecretValue{"sqlite3://:memory:"};
+        cfg.MODE_STORES_HISTORY = false;
+        cfg.MODE_USES_IN_MEMORY_LEDGER = true;
+        cfg.MODE_ENABLES_BUCKETLIST = true;
         VirtualClock clock;
-        auto app =
-            createTestApplication(clock, cfg, /*newdb=*/false,
-                                  Application::AppMode::REPLAY_IN_MEMORY);
+        auto app = createTestApplication(clock, cfg, /*newdb=*/false);
 
         CatchupConfiguration cc{CatchupConfiguration::CURRENT,
                                 std::numeric_limits<uint32_t>::max(),

--- a/src/ledger/test/LedgerManagerTests.cpp
+++ b/src/ledger/test/LedgerManagerTests.cpp
@@ -43,9 +43,8 @@ class LedgerManagerForTests : public LedgerManagerImpl
 class LedgerManagerTestApplication : public TestApplication
 {
   public:
-    LedgerManagerTestApplication(VirtualClock& clock, Config const& cfg,
-                                 Application::AppMode mode)
-        : TestApplication(clock, cfg, mode)
+    LedgerManagerTestApplication(VirtualClock& clock, Config const& cfg)
+        : TestApplication(clock, cfg)
     {
     }
 

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -38,41 +38,8 @@ validateNetworkPassphrase(Application::pointer app)
 }
 
 Application::pointer
-Application::create(VirtualClock& clock, Config const& cfg, bool newDB,
-                    AppMode mode)
+Application::create(VirtualClock& clock, Config const& cfg, bool newDB)
 {
-    return create<ApplicationImpl>(clock, cfg, newDB, mode);
-}
-
-bool
-Application::modeHasOverlay(AppMode m)
-{
-    switch (m)
-    {
-    case AppMode::RUN_LIVE_NODE:
-        return true;
-    case AppMode::RELAY_LIVE_TRAFFIC:
-        return true;
-    case AppMode::REPLAY_IN_MEMORY:
-        return false;
-    default:
-        throw std::runtime_error("unhandled application mode");
-    }
-}
-
-bool
-Application::modeHasDatabase(AppMode m)
-{
-    switch (m)
-    {
-    case AppMode::RUN_LIVE_NODE:
-        return true;
-    case AppMode::RELAY_LIVE_TRAFFIC:
-        return false;
-    case AppMode::REPLAY_IN_MEMORY:
-        return false;
-    default:
-        throw std::runtime_error("unhandled application mode");
-    }
+    return create<ApplicationImpl>(clock, cfg, newDB);
 }
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -62,11 +62,9 @@ static const int SHUTDOWN_DELAY_SECONDS = 1;
 namespace stellar
 {
 
-ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg,
-                                 AppMode mode)
+ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     : mVirtualClock(clock)
     , mConfig(cfg)
-    , mAppMode(mode)
     , mWorkerIOContext(mConfig.WORKER_THREADS)
     , mWork(std::make_unique<asio::io_context::work>(mWorkerIOContext))
     , mWorkerThreads()
@@ -126,10 +124,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg,
 void
 ApplicationImpl::initialize(bool createNewDB)
 {
-    if (modeHasDatabase(mAppMode))
-    {
-        mDatabase = std::make_unique<Database>(*this);
-    }
+    mDatabase = std::make_unique<Database>(*this);
     mPersistentState = std::make_unique<PersistentState>(*this);
     mOverlayManager = createOverlayManager();
     mLedgerManager = createLedgerManager();
@@ -140,31 +135,23 @@ ApplicationImpl::initialize(bool createNewDB)
     mHistoryArchiveManager = std::make_unique<HistoryArchiveManager>(*this);
     mHistoryManager = HistoryManager::create(*this);
     mInvariantManager = createInvariantManager();
-    if (modeHasDatabase(mAppMode))
-    {
-        mMaintainer = std::make_unique<Maintainer>(*this);
-    }
+    mMaintainer = std::make_unique<Maintainer>(*this);
     mCommandHandler = std::make_unique<CommandHandler>(*this);
     mWorkScheduler = WorkScheduler::create(*this);
     mBanManager = BanManager::create(*this);
     mStatusManager = std::make_unique<StatusManager>();
 
-    switch (mAppMode)
+    if (getConfig().MODE_USES_IN_MEMORY_LEDGER)
     {
-    case AppMode::RUN_LIVE_NODE:
-        mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
-            *mDatabase, mConfig.ENTRY_CACHE_SIZE,
-            mConfig.BEST_OFFERS_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE);
-        break;
-    case AppMode::REPLAY_IN_MEMORY:
         mLedgerTxnRoot = std::make_unique<InMemoryLedgerTxnRoot>();
         mNeverCommittingLedgerTxn =
             std::make_unique<LedgerTxn>(*mLedgerTxnRoot);
-        break;
-    case AppMode::RELAY_LIVE_TRAFFIC:
-        break;
-    default:
-        throw std::runtime_error("unhandled application mode");
+    }
+    else
+    {
+        mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
+            *mDatabase, mConfig.ENTRY_CACHE_SIZE,
+            mConfig.BEST_OFFERS_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE);
     }
 
     BucketListIsConsistentWithDatabase::registerInvariant(*this);
@@ -193,11 +180,8 @@ ApplicationImpl::initialize(bool createNewDB)
 void
 ApplicationImpl::newDB()
 {
-    if (modeHasDatabase(mAppMode))
-    {
-        mDatabase->initialize();
-        mDatabase->upgradeToCurrentSchema();
-    }
+    mDatabase->initialize();
+    mDatabase->upgradeToCurrentSchema();
     mBucketManager->dropAll();
     mLedgerManager->startNewLedger();
 }
@@ -205,10 +189,7 @@ ApplicationImpl::newDB()
 void
 ApplicationImpl::upgradeDB()
 {
-    if (modeHasDatabase(mAppMode))
-    {
-        mDatabase->upgradeToCurrentSchema();
-    }
+    mDatabase->upgradeToCurrentSchema();
 }
 
 void
@@ -366,18 +347,6 @@ ApplicationImpl::~ApplicationImpl()
     reportCfgMetrics();
     shutdownMainIOContext();
     joinAllThreads();
-    if (!modeHasDatabase(mAppMode))
-    {
-        // Note: BucketManager::dropAll will delete the $BUCKETDIR/tmp which is
-        // where process and history manager write _their_ temp files to, so we
-        // make sure to tear them down first here.
-        mProcessManager = nullptr;
-        mHistoryManager = nullptr;
-        if (mBucketManager)
-        {
-            mBucketManager->dropAll();
-        }
-    }
     LOG(INFO) << "Application destroyed";
 }
 
@@ -395,23 +364,7 @@ ApplicationImpl::start()
         CLOG(INFO, "Ledger") << "Skipping application start up";
         return;
     }
-    switch (mAppMode)
-    {
-    case AppMode::RUN_LIVE_NODE:
-        // Default mode, don't mention modes; most users are not interested.
-        CLOG(INFO, "Ledger") << "Starting up application";
-        break;
-    case AppMode::RELAY_LIVE_TRAFFIC:
-        CLOG(INFO, "Ledger") << "Starting up application"
-                             << " in RELAY_LIVE_TRAFFIC mode";
-        break;
-    case AppMode::REPLAY_IN_MEMORY:
-        CLOG(INFO, "Ledger") << "Starting up application"
-                             << " in REPLAY_IN_MEMORY mode";
-        break;
-    default:
-        throw std::runtime_error("unhandled application mode");
-    }
+    CLOG(INFO, "Ledger") << "Starting up application";
     mStarted = true;
 
     if (mConfig.TESTING_UPGRADE_DATETIME.time_since_epoch().count() != 0)
@@ -438,18 +391,23 @@ ApplicationImpl::start()
         throw std::invalid_argument("NODE_IS_VALIDATOR is set");
     }
 
-    if (!modeHasDatabase())
+    if (mConfig.NODE_IS_VALIDATOR)
     {
-        if (mConfig.NODE_IS_VALIDATOR)
+        if (mConfig.MODE_USES_IN_MEMORY_LEDGER)
         {
-            LOG(ERROR) << "Starting stellar-core in a non-database mode "
+            LOG(ERROR) << "Starting stellar-core with in-memory ledger mode "
                           "requires NODE_IS_VALIDATOR to be unset";
             throw std::invalid_argument("NODE_IS_VALIDATOR is set");
         }
-        if (getHistoryArchiveManager().hasAnyWritableHistoryArchive())
+    }
+
+    if (getHistoryArchiveManager().hasAnyWritableHistoryArchive())
+    {
+        if (!mConfig.MODE_STORES_HISTORY)
         {
-            LOG(ERROR) << "Starting stellar-core in a non-database mode "
-                          "requires all history archives to be non-writable";
+            LOG(ERROR) << "Starting stellar-core in a mode that does not store "
+                          "history data requires all history archives to be "
+                          "non-writable";
             throw std::invalid_argument("some history archives are writable");
         }
     }
@@ -472,13 +430,10 @@ ApplicationImpl::start()
 
             // restores Herder's state before starting overlay
             mHerder->restoreState();
-            if (modeHasDatabase(mAppMode))
-            {
-                // set known cursors before starting maintenance job
-                ExternalQueue ps(*this);
-                ps.setInitialCursors(mConfig.KNOWN_CURSORS);
-                mMaintainer->start();
-            }
+            // set known cursors before starting maintenance job
+            ExternalQueue ps(*this);
+            ps.setInitialCursors(mConfig.KNOWN_CURSORS);
+            mMaintainer->start();
             mOverlayManager->start();
             auto npub = mHistoryManager->publishQueuedHistory();
             if (npub != 0)
@@ -686,12 +641,6 @@ ApplicationImpl::isStopping() const
     return mStopping;
 }
 
-Application::AppMode
-ApplicationImpl::getMode() const
-{
-    return mAppMode;
-}
-
 VirtualClock&
 ApplicationImpl::getClock()
 {
@@ -790,7 +739,6 @@ ApplicationImpl::getHistoryManager()
 Maintainer&
 ApplicationImpl::getMaintainer()
 {
-    releaseAssertOrThrow(modeHasDatabase(mAppMode));
     return *mMaintainer;
 }
 
@@ -827,7 +775,6 @@ ApplicationImpl::getOverlayManager()
 Database&
 ApplicationImpl::getDatabase() const
 {
-    releaseAssertOrThrow(modeHasDatabase(mAppMode));
     return *mDatabase;
 }
 
@@ -940,17 +887,7 @@ AbstractLedgerTxnParent&
 ApplicationImpl::getLedgerTxnRoot()
 {
     assertThreadIsMain();
-    switch (mAppMode)
-    {
-    case AppMode::RUN_LIVE_NODE:
-        return *mLedgerTxnRoot;
-    case AppMode::REPLAY_IN_MEMORY:
-        return *mNeverCommittingLedgerTxn;
-    case AppMode::RELAY_LIVE_TRAFFIC:
-        throw std::runtime_error(
-            "accessing LedgerTxnRoot in RELAY_LIVE_TRAFFIC mode");
-    default:
-        throw std::runtime_error("unhandled application mode");
-    }
+    return mConfig.MODE_USES_IN_MEMORY_LEDGER ? *mNeverCommittingLedgerTxn
+                                              : *mLedgerTxnRoot;
 }
 }

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -37,7 +37,7 @@ class LoadGenerator;
 class ApplicationImpl : public Application
 {
   public:
-    ApplicationImpl(VirtualClock& clock, Config const& cfg, AppMode mode);
+    ApplicationImpl(VirtualClock& clock, Config const& cfg);
     virtual ~ApplicationImpl() override;
 
     virtual void initialize(bool newDB) override;
@@ -49,7 +49,6 @@ class ApplicationImpl : public Application
     virtual State getState() const override;
     virtual std::string getStateHuman() const override;
     virtual bool isStopping() const override;
-    virtual AppMode getMode() const override;
     virtual VirtualClock& getClock() override;
     virtual medida::MetricsRegistry& getMetrics() override;
     virtual void syncOwnMetrics() override;
@@ -125,7 +124,6 @@ class ApplicationImpl : public Application
   private:
     VirtualClock& mVirtualClock;
     Config mConfig;
-    AppMode const mAppMode;
 
     // NB: The io_context should come first, then the 'manager' sub-objects,
     // then the threads. Do not reorder these fields.
@@ -158,7 +156,7 @@ class ApplicationImpl : public Application
     std::unique_ptr<StatusManager> mStatusManager;
     std::unique_ptr<AbstractLedgerTxnParent> mLedgerTxnRoot;
 
-    // This exists for use in AppMode::REPLAY_IN_MEMORY only: the
+    // This exists for use in MODE_USES_IN_MEMORY_LEDGER only: the
     // mLedgerTxnRoot will be an InMemoryLedgerTxnRoot which is a _stub_
     // AbstractLedgerTxnParent that refuses all commits and answers null to all
     // queries; then an inner "never-committing" sub-LedgerTxn is constructed

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -43,6 +43,11 @@ runWithConfig(Config cfg)
         cfg.FORCE_SCP = true;
     }
 
+    if (cfg.NODE_IS_VALIDATOR && cfg.DATABASE.value == "sqlite3://:memory:")
+    {
+        cfg.FORCE_SCP = true;
+    }
+
     LOG(INFO) << "Starting stellar-core " << STELLAR_CORE_VERSION;
     VirtualClock clock(VirtualClock::REAL_TIME);
     Application::pointer app;

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -71,7 +71,7 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
 
     mServer->add404(std::bind(&CommandHandler::fileNotFound, this, _1, _2));
 
-    if (mApp.modeHasDatabase())
+    if (mApp.getConfig().MODE_STORES_HISTORY)
     {
         addRoute("dropcursor", &CommandHandler::dropcursor);
         addRoute("getcursor", &CommandHandler::getcursor);

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -541,35 +541,44 @@ runCatchup(CommandLineArgs const& args)
                 config.AUTOMATIC_MAINTENANCE_COUNT = 1000000;
             }
 
-            auto mode = (replayInMemory ? Application::AppMode::REPLAY_IN_MEMORY
-                                        : Application::AppMode::RUN_LIVE_NODE);
-
-            auto newDb = false;
-            if (!Application::modeHasDatabase(mode))
+            if (replayInMemory)
             {
-                // Need to "initialize a new db" if running in memory.
-                newDb = true;
+                // Adjust configs for in-memory-replay mode
+                config.DATABASE = SecretValue{"sqlite3://:memory:"};
+                config.MODE_STORES_HISTORY = false;
+                config.MODE_USES_IN_MEMORY_LEDGER = true;
+                config.MODE_ENABLES_BUCKETLIST = true;
                 // And don't bother fsyncing buckets without a DB,
                 // they're temporary anyways.
                 config.DISABLE_XDR_FSYNC = true;
             }
 
             VirtualClock clock(VirtualClock::REAL_TIME);
-            auto app = Application::create(clock, config, newDb, mode);
-            auto const& ham = app->getHistoryArchiveManager();
-            auto archivePtr = ham.getHistoryArchive(archive);
-            if (iequals(archive, "any"))
+            int result;
             {
-                archivePtr = ham.selectRandomReadableHistoryArchive();
+                auto app = Application::create(clock, config, replayInMemory);
+                auto const& ham = app->getHistoryArchiveManager();
+                auto archivePtr = ham.getHistoryArchive(archive);
+                if (iequals(archive, "any"))
+                {
+                    archivePtr = ham.selectRandomReadableHistoryArchive();
+                }
+
+                Json::Value catchupInfo;
+                result = catchup(
+                    app, parseCatchup(catchupString, completeValidation),
+                    catchupInfo, archivePtr);
+                if (!catchupInfo.isNull())
+                {
+                    writeCatchupInfo(catchupInfo, outputFile);
+                }
             }
 
-            Json::Value catchupInfo;
-            auto result =
-                catchup(app, parseCatchup(catchupString, completeValidation),
-                        catchupInfo, archivePtr);
-            if (!catchupInfo.isNull())
+            if (replayInMemory)
             {
-                writeCatchupInfo(catchupInfo, outputFile);
+                // Clean up `buckets` folder when in in-memory-replay mode
+                VirtualClock clockBuckets(VirtualClock::REAL_TIME);
+                auto app = Application::create(clockBuckets, config, true);
             }
 
             return result;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -122,6 +122,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     UNSAFE_QUORUM = false;
     DISABLE_BUCKET_GC = false;
     DISABLE_XDR_FSYNC = false;
+    MAX_SLOTS_TO_REMEMBER = 12;
     METADATA_OUTPUT_STREAM = "";
 
     LOG_FILE_PATH = "stellar-core.%datetime{%Y.%M.%d-%H:%m:%s}.log";
@@ -731,6 +732,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING =
                     readInt<uint32_t>(item, 0, UINT32_MAX - 1);
+            }
+            else if (item.first == "MAX_SLOTS_TO_REMEMBER")
+            {
+                MAX_SLOTS_TO_REMEMBER = readInt<uint32>(item);
             }
             else if (item.first ==
                      "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING")

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -34,7 +34,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
     "ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING",
     "ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING",
-    "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING"};
+    "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING",
+    "OP_APPLY_SLEEP_TIME_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -87,6 +88,11 @@ Config::Config() : NODE_SEED(SecretKey::random())
     // fill in defaults
 
     // non configurable
+    MODE_ENABLES_BUCKETLIST = true;
+    MODE_USES_IN_MEMORY_LEDGER = false;
+    MODE_STORES_HISTORY = true;
+    OP_APPLY_SLEEP_TIME_FOR_TESTING = 0;
+
     FORCE_SCP = false;
     LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION;
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -188,6 +188,25 @@ class Config : public std::enable_shared_from_this<Config>
     // system.
     bool ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING;
 
+    // A config parameter that forces transaction application during ledger
+    // close to sleep for a given number of microseconds. This option is only
+    // for consensus and overlay simulation testing.
+    uint32_t OP_APPLY_SLEEP_TIME_FOR_TESTING;
+
+    // A config parameter that allows a node to generate buckets. This should
+    // be set to `false` only for testing purposes.
+    bool MODE_ENABLES_BUCKETLIST;
+
+    // A config parameter that uses a never-committing ledger. This means that
+    // all ledger entries will be kept in memory, and not persisted to DB
+    // (relevant tables won't even be created). This should not be set for
+    // production validators.
+    bool MODE_USES_IN_MEMORY_LEDGER;
+
+    // A config parameter that stores historical data, such as transactions,
+    // fees, and scp history in the database
+    bool MODE_STORES_HISTORY;
+
     // A config to allow connections to localhost
     // this should only be enabled when testing as it's a security issue
     bool ALLOW_LOCALHOST_FOR_TESTING;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -242,6 +242,10 @@ class Config : public std::enable_shared_from_this<Config>
     // you want to make that trade.
     bool DISABLE_XDR_FSYNC;
 
+    // Number of most recent ledgers to remember. Defaults to 12, or
+    // approximately ~1 min of network activity.
+    uint32 MAX_SLOTS_TO_REMEMBER;
+
     // A string specifying a stream to write fine-grained metadata to for each
     // ledger close while running. This will be opened at startup and
     // synchronously streamed-to during both catchup and live ledger-closing.

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -25,7 +25,6 @@ string ExternalQueue::kSQLCreateStatement =
 
 ExternalQueue::ExternalQueue(Application& app) : mApp(app)
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
 }
 
 void

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -15,7 +15,6 @@ namespace stellar
 
 Maintainer::Maintainer(Application& app) : mApp{app}, mTimer{mApp}
 {
-    releaseAssertOrThrow(mApp.modeHasDatabase());
 }
 
 void

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -28,11 +28,6 @@ std::string PersistentState::kSQLCreateStatement =
 
 PersistentState::PersistentState(Application& app) : mApp(app)
 {
-    if (!mApp.modeHasDatabase())
-    {
-        mNonDBState =
-            std::make_unique<std::unordered_map<std::string, std::string>>();
-    }
 }
 
 void
@@ -100,13 +95,6 @@ PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
 void
 PersistentState::updateDb(std::string const& entry, std::string const& value)
 {
-    if (!mApp.modeHasDatabase())
-    {
-        releaseAssertOrThrow(mNonDBState);
-        (*mNonDBState)[entry] = value;
-        return;
-    }
-
     auto prep = mApp.getDatabase().getPreparedStatement(
         "UPDATE storestate SET state = :v WHERE statename = :n;");
 
@@ -139,12 +127,6 @@ PersistentState::updateDb(std::string const& entry, std::string const& value)
 std::string
 PersistentState::getFromDb(std::string const& entry)
 {
-    if (!mApp.modeHasDatabase())
-    {
-        releaseAssertOrThrow(mNonDBState);
-        return (*mNonDBState)[entry];
-    }
-
     std::string res;
 
     auto& db = mApp.getDatabase();

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -72,7 +72,7 @@ PersistentState::getSCPStateAllSlots()
 {
     // Collect all slots persisted
     std::vector<std::string> states;
-    for (uint32 i = 0; i <= Herder::MAX_SLOTS_TO_REMEMBER; i++)
+    for (uint32 i = 0; i <= mApp.getConfig().MAX_SLOTS_TO_REMEMBER; i++)
     {
         auto val = getFromDb(getStoreStateName(kLastSCPData, i));
         if (!val.empty())
@@ -87,8 +87,8 @@ PersistentState::getSCPStateAllSlots()
 void
 PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
 {
-    auto slotIdx =
-        static_cast<uint32>(slot % (Herder::MAX_SLOTS_TO_REMEMBER + 1));
+    auto slotIdx = static_cast<uint32>(
+        slot % (mApp.getConfig().MAX_SLOTS_TO_REMEMBER + 1));
     updateDb(getStoreStateName(kLastSCPData, slotIdx), value);
 }
 

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -5,9 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/Application.h"
-#include <memory>
 #include <string>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -43,12 +41,6 @@ class PersistentState
     static std::string mapping[kLastEntry];
 
     Application& mApp;
-
-    // When running in a mode with !Application::modeHasDatabase() we still let
-    // subsystems write "persistent" root-state values like the LCL and LCL HAS
-    // to this object. In that case such values "persist" only across ledgers /
-    // calls to this object, not restarts of the process.
-    std::unique_ptr<std::unordered_map<std::string, std::string>> mNonDBState;
 
     std::string getStoreStateName(Entry n, uint32 subscript = 0);
     void updateDb(std::string const& entry, std::string const& value);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1015,9 +1015,10 @@ Peer::recvAuth(StellarMessage const& msg)
     // possible) we need to ask for older slots in case other peers need
     // messages we didn't need ourself
     auto low = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
-    if (low > Herder::MAX_SLOTS_TO_REMEMBER)
+    auto maxSlots = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+    if (low > maxSlots)
     {
-        low -= Herder::MAX_SLOTS_TO_REMEMBER;
+        low -= maxSlots;
     }
     else
     {

--- a/src/overlay/test/ItemFetcherTests.cpp
+++ b/src/overlay/test/ItemFetcherTests.cpp
@@ -40,9 +40,8 @@ class HerderStub : public HerderImpl
 class ApplicationStub : public TestApplication
 {
   public:
-    ApplicationStub(VirtualClock& clock, Config const& cfg,
-                    Application::AppMode mode)
-        : TestApplication(clock, cfg, mode)
+    ApplicationStub(VirtualClock& clock, Config const& cfg)
+        : TestApplication(clock, cfg)
     {
     }
 

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -84,8 +84,7 @@ class OverlayManagerTests
     class ApplicationStub : public TestApplication
     {
       public:
-        ApplicationStub(VirtualClock& clock, Config const& cfg,
-                        Application::AppMode mode)
+        ApplicationStub(VirtualClock& clock, Config const& cfg)
             : TestApplication(clock, cfg)
         {
         }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -88,9 +88,8 @@ TestInvariantManager::handleInvariantFailure(
     throw InvariantDoesNotHold{message};
 }
 
-TestApplication::TestApplication(VirtualClock& clock, Config const& cfg,
-                                 AppMode mode)
-    : ApplicationImpl(clock, cfg, mode)
+TestApplication::TestApplication(VirtualClock& clock, Config const& cfg)
+    : ApplicationImpl(clock, cfg)
 {
 }
 

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -59,8 +59,7 @@ class TestInvariantManager : public InvariantManagerImpl
 class TestApplication : public ApplicationImpl
 {
   public:
-    TestApplication(VirtualClock& clock, Config const& cfg,
-                    AppMode mode = AppMode::RUN_LIVE_NODE);
+    TestApplication(VirtualClock& clock, Config const& cfg);
 
   private:
     std::unique_ptr<InvariantManager> createInvariantManager() override;
@@ -70,13 +69,11 @@ template <typename T = TestApplication,
           typename = typename std::enable_if<
               std::is_base_of<TestApplication, T>::value>::type>
 std::shared_ptr<T>
-createTestApplication(
-    VirtualClock& clock, Config const& cfg, bool newDB = true,
-    Application::AppMode mode = Application::AppMode::RUN_LIVE_NODE)
+createTestApplication(VirtualClock& clock, Config const& cfg, bool newDB = true)
 {
     Config c2(cfg);
     c2.adjust();
-    auto app = Application::create<T>(clock, c2, newDB, mode);
+    auto app = Application::create<T>(clock, c2, newDB);
     return app;
 }
 


### PR DESCRIPTION
Additional changes on top of #2343, focused around skipping application and validation of transactions in consensus simulation mode. For this mode, I've used the load generator to inject traffic, so it currently submits simple payments (we could certainly change how loadgen generates traffic, but it's probably not very useful since we're skipping validation and application anyway).