### PR TITLE
doc: make README header engaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-[![Build Status](https://travis-ci.org/stellar/stellar-core.svg?branch=auto)](https://travis-ci.org/stellar/stellar-core)
-
-
-# stellar-core
+<div align="center">
+<a href="https://stellar.org"><img alt="Stellar" src="https://www.stellar.org/old-content/2019/03/stellar-logo-solo-1.png" width="558" /></a>
+<br/>
+<strong>Creating equitable access to the global financial system</strong>
+<h1>Stellar Core</h1>
+</div>
+<p align="center">
+<a href="https://travis-ci.org/stellar/stellar-core"><img alt="Build Status" src="https://travis-ci.org/stellar/stellar-core.svg?branch=auto" /></a>
+</p>
 
 Stellar-core is a replicated state machine that maintains a local copy of a cryptographic ledger and processes transactions against it, in consensus with a set of peers.
 It implements the [Stellar Consensus Protocol](https://github.com/stellar/stellar-core/blob/master/src/scp/readme.md), a _federated_ consensus protocol.


### PR DESCRIPTION
# Description

Change the beginning of the README to include the Stellar logo, and Stellar's mission.

See it rendered at:
https://github.com/leighmcculloch/stellar--stellar-core/blob/sparkle/README.md

This repository is an entry point to external contributions and interest. At GitHub Universe one of the talks I attended talked about how creating an inviting and engaging README makes a huge difference to engaging developers who discover a project. The [dev.to README] was given as an example. Adding our logo and including our mission is just one small thing we can to engage a newcomer.

This same change has been made on some of our other repositories: stellar/go#1948, stellar/stellar-protocol#465, stellar/js-stellar-sdk#459.

[dev.to README]: https://github.com/thepracticaldev/dev.to/blob/master/README.md

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] ~Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)~
- [x] ~Compiles~
- [x] ~Ran all tests~
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
