### PR TITLE
Ignore any archive write commands in simulation mode

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -937,6 +937,8 @@ runSimulate(CommandLineArgs const& args)
         [&] {
             auto config = configOption.getConfig();
             config.setNoListen();
+            LOG(INFO) << "Publishing is disabled in `simulate` mode";
+            config.setNoPublish();
 
             VirtualClock clock(VirtualClock::REAL_TIME);
             auto app = Application::create(clock, config, false);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1436,6 +1436,15 @@ Config::setNoListen()
     MANUAL_CLOSE = true;
 }
 
+void
+Config::setNoPublish()
+{
+    for (auto& item : HISTORY)
+    {
+        item.second.mPutCmd = "";
+    }
+}
+
 SCPQuorumSet
 Config::generateQuorumSetHelper(
     std::vector<ValidatorEntry>::const_iterator begin,

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -399,6 +399,7 @@ class Config : public std::enable_shared_from_this<Config>
 
     void logBasicInfo();
     void setNoListen();
+    void setNoPublish();
 
     // function to stringify a quorum set
     std::string toString(SCPQuorumSet const& qset);


### PR DESCRIPTION
After discussing a bit with @jonjove, it looks like it makes sense to skip publishing in tx simulation mode, since its unclear how to interpret its performance impact given that we are not closing 5-second ledgers (publish during catchup tends to fall behind anyway). It is also a bit too easy to publish to an archive by mistake right now, so I suggest we avoid publishing, and if in the future we can always add a flag like `--publish` if we want to test that. If we go this route, this should also resolve https://github.com/stellar/stellar-core/issues/2196