### PR TITLE
Add SECTION so overlapping protocol versions don't conflict and cause Catch to skip test

### DIFF
--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1889,9 +1889,15 @@ TEST_CASE("upgrade base reserve", "[upgrades]")
             REQUIRE(getAssetLiabilities(a2, cur2) == Liabilities{8000, 4000});
         };
 
-        for_versions_from(10, *app, [&] { increaseReserveFromV10(false); });
+        SECTION("authorized")
+        {
+            for_versions_from(10, *app, [&] { increaseReserveFromV10(false); });
+        }
 
-        for_versions_from(13, *app, [&] { increaseReserveFromV10(true); });
+        SECTION("authorized to maintain liabilities")
+        {
+            for_versions_from(13, *app, [&] { increaseReserveFromV10(true); });
+        }
     }
 }
 


### PR DESCRIPTION
# Description
The `increaseReserveFromV10(true)` isn't being run because the `SECTION` names for this test are identical to the `increaseReserveFromV10(false)` test. Catch thinks it's a duplicate test and skips it.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
