### PR TITLE
log getpeername errors explicitly

### DIFF
--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1076,6 +1076,13 @@ Peer::recvHello(Hello const& elo)
     mState = GOT_HELLO;
 
     auto ip = getIP();
+    if (ip.empty())
+    {
+        drop("failed to determine remote address",
+             Peer::DropDirection::WE_DROPPED_REMOTE,
+             Peer::DropMode::IGNORE_WRITE_QUEUE);
+        return;
+    }
     mAddress =
         PeerBareAddress{ip, static_cast<unsigned short>(elo.listeningPort)};
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -126,7 +126,12 @@ TCPPeer::getIP() const
 
     asio::error_code ec;
     auto ep = mSocket->next_layer().remote_endpoint(ec);
-    if (!ec)
+    if (ec)
+    {
+        CLOG(ERROR, "Overlay")
+            << "Could not determine remote endpoint: " << ec.message();
+    }
+    else
     {
         result = ep.address().to_string();
     }


### PR DESCRIPTION
This just improves reporting-precision of errors from getpeername / remote peer resolution, to help diagnose rare network conditions.