### PR TITLE
Checkpoint ledger arithmetic and catchup range arithmetic cleanup

### DIFF
--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -29,7 +29,7 @@ ApplyCheckpointWork::ApplyCheckpointWork(Application& app,
                                          LedgerRange const& range)
     : BasicWork(app,
                 "apply-ledgers-" +
-                    fmt::format("{}-{}", range.mFirst, range.mLast),
+                    fmt::format("{}-{}", range.mFirst, range.limit()),
                 BasicWork::RETRY_NEVER)
     , mDownloadDir(downloadDir)
     , mLedgerRange(range)
@@ -48,7 +48,7 @@ ApplyCheckpointWork::ApplyCheckpointWork(Application& app,
         throw std::runtime_error(
             "Ledger range start must be aligned with checkpoint start");
     }
-    if (mLedgerRange.mLast > mCheckpoint)
+    if (mLedgerRange.mCount > 0 && mLedgerRange.last() > mCheckpoint)
     {
         throw std::runtime_error(
             "Ledger range must span at most 1 checkpoint worth of ledgers");
@@ -285,7 +285,8 @@ ApplyCheckpointWork::onRun()
         }
 
         auto const& lm = mApp.getLedgerManager();
-        auto done = lm.getLastClosedLedgerNum() == mLedgerRange.mLast;
+        auto done = (mLedgerRange.mCount == 0 ||
+                     lm.getLastClosedLedgerNum() == mLedgerRange.last());
 
         if (done)
         {

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -279,11 +279,6 @@ ApplyCheckpointWork::onRun()
             }
         }
 
-        if (!mFilesOpen)
-        {
-            openInputFiles();
-        }
-
         auto const& lm = mApp.getLedgerManager();
         auto done = (mLedgerRange.mCount == 0 ||
                      lm.getLastClosedLedgerNum() == mLedgerRange.last());
@@ -291,6 +286,11 @@ ApplyCheckpointWork::onRun()
         if (done)
         {
             return State::WORK_SUCCESS;
+        }
+
+        if (!mFilesOpen)
+        {
+            openInputFiles();
         }
 
         auto lcd = getNextLedgerCloseData();

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -42,8 +42,7 @@ ApplyCheckpointWork::ApplyCheckpointWork(Application& app,
 {
     // Ledger range check to enforce application of a single checkpoint
     auto const& hm = mApp.getHistoryManager();
-    auto low = std::max(LedgerManager::GENESIS_LEDGER_SEQ,
-                        hm.prevCheckpointLedger(mCheckpoint));
+    auto low = hm.firstLedgerInCheckpointContaining(mCheckpoint);
     if (mLedgerRange.mFirst != low)
     {
         throw std::runtime_error(

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -116,7 +116,8 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
     // for the sake of simplicity at the moment it's set to one ledger
     // after the first buffered one.
     std::string message;
-    uint32_t catchupTriggerLedger = firstLedgerInBuffer + 1;
+    uint32_t catchupTriggerLedger =
+        hm.ledgerToTriggerCatchup(firstLedgerInBuffer);
     if (lastReceivedLedgerSeq >= catchupTriggerLedger)
     {
         message = fmt::format("Starting catchup after ensuring checkpoint "

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -57,71 +57,82 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
 
     uint32_t lastReceivedLedgerSeq = ledgerData.getLedgerSeq();
 
-    // Caught up
+    // If LCL is already at-or-ahead of the ledger we just received from the
+    // network, we're up to date. Return early, nothing to do.
     if (lastReceivedLedgerSeq <=
         mApp.getLedgerManager().getLastClosedLedgerNum())
     {
         return;
     }
 
-    auto addLedgerData = [&]() { addToSyncingLedgers(ledgerData); };
+    // For the rest of this method: we know LCL has fallen behind the network,
+    // we only need to decide whether to buffer the newly received ledger and/or
+    // start the CatchupWork state machine.
+    //
+    // Assuming we fell out of sync at ledger K, we wait for the first ledger L
+    // of the checkpoint following K, and begin buffering from there. When we
+    // reach L+1 we assume the checkpoint covering K has probably been published
+    // to history and commence catchup, running the (checkpoint-driven) catchup
+    // state machine to ledger L-1 (the end of the checkpoint covering K) and
+    // then replay buffered ledgers from L onwards.
 
-    if (!mCatchupWork)
+    // First: if CatchupWork has started, just buffer and return early.
+    if (mCatchupWork)
     {
-        uint32_t checkpointLedger;
-        if (!mSyncingLedgers.empty())
-        {
-            // front of mSyncingLedgers should always be a checkpoint ledger if
-            // catchup is not running
-            uint32_t firstBufferedLedgerSeq =
-                mSyncingLedgers.front().getLedgerSeq();
+        addToSyncingLedgers(ledgerData);
+        logAndUpdateCatchupStatus(true);
+        return;
+    }
 
-            checkpointLedger = mApp.getHistoryManager().nextCheckpointLedger(
-                firstBufferedLedgerSeq);
-            assert(checkpointLedger == firstBufferedLedgerSeq);
+    // Next switch between 3 cases: starting buffering, waiting to
+    // buffer, and already buffering.
+    auto& hm = mApp.getHistoryManager();
+    uint32_t firstLedgerInBuffer;
+    if (mSyncingLedgers.empty())
+    {
+        if (hm.isFirstLedgerInCheckpoint(lastReceivedLedgerSeq))
+        {
+            // Case 1: At the ledger where we should start buffering.
+            addToSyncingLedgers(ledgerData);
+            firstLedgerInBuffer = lastReceivedLedgerSeq;
         }
         else
         {
-            checkpointLedger = mApp.getHistoryManager().nextCheckpointLedger(
-                lastReceivedLedgerSeq);
-
-            // We wait until checkpoint + 1 ledger is closed before we start
-            // catchup, but we want to catchup to checkpoint - 1 so we don't
-            // have to wait for the next checkpoint snapshot. We need to
-            // buffer the checkpoint ledger because of this.
-            if (lastReceivedLedgerSeq == checkpointLedger)
-            {
-                addLedgerData();
-            }
+            // Case 2: Still waiting to start buffering.
+            firstLedgerInBuffer =
+                hm.firstLedgerAfterCheckpointContaining(lastReceivedLedgerSeq);
         }
-
-        std::string message;
-        uint32_t catchupTriggerLedger = checkpointLedger + 1;
-        if (lastReceivedLedgerSeq >= catchupTriggerLedger)
-        {
-            addLedgerData();
-
-            message = fmt::format("Starting catchup after ensuring checkpoint "
-                                  "ledger {} was closed on network",
-                                  catchupTriggerLedger);
-
-            startOnlineCatchup();
-        }
-        else
-        {
-            auto eta = (catchupTriggerLedger - lastReceivedLedgerSeq) *
-                       mApp.getConfig().getExpectedLedgerCloseTime();
-            message = fmt::format("Waiting for trigger ledger: {}/{}, ETA: {}s",
-                                  lastReceivedLedgerSeq, catchupTriggerLedger,
-                                  eta.count());
-        }
-        logAndUpdateCatchupStatus(true, message);
     }
     else
     {
-        addLedgerData();
-        logAndUpdateCatchupStatus(true);
+        // Case 3: Already buffering, keep buffering.
+        addToSyncingLedgers(ledgerData);
+        firstLedgerInBuffer = mSyncingLedgers.front().getLedgerSeq();
     }
+    assert(hm.isFirstLedgerInCheckpoint(firstLedgerInBuffer));
+
+    // Finally we wait some number of ledgers beyond the first buffered
+    // ledger before we trigger the CatchupWork. This could be any number,
+    // for the sake of simplicity at the moment it's set to one ledger
+    // after the first buffered one.
+    std::string message;
+    uint32_t catchupTriggerLedger = firstLedgerInBuffer + 1;
+    if (lastReceivedLedgerSeq >= catchupTriggerLedger)
+    {
+        message = fmt::format("Starting catchup after ensuring checkpoint "
+                              "ledger {} was closed on network",
+                              catchupTriggerLedger);
+        startOnlineCatchup();
+    }
+    else
+    {
+        auto eta = (catchupTriggerLedger - lastReceivedLedgerSeq) *
+                   mApp.getConfig().getExpectedLedgerCloseTime();
+        message = fmt::format("Waiting for trigger ledger: {}/{}, ETA: {}s",
+                              lastReceivedLedgerSeq, catchupTriggerLedger,
+                              eta.count());
+    }
+    logAndUpdateCatchupStatus(true, message);
 }
 
 void

--- a/src/catchup/CatchupRange.cpp
+++ b/src/catchup/CatchupRange.cpp
@@ -78,7 +78,7 @@ calculateCatchupRange(uint32_t lcl, CatchupConfiguration const& cfg,
         return CatchupRange(applyBucketsOnlyAt);
     }
 
-    uint32_t targetStart = cfg.toLedger() - cfg.count();
+    uint32_t targetStart = cfg.toLedger() - cfg.count() + 1;
     uint32_t firstInCheckpoint =
         hm.firstLedgerInCheckpointContaining(targetStart);
 

--- a/src/catchup/CatchupRange.cpp
+++ b/src/catchup/CatchupRange.cpp
@@ -1,0 +1,175 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "catchup/CatchupRange.h"
+#include "catchup/CatchupConfiguration.h"
+#include "history/HistoryManager.h"
+#include "ledger/LedgerManager.h"
+#include "util/Logging.h"
+#include <lib/util/format.h>
+
+namespace
+{
+using namespace stellar;
+void
+checkCatchupPreconditions(uint32_t lastClosedLedger,
+                          CatchupConfiguration const& configuration)
+{
+    if (lastClosedLedger == 0)
+    {
+        throw std::invalid_argument{"lastClosedLedger == 0"};
+    }
+
+    if (configuration.toLedger() <= lastClosedLedger)
+    {
+        throw std::invalid_argument{
+            "configuration.toLedger() <= lastClosedLedger"};
+    }
+
+    if (configuration.toLedger() <= LedgerManager::GENESIS_LEDGER_SEQ)
+    {
+        throw std::invalid_argument{
+            "configuration.toLedger() <= LedgerManager::GENESIS_LEDGER_SEQ"};
+    }
+
+    if (configuration.toLedger() == CatchupConfiguration::CURRENT)
+    {
+        throw std::invalid_argument{
+            "configuration.toLedger() == CatchupConfiguration::CURRENT"};
+    }
+}
+
+CatchupRange
+calculateCatchupRange(uint32_t lcl, CatchupConfiguration const& cfg,
+                      HistoryManager const& hm)
+{
+    checkCatchupPreconditions(lcl, cfg);
+    const uint32_t init = LedgerManager::GENESIS_LEDGER_SEQ;
+
+    // Case 1: replay from LCL as we're already past genesis.
+    if (lcl > init)
+    {
+        LedgerRange replay(lcl + 1, cfg.toLedger() - lcl);
+        // CLOG(TRACE, "History") << "CatchupRange: case 1 (lcl is past
+        // genesis)";
+        return CatchupRange(replay);
+    }
+
+    // All remaining cases have LCL == genesis.
+    assert(lcl == init);
+    LedgerRange fullReplay(init + 1, cfg.toLedger() - init);
+
+    // Case 2: full replay because count >= target - init.
+    if (cfg.count() >= cfg.toLedger() - init)
+    {
+        // CLOG(TRACE, "History") << "CatchupRange: case 2 (count passes
+        // target)";
+        return CatchupRange(fullReplay);
+    }
+
+    // Case 3: special case of buckets only, no replay; only
+    // possible when targeting the exact end of a checkpoint.
+    if (cfg.count() == 0 && hm.isLastLedgerInCheckpoint(cfg.toLedger()))
+    {
+        uint32_t applyBucketsOnlyAt = cfg.toLedger();
+        // CLOG(TRACE, "History") << "CatchupRange: case 3 (checkpoint
+        // boundary)";
+        return CatchupRange(applyBucketsOnlyAt);
+    }
+
+    uint32_t targetStart = cfg.toLedger() - cfg.count();
+    uint32_t firstInCheckpoint =
+        hm.firstLedgerInCheckpointContaining(targetStart);
+
+    // Case 4: target is inside first checkpoint, just replay.
+    if (firstInCheckpoint == init)
+    {
+        // CLOG(TRACE, "History") << "CatchupRange: case 4 (in first
+        // checkpoint)";
+        return CatchupRange(fullReplay);
+    }
+
+    // Case 5: apply buckets, then replay.
+    uint32_t applyBucketsAt =
+        hm.lastLedgerBeforeCheckpointContaining(targetStart);
+    LedgerRange replay(firstInCheckpoint, cfg.toLedger() - applyBucketsAt);
+    // CLOG(TRACE, "History") << "CatchupRange: case 5 (apply buckets and
+    // replay)";
+    return CatchupRange(applyBucketsAt, replay);
+}
+}
+
+namespace stellar
+{
+
+CatchupRange::CatchupRange(uint32_t applyBucketsAtLedger)
+    : mApplyBuckets(true)
+    , mApplyBucketsAtLedger(applyBucketsAtLedger)
+    , mReplayRange(0, 0)
+{
+    // CLOG(TRACE, "History") << "CatchupRange: apply buckets only at "
+    //                        << mApplyBucketsAtLedger;
+    checkInvariants();
+}
+
+CatchupRange::CatchupRange(LedgerRange const& replayRange)
+    : mApplyBuckets(false), mApplyBucketsAtLedger(0), mReplayRange(replayRange)
+{
+    // CLOG(TRACE, "History") << "CatchupRange: no buckets"
+    //                        << ", replayFirst=" << getReplayFirst()
+    //                        << ", replayCount=" << getReplayCount();
+    checkInvariants();
+}
+
+CatchupRange::CatchupRange(uint32_t applyBucketsAtLedger,
+                           LedgerRange const& replayRange)
+    : mApplyBuckets(true)
+    , mApplyBucketsAtLedger(applyBucketsAtLedger)
+    , mReplayRange(replayRange)
+{
+    // CLOG(TRACE, "History") << "CatchupRange: apply buckets at "
+    //                        << mApplyBucketsAtLedger
+    //                        << ", replayFirst=" << getReplayFirst()
+    //                        << ", replayCount=" << getReplayCount();
+    checkInvariants();
+}
+
+CatchupRange::CatchupRange(uint32_t lastClosedLedger,
+                           CatchupConfiguration const& configuration,
+                           HistoryManager const& historyManager)
+    : CatchupRange(calculateCatchupRange(lastClosedLedger, configuration,
+                                         historyManager))
+{
+    checkInvariants();
+}
+
+void
+CatchupRange::checkInvariants()
+{
+    // Must be applying buckets and/or replaying.
+    assert(applyBuckets() || replayLedgers());
+
+    if (!applyBuckets() && replayLedgers())
+    {
+        // Cases 1, 2 and 4: no buckets, only replay.
+        assert(mApplyBucketsAtLedger == 0);
+        assert(mReplayRange.mFirst != 0);
+    }
+
+    else if (applyBuckets() && replayLedgers())
+    {
+        // Case 5: buckets and replay.
+        assert(mApplyBucketsAtLedger != 0);
+        assert(mReplayRange.mFirst != 0);
+        assert(mApplyBucketsAtLedger + 1 == mReplayRange.mFirst);
+    }
+
+    else
+    {
+        // Case 3: buckets only, no replay.
+        assert(applyBuckets() && !replayLedgers());
+        assert(mReplayRange.mFirst == 0);
+    }
+}
+}

--- a/src/catchup/CatchupRange.h
+++ b/src/catchup/CatchupRange.h
@@ -1,0 +1,186 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "catchup/CatchupConfiguration.h"
+#include "ledger/LedgerRange.h"
+#include <stdexcept>
+
+namespace stellar
+{
+
+class HistoryManager;
+struct CheckpointRange;
+
+// Range required to do a catchup.
+//
+// Ranges originate in CatchupConfigurations which have "last" ledger L to catch
+// up to, and a count C of ledgers "before" L to replay.
+//
+// We transform this (along with knowledge of the current LCL) into a pair of at
+// least one -- possibly both -- of a checkpoint bucket-apply and a half-open
+// LedgerRange to replay.
+//
+// Such a replay range, if nonempty, will start immediately following the LCL or
+// the bucket-apply. There are thus five possible cases:
+//
+//   1. LCL is not genesis, we replay from LCL.
+//   2. Requested count C exceeds L, we replay from LCL.
+//   3. C is zero and L is on a checkpoint, we only apply buckets.
+//   4. L is within the first checkpoint, we replay from LCL.
+//   5. Otherwise we apply buckets at previous checkpoint, then replay.
+
+class CatchupRange
+{
+    // Whether to apply buckets.
+    bool const mApplyBuckets;
+
+    // Which ledger to apply buckets at, or zero if !mApplyBuckets.
+    uint32_t const mApplyBucketsAtLedger;
+
+    // After possibly applying buckets, replay a half-open range of ledgers.
+    // In other words if mReplayRange.mCount is zero, no replay happens.
+    LedgerRange const mReplayRange;
+
+    void checkInvariants();
+
+  public:
+    // Return a LedgerRange spanning both the apply-buckets phase (if it
+    // exists) and the replay phase.
+    LedgerRange
+    getFullRangeIncludingBucketApply() const
+    {
+        if (mApplyBuckets)
+        {
+            assert(mReplayRange.mCount == 0 ||
+                   mReplayRange.mFirst == mApplyBucketsAtLedger + 1);
+            return LedgerRange(mApplyBucketsAtLedger, mReplayRange.mCount + 1);
+        }
+        else
+        {
+            return mReplayRange;
+        }
+    }
+
+    uint32_t
+    count() const
+    {
+        if (mApplyBuckets)
+        {
+            return mReplayRange.mCount + 1;
+        }
+        return mReplayRange.mCount;
+    }
+
+    uint32_t
+    first() const
+    {
+        if (mApplyBuckets)
+        {
+            return mApplyBucketsAtLedger;
+        }
+        else
+        {
+            return mReplayRange.mFirst;
+        }
+    }
+
+    uint32_t
+    last() const
+    {
+        if (mReplayRange.mCount != 0)
+        {
+            return mReplayRange.last();
+        }
+        else
+        {
+            // If we're not doing any ledger replay, we should at least be
+            // applying buckets.
+            assert(mApplyBuckets);
+            return mApplyBucketsAtLedger;
+        }
+    }
+
+    // Return the LedgerRange that covers the ledger-replay part of this
+    // catchup.
+    LedgerRange
+    getReplayRange() const
+    {
+        return mReplayRange;
+    }
+
+    bool
+    replayLedgers() const
+    {
+        return mReplayRange.mCount > 0;
+    }
+
+    uint32_t
+    getReplayFirst() const
+    {
+        return mReplayRange.mFirst;
+    }
+
+    uint32_t
+    getReplayCount() const
+    {
+        return mReplayRange.mCount;
+    }
+
+    // Return first+count, which is one-past-the-last ledger to replay.
+    // Best to use this in a loop header to properly handle count=0.
+    uint32_t
+    getReplayLimit() const
+    {
+        return mReplayRange.limit();
+    }
+
+    // Return first+count-1 which is the last ledger to replay, but
+    // throw if count==0. Use only in rare "inclusive range" cases.
+    uint32_t
+    getReplayLast() const
+    {
+        return mReplayRange.last();
+    }
+
+    bool
+    applyBuckets() const
+    {
+        return mApplyBuckets;
+    }
+
+    uint32_t
+    getBucketApplyLedger() const
+    {
+        if (!mApplyBuckets)
+        {
+            throw std::logic_error("getBucketApplyLedger() cannot be called on "
+                                   "CatchupRange when mApplyBuckets == false");
+        }
+        return mApplyBucketsAtLedger;
+    }
+
+    /**
+     * Preconditions:
+     * * lastClosedLedger > 0
+     * * configuration.toLedger() > LedgerManager::GENESIS_LEDGER_SEQ
+     * * configuration.toLedger() > lastClosedLedger
+     * * configuration.toLedger() != CatchupConfiguration::CURRENT
+     */
+    explicit CatchupRange(uint32_t lastClosedLedger,
+                          CatchupConfiguration const& configuration,
+                          HistoryManager const& historyManager);
+
+    // Apply buckets only, no replay.
+    explicit CatchupRange(uint32_t applyBucketsAtLedger);
+
+    // Replay only, no buckets.
+    explicit CatchupRange(LedgerRange const& replayRange);
+
+    // Apply buckets then replay.
+    explicit CatchupRange(uint32_t applyBucketsAtLedger,
+                          LedgerRange const& replayRange);
+};
+}

--- a/src/catchup/CatchupRange.h
+++ b/src/catchup/CatchupRange.h
@@ -54,8 +54,6 @@ class CatchupRange
     {
         if (mApplyBuckets)
         {
-            assert(mReplayRange.mCount == 0 ||
-                   mReplayRange.mFirst == mApplyBucketsAtLedger + 1);
             return LedgerRange(mApplyBucketsAtLedger, mReplayRange.mCount + 1);
         }
         else

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -199,9 +199,8 @@ CatchupWork::runCatchupStep()
         auto toCheckpoint =
             mCatchupConfiguration.toLedger() == CatchupConfiguration::CURRENT
                 ? CatchupConfiguration::CURRENT
-                : mApp.getHistoryManager().nextCheckpointLedger(
-                      mCatchupConfiguration.toLedger() + 1) -
-                      1;
+                : mApp.getHistoryManager().checkpointContainingLedger(
+                      mCatchupConfiguration.toLedger());
         mGetHistoryArchiveStateWork =
             addWork<GetHistoryArchiveStateWork>(toCheckpoint, mArchive);
         mCurrentWork = mGetHistoryArchiveStateWork;

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -31,10 +31,17 @@ struct CheckpointRange;
 //    ignore C and just replay from LCL-to-L to avoid the possibility of
 //    introducing gaps into our replay.
 //
-//  - This leaves two sub-cases, both with LCL == GENESIS_LEDGER_SEQ:
+//  - This leaves three cases, both with LCL == GENESIS_LEDGER_SEQ:
 //
-//    - When LCL + C > L, the user asked for something nonsensical but again we
-//      just interpret this as meaning "replay from LCL-to-L".
+//    - When LCL + C > L, the user asked for more ledgers to be replayed than
+//      exist in the range [LCL+1, L] but again we just interpret this as
+//      meaning "replay from LCL-to-L".
+//
+//    - If C=0 and L is the last ledger in a checkpoint, we can land _on_ that
+//      checkpoint just by doing bucket apply. This produces a somewhat
+//      weird-looking catchup range where first=L+1 and last=L -- i.e.  first is
+//      _after_ last! -- but it's consistent with the normal rule that
+//      first=(last-count)+1 that holds the rest of the time.
 //
 //    - Otherwise the user is implicitly asking for the range of size C given by
 //      the interval [K, L] to be replayed, where K=(L-C)+1. We then round down

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -48,8 +48,7 @@ DownloadApplyTxsWork::yieldMoreWork()
         std::make_shared<GetAndUnzipRemoteFileWork>(mApp, ft, mArchive);
 
     auto const& hm = mApp.getHistoryManager();
-    auto low = std::max(LedgerManager::GENESIS_LEDGER_SEQ,
-                        hm.prevCheckpointLedger(mCheckpointToQueue));
+    auto low = hm.firstLedgerInCheckpointContaining(mCheckpointToQueue);
     auto high = std::min(mCheckpointToQueue, mRange.mLast);
     auto apply = std::make_shared<ApplyCheckpointWork>(mApp, mDownloadDir,
                                                        LedgerRange{low, high});

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -105,14 +105,11 @@ VerifyLedgerChainWork::VerifyLedgerChainWork(
 std::string
 VerifyLedgerChainWork::getStatus() const
 {
-    if (!isDone() && !isAborting())
+    if (!isDone() && !isAborting() && mRange.mCount != 0)
     {
-        if (mRange.mCount != 0)
-        {
-            std::string task = "verifying checkpoint";
-            return fmtProgress(mApp, task, mRange,
-                               (mRange.last() - mCurrCheckpoint));
-        }
+        std::string task = "verifying checkpoint";
+        return fmtProgress(mApp, task, mRange,
+                           (mRange.last() - mCurrCheckpoint));
     }
     return BasicWork::getStatus();
 }

--- a/src/catchup/simulation/HistoryArchiveStream.cpp
+++ b/src/catchup/simulation/HistoryArchiveStream.cpp
@@ -202,7 +202,7 @@ HistoryArchiveStream::getNextLedger(LedgerHeaderHistoryEntry& header,
                                     TransactionHistoryEntry& transaction,
                                     TransactionHistoryResultEntry& result)
 {
-    if (mHeaderHistory.header.ledgerSeq < mRange.mLast)
+    if (mHeaderHistory.header.ledgerSeq < mRange.limit())
     {
         if (mHeaderHistory.header.ledgerSeq == 0)
         {

--- a/src/catchup/simulation/HistoryArchiveStream.cpp
+++ b/src/catchup/simulation/HistoryArchiveStream.cpp
@@ -202,7 +202,7 @@ HistoryArchiveStream::getNextLedger(LedgerHeaderHistoryEntry& header,
                                     TransactionHistoryEntry& transaction,
                                     TransactionHistoryResultEntry& result)
 {
-    if (mHeaderHistory.header.ledgerSeq < mRange.limit())
+    if (mRange.mCount > 0 && mHeaderHistory.header.ledgerSeq < mRange.last())
     {
         if (mHeaderHistory.header.ledgerSeq == 0)
         {

--- a/src/catchup/simulation/HistoryArchiveStream.cpp
+++ b/src/catchup/simulation/HistoryArchiveStream.cpp
@@ -15,11 +15,14 @@ HistoryArchiveStream::HistoryArchiveStream(TmpDir const& downloadDir,
                                            HistoryManager const& hm)
     : mDownloadDir(downloadDir), mRange(range), mHistoryManager(hm)
 {
-    if (mRange.mFirst != 1 &&
-        mHistoryManager.nextCheckpointLedger(mRange.mFirst) != mRange.mFirst)
+    // If we're trying to start reading from some place that's not a checkpoint
+    // boundary, we need to scan the stream forward from the checkpoint boundary
+    // to just before the target ledger.
+    if (!mHistoryManager.isFirstLedgerInCheckpoint(mRange.mFirst))
     {
-        uint32_t prev = mHistoryManager.prevCheckpointLedger(mRange.mFirst);
-        readHeaderHistory(std::max<uint32_t>(1, prev));
+        uint32_t first =
+            mHistoryManager.firstLedgerInCheckpointContaining(mRange.mFirst);
+        readHeaderHistory(first);
         readTransactionHistory();
         readResultHistory();
         while (mHeaderHistory.header.ledgerSeq != mRange.mFirst - 1)
@@ -36,9 +39,10 @@ HistoryArchiveStream::readHeaderHistory(uint32_t ledgerSeq)
 {
     LedgerHeaderHistoryEntry lhhe;
 
-    if (ledgerSeq == 1 ||
-        mHistoryManager.nextCheckpointLedger(ledgerSeq) == ledgerSeq)
+    if (mHistoryManager.isFirstLedgerInCheckpoint(ledgerSeq))
     {
+        // If we're being asked to start reading a _new_ checkpoint but there's
+        // an existing stream open, it should be done reading its checkpoint.
         if (mHeaderStream && mHeaderStream.readOne(lhhe))
         {
             throw std::runtime_error(
@@ -84,15 +88,19 @@ HistoryArchiveStream::readTransactionHistory()
     TransactionHistoryEntry txhe;
 
     uint32_t ledgerSeq = mHeaderHistory.header.ledgerSeq;
-    if (ledgerSeq == 1 ||
-        mHistoryManager.nextCheckpointLedger(ledgerSeq) == ledgerSeq)
+    if (mHistoryManager.isFirstLedgerInCheckpoint(ledgerSeq))
     {
+        // If we're being asked to start reading a _new_ checkpoint but there's
+        // an existing buffered transaction it should be in the past.
         if (mTransactionHistory.ledgerSeq >= ledgerSeq)
         {
             throw std::runtime_error("Buffered transaction history should not "
                                      "be ahead at end of checkpoint");
         }
 
+        // If we're being asked to start reading a _new_ checkpoint but there's
+        // an existing transaction stream open, it should be done reading its
+        // checkpoint.
         if (mTransactionStream && mTransactionStream.readOne(txhe))
         {
             throw std::runtime_error(
@@ -144,15 +152,19 @@ HistoryArchiveStream::readResultHistory()
     TransactionHistoryResultEntry txre;
 
     uint32_t ledgerSeq = mHeaderHistory.header.ledgerSeq;
-    if (ledgerSeq == 1 ||
-        mHistoryManager.nextCheckpointLedger(ledgerSeq) == ledgerSeq)
+    if (mHistoryManager.isFirstLedgerInCheckpoint(ledgerSeq))
     {
+        // If we're being asked to start reading a _new_ checkpoint but there's
+        // an existing buffered result it should be in the past.
         if (mResultHistory.ledgerSeq >= ledgerSeq)
         {
             throw std::runtime_error("Buffered result history should not be "
                                      "ahead at end of checkpoint");
         }
 
+        // If we're being asked to start reading a _new_ checkpoint but there's
+        // an existing result stream open, it should be done reading its
+        // checkpoint.
         if (mResultStream && mResultStream.readOne(txre))
         {
             throw std::runtime_error(

--- a/src/catchup/test/CatchupWorkTests.cpp
+++ b/src/catchup/test/CatchupWorkTests.cpp
@@ -137,10 +137,15 @@ TEST_CASE("compute CatchupRange from CatchupConfiguration", "[catchup]")
         auto name = fmt::format("lcl = {}, to ledger = {}, count = {}",
                                 lastClosedLedger, configuration.toLedger(),
                                 configuration.count());
-        LOG(DEBUG) << "Catchup configuration: " << name;
+        CLOG(DEBUG, "History") << "Catchup configuration: " << name;
         {
             auto range =
                 CatchupRange{lastClosedLedger, configuration, historyManager};
+
+            CLOG(DEBUG, "History")
+                << "computed range: first=" << range.mLedgers.mFirst
+                << ", count=" << range.mLedgers.mCount
+                << ", last=" << range.getLast();
 
             // we need to finish where we wanted to finish
             REQUIRE(configuration.toLedger() == range.getLast());
@@ -159,9 +164,66 @@ TEST_CASE("compute CatchupRange from CatchupConfiguration", "[catchup]")
                 REQUIRE(range.mLedgers.mFirst ==
                         range.getBucketApplyLedger() + 1);
 
-                // we are applying at least configuration.count(), mCount comes
-                // from applying ledgers, 1 from applying buckets
-                REQUIRE(range.mLedgers.mCount + 1 >= configuration.count());
+                // we are applying at least configuration.count() ledgers
+                REQUIRE(range.mLedgers.mCount >= configuration.count());
+
+                // Check that we're covering the first ledger implied by the
+                // user-provided last-ledger/count. The meaning of a given
+                // last/count pair is a little subtle because ledger replay is
+                // implicitly a closed range like [lo,hi] and a count of 0 means
+                // "try to replay nothing" which can't be represented as such,
+                // means the user doesn't really want replay if we can avoid it.
+                //
+                // We therefore define an "intended first" value like so:
+                //
+                // first = count == 0 ? last : (last+1)-count.
+                //
+                // i.e. 63/0 => first=63
+                //      64/0 => first=64
+                //      64/1 => first=64
+                //      64/2 => first=63
+                //
+                if (configuration.count() <= (configuration.toLedger() + 1))
+                {
+                    uint32_t intendedFirst =
+                        (configuration.count() == 0
+                             ? configuration.toLedger()
+                             : (configuration.toLedger() + 1) -
+                                   configuration.count());
+                    if (historyManager.isLastLedgerInCheckpoint(
+                            configuration.toLedger()) &&
+                        configuration.count() == 0)
+                    {
+                        // The weird special case:
+                        //
+                        // user requested something like 63/0, so
+                        // intendedFirst=63, and we can actually achieve "no
+                        // replay" because they want a ledger for which there
+                        // are buckets available. This is represented as a range
+                        // with first _after_ last.
+                        //
+                        // range.first=64, range.last=63, range.count=0
+                        REQUIRE(historyManager.isFirstLedgerInCheckpoint(
+                            range.mLedgers.mFirst));
+                        REQUIRE(historyManager.isLastLedgerInCheckpoint(
+                            range.getLast()));
+                        REQUIRE(intendedFirst == range.getBucketApplyLedger());
+                        REQUIRE(intendedFirst == range.getLast());
+                        REQUIRE(range.mLedgers.mFirst == range.getLast() + 1);
+                        REQUIRE(range.mLedgers.mCount == 0);
+                    }
+                    else
+                    {
+                        // Otherwise regardless of whether they asked for "no
+                        // replay", they will get _some_ replay because whatever
+                        // ledger they implied starting on happens _after_ a
+                        // bucket-apply ledger.
+                        REQUIRE(range.getBucketApplyLedger() < intendedFirst);
+                        REQUIRE(range.mLedgers.mFirst <= intendedFirst);
+                        REQUIRE(intendedFirst <= range.getLast());
+                        REQUIRE(range.mLedgers.mCount > 0);
+                    }
+                }
 
                 if (std::numeric_limits<uint32_t>::max() -
                         historyManager.getCheckpointFrequency() >=

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -279,6 +279,17 @@ class HistoryManager
         return first + size;                                // == 64, 128, 192
     }
 
+    // Return the last ledger before the checkpoint containing a given ledger,
+    // or zero if `ledger` is contained inside the first checkpoint.
+    uint32_t
+    lastLedgerBeforeCheckpointContaining(uint32_t ledger) const
+    {
+        uint32_t last = checkpointContainingLedger(ledger); // == 63, 127, 191
+        uint32_t size = sizeOfCheckpointContaining(ledger); // == 63, 64, 64
+        assert(last >= size);
+        return last - size; // == 0, 63, 127
+    }
+
     // Return the ledger to trigger the catchup machinery on, given a ledger
     // that is the start of a checkpoint buffered in the catchup manager.
     uint32_t

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -219,6 +219,15 @@ class HistoryManager
     // account of manual checkpoints.
     virtual uint32_t checkpointContainingLedger(uint32_t ledger) const = 0;
 
+    // Return true iff closing `ledger` should cause publishing a checkpoint.
+    // Equivalent to `ledger == checkpointContainingLedger(ledger)` but a little
+    // more obviously named.
+    bool
+    publishCheckpointOnLedgerClose(uint32_t ledger) const
+    {
+        return checkpointContainingLedger(ledger) == ledger;
+    }
+
     // Given a "current ledger" (not LCL) for a node, return the "current
     // ledger" value at which the previous scheduled checkpoint should have
     // occurred, by rounding-down to the next multiple of checkpoint

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -236,6 +236,18 @@ class HistoryManager
         return checkpointContainingLedger(ledger) == ledger;
     }
 
+    bool
+    isFirstLedgerInCheckpoint(uint32_t ledger) const
+    {
+        return firstLedgerInCheckpointContaining(ledger) == ledger;
+    }
+
+    bool
+    isLastLedgerInCheckpoint(uint32_t ledger) const
+    {
+        return checkpointContainingLedger(ledger) == ledger;
+    }
+
     // Return the number of ledgers in the checkpoint containing a given ledger.
     uint32_t
     sizeOfCheckpointContaining(uint32_t ledger) const

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -288,22 +288,6 @@ class HistoryManager
         return firstLedgerOfBufferedCheckpoint + 1;
     }
 
-    // Given a "current ledger" (not LCL) for a node, return the "current
-    // ledger" value at which the previous scheduled checkpoint should have
-    // occurred, by rounding-down to the next multiple of checkpoint
-    // frequency. This does not consult the network nor take account of manual
-    // checkpoints.
-    virtual uint32_t prevCheckpointLedger(uint32_t ledger) const = 0;
-
-    // Given a "current ledger" (not LCL) for a node, return the "current
-    // ledger" value at which the next checkpoint should occur; usually this
-    // returns the next scheduled checkpoint by rounding-up to the next
-    // multiple of checkpoint frequency, but when catching up to a manual
-    // checkpoint it will return the ledger passed in, indicating that the
-    // "next" checkpoint-ledger to look forward to is the same as the "init"
-    // ledger of the catchup operation.
-    virtual uint32_t nextCheckpointLedger(uint32_t ledger) const = 0;
-
     // Emit a log message and set StatusManager HISTORY_PUBLISH status to
     // describe current publish state.
     virtual void logAndUpdatePublishStatus() = 0;

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -279,6 +279,15 @@ class HistoryManager
         return first + size;                                // == 64, 128, 192
     }
 
+    // Return the ledger to trigger the catchup machinery on, given a ledger
+    // that is the start of a checkpoint buffered in the catchup manager.
+    uint32_t
+    ledgerToTriggerCatchup(uint32_t firstLedgerOfBufferedCheckpoint)
+    {
+        assert(isFirstLedgerInCheckpoint(firstLedgerOfBufferedCheckpoint));
+        return firstLedgerOfBufferedCheckpoint + 1;
+    }
+
     // Given a "current ledger" (not LCL) for a node, return the "current
     // ledger" value at which the previous scheduled checkpoint should have
     // occurred, by rounding-down to the next multiple of checkpoint

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -48,17 +48,23 @@
  * number and most recent bucket hashes). As per RFC 5785, this checkpoint is
  * stored at .well-known/stellar-history.json as a JSON file.
  *
- * Checkpoints are made every 64 ledgers, which (at 5s ledger close time) is
- * 320s or about 5m20s. There will be 11 checkpoints per hour, 270 per day, and
- * 98,550 per year. Counting checkpoints within a 32bit value gives 43,581 years
- * of service for the system.
+ * Checkpoints are made "every 64 ledgers", when LCL is one-less-than a multiple
+ * of 64. In other words, at LCL=63, 127, 191, 255, etc. or in other other words
+ * checkpoint K covers the inclusive ledger range [K*64, ((K+1)*64)-1], and each
+ * of those ranges should contain exactly 64 ledgers, with the exception of the
+ * first checkpoint, which has only 63 ledgers: there is no ledger 0.
+ *
+ * Checkpointing every 64 ledgers means (at 5s ledger close time) each
+ * checkpoint happens every 320s, or about 5m20s. There will be 11 checkpoints
+ * per hour, 270 per day, and 98,550 per year. Counting checkpoints within a
+ * 32bit value gives 43,581 years of service for the system.
  *
  * While the _most recent_ checkpoint is in .well-known/stellar-history.json,
  * each checkpoint is also stored permanently at a path whose name includes the
  * last ledger number in the checkpoint (as a 32-bit hex string) and stored in a
- * 3-level deep directory tree of hex digit prefixes. For example, checkpoint at
- * current ledger-number 0x12345678 will write ledgers up to and including
- * ledger 0x12345677 and be described by file
+ * 3-level deep directory tree of hex digit prefixes.
+ *
+ * For example, checkpoint made with LCL=0x12345677 will be described by file
  * history/12/34/56/history-0x12345677.json and the associated history block
  * will be written to the two files ledger/12/34/56/ledger-0x12345677.xdr.gz and
  * transaction/12/34/56/transaction-0x12345677.xdr.gz
@@ -70,10 +76,9 @@
  * bucket/AA/BB/CC/bucket-<AABBCCDEFG...>.xdr.gz
  *
  * The first ledger and transaction files (containing the genesis ledger #1, and
- * the subsequent 62 ledgers) are checkpointed when LedgerManager's
- * currentLedger is 64 = 0x40, so the last ledger published into that snapshot
- * is 0x3f, and it's stored in files ledger/00/00/00/ledger-0x0000003f.xdr.gz
- * and transaction/00/00/00/transaction-0x0000003f.xdr.gz, and described by
+ * the subsequent 62 ledgers) are checkpointed at LCL 63 (a.k.a. 0x3f), and it's
+ * stored in files ledger/00/00/00/ledger-0x0000003f.xdr.gz and
+ * transaction/00/00/00/transaction-0x0000003f.xdr.gz, and described by
  * history/00/00/00/history-0x0000003f.json.
  *
  * A pseudo-checkpoint describing the system-state before any transactions are

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -94,6 +94,7 @@ HistoryManagerImpl::getCheckpointFrequency() const
     }
 }
 
+// Returns the maximum multiple-of-freq that is <= ledger.
 uint32_t
 HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger) const
 {
@@ -101,6 +102,7 @@ HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger) const
     return (ledger / freq) * freq;
 }
 
+// Returns the minimum multiple-of-freq that is >= ledger.
 uint32_t
 HistoryManagerImpl::nextCheckpointLedger(uint32_t ledger) const
 {

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -94,24 +94,6 @@ HistoryManagerImpl::getCheckpointFrequency() const
     }
 }
 
-// Returns the maximum multiple-of-freq that is <= ledger.
-uint32_t
-HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger) const
-{
-    uint32_t freq = getCheckpointFrequency();
-    return (ledger / freq) * freq;
-}
-
-// Returns the minimum multiple-of-freq that is >= ledger.
-uint32_t
-HistoryManagerImpl::nextCheckpointLedger(uint32_t ledger) const
-{
-    uint32_t freq = getCheckpointFrequency();
-    if (ledger == 0)
-        return freq;
-    return (((ledger + freq - 1) / freq) * freq);
-}
-
 void
 HistoryManagerImpl::logAndUpdatePublishStatus()
 {

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -227,8 +227,8 @@ HistoryManagerImpl::getMaxLedgerQueuedToPublish()
 bool
 HistoryManagerImpl::maybeQueueHistoryCheckpoint()
 {
-    uint32_t seq = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
-    if (seq != nextCheckpointLedger(seq))
+    uint32_t lcl = mApp.getLedgerManager().getLastClosedLedgerNum();
+    if (!publishCheckpointOnLedgerClose(lcl))
     {
         return false;
     }

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -97,7 +97,11 @@ HistoryManagerImpl::getCheckpointFrequency() const
 uint32_t
 HistoryManagerImpl::checkpointContainingLedger(uint32_t ledger) const
 {
-    return nextCheckpointLedger(ledger + 1) - 1;
+    uint32_t freq = getCheckpointFrequency();
+    // Round-up to next multiple of freq, then subtract 1 since checkpoints are
+    // numbered for (and cover ledgers up to) the last ledger in them, which is
+    // one-before the next multiple of freq.
+    return (((ledger / freq) + 1) * freq) - 1;
 }
 
 uint32_t

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -95,16 +95,6 @@ HistoryManagerImpl::getCheckpointFrequency() const
 }
 
 uint32_t
-HistoryManagerImpl::checkpointContainingLedger(uint32_t ledger) const
-{
-    uint32_t freq = getCheckpointFrequency();
-    // Round-up to next multiple of freq, then subtract 1 since checkpoints are
-    // numbered for (and cover ledgers up to) the last ledger in them, which is
-    // one-before the next multiple of freq.
-    return (((ledger / freq) + 1) * freq) - 1;
-}
-
-uint32_t
 HistoryManagerImpl::prevCheckpointLedger(uint32_t ledger) const
 {
     uint32_t freq = getCheckpointFrequency();

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -48,7 +48,6 @@ class HistoryManagerImpl : public HistoryManager
     ~HistoryManagerImpl() override;
 
     uint32_t getCheckpointFrequency() const override;
-    uint32_t checkpointContainingLedger(uint32_t ledger) const override;
     uint32_t prevCheckpointLedger(uint32_t ledger) const override;
     uint32_t nextCheckpointLedger(uint32_t ledger) const override;
 

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -48,8 +48,6 @@ class HistoryManagerImpl : public HistoryManager
     ~HistoryManagerImpl() override;
 
     uint32_t getCheckpointFrequency() const override;
-    uint32_t prevCheckpointLedger(uint32_t ledger) const override;
-    uint32_t nextCheckpointLedger(uint32_t ledger) const override;
 
     void logAndUpdatePublishStatus() override;
 

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -35,23 +35,46 @@
 using namespace stellar;
 using namespace historytestutils;
 
-TEST_CASE("next checkpoint ledger", "[history]")
+TEST_CASE("checkpoint containing ledger", "[history]")
 {
-    CatchupSimulation catchupSimulation{};
-    HistoryManager& hm = catchupSimulation.getApp().getHistoryManager();
-    REQUIRE(hm.nextCheckpointLedger(0) == 64);
-    REQUIRE(hm.nextCheckpointLedger(1) == 64);
-    REQUIRE(hm.nextCheckpointLedger(32) == 64);
-    REQUIRE(hm.nextCheckpointLedger(62) == 64);
-    REQUIRE(hm.nextCheckpointLedger(63) == 64);
-    REQUIRE(hm.nextCheckpointLedger(64) == 64);
-    REQUIRE(hm.nextCheckpointLedger(65) == 128);
-    REQUIRE(hm.nextCheckpointLedger(66) == 128);
-    REQUIRE(hm.nextCheckpointLedger(126) == 128);
-    REQUIRE(hm.nextCheckpointLedger(127) == 128);
-    REQUIRE(hm.nextCheckpointLedger(128) == 128);
-    REQUIRE(hm.nextCheckpointLedger(129) == 192);
-    REQUIRE(hm.nextCheckpointLedger(130) == 192);
+    VirtualClock clock;
+    auto app = createTestApplication(clock, getTestConfig());
+    auto& hm = app->getHistoryManager();
+    // Technically ledger 0 doesn't exist so it's not "in" any checkpoint; but
+    // the first checkpoint's ledger range covers ledger 0 so we consider it
+    // "contained" in that checkpoint for the sake of this function.
+    CHECK(hm.checkpointContainingLedger(0) == 0x3f);
+    CHECK(hm.checkpointContainingLedger(1) == 0x3f);
+    CHECK(hm.checkpointContainingLedger(2) == 0x3f);
+    CHECK(hm.checkpointContainingLedger(3) == 0x3f);
+    // ...
+    CHECK(hm.checkpointContainingLedger(61) == 0x3f);
+    CHECK(hm.checkpointContainingLedger(62) == 0x3f);
+    CHECK(hm.checkpointContainingLedger(63) == 0x3f);
+    CHECK(hm.checkpointContainingLedger(64) == 0x7f);
+    CHECK(hm.checkpointContainingLedger(65) == 0x7f);
+    CHECK(hm.checkpointContainingLedger(66) == 0x7f);
+    // ...
+    CHECK(hm.checkpointContainingLedger(125) == 0x7f);
+    CHECK(hm.checkpointContainingLedger(126) == 0x7f);
+    CHECK(hm.checkpointContainingLedger(127) == 0x7f);
+    CHECK(hm.checkpointContainingLedger(128) == 0xbf);
+    CHECK(hm.checkpointContainingLedger(129) == 0xbf);
+    CHECK(hm.checkpointContainingLedger(130) == 0xbf);
+    // ...
+    CHECK(hm.checkpointContainingLedger(189) == 0xbf);
+    CHECK(hm.checkpointContainingLedger(190) == 0xbf);
+    CHECK(hm.checkpointContainingLedger(191) == 0xbf);
+    CHECK(hm.checkpointContainingLedger(192) == 0xff);
+    CHECK(hm.checkpointContainingLedger(193) == 0xff);
+    CHECK(hm.checkpointContainingLedger(194) == 0xff);
+    // ...
+    CHECK(hm.checkpointContainingLedger(253) == 0xff);
+    CHECK(hm.checkpointContainingLedger(254) == 0xff);
+    CHECK(hm.checkpointContainingLedger(255) == 0xff);
+    CHECK(hm.checkpointContainingLedger(256) == 0x13f);
+    CHECK(hm.checkpointContainingLedger(257) == 0x13f);
+    CHECK(hm.checkpointContainingLedger(258) == 0x13f);
 }
 
 TEST_CASE("HistoryManager compress", "[history]")

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -748,8 +748,18 @@ CatchupSimulation::catchupOnline(Application::pointer app, uint32_t initLedger,
     // and as near as we can get to the first ledger of the block after
     // initLedger (inclusive), so that there's something to knit-up with. Do not
     // externalize anything we haven't yet published, of course.
-    uint32_t triggerLedger =
-        mApp.getHistoryManager().nextCheckpointLedger(initLedger) + 1;
+    uint32_t firstLedgerInCheckpoint;
+    if (hm.isFirstLedgerInCheckpoint(initLedger))
+    {
+        firstLedgerInCheckpoint = initLedger;
+    }
+    else
+    {
+        firstLedgerInCheckpoint =
+            hm.firstLedgerAfterCheckpointContaining(initLedger);
+    }
+
+    uint32_t triggerLedger = hm.ledgerToTriggerCatchup(firstLedgerInCheckpoint);
     for (uint32_t n = initLedger; n <= triggerLedger + bufferLedgers; ++n)
     {
         externalize(n);

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -558,8 +558,8 @@ CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger)
     auto& hm = mApp.getHistoryManager();
     while (lm.getLastClosedLedgerNum() < targetLedger)
     {
-        if (lm.getLastClosedLedgerNum() + 1 ==
-            mTestProtocolShadowsRemovedLedgerSeq)
+        auto lcl = lm.getLastClosedLedgerNum();
+        if (lcl + 1 == mTestProtocolShadowsRemovedLedgerSeq)
         {
             // Force proto 12 upgrade
             generateRandomLedger(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED);
@@ -569,8 +569,7 @@ CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger)
             generateRandomLedger();
         }
 
-        auto seq = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
-        if (seq == hm.nextCheckpointLedger(seq))
+        if (hm.publishCheckpointOnLedgerClose(lcl))
         {
             mBucketListAtLastPublish =
                 getApp().getBucketManager().getBucketList();

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -251,22 +251,16 @@ TestLedgerChainGenerator::makeOneLedgerFile(
     uint32_t currCheckpoint, Hash prevHash,
     HistoryManager::LedgerVerificationStatus state)
 {
-    auto initLedger =
-        mApp.getHistoryManager().prevCheckpointLedger(currCheckpoint);
-    auto frequency = mApp.getHistoryManager().getCheckpointFrequency();
-    if (initLedger == 0)
-    {
-        initLedger = LedgerManager::GENESIS_LEDGER_SEQ;
-        frequency -= 1;
-    }
+    auto& hm = mApp.getHistoryManager();
+    auto initLedger = hm.firstLedgerInCheckpointContaining(currCheckpoint);
+    auto size = hm.sizeOfCheckpointContaining(currCheckpoint);
 
     LedgerHeaderHistoryEntry first, last, lcl;
     lcl.header.ledgerSeq = initLedger;
     lcl.header.previousLedgerHash = prevHash;
 
     std::vector<LedgerHeaderHistoryEntry> ledgerChain =
-        LedgerTestUtils::generateLedgerHeadersForCheckpoint(lcl, frequency,
-                                                            state);
+        LedgerTestUtils::generateLedgerHeadersForCheckpoint(lcl, size, state);
 
     createHistoryFiles(ledgerChain, first, last, currCheckpoint);
     return CheckpointEnds(first, last);
@@ -281,7 +275,7 @@ TestLedgerChainGenerator::makeLedgerChainFiles(
 
     LedgerHeaderHistoryEntry first, last;
     for (auto i = mCheckpointRange.mFirst; i <= mCheckpointRange.mLast;
-         i += mApp.getHistoryManager().getCheckpointFrequency())
+         i += mApp.getHistoryManager().sizeOfCheckpointContaining(i))
     {
         // Only corrupt first checkpoint (last to be verified)
         if (i != mCheckpointRange.mFirst)

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -18,7 +18,7 @@ BatchDownloadWork::BatchDownloadWork(Application& app, CheckpointRange range,
                                      TmpDir const& downloadDir,
                                      std::shared_ptr<HistoryArchive> archive)
     : BatchWork(app, fmt::format("batch-download-{:s}-{:08x}-{:08x}", type,
-                                 range.mFirst, range.mLast))
+                                 range.mFirst, range.limit()))
     , mRange(range)
     , mNext(range.mFirst)
     , mFileType(type)
@@ -33,7 +33,7 @@ BatchDownloadWork::getStatus() const
     if (!isDone() && !isAborting())
     {
         auto task = fmt::format("downloading {:s} files", mFileType);
-        return fmtProgress(mApp, task, mRange.mFirst, mRange.mLast, mNext);
+        return fmtProgress(mApp, task, mRange.getLedgerRange(), mNext);
     }
     return BatchWork::getStatus();
 }
@@ -61,7 +61,7 @@ BatchDownloadWork::yieldMoreWork()
 bool
 BatchDownloadWork::hasNext() const
 {
-    return mNext <= mRange.mLast;
+    return mNext < mRange.limit();
 }
 
 void

--- a/src/historywork/DownloadVerifyTxResultsWork.cpp
+++ b/src/historywork/DownloadVerifyTxResultsWork.cpp
@@ -33,7 +33,7 @@ DownloadVerifyTxResultsWork::getStatus() const
     {
         auto task = fmt::format("Downloading and verifying {:s} files",
                                 HISTORY_FILE_TYPE_RESULTS);
-        return fmtProgress(mApp, task, mRange.mFirst, mRange.mLast,
+        return fmtProgress(mApp, task, mRange.getLedgerRange(),
                            mCurrCheckpoint);
     }
     return BatchWork::getStatus();
@@ -42,7 +42,7 @@ DownloadVerifyTxResultsWork::getStatus() const
 bool
 DownloadVerifyTxResultsWork::hasNext() const
 {
-    return mCurrCheckpoint <= mRange.mLast;
+    return mCurrCheckpoint < mRange.limit();
 }
 
 void

--- a/src/historywork/FetchRecentQsetsWork.cpp
+++ b/src/historywork/FetchRecentQsetsWork.cpp
@@ -62,7 +62,7 @@ FetchRecentQsetsWork::doWork()
     {
         CLOG(INFO, "History") << "Downloading historical SCP messages: ["
                               << firstSeq << ", " << lastSeq << "]";
-        auto range = CheckpointRange{firstSeq, lastSeq, step};
+        auto range = CheckpointRange::inclusive(firstSeq, lastSeq, step);
         mDownloadSCPMessagesWork = addWork<BatchDownloadWork>(
             range, HISTORY_FILE_TYPE_SCP, *mDownloadDir);
         return State::WORK_RUNNING;

--- a/src/historywork/Progress.cpp
+++ b/src/historywork/Progress.cpp
@@ -4,6 +4,7 @@
 
 #include "historywork/Progress.h"
 #include "history/HistoryManager.h"
+#include "ledger/LedgerRange.h"
 #include "lib/util/format.h"
 #include "main/Application.h"
 
@@ -11,10 +12,18 @@ namespace stellar
 {
 
 std::string
-fmtProgress(Application& app, std::string const& task, uint32_t first,
-            uint32_t last, uint32_t curr)
+fmtProgress(Application& app, std::string const& task, LedgerRange const& range,
+            uint32_t curr)
 {
     auto step = app.getHistoryManager().getCheckpointFrequency();
+    // Step is only ever 8 or 64.
+    assert(step != 0);
+    if (range.mCount == 0)
+    {
+        return fmt::format("{:s} 0/0 (100%)", task);
+    }
+    auto first = range.mFirst;
+    auto last = range.last();
     if (curr > last)
     {
         curr = last;
@@ -22,10 +31,6 @@ fmtProgress(Application& app, std::string const& task, uint32_t first,
     if (curr < first)
     {
         curr = first;
-    }
-    if (step == 0)
-    {
-        step = 1;
     }
     if (last < first)
     {

--- a/src/historywork/Progress.h
+++ b/src/historywork/Progress.h
@@ -8,7 +8,8 @@ namespace stellar
 {
 
 class Application;
+struct LedgerRange;
 
 std::string fmtProgress(Application& app, std::string const& task,
-                        uint32_t first, uint32_t last, uint32_t curr);
+                        LedgerRange const& range, uint32_t curr);
 }

--- a/src/historywork/VerifyTxResultsWork.cpp
+++ b/src/historywork/VerifyTxResultsWork.cpp
@@ -147,8 +147,7 @@ VerifyTxResultsWork::getCurrentTxResultSet(uint32_t ledger)
             auto readLedger = mTxResultEntry.ledgerSeq;
             auto const& hm = mApp.getHistoryManager();
 
-            auto low = std::max(LedgerManager::GENESIS_LEDGER_SEQ,
-                                hm.prevCheckpointLedger(mCheckpoint));
+            auto low = hm.firstLedgerInCheckpointContaining(mCheckpoint);
             if (readLedger > mCheckpoint || readLedger < low)
             {
                 throw std::runtime_error("Results outside of checkpoint range");

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -154,7 +154,7 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
         }
     }
 
-    LedgerRange range{oldestLedger, newestLedger};
+    auto range = LedgerRange::inclusive(oldestLedger, newestLedger);
     std::string countFormat = "Incorrect {} count: Bucket = {} Database = {}";
     auto& ltxRoot = mApp.getLedgerTxnRoot();
     uint64_t nAccountsInDb = ltxRoot.countObjects(ACCOUNT, range);

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -292,13 +292,17 @@ class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
         if (!mAdded)
         {
             uint32_t minLedger = mEntry.lastModifiedLedgerSeq;
-            uint32_t maxLedger = std::numeric_limits<int32_t>::max();
+            uint32_t maxLedger = std::numeric_limits<int32_t>::max() - 1;
             auto& ltxRoot = mApp.getLedgerTxnRoot();
             size_t count =
-                ltxRoot.countObjects(ACCOUNT, {minLedger, maxLedger}) +
-                ltxRoot.countObjects(DATA, {minLedger, maxLedger}) +
-                ltxRoot.countObjects(OFFER, {minLedger, maxLedger}) +
-                ltxRoot.countObjects(TRUSTLINE, {minLedger, maxLedger});
+                ltxRoot.countObjects(
+                    ACCOUNT, LedgerRange::inclusive(minLedger, maxLedger)) +
+                ltxRoot.countObjects(
+                    DATA, LedgerRange::inclusive(minLedger, maxLedger)) +
+                ltxRoot.countObjects(
+                    OFFER, LedgerRange::inclusive(minLedger, maxLedger)) +
+                ltxRoot.countObjects(
+                    TRUSTLINE, LedgerRange::inclusive(minLedger, maxLedger));
 
             if (count > 0)
             {

--- a/src/ledger/CheckpointRange.cpp
+++ b/src/ledger/CheckpointRange.cpp
@@ -12,32 +12,51 @@
 namespace stellar
 {
 
-CheckpointRange::CheckpointRange(uint32_t first, uint32_t last,
+CheckpointRange::CheckpointRange(uint32_t first, uint32_t count,
                                  uint32_t frequency)
-    : mFirst{first}, mLast{last}, mFrequency{frequency}
+    : mFirst{first}, mCount{count}, mFrequency{frequency}
 {
     assert(mFirst > 0);
-    assert(mLast >= mFirst);
     assert((mFirst + 1) % mFrequency == 0);
-    assert((mLast + 1) % mFrequency == 0);
+}
+
+namespace
+{
+uint32_t
+checkpointCount(uint32_t firstCheckpoint, LedgerRange const& r,
+                HistoryManager const& hm)
+{
+    if (r.mCount == 0)
+    {
+        return 0;
+    }
+    uint32_t lastCheckpoint = hm.checkpointContainingLedger(r.last());
+    return 1 +
+           ((lastCheckpoint - firstCheckpoint) / hm.getCheckpointFrequency());
+}
 }
 
 CheckpointRange::CheckpointRange(LedgerRange const& ledgerRange,
                                  HistoryManager const& historyManager)
     : mFirst{historyManager.checkpointContainingLedger(ledgerRange.mFirst)}
-    , mLast{historyManager.checkpointContainingLedger(ledgerRange.mLast)}
+    , mCount{checkpointCount(mFirst, ledgerRange, historyManager)}
     , mFrequency{historyManager.getCheckpointFrequency()}
 {
     assert(mFirst > 0);
-    assert(mLast >= mFirst);
     assert((mFirst + 1) % mFrequency == 0);
-    assert((mLast + 1) % mFrequency == 0);
+    assert(limit() >= mFirst);
+    assert((limit() + 1) % mFrequency == 0);
+    if (mCount != 0)
+    {
+        assert(last() >= mFirst);
+        assert((last() + 1) % mFrequency == 0);
+    }
 }
 
 std::string
 CheckpointRange::toString() const
 {
-    return fmt::format("{}..{}", mFirst + 1 - mFrequency, mLast);
+    return fmt::format("[{},{})", mFirst, limit());
 }
 
 bool
@@ -47,7 +66,7 @@ operator==(CheckpointRange const& x, CheckpointRange const& y)
     {
         return false;
     }
-    if (x.mLast != y.mLast)
+    if (x.mCount != y.mCount)
     {
         return false;
     }

--- a/src/ledger/CheckpointRange.h
+++ b/src/ledger/CheckpointRange.h
@@ -29,7 +29,16 @@ struct CheckpointRange final
         // CheckpointRange is half-open: in exchange for being able to represent
         // empty ranges, it can't represent ranges that include UINT32_MAX.
         assert(last < std::numeric_limits<int32_t>::max());
-        return CheckpointRange(first, last - first + 1, frequency);
+
+        // First and last must both be ledgers identifying checkpoints (i.e. one
+        // less than multiples of frequency), and last must be >= first. The
+        // resulting count will always be 1 or more since this is an inclusive
+        // range.
+        assert(last >= first);
+        assert((first + 1) % frequency == 0);
+        assert((last + 1) % frequency == 0);
+        uint32_t count = 1 + ((last - first) / frequency);
+        return CheckpointRange(first, count, frequency);
     }
     CheckpointRange(LedgerRange const& ledgerRange,
                     HistoryManager const& historyManager);

--- a/src/ledger/LedgerRange.cpp
+++ b/src/ledger/LedgerRange.cpp
@@ -10,17 +10,16 @@
 namespace stellar
 {
 
-LedgerRange::LedgerRange(uint32_t first, uint32_t last)
-    : mFirst{first}, mLast{last}
+LedgerRange::LedgerRange(uint32_t first, uint32_t count)
+    : mFirst{first}, mCount{count}
 {
-    assert(mFirst > 0);
-    assert(mLast >= mFirst);
+    assert(count == 0 || mFirst > 0);
 }
 
 std::string
 LedgerRange::toString() const
 {
-    return fmt::format("{}..{}", mFirst, mLast);
+    return fmt::format("[{},{})", mFirst, mFirst + mCount);
 }
 
 bool
@@ -30,7 +29,7 @@ operator==(LedgerRange const& x, LedgerRange const& y)
     {
         return false;
     }
-    if (x.mLast != y.mLast)
+    if (x.mCount != y.mCount)
     {
         return false;
     }

--- a/src/ledger/LedgerRange.h
+++ b/src/ledger/LedgerRange.h
@@ -7,6 +7,7 @@
 #include "util/optional.h"
 #include "xdr/Stellar-types.h"
 #include <cstdint>
+#include <stdexcept>
 
 namespace stellar
 {
@@ -14,14 +15,45 @@ namespace stellar
 // history entry, useful for catchup and ledger verification purposes.
 using LedgerNumHashPair = std::pair<uint32_t, optional<Hash>>;
 
+// Represents a half-open range of ledgers [first, first+count).
+// If count is zero, this represents _no_ ledgers.
 struct LedgerRange final
 {
   public:
     uint32_t const mFirst;
-    uint32_t const mLast;
+    uint32_t const mCount;
 
-    LedgerRange(uint32_t first, uint32_t last);
+    LedgerRange(uint32_t first, uint32_t count);
+    static LedgerRange
+    inclusive(uint32_t first, uint32_t last)
+    {
+        // LedgerRange is half-open: in exchange for being able to represent
+        // empty ranges, it can't represent ranges that include UINT32_MAX.
+        assert(last < std::numeric_limits<int32_t>::max());
+        return LedgerRange(first, last - first + 1);
+    }
     std::string toString() const;
+
+    // Return first+count, which is the _exclusive_ range limit.
+    // Best to use this in a loop header to properly handle count=0.
+    uint32_t
+    limit() const
+    {
+        return mFirst + mCount;
+    }
+
+    // Return first+count-1 unless count == 0, in which case throw.
+    // This is the _inclusive_ range limit, meaningful iff count != 0.
+    uint32_t
+    last() const
+    {
+        if (mCount == 0)
+        {
+            throw std::logic_error("last() cannot be called on "
+                                   "LedgerRange when mCount == 0");
+        }
+        return limit() - 1;
+    }
 
     friend bool operator==(LedgerRange const& x, LedgerRange const& y);
     friend bool operator!=(LedgerRange const& x, LedgerRange const& y);

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2181,11 +2181,11 @@ LedgerTxnRoot::Impl::countObjects(LedgerEntryType let,
 
     std::string query = "SELECT COUNT(*) FROM " +
                         tableFromLedgerEntryType(let) +
-                        " WHERE lastmodified >= :v1 AND lastmodified <= :v2;";
+                        " WHERE lastmodified >= :v1 AND lastmodified < :v2;";
     uint64_t count = 0;
     int first = static_cast<int>(ledgers.mFirst);
-    int last = static_cast<int>(ledgers.mLast);
-    mDatabase.getSession() << query, into(count), use(first), use(last);
+    int limit = static_cast<int>(ledgers.limit());
+    mDatabase.getSession() << query, into(count), use(first), use(limit);
     return count;
 }
 

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -366,12 +366,12 @@ generateValidDataEntries(size_t n)
 
 std::vector<LedgerHeaderHistoryEntry>
 generateLedgerHeadersForCheckpoint(
-    LedgerHeaderHistoryEntry firstLedger, uint32_t freq,
+    LedgerHeaderHistoryEntry firstLedger, uint32_t size,
     HistoryManager::LedgerVerificationStatus state)
 {
     static auto vecgen =
         autocheck::list_of(autocheck::generator<LedgerHeaderHistoryEntry>());
-    auto res = vecgen(freq);
+    auto res = vecgen(size);
     makeValid(res, firstLedger, state);
     return res;
 }

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -46,7 +46,7 @@ DataEntry generateValidDataEntry(size_t b = 3);
 std::vector<DataEntry> generateValidDataEntries(size_t n);
 
 std::vector<LedgerHeaderHistoryEntry> generateLedgerHeadersForCheckpoint(
-    LedgerHeaderHistoryEntry firstLedger, uint32_t freq,
+    LedgerHeaderHistoryEntry firstLedger, uint32_t size,
     HistoryManager::LedgerVerificationStatus state =
         HistoryManager::VERIFY_STATUS_OK);
 }

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -946,7 +946,8 @@ runSimulate(CommandLineArgs const& args)
             auto app = Application::create(clock, config, false);
             app->start();
 
-            LedgerRange lr{firstLedgerInclusive, lastLedgerInclusive};
+            auto lr = LedgerRange::inclusive(firstLedgerInclusive,
+                                             lastLedgerInclusive);
             CheckpointRange cr(lr, app->getHistoryManager());
             TmpDir dir(app->getTmpDirManager().tmpDir("simulate"));
 

--- a/src/test/TestPrinter.cpp
+++ b/src/test/TestPrinter.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "test/TestPrinter.h"
+#include "catchup/CatchupRange.h"
 #include "lib/util/format.h"
 #include "test/TestMarket.h"
 
@@ -21,8 +22,9 @@ StringMaker<stellar::OfferState>::convert(stellar::OfferState const& os)
 std::string
 StringMaker<stellar::CatchupRange>::convert(stellar::CatchupRange const& cr)
 {
-    return fmt::format("[{}..{}], applyBuckets: {}", cr.mLedgers.mFirst,
-                       cr.getLast(), cr.getBucketApplyLedger());
+    return fmt::format("[{},{}), applyBuckets: {}", cr.getReplayFirst(),
+                       cr.getReplayLimit(),
+                       cr.applyBuckets() ? cr.getBucketApplyLedger() : 0);
 }
 
 std::string


### PR DESCRIPTION
This is somewhat involved in terms of the quantity of cleanup -- far more than I was expecting at first! -- but ultimately only fixes two "bugs" (that you might not even consider as bugs):

  - The "bug" that motivated all this: running catchup on a range like 66/4 would attempt to catchup by applying checkpoint 63 then replaying 3 ledgers: 64, 65, 66. This might or might not be a "bug" depending on how you look at it, but it certainly doesn't do two of the most likely things the user might have wanted: it doesn't replay 4 ledgers, and it doesn't replay ledger 63 (which is 66+1-4). So now this is fixed! Now we'll replay ledgers 1..66 in that case -- to be sure we span at least 4 ledgers before 66 -- and the cases where we'll apply buckets are those where it happens _strictly before_ the range the user requested. This fix starts with removing an incorrect special case in `computeCatchupledgers` in 56dbb965e0b6358171452b1d2329a47a99ad1a3f but that function is subsequently entirely rewritten and then replaced in 06aef10726db634d8316c719c59a9dd6b47938d8 and 8acefa2202fdecb9c5369ad1639534b2d28f102b

  - The `CatchupManagerImpl::processLedger` function was a little too dependent on the catchup trigger window being exactly one ledger past the checkpoint at the start of the ledger buffer: if that's ever changed in the future (eg. due to fixing https://github.com/stellar/stellar-core/issues/2455) we might introduce a gap in the ledger buffer. So that entire function was rewritten a bit with an eye to clarity (and eliminating that potential future "bug") in 220ad10cb942cff3f64f52830842c6fc3e70a8f6

The remainder of the PR is just "cleanup", which broadly falls into these categories:

  - Removing the concept of "current ledger" (one past LCL) from the `HistoryManager` interface entirely. This has been there for years and has always been a source of confusion.
  - Adding a bunch of helper methods to `HistoryManager` with semantically-more-meaningful names than `nextCheckpointLedger` and `prevCheckpointLedger` (which were related to "current ledger" anyway), and moving all code that used those two methods over to the new more-meaningfully-named methods.
  - Splitting the `CatchupRange` type from a combined (and extremely confusing) hybrid representation of a bucket-apply checkpoint and a ledger-apply range to a class that separately represents those elements, and improving/simplifying/documenting the logic that constructs it.
  - Changing `LedgerRange`, `CheckpointRange` and `CatchupRange` to deal explicitly with empty ledger-apply ranges in catchup, switching them from closed `[lo,hi]` ranges to half-open `[lo,lo+count)` ranges that support a count of zero.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
