### PR TITLE
IWYU bucket/* and related fallout

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -8,25 +8,22 @@
 #include "util/asio.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketApplicator.h"
-#include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketOutputIterator.h"
 #include "bucket/LedgerCmp.h"
 #include "bucket/MergeKey.h"
-#include "crypto/Hex.h"
-#include "crypto/Random.h"
-#include "crypto/SHA.h"
-#include "database/Database.h"
 #include "lib/util/format.h"
 #include "main/Application.h"
+#include "main/Config.h"
 #include "medida/timer.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
-#include "util/TmpDir.h"
-#include "util/XDRStream.h"
-#include "xdrpp/message.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
+#include <algorithm>
 #include <cassert>
-#include <future>
+#include <chrono>
+#include <stdexcept>
 
 namespace stellar
 {

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -4,12 +4,13 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "bucket/LedgerCmp.h"
-#include "crypto/Hex.h"
-#include "overlay/StellarXDR.h"
 #include "util/NonCopyable.h"
-#include "util/XDRStream.h"
+#include "xdr/Stellar-types.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace stellar
 {
@@ -27,8 +28,10 @@ namespace stellar
 
 class Application;
 class BucketManager;
+struct BucketEntry;
 class BucketList;
-class Database;
+struct LedgerEntry;
+struct LedgerKey;
 
 class Bucket : public std::enable_shared_from_this<Bucket>,
                public NonMovableOrCopyable

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -6,11 +6,11 @@
 #include "bucket/BucketApplicator.h"
 #include "bucket/Bucket.h"
 #include "ledger/LedgerTxn.h"
-#include "ledger/LedgerTxnEntry.h"
 #include "lib/util/format.h"
 #include "main/Application.h"
 #include "util/Logging.h"
-#include "util/types.h"
+#include <chrono>
+#include <stdexcept>
 
 namespace stellar
 {

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -4,16 +4,19 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "bucket/Bucket.h"
 #include "bucket/BucketInputIterator.h"
 #include "util/Timer.h"
-#include "util/XDRStream.h"
+#include <cstddef>
+#include <cstdint>
 #include <memory>
+#include <string>
 
 namespace stellar
 {
 
 class Application;
+class Bucket;
+struct BucketEntry;
 
 // Class that represents a single apply-bucket-to-database operation in
 // progress. Used during history catchup to split up the task of applying

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -4,6 +4,10 @@
 
 #include "bucket/BucketInputIterator.h"
 #include "bucket/Bucket.h"
+#include "util/Logging.h"
+#include <memory>
+#include <stdexcept>
+#include <string>
 
 namespace stellar
 {

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -4,10 +4,10 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "bucket/LedgerCmp.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
 
+#include <cstddef>
 #include <memory>
 
 namespace stellar

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -2,22 +2,24 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "BucketList.h"
+#include "bucket/BucketList.h"
 #include "bucket/Bucket.h"
-#include "bucket/BucketManager.h"
-#include "bucket/LedgerCmp.h"
-#include "crypto/Hex.h"
-#include "crypto/Random.h"
 #include "crypto/SHA.h"
 #include "main/Application.h"
+#include "main/Config.h"
 #include "util/Logging.h"
-#include "util/XDRStream.h"
 #include "util/format.h"
-#include "util/types.h"
+#include <array>
 #include <cassert>
+#include <limits>
+#include <memory>
+#include <stdexcept>
 
 namespace stellar
 {
+
+struct LedgerEntry;
+struct LedgerKey;
 
 BucketLevel::BucketLevel(uint32_t i)
     : mLevel(i)

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -5,9 +5,11 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "bucket/FutureBucket.h"
-#include "overlay/StellarXDR.h"
-#include "xdrpp/message.h"
-#include <future>
+#include "xdr/Stellar-types.h"
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <vector>
 
 namespace stellar
 {
@@ -295,6 +297,8 @@ namespace stellar
 
 class Application;
 class Bucket;
+struct LedgerEntry;
+struct LedgerKey;
 
 namespace testutil
 {

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -5,12 +5,13 @@
 #include "bucket/BucketManagerImpl.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketList.h"
+#include "bucket/FutureBucket.h"
 #include "crypto/Hex.h"
+#include "history/HistoryArchive.h"
 #include "history/HistoryManager.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
 #include "main/Config.h"
-#include "overlay/StellarXDR.h"
 #include "util/Fs.h"
 #include "util/GlobalChecks.h"
 #include "util/LogSlowExecution.h"
@@ -18,10 +19,22 @@
 #include "util/TmpDir.h"
 #include "util/format.h"
 #include "util/types.h"
-#include <fstream>
+#include "xdr/Stellar-ledger.h"
+
+#include <array>
+#include <cassert>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <exception>
+#include <iterator>
 #include <map>
 #include <regex>
 #include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
 
 #include "medida/counter.h"
 #include "medida/meter.h"
@@ -30,6 +43,8 @@
 
 namespace stellar
 {
+
+struct LedgerEntry;
 
 std::unique_ptr<BucketManager>
 BucketManager::create(Application& app)

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -1,15 +1,21 @@
 #pragma once
 
-#include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketMergeMap.h"
-#include "overlay/StellarXDR.h"
+#include "bucket/MergeKey.h"
+#include "xdr/Stellar-types.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <future>
 #include <map>
+#include <medida/timer.h>
 #include <memory>
 #include <mutex>
 #include <set>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
 // Copyright 2015 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
@@ -17,7 +23,6 @@
 
 namespace medida
 {
-class Timer;
 class Meter;
 class Counter;
 }
@@ -26,10 +31,14 @@ namespace stellar
 {
 
 class TmpDir;
+class TmpDirManager;
 class Application;
 class Bucket;
 class BucketList;
 struct HistoryArchiveState;
+struct LedgerEntry;
+struct LedgerHeader;
+struct LedgerKey;
 
 class BucketManagerImpl : public BucketManager
 {

--- a/src/bucket/BucketMergeMap.cpp
+++ b/src/bucket/BucketMergeMap.cpp
@@ -3,8 +3,14 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "bucket/BucketMergeMap.h"
+#include "bucket/MergeKey.h"
 #include "crypto/Hex.h"
+#include "util/HashOfHash.h"
 #include "util/Logging.h"
+#include <array>
+#include <cassert>
+#include <utility>
+#include <xdrpp/types.h>
 
 namespace
 {

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -5,7 +5,14 @@
 #include "bucket/BucketOutputIterator.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketManager.h"
+#include "crypto/Hex.h"
 #include "crypto/Random.h"
+#include "util/Logging.h"
+#include <algorithm>
+#include <cassert>
+#include <cstdio>
+#include <ios>
+#include <stdexcept>
 
 namespace stellar
 {

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -4,11 +4,12 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "bucket/BucketManager.h"
 #include "bucket/LedgerCmp.h"
+#include "crypto/SHA.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -17,6 +18,8 @@ namespace stellar
 
 class Bucket;
 class BucketManager;
+struct MergeCounters;
+struct MergeKey;
 
 // Helper class that writes new elements to a file and returns a bucket
 // when finished.

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -14,14 +14,23 @@
 #include "bucket/MergeKey.h"
 #include "crypto/Hex.h"
 #include "main/Application.h"
+#include "main/Config.h"
 #include "main/ErrorMessages.h"
 #include "util/LogSlowExecution.h"
 #include "util/Logging.h"
 #include "util/format.h"
+#include "xdr/Stellar-types.h"
 
-#include "medida/metrics_registry.h"
+#include <medida/metrics_registry.h>
+#include <medida/timer.h>
+#include <medida/timer_context.h>
 
+#include <algorithm>
+#include <array>
 #include <chrono>
+#include <cstddef>
+#include <exception>
+#include <functional>
 
 namespace stellar
 {

--- a/src/bucket/FutureBucket.h
+++ b/src/bucket/FutureBucket.h
@@ -4,10 +4,12 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "overlay/StellarXDR.h"
+#include <cassert>
 #include <cereal/cereal.hpp>
+#include <cstdint>
 #include <future>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/src/bucket/MergeKey.cpp
+++ b/src/bucket/MergeKey.cpp
@@ -3,8 +3,12 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "bucket/MergeKey.h"
+#include "bucket/Bucket.h"
 #include "crypto/Hex.h"
+#include <array>
+#include <memory>
 #include <sstream>
+#include <string>
 
 namespace stellar
 {

--- a/src/bucket/MergeKey.h
+++ b/src/bucket/MergeKey.h
@@ -3,14 +3,17 @@
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
-#include "bucket/Bucket.h"
 #include "xdr/Stellar-types.h"
-#include <cstdint>
 #include <iosfwd>
+#include <memory>
+#include <system_error>
 #include <vector>
 
 namespace stellar
 {
+
+class Bucket;
+
 // Key type for cache of merges-in-progress. These only exist to enable
 // re-attaching a deserialized FutureBucket to a std::shared_future, or (if the
 // merge is finished and has been promoted to a live bucket) to identify which

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -14,19 +14,40 @@
 #include "bucket/BucketInputIterator.h"
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
-#include "bucket/BucketOutputIterator.h"
 #include "bucket/BucketTests.h"
+#include "bucket/FutureBucket.h"
+#include "crypto/Hex.h"
+#include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/Config.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/Logging.h"
 #include "util/Math.h"
 #include "util/Timer.h"
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
 #include "xdrpp/autocheck.h"
 
+#include <algorithm>
+#include <autocheck/generator.hpp>
+#include <cstddef>
+#include <cstdint>
 #include <deque>
+#include <functional>
+#include <future>
+#include <iomanip>
+#include <limits>
+#include <medida/timer.h>
+#include <memory>
+#include <random>
+#include <set>
 #include <sstream>
+#include <string>
+#include <system_error>
+#include <vector>
 
 using namespace stellar;
 using namespace BucketTests;

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -12,22 +12,55 @@
 #include "util/asio.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketInputIterator.h"
+#include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketManagerImpl.h"
 #include "bucket/BucketTests.h"
+#include "bucket/FutureBucket.h"
+#include "crypto/Hex.h"
+#include "crypto/SecretKey.h"
+#include "herder/LedgerCloseData.h"
+#include "herder/TxSetFrame.h"
+#include "history/HistoryArchive.h"
 #include "history/HistoryArchiveManager.h"
+#include "history/HistoryManager.h"
+#include "history/test/HistoryTestsUtils.h"
+#include "ledger/LedgerManager.h"
+#include "ledger/LedgerManagerImpl.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
+#include "main/ApplicationImpl.h"
 #include "main/Config.h"
 #include "main/ExternalQueue.h"
+#include "overlay/StellarXDR.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/Fs.h"
+#include "util/Logging.h"
 #include "util/Math.h"
 #include "util/Timer.h"
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
+#include "xdr/Stellar-types.h"
 
+#include <array>
+#include <chrono>
+#include <condition_variable>
 #include <cstdio>
+#include <iostream>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 using namespace stellar;
 using namespace BucketTests;

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -2,13 +2,28 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/Bucket.h"
 #include "bucket/BucketMergeMap.h"
 #include "bucket/BucketTests.h"
+#include "bucket/MergeKey.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
+#include "main/Config.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/Timer.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
+#include "xdr/Stellar-types.h"
+
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <set>
+#include <unordered_set>
+#include <vector>
+#include <xdrpp/types.h>
 
 using namespace stellar;
 

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -14,17 +14,36 @@
 #include "bucket/BucketTests.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketInputIterator.h"
+#include "bucket/BucketManager.h"
+#include "bucket/BucketOutputIterator.h"
+#include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
+#include "main/Config.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
 #include "util/Math.h"
 #include "util/Timer.h"
+#include "util/types.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
+#include "xdr/Stellar-types.h"
 #include "xdrpp/autocheck.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 using namespace stellar;
 

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -6,9 +6,18 @@
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
 #include "catchup/ApplyLedgerWork.h"
+#include "crypto/Hex.h"
+#include "herder/LedgerCloseData.h"
+#include "herder/TxSetFrame.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
+#include "util/Logging.h"
+#include "work/ConditionalWork.h"
 
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <string>
 #include <util/format.h>
 
 namespace stellar

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "bucket/BucketInputIterator.h"
+#include "bucket/BucketManager.h"
 #include "bucket/BucketTests.h"
 #include "herder/Herder.h"
 #include "herder/LedgerCloseData.h"

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -5,6 +5,7 @@
 #include "invariant/BucketListIsConsistentWithDatabase.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketInputIterator.h"
+#include "bucket/LedgerCmp.h"
 #include "crypto/Hex.h"
 #include "invariant/InvariantManager.h"
 #include "ledger/LedgerRange.h"

--- a/src/util/HashOfHash.cpp
+++ b/src/util/HashOfHash.cpp
@@ -1,5 +1,7 @@
 #include "HashOfHash.h"
+#include "crypto/ByteSlice.h"
 #include "crypto/ShortHash.h"
+#include "xdr/Stellar-types.h"
 
 namespace std
 {

--- a/src/util/HashOfHash.h
+++ b/src/util/HashOfHash.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <cstddef>
+#include <unordered_map>
 #include <xdr/Stellar-types.h>
 
 namespace std


### PR DESCRIPTION
An initial run + manual application of the suggestions of [IWYU ("include what you use")](https://include-what-you-use.org/) on the bucket directory.

IWYU follows a simple rule that does cause more includes (typically) to need to be listed explicitly in .cpp files, but the goal is to cut down the cross-inclusion of .h files, thus limiting the number of compilation units that get rebuilt when you touch any given file. You can't _entirely_ do it directory-at-a-time but you can do "a set of files plus the transitive effects in others", which is not _so_ bad if you try to go bottom-up.

Posting for discussion but also, if doing this (even in pieces) is agreeable, ~a request to merge this one piece: it'll likely bitrot pretty quickly~. I am happy to do a few of these and/or show others how to do it and/or post the IWYU output I got from my own run here so you can just work from what it says to do. Its suggestions are mostly correct, if occasionally stylistically off a bit.

EDIT: actually I want to work on automating this a little more before we merge it. But I'd appreciate any initial thoughts as it'll be a big bulk-edit in any case, and there's no point doing it if everyone hates it.