### PR TITLE
Introduce a constant for the maximum nesting level for quorums

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -26,6 +26,7 @@
 namespace stellar
 {
 const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 13;
+const uint32 Config::MAXIMUM_QUORUM_NESTING_LEVEL = 4;
 
 // Options that must only be used for testing
 static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
@@ -259,7 +260,7 @@ Config::loadQset(std::shared_ptr<cpptoml::table> group, SCPQuorumSet& qset,
         throw std::invalid_argument("invalid entry in quorum set definition");
     }
 
-    if (level > 2)
+    if (level > Config::MAXIMUM_QUORUM_NESTING_LEVEL)
     {
         throw std::invalid_argument("too many levels in quorum set");
     }

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -102,6 +102,8 @@ class Config : public std::enable_shared_from_this<Config>
 
   public:
     static const uint32 CURRENT_LEDGER_PROTOCOL_VERSION;
+    // level = 0 when there is no nesting.
+    static const uint32 MAXIMUM_QUORUM_NESTING_LEVEL;
 
     typedef std::shared_ptr<Config> pointer;
 

--- a/src/scp/QuorumSetUtils.cpp
+++ b/src/scp/QuorumSetUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "QuorumSetUtils.h"
 
+#include "main/Config.h"
 #include "util/XDROperators.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-types.h"
@@ -46,7 +47,7 @@ QuorumSetSanityChecker::QuorumSetSanityChecker(SCPQuorumSet const& qSet,
 bool
 QuorumSetSanityChecker::checkSanity(SCPQuorumSet const& qSet, int depth)
 {
-    if (depth > 4)
+    if (depth > Config::MAXIMUM_QUORUM_NESTING_LEVEL)
         return false;
 
     if (qSet.threshold < 1)


### PR DESCRIPTION
# Description

Currently, the "explicit" quorum definition allows the nesting level to be only up to 2, but the "implicit" quorum definition allows the nesting level to be up to 4.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
