### PR TITLE
Clear metrics when running simulation replay

### DIFF
--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -24,6 +24,7 @@ namespace stellar
 {
 namespace txsimulation
 {
+constexpr uint32_t const CLEAR_METRICS_AFTER_NUM_LEDGERS = 100;
 
 TxSimApplyTransactionsWork::TxSimApplyTransactionsWork(
     Application& app, TmpDir const& downloadDir, LedgerRange const& range,
@@ -555,9 +556,18 @@ TxSimApplyTransactionsWork::onRun()
         {
             return mApplyLedgerWork->getState();
         }
-        else if (mVerifyResults)
+        else
         {
-            checkResults(mApp, header.ledgerSeq, mResults);
+            if (mVerifyResults)
+            {
+                checkResults(mApp, header.ledgerSeq, mResults);
+            }
+            auto applied = lm.getLastClosedLedgerNum() - mRange.mFirst + 1;
+            if (applied == CLEAR_METRICS_AFTER_NUM_LEDGERS)
+            {
+                std::string domain;
+                mApp.clearMetrics(domain);
+            }
         }
     }
 


### PR DESCRIPTION
Allow replay simulation to ramp up a bit before gathering metrics for analysis