### PR TITLE
Fix TxTest invariant - related to removing pre-auth signers

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -235,14 +235,13 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
                     else
                     {
                         auto ltxDelta = ltxTx.getDelta();
-                        REQUIRE(ltxDelta.entry.size() == 1);
-                        auto current = ltxDelta.entry.begin()->second.current;
-                        REQUIRE(current);
-                        auto previous = ltxDelta.entry.begin()->second.previous;
-                        REQUIRE(previous);
-                        auto currAcc = current->data.account();
-                        REQUIRE(currAcc.accountID ==
-                                srcAccountBefore.accountID);
+                        for (auto const& kvp : ltxDelta.entry)
+                        {
+                            auto current = kvp.second.current;
+                            REQUIRE(current);
+                            auto previous = kvp.second.previous;
+                            REQUIRE(previous);
+                        }
                         // could check more here if needed
                     }
                 }


### PR DESCRIPTION
# Description
There is an invariant in `TxTests.cpp` that verifies that only one account is modified on a transaction failure, which isn't always true. 

I added a test case that failed due to this invariant. In this test case, pre-auth signers are removed from two accounts, but the transaction fails due to there being too many signatures on the transaction.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
