### PR TITLE
Fix how we schedule trigger timer

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -653,79 +653,73 @@ HerderImpl::getTransactionQueue()
 #endif
 
 void
-HerderImpl::processSCPQueueAndTrigger()
-{
-    if (mApp.isStopping())
-    {
-        return;
-    }
-    auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
-    uint64_t nextIndex = mHerderSCPDriver.nextConsensusLedgerIndex();
-
-    // process any statements up to this slot (this may trigger externalize)
-    processSCPQueueUpToIndex(nextIndex);
-
-    // if externalize got called for a future slot, this is as far as we go this
-    // time around (and we let the other `ledgerClosed` event for the other
-    // ledger perform its work as it may cause some more ledgers to close)
-    if (nextIndex != mHerderSCPDriver.nextConsensusLedgerIndex())
-    {
-        return;
-    }
-
-    if (!mLedgerManager.isSynced())
-    {
-        CLOG(DEBUG, "Herder")
-            << "Not presently synced, not triggering ledger-close.";
-        return;
-    }
-
-    auto seconds = mApp.getConfig().getExpectedLedgerCloseTime();
-
-    // bootstrap with a pessimistic estimate of when
-    // the ballot protocol started last
-    auto lastBallotStart = mApp.getClock().now() - seconds;
-    auto lastStart = mHerderSCPDriver.getPrepareStart(lastIndex);
-    if (lastStart)
-    {
-        lastBallotStart = *lastStart;
-    }
-    // even if ballot protocol started before triggering, we just use that time
-    // as reference point for triggering again (this may trigger right away if
-    // externalizing took a long time)
-    mTriggerTimer.expires_at(lastBallotStart + seconds);
-
-    if (!mApp.getConfig().MANUAL_CLOSE)
-        mTriggerTimer.async_wait(std::bind(&HerderImpl::triggerNextLedger, this,
-                                           static_cast<uint32_t>(nextIndex)),
-                                 &VirtualTimer::onFailureNoop);
-}
-
-void
 HerderImpl::ledgerClosed(bool synchronous)
 {
-    // this method is triggered every time a ledger is externalized
-    // it performs some cleanup and also decides if it needs to schedule
-    // triggering the next ledger
+    // this method is triggered every time the most recent ledger is
+    // externalized it performs some cleanup and also decides if it needs to
+    // schedule triggering the next ledger
 
     mTriggerTimer.cancel();
 
     CLOG(TRACE, "Herder") << "HerderImpl::ledgerClosed";
 
     auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
+    uint64_t nextIndex = mHerderSCPDriver.nextConsensusLedgerIndex();
 
     mPendingEnvelopes.slotClosed(lastIndex);
 
     mApp.getOverlayManager().ledgerClosed(lastIndex);
 
-    if (synchronous)
+    if (mLedgerManager.isSynced())
     {
-        processSCPQueueAndTrigger();
+        // if we're in sync, we setup mTriggerTimer
+        // it may get cancelled if a more recent ledger externalizes
+
+        auto seconds = mApp.getConfig().getExpectedLedgerCloseTime();
+
+        // bootstrap with a pessimistic estimate of when
+        // the ballot protocol started last
+        auto lastBallotStart = mApp.getClock().now() - seconds;
+        auto lastStart = mHerderSCPDriver.getPrepareStart(lastIndex);
+        if (lastStart)
+        {
+            lastBallotStart = *lastStart;
+        }
+        // even if ballot protocol started before triggering, we just use that
+        // time as reference point for triggering again (this may trigger right
+        // away if externalizing took a long time)
+        mTriggerTimer.expires_at(lastBallotStart + seconds);
+
+        if (!mApp.getConfig().MANUAL_CLOSE)
+            mTriggerTimer.async_wait(
+                std::bind(&HerderImpl::triggerNextLedger, this,
+                          static_cast<uint32_t>(nextIndex)),
+                &VirtualTimer::onFailureNoop);
     }
     else
     {
-        mApp.postOnMainThread([this]() { processSCPQueueAndTrigger(); },
-                              "processSCPQueueAndTrigger");
+        CLOG(DEBUG, "Herder")
+            << "Not presently synced, not triggering ledger-close.";
+    }
+
+    // process any statements up to the next slot
+    // this may cause it to externalize
+    auto processSCPQueueSomeMore = [this, nextIndex]() {
+        if (mApp.isStopping())
+        {
+            return;
+        }
+        processSCPQueueUpToIndex(nextIndex);
+    };
+
+    if (synchronous)
+    {
+        processSCPQueueSomeMore();
+    }
+    else
+    {
+        mApp.postOnMainThread(processSCPQueueSomeMore,
+                              "processSCPQueueSomeMore");
     }
 }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -192,7 +192,8 @@ HerderImpl::processExternalized(uint64 slotIndex, StellarValue const& value)
     // tell the LedgerManager that this value got externalized
     // LedgerManager will perform the proper action based on its internal
     // state: apply, trigger catchup, etc
-    LedgerCloseData ledgerData(slotIndex, externalizedSet, value);
+    LedgerCloseData ledgerData(static_cast<uint32_t>(slotIndex),
+                               externalizedSet, value);
     mLedgerManager.valueExternalized(ledgerData);
 }
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -122,7 +122,6 @@ class HerderImpl : public Herder
     // * it's recent enough (if `enforceRecent` is set)
     bool checkCloseTime(SCPEnvelope const& envelope, bool enforceRecent);
 
-    void processSCPQueueAndTrigger();
     void ledgerClosed(bool synchronous);
 
     void startRebroadcastTimer();

--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -22,7 +22,7 @@ getMinBalance(LedgerHeader const& header, uint32_t ownerCount)
     if (header.ledgerVersion <= 8)
         return (2 + ownerCount) * header.baseReserve;
     else
-        return (2 + ownerCount) * int64_t(header.baseReserve);
+        return (2LL + ownerCount) * int64_t(header.baseReserve);
 }
 
 static int64_t

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -370,7 +370,7 @@ LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
     if (lh.ledgerVersion <= 8)
         return (2 + ownerCount) * lh.baseReserve;
     else
-        return (2 + ownerCount) * int64_t(lh.baseReserve);
+        return (2LL + ownerCount) * int64_t(lh.baseReserve);
 }
 
 uint32_t

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -559,7 +559,7 @@ getMinBalance(LedgerTxnHeader const& header, uint32_t ownerCount)
     if (lh.ledgerVersion <= 8)
         return (2 + ownerCount) * lh.baseReserve;
     else
-        return (2 + ownerCount) * int64_t(lh.baseReserve);
+        return (2LL + ownerCount) * int64_t(lh.baseReserve);
 }
 
 int64_t

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -17,17 +17,6 @@ rand_fraction()
     return uniformFractionDistribution(gRandomEngine);
 }
 
-size_t
-rand_pareto(float alpha, size_t max)
-{
-    // from http://www.pamvotis.org/vassis/RandGen.htm
-    float f =
-        static_cast<float>(1) /
-        static_cast<float>(pow(rand_fraction(), static_cast<float>(1) / alpha));
-    // modified into a truncated pareto
-    return static_cast<size_t>(f * max - 1) % max;
-}
-
 bool
 rand_flip()
 {

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -12,8 +12,6 @@ namespace stellar
 {
 double rand_fraction();
 
-size_t rand_pareto(float alpha, size_t max);
-
 bool rand_flip();
 
 extern std::default_random_engine gRandomEngine;

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -352,7 +352,7 @@ VirtualClock::duration
 BasicWork::getRetryDelay() const
 {
     // Cap to 512 sec or ~8 minutes
-    uint64_t m = 2 << std::min(uint64_t(8), uint64_t(mRetries));
+    uint64_t m = 2ULL << std::min(uint64_t(8), uint64_t(mRetries));
     return std::chrono::seconds(rand_uniform<uint64_t>(1ULL, m));
 }
 


### PR DESCRIPTION
This PR fixes a potential issue introduced in b28fca6fa71d11fd644d4e0d5e8de9bdc3a764d3 : 

in that change, we schedule starting nomination from within the callback that gets posted when a ledger closes.

The problem is that if for some reason the execution of the callback is delayed (the scheduler may decide to prioritize other actions), the node may miss its window to start nomination (timers do not get throttled the same way).
