### PR TITLE
Issue #2615: Add missing string to log message

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -327,8 +327,8 @@ Database::addTextColumn(std::string const& table, std::string const& column)
 {
     std::string addColumnStr("ALTER TABLE " + table + " ADD " + column +
                              " TEXT;");
-    CLOG(INFO, "Database") << "Adding column '"
-                           << "' to table '" << table << "'";
+    CLOG(INFO, "Database") << "Adding column '" << column << "' to table '"
+                           << table << "'";
     mSession << addColumnStr;
 }
 


### PR DESCRIPTION
I managed to drop the intended column string in a database
schema upgrade log message in PR 2593 for issue 2570.

# Description

Resolves #2615

Adds `column` string that I'd intended to log in `Database::addTextColumn()`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md) (N/A)
