### PR TITLE
Improve archive failure logging

### DIFF
--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -6,6 +6,7 @@
 
 #include "herder/LedgerCloseData.h"
 #include "herder/TxSetFrame.h"
+#include "history/HistoryArchive.h"
 #include "ledger/LedgerRange.h"
 #include "util/XDRStream.h"
 #include "work/ConditionalWork.h"
@@ -54,6 +55,7 @@ class ApplyCheckpointWork : public BasicWork
     XDRInputFileStream mTxIn;
     TransactionHistoryEntry mTxHistoryEntry;
     LedgerHeaderHistoryEntry mHeaderHistoryEntry;
+    OnFailureCallback mOnFailure;
 
     medida::Meter& mApplyLedgerSuccess;
     medida::Meter& mApplyLedgerFailure;
@@ -69,9 +71,10 @@ class ApplyCheckpointWork : public BasicWork
 
   public:
     ApplyCheckpointWork(Application& app, TmpDir const& downloadDir,
-                        LedgerRange const& range);
+                        LedgerRange const& range, OnFailureCallback cb);
     ~ApplyCheckpointWork() = default;
     std::string getStatus() const override;
+    void onFailureRaise() override;
     void shutdown() override;
 
   protected:

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -51,8 +51,29 @@ DownloadApplyTxsWork::yieldMoreWork()
     auto const& hm = mApp.getHistoryManager();
     auto low = hm.firstLedgerInCheckpointContaining(mCheckpointToQueue);
     auto high = std::min(mCheckpointToQueue, mRange.last());
+
+    TmpDir const& dir = mDownloadDir;
+    uint32_t checkpoint = mCheckpointToQueue;
+    auto getFileWeak = std::weak_ptr<GetAndUnzipRemoteFileWork>(getAndUnzip);
+
+    OnFailureCallback cb = [getFileWeak, checkpoint, &dir]() {
+        auto getFile = getFileWeak.lock();
+        if (getFile)
+        {
+            auto archive = getFile->getArchive();
+            if (archive)
+            {
+                FileTransferInfo ti(dir, HISTORY_FILE_TYPE_TRANSACTIONS,
+                                    checkpoint);
+                CLOG(ERROR, "History")
+                    << fmt::format("Archive {} maybe contains corrupt file {}",
+                                   archive->getName(), ti.remoteName());
+            }
+        }
+    };
+
     auto apply = std::make_shared<ApplyCheckpointWork>(
-        mApp, mDownloadDir, LedgerRange::inclusive(low, high));
+        mApp, mDownloadDir, LedgerRange::inclusive(low, high), cb);
 
     std::vector<std::shared_ptr<BasicWork>> seq{getAndUnzip};
 

--- a/src/historywork/GetAndUnzipRemoteFileWork.h
+++ b/src/historywork/GetAndUnzipRemoteFileWork.h
@@ -13,14 +13,15 @@ namespace stellar
 {
 
 class HistoryArchive;
+class GetRemoteFileWork;
 
 class GetAndUnzipRemoteFileWork : public Work
 {
-    std::shared_ptr<BasicWork> mGetRemoteFileWork;
+    std::shared_ptr<GetRemoteFileWork> mGetRemoteFileWork;
     std::shared_ptr<BasicWork> mGunzipFileWork;
 
     FileTransferInfo mFt;
-    std::shared_ptr<HistoryArchive> mArchive;
+    std::shared_ptr<HistoryArchive> const mArchive;
 
     medida::Meter& mDownloadStart;
     medida::Meter& mDownloadSuccess;
@@ -37,6 +38,7 @@ class GetAndUnzipRemoteFileWork : public Work
         std::shared_ptr<HistoryArchive> archive = nullptr);
     ~GetAndUnzipRemoteFileWork() = default;
     std::string getStatus() const override;
+    std::shared_ptr<HistoryArchive> getArchive() const;
 
   protected:
     void doReset() override;

--- a/src/historywork/GetHistoryArchiveStateWork.h
+++ b/src/historywork/GetHistoryArchiveStateWork.h
@@ -16,10 +16,11 @@ namespace stellar
 {
 
 class HistoryArchive;
+class GetRemoteFileWork;
 
 class GetHistoryArchiveStateWork : public Work
 {
-    std::shared_ptr<BasicWork> mGetRemoteFile;
+    std::shared_ptr<GetRemoteFileWork> mGetRemoteFile;
 
     HistoryArchiveState mState;
     uint32_t mSeq;

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -3,10 +3,12 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "historywork/GetRemoteFileWork.h"
+#include "fmt/format.h"
 #include "history/HistoryArchive.h"
 #include "history/HistoryArchiveManager.h"
 #include "history/HistoryManager.h"
 #include "main/Application.h"
+#include "util/Logging.h"
 
 namespace stellar
 {
@@ -57,7 +59,16 @@ void
 GetRemoteFileWork::onFailureRaise()
 {
     assert(mCurrentArchive);
+    CLOG(ERROR, "History") << fmt::format(
+        "Could not download file: archive {} maybe missing file {}",
+        mCurrentArchive->getName(), mRemote);
     mCurrentArchive->markFailure();
     RunCommandWork::onFailureRaise();
+}
+
+std::shared_ptr<HistoryArchive>
+GetRemoteFileWork::getCurrentArchive() const
+{
+    return mCurrentArchive;
 }
 }

--- a/src/historywork/GetRemoteFileWork.h
+++ b/src/historywork/GetRemoteFileWork.h
@@ -15,7 +15,7 @@ class GetRemoteFileWork : public RunCommandWork
 {
     std::string const mRemote;
     std::string const mLocal;
-    std::shared_ptr<HistoryArchive> mArchive;
+    std::shared_ptr<HistoryArchive> const mArchive;
     std::shared_ptr<HistoryArchive> mCurrentArchive;
     CommandInfo getCommand() override;
 
@@ -28,6 +28,7 @@ class GetRemoteFileWork : public RunCommandWork
                       std::shared_ptr<HistoryArchive> archive = nullptr,
                       size_t maxRetries = BasicWork::RETRY_A_LOT);
     ~GetRemoteFileWork() = default;
+    std::shared_ptr<HistoryArchive> getCurrentArchive() const;
 
   protected:
     void onReset() override;

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -23,11 +23,12 @@ namespace stellar
 
 VerifyBucketWork::VerifyBucketWork(
     Application& app, std::map<std::string, std::shared_ptr<Bucket>>& buckets,
-    std::string const& bucketFile, uint256 const& hash)
+    std::string const& bucketFile, uint256 const& hash, OnFailureCallback cb)
     : BasicWork(app, "verify-bucket-hash-" + bucketFile, BasicWork::RETRY_NEVER)
     , mBuckets(buckets)
     , mBucketFile(bucketFile)
     , mHash(hash)
+    , mOnFailure(cb)
     , mVerifyBucketSuccess(app.getMetrics().NewMeter(
           {"history", "verify-bucket", "success"}, "event"))
     , mVerifyBucketFailure(app.getMetrics().NewMeter(
@@ -144,5 +145,14 @@ VerifyBucketWork::spawnVerifier()
                 "VerifyBucket: finish");
         },
         "VerifyBucket: start in background");
+}
+
+void
+VerifyBucketWork::onFailureRaise()
+{
+    if (mOnFailure)
+    {
+        mOnFailure();
+    }
 }
 }

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -28,13 +28,16 @@ class VerifyBucketWork : public BasicWork
     void adoptBucket();
     void spawnVerifier();
 
+    OnFailureCallback mOnFailure;
+
     medida::Meter& mVerifyBucketSuccess;
     medida::Meter& mVerifyBucketFailure;
 
   public:
     VerifyBucketWork(Application& app,
                      std::map<std::string, std::shared_ptr<Bucket>>& buckets,
-                     std::string const& bucketFile, uint256 const& hash);
+                     std::string const& bucketFile, uint256 const& hash,
+                     OnFailureCallback cb);
     ~VerifyBucketWork() = default;
 
   protected:
@@ -44,5 +47,6 @@ class VerifyBucketWork : public BasicWork
     {
         return true;
     };
+    void onFailureRaise() override;
 };
 }

--- a/src/work/Work.h
+++ b/src/work/Work.h
@@ -31,6 +31,10 @@ class Application;
  *  flatter structures for better efficiency; they can use WorkSequence
  *  if a long serial order needs to be enforced.
  */
+
+// Helper lambda that parent work can pass to children
+using OnFailureCallback = std::function<void()>;
+
 class Work : public BasicWork
 {
   public:


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core/issues/2329

Main changes include tracking get/put failure rates per each archive, and more consistent/informative logging across history works. These logs should give node operators a rough idea on what the problem might be and which archive to investigate. 