### PR TITLE
Set `feeCharged` with the min fee for core to accept a transaction

### DIFF
--- a/lib/util/uint128_t.cpp
+++ b/lib/util/uint128_t.cpp
@@ -28,6 +28,7 @@ uint128_t::operator bool() const{
 uint128_t::operator char() const{
     return (char) LOWER;
 }
+
 uint128_t::operator int() const{
     return (int) LOWER;
 }

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -28,6 +28,18 @@ a bug in operator*.
 
 Thanks to Fran�ois Dessenne for convincing me
 to do a general rewrite of this class.
+
+when defining UNSAFE_UINT128_OPS additional behaviors are enabled.
+
+for example:
+// implicit typecast Operators,
+// short for (short)uint128_t(y).lower()
+// or (char)uint128_t(y)
+char x = uint128_t(y);
+
+// arithmetic operators with short type as lhs,
+// short for 2 * uint128_t(y).lower()
+auto x = 2 * uint128_t(y);
 */
 
 #ifndef __UINT128_T__
@@ -38,6 +50,12 @@ to do a general rewrite of this class.
 #include <stdint.h>
 #include <utility>
 #include <string>
+
+#ifdef UNSAFE_UINT128_OPS
+#define IMPLICIT_UNSAFE_UINT128_OPS
+#else
+#define IMPLICIT_UNSAFE_UINT128_OPS explicit
+#endif
 
 class uint128_t{
     private:
@@ -70,13 +88,13 @@ class uint128_t{
         }
 
         // Typecast Operators
-        operator bool() const;
-        operator char() const;
-        operator int() const;
-        operator uint8_t() const;
-        operator uint16_t() const;
-        operator uint32_t() const;
-        operator uint64_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator bool() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator char() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator int() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint8_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint16_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint32_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint64_t() const;
 
         // Bitwise Operators
         uint128_t operator&(const uint128_t & rhs) const;
@@ -334,6 +352,7 @@ template <typename T> bool operator<=(const T & lhs, const uint128_t & rhs){
     return ((uint64_t) lhs <= rhs.lower());
 }
 
+#ifdef UNSAFE_UINT128_OPS
 // Arithmetic Operators
 template <typename T> T operator+(const T & lhs, const uint128_t & rhs){
     return (T) (rhs + lhs);
@@ -379,6 +398,7 @@ template <typename T> T & operator%=(T & lhs, const uint128_t & rhs){
     lhs = (T) (uint128_t(lhs) % rhs);
     return lhs;
 }
+#endif
 
 // IO Operator
 std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs);

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -526,7 +526,7 @@ TxSetFrame::getTotalFees(LedgerHeader const& lh) const
     return std::accumulate(mTransactions.begin(), mTransactions.end(),
                            int64_t(0),
                            [&](int64_t t, TransactionFrameBasePtr const& tx) {
-                               return t + tx->getFee(lh, baseFee);
+                               return t + tx->getFee(lh, baseFee, true);
                            });
 }
 

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1080,6 +1080,9 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                     auto tx = transaction(*app, account1, i, 1, 100);
                     auto fb = feeBump(*app, feeSource, tx, 399);
                     test.add(fb, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                    auto const& res = fb->getResult();
+                    REQUIRE(res.result.code() == txINSUFFICIENT_FEE);
+                    REQUIRE(res.feeCharged == 4000);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
             }
@@ -1095,6 +1098,9 @@ TEST_CASE("replace by fee", "[herder][transactionqueue]")
                     auto tx = transaction(*app, account1, i, 1, 100);
                     auto fb = feeBump(*app, feeSource, tx, 3999);
                     test.add(fb, TransactionQueue::AddResult::ADD_STATUS_ERROR);
+                    auto const& res = fb->getResult();
+                    REQUIRE(res.result.code() == txINSUFFICIENT_FEE);
+                    REQUIRE(res.feeCharged == 4000);
                     test.check({{{account1, 0, txs}, {account2}}, {}});
                 }
             }

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -4,6 +4,7 @@
 
 #include "main/CommandLine.h"
 #include "catchup/CatchupConfiguration.h"
+#include "herder/Herder.h"
 #include "history/HistoryArchiveManager.h"
 #include "history/InferredQuorumUtils.h"
 #include "ledger/LedgerManager.h"

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -69,7 +69,7 @@ class FuzzTransactionFrame : public TransactionFrame
     attemptApplication(Application& app, AbstractLedgerTxn& ltx)
     {
         // reset results of operations
-        resetResults(ltx.getHeader(), 0);
+        resetResults(ltx.getHeader(), 0, true);
 
         // attempt application of transaction without accounting for sequence
         // number, processing the fee, or committing the LedgerTxn

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -46,7 +46,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     void removeOneTimeSignerKeyFromFeeSource(AbstractLedgerTxn& ltx) const;
 
   protected:
-    void resetResults(LedgerHeader const& header, int64_t baseFee);
+    void resetResults(LedgerHeader const& header, int64_t baseFee,
+                      bool applying);
 
   public:
     FeeBumpTransactionFrame(Hash const& networkID,
@@ -69,7 +70,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     int64_t getFeeBid() const override;
     int64_t getMinFee(LedgerHeader const& header) const override;
-    int64_t getFee(LedgerHeader const& header, int64_t baseFee) const override;
+    int64_t getFee(LedgerHeader const& header, int64_t baseFee,
+                   bool applying) const override;
 
     Hash const& getContentsHash() const override;
     Hash const& getFullHash() const override;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -141,7 +141,8 @@ class TransactionFrame : public TransactionFrameBase
         return getResult().result.code();
     }
 
-    void resetResults(LedgerHeader const& header, int64_t baseFee);
+    void resetResults(LedgerHeader const& header, int64_t baseFee,
+                      bool applying);
 
     TransactionEnvelope const& getEnvelope() const override;
     TransactionEnvelope& getEnvelope();
@@ -157,8 +158,8 @@ class TransactionFrame : public TransactionFrameBase
 
     int64_t getMinFee(LedgerHeader const& header) const override;
 
-    virtual int64_t getFee(LedgerHeader const& header,
-                           int64_t baseFee) const override;
+    virtual int64_t getFee(LedgerHeader const& header, int64_t baseFee,
+                           bool applying) const override;
 
     void addSignature(SecretKey const& secretKey);
     void addSignature(DecoratedSignature const& signature);

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -35,8 +35,8 @@ class TransactionFrameBase
 
     virtual int64_t getFeeBid() const = 0;
     virtual int64_t getMinFee(LedgerHeader const& header) const = 0;
-    virtual int64_t getFee(LedgerHeader const& header,
-                           int64_t baseFee) const = 0;
+    virtual int64_t getFee(LedgerHeader const& header, int64_t baseFee,
+                           bool applying) const = 0;
 
     virtual Hash const& getContentsHash() const = 0;
     virtual Hash const& getFullHash() const = 0;

--- a/src/transactions/simulation/TxSimFeeBumpTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimFeeBumpTransactionFrame.cpp
@@ -26,7 +26,7 @@ TxSimFeeBumpTransactionFrame::TxSimFeeBumpTransactionFrame(
 
 int64_t
 TxSimFeeBumpTransactionFrame::getFee(const stellar::LedgerHeader& header,
-                                     int64_t baseFee) const
+                                     int64_t baseFee, bool applying) const
 {
     return mSimulationResult.feeCharged;
 }
@@ -35,7 +35,7 @@ void
 TxSimFeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
                                                int64_t baseFee)
 {
-    resetResults(ltx.loadHeader().current(), baseFee);
+    resetResults(ltx.loadHeader().current(), baseFee, true);
 
     auto feeSource = stellar::loadAccount(ltx, getFeeSourceID());
     if (!feeSource)

--- a/src/transactions/simulation/TxSimFeeBumpTransactionFrame.h
+++ b/src/transactions/simulation/TxSimFeeBumpTransactionFrame.h
@@ -25,7 +25,8 @@ class TxSimFeeBumpTransactionFrame : public FeeBumpTransactionFrame
     {
     }
 
-    int64_t getFee(LedgerHeader const& header, int64_t baseFee) const override;
+    int64_t getFee(LedgerHeader const& header, int64_t baseFee,
+                   bool applying) const override;
     void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
 };
 }

--- a/src/transactions/simulation/TxSimTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimTransactionFrame.cpp
@@ -79,7 +79,8 @@ TxSimTransactionFrame::isBadSeq(int64_t seqNum) const
 }
 
 int64_t
-TxSimTransactionFrame::getFee(LedgerHeader const& header, int64_t baseFee) const
+TxSimTransactionFrame::getFee(LedgerHeader const& header, int64_t baseFee,
+                              bool applying) const
 {
     return mSimulationResult.feeCharged;
 }
@@ -90,7 +91,7 @@ TxSimTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
     mCachedAccount.reset();
 
     auto header = ltx.loadHeader();
-    resetResults(header.current(), baseFee);
+    resetResults(header.current(), baseFee, true);
 
     auto sourceAccount = loadSourceAccount(ltx, header);
     if (!sourceAccount)

--- a/src/transactions/simulation/TxSimTransactionFrame.h
+++ b/src/transactions/simulation/TxSimTransactionFrame.h
@@ -27,7 +27,8 @@ class TxSimTransactionFrame : public TransactionFrame
 
     bool isBadSeq(int64_t seqNum) const override;
 
-    int64_t getFee(LedgerHeader const& header, int64_t baseFee) const override;
+    int64_t getFee(LedgerHeader const& header, int64_t baseFee,
+                   bool applying) const override;
 
     void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
     void processSeqNum(AbstractLedgerTxn& ltx) override;

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -93,6 +93,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
+                REQUIRE(fb->getResult().feeCharged == 2 * fee);
             });
         }
 
@@ -104,6 +105,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 REQUIRE(!fb->checkValid(ltx, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
+                REQUIRE(fb->getResult().feeCharged == 2 * 101);
             });
         }
 

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -1399,6 +1399,9 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                     applyCheck(txFrame, *app);
 
                     REQUIRE(txFrame->getResultCode() == txINSUFFICIENT_FEE);
+                    // during apply, feeCharged is smaller in this case
+                    REQUIRE(txFrame->getResult().feeCharged ==
+                            app->getLedgerManager().getLastTxFee() - 1);
                 });
             }
 

--- a/src/transactions/test/TxResultsTests.cpp
+++ b/src/transactions/test/TxResultsTests.cpp
@@ -241,7 +241,7 @@ TEST_CASE("txresults", "[tx][txresults]")
             {
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({});
-                    validateTxResults(tx, *app, {0, txMISSING_OPERATION});
+                    validateTxResults(tx, *app, {baseFee, txMISSING_OPERATION});
                 });
             }
 
@@ -268,8 +268,7 @@ TEST_CASE("txresults", "[tx][txresults]")
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({payment(root, 1)});
                     setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
-                    validateTxResults(tx, *app,
-                                      {baseFee - 1, txINSUFFICIENT_FEE});
+                    validateTxResults(tx, *app, {baseFee, txINSUFFICIENT_FEE});
                 });
             }
 
@@ -307,7 +306,7 @@ TEST_CASE("txresults", "[tx][txresults]")
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({});
                     getSignatures(tx).clear();
-                    validateTxResults(tx, *app, {0, txMISSING_OPERATION});
+                    validateTxResults(tx, *app, {baseFee, txMISSING_OPERATION});
                 });
             }
 
@@ -337,8 +336,7 @@ TEST_CASE("txresults", "[tx][txresults]")
                     auto tx = a.tx({payment(root, 1)});
                     getSignatures(tx).clear();
                     setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
-                    validateTxResults(tx, *app,
-                                      {baseFee - 1, txINSUFFICIENT_FEE});
+                    validateTxResults(tx, *app, {baseFee, txINSUFFICIENT_FEE});
                 });
             }
 
@@ -389,7 +387,7 @@ TEST_CASE("txresults", "[tx][txresults]")
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({});
                     tx->addSignature(a);
-                    validateTxResults(tx, *app, {0, txMISSING_OPERATION});
+                    validateTxResults(tx, *app, {baseFee, txMISSING_OPERATION});
                 });
             }
 
@@ -419,8 +417,7 @@ TEST_CASE("txresults", "[tx][txresults]")
                     auto tx = a.tx({payment(root, 1)});
                     tx->addSignature(a);
                     setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
-                    validateTxResults(tx, *app,
-                                      {baseFee - 1, txINSUFFICIENT_FEE});
+                    validateTxResults(tx, *app, {baseFee, txINSUFFICIENT_FEE});
                 });
             }
 


### PR DESCRIPTION
# Description

Resolves #2505 

replaces #2521

This PR tweaks the behavior when checking validity such that `feeCharged` in the `TransactionResult` is always set with the minimum fee that core expects for that transaction to be accepted in the transaction queue and to pass validity in general.

Core was *almost* doing this, this PR makes it that it's doing it consistently for all instances of `txINSUFFICIENT_FEE`.

I decided to *not* touch the code at all in the "apply" case even though I *think* that with today's logic it's actually not possible to reach some of the conditions that are in the codebase. Given how critical fees are in the system, I figured this was the more conservative approach and that has less chance of breaking in the future.
