### PR TITLE
Add replacements urls

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -1,5 +1,6 @@
 ---
 title: Commands
+replacement: https://developers.stellar.org/docs/run-core-node/commands/
 ---
 
 stellar-core can be controlled via the following commands.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,5 +1,6 @@
 ---
 title: Versioning
+replacement: https://developers.stellar.org/docs/glossary/versioning/
 ---
 
 This document describes the various mechanisms used to keep the overall system working as it evolves.


### PR DESCRIPTION
# Description

New documentation ([`developers.stellar.org`](https://developers.stellar.org)) is leaving beta soon, and as part of the launch we want to redirect visitors from old content to the new replacement links. This content change will be consumed by stellar/developers#142

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] ~~Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)~~
- [ ] ~~Compiles~~
- [ ] ~~Ran all tests~~
- [ ] ~~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~~

(touches documentation only)
