### PR TITLE
Quorum check interrupt

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -89,6 +89,7 @@ class Herder
     virtual void syncMetrics() = 0;
 
     virtual void bootstrap() = 0;
+    virtual void shutdown() = 0;
 
     // restores Herder's state from disk
     virtual void restoreState() = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -132,6 +132,19 @@ HerderImpl::bootstrap()
 }
 
 void
+HerderImpl::shutdown()
+{
+    if (mLastQuorumMapIntersectionState.mRecalculating)
+    {
+        // We want to interrupt any calculation-in-progress at shutdown to
+        // avoid a long pause joining worker threads.
+        CLOG(DEBUG, "Herder")
+            << "Shutdown interrupting quorum transitive closure analysis.";
+        mLastQuorumMapIntersectionState.mInterruptFlag = true;
+    }
+}
+
+void
 HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
 {
     const int DUMP_SCP_TIMEOUT_SECONDS = 20;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1106,23 +1106,54 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
     {
         return;
     }
-    if (!mLastQuorumMapIntersectionState.mRecalculating)
+    QuorumTracker::QuorumMap const& qmap = getCurrentlyTrackedQuorum();
+    Hash curr = getQmapHash(qmap);
+    if (mLastQuorumMapIntersectionState.mLastCheckQuorumMapHash == curr)
     {
-        QuorumTracker::QuorumMap const& qmap = getCurrentlyTrackedQuorum();
-        Hash curr = getQmapHash(qmap);
-        if (mLastQuorumMapIntersectionState.mLastCheckQuorumMapHash != curr)
+        // Everything's stable, nothing to do.
+        return;
+    }
+
+    if (mLastQuorumMapIntersectionState.mRecalculating)
+    {
+        // Already recalculating. If we're recalculating for the hash we want,
+        // we do nothing, just wait for it to finish. If we're recalculating for
+        // a hash that has changed _again_ (since the calculation started), we
+        // _interrupt_ the calculation-in-progress: we'll return to this
+        // function on the next externalize and start a new calculation for the
+        // new hash we want.
+        if (mLastQuorumMapIntersectionState.mCheckingQuorumMapHash == curr)
         {
-            CLOG(INFO, "Herder")
-                << "Transitive closure of quorum has changed, re-analyzing.";
-            mLastQuorumMapIntersectionState.mRecalculating = true;
-            auto& cfg = mApp.getConfig();
-            auto ledger = getCurrentLedgerSeq();
-            auto nNodes = qmap.size();
-            auto qic = QuorumIntersectionChecker::create(qmap, cfg);
-            auto& hState = mLastQuorumMapIntersectionState;
-            auto& app = mApp;
-            auto worker = [curr, ledger, nNodes, qic, qmap, cfg, &app,
-                           &hState] {
+            CLOG(DEBUG, "Herder")
+                << "Transitive closure of quorum has changed, "
+                << "already analyzing new configuration.";
+        }
+        else
+        {
+            CLOG(DEBUG, "Herder")
+                << "Transitive closure of quorum has changed, "
+                << "interrupting existing analysis.";
+            mLastQuorumMapIntersectionState.mInterruptFlag = true;
+        }
+    }
+    else
+    {
+        CLOG(INFO, "Herder")
+            << "Transitive closure of quorum has changed, re-analyzing.";
+        // Not currently recalculating: start doing so.
+        mLastQuorumMapIntersectionState.mRecalculating = true;
+        mLastQuorumMapIntersectionState.mInterruptFlag = false;
+        mLastQuorumMapIntersectionState.mCheckingQuorumMapHash = curr;
+        auto& cfg = mApp.getConfig();
+        auto qic = QuorumIntersectionChecker::create(
+            qmap, cfg, mLastQuorumMapIntersectionState.mInterruptFlag);
+        auto ledger = getCurrentLedgerSeq();
+        auto nNodes = qmap.size();
+        auto& hState = mLastQuorumMapIntersectionState;
+        auto& app = mApp;
+        auto worker = [curr, ledger, nNodes, qic, qmap, cfg, &app, &hState] {
+            try
+            {
                 bool ok = qic->networkEnjoysQuorumIntersection();
                 auto split = qic->getPotentialSplit();
                 std::set<std::set<PublicKey>> critical;
@@ -1132,14 +1163,17 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
                     // intersecting; if not intersecting we should finish ASAP
                     // and raise an alarm.
                     critical = QuorumIntersectionChecker::
-                        getIntersectionCriticalGroups(qmap, cfg);
+                        getIntersectionCriticalGroups(qmap, cfg,
+                                                      hState.mInterruptFlag);
                 }
                 app.postOnMainThread(
                     [ok, curr, ledger, nNodes, split, critical, &hState] {
                         hState.mRecalculating = false;
+                        hState.mInterruptFlag = false;
                         hState.mNumNodes = nNodes;
                         hState.mLastCheckLedger = ledger;
                         hState.mLastCheckQuorumMapHash = curr;
+                        hState.mCheckingQuorumMapHash = Hash{};
                         hState.mPotentialSplit = split;
                         hState.mIntersectionCriticalNodes = critical;
                         if (ok)
@@ -1148,9 +1182,21 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
                         }
                     },
                     "QuorumIntersectionChecker");
-            };
-            mApp.postOnBackgroundThread(worker, "QuorumIntersectionChecker");
-        }
+            }
+            catch (QuorumIntersectionChecker::InterruptedException& ie)
+            {
+                CLOG(DEBUG, "Herder")
+                    << "Quorum transitive closure analysis interrupted.";
+                app.postOnMainThread(
+                    [&hState] {
+                        hState.mRecalculating = false;
+                        hState.mInterruptFlag = false;
+                        hState.mCheckingQuorumMapHash = Hash{};
+                    },
+                    "QuorumIntersectionChecker interrupted");
+            }
+        };
+        mApp.postOnBackgroundThread(worker, "QuorumIntersectionChecker");
     }
 }
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -45,6 +45,7 @@ class HerderImpl : public Herder
 
     // Bootstraps the HerderImpl if we're creating a new Network
     void bootstrap() override;
+    void shutdown() override;
 
     void restoreState() override;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -201,7 +201,9 @@ class HerderImpl : public Herder
         uint32_t mLastGoodLedger{0};
         size_t mNumNodes{0};
         Hash mLastCheckQuorumMapHash{};
+        Hash mCheckingQuorumMapHash{};
         bool mRecalculating{false};
+        std::atomic<bool> mInterruptFlag{false};
         std::pair<std::vector<PublicKey>, std::vector<PublicKey>>
             mPotentialSplit{};
         std::set<std::set<PublicKey>> mIntersectionCriticalNodes{};

--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -17,16 +17,25 @@ class QuorumIntersectionChecker
   public:
     static std::shared_ptr<QuorumIntersectionChecker>
     create(stellar::QuorumTracker::QuorumMap const& qmap,
-           stellar::Config const& cfg, bool quiet = false);
+           stellar::Config const& cfg, std::atomic<bool>& interruptFlag,
+           bool quiet = false);
 
     static std::set<std::set<PublicKey>>
     getIntersectionCriticalGroups(stellar::QuorumTracker::QuorumMap const& qmap,
-                                  stellar::Config const& cfg);
+                                  stellar::Config const& cfg,
+                                  std::atomic<bool>& interruptFlag);
 
     virtual ~QuorumIntersectionChecker(){};
     virtual bool networkEnjoysQuorumIntersection() const = 0;
     virtual size_t getMaxQuorumsFound() const = 0;
     virtual std::pair<std::vector<PublicKey>, std::vector<PublicKey>>
     getPotentialSplit() const = 0;
+
+    // If any thread sets the atomic interruptFlag passed into any of the above
+    // methods, any calculation-in-progress will throw InterruptedException and
+    // unwind.
+    struct InterruptedException
+    {
+    };
 };
 }

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -519,6 +519,10 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     // remainder of the search.
     TarjanSCCCalculator mTSC;
 
+    // Interruption flag: setting this causes the QIC / MQEs to throw
+    // InterruptedException at the nearest convenient moment.
+    std::atomic<bool>& mInterruptFlag;
+
     QBitSet convertSCPQuorumSet(stellar::SCPQuorumSet const& sqs);
     void buildGraph(stellar::QuorumTracker::QuorumMap const& qmap);
     void buildSCCs();
@@ -537,6 +541,7 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
   public:
     QuorumIntersectionCheckerImpl(stellar::QuorumTracker::QuorumMap const& qmap,
                                   stellar::Config const& cfg,
+                                  std::atomic<bool>& interruptFlag,
                                   bool quiet = false);
     bool networkEnjoysQuorumIntersection() const override;
 

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -37,7 +37,8 @@ TEST_CASE("quorum intersection basic 4-node", "[herder][quorumintersection]")
     qm[pkD] = make_shared<QS>(2, VK({pkA, pkB, pkC}), VQ{});
 
     Config cfg(getTestConfig());
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -77,7 +78,8 @@ TEST_CASE("quorum intersection 6-node with subquorums",
     qm[pkF] = make_shared<QS>(2, VK{}, VQ({qsABC, qsABD, qsABE}));
 
     Config cfg(getTestConfig());
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -101,7 +103,8 @@ TEST_CASE("quorum non intersection basic 6-node",
     qm[pkF] = make_shared<QS>(2, VK({pkA, pkB, pkC, pkD, pkE}), VQ{});
 
     Config cfg(getTestConfig());
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -144,7 +147,8 @@ TEST_CASE("quorum non intersection 6-node with subquorums",
     qm[pkF] = make_shared<QS>(2, VK{}, VQ({qsABF, qsADF, qsBDF}));
 
     Config cfg(getTestConfig());
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -219,7 +223,8 @@ TEST_CASE("quorum plausible non intersection", "[herder][quorumintersection]")
     qm[pkCOINQVEST1] = qsCOINQVEST;
     qm[pkCOINQVEST2] = qsCOINQVEST;
 
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -353,7 +358,8 @@ TEST_CASE("quorum intersection 4-org fully-connected, elide all minquorums",
     auto qm = interconnectOrgs(orgs, [](size_t i, size_t j) { return true; });
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -370,7 +376,8 @@ TEST_CASE("quorum intersection 3-org 3-node open line",
     auto qm = interconnectOrgsBidir(orgs, {{0, 1}, {1, 2}});
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -386,7 +393,8 @@ TEST_CASE("quorum intersection 3-org 2-node open line",
     auto qm = interconnectOrgsBidir(orgs, {{0, 1}, {1, 2}});
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -405,7 +413,8 @@ TEST_CASE("quorum intersection 3-org 3-node closed ring",
     auto qm = interconnectOrgsBidir(orgs, {{0, 1}, {1, 2}, {0, 2}});
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -429,7 +438,8 @@ TEST_CASE("quorum intersection 3-org 3-node closed one-way ring",
                                            });
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -453,7 +463,8 @@ TEST_CASE("quorum intersection 3-org 2-node closed one-way ring",
                                            });
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -482,7 +493,8 @@ TEST_CASE("quorum intersection 3-org 2-node 2-of-3 asymmetric",
                                            });
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -528,7 +540,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery dangling",
          {3, 7}});
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -580,7 +593,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery balanced",
          {2, 7}});
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -627,7 +641,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery unbalanced",
          {3, 7}});
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -679,7 +694,8 @@ TEST_CASE("quorum intersection 6-org 1-node 4-null qsets",
 
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 }
@@ -724,7 +740,8 @@ TEST_CASE("quorum intersection 4-org 1-node 4-null qsets",
 
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 }
@@ -736,7 +753,8 @@ TEST_CASE("quorum intersection 6-org 3-node fully-connected",
     auto qm = interconnectOrgs(orgs, [](size_t i, size_t j) { return true; });
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -749,8 +767,36 @@ TEST_CASE("quorum intersection scaling test",
     auto qm = interconnectOrgs(orgs, [](size_t i, size_t j) { return true; });
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
+}
+
+TEST_CASE("quorum intersection interruption", "[herder][quorumintersection]")
+{
+    auto orgs = generateOrgs(16);
+    auto qm = interconnectOrgs(orgs, [](size_t i, size_t j) { return true; });
+    Config cfg(getTestConfig());
+    cfg = configureShortNames(cfg, orgs);
+    std::atomic<bool> interruptFlag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, interruptFlag);
+    std::thread canceller([&interruptFlag]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        interruptFlag = true;
+    });
+    REQUIRE_THROWS_AS(qic->networkEnjoysQuorumIntersection(),
+                      QuorumIntersectionChecker::InterruptedException);
+    canceller.join();
+    interruptFlag = false;
+
+    std::thread canceller2([&interruptFlag]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        interruptFlag = true;
+    });
+    REQUIRE_THROWS_AS(
+        qic->getIntersectionCriticalGroups(qm, cfg, interruptFlag),
+        QuorumIntersectionChecker::InterruptedException);
+    canceller2.join();
 }
 
 static void
@@ -832,11 +878,12 @@ TEST_CASE("quorum intersection criticality",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
     auto groups =
-        QuorumIntersectionChecker::getIntersectionCriticalGroups(qm, cfg);
+        QuorumIntersectionChecker::getIntersectionCriticalGroups(qm, cfg, flag);
     REQUIRE(groups.size() == 1);
     REQUIRE(groups == std::set<std::set<PublicKey>>{{orgs[3][0]}});
 }
@@ -894,7 +941,8 @@ TEST_CASE("quorum intersection finds smaller SCC with quorums",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
-    auto qic = QuorumIntersectionChecker::create(qm, cfg);
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() != 0);
 }

--- a/src/history/InferredQuorumUtils.cpp
+++ b/src/history/InferredQuorumUtils.cpp
@@ -41,7 +41,8 @@ checkQuorumIntersection(Config const& cfg, uint32_t ledgerNum)
     LOG(INFO) << "Checking last-heard quorum from herder";
     app->start();
     auto qmap = getQuorumMapForLedger(app, ledgerNum);
-    auto qic = QuorumIntersectionChecker::create(qmap, cfg);
+    std::atomic<bool> interruptFlag{false};
+    auto qic = QuorumIntersectionChecker::create(qmap, cfg, interruptFlag);
     qic->networkEnjoysQuorumIntersection();
 }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -487,6 +487,10 @@ ApplicationImpl::gracefulStop()
     {
         mBucketManager->shutdown();
     }
+    if (mHerder)
+    {
+        mHerder->shutdown();
+    }
 
     mStoppingTimer.expires_from_now(
         std::chrono::seconds(SHUTDOWN_DELAY_SECONDS));

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -266,7 +266,14 @@ runTest(CommandLineArgs const& args)
     }
 
     auto r = session.run();
-    gTestRoots.clear();
+    while (!gTestRoots.empty())
+    {
+        // Don't call gTestRoots.clear() here -- order of deletion is
+        // not actually specified by vector::clear, and varies between
+        // different C++ stdlibs, and we're (ulp) relying on destructor
+        // order to clean up tmpdirs sensibly. Instead: pop repeatedly.
+        gTestRoots.pop_back();
+    }
     gTestCfg->clear();
     if (r != 0)
     {

--- a/src/util/TmpDir.cpp
+++ b/src/util/TmpDir.cpp
@@ -51,8 +51,11 @@ TmpDir::~TmpDir()
 
     try
     {
-        fs::deltree(*mPath);
-        LOG(DEBUG) << "TmpDir deleted: " << *mPath;
+        if (fs::exists(*mPath))
+        {
+            fs::deltree(*mPath);
+            LOG(DEBUG) << "TmpDir deleted: " << *mPath;
+        }
     }
     catch (std::runtime_error& e)
     {


### PR DESCRIPTION
# Description

This adds an asynchronous inter-thread interruption mechanism to the quorum intersection checking subsystem (which runs on a background thread) and triggers it on both server shutdown concurrent quorum changes during a running calculation. Rather than thread an interruption status all the way in and out of every line of the subsystem, I just have it throw and catch an exception. This shouldn't happen especially often.

Also includes two fixes that both address (in different ways) a sporadic bug I've seen lately concerning deleting tmpdirs in the wrong order during shutdown.

Resolves #2189 
Resolves #2443

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
