### PR TITLE
test infra: fix filtering of test cases

### DIFF
--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -510,7 +510,7 @@ TEST_CASE("bucketmanager reattach to running merge", "[bucket][bucketmanager]")
     });
 }
 
-TEST_CASE("bucketmanager don't leak empty-merge futures",
+TEST_CASE("bucketmanager do not leak empty-merge futures",
           "[bucket][bucketmanager]")
 {
     // The point of this test is to confirm that

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -347,7 +347,7 @@ interconnectOrgsBidir(xdr::xvector<xdr::xvector<PublicKey>> const& orgs,
                             ownThreshPct, innerThreshPct);
 }
 
-TEST_CASE("quorum intersection 4-org fully-connected, elide all minquorums",
+TEST_CASE("quorum intersection 4-org fully-connected - elide all minquorums",
           "[herder][quorumintersection]")
 {
     // Generate a typical all-to-all multi-org graph that checks quickly: every

--- a/src/test/selftest-parallel
+++ b/src/test/selftest-parallel
@@ -10,7 +10,7 @@ if [[ -z "$NUM_PARTITIONS" ]]; then
     NUM_PARTITIONS=1
 fi
 if [[ -z "$RUN_PARTITIONS" ]]; then
-    RUN_PARTITIONS=$(seq 0 $((NUM_PARTITIONS-1)));
+    RUN_PARTITIONS=$(seq 0 $((NUM_PARTITIONS-1)))
 fi
 if [[ -z "$TEST_SPEC" ]]; then
     TEST_SPEC="~[acceptance]~[.]" # All non-hidden non-acceptance tests by default
@@ -29,6 +29,8 @@ cleanup() {
 TEST_PARTITIONS_DIR=$(mktemp -d ./test-partitions.XXXXXXXX)
 trap cleanup 0 2 15 ERR
 
+# tests with special characters like "," may cause weird interactions with catch
+# so we white list characters that can be used for test case names
 perl -e '
          use List::Util qw/shuffle/;
          srand($ARGV[3]);
@@ -37,10 +39,14 @@ perl -e '
          my $test_partitions_dir = $ARGV[2];
          my @all_tests = shuffle `./stellar-core test --ll FATAL --list-test-names-only $test_spec`;
          for (my $p = 0; $p < $num_partitions; $p++) {
-             die "Invalid test name \"$p\"" if $p =~ /[^A-Za-z0-9 _()]/;
              open(my $out, ">", "$test_partitions_dir/test-partition-$p.txt");
+             my $pre="";
              for (my $i = $p; $i < @all_tests; $i+=$num_partitions) {
-                 print $out $all_tests[$i];
+                my $tn = $all_tests[$i];
+                chomp $tn;
+                die "Invalid test name \"$tn\"" if $tn =~ m{[^-A-Za-z0-9 _():/]};
+                print $out "$pre$tn";
+                $pre="\n";
              }
              close $out;
          }' -- "$NUM_PARTITIONS" "$TEST_SPEC" "$TEST_PARTITIONS_DIR" "$RND_SEED"
@@ -49,11 +55,8 @@ runpart()
 {
   local PART=$1
   shift
-  C=""
-  for i in "$@"
-  do
-    C="$i,$C"
-  done
+  local IFS=","
+  C="$*"
   "$COMMAND" $((50*(PART-1))) "$C"
   exit $?
 }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -277,7 +277,7 @@ runTest(CommandLineArgs const& args)
     gTestCfg->clear();
     if (r != 0)
     {
-        LOG(FATAL) << "Nonzero test result with --rng-seed " << seed;
+        LOG(ERROR) << "Nonzero test result with --rng-seed " << seed;
     }
     return r;
 }


### PR DESCRIPTION
# Description

Resolves #2438

The script used to ensure that test cases don't use characters that may confuse Catch was buggy, and was actually not checking anything.

This PR fixes the script and the couple test cases that use bad characters in their name.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
