### PR TITLE
prefetch hit-rate metric updates

### DIFF
--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -45,11 +45,11 @@ class LedgerManagerImpl : public LedgerManager
     medida::Timer& mTransactionApply;
     medida::Histogram& mTransactionCount;
     medida::Histogram& mOperationCount;
+    medida::Histogram& mPrefetchHitRate;
     medida::Counter& mInternalErrorCount;
     medida::Timer& mLedgerClose;
     medida::Timer& mLedgerAgeClosed;
     medida::Counter& mLedgerAge;
-    medida::Counter& mPrefetchHitRate;
     VirtualClock::time_point mLastClose;
 
     std::unique_ptr<VirtualClock::time_point> mStartCatchup;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -663,7 +663,8 @@ class LedgerTxnRoot::Impl
     std::unique_ptr<LedgerHeader> mHeader;
     mutable EntryCache mEntryCache;
     mutable BestOffersCache mBestOffersCache;
-    mutable uint64_t mTotalPrefetchHits{0};
+    mutable uint64_t mPrefetchHits{0};
+    mutable uint64_t mPrefetchMisses{0};
 
     size_t mMaxCacheSize;
     size_t mBulkLoadBatchSize;


### PR DESCRIPTION
Resolves #2470 

With this change, we now collect prefetch hit-rates per ledger, and track them via a histogram (5-minute sliding window)