### PR TITLE
Make print-xdr display account IDs properly

### DIFF
--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -1,8 +1,10 @@
 #include "main/dumpxdr.h"
 #include "crypto/Hex.h"
 #include "crypto/SecretKey.h"
+#include "crypto/StrKey.h"
 #include "transactions/SignatureUtils.h"
 #include "transactions/TransactionBridge.h"
+#include "transactions/TransactionUtils.h"
 #include "util/Decoder.h"
 #include "util/Fs.h"
 #include "util/XDROperators.h"
@@ -111,9 +113,26 @@ namespace stellar
 {
 
 std::string
-xdr_printer(const PublicKey& pk)
+xdr_printer(PublicKey const& pk)
 {
     return KeyUtils::toStrKey<PublicKey>(pk);
+}
+
+std::string
+xdr_printer(MuxedAccount const& muxedAccount)
+{
+    switch (muxedAccount.type())
+    {
+    case KEY_TYPE_ED25519:
+        return KeyUtils::toStrKey(toAccountID(muxedAccount));
+    case KEY_TYPE_MUXED_ED25519:
+        return fmt::format("{{ id = {}, accountID = {} }}",
+                           muxedAccount.med25519().id,
+                           KeyUtils::toStrKey(toAccountID(muxedAccount)));
+    default:
+        // this would be a bug
+        abort();
+    }
 }
 
 template <typename T>

--- a/src/overlay/StellarXDR.h
+++ b/src/overlay/StellarXDR.h
@@ -8,5 +8,6 @@
 namespace stellar
 {
 
-std::string xdr_printer(const PublicKey& pk);
+std::string xdr_printer(PublicKey const& pk);
+std::string xdr_printer(MuxedAccount const& ma);
 }


### PR DESCRIPTION
# Description

Resolves issue #2528  by implementing xdr_printer for MuxedAccount

This change is almost the same as PR https://github.com/stellar/stellar-core/pull/2536, but I closed the PR because I accidentally created the PR from my master branch, which created some problems.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
