### PR TITLE
Do not fsync metadata output stream, pipes do not support.

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1029,8 +1029,10 @@ LedgerManagerImpl::setupLedgerCloseMetaStream()
     auto& cfg = mApp.getConfig();
     if (cfg.METADATA_OUTPUT_STREAM != "")
     {
+        // We can't be sure we're writing to a stream that supports fsync;
+        // pipes typically error when you try. So we don't do it.
         mMetaStream =
-            std::make_unique<XDROutputFileStream>(/*fsyncOnClose=*/true);
+            std::make_unique<XDROutputFileStream>(/*fsyncOnClose=*/false);
         std::regex fdrx("^fd:([0-9]+)$");
         std::smatch sm;
         if (std::regex_match(cfg.METADATA_OUTPUT_STREAM, sm, fdrx))


### PR DESCRIPTION
This just changes the metadata output stream to not fsync on close: pipes don't support that, and we really can't tell when we have or don't-have a pipe.