### PR TITLE
Remove accountbalances index, no longer used outside full replay.

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -235,6 +235,10 @@ Database::applySchemaUpgrade(unsigned long vers)
                      << "ALTER COLUMN assetcode "
                      << "TYPE VARCHAR(12) COLLATE \"C\"";
         }
+
+        // With inflation disabled, it's not worth keeping
+        // the accountbalances index around.
+        mSession << "DROP INDEX IF EXISTS accountbalances";
         break;
     default:
         throw std::runtime_error("Unknown DB schema version");

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -478,9 +478,6 @@ LedgerTxnRoot::Impl::dropAccounts()
            "signers            TEXT,"
            "lastmodified       INT          NOT NULL"
            ");";
-    mDatabase.getSession()
-        << "CREATE INDEX accountbalances ON accounts (balance) WHERE "
-           "balance >= 1000000000";
 }
 
 class BulkLoadAccountsOperation


### PR DESCRIPTION
This change removes the partial index on accounts.balance that indexed accounts with balances over 1000000000 stroops (100 XLM ~~ $5). This index existed to support running the inflation operation at low latency, which is no longer required as we never do it during live operation, only during full replay (when replaying ledgers from history, when inflation still existed).

During full replay, we run inflation only once every week of replay (~every 120,000 ledgers) and at least on my machine, even on a completely cold slow spinning disk with all caches dropped postgres only takes 15s to do a sequential scan of the accounts table (which is what it'll be doing to run inflation without the index); and 2s if it's warm / cached. So paying this scan cost once every 120k ledgers of replay will not be noticeable. We're not closing live ledgers to a slight latency hiccup is no big deal.

Conversely, removing this index means that postgres doesn't have to do index maintenance during updates to the accounts table and can get away with [HOT updates](https://github.com/postgres/postgres/blob/master/src/backend/access/heap/README.HOT). My measurements (on a relatively small 6400-ledger replay range) show it going from 1.27% HOT updates on the accounts table to 66.57%, and ... I _think_ speeding up a fair bit?

It's a very noisy signal: best-case runs are similar, but worst-case, means or medians look closer to twice as fast (tens of minutes faster) without the index. I expect reality is somewhere inbetween, but there's no sign of it going _slower_.

Anyway at current ledger it's over 28MB of index, the 3rd largest index in the DB after those on the primary keys of accounts and trustlines (and likely the most actively _churning_ index -- there are almost a million accounts with balances that high now). So I think it's worth axeing.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
