### PR TITLE
Path payment test fixes

### DIFF
--- a/src/transactions/test/PathPaymentStrictSendTests.cpp
+++ b/src/transactions/test/PathPaymentStrictSendTests.cpp
@@ -1916,108 +1916,6 @@ TEST_CASE("pathpayment strict send", "[tx][pathpayment]")
         });
     }
 
-    SECTION("uses all offers in a loop")
-    {
-        auto useAllOffersInLoop = [&](TestAccount* issuerToDelete) {
-            auto market = TestMarket{*app};
-            auto source = root.create("source", minBalance4);
-            auto destination = root.create("destination", minBalance1);
-            auto mm12 = root.create("mm12", minBalance3);
-            auto mm23 = root.create("mm23", minBalance3);
-            auto mm34 = root.create("mm34", minBalance3);
-            auto mm41 = root.create("mm41", minBalance3);
-
-            source.changeTrust(cur1, 16000);
-            mm12.changeTrust(cur1, 16000);
-            mm12.changeTrust(cur2, 16000);
-            mm23.changeTrust(cur2, 16000);
-            mm23.changeTrust(cur3, 16000);
-            mm34.changeTrust(cur3, 16000);
-            mm34.changeTrust(cur4, 16000);
-            mm41.changeTrust(cur4, 16000);
-            mm41.changeTrust(cur1, 16000);
-            destination.changeTrust(cur4, 16000);
-
-            gateway.pay(source, cur1, 8000);
-            gateway.pay(mm12, cur2, 8000);
-            gateway2.pay(mm23, cur3, 8000);
-            gateway2.pay(mm34, cur4, 8000);
-            gateway.pay(mm41, cur1, 8000);
-
-            auto o1 = market.requireChangesWithOffer({}, [&] {
-                return market.addOffer(mm12, {cur2, cur1, Price{2, 1}, 1000});
-            });
-            auto o2 = market.requireChangesWithOffer({}, [&] {
-                return market.addOffer(mm23, {cur3, cur2, Price{2, 1}, 1000});
-            });
-            auto o3 = market.requireChangesWithOffer({}, [&] {
-                return market.addOffer(mm34, {cur4, cur3, Price{2, 1}, 1000});
-            });
-            auto o4 = market.requireChangesWithOffer({}, [&] {
-                return market.addOffer(mm41, {cur1, cur4, Price{2, 1}, 1000});
-            });
-
-            for_versions_from(12, *app, [&] {
-                uint32_t ledgerVersion;
-                {
-                    LedgerTxn ltx(app->getLedgerTxnRoot());
-                    ledgerVersion = ltx.loadHeader().current().ledgerVersion;
-                }
-                if (issuerToDelete && ledgerVersion >= 13)
-                {
-                    closeLedgerOn(*app, 3, 1, 1, 2016);
-                    // remove issuer
-                    issuerToDelete->merge(root);
-                }
-
-                auto actual = std::vector<ClaimOfferAtom>{};
-                market.requireChanges(
-                    {{o1.key, {cur2, cur1, Price{2, 1}, 320}},
-                     {o2.key, {cur3, cur2, Price{2, 1}, 660}},
-                     {o3.key, {cur4, cur3, Price{2, 1}, 830}},
-                     {o4.key, {cur1, cur4, Price{2, 1}, 920}}},
-                    [&] {
-                        actual = source
-                                     .pathPaymentStrictSend(
-                                         destination, cur1, 1280, cur4, 10,
-                                         {cur2, cur3, cur4, cur1, cur2, cur3})
-                                     .success()
-                                     .offers;
-                    });
-                auto expected = std::vector<ClaimOfferAtom>{
-                    o1.exchanged(640, 1280), o2.exchanged(320, 640),
-                    o3.exchanged(160, 320),  o4.exchanged(80, 160),
-                    o1.exchanged(40, 80),    o2.exchanged(20, 40),
-                    o3.exchanged(10, 20)};
-                checkClaimedOffers(actual, expected, 1280, 10);
-                // clang-format off
-                market.requireBalances(
-                    {{source, {{xlm, minBalance4 - 2 * txfee}, {cur1, 6720}, {cur2, 0}, {cur3, 0}, {cur4, 0}}},
-                    {mm12, {{xlm, minBalance3 - 3 * txfee}, {cur1, 1360}, {cur2, 7320}, {cur3, 0}, {cur4, 0}}},
-                    {mm23, {{xlm, minBalance3 - 3 * txfee}, {cur1, 0}, {cur2, 680}, {cur3, 7660}, {cur4, 0}}},
-                    {mm34, {{xlm, minBalance3 - 3 * txfee}, {cur1, 0}, {cur2, 0}, {cur3, 340}, {cur4, 7830}}},
-                    {mm41, {{xlm, minBalance3 - 3 * txfee}, {cur1, 7920}, {cur2, 0}, {cur3, 0}, {cur4, 160}}},
-                    {destination, {{xlm, minBalance1 - txfee}, {cur1, 0}, {cur2, 0}, {cur3, 0}, {cur4, 10}}}});
-                // clang-format on
-            });
-        };
-
-        SECTION("no issuers missing")
-        {
-            useAllOffersInLoop(nullptr);
-        }
-
-        SECTION("outside issuers missing")
-        {
-            useAllOffersInLoop(&gateway);
-        }
-
-        SECTION("inside issuers missing")
-        {
-            useAllOffersInLoop(&gateway2);
-        }
-    }
-
     SECTION("with rounding errors")
     {
         auto market = TestMarket{*app};
@@ -2432,5 +2330,132 @@ TEST_CASE("pathpayment strict send", "[tx][pathpayment]")
                                              {cur1, cur2});
             });
         }
+    }
+}
+
+TEST_CASE("pathpayment strict send uses all offers in a loop",
+          "[tx][pathpayment]")
+{
+    // This test would downgrade the bucket protocol from >12 to 12
+    // with USE_CONFIG_FOR_GENESIS.  Some other tests in this module,
+    // however, rely on that being set, so we separate this one
+    // out into a test case with its own Application object.
+    Config cfg = getTestConfig();
+    cfg.USE_CONFIG_FOR_GENESIS = false;
+    VirtualClock clock;
+    auto app = createTestApplication(clock, cfg);
+    app->start();
+    auto& lm = app->getLedgerManager();
+    auto const txfee = lm.getLastTxFee();
+    auto const minBalance1 = lm.getLastMinBalance(1) + 10 * txfee;
+    auto const minBalance3 = lm.getLastMinBalance(3) + 10 * txfee;
+    auto const minBalance4 = lm.getLastMinBalance(4) + 10 * txfee;
+    auto const minBalance5 = lm.getLastMinBalance(5) + 10 * txfee;
+    auto root = TestAccount::createRoot(*app);
+    auto gateway = root.create("gate1", minBalance5);
+    auto gateway2 = root.create("gate2", minBalance5);
+
+    auto useAllOffersInLoop = [&](TestAccount* issuerToDelete) {
+        for_versions_from(12, *app, [&] {
+            auto market = TestMarket{*app};
+            auto source = root.create("source", minBalance4);
+            auto destination = root.create("destination", minBalance1);
+            auto mm12 = root.create("mm12", minBalance3);
+            auto mm23 = root.create("mm23", minBalance3);
+            auto mm34 = root.create("mm34", minBalance3);
+            auto mm41 = root.create("mm41", minBalance3);
+            auto xlm = makeNativeAsset();
+            auto cur1 = makeAsset(gateway, "CUR1");
+            auto cur2 = makeAsset(gateway, "CUR2");
+            auto cur3 = makeAsset(gateway2, "CUR3");
+            auto cur4 = makeAsset(gateway2, "CUR4");
+
+            source.changeTrust(cur1, 16000);
+            mm12.changeTrust(cur1, 16000);
+            mm12.changeTrust(cur2, 16000);
+            mm23.changeTrust(cur2, 16000);
+            mm23.changeTrust(cur3, 16000);
+            mm34.changeTrust(cur3, 16000);
+            mm34.changeTrust(cur4, 16000);
+            mm41.changeTrust(cur4, 16000);
+            mm41.changeTrust(cur1, 16000);
+            destination.changeTrust(cur4, 16000);
+
+            gateway.pay(source, cur1, 8000);
+            gateway.pay(mm12, cur2, 8000);
+            gateway2.pay(mm23, cur3, 8000);
+            gateway2.pay(mm34, cur4, 8000);
+            gateway.pay(mm41, cur1, 8000);
+
+            auto o1 = market.requireChangesWithOffer({}, [&] {
+                return market.addOffer(mm12, {cur2, cur1, Price{2, 1}, 1000});
+            });
+            auto o2 = market.requireChangesWithOffer({}, [&] {
+                return market.addOffer(mm23, {cur3, cur2, Price{2, 1}, 1000});
+            });
+            auto o3 = market.requireChangesWithOffer({}, [&] {
+                return market.addOffer(mm34, {cur4, cur3, Price{2, 1}, 1000});
+            });
+            auto o4 = market.requireChangesWithOffer({}, [&] {
+                return market.addOffer(mm41, {cur1, cur4, Price{2, 1}, 1000});
+            });
+
+            uint32_t ledgerVersion;
+            {
+                LedgerTxn ltx(app->getLedgerTxnRoot());
+                ledgerVersion = ltx.loadHeader().current().ledgerVersion;
+            }
+            if (issuerToDelete && ledgerVersion >= 13)
+            {
+                closeLedgerOn(*app, 2, 1, 1, 2016);
+                // remove issuer
+                issuerToDelete->merge(root);
+            }
+
+            auto actual = std::vector<ClaimOfferAtom>{};
+            market.requireChanges(
+                {{o1.key, {cur2, cur1, Price{2, 1}, 320}},
+                 {o2.key, {cur3, cur2, Price{2, 1}, 660}},
+                 {o3.key, {cur4, cur3, Price{2, 1}, 830}},
+                 {o4.key, {cur1, cur4, Price{2, 1}, 920}}},
+                [&] {
+                    actual = source
+                                 .pathPaymentStrictSend(
+                                     destination, cur1, 1280, cur4, 10,
+                                     {cur2, cur3, cur4, cur1, cur2, cur3})
+                                 .success()
+                                 .offers;
+                });
+            auto expected = std::vector<ClaimOfferAtom>{
+                o1.exchanged(640, 1280), o2.exchanged(320, 640),
+                o3.exchanged(160, 320),  o4.exchanged(80, 160),
+                o1.exchanged(40, 80),    o2.exchanged(20, 40),
+                o3.exchanged(10, 20)};
+            checkClaimedOffers(actual, expected, 1280, 10);
+            // clang-format off
+            market.requireBalances(
+                {{source, {{xlm, minBalance4 - 2 * txfee}, {cur1, 6720}, {cur2, 0}, {cur3, 0}, {cur4, 0}}},
+                {mm12, {{xlm, minBalance3 - 3 * txfee}, {cur1, 1360}, {cur2, 7320}, {cur3, 0}, {cur4, 0}}},
+                {mm23, {{xlm, minBalance3 - 3 * txfee}, {cur1, 0}, {cur2, 680}, {cur3, 7660}, {cur4, 0}}},
+                {mm34, {{xlm, minBalance3 - 3 * txfee}, {cur1, 0}, {cur2, 0}, {cur3, 340}, {cur4, 7830}}},
+                {mm41, {{xlm, minBalance3 - 3 * txfee}, {cur1, 7920}, {cur2, 0}, {cur3, 0}, {cur4, 160}}},
+                {destination, {{xlm, minBalance1 - txfee}, {cur1, 0}, {cur2, 0}, {cur3, 0}, {cur4, 10}}}});
+            // clang-format on
+        });
+    };
+
+    SECTION("no issuers missing")
+    {
+        useAllOffersInLoop(nullptr);
+    }
+
+    SECTION("outside issuers missing")
+    {
+        useAllOffersInLoop(&gateway);
+    }
+
+    SECTION("inside issuers missing")
+    {
+        useAllOffersInLoop(&gateway2);
     }
 }


### PR DESCRIPTION
# Description

Split "offers in a loop" path payment tests into separate TEST_CASES
so that they can use Application objects without USE_CONFIG_FOR_GENESIS.

The path payment and strict path payment "use all offers in a loop"
tests perform modifications (an account merge and a ledger close)
in a for_versions() loop when and only when the protocol version is
13 or greater.  In master currently, it is 13, so the modifications are
performed only in version 13, which, because it is the current version,
is also the maximum protocol version of any bucket.

When the version is bumped to 14, however, there will be version-14
buckets from previous tests when the "use all offers in a loop" tests
try to perform modifications while running protocol 13.  This will
cause the bucket merge code to crash, as it will find existing buckets
of version 14 but it will be running with a maximum supported
protocol of 13 (during that iteration of for_versions()).

Other tests have faced this problem, and there is a test-only Config
option which works around it: disabling USE_CONFIG_FOR_GENESIS,
which those other tests do.

However, many of the path payment and strict path payment tests
depend upon USE_CONFIG_FOR_GENESIS, so we can't just turn it
off throughout all the path payment tests without changing many
other tests.  Therefore, this pull request fixes the problem by splitting
the "use all offers in a loop" tests, which are currently SECTION()s,
into their own TEST_CASE()s, with their own Application objects,
which use Config objects with USE_CONFIG_FOR_GENESIS disabled.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

(Regarding performance, only very short-running tests are changed.)