### PR TITLE
Use simple "C" collation on varchar / text index columns.

### DIFF
--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -159,6 +159,13 @@ class Database : NonMovableOrCopyable
     // Return true if the Database target is SQLite, otherwise false.
     bool isSqlite() const;
 
+    // Return an optional SQL COLLATION clause to use for text-typed columns in
+    // this database, in order to ensure they're compared "simply" using
+    // byte-value comparisons, i.e. in a non-language-sensitive fashion.  For
+    // Postgresql this will be 'COLLATE "C"' and for SQLite, nothing (its
+    // defaults are correct already).
+    std::string getSimpleCollationClause() const;
+
     // Call `op` back with the specific database backend subtype in use.
     template <typename T>
     T doDatabaseTypeSpecificOperation(DatabaseTypeSpecificOperation<T>& op);

--- a/src/ledger/LedgerHeaderUtils.cpp
+++ b/src/ledger/LedgerHeaderUtils.cpp
@@ -197,10 +197,13 @@ copyToStream(Database& db, soci::session& sess, uint32_t ledgerSeq,
 void
 dropAll(Database& db)
 {
+    std::string coll = db.getSimpleCollationClause();
+
     db.getSession() << "DROP TABLE IF EXISTS ledgerheaders;";
     db.getSession() << "CREATE TABLE ledgerheaders ("
-                       "ledgerhash      CHARACTER(64) PRIMARY KEY,"
-                       "prevhash        CHARACTER(64) NOT NULL,"
+                    << "ledgerhash      CHARACTER(64) " << coll
+                    << " PRIMARY KEY,"
+                    << "prevhash        CHARACTER(64) NOT NULL,"
                        "bucketlisthash  CHARACTER(64) NOT NULL,"
                        "ledgerseq       INT UNIQUE CHECK (ledgerseq >= 0),"
                        "closetime       BIGINT NOT NULL CHECK (closetime >= 0),"

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -459,11 +459,13 @@ LedgerTxnRoot::Impl::dropAccounts()
     mDatabase.getSession() << "DROP TABLE IF EXISTS accounts;";
     mDatabase.getSession() << "DROP TABLE IF EXISTS signers;";
 
+    std::string coll = mDatabase.getSimpleCollationClause();
+
     mDatabase.getSession()
         << "CREATE TABLE accounts"
-           "("
-           "accountid          VARCHAR(56)  PRIMARY KEY,"
-           "balance            BIGINT       NOT NULL CHECK (balance >= 0),"
+        << "("
+        << "accountid          VARCHAR(56)  " << coll << " PRIMARY KEY,"
+        << "balance            BIGINT       NOT NULL CHECK (balance >= 0),"
            "buyingliabilities  BIGINT CHECK (buyingliabilities >= 0),"
            "sellingliabilities BIGINT CHECK (sellingliabilities >= 0),"
            "seqnum             BIGINT       NOT NULL,"

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -278,12 +278,16 @@ LedgerTxnRoot::Impl::dropData()
     mEntryCache.clear();
     mBestOffersCache.clear();
 
+    std::string coll = mDatabase.getSimpleCollationClause();
+
     mDatabase.getSession() << "DROP TABLE IF EXISTS accountdata;";
     mDatabase.getSession() << "CREATE TABLE accountdata"
-                              "("
-                              "accountid    VARCHAR(56)  NOT NULL,"
-                              "dataname     VARCHAR(88)  NOT NULL,"
-                              "datavalue    VARCHAR(112) NOT NULL,"
+                           << "("
+                           << "accountid    VARCHAR(56) " << coll
+                           << " NOT NULL,"
+                           << "dataname     VARCHAR(88) " << coll
+                           << " NOT NULL,"
+                           << "datavalue    VARCHAR(112) NOT NULL,"
                               "lastmodified INT          NOT NULL,"
                               "PRIMARY KEY  (accountid, dataname)"
                               ");";

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -612,15 +612,17 @@ LedgerTxnRoot::Impl::dropOffers()
     mEntryCache.clear();
     mBestOffersCache.clear();
 
+    std::string coll = mDatabase.getSimpleCollationClause();
+
     mDatabase.getSession() << "DROP TABLE IF EXISTS offers;";
     mDatabase.getSession()
         << "CREATE TABLE offers"
-           "("
-           "sellerid         VARCHAR(56)      NOT NULL,"
-           "offerid          BIGINT           NOT NULL CHECK (offerid >= 0),"
-           "sellingasset     TEXT             NOT NULL,"
-           "buyingasset      TEXT             NOT NULL,"
-           "amount           BIGINT           NOT NULL CHECK (amount >= 0),"
+        << "("
+        << "sellerid         VARCHAR(56) " << coll << "NOT NULL,"
+        << "offerid          BIGINT           NOT NULL CHECK (offerid >= 0),"
+        << "sellingasset     TEXT " << coll << " NOT NULL,"
+        << "buyingasset      TEXT " << coll << " NOT NULL,"
+        << "amount           BIGINT           NOT NULL CHECK (amount >= 0),"
            "pricen           INT              NOT NULL,"
            "priced           INT              NOT NULL,"
            "price            DOUBLE PRECISION NOT NULL,"

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -400,15 +400,17 @@ LedgerTxnRoot::Impl::dropTrustLines()
     mEntryCache.clear();
     mBestOffersCache.clear();
 
+    std::string coll = mDatabase.getSimpleCollationClause();
+
     mDatabase.getSession() << "DROP TABLE IF EXISTS trustlines;";
     mDatabase.getSession()
         << "CREATE TABLE trustlines"
-           "("
-           "accountid    VARCHAR(56)     NOT NULL,"
-           "assettype    INT             NOT NULL,"
-           "issuer       VARCHAR(56)     NOT NULL,"
-           "assetcode    VARCHAR(12)     NOT NULL,"
-           "tlimit       BIGINT          NOT NULL CHECK (tlimit > 0),"
+        << "("
+        << "accountid    VARCHAR(56) " << coll << " NOT NULL,"
+        << "assettype    INT             NOT NULL,"
+        << "issuer       VARCHAR(56) " << coll << " NOT NULL,"
+        << "assetcode    VARCHAR(12) " << coll << " NOT NULL,"
+        << "tlimit       BIGINT          NOT NULL CHECK (tlimit > 0),"
            "balance      BIGINT          NOT NULL CHECK (balance >= 0),"
            "buyingliabilities BIGINT CHECK (buyingliabilities >= 0),"
            "sellingliabilities BIGINT CHECK (sellingliabilities >= 0),"


### PR DESCRIPTION
# Description

This is a more-or-less free perf win on postgresql: switch text-typed columns that participate in indexing (eg. primary keys) from default collation (which uses strcoll_l language-aware collation) to "C" byte-level collation. Cuts livenet bucket-apply / fast-catchup time from 5 minutes to 4 minutes on my workstation.

Perhaps surprisingly, the ALTER TABLE bit during schema upgrade doesn't take especially long, only a few seconds. I believe it causes a REINDEX which does something like a sequential page-by-page rebuild of the index btrees, the largest of which are like 700MB; but it's also possibly the case that it notices there's no actual moving-of-data to do, everything's already in the correct order? Anyway it does not seem like it's operationally dangerous to be doing as part of a normal schema upgrade.

I'll do some timings of tx latency tomorrow -- bucket-apply is probably the worst possible case, so I expect a less noticable win -- but I _expect_ this should be neutral-to-positive for basically all cases.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
