### PR TITLE
Correctly reset catchup status

### DIFF
--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -241,9 +241,9 @@ void
 CatchupManagerImpl::trimAndReset()
 {
     assert(mCatchupWork);
+    mCatchupWork.reset();
 
     logAndUpdateCatchupStatus(true);
-    mCatchupWork.reset();
     trimSyncingLedgers();
 }
 


### PR DESCRIPTION
Catchup refactor resulted in not clearing catchup status.