### PR TITLE
Fix compile error (non C++ 14 compliant code)

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -414,9 +414,8 @@ Database::copyIndividualAccountExtensionFieldsToOpaqueXDR()
         extension.v(1);
         extension.v1().liabilities.buying = row.get<long long>(1);
         extension.v1().liabilities.selling = row.get<long long>(2);
-        return Fields{.mAccountID = row.get<std::string>(0),
-                      .mExtension =
-                          decoder::encode_b64(xdr::xdr_to_opaque(extension))};
+        return Fields{row.get<std::string>(0),
+                      decoder::encode_b64(xdr::xdr_to_opaque(extension))};
     };
 
     std::string const updateStr =
@@ -469,11 +468,9 @@ Database::copyIndividualTrustLineExtensionFieldsToOpaqueXDR()
         extension.v(1);
         extension.v1().liabilities.buying = row.get<long long>(3);
         extension.v1().liabilities.selling = row.get<long long>(4);
-        return Fields{.mAccountID = row.get<std::string>(0),
-                      .mIssuerID = row.get<std::string>(1),
-                      .mAssetID = row.get<std::string>(2),
-                      .mExtension =
-                          decoder::encode_b64(xdr::xdr_to_opaque(extension))};
+        return Fields{row.get<std::string>(0), row.get<std::string>(1),
+                      row.get<std::string>(2),
+                      decoder::encode_b64(xdr::xdr_to_opaque(extension))};
     };
 
     std::string const updateStr =

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -401,7 +401,7 @@ TEST_CASE("load example configs", "[config]")
 TEST_CASE("nesting level", "[config]")
 {
     auto makePublicKey = [](int i) {
-        auto hash = sha256(std::string{"NODE_SEED_"} + std::to_string(i));
+        auto hash = sha256(fmt::format("NODE_SEED_{}", i));
         auto secretKey = SecretKey::fromSeed(hash);
         return secretKey.getStrKeyPublic();
     };
@@ -416,13 +416,13 @@ VALIDATORS=[
     "{} {}"
 ]
 )";
-    for (int nestingLevel = 0; nestingLevel < 10; nestingLevel++)
+    for (uint32 nestingLevel = 0; nestingLevel < 10; nestingLevel++)
     {
         configNesting += fmt::format(
             quorumSetTemplate, quorumSetNumber, makePublicKey(nestingLevel * 2),
             char('A' + nestingLevel * 2), makePublicKey(nestingLevel * 2 + 1),
             char('A' + nestingLevel * 2 + 1));
-        SECTION(std::string{"nesting level = "} + std::to_string(nestingLevel))
+        SECTION(fmt::format("nesting level = {}", nestingLevel))
         {
             Config c;
             std::stringstream ss(configNesting);


### PR DESCRIPTION
Struct initialization is a C99 extension https://en.cppreference.com/w/c/language/struct_initialization

in C++ this was added in C++ 20 as designator initializers https://en.cppreference.com/w/cpp/language/aggregate_initialization

For some reason both clang and g++ both allow this to compile in standard compliance mode, and the only way to reveal this (as a warning) seems to build with `-Wc99-extensions` .
