### PR TITLE
Prioritize write traffic

### DIFF
--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -13,6 +13,10 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewMeter({"overlay", "message", "read"}, "message"))
     , mMessageWrite(
           app.getMetrics().NewMeter({"overlay", "message", "write"}, "message"))
+    , mAsyncRead(
+          app.getMetrics().NewMeter({"overlay", "async", "read"}, "call"))
+    , mAsyncWrite(
+          app.getMetrics().NewMeter({"overlay", "async", "write"}, "call"))
     , mByteRead(app.getMetrics().NewMeter({"overlay", "byte", "read"}, "byte"))
     , mByteWrite(
           app.getMetrics().NewMeter({"overlay", "byte", "write"}, "byte"))

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -65,10 +65,14 @@ OverlayMetrics::OverlayMetrics(Application& app)
     , mRecvSurveyResponseTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "survey-response"}))
 
-    , mMessageDelayInWriteQueueTimer(
-          app.getMetrics().NewTimer({"overlay", "delay", "write-queue"}))
-    , mMessageDelayInAsyncWriteTimer(
-          app.getMetrics().NewTimer({"overlay", "delay", "async-write"}))
+    , mMessageDelayInFetchWriteQueueTimer(
+          app.getMetrics().NewTimer({"overlay", "fetch", "delay-write-queue"}))
+    , mMessageDelayInFloodWriteQueueTimer(
+          app.getMetrics().NewTimer({"overlay", "flood", "delay-write-queue"}))
+    , mMessageDelayInFetchAsyncWriteTimer(
+          app.getMetrics().NewTimer({"overlay", "fetch", "delay-async-write"}))
+    , mMessageDelayInFloodAsyncWriteTimer(
+          app.getMetrics().NewTimer({"overlay", "flood", "delay-async-write"}))
 
     , mSendErrorMeter(
           app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -26,6 +26,8 @@ struct OverlayMetrics
     OverlayMetrics(Application& app);
     medida::Meter& mMessageRead;
     medida::Meter& mMessageWrite;
+    medida::Meter& mAsyncRead;
+    medida::Meter& mAsyncWrite;
     medida::Meter& mByteRead;
     medida::Meter& mByteWrite;
     medida::Meter& mErrorRead;

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -57,8 +57,10 @@ struct OverlayMetrics
     medida::Timer& mRecvSurveyRequestTimer;
     medida::Timer& mRecvSurveyResponseTimer;
 
-    medida::Timer& mMessageDelayInWriteQueueTimer;
-    medida::Timer& mMessageDelayInAsyncWriteTimer;
+    medida::Timer& mMessageDelayInFetchWriteQueueTimer;
+    medida::Timer& mMessageDelayInFloodWriteQueueTimer;
+    medida::Timer& mMessageDelayInFetchAsyncWriteTimer;
+    medida::Timer& mMessageDelayInFloodAsyncWriteTimer;
 
     medida::Meter& mSendErrorMeter;
     medida::Meter& mSendHelloMeter;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -53,7 +53,7 @@ Peer::Peer(Application& app, PeerRole role)
     , mIdleTimer(app)
     , mLastRead(app.getClock().now())
     , mLastWrite(app.getClock().now())
-    , mLastEmpty(app.getClock().now())
+    , mEnqueueTimeOfLastWrite(app.getClock().now())
     , mPeerMetrics(app.getClock().now())
 {
     auto bytes = randomBytes(mSendNonce.size());
@@ -210,7 +210,7 @@ Peer::idleTimerExpired(asio::error_code const& error)
             drop("idle timeout", Peer::DropDirection::WE_DROPPED_REMOTE,
                  Peer::DropMode::IGNORE_WRITE_QUEUE);
         }
-        else if (((now - mLastEmpty) >= stragglerTimeout))
+        else if (((now - mEnqueueTimeOfLastWrite) >= stragglerTimeout))
         {
             getOverlayMetrics().mTimeoutStraggler.Mark();
             drop("straggling (cannot keep up)",

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -490,7 +490,7 @@ Peer::sendMessage(StellarMessage const& msg)
         break;
     case TRANSACTION:
         getOverlayMetrics().mSendTransactionMeter.Mark();
-        priority = Peer::MessagePriority::FETCH_PRIORITY;
+        priority = Peer::MessagePriority::FLOOD_PRIORITY;
         break;
     case GET_SCP_QUORUMSET:
         getOverlayMetrics().mSendGetSCPQuorumSetMeter.Mark();

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -374,6 +374,8 @@ Peer::sendMessage(StellarMessage const& msg)
             << " to : " << mApp.getConfig().toShortString(mPeerID) << " @"
             << mApp.getConfig().PEER_PORT;
 
+    auto priority = Peer::MessagePriority::TOP_PRIORITY;
+
     switch (msg.type())
     {
     case ERROR_MSG:
@@ -402,6 +404,7 @@ Peer::sendMessage(StellarMessage const& msg)
         break;
     case TRANSACTION:
         getOverlayMetrics().mSendTransactionMeter.Mark();
+        priority = Peer::MessagePriority::TOP_PRIORITY;
         break;
     case GET_SCP_QUORUMSET:
         getOverlayMetrics().mSendGetSCPQuorumSetMeter.Mark();
@@ -433,7 +436,7 @@ Peer::sendMessage(StellarMessage const& msg)
         ++mSendMacSeq;
     }
     xdr::msg_ptr xdrBytes(xdr::xdr_to_msg(amsg));
-    this->sendMessage(std::move(xdrBytes));
+    this->sendMessage(std::move(xdrBytes), priority);
 }
 
 void

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -64,6 +64,14 @@ class Peer : public std::enable_shared_from_this<Peer>,
         WE_DROPPED_REMOTE
     };
 
+    enum class MessagePriority
+    {
+        // At the moment we only have a two-priority-level queueing system; we
+        // might have more priorities later but this should be enough.
+        TOP_PRIORITY,
+        LOW_PRIORITY
+    };
+
     struct PeerMetrics
     {
         PeerMetrics(VirtualClock::time_point connectedTime);
@@ -153,7 +161,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // put in a reused/non-owned buffer without having to buffer/queue
     // messages somewhere else. The async write request will point _into_
     // this owned buffer. This is really the best we can do.
-    virtual void sendMessage(xdr::msg_ptr&& xdrBytes) = 0;
+    virtual void sendMessage(xdr::msg_ptr&& xdrBytes,
+                             MessagePriority priority) = 0;
     virtual void
     connected()
     {

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -98,7 +98,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
         VirtualClock::time_point mEnqueuedTime;
         VirtualClock::time_point mIssuedTime;
         VirtualClock::time_point mCompletedTime;
-        void recordWriteTiming(OverlayMetrics& metrics);
+        void recordWriteTiming(OverlayMetrics& metrics,
+                               MessagePriority priority);
         xdr::msg_ptr mMessage;
     };
 
@@ -184,6 +185,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void enqueueMessage(xdr::msg_ptr&& xdrBytes, MessagePriority priority);
     bool anyWriteQueueReady();
     std::deque<std::shared_ptr<TimestampedMessage>>& getNextWriteQueue();
+    MessagePriority
+    queuePriority(std::deque<std::shared_ptr<TimestampedMessage>> const&) const;
 
     virtual AuthCert getAuthCert();
 

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -252,7 +252,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     virtual void connectHandler(asio::error_code const& ec);
 
     virtual void
-    writeHandler(asio::error_code const& error, size_t bytes_transferred)
+    writeHandler(asio::error_code const& error, size_t bytes_transferred,
+                 size_t messages_transferred)
     {
     }
 

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -68,8 +68,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     {
         // At the moment we only have a two-priority-level queueing system; we
         // might have more priorities later but this should be enough.
-        TOP_PRIORITY,
-        LOW_PRIORITY
+        FETCH_PRIORITY,
+        FLOOD_PRIORITY
     };
 
     struct PeerMetrics
@@ -130,8 +130,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     PeerMetrics mPeerMetrics;
 
-    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueTopPriority;
-    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueLowPriority;
+    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueFetchPriority;
+    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueFloodPriority;
     size_t mNextWriteQueue{0};
 
     OverlayMetrics& getOverlayMetrics();

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -126,7 +126,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     VirtualTimer mIdleTimer;
     VirtualClock::time_point mLastRead;
     VirtualClock::time_point mLastWrite;
-    VirtualClock::time_point mLastEmpty;
+    VirtualClock::time_point mEnqueueTimeOfLastWrite;
 
     PeerMetrics mPeerMetrics;
 

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -57,8 +57,8 @@ PeerDoor::acceptNextPeer()
     }
 
     CLOG(DEBUG, "Overlay") << "PeerDoor acceptNextPeer()";
-    auto sock = make_shared<TCPPeer::SocketType>(
-        mApp.getClock().getIOContext(), TCPPeer::BUFSZ, TCPPeer::BUFSZ);
+    auto sock = make_shared<TCPPeer::SocketType>(mApp.getClock().getIOContext(),
+                                                 TCPPeer::BUFSZ);
     mAcceptor.async_accept(sock->next_layer(),
                            [this, sock](asio::error_code const& ec) {
                                if (ec)

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -57,8 +57,8 @@ PeerDoor::acceptNextPeer()
     }
 
     CLOG(DEBUG, "Overlay") << "PeerDoor acceptNextPeer()";
-    auto sock =
-        make_shared<TCPPeer::SocketType>(mApp.getClock().getIOContext());
+    auto sock = make_shared<TCPPeer::SocketType>(
+        mApp.getClock().getIOContext(), TCPPeer::BUFSZ, TCPPeer::BUFSZ);
     mAcceptor.async_accept(sock->next_layer(),
                            [this, sock](asio::error_code const& ec) {
                                if (ec)

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -234,7 +234,6 @@ TCPPeer::messageSender()
     // if nothing to do, mark progress and return.
     if (!anyWriteQueueReady())
     {
-        mLastEmpty = mApp.getClock().now();
         self->mWriting = false;
         // there is nothing to send and delayed shutdown was
         // requested - time to perform it
@@ -259,6 +258,7 @@ TCPPeer::messageSender()
     assert(mWriteBuffers.empty());
     auto now = mApp.getClock().now();
     size_t expected_length = 0;
+    mEnqueueTimeOfLastWrite = writeQueue.back()->mEnqueuedTime;
     for (auto& tsm : writeQueue)
     {
         tsm->mIssuedTime = now;

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -290,7 +290,8 @@ TCPPeer::messageSender()
             while (!self->mWriteBuffers.empty())
             {
                 (*i)->mCompletedTime = now;
-                (*i)->recordWriteTiming(self->getOverlayMetrics());
+                (*i)->recordWriteTiming(self->getOverlayMetrics(),
+                                        self->queuePriority(writeQueue));
                 ++i;
                 self->mWriteBuffers.pop_back();
             }
@@ -305,17 +306,6 @@ TCPPeer::messageSender()
                 self->messageSender();
             }
         });
-}
-
-void
-TCPPeer::TimestampedMessage::recordWriteTiming(OverlayMetrics& metrics)
-{
-    auto qdelay = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        mIssuedTime - mEnqueuedTime);
-    auto wdelay = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        mCompletedTime - mIssuedTime);
-    metrics.mMessageDelayInWriteQueueTimer.Update(qdelay);
-    metrics.mMessageDelayInAsyncWriteTimer.Update(wdelay);
 }
 
 void

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -41,13 +41,15 @@ class TCPPeer : public Peer
     std::vector<uint8_t> mIncomingBody;
 
     std::vector<asio::mutable_buffer> mWriteBuffers;
-    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueue;
+    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueTopPriority;
+    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueLowPriority;
     bool mWriting{false};
     bool mDelayedShutdown{false};
     bool mShutdownScheduled{false};
 
     void recvMessage();
-    void sendMessage(xdr::msg_ptr&& xdrBytes) override;
+    void sendMessage(xdr::msg_ptr&& xdrBytes,
+                     MessagePriority priority) override;
 
     void messageSender();
 

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -37,7 +37,7 @@ class TCPPeer : public Peer
     bool mShutdownScheduled{false};
 
     void recvMessage();
-    void sendMessage(xdr::msg_ptr&& xdrBytes,
+    void sendMessage(StellarMessage const& smsg,
                      MessagePriority priority) override;
 
     void messageSender();

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -27,22 +27,11 @@ class TCPPeer : public Peer
     static constexpr size_t BUFSZ = 0x100000; // 1MB
 
   private:
-    struct TimestampedMessage
-    {
-        VirtualClock::time_point mEnqueuedTime;
-        VirtualClock::time_point mIssuedTime;
-        VirtualClock::time_point mCompletedTime;
-        void recordWriteTiming(OverlayMetrics& metrics);
-        xdr::msg_ptr mMessage;
-    };
-
     std::shared_ptr<SocketType> mSocket;
     std::vector<uint8_t> mIncomingHeader;
     std::vector<uint8_t> mIncomingBody;
 
     std::vector<asio::mutable_buffer> mWriteBuffers;
-    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueTopPriority;
-    std::deque<std::shared_ptr<TimestampedMessage>> mWriteQueueLowPriority;
     bool mWriting{false};
     bool mDelayedShutdown{false};
     bool mShutdownScheduled{false};

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -24,6 +24,7 @@ class TCPPeer : public Peer
 {
   public:
     typedef asio::buffered_stream<asio::ip::tcp::socket> SocketType;
+    static constexpr size_t BUFSZ = 0x100000; // 1MB
 
   private:
     struct TimestampedMessage

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -267,19 +267,19 @@ LoopbackPeer::deliverAll()
 void
 LoopbackPeer::dropAll()
 {
-    mWriteQueueTopPriority.clear();
-    mWriteQueueLowPriority.clear();
+    mWriteQueueFetchPriority.clear();
+    mWriteQueueFloodPriority.clear();
 }
 
 size_t
 LoopbackPeer::getBytesQueued() const
 {
     size_t t = 0;
-    for (auto const& m : mWriteQueueTopPriority)
+    for (auto const& m : mWriteQueueFetchPriority)
     {
         t += m->mMessage->raw_size();
     }
-    for (auto const& m : mWriteQueueLowPriority)
+    for (auto const& m : mWriteQueueFloodPriority)
     {
         t += m->mMessage->raw_size();
     }
@@ -289,7 +289,7 @@ LoopbackPeer::getBytesQueued() const
 size_t
 LoopbackPeer::getMessagesQueued() const
 {
-    return (mWriteQueueTopPriority.size() + mWriteQueueLowPriority.size());
+    return (mWriteQueueFetchPriority.size() + mWriteQueueFloodPriority.size());
 }
 
 LoopbackPeer::Stats const&
@@ -313,8 +313,8 @@ LoopbackPeer::setCorked(bool c)
 void
 LoopbackPeer::clearInAndOutQueues()
 {
-    mWriteQueueTopPriority.clear();
-    mWriteQueueLowPriority.clear();
+    mWriteQueueFetchPriority.clear();
+    mWriteQueueFloodPriority.clear();
     mInQueue = std::queue<xdr::msg_ptr>();
 }
 

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -230,6 +230,8 @@ LoopbackPeer::deliverOne()
         size_t nBytes = msg->mMessage->raw_size();
         mStats.bytesDelivered += nBytes;
 
+        mEnqueueTimeOfLastWrite = msg->mEnqueuedTime;
+
         // Pass ownership of a serialized XDR message buffer to a recvMesage
         // callback event against the remote Peer, posted on the remote
         // Peer's io_context.
@@ -244,10 +246,6 @@ LoopbackPeer::deliverOne()
         }
         LoadManager::PeerContext loadCtx(mApp, mPeerID);
         mLastWrite = mApp.getClock().now();
-        if (outQueue.empty())
-        {
-            mLastEmpty = mApp.getClock().now();
-        }
         getOverlayMetrics().mMessageWrite.Mark();
         getOverlayMetrics().mByteWrite.Mark(nBytes);
         ++mPeerMetrics.mMessageWrite;

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -51,7 +51,7 @@ class LoopbackPeer : public Peer
 
     Stats mStats;
 
-    void sendMessage(xdr::msg_ptr&& xdrBytes,
+    void sendMessage(StellarMessage const& smsg,
                      MessagePriority priority) override;
     AuthCert getAuthCert() override;
 
@@ -70,7 +70,6 @@ class LoopbackPeer : public Peer
     void deliverOne();
     void deliverAll();
     void dropAll();
-    size_t getBytesQueued() const;
     size_t getMessagesQueued() const;
 
     Stats const& getStats() const;

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -25,9 +25,7 @@ class LoopbackPeer : public Peer
 {
   private:
     std::weak_ptr<LoopbackPeer> mRemote;
-    std::deque<xdr::msg_ptr> mOutQueueTopPriority; // sending queue
-    std::deque<xdr::msg_ptr> mOutQueueLowPriority; // sending queue
-    std::queue<xdr::msg_ptr> mInQueue;             // receiving queue
+    std::queue<xdr::msg_ptr> mInQueue; // receiving queue
 
     bool mCorked{false};
     bool mStraggling{false};

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -25,8 +25,9 @@ class LoopbackPeer : public Peer
 {
   private:
     std::weak_ptr<LoopbackPeer> mRemote;
-    std::deque<xdr::msg_ptr> mOutQueue; // sending queue
-    std::queue<xdr::msg_ptr> mInQueue;  // receiving queue
+    std::deque<xdr::msg_ptr> mOutQueueTopPriority; // sending queue
+    std::deque<xdr::msg_ptr> mOutQueueLowPriority; // sending queue
+    std::queue<xdr::msg_ptr> mInQueue;             // receiving queue
 
     bool mCorked{false};
     bool mStraggling{false};
@@ -52,7 +53,8 @@ class LoopbackPeer : public Peer
 
     Stats mStats;
 
-    void sendMessage(xdr::msg_ptr&& xdrBytes) override;
+    void sendMessage(xdr::msg_ptr&& xdrBytes,
+                     MessagePriority priority) override;
     AuthCert getAuthCert() override;
 
     void processInQueue();

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -50,7 +50,7 @@ class PeerStub : public Peer
     {
     }
     virtual void
-    sendMessage(xdr::msg_ptr&& xdrBytes, MessagePriority priority) override
+    sendMessage(StellarMessage const& msg, MessagePriority priority) override
     {
         sent++;
     }

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -50,7 +50,7 @@ class PeerStub : public Peer
     {
     }
     virtual void
-    sendMessage(xdr::msg_ptr&& xdrBytes) override
+    sendMessage(xdr::msg_ptr&& xdrBytes, MessagePriority priority) override
     {
         sent++;
     }


### PR DESCRIPTION
This builds on https://github.com/stellar/stellar-core/pull/2413, adding a dual-priority scheme to outgoing traffic: transactions are flood priority, everything else is fetch. Fetch-priority traffic gets sent before flood-priority 3 times out of every 4 sends (so flood eventually always gets sent -- just might be held up a bit).

@marta-lokhova would you be willing to run another load test to see how this goes?