### PR TITLE
TCPPeer: avoid bouncing off ASIO before calling messageSender at first

### DIFF
--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -153,12 +153,7 @@ TCPPeer::sendMessage(xdr::msg_ptr&& xdrBytes)
     if (!mWriting)
     {
         mWriting = true;
-        // Post a write to the next crank. We do this asynchronously so
-        // we have a (brief but important) chance to enqueue a bunch of messages
-        // before we issue the write.
-        auto self = static_pointer_cast<TCPPeer>(shared_from_this());
-        self->getApp().postOnMainThread([self]() { self->messageSender(); },
-                                        "TCPPeer: messageSender");
+        messageSender();
     }
 }
 


### PR DESCRIPTION
This is plausibly causing more latency than it's helping in throughput (see ongoing saga of https://github.com/stellar/stellar-core/issues/2441)