### PR TITLE
Cache the result of TxSetFrame::checkValid between calls.

### DIFF
--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -7,6 +7,7 @@
 #include "ledger/LedgerHashUtils.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrame.h"
+#include "util/optional.h"
 #include <deque>
 #include <functional>
 #include <unordered_map>
@@ -39,8 +40,11 @@ class AbstractTxSetFrameForApply
 
 class TxSetFrame : public AbstractTxSetFrameForApply
 {
-    bool mHashIsValid;
-    Hash mHash;
+    optional<Hash> mHash{nullptr};
+
+    // mValid caches both the last app LCL that we checked
+    // vaidity for, and the result of that validity check.
+    optional<std::pair<Hash, bool>> mValid{nullptr};
 
     Hash mPreviousLedgerHash;
 
@@ -89,7 +93,8 @@ class TxSetFrame : public AbstractTxSetFrameForApply
     add(TransactionFrameBasePtr tx)
     {
         mTransactions.push_back(tx);
-        mHashIsValid = false;
+        mHash.reset();
+        mValid.reset();
     }
 
     size_t size(LedgerHeader const& lh) const;


### PR DESCRIPTION
This improves performance of receiving multiple SCP messages that reference the same txset.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

(Perf summary: shifts a bunch of ~1ms redundant verifies to ~10usec each. Overall effect depends on txset size and load, but it generally wins more the more heavily loaded we are.)