### PR TITLE
Bump sqlite page size to 64k.

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -366,6 +366,24 @@ Database::initialize()
     // normally you do not want to touch this section as
     // schema updates are done in applySchemaUpgrade
 
+    if (isSqlite() && mApp.getConfig().DATABASE.value != "sqlite3://:memory:")
+    {
+        // When we're in non-memory (i.e. "disk") mode of SQLite we want to bump
+        // up the page size to 64k (the maximum supported). On fast SSDs / NVMe
+        // this actually is a slight speed-loss, but it's a significant win on
+        // slow disks (spinning platters, low-IOPS EBS, etc.)
+        //
+        // To do this we need to disable journalling, adjust the page_size, then
+        // vacuum and re-enable journalling. NB: WAL mode is _ignored_ in memory
+        // mode, so it's important that this code not run in memory mode, it'll
+        // disable all journalling and silently _not_ re-enable it.
+
+        mSession << "PRAGMA journal_mode = OFF";
+        mSession << "PRAGMA page_size = 65536";
+        mSession << "VACUUM";
+        mSession << "PRAGMA journal_mode = WAL";
+    }
+
     // only time this section should be modified is when
     // consolidating changes found in applySchemaUpgrade here
     Upgrades::dropAll(*this);

--- a/src/database/test/DatabaseTests.cpp
+++ b/src/database/test/DatabaseTests.cpp
@@ -71,6 +71,15 @@ TEST_CASE("database smoketest", "[db]")
     transactionTest(app);
 }
 
+TEST_CASE("database on-disk smoketest", "[db]")
+{
+    Config const& cfg = getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE);
+
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+    transactionTest(app);
+}
+
 void
 checkMVCCIsolation(Application::pointer app)
 {


### PR DESCRIPTION
# Description

Another more-or-less free perf win, this time on sqlite: increase the page size to 64k. This is slightly slower on super-fast SSD / NVMe but significantly faster on anything that doesn't have those sweet near-instantaneous random reads. For example, here is a slow spinning disk:

~~~
=================================
4k pages:
=================================
         POI     Count  Duration    Min Duration    Avg Duration    Std Dev Duration    Max Duration
         All     2,975   45.28 s        25.44 µs        15.22 ms           218.51 ms         7.52 s
   tx::apply     2,929   10.30 s        25.44 µs         3.52 ms            45.92 ms         2.34 s
    prefetch        22   30.91 s        17.82 ms         1.41 s              2.08 s          7.52 s
   bulkApply        12    2.40 s         1.57 ms       199.81 ms           291.53 ms       899.49 ms
soci::commit        12    1.67 s       112.71 µs       139.40 ms           198.56 ms       488.54 ms

       State     Count  Duration    Min Duration    Avg Duration    Std Dev Duration    Max Duration
         All    59,777   48.11 s           99 ns       804.76 µs             4.22 ms       653.21 ms
     Running    24,391    5.01 s          523 ns       205.28 µs           631.42 µs        10.00 ms
     Blocked    10,993   42.09 s          634 ns         3.83 ms             6.77 ms       448.23 ms

=================================
64k pages:
=================================

         POI     Count  Duration    Min Duration    Avg Duration    Std Dev Duration    Max Duration
         All     2,975   32.25 s        24.50 µs        10.84 ms           152.16 ms         5.34 s
   tx::apply     2,929    7.76 s        24.50 µs         2.65 ms            30.13 ms         1.49 s
    prefetch        22   20.59 s        25.84 ms       935.76 ms             1.45 s          5.34 s
   bulkApply        12  909.07 ms        1.44 ms        75.76 ms           140.52 ms       456.46 ms
soci::commit        12    3.00 s       112.44 µs       249.62 ms           450.42 ms         1.25 s

       State     Count  Duration    Min Duration    Avg Duration    Std Dev Duration    Max Duration
         All    41,360   34.84 s           95 ns       842.33 µs             4.31 ms       516.10 ms
     Running    17,404    5.02 s          388 ns       288.40 µs           846.74 µs        10.17 ms
     Blocked     6,550   29.04 s          265 ns         4.43 ms             7.71 ms       163.17 ms
~~~

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
