### PR TITLE
Have both docker containers in install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,8 @@ These are instructions for building stellar-core from source.
 
 For a potentially quicker set up, the following projects could be good alternatives:
 
-* stellar-core in a [docker container](https://github.com/stellar/docker-stellar-core-horizon)
+* stellar-core in a [docker container](https://github.com/stellar/docker-stellar-core)
+* stellar-core and [horizon](https://github.com/stellar/go/tree/master/services/horizon) in a [docker container](https://github.com/stellar/docker-stellar-core-horizon)
 * pre-compiled [packages](https://github.com/stellar/packages)
 
 ## Picking a version to run


### PR DESCRIPTION
# Description

Changes the install instructions to link to both the solo stellar-core docker container and the quickstart docker container that includes both.

I was trying to run just stellar-core in a docker container and just discovered we maintain not only the quickstart image but also a `stellar/stellar-core` image. When reading the install instructions the first image that is referenced sounds like an image that will just run stellar-core so I think it would be more intuitive to link to that, alongside linking to the quickstart container that runs both.

It's possible I'm missing something and there's a reason we don't encourage use of the solo stellar-core image, if so please disregard/close this PR. I just would have found this helpful in my own use of stellar-core.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] ~Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)~
- [x] ~Compiles~
- [x] ~Ran all tests~
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
