### PR TITLE
Clean up buckets in in-memory mode in BucketManager::shutdown, not runCatchup

### DIFF
--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -48,6 +48,8 @@ class BucketManagerImpl : public BucketManager
     medida::Counter& mSharedBucketsSize;
     MergeCounters mMergeCounters;
 
+    bool const mDeleteEntireBucketDirInDtor;
+
     // Records bucket-merges that are currently _live_ in some FutureBucket, in
     // the sense of either running, or finished (with or without the
     // FutureBucket being resolved). Entries in this map will be cleared when
@@ -64,7 +66,8 @@ class BucketManagerImpl : public BucketManager
     BucketMergeMap mFinishedMerges;
 
     void cleanupStaleFiles();
-    void cleanDir();
+    void deleteTmpDirAndUnlockBucketDir();
+    void deleteEntireBucketDir();
     bool renameBucket(std::string const& src, std::string const& dst);
 
 #ifdef BUILD_TESTS

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -600,14 +600,6 @@ runCatchup(CommandLineArgs const& args)
                     writeCatchupInfo(catchupInfo, outputFile);
                 }
             }
-
-            if (replayInMemory)
-            {
-                // Clean up `buckets` folder when in in-memory-replay mode
-                VirtualClock clockBuckets(VirtualClock::REAL_TIME);
-                auto app = Application::create(clockBuckets, config, true);
-            }
-
             return result;
         });
 }


### PR DESCRIPTION
In 0c423487b7a1441dc8a0ed612cb5cb2aad8ad2c1 the `runCatchup` code was modified to "clean up" the buckets folder at the end of an in-memory-replay catchup by constructing a second application in newdb=true mode, and then immediately shutting it down. This does technically work but it means that the app is started-and-stopped _twice_ In a catchup run, and if there's anything in the catchup run that's only supposed to happen once this will try to happen twice, and potentially fail the second time.

Specifically: if we run with a metadata output stream set to a file descriptor, it'll be closed on the first application shutdown and then you'll get a spurious error when the second application attempts to re-open it.

In general I think this "run the app twice" approach probably isn't ideal. At very least not what a casual reader of ApplicationImpl is going to expect. So this PR suggests removing it and achieving the same cleanup by teaching the BucketManagerImpl to purge the bucket directory on shutdown in in-memory-replay mode instead.