### PR TITLE
Increase catchup timeout in testcases for address sanitizer

### DIFF
--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -785,7 +785,7 @@ CatchupSimulation::catchupOnline(Application::pointer app, uint32_t initLedger,
     };
 
     auto lastLedger = lm.getLastClosedLedgerNum();
-    crankUntil(app, catchupIsDone, std::chrono::seconds{30});
+    crankUntil(app, catchupIsDone, std::chrono::seconds{60});
 
     if (lm.getLastClosedLedgerNum() == triggerLedger + bufferLedgers)
     {


### PR DESCRIPTION
# Description

The `Catchup recent` test was failing when stellar-core was built with address sanitizer. Address sanitizer introduces a slowdown, so the 30 second timeout wasn't sufficient. 

According to https://clang.llvm.org/docs/AddressSanitizer.html, the **"Typical slowdown introduced by AddressSanitizer is 2x"**, so I doubled the timeout to 60 seconds.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
