### PR TITLE
Fix LiabilitiesMatchOffers invariant

### DIFF
--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -174,9 +174,9 @@ shouldCheckAccount(std::shared_ptr<LedgerEntry const> const& current,
     if (ledgerVersion >= 10)
     {
         bool sellingLiabilitiesInc =
-            getSellingLiabilities(*current) > getSellingLiabilities(*current);
+            getSellingLiabilities(*current) > getSellingLiabilities(*previous);
         bool buyingLiabilitiesInc =
-            getBuyingLiabilities(*current) > getBuyingLiabilities(*current);
+            getBuyingLiabilities(*current) > getBuyingLiabilities(*previous);
         bool didLiabilitiesIncrease =
             sellingLiabilitiesInc || buyingLiabilitiesInc;
         return didBalanceDecrease || didLiabilitiesIncrease;


### PR DESCRIPTION
I discovered a small bug in `LiabilitiesMatchOffers` while reviewing #2356. This PR resolves the bug and improves the test suite.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
