### PR TITLE
Remove forward-declaration of stellar::Config from SCP

### DIFF
--- a/src/scp/QuorumSetUtils.h
+++ b/src/scp/QuorumSetUtils.h
@@ -8,8 +8,6 @@
 
 namespace stellar
 {
-class Config;
-
 bool isQuorumSetSane(SCPQuorumSet const& qSet, bool extraChecks);
 
 // normalize the quorum set, optionally removing idToRemove


### PR DESCRIPTION
```
It was originally added as part of PR #2127,
and should have been removed as part of the fix for #2152.
```