### PR TITLE
Avoid too aggressive processing of scp queue

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -449,6 +449,10 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
     {
         minLedgerSeq -= maxSlotsToRemember;
     }
+    else
+    {
+        minLedgerSeq = LedgerManager::GENESIS_LEDGER_SEQ;
+    }
 
     uint32_t maxLedgerSeq = std::numeric_limits<uint32>::max();
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -130,7 +130,7 @@ HerderImpl::bootstrap()
     mLedgerManager.bootstrap();
     mHerderSCPDriver.bootstrap();
 
-    ledgerClosed();
+    ledgerClosed(true);
 }
 
 void
@@ -236,7 +236,7 @@ HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
         mPendingEnvelopes.eraseBelow(maxSlot);
     }
 
-    ledgerClosed();
+    ledgerClosed(false);
 
     // Check to see if quorums have changed and we need to reanalyze.
     checkAndMaybeReanalyzeQuorumMap();
@@ -633,25 +633,21 @@ HerderImpl::getTransactionQueue()
 #endif
 
 void
-HerderImpl::ledgerClosed()
+HerderImpl::processSCPQueueAndTrigger()
 {
-    mTriggerTimer.cancel();
-
-    CLOG(TRACE, "Herder") << "HerderImpl::ledgerClosed";
-
+    if (mApp.isStopping())
+    {
+        return;
+    }
     auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
-
-    mPendingEnvelopes.slotClosed(lastIndex);
-
-    mApp.getOverlayManager().ledgerClosed(lastIndex);
-
     uint64_t nextIndex = mHerderSCPDriver.nextConsensusLedgerIndex();
 
     // process any statements up to this slot (this may trigger externalize)
     processSCPQueueUpToIndex(nextIndex);
 
-    // if externalize got called for a future slot, we don't
-    // need to trigger (the now obsolete) next round
+    // if externalize got called for a future slot, this is as far as we go this
+    // time around (and we let the other `ledgerClosed` event for the other
+    // ledger perform its work as it may cause some more ledgers to close)
     if (nextIndex != mHerderSCPDriver.nextConsensusLedgerIndex())
     {
         return;
@@ -683,6 +679,36 @@ HerderImpl::ledgerClosed()
         mTriggerTimer.async_wait(std::bind(&HerderImpl::triggerNextLedger, this,
                                            static_cast<uint32_t>(nextIndex)),
                                  &VirtualTimer::onFailureNoop);
+}
+
+void
+HerderImpl::ledgerClosed(bool synchronous)
+{
+    // this method is triggered every time a ledger is externalized
+    // it performs some cleanup and also decides if it needs to schedule
+    // triggering the next ledger
+
+    mTriggerTimer.cancel();
+
+    CLOG(TRACE, "Herder") << "HerderImpl::ledgerClosed";
+
+    auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
+
+    mPendingEnvelopes.slotClosed(lastIndex);
+
+    mApp.getOverlayManager().ledgerClosed(lastIndex);
+
+    if (synchronous)
+    {
+        processSCPQueueAndTrigger();
+    }
+    else
+    {
+        mApp.postOnMainThread(
+            [this]() { processSCPQueueAndTrigger(); },
+            {VirtualClock::ExecutionCategory::Type::NORMAL_EVENT,
+             "processSCPQueueAndTrigger"});
+    }
 }
 
 bool

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -121,7 +121,8 @@ class HerderImpl : public Herder
     // * it's recent enough (if `enforceRecent` is set)
     bool checkCloseTime(SCPEnvelope const& envelope, bool enforceRecent);
 
-    void ledgerClosed();
+    void processSCPQueueAndTrigger();
+    void ledgerClosed(bool synchronous);
 
     void startRebroadcastTimer();
     void rebroadcast();


### PR DESCRIPTION
This PR adjust how we process the SCP queue when we close a ledger:
in the event of a flood of externalize message (local node was stuck for some reason), there is a small possibility that the node receives enough SCP messages to externalize multiple slots in one go.

In master, this can cause arbitrary delays in processing a single message, as we recursively try to consume messages from the SCP queue.

This PR changes that, and instead posts an event back onto the main thread:
with this change, only one ledger is closed for a given message.
