### PR TITLE
Improve precision of transaction expiration while flooding

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -844,12 +844,13 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
     // during last few ledger closes
     auto const& lcl = mLedgerManager.getLastClosedLedgerHeader();
     auto proposedSet = mTransactionQueue.toTxSet(lcl);
-    auto removed = proposedSet->trimInvalid(mApp);
+
+    auto removed = proposedSet->trimInvalid(mApp, 0);
     mTransactionQueue.ban(removed);
 
     proposedSet->surgePricingFilter(mApp);
 
-    if (!proposedSet->checkValid(mApp))
+    if (!proposedSet->checkValid(mApp, 0))
     {
         throw std::runtime_error("wanting to emit an invalid txSet");
     }
@@ -1523,7 +1524,8 @@ HerderImpl::updateTransactionQueue(
     auto lhhe = mLedgerManager.getLastClosedLedgerHeader();
     lhhe.hash = HashUtils::random();
     auto txSet = mTransactionQueue.toTxSet(lhhe);
-    auto removed = txSet->trimInvalid(mApp);
+
+    auto removed = txSet->trimInvalid(mApp, 0);
     mTransactionQueue.ban(removed);
 
     // Rebroadcast transactions, sorted in apply-order to maximize chances of

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -351,7 +351,7 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
 
         res = SCPDriver::kInvalidValue;
     }
-    else if (!txSet->checkValid(mApp))
+    else if (!txSet->checkValid(mApp, 0))
     {
         if (Logging::logDebug("Herder"))
             CLOG(DEBUG, "Herder")
@@ -721,7 +721,7 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
     }
 
     // just to be sure
-    auto removed = bestTxSet->trimInvalid(mApp);
+    auto removed = bestTxSet->trimInvalid(mApp, 0);
     comp.txSetHash = bestTxSet->getContentsHash();
 
     if (removed.size() != 0)

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -187,8 +187,12 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
         return TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER;
     }
 
+    auto closeTime = mApp.getLedgerManager()
+                         .getLastClosedLedgerHeader()
+                         .header.scpValue.closeTime;
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
-    if (!tx->checkValid(ltx, seqNum, 0))
+    if (!tx->checkValid(ltx, seqNum,
+                        getUpperBoundCloseTimeOffset(mApp, closeTime)))
     {
         return TransactionQueue::AddResult::ADD_STATUS_ERROR;
     }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -188,7 +188,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
     }
 
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
-    if (!tx->checkValid(ltx, seqNum))
+    if (!tx->checkValid(ltx, seqNum, 0))
     {
         return TransactionQueue::AddResult::ADD_STATUS_ERROR;
     }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -284,7 +284,7 @@ TxSetFrame::surgePricingFilter(Application& app)
 bool
 TxSetFrame::checkOrTrim(Application& app,
                         std::vector<TransactionFrameBasePtr>& trimmed,
-                        bool justCheck)
+                        bool justCheck, uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -298,7 +298,7 @@ TxSetFrame::checkOrTrim(Application& app,
         while (iter != kv.second.end())
         {
             auto tx = *iter;
-            if (!tx->checkValid(ltx, lastSeq))
+            if (!tx->checkValid(ltx, lastSeq, upperBoundCloseTimeOffset))
             {
                 if (justCheck)
                 {
@@ -367,12 +367,12 @@ TxSetFrame::checkOrTrim(Application& app,
 }
 
 std::vector<TransactionFrameBasePtr>
-TxSetFrame::trimInvalid(Application& app)
+TxSetFrame::trimInvalid(Application& app, uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     std::vector<TransactionFrameBasePtr> trimmed;
     sortForHash();
-    checkOrTrim(app, trimmed, false);
+    checkOrTrim(app, trimmed, false, upperBoundCloseTimeOffset);
     return trimmed;
 }
 
@@ -380,7 +380,7 @@ TxSetFrame::trimInvalid(Application& app)
 // the fees of all the tx it has submitted in this set
 // check seq num
 bool
-TxSetFrame::checkValid(Application& app)
+TxSetFrame::checkValid(Application& app, uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     auto& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
@@ -420,7 +420,7 @@ TxSetFrame::checkValid(Application& app)
     }
 
     std::vector<TransactionFrameBasePtr> trimmed;
-    bool valid = checkOrTrim(app, trimmed, true);
+    bool valid = checkOrTrim(app, trimmed, true, upperBoundCloseTimeOffset);
     mValid = make_optional<std::pair<Hash, bool>>(lcl.hash, valid);
     return valid;
 }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -52,7 +52,7 @@ class TxSetFrame : public AbstractTxSetFrameForApply
 
     bool checkOrTrim(Application& app,
                      std::vector<TransactionFrameBasePtr>& trimmed,
-                     bool justCheck);
+                     bool justCheck, uint64_t upperBoundCloseTimeOffset);
 
     std::unordered_map<AccountID, AccountTransactionQueue>
     buildAccountTxQueues();
@@ -80,11 +80,12 @@ class TxSetFrame : public AbstractTxSetFrameForApply
 
     std::vector<TransactionFrameBasePtr> sortForApply() override;
 
-    bool checkValid(Application& app);
+    bool checkValid(Application& app, uint64_t upperBoundCloseTimeOffset);
 
     // remove invalid transaction from this set and return those removed
     // transactions
-    std::vector<TransactionFrameBasePtr> trimInvalid(Application& app);
+    std::vector<TransactionFrameBasePtr>
+    trimInvalid(Application& app, uint64_t upperBoundCloseTimeOffset);
     void surgePricingFilter(Application& app);
 
     void removeTx(TransactionFrameBasePtr tx);

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -121,7 +121,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
     AccountEntry srcAccountBefore;
     {
         LedgerTxn ltxFeeProc(ltx);
-        check = tx->checkValid(ltxFeeProc, 0);
+        check = tx->checkValid(ltxFeeProc, 0, 0);
         checkResult = tx->getResult();
         REQUIRE((!check || checkResult.result.code() == txSUCCESS));
 
@@ -306,7 +306,7 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
     auto shouldValidateOk = validationResult.code == txSUCCESS;
     {
         LedgerTxn ltx(app.getLedgerTxnRoot());
-        REQUIRE(tx->checkValid(ltx, 0) == shouldValidateOk);
+        REQUIRE(tx->checkValid(ltx, 0, 0) == shouldValidateOk);
     }
     REQUIRE(tx->getResult().result.code() == validationResult.code);
     REQUIRE(tx->getResult().feeCharged == validationResult.fee);
@@ -346,7 +346,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
     }
 
     txSet->sortForHash();
-    REQUIRE(txSet->checkValid(app));
+    REQUIRE(txSet->checkValid(app, 0));
 
     StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
                     emptyUpgradeSteps, STELLAR_VALUE_BASIC);

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -143,7 +143,8 @@ FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
 
 bool
 FeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
-                                    SequenceNumber current)
+                                    SequenceNumber current,
+                                    uint64_t upperBoundCloseTimeOffset)
 {
     LedgerTxn ltx(ltxOuter);
     auto minBaseFee = ltx.loadHeader().current().baseFee;
@@ -163,7 +164,8 @@ FeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
         return false;
     }
 
-    bool res = mInnerTx->checkValid(ltx, current, false);
+    bool res =
+        mInnerTx->checkValid(ltx, current, false, upperBoundCloseTimeOffset);
     updateResult(getResult(), mInnerTx);
     return res;
 }

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -62,8 +62,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     bool apply(Application& app, AbstractLedgerTxn& ltx,
                TransactionMeta& meta) override;
 
-    bool checkValid(AbstractLedgerTxn& ltxOuter,
-                    SequenceNumber current) override;
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t upperBoundCloseTimeOffset) override;
 
     TransactionEnvelope const& getEnvelope() const override;
 

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -65,16 +65,19 @@ class TransactionFrame : public TransactionFrameBase
     };
 
     virtual bool isTooEarly(LedgerTxnHeader const& header) const;
-    virtual bool isTooLate(LedgerTxnHeader const& header) const;
+    virtual bool isTooLate(LedgerTxnHeader const& header,
+                           uint64_t upperBoundCloseTimeOffset) const;
 
-    bool commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee);
+    bool commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee,
+                              uint64_t upperBoundCloseTimeOffset);
 
     virtual bool isBadSeq(int64_t seqNum) const;
 
     ValidationType commonValid(SignatureChecker& signatureChecker,
                                AbstractLedgerTxn& ltxOuter,
                                SequenceNumber current, bool applying,
-                               bool chargeFee);
+                               bool chargeFee,
+                               uint64_t upperBoundCloseTimeOffset);
 
     virtual std::shared_ptr<OperationFrame>
     makeOperation(Operation const& op, OperationResult& res, size_t index);
@@ -167,9 +170,9 @@ class TransactionFrame : public TransactionFrameBase
                                  AccountID const& accountID);
 
     bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
-                    bool chargeFee);
-    bool checkValid(AbstractLedgerTxn& ltxOuter,
-                    SequenceNumber current) override;
+                    bool chargeFee, uint64_t upperBoundCloseTimeOffset);
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t upperBoundCloseTimeOffset) override;
 
     void insertKeysForFeeProcessing(
         std::unordered_set<LedgerKey>& keys) const override;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -28,8 +28,8 @@ class TransactionFrameBase
     virtual bool apply(Application& app, AbstractLedgerTxn& ltx,
                        TransactionMeta& meta) = 0;
 
-    virtual bool checkValid(AbstractLedgerTxn& ltxOuter,
-                            SequenceNumber current) = 0;
+    virtual bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                            uint64_t upperBoundCloseTimeOffset) = 0;
 
     virtual TransactionEnvelope const& getEnvelope() const = 0;
 

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -822,6 +822,20 @@ trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header)
     return trustLineFlagIsValid(flag, header.current().ledgerVersion);
 }
 
+uint64_t
+getUpperBoundCloseTimeOffset(Application& app, uint64_t lastCloseTime)
+{
+    uint64_t currentTime = VirtualClock::to_time_t(app.getClock().system_now());
+
+    // account for the time between closeTime and now
+    uint64_t closeTimeDrift =
+        currentTime <= lastCloseTime ? 0 : currentTime - lastCloseTime;
+
+    return app.getConfig().getExpectedLedgerCloseTime().count() *
+               EXPECTED_CLOSE_TIME_MULT +
+           closeTimeDrift;
+}
+
 namespace detail
 {
 struct MuxChecker

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -9,6 +9,7 @@
 namespace stellar
 {
 
+class Application;
 class ConstLedgerTxnEntry;
 class ConstTrustLineWrapper;
 class AbstractLedgerTxn;
@@ -26,6 +27,7 @@ LedgerKey dataKey(AccountID const& accountID, std::string const& dataName);
 
 uint32_t const FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS = 11;
 uint32_t const ACCOUNT_SUBENTRY_LIMIT = 1000;
+int32_t const EXPECTED_CLOSE_TIME_MULT = 2;
 
 LedgerTxnEntry loadAccount(AbstractLedgerTxn& ltx, AccountID const& accountID);
 
@@ -148,4 +150,6 @@ bool trustLineFlagIsValid(uint32_t flag, uint32_t ledgerVersion);
 bool trustLineFlagIsValid(uint32_t flag, LedgerTxnHeader const& header);
 
 bool hasMuxedAccount(TransactionEnvelope const& e);
+
+uint64_t getUpperBoundCloseTimeOffset(Application& app, uint64_t lastCloseTime);
 }

--- a/src/transactions/simulation/TxSimTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimTransactionFrame.cpp
@@ -65,7 +65,8 @@ TxSimTransactionFrame::isTooEarly(LedgerTxnHeader const& header) const
 }
 
 bool
-TxSimTransactionFrame::isTooLate(LedgerTxnHeader const& header) const
+TxSimTransactionFrame::isTooLate(LedgerTxnHeader const& header,
+                                 uint64_t upperBoundCloseTimeOffset) const
 {
     return mSimulationResult.result.code() == txTOO_LATE;
 }

--- a/src/transactions/simulation/TxSimTransactionFrame.h
+++ b/src/transactions/simulation/TxSimTransactionFrame.h
@@ -18,7 +18,8 @@ class TxSimTransactionFrame : public TransactionFrame
 
   protected:
     bool isTooEarly(LedgerTxnHeader const& header) const override;
-    bool isTooLate(LedgerTxnHeader const& header) const override;
+    bool isTooLate(LedgerTxnHeader const& header,
+                   uint64_t upperBoundCloseTimeOffset) const override;
 
     std::shared_ptr<OperationFrame> makeOperation(Operation const& op,
                                                   OperationResult& res,

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -80,7 +80,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee, fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txNOT_SUPPORTED);
             });
         }
@@ -91,7 +91,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee - 1, 1, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
             });
         }
@@ -102,7 +102,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee + 1, 101, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
             });
         }
@@ -114,7 +114,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txNO_ACCOUNT);
             });
         }
@@ -129,7 +129,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH);
             });
         }
@@ -147,7 +147,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH);
             });
         }
@@ -159,7 +159,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_BALANCE);
             });
         }
@@ -176,7 +176,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH_EXTRA);
             });
         }
@@ -190,7 +190,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_FAILED);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -207,7 +207,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, -1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_FAILED);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -227,7 +227,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(fb->checkValid(ltx, 0));
+                REQUIRE(fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_SUCCESS);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -271,7 +271,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                 }
                 acc.merge(root);
                 {
@@ -291,7 +291,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                 }
                 acc.setOptions(setMasterWeight(0));
                 {
@@ -311,7 +311,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                 }
                 acc.pay(root, 2 * fee);
                 {
@@ -337,7 +337,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                     app->getNetworkID(), fbXDR);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                 }
 
                 auto setOptionsTx = acc.tx({setOptions(setLowThreshold(1))});
@@ -361,7 +361,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                 }
 
                 auto setOptionsOp = setOptions(setMasterWeight(0));
@@ -391,7 +391,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, INT64_MAX);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                 }
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -434,7 +434,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0));
                     REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_SUCCESS);
                 }
                 {

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -359,7 +359,7 @@ TEST_CASE("manage buy offer liabilities", "[tx][offers]")
 
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                tx->checkValid(ltx, 0);
+                tx->checkValid(ltx, 0, 0);
             }
 
             auto buyOp = std::static_pointer_cast<ManageBuyOfferOpFrame>(

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -467,7 +467,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             setup();
                             {
                                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                                REQUIRE(!tx->checkValid(ltx, 0));
+                                REQUIRE(!tx->checkValid(ltx, 0, 0));
                             }
                             REQUIRE(tx->getResultCode() == txBAD_SEQ);
                             REQUIRE(getAccountSigners(a1, *app).size() == 1);
@@ -1185,7 +1185,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(!tx->checkValid(ltx, 0));
+                    REQUIRE(!tx->checkValid(ltx, 0, 0));
                 }
 
                 applyCheck(tx, *app);
@@ -1209,7 +1209,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(!tx->checkValid(ltx, 0));
+                            REQUIRE(!tx->checkValid(ltx, 0, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txFAILED);
@@ -1223,7 +1223,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -1240,7 +1240,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -1265,7 +1265,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(!tx->checkValid(ltx, 0));
+                            REQUIRE(!tx->checkValid(ltx, 0, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1292,7 +1292,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1318,7 +1318,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0));
+                            REQUIRE(tx->checkValid(ltx, 0, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1408,7 +1408,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     setup();
                     {
                         LedgerTxn ltx(app->getLedgerTxnRoot());
-                        REQUIRE(!txFrame->checkValid(ltx, 0));
+                        REQUIRE(!txFrame->checkValid(ltx, 0, 0));
                     }
                     REQUIRE(txFrame->getResultCode() == txBAD_SEQ);
                 });
@@ -1481,7 +1481,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     setSeqNum(txFrame, txFrame->getSeqNum() - 1);
                     {
                         LedgerTxn ltx(app->getLedgerTxnRoot());
-                        REQUIRE(!txFrame->checkValid(ltx, 0));
+                        REQUIRE(!txFrame->checkValid(ltx, 0, 0));
                     }
 
                     REQUIRE(txFrame->getResultCode() == txBAD_SEQ);


### PR DESCRIPTION

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
