### PR TITLE
Use fixed histogram for ledger close time

### DIFF
--- a/Builds/VisualStudio/libmedida/libmedida.vcxproj
+++ b/Builds/VisualStudio/libmedida/libmedida.vcxproj
@@ -207,6 +207,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\lib\libmedida\src\medida\buckets.cc" />
     <ClCompile Include="..\..\..\lib\libmedida\src\medida\counter.cc" />
     <ClCompile Include="..\..\..\lib\libmedida\src\medida\histogram.cc" />
     <ClCompile Include="..\..\..\lib\libmedida\src\medida\meter.cc" />
@@ -229,6 +230,7 @@
     <ClCompile Include="..\..\..\lib\libmedida\src\medida\timer_context.cc" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\..\lib\libmedida\src\medida\buckets.h" />
     <ClInclude Include="..\..\..\lib\libmedida\src\medida\counter.h" />
     <ClInclude Include="..\..\..\lib\libmedida\src\medida\histogram.h" />
     <ClInclude Include="..\..\..\lib\libmedida\src\medida\medida.h" />

--- a/Builds/VisualStudio/libmedida/libmedida.vcxproj.filters
+++ b/Builds/VisualStudio/libmedida/libmedida.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="..\..\..\lib\libmedida\src\medida\stats\sliding_window_sample.cc">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\lib\libmedida\src\medida\buckets.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\lib\libmedida\src\medida\counter.h">
@@ -139,6 +142,9 @@
     </ClInclude>
     <ClInclude Include="..\..\..\lib\libmedida\src\medida\stats\sliding_window_sample.h">
       <Filter>Source Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\lib\libmedida\src\medida\buckets.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,6 +19,8 @@ Tracks aggregates (count, min, max, mean, percentiles, etc) of samples expressed
 Tracks aggregates (count, min, max, mean, etc),  rate (1m, 5m, 15m) for samples
 expressed in base unit.
 
+### Buckets (`NewBuckets`)
+Tracks multiple timers organized into disjoint buckets.
 
 Metric name                              | Type      | Description
 ---------------------------------------  | --------  | --------------------
@@ -49,7 +51,7 @@ history.publish.success                  | meter     | published completed succe
 history.publish.time                     | timer     | time to successfuly publish history
 history.verify-<X>.failure               | meter     | verification of <X> failed
 history.verify-<X>.success               | meter     | verification of <X> succeeded
-ledger.age.closed                        | timer     | time between ledgers
+ledger.age.closed                        | bucket     | time between ledgers
 ledger.age.current-seconds               | counter   | gap between last close ledger time and current time
 ledger.catchup.duration                  | timer     | time between entering LM_CATCHING_UP_STATE and entering LM_SYNCED_STATE
 ledger.invariant.failure                 | counter   | number of times invariants failed

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -34,6 +34,7 @@
 #include "util/XDROperators.h"
 #include "util/format.h"
 
+#include "medida/buckets.h"
 #include "medida/counter.h"
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
@@ -119,7 +120,8 @@ LedgerManagerImpl::LedgerManagerImpl(Application& app)
           app.getMetrics().NewHistogram({"ledger", "prefetch", "hit-rate"},
                                         medida::SamplingInterface::kSliding))
     , mLedgerClose(app.getMetrics().NewTimer({"ledger", "ledger", "close"}))
-    , mLedgerAgeClosed(app.getMetrics().NewTimer({"ledger", "age", "closed"}))
+    , mLedgerAgeClosed(app.getMetrics().NewBuckets(
+          {"ledger", "age", "closed"}, {5000.0, 7000.0, 10000.0, 20000.0}))
     , mLedgerAge(
           app.getMetrics().NewCounter({"ledger", "age", "current-seconds"}))
     , mLastClose(mApp.getClock().now())

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -24,6 +24,7 @@ namespace medida
 class Timer;
 class Counter;
 class Histogram;
+class Buckets;
 }
 
 namespace stellar
@@ -47,7 +48,7 @@ class LedgerManagerImpl : public LedgerManager
     medida::Histogram& mOperationCount;
     medida::Histogram& mPrefetchHitRate;
     medida::Timer& mLedgerClose;
-    medida::Timer& mLedgerAgeClosed;
+    medida::Buckets& mLedgerAgeClosed;
     medida::Counter& mLedgerAge;
     VirtualClock::time_point mLastClose;
 

--- a/src/transactions/test/AllowTrustTests.cpp
+++ b/src/transactions/test/AllowTrustTests.cpp
@@ -189,15 +189,15 @@ TEST_CASE("authorized to maintain liabilities", "[tx][allowtrust]")
 
         SECTION("can't add offer")
         {
-            OfferState offer(usd, idr, Price{1, 1}, 1000);
+            OfferState offerState(usd, idr, Price{1, 1}, 1000);
             if (buyIsOnlyAllowedToMaintainLiabilities)
             {
-                REQUIRE_THROWS_AS(market.addOffer(a1, offer),
+                REQUIRE_THROWS_AS(market.addOffer(a1, offerState),
                                   ex_MANAGE_SELL_OFFER_BUY_NOT_AUTHORIZED);
             }
             else
             {
-                REQUIRE_THROWS_AS(market.addOffer(a1, offer),
+                REQUIRE_THROWS_AS(market.addOffer(a1, offerState),
                                   ex_MANAGE_SELL_OFFER_SELL_NOT_AUTHORIZED);
             }
         }

--- a/src/util/MetricResetter.cpp
+++ b/src/util/MetricResetter.cpp
@@ -30,4 +30,10 @@ MetricResetter::Process(medida::Timer& timer)
 {
     timer.Clear();
 }
+
+void
+MetricResetter::Process(medida::Buckets& buckets)
+{
+    buckets.Clear();
+}
 }

--- a/src/util/MetricResetter.h
+++ b/src/util/MetricResetter.h
@@ -9,9 +9,6 @@
 namespace medida
 {
 class MetricsRegistry;
-class Meter;
-class Counter;
-class Timer;
 }
 
 namespace stellar
@@ -26,5 +23,6 @@ class MetricResetter : public medida::MetricProcessor
     void Process(medida::Meter& meter) override;
     void Process(medida::Histogram& histogram) override;
     void Process(medida::Timer& timer) override;
+    void Process(medida::Buckets& buckets) override;
 };
 }


### PR DESCRIPTION
# Description

Resolves #2480

https://github.com/stellar/medida/pull/18 needs to be merged first

This PR uses the new "Buckets" type in medida to expose ledger close times as fixed buckets.


The metric shows up as:
```json
{
  "type": "buckets",
  "boundary_unit": "ms",
  "buckets": [
    {
      "boundary": 5000,
      "type": "timer",
      "count": 11,
      "event_type": "calls",
      "rate_unit": "s",
      "mean_rate": 0.113287,
      "1_min_rate": 0.234886,
      "5_min_rate": 0.174176,
      "15_min_rate": 0.0731516,
      "duration_unit": "ms",
      "min": 315.725,
      "max": 4998.54,
      "mean": 2889.55,
      "stddev": 2400.13,
      "sum": 31785,
      "median": 4965.33,
      "75%": 4969.9,
      "95%": 4997.4,
      "98%": 4998.08,
      "99%": 4998.31,
      "99.9%": 4998.52
    },
    {
      "boundary": 7000,
      "type": "timer",
      "count": 7,
      "event_type": "calls",
      "rate_unit": "s",
      "mean_rate": 0.0116192,
      "1_min_rate": 0.0500496,
      "5_min_rate": 0.0215931,
      "15_min_rate": 0.00827851,
      "duration_unit": "ms",
      "min": 5009.06,
      "max": 6047.07,
      "mean": 5197.04,
      "stddev": 379.14,
      "sum": 36379.3,
      "median": 5038.2,
      "75%": 5115.01,
      "95%": 5786.75,
      "98%": 5942.95,
      "99%": 5995.01,
      "99.9%": 6041.87
    },
    {
      "boundary": 10000,
      "type": "timer",
      "count": 0,
      "event_type": "calls",
      "rate_unit": "s",
      "mean_rate": 0,
      "1_min_rate": 0,
      "5_min_rate": 0,
      "15_min_rate": 0,
      "duration_unit": "ms",
      "min": 0,
      "max": 0,
      "mean": 0,
      "stddev": 0,
      "sum": 0,
      "median": 0,
      "75%": 0,
      "95%": 0,
      "98%": 0,
      "99%": 0,
      "99.9%": 0
    },
    {
      "boundary": 20000,
      "type": "timer",
      "count": 1,
      "event_type": "calls",
      "rate_unit": "s",
      "mean_rate": 0.0014524,
      "1_min_rate": 0.00755367,
      "5_min_rate": 0.00284525,
      "15_min_rate": 0.00105399,
      "duration_unit": "ms",
      "min": 15494.2,
      "max": 15494.2,
      "mean": 15494.2,
      "stddev": 0,
      "sum": 15494.2,
      "median": 15494.2,
      "75%": 15494.2,
      "95%": 15494.2,
      "98%": 15494.2,
      "99%": 15494.2,
      "99.9%": 15494.2
    },
    {
      "boundary": 1.79769e+308,
      "type": "timer",
      "count": 1,
      "event_type": "calls",
      "rate_unit": "s",
      "mean_rate": 0.0043572,
      "1_min_rate": 0.00337451,
      "5_min_rate": 0.00416035,
      "15_min_rate": 0.00189755,
      "duration_unit": "ms",
      "min": 24766,
      "max": 24766,
      "mean": 24766,
      "stddev": 0,
      "sum": 24766,
      "median": 24766,
      "75%": 24766,
      "95%": 24766,
      "98%": 24766,
      "99%": 24766,
      "99.9%": 24766
    }
  ]
}
```

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
