### PR TITLE
Add minimum Fee Bump replacement fee to `POST /tx`'s  response

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -101,7 +101,7 @@ class Herder
     virtual TransactionQueue::AddStatus
     recvTransaction(TransactionFrameBasePtr tx) = 0;
     virtual TransactionQueue::AddStatus
-    recvTransaction(TransactionFrameBasePtr tx, int64_t &feeRecommendation) = 0;
+    recvTransaction(TransactionFrameBasePtr tx, int64_t& minFee) = 0;
 
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -98,8 +98,11 @@ class Herder
                                   SCPQuorumSet const& qset) = 0;
     virtual bool recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
-    virtual TransactionQueue::AddResult
+    virtual TransactionQueue::AddStatus
     recvTransaction(TransactionFrameBasePtr tx) = 0;
+    virtual TransactionQueue::AddStatus
+    recvTransaction(TransactionFrameBasePtr tx, int64_t &feeRecommendation) = 0;
+
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;
     virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -313,7 +313,7 @@ TransactionQueue::AddResult
 HerderImpl::recvTransaction(TransactionFrameBasePtr tx)
 {
     auto result = mTransactionQueue.tryAdd(tx);
-    if (result == TransactionQueue::AddResult::ADD_STATUS_PENDING)
+    if (result.mStatus == TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
         if (Logging::logTrace("Herder"))
             CLOG(TRACE, "Herder")

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -317,8 +317,7 @@ HerderImpl::recvTransaction(TransactionFrameBasePtr tx)
 }
 
 TransactionQueue::AddStatus
-HerderImpl::recvTransaction(TransactionFrameBasePtr tx,
-                            int64_t& feeRecommendation)
+HerderImpl::recvTransaction(TransactionFrameBasePtr tx, int64_t& minFee)
 {
     auto result = mTransactionQueue.tryAdd(tx);
     if (result.mStatus == TransactionQueue::AddStatus::ADD_STATUS_PENDING)
@@ -328,7 +327,7 @@ HerderImpl::recvTransaction(TransactionFrameBasePtr tx,
                 << "recv transaction " << hexAbbrev(tx->getFullHash())
                 << " for " << KeyUtils::toShortString(tx->getSourceID());
     }
-    feeRecommendation = result.mFeeRecommendation;
+    minFee = result.mFeeBumpMinFee;
     return result.mStatus;
 }
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -62,8 +62,8 @@ class HerderImpl : public Herder
     TransactionQueue::AddStatus
     recvTransaction(TransactionFrameBasePtr tx) override;
 
-    TransactionQueue::AddStatus
-    recvTransaction(TransactionFrameBasePtr tx, int64_t &feeRecommendation) override;
+    TransactionQueue::AddStatus recvTransaction(TransactionFrameBasePtr tx,
+                                                int64_t& minFee) override;
 
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -59,8 +59,11 @@ class HerderImpl : public Herder
     void valueExternalized(uint64 slotIndex, StellarValue const& value);
     void emitEnvelope(SCPEnvelope const& envelope);
 
-    TransactionQueue::AddResult
+    TransactionQueue::AddStatus
     recvTransaction(TransactionFrameBasePtr tx) override;
+
+    TransactionQueue::AddStatus
+    recvTransaction(TransactionFrameBasePtr tx, int64_t &feeRecommendation) override;
 
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -72,7 +72,7 @@ class TransactionQueue
     struct AddResult
     {
         AddStatus mStatus;
-        int64_t mFeeRecommendation;
+        int64_t mFeeBumpMinFee;
     };
 
     /*

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -59,22 +59,20 @@ class TransactionQueue
   public:
     static int64_t const FEE_MULTIPLIER;
 
-    struct FeeRateRecommendation {
-        int64_t n;
-        int64_t d;
+    enum class AddStatus
+    {
+        ADD_STATUS_PENDING = 0,
+        ADD_STATUS_DUPLICATE,
+        ADD_STATUS_ERROR,
+        ADD_STATUS_TRY_AGAIN_LATER,
+        ADD_STATUS_COUNT,
+        ADD_STATUS_BAD_REPLACE_BY_FEE,
     };
 
     struct AddResult
     {
-        enum {
-            ADD_STATUS_PENDING = 0,
-            ADD_STATUS_DUPLICATE,
-            ADD_STATUS_ERROR,
-            ADD_STATUS_TRY_AGAIN_LATER,
-            ADD_STATUS_COUNT,
-        } mStatus;
-
-        FeeRateRecommendation mFeeRateRecommendation;
+        AddStatus mStatus;
+        int64_t mFeeRecommendation;
     };
 
     /*
@@ -206,6 +204,6 @@ class TransactionQueue
 };
 
 static const char* TX_STATUS_STRING[static_cast<int>(
-    TransactionQueue::AddResult::ADD_STATUS_COUNT)] = {
+    TransactionQueue::AddStatus::ADD_STATUS_COUNT)] = {
     "PENDING", "DUPLICATE", "ERROR", "TRY_AGAIN_LATER"};
 }

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -65,8 +65,8 @@ class TransactionQueue
         ADD_STATUS_DUPLICATE,
         ADD_STATUS_ERROR,
         ADD_STATUS_TRY_AGAIN_LATER,
-        ADD_STATUS_COUNT,
         ADD_STATUS_BAD_REPLACE_BY_FEE,
+        ADD_STATUS_COUNT,
     };
 
     struct AddResult
@@ -205,5 +205,5 @@ class TransactionQueue
 
 static const char* TX_STATUS_STRING[static_cast<int>(
     TransactionQueue::AddStatus::ADD_STATUS_COUNT)] = {
-    "PENDING", "DUPLICATE", "ERROR", "TRY_AGAIN_LATER"};
+    "PENDING", "DUPLICATE", "ERROR", "TRY_AGAIN_LATER", "REPLACE_BY_FEE"};
 }

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -59,13 +59,22 @@ class TransactionQueue
   public:
     static int64_t const FEE_MULTIPLIER;
 
-    enum class AddResult
+    struct FeeRateRecommendation {
+        int64_t n;
+        int64_t d;
+    };
+
+    struct AddResult
     {
-        ADD_STATUS_PENDING = 0,
-        ADD_STATUS_DUPLICATE,
-        ADD_STATUS_ERROR,
-        ADD_STATUS_TRY_AGAIN_LATER,
-        ADD_STATUS_COUNT
+        enum {
+            ADD_STATUS_PENDING = 0,
+            ADD_STATUS_DUPLICATE,
+            ADD_STATUS_ERROR,
+            ADD_STATUS_TRY_AGAIN_LATER,
+            ADD_STATUS_COUNT,
+        } mStatus;
+
+        FeeRateRecommendation mFeeRateRecommendation;
     };
 
     /*

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -49,7 +49,6 @@ TEST_CASE("standalone", "[herder][acceptance]")
     cfg.QUORUM_SET.validators.push_back(v0NodeID);
 
     for_all_versions(cfg, [&](Config const& cfg1) {
-
         VirtualClock clock;
         Application::pointer app = createTestApplication(clock, cfg1);
 
@@ -72,8 +71,8 @@ TEST_CASE("standalone", "[herder][acceptance]")
             VirtualTimer setupTimer(*app);
 
             auto feedTx = [&](TransactionFramePtr& tx) {
-                REQUIRE(app->getHerder().recvTransaction(tx).mStatus ==
-                        TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                REQUIRE(app->getHerder().recvTransaction(tx) ==
+                        TransactionQueue::AddStatus::ADD_STATUS_PENDING);
             };
 
             auto waitForExternalize = [&]() {
@@ -1937,8 +1936,8 @@ TEST_CASE("do not flood too many transactions", "[herder]")
             ops.emplace_back(payment(source, i));
         }
         auto tx = source.tx(ops);
-        REQUIRE(herder.recvTransaction(tx).mStatus ==
-                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        REQUIRE(herder.recvTransaction(tx) ==
+                TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         return tx;
     };
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -72,7 +72,7 @@ TEST_CASE("standalone", "[herder][acceptance]")
             VirtualTimer setupTimer(*app);
 
             auto feedTx = [&](TransactionFramePtr& tx) {
-                REQUIRE(app->getHerder().recvTransaction(tx) ==
+                REQUIRE(app->getHerder().recvTransaction(tx).mStatus ==
                         TransactionQueue::AddResult::ADD_STATUS_PENDING);
             };
 
@@ -1937,7 +1937,7 @@ TEST_CASE("do not flood too many transactions", "[herder]")
             ops.emplace_back(payment(source, i));
         }
         auto tx = source.tx(ops);
-        REQUIRE(herder.recvTransaction(tx) ==
+        REQUIRE(herder.recvTransaction(tx).mStatus ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
         return tx;
     };

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -85,9 +85,9 @@ class TransactionQueueTest
 
     void
     add(TransactionFrameBasePtr const& tx,
-        TransactionQueue::AddResult AddResult)
+        int status)
     {
-        REQUIRE(mTransactionQueue.tryAdd(tx) == AddResult);
+        REQUIRE(mTransactionQueue.tryAdd(tx).mStatus == status);
     }
 
     void
@@ -712,7 +712,7 @@ TEST_CASE("transaction queue starting sequence boundary",
     TransactionQueue tq(*app, 4, 10, 4);
     for (size_t i = 1; i <= 4; ++i)
     {
-        REQUIRE(tq.tryAdd(transaction(*app, acc1, i, 1, 100)) ==
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, i, 1, 100)).mStatus ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
     }
 
@@ -1217,7 +1217,7 @@ TEST_CASE("remove applied", "[herder][transactionqueue]")
     }
 
     REQUIRE(tq.toTxSet({})->mTransactions.size() == 1);
-    REQUIRE(herder.recvTransaction(tx4) ==
+    REQUIRE(herder.recvTransaction(tx4).mStatus ==
             TransactionQueue::AddResult::ADD_STATUS_PENDING);
     REQUIRE(tq.toTxSet({})->mTransactions.size() == 2);
 }

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -84,8 +84,7 @@ class TransactionQueueTest
     }
 
     void
-    add(TransactionFrameBasePtr const& tx,
-        int status)
+    add(TransactionFrameBasePtr const& tx, TransactionQueue::AddStatus status)
     {
         REQUIRE(mTransactionQueue.tryAdd(tx).mStatus == status);
     }
@@ -233,140 +232,140 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     SECTION("small sequence number")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T0, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T0, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1}, {account2}}, {}});
     }
 
     SECTION("big sequence number")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1}, {account2}}, {}});
     }
 
     SECTION("good sequence number")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good sequence number, same twice")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
     }
 
     SECTION("good then small sequence number")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then big sequence number")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then good sequence number")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
     }
 
     SECTION("good sequence number, same twice with shift")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE);
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then big sequence number, with shift")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then good sequence number, with shift")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}}, {account2}}, {}});
     }
 
     SECTION("good sequence number, same twice with double shift")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}, {}});
         test.shift();
         test.check({{{account1, 2, {txSeqA1T1}}, {account2}}, {}});
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE);
         test.check({{{account1, 2, {txSeqA1T1}}, {account2}}, {}});
     }
 
     SECTION("good then big sequence number, with double shift")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
     }
 
     SECTION("good then good sequence number, with double shift")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 2, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}}, {account2}}});
     }
 
     SECTION("good sequence number, same twice with four shifts, then two more")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
@@ -377,20 +376,20 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.shift();
         test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
         test.add(txSeqA1T1,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
         test.shift();
         test.check({{{account1}, {account2}}, {{}, {txSeqA1T1}}});
         test.shift();
         test.check({{{account1}, {account2}}});
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
     }
 
     SECTION("good then big sequence number, with four shifts")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
@@ -400,14 +399,14 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.check({{{account1, 3, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
     }
 
     SECTION("good then small sequence number, with four shifts")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
@@ -417,7 +416,7 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.check({{{account1, 3, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
-        test.add(txSeqA1T0, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T0, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1}, {account2}}, {{txSeqA1T1}}});
     }
 
@@ -425,21 +424,21 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     {
         TransactionQueueTest test{*app};
         test.add(invalidTransaction(*app, account1, 1),
-                 TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                 TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1}, {account2}}});
     }
 
     SECTION("multiple good sequence numbers, with four shifts")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check(
             {{{account1, 0, {txSeqA1T1, txSeqA1T2, txSeqA1T3}}, {account2}}});
-        test.add(txSeqA1T4, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T4, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check(
             {{{account1, 0, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
               {account2}}});
@@ -468,9 +467,9 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     SECTION("multiple good sequence numbers, with replace")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}}, {account2}}});
@@ -481,25 +480,25 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.shift();
         test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
         test.add(txSeqA1T1,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
         test.add(txSeqA1T2,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
-        test.add(txSeqA1T2V2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+        test.add(txSeqA1T2V2, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
         test.check({{{account1}, {account2}}, {{txSeqA1T1, txSeqA1T2}}});
-        test.add(txSeqA1T1V2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1V2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1V2}}, {account2}},
                     {{txSeqA1T1, txSeqA1T2}}});
         test.add(txSeqA1T1,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.check({{{account1, 0, {txSeqA1T1V2}}, {account2}},
                     {{txSeqA1T1, txSeqA1T2}}});
         test.add(txSeqA1T2,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.check({{{account1, 0, {txSeqA1T1V2}}, {account2}},
                     {{txSeqA1T1, txSeqA1T2}}});
-        test.add(txSeqA1T2V2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2V2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1V2, txSeqA1T2V2}}, {account2}},
                     {{txSeqA1T1, txSeqA1T2}}});
     }
@@ -507,21 +506,21 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     SECTION("multiple good sequence numbers, with shifts between")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 1, {txSeqA1T1, txSeqA1T2}}, {account2}}});
         test.shift();
         test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}}, {account2}}});
-        test.add(txSeqA1T3, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T3, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check(
             {{{account1, 2, {txSeqA1T1, txSeqA1T2, txSeqA1T3}}, {account2}}});
         test.shift();
         test.check(
             {{{account1, 3, {txSeqA1T1, txSeqA1T2, txSeqA1T3}}, {account2}}});
-        test.add(txSeqA1T4, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T4, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check(
             {{{account1, 3, {txSeqA1T1, txSeqA1T2, txSeqA1T3, txSeqA1T4}},
               {account2}}});
@@ -539,14 +538,14 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         "multiple good sequence numbers, different accounts, with four shifts")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
                      {account2, 0, {txSeqA2T1}}}});
-        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
                      {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
         test.shift();
@@ -567,21 +566,21 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
             "between")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
         test.shift();
         test.check({{{account1, 1, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 1, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
         test.shift();
         test.check({{{account1, 2, {txSeqA1T1}}, {account2, 1, {txSeqA2T1}}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 2, {txSeqA1T1, txSeqA1T2}},
                      {account2, 1, {txSeqA2T1}}}});
         test.shift();
         test.check({{{account1, 3, {txSeqA1T1, txSeqA1T2}},
                      {account2, 2, {txSeqA2T1}}}});
-        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 3, {txSeqA1T1, txSeqA1T2}},
                      {account2, 2, {txSeqA2T1, txSeqA2T2}}}});
         test.shift();
@@ -599,14 +598,14 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     SECTION("multiple good sequence numbers, different accounts, with remove")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
                      {account2, 0, {txSeqA2T1}}}});
-        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1, txSeqA1T2}},
                      {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
         test.shift();
@@ -616,11 +615,11 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.check({{{account1, 0, {txSeqA1T2}}, {account2}}});
         test.removeApplied({txSeqA1T2});
         test.check({{{account1}, {account2}}});
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2}}});
-        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}}, {account2, 0, {txSeqA2T1}}}});
-        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}},
                      {account2, 0, {txSeqA2T1, txSeqA2T2}}}});
         test.removeApplied({txSeqA2T1});
@@ -634,16 +633,16 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     SECTION("multiple good sequence numbers, different accounts, with ban")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.add(txSeqA2T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.add(txSeqA1T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.add(txSeqA2T2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
+        test.add(txSeqA2T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
+        test.add(txSeqA1T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
+        test.add(txSeqA2T2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.shift();
         test.ban({txSeqA1T1, txSeqA2T2, txSeqA3T1});
         test.check({{{account1}, {account2, 1, {txSeqA2T1}}},
                     {{txSeqA1T1, txSeqA1T2, txSeqA2T2, txSeqA3T1}}});
         test.add(txSeqA1T1,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.check({{{account1}, {account2, 1, {txSeqA2T1}}},
                     {{txSeqA1T1, txSeqA1T2, txSeqA2T2, txSeqA3T1}}});
 
@@ -652,13 +651,13 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
         test.check({{{account1}, {account2, 2, {txSeqA2T1}}},
                     {{}, {txSeqA1T1, txSeqA1T2, txSeqA2T2, txSeqA3T1}}});
         test.add(txSeqA1T1,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         test.add(txSeqA3T1,
-                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                 TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
         // not banned anymore
         test.shift();
-        test.add(txSeqA1T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
-        test.add(txSeqA3T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA1T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
+        test.add(txSeqA3T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {txSeqA1T1}},
                      {account2, 3, {txSeqA2T1}},
                      {account3, 0, {txSeqA3T1}}}});
@@ -666,7 +665,7 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
     SECTION("many transactions hit the pool limit")
     {
         TransactionQueueTest test{*app};
-        test.add(txSeqA3T1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(txSeqA3T1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         std::vector<TransactionFrameBasePtr> a3Txs({txSeqA3T1});
         std::vector<TransactionFrameBasePtr> banned;
 
@@ -676,14 +675,14 @@ TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
             if (i <= 8)
             {
                 test.add(txSeqA3Ti,
-                         TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                         TransactionQueue::AddStatus::ADD_STATUS_PENDING);
                 a3Txs.emplace_back(txSeqA3Ti);
             }
             else
             {
                 test.add(
                     txSeqA3Ti,
-                    TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER);
+                    TransactionQueue::AddStatus::ADD_STATUS_TRY_AGAIN_LATER);
                 banned.emplace_back(txSeqA3Ti);
                 test.check({{{account3, 0, a3Txs}}, {banned}});
             }
@@ -713,7 +712,7 @@ TEST_CASE("transaction queue starting sequence boundary",
     for (size_t i = 1; i <= 4; ++i)
     {
         REQUIRE(tq.tryAdd(transaction(*app, acc1, i, 1, 100)).mStatus ==
-                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                TransactionQueue::AddStatus::ADD_STATUS_PENDING);
     }
 
     auto checkTxSet = [&](uint32_t ledgerSeq, size_t size) {
@@ -750,7 +749,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx = transaction(*app, account1, 1, 1, 100);
         auto fb = feeBump(*app, account1, tx, 200);
-        test.add(fb, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
 
         for (int i = 0; i <= 3; ++i)
         {
@@ -765,7 +764,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx = transaction(*app, account1, 1, 1, 100);
         auto fb = feeBump(*app, account2, tx, 200);
-        test.add(fb, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb}}, {account2, 0}}, {}});
 
         for (int i = 1; i <= 3; ++i)
@@ -783,7 +782,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account1, 1, 1, 100);
         auto fb1 = feeBump(*app, account3, tx1, 200);
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
 
         test.shift();
@@ -791,7 +790,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
 
         auto tx2 = transaction(*app, account2, 1, 1, 100);
         auto fb2 = feeBump(*app, account3, tx2, 200);
-        test.add(fb2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
 
         for (int i = 1; i <= 3; ++i)
         {
@@ -813,14 +812,14 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account1, 1, 1, 100);
         auto fb1 = feeBump(*app, account3, tx1, 200);
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
 
         test.shift();
         test.check({{{account1, 1, {fb1}}, {account2}, {account3, 0}}, {}});
 
         auto tx2 = transaction(*app, account3, 1, 1, 100);
-        test.add(tx2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(tx2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
 
         for (int i = 1; i <= 3; ++i)
         {
@@ -839,7 +838,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
     {
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account3, 1, 1, 100);
-        test.add(tx1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(tx1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1}, {account2}, {account3, 0, {tx1}}}, {}});
 
         test.shift();
@@ -847,7 +846,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
 
         auto tx2 = transaction(*app, account1, 1, 1, 100);
         auto fb2 = feeBump(*app, account3, tx2, 200);
-        test.add(fb2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
 
         for (int i = 1; i <= 3; ++i)
         {
@@ -868,12 +867,12 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account1, 1, 1, 100);
         auto fb1 = feeBump(*app, account1, tx1, 200);
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3}}, {}});
 
         auto tx2 = transaction(*app, account1, 2, 1, 100);
         auto fb2 = feeBump(*app, account1, tx2, 200);
-        test.add(fb2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1, fb2}}, {account2}, {account3}}, {}});
 
         test.shift();
@@ -909,12 +908,12 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account1, 1, 1, 100);
         auto fb1 = feeBump(*app, account3, tx1, 200);
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
 
         auto tx2 = transaction(*app, account1, 2, 1, 100);
         auto fb2 = feeBump(*app, account3, tx2, 200);
-        test.add(fb2, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb2, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check(
             {{{account1, 0, {fb1, fb2}}, {account2}, {account3, 0}}, {}});
 
@@ -951,13 +950,13 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account1, 1, 1, 100);
         auto fb1 = feeBump(*app, account3, tx1, minBalance2 - minBalance0 - 1);
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
 
         SECTION("transaction")
         {
             auto tx2 = transaction(*app, account3, 1, 1, 100);
-            test.add(tx2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+            test.add(tx2, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
             REQUIRE(tx2->getResultCode() == txINSUFFICIENT_BALANCE);
             test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
         }
@@ -966,7 +965,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         {
             auto tx2 = transaction(*app, account3, 1, 1, 100);
             auto fb2 = feeBump(*app, account3, tx2, 200);
-            test.add(fb2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+            test.add(fb2, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
             REQUIRE(fb2->getResultCode() == txINSUFFICIENT_BALANCE);
             test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
         }
@@ -975,7 +974,7 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         {
             auto tx2 = transaction(*app, account2, 1, 1, 100);
             auto fb2 = feeBump(*app, account3, tx2, 200);
-            test.add(fb2, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+            test.add(fb2, TransactionQueue::AddStatus::ADD_STATUS_ERROR);
             REQUIRE(fb2->getResultCode() == txINSUFFICIENT_BALANCE);
             test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
         }
@@ -986,11 +985,11 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
         TransactionQueueTest test{*app};
         auto tx1 = transaction(*app, account1, 1, 1, 100);
         auto fb1 = feeBump(*app, account3, tx1, minBalance2 - minBalance0 - 1);
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
-        test.add(fb1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.add(fb1, TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
-        test.add(tx1, TransactionQueue::AddResult::ADD_STATUS_DUPLICATE);
+        test.add(tx1, TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE);
         test.check({{{account1, 0, {fb1}}, {account2}, {account3, 0}}, {}});
     }
 }
@@ -1011,7 +1010,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
         {
             txs.emplace_back(transaction(*app, account1, i, 1, 200));
             test.add(txs.back(),
-                     TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                     TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         }
         return txs;
     };
@@ -1025,7 +1024,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
             auto fb = feeBump(*app, feeSource, tx, 400);
             txs.emplace_back(fb);
             test.add(txs.back(),
-                     TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                     TransactionQueue::AddStatus::ADD_STATUS_PENDING);
         }
         return txs;
     };
@@ -1037,7 +1036,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
             for (uint32_t i = 1; i <= 3; ++i)
             {
                 test.add(transaction(*app, account1, i, 1, 199),
-                         TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                         TransactionQueue::AddStatus::ADD_STATUS_ERROR);
                 test.check({{{account1, 0, txs}, {account2}}, {}});
             }
         }
@@ -1047,7 +1046,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
             for (uint32_t i = 1; i <= 3; ++i)
             {
                 test.add(transaction(*app, account1, i, 1, 1999),
-                         TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                         TransactionQueue::AddStatus::ADD_STATUS_ERROR);
                 test.check({{{account1, 0, txs}, {account2}}, {}});
             }
         }
@@ -1060,7 +1059,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                 SECTION(position[i - 1] + " transaction")
                 {
                     test.add(transaction(*app, account1, i, 1, 2000),
-                             TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                             TransactionQueue::AddStatus::ADD_STATUS_ERROR);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
             }
@@ -1078,7 +1077,8 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                 {
                     auto tx = transaction(*app, account1, i, 1, 100);
                     auto fb = feeBump(*app, feeSource, tx, 399);
-                    test.add(fb, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                    test.add(fb, TransactionQueue::AddStatus::
+                                     ADD_STATUS_BAD_REPLACE_BY_FEE);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
             }
@@ -1093,7 +1093,8 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                 {
                     auto tx = transaction(*app, account1, i, 1, 100);
                     auto fb = feeBump(*app, feeSource, tx, 3999);
-                    test.add(fb, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                    test.add(fb, TransactionQueue::AddStatus::
+                                     ADD_STATUS_BAD_REPLACE_BY_FEE);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
             }
@@ -1111,7 +1112,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                     auto fb = feeBump(*app, account1, tx, 4000);
                     txs[i - 1] = fb;
                     test.add(fb,
-                             TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                             TransactionQueue::AddStatus::ADD_STATUS_PENDING);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
                 SECTION(position[i - 1] +
@@ -1121,7 +1122,7 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                     auto fb = feeBump(*app, account2, tx, 4000);
                     txs[i - 1] = fb;
                     test.add(fb,
-                             TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                             TransactionQueue::AddStatus::ADD_STATUS_PENDING);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
             }
@@ -1217,7 +1218,7 @@ TEST_CASE("remove applied", "[herder][transactionqueue]")
     }
 
     REQUIRE(tq.toTxSet({})->mTransactions.size() == 1);
-    REQUIRE(herder.recvTransaction(tx4).mStatus ==
-            TransactionQueue::AddResult::ADD_STATUS_PENDING);
+    REQUIRE(herder.recvTransaction(tx4) ==
+            TransactionQueue::AddStatus::ADD_STATUS_PENDING);
     REQUIRE(tq.toTxSet({})->mTransactions.size() == 2);
 }

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -568,8 +568,9 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
         {
             // add it to our current set
             // and make sure it is valid
-            TransactionQueue::AddResult status =
+            auto result =
                 mApp.getHerder().recvTransaction(transaction);
+            auto status = result.mStatus;
 
             if (status == TransactionQueue::AddResult::ADD_STATUS_PENDING)
             {
@@ -583,6 +584,14 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
                    << "\"status\": "
                    << "\"" << TX_STATUS_STRING[static_cast<int>(status)]
                    << "\"";
+            if (result.mFeeRateRecommendation.d > 0)
+            {
+                output << " , \"fee_rate_recommendation\": \""
+                       << "{"
+                       << "\"n\": " << result.mFeeRateRecommendation.n
+                       << " , \"d\": " << result.mFeeRateRecommendation.d
+                       << "}";
+            }
             if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
             {
                 std::string resultBase64;
@@ -889,7 +898,7 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
             txFrame = fromAccount.tx({payment(toAccount, paymentAmount)});
         }
 
-        switch (mApp.getHerder().recvTransaction(txFrame))
+        switch (mApp.getHerder().recvTransaction(txFrame).mStatus)
         {
         case TransactionQueue::AddResult::ADD_STATUS_PENDING:
             root["status"] = "pending";

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -587,7 +587,7 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
             }
             break;
             case TransactionQueue::AddStatus::ADD_STATUS_BAD_REPLACE_BY_FEE:
-                output << " , \"min_fee\": \"" << feeBumpMinFee << "\"";
+                output << " , \"min_fee\": " << feeBumpMinFee;
                 break;
             case TransactionQueue::AddStatus::ADD_STATUS_ERROR:
             {

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -568,9 +568,9 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
         {
             // add it to our current set
             // and make sure it is valid
-            int64_t feeRecommendation;
-            auto status = mApp.getHerder().recvTransaction(transaction,
-                                                           feeRecommendation);
+            int64_t feeBumpMinFee;
+            auto status =
+                mApp.getHerder().recvTransaction(transaction, feeBumpMinFee);
             output << "{"
                    << "\"status\": "
                    << "\"" << TX_STATUS_STRING[static_cast<int>(status)]
@@ -587,8 +587,7 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
             }
             break;
             case TransactionQueue::AddStatus::ADD_STATUS_BAD_REPLACE_BY_FEE:
-                output << " , \"fee_recommendation\": \"" << feeRecommendation
-                       << "\"";
+                output << " , \"min_fee\": \"" << feeBumpMinFee << "\"";
                 break;
             case TransactionQueue::AddStatus::ADD_STATUS_ERROR:
             {

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -784,15 +784,16 @@ Peer::recvTransaction(StellarMessage const& msg)
     {
         // add it to our current set
         // and make sure it is valid
-        auto recvRes = mApp.getHerder().recvTransaction(transaction);
+        auto recvResStatus =
+            mApp.getHerder().recvTransaction(transaction).mStatus;
 
-        if (recvRes == TransactionQueue::AddResult::ADD_STATUS_PENDING ||
-            recvRes == TransactionQueue::AddResult::ADD_STATUS_DUPLICATE)
+        if (recvResStatus == TransactionQueue::AddResult::ADD_STATUS_PENDING ||
+            recvResStatus == TransactionQueue::AddResult::ADD_STATUS_DUPLICATE)
         {
             // record that this peer sent us this transaction
             mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
 
-            if (recvRes == TransactionQueue::AddResult::ADD_STATUS_PENDING)
+            if (recvResStatus == TransactionQueue::AddResult::ADD_STATUS_PENDING)
             {
                 // if it's a new transaction, broadcast it
                 mApp.getOverlayManager().broadcastMessage(msg);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -595,7 +595,7 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
                     cat, toString(), mApp.getConfig().PEER_PORT);
 
     mApp.postOnMainThread(
-        [ err, weak, sm = StellarMessage(stellarMsg) ]() {
+        [err, weak, sm = StellarMessage(stellarMsg)]() {
             auto self = weak.lock();
             if (self)
             {
@@ -784,16 +784,16 @@ Peer::recvTransaction(StellarMessage const& msg)
     {
         // add it to our current set
         // and make sure it is valid
-        auto recvResStatus =
-            mApp.getHerder().recvTransaction(transaction).mStatus;
+        auto recvResStatus = mApp.getHerder().recvTransaction(transaction);
 
-        if (recvResStatus == TransactionQueue::AddResult::ADD_STATUS_PENDING ||
-            recvResStatus == TransactionQueue::AddResult::ADD_STATUS_DUPLICATE)
+        if (recvResStatus == TransactionQueue::AddStatus::ADD_STATUS_PENDING ||
+            recvResStatus == TransactionQueue::AddStatus::ADD_STATUS_DUPLICATE)
         {
             // record that this peer sent us this transaction
             mApp.getOverlayManager().recvFloodedMsg(msg, shared_from_this());
 
-            if (recvResStatus == TransactionQueue::AddResult::ADD_STATUS_PENDING)
+            if (recvResStatus ==
+                TransactionQueue::AddStatus::ADD_STATUS_PENDING)
             {
                 // if it's a new transaction, broadcast it
                 mApp.getOverlayManager().broadcastMessage(msg);

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -145,7 +145,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             // this is basically a modified version of Peer::recvTransaction
             auto msg = tx1->toStellarMessage();
             auto res = inApp->getHerder().recvTransaction(tx1);
-            REQUIRE(res == TransactionQueue::AddResult::ADD_STATUS_PENDING);
+            REQUIRE(res == TransactionQueue::AddStatus::ADD_STATUS_PENDING);
             inApp->getOverlayManager().broadcastMessage(msg);
         };
 

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -121,7 +121,7 @@ class LoadGenerator
                                              uint32_t ledgerNum,
                                              uint64_t sourceAccount);
     void maybeHandleFailedTx(TestAccountPtr sourceAccount,
-                             TransactionQueue::AddResult status,
+                             TransactionQueue::AddResult result,
                              TransactionResultCode code);
     TxInfo creationTransaction(uint64_t startAccount, uint64_t numItems,
                                uint32_t ledgerNum);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -71,7 +71,7 @@ class LoadGenerator
         // re-submit. Any other code points to a loadgen misconfigurations, as
         // transactions must have valid (pre-generated) source accounts,
         // sufficient balances etc.
-        TransactionQueue::AddResult execute(Application& app, bool isCreate,
+        TransactionQueue::AddStatus execute(Application& app, bool isCreate,
                                             TransactionResultCode& code,
                                             int32_t batchSize);
     };
@@ -121,7 +121,7 @@ class LoadGenerator
                                              uint32_t ledgerNum,
                                              uint64_t sourceAccount);
     void maybeHandleFailedTx(TestAccountPtr sourceAccount,
-                             TransactionQueue::AddResult result,
+                             TransactionQueue::AddStatus status,
                              TransactionResultCode code);
     TxInfo creationTransaction(uint64_t startAccount, uint64_t numItems,
                                uint32_t ledgerNum);

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -179,6 +179,8 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
     }
 
     auto const& lh = header.current();
+    // The weighted fee per operation should be higher than in the inner
+    // transaction
     auto v1 = bigMultiply(getFeeBid(), mInnerTx->getMinFee(lh));
     auto v2 = bigMultiply(mInnerTx->getFeeBid(), getMinFee(lh));
     if (v1 < v2)

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -179,8 +179,7 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
     }
 
     auto const& lh = header.current();
-    // The weighted fee per operation should be higher than in the inner
-    // transaction
+    // The fee per operation should be higher than in the inner transaction
     auto v1 = bigMultiply(getFeeBid(), mInnerTx->getMinFee(lh));
     auto v2 = bigMultiply(mInnerTx->getFeeBid(), getMinFee(lh));
     if (v1 < v2)


### PR DESCRIPTION
# Description

Fixes #2505

When the fee of a Fee Bump transaction isn't high enough to satisfy the replace-by-fee requirement, include ~a fee-rate hint to~ the minimum Fee Bump replacement fee to:

1. Be more precise on why the fee wasn't enough.
2. Give the user an opportunity to recreate a transaction with an acceptable fee (although the fee requirement is dynamic, so, there are no guarantees).

The ~hint~ minimum fee is represented as an ~rational number (i.e. providing a numerator and denominator)~  integer in the JSON response. Here is an example:

```
"min_fee": 11,
```

This approach is reactive (i.e. the user needs to try submitting a transaction in order get ~a hint~ the minimum).

Alternatively we could add a separate endpoint (or a query parameter) to only check the fee required. I think being reactive is sufficient and adding a preliminary check adds unnecessary complexity, but, I am happy to be proven wrong.

I am really looking forward to your feedback. This is my first Core PR and I haven't done C++ in 12 years, so be prepared to read cringy code.

Tests will be added once a get a GA on the approach.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
