### PR TITLE
Update overlay default

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -144,8 +144,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_AUTHENTICATION_TIMEOUT = 2;
     PEER_TIMEOUT = 30;
     PEER_STRAGGLER_TIMEOUT = 120;
-    MAX_BATCH_READ_PERIOD_MS = std::chrono::milliseconds(100);
-    MAX_BATCH_READ_COUNT = 1024;
+    MAX_BATCH_READ_PERIOD_MS = std::chrono::milliseconds(1);
+    MAX_BATCH_READ_COUNT = 1;
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
     PREFERRED_PEERS_ONLY = false;

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -153,12 +153,7 @@ TCPPeer::sendMessage(xdr::msg_ptr&& xdrBytes)
     if (!mWriting)
     {
         mWriting = true;
-        // Post a write to the next crank. We do this asynchronously so
-        // we have a (brief but important) chance to enqueue a bunch of messages
-        // before we issue the write.
-        auto self = static_pointer_cast<TCPPeer>(shared_from_this());
-        self->getApp().postOnMainThread([self]() { self->messageSender(); },
-                                        "TCPPeer: messageSender");
+        messageSender();
     }
 }
 


### PR DESCRIPTION
# Description

This PR updates the defaults used to batch reads to be less aggressive.
It also schedules the first write right away instead of trying to wait for more writes.
