### PR TITLE
ensure that operation level meta is cleared during an internal error

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -171,9 +171,10 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
     bool res = false;
     {
         LedgerTxn ltxTx(ltx);
+        TransactionMeta tm(2);
         try
         {
-            res = tx->apply(app, ltxTx);
+            res = tx->apply(app, ltxTx, tm);
         }
         catch (...)
         {
@@ -181,6 +182,10 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
         }
         REQUIRE((!res || tx->getResultCode() == txSUCCESS));
 
+        if (!res || tx->getResultCode() != txSUCCESS)
+        {
+            REQUIRE(tm.v2().operations.size() == 0);
+        }
         // checks that the failure is the same if pre checks failed
         if (!check)
         {


### PR DESCRIPTION
This PR fixes an issue in the meta generation when encountering `txINTERNAL_ERROR`:
for a transaction with more than one operation, the code was keeping meta for operations that succeeded before the operation that triggered the internal error, even though the actual changes were never committed.

Thanks @bartekn for the report