### PR TITLE
Remove use of the term whitelist

### DIFF
--- a/src/work/BasicWork.h
+++ b/src/work/BasicWork.h
@@ -238,7 +238,7 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
     size_t mRetries{0};
     size_t const mMaxRetries{RETRY_A_FEW};
 
-    // Whitelist legal state transitions in work state machine
+    // Legal and allowed state transitions in work state machine
     static std::set<Transition> const ALLOWED_TRANSITIONS;
 };
 }


### PR DESCRIPTION
# Description

## What
Remove use of the term whitelist from comment.

## Why
See stellar/stellar-protocol@e2c2903a8e9362ebbb894feea0545c0970faf8c4.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
