### PR TITLE
Scp flood fix

### DIFF
--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -320,13 +320,16 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
             mFetchDuration.Update(durationNano);
             Hash h = Slot::getCompanionQuorumSetHashFromStatement(
                 envelope.statement);
-            CLOG(TRACE, "Perf")
-                << "Herder fetched for envelope "
-                << hexAbbrev(sha256(xdr::xdr_to_opaque(envelope)))
-                << " with txsets " << txSetsToStr(envelope) << " and qset "
-                << hexAbbrev(h) << " in "
-                << std::chrono::duration<double>(durationNano).count()
-                << " seconds";
+            if (Logging::logTrace("Perf"))
+            {
+                CLOG(TRACE, "Perf")
+                    << "Herder fetched for envelope "
+                    << hexAbbrev(sha256(xdr::xdr_to_opaque(envelope)))
+                    << " with txsets " << txSetsToStr(envelope) << " and qset "
+                    << hexAbbrev(h) << " in "
+                    << std::chrono::duration<double>(durationNano).count()
+                    << " seconds";
+            }
 
             // move the item from fetching to processed
             processed.emplace(envelope);

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -143,4 +143,10 @@ Floodgate::shutdown()
     mShuttingDown = true;
     mFloodMap.clear();
 }
+
+void
+Floodgate::forgetRecord(Hash const& h)
+{
+    mFloodMap.erase(h);
+}
 }

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -54,13 +54,13 @@ Floodgate::clearBelow(uint32_t currentLedger)
 }
 
 bool
-Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer)
+Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer, Hash& index)
 {
+    index = sha256(xdr::xdr_to_opaque(msg));
     if (mShuttingDown)
     {
         return false;
     }
-    Hash index = sha256(xdr::xdr_to_opaque(msg));
     auto result = mFloodMap.find(index);
     if (result == mFloodMap.end())
     { // we have never seen this message

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -44,7 +44,7 @@ class Floodgate
                     Peer::pointer peer);
     };
 
-    std::map<uint256, FloodRecord::pointer> mFloodMap;
+    std::map<Hash, FloodRecord::pointer> mFloodMap;
     Application& mApp;
     medida::Counter& mFloodMapSize;
     medida::Meter& mSendFromBroadcast;
@@ -55,7 +55,9 @@ class Floodgate
     // Floodgate will be cleared after every ledger close
     void clearBelow(uint32_t currentLedger);
     // returns true if this is a new record
-    bool addRecord(StellarMessage const& msg, Peer::pointer fromPeer);
+    // fills msgID with msg's hash
+    bool addRecord(StellarMessage const& msg, Peer::pointer fromPeer,
+                   Hash& msgID);
 
     // only flood messages to peers that are at least minOverlayVersion
     void broadcast(StellarMessage const& msg, bool force,

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -63,8 +63,13 @@ class Floodgate
     void broadcast(StellarMessage const& msg, bool force,
                    uint32_t minOverlayVersion);
 
-    // returns the list of peers that sent us the item with hash `h`
-    std::set<Peer::pointer> getPeersKnows(Hash const& h);
+    // returns the list of peers that sent us the item with hash `msgID`
+    // NB: `msgID` is the hash of a `StellarMessage`
+    std::set<Peer::pointer> getPeersKnows(Hash const& msgID);
+
+    // removes the record corresponding to `msgID`
+    // `msgID` corresponds to a `StellarMessage`
+    void forgetRecord(Hash const& msgID);
 
     void shutdown();
 };

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -24,7 +24,7 @@ ItemFetcher::ItemFetcher(Application& app, AskPeer askPeer)
 }
 
 void
-ItemFetcher::fetch(Hash itemHash, const SCPEnvelope& envelope)
+ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
 {
     CLOG(TRACE, "Overlay") << "fetch " << hexAbbrev(itemHash);
     auto entryIt = mTrackers.find(itemHash);
@@ -44,7 +44,7 @@ ItemFetcher::fetch(Hash itemHash, const SCPEnvelope& envelope)
 }
 
 void
-ItemFetcher::stopFetch(Hash itemHash, const SCPEnvelope& envelope)
+ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
 {
     CLOG(TRACE, "Overlay") << "stopFetch " << hexAbbrev(itemHash);
     const auto& iter = mTrackers.find(itemHash);
@@ -65,7 +65,7 @@ ItemFetcher::stopFetch(Hash itemHash, const SCPEnvelope& envelope)
 }
 
 uint64
-ItemFetcher::getLastSeenSlotIndex(Hash itemHash) const
+ItemFetcher::getLastSeenSlotIndex(Hash const& itemHash) const
 {
     auto iter = mTrackers.find(itemHash);
     if (iter == mTrackers.end())
@@ -77,7 +77,7 @@ ItemFetcher::getLastSeenSlotIndex(Hash itemHash) const
 }
 
 std::vector<SCPEnvelope>
-ItemFetcher::fetchingFor(Hash itemHash) const
+ItemFetcher::fetchingFor(Hash const& itemHash) const
 {
     auto result = std::vector<SCPEnvelope>{};
     auto iter = mTrackers.find(itemHash);

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -52,25 +52,25 @@ class ItemFetcher : private NonMovableOrCopyable
      * Fetch data identified by @p hash and needed by @p envelope. Multiple
      * envelopes may require one set of data.
      */
-    void fetch(Hash itemHash, const SCPEnvelope& envelope);
+    void fetch(Hash const& itemHash, SCPEnvelope const& envelope);
 
     /**
      * Stops fetching data identified by @p hash for @p envelope. If other
      * envelopes requires this data, it is still being fetched, but
      * @p envelope will not be notified about it.
      */
-    void stopFetch(Hash itemHash, const SCPEnvelope& envelope);
+    void stopFetch(Hash const& itemHash, SCPEnvelope const& envelope);
 
     /**
      * Return biggest slot index seen for given hash. If 0, then given hash
      * is not being fetched.
      */
-    uint64 getLastSeenSlotIndex(Hash itemHash) const;
+    uint64 getLastSeenSlotIndex(Hash const& itemHash) const;
 
     /**
      * Return envelopes that require data identified by @p hash.
      */
-    std::vector<SCPEnvelope> fetchingFor(Hash itemHash) const;
+    std::vector<SCPEnvelope> fetchingFor(Hash const& itemHash) const;
 
     /**
      * Called periodically to remove old envelopes from list (with ledger id

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -75,8 +75,16 @@ class OverlayManager
     // that peer. This does _not_ cause the message to be broadcast anew; to do
     // that, call broadcastMessage, above.
     // Returns true if this is a new message
-    virtual bool recvFloodedMsg(StellarMessage const& msg,
-                                Peer::pointer peer) = 0;
+    // fills msgID with msg's hash
+    virtual bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
+                                  Hash& msgID) = 0;
+
+    bool
+    recvFloodedMsg(StellarMessage const& msg, Peer::pointer peer)
+    {
+        Hash msgID;
+        return recvFloodedMsgID(msg, peer, msgID);
+    }
 
     // Return a list of random peers from the set of authenticated peers.
     virtual std::vector<Peer::pointer> getRandomAuthenticatedPeers() = 0;

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -86,6 +86,11 @@ class OverlayManager
         return recvFloodedMsgID(msg, peer, msgID);
     }
 
+    // removes msgID from the floodgate's internal state
+    // as it's not tracked anymore, calling "broadcast" with a (now forgotten)
+    // message with the ID msgID will cause it to be broadcast to all peers
+    virtual void forgetFloodedMsg(Hash const& msgID) = 0;
+
     // Return a list of random peers from the set of authenticated peers.
     virtual std::vector<Peer::pointer> getRandomAuthenticatedPeers() = 0;
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -875,10 +875,11 @@ OverlayManagerImpl::shufflePeerList(std::vector<Peer::pointer>& peerList)
 }
 
 bool
-OverlayManagerImpl::recvFloodedMsg(StellarMessage const& msg,
-                                   Peer::pointer peer)
+OverlayManagerImpl::recvFloodedMsgID(StellarMessage const& msg,
+                                     Peer::pointer peer, Hash& msgID)
 {
-    return mFloodGate.addRecord(msg, peer);
+    return mFloodGate.addRecord(msg, peer, msgID);
+}
 }
 
 void

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -880,6 +880,11 @@ OverlayManagerImpl::recvFloodedMsgID(StellarMessage const& msg,
 {
     return mFloodGate.addRecord(msg, peer, msgID);
 }
+
+void
+OverlayManagerImpl::forgetFloodedMsg(Hash const& msgID)
+{
+    mFloodGate.forgetRecord(msgID);
 }
 
 void

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -103,6 +103,7 @@ class OverlayManagerImpl : public OverlayManager
     void ledgerClosed(uint32_t lastClosedledgerSeq) override;
     bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
                           Hash& msgID) override;
+    void forgetFloodedMsg(Hash const& msgID) override;
     void broadcastMessage(StellarMessage const& msg, bool force = false,
                           uint32_t minOverlayVersion = 0) override;
     void connectTo(PeerBareAddress const& address) override;

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -101,7 +101,8 @@ class OverlayManagerImpl : public OverlayManager
     ~OverlayManagerImpl();
 
     void ledgerClosed(uint32_t lastClosedledgerSeq) override;
-    bool recvFloodedMsg(StellarMessage const& msg, Peer::pointer peer) override;
+    bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
+                          Hash& msgID) override;
     void broadcastMessage(StellarMessage const& msg, bool force = false,
                           uint32_t minOverlayVersion = 0) override;
     void connectTo(PeerBareAddress const& address) override;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -29,6 +29,9 @@ OverlayMetrics::OverlayMetrics(Application& app)
     , mTimeoutStraggler(app.getMetrics().NewMeter(
           {"overlay", "timeout", "straggler"}, "timeout"))
 
+    , mItemFetcherNextPeer(app.getMetrics().NewMeter(
+          {"overlay", "item-fetcher", "next-peer"}, "item-fetcher"))
+
     , mRecvErrorTimer(app.getMetrics().NewTimer({"overlay", "recv", "error"}))
     , mRecvHelloTimer(app.getMetrics().NewTimer({"overlay", "recv", "hello"}))
     , mRecvAuthTimer(app.getMetrics().NewTimer({"overlay", "recv", "auth"}))

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -35,6 +35,8 @@ struct OverlayMetrics
     medida::Meter& mTimeoutIdle;
     medida::Meter& mTimeoutStraggler;
 
+    medida::Meter& mItemFetcherNextPeer;
+
     medida::Timer& mRecvErrorTimer;
     medida::Timer& mRecvHelloTimer;
     medida::Timer& mRecvAuthTimer;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -758,10 +758,15 @@ Peer::recvSCPMessage(StellarMessage const& msg)
                                 : (getOverlayMetrics()
                                        .mRecvSCPNominateTimer.TimeScope()))));
 
+    // add it to the floodmap so that this peer gets credit for it
+    Hash msgID;
+    mApp.getOverlayManager().recvFloodedMsgID(msg, shared_from_this(), msgID);
+
     auto res = mApp.getHerder().recvSCPEnvelope(envelope);
     if (res != Herder::ENVELOPE_STATUS_DISCARDED)
     {
-        mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
+        // the message was discarded, remove it from the floodmap as well
+        mApp.getOverlayManager().forgetFloodedMsg(msgID);
     }
 }
 

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -179,6 +179,8 @@ Tracker::listen(const SCPEnvelope& env)
     StellarMessage m;
     m.type(SCP_MESSAGE);
     m.envelope() = env;
+
+    // NB: hash here is of StellarMessage
     mWaitingEnvelopes.push_back(
         std::make_pair(sha256(xdr::xdr_to_opaque(m)), env));
 }

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -4,6 +4,7 @@
 
 #include "Tracker.h"
 
+#include "OverlayMetrics.h"
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
 #include "herder/Herder.h"
@@ -26,8 +27,8 @@ Tracker::Tracker(Application& app, Hash const& hash, AskPeer& askPeer)
     , mNumListRebuild(0)
     , mTimer(app)
     , mItemHash(hash)
-    , mTryNextPeer(app.getMetrics().NewMeter(
-          {"overlay", "item-fetcher", "next-peer"}, "item-fetcher"))
+    , mTryNextPeer(
+          app.getOverlayManager().getOverlayMetrics().mItemFetcherNextPeer)
     , mFetchTime("fetch-" + hexAbbrev(hash), LogSlowExecution::Mode::MANUAL)
 {
     assert(mAskPeer);

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -248,8 +248,12 @@ class OverlayManagerTests
         StellarMessage AtoC = a.tx({payment(b, 10)})->toStellarMessage();
         auto i = 0;
         for (auto p : pm.mOutboundPeers.mAuthenticated)
+        {
             if (i++ == 2)
+            {
                 pm.recvFloodedMsg(AtoC, p.second);
+            }
+        }
         pm.broadcastMessage(AtoC);
         std::vector<int> expected{1, 1, 0, 1, 1};
         REQUIRE(sentCounts(pm) == expected);

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -149,17 +149,8 @@ mkdir(std::string const& name)
 void
 deltree(std::string const& d)
 {
-    SHFILEOPSTRUCT s = {0};
-    std::string from = d;
-    from.push_back('\0');
-    from.push_back('\0');
-    s.wFunc = FO_DELETE;
-    s.pFrom = from.data();
-    s.fFlags = FOF_NO_UI;
-    if (SHFileOperation(&s) != 0)
-    {
-        throw FileSystemException("SHFileOperation failed in deltree");
-    }
+    namespace fs = std::experimental::filesystem;
+    fs::remove_all(fs::path(d));
 }
 
 std::vector<std::string>


### PR DESCRIPTION
# Description

Resolves #2368 

This PR fixes a bug in how we track SCP messages in the floodmap:
basically we were adding the message only *after* it was fed to herder, so when it tried to download related data (quorumset/txset), it would fail to find the right peer and default to "any random connection". This could cause arbitrary delays as peers would reply with "don't have".

I tried to add more tests using metrics (as we should normally have "don't have" messages in the SCP flooding tests) - but while the metrics look a lot better after this fix, they sometimes are non 0 due to the way the `Simulation` class works.

I've decided to not include those additional checks in tests for now (see https://github.com/MonsieurNicolas/stellar-core/tree/scpFloodFixWithTests to see the type of changes I tried to make) as I suspect the "right number" depends on too many factors (from topology, random seed, load on the machine running tests).
