### PR TITLE
SCP: properly clear state during internal transition

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -477,11 +477,15 @@ BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
 
     mCurrentBallot = makeBallot(ballot);
 
+    // note: we have to clear some fields (and recompute them based on latest
+    // messages)
     // invariant: h.value = b.value
     if (mHighBallot && !areBallotsCompatible(mCurrentBallot->getBallot(),
                                              mHighBallot->getBallot()))
     {
         mHighBallot.reset();
+        // invariant: c set only when h is set
+        mCommit.reset();
     }
 
     if (gotBumped)


### PR DESCRIPTION
This PR fixes an edge case that was not covered in a fix from a couple years ago in 675382d8e9c81244d9408b96a8463739e070a0bc

Basically, as the SCP state machine goes through a few internal transitions, it has to meet all invariants; yet in this case we forgot to reset `c` (that may or may not be set again in a later transition).
