### PR TITLE
Dump xdr to json

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -629,9 +629,11 @@ int
 runDumpXDR(CommandLineArgs const& args)
 {
     std::string xdr;
+    bool json = false;
+    auto jsonOption = clara::Opt{json}["--json"]("dump json");
 
-    return runWithHelp(args, {fileNameParser(xdr)}, [&] {
-        dumpXdrStream(xdr);
+    return runWithHelp(args, {jsonOption, fileNameParser(xdr)}, [&] {
+        dumpXdrStream(xdr, json);
         return 0;
     });
 }

--- a/src/main/dumpxdr.h
+++ b/src/main/dumpxdr.h
@@ -9,7 +9,7 @@
 namespace stellar
 {
 
-void dumpXdrStream(std::string const& filename);
+void dumpXdrStream(std::string const& filename, bool json);
 void printXdr(std::string const& filename, std::string const& filetype,
               bool base64);
 void signtxn(std::string const& filename, std::string netId, bool base64);

--- a/src/transactions/test/PathPaymentStrictSendTests.cpp
+++ b/src/transactions/test/PathPaymentStrictSendTests.cpp
@@ -47,25 +47,6 @@ rotateRight(std::deque<T>& d)
 }
 
 std::string
-assetToString(const Asset& asset)
-{
-    auto r = std::string{};
-    switch (asset.type())
-    {
-    case stellar::ASSET_TYPE_NATIVE:
-        r = std::string{"XLM"};
-        break;
-    case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
-        assetCodeToStr(asset.alphaNum4().assetCode, r);
-        break;
-    case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
-        assetCodeToStr(asset.alphaNum12().assetCode, r);
-        break;
-    }
-    return r;
-};
-
-std::string
 assetPathToString(const std::deque<Asset>& assets)
 {
     auto r = assetToString(assets[0]);

--- a/src/transactions/test/PathPaymentTests.cpp
+++ b/src/transactions/test/PathPaymentTests.cpp
@@ -52,25 +52,6 @@ rotateRight(std::deque<T>& d)
 }
 
 std::string
-assetToString(const Asset& asset)
-{
-    auto r = std::string{};
-    switch (asset.type())
-    {
-    case stellar::ASSET_TYPE_NATIVE:
-        r = std::string{"XLM"};
-        break;
-    case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
-        assetCodeToStr(asset.alphaNum4().assetCode, r);
-        break;
-    case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
-        assetCodeToStr(asset.alphaNum12().assetCode, r);
-        break;
-    }
-    return r;
-};
-
-std::string
 assetPathToString(const std::deque<Asset>& assets)
 {
     auto r = assetToString(assets[0]);

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -70,6 +70,25 @@ strToAssetCode(xdr::opaque_array<N>& ret, std::string const& str)
     std::copy(str.begin(), str.begin() + n, ret.begin());
 }
 
+inline std::string
+assetToString(const Asset& asset)
+{
+    auto r = std::string{};
+    switch (asset.type())
+    {
+    case stellar::ASSET_TYPE_NATIVE:
+        r = std::string{"XLM"};
+        break;
+    case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
+        assetCodeToStr(asset.alphaNum4().assetCode, r);
+        break;
+    case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
+        assetCodeToStr(asset.alphaNum12().assetCode, r);
+        break;
+    }
+    return r;
+};
+
 bool addBalance(int64_t& balance, int64_t delta,
                 int64_t maxBalance = std::numeric_limits<int64_t>::max());
 


### PR DESCRIPTION
This adds a new `--json` flag to `stellar-core dump-xdr` which can be useful if you want to actually process the XDR with some other tools. The existing textual dumps are nice to read but can't be processed by any other tools.

It includes a fix for the xdrpp submodule.

This change isn't perfect -- there's still one override I find a little dubious -- but it works well enough for our purposes.