### PR TITLE
Fix a typo in a command in testnet.md

### DIFF
--- a/docs/software/testnet.md
+++ b/docs/software/testnet.md
@@ -8,7 +8,7 @@ Review the [admin guide](./admin.md) for more detailed information.
 
 First, make sure you have copied the example config to your current working directory.
 From the TLD of the repo, run
-`cp docs/stellar_core_standalone.cfg ./bin/stellar-core.cfg`
+`cp docs/stellar-core_standalone.cfg ./bin/stellar-core.cfg`
 
 By default stellar-core waits to hear from the network for a ledger close before
 it starts emitting its own SCP messages. This works fine in the common case but


### PR DESCRIPTION
# Description

The file name in the command is incorrect.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
