### PR TITLE
Fix seqnum processing in transaction simulation

### DIFF
--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -90,7 +90,7 @@ class TransactionFrame : public TransactionFrameBase
     bool applyOperations(SignatureChecker& checker, Application& app,
                          AbstractLedgerTxn& ltx, TransactionMeta& meta);
 
-    void processSeqNum(AbstractLedgerTxn& ltx);
+    virtual void processSeqNum(AbstractLedgerTxn& ltx);
 
     bool processSignatures(ValidationType cv,
                            SignatureChecker& signatureChecker,

--- a/src/transactions/simulation/SimulationTransactionFrame.cpp
+++ b/src/transactions/simulation/SimulationTransactionFrame.cpp
@@ -100,4 +100,16 @@ SimulationTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
         acc.seqNum = mEnvelope.v0().tx.seqNum;
     }
 }
+
+void
+SimulationTransactionFrame::processSeqNum(AbstractLedgerTxn& ltx)
+{
+    auto header = ltx.loadHeader();
+    if (header.current().ledgerVersion >= 10)
+    {
+        auto sourceAccount = loadSourceAccount(ltx, header);
+        sourceAccount.current().data.account().seqNum =
+            mEnvelope.v0().tx.seqNum;
+    }
+}
 }

--- a/src/transactions/simulation/SimulationTransactionFrame.h
+++ b/src/transactions/simulation/SimulationTransactionFrame.h
@@ -26,6 +26,7 @@ class SimulationTransactionFrame : public TransactionFrame
     int64_t getFee(LedgerHeader const& header, int64_t baseFee) const override;
 
     void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
+    void processSeqNum(AbstractLedgerTxn& ltx) override;
 
   public:
     SimulationTransactionFrame(Hash const& networkID,


### PR DESCRIPTION
It appears that `simulate` command does not work correctly when `ops-per-ledger` is less max ops per ledger config (i.e., 1000), since it is possible to split multiple operations for an account across multiple ledgers and fail in `processSeqNum`. This PR overrides `processSeqNum` similarly to how it's done for `processFeeSeqNum`.