### PR TITLE
Retry interrupted io

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -273,6 +273,7 @@ exit /b 0
     <ClCompile Include="..\..\src\catchup\ApplyLedgerWork.cpp" />
     <ClCompile Include="..\..\src\catchup\CatchupConfiguration.cpp" />
     <ClCompile Include="..\..\src\catchup\CatchupManagerImpl.cpp" />
+    <ClCompile Include="..\..\src\catchup\CatchupRange.cpp" />
     <ClCompile Include="..\..\src\catchup\CatchupWork.cpp" />
     <ClCompile Include="..\..\src\catchup\simulation\ApplyTransactionsWork.cpp" />
     <ClCompile Include="..\..\src\catchup\simulation\HistoryArchiveStream.cpp" />
@@ -604,6 +605,7 @@ exit /b 0
     <ClInclude Include="..\..\src\catchup\CatchupConfiguration.h" />
     <ClInclude Include="..\..\src\catchup\CatchupManager.h" />
     <ClInclude Include="..\..\src\catchup\CatchupManagerImpl.h" />
+    <ClInclude Include="..\..\src\catchup\CatchupRange.h" />
     <ClInclude Include="..\..\src\catchup\CatchupWork.h" />
     <ClInclude Include="..\..\src\catchup\DownloadApplyTxsWork.h" />
     <ClInclude Include="..\..\src\catchup\simulation\ApplyTransactionsWork.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1038,6 +1038,9 @@
     <ClCompile Include="..\..\src\transactions\TransactionSQL.cpp">
       <Filter>transactions</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\catchup\CatchupRange.cpp">
+      <Filter>catchup</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">
@@ -1795,6 +1798,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\transactions\TransactionSQL.h">
       <Filter>transactions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\catchup\CatchupRange.h">
+      <Filter>catchup</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -138,7 +138,7 @@ Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
               std::vector<LedgerEntry> const& initEntries,
               std::vector<LedgerEntry> const& liveEntries,
               std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
-              bool doFsync)
+              asio::io_context& ctx, bool doFsync)
 {
     // When building fresh buckets after protocol version 10 (i.e. version
     // 11-or-after) we differentiate INITENTRY from LIVEENTRY. In older
@@ -152,7 +152,7 @@ Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
         convertToBucketEntry(useInit, initEntries, liveEntries, deadEntries);
 
     MergeCounters mc;
-    BucketOutputIterator out(bucketManager.getTmpDir(), true, meta, mc,
+    BucketOutputIterator out(bucketManager.getTmpDir(), true, meta, mc, ctx,
                              doFsync);
     for (auto const& e : entries)
     {
@@ -589,7 +589,8 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
               std::shared_ptr<Bucket> const& oldBucket,
               std::shared_ptr<Bucket> const& newBucket,
               std::vector<std::shared_ptr<Bucket>> const& shadows,
-              bool keepDeadEntries, bool countMergeEvents, bool doFsync)
+              bool keepDeadEntries, bool countMergeEvents,
+              asio::io_context& ctx, bool doFsync)
 {
     // This is the key operation in the scheme: merging two (read-only)
     // buckets together into a new 3rd bucket, while calculating its hash,
@@ -614,7 +615,7 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
     BucketMetadata meta;
     meta.ledgerVersion = protocolVersion;
     BucketOutputIterator out(bucketManager.getTmpDir(), keepDeadEntries, meta,
-                             mc, doFsync);
+                             mc, ctx, doFsync);
 
     BucketEntryIdCmp cmp;
     while (oi || ni)

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -85,7 +85,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
           std::vector<LedgerEntry> const& initEntries,
           std::vector<LedgerEntry> const& liveEntries,
           std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
-          bool doFsync);
+          asio::io_context& ctx, bool doFsync);
 
     // Merge two buckets together, producing a fresh one. Entries in `oldBucket`
     // are overridden in the fresh bucket by keywise-equal entries in
@@ -103,7 +103,8 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
           std::shared_ptr<Bucket> const& oldBucket,
           std::shared_ptr<Bucket> const& newBucket,
           std::vector<std::shared_ptr<Bucket>> const& shadows,
-          bool keepDeadEntries, bool countMergeEvents, bool doFsync);
+          bool keepDeadEntries, bool countMergeEvents, asio::io_context& ctx,
+          bool doFsync);
 
     static uint32_t getBucketVersion(std::shared_ptr<Bucket> const& bucket);
 };

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -566,7 +566,8 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
     mLevels[0].prepare(app, currLedger, currLedgerProtocol,
                        Bucket::fresh(app.getBucketManager(), currLedgerProtocol,
                                      initEntries, liveEntries, deadEntries,
-                                     countMergeEvents, doFsync),
+                                     countMergeEvents,
+                                     app.getClock().getIOContext(), doFsync),
                        shadows, countMergeEvents);
     mLevels[0].commit();
 

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -35,9 +35,10 @@ randomBucketName(std::string const& tmpDir)
 BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
                                            bool keepDeadEntries,
                                            BucketMetadata const& meta,
-                                           MergeCounters& mc, bool doFsync)
+                                           MergeCounters& mc,
+                                           asio::io_context& ctx, bool doFsync)
     : mFilename(randomBucketName(tmpDir))
-    , mOut(doFsync)
+    , mOut(ctx, doFsync)
     , mBuf(nullptr)
     , mHasher(SHA256::create())
     , mKeepDeadEntries(keepDeadEntries)

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -45,7 +45,7 @@ class BucketOutputIterator
     // (or forget to do), it's handled automatically.
     BucketOutputIterator(std::string const& tmpDir, bool keepDeadEntries,
                          BucketMetadata const& meta, MergeCounters& mc,
-                         bool doFsync);
+                         asio::io_context& ctx, bool doFsync);
 
     void put(BucketEntry const& e);
 

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -354,6 +354,7 @@ FutureBucket::startMerge(Application& app, uint32_t maxProtocolVersion,
                 auto res = Bucket::merge(
                     bm, maxProtocolVersion, curr, snap, shadows,
                     BucketList::keepDeadEntries(level), countMergeEvents,
+                    app.getClock().getIOContext(),
                     !app.getConfig().DISABLE_XDR_FSYNC);
 
                 CLOG(TRACE, "Bucket")

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -285,12 +285,12 @@ TEST_CASE("bucket tombstones expire at bottom level",
             level.setCurr(Bucket::fresh(
                 bm, getAppLedgerVersion(app), {},
                 LedgerTestUtils::generateValidLedgerEntries(8), deadGen(8),
-                /*countMergeEvents=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
                 /*doFsync=*/true));
             level.setSnap(Bucket::fresh(
                 bm, getAppLedgerVersion(app), {},
                 LedgerTestUtils::generateValidLedgerEntries(8), deadGen(8),
-                /*countMergeEvents=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
                 /*doFsync=*/true));
         }
 

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -285,7 +285,8 @@ TEST_CASE("bucketmanager ownership", "[bucket][bucketmanager]")
         {
             std::shared_ptr<Bucket> b2 = Bucket::fresh(
                 app->getBucketManager(), getAppLedgerVersion(app), {}, live,
-                dead, /*countMergeEvents=*/true, /*doFsync=*/true);
+                dead, /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             b1 = b2;
 
             // Bucket is referenced by b1, b2 and the BucketManager.
@@ -293,10 +294,12 @@ TEST_CASE("bucketmanager ownership", "[bucket][bucketmanager]")
 
             std::shared_ptr<Bucket> b3 = Bucket::fresh(
                 app->getBucketManager(), getAppLedgerVersion(app), {}, live,
-                dead, /*countMergeEvents=*/true, /*doFsync=*/true);
+                dead, /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             std::shared_ptr<Bucket> b4 = Bucket::fresh(
                 app->getBucketManager(), getAppLedgerVersion(app), {}, live,
-                dead, /*countMergeEvents=*/true, /*doFsync=*/true);
+                dead, /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             // Bucket is referenced by b1, b2, b3, b4 and the BucketManager.
             CHECK(b1.use_count() == 5);
         }

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -27,7 +27,8 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
         std::shared_ptr<Bucket> b1 =
             Bucket::fresh(app->getBucketManager(),
                           BucketTests::getAppLedgerVersion(app), {}, live, {},
-                          /*countMergeEvents=*/true, /*doFsync=*/true);
+                          /*countMergeEvents=*/true, clock.getIOContext(),
+                          /*doFsync=*/true);
         return b1;
     };
 

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -128,7 +128,8 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
         CLOG(DEBUG, "Bucket") << "Hashing entries";
         std::shared_ptr<Bucket> b1 = Bucket::fresh(
             app->getBucketManager(), getAppLedgerVersion(app), {}, live, dead,
-            /*countMergeEvents=*/true, /*doFsync=*/true);
+            /*countMergeEvents=*/true, clock.getIOContext(),
+            /*doFsync=*/true);
         for (uint32_t i = 0; i < 5; ++i)
         {
             CLOG(DEBUG, "Bucket") << "Merging 10000 new ledger entries into "
@@ -138,17 +139,18 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
             for (auto& e : dead)
                 e = deadGen(3);
             {
-                b1 = Bucket::merge(app->getBucketManager(),
-                                   app->getConfig().LEDGER_PROTOCOL_VERSION, b1,
-                                   Bucket::fresh(app->getBucketManager(),
-                                                 getAppLedgerVersion(app), {},
-                                                 live, dead,
-                                                 /*countMergeEvents=*/true,
-                                                 /*doFsync=*/true),
-                                   /*shadows=*/{},
-                                   /*keepDeadEntries=*/true,
-                                   /*countMergeEvents=*/true,
-                                   /*doFsync=*/true);
+                b1 = Bucket::merge(
+                    app->getBucketManager(),
+                    app->getConfig().LEDGER_PROTOCOL_VERSION, b1,
+                    Bucket::fresh(app->getBucketManager(),
+                                  getAppLedgerVersion(app), {}, live, dead,
+                                  /*countMergeEvents=*/true,
+                                  clock.getIOContext(),
+                                  /*doFsync=*/true),
+                    /*shadows=*/{},
+                    /*keepDeadEntries=*/true,
+                    /*countMergeEvents=*/true, clock.getIOContext(),
+                    /*doFsync=*/true);
             }
         }
         CLOG(DEBUG, "Bucket")
@@ -196,13 +198,16 @@ TEST_CASE("merging bucket entries", "[bucket]")
                 auto deadEntry = LedgerEntryKey(liveEntry);
                 auto bLive = Bucket::fresh(bm, vers, {}, {liveEntry}, {},
                                            /*countMergeEvents=*/true,
+                                           clock.getIOContext(),
                                            /*doFsync=*/true);
                 auto bDead = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
                                            /*countMergeEvents=*/true,
+                                           clock.getIOContext(),
                                            /*doFsync=*/true);
                 auto b1 = Bucket::merge(bm, vers, bLive, bDead, /*shadows=*/{},
                                         /*keepDeadEntries=*/true,
                                         /*countMergeEvents=*/true,
+                                        clock.getIOContext(),
                                         /*doFsync=*/true);
                 CHECK(countEntries(b1) == 1);
             }
@@ -225,16 +230,19 @@ TEST_CASE("merging bucket entries", "[bucket]")
                     dead.push_back(LedgerEntryKey(e));
                 }
             }
-            auto bLive = Bucket::fresh(bm, vers, {}, live, {},
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto bDead = Bucket::fresh(bm, vers, {}, {}, dead,
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto b1 = Bucket::merge(bm, vers, bLive, bDead, /*shadows=*/{},
-                                    /*keepDeadEntries=*/true,
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
+            auto bLive =
+                Bucket::fresh(bm, vers, {}, live, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto bDead =
+                Bucket::fresh(bm, vers, {}, {}, dead,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto b1 =
+                Bucket::merge(bm, vers, bLive, bDead, /*shadows=*/{},
+                              /*keepDeadEntries=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
             EntryCounts e(b1);
             CHECK(e.sum() == live.size());
             CLOG(DEBUG, "Bucket") << "post-merge live count: " << e.nLive
@@ -250,10 +258,10 @@ TEST_CASE("merging bucket entries", "[bucket]")
             {
                 e = LedgerTestUtils::generateValidLedgerEntry(10);
             }
-            std::shared_ptr<Bucket> b1 =
-                Bucket::fresh(app->getBucketManager(), getAppLedgerVersion(app),
-                              {}, live, dead, /*countMergeEvents=*/true,
-                              /*doFsync=*/true);
+            std::shared_ptr<Bucket> b1 = Bucket::fresh(
+                app->getBucketManager(), getAppLedgerVersion(app), {}, live,
+                dead, /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             std::random_shuffle(live.begin(), live.end());
             size_t liveCount = live.size();
             for (auto& e : live)
@@ -264,15 +272,15 @@ TEST_CASE("merging bucket entries", "[bucket]")
                     ++liveCount;
                 }
             }
-            std::shared_ptr<Bucket> b2 =
-                Bucket::fresh(app->getBucketManager(), getAppLedgerVersion(app),
-                              {}, live, dead, /*countMergeEvents=*/true,
-                              /*doFsync=*/true);
+            std::shared_ptr<Bucket> b2 = Bucket::fresh(
+                app->getBucketManager(), getAppLedgerVersion(app), {}, live,
+                dead, /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             std::shared_ptr<Bucket> b3 =
                 Bucket::merge(app->getBucketManager(),
                               app->getConfig().LEDGER_PROTOCOL_VERSION, b1, b2,
                               /*shadows=*/{}, /*keepDeadEntries=*/true,
-                              /*countMergeEvents=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
                               /*doFsync=*/true);
             CHECK(countEntries(b3) == liveCount);
         }
@@ -343,46 +351,54 @@ TEST_CASE("merges proceed old-style despite newer shadows",
     LedgerEntry liveEntry = generateAccount();
     LedgerEntry otherLiveA = generateDifferentAccount({liveEntry});
 
-    auto b10first = Bucket::fresh(bm, v10, {}, {liveEntry}, {},
-                                  /*countMergeEvents=*/true,
-                                  /*doFsync=*/true);
-    auto b10second = Bucket::fresh(bm, v10, {}, {otherLiveA}, {},
-                                   /*countMergeEvents=*/true,
-                                   /*doFsync=*/true);
+    auto b10first =
+        Bucket::fresh(bm, v10, {}, {liveEntry}, {},
+                      /*countMergeEvents=*/true, clock.getIOContext(),
+                      /*doFsync=*/true);
+    auto b10second =
+        Bucket::fresh(bm, v10, {}, {otherLiveA}, {},
+                      /*countMergeEvents=*/true, clock.getIOContext(),
+                      /*doFsync=*/true);
 
-    auto b11first = Bucket::fresh(bm, v11, {}, {liveEntry}, {},
-                                  /*countMergeEvents=*/true,
-                                  /*doFsync=*/true);
-    auto b11second = Bucket::fresh(bm, v11, {}, {otherLiveA}, {},
-                                   /*countMergeEvents=*/true,
-                                   /*doFsync=*/true);
+    auto b11first =
+        Bucket::fresh(bm, v11, {}, {liveEntry}, {},
+                      /*countMergeEvents=*/true, clock.getIOContext(),
+                      /*doFsync=*/true);
+    auto b11second =
+        Bucket::fresh(bm, v11, {}, {otherLiveA}, {},
+                      /*countMergeEvents=*/true, clock.getIOContext(),
+                      /*doFsync=*/true);
 
     auto b12first =
         Bucket::fresh(bm, v12, {}, {liveEntry}, {}, /*countMergeEvents=*/true,
+                      clock.getIOContext(),
                       /*doFsync=*/true);
-    auto b12second = Bucket::fresh(bm, v12, {}, {otherLiveA}, {},
-                                   /*countMergeEvents=*/true,
-                                   /*doFsync=*/true);
+    auto b12second =
+        Bucket::fresh(bm, v12, {}, {otherLiveA}, {},
+                      /*countMergeEvents=*/true, clock.getIOContext(),
+                      /*doFsync=*/true);
 
     SECTION("shadow version 12")
     {
         // With proto 12, new bucket version solely depends on the snap version
-        auto bucket = Bucket::merge(bm, v12, b11first, b11second,
-                                    /*shadows=*/{b12first},
-                                    /*keepDeadEntries=*/true,
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
+        auto bucket =
+            Bucket::merge(bm, v12, b11first, b11second,
+                          /*shadows=*/{b12first},
+                          /*keepDeadEntries=*/true,
+                          /*countMergeEvents=*/true, clock.getIOContext(),
+                          /*doFsync=*/true);
         REQUIRE(Bucket::getBucketVersion(bucket) == v11);
     }
     SECTION("shadow versions mixed, pick lower")
     {
         // Merging older version (10) buckets, with mixed versions of shadows
         // (11, 12) Pick initentry (11) style merge
-        auto bucket = Bucket::merge(bm, v12, b10first, b10second,
-                                    /*shadows=*/{b12first, b11second},
-                                    /*keepDeadEntries=*/true,
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
+        auto bucket =
+            Bucket::merge(bm, v12, b10first, b10second,
+                          /*shadows=*/{b12first, b11second},
+                          /*keepDeadEntries=*/true,
+                          /*countMergeEvents=*/true, clock.getIOContext(),
+                          /*doFsync=*/true);
         REQUIRE(Bucket::getBucketVersion(bucket) == v11);
     }
     SECTION("refuse to merge new version with shadow")
@@ -391,6 +407,7 @@ TEST_CASE("merges proceed old-style despite newer shadows",
                                         /*shadows=*/{b12first},
                                         /*keepDeadEntries=*/true,
                                         /*countMergeEvents=*/true,
+                                        clock.getIOContext(),
                                         /*doFsync=*/true),
                           std::runtime_error);
     }
@@ -407,21 +424,22 @@ TEST_CASE("merges refuse to exceed max protocol version",
     LedgerEntry liveEntry = generateAccount();
     LedgerEntry otherLiveA = generateDifferentAccount({liveEntry});
     auto bold1 = Bucket::fresh(bm, vers - 1, {}, {liveEntry}, {},
-                               /*countMergeEvents=*/true,
+                               /*countMergeEvents=*/true, clock.getIOContext(),
                                /*doFsync=*/true);
     auto bold2 = Bucket::fresh(bm, vers - 1, {}, {otherLiveA}, {},
-                               /*countMergeEvents=*/true,
+                               /*countMergeEvents=*/true, clock.getIOContext(),
                                /*doFsync=*/true);
-    auto bnew1 =
-        Bucket::fresh(bm, vers, {}, {liveEntry}, {}, /*countMergeEvents=*/true,
-                      /*doFsync=*/true);
+    auto bnew1 = Bucket::fresh(bm, vers, {}, {liveEntry}, {},
+                               /*countMergeEvents=*/true, clock.getIOContext(),
+                               /*doFsync=*/true);
     auto bnew2 = Bucket::fresh(bm, vers, {}, {otherLiveA}, {},
-                               /*countMergeEvents=*/true,
+                               /*countMergeEvents=*/true, clock.getIOContext(),
                                /*doFsync=*/true);
     REQUIRE_THROWS_AS(Bucket::merge(bm, vers - 1, bnew1, bnew2,
                                     /*shadows=*/{},
                                     /*keepDeadEntries=*/true,
                                     /*countMergeEvents=*/true,
+                                    clock.getIOContext(),
                                     /*doFsync=*/true),
                       std::runtime_error);
 }
@@ -442,7 +460,8 @@ TEST_CASE("bucket output iterator rejects wrong-version entries",
     metaEntry.type(METAENTRY);
     metaEntry.metaEntry() = meta;
     MergeCounters mc;
-    BucketOutputIterator out(bm.getTmpDir(), true, meta, mc, /*doFsync=*/true);
+    BucketOutputIterator out(bm.getTmpDir(), true, meta, mc,
+                             clock.getIOContext(), /*doFsync=*/true);
     REQUIRE_THROWS_AS(out.put(initEntry), std::runtime_error);
     REQUIRE_THROWS_AS(out.put(metaEntry), std::runtime_error);
 }
@@ -481,17 +500,19 @@ TEST_CASE("merging bucket entries with initentry", "[bucket][initentry]")
 
         SECTION("dead and init account entries merge correctly")
         {
-            auto bInit = Bucket::fresh(bm, vers, {initEntry}, {}, {},
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto bDead = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto b1 = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, bInit,
-                                    bDead, /*shadows=*/{},
-                                    /*keepDeadEntries=*/true,
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
+            auto bInit =
+                Bucket::fresh(bm, vers, {initEntry}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto bDead =
+                Bucket::fresh(bm, vers, {}, {}, {deadEntry},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto b1 = Bucket::merge(
+                bm, cfg.LEDGER_PROTOCOL_VERSION, bInit, bDead, /*shadows=*/{},
+                /*keepDeadEntries=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             // In initEra, the INIT will make it through fresh() to the bucket,
             // and mutually annihilate on contact with the DEAD, leaving 0
             // entries. Pre-initEra, the INIT will downgrade to a LIVE during
@@ -515,25 +536,28 @@ TEST_CASE("merging bucket entries with initentry", "[bucket][initentry]")
         SECTION("dead and init entries merge with intervening live entries "
                 "correctly")
         {
-            auto bInit = Bucket::fresh(bm, vers, {initEntry}, {}, {},
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto bLive = Bucket::fresh(bm, vers, {}, {liveEntry}, {},
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto bDead = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
-                                       /*countMergeEvents=*/true,
-                                       /*doFsync=*/true);
-            auto bmerge1 = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, bInit,
-                                         bLive, /*shadows=*/{},
-                                         /*keepDeadEntries=*/true,
-                                         /*countMergeEvents=*/true,
-                                         /*doFsync=*/true);
-            auto b1 = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, bmerge1,
-                                    bDead, /*shadows=*/{},
-                                    /*keepDeadEntries=*/true,
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
+            auto bInit =
+                Bucket::fresh(bm, vers, {initEntry}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto bLive =
+                Bucket::fresh(bm, vers, {}, {liveEntry}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto bDead =
+                Bucket::fresh(bm, vers, {}, {}, {deadEntry},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto bmerge1 = Bucket::merge(
+                bm, cfg.LEDGER_PROTOCOL_VERSION, bInit, bLive, /*shadows=*/{},
+                /*keepDeadEntries=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
+            auto b1 = Bucket::merge(
+                bm, cfg.LEDGER_PROTOCOL_VERSION, bmerge1, bDead, /*shadows=*/{},
+                /*keepDeadEntries=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             // The same thing should happen here as above, except that the INIT
             // will merge-over the LIVE during fresh().
             EntryCounts e(b1);
@@ -554,16 +578,18 @@ TEST_CASE("merging bucket entries with initentry", "[bucket][initentry]")
         SECTION("dead and init entries annihilate multiple live entries via "
                 "separate buckets")
         {
-            auto bold = Bucket::fresh(bm, vers, {initEntry}, {}, {},
-                                      /*countMergeEvents=*/true,
-                                      /*doFsync=*/true);
+            auto bold =
+                Bucket::fresh(bm, vers, {initEntry}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
             auto bmed = Bucket::fresh(
                 bm, vers, {}, {otherLiveA, otherLiveB, liveEntry, otherLiveC},
-                {}, /*countMergeEvents=*/true,
+                {}, /*countMergeEvents=*/true, clock.getIOContext(),
                 /*doFsync=*/true);
-            auto bnew = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
-                                      /*countMergeEvents=*/true,
-                                      /*doFsync=*/true);
+            auto bnew =
+                Bucket::fresh(bm, vers, {}, {}, {deadEntry},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
             EntryCounts eold(bold), emed(bmed), enew(bnew);
             if (initEra)
             {
@@ -592,16 +618,16 @@ TEST_CASE("merging bucket entries with initentry", "[bucket][initentry]")
             CHECK(enew.nLive == 0);
             CHECK(enew.nDead == 1);
 
-            auto bmerge1 = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, bold,
-                                         bmed, /*shadows=*/{},
-                                         /*keepDeadEntries=*/true,
-                                         /*countMergeEvents=*/true,
-                                         /*doFsync=*/true);
-            auto bmerge2 = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION,
-                                         bmerge1, bnew, /*shadows=*/{},
-                                         /*keepDeadEntries=*/true,
-                                         /*countMergeEvents=*/true,
-                                         /*doFsync=*/true);
+            auto bmerge1 = Bucket::merge(
+                bm, cfg.LEDGER_PROTOCOL_VERSION, bold, bmed, /*shadows=*/{},
+                /*keepDeadEntries=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
+            auto bmerge2 = Bucket::merge(
+                bm, cfg.LEDGER_PROTOCOL_VERSION, bmerge1, bnew, /*shadows=*/{},
+                /*keepDeadEntries=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             EntryCounts emerge1(bmerge1), emerge2(bmerge2);
             if (initEra)
             {
@@ -666,20 +692,24 @@ TEST_CASE("merging bucket entries with initentry with shadows",
             // In pre-11 versions, shadows _do_ eliminate lifecycle entries
             // (INIT/DEAD). In 11-and-after versions, shadows _don't_ eliminate
             // lifecycle entries.
-            auto shadow = Bucket::fresh(bm, vers, {}, {liveEntry}, {},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
-            auto b1 = Bucket::fresh(bm, vers, {initEntry}, {}, {},
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
-            auto b2 = Bucket::fresh(bm, vers, {otherInitA}, {}, {},
-                                    /*countMergeEvents=*/true,
-                                    /*doFsync=*/true);
-            auto merged = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, b1, b2,
-                                        /*shadows=*/{shadow},
-                                        /*keepDeadEntries=*/true,
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
+            auto shadow =
+                Bucket::fresh(bm, vers, {}, {liveEntry}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto b1 =
+                Bucket::fresh(bm, vers, {initEntry}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto b2 =
+                Bucket::fresh(bm, vers, {otherInitA}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto merged =
+                Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, b1, b2,
+                              /*shadows=*/{shadow},
+                              /*keepDeadEntries=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
             EntryCounts e(merged);
             if (initEra)
             {
@@ -704,21 +734,26 @@ TEST_CASE("merging bucket entries with initentry with shadows",
             // INIT. See comment in `maybePut` in Bucket.cpp.
             //
             // (level1 is newest here, level5 is oldest)
-            auto level1 = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
-            auto level2 = Bucket::fresh(bm, vers, {initEntry2}, {}, {},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
-            auto level3 = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
+            auto level1 =
+                Bucket::fresh(bm, vers, {}, {}, {deadEntry},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto level2 =
+                Bucket::fresh(bm, vers, {initEntry2}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto level3 =
+                Bucket::fresh(bm, vers, {}, {}, {deadEntry},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
             auto level4 =
                 Bucket::fresh(bm, vers, {}, {}, {}, /*countMergeEvents=*/true,
+                              clock.getIOContext(),
                               /*doFsync=*/true);
-            auto level5 = Bucket::fresh(bm, vers, {initEntry}, {}, {},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
+            auto level5 =
+                Bucket::fresh(bm, vers, {initEntry}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
 
             // Do a merge between levels 4 and 3, with shadows from 2 and 1,
             // risking shadowing-out level 3. Level 4 is a placeholder here,
@@ -728,7 +763,7 @@ TEST_CASE("merging bucket entries with initentry with shadows",
                 Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, level4, level3,
                               /*shadows=*/{level2, level1},
                               /*keepDeadEntries=*/true,
-                              /*countMergeEvents=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
                               /*doFsync=*/true);
             EntryCounts e43(merge43);
             if (initEra)
@@ -754,7 +789,7 @@ TEST_CASE("merging bucket entries with initentry with shadows",
                 Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, level2, level1,
                               /*shadows=*/{},
                               /*keepDeadEntries=*/true,
-                              /*countMergeEvents=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
                               /*doFsync=*/true);
             EntryCounts e21(merge21);
             if (initEra)
@@ -780,14 +815,14 @@ TEST_CASE("merging bucket entries with initentry with shadows",
                 Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, merge43, merge21,
                               /*shadows=*/{},
                               /*keepDeadEntries=*/true,
-                              /*countMergeEvents=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
                               /*doFsync=*/true);
-            auto merge54321 = Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION,
-                                            level5, merge4321,
-                                            /*shadows=*/{},
-                                            /*keepDeadEntries=*/true,
-                                            /*countMergeEvents=*/true,
-                                            /*doFsync=*/true);
+            auto merge54321 = Bucket::merge(
+                bm, cfg.LEDGER_PROTOCOL_VERSION, level5, merge4321,
+                /*shadows=*/{},
+                /*keepDeadEntries=*/true,
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true);
             EntryCounts e54321(merge21);
             if (initEra)
             {
@@ -816,15 +851,18 @@ TEST_CASE("merging bucket entries with initentry with shadows",
             // `maybePut` in Bucket.cpp.
             //
             // (level1 is newest here, level3 is oldest)
-            auto level1 = Bucket::fresh(bm, vers, {}, {}, {deadEntry},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
-            auto level2 = Bucket::fresh(bm, vers, {}, {liveEntry}, {},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
-            auto level3 = Bucket::fresh(bm, vers, {initEntry}, {}, {},
-                                        /*countMergeEvents=*/true,
-                                        /*doFsync=*/true);
+            auto level1 =
+                Bucket::fresh(bm, vers, {}, {}, {deadEntry},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto level2 =
+                Bucket::fresh(bm, vers, {}, {liveEntry}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
+            auto level3 =
+                Bucket::fresh(bm, vers, {initEntry}, {}, {},
+                              /*countMergeEvents=*/true, clock.getIOContext(),
+                              /*doFsync=*/true);
 
             // Do a merge between levels 3 and 2, with shadow from 1, risking
             // shadowing-out the init on level 3. Level 2 is a placeholder here,
@@ -834,7 +872,7 @@ TEST_CASE("merging bucket entries with initentry with shadows",
                 Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, level3, level2,
                               /*shadows=*/{level1},
                               /*keepDeadEntries=*/true,
-                              /*countMergeEvents=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
                               /*doFsync=*/true);
             EntryCounts e32(merge32);
             if (initEra)
@@ -861,7 +899,7 @@ TEST_CASE("merging bucket entries with initentry with shadows",
                 Bucket::merge(bm, cfg.LEDGER_PROTOCOL_VERSION, merge32, level1,
                               /*shadows=*/{},
                               /*keepDeadEntries=*/true,
-                              /*countMergeEvents=*/true,
+                              /*countMergeEvents=*/true, clock.getIOContext(),
                               /*doFsync=*/true);
             EntryCounts e321(merge321);
             if (initEra)
@@ -907,11 +945,13 @@ TEST_CASE("bucket apply", "[bucket]")
 
         std::shared_ptr<Bucket> birth = Bucket::fresh(
             app->getBucketManager(), getAppLedgerVersion(app), {}, live, noDead,
-            /*countMergeEvents=*/true, /*doFsync=*/true);
+            /*countMergeEvents=*/true, clock.getIOContext(),
+            /*doFsync=*/true);
 
         std::shared_ptr<Bucket> death = Bucket::fresh(
             app->getBucketManager(), getAppLedgerVersion(app), {}, noLive, dead,
-            /*countMergeEvents=*/true, /*doFsync=*/true);
+            /*countMergeEvents=*/true, clock.getIOContext(),
+            /*doFsync=*/true);
 
         CLOG(INFO, "Bucket")
             << "Applying bucket with " << live.size() << " live entries";
@@ -951,7 +991,8 @@ TEST_CASE("bucket apply bench", "[bucketbench][!hide]")
 
         std::shared_ptr<Bucket> birth = Bucket::fresh(
             app->getBucketManager(), getAppLedgerVersion(app), {}, live, noDead,
-            /*countMergeEvents=*/true, /*doFsync=*/true);
+            /*countMergeEvents=*/true, clock.getIOContext(),
+            /*doFsync=*/true);
 
         CLOG(INFO, "Bucket")
             << "Applying bucket with " << live.size() << " live entries";

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -65,8 +65,9 @@ StateSnapshot::writeHistoryBlocks() const
     size_t nHeaders;
     {
         bool doFsync = !mApp.getConfig().DISABLE_XDR_FSYNC;
-        XDROutputFileStream ledgerOut(doFsync), txOut(doFsync),
-            txResultOut(doFsync), scpHistory(doFsync);
+        asio::io_context& ctx = mApp.getClock().getIOContext();
+        XDROutputFileStream ledgerOut(ctx, doFsync), txOut(ctx, doFsync),
+            txResultOut(ctx, doFsync), scpHistory(ctx, doFsync);
         ledgerOut.open(mLedgerSnapFile->localPath_nogz());
         txOut.open(mTransactionSnapFile->localPath_nogz());
         txResultOut.open(mTransactionResultSnapFile->localPath_nogz());

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -360,7 +360,8 @@ TEST_CASE("Tx results verification", "[batching][resultsverification]")
         lastEntry.header.txSetResultHash = HashUtils::random();
         std::remove(ft.localPath_nogz().c_str());
 
-        XDROutputFileStream out(true);
+        XDROutputFileStream out(
+            catchupSimulation.getApp().getClock().getIOContext(), true);
         out.open(ft.localPath_nogz());
         for (auto const& item : entries)
         {
@@ -391,7 +392,8 @@ TEST_CASE("Tx results verification", "[batching][resultsverification]")
         REQUIRE_FALSE(entries.empty());
         std::remove(ft.localPath_nogz().c_str());
 
-        XDROutputFileStream out(true);
+        XDROutputFileStream out(
+            catchupSimulation.getApp().getClock().getIOContext(), true);
         out.open(ft.localPath_nogz());
         // Duplicate entries
         for (int i = 0; i < entries.size(); ++i)

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -104,7 +104,8 @@ class BucketOutputIteratorForTesting : public BucketOutputIterator
   public:
     explicit BucketOutputIteratorForTesting(std::string const& tmpDir,
                                             uint32_t protocolVersion,
-                                            MergeCounters& mc);
+                                            MergeCounters& mc,
+                                            asio::io_context& ctx);
     std::pair<std::string, uint256> writeTmpTestBucket();
 };
 

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -149,7 +149,7 @@ struct BucketListGenerator
     }
 
     HistoryArchiveState
-    getHistoryArchiveState() const
+    getHistoryArchiveState()
     {
         auto& blGenerate = mAppGenerate->getBucketManager().getBucketList();
         auto& bmApply = mAppApply->getBucketManager();
@@ -163,7 +163,8 @@ struct BucketListGenerator
             auto keepDead = BucketList::keepDeadEntries(i);
             {
                 BucketOutputIterator out(bmApply.getTmpDir(), keepDead, meta,
-                                         mergeCounters, /*doFsync=*/true);
+                                         mergeCounters, mClock.getIOContext(),
+                                         /*doFsync=*/true);
                 for (BucketInputIterator in (level.getCurr()); in; ++in)
                 {
                     out.put(*in);
@@ -172,7 +173,8 @@ struct BucketListGenerator
             }
             {
                 BucketOutputIterator out(bmApply.getTmpDir(), keepDead, meta,
-                                         mergeCounters, /*doFsync=*/true);
+                                         mergeCounters, mClock.getIOContext(),
+                                         /*doFsync=*/true);
                 for (BucketInputIterator in (level.getSnap()); in; ++in)
                 {
                     out.put(*in);

--- a/src/ledger/CheckpointRange.h
+++ b/src/ledger/CheckpointRange.h
@@ -28,7 +28,7 @@ struct CheckpointRange final
     {
         // CheckpointRange is half-open: in exchange for being able to represent
         // empty ranges, it can't represent ranges that include UINT32_MAX.
-        assert(last < std::numeric_limits<int32_t>::max());
+        assert(last < std::numeric_limits<uint32_t>::max());
 
         // First and last must both be ledgers identifying checkpoints (i.e. one
         // less than multiples of frequency), and last must be >= first. The

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -768,8 +768,9 @@ LedgerManagerImpl::setupLedgerCloseMetaStream()
     {
         // We can't be sure we're writing to a stream that supports fsync;
         // pipes typically error when you try. So we don't do it.
-        mMetaStream =
-            std::make_unique<XDROutputFileStream>(/*fsyncOnClose=*/false);
+        mMetaStream = std::make_unique<XDROutputFileStream>(
+            mApp.getClock().getIOContext(),
+            /*fsyncOnClose=*/false);
         std::regex fdrx("^fd:([0-9]+)$");
         std::smatch sm;
         if (std::regex_match(cfg.METADATA_OUTPUT_STREAM, sm, fdrx))

--- a/src/ledger/LedgerRange.h
+++ b/src/ledger/LedgerRange.h
@@ -29,7 +29,7 @@ struct LedgerRange final
     {
         // LedgerRange is half-open: in exchange for being able to represent
         // empty ranges, it can't represent ranges that include UINT32_MAX.
-        assert(last < std::numeric_limits<int32_t>::max());
+        assert(last < std::numeric_limits<uint32_t>::max());
         return LedgerRange(first, last - first + 1);
     }
     std::string toString() const;

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -237,7 +237,8 @@ TransactionFuzzer::xdrSizeLimit()
 void
 TransactionFuzzer::genFuzz(std::string const& filename)
 {
-    XDROutputFileStream out(/*doFsync=*/false);
+    XDROutputFileStream out(mApp->getClock().getIOContext(),
+                            /*doFsync=*/false);
     out.open(filename);
     autocheck::generator<Operation> gen;
     xdr::xvector<Operation> ops;
@@ -352,7 +353,9 @@ OverlayFuzzer::xdrSizeLimit()
 void
 OverlayFuzzer::genFuzz(std::string const& filename)
 {
-    XDROutputFileStream out(/*doFsync=*/false);
+    VirtualClock clock;
+    XDROutputFileStream out(clock.getIOContext(),
+                            /*doFsync=*/false);
     out.open(filename);
     autocheck::generator<StellarMessage> gen;
     StellarMessage m(gen(FUZZER_INITIAL_CORPUS_MESSAGE_GEN_UPPERBOUND));

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -83,25 +83,32 @@ unlockFile(std::string const& path)
 }
 
 void
-flushFileChanges(FILE* fp)
+flushFileChanges(stream_t::native_handle_type fh)
 {
-    int fd = _fileno(fp);
-    if (fd == -1)
-    {
-        FileSystemException::failWithErrno(
-            "fs::flushFileChanges() failed on _fileno(): ");
-    }
-    HANDLE fh = (HANDLE)_get_osfhandle(fd);
-    if (fh == INVALID_HANDLE_VALUE)
-    {
-        FileSystemException::failWithErrno(
-            "fs::flushFileChanges() failed on _get_osfhandle(): ");
-    }
     if (FlushFileBuffers(fh) == FALSE)
     {
         FileSystemException::failWithGetLastError(
             "fs::flushFileChanges() failed on _get_osfhandle(): ");
     }
+}
+
+stream_t::native_handle_type
+openFileToWrite(std::string const& path)
+{
+    HANDLE h = ::CreateFile(path.c_str(),
+                            GENERIC_WRITE,         // DesiredAccess
+                            FILE_SHARE_READ,       // ShareMode
+                            NULL,                  // SecurityAttributes
+                            CREATE_ALWAYS,         // CreationDisposition
+                            FILE_ATTRIBUTE_NORMAL, // FlagsAndAttributes
+                            NULL);                 // TemplateFile
+
+    if (h == INVALID_HANDLE_VALUE)
+    {
+        FileSystemException::failWithGetLastError(
+            "fs::openFileToWrite() failed on CreateFile(): ");
+    }
+    return h;
 }
 
 bool
@@ -234,19 +241,34 @@ unlockFile(std::string const& path)
 }
 
 void
-flushFileChanges(FILE* fp)
+flushFileChanges(stream_t::native_handle_type fd)
 {
-    int fd = fileno(fp);
-    if (fd == -1)
+    while (fsync(fd) == -1)
     {
-        FileSystemException::failWithErrno(
-            "fs::flushFileChanges() failed on fileno(): ");
-    }
-    if (fsync(fd) == -1)
-    {
+        if (errno == EINTR)
+        {
+            continue;
+        }
         FileSystemException::failWithErrno(
             "fs::flushFileChanges() failed on fsync(): ");
     }
+}
+
+stream_t::native_handle_type
+openFileToWrite(std::string const& path)
+{
+    int fd;
+    while ((fd = ::open(path.c_str(), O_CREAT | O_WRONLY | O_APPEND, 0644)) ==
+           -1)
+    {
+        if (errno == EINTR)
+        {
+            continue;
+        }
+        FileSystemException::failWithErrno(std::string("fs::openFile(\"") +
+                                           path + "\") failed: ");
+    }
+    return fd;
 }
 
 bool
@@ -257,19 +279,31 @@ durableRename(std::string const& src, std::string const& dst,
     {
         return false;
     }
-    auto dfd = open(dir.c_str(), O_RDONLY);
-    if (dfd == -1)
+    int dfd;
+    while ((dfd = open(dir.c_str(), O_RDONLY)) == -1)
     {
+        if (errno == EINTR)
+        {
+            continue;
+        }
         FileSystemException::failWithErrno(
             std::string("Failed to open directory ") + dir + " :");
     }
-    if (fsync(dfd) == -1)
+    while (fsync(dfd) == -1)
     {
+        if (errno == EINTR)
+        {
+            continue;
+        }
         FileSystemException::failWithErrno(
             std::string("Failed to fsync directory ") + dir + " :");
     }
-    if (close(dfd) == -1)
+    while (close(dfd) == -1)
     {
+        if (errno == EINTR)
+        {
+            continue;
+        }
         FileSystemException::failWithErrno(
             std::string("Failed to close directory ") + dir + " :");
     }

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -4,6 +4,8 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "util/asio.h"
+
 #include <functional>
 #include <string>
 #include <vector>
@@ -12,6 +14,20 @@ namespace stellar
 {
 namespace fs
 {
+
+// An AWS EBS IOP is 256kb, so we try to write those.
+inline constexpr size_t
+bufsz()
+{
+    return 0x40000;
+}
+
+// Platform-specific synchronous stream type.
+#ifdef _WIN32
+using stream_t = asio::windows::stream_handle;
+#else
+using stream_t = asio::posix::stream_descriptor;
+#endif
 
 ////
 // Utility functions for operating on the filesystem.
@@ -23,7 +39,10 @@ void lockFile(std::string const& path);
 void unlockFile(std::string const& path);
 
 // Call fsync() on POSIX or FlushFileBuffers() on Win32.
-void flushFileChanges(FILE* fp);
+void flushFileChanges(stream_t::native_handle_type h);
+
+// Open a native handle (fd or HANDLE) for writing.
+stream_t::native_handle_type openFileToWrite(std::string const& path);
 
 // On POSIX, do rename(src, dst) then open dir and fsync() it
 // too: a necessary second step for ensuring durability.

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -30,7 +30,7 @@ using native_handle_t = HANDLE;
 #else
 using stream_t = asio::posix::stream_descriptor;
 using random_access_t = asio::posix::stream_descriptor;
-using handle_t = int;
+using native_handle_t = int;
 #endif
 
 ////

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -304,6 +304,10 @@ class XDROutputFileStream
         {
             asio::error_code ec;
             auto buf = asio::buffer(mBuf.data() + written, to_write - written);
+#ifdef _WIN32
+            // Calling asio::write_at on the asio::posix::stream_descriptor
+            // will not even compile; so this one bit has to also be platform
+            // guarded.
             if (mUsingRandomAccessHandle)
             {
                 size_t n = asio::write_at(
@@ -312,6 +316,7 @@ class XDROutputFileStream
                 mRandomAccessNextWriteOffset += n;
             }
             else
+#endif
             {
                 written += asio::write(mBufferedWriteStream, buf, ec);
             }

--- a/src/util/test/XDRStreamTests.cpp
+++ b/src/util/test/XDRStreamTests.cpp
@@ -16,7 +16,8 @@ using namespace stellar;
 
 TEST_CASE("XDROutputFileStream fail modes", "[xdrstream]")
 {
-    XDROutputFileStream out(/*doFsync=*/true);
+    VirtualClock clock;
+    XDROutputFileStream out(clock.getIOContext(), /*doFsync=*/true);
     auto filename = "someFile";
 
     SECTION("open throws")
@@ -45,6 +46,7 @@ TEST_CASE("XDROutputFileStream fail modes", "[xdrstream]")
 
 TEST_CASE("XDROutputFileStream fsync bench", "[!hide][xdrstream][bench]")
 {
+    VirtualClock clock;
     Config const& cfg = getTestConfig(0);
 
     auto hasher = SHA256::create();
@@ -56,8 +58,8 @@ TEST_CASE("XDROutputFileStream fsync bench", "[!hide][xdrstream][bench]")
 
     for (int i = 0; i < 10; ++i)
     {
-        XDROutputFileStream outFsync(/*doFsync=*/true);
-        XDROutputFileStream outNoFsync(/*doFsync=*/false);
+        XDROutputFileStream outFsync(clock.getIOContext(), /*doFsync=*/true);
+        XDROutputFileStream outNoFsync(clock.getIOContext(), /*doFsync=*/false);
 
         outFsync.open(
             fmt::format("{}/outFsync-{}.xdr", cfg.BUCKET_DIR_PATH, i));


### PR DESCRIPTION
# Description

This PR improves the XDRStream type to accommodate its use in streaming LedgerCloseMeta records over a pipe to a host process when running in "captive" mode (as in https://github.com/stellar/go/pull/2322)

The following improvements are made:
  - To deal with the fact that pipe writes fail with EINTR sometimes -- and that this is specified as leaving the contents of `FILE*` write buffers in an undefined state, which we've in fact observed as data corruption when streaming large test ranges -- we switch to using asio sychronous stream types (`asio::posix::stream_descriptor` and `asio::windows::stream_handle`).
  - To deal with the fact that these types need to be associated with an `asio::io_context`, one is threaded through all the construction sites. Occasionally a new one is constructed in a test.
  - To deal with the fact that these types can still be interrupted when writing (fail with `asio::error::interrupted`) the write calls are turned into loops that test for this code; the advantage is that they do _not_ invalidate their buffers (thereby corrupting output) when interrupted.
  - To deal with the fact that on windows only named pipes should be streams, and files need to use the `asio::windows::random_access_handle` type to avoid writing all output at the same offset (0) the `XDRStream` type is given _two_ different handles, one stream and one random access, and a crude test is made on the filename when opening on windows to see if it's in the named-pipe namespace or not.

This is all somewhat ridiculous but it does allow us to pass all tests and stream to a parent horizon process on both linux and windows.
<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
