### PR TITLE
Os signposts

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -23,6 +23,7 @@
 #include "util/Algoritm.h"
 #include "util/Decoder.h"
 #include "util/Logging.h"
+#include "util/Signpost.h"
 #include "util/XDROperators.h"
 #include "util/XDRStream.h"
 #include "xdrpp/marshal.h"
@@ -667,6 +668,7 @@ bool
 TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
                         TransactionMeta& meta)
 {
+    STELLAR_SIGNPOST_INTERVAL_BEGIN("TransactionFrame::apply");
     mCachedAccount.reset();
     SignatureChecker signatureChecker{ltx.loadHeader().current().ledgerVersion,
                                       getContentsHash(), mEnvelope.signatures};
@@ -691,7 +693,9 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
         ltxTx.commit();
         valid = signaturesValid && (cv == ValidationType::kFullyValid);
     }
-    return valid && applyOperations(signatureChecker, app, ltx, meta);
+    bool ret = valid && applyOperations(signatureChecker, app, ltx, meta);
+    STELLAR_SIGNPOST_INTERVAL_END("TransactionFrame::apply");
+    return ret;
 }
 
 StellarMessage

--- a/src/util/FileSystemException.cpp
+++ b/src/util/FileSystemException.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/util/Signpost.cpp
+++ b/src/util/Signpost.cpp
@@ -1,0 +1,24 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/Signpost.h"
+
+#if defined(__APPLE__)
+
+namespace stellar
+{
+os_log_t signpostLogHandle = nullptr;
+
+void
+ensureSignpostLogHandle()
+{
+    if (!signpostLogHandle)
+    {
+        signpostLogHandle = os_log_create("org.stellar.core",
+                                          OS_LOG_CATEGORY_POINTS_OF_INTEREST);
+    }
+}
+}
+
+#endif

--- a/src/util/Signpost.h
+++ b/src/util/Signpost.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
@@ -28,7 +30,7 @@ do {                                                                    \
 
 #else
 
-#define STELLAR_SIGNPOST_INTERVAL_BEGIN(id, name) ((void)0)
-#define STELLAR_SIGNPOST_INTERVAL_END(id, name)  ((void)0)
+#define STELLAR_SIGNPOST_INTERVAL_BEGIN(name) ((void)0)
+#define STELLAR_SIGNPOST_INTERVAL_END(name)  ((void)0)
 
 #endif

--- a/src/util/Signpost.h
+++ b/src/util/Signpost.h
@@ -1,0 +1,34 @@
+// Copyright 2019 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+// This is a thin wrapper over Apple's os_signpost interface for noting
+// point-of-interest intervals in a performance profile.
+
+#if defined(__APPLE__)
+#include <os/log.h>
+#include <os/signpost.h>
+
+namespace stellar
+{
+extern os_log_t signpostLogHandle;
+void ensureSignpostLogHandle();
+}
+
+#define STELLAR_SIGNPOST_INTERVAL_BEGIN(name)                           \
+do {                                                                    \
+    stellar::ensureSignpostLogHandle();                                 \
+    os_signpost_interval_begin(stellar::signpostLogHandle,              \
+                               OS_SIGNPOST_ID_EXCLUSIVE, name);         \
+ } while(0)
+
+#define STELLAR_SIGNPOST_INTERVAL_END(name)                             \
+    os_signpost_interval_end(stellar::signpostLogHandle,                \
+                             OS_SIGNPOST_ID_EXCLUSIVE, name)            \
+
+#else
+
+#define STELLAR_SIGNPOST_INTERVAL_BEGIN(id, name) ((void)0)
+#define STELLAR_SIGNPOST_INTERVAL_END(id, name)  ((void)0)
+
+#endif


### PR DESCRIPTION
# Description

This adds some low-latency signposts to the transaction processing phases. These turn into short writes to the os_log subsystem on MacOS and are surfaced in Instruments.app, helping to show which parts of a profile do what.

They're no-ops on Linux or Windows.

Each signpost costs 1 syscall at about 10us. The finest-grain signpost in this PR is the transaction apply one; currently we're closing something like 100tx/ledger at something like 100ms; this would add 1ms to that close time. If that's still too much I can remove the inner per-tx signpost.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
