### PR TITLE
Make the order of applying changes more clear

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -139,11 +139,10 @@ A process (singleton) can import data from the [historical SQL tables](#sql-tabl
 
 The data that needs to be processed as ledger closes is, in order:
 * the ledger header (in `ledgerheaders`)
-* transaction set "meta"
-  * `txfee` - before and after changes related to fee processing (fees are processed before everything else)
-  * transactions in `txhistory`
-    * before and after state at operation granularity
-    * also contains associated `TransactionResult`
+* `txfee` - before and after changes related to fee processing (fees of all transactions are processed before everything else below: TX1_FEE, TX2_FEE, ..., TX1_META, TX2_META, ...)
+* transaction set "meta" (transactions in `txhistory`):
+  * before and after state at operation granularity
+  * also contains associated `TransactionResult`
 * ledger upgrades "meta" (in `upgradehistory`)
   * contains ledger entries before/after of ledger entries that potentially get modified by upgrades
   * contains network wide settings upgrade information (protocol version, base fee, etc)


### PR DESCRIPTION
I found edited part to be confusing. Maybe because of indentation I understood that one should process fee and then meta of each tx one after another, however you should process fee changes of ALL txs first before processing meta changes.