### PR TITLE
Missing piece for bug #2226, METADATA_OUTPUT_STREAM should deny NODE_…

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -995,14 +995,19 @@ LedgerManagerImpl::setupLedgerCloseMetaStream()
     {
         mMetaStream =
             std::make_unique<XDROutputFileStream>(/*fsyncOnClose=*/true);
-        std::regex fdrx("^fd:([0-9])+$");
+        std::regex fdrx("^fd:([0-9]+)$");
         std::smatch sm;
         if (std::regex_match(cfg.METADATA_OUTPUT_STREAM, sm, fdrx))
         {
-            mMetaStream->fdopen(std::stoi(sm[1]));
+            int fd = std::stoi(sm[1]);
+            CLOG(INFO, "Ledger")
+                << "Streaming metadata to file descriptor " << fd;
+            mMetaStream->fdopen(fd);
         }
         else
         {
+            CLOG(INFO, "Ledger") << "Streaming metadata to '"
+                                 << cfg.METADATA_OUTPUT_STREAM << "'";
             mMetaStream->open(cfg.METADATA_OUTPUT_STREAM);
         }
     }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -431,6 +431,13 @@ ApplicationImpl::start()
         mConfig.FORCE_SCP = true;
     }
 
+    if (mConfig.METADATA_OUTPUT_STREAM != "" && mConfig.NODE_IS_VALIDATOR)
+    {
+        LOG(ERROR) << "Starting stellar-core with METADATA_OUTPUT_STREAM "
+                      "requires NODE_IS_VALIDATOR to be unset";
+        throw std::invalid_argument("NODE_IS_VALIDATOR is set");
+    }
+
     if (!modeHasDatabase())
     {
         if (mConfig.NODE_IS_VALIDATOR)


### PR DESCRIPTION
Another small missing piece. We deny NODE_IS_VALIDATOR for non-DB mode, but also ought to deny it any time METADATA_OUTPUT_STREAM is set.