### PR TITLE
Initial Gitpod support for stellar-core

### DIFF
--- a/.devcontainer/.gitpod.Dockerfile
+++ b/.devcontainer/.gitpod.Dockerfile
@@ -35,6 +35,9 @@ RUN sudo apt-get -y install clang clangd clang-tools libc++-dev libc++abi-dev cc
 # Install postgresql to enable tests under make check
 RUN sudo apt-get -y install postgresql
 
+# Install some Tracy dependencies
+RUN sudo apt-get -y install libtbb-dev libmkl-tbb-thread
+
 # Install electron dependencies for GUI apps over noVNC
 RUN sudo apt-get install -y libasound2-dev libgtk-3-dev libnss3-dev
 

--- a/.devcontainer/.gitpod.Dockerfile
+++ b/.devcontainer/.gitpod.Dockerfile
@@ -1,0 +1,63 @@
+FROM gitpod/workspace-full-vnc:latest
+
+# Work around https://github.com/sudo-project/sudo/issues/42
+USER root
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+
+# Switch back to non-root user
+USER gitpod
+ENV HOME=/home/gitpod
+WORKDIR $HOME
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Try to suppress any future interactive tzdata installation nonsense
+RUN sudo ln -fs /usr/share/zoneinfo/UTC /etc/localtime \
+    && sudo apt-get -y install tzdata \
+    && sudo dpkg-reconfigure --frontend noninteractive tzdata
+
+# Add test tool chain
+# NOTE: newer version of the compilers are not
+#    provided by stock distributions
+#    and are provided by the /test toolchain
+RUN sudo apt-get update \
+    && sudo apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && sudo apt-get -y install software-properties-common \
+    && sudo apt-get -y install git iproute2 procps lsb-release \
+    && sudo apt-get update
+
+# Install common compilation tools
+RUN sudo apt-get -y install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel bear
+RUN sudo apt-get -y install clang clangd clang-tools libc++-dev libc++abi-dev ccache neovim
+
+# Install postgresql to enable tests under make check
+RUN sudo apt-get -y install postgresql
+
+# Install electron dependencies for GUI apps over noVNC
+RUN sudo apt-get install -y libasound2-dev libgtk-3-dev libnss3-dev
+
+# Install some other potential dependencies for GUI apps
+RUN sudo apt-get install -y libcapstone-dev libfreetype6-dev libglfw3-dev libgtk2.0-dev libgtk-3-0
+
+# Set up locale
+RUN sudo sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && sudo locale-gen
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# Install clang-format for formatting, and link it into a directory in the $PATH
+# (For now, our standard is an old version of clang-format, 5.0.2)
+RUN sudo apt-get -y install curl
+RUN sudo curl https://releases.llvm.org/5.0.2/clang+llvm-5.0.2-x86_64-linux-gnu-ubuntu-16.04.tar.xz | sudo tar -xJf - -C /usr/local
+RUN sudo ln -sf /usr/local/clang+llvm-5.0.2-x86_64-linux-gnu-ubuntu-16.04/bin/clang-format /usr/bin
+
+# git configuration
+RUN sudo git config --system pull.rebase true
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=
+ENV DEBCONF_NONINTERACTIVE_SEEN=

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ compile_commands.json
 # text editors
 *~
 *.swp
-**/.vscode/*
 
 .libs
 .deps

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,34 @@
+image:
+  file: .devcontainer/.gitpod.Dockerfile
+  context: .devcontainer
+
+tasks:
+  - init: >
+      git submodule init
+      && git submodule update
+      && ./autogen.sh
+      && ./configure --enable-ccache --enable-tracy --enable-tracy-capture --enable-tracy-gui
+      && bear make
+      && make check
+  - command: echo "Welcome to the stellar-core Gitpod development environment."
+
+vscode:
+  extensions:
+    - llvm-vs-code-extensions.vscode-clangd@0.1.5:VVxg4kW5VbJUP3ysCuG3Fg==
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to true)
+    addComment: true
+    # add a "Review in Gitpod" button to pull requests (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: prebuilt-in-gitpod

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,8 @@ tasks:
       && ./autogen.sh
       && ./configure --enable-ccache --enable-tracy --enable-tracy-capture --enable-tracy-gui
       && bear make
+      && (cd lib/tracy/capture/build/unix ; make)
+      && (cd lib/tracy/profiler/build/unix ; make)
       && make check
   - command: echo "Welcome to the stellar-core Gitpod development environment."
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.rulers": [
+        80
+    ],
+    "editor.formatOnSave": true
+}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,7 @@ These are instructions for building stellar-core from source.
 
 For a potentially quicker set up, the following projects could be good alternatives:
 
+* stellar-core on [Gitpod](https://gitpod.io/#https://github.com/stellar/stellar-core)
 * stellar-core in a [docker container](https://github.com/stellar/docker-stellar-core)
 * stellar-core and [horizon](https://github.com/stellar/go/tree/master/services/horizon) in a [docker container](https://github.com/stellar/docker-stellar-core-horizon)
 * pre-compiled [packages](https://github.com/stellar/packages)
@@ -25,6 +26,12 @@ For convenience, we also keep a record in the form of release tags of the
  versions that make it to production:
  * pre-releases are versions that get deployed to testnet
  * releases are versions that made it all the way in prod
+
+## Zero-install browser-based cloud IDE with Gitpod
+
+To browse, build, test, and develop Stellar Core code in your browser using
+[Gitpod](https://www.gitpod.io/), click
+[here](https://gitpod.io/#https://github.com/stellar/stellar-core).
 
 ## Containerized dev environment
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/stellar/stellar-core)
+
 <div align="center">
 <a href="https://stellar.org"><img alt="Stellar" src="https://github.com/stellar/.github/raw/master/stellar-logo.png" width="558" /></a>
 <br/>

--- a/stellar-core-testnet-sqlite.cfg
+++ b/stellar-core-testnet-sqlite.cfg
@@ -1,0 +1,33 @@
+NODE_IS_VALIDATOR=false
+NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+DATABASE="sqlite3://stellar-testnet.db"
+
+KNOWN_PEERS=[
+"core-testnet1.stellar.org",
+"core-testnet2.stellar.org",
+"core-testnet3.stellar.org"]
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="testnet.stellar.org"
+QUALITY="HIGH"
+
+[[VALIDATORS]]
+NAME="sdftest1"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GDKXE2OZMJIPOSLNA6N6F2BVCI3O777I2OOC4BV7VOYUEHYX7RTRYA7Y"
+ADDRESS="core-testnet1.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_001/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdftest2"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GCUCJTIYXSOXKBSNFGNFWW5MUQ54HKRPGJUTQFJ5RQXZXNOLNXYDHRAP"
+ADDRESS="core-testnet2.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_002/{0} -o {1}"
+
+[[VALIDATORS]]
+NAME="sdftest3"
+HOME_DOMAIN="testnet.stellar.org"
+PUBLIC_KEY="GC2V2EFSXN6SQTWVYA5EPJPBWWIMSD2XQNKUOHGEKB535AQE2I6IXV2Z"
+ADDRESS="core-testnet3.stellar.org"
+HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{0} -o {1}"

--- a/stellar-core-validator-sqlite.cfg
+++ b/stellar-core-validator-sqlite.cfg
@@ -1,0 +1,76 @@
+# This is an example config for setting up a validator.
+# see https://www.stellar.org/developers/stellar-core/software/admin.html
+# for how to properly configure your environment
+
+# run `stellar-core gen-seed` to generate a public key and secret seed.
+# Let us know the public key so we can add you to the validator list.
+# set NODE_SEED below to the secret seed generated above.
+
+# uncomment those two lines if you are running a validator node
+# NODE_SEED="S123456ABCDE"
+# NODE_IS_VALIDATOR=true
+
+DATABASE="sqlite3://sqlite.db"
+
+AUTOMATIC_MAINTENANCE_PERIOD=60
+AUTOMATIC_MAINTENANCE_COUNT=50000
+
+#FAILURE_SAFETY is minimum number of nodes that are allowed to fail before you no longer have quorum
+FAILURE_SAFETY=1
+
+# number of ledgers to synchronize (time in seconds divided by 5)
+# NB: full validators should run with CATCHUP_COMPLETE=true instead
+# CATCHUP_RECENT=60480 # probably not useful for testing
+
+NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+
+# Populate NODE_NAMES, KNOW_PEERS, QUORUM and HISTORY sections with information
+# on other validators
+# for example https://github.com/stellar/docs/blob/master/validators.md
+# or from https://dashboard.stellar.org/
+NODE_NAMES=[
+"GDIQKLQVOCD5UD6MUI5D5PTPVX7WTP5TAPP5OBMOLENBBD5KG434KYQ2  stronghold1",
+"GAOO3LWBC4XF6VWRP5ESJ6IBHAISVJMSBTALHOQM2EZG7Q477UWA6L7U  eno",
+"GCJCSMSPIWKKPR7WEPIQG63PDF7JGGEENRC33OKVBSPUDIRL6ZZ5M7OO  tempo.eu.com",
+"GC5SXLNAM3C4NMGK2PXK4R34B5GNZ47FYQ24ZIBFDFOCU6D4KBN4POAE  satoshipay",
+"GD7FVHL2KUTUYNOJFRUUDJPDRO2MAZJ5KP6EBCU6LKXHYGZDUFBNHXQI  umbrel",
+"GCGB2S2KGYARPVIA37HYZXVRM2YZUEXA6S33ZU5BUDC6THSB62LZSTYH  sdf_watcher1",
+"GCM6QMP3DLRPTAZW2UZPCPX2LF3SXWXKPMP3GKFZBDSF3QZGV2G5QSTK  sdf_watcher2",
+"GABMKJM6I25XI4K7U6XWMULOUQIQ27BCTMLS6BYYSOWKTBUXVRJSXHYQ  sdf_watcher3",
+]
+
+# KNOWN_PEERS=[
+# "core-live-a.stellar.org:11625",
+# "core-live-b.stellar.org:11625",
+# "core-live-c.stellar.org:11625",
+# "validator1.stellar.stronghold.co",
+# "stellar.256kw.com",
+# "stellar1.tempo.eu.com",
+# "stellar.satoshipay.io"
+# ]
+
+# full validators (with history archive)
+[QUORUM_SET]
+VALIDATORS=[
+"$sdf_watcher1", "$sdf_watcher2", "$sdf_watcher3"
+]
+
+# other validators that you want to include
+# for best result, use a number of validators
+# that can be expressed as 3f+1 (4, 7, 10 ,...)
+[QUORUM_SET.basic]
+VALIDATORS=[
+"$stronghold1", "$eno", "$tempo.eu.com", "$satoshipay"
+]
+
+# History archives
+
+# Stellar.org history store
+[HISTORY.sdf1]
+get="curl -sf http://history.stellar.org/prd/core-live/core_live_001/{0} -o {1}"
+
+[HISTORY.sdf2]
+get="curl -sf http://history.stellar.org/prd/core-live/core_live_002/{0} -o {1}"
+
+[HISTORY.sdf3]
+get="curl -sf http://history.stellar.org/prd/core-live/core_live_003/{0} -o {1}"


### PR DESCRIPTION
# Description

Provide some initial Gitpod-specific support to enable
zero-install, one-click development of Stellar Core by
anyone who can browse the Web.

[Gitpod](https://gitpod.io/) is a development-environment-as-a-service which allows you to log in with a GitHub (or GitLab) account and use an in-browser form of the Eclipse Theia IDE (which resembles Visual Studio Code, but is a different codebase) in a cloud Docker workspace built according to a Dockerfile specification that you can customize, with access to whichever GitHub/GitLab branch you point it to.

They offer anyone some free hours per month to work on open-source projects (such as Stellar Core), and paid plans for more time.  They also offer, in effect, free "Professional" licenses upon request to people who work on open source as a primary profession.

I'm suggesting that we provide some integration with Gitpod, implemented in this PR, to allow online source navigation, formatting according to our standards, building, and testing of stellar-core, all with no installation, or requirement for any hardware or access beyond what's required to browse the Web.  I feel this would be beautifully aligned with our mission -- we hope to provide equitable access to the global financial system, and I feel that zero-install, one-click development of Stellar's open-source code would also provide equitable access to the development of the _means_ of providing equitable access to the global financial system.

I also feel it could provide significant benefits even to the developers within SDF who already have faster, more feature-rich local development environments, because of the convenience that it offers for spinning up new ones:  Gitpod [can be configured](https://github.com/apps/gitpod-io) to perform prebuilds automatically from commits and pull requests, so that, for example, around an hour after a pull request is submitted, a reviewer (or anyone interested) should be able to click a button on the PR and quickly land in a development environment containing all the changes from that PR, with a build and test already run, and source navigation with a full IDE enabled on the source base that would result from merging the PR.  A reviewer could thus not only quickly examine the environment that would result, but even perform tests in it.

Gitpod also let me know that we could, if we provide this support, get a bit of exposure from adding ourselves to their [list of "frictionless" open source projects](https://contribute.dev/).

This is a minimal start to Gitpod support; some of those "frictionless" projects illustrate much fancier initial impressions than this PR alone would give.  However, I think it's enough for a starting point -- I think you could do real development with it.

The Gitpod-specific Dockerfile provided by this PR has some code duplication with our existing Dockerfile for Visual Studio Code.  I haven't yet found a community-standard way of sharing code between Gitpod and VSCode Dockerfiles; that would be one nice thing to do in the long run, if we accept this PR.  In the very short run, though, maybe that (temporary, I hope) duplication is a strength, in that this PR doesn't introduce the risk of changing anything in our existing Dockerfile (or any other existing code, other than to document that Gitpod becomes an "installation" option).

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md) (N/A)