### PR TITLE
Verify ledger chain command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ compile_commands.json
 *~
 *.swp
 **/.vscode/*
+.idea
+.clangd
 
 .libs
 .deps

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -102,6 +102,45 @@ to disable that if that's not what you want to do!
 
 `catchup` may exit with a publish backlog (see below).
 
+##### Trusted ledger hashes
+
+By default the offline `catchup` command will trust and replay whatever it downloads from an
+archive. If the archive contents are malformed or tampered with, or corrupted in transit over an
+insecure connection, this will only be discovered after catchup is complete, when the node tries to
+join a network and acquire consensus. Until then, the node risks being exposed to (and replaying)
+malformed input from the archive.
+
+In order to mitigate this risk, stellar-core can emit a "reference file" full of trusted hashes for
+the ledgers of checkpoints, anchored in an SCP consensus ledger value observed on the network it is
+configured to trust.
+
+This reference file can then be reused by running `catchup` with the `--trusted-checkpoint-hashes`
+argument, passing the reference filename. Catchup will then check the target checkpoint against
+the reference file _before_ replaying them, and fail if there is a hash mismatch.
+
+To construct such a reference file, run the `verify-checkpoints` command, passing a config file as
+usual (to specify the trusted network and quorum slice) and an `--output-filename` argument
+specifying the reference file to save the trusted hashes in.
+
+The emitted content of the refernce file will be a single JSON array of pairs of checkpoint ledger
+numbers and strings holding hashes of ledger headers. For example, it might read:
+
+```
+[
+[30393791, "a691c7cb9ea89f2936ab4a7f717856b0ecd7fd4f9e13662c03b77db931d53583"],
+[30393727, "b911ef040b3babd021c40548d9f4c47f07d4f94481d65d51356450ac4357e62a"],
+[30393663, "6785f25a9357d73001d33ad1883867f68e88d83f5dddf699324ecc0fa60dfa10"],
+[30393599, "87cbd968a01c92658224e518d7cc7e9ab421c21a969cc726a0d2cff3c4300e0a"],
+...
+]
+```
+
+The file will contain one line per checkpoint for the entire history of the archive. This may be
+quite large: hundreds of thousands of lines. Furthermore, generating the reference file will take
+some time, as the entire sequence of ledger _headers_ in the archive (though none of the
+transactions or ledger states) must be downloaded and verified sequentially. It may therefore be
+worthwhile to save and reuse such a trusted reference file multiple times before regenerating it.
+
 ##### Experimental fast "meta data generation"
 `catchup` has a command line flag `--replay-in-memory` that when combined with the
 `METADATA_OUTPUT_STREAM` allows a stellar-core instance to stream meta data instead

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -26,6 +26,9 @@ Command options can only by placed after command.
   that at least LEDGER-COUNT entries are present in history table afterwards.
   For instances that already have some history entries, all ledgers since last
   closed ledger will be replayed.
+  Option **--trusted-checkpoint-hashes <FILE-NAME>** checks the destination
+  ledger hash against the provided reference list of trusted hashes. See the
+  command verify-checkpoints for details.
 * **check-quorum**:   Check quorum intersection from history to ensure there is
   closure over all the validators in the network.
 * **convert-id <ID>**: Will output the passed ID in all known forms and then
@@ -98,6 +101,12 @@ Command options can only by placed after command.
     `stellar-core test -a --version 9 --version 10 "[tx]"`
 * **upgrade-db**: Upgrades local database to current schema version. This is
   usually done automatically during stellar-core run or other command.
+* **verify-checkpoints**: Listens to the network until it observes a consensus
+  hash for a checkpoint ledger, and then verifies the entire earlier history
+  of an archive that ends in that ledger hash, writing the output to a reference
+  list of trusted checkpoint hashes.
+  Option **--output-filename <FILE-NAME>** is mandatory and specifies the file
+  to write the trusted checkpoint hashes to.
 * **version**: Print version info and then exit.
 * **write-quorum**: Print a quorum set graph from history.
 

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -43,7 +43,7 @@ ApplyBufferedLedgersWork::onRun()
         return State::WORK_SUCCESS;
     }
 
-    LedgerCloseData lcd = cm.getBufferedLedger();
+    LedgerCloseData lcd = cm.getFirstBufferedLedger();
 
     auto& lm = mApp.getLedgerManager();
     uint32_t expectedLedger = lm.getLastClosedLedgerNum() + 1;

--- a/src/catchup/CatchupManager.h
+++ b/src/catchup/CatchupManager.h
@@ -64,7 +64,8 @@ class CatchupManager
 
     // popBufferedLedger will throw if there are no buffered ledgers
     virtual bool hasBufferedLedger() const = 0;
-    virtual LedgerCloseData const& getBufferedLedger() const = 0;
+    virtual LedgerCloseData const& getFirstBufferedLedger() const = 0;
+    virtual LedgerCloseData const& getLastBufferedLedger() const = 0;
     virtual void popBufferedLedger() = 0;
 
     // Ensure any metrics that are "current state" gauge-like counters reflect

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -129,7 +129,8 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
 
     std::string message;
     uint32_t lastLedgerInBuffer = mSyncingLedgers.crbegin()->first;
-    if (it != mSyncingLedgers.end() && it->first < lastLedgerInBuffer)
+    if (mApp.getConfig().MODE_DOES_CATCHUP && it != mSyncingLedgers.end() &&
+        it->first < lastLedgerInBuffer)
     {
         message = fmt::format("Starting catchup after ensuring checkpoint "
                               "ledger {} was closed on network",

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -260,15 +260,27 @@ CatchupManagerImpl::hasBufferedLedger() const
 }
 
 LedgerCloseData const&
-CatchupManagerImpl::getBufferedLedger() const
+CatchupManagerImpl::getFirstBufferedLedger() const
 {
     if (!hasBufferedLedger())
     {
         throw std::runtime_error(
-            "getBufferedLedger called when mSyncingLedgers is empty!");
+            "getFirstBufferedLedger called when mSyncingLedgers is empty!");
     }
 
     return mSyncingLedgers.cbegin()->second;
+}
+
+LedgerCloseData const&
+CatchupManagerImpl::getLastBufferedLedger() const
+{
+    if (!hasBufferedLedger())
+    {
+        throw std::runtime_error(
+            "getLastBufferedLedger called when mSyncingLedgers is empty!");
+    }
+
+    return mSyncingLedgers.crbegin()->second;
 }
 
 void

--- a/src/catchup/CatchupManagerImpl.h
+++ b/src/catchup/CatchupManagerImpl.h
@@ -55,7 +55,8 @@ class CatchupManagerImpl : public CatchupManager
     void logAndUpdateCatchupStatus(bool contiguous) override;
 
     bool hasBufferedLedger() const override;
-    LedgerCloseData const& getBufferedLedger() const override;
+    LedgerCloseData const& getFirstBufferedLedger() const override;
+    LedgerCloseData const& getLastBufferedLedger() const override;
     void popBufferedLedger() override;
 
     void syncMetrics() override;

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -87,6 +87,8 @@ class CatchupWork : public Work
     std::shared_ptr<GetHistoryArchiveStateWork> mGetBucketStateWork;
 
     WorkSeqPtr mDownloadVerifyLedgersSeq;
+    std::promise<LedgerNumHashPair> mRangeEndPromise;
+    std::shared_future<LedgerNumHashPair> mRangeEndFuture;
     std::shared_ptr<VerifyLedgerChainWork> mVerifyLedgers;
     std::shared_ptr<Work> mVerifyTxResults;
     WorkSeqPtr mBucketVerifyApplySeq;

--- a/src/catchup/VerifyLedgerChainWork.h
+++ b/src/catchup/VerifyLedgerChainWork.h
@@ -7,6 +7,9 @@
 #include "history/HistoryManager.h"
 #include "ledger/LedgerRange.h"
 #include "work/Work.h"
+#include <future>
+#include <iosfwd>
+#include <vector>
 
 namespace medida
 {
@@ -27,16 +30,34 @@ class VerifyLedgerChainWork : public BasicWork
     TmpDir const& mDownloadDir;
     LedgerRange const mRange;
     uint32_t mCurrCheckpoint;
-    LedgerNumHashPair const& mLastClosed;
-    LedgerNumHashPair const mTrustedEndLedger;
+    LedgerNumHashPair const mLastClosed;
 
-    // First ledger of last verified checkpoint. Needed for a checkpoint that
-    // is being verified: last ledger in current checkpoint must agree with
-    // mVerifiedAhead
+    // Incoming var to read trusted hash of max ledger from. We use a
+    // shared_future here because it allows reading the value multiple
+    // times and we might be reset and re-run.
+    std::shared_future<LedgerNumHashPair> const mTrustedMaxLedger;
+
+    // Outgoing var to write minimum verified ledger's PreviousLedgerHash to.
+    std::promise<LedgerNumHashPair> mVerifiedMinLedgerPrev;
+
+    // Cached read-side of mVerifiedMinLedgerPrev -- unfortunately one can
+    // only call get_future once on a promise, so we must build (and retain)
+    // a shared_future from the result of that call on construction.
+    std::shared_future<LedgerNumHashPair> mVerifiedMinLedgerPrevFuture;
+
+    // Propagation link written on each call to verifyHistoryOfSingleCheckpoint,
+    // must match max ledger in current call to verifyHistoryOfSingleCheckpoint.
     LedgerNumHashPair mVerifiedAhead;
 
-    // First ledger in the range
-    LedgerHeaderHistoryEntry mVerifiedLedgerRangeStart{};
+    // Max ledger of the min checkpoint in the verified range. This is the
+    // "checkpoint ledger" of the min checkpoint during catchup, which is also
+    // where the bucket applicator will apply buckets.
+    LedgerHeaderHistoryEntry mMaxVerifiedLedgerOfMinCheckpoint{};
+
+    // Buffered ledger hashes that have been verified and optional output stream
+    // to write them to.
+    std::vector<LedgerNumHashPair> mVerifiedLedgers;
+    std::shared_ptr<std::ofstream> mOutputStream;
 
     medida::Meter& mVerifyLedgerSuccess;
     medida::Meter& mVerifyLedgerChainSuccess;
@@ -45,23 +66,31 @@ class VerifyLedgerChainWork : public BasicWork
     HistoryManager::LedgerVerificationStatus verifyHistoryOfSingleCheckpoint();
 
   public:
-    VerifyLedgerChainWork(Application& app, TmpDir const& downloadDir,
-                          LedgerRange range,
-                          LedgerNumHashPair const& lastClosedLedger,
-                          LedgerNumHashPair ledgerRangeEnd);
+    VerifyLedgerChainWork(
+        Application& app, TmpDir const& downloadDir, LedgerRange const& range,
+        LedgerNumHashPair const& lastClosedLedger,
+        std::shared_future<LedgerNumHashPair> trustedMaxLedger,
+        std::shared_ptr<std::ofstream> outputStream = nullptr);
     ~VerifyLedgerChainWork() override = default;
     std::string getStatus() const override;
 
-    LedgerHeaderHistoryEntry
-    getVerifiedLedgerRangeStart()
+    std::shared_future<LedgerNumHashPair>
+    getVerifiedMinLedgerPrev() const
     {
-        return mVerifiedLedgerRangeStart;
+        return mVerifiedMinLedgerPrevFuture;
+    }
+
+    LedgerHeaderHistoryEntry
+    getMaxVerifiedLedgerOfMinCheckpoint()
+    {
+        return mMaxVerifiedLedgerOfMinCheckpoint;
     }
 
   protected:
     void onReset() override;
 
     BasicWork::State onRun() override;
+    void onSuccess() override;
     bool
     onAbort() override
     {

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -138,6 +138,9 @@ HerderImpl::bootstrap()
 void
 HerderImpl::shutdown()
 {
+    mTrackingTimer.cancel();
+    mRebroadcastTimer.cancel();
+    mTriggerTimer.cancel();
     if (mLastQuorumMapIntersectionState.mRecalculating)
     {
         // We want to interrupt any calculation-in-progress at shutdown to

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1336,7 +1336,7 @@ TEST_CASE("Introduce and fix gap without starting catchup",
     catchupSimulation.externalizeLedger(herder, nextLedger + 1);
     REQUIRE(!lm.isSynced());
     REQUIRE(cm.hasBufferedLedger());
-    REQUIRE(cm.getBufferedLedger().getLedgerSeq() == nextLedger + 5);
+    REQUIRE(cm.getFirstBufferedLedger().getLedgerSeq() == nextLedger + 5);
 
     // Fill in the second gap. All buffered ledgers should be applied, but we
     // wait for another ledger to close to get in sync

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -228,8 +228,12 @@ TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
                                          make_optional<Hash>(lcl.hash));
         auto ledgerRangeEnd = LedgerNumHashPair(last.header.ledgerSeq,
                                                 make_optional<Hash>(last.hash));
-        auto w = wm.executeWork<VerifyLedgerChainWork>(tmpDir, ledgerRange,
-                                                       lclPair, ledgerRangeEnd);
+        std::promise<LedgerNumHashPair> ledgerRangeEndPromise;
+        std::shared_future<LedgerNumHashPair> ledgerRangeEndFuture =
+            ledgerRangeEndPromise.get_future().share();
+        ledgerRangeEndPromise.set_value(ledgerRangeEnd);
+        auto w = wm.executeWork<VerifyLedgerChainWork>(
+            tmpDir, ledgerRange, lclPair, ledgerRangeEndFuture);
         REQUIRE(expectedState == w->getState());
     };
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -615,6 +615,28 @@ CatchupSimulation::ensureOnlineCatchupPossible(uint32_t targetLedger,
     ensurePublishesComplete();
 }
 
+LedgerNumHashPair
+CatchupSimulation::getLastPublishedCheckpoint() const
+{
+    LedgerNumHashPair pair;
+    assert(mLedgerHashes.size() == mLedgerSeqs.size());
+    auto hi = mLedgerHashes.rbegin();
+    auto si = mLedgerSeqs.rbegin();
+    auto const& hm = mApp.getHistoryManager();
+    while (si != mLedgerSeqs.rend())
+    {
+        if (hm.isLastLedgerInCheckpoint(*si))
+        {
+            pair.first = *si;
+            pair.second = make_optional<Hash>(*hi);
+            break;
+        }
+        ++hi;
+        ++si;
+    }
+    return pair;
+}
+
 void
 CatchupSimulation::crankUntil(Application::pointer app,
                               std::function<bool()> const& predicate,

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -273,6 +273,8 @@ class CatchupSimulation
     void ensureOnlineCatchupPossible(uint32_t targetLedger,
                                      uint32_t bufferLedgers = 0);
 
+    LedgerNumHashPair getLastPublishedCheckpoint() const;
+
     Application::pointer createCatchupApplication(uint32_t count,
                                                   Config::TestDbMode dbMode,
                                                   std::string const& appName,

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -1,0 +1,200 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "historywork/WriteVerifiedCheckpointHashesWork.h"
+#include "catchup/VerifyLedgerChainWork.h"
+#include "history/HistoryManager.h"
+#include "historywork/BatchDownloadWork.h"
+#include "ledger/LedgerManager.h"
+#include "ledger/LedgerRange.h"
+#include "main/Application.h"
+#include "util/Logging.h"
+#include "work/ConditionalWork.h"
+#include <Tracy.hpp>
+#include <algorithm>
+#include <fmt/format.h>
+
+namespace stellar
+{
+
+Hash
+WriteVerifiedCheckpointHashesWork::loadHashFromJsonOutput(
+    uint32_t seq, std::string const& filename)
+{
+    std::ifstream in(filename);
+    if (!in)
+    {
+        throw std::runtime_error("error opening " + filename);
+    }
+    Json::Value root;
+    Json::Reader rdr;
+    if (!rdr.parse(in, root))
+    {
+        throw std::runtime_error("failed to parse JSON input " + filename);
+    }
+    if (!root.isArray())
+    {
+        throw std::runtime_error("expected top-level array in " + filename);
+    }
+    for (auto const& jpair : root)
+    {
+        if (!jpair.isArray() || (jpair.size() != 2))
+        {
+            throw std::runtime_error("expecting 2-element sub-array in " +
+                                     filename);
+        }
+        if (jpair[0].asUInt() == seq)
+        {
+            return hexToBin256(jpair[1].asString());
+        }
+    }
+    return Hash{};
+}
+
+WriteVerifiedCheckpointHashesWork::WriteVerifiedCheckpointHashesWork(
+    Application& app, LedgerNumHashPair rangeEnd, std::string const& outputFile,
+    std::shared_ptr<HistoryArchive> archive)
+    : BatchWork(app, "write-verified-checkpoint-hashes")
+    , mRangeEnd(rangeEnd)
+    , mRangeEndPromise()
+    , mRangeEndFuture(mRangeEndPromise.get_future().share())
+    , mCurrCheckpoint(rangeEnd.first)
+    , mArchive(archive)
+    , mOutputFileName(outputFile)
+{
+    mRangeEndPromise.set_value(mRangeEnd);
+    if (mArchive)
+    {
+        CLOG(INFO, "History") << "selected archive " << mArchive->getName();
+    }
+    startOutputFile();
+}
+
+WriteVerifiedCheckpointHashesWork::~WriteVerifiedCheckpointHashesWork()
+{
+    endOutputFile();
+}
+
+bool
+WriteVerifiedCheckpointHashesWork::hasNext() const
+{
+    return mCurrCheckpoint != LedgerManager::GENESIS_LEDGER_SEQ;
+}
+
+std::shared_ptr<BasicWork>
+WriteVerifiedCheckpointHashesWork::yieldMoreWork()
+{
+    ZoneScoped;
+    if (!hasNext())
+    {
+        throw std::runtime_error("nothing to iterate over");
+    }
+
+    auto const& hm = mApp.getHistoryManager();
+    uint32_t const freq = hm.getCheckpointFrequency();
+
+    auto const lclHe = mApp.getLedgerManager().getLastClosedLedgerHeader();
+    LedgerNumHashPair const lcl(lclHe.header.ledgerSeq,
+                                make_optional<Hash>(lclHe.hash));
+    uint32_t const span = NESTED_DOWNLOAD_BATCH_SIZE * freq;
+    uint32_t const last = mCurrCheckpoint;
+    uint32_t const first =
+        last <= span ? LedgerManager::GENESIS_LEDGER_SEQ
+                     : hm.firstLedgerInCheckpointContaining(last - span);
+
+    LedgerRange const ledgerRange = LedgerRange::inclusive(first, last);
+    CheckpointRange const checkpointRange(ledgerRange, hm);
+
+    std::string const checkpointStr = std::to_string(mCurrCheckpoint);
+
+    // Clear out TmpDirs of any previous WorkSequences that are now done.
+    {
+        auto i = std::remove_if(
+            mTmpDirs.begin(), mTmpDirs.end(),
+            [](std::pair<std::shared_ptr<WorkSequence>, std::shared_ptr<TmpDir>>
+                   pair) -> bool { return pair.first->isDone(); });
+        mTmpDirs.erase(i, mTmpDirs.end());
+    }
+
+    auto tmpDir = std::make_shared<TmpDir>(
+        mApp.getTmpDirManager().tmpDir("verify-" + checkpointStr));
+    auto getWork = std::make_shared<BatchDownloadWork>(
+        mApp, checkpointRange, HISTORY_FILE_TYPE_LEDGER, *tmpDir, mArchive);
+
+    // When we have a previous-work, we grab a future attached to the promise it
+    // will fulfill when it runs. This promise might not have a value _yet_ but
+    // a shared reference to it will allow the currWork we're building to read
+    // the value when it is filled in (which happens before the currWork is
+    // allowed to run).
+    //
+    // When we don't have a previous-work we're at the start of the chain, where
+    // we use the local promise (and accompanying shared_future) we built from
+    // the trusted mRangeEnd value we were constructed with).
+    std::shared_future<LedgerNumHashPair> prevTrusted =
+        (mPrevVerifyWork ? mPrevVerifyWork->getVerifiedMinLedgerPrev()
+                         : mRangeEndFuture);
+
+    auto currWork = std::make_shared<VerifyLedgerChainWork>(
+        mApp, *tmpDir, ledgerRange, lcl, prevTrusted, mOutputFile);
+    auto prevWork = mPrevVerifyWork;
+    auto predicate = [prevWork]() {
+        if (!prevWork)
+        {
+            return true;
+        }
+        return (prevWork->getState() == State::WORK_SUCCESS);
+    };
+
+    auto condWork = std::make_shared<ConditionalWork>(
+        mApp, "await-input-to-verify-" + checkpointStr, predicate, currWork);
+
+    std::vector<std::shared_ptr<BasicWork>> seq{getWork, condWork};
+    auto workSeq = std::make_shared<WorkSequence>(
+        mApp, "download-verify-ledger-" + checkpointStr, seq);
+
+    mTmpDirs.emplace_back(workSeq, tmpDir);
+    assert(first >= 1);
+    mCurrCheckpoint = std::max(LedgerManager::GENESIS_LEDGER_SEQ, first - 1);
+    mPrevVerifyWork = currWork;
+    return workSeq;
+}
+
+void
+WriteVerifiedCheckpointHashesWork::startOutputFile()
+{
+    assert(!mOutputFile);
+    auto mode = std::ios::out | std::ios::trunc;
+    mOutputFile = std::make_shared<std::ofstream>(mOutputFileName, mode);
+    if (!*mOutputFile)
+    {
+        throw std::runtime_error("error opening output file " +
+                                 mOutputFileName);
+    }
+    (*mOutputFile) << "[";
+}
+
+void
+WriteVerifiedCheckpointHashesWork::endOutputFile()
+{
+    if (mOutputFile && mOutputFile->is_open())
+    {
+        // Each line of output made by a VerifyLedgerChainWork has a trailing
+        // comma, and trailing commas are not a valid end of a JSON array; so we
+        // terminate the array here with an entry that does _not_ have a
+        // trailing comma (and identifies an invalid ledger number anyways).
+        (*mOutputFile) << "\n[0, \"\"]\n]\n";
+        mOutputFile->close();
+        mOutputFile.reset();
+    }
+}
+
+void
+WriteVerifiedCheckpointHashesWork::resetIter()
+{
+    mCurrCheckpoint = mRangeEnd.first;
+    mTmpDirs.clear();
+    endOutputFile();
+    startOutputFile();
+}
+}

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.h
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.h
@@ -1,0 +1,77 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "ledger/LedgerRange.h"
+#include "work/BatchWork.h"
+#include <future>
+#include <iosfwd>
+
+namespace stellar
+{
+
+class VerifyLedgerChainWork;
+class HistoryArchive;
+class WorkSequence;
+class TmpDir;
+
+class WriteVerifiedCheckpointHashesWork : public BatchWork
+{
+  protected:
+    bool hasNext() const override;
+    std::shared_ptr<BasicWork> yieldMoreWork() override;
+    void resetIter() override;
+
+  public:
+    WriteVerifiedCheckpointHashesWork(
+        Application& app, LedgerNumHashPair rangeEnd,
+        std::string const& outputFile,
+        std::shared_ptr<HistoryArchive> archive = nullptr);
+    ~WriteVerifiedCheckpointHashesWork();
+
+    // Helper to load a hash back from a file produced by this class.
+    static Hash loadHashFromJsonOutput(uint32_t seq,
+                                       std::string const& filename);
+
+  private:
+    // This class is a batch work, but it also creates a conditional dependency
+    // chain among its batch elements (for trusted ledger propagation): this
+    // dependency chain can in turn cause the BatchWork logic to stall, failing
+    // to saturate the parallel subprocess-execution system. So to keep the
+    // latter busy we introduce an inner level of fully-parallelizable batching
+    // of downloads. Empirically this seems to work well at a fixed size.
+    static constexpr uint32_t NESTED_DOWNLOAD_BATCH_SIZE = 64;
+
+    // We make a TmpDir for each inner WorkSequence we run, but delete them on
+    // the end of each to free up disk space. Since the inner WorkSequences end
+    // in unpredictable order we just keep them in a vector and scan it each
+    // time we wake up. It's no bigger than Config::MAX_CONCURRENT_SUBPROCESSES.
+    std::vector<
+        std::pair<std::shared_ptr<WorkSequence>, std::shared_ptr<TmpDir>>>
+        mTmpDirs;
+
+    // Total range to verify is implicitly 1 .. mRangeEnd.first
+    LedgerNumHashPair const mRangeEnd;
+
+    // We form a promise and an associated shared_future that hold a copy
+    // of mRangeEnd so that we can provide it to the work that we yield
+    // for the first entry in the verification chain.
+    std::promise<LedgerNumHashPair> mRangeEndPromise;
+    std::shared_future<LedgerNumHashPair> mRangeEndFuture;
+
+    // mCurrCheckpoint == LedgerManager::GENESIS_LEDGER_SEQ if we're done, or
+    // else some checkpoint-boundary ledger >= 63
+    uint32_t mCurrCheckpoint;
+
+    std::shared_ptr<VerifyLedgerChainWork> mPrevVerifyWork;
+
+    std::shared_ptr<HistoryArchive> mArchive;
+
+    void startOutputFile();
+    void endOutputFile();
+    std::shared_ptr<std::ofstream> mOutputFile;
+    std::string mOutputFileName;
+};
+}

--- a/src/historywork/test/HistoryWorkTests.cpp
+++ b/src/historywork/test/HistoryWorkTests.cpp
@@ -1,0 +1,44 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "history/HistoryArchiveManager.h"
+#include "history/test/HistoryTestsUtils.h"
+#include "historywork/WriteVerifiedCheckpointHashesWork.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+#include "util/Logging.h"
+#include "util/Timer.h"
+#include "work/WorkScheduler.h"
+#include <lib/catch.hpp>
+#include <lib/json/json.h>
+
+using namespace stellar;
+using namespace historytestutils;
+
+TEST_CASE("write verified checkpoint hashes", "[historywork]")
+{
+    CatchupSimulation catchupSimulation{};
+    auto checkpointLedger = catchupSimulation.getLastCheckpointLedger(5);
+    catchupSimulation.ensureOnlineCatchupPossible(checkpointLedger, 5);
+
+    auto pair = catchupSimulation.getLastPublishedCheckpoint();
+    auto tmpDir = catchupSimulation.getApp().getTmpDirManager().tmpDir(
+        "write-checkpoint-hashes-test");
+    auto file = tmpDir.getName() + "/verified-ledgers.json";
+    auto& wm = catchupSimulation.getApp().getWorkScheduler();
+    {
+        auto w = wm.executeWork<WriteVerifiedCheckpointHashesWork>(pair, file);
+        REQUIRE(w->getState() == BasicWork::State::WORK_SUCCESS);
+    }
+    // Make sure w is destroyed.
+    wm.shutdown();
+    while (wm.getState() != BasicWork::State::WORK_ABORTED)
+    {
+        catchupSimulation.getClock().crank();
+    }
+
+    Hash h = WriteVerifiedCheckpointHashesWork::loadHashFromJsonOutput(
+        pair.first, file);
+    REQUIRE(h == *pair.second);
+}

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -92,6 +92,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MODE_ENABLES_BUCKETLIST = true;
     MODE_USES_IN_MEMORY_LEDGER = false;
     MODE_STORES_HISTORY = true;
+    MODE_DOES_CATCHUP = true;
     OP_APPLY_SLEEP_TIME_FOR_TESTING = 0;
 
     FORCE_SCP = false;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -209,6 +209,12 @@ class Config : public std::enable_shared_from_this<Config>
     // fees, and scp history in the database
     bool MODE_STORES_HISTORY;
 
+    // A config parameter that controls whether core automatically catches up
+    // when it has buffered enough input; if false an out-of-sync node will
+    // remain out-of-sync, buffering ledgers from the network in memory until
+    // it is halted.
+    bool MODE_DOES_CATCHUP;
+
     // A config to allow connections to localhost
     // this should only be enabled when testing as it's a security issue
     bool ALLOW_LOCALHOST_FOR_TESTING;


### PR DESCRIPTION
Initial sketch of a new subcommand that verifies an archive's ledger chain in full, based on the user's current qset's network consensus, and writes the resulting verified sequence of checkpoint hashes to a file.

Also includes a new WriteOnceSharedVar utility class (which it uses) to help with inter-work dataflow communication (i.e. partially addressing #2229)

Now also includes change to `catchup` to allow it to _use_ such a file full of verified checkpoint hashes to anchor its trust.

Now also includes docs.
