### PR TITLE
Add tracy submodule, integrate client into build, annotate core.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/fmt"]
 	path = lib/fmt
 	url = https://github.com/fmtlib/fmt
+[submodule "lib/tracy"]
+	path = lib/tracy
+	url = https://github.com/stellar/tracy

--- a/COPYING
+++ b/COPYING
@@ -197,3 +197,11 @@ lib/util/finally.h
   (https://github.com/Microsoft/GSL)
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
+
+lib/tracy
+
+  Tracy Profiler
+  Copyright (c) 2017-2020, Bartosz Taudul <wolf.pld@gmail.com>
+  (https://bitbucket.org/wolfpld/tracy)
+  Licensed under the 3-clause BSD license.
+  (https://opensource.org/licenses/BSD-3-Clause)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -133,3 +133,20 @@ Here are sample steps to achieve this:
     git clone https://github.com/stellar/stellar-core.git
     cd stellar-core/
     ./autogen.sh && ./configure && make -j6
+
+## Building with Tracing
+
+Configuring with `--enable-tracy` will build and embed the client component of the [Tracy](https://github.com/wolfpld/tracy) high-resolution tracing system in the `stellar-core` binary.
+
+The tracing client will activate automatically when stellar-core is running, and will listen for connections from Tracy servers (a command-line capture utility, or a cross-platform GUI).
+
+The Tracy server components can also be compiled by configuring with `--enable-tracy-gui` or `--enable-tracy-capture`.
+
+The GUI depends on the `capstone`, `freetype` and `glfw` libraries and their headers, and on linux or BSD the `GTK-2.0` libraries and headers. On Windows and MacOS, native toolkits are used instead.
+
+
+    # On Ubuntu
+    $ sudo apt-get install libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev
+
+    # On MacOS
+    $ brew install capstone freetype2 glfw

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,30 @@ fuzz-testcases fuzz fuzz-clean: all
 	cd src && $(MAKE) $(AM_MAKEFLAGS) $@
 endif # USE_AFL_FUZZ
 
+if USE_TRACY_GUI
+TRACY_GUI_DIR=$(top_srcdir)/lib/tracy/profiler
+TRACY_GUI_SOURCE=$(TRACY_GUI_DIR)/src
+TRACY_GUI_BUILD=$(TRACY_GUI_DIR)/build/unix
+
+$(TRACY_GUI_BUILD)/Tracy-release: $(wildcard $(TRACY_GUI_SOURCE)/*.*)
+	$(MAKE) -C $(TRACY_GUI_BUILD) release CC="$(CC)" CXX="$(CXX)"
+
+tracy-gui: $(TRACY_GUI_BUILD)/Tracy-release
+	cp -v $< $@
+endif # USE_TRACY_GUI
+
+if USE_TRACY_CAPTURE
+TRACY_CAPTURE_DIR=$(top_srcdir)/lib/tracy/capture
+TRACY_CAPTURE_SOURCE=$(TRACY_CAPTURE_DIR)/src
+TRACY_CAPTURE_BUILD=$(TRACY_CAPTURE_DIR)/build/unix
+
+$(TRACY_CAPTURE_BUILD)/capture-release: $(wildcard $(TRACY_CAPTURE_SOURCE)/*.*)
+	$(MAKE) -C $(TRACY_CAPTURE_BUILD) release CC="$(CC)" CXX="$(CXX)"
+
+tracy-capture: $(TRACY_CAPTURE_BUILD)/capture-release
+	cp -v $< $@
+endif # USE_TRACY_CAPTURE
+
 EXTRA_DIST = stellar-core.supp test/testnet/multitail.conf	\
 	test/testnet/run-test.sh README.md make-mks
 

--- a/common.mk
+++ b/common.mk
@@ -8,11 +8,22 @@ AM_CPPFLAGS += -isystem "$(top_srcdir)/lib"             \
 	-isystem "$(top_srcdir)/lib/cereal/include"         \
 	-isystem "$(top_srcdir)/lib/util"                   \
 	-isystem "$(top_srcdir)/lib/fmt/include"            \
-	-isystem "$(top_srcdir)/lib/soci/src/core"
+	-isystem "$(top_srcdir)/lib/soci/src/core"          \
+	-isystem "$(top_srcdir)/lib/tracy"
 
 if USE_POSTGRES
 AM_CPPFLAGS += -DUSE_POSTGRES=1 $(libpq_CFLAGS)
 endif # USE_POSTGRES
+
+# USE_TRACY and tracy_CFLAGS here represent the case of enabling
+# tracy at configure-time; but even when it is disabled we want
+# its includes in the CPPFLAGS above, so its (disabled) headers
+# and zone-definition macros are included in our code (and
+# compiled to no-ops).
+if USE_TRACY
+AM_CPPFLAGS += -DUSE_TRACY $(tracy_CFLAGS)
+endif # USE_TRACY
+
 if BUILD_TESTS
 AM_CPPFLAGS += -DBUILD_TESTS=1
 endif # BUILD_TESTS

--- a/configure.ac
+++ b/configure.ac
@@ -11,6 +11,7 @@ AC_INIT([stellar-core],[0.1],[],[],[http://www.stellar.org])
 AM_INIT_AUTOMAKE([-Wall -Wextra -Wconversion subdir-objects tar-ustar silent-rules])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_MACRO_DIR([m4])
+AC_CANONICAL_HOST
 
 AC_ARG_VAR([LIBCXX_PATH], [path to libc++ and libc++abi])
 
@@ -292,6 +293,44 @@ AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],
         [Disable building test suite]))
 AM_CONDITIONAL(BUILD_TESTS, [test x$enable_tests != xno])
+
+AC_ARG_ENABLE(tracy,
+    AS_HELP_STRING([--enable-tracy],
+        [Enable 'tracy' profiler/tracer client stub]))
+AM_CONDITIONAL(USE_TRACY, [test x$enable_tracy = xyes])
+tracy_CFLAGS='-DTRACY_ENABLE -DTRACY_ON_DEMAND -DTRACY_NO_BROADCAST -DTRACY_ONLY_LOCALHOST'
+if test x"$enable_tracy" = xyes; then
+    case "${host_os}" in
+        *darwin*)
+            ;;
+        *)
+            LDFLAGS+=" -ldl "
+            ;;
+    esac
+fi
+AC_SUBST(tracy_CFLAGS)
+
+AC_ARG_ENABLE(tracy-gui,
+    AS_HELP_STRING([--enable-tracy-gui],
+        [Enable 'tracy' profiler/tracer server GUI]))
+AM_CONDITIONAL(USE_TRACY_GUI, [test x$enable_tracy_gui = xyes])
+if test x"$enable_tracy_gui" = xyes; then
+    PKG_CHECK_MODULES(capstone, capstone)
+    PKG_CHECK_MODULES(freetype, freetype2)
+    PKG_CHECK_MODULES(glfw, glfw3)
+    case "${host_os}" in
+        *darwin*)
+            ;;
+        *)
+            PKG_CHECK_MODULES(gtk, gtk+-2.0)
+            ;;
+    esac
+fi
+
+AC_ARG_ENABLE(tracy-capture,
+    AS_HELP_STRING([--enable-tracy-capture],
+        [Enable 'tracy' profiler/tracer capture program]))
+AM_CONDITIONAL(USE_TRACY_CAPTURE, [test x$enable_tracy_capture = xyes])
 
 # Need this to pass through ccache for xdrpp, libsodium
 esc() {

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -23,6 +23,9 @@ libsoci_a_SOURCES += $(SOCI_PG_FILES)
 endif # USE_POSTGRES
 
 lib3rdparty_a_SOURCES = $(UTIL_FILES) $(ASIO_CXX_FILES) $(JSON_FILES) $(SQLITE3_FILES)
+if USE_TRACY
+lib3rdparty_a_SOURCES += $(TRACY_CXX_FILES)
+endif # USE_TRACY
 noinst_HEADERS = $(MISC_H_FILES) $(ASIO_H_FILES)
 
 # Suppress any installation of SUBDIRS, which may be distributed separately

--- a/make-mks
+++ b/make-mks
@@ -51,6 +51,7 @@ listall() {
  # The following does not work without boost or -DASIO_STANDALONE=1
  #echo ASIO_CXX_FILES = asio/src/*.cpp
  echo ASIO_CXX_FILES = asio.cpp
+ echo TRACY_CXX_FILES = tracy/TracyClient.cpp
  echo JSON_FILES = $(listall json)
 
  echo MISC_H_FILES = *.hpp $(listall autocheck cereal fmt)

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -24,6 +24,7 @@
 #include "util/TmpDir.h"
 #include "util/XDRStream.h"
 #include "xdrpp/message.h"
+#include <Tracy.hpp>
 #include <cassert>
 #include <fmt/format.h>
 #include <future>
@@ -84,6 +85,7 @@ Bucket::containsBucketIdentity(BucketEntry const& id) const
 void
 Bucket::apply(Application& app) const
 {
+    ZoneScoped;
     BucketApplicator applicator(app, app.getConfig().LEDGER_PROTOCOL_VERSION,
                                 shared_from_this());
     BucketApplicator::Counters counters(app.getClock().now());
@@ -140,6 +142,7 @@ Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
               std::vector<LedgerKey> const& deadEntries, bool countMergeEvents,
               asio::io_context& ctx, bool doFsync)
 {
+    ZoneScoped;
     // When building fresh buckets after protocol version 10 (i.e. version
     // 11-or-after) we differentiate INITENTRY from LIVEENTRY. In older
     // protocols, for compatibility sake, we mark both cases as LIVEENTRY.
@@ -592,6 +595,7 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
               bool keepDeadEntries, bool countMergeEvents,
               asio::io_context& ctx, bool doFsync)
 {
+    ZoneScoped;
     // This is the key operation in the scheme: merging two (read-only)
     // buckets together into a new 3rd bucket, while calculating its hash,
     // in a single pass.

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -4,6 +4,7 @@
 
 #include "bucket/BucketInputIterator.h"
 #include "bucket/Bucket.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -14,6 +15,7 @@ namespace stellar
 void
 BucketInputIterator::loadEntry()
 {
+    ZoneScoped;
     if (mIn.readOne(mEntry))
     {
         mEntryPtr = &mEntry;

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -13,6 +13,7 @@
 #include "util/Logging.h"
 #include "util/XDRStream.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 #include <cassert>
 #include <fmt/format.h>
 
@@ -156,6 +157,7 @@ BucketLevel::prepare(Application& app, uint32_t currLedger,
                      std::vector<std::shared_ptr<Bucket>> const& shadows,
                      bool countMergeEvents)
 {
+    ZoneScoped;
     // If more than one absorb is pending at the same time, we have a logic
     // error in our caller (and all hell will break loose).
     assert(!mNextCurr.isMerging());
@@ -364,6 +366,7 @@ BucketList::oldestLedgerInSnap(uint32_t ledger, uint32_t level)
 uint256
 BucketList::getHash() const
 {
+    ZoneScoped;
     auto hsh = SHA256::create();
     for (auto const& lev : mLevels)
     {
@@ -425,6 +428,7 @@ BucketList::getLevel(uint32_t i)
 void
 BucketList::resolveAnyReadyFutures()
 {
+    ZoneScoped;
     for (auto& level : mLevels)
     {
         if (level.getNext().isMerging() && level.getNext().mergeComplete())
@@ -437,6 +441,7 @@ BucketList::resolveAnyReadyFutures()
 bool
 BucketList::futuresAllResolved(uint32_t maxLevel) const
 {
+    ZoneScoped;
     assert(maxLevel < mLevels.size());
 
     for (uint32_t i = 0; i <= maxLevel; i++)
@@ -470,6 +475,7 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
                      std::vector<LedgerEntry> const& liveEntries,
                      std::vector<LedgerKey> const& deadEntries)
 {
+    ZoneScoped;
     assert(currLedger > 0);
 
     std::vector<std::shared_ptr<Bucket>> shadows;
@@ -597,6 +603,7 @@ void
 BucketList::restartMerges(Application& app, uint32_t maxProtocolVersion,
                           uint32_t ledger)
 {
+    ZoneScoped;
     for (uint32_t i = 0; i < static_cast<uint32>(mLevels.size()); i++)
     {
         auto& level = mLevels[i];

--- a/src/bucket/BucketMergeMap.cpp
+++ b/src/bucket/BucketMergeMap.cpp
@@ -5,12 +5,14 @@
 #include "bucket/BucketMergeMap.h"
 #include "crypto/Hex.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace
 {
 std::unordered_set<stellar::Hash>
 getMergeKeyHashes(stellar::MergeKey const& key)
 {
+    ZoneScoped;
     std::unordered_set<stellar::Hash> hashes;
     hashes.emplace(key.mInputCurrBucket);
     hashes.emplace(key.mInputSnapBucket);
@@ -28,6 +30,7 @@ namespace stellar
 void
 BucketMergeMap::recordMerge(MergeKey const& input, Hash const& output)
 {
+    ZoneScoped;
     mMergeKeyToOutput.emplace(input, output);
     mOutputToMergeKey.emplace(output, input);
     for (auto const& in : getMergeKeyHashes(input))
@@ -41,6 +44,7 @@ BucketMergeMap::recordMerge(MergeKey const& input, Hash const& output)
 std::unordered_set<MergeKey>
 BucketMergeMap::forgetAllMergesProducing(Hash const& outputBeingDropped)
 {
+    ZoneScoped;
     std::unordered_set<MergeKey> ret;
     auto mergesProducingOutput =
         mOutputToMergeKey.equal_range(outputBeingDropped);
@@ -102,6 +106,7 @@ BucketMergeMap::forgetAllMergesProducing(Hash const& outputBeingDropped)
 bool
 BucketMergeMap::findMergeFor(MergeKey const& input, Hash& output)
 {
+    ZoneScoped;
     auto i = mMergeKeyToOutput.find(input);
     if (i != mMergeKeyToOutput.end())
     {
@@ -115,6 +120,7 @@ void
 BucketMergeMap::getOutputsUsingInput(Hash const& input,
                                      std::set<Hash>& outputs) const
 {
+    ZoneScoped;
     auto pair = mInputToOutput.equal_range(input);
     for (auto i = pair.first; i != pair.second; ++i)
     {

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -6,6 +6,7 @@
 #include "bucket/Bucket.h"
 #include "bucket/BucketManager.h"
 #include "crypto/Random.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -15,6 +16,7 @@ namespace
 std::string
 randomBucketName(std::string const& tmpDir)
 {
+    ZoneScoped;
     for (;;)
     {
         std::string name =
@@ -45,6 +47,7 @@ BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
     , mMeta(meta)
     , mMergeCounters(mc)
 {
+    ZoneScoped;
     CLOG(TRACE, "Bucket") << "BucketOutputIterator opening file to write: "
                           << mFilename;
     // Will throw if unable to open the file
@@ -64,6 +67,7 @@ BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
 void
 BucketOutputIterator::put(BucketEntry const& e)
 {
+    ZoneScoped;
     Bucket::checkProtocolLegality(e, mMeta.ledgerVersion);
     if (e.type() == METAENTRY)
     {
@@ -110,6 +114,7 @@ std::shared_ptr<Bucket>
 BucketOutputIterator::getBucket(BucketManager& bucketManager,
                                 MergeKey* mergeKey)
 {
+    ZoneScoped;
     if (mBuf)
     {
         mOut.writeOne(*mBuf, mHasher.get(), &mBytesPut);

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -15,6 +15,7 @@
 #include "invariant/InvariantManager.h"
 #include "ledger/LedgerTxn.h"
 #include "main/Application.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
@@ -63,6 +64,7 @@ ApplyBucketsWork::getBucket(std::string const& hash)
 void
 ApplyBucketsWork::onReset()
 {
+    ZoneScoped;
     CLOG(INFO, "History") << "Applying buckets";
 
     mTotalBuckets = 0;
@@ -102,6 +104,7 @@ ApplyBucketsWork::onReset()
 void
 ApplyBucketsWork::startLevel()
 {
+    ZoneScoped;
     assert(isLevelComplete());
 
     CLOG(DEBUG, "History") << "ApplyBuckets : starting level " << mLevel;
@@ -148,6 +151,7 @@ ApplyBucketsWork::startLevel()
 BasicWork::State
 ApplyBucketsWork::onRun()
 {
+    ZoneScoped;
     if (!mHaveCheckedApplyStateValidity && mLevel == BucketList::kNumLevels - 1)
     {
         if (!mApplyState.containsValidBuckets(mApp))
@@ -215,6 +219,7 @@ void
 ApplyBucketsWork::advance(std::string const& bucketName,
                           BucketApplicator& applicator)
 {
+    ZoneScoped;
     assert(applicator);
     assert(mTotalSize != 0);
     auto sz = applicator.advance(mCounters);

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -8,7 +8,7 @@
 #include "catchup/ApplyLedgerWork.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
-
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -27,6 +27,7 @@ ApplyBufferedLedgersWork::onReset()
 BasicWork::State
 ApplyBufferedLedgersWork::onRun()
 {
+    ZoneScoped;
     if (mConditionalWork)
     {
         mConditionalWork->crankWork();
@@ -98,6 +99,7 @@ ApplyBufferedLedgersWork::getStatus() const
 void
 ApplyBufferedLedgersWork::shutdown()
 {
+    ZoneScoped;
     if (mConditionalWork)
     {
         mConditionalWork->shutdown();
@@ -108,6 +110,7 @@ ApplyBufferedLedgersWork::shutdown()
 bool
 ApplyBufferedLedgersWork::onAbort()
 {
+    ZoneScoped;
     if (mConditionalWork && !mConditionalWork->isDone())
     {
         mConditionalWork->crankWork();

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -16,7 +16,7 @@
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
 #include "util/FileSystemException.h"
-
+#include <Tracy.hpp>
 #include <fmt/format.h>
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
@@ -78,6 +78,7 @@ ApplyCheckpointWork::onReset()
 void
 ApplyCheckpointWork::openInputFiles()
 {
+    ZoneScoped;
     mHdrIn.close();
     mTxIn.close();
     FileTransferInfo hi(mDownloadDir, HISTORY_FILE_TYPE_LEDGER, mCheckpoint);
@@ -97,6 +98,7 @@ ApplyCheckpointWork::openInputFiles()
 TxSetFramePtr
 ApplyCheckpointWork::getCurrentTxSet()
 {
+    ZoneScoped;
     auto& lm = mApp.getLedgerManager();
     auto seq = lm.getLastClosedLedgerNum() + 1;
 
@@ -131,6 +133,7 @@ ApplyCheckpointWork::getCurrentTxSet()
 std::shared_ptr<LedgerCloseData>
 ApplyCheckpointWork::getNextLedgerCloseData()
 {
+    ZoneScoped;
     if (!mHdrIn || !mHdrIn.readOne(mHeaderHistoryEntry))
     {
         throw std::runtime_error("No more ledgers to replay!");
@@ -243,6 +246,7 @@ ApplyCheckpointWork::getNextLedgerCloseData()
 BasicWork::State
 ApplyCheckpointWork::onRun()
 {
+    ZoneScoped;
     try
     {
         if (mConditionalWork)
@@ -338,6 +342,7 @@ ApplyCheckpointWork::onRun()
 void
 ApplyCheckpointWork::shutdown()
 {
+    ZoneScoped;
     if (mConditionalWork)
     {
         mConditionalWork->shutdown();
@@ -348,6 +353,7 @@ ApplyCheckpointWork::shutdown()
 bool
 ApplyCheckpointWork::onAbort()
 {
+    ZoneScoped;
     if (mConditionalWork && !mConditionalWork->isDone())
     {
         mConditionalWork->crankWork();

--- a/src/catchup/ApplyLedgerWork.cpp
+++ b/src/catchup/ApplyLedgerWork.cpp
@@ -5,6 +5,7 @@
 #include "catchup/ApplyLedgerWork.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -21,6 +22,7 @@ ApplyLedgerWork::ApplyLedgerWork(Application& app,
 BasicWork::State
 ApplyLedgerWork::onRun()
 {
+    ZoneScoped;
     mApp.getLedgerManager().closeLedger(mLedgerCloseData);
     return BasicWork::State::WORK_SUCCESS;
 }

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -15,6 +15,7 @@
 #include "util/Logging.h"
 #include "util/StatusManager.h"
 #include "work/WorkScheduler.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -59,6 +60,7 @@ CatchupManagerImpl::getCatchupCount()
 void
 CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
 {
+    ZoneScoped;
     if (mCatchupWork && mCatchupWork->isDone())
     {
         trimAndReset();
@@ -175,6 +177,7 @@ void
 CatchupManagerImpl::startCatchup(CatchupConfiguration configuration,
                                  std::shared_ptr<HistoryArchive> archive)
 {
+    ZoneScoped;
     auto lastClosedLedger = mApp.getLedgerManager().getLastClosedLedgerNum();
     if ((configuration.toLedger() != CatchupConfiguration::CURRENT) &&
         (configuration.toLedger() <= lastClosedLedger))
@@ -349,6 +352,7 @@ CatchupManagerImpl::trimSyncingLedgers()
 void
 CatchupManagerImpl::tryApplySyncingLedgers()
 {
+    ZoneScoped;
     auto const& ledgerHeader =
         mApp.getLedgerManager().getLastClosedLedgerHeader();
 

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -22,6 +22,7 @@
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -78,6 +79,7 @@ CatchupWork::getStatus() const
 void
 CatchupWork::doReset()
 {
+    ZoneScoped;
     mBucketsAppliedEmitted = false;
     mTransactionsVerifyEmitted = false;
     mBuckets.clear();
@@ -111,6 +113,7 @@ void
 CatchupWork::downloadVerifyLedgerChain(CatchupRange const& catchupRange,
                                        LedgerNumHashPair rangeEnd)
 {
+    ZoneScoped;
     auto verifyRange = catchupRange.getFullRangeIncludingBucketApply();
     assert(verifyRange.mCount != 0);
     auto checkpointRange =
@@ -130,6 +133,7 @@ CatchupWork::downloadVerifyLedgerChain(CatchupRange const& catchupRange,
 void
 CatchupWork::downloadVerifyTxResults(CatchupRange const& catchupRange)
 {
+    ZoneScoped;
     auto range = catchupRange.getReplayRange();
     auto checkpointRange = CheckpointRange{range, mApp.getHistoryManager()};
     mVerifyTxResults = std::make_shared<DownloadVerifyTxResultsWork>(
@@ -146,6 +150,7 @@ CatchupWork::alreadyHaveBucketsHistoryArchiveState(uint32_t atCheckpoint) const
 WorkSeqPtr
 CatchupWork::downloadApplyBuckets()
 {
+    ZoneScoped;
     auto const& has = mGetBucketStateWork->getHistoryArchiveState();
     std::vector<std::string> hashes = has.differingBuckets(mLocalState);
     auto getBuckets = std::make_shared<DownloadBucketsWork>(
@@ -187,6 +192,7 @@ CatchupWork::assertBucketState()
 void
 CatchupWork::downloadApplyTransactions(CatchupRange const& catchupRange)
 {
+    ZoneScoped;
     auto waitForPublish = mCatchupConfiguration.offline();
     auto range = catchupRange.getReplayRange();
     mTransactionsVerifyApplySeq = std::make_shared<DownloadApplyTxsWork>(
@@ -196,6 +202,7 @@ CatchupWork::downloadApplyTransactions(CatchupRange const& catchupRange)
 BasicWork::State
 CatchupWork::runCatchupStep()
 {
+    ZoneScoped;
     // Step 1: Get history archive state
     if (!mGetHistoryArchiveStateWork)
     {
@@ -402,6 +409,7 @@ CatchupWork::runCatchupStep()
 BasicWork::State
 CatchupWork::doWork()
 {
+    ZoneScoped;
     auto nextState = runCatchupStep();
     auto& cm = mApp.getCatchupManager();
 

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -10,7 +10,7 @@
 #include "ledger/LedgerManager.h"
 #include "work/ConditionalWork.h"
 #include "work/WorkSequence.h"
-
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -34,6 +34,7 @@ DownloadApplyTxsWork::DownloadApplyTxsWork(
 std::shared_ptr<BasicWork>
 DownloadApplyTxsWork::yieldMoreWork()
 {
+    ZoneScoped;
     if (!hasNext())
     {
         throw std::runtime_error("Work has no more children to iterate over!");

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -11,6 +11,7 @@
 #include "util/FileSystemException.h"
 #include "util/XDRStream.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
@@ -21,6 +22,7 @@ namespace stellar
 static HistoryManager::LedgerVerificationStatus
 verifyLedgerHistoryEntry(LedgerHeaderHistoryEntry const& hhe)
 {
+    ZoneScoped;
     Hash calculated = sha256(xdr::xdr_to_opaque(hhe.header));
     if (calculated != hhe.hash)
     {
@@ -56,6 +58,7 @@ static HistoryManager::LedgerVerificationStatus
 verifyLastLedgerInCheckpoint(LedgerHeaderHistoryEntry const& ledger,
                              LedgerNumHashPair const& verifiedAhead)
 {
+    ZoneScoped;
     // When last ledger in the checkpoint is reached, verify its hash against
     // the next checkpoint.
     assert(ledger.header.ledgerSeq == verifiedAhead.first);
@@ -130,6 +133,7 @@ VerifyLedgerChainWork::onReset()
 HistoryManager::LedgerVerificationStatus
 VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
 {
+    ZoneScoped;
     // When verifying a checkpoint, we rely on the fact that the next checkpoint
     // has been verified (unless there's 1 checkpoint).
     // Once the end of the range is reached, ensure that the chain agrees with
@@ -295,6 +299,7 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
 BasicWork::State
 VerifyLedgerChainWork::onRun()
 {
+    ZoneScoped;
     if (mRange.mCount == 0)
     {
         CLOG(INFO, "History") << "History chain [0,0) trivially verified";

--- a/src/crypto/Curve25519.cpp
+++ b/src/crypto/Curve25519.cpp
@@ -5,6 +5,7 @@
 #include "crypto/Curve25519.h"
 #include "crypto/SHA.h"
 #include "util/HashOfHash.h"
+#include <Tracy.hpp>
 #include <functional>
 
 #ifdef MSAN_ENABLED
@@ -28,6 +29,7 @@ curve25519RandomSecret()
 Curve25519Public
 curve25519DerivePublic(Curve25519Secret const& sec)
 {
+    ZoneScoped;
     Curve25519Public out;
     if (crypto_scalarmult_base(out.key.data(), sec.key.data()) != 0)
     {
@@ -49,6 +51,7 @@ curve25519DeriveSharedKey(Curve25519Secret const& localSecret,
                           Curve25519Public const& localPublic,
                           Curve25519Public const& remotePublic, bool localFirst)
 {
+    ZoneScoped;
     auto const& publicA = localFirst ? localPublic : remotePublic;
     auto const& publicB = localFirst ? remotePublic : localPublic;
 
@@ -75,6 +78,7 @@ curve25519Decrypt(Curve25519Secret const& localSecret,
                   Curve25519Public const& localPublic,
                   ByteSlice const& encrypted)
 {
+    ZoneScoped;
     if (encrypted.size() < crypto_box_SEALBYTES)
     {
         throw CryptoError(

--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -6,6 +6,7 @@
 #include "crypto/ByteSlice.h"
 #include "crypto/Curve25519.h"
 #include "util/NonCopyable.h"
+#include <Tracy.hpp>
 #include <sodium.h>
 
 namespace stellar
@@ -15,6 +16,7 @@ namespace stellar
 uint256
 sha256(ByteSlice const& bin)
 {
+    ZoneScoped;
     uint256 out;
     if (crypto_hash_sha256(out.data(), bin.data(), bin.size()) != 0)
     {
@@ -59,6 +61,7 @@ SHA256Impl::reset()
 void
 SHA256Impl::add(ByteSlice const& bin)
 {
+    ZoneScoped;
     if (mFinished)
     {
         throw std::runtime_error("adding bytes to finished SHA256");
@@ -89,6 +92,7 @@ SHA256Impl::finish()
 HmacSha256Mac
 hmacSha256(HmacSha256Key const& key, ByteSlice const& bin)
 {
+    ZoneScoped;
     HmacSha256Mac out;
     if (crypto_auth_hmacsha256(out.mac.data(), bin.data(), bin.size(),
                                key.key.data()) != 0)
@@ -102,6 +106,7 @@ bool
 hmacSha256Verify(HmacSha256Mac const& hmac, HmacSha256Key const& key,
                  ByteSlice const& bin)
 {
+    ZoneScoped;
     return 0 == crypto_auth_hmacsha256_verify(hmac.mac.data(), bin.data(),
                                               bin.size(), key.key.data());
 }
@@ -110,6 +115,7 @@ hmacSha256Verify(HmacSha256Mac const& hmac, HmacSha256Key const& key,
 HmacSha256Key
 hkdfExtract(ByteSlice const& bin)
 {
+    ZoneScoped;
     HmacSha256Key zerosalt;
     auto mac = hmacSha256(zerosalt, bin);
     HmacSha256Key key;
@@ -121,6 +127,7 @@ hkdfExtract(ByteSlice const& bin)
 HmacSha256Key
 hkdfExpand(HmacSha256Key const& key, ByteSlice const& bin)
 {
+    ZoneScoped;
     std::vector<uint8_t> bytes(bin.begin(), bin.end());
     bytes.push_back(1);
     auto mac = hmacSha256(key, bytes);

--- a/src/crypto/StrKey.cpp
+++ b/src/crypto/StrKey.cpp
@@ -6,6 +6,7 @@
 #include "util/Decoder.h"
 #include "util/SecretValue.h"
 #include "util/crc16.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -15,6 +16,7 @@ namespace strKey
 SecretValue
 toStrKey(uint8_t ver, ByteSlice const& bin)
 {
+    ZoneScoped;
     ver <<= 3; // promote to 8 bits
     std::vector<uint8_t> toEncode;
     toEncode.reserve(1 + bin.size() + 2);
@@ -42,6 +44,7 @@ bool
 fromStrKey(std::string const& strKey, uint8_t& outVersion,
            std::vector<uint8_t>& decoded)
 {
+    ZoneScoped;
     // check that there is no trailing data
     size_t s = strKey.size();
     // base 32 data size is (s * 5)/8 => has to be a multiple of 8

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -11,6 +11,7 @@
 #include "scp/Slot.h"
 #include "util/Decoder.h"
 #include "util/XDRStream.h"
+#include <Tracy.hpp>
 
 #include <soci.h>
 #include <xdrpp/marshal.h>
@@ -37,6 +38,7 @@ HerderPersistenceImpl::saveSCPHistory(uint32_t seq,
                                       std::vector<SCPEnvelope> const& envs,
                                       QuorumTracker::QuorumMap const& qmap)
 {
+    ZoneScoped;
     if (envs.empty())
     {
         return;
@@ -214,6 +216,7 @@ HerderPersistence::copySCPHistoryToStream(Database& db, soci::session& sess,
                                           uint32_t ledgerCount,
                                           XDROutputFileStream& scpHistory)
 {
+    ZoneScoped;
     uint32_t begin = ledgerSeq, end = ledgerSeq + ledgerCount;
     size_t n = 0;
 
@@ -297,6 +300,7 @@ optional<Hash>
 HerderPersistence::getNodeQuorumSet(Database& db, soci::session& sess,
                                     NodeID const& nodeID)
 {
+    ZoneScoped;
     std::string nodeIDStrKey = KeyUtils::toStrKey(nodeID);
     std::string qsethHex;
 
@@ -320,6 +324,7 @@ SCPQuorumSetPtr
 HerderPersistence::getQuorumSet(Database& db, soci::session& sess,
                                 Hash const& qSetHash)
 {
+    ZoneScoped;
     SCPQuorumSetPtr res;
     SCPQuorumSet qset;
     std::string qset64, qSetHashHex;
@@ -350,6 +355,7 @@ HerderPersistence::getQuorumSet(Database& db, soci::session& sess,
 void
 HerderPersistence::dropAll(Database& db)
 {
+    ZoneScoped;
     db.getSession() << "DROP TABLE IF EXISTS scphistory";
 
     db.getSession() << "DROP TABLE IF EXISTS scpquorums";
@@ -388,6 +394,7 @@ void
 HerderPersistence::deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                     uint32_t count)
 {
+    ZoneScoped;
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
                                           "scphistory", "ledgerseq");
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -11,6 +11,7 @@
 #include "scp/QuorumSetUtils.h"
 #include "scp/Slot.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <unordered_set>
 #include <xdrpp/marshal.h>
 
@@ -105,6 +106,7 @@ PendingEnvelopes::putQSet(Hash const& qSetHash, SCPQuorumSet const& qSet)
 void
 PendingEnvelopes::addSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 {
+    ZoneScoped;
     putQSet(hash, q);
     mQuorumSetFetcher.recv(hash, mFetchQsetTimer);
 }
@@ -112,6 +114,7 @@ PendingEnvelopes::addSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 bool
 PendingEnvelopes::recvSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 {
+    ZoneScoped;
     CLOG(TRACE, "Herder") << "Got SCPQSet " << hexAbbrev(hash);
 
     auto lastSeenSlotIndex = mQuorumSetFetcher.getLastSeenSlotIndex(hash);
@@ -135,6 +138,7 @@ PendingEnvelopes::recvSCPQuorumSet(Hash const& hash, SCPQuorumSet const& q)
 void
 PendingEnvelopes::discardSCPEnvelopesWithQSet(Hash const& hash)
 {
+    ZoneScoped;
     CLOG(TRACE, "Herder") << "Discarding SCP Envelopes with SCPQSet "
                           << hexAbbrev(hash);
 
@@ -159,6 +163,8 @@ PendingEnvelopes::updateMetrics()
         fetching += v.mFetchingEnvelopes.size();
         ready += v.mReadyEnvelopes.size();
     }
+    TracyPlot("scp.pending.processed", processed);
+    TracyPlot("scp.pending.fetching", fetching);
     mProcessedCount.set_count(processed);
     mDiscardedCount.set_count(discarded);
     mFetchingCount.set_count(fetching);
@@ -214,6 +220,7 @@ void
 PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
                            TxSetFramePtr txset)
 {
+    ZoneScoped;
     CLOG(TRACE, "Herder") << "Add TxSet " << hexAbbrev(hash);
 
     putTxSet(hash, lastSeenSlotIndex, txset);
@@ -223,6 +230,7 @@ PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
 bool
 PendingEnvelopes::recvTxSet(Hash const& hash, TxSetFramePtr txset)
 {
+    ZoneScoped;
     CLOG(TRACE, "Herder") << "Got TxSet " << hexAbbrev(hash);
 
     auto lastSeenSlotIndex = mTxSetFetcher.getLastSeenSlotIndex(hash);
@@ -264,6 +272,7 @@ txSetsToStr(SCPEnvelope const& envelope)
 Herder::EnvelopeStatus
 PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
 {
+    ZoneScoped;
     auto const& nodeID = envelope.statement.nodeID;
     if (!isNodeDefinitelyInQuorum(nodeID))
     {
@@ -432,6 +441,7 @@ PendingEnvelopes::clearQSetCache()
 void
 PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
 {
+    ZoneScoped;
     if (Logging::logTrace("Herder"))
     {
         CLOG(TRACE, "Herder") << "Envelope ready "
@@ -469,6 +479,7 @@ PendingEnvelopes::isFullyFetched(SCPEnvelope const& envelope)
 void
 PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
 {
+    ZoneScoped;
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
 
     bool needSomething = false;
@@ -499,6 +510,7 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
 void
 PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
 {
+    ZoneScoped;
     Hash h = Slot::getCompanionQuorumSetHashFromStatement(envelope.statement);
     mQuorumSetFetcher.stopFetch(h, envelope);
 

--- a/src/herder/QuorumTracker.cpp
+++ b/src/herder/QuorumTracker.cpp
@@ -4,6 +4,7 @@
 
 #include "herder/QuorumTracker.h"
 #include "scp/LocalNode.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -46,6 +47,7 @@ QuorumTracker::expand(NodeID const& id, SCPQuorumSetPtr qSet)
 void
 QuorumTracker::rebuild(std::function<SCPQuorumSetPtr(NodeID const&)> lookup)
 {
+    ZoneScoped;
     mQuorum.clear();
     auto local = mSCP.getLocalNode();
     std::set<NodeID> backlog;

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -12,6 +12,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/HashOfHash.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 #include <algorithm>
 #include <fmt/format.h>
@@ -113,6 +114,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
                          AccountStates::iterator& stateIter,
                          TimestampedTransactions::iterator& oldTxIter)
 {
+    ZoneScoped;
     if (isBanned(tx->getFullHash()))
     {
         return TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER;
@@ -227,6 +229,7 @@ TransactionQueue::releaseFeeMaybeEraseAccountState(TransactionFrameBasePtr tx)
 TransactionQueue::AddResult
 TransactionQueue::tryAdd(TransactionFrameBasePtr tx)
 {
+    ZoneScoped;
     AccountStates::iterator stateIter;
     TimestampedTransactions::iterator oldTxIter;
     auto const res = canAdd(tx, stateIter, oldTxIter);
@@ -266,6 +269,7 @@ TransactionQueue::dropTransactions(AccountStates::iterator stateIter,
                                    TimestampedTransactions::iterator begin,
                                    TimestampedTransactions::iterator end)
 {
+    ZoneScoped;
     // Remove fees and update queue size for each transaction to be dropped.
     // Note releaseFeeMaybeEraseSourceAccount may erase other iterators from
     // mAccountStates, but it will not erase stateIter because it has at least
@@ -299,6 +303,7 @@ TransactionQueue::dropTransactions(AccountStates::iterator stateIter,
 void
 TransactionQueue::removeApplied(Transactions const& appliedTxs)
 {
+    ZoneScoped;
     // Find the highest sequence number that was applied for each source account
     std::map<AccountID, int64_t> seqByAccount;
     std::unordered_set<Hash> appliedHashes;
@@ -393,6 +398,7 @@ findTx(TransactionFrameBasePtr tx,
 void
 TransactionQueue::ban(Transactions const& banTxs)
 {
+    ZoneScoped;
     auto& bannedFront = mBannedTransactions.front();
 
     // Group the transactions by source account and ban all the transactions
@@ -481,6 +487,7 @@ TransactionQueue::getAccountTransactionQueueInfo(
 void
 TransactionQueue::shift()
 {
+    ZoneScoped;
     mBannedTransactions.pop_back();
     mBannedTransactions.emplace_front();
 
@@ -558,6 +565,7 @@ TransactionQueue::isBanned(Hash const& hash) const
 std::shared_ptr<TxSetFrame>
 TransactionQueue::toTxSet(LedgerHeaderHistoryEntry const& lcl) const
 {
+    ZoneScoped;
     auto result = std::make_shared<TxSetFrame>(lcl.hash);
 
     uint32_t const nextLedgerSeq = lcl.header.ledgerSeq + 1;

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -16,6 +16,7 @@
 #include "util/Logging.h"
 #include "util/Timer.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/cereal.hpp>
 #include <fmt/format.h>
@@ -390,6 +391,7 @@ Upgrades::storeUpgradeHistory(Database& db, uint32_t ledgerSeq,
                               LedgerUpgrade const& upgrade,
                               LedgerEntryChanges const& changes, int index)
 {
+    ZoneScoped;
     xdr::opaque_vec<> upgradeContent(xdr::xdr_to_opaque(upgrade));
     std::string upgradeContent64 = decoder::encode_b64(upgradeContent);
 
@@ -421,6 +423,7 @@ Upgrades::storeUpgradeHistory(Database& db, uint32_t ledgerSeq,
 void
 Upgrades::deleteOldEntries(Database& db, uint32_t ledgerSeq, uint32_t count)
 {
+    ZoneScoped;
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
                                           "upgradehistory", "ledgerseq");
 }

--- a/src/history/FileTransferInfo.cpp
+++ b/src/history/FileTransferInfo.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "FileTransferInfo.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -15,6 +16,7 @@ char const* HISTORY_FILE_TYPE_SCP = "scp";
 std::string
 FileTransferInfo::getLocalDir(TmpDir const& localRoot) const
 {
+    ZoneScoped;
     auto localDir = localRoot.getName();
     localDir += "/" + fs::remoteDir(mType, mHexDigits);
     int retries = 5;

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -18,6 +18,7 @@
 #include "process/ProcessManager.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 #include <cereal/archives/json.hpp>
@@ -58,6 +59,7 @@ formatString(std::string const& templateString, Tokens const&... tokens)
 bool
 HistoryArchiveState::futuresAllResolved() const
 {
+    ZoneScoped;
     for (auto const& level : currentBuckets)
     {
         if (level.next.isMerging())
@@ -79,6 +81,7 @@ HistoryArchiveState::futuresAllClear() const
 void
 HistoryArchiveState::resolveAllFutures()
 {
+    ZoneScoped;
     for (auto& level : currentBuckets)
     {
         if (level.next.isMerging())
@@ -91,6 +94,7 @@ HistoryArchiveState::resolveAllFutures()
 void
 HistoryArchiveState::resolveAnyReadyFutures()
 {
+    ZoneScoped;
     for (auto& level : currentBuckets)
     {
         if (level.next.isMerging() && level.next.mergeComplete())
@@ -103,6 +107,7 @@ HistoryArchiveState::resolveAnyReadyFutures()
 void
 HistoryArchiveState::save(std::string const& outFile) const
 {
+    ZoneScoped;
     std::ofstream out(outFile);
     cereal::JSONOutputArchive ar(out);
     serialize(ar);
@@ -111,6 +116,7 @@ HistoryArchiveState::save(std::string const& outFile) const
 std::string
 HistoryArchiveState::toString() const
 {
+    ZoneScoped;
     // We serialize-to-a-string any HAS, regardless of resolvedness, as we are
     // usually doing this to write to the database on the main thread, just as a
     // durability step: we don't want to block.
@@ -125,6 +131,7 @@ HistoryArchiveState::toString() const
 void
 HistoryArchiveState::load(std::string const& inFile)
 {
+    ZoneScoped;
     std::ifstream in(inFile);
     cereal::JSONInputArchive ar(in);
     serialize(ar);
@@ -139,6 +146,7 @@ HistoryArchiveState::load(std::string const& inFile)
 void
 HistoryArchiveState::fromString(std::string const& str)
 {
+    ZoneScoped;
     std::istringstream in(str);
     cereal::JSONInputArchive ar(in);
     serialize(ar);
@@ -185,6 +193,7 @@ HistoryArchiveState::localName(Application& app, std::string const& archiveName)
 Hash
 HistoryArchiveState::getBucketListHash() const
 {
+    ZoneScoped;
     // NB: This hash algorithm has to match "what the BucketList does" to
     // calculate its BucketList hash exactly. It's not a particularly complex
     // algorithm -- just hash all the hashes of all the bucket levels, in order,
@@ -208,6 +217,7 @@ HistoryArchiveState::getBucketListHash() const
 std::vector<std::string>
 HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
 {
+    ZoneScoped;
     assert(futuresAllResolved());
     std::set<std::string> inhibit;
     uint256 zero;
@@ -251,6 +261,7 @@ HistoryArchiveState::differingBuckets(HistoryArchiveState const& other) const
 std::vector<std::string>
 HistoryArchiveState::allBuckets() const
 {
+    ZoneScoped;
     std::set<std::string> buckets;
     for (auto const& level : currentBuckets)
     {
@@ -265,6 +276,7 @@ HistoryArchiveState::allBuckets() const
 bool
 HistoryArchiveState::containsValidBuckets(Application& app) const
 {
+    ZoneScoped;
     // This function assumes presence of required buckets to verify state
     // Level 0 future buckets are always clear
     assert(currentBuckets[0].next.isClear());
@@ -305,6 +317,7 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
 void
 HistoryArchiveState::prepareForPublish(Application& app)
 {
+    ZoneScoped;
     // Level 0 future buckets are always clear
     assert(currentBuckets[0].next.isClear());
 

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -35,6 +35,7 @@
 #include "util/TmpDir.h"
 #include "work/WorkScheduler.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 #include <fstream>
@@ -126,6 +127,7 @@ HistoryManagerImpl::logAndUpdatePublishStatus()
 size_t
 HistoryManagerImpl::publishQueueLength() const
 {
+    ZoneScoped;
     uint32_t count;
     auto prep = mApp.getDatabase().getPreparedStatement(
         "SELECT count(ledger) FROM publishqueue;");
@@ -139,6 +141,7 @@ HistoryManagerImpl::publishQueueLength() const
 string const&
 HistoryManagerImpl::getTmpDir()
 {
+    ZoneScoped;
     if (!mWorkDir)
     {
         TmpDir t = mApp.getTmpDirManager().tmpDir("history");
@@ -165,6 +168,7 @@ HistoryManagerImpl::inferQuorum(uint32_t ledgerNum)
 uint32_t
 HistoryManagerImpl::getMinLedgerQueuedToPublish()
 {
+    ZoneScoped;
     uint32_t seq;
     soci::indicator minIndicator;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -183,6 +187,7 @@ HistoryManagerImpl::getMinLedgerQueuedToPublish()
 uint32_t
 HistoryManagerImpl::getMaxLedgerQueuedToPublish()
 {
+    ZoneScoped;
     uint32_t seq;
     soci::indicator maxIndicator;
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -221,6 +226,7 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint()
 void
 HistoryManagerImpl::queueCurrentHistory()
 {
+    ZoneScoped;
     auto ledger = mApp.getLedgerManager().getLastClosedLedgerNum();
     HistoryArchiveState has(ledger, mApp.getBucketManager().getBucketList());
 
@@ -252,6 +258,7 @@ HistoryManagerImpl::queueCurrentHistory()
 void
 HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 {
+    ZoneScoped;
     if (mPublishWork)
     {
         return;
@@ -299,6 +306,7 @@ HistoryManagerImpl::publishQueuedHistory()
     }
 #endif
 
+    ZoneScoped;
     std::string state;
 
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -322,6 +330,7 @@ HistoryManagerImpl::publishQueuedHistory()
 std::vector<HistoryArchiveState>
 HistoryManagerImpl::getPublishQueueStates()
 {
+    ZoneScoped;
     std::vector<HistoryArchiveState> states;
 
     std::string state;
@@ -343,6 +352,7 @@ HistoryManagerImpl::getPublishQueueStates()
 PublishQueueBuckets::BucketCount
 HistoryManagerImpl::loadBucketsReferencedByPublishQueue()
 {
+    ZoneScoped;
     auto states = getPublishQueueStates();
     PublishQueueBuckets::BucketCount result{};
     for (auto const& s : states)
@@ -359,6 +369,7 @@ HistoryManagerImpl::loadBucketsReferencedByPublishQueue()
 std::vector<std::string>
 HistoryManagerImpl::getBucketsReferencedByPublishQueue()
 {
+    ZoneScoped;
     if (!mPublishQueueBucketsFilled)
     {
         mPublishQueueBuckets.setBuckets(loadBucketsReferencedByPublishQueue());
@@ -377,6 +388,7 @@ HistoryManagerImpl::getBucketsReferencedByPublishQueue()
 std::vector<std::string>
 HistoryManagerImpl::getMissingBucketsReferencedByPublishQueue()
 {
+    ZoneScoped;
     auto states = getPublishQueueStates();
     std::set<std::string> buckets;
     for (auto const& s : states)
@@ -392,6 +404,7 @@ HistoryManagerImpl::historyPublished(
     uint32_t ledgerSeq, std::vector<std::string> const& originalBuckets,
     bool success)
 {
+    ZoneScoped;
     if (success)
     {
         auto iter = mEnqueueTimes.find(ledgerSeq);

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -18,6 +18,7 @@
 #include "transactions/TransactionSQL.h"
 #include "util/Logging.h"
 #include "util/XDRStream.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -48,6 +49,7 @@ StateSnapshot::StateSnapshot(Application& app, HistoryArchiveState const& state)
 bool
 StateSnapshot::writeHistoryBlocks() const
 {
+    ZoneScoped;
     std::unique_ptr<soci::session> snapSess(
         mApp.getDatabase().canUsePool()
             ? std::make_unique<soci::session>(mApp.getDatabase().getPool())
@@ -130,6 +132,7 @@ StateSnapshot::writeHistoryBlocks() const
 std::vector<std::shared_ptr<FileTransferInfo>>
 StateSnapshot::differingHASFiles(HistoryArchiveState const& other)
 {
+    ZoneScoped;
     std::vector<std::shared_ptr<FileTransferInfo>> files{};
     auto addIfExists = [&](std::shared_ptr<FileTransferInfo> const& f) {
         if (f && fs::exists(f->localPath_nogz()))

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -9,6 +9,7 @@
 #include "historywork/GetAndUnzipRemoteFileWork.h"
 #include "historywork/Progress.h"
 #include "main/Application.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -41,6 +42,7 @@ BatchDownloadWork::getStatus() const
 std::shared_ptr<BasicWork>
 BatchDownloadWork::yieldMoreWork()
 {
+    ZoneScoped;
     if (!hasNext())
     {
         CLOG(WARNING, "Work")

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -8,6 +8,7 @@
 #include "history/HistoryArchive.h"
 #include "historywork/GetAndUnzipRemoteFileWork.h"
 #include "historywork/VerifyBucketWork.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -60,6 +61,7 @@ DownloadBucketsWork::resetIter()
 std::shared_ptr<BasicWork>
 DownloadBucketsWork::yieldMoreWork()
 {
+    ZoneScoped;
     if (!hasNext())
     {
         throw std::runtime_error("Nothing to iterate over!");

--- a/src/historywork/DownloadVerifyTxResultsWork.cpp
+++ b/src/historywork/DownloadVerifyTxResultsWork.cpp
@@ -10,6 +10,7 @@
 #include "historywork/Progress.h"
 #include "historywork/VerifyTxResultsWork.h"
 #include "work/WorkSequence.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -54,6 +55,7 @@ DownloadVerifyTxResultsWork::resetIter()
 std::shared_ptr<BasicWork>
 DownloadVerifyTxResultsWork::yieldMoreWork()
 {
+    ZoneScoped;
     if (!hasNext())
     {
         throw std::runtime_error("Nothing to iterate over!");

--- a/src/historywork/FetchRecentQsetsWork.cpp
+++ b/src/historywork/FetchRecentQsetsWork.cpp
@@ -12,6 +12,7 @@
 #include "util/FileSystemException.h"
 #include "util/TmpDir.h"
 #include "util/XDRStream.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -37,6 +38,7 @@ FetchRecentQsetsWork::doReset()
 BasicWork::State
 FetchRecentQsetsWork::doWork()
 {
+    ZoneScoped;
     // Phase 1: fetch remote history archive state
     if (!mGetHistoryArchiveStateWork)
     {

--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -7,6 +7,7 @@
 #include "historywork/GetRemoteFileWork.h"
 #include "historywork/GunzipFileWork.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -69,6 +70,7 @@ GetAndUnzipRemoteFileWork::onSuccess()
 BasicWork::State
 GetAndUnzipRemoteFileWork::doWork()
 {
+    ZoneScoped;
     if (mGunzipFileWork)
     {
         // Download completed, unzipping started
@@ -114,6 +116,7 @@ GetAndUnzipRemoteFileWork::doWork()
 bool
 GetAndUnzipRemoteFileWork::validateFile()
 {
+    ZoneScoped;
     if (!fs::exists(mFt.localPath_gz_tmp()))
     {
         CLOG(ERROR, "History") << "Downloading and unzipping "

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -9,6 +9,7 @@
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
@@ -36,6 +37,7 @@ GetHistoryArchiveStateWork::GetHistoryArchiveStateWork(
 BasicWork::State
 GetHistoryArchiveStateWork::doWork()
 {
+    ZoneScoped;
     if (mGetRemoteFile)
     {
         auto state = mGetRemoteFile->getState();

--- a/src/historywork/PublishWork.cpp
+++ b/src/historywork/PublishWork.cpp
@@ -8,6 +8,7 @@
 #include "history/StateSnapshot.h"
 #include "main/Application.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -29,6 +30,7 @@ PublishWork::PublishWork(Application& app,
 void
 PublishWork::onFailureRaise()
 {
+    ZoneScoped;
     // use mOriginalBuckets as mSnapshot->mLocalState.allBuckets() could change
     // in meantime
     mApp.getHistoryManager().historyPublished(
@@ -38,6 +40,7 @@ PublishWork::onFailureRaise()
 void
 PublishWork::onSuccess()
 {
+    ZoneScoped;
     // use mOriginalBuckets as mSnapshot->mLocalState.allBuckets() could change
     // in meantime
     mApp.getHistoryManager().historyPublished(

--- a/src/historywork/PutFilesWork.cpp
+++ b/src/historywork/PutFilesWork.cpp
@@ -8,6 +8,7 @@
 #include "historywork/MakeRemoteDirWork.h"
 #include "historywork/PutRemoteFileWork.h"
 #include "work/WorkSequence.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -28,6 +29,7 @@ PutFilesWork::PutFilesWork(Application& app,
 BasicWork::State
 PutFilesWork::doWork()
 {
+    ZoneScoped;
     if (!mChildrenSpawned)
     {
         for (auto const& f : mSnapshot->differingHASFiles(mRemoteState))

--- a/src/historywork/PutHistoryArchiveStateWork.cpp
+++ b/src/historywork/PutHistoryArchiveStateWork.cpp
@@ -8,6 +8,7 @@
 #include "historywork/PutRemoteFileWork.h"
 #include "main/ErrorMessages.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -38,6 +39,7 @@ PutHistoryArchiveStateWork::doReset()
 BasicWork::State
 PutHistoryArchiveStateWork::doWork()
 {
+    ZoneScoped;
     if (!mPutRemoteFileWork)
     {
         try
@@ -63,6 +65,7 @@ PutHistoryArchiveStateWork::doWork()
 void
 PutHistoryArchiveStateWork::spawnPublishWork()
 {
+    ZoneScoped;
     // Put the file in the history/ww/xx/yy/history-wwxxyyzz.json file
     auto seqName = HistoryArchiveState::remoteName(mState.currentLedger);
     auto seqDir = HistoryArchiveState::remoteDir(mState.currentLedger);

--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -12,6 +12,7 @@
 #include "historywork/PutHistoryArchiveStateWork.h"
 #include "main/Application.h"
 #include "work/WorkSequence.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -31,6 +32,7 @@ PutSnapshotFilesWork::PutSnapshotFilesWork(
 BasicWork::State
 PutSnapshotFilesWork::doWork()
 {
+    ZoneScoped;
     if (!mUploadSeqs.empty())
     {
         return WorkUtils::getWorkStatus(mUploadSeqs);

--- a/src/historywork/ResolveSnapshotWork.cpp
+++ b/src/historywork/ResolveSnapshotWork.cpp
@@ -6,6 +6,7 @@
 #include "history/StateSnapshot.h"
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -25,6 +26,7 @@ ResolveSnapshotWork::ResolveSnapshotWork(
 BasicWork::State
 ResolveSnapshotWork::onRun()
 {
+    ZoneScoped;
     if (mEc)
     {
         return State::WORK_FAILURE;

--- a/src/historywork/RunCommandWork.cpp
+++ b/src/historywork/RunCommandWork.cpp
@@ -5,6 +5,7 @@
 #include "historywork/RunCommandWork.h"
 #include "main/Application.h"
 #include "process/ProcessManager.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -18,6 +19,7 @@ RunCommandWork::RunCommandWork(Application& app, std::string const& name,
 BasicWork::State
 RunCommandWork::onRun()
 {
+    ZoneScoped;
     if (mDone)
     {
         return mEc ? State::WORK_FAILURE : State::WORK_SUCCESS;
@@ -67,6 +69,7 @@ RunCommandWork::onReset()
 bool
 RunCommandWork::onAbort()
 {
+    ZoneScoped;
     auto process = mExitEvent.lock();
     if (!process)
     {

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -12,6 +12,7 @@
 #include "util/Logging.h"
 #include <fmt/format.h>
 
+#include <Tracy.hpp>
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
 
@@ -37,6 +38,7 @@ VerifyBucketWork::VerifyBucketWork(
 BasicWork::State
 VerifyBucketWork::onRun()
 {
+    ZoneScoped;
     if (mDone)
     {
         if (mEc)
@@ -57,6 +59,7 @@ VerifyBucketWork::onRun()
 void
 VerifyBucketWork::adoptBucket()
 {
+    ZoneScoped;
     assert(mDone);
     assert(!mEc);
 
@@ -79,6 +82,7 @@ VerifyBucketWork::spawnVerifier()
             auto hasher = SHA256::create();
             asio::error_code ec;
             {
+                ZoneNamedN(verifyZone, "bucket verify", true);
                 CLOG(INFO, "History")
                     << fmt::format("Verifying bucket {}", binToHex(hash));
 

--- a/src/historywork/VerifyTxResultsWork.cpp
+++ b/src/historywork/VerifyTxResultsWork.cpp
@@ -9,6 +9,7 @@
 #include "util/FileSystemException.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -50,6 +51,7 @@ VerifyTxResultsWork::onRun()
         auto self = weak.lock();
         if (self)
         {
+            ZoneScoped;
             asio::error_code ec;
             auto verified = self->verifyTxResultsOfCheckpoint();
             CLOG(TRACE, "History")
@@ -85,6 +87,7 @@ VerifyTxResultsWork::onRun()
 bool
 VerifyTxResultsWork::verifyTxResultsOfCheckpoint()
 {
+    ZoneScoped;
     try
     {
         FileTransferInfo hi(mDownloadDir, HISTORY_FILE_TYPE_LEDGER,
@@ -137,6 +140,7 @@ VerifyTxResultsWork::verifyTxResultsOfCheckpoint()
 TransactionHistoryResultEntry
 VerifyTxResultsWork::getCurrentTxResultSet(uint32_t ledger)
 {
+    ZoneScoped;
     TransactionHistoryResultEntry trs;
     trs.ledgerSeq = ledger;
 

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -8,6 +8,7 @@
 #include "historywork/Progress.h"
 #include "main/Application.h"
 #include "util/XDRStream.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -39,6 +40,7 @@ WriteSnapshotWork::onRun()
         {
             return;
         }
+        ZoneScoped;
 
         auto snap = self->mSnapshot;
         bool success = true;

--- a/src/ledger/LedgerHeaderUtils.cpp
+++ b/src/ledger/LedgerHeaderUtils.cpp
@@ -11,6 +11,7 @@
 #include "util/XDRStream.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 #include <util/basen.h>
 
@@ -36,6 +37,7 @@ isValid(LedgerHeader const& lh)
 void
 storeInDatabase(Database& db, LedgerHeader const& header)
 {
+    ZoneScoped;
     if (!isValid(header))
     {
         throw std::runtime_error("invalid ledger header (insert)");
@@ -76,6 +78,7 @@ storeInDatabase(Database& db, LedgerHeader const& header)
 LedgerHeader
 decodeFromData(std::string const& data)
 {
+    ZoneScoped;
     LedgerHeader lh;
     std::vector<uint8_t> decoded;
     decoder::decode_b64(data, decoded);
@@ -94,6 +97,7 @@ decodeFromData(std::string const& data)
 std::shared_ptr<LedgerHeader>
 loadByHash(Database& db, Hash const& hash)
 {
+    ZoneScoped;
     std::shared_ptr<LedgerHeader> lhPtr;
 
     std::string hash_s(binToHex(hash));
@@ -129,6 +133,7 @@ loadByHash(Database& db, Hash const& hash)
 std::shared_ptr<LedgerHeader>
 loadBySequence(Database& db, soci::session& sess, uint32_t seq)
 {
+    ZoneScoped;
     std::shared_ptr<LedgerHeader> lhPtr;
 
     std::string headerEncoded;
@@ -158,6 +163,7 @@ loadBySequence(Database& db, soci::session& sess, uint32_t seq)
 void
 deleteOldEntries(Database& db, uint32_t ledgerSeq, uint32_t count)
 {
+    ZoneScoped;
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
                                           "ledgerheaders", "ledgerseq");
 }
@@ -166,6 +172,7 @@ size_t
 copyToStream(Database& db, soci::session& sess, uint32_t ledgerSeq,
              uint32_t ledgerCount, XDROutputFileStream& headersOut)
 {
+    ZoneScoped;
     uint32_t begin = ledgerSeq, end = ledgerSeq + ledgerCount;
     assert(begin <= end);
 

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -17,6 +17,7 @@
 #include "util/types.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <soci.h>
 
 namespace stellar
@@ -2079,26 +2080,34 @@ LedgerTxnRoot::Impl::bulkApply(BulkLedgerEntryChangeAccumulator& bleca,
 void
 LedgerTxnRoot::Impl::commitChild(EntryIterator iter, LedgerTxnConsistency cons)
 {
+    ZoneScoped;
     // Assignment of xdrpp objects does not have the strong exception safety
     // guarantee, so use std::unique_ptr<...>::swap to achieve it
     auto childHeader = std::make_unique<LedgerHeader>(mChild->getHeader());
 
     auto bleca = BulkLedgerEntryChangeAccumulator();
+    int64_t counter{0};
     try
     {
         while ((bool)iter)
         {
             bleca.accumulate(iter);
             ++iter;
+            ++counter;
             size_t bufferThreshold =
                 (bool)iter ? LEDGER_ENTRY_BATCH_COMMIT_SIZE : 0;
             bulkApply(bleca, bufferThreshold, cons);
         }
+        // FIXME: there is no medida historgram for this presently,
+        // but maybe we would like one?
+        TracyPlot("ledger.entry.commit", counter);
+
         // NB: we want to clear the prepared statement cache _before_
         // committing; on postgres this doesn't matter but on SQLite the passive
         // WAL-auto-checkpointing-at-commit behaviour will starve if there are
         // still prepared statements open at commit time.
         mDatabase.clearPreparedStatementCache();
+        ZoneNamedN(commitZone, "SOCI commit", true);
         mTransaction->commit();
     }
     catch (std::exception& e)
@@ -2243,6 +2252,7 @@ LedgerTxnRoot::prefetch(std::unordered_set<LedgerKey> const& keys)
 uint32_t
 LedgerTxnRoot::Impl::prefetch(std::unordered_set<LedgerKey> const& keys)
 {
+    ZoneScoped;
     uint32_t total = 0;
 
     std::unordered_set<LedgerKey> accounts;
@@ -2348,6 +2358,7 @@ LedgerTxnRoot::getAllOffers()
 std::unordered_map<LedgerKey, LedgerEntry>
 LedgerTxnRoot::Impl::getAllOffers()
 {
+    ZoneScoped;
     std::vector<LedgerEntry> offers;
     try
     {
@@ -2382,6 +2393,7 @@ LedgerTxnRoot::getBestOffer(Asset const& buying, Asset const& selling)
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::getBestOffer(Asset const& buying, Asset const& selling)
 {
+    ZoneScoped;
     // Note: Elements of mBestOffersCache are properly sorted lists of the best
     // offers for a certain asset pair. This function maintaints the invariant
     // that the lists of best offers remain properly sorted. The sort order is
@@ -2431,6 +2443,7 @@ std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::getBestOffer(Asset const& buying, Asset const& selling,
                                   OfferDescriptor const& worseThan)
 {
+    ZoneScoped;
     // Note: Elements of mBestOffersCache are properly sorted lists of the best
     // offers for a certain asset pair. This function maintaints the invariant
     // that the lists of best offers remain properly sorted. The sort order is
@@ -2505,6 +2518,7 @@ std::unordered_map<LedgerKey, LedgerEntry>
 LedgerTxnRoot::Impl::getOffersByAccountAndAsset(AccountID const& account,
                                                 Asset const& asset)
 {
+    ZoneScoped;
     std::vector<LedgerEntry> offers;
     try
     {
@@ -2577,12 +2591,17 @@ LedgerTxnRoot::getNewestVersion(LedgerKey const& key) const
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::getNewestVersion(LedgerKey const& key) const
 {
+    ZoneScoped;
     if (mEntryCache.exists(key))
     {
+        std::string zoneTxt("hit");
+        ZoneText(zoneTxt.c_str(), zoneTxt.size());
         return getFromEntryCache(key);
     }
     else
     {
+        std::string zoneTxt("miss");
+        ZoneText(zoneTxt.c_str(), zoneTxt.size());
         ++mPrefetchMisses;
     }
 

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -13,6 +13,7 @@
 #include "util/XDROperators.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -20,6 +21,7 @@ namespace stellar
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::loadAccount(LedgerKey const& key) const
 {
+    ZoneScoped;
     std::string actIDStrKey = KeyUtils::toStrKey(key.account().accountID);
 
     std::string inflationDest, homeDomain, thresholds, signers;
@@ -437,6 +439,8 @@ void
 LedgerTxnRoot::Impl::bulkUpsertAccounts(
     std::vector<EntryIterator> const& entries)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkUpsertAccountsOperation op(mDatabase, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -445,6 +449,8 @@ void
 LedgerTxnRoot::Impl::bulkDeleteAccounts(
     std::vector<EntryIterator> const& entries, LedgerTxnConsistency cons)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkDeleteAccountsOperation op(mDatabase, cons, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -644,6 +650,8 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadAccounts(
     std::unordered_set<LedgerKey> const& keys) const
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(keys.size()));
     if (!keys.empty())
     {
         BulkLoadAccountsOperation op(mDatabase, keys);

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -10,6 +10,7 @@
 #include "util/Decoder.h"
 #include "util/Logging.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -17,6 +18,7 @@ namespace stellar
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::loadData(LedgerKey const& key) const
 {
+    ZoneScoped;
     std::string actIDStrKey = KeyUtils::toStrKey(key.data().accountID);
     std::string dataName = decoder::encode_b64(key.data().dataName);
 
@@ -259,6 +261,8 @@ void
 LedgerTxnRoot::Impl::bulkUpsertAccountData(
     std::vector<EntryIterator> const& entries)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkUpsertDataOperation op(mDatabase, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -267,6 +271,8 @@ void
 LedgerTxnRoot::Impl::bulkDeleteAccountData(
     std::vector<EntryIterator> const& entries, LedgerTxnConsistency cons)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkDeleteDataOperation op(mDatabase, cons, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -422,6 +428,8 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadData(
     std::unordered_set<LedgerKey> const& keys) const
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(keys.size()));
     if (!keys.empty())
     {
         BulkLoadDataOperation op(mDatabase, keys);

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -13,6 +13,7 @@
 #include "util/XDROperators.h"
 #include "util/types.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -20,6 +21,7 @@ namespace stellar
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::loadOffer(LedgerKey const& key) const
 {
+    ZoneScoped;
     int64_t offerID = key.offer().offerID;
     if (offerID < 0)
     {
@@ -50,6 +52,7 @@ LedgerTxnRoot::Impl::loadOffer(LedgerKey const& key) const
 std::vector<LedgerEntry>
 LedgerTxnRoot::Impl::loadAllOffers() const
 {
+    ZoneScoped;
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
                       "amount, pricen, priced, flags, lastmodified "
                       "FROM offers";
@@ -68,6 +71,7 @@ LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
                                     Asset const& buying, Asset const& selling,
                                     size_t numOffers) const
 {
+    ZoneScoped;
     // price is an approximation of the actual n/d (truncated math, 15 digits)
     // ordering by offerid gives precendence to older offers for fairness
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
@@ -98,6 +102,7 @@ LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
                                     OfferDescriptor const& worseThan,
                                     size_t numOffers) const
 {
+    ZoneScoped;
     // ManageOffer and related operations won't work correctly with an offerID
     // equal to or exceeding INT64_MAX, so there is no reason to support it
     // here. We are far from this limit anyway.
@@ -198,6 +203,7 @@ std::vector<LedgerEntry>
 LedgerTxnRoot::Impl::loadOffersByAccountAndAsset(AccountID const& accountID,
                                                  Asset const& asset) const
 {
+    ZoneScoped;
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
                       "amount, pricen, priced, flags, lastmodified "
                       "FROM offers WHERE sellerid = :v1 AND "
@@ -240,6 +246,7 @@ std::deque<LedgerEntry>::const_iterator
 LedgerTxnRoot::Impl::loadOffers(StatementContext& prep,
                                 std::deque<LedgerEntry>& offers) const
 {
+    ZoneScoped;
     std::string actIDStrKey;
     std::string sellingAsset, buyingAsset;
 
@@ -278,6 +285,7 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep,
 std::vector<LedgerEntry>
 LedgerTxnRoot::Impl::loadOffers(StatementContext& prep) const
 {
+    ZoneScoped;
     std::vector<LedgerEntry> offers;
 
     std::string actIDStrKey;
@@ -594,6 +602,8 @@ class BulkDeleteOffersOperation : public DatabaseTypeSpecificOperation<void>
 void
 LedgerTxnRoot::Impl::bulkUpsertOffers(std::vector<EntryIterator> const& entries)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkUpsertOffersOperation op(mDatabase, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -602,6 +612,8 @@ void
 LedgerTxnRoot::Impl::bulkDeleteOffers(std::vector<EntryIterator> const& entries,
                                       LedgerTxnConsistency cons)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkDeleteOffersOperation op(mDatabase, cons, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -774,6 +786,8 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadOffers(
     std::unordered_set<LedgerKey> const& keys) const
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(keys.size()));
     if (!keys.empty())
     {
         BulkLoadOffersOperation op(mDatabase, keys, mHeader->ledgerVersion);

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -9,6 +9,7 @@
 #include "ledger/LedgerTxnImpl.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -47,6 +48,7 @@ getTrustLineStrings(AccountID const& accountID, Asset const& asset,
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::loadTrustLine(LedgerKey const& key) const
 {
+    ZoneScoped;
     std::string accountIDStr, issuerStr, assetStr;
     getTrustLineStrings(key.trustLine().accountID, key.trustLine().asset,
                         accountIDStr, issuerStr, assetStr);
@@ -381,6 +383,8 @@ void
 LedgerTxnRoot::Impl::bulkUpsertTrustLines(
     std::vector<EntryIterator> const& entries)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkUpsertTrustLinesOperation op(mDatabase, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -389,6 +393,8 @@ void
 LedgerTxnRoot::Impl::bulkDeleteTrustLines(
     std::vector<EntryIterator> const& entries, LedgerTxnConsistency cons)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(entries.size()));
     BulkDeleteTrustLinesOperation op(mDatabase, cons, entries);
     mDatabase.doDatabaseTypeSpecificOperation(op);
 }
@@ -615,6 +621,8 @@ std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadTrustLines(
     std::unordered_set<LedgerKey> const& keys) const
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(keys.size()));
     if (!keys.empty())
     {
         BulkLoadTrustLinesOperation op(mDatabase, keys);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -21,6 +21,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
 #include "util/StatusManager.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 #include "medida/reporting/json_reporter.h"
@@ -119,6 +120,7 @@ CommandHandler::safeRouter(CommandHandler::HandlerRoute route,
 {
     try
     {
+        ZoneNamedN(httpZone, "HTTP command handler", true);
         route(this, params, retStr);
     }
     catch (std::exception const& e)
@@ -211,6 +213,7 @@ parseParam(std::map<std::string, std::string> const& map,
 void
 CommandHandler::peers(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
 
@@ -261,12 +264,14 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
 void
 CommandHandler::info(std::string const&, std::string& retStr)
 {
+    ZoneScoped;
     retStr = mApp.getJsonInfo().toStyledString();
 }
 
 void
 CommandHandler::metrics(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     mApp.syncAllMetrics();
     medida::reporting::JsonReporter jr(mApp.getMetrics());
     retStr = jr.Report();
@@ -275,6 +280,7 @@ CommandHandler::metrics(std::string const& params, std::string& retStr)
 void
 CommandHandler::logRotate(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     retStr = "Log rotate...";
 
     Logging::rotate();
@@ -283,6 +289,7 @@ CommandHandler::logRotate(std::string const& params, std::string& retStr)
 void
 CommandHandler::connect(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
 
@@ -306,6 +313,7 @@ CommandHandler::connect(std::string const& params, std::string& retStr)
 void
 CommandHandler::dropPeer(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
 
@@ -353,6 +361,7 @@ CommandHandler::dropPeer(std::string const& params, std::string& retStr)
 void
 CommandHandler::bans(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     Json::Value root;
 
     root["bans"];
@@ -370,6 +379,7 @@ CommandHandler::bans(std::string const& params, std::string& retStr)
 void
 CommandHandler::unban(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
 
@@ -399,6 +409,7 @@ CommandHandler::unban(std::string const& params, std::string& retStr)
 void
 CommandHandler::upgrades(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
     auto s = retMap["mode"];
@@ -456,6 +467,7 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
 void
 CommandHandler::quorum(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
 
@@ -492,6 +504,7 @@ CommandHandler::quorum(std::string const& params, std::string& retStr)
 void
 CommandHandler::scpInfo(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> retMap;
     http::server::server::parseParams(params, retMap);
     size_t lim = 2;
@@ -505,6 +518,7 @@ CommandHandler::scpInfo(std::string const& params, std::string& retStr)
 void
 CommandHandler::ll(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     Json::Value root;
 
     std::map<std::string, std::string> retMap;
@@ -541,6 +555,7 @@ CommandHandler::ll(std::string const& params, std::string& retStr)
 void
 CommandHandler::tx(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::ostringstream output;
 
     const std::string prefix("?blob=");
@@ -606,6 +621,7 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
 void
 CommandHandler::dropcursor(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
     std::string const& id = map["id"];
@@ -625,6 +641,7 @@ CommandHandler::dropcursor(std::string const& params, std::string& retStr)
 void
 CommandHandler::setcursor(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
     std::string const& id = map["id"];
@@ -646,6 +663,7 @@ CommandHandler::setcursor(std::string const& params, std::string& retStr)
 void
 CommandHandler::getcursor(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     Json::Value root;
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
@@ -674,6 +692,7 @@ CommandHandler::getcursor(std::string const& params, std::string& retStr)
 void
 CommandHandler::maintenance(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
     if (map["queue"] == "true")
@@ -693,6 +712,7 @@ CommandHandler::maintenance(std::string const& params, std::string& retStr)
 void
 CommandHandler::clearMetrics(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
 
@@ -707,6 +727,7 @@ CommandHandler::clearMetrics(std::string const& params, std::string& retStr)
 void
 CommandHandler::surveyTopology(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
 
@@ -729,6 +750,7 @@ CommandHandler::surveyTopology(std::string const& params, std::string& retStr)
 void
 CommandHandler::stopSurvey(std::string const&, std::string& retStr)
 {
+    ZoneScoped;
     auto& surveyManager = mApp.getOverlayManager().getSurveyManager();
     surveyManager.stopSurvey();
     retStr = "survey stopped";
@@ -737,6 +759,7 @@ CommandHandler::stopSurvey(std::string const&, std::string& retStr)
 void
 CommandHandler::getSurveyResult(std::string const&, std::string& retStr)
 {
+    ZoneScoped;
     auto& surveyManager = mApp.getOverlayManager().getSurveyManager();
     retStr = surveyManager.getJsonResults().toStyledString();
 }
@@ -745,6 +768,7 @@ CommandHandler::getSurveyResult(std::string const&, std::string& retStr)
 void
 CommandHandler::generateLoad(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     if (mApp.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
     {
         uint32_t nAccounts = 1000;
@@ -802,6 +826,7 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
 void
 CommandHandler::testAcc(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     using namespace txtest;
 
     std::map<std::string, std::string> retMap;
@@ -842,6 +867,7 @@ CommandHandler::testAcc(std::string const& params, std::string& retStr)
 void
 CommandHandler::testTx(std::string const& params, std::string& retStr)
 {
+    ZoneScoped;
     using namespace txtest;
 
     std::map<std::string, std::string> retMap;

--- a/src/main/ExternalQueue.cpp
+++ b/src/main/ExternalQueue.cpp
@@ -9,6 +9,7 @@
 #include "ledger/LedgerManager.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <limits>
 #include <regex>
 
@@ -55,6 +56,7 @@ ExternalQueue::setInitialCursors(std::vector<std::string> const& initialResids)
 void
 ExternalQueue::addCursorForResource(std::string const& resid, uint32 cursor)
 {
+    ZoneScoped;
     if (getCursor(resid).empty())
     {
         setCursorForResource(resid, cursor);
@@ -64,6 +66,7 @@ ExternalQueue::addCursorForResource(std::string const& resid, uint32 cursor)
 void
 ExternalQueue::setCursorForResource(std::string const& resid, uint32 cursor)
 {
+    ZoneScoped;
     checkID(resid);
 
     std::string old(getCursor(resid));
@@ -102,6 +105,7 @@ void
 ExternalQueue::getCursorForResource(std::string const& resid,
                                     std::map<std::string, uint32>& curMap)
 {
+    ZoneScoped;
     // no resid set, get all cursors
     if (resid.empty())
     {
@@ -141,6 +145,7 @@ ExternalQueue::getCursorForResource(std::string const& resid,
 void
 ExternalQueue::deleteCursor(std::string const& resid)
 {
+    ZoneScoped;
     checkID(resid);
 
     auto timer = mApp.getDatabase().getInsertTimer("pubsub");
@@ -155,6 +160,7 @@ ExternalQueue::deleteCursor(std::string const& resid)
 void
 ExternalQueue::deleteOldEntries(uint32 count)
 {
+    ZoneScoped;
     auto& db = mApp.getDatabase();
     int m;
     soci::indicator minIndicator;
@@ -211,6 +217,7 @@ ExternalQueue::checkID(std::string const& resid)
 std::string
 ExternalQueue::getCursor(std::string const& resid)
 {
+    ZoneScoped;
     checkID(resid);
     std::string res;
 

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -8,6 +8,7 @@
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/numeric.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -20,6 +21,7 @@ Maintainer::Maintainer(Application& app) : mApp{app}, mTimer{mApp}
 void
 Maintainer::start()
 {
+    ZoneScoped;
     auto& c = mApp.getConfig();
     if (c.AUTOMATIC_MAINTENANCE_PERIOD.count() > 0 &&
         c.AUTOMATIC_MAINTENANCE_COUNT > 0)
@@ -50,6 +52,7 @@ Maintainer::scheduleMaintenance()
 void
 Maintainer::tick()
 {
+    ZoneScoped;
     performMaintenance(mApp.getConfig().AUTOMATIC_MAINTENANCE_COUNT);
     scheduleMaintenance();
 }
@@ -57,6 +60,7 @@ Maintainer::tick()
 void
 Maintainer::performMaintenance(uint32_t count)
 {
+    ZoneScoped;
     LOG(INFO) << "Performing maintenance";
     ExternalQueue ps{mApp};
     ps.deleteOldEntries(count);

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -9,6 +9,7 @@
 #include "ledger/LedgerManager.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -57,6 +58,7 @@ PersistentState::getStoreStateName(PersistentState::Entry n, uint32 subscript)
 std::string
 PersistentState::getState(PersistentState::Entry entry)
 {
+    ZoneScoped;
     return getFromDb(getStoreStateName(entry));
 }
 
@@ -64,12 +66,14 @@ void
 PersistentState::setState(PersistentState::Entry entry,
                           std::string const& value)
 {
+    ZoneScoped;
     updateDb(getStoreStateName(entry), value);
 }
 
 std::vector<std::string>
 PersistentState::getSCPStateAllSlots()
 {
+    ZoneScoped;
     // Collect all slots persisted
     std::vector<std::string> states;
     for (uint32 i = 0; i <= mApp.getConfig().MAX_SLOTS_TO_REMEMBER; i++)
@@ -87,6 +91,7 @@ PersistentState::getSCPStateAllSlots()
 void
 PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
 {
+    ZoneScoped;
     auto slotIdx = static_cast<uint32>(
         slot % (mApp.getConfig().MAX_SLOTS_TO_REMEMBER + 1));
     updateDb(getStoreStateName(kLastSCPData, slotIdx), value);
@@ -95,6 +100,7 @@ PersistentState::setSCPStateForSlot(uint64 slot, std::string const& value)
 void
 PersistentState::updateDb(std::string const& entry, std::string const& value)
 {
+    ZoneScoped;
     auto prep = mApp.getDatabase().getPreparedStatement(
         "UPDATE storestate SET state = :v WHERE statename = :n;");
 
@@ -127,6 +133,7 @@ PersistentState::updateDb(std::string const& entry, std::string const& value)
 std::string
 PersistentState::getFromDb(std::string const& entry)
 {
+    ZoneScoped;
     std::string res;
 
     auto& db = mApp.getDatabase();

--- a/src/overlay/BanManagerImpl.cpp
+++ b/src/overlay/BanManagerImpl.cpp
@@ -8,6 +8,7 @@
 #include "database/Database.h"
 #include "main/Application.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -31,6 +32,7 @@ BanManagerImpl::~BanManagerImpl()
 void
 BanManagerImpl::banNode(NodeID nodeID)
 {
+    ZoneScoped;
     if (isBanned(nodeID))
     {
         return;
@@ -52,6 +54,7 @@ BanManagerImpl::banNode(NodeID nodeID)
 void
 BanManagerImpl::unbanNode(NodeID nodeID)
 {
+    ZoneScoped;
     auto nodeIDString = KeyUtils::toStrKey(nodeID);
     CLOG(INFO, "Overlay") << "unban " << nodeIDString;
     auto timer = mApp.getDatabase().getDeleteTimer("ban");
@@ -66,6 +69,7 @@ BanManagerImpl::unbanNode(NodeID nodeID)
 bool
 BanManagerImpl::isBanned(NodeID nodeID)
 {
+    ZoneScoped;
     auto nodeIDString = KeyUtils::toStrKey(nodeID);
     auto timer = mApp.getDatabase().getSelectTimer("ban");
     auto prep = mApp.getDatabase().getPreparedStatement(
@@ -82,6 +86,7 @@ BanManagerImpl::isBanned(NodeID nodeID)
 std::vector<std::string>
 BanManagerImpl::getBans()
 {
+    ZoneScoped;
     std::vector<std::string> result;
     std::string nodeIDString;
     auto timer = mApp.getDatabase().getSelectTimer("ban");

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -14,6 +14,7 @@
 #include "overlay/Tracker.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -26,6 +27,7 @@ ItemFetcher::ItemFetcher(Application& app, AskPeer askPeer)
 void
 ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
 {
+    ZoneScoped;
     CLOG(TRACE, "Overlay") << "fetch " << hexAbbrev(itemHash);
     auto entryIt = mTrackers.find(itemHash);
     if (entryIt == mTrackers.end())
@@ -46,6 +48,7 @@ ItemFetcher::fetch(Hash const& itemHash, const SCPEnvelope& envelope)
 void
 ItemFetcher::stopFetch(Hash const& itemHash, SCPEnvelope const& envelope)
 {
+    ZoneScoped;
     const auto& iter = mTrackers.find(itemHash);
     if (iter != mTrackers.end())
     {
@@ -109,6 +112,7 @@ ItemFetcher::stopFetchingBelow(uint64 slotIndex)
 void
 ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex)
 {
+    ZoneScoped;
     for (auto iter = mTrackers.begin(); iter != mTrackers.end();)
     {
         if (!iter->second->clearEnvelopesBelow(slotIndex))
@@ -125,6 +129,7 @@ ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex)
 void
 ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
 {
+    ZoneScoped;
     const auto& iter = mTrackers.find(itemHash);
     if (iter != mTrackers.end())
     {
@@ -135,6 +140,7 @@ ItemFetcher::doesntHave(Hash const& itemHash, Peer::pointer peer)
 void
 ItemFetcher::recv(Hash itemHash, medida::Timer& timer)
 {
+    ZoneScoped;
     const auto& iter = mTrackers.find(itemHash);
 
     if (iter != mTrackers.end())

--- a/src/overlay/LoadManager.cpp
+++ b/src/overlay/LoadManager.cpp
@@ -11,6 +11,7 @@
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 #include <chrono>
@@ -182,6 +183,7 @@ LoadManager::PeerContext::PeerContext(Application& app, NodeID const& node)
 
 LoadManager::PeerContext::~PeerContext()
 {
+    ZoneScoped;
     if (!isZero(mNode.ed25519()))
     {
         auto pc = mApp.getOverlayManager().getLoadManager().getPeerCosts(mNode);

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -12,6 +12,7 @@
 #include "util/Math.h"
 #include "util/must_use.h"
 
+#include <Tracy.hpp>
 #include <algorithm>
 #include <cmath>
 #include <fmt/format.h>
@@ -91,6 +92,7 @@ PeerManager::PeerManager(Application& app)
 std::vector<PeerBareAddress>
 PeerManager::loadRandomPeers(PeerQuery const& query, int size)
 {
+    ZoneScoped;
     // BATCH_SIZE should always be bigger, so it should win anyway
     size = std::max(size, BATCH_SIZE);
 
@@ -166,6 +168,7 @@ void
 PeerManager::removePeersWithManyFailures(int minNumFailures,
                                          PeerBareAddress const* address)
 {
+    ZoneScoped;
     try
     {
         auto& db = mApp.getDatabase();
@@ -204,6 +207,7 @@ PeerManager::removePeersWithManyFailures(int minNumFailures,
 std::vector<PeerBareAddress>
 PeerManager::getPeersToSend(int size, PeerBareAddress const& address)
 {
+    ZoneScoped;
     auto keep = [&](PeerBareAddress const& pba) {
         return !pba.isPrivate() && pba != address;
     };
@@ -223,6 +227,7 @@ PeerManager::getPeersToSend(int size, PeerBareAddress const& address)
 std::pair<PeerRecord, bool>
 PeerManager::load(PeerBareAddress const& address)
 {
+    ZoneScoped;
     auto result = PeerRecord{};
     auto inDatabase = false;
 
@@ -266,6 +271,7 @@ void
 PeerManager::store(PeerBareAddress const& address, PeerRecord const& peerRecord,
                    bool inDatabase)
 {
+    ZoneScoped;
     std::string query;
 
     if (inDatabase)
@@ -399,6 +405,7 @@ PeerManager::update(PeerRecord& peer, BackOffUpdate backOff, Application& app)
 void
 PeerManager::ensureExists(PeerBareAddress const& address)
 {
+    ZoneScoped;
     auto peer = load(address);
     if (!peer.second)
     {
@@ -411,6 +418,7 @@ PeerManager::ensureExists(PeerBareAddress const& address)
 void
 PeerManager::update(PeerBareAddress const& address, TypeUpdate type)
 {
+    ZoneScoped;
     auto peer = load(address);
     update(peer.first, type);
     store(address, peer.first, peer.second);
@@ -419,6 +427,7 @@ PeerManager::update(PeerBareAddress const& address, TypeUpdate type)
 void
 PeerManager::update(PeerBareAddress const& address, BackOffUpdate backOff)
 {
+    ZoneScoped;
     auto peer = load(address);
     update(peer.first, backOff, mApp);
     store(address, peer.first, peer.second);
@@ -428,6 +437,7 @@ void
 PeerManager::update(PeerBareAddress const& address, TypeUpdate type,
                     BackOffUpdate backOff)
 {
+    ZoneScoped;
     auto peer = load(address);
     update(peer.first, type);
     update(peer.first, backOff, mApp);
@@ -438,6 +448,7 @@ int
 PeerManager::countPeers(std::string const& where,
                         std::function<void(soci::statement&)> const& bind)
 {
+    ZoneScoped;
     int count = 0;
 
     try
@@ -465,6 +476,7 @@ std::vector<PeerBareAddress>
 PeerManager::loadPeers(int limit, int offset, std::string const& where,
                        std::function<void(soci::statement&)> const& bind)
 {
+    ZoneScoped;
     auto result = std::vector<PeerBareAddress>{};
 
     try

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -18,6 +18,7 @@
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 using namespace soci;
@@ -226,6 +227,7 @@ TCPPeer::shutdown()
 void
 TCPPeer::messageSender()
 {
+    ZoneScoped;
     assertThreadIsMain();
 
     // if nothing to do, mark progress and return.
@@ -333,6 +335,7 @@ TCPPeer::writeHandler(asio::error_code const& error,
                       std::size_t bytes_transferred,
                       size_t messages_transferred)
 {
+    ZoneScoped;
     assertThreadIsMain();
     mLastWrite = mApp.getClock().now();
 
@@ -424,6 +427,7 @@ TCPPeer::noteFullyReadBody(size_t nbytes)
 void
 TCPPeer::startRead()
 {
+    ZoneScoped;
     assertThreadIsMain();
     if (shouldAbort())
     {
@@ -606,6 +610,7 @@ TCPPeer::readBodyHandler(asio::error_code const& error,
 void
 TCPPeer::recvMessage()
 {
+    ZoneScoped;
     assertThreadIsMain();
 
     try

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -15,6 +15,7 @@
 #include "util/Math.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -52,6 +53,7 @@ Tracker::pop()
 bool
 Tracker::clearEnvelopesBelow(uint64 slotIndex)
 {
+    ZoneScoped;
     for (auto iter = mWaitingEnvelopes.begin();
          iter != mWaitingEnvelopes.end();)
     {
@@ -88,6 +90,7 @@ Tracker::doesntHave(Peer::pointer peer)
 void
 Tracker::tryNextPeer()
 {
+    ZoneScoped;
     // will be called by some timer or when we get a
     // response saying they don't have it
     CLOG(TRACE, "Overlay") << "tryNextPeer " << hexAbbrev(mItemHash)
@@ -212,6 +215,7 @@ Tracker::tryNextPeer()
 void
 Tracker::listen(const SCPEnvelope& env)
 {
+    ZoneScoped;
     mLastSeenSlotIndex = std::max(env.statement.slotIndex, mLastSeenSlotIndex);
 
     StellarMessage m;
@@ -226,6 +230,7 @@ Tracker::listen(const SCPEnvelope& env)
 void
 Tracker::discard(const SCPEnvelope& env)
 {
+    ZoneScoped;
     auto matchEnvelope = [&env](std::pair<Hash, SCPEnvelope> const& x) {
         return x.second == env;
     };

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -17,6 +17,7 @@
 #include "util/Fs.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 #include <algorithm>
@@ -88,6 +89,7 @@ class ProcessExitEvent::Impl
     bool
     finish()
     {
+        ZoneScoped;
         if (!mOutFile.empty())
         {
             if (fs::exists(mOutFile))
@@ -191,6 +193,7 @@ ProcessManagerImpl::shutdown()
 bool
 ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
+    ZoneScoped;
     if (!pe)
     {
         CLOG(ERROR, "Process")
@@ -289,6 +292,7 @@ struct InfoHelper
     void
     prepare()
     {
+        ZoneScoped;
         if (mInitialized)
         {
             throw std::runtime_error(
@@ -331,6 +335,7 @@ struct InfoHelper
 void
 ProcessExitEvent::Impl::run()
 {
+    ZoneScoped;
     auto manager = mProcManagerImpl.lock();
     assert(manager && !manager->isShutdown());
     if (mRunning)
@@ -459,6 +464,7 @@ ProcessExitEvent::Impl::run()
 asio::error_code
 ProcessManagerImpl::handleProcessTermination(int pid, int /*status*/)
 {
+    ZoneScoped;
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     auto ec = asio::error_code();
     auto process = mProcesses.find(pid);
@@ -473,6 +479,7 @@ ProcessManagerImpl::handleProcessTermination(int pid, int /*status*/)
 bool
 ProcessManagerImpl::cleanShutdown(ProcessExitEvent& pe)
 {
+    ZoneScoped;
     if (!GenerateConsoleCtrlEvent(CTRL_C_EVENT, pe.mImpl->getProcessId()))
     {
         CLOG(WARNING, "Process")
@@ -486,6 +493,7 @@ ProcessManagerImpl::cleanShutdown(ProcessExitEvent& pe)
 bool
 ProcessManagerImpl::forceShutdown(ProcessExitEvent& pe)
 {
+    ZoneScoped;
     if (!TerminateProcess(pe.mImpl->mProcessHandle.native_handle(), 1))
     {
         CLOG(WARNING, "Process")
@@ -563,6 +571,7 @@ ProcessManagerImpl::handleSignalWait()
 asio::error_code
 ProcessManagerImpl::handleProcessTermination(int pid, int status)
 {
+    ZoneScoped;
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     auto ec = asio::error_code();
 
@@ -644,6 +653,7 @@ ProcessManagerImpl::handleProcessTermination(int pid, int status)
 bool
 ProcessManagerImpl::cleanShutdown(ProcessExitEvent& pe)
 {
+    ZoneScoped;
     const int pid = pe.mImpl->getProcessId();
     if (kill(pid, SIGINT) != 0)
     {
@@ -657,6 +667,7 @@ ProcessManagerImpl::cleanShutdown(ProcessExitEvent& pe)
 bool
 ProcessManagerImpl::forceShutdown(ProcessExitEvent& pe)
 {
+    ZoneScoped;
     const int pid = pe.mImpl->getProcessId();
     if (kill(pid, SIGKILL) != 0)
     {
@@ -680,6 +691,7 @@ split(std::string const& s)
 void
 ProcessExitEvent::Impl::run()
 {
+    ZoneScoped;
     auto manager = mProcManagerImpl.lock();
     assert(manager && !manager->isShutdown());
     if (mRunning)
@@ -742,6 +754,7 @@ ProcessExitEvent::Impl::run()
 std::weak_ptr<ProcessExitEvent>
 ProcessManagerImpl::runProcess(std::string const& cmdLine, std::string outFile)
 {
+    ZoneScoped;
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
     auto pe =
         std::shared_ptr<ProcessExitEvent>(new ProcessExitEvent(mIOContext));
@@ -763,6 +776,7 @@ ProcessManagerImpl::runProcess(std::string const& cmdLine, std::string outFile)
 void
 ProcessManagerImpl::maybeRunPendingProcesses()
 {
+    ZoneScoped;
     if (mIsShutdown)
     {
         return;

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -14,6 +14,7 @@
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <functional>
 
 namespace stellar
@@ -149,6 +150,7 @@ BallotProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
 SCP::EnvelopeState
 BallotProtocol::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
 {
+    ZoneScoped;
     dbgAssert(envelope->getStatement().slotIndex == mSlot.getSlotIndex());
 
     SCPStatement const& statement = envelope->getStatement();
@@ -307,6 +309,7 @@ BallotProtocol::isStatementSane(SCPStatement const& st, bool self)
 bool
 BallotProtocol::abandonBallot(uint32 n)
 {
+    ZoneScoped;
     CLOG(TRACE, "SCP") << "BallotProtocol::abandonBallot";
     bool res = false;
     auto v = mSlot.getLatestCompositeCandidate();
@@ -349,6 +352,7 @@ BallotProtocol::bumpState(Value const& value, bool force)
 bool
 BallotProtocol::bumpState(Value const& value, uint32 n)
 {
+    ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
     {
         return false;
@@ -390,6 +394,7 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
 bool
 BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
 {
+    ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
     {
         return false;
@@ -442,6 +447,10 @@ BallotProtocol::updateCurrentValue(SCPBallot const& ballot)
 void
 BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
 {
+    ZoneScoped;
+    ZoneValue(static_cast<int64_t>(mSlot.getSlotIndex()));
+    ZoneValue(static_cast<int64_t>(ballot.counter));
+
     if (Logging::logTrace("SCP"))
         CLOG(TRACE, "SCP") << "BallotProtocol::bumpToBallot"
                            << " i: " << mSlot.getSlotIndex()
@@ -511,6 +520,7 @@ BallotProtocol::ballotProtocolTimerExpired()
 SCPStatement
 BallotProtocol::createStatement(SCPStatementType const& type)
 {
+    ZoneScoped;
     SCPStatement statement;
 
     checkInvariants();
@@ -572,6 +582,7 @@ BallotProtocol::createStatement(SCPStatementType const& type)
 void
 BallotProtocol::emitCurrentStateStatement()
 {
+    ZoneScoped;
     SCPStatementType t;
 
     switch (mPhase)
@@ -670,6 +681,7 @@ BallotProtocol::checkInvariants()
 std::set<SCPBallot>
 BallotProtocol::getPrepareCandidates(SCPStatement const& hint)
 {
+    ZoneScoped;
     std::set<SCPBallot> hintBallots;
 
     switch (hint.pledges.type())
@@ -786,6 +798,7 @@ BallotProtocol::updateCurrentIfNeeded(SCPBallot const& h)
 bool
 BallotProtocol::attemptAcceptPrepared(SCPStatement const& hint)
 {
+    ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
     {
         return false;
@@ -873,6 +886,7 @@ BallotProtocol::attemptAcceptPrepared(SCPStatement const& hint)
 bool
 BallotProtocol::setAcceptPrepared(SCPBallot const& ballot)
 {
+    ZoneScoped;
     if (Logging::logTrace("SCP"))
         CLOG(TRACE, "SCP") << "BallotProtocol::setAcceptPrepared"
                            << " i: " << mSlot.getSlotIndex()
@@ -910,6 +924,7 @@ BallotProtocol::setAcceptPrepared(SCPBallot const& ballot)
 bool
 BallotProtocol::attemptConfirmPrepared(SCPStatement const& hint)
 {
+    ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE)
     {
         return false;
@@ -1030,6 +1045,7 @@ BallotProtocol::commitPredicate(SCPBallot const& ballot, Interval const& check,
 bool
 BallotProtocol::setConfirmPrepared(SCPBallot const& newC, SCPBallot const& newH)
 {
+    ZoneScoped;
     if (Logging::logTrace("SCP"))
         CLOG(TRACE, "SCP") << "BallotProtocol::setConfirmPrepared"
                            << " i: " << mSlot.getSlotIndex()
@@ -1166,6 +1182,7 @@ BallotProtocol::getCommitBoundariesFromStatements(SCPBallot const& ballot)
 bool
 BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
 {
+    ZoneScoped;
     if (mPhase != SCP_PHASE_PREPARE && mPhase != SCP_PHASE_CONFIRM)
     {
         return false;
@@ -1291,6 +1308,7 @@ BallotProtocol::attemptAcceptCommit(SCPStatement const& hint)
 bool
 BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
 {
+    ZoneScoped;
     if (Logging::logTrace("SCP"))
         CLOG(TRACE, "SCP") << "BallotProtocol::setAcceptCommit"
                            << " i: " << mSlot.getSlotIndex()
@@ -1383,6 +1401,7 @@ hasVBlockingSubsetStrictlyAheadOf(
 bool
 BallotProtocol::attemptBump()
 {
+    ZoneScoped;
     if (mPhase == SCP_PHASE_PREPARE || mPhase == SCP_PHASE_CONFIRM)
     {
 
@@ -1427,6 +1446,7 @@ BallotProtocol::attemptBump()
 bool
 BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
 {
+    ZoneScoped;
     if (mPhase != SCP_PHASE_CONFIRM)
     {
         return false;
@@ -1491,6 +1511,7 @@ BallotProtocol::attemptConfirmCommit(SCPStatement const& hint)
 bool
 BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
 {
+    ZoneScoped;
     if (Logging::logTrace("SCP"))
         CLOG(TRACE, "SCP") << "BallotProtocol::setConfirmCommit"
                            << " i: " << mSlot.getSlotIndex()
@@ -1714,6 +1735,7 @@ BallotProtocol::areBallotsLessAndCompatible(SCPBallot const& b1,
 void
 BallotProtocol::setStateFromEnvelope(SCPEnvelopeWrapperPtr e)
 {
+    ZoneScoped;
     if (mCurrentBallot)
     {
         throw std::runtime_error(
@@ -1844,6 +1866,7 @@ BallotProtocol::getExternalizingState() const
 void
 BallotProtocol::advanceSlot(SCPStatement const& hint)
 {
+    ZoneScoped;
     mCurrentMessageLevel++;
     if (Logging::logTrace("SCP"))
         CLOG(TRACE, "SCP") << "BallotProtocol::advanceSlot "
@@ -1939,6 +1962,7 @@ BallotProtocol::getStatementValues(SCPStatement const& st)
 SCPDriver::ValidationLevel
 BallotProtocol::validateValues(SCPStatement const& st)
 {
+    ZoneScoped;
     std::set<Value> values;
 
     values = getStatementValues(st);
@@ -1971,6 +1995,7 @@ BallotProtocol::validateValues(SCPStatement const& st)
 void
 BallotProtocol::sendLatestEnvelope()
 {
+    ZoneScoped;
     // emit current envelope if needed
     if (mCurrentMessageLevel == 0 && mLastEnvelope && mSlot.isFullyValidated())
     {
@@ -2150,12 +2175,14 @@ bool
 BallotProtocol::federatedAccept(StatementPredicate voted,
                                 StatementPredicate accepted)
 {
+    ZoneScoped;
     return mSlot.federatedAccept(voted, accepted, mLatestEnvelopes);
 }
 
 bool
 BallotProtocol::federatedRatify(StatementPredicate voted)
 {
+    ZoneScoped;
     return mSlot.federatedRatify(voted, mLatestEnvelopes);
 }
 
@@ -2170,6 +2197,7 @@ BallotProtocol::checkHeardFromQuorum()
     // for a given counter on the local node
     if (mCurrentBallot)
     {
+        ZoneScoped;
         if (LocalNode::isQuorum(
                 getLocalNode()->getQuorumSet(), mLatestEnvelopes,
                 std::bind(&Slot::getQuorumSetFromStatement, &mSlot, _1),

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -13,6 +13,7 @@
 #include "util/XDROperators.h"
 #include "util/numeric.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <algorithm>
 #include <functional>
 #include <unordered_set>
@@ -46,6 +47,7 @@ LocalNode::buildSingletonQSet(NodeID const& nodeID)
 void
 LocalNode::updateQuorumSet(SCPQuorumSet const& qSet)
 {
+    ZoneScoped;
     mQSetHash = sha256(xdr::xdr_to_opaque(qSet));
     mQSet = qSet;
 }
@@ -215,6 +217,7 @@ LocalNode::isVBlocking(SCPQuorumSet const& qSet,
                        std::map<NodeID, SCPEnvelopeWrapperPtr> const& map,
                        std::function<bool(SCPStatement const&)> const& filter)
 {
+    ZoneScoped;
     std::vector<NodeID> pNodes;
     for (auto const& it : map)
     {
@@ -234,6 +237,7 @@ LocalNode::isQuorum(
     std::function<SCPQuorumSetPtr(SCPStatement const&)> const& qfun,
     std::function<bool(SCPStatement const&)> const& filter)
 {
+    ZoneScoped;
     std::vector<NodeID> pNodes;
     for (auto const& it : map)
     {
@@ -291,6 +295,7 @@ LocalNode::findClosestVBlocking(SCPQuorumSet const& qset,
                                 std::set<NodeID> const& nodes,
                                 NodeID const* excluded)
 {
+    ZoneScoped;
     size_t leftTillBlock =
         ((1 + qset.validators.size() + qset.innerSets.size()) - qset.threshold);
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -14,6 +14,7 @@
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 #include <algorithm>
 #include <functional>
 
@@ -73,12 +74,14 @@ NominationProtocol::isSubsetHelper(xdr::xvector<Value> const& p,
 SCPDriver::ValidationLevel
 NominationProtocol::validateValue(Value const& v)
 {
+    ZoneScoped;
     return mSlot.getSCPDriver().validateValue(mSlot.getSlotIndex(), v, true);
 }
 
 ValueWrapperPtr
 NominationProtocol::extractValidValue(Value const& value)
 {
+    ZoneScoped;
     return mSlot.getSCPDriver().extractValidValue(mSlot.getSlotIndex(), value);
 }
 
@@ -144,6 +147,7 @@ NominationProtocol::recordEnvelope(SCPEnvelopeWrapperPtr env)
 void
 NominationProtocol::emitNomination()
 {
+    ZoneScoped;
     SCPStatement st;
     st.nodeID = mSlot.getLocalNode()->getNodeID();
     st.pledges.type(SCP_ST_NOMINATE);
@@ -216,6 +220,7 @@ NominationProtocol::applyAll(SCPNomination const& nom,
 void
 NominationProtocol::updateRoundLeaders()
 {
+    ZoneScoped;
     SCPQuorumSet myQSet = mSlot.getLocalNode()->getQuorumSet();
 
     // initialize priority with value derived from self
@@ -255,6 +260,7 @@ NominationProtocol::updateRoundLeaders()
 uint64
 NominationProtocol::hashNode(bool isPriority, NodeID const& nodeID)
 {
+    ZoneScoped;
     dbgAssert(!mPreviousValue.empty());
     return mSlot.getSCPDriver().computeHashNode(
         mSlot.getSlotIndex(), mPreviousValue, isPriority, mRoundNumber, nodeID);
@@ -263,6 +269,7 @@ NominationProtocol::hashNode(bool isPriority, NodeID const& nodeID)
 uint64
 NominationProtocol::hashValue(Value const& value)
 {
+    ZoneScoped;
     dbgAssert(!mPreviousValue.empty());
     return mSlot.getSCPDriver().computeValueHash(
         mSlot.getSlotIndex(), mPreviousValue, mRoundNumber, value);
@@ -272,6 +279,7 @@ uint64
 NominationProtocol::getNodePriority(NodeID const& nodeID,
                                     SCPQuorumSet const& qset)
 {
+    ZoneScoped;
     uint64 res;
     uint64 w;
 
@@ -301,6 +309,7 @@ NominationProtocol::getNodePriority(NodeID const& nodeID,
 ValueWrapperPtr
 NominationProtocol::getNewValueFromNomination(SCPNomination const& nom)
 {
+    ZoneScoped;
     // pick the highest value we don't have from the leader
     // sorted using hashValue.
     ValueWrapperPtr newVote;
@@ -336,6 +345,7 @@ NominationProtocol::getNewValueFromNomination(SCPNomination const& nom)
 SCP::EnvelopeState
 NominationProtocol::processEnvelope(SCPEnvelopeWrapperPtr envelope)
 {
+    ZoneScoped;
     auto const& st = envelope->getStatement();
     auto const& nom = st.pledges.nominate();
 
@@ -464,6 +474,7 @@ bool
 NominationProtocol::nominate(ValueWrapperPtr value, Value const& previousValue,
                              bool timedout)
 {
+    ZoneScoped;
     if (Logging::logDebug("SCP"))
         CLOG(DEBUG, "SCP") << "NominationProtocol::nominate (" << mRoundNumber
                            << ") "

--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -30,6 +31,7 @@ AllowTrustOpFrame::getThresholdLevel() const
 bool
 AllowTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "AllowTrustOp apply", true);
     if (ltx.loadHeader().current().ledgerVersion > 2)
     {
         if (mAllowTrust.trustor == getSourceID())

--- a/src/transactions/BumpSequenceOpFrame.cpp
+++ b/src/transactions/BumpSequenceOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "main/Application.h"
 #include "transactions/TransactionFrame.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -35,6 +36,7 @@ BumpSequenceOpFrame::isVersionSupported(uint32_t protocolVersion) const
 bool
 BumpSequenceOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "BumpSequenceOp apply", true);
     LedgerTxn ltxInner(ltx);
     auto header = ltxInner.loadHeader();
     auto sourceAccountEntry = loadSourceAccount(ltxInner, header);

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -26,6 +27,7 @@ ChangeTrustOpFrame::ChangeTrustOpFrame(Operation const& op,
 bool
 ChangeTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "ChangeTrustOp apply", true);
     auto header = ltx.loadHeader();
     auto issuerID = getIssuer(mChangeTrust.line);
 

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -12,6 +12,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 #include <algorithm>
 
 #include "main/Application.h"
@@ -32,6 +33,7 @@ CreateAccountOpFrame::CreateAccountOpFrame(Operation const& op,
 bool
 CreateAccountOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "CreateAccountOp apply", true);
     if (!stellar::loadAccount(ltx, mCreateAccount.destination))
     {
         auto header = ltx.loadHeader();

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -13,6 +13,7 @@
 #include "util/Logging.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -29,6 +30,7 @@ ManageDataOpFrame::ManageDataOpFrame(Operation const& op, OperationResult& res,
 bool
 ManageDataOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "ManageDataOp apply", true);
     auto header = ltx.loadHeader();
     if (header.current().ledgerVersion == 3)
     {

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -9,6 +9,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/OfferExchange.h"
 #include "transactions/TransactionUtils.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -202,6 +203,12 @@ ManageOfferOpFrameBase::computeOfferExchangeParameters(
 bool
 ManageOfferOpFrameBase::doApply(AbstractLedgerTxn& ltxOuter)
 {
+    ZoneNamedN(applyZone, "ManageOfferOp apply", true);
+    std::string pairStr = assetToString(mSheep);
+    pairStr += ":";
+    pairStr += assetToString(mWheat);
+    ZoneTextV(applyZone, pairStr.c_str(), pairStr.size());
+
     LedgerTxn ltx(ltxOuter);
     if (!checkOfferValid(ltx))
     {

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 using namespace soci;
 
@@ -47,6 +48,7 @@ MergeOpFrame::isSeqnumTooFar(LedgerTxnHeader const& header,
 bool
 MergeOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "MergeOp apply", true);
     auto header = ltx.loadHeader();
 
     auto otherAccount =

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -12,6 +12,7 @@
 #include "lib/util/uint128_t.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -112,6 +113,7 @@ ExchangeResult
 exchangeV2(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
            int64_t maxSheepSend)
 {
+    ZoneScoped;
     auto result = ExchangeResult{};
     result.reduced = wheatReceived > maxWheatReceive;
     wheatReceived = std::min(wheatReceived, maxWheatReceive);
@@ -136,6 +138,7 @@ ExchangeResult
 exchangeV3(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
            int64_t maxSheepSend)
 {
+    ZoneScoped;
     auto result = ExchangeResult{};
     result.reduced = wheatReceived > maxWheatReceive;
     result.numWheatReceived = std::min(wheatReceived, maxWheatReceive);
@@ -539,6 +542,7 @@ ExchangeResultV10
 exchangeV10(Price price, int64_t maxWheatSend, int64_t maxWheatReceive,
             int64_t maxSheepSend, int64_t maxSheepReceive, RoundingType round)
 {
+    ZoneScoped;
     auto beforeThresholds = exchangeV10WithoutPriceErrorThresholds(
         price, maxWheatSend, maxWheatReceive, maxSheepSend, maxSheepReceive,
         round);
@@ -903,6 +907,7 @@ adjustOffer(LedgerTxnHeader const& header, LedgerTxnEntry& offer,
 int64_t
 adjustOffer(Price const& price, int64_t maxWheatSend, int64_t maxSheepReceive)
 {
+    ZoneScoped;
     auto res = exchangeV10(price, maxWheatSend, INT64_MAX, INT64_MAX,
                            maxSheepReceive, RoundingType::NORMAL);
     return res.numWheatReceived;
@@ -917,6 +922,7 @@ performExchange(LedgerTxnHeader const& header,
                 int64_t maxWheatReceived, int64_t& numWheatReceived,
                 int64_t maxSheepSend, int64_t& numSheepSend, int64_t& newAmount)
 {
+    ZoneScoped;
     auto const& offer = sellingWheatOffer.current().data.offer();
     Asset const& sheep = offer.buying;
     Asset const& wheat = offer.selling;
@@ -964,6 +970,7 @@ crossOffer(AbstractLedgerTxn& ltx, LedgerTxnEntry& sellingWheatOffer,
            int64_t maxSheepSend, int64_t& numSheepSend,
            std::vector<ClaimOfferAtom>& offerTrail)
 {
+    ZoneScoped;
     assert(maxWheatReceived > 0);
     assert(maxSheepSend > 0);
 
@@ -1080,6 +1087,7 @@ crossOfferV10(AbstractLedgerTxn& ltx, LedgerTxnEntry& sellingWheatOffer,
               int64_t maxSheepSend, int64_t& numSheepSend, bool& wheatStays,
               RoundingType round, std::vector<ClaimOfferAtom>& offerTrail)
 {
+    ZoneScoped;
     assert(maxWheatReceived > 0);
     assert(maxSheepSend > 0);
     auto header = ltx.loadHeader();
@@ -1212,6 +1220,12 @@ convertWithOffers(
     std::function<OfferFilterResult(LedgerTxnEntry const&)> filter,
     std::vector<ClaimOfferAtom>& offerTrail, int64_t maxOffersToCross)
 {
+    ZoneScoped;
+    std::string pairStr = assetToString(sheep);
+    pairStr += ":";
+    pairStr += assetToString(wheat);
+    ZoneText(pairStr.c_str(), pairStr.size());
+
     // If offerTrail is not empty at the start, then the limit maxOffersToCross
     // will not be imposed correctly.
     assert(offerTrail.empty());

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -20,7 +20,7 @@
 #include "transactions/TransactionFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
-
+#include <Tracy.hpp>
 #include <xdrpp/printer.h>
 
 namespace stellar
@@ -96,6 +96,7 @@ bool
 OperationFrame::apply(SignatureChecker& signatureChecker,
                       AbstractLedgerTxn& ltx)
 {
+    ZoneScoped;
     bool res;
     if (Logging::logTrace("Tx"))
     {
@@ -130,6 +131,7 @@ bool
 OperationFrame::checkSignature(SignatureChecker& signatureChecker,
                                AbstractLedgerTxn& ltx, bool forApply)
 {
+    ZoneScoped;
     auto header = ltx.loadHeader();
     auto sourceAccount = loadSourceAccount(ltx, header);
     if (sourceAccount)
@@ -183,6 +185,7 @@ bool
 OperationFrame::checkValid(SignatureChecker& signatureChecker,
                            AbstractLedgerTxn& ltxOuter, bool forApply)
 {
+    ZoneScoped;
     // Note: ltx is always rolled back so checkValid never modifies the ledger
     LedgerTxn ltx(ltxOuter);
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
@@ -220,6 +223,7 @@ LedgerTxnEntry
 OperationFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
                                   LedgerTxnHeader const& header)
 {
+    ZoneScoped;
     return mParentTx.loadAccount(ltx, header, getSourceID());
 }
 

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -9,6 +9,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/TransactionUtils.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -23,6 +24,17 @@ PathPaymentStrictReceiveOpFrame::PathPaymentStrictReceiveOpFrame(
 bool
 PathPaymentStrictReceiveOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "PathPaymentStrictReceiveOp apply", true);
+    std::string pathStr = assetToString(getSourceAsset());
+    for (auto const& asset : mPathPayment.path)
+    {
+        pathStr += "->";
+        pathStr += assetToString(asset);
+    }
+    pathStr += "->";
+    pathStr += assetToString(getDestAsset());
+    ZoneTextV(applyZone, pathStr.c_str(), pathStr.size());
+
     setResultSuccess();
 
     bool doesSourceAccountExist = true;

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -9,6 +9,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/TransactionUtils.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -29,6 +30,17 @@ PathPaymentStrictSendOpFrame::isVersionSupported(uint32_t protocolVersion) const
 bool
 PathPaymentStrictSendOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "PathPaymentStrictSendOp apply", true);
+    std::string pathStr = assetToString(getSourceAsset());
+    for (auto const& asset : mPathPayment.path)
+    {
+        pathStr += "->";
+        pathStr += assetToString(asset);
+    }
+    pathStr += "->";
+    pathStr += assetToString(getDestAsset());
+    ZoneTextV(applyZone, pathStr.c_str(), pathStr.size());
+
     setResultSuccess();
 
     bool bypassIssuerCheck = shouldBypassIssuerCheck(mPathPayment.path);

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -9,6 +9,7 @@
 #include "ledger/LedgerTxnHeader.h"
 #include "transactions/PathPaymentStrictReceiveOpFrame.h"
 #include "transactions/TransactionUtils.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -24,6 +25,10 @@ PaymentOpFrame::PaymentOpFrame(Operation const& op, OperationResult& res,
 bool
 PaymentOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "PaymentOp apply", true);
+    std::string payStr = assetToString(mPayment.asset);
+    ZoneTextV(applyZone, payStr.c_str(), payStr.size());
+
     // if sending to self XLM directly, just mark as success, else we need at
     // least to check trustlines
     // in ledger version 2 it would work for any asset type

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -43,6 +44,8 @@ SetOptionsOpFrame::getThresholdLevel() const
 bool
 SetOptionsOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    ZoneNamedN(applyZone, "SetOptionsOp apply", true);
+
     auto header = ltx.loadHeader();
     auto sourceAccount = loadSourceAccount(ltx, header);
     auto& account = sourceAccount.current().data.account();

--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -11,6 +11,7 @@
 #include "transactions/SignatureUtils.h"
 #include "util/Algoritm.h"
 #include "util/XDROperators.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {

--- a/src/transactions/SignatureUtils.cpp
+++ b/src/transactions/SignatureUtils.cpp
@@ -8,6 +8,7 @@
 #include "crypto/SecretKey.h"
 #include "crypto/SignerKey.h"
 #include "xdr/Stellar-transaction.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -18,6 +19,7 @@ namespace SignatureUtils
 DecoratedSignature
 sign(SecretKey const& secretKey, Hash const& hash)
 {
+    ZoneScoped;
     DecoratedSignature result;
     result.signature = secretKey.sign(hash);
     result.hint = getHint(secretKey.getPublicKey().ed25519());
@@ -45,6 +47,7 @@ verify(DecoratedSignature const& sig, PublicKey const& pubKey, Hash const& hash)
 DecoratedSignature
 signHashX(const ByteSlice& x)
 {
+    ZoneScoped;
     DecoratedSignature result;
     Signature out(0, 0);
     out.resize(static_cast<uint32_t>(x.size()));
@@ -57,6 +60,7 @@ signHashX(const ByteSlice& x)
 bool
 verifyHashX(DecoratedSignature const& sig, SignerKey const& signerKey)
 {
+    ZoneScoped;
     if (!doesHintMatch(signerKey.hashX(), sig.hint))
         return false;
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -31,6 +31,7 @@
 #include "util/XDRStream.h"
 #include "xdrpp/marshal.h"
 #include "xdrpp/printer.h"
+#include <Tracy.hpp>
 #include <string>
 
 #include "medida/meter.h"
@@ -181,6 +182,7 @@ TransactionFrame::checkSignature(SignatureChecker& signatureChecker,
                                  LedgerTxnEntry const& account,
                                  int32_t neededWeight)
 {
+    ZoneScoped;
     auto& acc = account.current().data.account();
     std::vector<Signer> signers;
     if (acc.thresholds[0])
@@ -198,6 +200,7 @@ bool
 TransactionFrame::checkSignatureNoAccount(SignatureChecker& signatureChecker,
                                           AccountID const& accountID)
 {
+    ZoneScoped;
     std::vector<Signer> signers;
     auto signerKey = KeyUtils::convertKey<SignerKey>(accountID);
     signers.push_back(Signer(signerKey, 1));
@@ -208,6 +211,7 @@ LedgerTxnEntry
 TransactionFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
                                     LedgerTxnHeader const& header)
 {
+    ZoneScoped;
     auto res = loadAccount(ltx, header, getSourceID());
     if (header.current().ledgerVersion < 8)
     {
@@ -230,6 +234,7 @@ TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
                               LedgerTxnHeader const& header,
                               AccountID const& accountID)
 {
+    ZoneScoped;
     if (header.current().ledgerVersion < 8 && mCachedAccount &&
         mCachedAccount->data.account().accountID == accountID)
     {
@@ -317,6 +322,7 @@ TransactionFrame::isTooLate(LedgerTxnHeader const& header) const
 bool
 TransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee)
 {
+    ZoneScoped;
     // this function does validations that are independent of the account state
     //    (stay true regardless of other side effects)
     auto header = ltx.loadHeader();
@@ -369,6 +375,7 @@ TransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee)
 void
 TransactionFrame::processSeqNum(AbstractLedgerTxn& ltx)
 {
+    ZoneScoped;
     auto header = ltx.loadHeader();
     if (header.current().ledgerVersion >= 10)
     {
@@ -386,6 +393,7 @@ TransactionFrame::processSignatures(ValidationType cv,
                                     SignatureChecker& signatureChecker,
                                     AbstractLedgerTxn& ltxOuter)
 {
+    ZoneScoped;
     bool maybeValid = (cv == ValidationType::kMaybeValid);
     uint32_t ledgerVersion = ltxOuter.loadHeader().current().ledgerVersion;
     if (ledgerVersion < 10)
@@ -447,6 +455,7 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
                               SequenceNumber current, bool applying,
                               bool chargeFee)
 {
+    ZoneScoped;
     LedgerTxn ltx(ltxOuter);
     ValidationType res = ValidationType::kInvalid;
 
@@ -505,6 +514,7 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
 void
 TransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
 {
+    ZoneScoped;
     mCachedAccount.reset();
 
     auto header = ltx.loadHeader();
@@ -568,6 +578,7 @@ TransactionFrame::removeAccountSigner(AbstractLedgerTxn& ltxOuter,
                                       AccountID const& accountID,
                                       SignerKey const& signerKey) const
 {
+    ZoneScoped;
     LedgerTxn ltx(ltxOuter);
 
     auto account = stellar::loadAccount(ltx, accountID);
@@ -595,6 +606,7 @@ bool
 TransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
                              SequenceNumber current, bool chargeFee)
 {
+    ZoneScoped;
     mCachedAccount.reset();
 
     LedgerTxn ltx(ltxOuter);
@@ -678,6 +690,7 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                                   Application& app, AbstractLedgerTxn& ltx,
                                   TransactionMeta& outerMeta)
 {
+    ZoneScoped;
     try
     {
         bool success = true;
@@ -779,6 +792,7 @@ bool
 TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
                         TransactionMeta& meta, bool chargeFee)
 {
+    ZoneScoped;
     try
     {
         mCachedAccount.reset();

--- a/src/transactions/TransactionSQL.cpp
+++ b/src/transactions/TransactionSQL.cpp
@@ -11,6 +11,7 @@
 #include "util/Decoder.h"
 #include "util/XDRStream.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -20,6 +21,7 @@ storeTransaction(Database& db, uint32_t ledgerSeq,
                  TransactionFrameBasePtr const& tx, TransactionMeta& tm,
                  TransactionResultSet const& resultSet)
 {
+    ZoneScoped;
     std::string txBody =
         decoder::encode_b64(xdr::xdr_to_opaque(tx->getEnvelope()));
     std::string txResult =
@@ -58,6 +60,7 @@ storeTransactionFee(Database& db, uint32_t ledgerSeq,
                     TransactionFrameBasePtr const& tx,
                     LedgerEntryChanges const& changes, uint32_t txIndex)
 {
+    ZoneScoped;
     std::string txChanges = decoder::encode_b64(xdr::xdr_to_opaque(changes));
 
     std::string txIDString = binToHex(tx->getContentsHash());
@@ -87,6 +90,7 @@ storeTransactionFee(Database& db, uint32_t ledgerSeq,
 TransactionResultSet
 getTransactionHistoryResults(Database& db, uint32 ledgerSeq)
 {
+    ZoneScoped;
     TransactionResultSet res;
     std::string txresult64;
     auto prep =
@@ -117,6 +121,7 @@ getTransactionHistoryResults(Database& db, uint32 ledgerSeq)
 std::vector<LedgerEntryChanges>
 getTransactionFeeMeta(Database& db, uint32 ledgerSeq)
 {
+    ZoneScoped;
     std::vector<LedgerEntryChanges> res;
     std::string changes64;
     auto prep =
@@ -148,6 +153,7 @@ saveTransactionHelper(Database& db, soci::session& sess, uint32 ledgerSeq,
                       XDROutputFileStream& txOut,
                       XDROutputFileStream& txResultOut)
 {
+    ZoneScoped;
     // prepare the txset for saving
     auto lh = LedgerHeaderUtils::loadBySequence(db, sess, ledgerSeq);
     if (!lh)
@@ -170,6 +176,7 @@ copyTransactionsToStream(Hash const& networkID, Database& db,
                          uint32_t ledgerCount, XDROutputFileStream& txOut,
                          XDROutputFileStream& txResultOut)
 {
+    ZoneScoped;
     auto timer = db.getSelectTimer("txhistory");
     std::string txBody, txResult, txMeta;
     uint32_t begin = ledgerSeq, end = ledgerSeq + ledgerCount;
@@ -246,6 +253,7 @@ copyTransactionsToStream(Hash const& networkID, Database& db,
 void
 dropTransactionHistory(Database& db)
 {
+    ZoneScoped;
     db.getSession() << "DROP TABLE IF EXISTS txhistory";
 
     db.getSession() << "DROP TABLE IF EXISTS txfeehistory";
@@ -275,6 +283,7 @@ void
 deleteOldTransactionHistoryEntries(Database& db, uint32_t ledgerSeq,
                                    uint32_t count)
 {
+    ZoneScoped;
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
                                           "txhistory", "ledgerseq");
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -11,6 +11,7 @@
 #include "transactions/OfferExchange.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -71,12 +72,14 @@ dataKey(AccountID const& accountID, std::string const& dataName)
 LedgerTxnEntry
 loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID)
 {
+    ZoneScoped;
     return ltx.load(accountKey(accountID));
 }
 
 ConstLedgerTxnEntry
 loadAccountWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID)
 {
+    ZoneScoped;
     return ltx.loadWithoutRecord(accountKey(accountID));
 }
 
@@ -84,12 +87,14 @@ LedgerTxnEntry
 loadData(AbstractLedgerTxn& ltx, AccountID const& accountID,
          std::string const& dataName)
 {
+    ZoneScoped;
     return ltx.load(dataKey(accountID, dataName));
 }
 
 LedgerTxnEntry
 loadOffer(AbstractLedgerTxn& ltx, AccountID const& sellerID, int64_t offerID)
 {
+    ZoneScoped;
     return ltx.load(offerKey(sellerID, offerID));
 }
 
@@ -97,6 +102,7 @@ TrustLineWrapper
 loadTrustLine(AbstractLedgerTxn& ltx, AccountID const& accountID,
               Asset const& asset)
 {
+    ZoneScoped;
     return TrustLineWrapper(ltx, accountID, asset);
 }
 
@@ -104,6 +110,7 @@ ConstTrustLineWrapper
 loadTrustLineWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID,
                            Asset const& asset)
 {
+    ZoneScoped;
     return ConstTrustLineWrapper(ltx, accountID, asset);
 }
 
@@ -111,6 +118,7 @@ TrustLineWrapper
 loadTrustLineIfNotNative(AbstractLedgerTxn& ltx, AccountID const& accountID,
                          Asset const& asset)
 {
+    ZoneScoped;
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
         return {};
@@ -123,6 +131,7 @@ loadTrustLineWithoutRecordIfNotNative(AbstractLedgerTxn& ltx,
                                       AccountID const& accountID,
                                       Asset const& asset)
 {
+    ZoneScoped;
     if (asset.type() == ASSET_TYPE_NATIVE)
     {
         return {};
@@ -135,6 +144,7 @@ acquireOrReleaseLiabilities(AbstractLedgerTxn& ltx,
                             LedgerTxnHeader const& header,
                             LedgerTxnEntry const& offerEntry, bool isAcquire)
 {
+    ZoneScoped;
     // This should never happen
     auto const& offer = offerEntry.current().data.offer();
     if (offer.buying == offer.selling)

--- a/src/util/Scheduler.cpp
+++ b/src/util/Scheduler.cpp
@@ -5,6 +5,7 @@
 #include "util/Scheduler.h"
 #include "lib/util/finally.h"
 #include "util/Timer.h"
+#include <Tracy.hpp>
 #include <cassert>
 
 namespace stellar
@@ -142,6 +143,8 @@ class Scheduler::ActionQueue
     void
     runNext(VirtualClock& clock, nsecs minTotalService)
     {
+        ZoneScoped;
+        ZoneText(mName.c_str(), mName.size());
         auto before = clock.now();
         Action action = std::move(mActions.front().mAction);
         mActions.pop_front();

--- a/src/util/TmpDir.cpp
+++ b/src/util/TmpDir.cpp
@@ -9,12 +9,14 @@
 #include "main/Config.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
 
 TmpDir::TmpDir(std::string const& prefix)
 {
+    ZoneScoped;
     size_t attempts = 0;
     for (;;)
     {
@@ -44,6 +46,7 @@ TmpDir::getName() const
 
 TmpDir::~TmpDir()
 {
+    ZoneScoped;
     if (!mPath)
     {
         return;
@@ -80,6 +83,7 @@ TmpDirManager::~TmpDirManager()
 void
 TmpDirManager::clean()
 {
+    ZoneScoped;
     if (fs::exists(mRoot))
     {
         LOG(DEBUG) << "TmpDirManager cleaning: " << mRoot;

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -10,6 +10,7 @@
 #include "util/Fs.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
+#include <Tracy.hpp>
 
 #include <fstream>
 #include <string>
@@ -41,12 +42,14 @@ class XDRInputFileStream
     void
     close()
     {
+        ZoneScoped;
         mIn.close();
     }
 
     void
     open(std::string const& filename)
     {
+        ZoneScoped;
         mIn.open(filename, std::ifstream::binary);
         if (!mIn)
         {
@@ -84,6 +87,7 @@ class XDRInputFileStream
     bool
     readOne(T& out)
     {
+        ZoneScoped;
         char szBuf[4];
         if (!mIn.read(szBuf, 4))
         {
@@ -176,6 +180,7 @@ class XDROutputFileStream
     void
     close()
     {
+        ZoneScoped;
         if (!isOpen())
         {
             FileSystemException::failWith(
@@ -220,6 +225,7 @@ class XDROutputFileStream
     void
     flush()
     {
+        ZoneScoped;
         if (!isOpen())
         {
             FileSystemException::failWith(
@@ -248,6 +254,7 @@ class XDROutputFileStream
     void
     open(std::string const& filename)
     {
+        ZoneScoped;
         mUsingRandomAccessHandle = fs::shouldUseRandomAccessHandle(filename);
         if (isOpen())
         {
@@ -275,6 +282,7 @@ class XDROutputFileStream
     void
     writeOne(T const& t, SHA256* hasher = nullptr, size_t* bytesPut = nullptr)
     {
+        ZoneScoped;
         if (!isOpen())
         {
             FileSystemException::failWith(

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -5,6 +5,7 @@
 #include "work/BasicWork.h"
 #include "util/Logging.h"
 #include "util/Math.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -330,6 +331,7 @@ BasicWork::wakeSelfUpCallback(std::function<void()> innerCallback)
 void
 BasicWork::crankWork()
 {
+    ZoneScoped;
     assert(!isDone() && mState != InternalState::WAITING);
 
     InternalState nextState;

--- a/src/work/BatchWork.cpp
+++ b/src/work/BatchWork.cpp
@@ -5,6 +5,7 @@
 #include "work/BatchWork.h"
 #include "catchup/CatchupManager.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -25,6 +26,7 @@ BatchWork::doReset()
 BasicWork::State
 BatchWork::doWork()
 {
+    ZoneScoped;
     if (anyChildRaiseFailure())
     {
         return State::WORK_FAILURE;
@@ -62,6 +64,7 @@ BatchWork::doWork()
 void
 BatchWork::addMoreWorkIfNeeded()
 {
+    ZoneScoped;
     if (isAborting())
     {
         throw std::runtime_error(getName() + " is being aborted!");

--- a/src/work/ConditionalWork.cpp
+++ b/src/work/ConditionalWork.cpp
@@ -4,6 +4,7 @@
 
 #include "ConditionalWork.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -35,6 +36,7 @@ ConditionalWork::ConditionalWork(Application& app, std::string name,
 BasicWork::State
 ConditionalWork::onRun()
 {
+    ZoneScoped;
     if (mWorkStarted)
     {
         mConditionedWork->crankWork();
@@ -75,6 +77,7 @@ ConditionalWork::onRun()
 void
 ConditionalWork::shutdown()
 {
+    ZoneScoped;
     if (mWorkStarted)
     {
         mConditionedWork->shutdown();
@@ -85,6 +88,7 @@ ConditionalWork::shutdown()
 bool
 ConditionalWork::onAbort()
 {
+    ZoneScoped;
     if (mWorkStarted && !mConditionedWork->isDone())
     {
         mConditionedWork->crankWork();

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -4,6 +4,7 @@
 
 #include "work/Work.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 #include <fmt/format.h>
 
 namespace stellar
@@ -35,6 +36,7 @@ Work::getStatus() const
 void
 Work::shutdown()
 {
+    ZoneScoped;
     shutdownChildren();
     BasicWork::shutdown();
 }
@@ -42,6 +44,7 @@ Work::shutdown()
 BasicWork::State
 Work::onRun()
 {
+    ZoneScoped;
     if (mAbortChildrenButNotSelf)
     {
         // Stop whatever work was doing, just wait for children to abort
@@ -80,6 +83,7 @@ Work::onRun()
 bool
 Work::onAbort()
 {
+    ZoneScoped;
     auto child = yieldNextRunningChild();
     if (child)
     {
@@ -120,6 +124,7 @@ Work::shutdownChildren()
 void
 Work::onReset()
 {
+    ZoneScoped;
     clearChildren();
     mAbortChildrenButNotSelf = false;
     doReset();
@@ -133,6 +138,7 @@ Work::doReset()
 void
 Work::clearChildren()
 {
+    ZoneScoped;
     assert(allChildrenDone());
     mDoneChildren += mChildren.size();
     mChildren.clear();

--- a/src/work/WorkSequence.cpp
+++ b/src/work/WorkSequence.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "WorkSequence.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -19,6 +20,7 @@ WorkSequence::WorkSequence(Application& app, std::string name,
 BasicWork::State
 WorkSequence::onRun()
 {
+    ZoneScoped;
     if (mNextInSequence == mSequenceOfWork.end())
     {
         // Completed all the work
@@ -53,6 +55,7 @@ WorkSequence::onRun()
 bool
 WorkSequence::onAbort()
 {
+    ZoneScoped;
     if (mCurrentExecuting && !mCurrentExecuting->isDone())
     {
         // Wait for the current work in sequence to finish aborting
@@ -65,6 +68,7 @@ WorkSequence::onAbort()
 void
 WorkSequence::onReset()
 {
+    ZoneScoped;
     assert(std::all_of(
         mSequenceOfWork.cbegin(), mNextInSequence,
         [](std::shared_ptr<BasicWork> const& w) { return w->isDone(); }));
@@ -85,6 +89,7 @@ WorkSequence::getStatus() const
 void
 WorkSequence::shutdown()
 {
+    ZoneScoped;
     if (mCurrentExecuting)
     {
         mCurrentExecuting->shutdown();


### PR DESCRIPTION
This change does 3 things in 3 commits:

  - Adds a new submodule which contains the [Tracy](https://github.com/wolfpld/tracy) tracing system, both client and server components. It's not especially big.
  - Integrates the submodule and its client component (that is embedded in the traced program) `TracyClient.cpp` into stellar-core. This component automatically spawns a thread listening on port 8086 for Tracy server connections (the "server" here being a command-line trace recorder or a workstation GUI process), and feeds trace data to the server. When no server is connected, the client component is idle and any annotations in the traced program are no-ops.
  - Annotates stellar-core in a few hundred places with the RAII guard object that logs entry and exit of a "zone" in the client's trace-recording machinery. These are very lightweight no-ops when no server is connected, and appear to cost about 5% of CPU time when active/tracing (and generating tens of MB of trace data per second to the connected server). In a few places I've also added numeric plot tracing (`TracyPlot`) of metrics we're recording, or textual notes (`ZoneText`) or values (`ZoneValue`) attached to zones that further classifies the events at each Zone.

I believe this is ready to land now. Following pieces are wrapped up:

  - [x] Disabled tracy in build by default, must pass `--enable-tracy`.
  - [x] Modified to only listen on localhost, not 0.0.0.0
  - [x] Integrated building of the server components (GUI and recorder) with the core build system: configure with `--enable-tracy-capture` and/or `--enable-tracy-gui`
  - [x] Upstreamed fixes for submodule integration.
  - [x] Rebased on master.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

Performance is negligibly affected when tracing is off, and tolerably so when it's on (which is only during the time that it's recording / streaming to a server -- gui or capture tool)

~~~
-- tracy symbols when not tracing --

0.03%    tracy::GetProfiler             
0.01%    tracy::Thread::Launch          
0.01%    tracy::Thread::Launch          
0.01%    tracy::Profiler::Worker        
0.00%    tracy::Profiler::CompressWorker

-- tracy symbols when tracing --

4.28%    tracy::Thread::Launch
4.26%    tracy::Profiler::Worker
2.88%    tracy::LZ4_compress_fast_continue
2.87%    tracy::Profiler::CommitData
1.18%    tracy::Profiler::Dequeue
0.83%    tracy::moodycamel::ConcurrentQueue<tracy::QueueItem, tracy::moodycamel::ConcurrentQueueDefaultTraits>::try_dequeue_bulk_single<tracy::QueueItem*>
0.08%    tracy::GetProfiler
0.06%    tracy::moodycamel::ConcurrentQueue<tracy::QueueItem, tracy::moodycamel::ConcurrentQueueDefaultTraits>::ExplicitProducer::enqueue_begin_alloc
0.05%    TLS init function for tracy::s_rpmalloc_thread_init
0.03%    tracy::moodycamel::ConcurrentQueue<tracy::QueueItem, tracy::moodycamel::ConcurrentQueueDefaultTraits>::ExplicitProducer::dequeue_bulk<tracy::QueueItem*>
0.01%    tracy::Thread::Launch
0.01%    tracy::Profiler::CompressWorker
0.01%    tracy::Profiler::ProcessSysTime
0.00%    tracy::GetToken
0.00%    tracy::Profiler::HandleServerQuery
0.00%    tracy::Profiler::DequeueSerial
0.00%    tracy::moodycamel::ConcurrentQueue<tracy::QueueItem, tracy::moodycamel::ConcurrentQueueDefaultTraits>::recycle_or_create_producer
0.00%    tracy::_memory_allocate
0.00%    tracy::_memory_map_spans
~~~