### PR TITLE
Issue #2570: DB schema change to make extensions opaque

### DIFF
--- a/docs/db-schema.md
+++ b/docs/db-schema.md
@@ -51,8 +51,8 @@ homedomain | VARCHAR(44) | (BASE64)
 thresholds | TEXT | (BASE64)
 flags | INT NOT NULL |
 lastmodified | INT NOT NULL | lastModifiedLedgerSeq
-buyingliabilities | BIGINT CHECK (buyingliabilities >= 0) |
-sellingliabilities | BIGINT CHECK (sellingliabilities >= 0) |
+extension | TEXT | Extension specific to AccountEntry (XDR)
+ledgerext | TEXT | Extension common to all LedgerEntry types (XDR)
 signers | TEXT | (XDR)
 
 ## offers
@@ -73,6 +73,8 @@ priced | INT NOT NULL | Price.d
 price | DOUBLE PRECISION NOT NULL | computed price n/d, used for ordering offers
 flags | INT NOT NULL |
 lastmodified | INT NOT NULL | lastModifiedLedgerSeq
+extension | TEXT | Extension specific to OfferEntry (XDR)
+ledgerext | TEXT | Extension common to all LedgerEntry types (XDR)
 (offerid) | PRIMARY KEY |
 
 ## trustlines
@@ -91,8 +93,8 @@ tlimit | BIGINT NOT NULL DEFAULT 0 CHECK (tlimit >= 0) | limit
 balance | BIGINT NOT NULL DEFAULT 0 CHECK (balance >= 0) |
 flags | INT NOT NULL |
 lastmodified | INT NOT NULL | lastModifiedLedgerSeq
-buyingliabilities | BIGINT CHECK (buyingliabilities >= 0) |
-sellingliabilities | BIGINT CHECK (sellingliabilities >= 0) |
+extension | TEXT | Extension specific to TrustLineEntry (XDR)
+ledgerext | TEXT | Extension common to all LedgerEntry types (XDR)
 (accountid, issuer, assetcode) | PRIMARY KEY |
 
 ## accountdata
@@ -107,6 +109,8 @@ accountid | VARCHAR(56) NOT NULL | (STRKEY)
 dataname | VARCHAR(88) NOT NULL | (BASE64)
 datavalue | VARCHAR(112) NOT NULL | (BASE64)
 lastmodified | INT NOT NULL | lastModifiedLedgerSeq
+extension | TEXT | Extension specific to DataEntry (XDR)
+ledgerext | TEXT | Extension common to all LedgerEntry types (XDR)
 (accountid, dataname) | PRIMARY KEY |
 
 ## txhistory

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -277,6 +277,7 @@ Database::upgradeToCurrentSchema()
                          std::to_string(SCHEMA_VERSION));
         throw std::runtime_error(s);
     }
+    actBeforeDBSchemaUpgrade();
     while (vers < SCHEMA_VERSION)
     {
         ++vers;

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -14,6 +14,8 @@
 #include "util/Logging.h"
 #include "util/Timer.h"
 #include "util/types.h"
+#include <error.h>
+#include <fmt/format.h>
 
 #include "bucket/BucketManager.h"
 #include "herder/HerderPersistence.h"
@@ -31,6 +33,7 @@
 #include "medida/counter.h"
 #include "medida/metrics_registry.h"
 #include "medida/timer.h"
+#include "xdr/Stellar-ledger-entries.h"
 
 #include <lib/soci/src/backends/sqlite3/soci-sqlite3.h>
 #include <string>
@@ -59,7 +62,7 @@ bool Database::gDriversRegistered = false;
 
 // smallest schema version supported
 static unsigned long const MIN_SCHEMA_VERSION = 9;
-static unsigned long const SCHEMA_VERSION = 12;
+static unsigned long const SCHEMA_VERSION = 13;
 
 // These should always match our compiled version precisely, since we are
 // using a bundled version to get access to carray(). But in case someone
@@ -254,6 +257,33 @@ Database::applySchemaUpgrade(unsigned long vers)
         // the accountbalances index around.
         mSession << "DROP INDEX IF EXISTS accountbalances";
         break;
+    case 13:
+        if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
+        {
+            // Add columns for the LedgerEntry extension to each of
+            // the tables that stores a type of ledger entry.
+            addTextColumn("accounts", "ledgerext");
+            addTextColumn("trustlines", "ledgerext");
+            addTextColumn("accountdata", "ledgerext");
+            addTextColumn("offers", "ledgerext");
+            // Absorb the explicit columns of the extension fields of
+            // AccountEntry and TrustLineEntry into single opaque
+            // blobs of XDR each of which represents an entire extension.
+            convertAccountExtensionsToOpaqueXDR();
+            convertTrustLineExtensionsToOpaqueXDR();
+            // Neither earlier schema versions nor the one that we're upgrading
+            // to now had any extension columns in the offers or accountdata
+            // tables, but we add columns in this version, even though we're not
+            // going to use them for anything other than writing out opaque
+            // base64-encoded empty v0 XDR extensions, so that, as with the
+            // other LedgerEntry extensions, we'll be able to add such
+            // extensions in the future without bumping the database schema
+            // version, writing any upgrade code, or changing the SQL that reads
+            // and writes those tables.
+            addTextColumn("offers", "extension");
+            addTextColumn("accountdata", "extension");
+        }
+        break;
     default:
         throw std::runtime_error("Unknown DB schema version");
     }
@@ -290,6 +320,189 @@ Database::upgradeToCurrentSchema()
     }
     CLOG(INFO, "Database") << "DB schema is in current version";
     assert(vers == SCHEMA_VERSION);
+}
+
+void
+Database::addTextColumn(std::string const& table, std::string const& column)
+{
+    std::string addColumnStr("ALTER TABLE " + table + " ADD " + column +
+                             " TEXT;");
+    CLOG(INFO, "Database") << "Adding column '"
+                           << "' to table '" << table << "'";
+    mSession << addColumnStr;
+}
+
+void
+Database::dropNullableColumn(std::string const& table,
+                             std::string const& column)
+{
+    // SQLite doesn't give us a way of dropping a column with a single
+    // SQL command.  If we need it in production, we could re-create the
+    // table without the column and drop the old one.  Since we currently
+    // use SQLite only for testing and PostgreSQL in production, we simply
+    // leave the unused columm around in SQLite at the moment, and NULL
+    // out all of the cells in that column.
+    if (!isSqlite())
+    {
+        std::string dropColumnStr("ALTER TABLE " + table + " DROP COLUMN " +
+                                  column);
+        CLOG(INFO, "Database") << "Dropping column '" << column
+                               << "' from table '" << table << "'";
+
+        mSession << dropColumnStr;
+    }
+    else
+    {
+        std::string nullColumnStr("UPDATE " + table + " SET " + column +
+                                  " = NULL");
+        CLOG(INFO, "Database") << "Setting all cells of column '" << column
+                               << "' in table '" << table << "' to NULL";
+
+        mSession << nullColumnStr;
+    }
+}
+
+std::string
+Database::getOldLiabilitySelect(std::string const& table,
+                                std::string const& fields)
+{
+    return fmt::format("SELECT {}, "
+                       "buyingliabilities, sellingliabilities FROM {} WHERE "
+                       "buyingliabilities IS NOT NULL OR "
+                       "sellingliabilities IS NOT NULL",
+                       fields, table);
+}
+
+void
+Database::convertAccountExtensionsToOpaqueXDR()
+{
+    addTextColumn("accounts", "extension");
+    copyIndividualAccountExtensionFieldsToOpaqueXDR();
+    dropNullableColumn("accounts", "buyingliabilities");
+    dropNullableColumn("accounts", "sellingliabilities");
+}
+
+void
+Database::convertTrustLineExtensionsToOpaqueXDR()
+{
+    addTextColumn("trustlines", "extension");
+    copyIndividualTrustLineExtensionFieldsToOpaqueXDR();
+    dropNullableColumn("trustlines", "buyingliabilities");
+    dropNullableColumn("trustlines", "sellingliabilities");
+}
+
+void
+Database::copyIndividualAccountExtensionFieldsToOpaqueXDR()
+{
+    std::string const tableStr = "accounts";
+
+    CLOG(INFO, "Database") << "Updating extension schema for " << tableStr;
+
+    // <accountID, extension>
+    struct Fields
+    {
+        std::string mAccountID;
+        std::string mExtension;
+    };
+
+    std::string const fieldsStr = "accountid";
+    std::string const selectStr = getOldLiabilitySelect(tableStr, fieldsStr);
+    auto makeFields = [](soci::row const& row) {
+        AccountEntry::_ext_t extension;
+        // getOldLiabilitySelect() places the buying and selling extension
+        // column names after the key field in the SQL select string.
+        extension.v(1);
+        extension.v1().liabilities.buying = row.get<long long>(1);
+        extension.v1().liabilities.selling = row.get<long long>(2);
+        return Fields{.mAccountID = row.get<std::string>(0),
+                      .mExtension =
+                          decoder::encode_b64(xdr::xdr_to_opaque(extension))};
+    };
+
+    std::string const updateStr =
+        "UPDATE accounts SET extension = :ext WHERE accountID = :id";
+    auto prepUpdate = [](soci::statement& st_update, Fields const& data) {
+        st_update.exchange(soci::use(data.mExtension)),
+            st_update.exchange(soci::use(data.mAccountID));
+    };
+
+    auto postUpdate = [](long long const affected_rows, Fields const& data) {
+        if (affected_rows != 1)
+        {
+            throw std::runtime_error(fmt::format(
+                "{}: updating account with account ID {} affected {} row(s) ",
+                __func__, data.mAccountID, affected_rows));
+        }
+    };
+
+    size_t numUpdated = selectUpdateMap<Fields>(
+        *this, selectStr, makeFields, updateStr, prepUpdate, postUpdate);
+
+    CLOG(INFO, "Database") << __func__ << ": updated " << numUpdated
+                           << " records(s) with liabilities in " << tableStr
+                           << " table";
+}
+
+void
+Database::copyIndividualTrustLineExtensionFieldsToOpaqueXDR()
+{
+    std::string const tableStr = "trustlines";
+
+    CLOG(INFO, "Database") << __func__ << ": updating extension schema for "
+                           << tableStr;
+
+    // <accountID, issuer_id, asset_id, extension>
+    struct Fields
+    {
+        std::string mAccountID;
+        std::string mIssuerID;
+        std::string mAssetID;
+        std::string mExtension;
+    };
+
+    std::string const fieldsStr = "accountid, issuer, assetcode";
+    std::string const selectStr = getOldLiabilitySelect(tableStr, fieldsStr);
+    auto makeFields = [](soci::row const& row) {
+        TrustLineEntry::_ext_t extension;
+        // getOldLiabilitySelect() places the buying and selling extension
+        // column names after the three key fields in the SQL select string.
+        extension.v(1);
+        extension.v1().liabilities.buying = row.get<long long>(3);
+        extension.v1().liabilities.selling = row.get<long long>(4);
+        return Fields{.mAccountID = row.get<std::string>(0),
+                      .mIssuerID = row.get<std::string>(1),
+                      .mAssetID = row.get<std::string>(2),
+                      .mExtension =
+                          decoder::encode_b64(xdr::xdr_to_opaque(extension))};
+    };
+
+    std::string const updateStr =
+        "UPDATE trustlines SET extension = :ext WHERE accountID = :id "
+        "AND issuer = :issuer_id AND assetcode = :asset_id";
+    auto prepUpdate = [](soci::statement& st_update, Fields const& data) {
+        st_update.exchange(soci::use(data.mExtension));
+        st_update.exchange(soci::use(data.mAccountID));
+        st_update.exchange(soci::use(data.mIssuerID));
+        st_update.exchange(soci::use(data.mAssetID));
+    };
+
+    auto postUpdate = [](long long const affected_rows, Fields const& data) {
+        if (affected_rows != 1)
+        {
+            throw std::runtime_error(fmt::format(
+                "{}: updating trustline with account ID {}, issuer {}, and "
+                "asset {} affected {} row(s)",
+                __func__, data.mAccountID, data.mIssuerID, data.mAssetID,
+                affected_rows));
+        }
+    };
+
+    size_t numUpdated = selectUpdateMap<Fields>(
+        *this, selectStr, makeFields, updateStr, prepUpdate, postUpdate);
+
+    CLOG(INFO, "Database") << __func__ << ": updated " << numUpdated
+                           << " records(s) with liabilities in " << tableStr
+                           << " table";
 }
 
 void

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -9,6 +9,7 @@
 #include "main/Application.h"
 #include "main/Config.h"
 #include "overlay/StellarXDR.h"
+#include "util/Decoder.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
@@ -32,6 +33,7 @@
 #include "medida/timer.h"
 
 #include <lib/soci/src/backends/sqlite3/soci-sqlite3.h>
+#include <string>
 #ifdef USE_POSTGRES
 #include <lib/soci/src/backends/postgresql/soci-postgresql.h>
 #endif

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -247,4 +247,23 @@ class DBTimeExcluder : NonCopyable
     DBTimeExcluder(Application& mApp);
     ~DBTimeExcluder();
 };
+
+template <typename T>
+void
+decodeOpaqueXDR(std::string const& in, T& out)
+{
+    std::vector<uint8_t> opaque;
+    decoder::decode_b64(in, opaque);
+    xdr::xdr_from_opaque(opaque, out);
+}
+
+template <typename T>
+void
+decodeOpaqueXDR(std::string const& in, soci::indicator const& ind, T& out)
+{
+    if (ind == soci::i_ok)
+    {
+        decodeOpaqueXDR(in, out);
+    }
+}
 }

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -106,6 +106,22 @@ class Database : NonMovableOrCopyable
     static void registerDrivers();
     void applySchemaUpgrade(unsigned long vers);
 
+    // Convert the accounts table from using explicit entries for
+    // extension fields into storing the entire extension as opaque XDR.
+    void convertAccountExtensionsToOpaqueXDR();
+    void copyIndividualAccountExtensionFieldsToOpaqueXDR();
+
+    std::string getOldLiabilitySelect(std::string const& table,
+                                      std::string const& fields);
+    void addTextColumn(std::string const& table, std::string const& column);
+    void dropNullableColumn(std::string const& table,
+                            std::string const& column);
+
+    // Convert the trustlines table from using explicit entries for
+    // extension fields into storing the entire extension as opaque XDR.
+    void convertTrustLineExtensionsToOpaqueXDR();
+    void copyIndividualTrustLineExtensionFieldsToOpaqueXDR();
+
   public:
     // Instantiate object and connect to app.getConfig().DATABASE;
     // if there is a connection error, this will throw.

--- a/src/database/test/DatabaseTests.cpp
+++ b/src/database/test/DatabaseTests.cpp
@@ -4,16 +4,22 @@
 
 #include "util/asio.h"
 #include "crypto/Hex.h"
+#include "crypto/KeyUtils.h"
 #include "database/Database.h"
+#include "ledger/LedgerTxn.h"
+#include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/Config.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
+#include "util/Decoder.h"
 #include "util/Logging.h"
 #include "util/Math.h"
 #include "util/Timer.h"
 #include "util/TmpDir.h"
+#include "util/optional.h"
+#include <algorithm>
 #include <random>
 
 using namespace stellar;
@@ -394,3 +400,300 @@ class SchemaUpgradeTestApplication : public TestApplication
                                                            mPreUpgradeFunc);
     }
 };
+
+// This tests upgrading from MIN_SCHEMA_VERSION to SCHEMA_VERSION by creating
+// ledger entries with the old MIN_SCHEMA_VERSION after database creation, then
+// validating their contents after the upgrade to SCHEMA_VERSION.
+TEST_CASE("schema upgrade test", "[db]")
+{
+    using OptLiabilities = stellar::optional<Liabilities>;
+
+    auto addOneOldSchemaAccount = [](SchemaUpgradeTestApplication& app,
+                                     AccountEntry const& ae) {
+        auto& session = app.getDatabase().getSession();
+        auto accountIDStr = KeyUtils::toStrKey<PublicKey>(ae.accountID);
+        auto inflationDestStr =
+            ae.inflationDest ? KeyUtils::toStrKey<PublicKey>(*ae.inflationDest)
+                             : "";
+        auto inflationDestInd = ae.inflationDest ? soci::i_ok : soci::i_null;
+        auto homeDomainStr = decoder::encode_b64(ae.homeDomain);
+        auto signersStr = decoder::encode_b64(xdr::xdr_to_opaque(ae.signers));
+        auto thresholdsStr = decoder::encode_b64(ae.thresholds);
+        bool const liabilitiesPresent = (ae.ext.v() >= 1);
+        int64_t buyingLiabilities =
+            liabilitiesPresent ? ae.ext.v1().liabilities.buying : 0;
+        int64_t sellingLiabilities =
+            liabilitiesPresent ? ae.ext.v1().liabilities.selling : 0;
+        soci::indicator liabilitiesInd =
+            liabilitiesPresent ? soci::i_ok : soci::i_null;
+
+        soci::transaction tx(session);
+
+        // Use raw SQL to perform database operations, since we're writing in an
+        // old database format, and calling standard interfaces to create
+        // accounts or trustlines would use SQL corresponding to the new format
+        // to which we'll soon upgrade.
+        session << "INSERT INTO accounts ( "
+                   "accountid, balance, seqnum, numsubentries, inflationdest,"
+                   "homedomain, thresholds, signers, flags, lastmodified, "
+                   "buyingliabilities, sellingliabilities "
+                   ") VALUES ( "
+                   ":id, :v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10, "
+                   ":v11 "
+                   ")",
+            soci::use(accountIDStr), soci::use(ae.balance),
+            soci::use(ae.seqNum), soci::use(ae.numSubEntries),
+            soci::use(inflationDestStr, inflationDestInd),
+            soci::use(homeDomainStr), soci::use(thresholdsStr),
+            soci::use(signersStr), soci::use(ae.flags),
+            soci::use(app.getLedgerManager().getLastClosedLedgerNum()),
+            soci::use(buyingLiabilities, liabilitiesInd),
+            soci::use(sellingLiabilities, liabilitiesInd);
+
+        tx.commit();
+    };
+
+    auto addOneOldSchemaTrustLine = [](SchemaUpgradeTestApplication& app,
+                                       TrustLineEntry const& tl) {
+        auto& session = app.getDatabase().getSession();
+        std::string accountIDStr, issuerStr, assetCodeStr;
+        getTrustLineStrings(tl.accountID, tl.asset, accountIDStr, issuerStr,
+                            assetCodeStr);
+        int32_t assetType = tl.asset.type();
+        bool const liabilitiesPresent = (tl.ext.v() >= 1);
+        int64_t buyingLiabilities =
+            liabilitiesPresent ? tl.ext.v1().liabilities.buying : 0;
+        int64_t sellingLiabilities =
+            liabilitiesPresent ? tl.ext.v1().liabilities.selling : 0;
+        soci::indicator liabilitiesInd =
+            liabilitiesPresent ? soci::i_ok : soci::i_null;
+
+        soci::transaction tx(session);
+
+        session << "INSERT INTO trustlines ( "
+                   "accountid, assettype, issuer, assetcode,"
+                   "tlimit, balance, flags, lastmodified, "
+                   "buyingliabilities, sellingliabilities "
+                   ") VALUES ( "
+                   ":id, :v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9 "
+                   ")",
+            soci::use(accountIDStr), soci::use(assetType), soci::use(issuerStr),
+            soci::use(assetCodeStr), soci::use(tl.limit), soci::use(tl.balance),
+            soci::use(tl.flags),
+            soci::use(app.getLedgerManager().getLastClosedLedgerNum()),
+            soci::use(buyingLiabilities, liabilitiesInd),
+            soci::use(sellingLiabilities, liabilitiesInd);
+
+        tx.commit();
+    };
+
+    auto addOneOldSchemaDataEntry = [](SchemaUpgradeTestApplication& app,
+                                       DataEntry const& de) {
+        auto& session = app.getDatabase().getSession();
+        auto accountIDStr = KeyUtils::toStrKey<PublicKey>(de.accountID);
+        auto dataNameStr = decoder::encode_b64(de.dataName);
+        auto dataValueStr = decoder::encode_b64(de.dataValue);
+
+        soci::transaction tx(session);
+
+        session << "INSERT INTO accountdata ( "
+                   "accountid, dataname, datavalue, lastmodified "
+                   ") VALUES ( :id, :v1, :v2, :v3 )",
+            soci::use(accountIDStr), soci::use(dataNameStr),
+            soci::use(dataValueStr),
+            soci::use(app.getLedgerManager().getLastClosedLedgerNum());
+
+        tx.commit();
+    };
+
+    auto addOneOldSchemaOfferEntry = [](SchemaUpgradeTestApplication& app,
+                                        OfferEntry const& oe) {
+        auto& session = app.getDatabase().getSession();
+        auto sellerIDStr = KeyUtils::toStrKey(oe.sellerID);
+        auto sellingStr = decoder::encode_b64(xdr::xdr_to_opaque(oe.selling));
+        auto buyingStr = decoder::encode_b64(xdr::xdr_to_opaque(oe.buying));
+        double price = double(oe.price.n) / double(oe.price.d);
+
+        soci::transaction tx(session);
+
+        session << "INSERT INTO offers ( "
+                   "sellerid, offerid, sellingasset, buyingasset, "
+                   "amount, pricen, priced, price, flags, lastmodified "
+                   ") VALUES ( "
+                   ":v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10 "
+                   ")",
+            soci::use(sellerIDStr), soci::use(oe.offerID),
+            soci::use(sellingStr), soci::use(buyingStr), soci::use(oe.amount),
+            soci::use(oe.price.n), soci::use(oe.price.d), soci::use(price),
+            soci::use(oe.flags),
+            soci::use(app.getLedgerManager().getLastClosedLedgerNum());
+
+        tx.commit();
+    };
+
+    auto prepOldSchemaDB =
+        [addOneOldSchemaAccount, addOneOldSchemaTrustLine,
+         addOneOldSchemaDataEntry,
+         addOneOldSchemaOfferEntry](SchemaUpgradeTestApplication& app,
+                                    std::vector<AccountEntry> const& aes,
+                                    std::vector<TrustLineEntry> const& tls,
+                                    DataEntry const& de, OfferEntry const& oe) {
+            for (auto ae : aes)
+            {
+                addOneOldSchemaAccount(app, ae);
+            }
+
+            for (auto tl : tls)
+            {
+                addOneOldSchemaTrustLine(app, tl);
+            }
+
+            addOneOldSchemaDataEntry(app, de);
+            addOneOldSchemaOfferEntry(app, oe);
+        };
+
+    auto testOneDBMode = [prepOldSchemaDB](Config::TestDbMode const dbMode) {
+        // A vector of optional Liabilities entries, for each of which the test
+        // will generate a valid account.
+        auto const accOptLiabilities = {
+            nullopt<Liabilities>(),
+            make_optional<Liabilities>(Liabilities{12, 17}),
+            make_optional<Liabilities>(Liabilities{4, 0}),
+            nullopt<Liabilities>(),
+            make_optional<Liabilities>(Liabilities{3, 0}),
+            make_optional<Liabilities>(Liabilities{11, 11}),
+            make_optional<Liabilities>(Liabilities{0, 0})};
+
+        // A vector of optional Liabilities entries, for each of which the test
+        // will generate a valid trustline.
+        auto const tlOptLiabilities = {
+            make_optional<Liabilities>(Liabilities{1, 0}),
+            make_optional<Liabilities>(Liabilities{0, 6}),
+            nullopt<Liabilities>(),
+            make_optional<Liabilities>(Liabilities{0, 0}),
+            make_optional<Liabilities>(Liabilities{5, 8}),
+            nullopt<Liabilities>()};
+
+        // Generate from each of the optional liabilities in accOptLiabilities a
+        // new valid account.
+        std::vector<AccountEntry> accountEntries;
+        std::transform(
+            accOptLiabilities.begin(), accOptLiabilities.end(),
+            std::back_inserter(accountEntries), [](OptLiabilities const& aol) {
+                AccountEntry ae = LedgerTestUtils::generateValidAccountEntry();
+                if (aol)
+                {
+                    ae.ext.v(1);
+                    ae.ext.v1().liabilities = *aol;
+                }
+                else
+                {
+                    ae.ext.v(0);
+                }
+                return ae;
+            });
+
+        // Generate from each of the optional liabilities in tlOptLiabilities a
+        // new valid trustline.
+        std::vector<TrustLineEntry> trustLineEntries;
+        std::transform(tlOptLiabilities.begin(), tlOptLiabilities.end(),
+                       std::back_inserter(trustLineEntries),
+                       [](OptLiabilities const& tlol) {
+                           TrustLineEntry tl =
+                               LedgerTestUtils::generateValidTrustLineEntry();
+                           if (tlol)
+                           {
+                               tl.ext.v(1);
+                               tl.ext.v1().liabilities = *tlol;
+                           }
+                           else
+                           {
+                               tl.ext.v(0);
+                           }
+                           return tl;
+                       });
+
+        // Create a data entry to test that its extension and ledger
+        // entry extension have the default (empty-XDR-union) values.
+        auto de = LedgerTestUtils::generateValidDataEntry();
+        REQUIRE(de.ext.v() == 0);
+        REQUIRE(de.ext == DataEntry::_ext_t());
+
+        // Create an offer entry to test that its extension and ledger
+        // entry extension have the default (empty-XDR-union) values.
+        auto oe = LedgerTestUtils::generateValidOfferEntry();
+        REQUIRE(oe.ext.v() == 0);
+        REQUIRE(oe.ext == OfferEntry::_ext_t());
+
+        // Create the application, with the code above that inserts old-schema
+        // accounts and trustlines into the database injected between database
+        // creation and upgrade.
+        Config const& cfg = getTestConfig(0, dbMode);
+        VirtualClock clock;
+        Application::pointer app =
+            createTestApplication<SchemaUpgradeTestApplication,
+                                  SchemaUpgradeTestApplication::PreUpgradeFunc>(
+                clock, cfg,
+                [prepOldSchemaDB, accountEntries, trustLineEntries, de,
+                 oe](SchemaUpgradeTestApplication& sapp) {
+                    prepOldSchemaDB(sapp, accountEntries, trustLineEntries, de,
+                                    oe);
+                });
+        app->start();
+
+        // Validate that the accounts and trustlines have the expected
+        // liabilities and ledger entry extensions now that the database upgrade
+        // has completed.
+
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+
+        for (auto ae : accountEntries)
+        {
+            LedgerEntry entry;
+            entry.data.type(ACCOUNT);
+            entry.data.account() = ae;
+            LedgerKey key = LedgerEntryKey(entry);
+            auto aeUpgraded = ltx.load(key);
+            REQUIRE(aeUpgraded.current() == entry);
+        }
+
+        for (auto tl : trustLineEntries)
+        {
+            LedgerEntry entry;
+            entry.data.type(TRUSTLINE);
+            entry.data.trustLine() = tl;
+            LedgerKey key = LedgerEntryKey(entry);
+            auto tlUpgraded = ltx.load(key);
+            REQUIRE(tlUpgraded.current() == entry);
+        }
+
+        {
+            LedgerEntry entry;
+            entry.data.type(DATA);
+            entry.data.data() = de;
+            LedgerKey key = LedgerEntryKey(entry);
+            auto deUpgraded = ltx.load(key);
+            REQUIRE(deUpgraded.current() == entry);
+        }
+
+        {
+            LedgerEntry entry;
+            entry.data.type(OFFER);
+            entry.data.offer() = oe;
+            LedgerKey key = LedgerEntryKey(entry);
+            auto oeUpgraded = ltx.load(key);
+            REQUIRE(oeUpgraded.current() == entry);
+        }
+    };
+
+    for (auto dbMode :
+         {Config::TESTDB_IN_MEMORY_SQLITE, Config::TESTDB_ON_DISK_SQLITE
+#ifdef USE_POSTGRES
+          ,
+          Config::TESTDB_POSTGRESQL
+#endif // USE_POSTGRES
+         })
+    {
+        testOneDBMode(dbMode);
+    }
+}

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -330,6 +330,10 @@ class WorstBestOfferIterator
     std::shared_ptr<OfferDescriptor const> const& offerDescriptor() const;
 };
 
+void getTrustLineStrings(AccountID const& accountID, Asset const& asset,
+                         std::string& accountIDStr, std::string& issuerStr,
+                         std::string& assetCodeStr);
+
 // An abstraction for an object that can be the parent of an AbstractLedgerTxn
 // (discussed below). Allows children to commit atomically to the parent. Has no
 // notion of a LedgerTxnEntry or LedgerTxnHeader (discussed respectively in

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -31,7 +31,8 @@ LedgerTxnRoot::Impl::loadOffer(LedgerKey const& key) const
     std::string actIDStrKey = KeyUtils::toStrKey(key.offer().sellerID);
 
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
-                      "amount, pricen, priced, flags, lastmodified "
+                      "amount, pricen, priced, flags, lastmodified, extension, "
+                      "ledgerext "
                       "FROM offers "
                       "WHERE sellerid= :id AND offerid= :offerid";
     auto prep = mDatabase.getPreparedStatement(sql);
@@ -54,8 +55,8 @@ LedgerTxnRoot::Impl::loadAllOffers() const
 {
     ZoneScoped;
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
-                      "amount, pricen, priced, flags, lastmodified "
-                      "FROM offers";
+                      "amount, pricen, priced, flags, lastmodified, extension, "
+                      "ledgerext FROM offers";
     auto prep = mDatabase.getPreparedStatement(sql);
 
     std::vector<LedgerEntry> offers;
@@ -75,8 +76,8 @@ LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
     // price is an approximation of the actual n/d (truncated math, 15 digits)
     // ordering by offerid gives precendence to older offers for fairness
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
-                      "amount, pricen, priced, flags, lastmodified "
-                      "FROM offers "
+                      "amount, pricen, priced, flags, lastmodified, extension, "
+                      "ledgerext FROM offers "
                       "WHERE sellingasset = :v1 AND buyingasset = :v2 "
                       "ORDER BY price, offerid LIMIT :n";
 
@@ -116,16 +117,19 @@ LedgerTxnRoot::Impl::loadBestOffers(std::deque<LedgerEntry>& offers,
     std::string sql =
         "WITH r1 AS "
         "(SELECT sellerid, offerid, sellingasset, buyingasset, amount, price, "
-        "pricen, priced, flags, lastmodified FROM offers "
+        "pricen, priced, flags, lastmodified, extension, "
+        "ledgerext FROM offers "
         "WHERE sellingasset = :v1 AND buyingasset = :v2 AND price > :v3 "
         "ORDER BY price, offerid LIMIT :v4), "
         "r2 AS "
         "(SELECT sellerid, offerid, sellingasset, buyingasset, amount, price, "
-        "pricen, priced, flags, lastmodified FROM offers "
+        "pricen, priced, flags, lastmodified, extension, "
+        "ledgerext FROM offers "
         "WHERE sellingasset = :v5 AND buyingasset = :v6 AND price = :v7 "
         "AND offerid >= :v8 ORDER BY price, offerid LIMIT :v9) "
         "SELECT sellerid, offerid, sellingasset, buyingasset, "
-        "amount, pricen, priced, flags, lastmodified "
+        "amount, pricen, priced, flags, lastmodified, extension, "
+        "ledgerext "
         "FROM (SELECT * FROM r1 UNION ALL SELECT * FROM r2) AS res "
         "ORDER BY price, offerid LIMIT :v10";
 
@@ -205,7 +209,8 @@ LedgerTxnRoot::Impl::loadOffersByAccountAndAsset(AccountID const& accountID,
 {
     ZoneScoped;
     std::string sql = "SELECT sellerid, offerid, sellingasset, buyingasset, "
-                      "amount, pricen, priced, flags, lastmodified "
+                      "amount, pricen, priced, flags, lastmodified, extension, "
+                      "ledgerext "
                       "FROM offers WHERE sellerid = :v1 AND "
                       "(sellingasset = :v2 OR buyingasset = :v3)";
     // Note: v2 == v3 but positional parameters are faster
@@ -249,6 +254,10 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep,
     ZoneScoped;
     std::string actIDStrKey;
     std::string sellingAsset, buyingAsset;
+    std::string extensionStr;
+    soci::indicator extensionInd;
+    std::string ledgerExtStr;
+    soci::indicator ledgerExtInd;
 
     LedgerEntry le;
     le.data.type(OFFER);
@@ -264,6 +273,8 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep,
     st.exchange(soci::into(oe.price.d));
     st.exchange(soci::into(oe.flags));
     st.exchange(soci::into(le.lastModifiedLedgerSeq));
+    st.exchange(soci::into(extensionStr, extensionInd));
+    st.exchange(soci::into(ledgerExtStr, ledgerExtInd));
     st.define_and_bind();
     st.execute(true);
 
@@ -274,6 +285,10 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep,
         oe.sellerID = KeyUtils::fromStrKey<PublicKey>(actIDStrKey);
         oe.selling = processAsset(sellingAsset);
         oe.buying = processAsset(buyingAsset);
+
+        decodeOpaqueXDR(extensionStr, extensionInd, oe.ext);
+
+        decodeOpaqueXDR(ledgerExtStr, ledgerExtInd, le.ext);
 
         offers.emplace_back(le);
         st.fetch();
@@ -290,6 +305,10 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep) const
 
     std::string actIDStrKey;
     std::string sellingAsset, buyingAsset;
+    std::string extensionStr;
+    soci::indicator extensionInd;
+    std::string ledgerExtStr;
+    soci::indicator ledgerExtInd;
 
     LedgerEntry le;
     le.data.type(OFFER);
@@ -305,6 +324,8 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep) const
     st.exchange(soci::into(oe.price.d));
     st.exchange(soci::into(oe.flags));
     st.exchange(soci::into(le.lastModifiedLedgerSeq));
+    st.exchange(soci::into(extensionStr, extensionInd));
+    st.exchange(soci::into(ledgerExtStr, ledgerExtInd));
     st.define_and_bind();
     st.execute(true);
 
@@ -313,6 +334,10 @@ LedgerTxnRoot::Impl::loadOffers(StatementContext& prep) const
         oe.sellerID = KeyUtils::fromStrKey<PublicKey>(actIDStrKey);
         oe.selling = processAsset(sellingAsset);
         oe.buying = processAsset(buyingAsset);
+
+        decodeOpaqueXDR(extensionStr, extensionInd, oe.ext);
+
+        decodeOpaqueXDR(ledgerExtStr, ledgerExtInd, le.ext);
 
         offers.emplace_back(le);
         st.fetch();
@@ -334,6 +359,8 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
     std::vector<double> mPrices;
     std::vector<int32_t> mFlags;
     std::vector<int32_t> mLastModifieds;
+    std::vector<std::string> mExtensions;
+    std::vector<std::string> mLedgerExtensions;
 
     void
     accumulateEntry(LedgerEntry const& entry)
@@ -358,6 +385,10 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         mFlags.emplace_back(unsignedToSigned(offer.flags));
         mLastModifieds.emplace_back(
             unsignedToSigned(entry.lastModifiedLedgerSeq));
+        mExtensions.emplace_back(
+            decoder::encode_b64(xdr::xdr_to_opaque(offer.ext)));
+        mLedgerExtensions.emplace_back(
+            decoder::encode_b64(xdr::xdr_to_opaque(entry.ext)));
     }
 
   public:
@@ -375,6 +406,8 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         mPrices.reserve(entries.size());
         mFlags.reserve(entries.size());
         mLastModifieds.reserve(entries.size());
+        mExtensions.reserve(entries.size());
+        mLedgerExtensions.reserve(entries.size());
 
         for (auto const& e : entries)
         {
@@ -396,6 +429,8 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         mPrices.reserve(entries.size());
         mFlags.reserve(entries.size());
         mLastModifieds.reserve(entries.size());
+        mExtensions.reserve(entries.size());
+        mLedgerExtensions.reserve(entries.size());
 
         for (auto const& e : entries)
         {
@@ -407,21 +442,25 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
     void
     doSociGenericOperation()
     {
-        std::string sql = "INSERT INTO offers ( "
-                          "sellerid, offerid, sellingasset, buyingasset, "
-                          "amount, pricen, priced, price, flags, lastmodified "
-                          ") VALUES ( "
-                          ":v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10 "
-                          ") ON CONFLICT (offerid) DO UPDATE SET "
-                          "sellerid = excluded.sellerid, "
-                          "sellingasset = excluded.sellingasset, "
-                          "buyingasset = excluded.buyingasset, "
-                          "amount = excluded.amount, "
-                          "pricen = excluded.pricen, "
-                          "priced = excluded.priced, "
-                          "price = excluded.price, "
-                          "flags = excluded.flags, "
-                          "lastmodified = excluded.lastmodified ";
+        std::string sql =
+            "INSERT INTO offers ( "
+            "sellerid, offerid, sellingasset, buyingasset, "
+            "amount, pricen, priced, price, flags, lastmodified, extension, "
+            "ledgerext "
+            ") VALUES ( "
+            ":v1, :v2, :v3, :v4, :v5, :v6, :v7, :v8, :v9, :v10, :v11, :v12 "
+            ") ON CONFLICT (offerid) DO UPDATE SET "
+            "sellerid = excluded.sellerid, "
+            "sellingasset = excluded.sellingasset, "
+            "buyingasset = excluded.buyingasset, "
+            "amount = excluded.amount, "
+            "pricen = excluded.pricen, "
+            "priced = excluded.priced, "
+            "price = excluded.price, "
+            "flags = excluded.flags, "
+            "lastmodified = excluded.lastmodified, "
+            "extension = excluded.extension, "
+            "ledgerext = excluded.ledgerext";
         auto prep = mDB.getPreparedStatement(sql);
         soci::statement& st = prep.statement();
         st.exchange(soci::use(mSellerIDs));
@@ -434,6 +473,8 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         st.exchange(soci::use(mPrices));
         st.exchange(soci::use(mFlags));
         st.exchange(soci::use(mLastModifieds));
+        st.exchange(soci::use(mExtensions));
+        st.exchange(soci::use(mLedgerExtensions));
         st.define_and_bind();
         {
             auto timer = mDB.getUpsertTimer("offer");
@@ -458,7 +499,7 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
 
         std::string strSellerIDs, strOfferIDs, strSellingAssets,
             strBuyingAssets, strAmounts, strPriceNs, strPriceDs, strPrices,
-            strFlags, strLastModifieds;
+            strFlags, strLastModifieds, strExtensions, strLedgerExtensions;
 
         PGconn* conn = pg->conn_;
         marshalToPGArray(conn, strSellerIDs, mSellerIDs);
@@ -473,33 +514,41 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         marshalToPGArray(conn, strPrices, mPrices);
         marshalToPGArray(conn, strFlags, mFlags);
         marshalToPGArray(conn, strLastModifieds, mLastModifieds);
+        marshalToPGArray(conn, strExtensions, mExtensions);
+        marshalToPGArray(conn, strLedgerExtensions, mLedgerExtensions);
 
-        std::string sql = "WITH r AS (SELECT "
-                          "unnest(:v1::TEXT[]), "
-                          "unnest(:v2::BIGINT[]), "
-                          "unnest(:v3::TEXT[]), "
-                          "unnest(:v4::TEXT[]), "
-                          "unnest(:v5::BIGINT[]), "
-                          "unnest(:v6::INT[]), "
-                          "unnest(:v7::INT[]), "
-                          "unnest(:v8::DOUBLE PRECISION[]), "
-                          "unnest(:v9::INT[]), "
-                          "unnest(:v10::INT[]) "
-                          ")"
-                          "INSERT INTO offers ( "
-                          "sellerid, offerid, sellingasset, buyingasset, "
-                          "amount, pricen, priced, price, flags, lastmodified "
-                          ") SELECT * from r "
-                          "ON CONFLICT (offerid) DO UPDATE SET "
-                          "sellerid = excluded.sellerid, "
-                          "sellingasset = excluded.sellingasset, "
-                          "buyingasset = excluded.buyingasset, "
-                          "amount = excluded.amount, "
-                          "pricen = excluded.pricen, "
-                          "priced = excluded.priced, "
-                          "price = excluded.price, "
-                          "flags = excluded.flags, "
-                          "lastmodified = excluded.lastmodified ";
+        std::string sql =
+            "WITH r AS (SELECT "
+            "unnest(:v1::TEXT[]), "
+            "unnest(:v2::BIGINT[]), "
+            "unnest(:v3::TEXT[]), "
+            "unnest(:v4::TEXT[]), "
+            "unnest(:v5::BIGINT[]), "
+            "unnest(:v6::INT[]), "
+            "unnest(:v7::INT[]), "
+            "unnest(:v8::DOUBLE PRECISION[]), "
+            "unnest(:v9::INT[]), "
+            "unnest(:v10::INT[]), "
+            "unnest(:v11::TEXT[]), "
+            "unnest(:v12::TEXT[]) "
+            ")"
+            "INSERT INTO offers ( "
+            "sellerid, offerid, sellingasset, buyingasset, "
+            "amount, pricen, priced, price, flags, lastmodified, extension, "
+            "ledgerext "
+            ") SELECT * from r "
+            "ON CONFLICT (offerid) DO UPDATE SET "
+            "sellerid = excluded.sellerid, "
+            "sellingasset = excluded.sellingasset, "
+            "buyingasset = excluded.buyingasset, "
+            "amount = excluded.amount, "
+            "pricen = excluded.pricen, "
+            "priced = excluded.priced, "
+            "price = excluded.price, "
+            "flags = excluded.flags, "
+            "lastmodified = excluded.lastmodified, "
+            "extension = excluded.extension, "
+            "ledgerext = excluded.ledgerext";
         auto prep = mDB.getPreparedStatement(sql);
         soci::statement& st = prep.statement();
         st.exchange(soci::use(strSellerIDs));
@@ -512,6 +561,8 @@ class BulkUpsertOffersOperation : public DatabaseTypeSpecificOperation<void>
         st.exchange(soci::use(strPrices));
         st.exchange(soci::use(strFlags));
         st.exchange(soci::use(strLastModifieds));
+        st.exchange(soci::use(strExtensions));
+        st.exchange(soci::use(strLedgerExtensions));
         st.define_and_bind();
         {
             auto timer = mDB.getUpsertTimer("offer");
@@ -671,6 +722,10 @@ class BulkLoadOffersOperation
         int64_t amount;
         int64_t offerID;
         uint32_t flags, lastModified;
+        std::string extension;
+        soci::indicator extensionInd;
+        std::string ledgerExtension;
+        soci::indicator ledgerExtInd;
         Price price;
 
         st.exchange(soci::into(sellerID));
@@ -682,6 +737,8 @@ class BulkLoadOffersOperation
         st.exchange(soci::into(price.d));
         st.exchange(soci::into(flags));
         st.exchange(soci::into(lastModified));
+        st.exchange(soci::into(extension, extensionInd));
+        st.exchange(soci::into(ledgerExtension, ledgerExtInd));
         st.define_and_bind();
         {
             auto timer = mDb.getSelectTimer("offer");
@@ -710,6 +767,10 @@ class BulkLoadOffersOperation
                 oe.price = price;
                 oe.flags = flags;
                 le.lastModifiedLedgerSeq = lastModified;
+
+                decodeOpaqueXDR(extension, extensionInd, oe.ext);
+
+                decodeOpaqueXDR(ledgerExtension, ledgerExtInd, le.ext);
             }
 
             st.fetch();
@@ -743,7 +804,8 @@ class BulkLoadOffersOperation
     {
         std::string sql =
             "SELECT sellerid, offerid, sellingasset, buyingasset, "
-            "amount, pricen, priced, flags, lastmodified "
+            "amount, pricen, priced, flags, lastmodified, extension, "
+            "ledgerext "
             "FROM offers WHERE offerid IN carray(?, ?, 'int64')";
 
         auto prep = mDb.getPreparedStatement(sql);
@@ -772,7 +834,8 @@ class BulkLoadOffersOperation
         std::string sql =
             "WITH r AS (SELECT unnest(:v1::BIGINT[])) "
             "SELECT sellerid, offerid, sellingasset, buyingasset, "
-            "amount, pricen, priced, flags, lastmodified "
+            "amount, pricen, priced, flags, lastmodified, extension, "
+            "ledgerext "
             "FROM offers WHERE offerid IN (SELECT * FROM r)";
         auto prep = mDb.getPreparedStatement(sql);
         auto& st = prep.statement();

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -16,7 +16,7 @@
 namespace stellar
 {
 
-static void
+void
 getTrustLineStrings(AccountID const& accountID, Asset const& asset,
                     std::string& accountIDStr, std::string& issuerStr,
                     std::string& assetCodeStr)

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -282,11 +282,12 @@ class Application
     // copy made of `cfg`
     static pointer create(VirtualClock& clock, Config const& cfg,
                           bool newDB = true);
-    template <typename T>
+    template <typename T, typename... Args>
     static std::shared_ptr<T>
-    create(VirtualClock& clock, Config const& cfg, bool newDB = true)
+    create(VirtualClock& clock, Config const& cfg, Args&&... args,
+           bool newDB = true)
     {
-        auto ret = std::make_shared<T>(clock, cfg);
+        auto ret = std::make_shared<T>(clock, cfg, std::forward<Args>(args)...);
         ret->initialize(newDB);
         validateNetworkPassphrase(ret);
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -133,7 +133,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
 void
 ApplicationImpl::initialize(bool createNewDB)
 {
-    mDatabase = std::make_unique<Database>(*this);
+    mDatabase = createDatabase();
     mPersistentState = std::make_unique<PersistentState>(*this);
     mOverlayManager = createOverlayManager();
     mLedgerManager = createLedgerManager();
@@ -893,6 +893,12 @@ std::unique_ptr<LedgerManager>
 ApplicationImpl::createLedgerManager()
 {
     return LedgerManager::create(*this);
+}
+
+std::unique_ptr<Database>
+ApplicationImpl::createDatabase()
+{
+    return std::make_unique<Database>(*this);
 }
 
 AbstractLedgerTxnParent&

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -202,5 +202,6 @@ class ApplicationImpl : public Application
     virtual std::unique_ptr<InvariantManager> createInvariantManager();
     virtual std::unique_ptr<OverlayManager> createOverlayManager();
     virtual std::unique_ptr<LedgerManager> createLedgerManager();
+    virtual std::unique_ptr<Database> createDatabase();
 };
 }

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -65,15 +65,17 @@ class TestApplication : public ApplicationImpl
     std::unique_ptr<InvariantManager> createInvariantManager() override;
 };
 
-template <typename T = TestApplication,
+template <typename T = TestApplication, typename... Args,
           typename = typename std::enable_if<
               std::is_base_of<TestApplication, T>::value>::type>
 std::shared_ptr<T>
-createTestApplication(VirtualClock& clock, Config const& cfg, bool newDB = true)
+createTestApplication(VirtualClock& clock, Config const& cfg, Args&&... args,
+                      bool newDB = true)
 {
     Config c2(cfg);
     c2.adjust();
-    auto app = Application::create<T>(clock, c2, newDB);
+    auto app = Application::create<T, Args...>(
+        clock, c2, std::forward<Args>(args)..., newDB);
     return app;
 }
 

--- a/src/util/Decoder.h
+++ b/src/util/Decoder.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Copyright 2018 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
# Update DB schema to make all ledger entry extensions opaque

Resolves #2570 

This pull request changes the database schema as proposed in issue #2570 by converting the extension fields of AccountEntry, TrustLineEntry, DataEntry, OfferEntry, and LedgerEntry into opaque XDR.  It upgrades old databases by copying the existing transparent extensions (which are Liabilities fields in the case of AccountEntry and TrustLineEntry, and empty in the other cases) into new columns, and then deleting the column containing the transparent extensions.  (Extensions that were empty had no old columns; they simply gain new ones.)

The PR introduces a test which creates a mechanism for injecting code into points during application creation, in this case, between the creation of the database (which we do with an old schema) or the loading of an old database and the upgrading of the database to the new schema.  It injects code to use raw SQL to create ledger entries of all types while the database is in the old format.  Then, after the application initialization has completed, and the database has been upgraded, it uses the standard interfaces to load the accounts, trustlines, key-value data, and offers, and validate that they have been upgraded as expected (accounts or trustlines which had NULL Liabilities fields will now have NULL extension fields, while those which had non-NULL Liabilities will have non-NULL opaque extensions which decode to Liabilities fields equal to the old ones).

See https://github.com/stellar/stellar-core/pull/2584 for conversations about a previous version of this pull request, which is made obsolete by this one (which has had its history cleaned up, as well as having had extensive revisions since PR 2584).

I'm starting out by filing this PR as a draft because I still have to do some performance investigations on large, real-world databases; possible questions include:
- How long does upgrade take on the real database on a system such as owlbear?
- Does live performance on the real database change measurably after an upgrade on a system such as owlbear?
- Does PostgreSQL collation make any difference to live performance?  (Or does that only help with fields used as keys?)
- How long would a full database rewrite take as opposed to the column upgrade done by this code, and would there be a difference between the two in live performance afterwards?  (And if, for example, the full rewrite would take much longer, but would also produce better performance afterwards, is there a way that people can choose to take the time to do a full rewrite if they wish to?)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)