### PR TITLE
Clarify location of folders and logging when testing

### DIFF
--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -107,10 +107,6 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         Config& thisConfig = *cfgs[instanceNumber];
         thisConfig.USE_CONFIG_FOR_GENESIS = true;
 
-        std::ostringstream sstream;
-
-        sstream << "stellar" << instanceNumber << ".log";
-        thisConfig.LOG_FILE_PATH = sstream.str();
         thisConfig.BUCKET_DIR_PATH = rootDir + "bucket";
 
         thisConfig.INVARIANT_CHECKS = {".*"};
@@ -248,12 +244,15 @@ runTest(CommandLineArgs const& args)
     // not mixed with stellar-core logging.
     Logging::setFmt("<test>");
     Logging::setLogLevel(logLevel, nullptr);
-    Config const& cfg = getTestConfig();
-    Logging::setLoggingToFile(cfg.LOG_FILE_PATH);
+    // use base instance for logging as we're guaranteed to not have conflicting
+    // instances of stellar-core running at the same time with the same base
+    // instance
+    auto logFile = fmt::format("stellar{}.log", gBaseInstance);
+    Logging::setLoggingToFile(logFile);
     Logging::setLogLevel(logLevel, nullptr);
 
     LOG(INFO) << "Testing stellar-core " << STELLAR_CORE_VERSION;
-    LOG(INFO) << "Logging to " << cfg.LOG_FILE_PATH;
+    LOG(INFO) << "Logging to " << logFile;
 
     if (gVersionsToTest.empty())
     {

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -97,8 +97,14 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
 
     if (!cfgs[instanceNumber])
     {
+        if (gTestRoots.empty())
+        {
+            gTestRoots.emplace_back(
+                fmt::format("stellar-core-test-{}", gBaseInstance));
+        }
+        auto const& testBase = gTestRoots[0].getName();
         gTestRoots.emplace_back(
-            fmt::format("stellar-core-test-{}", instanceNumber));
+            fmt::format("{}/test-{}", testBase, instanceNumber));
 
         std::string rootDir = gTestRoots.back().getName();
         rootDir += "/";

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -97,7 +97,8 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
 
     if (!cfgs[instanceNumber])
     {
-        gTestRoots.emplace_back("stellar-core-test");
+        gTestRoots.emplace_back(
+            fmt::format("stellar-core-test-{}", instanceNumber));
 
         std::string rootDir = gTestRoots.back().getName();
         rootDir += "/";
@@ -166,8 +167,7 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
             thisConfig.DISABLE_XDR_FSYNC = true;
             break;
         case Config::TESTDB_ON_DISK_SQLITE:
-            dbname << "sqlite3://" << rootDir << "test" << instanceNumber
-                   << ".db";
+            dbname << "sqlite3://" << rootDir << "test.db";
             break;
 #ifdef USE_POSTGRES
         case Config::TESTDB_POSTGRESQL:


### PR DESCRIPTION
There was some confusion in #2404 about the organization of the test folders.

This PR doesn't functionally do much other than add an extra hint in the temp folder name containing the instance number and makes it obvious that there is one test folder per base instance - but that there is only one log file per stellar-core instance.