### PR TITLE
Make batch overlay operation configurable

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -125,6 +125,14 @@ PEER_TIMEOUT=30
 # time when authenticated.
 PEER_STRAGGLER_TIMEOUT=120
 
+# MAX_BATCH_READ_PERIOD_MS (Integer) default 100
+# How long this server can spend processing reads from a peer at once
+MAX_BATCH_READ_PERIOD_MS=100
+
+# MAX_BATCH_READ_COUNT (Integer) default 1024
+# How many messages can this server read at once from a peer
+MAX_BATCH_READ_COUNT=1024
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -279,6 +279,10 @@ CATCHUP_RECENT=1024
 # merging and vertification.
 WORKER_THREADS=10
 
+# QUORUM_INTERSECTION_CHECKER (boolean) default true
+# Enable/disable computation of quorum intersection monitoring
+QUORUM_INTERSECTION_CHECKER=true
+
 # MAX_CONCURRENT_SUBPROCESSES (integer) default 16
 # History catchup can potentialy spawn a bunch of sub-processes.
 # This limits the number that will be active at a time.

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -133,6 +133,14 @@ MAX_BATCH_READ_PERIOD_MS=100
 # How many messages can this server read at once from a peer
 MAX_BATCH_READ_COUNT=1024
 
+# MAX_BATCH_WRITE_COUNT (Integer) default 1024
+# How many messages can this server send at once to a peer
+MAX_BATCH_WRITE_COUNT=1024
+
+# MAX_BATCH_WRITE_BYTES (Integer) default 1048576 (1 Megabyte)
+# How many bytes can this server send at once to a peer
+MAX_BATCH_WRITE_BYTES=1048576
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -139,9 +139,22 @@ class DatabaseConfigureSessionOp : public DatabaseTypeSpecificOperation<void>
         }
 
         mSession << "PRAGMA journal_mode = WAL";
+        // FULL is needed as to ensure durability
+        // NORMAL is enough for non validating nodes
+        // mSession << "PRAGMA synchronous = NORMAL";
+
+        // number of pages in WAL file
+        mSession << "PRAGMA wal_autocheckpoint=10000";
+
         // busy_timeout gives room for external processes
         // that may lock the database for some time
         mSession << "PRAGMA busy_timeout = 10000";
+
+        // adjust caches
+        // 20000 pages
+        mSession << "PRAGMA cache_size=-20000";
+        // 100 MB map
+        mSession << "PRAGMA mmap_size=104857600";
 
         // Register the sqlite carray() extension we use for bulk operations.
         sqlite3_carray_init(sq->conn_, nullptr, nullptr);

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -66,18 +66,19 @@ class Herder
 
     enum EnvelopeStatus
     {
-        // for some reason this envelope was discarded - either is was invalid,
+        // for some reason this envelope was discarded - either it was invalid,
         // used unsane qset or was coming from node that is not in quorum
-        ENVELOPE_STATUS_DISCARDED,
+        ENVELOPE_STATUS_DISCARDED = -100,
         // envelope was skipped as it's from this validator
-        ENVELOPE_STATUS_SKIPPED_SELF,
+        ENVELOPE_STATUS_SKIPPED_SELF = -10,
+        // envelope was already processed
+        ENVELOPE_STATUS_PROCESSED = -1,
+
         // envelope data is currently being fetched
-        ENVELOPE_STATUS_FETCHING,
+        ENVELOPE_STATUS_FETCHING = 0,
         // current call to recvSCPEnvelope() was the first when the envelope
         // was fully fetched so it is ready for processing
-        ENVELOPE_STATUS_READY,
-        // envelope was already processed
-        ENVELOPE_STATUS_PROCESSED,
+        ENVELOPE_STATUS_READY = 1
     };
 
     virtual State getState() const = 0;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -144,6 +144,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_AUTHENTICATION_TIMEOUT = 2;
     PEER_TIMEOUT = 30;
     PEER_STRAGGLER_TIMEOUT = 120;
+    MAX_BATCH_READ_PERIOD_MS = std::chrono::milliseconds(100);
+    MAX_BATCH_READ_COUNT = 1024;
     PREFERRED_PEERS_ONLY = false;
 
     MINIMUM_IDLE_PERCENT = 0;
@@ -824,6 +826,15 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 PEER_STRAGGLER_TIMEOUT = readInt<unsigned short>(
                     item, 1, std::numeric_limits<unsigned short>::max());
+            }
+            else if (item.first == "MAX_BATCH_READ_PERIOD_MS")
+            {
+                MAX_BATCH_READ_PERIOD_MS =
+                    std::chrono::milliseconds(readInt<int>(item, 1));
+            }
+            else if (item.first == "MAX_BATCH_READ_COUNT")
+            {
+                MAX_BATCH_READ_COUNT = readInt<int>(item, 1);
             }
             else if (item.first == "PREFERRED_PEERS")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -146,6 +146,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_STRAGGLER_TIMEOUT = 120;
     MAX_BATCH_READ_PERIOD_MS = std::chrono::milliseconds(100);
     MAX_BATCH_READ_COUNT = 1024;
+    MAX_BATCH_WRITE_COUNT = 1024;
+    MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
     PREFERRED_PEERS_ONLY = false;
 
     MINIMUM_IDLE_PERCENT = 0;
@@ -835,6 +837,14 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "MAX_BATCH_READ_COUNT")
             {
                 MAX_BATCH_READ_COUNT = readInt<int>(item, 1);
+            }
+            else if (item.first == "MAX_BATCH_WRITE_COUNT")
+            {
+                MAX_BATCH_WRITE_COUNT = readInt<int>(item, 1);
+            }
+            else if (item.first == "MAX_BATCH_WRITE_BYTES")
+            {
+                MAX_BATCH_WRITE_BYTES = readInt<int>(item, 1);
             }
             else if (item.first == "PREFERRED_PEERS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -300,6 +300,8 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short PEER_STRAGGLER_TIMEOUT;
     std::chrono::milliseconds MAX_BATCH_READ_PERIOD_MS;
     int MAX_BATCH_READ_COUNT;
+    int MAX_BATCH_WRITE_COUNT;
+    int MAX_BATCH_WRITE_BYTES;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -298,6 +298,8 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short PEER_AUTHENTICATION_TIMEOUT;
     unsigned short PEER_TIMEOUT;
     unsigned short PEER_STRAGGLER_TIMEOUT;
+    std::chrono::milliseconds MAX_BATCH_READ_PERIOD_MS;
+    int MAX_BATCH_READ_COUNT;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 

--- a/src/overlay/BanManagerImpl.cpp
+++ b/src/overlay/BanManagerImpl.cpp
@@ -37,6 +37,9 @@ BanManagerImpl::banNode(NodeID nodeID)
     }
 
     auto nodeIDString = KeyUtils::toStrKey(nodeID);
+
+    CLOG(INFO, "Overlay") << "ban " << nodeIDString;
+
     auto timer = mApp.getDatabase().getInsertTimer("ban");
     auto prep = mApp.getDatabase().getPreparedStatement(
         "INSERT INTO ban (nodeid) VALUES(:n)");
@@ -50,6 +53,7 @@ void
 BanManagerImpl::unbanNode(NodeID nodeID)
 {
     auto nodeIDString = KeyUtils::toStrKey(nodeID);
+    CLOG(INFO, "Overlay") << "unban " << nodeIDString;
     auto timer = mApp.getDatabase().getDeleteTimer("ban");
     auto prep = mApp.getDatabase().getPreparedStatement(
         "DELETE FROM ban WHERE nodeid = :n;");

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -86,7 +86,6 @@ Floodgate::broadcast(StellarMessage const& msg, bool force,
         return;
     }
     Hash index = sha256(xdr::xdr_to_opaque(msg));
-    CLOG(TRACE, "Overlay") << "broadcast " << hexAbbrev(index);
 
     auto result = mFloodMap.find(index);
     if (result == mFloodMap.end() || force)
@@ -102,6 +101,7 @@ Floodgate::broadcast(StellarMessage const& msg, bool force,
     // make a copy, in case peers gets modified
     auto peers = mApp.getOverlayManager().getAuthenticatedPeers();
 
+    bool log = true;
     for (auto peer : peers)
     {
         assert(peer.second->isAuthenticated());
@@ -109,8 +109,9 @@ Floodgate::broadcast(StellarMessage const& msg, bool force,
             peer.second->getRemoteOverlayVersion() >= minOverlayVersion)
         {
             mSendFromBroadcast.Mark();
-            peer.second->sendMessage(msg);
+            peer.second->sendMessage(msg, log);
             peersTold.insert(peer.second->toString());
+            log = false;
         }
     }
     CLOG(TRACE, "Overlay") << "broadcast " << hexAbbrev(index) << " told "

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -46,7 +46,6 @@ ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
 void
 ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
 {
-    CLOG(TRACE, "Overlay") << "stopFetch " << hexAbbrev(itemHash);
     const auto& iter = mTrackers.find(itemHash);
     if (iter != mTrackers.end())
     {
@@ -61,6 +60,10 @@ ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
             // it
             tracker->cancel();
         }
+    }
+    else
+    {
+        CLOG(TRACE, "Overlay") << "stopFetch untracked " << hexAbbrev(itemHash);
     }
 }
 
@@ -154,7 +157,7 @@ ItemFetcher::recv(Hash itemHash, medida::Timer& timer)
     }
     else
     {
-        CLOG(TRACE, "Overlay") << "Recv " << hexAbbrev(itemHash);
+        CLOG(TRACE, "Overlay") << "Recv untracked " << hexAbbrev(itemHash);
     }
 }
 }

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -195,12 +195,6 @@ LoadManager::PeerContext::~PeerContext()
             mBytesRecvStart;
         auto query =
             (mApp.getDatabase().getQueryMeter().count() - mSQLQueriesStart);
-        if (Logging::logTrace("Overlay"))
-            CLOG(TRACE, "Overlay")
-                << "Debiting peer " << mApp.getConfig().toShortString(mNode)
-                << " time:" << timeMag(time.count())
-                << " send:" << byteMag(send) << " recv:" << byteMag(recv)
-                << " query:" << query;
         pc->mTimeSpent.Mark(time.count());
         pc->mBytesSend.Mark(send);
         pc->mBytesRecv.Mark(recv);

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -115,7 +115,7 @@ OverlayManagerImpl::PeersList::removePeer(Peer* peer)
                      [&](Peer::pointer const& p) { return p.get() == peer; });
     if (pendingIt != std::end(mPending))
     {
-        CLOG(DEBUG, "Overlay") << "Dropping pending " << mDirectionString
+        CLOG(TRACE, "Overlay") << "Dropping pending " << mDirectionString
                                << " peer: " << peer->toString();
         mPending.erase(pendingIt);
         mConnectionsDropped.Mark();
@@ -823,7 +823,7 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
         }
     }
 
-    CLOG(DEBUG, "Overlay") << "Peer " << pstr << " is not preferred @"
+    CLOG(TRACE, "Overlay") << "Peer " << pstr << " is not preferred @"
                            << mApp.getConfig().PEER_PORT;
     return false;
 }
@@ -970,7 +970,7 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
         {
             CLOG(TRACE, "Overlay")
                 << "recv: " << (unique ? "unique" : "duplicate") << " "
-                << Peer::msgSummary(stellarMsg) << " (" << msgType << ")"
+                << peer->msgSummary(stellarMsg) << " (" << msgType << ")"
                 << " of size: " << xdr::xdr_argpack_size(stellarMsg)
                 << " from: "
                 << mApp.getConfig().toShortString(peer->getPeerID()) << " @"

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -186,7 +186,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
         return mApp;
     }
 
-    static std::string msgSummary(StellarMessage const& stellarMsg);
+    std::string msgSummary(StellarMessage const& stellarMsg);
     void sendGetTxSet(uint256 const& setID);
     void sendGetQuorumSet(uint256 const& setID);
     void sendGetPeers();
@@ -194,7 +194,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void sendErrorAndDrop(ErrorCode error, std::string const& message,
                           DropMode dropMode);
 
-    void sendMessage(StellarMessage const& msg);
+    void sendMessage(StellarMessage const& msg, bool log = true);
 
     PeerRole
     getRole() const

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -435,7 +435,8 @@ TCPPeer::startRead()
     // We read large-ish (256KB) buffers of data from TCP which might have quite
     // a few messages in them. We want to digest as many of these
     // _synchronously_ as we can before we issue an async_read against ASIO.
-    YieldTimer yt(mApp.getClock());
+    YieldTimer yt(mApp.getClock(), mApp.getConfig().MAX_BATCH_READ_PERIOD_MS,
+                  mApp.getConfig().MAX_BATCH_READ_COUNT);
     while (mSocket->in_avail() >= HDRSZ && yt.shouldKeepGoing())
     {
         asio::error_code ec_hdr, ec_body;

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -447,11 +447,6 @@ BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
         }
     }
 
-    if (updated)
-    {
-        CLOG(TRACE, "SCP") << "BallotProtocol::updateCurrentValue updated";
-    }
-
     checkInvariants();
 
     return updated;

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -158,9 +158,6 @@ bool
 LocalNode::isQuorumSlice(SCPQuorumSet const& qSet,
                          std::vector<NodeID> const& nodeSet)
 {
-    CLOG(TRACE, "SCP") << "LocalNode::isQuorumSlice"
-                       << " nodeSet.size: " << nodeSet.size();
-
     return isQuorumSliceInternal(qSet, nodeSet);
 }
 
@@ -210,9 +207,6 @@ bool
 LocalNode::isVBlocking(SCPQuorumSet const& qSet,
                        std::vector<NodeID> const& nodeSet)
 {
-    CLOG(TRACE, "SCP") << "LocalNode::isVBlocking"
-                       << " nodeSet.size: " << nodeSet.size();
-
     return isVBlockingInternal(qSet, nodeSet);
 }
 


### PR DESCRIPTION
# Description

This PR does the following:
* makes the batch read/write configs
   * it looks like there are arbitrary delays in current master that are hard to pinpoint without being able to tweak how we bounce with the main thread
* cleans up logging
  * nodes produce way too much data in DEBUG (and TRACE) mode. Logging has so much overhead that nodes can't keep up with normal traffic.
  * add detail in the fewer places where we do want context
* makes a small adjustment to how we continue processing batch reads once we hit the limit.
   * Old version would always default to async read which translates to 2 round trips to the main thread. 
   * We may want to change the post to a delayed post as to ensure that we properly round robin between connections
