### PR TITLE
add an explicit error message when running into a crypto error

### DIFF
--- a/src/crypto/Curve25519.cpp
+++ b/src/crypto/Curve25519.cpp
@@ -31,7 +31,7 @@ curve25519DerivePublic(Curve25519Secret const& sec)
     Curve25519Public out;
     if (crypto_scalarmult_base(out.key.data(), sec.key.data()) != 0)
     {
-        throw std::runtime_error("Could not derive key (mult_base)");
+        throw CryptoError("Could not derive key (mult_base)");
     }
     return out;
 }
@@ -56,7 +56,7 @@ curve25519DeriveSharedKey(Curve25519Secret const& localSecret,
     if (crypto_scalarmult(q, localSecret.key.data(), remotePublic.key.data()) !=
         0)
     {
-        throw std::runtime_error("Could not derive shared key (mult)");
+        throw CryptoError("Could not derive shared key (mult)");
     }
 #ifdef MSAN_ENABLED
     __msan_unpoison(q, crypto_scalarmult_BYTES);
@@ -77,7 +77,7 @@ curve25519Decrypt(Curve25519Secret const& localSecret,
 {
     if (encrypted.size() < crypto_box_SEALBYTES)
     {
-        throw std::runtime_error(
+        throw CryptoError(
             "encrypted.size() is less than crypto_box_SEALBYTES!");
     }
 
@@ -88,7 +88,7 @@ curve25519Decrypt(Curve25519Secret const& localSecret,
                              encrypted.size(), localPublic.key.data(),
                              localSecret.key.data()) != 0)
     {
-        throw std::runtime_error("curve25519Decrypt failed");
+        throw CryptoError("curve25519Decrypt failed");
     }
 
     return decrypted;

--- a/src/crypto/Curve25519.h
+++ b/src/crypto/Curve25519.h
@@ -13,7 +13,13 @@
 
 namespace stellar
 {
-
+class CryptoError : public std::runtime_error
+{
+  public:
+    CryptoError(std::string const& msg) : std::runtime_error(msg)
+    {
+    }
+};
 // This module contains functions for doing ECDH on Curve25519. Despite the
 // equivalence between this curve and Ed25519 (used in signatures, see
 // SecretKey.h) we use Curve25519 keys _only_ for ECDH shared-key-agreement

--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -4,6 +4,7 @@
 
 #include "crypto/SHA.h"
 #include "crypto/ByteSlice.h"
+#include "crypto/Curve25519.h"
 #include "util/NonCopyable.h"
 #include <sodium.h>
 
@@ -17,7 +18,7 @@ sha256(ByteSlice const& bin)
     uint256 out;
     if (crypto_hash_sha256(out.data(), bin.data(), bin.size()) != 0)
     {
-        throw std::runtime_error("error from crypto_hash_sha256");
+        throw CryptoError("error from crypto_hash_sha256");
     }
     return out;
 }
@@ -50,7 +51,7 @@ SHA256Impl::reset()
 {
     if (crypto_hash_sha256_init(&mState) != 0)
     {
-        throw std::runtime_error("error from crypto_hash_sha256_init");
+        throw CryptoError("error from crypto_hash_sha256_init");
     }
     mFinished = false;
 }
@@ -64,7 +65,7 @@ SHA256Impl::add(ByteSlice const& bin)
     }
     if (crypto_hash_sha256_update(&mState, bin.data(), bin.size()) != 0)
     {
-        throw std::runtime_error("error from crypto_hash_sha256_update");
+        throw CryptoError("error from crypto_hash_sha256_update");
     }
 }
 
@@ -79,7 +80,7 @@ SHA256Impl::finish()
     }
     if (crypto_hash_sha256_final(&mState, out.data()) != 0)
     {
-        throw std::runtime_error("error from crypto_hash_sha256_final");
+        throw CryptoError("error from crypto_hash_sha256_final");
     }
     return out;
 }
@@ -92,7 +93,7 @@ hmacSha256(HmacSha256Key const& key, ByteSlice const& bin)
     if (crypto_auth_hmacsha256(out.mac.data(), bin.data(), bin.size(),
                                key.key.data()) != 0)
     {
-        throw std::runtime_error("error from crypto_auto_hmacsha256");
+        throw CryptoError("error from crypto_auto_hmacsha256");
     }
     return out;
 }

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/SecretKey.h"
+#include "crypto/Curve25519.h"
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
 #include "crypto/SHA.h"
@@ -88,7 +89,7 @@ SecretKey::getSeed() const
     if (crypto_sign_ed25519_sk_to_seed(seed.mSeed.data(), mSecretKey.data()) !=
         0)
     {
-        throw std::runtime_error("error extracting seed from secret key");
+        throw CryptoError("error extracting seed from secret key");
     }
     return seed;
 }
@@ -129,7 +130,7 @@ SecretKey::sign(ByteSlice const& bin) const
     if (crypto_sign_detached(out.data(), NULL, bin.data(), bin.size(),
                              mSecretKey.data()) != 0)
     {
-        throw std::runtime_error("error while signing");
+        throw CryptoError("error while signing");
     }
     return out;
 }
@@ -142,7 +143,7 @@ SecretKey::random()
     if (crypto_sign_keypair(sk.mPublicKey.ed25519().data(),
                             sk.mSecretKey.data()) != 0)
     {
-        throw std::runtime_error("error generating random secret key");
+        throw CryptoError("error generating random secret key");
     }
 #ifdef MSAN_ENABLED
     __msan_unpoison(out.key.data(), out.key.size());
@@ -190,12 +191,12 @@ SecretKey::fromSeed(ByteSlice const& seed)
 
     if (seed.size() != crypto_sign_SEEDBYTES)
     {
-        throw std::runtime_error("seed does not match byte size");
+        throw CryptoError("seed does not match byte size");
     }
     if (crypto_sign_seed_keypair(sk.mPublicKey.ed25519().data(),
                                  sk.mSecretKey.data(), seed.data()) != 0)
     {
-        throw std::runtime_error("error generating secret key from seed");
+        throw CryptoError("error generating secret key from seed");
     }
     return sk;
 }
@@ -210,7 +211,7 @@ SecretKey::fromStrKeySeed(std::string const& strKeySeed)
         (seed.size() != crypto_sign_SEEDBYTES) ||
         (strKeySeed.size() != strKey::getStrKeySize(crypto_sign_SEEDBYTES)))
     {
-        throw std::runtime_error("invalid seed");
+        throw CryptoError("invalid seed");
     }
 
     SecretKey sk;
@@ -218,7 +219,7 @@ SecretKey::fromStrKeySeed(std::string const& strKeySeed)
     if (crypto_sign_seed_keypair(sk.mPublicKey.ed25519().data(),
                                  sk.mSecretKey.data(), seed.data()) != 0)
     {
-        throw std::runtime_error("error generating secret key from seed");
+        throw CryptoError("error generating secret key from seed");
     }
     return sk;
 }
@@ -267,7 +268,7 @@ KeyFunctions<PublicKey>::toKeyType(strKey::StrKeyVersionByte keyVersion)
     case strKey::STRKEY_PUBKEY_ED25519:
         return PublicKeyType::PUBLIC_KEY_TYPE_ED25519;
     default:
-        throw std::invalid_argument("invalid public key type");
+        throw CryptoError("invalid public key type");
     }
 }
 
@@ -279,7 +280,7 @@ KeyFunctions<PublicKey>::toKeyVersion(PublicKeyType keyType)
     case PublicKeyType::PUBLIC_KEY_TYPE_ED25519:
         return strKey::STRKEY_PUBKEY_ED25519;
     default:
-        throw std::invalid_argument("invalid public key type");
+        throw CryptoError("invalid public key type");
     }
 }
 
@@ -291,7 +292,7 @@ KeyFunctions<PublicKey>::getKeyValue(PublicKey& key)
     case PUBLIC_KEY_TYPE_ED25519:
         return key.ed25519();
     default:
-        throw std::invalid_argument("invalid public key type");
+        throw CryptoError("invalid public key type");
     }
 }
 
@@ -303,7 +304,7 @@ KeyFunctions<PublicKey>::getKeyValue(PublicKey const& key)
     case PUBLIC_KEY_TYPE_ED25519:
         return key.ed25519();
     default:
-        throw std::invalid_argument("invalid public key type");
+        throw CryptoError("invalid public key type");
     }
 }
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -599,7 +599,18 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
             auto self = weak.lock();
             if (self)
             {
-                self->recvRawMessage(sm);
+                try
+                {
+                    self->recvRawMessage(sm);
+                }
+                catch (CryptoError const& e)
+                {
+                    CLOG(ERROR, "Overlay") << fmt::format(
+                        "Dropping connection with {}: {}", err, e.what());
+                    self->drop("Bad crypto request",
+                               Peer::DropDirection::WE_DROPPED_REMOTE,
+                               Peer::DropMode::IGNORE_WRITE_QUEUE);
+                }
             }
             else
             {

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/TCPPeer.h"
+#include "crypto/Curve25519.h"
 #include "database/Database.h"
 #include "main/Application.h"
 #include "main/Config.h"
@@ -621,6 +622,12 @@ TCPPeer::recvMessage()
     {
         CLOG(ERROR, "Overlay") << "recvMessage got a corrupt xdr: " << e.what();
         sendErrorAndDrop(ERR_DATA, "received corrupt XDR",
+                         Peer::DropMode::IGNORE_WRITE_QUEUE);
+    }
+    catch (CryptoError const& e)
+    {
+        CLOG(ERROR, "Overlay") << fmt::format("Crypto error: {}", e.what());
+        sendErrorAndDrop(ERR_DATA, "crypto error",
                          Peer::DropMode::IGNORE_WRITE_QUEUE);
     }
 }


### PR DESCRIPTION
When running into libsodium errors, we were throwing the generic "runtime_error", this PR gives them a dedicated type.
