### PR TITLE
Add support for CAP-0027

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,8 +25,9 @@ TEST_FILES = $(TESTDATA_DIR)/stellar-core_example.cfg $(TESTDATA_DIR)/stellar-co
 
 BUILT_SOURCES = $(SRC_X_FILES:.x=.h) main/StellarCoreVersion.cpp $(TEST_FILES)
 
+$(SRC_X_FILES:.x=.h): $(XDRC)
 SUFFIXES = .x .h
-.x.h: $(XDRC)
+.x.h:
 	$(XDRC) -hh -o $@ $<
 
 $(srcdir)/src.mk: $(top_srcdir)/make-mks

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -108,7 +108,8 @@ BucketInputIterator::~BucketInputIterator()
     mIn.close();
 }
 
-BucketInputIterator& BucketInputIterator::operator++()
+BucketInputIterator&
+BucketInputIterator::operator++()
 {
     if (mIn)
     {

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -262,7 +262,6 @@ TEST_CASE("bucket list shadowing pre/post proto 12", "[bucket][bucketlist]")
                 }
             }
         }
-
     });
 }
 

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -1383,7 +1383,6 @@ TEST_CASE("bucket persistence over app restart",
 
     Config cfg0(getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE));
     for_versions_with_differing_bucket_logic(cfg0, [&](Config const& cfg0) {
-
         Config cfg1(getTestConfig(1, Config::TESTDB_ON_DISK_SQLITE));
         cfg1.LEDGER_PROTOCOL_VERSION = cfg0.LEDGER_PROTOCOL_VERSION;
         cfg1.ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = true;

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -59,10 +59,8 @@ DownloadApplyTxsWork::yieldMoreWork()
     {
         auto prev = mLastYieldedWork;
         bool pqFellBehind = false;
-        auto predicate = [
-            prev, pqFellBehind, waitForPublish = mWaitForPublish, &hm
-        ]() mutable
-        {
+        auto predicate = [prev, pqFellBehind, waitForPublish = mWaitForPublish,
+                          &hm]() mutable {
             if (!prev)
             {
                 throw std::runtime_error("Download and apply txs: related Work "

--- a/src/crypto/Curve25519.cpp
+++ b/src/crypto/Curve25519.cpp
@@ -98,8 +98,8 @@ curve25519Decrypt(Curve25519Secret const& localSecret,
 namespace std
 {
 size_t
-hash<stellar::Curve25519Public>::
-operator()(stellar::Curve25519Public const& k) const noexcept
+hash<stellar::Curve25519Public>::operator()(
+    stellar::Curve25519Public const& k) const noexcept
 {
     return std::hash<stellar::uint256>()(k.key);
 }

--- a/src/database/test/DatabaseConnectionStringTest.cpp
+++ b/src/database/test/DatabaseConnectionStringTest.cpp
@@ -141,15 +141,14 @@ TEST_CASE("remove password from database connection string",
 
     SECTION("invalid connection string without backend name")
     {
-        REQUIRE(removePasswordFromConnectionString(
-                    R"(dbname=name password=abc)") ==
-                R"(dbname=name password=abc)");
+        REQUIRE(
+            removePasswordFromConnectionString(R"(dbname=name password=abc)") ==
+            R"(dbname=name password=abc)");
     }
 
     SECTION("ignore sqlite3://:memory:")
     {
-        REQUIRE(removePasswordFromConnectionString(
-                    R"(sqlite3://:memory:)") ==
+        REQUIRE(removePasswordFromConnectionString(R"(sqlite3://:memory:)") ==
                 R"(sqlite3://:memory:)");
     }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -545,16 +545,17 @@ HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer)
 {
     bool log = true;
     getSCP().processSlotsAscendingFrom(ledgerSeq, [&](uint64 seq) {
-        getSCP().processCurrentState(seq,
-                                     [&](SCPEnvelope const& e) {
-                                         StellarMessage m;
-                                         m.type(SCP_MESSAGE);
-                                         m.envelope() = e;
-                                         peer->sendMessage(m, log);
-                                         log = false;
-                                         return true;
-                                     },
-                                     false);
+        getSCP().processCurrentState(
+            seq,
+            [&](SCPEnvelope const& e) {
+                StellarMessage m;
+                m.type(SCP_MESSAGE);
+                m.envelope() = e;
+                peer->sendMessage(m, log);
+                log = false;
+                return true;
+            },
+            false);
         return true;
     });
 }

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -47,7 +47,6 @@ TEST_CASE("standalone", "[herder][acceptance]")
     cfg.QUORUM_SET.validators.push_back(v0NodeID);
 
     for_all_versions(cfg, [&](Config const& cfg1) {
-
         VirtualClock clock;
         Application::pointer app = createTestApplication(clock, cfg1);
 

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -313,18 +313,19 @@ interconnectOrgsUnidir(xdr::xvector<xdr::xvector<PublicKey>> const& orgs,
                        std::vector<std::pair<size_t, size_t>> edges,
                        size_t ownThreshPct = 67, size_t innerThreshPct = 51)
 {
-    return interconnectOrgs(orgs,
-                            [&edges](size_t i, size_t j) {
-                                for (auto const& e : edges)
-                                {
-                                    if (e.first == i && e.second == j)
-                                    {
-                                        return true;
-                                    }
-                                }
-                                return false;
-                            },
-                            ownThreshPct, innerThreshPct);
+    return interconnectOrgs(
+        orgs,
+        [&edges](size_t i, size_t j) {
+            for (auto const& e : edges)
+            {
+                if (e.first == i && e.second == j)
+                {
+                    return true;
+                }
+            }
+            return false;
+        },
+        ownThreshPct, innerThreshPct);
 }
 
 static QuorumTracker::QuorumMap
@@ -332,19 +333,20 @@ interconnectOrgsBidir(xdr::xvector<xdr::xvector<PublicKey>> const& orgs,
                       std::vector<std::pair<size_t, size_t>> edges,
                       size_t ownThreshPct = 67, size_t innerThreshPct = 51)
 {
-    return interconnectOrgs(orgs,
-                            [&edges](size_t i, size_t j) {
-                                for (auto const& e : edges)
-                                {
-                                    if ((e.first == i && e.second == j) ||
-                                        (e.first == j && e.second == i))
-                                    {
-                                        return true;
-                                    }
-                                }
-                                return false;
-                            },
-                            ownThreshPct, innerThreshPct);
+    return interconnectOrgs(
+        orgs,
+        [&edges](size_t i, size_t j) {
+            for (auto const& e : edges)
+            {
+                if ((e.first == i && e.second == j) ||
+                    (e.first == j && e.second == i))
+                {
+                    return true;
+                }
+            }
+            return false;
+        },
+        ownThreshPct, innerThreshPct);
 }
 
 TEST_CASE("quorum intersection 4-org fully-connected - elide all minquorums",

--- a/src/historywork/VerifyTxResultsWork.cpp
+++ b/src/historywork/VerifyTxResultsWork.cpp
@@ -45,8 +45,7 @@ VerifyTxResultsWork::onRun()
 
     std::weak_ptr<VerifyTxResultsWork> weak(
         std::static_pointer_cast<VerifyTxResultsWork>(shared_from_this()));
-    auto verify = [ weak, checkpoint = mCheckpoint ]()
-    {
+    auto verify = [weak, checkpoint = mCheckpoint]() {
         auto self = weak.lock();
         if (self)
         {

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -165,7 +165,7 @@ struct BucketListGenerator
                 BucketOutputIterator out(bmApply.getTmpDir(), keepDead, meta,
                                          mergeCounters, mClock.getIOContext(),
                                          /*doFsync=*/true);
-                for (BucketInputIterator in (level.getCurr()); in; ++in)
+                for (BucketInputIterator in(level.getCurr()); in; ++in)
                 {
                     out.put(*in);
                 }
@@ -175,7 +175,7 @@ struct BucketListGenerator
                 BucketOutputIterator out(bmApply.getTmpDir(), keepDead, meta,
                                          mergeCounters, mClock.getIOContext(),
                                          /*doFsync=*/true);
-                for (BucketInputIterator in (level.getSnap()); in; ++in)
+                for (BucketInputIterator in(level.getSnap()); in; ++in)
                 {
                     out.put(*in);
                 }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -110,7 +110,8 @@ EntryIterator::getImpl() const
     return mImpl;
 }
 
-EntryIterator& EntryIterator::operator++()
+EntryIterator&
+EntryIterator::operator++()
 {
     getImpl()->advance();
     return *this;
@@ -167,7 +168,8 @@ WorstBestOfferIterator::getImpl() const
     return mImpl;
 }
 
-WorstBestOfferIterator& WorstBestOfferIterator::operator++()
+WorstBestOfferIterator&
+WorstBestOfferIterator::operator++()
 {
     getImpl()->advance();
     return *this;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -825,7 +825,7 @@ ApplicationImpl::postOnMainThread(std::function<void()>&& f,
 {
     LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
                             "executed after"};
-    mVirtualClock.postToCurrentCrank([ this, f = std::move(f), isSlow ]() {
+    mVirtualClock.postToCurrentCrank([this, f = std::move(f), isSlow]() {
         mPostOnMainThreadDelay.Update(isSlow.checkElapsedTime());
         f();
     });
@@ -837,7 +837,7 @@ ApplicationImpl::postOnMainThreadWithDelay(std::function<void()>&& f,
 {
     LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
                             "executed after"};
-    mVirtualClock.postToNextCrank([ this, f = std::move(f), isSlow ]() {
+    mVirtualClock.postToNextCrank([this, f = std::move(f), isSlow]() {
         mPostOnMainThreadWithDelayDelay.Update(isSlow.checkElapsedTime());
         f();
     });
@@ -849,7 +849,7 @@ ApplicationImpl::postOnBackgroundThread(std::function<void()>&& f,
 {
     LogSlowExecution isSlow{std::move(jobName), LogSlowExecution::Mode::MANUAL,
                             "executed after"};
-    asio::post(getWorkerIOContext(), [ this, f = std::move(f), isSlow ]() {
+    asio::post(getWorkerIOContext(), [this, f = std::move(f), isSlow]() {
         mPostOnBackgroundThreadDelay.Update(isSlow.checkElapsedTime());
         f();
     });

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -98,24 +98,25 @@ const std::vector<std::pair<std::string, bool>>
 class ParserWithValidation
 {
   public:
-    ParserWithValidation(clara::Parser parser,
-                         std::function<std::string()> isValid = [] {
-                             return std::string{};
-                         })
+    ParserWithValidation(
+        clara::Parser parser,
+        std::function<std::string()> isValid = [] { return std::string{}; })
     {
         mParser = parser;
         mIsValid = isValid;
     }
 
-    ParserWithValidation(clara::Arg arg, std::function<std::string()> isValid =
-                                             [] { return std::string{}; })
+    ParserWithValidation(
+        clara::Arg arg,
+        std::function<std::string()> isValid = [] { return std::string{}; })
     {
         mParser = clara::Parser{} | arg;
         mIsValid = isValid;
     }
 
-    ParserWithValidation(clara::Opt opt, std::function<std::string()> isValid =
-                                             [] { return std::string{}; })
+    ParserWithValidation(
+        clara::Opt opt,
+        std::function<std::string()> isValid = [] { return std::string{}; })
     {
         mParser = clara::Parser{} | opt;
         mIsValid = isValid;

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -19,7 +19,8 @@
 #define HAVE_TERMIOS 1
 #endif
 #if HAVE_TERMIOS
-extern "C" {
+extern "C"
+{
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -52,7 +52,7 @@ TEST_CASE("transaction envelope bridge", "[commandhandler]")
             auto root = TestAccount::createRoot(*app);
 
             Transaction tx;
-            tx.sourceAccount = root;
+            tx.sourceAccount = toMuxedAccount(root);
             tx.fee = baseFee;
             tx.seqNum = root.nextSequenceNumber();
             tx.operations.emplace_back(payment(root, 1));
@@ -87,7 +87,7 @@ TEST_CASE("transaction envelope bridge", "[commandhandler]")
 
         TransactionEnvelope env(ENVELOPE_TYPE_TX);
         auto& tx = env.v1().tx;
-        tx.sourceAccount = root;
+        tx.sourceAccount = toMuxedAccount(root);
         tx.fee = baseFee;
         tx.seqNum = root.nextSequenceNumber();
         tx.operations.emplace_back(payment(root, 1));

--- a/src/overlay/PeerSharedKeyId.cpp
+++ b/src/overlay/PeerSharedKeyId.cpp
@@ -24,8 +24,8 @@ namespace std
 {
 
 size_t
-hash<stellar::PeerSharedKeyId>::
-operator()(stellar::PeerSharedKeyId const& x) const noexcept
+hash<stellar::PeerSharedKeyId>::operator()(
+    stellar::PeerSharedKeyId const& x) const noexcept
 {
     return std::hash<stellar::Curve25519Public>{}(x.mECDHPublicKey) ^
            std::hash<int>{}(static_cast<int>(x.mRole));

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -110,7 +110,7 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction, DropMode)
     if (remote)
     {
         remote->getApp().postOnMainThread(
-            [ remW = mRemote, reason, direction ]() {
+            [remW = mRemote, reason, direction]() {
                 auto remS = remW.lock();
                 if (remS)
                 {

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -2101,12 +2101,12 @@ BallotProtocol::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys)
         delayed = n_delayed;
     }
 
-    auto f = LocalNode::findClosestVBlocking(*qSet, mLatestEnvelopes,
-                                             [&](SCPStatement const& st) {
-                                                 return areBallotsCompatible(
-                                                     getWorkingBallot(st), b);
-                                             },
-                                             &id);
+    auto f = LocalNode::findClosestVBlocking(
+        *qSet, mLatestEnvelopes,
+        [&](SCPStatement const& st) {
+            return areBallotsCompatible(getWorkingBallot(st), b);
+        },
+        &id);
     ret["fail_at"] = static_cast<int>(f.size());
 
     if (!summary)

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -63,23 +63,23 @@ class LocalNode
 
     // `isVBlocking` tests if the filtered nodes V are a v-blocking set for
     // this node.
-    static bool
-    isVBlocking(SCPQuorumSet const& qSet,
-                std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
-                std::function<bool(SCPStatement const&)> const& filter =
-                    [](SCPStatement const&) { return true; });
+    static bool isVBlocking(
+        SCPQuorumSet const& qSet,
+        std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
+        std::function<bool(SCPStatement const&)> const& filter =
+            [](SCPStatement const&) { return true; });
 
     // `isQuorum` tests if the filtered nodes V form a quorum
     // (meaning for each v \in V there is q \in Q(v)
     // included in V and we have quorum on V for qSetHash). `qfun` extracts the
     // SCPQuorumSetPtr from the SCPStatement for its associated node in map
     // (required for transitivity)
-    static bool
-    isQuorum(SCPQuorumSet const& qSet,
-             std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
-             std::function<SCPQuorumSetPtr(SCPStatement const&)> const& qfun,
-             std::function<bool(SCPStatement const&)> const& filter =
-                 [](SCPStatement const&) { return true; });
+    static bool isQuorum(
+        SCPQuorumSet const& qSet,
+        std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
+        std::function<SCPQuorumSetPtr(SCPStatement const&)> const& qfun,
+        std::function<bool(SCPStatement const&)> const& filter =
+            [](SCPStatement const&) { return true; });
 
     // computes the distance to the set of v-blocking sets given
     // a set of nodes that agree (but can fail)

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -184,7 +184,8 @@ Topologies::branchedcycle(int nNodes, double quorumThresoldFraction,
     return simulation;
 }
 
-Simulation::pointer Topologies::hierarchicalQuorum(
+Simulation::pointer
+Topologies::hierarchicalQuorum(
     int nBranches, Simulation::Mode mode, Hash const& networkID,
     Simulation::ConfigGen confGen, int connectionsToCore,
     Simulation::QuorumSetAdjuster qSetAdjust) // Figure 3 from the paper

--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -67,7 +67,7 @@ TestAccount::tx(std::vector<Operation> const& ops, SequenceNumber sn)
 Operation
 TestAccount::op(Operation operation)
 {
-    operation.sourceAccount.activate() = getPublicKey();
+    operation.sourceAccount.activate() = toMuxedAccount(getPublicKey());
     return operation;
 }
 

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -445,7 +445,7 @@ transactionFromOperationsV1(Application& app, SecretKey const& from,
                             const std::vector<Operation>& ops, int fee)
 {
     TransactionEnvelope e(ENVELOPE_TYPE_TX);
-    e.v1().tx.sourceAccount = from.getPublicKey();
+    e.v1().tx.sourceAccount = toMuxedAccount(from.getPublicKey());
     e.v1().tx.fee =
         fee != 0 ? fee
                  : static_cast<uint32_t>(
@@ -520,7 +520,7 @@ payment(PublicKey const& to, int64_t amount)
     Operation op;
     op.body.type(PAYMENT);
     op.body.paymentOp().amount = amount;
-    op.body.paymentOp().destination = to;
+    op.body.paymentOp().destination = toMuxedAccount(to);
     op.body.paymentOp().asset.type(ASSET_TYPE_NATIVE);
     return op;
 }
@@ -531,7 +531,7 @@ payment(PublicKey const& to, Asset const& asset, int64_t amount)
     Operation op;
     op.body.type(PAYMENT);
     op.body.paymentOp().amount = amount;
-    op.body.paymentOp().destination = to;
+    op.body.paymentOp().destination = toMuxedAccount(to);
     op.body.paymentOp().asset = asset;
     return op;
 }
@@ -590,7 +590,7 @@ pathPayment(PublicKey const& to, Asset const& sendCur, int64_t sendMax,
     ppop.sendMax = sendMax;
     ppop.destAsset = destCur;
     ppop.destAmount = destAmount;
-    ppop.destination = to;
+    ppop.destination = toMuxedAccount(to);
     std::copy(std::begin(path), std::end(path), std::back_inserter(ppop.path));
 
     return op;
@@ -608,7 +608,7 @@ pathPaymentStrictSend(PublicKey const& to, Asset const& sendCur,
     ppop.sendAmount = sendAmount;
     ppop.destAsset = destCur;
     ppop.destMin = destMin;
-    ppop.destination = to;
+    ppop.destination = toMuxedAccount(to);
     std::copy(std::begin(path), std::end(path), std::back_inserter(ppop.path));
 
     return op;
@@ -1036,7 +1036,7 @@ accountMerge(PublicKey const& dest)
 {
     Operation op;
     op.body.type(ACCOUNT_MERGE);
-    op.body.destination() = dest;
+    op.body.destination() = toMuxedAccount(dest);
     return op;
 }
 

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -50,7 +50,7 @@ MergeOpFrame::doApply(AbstractLedgerTxn& ltx)
     auto header = ltx.loadHeader();
 
     auto otherAccount =
-        stellar::loadAccount(ltx, mOperation.body.destination());
+        stellar::loadAccount(ltx, toAccountID(mOperation.body.destination()));
     if (!otherAccount)
     {
         innerResult().code(ACCOUNT_MERGE_NO_ACCOUNT);
@@ -125,7 +125,7 @@ bool
 MergeOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
     // makes sure not merging into self
-    if (getSourceID() == mOperation.body.destination())
+    if (getSourceID() == toAccountID(mOperation.body.destination()))
     {
         innerResult().code(ACCOUNT_MERGE_MALFORMED);
         return false;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -151,7 +151,7 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
         }
 
         if (!mParentTx.checkSignatureNoAccount(signatureChecker,
-                                               *mOperation.sourceAccount))
+                                               toAccountID(*mOperation.sourceAccount)))
         {
             mResult.code(opBAD_AUTH);
             return false;
@@ -164,7 +164,7 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
 AccountID
 OperationFrame::getSourceID() const
 {
-    return mOperation.sourceAccount ? *mOperation.sourceAccount
+    return mOperation.sourceAccount ? toAccountID(*mOperation.sourceAccount)
                                     : mParentTx.getSourceID();
 }
 

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -150,8 +150,8 @@ OperationFrame::checkSignature(SignatureChecker& signatureChecker,
             return false;
         }
 
-        if (!mParentTx.checkSignatureNoAccount(signatureChecker,
-                                               toAccountID(*mOperation.sourceAccount)))
+        if (!mParentTx.checkSignatureNoAccount(
+                signatureChecker, toAccountID(*mOperation.sourceAccount)))
         {
             mResult.code(opBAD_AUTH);
             return false;

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -20,6 +20,12 @@ PathPaymentOpFrameBase::PathPaymentOpFrameBase(Operation const& op,
 {
 }
 
+AccountID
+PathPaymentOpFrameBase::getDestID() const
+{
+    return toAccountID(getDestMuxedAccount());
+}
+
 void
 PathPaymentOpFrameBase::insertLedgerKeysToPrefetch(
     std::unordered_set<LedgerKey>& keys) const

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -71,20 +71,20 @@ PathPaymentOpFrameBase::convert(AbstractLedgerTxn& ltx,
     assert(!(sendAsset == recvAsset));
 
     // sendAsset -> recvAsset
-    ConvertResult r = convertWithOffers(ltx, sendAsset, maxSend, amountSend,
-                                        recvAsset, maxRecv, amountRecv, round,
-                                        [this](LedgerTxnEntry const& o) {
-                                            auto const& offer =
-                                                o.current().data.offer();
-                                            if (offer.sellerID == getSourceID())
-                                            {
-                                                // we are crossing our own offer
-                                                setResultOfferCrossSelf();
-                                                return OfferFilterResult::eStop;
-                                            }
-                                            return OfferFilterResult::eKeep;
-                                        },
-                                        offerTrail, maxOffersToCross);
+    ConvertResult r = convertWithOffers(
+        ltx, sendAsset, maxSend, amountSend, recvAsset, maxRecv, amountRecv,
+        round,
+        [this](LedgerTxnEntry const& o) {
+            auto const& offer = o.current().data.offer();
+            if (offer.sellerID == getSourceID())
+            {
+                // we are crossing our own offer
+                setResultOfferCrossSelf();
+                return OfferFilterResult::eStop;
+            }
+            return OfferFilterResult::eKeep;
+        },
+        offerTrail, maxOffersToCross);
 
     if (amountSend < 0 || amountRecv < 0)
     {

--- a/src/transactions/PathPaymentOpFrameBase.h
+++ b/src/transactions/PathPaymentOpFrameBase.h
@@ -42,7 +42,8 @@ class PathPaymentOpFrameBase : public OperationFrame
 
     virtual Asset const& getSourceAsset() const = 0;
     virtual Asset const& getDestAsset() const = 0;
-    virtual AccountID const& getDestID() const = 0;
+    AccountID getDestID() const;
+    virtual MuxedAccount const& getDestMuxedAccount() const = 0;
     virtual xdr::xvector<Asset, 5> const& getPath() const = 0;
 
     virtual void setResultSuccess() = 0;

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -47,7 +47,7 @@ PathPaymentStrictReceiveOpFrame::doApply(AbstractLedgerTxn& ltx)
         return false;
     }
     innerResult().success().last = SimplePaymentResult(
-        getDestID(), getDestAsset(), mPathPayment.destAmount);
+        getDestMuxedAccount(), getDestAsset(), mPathPayment.destAmount);
 
     // build the full path from the destination, ending with sendAsset
     std::vector<Asset> fullPath;
@@ -159,8 +159,8 @@ PathPaymentStrictReceiveOpFrame::getDestAsset() const
     return mPathPayment.destAsset;
 }
 
-AccountID const&
-PathPaymentStrictReceiveOpFrame::getDestID() const
+MuxedAccount const&
+PathPaymentStrictReceiveOpFrame::getDestMuxedAccount() const
 {
     return mPathPayment.destination;
 }

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.h
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.h
@@ -31,7 +31,7 @@ class PathPaymentStrictReceiveOpFrame : public PathPaymentOpFrameBase
 
     Asset const& getSourceAsset() const override;
     Asset const& getDestAsset() const override;
-    AccountID const& getDestID() const override;
+    const MuxedAccount& getDestMuxedAccount() const override;
     xdr::xvector<Asset, 5> const& getPath() const override;
 
     void setResultSuccess() override;

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -104,8 +104,8 @@ PathPaymentStrictSendOpFrame::doApply(AbstractLedgerTxn& ltx)
     {
         return false;
     }
-    innerResult().success().last =
-        SimplePaymentResult(getDestMuxedAccount(), getDestAsset(), maxAmountSend);
+    innerResult().success().last = SimplePaymentResult(
+        getDestMuxedAccount(), getDestAsset(), maxAmountSend);
     return true;
 }
 

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -105,7 +105,7 @@ PathPaymentStrictSendOpFrame::doApply(AbstractLedgerTxn& ltx)
         return false;
     }
     innerResult().success().last =
-        SimplePaymentResult(getDestID(), getDestAsset(), maxAmountSend);
+        SimplePaymentResult(getDestMuxedAccount(), getDestAsset(), maxAmountSend);
     return true;
 }
 
@@ -152,8 +152,8 @@ PathPaymentStrictSendOpFrame::getDestAsset() const
     return mPathPayment.destAsset;
 }
 
-AccountID const&
-PathPaymentStrictSendOpFrame::getDestID() const
+MuxedAccount const&
+PathPaymentStrictSendOpFrame::getDestMuxedAccount() const
 {
     return mPathPayment.destination;
 }

--- a/src/transactions/PathPaymentStrictSendOpFrame.h
+++ b/src/transactions/PathPaymentStrictSendOpFrame.h
@@ -33,7 +33,7 @@ class PathPaymentStrictSendOpFrame : public PathPaymentOpFrameBase
 
     Asset const& getSourceAsset() const override;
     Asset const& getDestAsset() const override;
-    AccountID const& getDestID() const override;
+    MuxedAccount const& getDestMuxedAccount() const override;
     xdr::xvector<Asset, 5> const& getPath() const override;
 
     void setResultSuccess() override;

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -28,10 +28,11 @@ PaymentOpFrame::doApply(AbstractLedgerTxn& ltx)
     // least to check trustlines
     // in ledger version 2 it would work for any asset type
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
-    auto instantSuccess = ledgerVersion > 2
-        ? toAccountID(mPayment.destination) == getSourceID() &&
-        mPayment.asset.type() == ASSET_TYPE_NATIVE
-        : toAccountID(mPayment.destination) == getSourceID();
+    auto instantSuccess =
+        ledgerVersion > 2
+            ? toAccountID(mPayment.destination) == getSourceID() &&
+                  mPayment.asset.type() == ASSET_TYPE_NATIVE
+            : toAccountID(mPayment.destination) == getSourceID();
     if (instantSuccess)
     {
         innerResult().code(PAYMENT_SUCCESS);

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -29,9 +29,9 @@ PaymentOpFrame::doApply(AbstractLedgerTxn& ltx)
     // in ledger version 2 it would work for any asset type
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
     auto instantSuccess = ledgerVersion > 2
-                              ? mPayment.destination == getSourceID() &&
-                                    mPayment.asset.type() == ASSET_TYPE_NATIVE
-                              : mPayment.destination == getSourceID();
+        ? toAccountID(mPayment.destination) == getSourceID() &&
+        mPayment.asset.type() == ASSET_TYPE_NATIVE
+        : toAccountID(mPayment.destination) == getSourceID();
     if (instantSuccess)
     {
         innerResult().code(PAYMENT_SUCCESS);
@@ -128,13 +128,14 @@ void
 PaymentOpFrame::insertLedgerKeysToPrefetch(
     std::unordered_set<LedgerKey>& keys) const
 {
-    keys.emplace(accountKey(mPayment.destination));
+    auto dest = toAccountID(mPayment.destination);
+    keys.emplace(accountKey(dest));
 
     // Prefetch issuer for non-native assets
     if (mPayment.asset.type() != ASSET_TYPE_NATIVE)
     {
         // These are *maybe* needed; For now, we load everything
-        keys.emplace(trustlineKey(mPayment.destination, mPayment.asset));
+        keys.emplace(trustlineKey(dest, mPayment.asset));
         keys.emplace(trustlineKey(getSourceID(), mPayment.asset));
     }
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -321,9 +321,8 @@ TransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee)
     //    (stay true regardless of other side effects)
     auto header = ltx.loadHeader();
     uint32_t ledgerVersion = header.current().ledgerVersion;
-    if ((ledgerVersion < 13 &&
-         (mEnvelope.type() == ENVELOPE_TYPE_TX
-          || hasMuxedAccount(mEnvelope))) ||
+    if ((ledgerVersion < 13 && (mEnvelope.type() == ENVELOPE_TYPE_TX ||
+                                hasMuxedAccount(mEnvelope))) ||
         (ledgerVersion >= 13 && mEnvelope.type() == ENVELOPE_TYPE_TX_V0))
     {
         getResult().result.code(txNOT_SUPPORTED);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -122,7 +122,7 @@ TransactionFrame::getSourceID() const
         res.ed25519() = mEnvelope.v0().tx.sourceAccountEd25519;
         return res;
     }
-    return mEnvelope.v1().tx.sourceAccount;
+    return toAccountID(mEnvelope.v1().tx.sourceAccount);
 }
 
 uint32_t
@@ -321,7 +321,9 @@ TransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee)
     //    (stay true regardless of other side effects)
     auto header = ltx.loadHeader();
     uint32_t ledgerVersion = header.current().ledgerVersion;
-    if ((ledgerVersion < 13 && mEnvelope.type() == ENVELOPE_TYPE_TX) ||
+    if ((ledgerVersion < 13 &&
+         (mEnvelope.type() == ENVELOPE_TYPE_TX
+          || hasMuxedAccount(mEnvelope))) ||
         (ledgerVersion >= 13 && mEnvelope.type() == ENVELOPE_TYPE_TX_V0))
     {
         getResult().result.code(txNOT_SUPPORTED);

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -7,6 +7,7 @@
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrameBase.h"
 #include "util/types.h"
+#include "TransactionUtils.h"
 
 #include <memory>
 #include <set>

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -4,10 +4,10 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "TransactionUtils.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrameBase.h"
 #include "util/types.h"
-#include "TransactionUtils.h"
 
 #include <memory>
 #include <set>

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -766,10 +766,11 @@ trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion)
 }
 
 AccountID
-toAccountID(const MuxedAccount &m)
+toAccountID(const MuxedAccount& m)
 {
-    AccountID ret(static_cast<PublicKeyType>(m.type()&0xff));
-    switch (m.type()) {
+    AccountID ret(static_cast<PublicKeyType>(m.type() & 0xff));
+    switch (m.type())
+    {
     case KEY_TYPE_ED25519:
         ret.ed25519() = m.ed25519();
         break;
@@ -784,10 +785,11 @@ toAccountID(const MuxedAccount &m)
 }
 
 MuxedAccount
-toMuxedAccount(const AccountID &a)
+toMuxedAccount(const AccountID& a)
 {
-    MuxedAccount ret (static_cast<CryptoKeyType>(a.type()));
-    switch (a.type()) {
+    MuxedAccount ret(static_cast<CryptoKeyType>(a.type()));
+    switch (a.type())
+    {
     case PUBLIC_KEY_TYPE_ED25519:
         ret.ed25519() = a.ed25519();
         break;
@@ -801,34 +803,46 @@ trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header)
     return trustLineFlagIsValid(flag, header.current().ledgerVersion);
 }
 
-namespace detail {
-struct muxChecker {
+namespace detail
+{
+struct muxChecker
+{
     bool hasMuxedAccount = false;
 
-    void operator()(const stellar::MuxedAccount &t) {
+    void
+    operator()(const stellar::MuxedAccount& t)
+    {
         if (t.type() != stellar::KEY_TYPE_ED25519)
             hasMuxedAccount = true;
     }
 
 #if 1
-    template<typename T> std::enable_if_t<
-        (xdr::xdr_traits<T>::is_container || xdr::xdr_traits<T>::is_struct)>
-    operator()(const T &t) {
+    template <typename T>
+    std::enable_if_t<(xdr::xdr_traits<T>::is_container ||
+                      xdr::xdr_traits<T>::is_struct)>
+    operator()(const T& t)
+    {
         if (!hasMuxedAccount)
             xdr::xdr_traits<T>::save(*this, t);
     }
 
-    template<typename T> std::enable_if_t<
-        !(xdr::xdr_traits<T>::is_container || xdr::xdr_traits<T>::is_struct)>
-    operator()(const T &t) {
+    template <typename T>
+    std::enable_if_t<!(xdr::xdr_traits<T>::is_container ||
+                       xdr::xdr_traits<T>::is_struct)>
+    operator()(const T& t)
+    {
     }
 
 #else /* switch to this when C++17 is permissible */
-    template<typename T> void operator()(const T &t) {
-        if constexpr(xdr::xdr_traits<T>::is_container ||
-                     xdr::xdr_traits<T>::is_struct) {
-                if (!hasMuxedAccount)
-                    xdr::xdr_traits<T>::save(*this, t);
+    template <typename T>
+    void
+    operator()(const T& t)
+    {
+        if constexpr (xdr::xdr_traits<T>::is_container ||
+                      xdr::xdr_traits<T>::is_struct)
+        {
+            if (!hasMuxedAccount)
+                xdr::xdr_traits<T>::save(*this, t);
         }
     }
 #endif
@@ -836,7 +850,7 @@ struct muxChecker {
 } // namespace detail
 
 bool
-hasMuxedAccount(const TransactionEnvelope &e)
+hasMuxedAccount(const TransactionEnvelope& e)
 {
     detail::muxChecker c;
     c(e);

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -765,9 +765,81 @@ trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion)
     }
 }
 
+AccountID
+toAccountID(const MuxedAccount &m)
+{
+    AccountID ret(static_cast<PublicKeyType>(m.type()&0xff));
+    switch (m.type()) {
+    case KEY_TYPE_ED25519:
+        ret.ed25519() = m.ed25519();
+        break;
+    case KEY_TYPE_MUXED_ED25519:
+        ret.ed25519() = m.med25519().ed25519;
+        break;
+    default:
+        // Just to suppress warning
+        break;
+    }
+    return ret;
+}
+
+MuxedAccount
+toMuxedAccount(const AccountID &a)
+{
+    MuxedAccount ret (static_cast<CryptoKeyType>(a.type()));
+    switch (a.type()) {
+    case PUBLIC_KEY_TYPE_ED25519:
+        ret.ed25519() = a.ed25519();
+        break;
+    }
+    return ret;
+}
+
 bool
 trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header)
 {
     return trustLineFlagIsValid(flag, header.current().ledgerVersion);
 }
+
+namespace detail {
+struct muxChecker {
+    bool hasMuxedAccount = false;
+
+    void operator()(const stellar::MuxedAccount &t) {
+        if (t.type() != stellar::KEY_TYPE_ED25519)
+            hasMuxedAccount = true;
+    }
+
+#if 1
+    template<typename T> std::enable_if_t<
+        (xdr::xdr_traits<T>::is_container || xdr::xdr_traits<T>::is_struct)>
+    operator()(const T &t) {
+        if (!hasMuxedAccount)
+            xdr::xdr_traits<T>::save(*this, t);
+    }
+
+    template<typename T> std::enable_if_t<
+        !(xdr::xdr_traits<T>::is_container || xdr::xdr_traits<T>::is_struct)>
+    operator()(const T &t) {
+    }
+
+#else /* switch to this when C++17 is permissible */
+    template<typename T> void operator()(const T &t) {
+        if constexpr(xdr::xdr_traits<T>::is_container ||
+                     xdr::xdr_traits<T>::is_struct) {
+                if (!hasMuxedAccount)
+                    xdr::xdr_traits<T>::save(*this, t);
+        }
+    }
+#endif
+};
+} // namespace detail
+
+bool
+hasMuxedAccount(const TransactionEnvelope &e)
+{
+    detail::muxChecker c;
+    c(e);
+    return c.hasMuxedAccount;
 }
+} // namespace stellar

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-transaction.h"
 
 namespace stellar
 {
@@ -16,6 +17,7 @@ class LedgerTxnEntry;
 class LedgerTxnHeader;
 class TrustLineWrapper;
 struct LedgerKey;
+struct TransactionEnvelope;
 
 LedgerKey accountKey(AccountID const& accountID);
 LedgerKey trustlineKey(AccountID const& accountID, Asset const& asset);
@@ -135,9 +137,19 @@ void normalizeSigners(LedgerTxnEntry& entry);
 void releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
                         LedgerTxnEntry const& offer);
 
+inline const AccountID &toAccountID(const AccountID &a)
+{
+    return a;
+}
+
+AccountID toAccountID(const MuxedAccount &m);
+MuxedAccount toMuxedAccount(const AccountID &a);
+
 void setAuthorized(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
                    uint32_t authorized);
 
 bool trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion);
 bool trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header);
+
+bool hasMuxedAccount(const TransactionEnvelope &e);
 }

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -137,13 +137,14 @@ void normalizeSigners(LedgerTxnEntry& entry);
 void releaseLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
                         LedgerTxnEntry const& offer);
 
-inline const AccountID &toAccountID(const AccountID &a)
+inline const AccountID&
+toAccountID(const AccountID& a)
 {
     return a;
 }
 
-AccountID toAccountID(const MuxedAccount &m);
-MuxedAccount toMuxedAccount(const AccountID &a);
+AccountID toAccountID(const MuxedAccount& m);
+MuxedAccount toMuxedAccount(const AccountID& a);
 
 void setAuthorized(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
                    uint32_t authorized);
@@ -151,5 +152,5 @@ void setAuthorized(LedgerTxnHeader const& header, LedgerTxnEntry& entry,
 bool trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion);
 bool trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header);
 
-bool hasMuxedAccount(const TransactionEnvelope &e);
+bool hasMuxedAccount(const TransactionEnvelope& e);
 }

--- a/src/transactions/test/AllowTrustTests.cpp
+++ b/src/transactions/test/AllowTrustTests.cpp
@@ -233,7 +233,6 @@ TEST_CASE("authorized to maintain liabilities", "[tx][allowtrust]")
     }
 
     for_versions_from(13, *app, [&] {
-
         SECTION("offer tests")
         {
             SECTION("buying asset is only allowed to maintain liabilities")
@@ -294,7 +293,6 @@ TEST_CASE("authorized to maintain liabilities", "[tx][allowtrust]")
                                   ex_ALLOW_TRUST_CANT_REVOKE);
             }
         }
-
     });
 }
 

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -39,7 +39,7 @@ feeBumpUnsigned(TestAccount& feeSource, TestAccount& source, TestAccount& dest,
 
     auto& env = fb.feeBump().tx.innerTx;
     env.type(ENVELOPE_TYPE_TX);
-    env.v1().tx.sourceAccount = source;
+    env.v1().tx.sourceAccount = toMuxedAccount(source);
     env.v1().tx.fee = innerFee;
     env.v1().tx.seqNum = source.nextSequenceNumber();
     env.v1().tx.operations = {payment(dest, amount)};
@@ -364,7 +364,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 }
 
                 auto setOptionsOp = setOptions(setMasterWeight(0));
-                setOptionsOp.sourceAccount.activate() = root;
+                setOptionsOp.sourceAccount.activate() = toMuxedAccount(root);
                 auto setOptionsTx = acc.tx({setOptionsOp});
                 setOptionsTx->addSignature(root);
                 applyCheck(setOptionsTx, *app);

--- a/src/transactions/test/PathPaymentTests.cpp
+++ b/src/transactions/test/PathPaymentTests.cpp
@@ -3957,7 +3957,6 @@ TEST_CASE("pathpayment", "[tx][pathpayment]")
                     {destination, {{xlm, minBalance1 - txfee}, {cur1, 0}, {cur2, 0}, {cur3, 0}, {cur4, 10}}}});
                 // clang-format on
             });
-
         };
 
         SECTION("no issuers missing")

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -597,7 +597,6 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         closeLedgerOn(*app, 2, 1, 1, 2016);
 
                         auto runTest = [&](bool txAccountMissing) {
-
                             // Create merge tx
                             auto txMerge = b1.tx({accountMerge(a1)});
 

--- a/src/util/BitSet.h
+++ b/src/util/BitSet.h
@@ -11,7 +11,8 @@
 #include <ostream>
 #include <set>
 
-extern "C" {
+extern "C"
+{
 #include "util/cbitset.h"
 };
 

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -71,7 +71,7 @@ TEST_CASE("uint128_t", "[uint128]")
             BINOP(-);
             BINOP(*);
             BINOP(/);
-            BINOP (^);
+            BINOP(^);
             BINOP(&);
             BINOP(|);
             BINOP(%);

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -7,6 +7,17 @@
 namespace stellar
 {
 
+// Source or destination of a payment operation
+union MuxedAccount switch (CryptoKeyType type) {
+ case KEY_TYPE_ED25519:
+     uint256 ed25519;
+ case KEY_TYPE_MUXED_ED25519:
+     struct {
+         uint64 id;
+         uint256 ed25519;
+     } med25519;
+};
+
 struct DecoratedSignature
 {
     SignatureHint hint;  // last 4 bytes of the public key, used as a hint
@@ -55,7 +66,7 @@ struct CreateAccountOp
 */
 struct PaymentOp
 {
-    AccountID destination; // recipient of the payment
+    MuxedAccount destination; // recipient of the payment
     Asset asset;           // what they end up with
     int64 amount;          // amount they end up with
 };
@@ -78,7 +89,7 @@ struct PathPaymentStrictReceiveOp
                      // send (excluding fees).
                      // The operation will fail if can't be met
 
-    AccountID destination; // recipient of the payment
+    MuxedAccount destination; // recipient of the payment
     Asset destAsset;       // what they end up with
     int64 destAmount;      // amount they end up with
 
@@ -101,7 +112,7 @@ struct PathPaymentStrictSendOp
     Asset sendAsset;  // asset we pay with
     int64 sendAmount; // amount of sendAsset to send (excluding fees)
 
-    AccountID destination; // recipient of the payment
+    MuxedAccount destination; // recipient of the payment
     Asset destAsset;       // what they end up with
     int64 destMin;         // the minimum amount of dest asset to
                            // be received
@@ -286,7 +297,7 @@ struct Operation
     // sourceAccount is the account used to run the operation
     // if not set, the runtime defaults to "sourceAccount" specified at
     // the transaction level
-    AccountID* sourceAccount;
+    MuxedAccount* sourceAccount;
 
     union switch (OperationType type)
     {
@@ -307,7 +318,7 @@ struct Operation
     case ALLOW_TRUST:
         AllowTrustOp allowTrustOp;
     case ACCOUNT_MERGE:
-        AccountID destination;
+        MuxedAccount destination;
     case INFLATION:
         void;
     case MANAGE_DATA:
@@ -392,7 +403,7 @@ struct TransactionV0Envelope
 struct Transaction
 {
     // account used to run the transaction
-    AccountID sourceAccount;
+    MuxedAccount sourceAccount;
 
     // the fee the sourceAccount will pay
     uint32 fee;
@@ -563,7 +574,7 @@ enum PathPaymentStrictReceiveResultCode
 
 struct SimplePaymentResult
 {
-    AccountID destination;
+    MuxedAccount destination;
     Asset asset;
     int64 amount;
 };

--- a/src/xdr/Stellar-types.x
+++ b/src/xdr/Stellar-types.x
@@ -17,6 +17,7 @@ typedef hyper int64;
 enum CryptoKeyType
 {
     KEY_TYPE_ED25519 = 0,
+    KEY_TYPE_MUXED_ED25519 = 256,
     KEY_TYPE_PRE_AUTH_TX = 1,
     KEY_TYPE_HASH_X = 2
 };


### PR DESCRIPTION
# Description

Supports CAP-0027 by adding a `MuxedAccount` type that replaces an `AccountID` in a number of places.  `MuxedAccount` serializes to a superset of valid `AccountID`s to include an optional integer comment which has no affect.  `MuxedAccounts` that are not simple `AccountID`s are rejected before version 13 of the protocol.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
