### PR TITLE
Out of order ledger catchup recovery

### DIFF
--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -8,7 +8,6 @@
 #include "util/asio.h"
 #include "catchup/CatchupManagerImpl.h"
 #include "catchup/CatchupConfiguration.h"
-#include "catchup/CatchupWork.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
 #include "medida/meter.h"
@@ -20,6 +19,16 @@
 
 namespace stellar
 {
+
+template <typename T>
+T
+findFirstCheckpoint(T begin, T end, HistoryManager const& hm)
+{
+    return std::find_if(begin, end,
+                        [&hm](std::pair<uint32_t, LedgerCloseData> const& kvp) {
+                            return hm.isFirstLedgerInCheckpoint(kvp.first);
+                        });
+}
 
 std::unique_ptr<CatchupManager>
 CatchupManager::create(Application& app)
@@ -57,20 +66,30 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
 
     uint32_t lastReceivedLedgerSeq = ledgerData.getLedgerSeq();
 
-    // If LCL is already at-or-ahead of the ledger we just received from the
-    // network, we're up to date. Return early, nothing to do.
-    if (lastReceivedLedgerSeq <=
-        mApp.getLedgerManager().getLastClosedLedgerNum())
+    // 1. CatchupWork is not running yet
+    // 2. The ledger just received is equal to lcl
+    // then it's possible we're back in sync and we can attempt to apply
+    // mSyncingLedgers
+    if (!mCatchupWork && lastReceivedLedgerSeq ==
+                             mApp.getLedgerManager().getLastClosedLedgerNum())
     {
+        tryApplySyncingLedgers();
+        return;
+    }
+    else if (lastReceivedLedgerSeq <=
+             mApp.getLedgerManager().getLastClosedLedgerNum())
+    {
+        // If LCL is already at-or-ahead of the ledger we just received from the
+        // network, we're up to date. Return early, nothing to do.
         return;
     }
 
-    // For the rest of this method: we know LCL has fallen behind the network,
-    // we only need to decide whether to buffer the newly received ledger and/or
-    // start the CatchupWork state machine.
+    // For the rest of this method: we know LCL has fallen behind the network
+    // and we must buffer this ledger, we only need to decide whether to start
+    // the CatchupWork state machine.
     //
     // Assuming we fell out of sync at ledger K, we wait for the first ledger L
-    // of the checkpoint following K, and begin buffering from there. When we
+    // of the checkpoint following K to start catchup. When we
     // reach L+1 we assume the checkpoint covering K has probably been published
     // to history and commence catchup, running the (checkpoint-driven) catchup
     // state machine to ledger L-1 (the end of the checkpoint covering K) and
@@ -79,59 +98,75 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
     // First: if CatchupWork has started, just buffer and return early.
     if (mCatchupWork)
     {
+        // we don't want to buffer any ledgers at or below where we are catching
+        // up to
+        auto const& config = mCatchupWork->getCatchupConfiguration();
+        if (ledgerData.getLedgerSeq() <= config.toLedger())
+        {
+            return;
+        }
+
         addToSyncingLedgers(ledgerData);
         logAndUpdateCatchupStatus(true);
         return;
     }
 
-    // Next switch between 3 cases: starting buffering, waiting to
-    // buffer, and already buffering.
-    auto& hm = mApp.getHistoryManager();
-    uint32_t firstLedgerInBuffer;
-    if (mSyncingLedgers.empty())
-    {
-        if (hm.isFirstLedgerInCheckpoint(lastReceivedLedgerSeq))
-        {
-            // Case 1: At the ledger where we should start buffering.
-            addToSyncingLedgers(ledgerData);
-            firstLedgerInBuffer = lastReceivedLedgerSeq;
-        }
-        else
-        {
-            // Case 2: Still waiting to start buffering.
-            firstLedgerInBuffer =
-                hm.firstLedgerAfterCheckpointContaining(lastReceivedLedgerSeq);
-        }
-    }
-    else
-    {
-        // Case 3: Already buffering, keep buffering.
-        addToSyncingLedgers(ledgerData);
-        firstLedgerInBuffer = mSyncingLedgers.front().getLedgerSeq();
-    }
-    assert(hm.isFirstLedgerInCheckpoint(firstLedgerInBuffer));
+    // Next, we buffer every out of sync ledger to allow us to get back in sync
+    // in case the ledgers we're missing are received.
+    addToSyncingLedgers(ledgerData);
 
-    // Finally we wait some number of ledgers beyond the first buffered
-    // ledger before we trigger the CatchupWork. This could be any number,
-    // for the sake of simplicity at the moment it's set to one ledger
-    // after the first buffered one.
+    // Finally we wait some number of ledgers beyond the smallest buffered
+    // checkpoint ledger before we trigger the CatchupWork. This could be any
+    // number, for the sake of simplicity at the moment it's set to one ledger
+    // after the first buffered one. Since we can receive out of order ledgers,
+    // we just check for any ledger larger than the checkpoint
+
+    auto& hm = mApp.getHistoryManager();
+    auto it =
+        findFirstCheckpoint(mSyncingLedgers.begin(), mSyncingLedgers.end(), hm);
+
     std::string message;
-    uint32_t catchupTriggerLedger =
-        hm.ledgerToTriggerCatchup(firstLedgerInBuffer);
-    if (lastReceivedLedgerSeq >= catchupTriggerLedger)
+    uint32_t lastLedgerInBuffer = mSyncingLedgers.crbegin()->first;
+    if (it != mSyncingLedgers.end() && it->first < lastLedgerInBuffer)
     {
         message = fmt::format("Starting catchup after ensuring checkpoint "
                               "ledger {} was closed on network",
-                              catchupTriggerLedger);
+                              lastLedgerInBuffer);
+
+        // We only need ledgers starting from the checkpoint. We can
+        // remove all ledgers before this
+        mSyncingLedgers.erase(mSyncingLedgers.begin(), it);
+
         startOnlineCatchup();
     }
     else
     {
-        auto eta = (catchupTriggerLedger - lastReceivedLedgerSeq) *
-                   mApp.getConfig().getExpectedLedgerCloseTime();
-        message = fmt::format("Waiting for trigger ledger: {}/{}, ETA: {}s",
-                              lastReceivedLedgerSeq, catchupTriggerLedger,
-                              eta.count());
+        // get the smallest checkpoint we need to start catchup
+        uint32_t firstLedgerInBuffer = mSyncingLedgers.cbegin()->first;
+        uint32_t requiredFirstLedgerInCheckpoint =
+            hm.isFirstLedgerInCheckpoint(firstLedgerInBuffer)
+                ? firstLedgerInBuffer
+                : hm.firstLedgerAfterCheckpointContaining(firstLedgerInBuffer);
+
+        uint32_t catchupTriggerLedger =
+            hm.ledgerToTriggerCatchup(requiredFirstLedgerInCheckpoint);
+
+        // If the trigger ledger is behind the last ledger, that means we're
+        // waiting for out of order ledgers, which should arrive quickly
+        if (catchupTriggerLedger > lastLedgerInBuffer)
+        {
+            auto eta = (catchupTriggerLedger - lastLedgerInBuffer) *
+                       mApp.getConfig().getExpectedLedgerCloseTime();
+            message = fmt::format("Waiting for trigger ledger: {}/{}, ETA: {}s",
+                                  lastLedgerInBuffer, catchupTriggerLedger,
+                                  eta.count());
+        }
+        else
+        {
+            message = fmt::format(
+                "Waiting for out-of-order ledger(s). Trigger ledger: {}",
+                catchupTriggerLedger);
+        }
     }
     logAndUpdateCatchupStatus(true, message);
 }
@@ -229,7 +264,7 @@ CatchupManagerImpl::getBufferedLedger() const
             "getBufferedLedger called when mSyncingLedgers is empty!");
     }
 
-    return mSyncingLedgers.front();
+    return mSyncingLedgers.cbegin()->second;
 }
 
 void
@@ -241,7 +276,7 @@ CatchupManagerImpl::popBufferedLedger()
             "popBufferedLedger called when mSyncingLedgers is empty!");
     }
 
-    mSyncingLedgers.pop_front();
+    mSyncingLedgers.erase(mSyncingLedgers.cbegin());
 }
 
 void
@@ -263,7 +298,7 @@ CatchupManagerImpl::trimAndReset()
 void
 CatchupManagerImpl::addToSyncingLedgers(LedgerCloseData const& ledgerData)
 {
-    mSyncingLedgers.push_back(ledgerData);
+    mSyncingLedgers.emplace(ledgerData.getLedgerSeq(), ledgerData);
 
     CLOG(INFO, "Ledger") << "Close of ledger " << ledgerData.getLedgerSeq()
                          << " buffered";
@@ -277,9 +312,9 @@ CatchupManagerImpl::startOnlineCatchup()
     // catchup just before first buffered ledger that way we will have a
     // way to verify history consistency - compare previousLedgerHash of
     // buffered ledger with last one downloaded from history
-    auto firstBufferedLedgerSeq = mSyncingLedgers.front().getLedgerSeq();
-    auto hash = make_optional<Hash>(
-        mSyncingLedgers.front().getTxSet()->previousLedgerHash());
+    auto const& lcd = mSyncingLedgers.begin()->second;
+    auto firstBufferedLedgerSeq = lcd.getLedgerSeq();
+    auto hash = make_optional<Hash>(lcd.getTxSet()->previousLedgerHash());
     startCatchup({LedgerNumHashPair(firstBufferedLedgerSeq - 1, hash),
                   getCatchupCount(), CatchupConfiguration::Mode::ONLINE},
                  nullptr);
@@ -288,21 +323,15 @@ CatchupManagerImpl::startOnlineCatchup()
 void
 CatchupManagerImpl::trimSyncingLedgers()
 {
-    // look for the latest checkpoint
-    auto rit = mSyncingLedgers.rbegin();
-    auto rend = mSyncingLedgers.rend();
-    auto& hm = mApp.getHistoryManager();
-    while (rit != rend)
-    {
-        if (hm.isFirstLedgerInCheckpoint(rit->getLedgerSeq()))
-        {
-            break;
-        }
-        ++rit;
-    }
+    // Look for newest checkpoint ledger by using a reverse iterator
+    auto rit =
+        findFirstCheckpoint(mSyncingLedgers.rbegin(), mSyncingLedgers.rend(),
+                            mApp.getHistoryManager());
 
-    // only keep ledgers after start of the latest checkpoint (if it exists)
-    if (rit != rend)
+    // only keep ledgers after start of the latest checkpoint. If no checkpoint
+    // exists, then do nothing. We don't want to erase mSyncingLedgers in case
+    // we receive the missing ledgers and recover
+    if (rit != mSyncingLedgers.rend())
     {
         // rit points to a ledger that's the first in a checkpoint, like 64 or
         // 128; rit.base() is the underlying forward iterator one _past_ (in
@@ -315,9 +344,34 @@ CatchupManagerImpl::trimSyncingLedgers()
         // range [64, ...) or [128, ...) in mSyncingLedgers.
         mSyncingLedgers.erase(mSyncingLedgers.begin(), (++rit).base());
     }
-    else
+}
+
+void
+CatchupManagerImpl::tryApplySyncingLedgers()
+{
+    auto const& ledgerHeader =
+        mApp.getLedgerManager().getLastClosedLedgerHeader();
+
+    // We can apply mutiple ledgers here, which might be slow. This is a rare
+    // occurrence so we should be fine.
+    auto it = mSyncingLedgers.cbegin();
+    while (it != mSyncingLedgers.cend())
     {
-        mSyncingLedgers.clear();
+        auto const& lcd = it->second;
+
+        // we still have a missing ledger
+        if (ledgerHeader.header.ledgerSeq + 1 != lcd.getLedgerSeq())
+        {
+            break;
+        }
+
+        mApp.getLedgerManager().closeLedger(lcd);
+        CLOG(INFO, "History") << "Closed buffered ledger: "
+                              << LedgerManager::ledgerAbbrev(ledgerHeader);
+
+        ++it;
     }
+
+    mSyncingLedgers.erase(mSyncingLedgers.cbegin(), it);
 }
 }

--- a/src/catchup/CatchupManagerImpl.h
+++ b/src/catchup/CatchupManagerImpl.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "catchup/CatchupManager.h"
+#include "catchup/CatchupWork.h"
 #include <memory>
 
 namespace medida
@@ -22,15 +23,17 @@ class Work;
 class CatchupManagerImpl : public CatchupManager
 {
     Application& mApp;
-    std::shared_ptr<BasicWork> mCatchupWork;
+    std::shared_ptr<CatchupWork> mCatchupWork;
 
-    std::deque<LedgerCloseData> mSyncingLedgers;
+    // key is ledgerSeq
+    std::map<uint32_t, LedgerCloseData> mSyncingLedgers;
     medida::Counter& mSyncingLedgersSize;
 
     void addToSyncingLedgers(LedgerCloseData const& ledgerData);
     void startOnlineCatchup();
     void trimSyncingLedgers();
     void trimAndReset();
+    void tryApplySyncingLedgers();
     uint32_t getCatchupCount();
 
   public:

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -68,6 +68,12 @@ class CatchupWork : public Work
     virtual ~CatchupWork();
     std::string getStatus() const override;
 
+    CatchupConfiguration const&
+    getCatchupConfiguration() const
+    {
+        return mCatchupConfiguration;
+    }
+
   private:
     LedgerNumHashPair mLastClosedLedgerHashPair;
     CatchupConfiguration const mCatchupConfiguration;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -231,7 +231,7 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
     auto maxSlotsToRemember = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
     if (slotIndex > maxSlotsToRemember)
     {
-        auto maxSlot = slotIndex - maxSlotsToRemember;
+        auto maxSlot = slotIndex - maxSlotsToRemember + 1;
         getHerderSCPDriver().purgeSlots(maxSlot);
         mPendingEnvelopes.eraseBelow(maxSlot);
     }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -56,6 +56,7 @@ class HerderImpl : public Herder
         return mHerderSCPDriver;
     }
 
+    void processExternalized(uint64 slotIndex, StellarValue const& value);
     void valueExternalized(uint64 slotIndex, StellarValue const& value);
     void emitEnvelope(SCPEnvelope const& envelope);
 

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -7,6 +7,7 @@
 #include "bucket/BucketList.h"
 #include "catchup/VerifyLedgerChainWork.h"
 #include "crypto/Hex.h"
+#include "herder/HerderImpl.h"
 #include "herder/LedgerCloseData.h"
 #include "history/FileTransferInfo.h"
 #include "history/HistoryArchive.h"
@@ -280,7 +281,11 @@ class CatchupSimulation
                         bool extraValidation = false);
     bool catchupOnline(Application::pointer app, uint32_t initLedger,
                        uint32_t bufferLedgers = 0, uint32_t gapLedger = 0,
-                       int32_t numGapLedgers = 1);
+                       int32_t numGapLedgers = 1,
+                       std::vector<uint32_t> const& ledgersToInject = {});
+
+    // this method externalizes through herder
+    void externalizeLedger(HerderImpl& herder, uint32_t ledger);
 
     void crankUntil(Application::pointer app,
                     std::function<bool()> const& predicate,

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -452,22 +452,10 @@ LedgerManagerImpl::closeLedgerIf(LedgerCloseData const& ledgerData)
 {
     if (mLastClosedLedger.header.ledgerSeq + 1 == ledgerData.getLedgerSeq())
     {
-        if (mLastClosedLedger.hash ==
-            ledgerData.getTxSet()->previousLedgerHash())
-        {
-            closeLedger(ledgerData);
-            CLOG(INFO, "Ledger")
-                << "Closed ledger: " << ledgerAbbrev(mLastClosedLedger);
-            return CloseLedgerIfResult::CLOSED;
-        }
-        else
-        {
-            CLOG(FATAL, "Ledger") << "Network consensus for ledger "
-                                  << mLastClosedLedger.header.ledgerSeq
-                                  << " changed; this should never happen";
-            CLOG(FATAL, "Ledger") << POSSIBLY_CORRUPTED_QUORUM_SET;
-            throw std::runtime_error("Network consensus inconsistency");
-        }
+        closeLedger(ledgerData);
+        CLOG(INFO, "Ledger")
+            << "Closed ledger: " << ledgerAbbrev(mLastClosedLedger);
+        return CloseLedgerIfResult::CLOSED;
     }
     else if (ledgerData.getLedgerSeq() <= mLastClosedLedger.header.ledgerSeq)
     {

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -70,14 +70,7 @@ class LedgerManagerImpl : public LedgerManager
     void storeCurrentLedger(LedgerHeader const& header);
     void prefetchTransactionData(std::vector<TransactionFrameBasePtr>& txs);
     void prefetchTxSourceIds(std::vector<TransactionFrameBasePtr>& txs);
-
-    enum class CloseLedgerIfResult
-    {
-        CLOSED,
-        TOO_OLD,
-        TOO_NEW
-    };
-    CloseLedgerIfResult closeLedgerIf(LedgerCloseData const& ledgerData);
+    void closeLedgerIf(LedgerCloseData const& ledgerData);
 
     State mState;
     void setState(State s);


### PR DESCRIPTION
# Description

This PR includes Marta's `Herder` change that will allow out of order ledgers into `LedgerManager`.  `CatchupManager` was changed to account for out of order ledgers, and potentially recover if the missing ledgers are received before `CatchupWork` starts.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
