### PR TITLE
Improve logs and metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -74,7 +74,8 @@ overlay.delay.async-write                | timer     | time between each message
 overlay.delay.write-queue                | timer     | time between each message's entry and exit from peer write queue
 overlay.error.read                       | meter     | error while receiving a message
 overlay.error.write                      | meter     | error while sending a message
-overlay.fetch.item                       | timer     | time to complete fetching of an item (txset or qset)
+overlay.fetch.txset                      | timer     | time to complete fetching of a txset
+overlay.fetch.qset                       | timer     | time to complete fetching of a qset
 overlay.flood.broadcast                  | meter     | message sent as broadcast per peer
 overlay.flood.duplicate_recv             | meter     | number of bytes of flooded messages that have already been received
 overlay.flood.unique_recv                | meter     | number of bytes of flooded messages that have not yet been received

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -74,6 +74,7 @@ overlay.delay.async-write                | timer     | time between each message
 overlay.delay.write-queue                | timer     | time between each message's entry and exit from peer write queue
 overlay.error.read                       | meter     | error while receiving a message
 overlay.error.write                      | meter     | error while sending a message
+overlay.fetch.item                       | timer     | time to complete fetching of an item (txset or qset)
 overlay.flood.broadcast                  | meter     | message sent as broadcast per peer
 overlay.flood.duplicate_recv             | meter     | number of bytes of flooded messages that have already been received
 overlay.flood.unique_recv                | meter     | number of bytes of flooded messages that have not yet been received
@@ -102,7 +103,7 @@ scp.envelope.invalidsig                  | meter     | envelope failed signature
 scp.envelope.receive                     | meter     | SCP message received
 scp.envelope.sign                        | meter     | envelope signed
 scp.envelope.validsig                    | meter     | envelope signature verified
-scp.fetch.duration                       | timer     | time to complete fetching
+scp.fetch.envelope                       | timer     | time to complete fetching of an envelope
 scp.memory.cumulative-statements         | counter   | number of known SCP statements known
 scp.nomination.combinecandidates         | meter     | number of candidates per call
 scp.pending.discarded                    | counter   | number of discarded envelopes

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -41,6 +41,8 @@ PendingEnvelopes::PendingEnvelopes(Application& app, HerderImpl& herder)
           app.getMetrics().NewCounter({"scp", "pending", "fetching"}))
     , mReadyCount(app.getMetrics().NewCounter({"scp", "pending", "ready"}))
     , mFetchDuration(app.getMetrics().NewTimer({"scp", "fetch", "envelope"}))
+    , mFetchTxSetTimer(app.getMetrics().NewTimer({"overlay", "fetch", "txset"}))
+    , mFetchQsetTimer(app.getMetrics().NewTimer({"overlay", "fetch", "qset"}))
 {
 }
 
@@ -104,7 +106,7 @@ void
 PendingEnvelopes::addSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 {
     putQSet(hash, q);
-    mQuorumSetFetcher.recv(hash);
+    mQuorumSetFetcher.recv(hash, mFetchQsetTimer);
 }
 
 bool
@@ -215,7 +217,7 @@ PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
     CLOG(TRACE, "Herder") << "Add TxSet " << hexAbbrev(hash);
 
     putTxSet(hash, lastSeenSlotIndex, txset);
-    mTxSetFetcher.recv(hash);
+    mTxSetFetcher.recv(hash, mFetchTxSetTimer);
 }
 
 bool

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -67,6 +67,8 @@ class PendingEnvelopes
     medida::Counter& mFetchingCount;
     medida::Counter& mReadyCount;
     medida::Timer& mFetchDuration;
+    medida::Timer& mFetchTxSetTimer;
+    medida::Timer& mFetchQsetTimer;
 
     // discards all SCP envelopes thats use QSet with given hash,
     // as it is not sane QSet

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -132,7 +132,6 @@ ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
 void
 ItemFetcher::recv(Hash itemHash)
 {
-    CLOG(TRACE, "Overlay") << "Recv " << hexAbbrev(itemHash);
     const auto& iter = mTrackers.find(itemHash);
 
     if (iter != mTrackers.end())
@@ -151,6 +150,10 @@ ItemFetcher::recv(Hash itemHash)
         // stop the timer, stop requesting the item as we have it
         tracker->resetLastSeenSlotIndex();
         tracker->cancel();
+    }
+    else
+    {
+        CLOG(TRACE, "Overlay") << "Recv " << hexAbbrev(itemHash);
     }
 }
 }

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -130,7 +130,7 @@ ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
 }
 
 void
-ItemFetcher::recv(Hash itemHash)
+ItemFetcher::recv(Hash itemHash, medida::Timer& timer)
 {
     const auto& iter = mTrackers.find(itemHash);
 
@@ -143,6 +143,7 @@ ItemFetcher::recv(Hash itemHash)
         CLOG(TRACE, "Overlay")
             << "Recv " << hexAbbrev(itemHash) << " : " << tracker->size();
 
+        timer.Update(tracker->getDuration());
         while (!tracker->empty())
         {
             mApp.getHerder().recvSCPEnvelope(tracker->pop());

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -16,6 +16,7 @@
 namespace medida
 {
 class Counter;
+class Timer;
 }
 
 namespace stellar
@@ -89,7 +90,7 @@ class ItemFetcher : private NonMovableOrCopyable
      * added before with @see fetch and the same @p itemHash will be resent
      * to Herder, matching @see Tracker will be cleaned up.
      */
-    void recv(Hash itemHash);
+    void recv(Hash itemHash, medida::Timer& timer);
 
   protected:
     void stopFetchingBelowInternal(uint64 slotIndex);

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -169,8 +169,8 @@ class OverlayManager
 
     virtual bool isShuttingDown() const = 0;
 
-    virtual void recordDuplicateMessageMetric(StellarMessage const& stellarMsg,
-                                              Peer::pointer peer) = 0;
+    virtual void recordMessageMetric(StellarMessage const& stellarMsg,
+                                     Peer::pointer peer) = 0;
 
     virtual ~OverlayManager()
     {

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -85,8 +85,6 @@ class OverlayManagerImpl : public OverlayManager
 
     // NOTE: bool is used here as a placeholder, since no ValueType is needed.
     cache::lru_cache<uint64_t, bool> mMessageCache;
-    uint32_t mCheckPerfLogLevelCounter;
-    el::Level mPerfLogLevel;
 
     void tick();
     VirtualTimer mTimer;
@@ -149,8 +147,8 @@ class OverlayManagerImpl : public OverlayManager
 
     bool isShuttingDown() const override;
 
-    void recordDuplicateMessageMetric(StellarMessage const& stellarMsg,
-                                      Peer::pointer peer) override;
+    void recordMessageMetric(StellarMessage const& stellarMsg,
+                             Peer::pointer peer) override;
 
   private:
     struct ResolvedPeers

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -313,8 +313,8 @@ Peer::sendErrorAndDrop(ErrorCode error, std::string const& message,
     drop(message, DropDirection::WE_DROPPED_REMOTE, dropMode);
 }
 
-static std::string
-msgSummary(StellarMessage const& msg)
+std::string
+Peer::msgSummary(StellarMessage const& msg)
 {
     switch (msg.type())
     {
@@ -369,10 +369,12 @@ void
 Peer::sendMessage(StellarMessage const& msg)
 {
     if (Logging::logTrace("Overlay"))
+    {
         CLOG(TRACE, "Overlay")
             << "send: " << msgSummary(msg)
             << " to : " << mApp.getConfig().toShortString(mPeerID) << " @"
             << mApp.getConfig().PEER_PORT;
+    }
 
     switch (msg.type())
     {
@@ -528,12 +530,6 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
         return;
     }
 
-    if (Logging::logTrace("Overlay"))
-        CLOG(TRACE, "Overlay")
-            << "recv: " << msgSummary(stellarMsg)
-            << " from:" << mApp.getConfig().toShortString(mPeerID) << " @"
-            << mApp.getConfig().PEER_PORT;
-
     if (!isAuthenticated() && (stellarMsg.type() != HELLO) &&
         (stellarMsg.type() != AUTH) && (stellarMsg.type() != ERROR_MSG))
     {
@@ -546,8 +542,8 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
 
     assert(isAuthenticated() || stellarMsg.type() == HELLO ||
            stellarMsg.type() == AUTH || stellarMsg.type() == ERROR_MSG);
-    mApp.getOverlayManager().recordDuplicateMessageMetric(stellarMsg,
-                                                          shared_from_this());
+    mApp.getOverlayManager().recordMessageMetric(stellarMsg,
+                                                 shared_from_this());
 
     switch (stellarMsg.type())
     {

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -177,6 +177,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
         return mApp;
     }
 
+    static std::string msgSummary(StellarMessage const& stellarMsg);
     void sendGetTxSet(uint256 const& setID);
     void sendGetQuorumSet(uint256 const& setID);
     void sendGetPeers();

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -28,6 +28,7 @@ Tracker::Tracker(Application& app, Hash const& hash, AskPeer& askPeer)
     , mItemHash(hash)
     , mTryNextPeer(app.getMetrics().NewMeter(
           {"overlay", "item-fetcher", "next-peer"}, "item-fetcher"))
+    , mFetchTime("fetch-" + hexAbbrev(hash), LogSlowExecution::Mode::MANUAL)
 {
     assert(mAskPeer);
 }
@@ -198,5 +199,11 @@ Tracker::cancel()
 {
     mTimer.cancel();
     mLastSeenSlotIndex = 0;
+}
+
+std::chrono::milliseconds
+Tracker::getDuration()
+{
+    return mFetchTime.checkElapsedTime();
 }
 }

--- a/src/overlay/Tracker.h
+++ b/src/overlay/Tracker.h
@@ -21,6 +21,7 @@
  */
 
 #include "overlay/Peer.h"
+#include "util/LogSlowExecution.h"
 #include "util/Timer.h"
 #include "xdr/Stellar-types.h"
 
@@ -48,6 +49,7 @@ class Tracker
     Hash mItemHash;
     medida::Meter& mTryNextPeer;
     uint64 mLastSeenSlotIndex{0};
+    LogSlowExecution mFetchTime;
 
   public:
     /**
@@ -88,6 +90,11 @@ class Tracker
      * Pop envelope from stack.
      */
     SCPEnvelope pop();
+
+    /**
+     * Get duration since fetch start
+     */
+    std::chrono::milliseconds getDuration();
 
     /**
      * Called periodically to remove old envelopes from list (with ledger id

--- a/src/util/LogSlowExecution.h
+++ b/src/util/LogSlowExecution.h
@@ -19,7 +19,7 @@ class LogSlowExecution
 
     LogSlowExecution(
         std::string eventName, Mode mode = Mode::AUTOMATIC_RAII,
-        std::string message = "hung for",
+        std::string message = "took",
         std::chrono::milliseconds threshold = std::chrono::seconds(1))
         : mStart(std::chrono::system_clock::now())
         , mName(std::move(eventName))
@@ -43,7 +43,7 @@ class LogSlowExecution
             finish - mStart);
         auto tooSlow = elapsed > mThreshold;
 
-        LOG_IF(tooSlow, INFO)
+        CLOG_IF(tooSlow, INFO, "Perf")
             << "'" << mName << "' " << mMessage << " "
             << static_cast<float>(elapsed.count()) / 1000 << " s";
         return elapsed;

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -87,7 +87,7 @@ Logging::setFmt(std::string const& peerID, bool timestamps)
 
     gDefaultConf.setGlobally(el::ConfigurationType::Format, shortFmt);
     gDefaultConf.set(el::Level::Error, el::ConfigurationType::Format, longFmt);
-    gDefaultConf.set(el::Level::Trace, el::ConfigurationType::Format, longFmt);
+    gDefaultConf.set(el::Level::Trace, el::ConfigurationType::Format, shortFmt);
     gDefaultConf.set(el::Level::Fatal, el::ConfigurationType::Format, longFmt);
     el::Loggers::reconfigureAllLoggers(gDefaultConf);
 }


### PR DESCRIPTION
Main issue that I've encountered while running network simulations is our logs being too verbose but not very detailed at the same time. This PR attempts to make a few improvements (such as tracking life cycle of a txset, and consolidating info that used to take multiple logs in different places into a single log entry).

Also added a new metric to record duration of individual items being fetched: problem with `scp.fetch.duration` was that if we had outliers that for some reason got stuck, and then cleaned up, we never surfaced them. The ItemFetcher code is kind of messy (like we don't actually delete trackers right away, so I _think_ there might be some strange edge case where PendingEnvelopes reuses the same tracker object to fetch an item), but we can at least surface the outliers with this metric. 