### PR TITLE
[EXPERIMENT] pull-mode flooding

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -77,6 +77,9 @@ overlay.error.write                      | meter     | error while sending a mes
 overlay.fetch.txset                      | timer     | time to complete fetching of a txset
 overlay.fetch.qset                       | timer     | time to complete fetching of a qset
 overlay.flood.broadcast                  | meter     | message sent as broadcast per peer
+overlay.flood.advertized                 | meter     | message advertized to other peers
+overlay.flood.demanded                   | meter     | message demanded in response to advert from other peer
+overlay.flood.fulfilled                  | meter     | message message sent in response to demand from other peer
 overlay.flood.duplicate_recv             | meter     | number of bytes of flooded messages that have already been received
 overlay.flood.unique_recv                | meter     | number of bytes of flooded messages that have not yet been received
 overlay.inbound.attempt                  | meter     | inbound connection attempted (accepted on socket)
@@ -87,6 +90,7 @@ overlay.outbound-queue.scp               | timer     | time SCP traffic sits in 
 overlay.outbound-queue.tx                | timer     | time tx traffic sits in flow-controlled queues
 overlay.item-fetcher.next-peer           | meter     | ask for item past the first one
 overlay.memory.flood-known               | counter   | number of known flooded entries
+overlay.memory.pending-demands           | counter   | number of flood demands in-flight
 overlay.message.broadcast                | meter     | message broadcasted
 overlay.message.read                     | meter     | message received
 overlay.message.write                    | meter     | message sent

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -164,6 +164,20 @@ FLOOD_ARB_TX_BASE_ALLOWANCE = 5
 # numbers make for more forceful damping.
 FLOOD_ARB_TX_DAMPING_FACTOR = 0.8
 
+# FLOOD_TX_LAZY_PROBABILITY (Floating point) default 1.0
+# The probabiity (between 0.0 and 1.0) that a transaction is flooded
+# using the lazy strategy rather than the eager strategy. Lazy flooding
+# is very slightly slower, but uses much less network bandwidth, so is
+# preferred.
+FLOOD_TX_LAZY_PROBABILITY = 1.0
+
+# FLOOD_SCP_LAZY_PROBABILITY (Floating point) default 1.0
+# The probabiity (between 0.0 and 1.0) that an SCP message is flooded
+# using the lazy strategy rather than the eager strategy. Lazy flooding
+# is very slightly slower, but uses much less network bandwidth, so is
+# preferred.
+FLOOD_SCP_LAZY_PROBABILITY = 1.0
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/crypto/ShortHash.cpp
+++ b/src/crypto/ShortHash.cpp
@@ -68,6 +68,10 @@ XDRShortHasher::XDRShortHasher() : state(gKey)
     state = SipHash24(gKey);
 }
 
+XDRShortHasher::XDRShortHasher(ByteSlice key) : state(key.data())
+{
+}
+
 void
 XDRShortHasher::hashBytes(unsigned char const* bytes, size_t len)
 {

--- a/src/crypto/ShortHash.h
+++ b/src/crypto/ShortHash.h
@@ -26,6 +26,7 @@ struct XDRShortHasher : XDRHasher<XDRShortHasher>
 {
     SipHash24 state;
     XDRShortHasher();
+    XDRShortHasher(ByteSlice key);
     void hashBytes(unsigned char const*, size_t);
 };
 
@@ -46,6 +47,16 @@ uint64_t
 xdrComputeHash(T const& t)
 {
     XDRShortHasher xsh;
+    xdr::archive(xsh, t);
+    xsh.flush();
+    return xsh.state.digest();
+}
+
+template <typename T>
+uint64_t
+xdrComputeKeyedHash(T const& t, ByteSlice key)
+{
+    XDRShortHasher xsh(key);
     xdr::archive(xsh, t);
     xsh.flush();
     return xsh.state.digest();

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -128,7 +128,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAXIMUM_LEDGER_CLOSETIME_DRIFT = 50;
 
     OVERLAY_PROTOCOL_MIN_VERSION = 18;
-    OVERLAY_PROTOCOL_VERSION = 20;
+    OVERLAY_PROTOCOL_VERSION = 21;
 
     VERSION_STR = STELLAR_CORE_VERSION;
 
@@ -195,6 +195,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     FLOOD_TX_PERIOD_MS = 200;
     FLOOD_ARB_TX_BASE_ALLOWANCE = 5;
     FLOOD_ARB_TX_DAMPING_FACTOR = 0.8;
+    FLOOD_TX_LAZY_PROBABILITY = 1.0;
+    FLOOD_SCP_LAZY_PROBABILITY = 1.0;
 
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
@@ -1128,6 +1130,26 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 {
                     throw std::invalid_argument(
                         "bad value for FLOOD_OP_RATE_PER_LEDGER");
+                }
+            }
+            else if (item.first == "FLOOD_TX_LAZY_PROBABILITY")
+            {
+                FLOOD_TX_LAZY_PROBABILITY = readDouble(item);
+                if (FLOOD_TX_LAZY_PROBABILITY < 0.0 ||
+                    FLOOD_TX_LAZY_PROBABILITY > 1.0)
+                {
+                    throw std::invalid_argument(
+                        "bad value for FLOOD_TX_LAZY_PROBABILITY");
+                }
+            }
+            else if (item.first == "FLOOD_SCP_LAZY_PROBABILITY")
+            {
+                FLOOD_SCP_LAZY_PROBABILITY = readDouble(item);
+                if (FLOOD_SCP_LAZY_PROBABILITY < 0.0 ||
+                    FLOOD_SCP_LAZY_PROBABILITY > 1.0)
+                {
+                    throw std::invalid_argument(
+                        "bad value for FLOOD_SCP_LAZY_PROBABILITY");
                 }
             }
             else if (item.first == "FLOOD_TX_PERIOD_MS")

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -392,6 +392,8 @@ class Config : public std::enable_shared_from_this<Config>
     int FLOOD_TX_PERIOD_MS;
     int32_t FLOOD_ARB_TX_BASE_ALLOWANCE;
     double FLOOD_ARB_TX_DAMPING_FACTOR;
+    double FLOOD_TX_LAZY_PROBABILITY;
+    double FLOOD_SCP_LAZY_PROBABILITY;
     static constexpr size_t const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr size_t const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -199,6 +199,8 @@ TEST_CASE("application setup", "[applicationutils]")
         // Setup validator to publish
         cfg1 = histCfg.configure(cfg1, /* writable */ true);
         cfg1.MAX_SLOTS_TO_REMEMBER = 50;
+        cfg1.FLOOD_SCP_LAZY_PROBABILITY = 0.0;
+        cfg1.FLOOD_TX_LAZY_PROBABILITY = 0.0;
 
         Config cfg2 = getTestConfig(2);
         cfg2.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
@@ -209,6 +211,8 @@ TEST_CASE("application setup", "[applicationutils]")
         cfg2.MODE_AUTO_STARTS_OVERLAY = false;
         cfg2.DATABASE = SecretValue{minimalDBForInMemoryMode(cfg2)};
         cfg2.MODE_STORES_HISTORY_LEDGERHEADERS = true;
+        cfg2.FLOOD_SCP_LAZY_PROBABILITY = 0.0;
+        cfg2.FLOOD_TX_LAZY_PROBABILITY = 0.0;
         // Captive core points to a read-only archive maintained by the
         // validator
         cfg2 = histCfg.configure(cfg2, /* writable */ false);

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -6,6 +6,7 @@
 #include "crypto/BLAKE2.h"
 #include "crypto/Hex.h"
 #include "herder/Herder.h"
+#include "ledger/LedgerManager.h"
 #include "main/Application.h"
 #include "medida/counter.h"
 #include "medida/metrics_registry.h"
@@ -15,26 +16,42 @@
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include <Tracy.hpp>
+#include <fmt/chrono.h>
 #include <fmt/format.h>
 
 namespace stellar
 {
+
+constexpr std::chrono::seconds PENDING_DEMAND_TIMEOUT{1};
+constexpr size_t PENDING_DEMAND_LIMIT{1000000};
+
 Floodgate::FloodRecord::FloodRecord(StellarMessage const& msg, uint32_t ledger,
-                                    Peer::pointer peer)
-    : mLedgerSeq(ledger), mMessage(msg)
+                                    uint64_t keyedShortHash,
+                                    uint64_t unkeyedShortHash)
+    : mLedgerSeq(ledger)
+    , mMessage(msg)
+    , mKeyedShortHash(keyedShortHash)
+    , mUnkeyedShortHash(unkeyedShortHash)
 {
-    if (peer)
-        mPeersTold.insert(peer->toString());
 }
 
 Floodgate::Floodgate(Application& app)
     : mApp(app)
     , mFloodMapSize(
           app.getMetrics().NewCounter({"overlay", "memory", "flood-known"}))
+    , mPendingDemandsSize(
+          app.getMetrics().NewCounter({"overlay", "memory", "pending-demands"}))
     , mSendFromBroadcast(app.getMetrics().NewMeter(
           {"overlay", "flood", "broadcast"}, "message"))
+    , mMessagesAdvertized(app.getMetrics().NewMeter(
+          {"overlay", "flood", "advertized"}, "message"))
+    , mMessagesDemanded(app.getMetrics().NewMeter(
+          {"overlay", "flood", "demanded"}, "message"))
+    , mMessagesFulfilled(app.getMetrics().NewMeter(
+          {"overlay", "flood", "fulfilled"}, "message"))
     , mShuttingDown(false)
 {
+    mId = KeyUtils::toShortString(mApp.getConfig().NODE_SEED.getPublicKey());
 }
 
 // remove old flood records
@@ -46,6 +63,11 @@ Floodgate::clearBelow(uint32_t maxLedger)
     {
         if (it->second->mLedgerSeq < maxLedger)
         {
+            auto record = it->second;
+            mPendingDemands.erase(record->mKeyedShortHash);
+            mPendingDemands.erase(record->mUnkeyedShortHash);
+            mShortHashFloodMap.erase(record->mKeyedShortHash);
+            mShortHashFloodMap.erase(record->mUnkeyedShortHash);
             it = mFloodMap.erase(it);
         }
         else
@@ -53,33 +75,129 @@ Floodgate::clearBelow(uint32_t maxLedger)
             ++it;
         }
     }
+
+    auto now = mApp.getClock().now();
+    mPendingDemandCount.clear();
+    for (auto it = mPendingDemands.cbegin(); it != mPendingDemands.cend();)
+    {
+        // Every pending demand older than 1 ledger is erased. This is narrower
+        // than `maxLedger` because demands should really be fulfilled
+        // immediately -- much less than 5 seconds. We just use this
+        // `clearBelow` call as an opportunity to GC obsolete demands too.
+        if (now - it->second.second > Herder::EXP_LEDGER_TIMESPAN_SECONDS)
+        {
+            it = mPendingDemands.erase(it);
+        }
+        else
+        {
+            mPendingDemandCount[it->second.first]++;
+            ++it;
+        }
+    }
     mFloodMapSize.set_count(mFloodMap.size());
+    mPendingDemandsSize.set_count(mPendingDemands.size());
+}
+
+std::pair<std::map<Hash, Floodgate::FloodRecord::pointer>::iterator, bool>
+Floodgate::insert(StellarMessage const& msg, bool force)
+{
+    Hash index = xdrBlake2(msg);
+    auto seq = mApp.getHerder().trackingConsensusLedgerIndex();
+    auto iter = mFloodMap.find(index);
+    if (iter != mFloodMap.end())
+    {
+        if (force)
+        {
+            // "Force" means "clear the mPeersTold and reset seq" when there's
+            // an existing entry.
+            iter->second->mPeersTold.clear();
+            iter->second->mLedgerSeq = seq;
+        }
+        return std::make_pair(iter, false);
+    }
+
+    Hash LCLHash = mApp.getLedgerManager().getLastClosedLedgerHeader().hash;
+    Hash zeroHash;
+    uint64_t keyedShortHash =
+        shortHash::xdrComputeKeyedHash(msg, ByteSlice(LCLHash.data(), 16));
+    uint64_t unkeyedShortHash =
+        shortHash::xdrComputeKeyedHash(msg, ByteSlice(zeroHash.data(), 16));
+
+    removeAnyPendingDemand(keyedShortHash);
+    removeAnyPendingDemand(unkeyedShortHash);
+
+    FloodRecord::pointer rec = std::make_shared<FloodRecord>(
+        msg, seq, keyedShortHash, unkeyedShortHash);
+    mShortHashFloodMap.emplace(keyedShortHash, rec);
+    mShortHashFloodMap.emplace(unkeyedShortHash, rec);
+    auto ret = mFloodMap.emplace(index, rec);
+    releaseAssert(ret.second);
+    mFloodMapSize.set_count(mFloodMap.size());
+    TracyPlot("overlay.memory.flood-known",
+              static_cast<int64_t>(mFloodMap.size()));
+    return ret;
 }
 
 bool
 Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer, Hash& index)
 {
     ZoneScoped;
-    index = xdrBlake2(msg);
     if (mShuttingDown)
     {
+        index = xdrBlake2(msg);
         return false;
     }
-    auto result = mFloodMap.find(index);
-    if (result == mFloodMap.end())
-    { // we have never seen this message
-        mFloodMap[index] = std::make_shared<FloodRecord>(
-            msg, mApp.getHerder().trackingConsensusLedgerIndex(), peer);
-        mFloodMapSize.set_count(mFloodMap.size());
-        TracyPlot("overlay.memory.flood-known",
-                  static_cast<int64_t>(mFloodMap.size()));
-        return true;
-    }
-    else
+    auto pair = insert(msg);
+    index = pair.first->first;
+    FloodRecord::pointer record = pair.first->second;
+    if (peer)
     {
-        result->second->mPeersTold.insert(peer->toString());
-        return false;
+        record->mPeersTold.insert(peer->toString());
     }
+    return pair.second;
+}
+
+void
+Floodgate::removeAnyPendingDemand(uint64_t hash)
+{
+    auto i = mPendingDemands.find(hash);
+    if (i != mPendingDemands.end())
+    {
+        auto c = mPendingDemandCount.find(i->second.first);
+        releaseAssert(c->second != 0);
+        c->second -= 1;
+        mPendingDemands.erase(i);
+        mPendingDemandsSize.set_count(mPendingDemands.size());
+    }
+}
+
+void
+Floodgate::addPendingDemand(uint64_t hash, std::string const& peer)
+{
+    auto i = mPendingDemands.find(hash);
+    releaseAssert(i == mPendingDemands.end());
+    auto now = mApp.getClock().now();
+    mPendingDemands.emplace(hash, std::make_pair(peer, now));
+    mPendingDemandCount[peer]++;
+    mPendingDemandsSize.set_count(mPendingDemands.size());
+}
+
+bool
+Floodgate::shouldFloodLazily(StellarMessage const& msg, Peer::pointer peer)
+{
+    if (peer->supportsAdverts())
+    {
+        auto const& cfg = mApp.getConfig();
+        if (msg.type() == TRANSACTION)
+        {
+            return rand_flip(cfg.FLOOD_TX_LAZY_PROBABILITY);
+        }
+        else if (msg.type() == SCP_MESSAGE)
+        {
+            return rand_flip(cfg.FLOOD_SCP_LAZY_PROBABILITY);
+        }
+    }
+    return false;
 }
 
 // send message to anyone you haven't gotten it from
@@ -91,54 +209,185 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
     {
         return false;
     }
-    Hash index = xdrBlake2(msg);
 
-    FloodRecord::pointer fr;
-    auto result = mFloodMap.find(index);
-    if (result == mFloodMap.end() || force)
-    { // no one has sent us this message / start from scratch
-        fr = std::make_shared<FloodRecord>(
-            msg, mApp.getHerder().trackingConsensusLedgerIndex(),
-            Peer::pointer());
-        mFloodMap[index] = fr;
-        mFloodMapSize.set_count(mFloodMap.size());
-    }
-    else
-    {
-        fr = result->second;
-    }
-    // send it to people that haven't sent it to us
-    auto& peersTold = fr->mPeersTold;
+    auto pair = insert(msg, force);
+    Hash const& index = pair.first->first;
+    FloodRecord::pointer record = pair.first->second;
+
+    CLOG_TRACE(Overlay, "broadcast {}", hexAbbrev(index));
+
+    // Send (or at least advertize) it to people that haven't sent it to us
+    // and/or we haven't sent it to in full. We _might_ advertize the same
+    // message to the same peer twice if we somehow receive it twice and decide
+    // to call broadcast() twice before sending it to them; but we should only
+    // really be broadcast()'ing new messages anyway in our caller.
+    auto& peersTold = record->mPeersTold;
 
     // make a copy, in case peers gets modified
     auto peers = mApp.getOverlayManager().getAuthenticatedPeers();
 
     bool broadcasted = false;
     auto smsg = std::make_shared<StellarMessage const>(msg);
-    for (auto peer : peers)
+    for (auto& peer : peers)
     {
         releaseAssert(peer.second->isAuthenticated());
         if (peersTold.insert(peer.second->toString()).second)
         {
-            mSendFromBroadcast.Mark();
-            std::weak_ptr<Peer> weak(
-                std::static_pointer_cast<Peer>(peer.second));
-            mApp.postOnMainThread(
-                [smsg, weak, log = !broadcasted]() {
-                    auto strong = weak.lock();
-                    if (strong)
-                    {
-                        strong->sendMessage(smsg, log);
-                    }
-                },
-                fmt::format(FMT_STRING("broadcast to {}"),
-                            peer.second->toString()));
+            if (shouldFloodLazily(msg, peer.second))
+            {
+                uint64_t shortHash =
+                    (mApp.getState() == Application::State::APP_SYNCED_STATE
+                         ? record->mKeyedShortHash
+                         : record->mUnkeyedShortHash);
+                CLOG_TRACE(Overlay, "{} advertizing {} to {}", mId, shortHash,
+                           KeyUtils::toShortString(peer.second->getPeerID()));
+                mMessagesAdvertized.Mark();
+                peer.second->advertizeMessage(shortHash);
+            }
+            else
+            {
+                mSendFromBroadcast.Mark();
+                std::weak_ptr<Peer> weak(
+                    std::static_pointer_cast<Peer>(peer.second));
+                mApp.postOnMainThread(
+                    [smsg, weak, log = !broadcasted]() {
+                        auto strong = weak.lock();
+                        if (strong)
+                        {
+                            strong->sendMessage(smsg, log);
+                        }
+                    },
+                    fmt::format(FMT_STRING("broadcast to {}"),
+                                peer.second->toString()));
+            }
             broadcasted = true;
         }
     }
     CLOG_TRACE(Overlay, "broadcast {} told {}", hexAbbrev(index),
                peersTold.size());
     return broadcasted;
+}
+
+void
+Floodgate::demandMissing(FloodAdvert const& adv, Peer::pointer fromPeer)
+{
+    auto msg = std::make_shared<StellarMessage>();
+    msg->type(FLOOD_DEMAND);
+    FloodDemand& demand = msg->floodDemand();
+    auto now = mApp.getClock().now();
+    std::string peerID = fromPeer->toString();
+    for (uint64_t h : adv.hashes)
+    {
+        auto i = mShortHashFloodMap.find(h);
+        if (i != mShortHashFloodMap.end())
+        {
+            // We already got a full message for h; record that fromPeer also
+            // has the message, to inhibit advertizing or sending to fromPeer.
+            i->second->mPeersTold.insert(fromPeer->toString());
+            CLOG_TRACE(Overlay,
+                       "{} already have full message for {} advertied by {}",
+                       mId, h, KeyUtils::toShortString(fromPeer->getPeerID()));
+        }
+        else
+        {
+            auto existingDemand = mPendingDemands.find(h);
+            if (existingDemand != mPendingDemands.end())
+            {
+                CLOG_TRACE(Overlay, "{} already demanded {} advertized by {}",
+                           mId, h,
+                           KeyUtils::toShortString(fromPeer->getPeerID()));
+                std::chrono::milliseconds dur =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now - existingDemand->second.second);
+                if (dur < PENDING_DEMAND_TIMEOUT)
+                {
+                    // We don't have this message but we did already ask for it
+                    // from someone else, more recently than
+                    // PENDING_DEMAND_TIMEOUT, so we'll avoid asking for it here
+                    // and wait a bit, hoping the peer we demanded it from
+                    // fulfills the demand.
+                    continue;
+                }
+                else
+                {
+                    bool lastDemandWasThisPeer =
+                        existingDemand->second.first == peerID;
+
+                    // We don't have the message, we did demand it it, but the
+                    // peer we demanded it from hasn't fulfilled the demand
+                    // within a timeout; we'll forget the existing demand now,
+                    // in any case.
+                    CLOG_TRACE(Overlay,
+                               "demand for {} from {} expired after {}", h,
+                               existingDemand->second.first, dur);
+
+                    // NB: this call invalidates the iterator `existingDemand`.
+                    removeAnyPendingDemand(h);
+
+                    if (lastDemandWasThisPeer)
+                    {
+                        // This peer didn't answer our last demand. We'll avoid
+                        // demanding from them just now, to let someone else
+                        // have a chance to advertize and have us demand from
+                        // them instead. If nobody does, we'll demand again from
+                        // this peer on its next advertisement.
+                        CLOG_TRACE(Overlay,
+                                   "leaving opening for someone other than {} "
+                                   "to advertize {}",
+                                   peerID, h);
+                        continue;
+                    }
+                }
+            }
+
+            // We don't have this message in full and haven't demanded it yet
+            // from anyone who advertized it; ask now and leave a record that
+            // we've done so to avoid demanding it from others.
+            mMessagesDemanded.Mark();
+            if (mPendingDemandCount[peerID] < PENDING_DEMAND_LIMIT)
+            {
+                CLOG_TRACE(Overlay, "{} demanding {} from {}", mId, h,
+                           KeyUtils::toShortString(fromPeer->getPeerID()));
+                addPendingDemand(h, fromPeer->toString());
+            }
+            else
+            {
+                CLOG_TRACE(Overlay,
+                           "{} not demanding {} from {} -- already have {} "
+                           "demands pending",
+                           mId, h,
+                           KeyUtils::toShortString(fromPeer->getPeerID()),
+                           mPendingDemandCount[peerID]);
+            }
+            demand.hashes.emplace_back(h);
+        }
+    }
+    fromPeer->sendMessage(msg);
+}
+
+void
+Floodgate::fulfillDemand(FloodDemand const& dmd, Peer::pointer fromPeer)
+{
+    for (uint64_t h : dmd.hashes)
+    {
+        auto i = mShortHashFloodMap.find(h);
+        if (i == mShortHashFloodMap.end())
+        {
+            CLOG_TRACE(Overlay,
+                       "can't fulfill demand for {} demanded by {} -- don't "
+                       "know of message",
+                       mId, h, KeyUtils::toShortString(fromPeer->getPeerID()));
+        }
+        else
+        {
+            CLOG_TRACE(Overlay, "{} fulfilling demand for {} demanded by {}",
+                       mId, h, KeyUtils::toShortString(fromPeer->getPeerID()));
+            mMessagesFulfilled.Mark();
+            i->second->mPeersTold.insert(fromPeer->toString());
+            auto smsg = std::make_shared<StellarMessage>(i->second->mMessage);
+            fromPeer->sendMessage(smsg);
+        }
+    }
 }
 
 std::set<Peer::pointer>
@@ -166,12 +415,26 @@ Floodgate::shutdown()
 {
     mShuttingDown = true;
     mFloodMap.clear();
+    mShortHashFloodMap.clear();
+    mPendingDemands.clear();
 }
 
 void
 Floodgate::forgetRecord(Hash const& h)
 {
-    mFloodMap.erase(h);
+    CLOG_TRACE(Overlay, "{} forgetting {}", mId, hexAbbrev(h));
+    auto i = mFloodMap.find(h);
+    if (i != mFloodMap.end())
+    {
+        auto record = i->second;
+        mShortHashFloodMap.erase(record->mKeyedShortHash);
+        mShortHashFloodMap.erase(record->mUnkeyedShortHash);
+        mPendingDemands.erase(record->mKeyedShortHash);
+        mPendingDemands.erase(record->mUnkeyedShortHash);
+        mPendingDemandsSize.set_count(mPendingDemands.size());
+        mFloodMap.erase(i);
+        mFloodMapSize.set_count(mFloodMap.size());
+    }
 }
 
 void

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -7,6 +7,8 @@
 #include "overlay/Peer.h"
 #include "overlay/StellarXDR.h"
 #include <map>
+#include <memory>
+#include <set>
 
 /**
  * FloodGate keeps track of which peers have sent us which broadcast messages,
@@ -40,14 +42,69 @@ class Floodgate
         StellarMessage mMessage;
         std::set<std::string> mPeersTold;
 
+        // mKeyedShortHash is SIPHash24 of mMessage keyed by the the low 128
+        // bits of the LCL hash at which it was received (or broadcast). The
+        // hash keying serves two goals:
+        //
+        //  - Preventing accidental collision masking a tx: on next ledger
+        //    close, HerderImpl::updateTransactionQueue will rebroadcast any
+        //    _unconsumed_ txs in the tx queue under new hashes, so they will
+        //    just be delayed / sent twice by such accidental poisoning.
+        //
+        //  - Narrow the attack window for any _intentional_ poisoning to a
+        //    short real-time window: attacker would have to find a SIPHash24
+        //    preimage in the window of time between the LCL hash being known
+        //    and the broadcast they want to poison being flooded ahead of their
+        //    poison.
+        //
+        // We also calculate an mUnkeyedShortHash (well, keyed by 128 zero bits)
+        // representing the short hash value to use in adverts (and that other
+        // nodes will avertize to us) when out of sync.
+        uint64_t mKeyedShortHash;
+        uint64_t mUnkeyedShortHash;
+
         FloodRecord(StellarMessage const& msg, uint32_t ledger,
-                    Peer::pointer peer);
+                    uint64_t keyedShortHash, uint64_t unkeyedShortHash);
     };
 
+    bool shouldFloodLazily(StellarMessage const& msg, Peer::pointer peer);
+
+    std::pair<std::map<Hash, FloodRecord::pointer>::iterator, bool>
+    insert(StellarMessage const& msg, bool force = false);
+    void removeAnyPendingDemand(uint64_t hash);
+    void addPendingDemand(uint64_t hash, std::string const& peer);
+
+    // Messages in mFloodMap are those we have a full copy of, and are in the
+    // process of flooding to others.
     std::map<Hash, FloodRecord::pointer> mFloodMap;
+
+    // Pointers into the same map but indexed by short hash (both keyed and
+    // unkeyed).
+    std::map<uint64_t, FloodRecord::pointer> mShortHashFloodMap;
+
+    // The set of short hashes we've sent demands for, so we only demand them
+    // from one peer at a time. The value stored in this map is the time at
+    // which we made our last demand, and the peer we demanded it from. We use
+    // this to GC demands older than 1 ledger (in clearBelow) and more narrowly
+    // we allow re-issuing demands (to other peers) if a pending demand is older
+    // older than PENDING_DEMAND_TIMEOUT.
+    std::map<uint64_t, std::pair<std::string, VirtualClock::time_point>>
+        mPendingDemands;
+
+    // The current number of pending demands against a given peer. This is used
+    // to limit the amount of memory a peer can use by flooding us with a set of
+    // nonsense adverts and never answering demands for them. See
+    // PENDING_DEMAND_LIMIT.
+    std::map<std::string, size_t> mPendingDemandCount;
+
     Application& mApp;
+    std::string mId;
     medida::Counter& mFloodMapSize;
+    medida::Counter& mPendingDemandsSize;
     medida::Meter& mSendFromBroadcast;
+    medida::Meter& mMessagesAdvertized;
+    medida::Meter& mMessagesDemanded;
+    medida::Meter& mMessagesFulfilled;
     bool mShuttingDown;
 
   public:
@@ -61,6 +118,9 @@ class Floodgate
 
     // returns true if msg was sent to at least one peer
     bool broadcast(StellarMessage const& msg, bool force);
+
+    void demandMissing(FloodAdvert const& adv, Peer::pointer fromPeer);
+    void fulfillDemand(FloodDemand const& dmd, Peer::pointer fromPeer);
 
     // returns the list of peers that sent us the item with hash `msgID`
     // NB: `msgID` is the hash of a `StellarMessage`

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -90,6 +90,11 @@ class OverlayManager
     // message with the ID msgID will cause it to be broadcast to all peers
     virtual void forgetFloodedMsg(Hash const& msgID) = 0;
 
+    virtual void demandMissing(FloodAdvert const& adv,
+                               Peer::pointer fromPeer) = 0;
+    virtual void fulfillDemand(FloodDemand const& dmd,
+                               Peer::pointer fromPeer) = 0;
+
     // Return a list of random peers from the set of authenticated peers.
     virtual std::vector<Peer::pointer> getRandomAuthenticatedPeers() = 0;
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -955,6 +955,20 @@ OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force)
 }
 
 void
+OverlayManagerImpl::demandMissing(FloodAdvert const& adv,
+                                  Peer::pointer fromPeer)
+{
+    mFloodGate.demandMissing(adv, fromPeer);
+}
+
+void
+OverlayManagerImpl::fulfillDemand(FloodDemand const& dmd,
+                                  Peer::pointer fromPeer)
+{
+    mFloodGate.fulfillDemand(dmd, fromPeer);
+}
+
+void
 OverlayManager::dropAll(Database& db)
 {
     PeerManager::dropAll(db);
@@ -1029,7 +1043,8 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
 
     bool flood = false;
     if (isFloodMessage(stellarMsg) || stellarMsg.type() == SURVEY_REQUEST ||
-        stellarMsg.type() == SURVEY_RESPONSE)
+        stellarMsg.type() == SURVEY_RESPONSE ||
+        stellarMsg.type() == FLOOD_ADVERT || stellarMsg.type() == FLOOD_DEMAND)
     {
         flood = true;
     }

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -105,6 +105,8 @@ class OverlayManagerImpl : public OverlayManager
     void forgetFloodedMsg(Hash const& msgID) override;
     bool broadcastMessage(StellarMessage const& msg,
                           bool force = false) override;
+    void demandMissing(FloodAdvert const& adv, Peer::pointer fromPeer) override;
+    void fulfillDemand(FloodDemand const& dmd, Peer::pointer fromPeer) override;
     void connectTo(PeerBareAddress const& address) override;
 
     void addInboundConnection(Peer::pointer peer) override;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -73,6 +73,12 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "recv", "survey-request"}))
     , mRecvSurveyResponseTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "survey-response"}))
+
+    , mRecvFloodAdvertTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "flood-advert"}))
+    , mRecvFloodDemandTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "flood-demand"}))
+
     , mMessageDelayInWriteQueueTimer(
           app.getMetrics().NewTimer({"overlay", "delay", "write-queue"}))
     , mMessageDelayInAsyncWriteTimer(
@@ -114,6 +120,10 @@ OverlayMetrics::OverlayMetrics(Application& app)
           {"overlay", "send", "survey-request"}, "message"))
     , mSendSurveyResponseMeter(app.getMetrics().NewMeter(
           {"overlay", "send", "survey-response"}, "message"))
+    , mSendFloodAdvertMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "flood-advert"}, "message"))
+    , mSendFloodDemandMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "flood-demand"}, "message"))
     , mMessagesBroadcast(app.getMetrics().NewMeter(
           {"overlay", "message", "broadcast"}, "message"))
     , mPendingPeersSize(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -60,6 +60,9 @@ struct OverlayMetrics
     medida::Timer& mRecvSurveyRequestTimer;
     medida::Timer& mRecvSurveyResponseTimer;
 
+    medida::Timer& mRecvFloodAdvertTimer;
+    medida::Timer& mRecvFloodDemandTimer;
+
     medida::Timer& mMessageDelayInWriteQueueTimer;
     medida::Timer& mMessageDelayInAsyncWriteTimer;
 
@@ -83,6 +86,9 @@ struct OverlayMetrics
 
     medida::Meter& mSendSurveyRequestMeter;
     medida::Meter& mSendSurveyResponseMeter;
+
+    medida::Meter& mSendFloodAdvertMeter;
+    medida::Meter& mSendFloodDemandMeter;
 
     medida::Meter& mMessagesBroadcast;
     medida::Counter& mPendingPeersSize;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -129,6 +129,9 @@ class Peer : public std::enable_shared_from_this<Peer>,
     };
 
     Peer::FlowControlState flowControlEnabled() const;
+    static uint32_t const FIRST_OVERLAY_PROTOCOL_VERSION_SUPPORTING_ADVERTS;
+    static size_t const ADVERT_FLUSH_THRESHOLD;
+    static std::chrono::milliseconds const ADVERT_TIMER;
 
   protected:
     Application& mApp;
@@ -206,6 +209,15 @@ class Peer : public std::enable_shared_from_this<Peer>,
     PeerMetrics mPeerMetrics;
     ReadingCapacity mCapacity;
 
+    // As of MIN_OVERLAY_VERSION_FOR_FLOOD_ADVERT, peers accumulate an _advert_
+    // of flood messages, then periodically flush the advert and await a
+    // _demand_ message with a list of flood messages to send. Adverts are
+    // typically smaller than full messages and batching them means we also
+    // amortize the authentication framing.
+    StellarMessage mPendingAdvertMsg;
+    bool mAdvertTimerActive{false};
+    VirtualTimer mAdvertTimer;
+
     OverlayMetrics& getOverlayMetrics();
 
     bool shouldAbort() const;
@@ -233,6 +245,9 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void recvSCPQuorumSet(StellarMessage const& msg);
     void recvSCPMessage(StellarMessage const& msg);
     void recvGetSCPState(StellarMessage const& msg);
+
+    void recvFloodAdvert(StellarMessage const& msg);
+    void recvFloodDemand(StellarMessage const& msg);
 
     void sendHello();
     void sendAuth();
@@ -296,6 +311,10 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     void sendMessage(std::shared_ptr<StellarMessage const> msg,
                      bool log = true);
+
+    bool supportsAdverts() const;
+    void flushPendingAdvert();
+    void advertizeMessage(uint64_t shortHash);
 
     PeerRole
     getRole() const

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -529,6 +529,10 @@ TCPPeer::startRead()
 
     if (mSocket->in_avail() < HDRSZ)
     {
+        // We want to advertize floodable messages we just received
+        // _immediately_, in addition to any periodic flushes we do.
+        flushPendingAdvert();
+
         // If there wasn't enough readable in the buffered stream to even get a
         // header (message length), issue an async_read and hope that the
         // buffering pulls in much more than just the 4 bytes we ask for here.

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -78,7 +78,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             // Wait until all nodes externalize
             simulation->crankUntil(
                 [&]() { return simulation->haveAllExternalized(2, 1); },
-                std::chrono::seconds(1), false);
+                std::chrono::seconds(2), false);
             for (auto const& n : nodes)
             {
                 REQUIRE(n->getLedgerManager().isSynced());
@@ -87,7 +87,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
         else
         {
             // enough for connections to be made
-            simulation->crankForAtLeast(std::chrono::seconds(1), false);
+            simulation->crankForAtLeast(std::chrono::seconds(2), false);
         }
 
         expectedSeq = root.getLastSequenceNumber() + 1;

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -190,6 +190,7 @@ LoopbackPeer::processInQueue()
                                   "LoopbackPeer: processInQueue");
         }
     }
+    flushPendingAdvert();
 }
 
 void

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -357,6 +357,8 @@ TEST_CASE("outbound queue filtering", "[overlay][connections]")
         Simulation::OVER_LOOPBACK, networkID, [](int i) {
             auto cfg = getTestConfig(i, Config::TESTDB_ON_DISK_SQLITE);
             cfg.ENABLE_OVERLAY_FLOW_CONTROL = true;
+            cfg.FLOOD_SCP_LAZY_PROBABILITY = 0.0;
+            cfg.FLOOD_TX_LAZY_PROBABILITY = 0.0;
             cfg.MAX_SLOTS_TO_REMEMBER = 3;
             return cfg;
         });

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -19,18 +19,18 @@ namespace stellar
 {
 
 stellar_default_random_engine gRandomEngine;
-std::uniform_real_distribution<double> uniformFractionDistribution(0.0, 1.0);
-
-double
-rand_fraction()
-{
-    return uniformFractionDistribution(gRandomEngine);
-}
 
 bool
 rand_flip()
 {
     return (gRandomEngine() & 1);
+}
+
+bool
+rand_flip(double prob)
+{
+    std::bernoulli_distribution dist(prob);
+    return dist(gRandomEngine);
 }
 
 double

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -12,13 +12,13 @@
 
 namespace stellar
 {
-double rand_fraction();
 
 std::set<double> k_means(std::vector<double> const& points, uint32_t k);
 
 double closest_cluster(double p, std::set<double> const& centers);
 
 bool rand_flip();
+bool rand_flip(double prob);
 
 typedef std::minstd_rand stellar_default_random_engine;
 

--- a/src/xdr/Stellar-overlay.x
+++ b/src/xdr/Stellar-overlay.x
@@ -100,7 +100,9 @@ enum MessageType
     SURVEY_REQUEST = 14,
     SURVEY_RESPONSE = 15,
 
-    SEND_MORE = 16
+    SEND_MORE = 16,
+    FLOOD_ADVERT = 17,
+    FLOOD_DEMAND = 18
 };
 
 struct DontHave
@@ -183,6 +185,16 @@ case SURVEY_TOPOLOGY:
     TopologyResponseBody topologyResponseBody;
 };
 
+struct FloodAdvert
+{
+    uint64 hashes<>;
+};
+
+struct FloodDemand
+{
+    uint64 hashes<>;
+};
+
 union StellarMessage switch (MessageType type)
 {
 case ERROR_MSG:
@@ -211,6 +223,11 @@ case SURVEY_REQUEST:
 
 case SURVEY_RESPONSE:
     SignedSurveyResponseMessage signedSurveyResponseMessage;
+
+case FLOOD_ADVERT:
+     FloodAdvert floodAdvert;
+case FLOOD_DEMAND:
+     FloodDemand floodDemand;
 
 // SCP
 case GET_SCP_QUORUMSET:


### PR DESCRIPTION
# Pull-mode flooding

## High-level explanation of changes:

The change aims to reduce the amount of redundant flood-type traffic (that is, a message received by a peer along multiple connections). It does so in a very conventional fashion: switching from "eager" to "lazy" flooding.

Specifically, flood-type traffic is no longer propagated to neighbours as soon as it's received; rather it's _advertized_ with much smaller and denser batches of short (64 bit SIPHash-2-4) keyed hash codes. Advertisements are sent _fairly_ often but there's a slight buffering delay to allow combining a decent-sized number of them into a single message. When an advertisement is received, the receiver immediately responds with a _demand_ for all the hashes it hasn't yet seen, which the sender then immediately sends using the existing message types. Since advertisements are typically less than a tenth the size of the messages they're advertizing, this reduces the total traffic accordingly.

This change only modifies the flow of data between the floodgate and the IO queues -- data we've already committed to informing our neighbours about. It is thus fairly narrow and late in the full set of system queueing disciplines, and does not change most decisions around tx-queue throttling, surge-pricing, SCP rebroadcasting, etc.

It also only modifies flood traffic -- fetch traffic is unaffected.

It does add 2 WAN RTTs to flood traffic latency, and adds two possible attack vectors (that I am aware of):
  - a simple/dumb cache-poisoning vector where an attacker advertizes a message but then doesn't provide it when it's demanded. This is mitigated by making demands short-lived with a timeout, and allowing peers to race when re-advertizing a hash with a pending demand that's timed out.
  - a fancier cryptographic cache-poisoning vector where an attacker could send a message that collides with a target hash, inhibiting its peer from even demanding it from anyone (i.e. it thinks it already has message X when it really has Y, but hash(X) == hash(Y)). The hashes are keyed by LCL so this only works if an attacker can both collide a SipHash-2-4 in 5 seconds _and_ get their packet accepted before the target packet, so the odds seem tolerable to me, but it's worth considering (there are other options here including just using SHA256s, as I did in an earlier iteration, but the SipHash variant uses 1/4 as much bandwidth, and this is all about reducing bandwidth.)

The change can coexist with existing (eager) connections that do not yet support lazy flooding, and in fact can decide message-by-message which mode to use, so one way to further mitigate both the cache-poisoning vectors and any potential latency problems is to vary the entire flooding strategy stochastically (eg. send 75% of traffic lazily and 25% eagerly). My plan is to do this and make it a config option, because it's a simple dial to understand and also allows the operator to just turn it off if it's misbehaving.

A more sophisticated strategy could opt to set a per-link policy to construct (eg.) an eager spanning tree with a backup lazy mesh (as in [plumtree](https://asc.di.fct.unl.pt/~jleitao/pdf/srds07-leitao.pdf)) but this has potentially more complex/fragile dynamics so I am deferring it for now.

As a "prior art" / comparing-notes aside: this is similar to Bitcoin Core's "compact block" / low-bandwidth mode [BIP-152](https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki) except they use _even smaller_ 6-byte truncated SipHash-2-4s (again keyed with the previous block hash).

## Detailed explanation of changes:

  - The overlay protocol gets 2 new message types:
     - `FLOOD_ADVERT`: a list of short hashes available to be sent
     - `FLOOD_DEMAND`: a list of short hashes requested to be sent

  - Each `Peer` object gets 2 new fields:
     - A "pending" `FLOOD_ADVERT`, which accumulates outgoing 64-bit advert-codes (until it's ready to be flushed)
     - A timer
  - The `Peer` flushes its pending advert (sending it to its remote peer) on the earliest of 3 conditions:
       - The IO loop finishes processing an incoming (large) read buffer from the remote
       - The timer expires (every 100ms)
       - A threshold of pending advert-codes is reached (1024)

  - `Floodgate::FloodRecord` gets 2 new fields:
    - a short hash of the message keyed by the low 128 bits of the LCL to use when in sync
    - a short hash of the message keyed by all zeroes to use when out of sync

  - The `FloodGate` gets 2 new maps:
    - An index from short hashes to the existing `FloodRecord`s in `mFloodMap`
    - A map from demanded (but not yet received) short hashes to the ledger number they were demanded at, used to suppress multiple demands from being issued simultaneously, but also to eventually allow re-demanding if a demand is not fulfilled.

  - The implementations of `FloodGate::{addRecord,broadcast}` are partly merged into a new `FloodGate::insert` method, and `broadcast` is modified to push an advert into a `Peer`'s pending `FLOOD_ADVERT` when possible rather than sending a full eager message.

  - `FloodGate` and `OverlayManager` get 2 new methods:
    - `demandMissing`, called in response to receiving `FLOOD_ADVERT`. Sends a `FLOOD_DEMAND` for all the not-yet-known messages in the advert.
    - `fulfillDemand`, called in response to receiving a `FLOOD_DEMAND`. Sends all the messages that were demanded.

