### PR TITLE
Do not alter collation on the ledgerheaders.ledgerhash column, not worthwhile.

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -212,10 +212,6 @@ Database::applySchemaUpgrade(unsigned long vers)
                      << "ALTER COLUMN accountid "
                      << "TYPE VARCHAR(56) COLLATE \"C\"";
 
-            mSession << "ALTER TABLE ledgerheaders "
-                     << "ALTER COLUMN ledgerhash "
-                     << "TYPE CHARACTER(64) COLLATE \"C\"";
-
             mSession << "ALTER TABLE accountdata "
                      << "ALTER COLUMN accountid "
                      << "TYPE VARCHAR(56) COLLATE \"C\", "


### PR DESCRIPTION
This backs off very slightly on the change introduced in https://github.com/stellar/stellar-core/pull/2378 where we ALTERed the collation on all columns that use hashes as primary keys. Specifically it removes the alteration on ledgerheaders.ledgerhash, which we do not query at especially high speed, but that (on nodes with full history) can be quite enormous: we saw a 200 second ALTER TABLE on a 600GB database with full history. This doesn't seem like it's worth the cost of upgrading.

Note that doing (or not doing) this upgrade has no effect on semantics of queries we actually issue -- schema is compatible and queries all compare/execute identically with either collation. So if a peer _did_ upgrade using one of the earlier release candidates, it's no big deal either.