### PR TITLE
Improve Durability of Make Check

### DIFF
--- a/src/test/run-selftest-nopg
+++ b/src/test/run-selftest-nopg
@@ -8,7 +8,7 @@ BASE_INSTANCE="$1"
 TESTS="$2"
 
 if [[ "$ALL_VERSIONS" != "" ]]; then
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
 else
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
 fi

--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -94,7 +94,7 @@ else
     echo "PostgreSQL enabled for tests using existing database cluster"
 fi
 if [ "$ALL_VERSIONS" != "" ]; then
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
 else                                 
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
 fi

--- a/src/test/selftest-parallel
+++ b/src/test/selftest-parallel
@@ -51,6 +51,16 @@ perl -e '
              close $out;
          }' -- "$NUM_PARTITIONS" "$TEST_SPEC" "$TEST_PARTITIONS_DIR" "$RND_SEED"
 
+NUM_TESTS=0
+for p in $(seq 0 $((NUM_PARTITIONS-1))); do
+    NUM_TESTS=$((NUM_TESTS + $(awk 'END{print NR}' $TEST_PARTITIONS_DIR/test-partition-$p.txt)))
+done
+ACTUAL_NUM_TESTS=$(./stellar-core test --ll FATAL --list-test-names-only "$TEST_SPEC" | awk 'END{print NR}')
+if [[ $NUM_TESTS -ne $ACTUAL_NUM_TESTS ]]; then
+    echo "Partitions contain $NUM_TESTS tests, while stellar-core lists $ACTUAL_NUM_TESTS tests"
+    exit 1
+fi
+
 runpart()
 {
   local PART=$1

--- a/src/test/selftest-parallel
+++ b/src/test/selftest-parallel
@@ -40,13 +40,11 @@ perl -e '
          my @all_tests = shuffle `./stellar-core test --ll FATAL --list-test-names-only $test_spec`;
          for (my $p = 0; $p < $num_partitions; $p++) {
              open(my $out, ">", "$test_partitions_dir/test-partition-$p.txt");
-             my $pre="";
              for (my $i = $p; $i < @all_tests; $i+=$num_partitions) {
                 my $tn = $all_tests[$i];
                 chomp $tn;
                 die "Invalid test name \"$tn\"" if $tn =~ m{[^-A-Za-z0-9 _():/]};
-                print $out "$pre$tn";
-                $pre="\n";
+                print $out "$tn\n";
              }
              close $out;
          }' -- "$NUM_PARTITIONS" "$TEST_SPEC" "$TEST_PARTITIONS_DIR" "$RND_SEED"


### PR DESCRIPTION
This change does two things:
- improves the durability of make check such that it fails if it doesn't execute all the tests listed by `stellar-core test --list-test-names-only`
- fixes #2438 so that all tests execute 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)