### PR TITLE
Convert OverlaySurvey.py to Python 3

### DIFF
--- a/scripts/OverlaySurvey.py
+++ b/scripts/OverlaySurvey.py
@@ -180,7 +180,7 @@ def run_survey(args):
                 peer_list.append(key)
 
     if nx.is_empty(G):
-        print "Graph is empty!"
+        print("Graph is empty!")
         sys.exit(0)
 
     write_graph_stats(G, args.graphStats)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ This folder is for storing any scripts that may be helpful for using stellar-cor
 ### Overlay survey 
 - Name - `OverlaySurvey.py`
 - Description - A Python script that will walk the network using the Overlay survey mechanism to gather connection information. See [admin](./../docs/software/admin.md#overlay-topology-survey) for more information on the overlay survey. The survey will use the peers of the initial node to seed the survey.
-- Usage - Ex. `python OverlaySurvey.py -gs gs.json survey -n http://127.0.0.1:11626 -d 50 -sr sr.json -gmlw gmlw.graphml` to run the survey or `python OverlaySurvey.py -gs gs.json analyze -gmla gmla.graphml` to analyze an existing graph.
+- Usage - Ex. `python3 OverlaySurvey.py -gs gs.json survey -n http://127.0.0.1:11626 -d 50 -sr sr.json -gmlw gmlw.graphml` to run the survey or `python3 OverlaySurvey.py -gs gs.json analyze -gmla gmla.graphml` to analyze an existing graph.
     - `-gs GRAPHSTATS`, `--graphStats GRAPHSTATS` - output file for graph stats
     - sub command `survey` - run survey and analyze
         - `-n NODE`, `--node NODE` - address of initial survey node


### PR DESCRIPTION
# Description

Convert `OverlaySurvey.py` to Python 3. Unfortunately, this script is rather hard to test because the output is different when this script is run multiple times.

However, I tried running this with Python 2 and Python 3 at the same time on testnet, and the results seem fairly close by looking at the output files using yEd.

On top of that, the only change in the code is the parentheses, so it seems reasonable to assume that this change will not affect the performance.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
