### PR TITLE
Fix missing reference value scp

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -462,7 +462,6 @@ exit /b 0
     <ClCompile Include="..\..\src\main\Maintainer.cpp" />
     <ClCompile Include="..\..\src\main\PersistentState.cpp" />
     <ClCompile Include="..\..\src\main\StellarCoreVersion.cpp" />
-    <ClCompile Include="..\..\src\main\test\ApplicationTests.cpp" />
     <ClCompile Include="..\..\src\main\test\ConfigTests.cpp" />
     <ClCompile Include="..\..\src\main\test\ExternalQueueTests.cpp" />
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -687,9 +687,6 @@
     <ClCompile Include="..\..\src\ledger\test\SyncingLedgerChainTests.cpp">
       <Filter>ledger\tests</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\main\test\ApplicationTests.cpp">
-      <Filter>main\tests</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\main\test\ConfigTests.cpp">
       <Filter>main\tests</Filter>
     </ClCompile>

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -118,7 +118,10 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
         mQSet = mHerder.getQSet(qSetH);
         if (!mQSet)
         {
-            throw std::runtime_error("Wrapping an unknown qset from envelope");
+            throw std::runtime_error(
+                fmt::format("SCPHerderEnvelopeWrapper: Wrapping an unknown "
+                            "qset {} from envelope",
+                            hexAbbrev(qSetH)));
         }
         auto txSets = getTxSetHashes(e);
         for (auto const& txSetH : txSets)
@@ -131,7 +134,9 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
             else
             {
                 throw std::runtime_error(
-                    "Wrapping an unknown tx set from envelope");
+                    fmt::format("SCPHerderEnvelopeWrapper: Wrapping an unknown "
+                                "tx set {} from envelope",
+                                hexAbbrev(txSetH)));
             }
         }
     }
@@ -1026,8 +1031,9 @@ class SCPHerderValueWrapper : public ValueWrapper
         mTxSet = mHerder.getTxSet(sv.txSetHash);
         if (!mTxSet)
         {
-            throw std::runtime_error(
-                "SCPHerderValueWrapper tried to bind an unknown tx set");
+            throw std::runtime_error(fmt::format(
+                "SCPHerderValueWrapper tried to bind an unknown tx set {}",
+                hexAbbrev(sv.txSetHash)));
         }
     }
 };
@@ -1039,7 +1045,8 @@ HerderSCPDriver::wrapValue(Value const& val)
     auto b = mHerder.getHerderSCPDriver().toStellarValue(val, sv);
     if (!b)
     {
-        throw std::runtime_error("Invalid value in SCPHerderValueWrapper");
+        throw std::runtime_error(fmt::format(
+            "Invalid value in SCPHerderValueWrapper {}", binToHex(val)));
     }
     auto res = std::make_shared<SCPHerderValueWrapper>(sv, val, mHerder);
     return res;

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1936,6 +1936,10 @@ BallotProtocol::getStatementValues(SCPStatement const& st)
         {
             values.insert(prep.prepared->value);
         }
+        if (prep.preparedPrime)
+        {
+            values.insert(prep.preparedPrime->value);
+        }
     }
     break;
     case SCPStatementType::SCP_ST_CONFIRM:

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -144,7 +144,10 @@ Slot::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
     }
     catch (...)
     {
-        CLOG(FATAL, "SCP") << "SCP context:";
+        CLOG(FATAL, "SCP") << "SCP context ("
+                           << mSCP.getDriver().toShortString(
+                                  mSCP.getLocalNodeID())
+                           << "): ";
         CLOG(FATAL, "SCP") << getJsonInfo().toStyledString();
         CLOG(FATAL, "SCP") << "Exception processing SCP messages at "
                            << mSlotIndex << ", envelope: "


### PR DESCRIPTION
This PR fixes an issue introduced a long time ago ba4dd4a5071003681e1ec3b5874879487ec7e49f that became a real problem with the move to https://github.com/stellar/stellar-core/pull/2369

Basically: in a prepare statement, p' should be tracked like any other value (it was ignored).

This was causing tracking of related values to be wrong, which causes all sorts of downstream problems.