### PR TITLE
Small test code refactorings and other tiny cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@
 *.suo
 *.trs
 *.db
+.clangd
+*.xdr.gz
+stellar-core-test-*
+*history*.json
+test-*.txt
 
 # sourcetrail
 compile_commands.json

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -717,7 +717,7 @@ TEST_CASE("txset base fee", "[herder][txset]")
         auto balancesBefore = getBalances();
 
         // apply this
-        closeLedgerOn(*app, 2, 1, 1, 2020, txSet->mTransactions);
+        closeLedgerOn(*app, 2, 1, 1, 2020, 0, 0, 0, txSet->mTransactions);
 
         auto balancesAfter = getBalances();
         int64_t lowFee = INT64_MAX, highFee = 0;

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -103,7 +103,7 @@ time_t
 getTestDateTime(int day, int month, int year, int hour, int minute, int second)
 {
     auto tm = getTestDateTimeStruct(day, month, year, hour, minute, second);
-    return VirtualClock::tm_to_time_t(tm);
+    return VirtualClock::tmToSystemTimeT(tm);
 }
 
 time_t

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -100,18 +100,21 @@ TestApplication::createInvariantManager()
 }
 
 time_t
+getTestDateTime(int day, int month, int year, int hour, int minute, int second)
+{
+    auto tm = getTestDateTimeStruct(day, month, year, hour, minute, second);
+    return VirtualClock::tm_to_time_t(tm);
+}
+
+time_t
 getTestDate(int day, int month, int year)
 {
-    auto tm = getTestDateTime(day, month, year, 0, 0, 0);
-
-    VirtualClock::system_time_point tp = VirtualClock::tmToSystemPoint(tm);
-    time_t t = VirtualClock::to_time_t(tp);
-
-    return t;
+    return getTestDateTime(day, month, year, 0, 0, 0);
 }
 
 std::tm
-getTestDateTime(int day, int month, int year, int hour, int minute, int second)
+getTestDateTimeStruct(int day, int month, int year, int hour, int minute,
+                      int second)
 {
     std::tm tm = {0};
     tm.tm_hour = hour;
@@ -127,6 +130,6 @@ VirtualClock::system_time_point
 genesis(int minute, int second)
 {
     return VirtualClock::tmToSystemPoint(
-        getTestDateTime(1, 7, 2014, 0, minute, second));
+        getTestDateTimeStruct(1, 7, 2014, 0, minute, second));
 }
 }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -106,12 +106,6 @@ getTestDateTime(int day, int month, int year, int hour, int minute, int second)
     return VirtualClock::tmToSystemTimeT(tm);
 }
 
-time_t
-getTestDate(int day, int month, int year)
-{
-    return getTestDateTime(day, month, year, 0, 0, 0);
-}
-
 std::tm
 getTestDateTimeStruct(int day, int month, int year, int hour, int minute,
                       int second)

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -80,8 +80,10 @@ createTestApplication(VirtualClock& clock, Config const& cfg, Args&&... args,
 }
 
 time_t getTestDate(int day, int month, int year);
-std::tm getTestDateTime(int day, int month, int year, int hour, int minute,
-                        int second);
+time_t getTestDateTime(int day, int month, int year, int hour, int minute,
+                       int second);
+std::tm getTestDateTimeStruct(int day, int month, int year, int hour,
+                              int minute, int second);
 
 VirtualClock::system_time_point genesis(int minute, int second);
 }

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -79,9 +79,8 @@ createTestApplication(VirtualClock& clock, Config const& cfg, Args&&... args,
     return app;
 }
 
-time_t getTestDate(int day, int month, int year);
-time_t getTestDateTime(int day, int month, int year, int hour, int minute,
-                       int second);
+time_t getTestDateTime(int day, int month, int year, int hour = 0,
+                       int minute = 0, int second = 0);
 std::tm getTestDateTimeStruct(int day, int month, int year, int hour,
                               int minute, int second);
 

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -335,14 +335,6 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
 
 TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
-              std::vector<TransactionFrameBasePtr> const& txs)
-{
-    return closeLedgerOn(app, ledgerSeq, day, month, year, 0 /* hour */,
-                         0 /* minute */, 0 /* second */, txs);
-}
-
-TxSetResultMeta
-closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
               int hour, int minute, int second,
               std::vector<TransactionFrameBasePtr> const& txs)
 {

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -72,6 +72,15 @@ void validateTxResults(TransactionFramePtr const& tx, Application& app,
                        TransactionResult const& applyResult = {});
 
 TxSetResultMeta
+closeLedgerOn(Application& app, uint32 ledgerSeq, time_t closeTime,
+              std::vector<TransactionFrameBasePtr> const& txs = {});
+
+TxSetResultMeta
+closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
+              int hour, int minute, int second,
+              std::vector<TransactionFrameBasePtr> const& txs = {});
+
+TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
               std::vector<TransactionFrameBasePtr> const& txs = {});
 

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -77,11 +77,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, time_t closeTime,
 
 TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
-              int hour, int minute, int second,
-              std::vector<TransactionFrameBasePtr> const& txs = {});
-
-TxSetResultMeta
-closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
+              int hour = 0, int minute = 0, int second = 0,
               std::vector<TransactionFrameBasePtr> const& txs = {});
 
 SecretKey getRoot(Hash const& networkID);

--- a/src/test/run-selftest-nopg
+++ b/src/test/run-selftest-nopg
@@ -6,9 +6,10 @@
 
 BASE_INSTANCE="$1"
 TESTS="$2"
+: ${SELFTEST_LOG_LEVEL:="fatal"}
 
 if [[ "$ALL_VERSIONS" != "" ]]; then
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll $SELFTEST_LOG_LEVEL --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
 else
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll $SELFTEST_LOG_LEVEL --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
 fi

--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -9,6 +9,7 @@ TESTS="$2"
 if [[ -z "$TEMP_POSTGRES" ]]; then
     TEMP_POSTGRES=1
 fi
+: ${SELFTEST_LOG_LEVEL:="fatal"}
 
 PGDIRS=$(exec 2>/dev/null; cd /usr/lib/postgresql && ls -1d */bin | sort -rn | xargs realpath)
 
@@ -94,7 +95,7 @@ else
     echo "PostgreSQL enabled for tests using existing database cluster"
 fi
 if [ "$ALL_VERSIONS" != "" ]; then
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll $SELFTEST_LOG_LEVEL --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
 else                                 
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
+    ./stellar-core test --ll $SELFTEST_LOG_LEVEL --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
 fi

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -31,6 +31,7 @@
 #include "util/XDRStream.h"
 #include "xdrpp/marshal.h"
 #include "xdrpp/printer.h"
+#include <fmt/format.h>
 #include <Tracy.hpp>
 #include <string>
 
@@ -551,7 +552,11 @@ TransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
         {
             // this should not happen as the transaction set is sanitized for
             // sequence numbers
-            throw std::runtime_error("Unexpected account state");
+            throw std::runtime_error(fmt::format("Unexpected account state: "
+                                                 "account seqnum={}, "
+                                                 "tx seqnum={}",
+                                                 acc.seqNum,
+                                                 getSeqNum()));
         }
         acc.seqNum = getSeqNum();
     }

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -292,7 +292,7 @@ TEST_CASE("inflation", "[tx][inflation]")
 
     VirtualClock::system_time_point inflationStart;
     // inflation starts on 1-jul-2014
-    time_t start = getTestDate(1, 7, 2014);
+    time_t start = getTestDateTime(1, 7, 2014);
     inflationStart = VirtualClock::from_time_t(start);
 
     VirtualClock clock;

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -333,7 +333,7 @@ TEST_CASE("inflation", "[tx][inflation]")
 
             auto txFrame = root.tx({inflation()});
 
-            closeLedgerOn(*app, 4, 7, 7, 2014, {txFrame});
+            closeLedgerOn(*app, 4, 7, 7, 2014, 0, 0, 0, {txFrame});
             REQUIRE(getInflationSeq() == 1);
 
             REQUIRE_THROWS_AS(root.inflation(), ex_INFLATION_NOT_TIME);
@@ -376,7 +376,7 @@ TEST_CASE("inflation", "[tx][inflation]")
         auto target1tx = root.tx({createAccount(target1, minBalance)});
         auto target2tx = root.tx({createAccount(target2, minBalance)});
 
-        closeLedgerOn(*app, 2, 21, 7, 2014,
+        closeLedgerOn(*app, 2, 21, 7, 2014, 0, 0, 0,
                       {voter1tx, voter2tx, target1tx, target2tx});
 
         REQUIRE(getFeePool() == 1000000299);
@@ -387,7 +387,7 @@ TEST_CASE("inflation", "[tx][inflation]")
         auto setInflationDestination2 = voter2.tx(
             {setOptions(setInflationDestination(target2.getPublicKey()))});
 
-        closeLedgerOn(*app, 3, 21, 7, 2014,
+        closeLedgerOn(*app, 3, 21, 7, 2014, 0, 0, 0,
                       {setInflationDestination1, setInflationDestination2});
 
         REQUIRE(getFeePool() == 1000000499);
@@ -407,7 +407,7 @@ TEST_CASE("inflation", "[tx][inflation]")
         auto inflationTx = root.tx({inflation()});
 
         for_versions_to(7, *app, [&] {
-            closeLedgerOn(*app, 4, 21, 7, 2014, {inflationTx});
+            closeLedgerOn(*app, 4, 21, 7, 2014, 0, 0, 0, {inflationTx});
 
             REQUIRE(getFeePool() == 95361000000301);
             REQUIRE(getTotalCoins() == 1000095361000000298);
@@ -434,7 +434,7 @@ TEST_CASE("inflation", "[tx][inflation]")
         });
 
         for_versions(8, 11, *app, [&] {
-            closeLedgerOn(*app, 4, 21, 7, 2014, {inflationTx});
+            closeLedgerOn(*app, 4, 21, 7, 2014, 0, 0, 0, {inflationTx});
 
             REQUIRE(getFeePool() == 95361000000301);
             REQUIRE(getTotalCoins() == 1000190721000000000);

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -497,7 +497,8 @@ TEST_CASE("merge", "[tx][merge]")
                 auto tx2 = a1.tx({payment(root, 100)});
                 auto a1Balance = a1.getBalance();
                 auto b1Balance = b1.getBalance();
-                auto r = closeLedgerOn(*app, 3, 1, 1, 2017, {tx1, tx2});
+                auto r =
+                    closeLedgerOn(*app, 3, 1, 1, 2017, 0, 0, 0, {tx1, tx2});
                 checkTx(0, r, txSUCCESS);
                 checkTx(1, r, txNO_ACCOUNT);
 

--- a/src/transactions/test/PaymentTests.cpp
+++ b/src/transactions/test/PaymentTests.cpp
@@ -353,7 +353,7 @@ TEST_CASE("payment", "[tx][payment]")
             auto tx1 = b1.tx({payment(root, paymentAmount)});
             auto tx2 = b1.tx({payment(root, 6)});
 
-            auto r = closeLedgerOn(*app, 3, 1, 2, 2016, {tx1, tx2});
+            auto r = closeLedgerOn(*app, 3, 1, 2, 2016, 0, 0, 0, {tx1, tx2});
             checkTx(0, r, txSUCCESS);
             checkTx(1, r, txINSUFFICIENT_BALANCE);
 
@@ -368,7 +368,7 @@ TEST_CASE("payment", "[tx][payment]")
             auto tx1 = b1.tx({payment(root, paymentAmount)});
             auto tx2 = b1.tx({payment(root, 6)});
 
-            auto r = closeLedgerOn(*app, 3, 1, 2, 2016, {tx1, tx2});
+            auto r = closeLedgerOn(*app, 3, 1, 2, 2016, 0, 0, 0, {tx1, tx2});
             checkTx(0, r, txSUCCESS);
             checkTx(1, r, txFAILED);
             REQUIRE(r[1].first.result.result.results()[0]

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -632,7 +632,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             REQUIRE(getAccountSigners(root, *app).size() == 1);
 
                             // merge b1 into a1 and attempt the payment tx
-                            auto r = closeLedgerOn(*app, 3, 1, 2, 2016,
+                            auto r = closeLedgerOn(*app, 3, 1, 2, 2016, 0, 0, 0,
                                                    {txMerge, tx});
 
                             if (txAccountMissing)
@@ -939,12 +939,14 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         };
                         for_versions(3, 9, *app, [&] {
                             setup();
-                            closeLedgerOn(*app, 2, 1, 1, 2010, {tx1, tx2});
+                            closeLedgerOn(*app, 2, 1, 1, 2010, 0, 0, 0,
+                                          {tx1, tx2});
                             REQUIRE(getAccountSigners(root, *app).size() == 1);
                         });
                         for_versions_from(10, *app, [&] {
                             setup();
-                            closeLedgerOn(*app, 2, 1, 1, 2010, {tx1, tx2});
+                            closeLedgerOn(*app, 2, 1, 1, 2010, 0, 0, 0,
+                                          {tx1, tx2});
                             REQUIRE(getAccountSigners(root, *app).size() ==
                                     (alternative.autoRemove ? 0 : 1));
                         });
@@ -970,12 +972,14 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         };
                         for_versions(3, 9, *app, [&] {
                             setup();
-                            closeLedgerOn(*app, 2, 1, 1, 2010, {tx1, tx2});
+                            closeLedgerOn(*app, 2, 1, 1, 2010, 0, 0, 0,
+                                          {tx1, tx2});
                             REQUIRE(getAccountSigners(root, *app).size() == 1);
                         });
                         for_versions_from(10, *app, [&] {
                             setup();
-                            closeLedgerOn(*app, 2, 1, 1, 2010, {tx1, tx2});
+                            closeLedgerOn(*app, 2, 1, 1, 2010, 0, 0, 0,
+                                          {tx1, tx2});
                             REQUIRE(getAccountSigners(root, *app).size() ==
                                     (alternative.autoRemove ? 0 : 1));
                         });
@@ -1534,10 +1538,6 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     SECTION("accepted on time, but closed later "
                             "(protocol issue 622)")
                     {
-                        auto const ledgerVersion =
-                            app->getLedgerManager()
-                                .getLastClosedLedgerHeader()
-                                .header.ledgerVersion;
                         time_t const max_seconds = 30;
                         txFrame = root.tx(
                             {payment(a1.getPublicKey(), paymentAmount)});

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -597,7 +597,6 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         closeLedgerOn(*app, 2, 1, 1, 2016);
 
                         auto runTest = [&](bool txAccountMissing) {
-
                             // Create merge tx
                             auto txMerge = b1.tx({accountMerge(a1)});
 
@@ -1530,6 +1529,26 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         {
                             offsetTest(false);
                         }
+                    }
+
+                    SECTION("accepted on time, but closed later "
+                            "(protocol issue 622)")
+                    {
+                        auto const ledgerVersion =
+                            app->getLedgerManager()
+                                .getLastClosedLedgerHeader()
+                                .header.ledgerVersion;
+                        time_t const max_seconds = 30;
+                        txFrame = root.tx(
+                            {payment(a1.getPublicKey(), paymentAmount)});
+                        setMinTime(txFrame, 0);
+                        setMaxTime(txFrame, start + max_seconds);
+                        auto resultMeta = closeLedgerOn(
+                            *app, 3, start + max_seconds + 1, {txFrame});
+                        REQUIRE(resultMeta.size() == 1);
+                        TransactionResultCode const code =
+                            resultMeta.begin()->first.result.result.code();
+                        REQUIRE(code == txTOO_LATE);
                     }
                 });
             }

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -1427,7 +1427,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     // tx ok
                     // tx too old
                     VirtualClock::system_time_point ledgerTime;
-                    time_t start = getTestDate(1, 7, 2014);
+                    time_t start = getTestDateTime(1, 7, 2014);
                     ledgerTime = VirtualClock::from_time_t(start);
 
                     clock.setCurrentVirtualTime(ledgerTime);

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -2,11 +2,11 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "util/Timer.h"
 #include "main/Application.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/Scheduler.h"
+#include "util/Timer.h"
 #include <Tracy.hpp>
 #include <chrono>
 #include <cstdio>
@@ -154,7 +154,7 @@ VirtualClock::tmToSystemPoint(tm t)
 }
 
 std::time_t
-VirtualClock::tm_to_time_t(std::tm tm)
+VirtualClock::tmToSystemTimeT(std::tm tm)
 {
     return to_time_t(tmToSystemPoint(tm));
 }

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -153,6 +153,12 @@ VirtualClock::tmToSystemPoint(tm t)
     return VirtualClock::system_time_point() + std::chrono::seconds(tt);
 }
 
+std::time_t
+VirtualClock::tm_to_time_t(std::tm tm)
+{
+    return to_time_t(tmToSystemPoint(tm));
+}
+
 std::tm
 VirtualClock::isoStringToTm(std::string const& iso)
 {

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <time.h>
 
 namespace stellar
 {
@@ -103,7 +104,7 @@ class VirtualClock
     // believe in a concept of absolute time.
     static std::tm systemPointToTm(system_time_point);
     static VirtualClock::system_time_point tmToSystemPoint(tm t);
-    static std::time_t tm_to_time_t(std::tm tm);
+    static std::time_t tmToSystemTimeT(std::tm tm);
     static std::tm isoStringToTm(std::string const& iso);
     static std::string tmToISOString(std::tm const& tm);
     static std::string systemPointToISOString(system_time_point point);

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -103,6 +103,7 @@ class VirtualClock
     // believe in a concept of absolute time.
     static std::tm systemPointToTm(system_time_point);
     static VirtualClock::system_time_point tmToSystemPoint(tm t);
+    static std::time_t tm_to_time_t(std::tm tm);
     static std::tm isoStringToTm(std::string const& iso);
     static std::string tmToISOString(std::tm const& tm);
     static std::string systemPointToISOString(system_time_point point);


### PR DESCRIPTION
# Description

This PR contains some small pieces of refactoring in tests and log messages:

- Add versions of test utility interfaces which allow tests to specify more precise times for operations such as closeLedgerOn(), and a test illustrating their use
- Introduce an environment variable for controlling log level during "make check"
- .gitignore some test and editor artifacts
- Enhance an exception message which I happened to hit during testing of a separate change

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md) (N/A)
