### PR TITLE
Add timers for queueing delays from send queue and asio queue.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -70,6 +70,8 @@ overlay.byte.read                        | meter     | number of bytes received
 overlay.byte.write                       | meter     | number of bytes sent
 overlay.connection.authenticated         | counter   | number of authenticated peers
 overlay.connection.pending               | counter   | number of pending connections
+overlay.delay.async-write                | timer     | time between each message's async write issue and completion
+overlay.delay.write-queue                | timer     | time between each message's entry and exit from peer write queue
 overlay.error.read                       | meter     | error while receiving a message
 overlay.error.write                      | meter     | error while sending a message
 overlay.flood.broadcast                  | meter     | message sent as broadcast per peer

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -61,6 +61,11 @@ OverlayMetrics::OverlayMetrics(Application& app)
     , mRecvSurveyResponseTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "survey-response"}))
 
+    , mMessageDelayInWriteQueueTimer(
+          app.getMetrics().NewTimer({"overlay", "delay", "write-queue"}))
+    , mMessageDelayInAsyncWriteTimer(
+          app.getMetrics().NewTimer({"overlay", "delay", "async-write"}))
+
     , mSendErrorMeter(
           app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))
     , mSendHelloMeter(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -55,6 +55,9 @@ struct OverlayMetrics
     medida::Timer& mRecvSurveyRequestTimer;
     medida::Timer& mRecvSurveyResponseTimer;
 
+    medida::Timer& mMessageDelayInWriteQueueTimer;
+    medida::Timer& mMessageDelayInAsyncWriteTimer;
+
     medida::Meter& mSendErrorMeter;
     medida::Meter& mSendHelloMeter;
     medida::Meter& mSendAuthMeter;

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -26,11 +26,20 @@ class TCPPeer : public Peer
     typedef asio::buffered_stream<asio::ip::tcp::socket> SocketType;
 
   private:
+    struct TimestampedMessage
+    {
+        VirtualClock::time_point mEnqueuedTime;
+        VirtualClock::time_point mIssuedTime;
+        VirtualClock::time_point mCompletedTime;
+        void recordWriteTiming(OverlayMetrics& metrics);
+        xdr::msg_ptr mMessage;
+    };
+
     std::shared_ptr<SocketType> mSocket;
     std::vector<uint8_t> mIncomingHeader;
     std::vector<uint8_t> mIncomingBody;
 
-    std::queue<std::shared_ptr<xdr::msg_ptr>> mWriteQueue;
+    std::queue<std::shared_ptr<TimestampedMessage>> mWriteQueue;
     bool mWriting{false};
     bool mDelayedShutdown{false};
     bool mShutdownScheduled{false};


### PR DESCRIPTION
This adds two new timers that track the amount of time outgoing messages are delayed due to queueing in our TCPPeer class' internal queue and then again in ASIO between write-issue and completion.