### PR TITLE
Fix ManageOfferOpFrameBase::insertLedgerKeysToPrefetch

### DIFF
--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -509,11 +509,6 @@ void
 ManageOfferOpFrameBase::insertLedgerKeysToPrefetch(
     std::unordered_set<LedgerKey>& keys) const
 {
-    if (isDeleteOffer())
-    {
-        return;
-    }
-
     // Prefetch existing offer
     if (mOfferID)
     {


### PR DESCRIPTION
# Description

Fixes a minor issue in which `ManageOfferOpFrameBase` would not prefetch offers that are going to be deleted. Offers that are going to be deleted still must be loaded first, along with corresponding trust lines, in order to release liabilities. This change does cause the issuer to be loaded if the offer is going to be deleted, which isn't necessary, but this will no longer be the case once #2389 is merged. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
