### PR TITLE
Revert sqlite page size bump

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -431,24 +431,6 @@ Database::initialize()
     // normally you do not want to touch this section as
     // schema updates are done in applySchemaUpgrade
 
-    if (isSqlite() && mApp.getConfig().DATABASE.value != "sqlite3://:memory:")
-    {
-        // When we're in non-memory (i.e. "disk") mode of SQLite we want to bump
-        // up the page size to 64k (the maximum supported). On fast SSDs / NVMe
-        // this actually is a slight speed-loss, but it's a significant win on
-        // slow disks (spinning platters, low-IOPS EBS, etc.)
-        //
-        // To do this we need to disable journalling, adjust the page_size, then
-        // vacuum and re-enable journalling. NB: WAL mode is _ignored_ in memory
-        // mode, so it's important that this code not run in memory mode, it'll
-        // disable all journalling and silently _not_ re-enable it.
-
-        mSession << "PRAGMA journal_mode = OFF";
-        mSession << "PRAGMA page_size = 65536";
-        mSession << "VACUUM";
-        mSession << "PRAGMA journal_mode = WAL";
-    }
-
     // only time this section should be modified is when
     // consolidating changes found in applySchemaUpgrade here
     Upgrades::dropAll(*this);


### PR DESCRIPTION
# Description

There is a performance hit for high-IOPS low-throughput EBS volumes when the sqlite page size is bumped to 64k. This was shown when an internal testing parallel catchup test timed out after 12 hours, but succeeded in 9 hours when the sqlite change was removed.

I didn't revert the entire commit so we could keep the test case that was added.  

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
