### PR TITLE
Delayed externalize metric

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -116,8 +116,10 @@ scp.pending.ready                        | counter   | number of envelopes ready
 scp.sync.lost                            | meter     | validator lost sync
 scp.timeout.nominate                     | meter     | timeouts in nomination
 scp.timeout.prepare                      | meter     | timeouts in ballot protocol
-scp.timing.externalized                  | timer     | time spent in ballot protocol
 scp.timing.nominated                     | timer     | time spent in nomination
+scp.timing.externalized                  | timer     | time spent in ballot protocol
+scp.timing.externalize-lag               | timer     | delay between first externalize message and local node externalizing
+scp.timing.externalize-delay             | timer     | delay between local node externalizing and later externalize messages
 scp.value.invalid                        | meter     | SCP value is invalid
 scp.value.valid                          | meter     | SCP value is valid
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -589,13 +589,20 @@ HerderImpl::processSCPQueueUpToIndex(uint64 slotIndex)
 {
     while (true)
     {
-        SCPEnvelopeWrapperPtr env = mPendingEnvelopes.pop(slotIndex);
-        if (env)
+        SCPEnvelopeWrapperPtr envW = mPendingEnvelopes.pop(slotIndex);
+        if (envW)
         {
-            auto r = getSCP().receiveEnvelope(env);
+            auto r = getSCP().receiveEnvelope(envW);
             if (r == SCP::EnvelopeState::VALID)
             {
-                mPendingEnvelopes.envelopeProcessed(env->getEnvelope());
+                auto const& env = envW->getEnvelope();
+                auto const& st = env.statement;
+                if (st.pledges.type() == SCP_ST_EXTERNALIZE)
+                {
+                    mHerderSCPDriver.recordSCPExternalizeEvent(
+                        st.slotIndex, st.nodeID, false);
+                }
+                mPendingEnvelopes.envelopeProcessed(env);
             }
         }
         else

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -230,7 +230,7 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     if (slotIndex > maxSlotsToRemember)
     {
         auto maxSlot = slotIndex - maxSlotsToRemember;
-        getSCP().purgeSlots(maxSlot);
+        getHerderSCPDriver().purgeSlots(maxSlot);
         mPendingEnvelopes.eraseBelow(maxSlot);
     }
 

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -983,13 +983,19 @@ HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
         recordTiming(*SCPTiming.mPrepareStart, externalizeStart,
                      mSCPMetrics.mPrepareToExternalize, "Prepare");
     }
+}
 
+void
+HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex)
+{
     // Clean up timings map
     auto it = mSCPExecutionTimes.begin();
-    while (it != mSCPExecutionTimes.end() && it->first < slotIndex)
+    while (it != mSCPExecutionTimes.end() && it->first < maxSlotIndex)
     {
         it = mSCPExecutionTimes.erase(it);
     }
+
+    getSCP().purgeSlots(maxSlotIndex);
 }
 
 void

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -151,6 +151,9 @@ class HerderSCPDriver : public SCPDriver
 
     ValueWrapperPtr wrapValue(Value const& sv) override;
 
+    // clean up older slots
+    void purgeSlots(uint64_t maxSlotIndex);
+
   private:
     Application& mApp;
     HerderImpl& mHerder;

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -233,5 +233,11 @@ class HerderSCPDriver : public SCPDriver
 
     void timerCallbackWrapper(uint64_t slotIndex, int timerID,
                               std::function<void()> cb);
+
+    void recordLogTiming(VirtualClock::time_point start,
+                         VirtualClock::time_point end, medida::Timer& timer,
+                         std::string const& logStr,
+                         std::chrono::nanoseconds threshold,
+                         uint64_t slotIndex);
 };
 }

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -88,6 +88,8 @@ class HerderSCPDriver : public SCPDriver
 
     void recordSCPExecutionMetrics(uint64_t slotIndex);
     void recordSCPEvent(uint64_t slotIndex, bool isNomination);
+    void recordSCPExternalizeEvent(uint64_t slotIndex, NodeID const& id,
+                                   bool forceUpdateSelf);
 
     // envelope handling
     SCPEnvelopeWrapperPtr wrapEnvelope(SCPEnvelope const& envelope) override;
@@ -176,6 +178,10 @@ class HerderSCPDriver : public SCPDriver
         medida::Timer& mNominateToPrepare;
         medida::Timer& mPrepareToExternalize;
 
+        // Timers tracking externalize messages
+        medida::Timer& mExternalizeLag;
+        medida::Timer& mExternalizeDelay;
+
         SCPMetrics(Application& app);
     };
 
@@ -195,6 +201,10 @@ class HerderSCPDriver : public SCPDriver
         int64_t mNominationTimeoutCount{0};
         // Prepare timeouts before externalize
         int64_t mPrepareTimeoutCount{0};
+
+        // externalize timing information
+        optional<VirtualClock::time_point> mFirstExternalize;
+        optional<VirtualClock::time_point> mSelfExternalize;
     };
 
     // Map of time points for each slot to measure key protocol metrics:


### PR DESCRIPTION
# Description

Resolves #2451

This PR adds two new metrics to help track
* the "perceived lag" between network closing (modeled as delay between "first externalize event" and actual externalize)
* validators that are "behind" (modeled as delay between the node externalizing and receiving externalize messages from other nodes)

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
