### PR TITLE
Remove version-checks for LedgerTxn after protocol 13

### DIFF
--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -3349,12 +3349,7 @@ TEST_CASE("LedgerTxn bulk-load offers", "[ledgertxn]")
             ltx.commit();
         }
 
-        for_versions({12}, *app, [&]() {
-            app->getLedgerTxnRoot().prefetch({lk1, lk2});
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!ltx.load(lk1));
-        });
-        for_versions_from(13, *app, [&]() {
+        for_all_versions(*app, [&]() {
             app->getLedgerTxnRoot().prefetch({lk1, lk2});
             LedgerTxn ltx(app->getLedgerTxnRoot());
             REQUIRE(ltx.load(lk1));


### PR DESCRIPTION
# Description
Remove unnecessary version checks in `LedgerTxn`

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
