### PR TITLE
fix(INSTALL.md): fix libpq-fe.h file not found

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,6 +91,7 @@ When building on OSX, here's some dependencies you'll need:
 - brew install automake
 - brew install pkg-config
 - brew install libpqxx *(If ./configure later complains about libpq missing, try PKG_CONFIG_PATH='/usr/local/lib/pkgconfig')*
+- brew install postgresql *(deal with fatal error: 'libpq-fe.h' file not found stellar)
 - brew install parallel (required for running tests)
 
 ### Windows


### PR DESCRIPTION
# Description
Per description of [this](https://github.com/stellar/stellar-core/issues/864) issue. When installing Stellar-core on macOS Mojave, the solution to it indeed avoids compiling errors. However, some components can't work as expected after adopting the solution. With the line, `brew install postgresql`, instead, MacOS users can now install the system without potentially missing anything.
Resolves #X

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).
--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
