### PR TITLE
Make print-xdr display account IDs properly

### DIFF
--- a/docs/software/testnet.md
+++ b/docs/software/testnet.md
@@ -8,7 +8,7 @@ Review the [admin guide](./admin.md) for more detailed information.
 
 First, make sure you have copied the example config to your current working directory.
 From the TLD of the repo, run
-`cp docs/stellar_core_standalone.cfg ./bin/stellar-core.cfg`
+`cp docs/stellar-core_standalone.cfg ./bin/stellar-core.cfg`
 
 By default stellar-core waits to hear from the network for a ledger close before
 it starts emitting its own SCP messages. This works fine in the common case but

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -116,6 +116,13 @@ xdr_printer(const PublicKey& pk)
     return KeyUtils::toStrKey<PublicKey>(pk);
 }
 
+std::string 
+xdr_printer(const MuxedAccount& muxedAccount)
+{
+    return "muxedAccount xdr_printer has not been implmented!";
+}
+
+
 template <typename T>
 void
 dumpstream(XDRInputFileStream& in, bool json)

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -1,8 +1,10 @@
 #include "main/dumpxdr.h"
 #include "crypto/Hex.h"
 #include "crypto/SecretKey.h"
+#include "crypto/StrKey.h"
 #include "transactions/SignatureUtils.h"
 #include "transactions/TransactionBridge.h"
+#include "transactions/TransactionUtils.h"
 #include "util/Decoder.h"
 #include "util/Fs.h"
 #include "util/XDROperators.h"
@@ -119,7 +121,22 @@ xdr_printer(const PublicKey& pk)
 std::string 
 xdr_printer(const MuxedAccount& muxedAccount)
 {
-    return "muxedAccount xdr_printer has not been implmented!";
+    std::stringstream res;
+    switch (muxedAccount.type())
+    {
+        case KEY_TYPE_ED25519:
+            res << KeyUtils::toStrKey(toAccountID(muxedAccount));
+            break;
+        case KEY_TYPE_MUXED_ED25519:
+            res << "{ id = " << muxedAccount.med25519().id << ", ";
+            res << "accountID = " << KeyUtils::toStrKey(toAccountID(muxedAccount));
+            res << " }";
+            break;
+        default:
+            // this would be a bug
+            abort();
+    }
+    return res.str();
 }
 
 

--- a/src/overlay/StellarXDR.h
+++ b/src/overlay/StellarXDR.h
@@ -9,4 +9,5 @@ namespace stellar
 {
 
 std::string xdr_printer(const PublicKey& pk);
+std::string xdr_printer(const MuxedAccount& ma);
 }


### PR DESCRIPTION
# Description

Resolves #2528

<!---

Properly display accountID with `print-xdr`.

(I haven't run clang-format as it's taking my computer a while to finish installing it, but I will do so as soon as it is done.)
--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
