### PR TITLE
Fix remove and reset

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1406,7 +1406,7 @@ HerderImpl::updateTransactionQueue(
     std::vector<TransactionFrameBasePtr> const& applied)
 {
     // remove all these tx from mTransactionQueue
-    mTransactionQueue.removeAndReset(applied);
+    mTransactionQueue.removeApplied(applied);
     mTransactionQueue.shift();
 
     // Transactions in the queue need to be updated after the protocol 13

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -256,8 +256,12 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         TransactionQueueTest test{*app};
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
+        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
-        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
+        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
     }
 
     SECTION("good then small sequence number")

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -609,10 +609,12 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}},
                      {account2, 1, {txSeqA2T1, txSeqA2T2}}}});
         test.removeApplied({txSeqA1T1, txSeqA2T2});
-        test.check({{{account1, 0, {txSeqA1T2}}, {account2, 0, {txSeqA2T1}}}});
+        test.check({{{account1, 0, {txSeqA1T2}}, {account2}}});
         test.removeApplied({txSeqA1T2});
-        test.check({{{account1}, {account2, 0, {txSeqA2T1}}}});
+        test.check({{{account1}, {account2}}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
+        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
         test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}},

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -3,6 +3,8 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/SecretKey.h"
+#include "herder/Herder.h"
+#include "herder/HerderImpl.h"
 #include "herder/TransactionQueue.h"
 #include "test/TestAccount.h"
 #include "test/TestUtils.h"
@@ -89,10 +91,10 @@ class TransactionQueueTest
     }
 
     void
-    removeAndReset(std::vector<TransactionFrameBasePtr> const& toRemove)
+    removeApplied(std::vector<TransactionFrameBasePtr> const& toRemove)
     {
         auto size = mTransactionQueue.toTxSet({})->sizeTx();
-        mTransactionQueue.removeAndReset(toRemove);
+        mTransactionQueue.removeApplied(toRemove);
         REQUIRE(size - toRemove.size() >=
                 mTransactionQueue.toTxSet({})->sizeTx());
     }
@@ -606,20 +608,20 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}},
                      {account2, 1, {txSeqA2T1, txSeqA2T2}}}});
-        test.removeAndReset({txSeqA1T1, txSeqA2T2});
+        test.removeApplied({txSeqA1T1, txSeqA2T2});
         test.check({{{account1, 0, {txSeqA1T2}}, {account2, 0, {txSeqA2T1}}}});
-        test.removeAndReset({txSeqA1T2});
+        test.removeApplied({txSeqA1T2});
         test.check({{{account1}, {account2, 0, {txSeqA2T1}}}});
         test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
         test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}},
                      {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
-        test.removeAndReset({txSeqA2T1});
+        test.removeApplied({txSeqA2T1});
         test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T2}}}});
-        test.removeAndReset({txSeqA2T2});
+        test.removeApplied({txSeqA2T2});
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
-        test.removeAndReset({txSeqA1T1});
+        test.removeApplied({txSeqA1T1});
         test.check({{{account1}, {account2}}});
     }
 
@@ -885,12 +887,12 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
 
         SECTION("remove first")
         {
-            test.removeAndReset({fb1});
+            test.removeApplied({fb1});
             test.check({{{account1, 0, {fb2}}, {account2}, {account3}}, {}});
         }
         SECTION("remove second")
         {
-            test.removeAndReset({fb1, fb2});
+            test.removeApplied({fb1, fb2});
             test.check({{{account1}, {account2}, {account3}}, {}});
         }
     }
@@ -927,12 +929,12 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
 
         SECTION("remove first")
         {
-            test.removeAndReset({fb1});
+            test.removeApplied({fb1});
             test.check({{{account1, 0, {fb2}}, {account2}, {account3}}, {}});
         }
         SECTION("remove second")
         {
-            test.removeAndReset({fb1, fb2});
+            test.removeApplied({fb1, fb2});
             test.check({{{account1}, {account2}, {account3}}, {}});
         }
     }
@@ -1164,4 +1166,52 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
         auto txs = setupFeeBumps(test, account2);
         submitFeeBumps(test, txs);
     }
+}
+
+TEST_CASE("remove applied", "[herder][transactionqueue]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig();
+    auto app = createTestApplication(clock, cfg);
+    app->start();
+
+    auto& lm = app->getLedgerManager();
+    auto& herder = static_cast<HerderImpl&>(app->getHerder());
+    auto& tq = herder.getTransactionQueue();
+
+    auto root = TestAccount::createRoot(*app);
+    auto acc = root.create("A", lm.getLastMinBalance(2));
+
+    auto tx1a = root.tx({payment(root, 1)});
+    root.loadSequenceNumber();
+    auto tx1b = root.tx({payment(root, 2)});
+    auto tx2 = root.tx({payment(root, 3)});
+    auto tx3 = root.tx({payment(root, 4)});
+    auto tx4 = root.tx({payment(root, 5)});
+
+    herder.recvTransaction(tx1a);
+    herder.recvTransaction(tx2);
+    herder.recvTransaction(tx3);
+
+    {
+        auto const& lcl = lm.getLastClosedLedgerHeader();
+        auto ledgerSeq = lcl.header.ledgerSeq + 1;
+
+        auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
+        root.loadSequenceNumber();
+        txSet->add(tx1b);
+        txSet->add(tx2);
+        herder.getPendingEnvelopes().putTxSet(txSet->getContentsHash(),
+                                              ledgerSeq, txSet);
+
+        StellarValue sv{txSet->getContentsHash(), 2,
+                        xdr::xvector<UpgradeType, 6>{}, STELLAR_VALUE_BASIC};
+        herder.getHerderSCPDriver().valueExternalized(ledgerSeq,
+                                                      xdr::xdr_to_opaque(sv));
+    }
+
+    REQUIRE(tq.toTxSet({})->mTransactions.size() == 1);
+    REQUIRE(herder.recvTransaction(tx4) ==
+            TransactionQueue::AddResult::ADD_STATUS_PENDING);
+    REQUIRE(tq.toTxSet({})->mTransactions.size() == 2);
 }


### PR DESCRIPTION
This PR fixes two bugs in stellar-core, one moderate and one minor. Both of them are related to `TransactionQueue::removeAndReset`. 

### The Minor Bug 
`removeAndReset` does not correctly maintain `mSizeByAge` (see master:herder/TransactionQueue.cpp:260). When resetting the age, there may still be transactions in the queue for that source account.

### The Moderate Bug
`removeAndReset` can leave sequence number gaps in the queue for a source account. The root cause of this is that the semantics of `removeAndReset` are illogical. As implemented, the function finds transactions _by hash_ and removes them while keeping the backlog. Let’s consider an example of how this can go wrong. Suppose a source account has signed 4 transactions: 2 for the first sequence number, 1 for the second sequence number, and 1 for the third. It is possible for a node to have transactions 1a, 2, and 3 in its queue while the network applies 1b and 2. In this case, `removeAndReset` on that node will remove transaction 2 only, because 1a does not match 1b by hash. The result is that the queue for that transaction now contains transaction 1a and 3, which are not sequential! This already sounds like a problem, but what can happen as a consequence? The node can crash since #2419 because that PR depends on the invariant that the transactions are sequential (see `findBySeq`). The node might also proceed to drop valid transactions later because `trimInvalid` will find transaction 1a, notice it is invalid, and drop it along with all transactions having higher sequence numbers for the same source account (eg. transaction 3 which is actually valid). In a very unfortunate turn of events, there was actually a test that confirms that illogical behavior like this exists (see master:herder/test/TransactionQueueTests.cpp:611-612).

From the above analysis it should be clear that the semantics of `removeAndReset` are currently dangerous and wrong. Once a sequence number has been consumed it is unusable regardless of the transaction that consumed it. In other words, the correct behavior is to remove applied transactions _by sequence number_. Specifically, it should remove all transactions with a sequence number less-than-or-equal to the the highest sequence number applied for that source account regardless of whether any of those transactions are actually in the queue.

### The Solution
The new semantics for `removeAndReset` make it quite different from `ban`. Both of these functions were implemented in an inefficient way using `extract` (they repeatedly call `extract`  so map look-ups and vector operations are done multiple times). We make the following changes:

- Rename `removeAndReset` to `removeApplied`
- Remove `extract` and `find` entirely
- Implement a new function `dropTransactions` which is responsible only for dropping a provided list of transactions for a given source account and doing associate maintenance such as releasing fees
- Implement `removeApplied` efficiently with the semantics described above using `dropTransactions`
- Implement `ban` efficiently using `dropTransactions`
- Add comments to clarify how these functions work

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)