### PR TITLE
Implementation of CAP-0034 for stellar-protocol issue #622: Preserve Transaction-Set/Close-Time Affinity During Nomination

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -923,11 +923,7 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger)
         return;
     }
 
-    if (lcl.header.ledgerVersion >= 11)
-    {
-        // version 11 and above require values to be signed during nomination
-        signStellarValue(mApp.getConfig().NODE_SEED, newProposedValue);
-    }
+    signStellarValue(mApp.getConfig().NODE_SEED, newProposedValue);
     mHerderSCPDriver.nominate(slotIndex, newProposedValue, proposedSet,
                               lcl.header.scpValue);
 }

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -319,20 +319,16 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
         return SCPDriver::kInvalidValue;
     }
 
-    if ((!nomination || lcl.ledgerVersion < 11) &&
-        b.ext.v() != STELLAR_VALUE_BASIC)
+    if (!nomination && b.ext.v() != STELLAR_VALUE_BASIC)
     {
-        // ballot protocol or
-        // pre version 11 only supports BASIC
+        // ballot protocol only supports BASIC
         CLOG(TRACE, "Herder")
             << "HerderSCPDriver::validateValue"
             << " i: " << slotIndex << " invalid value type - expected BASIC";
         return SCPDriver::kInvalidValue;
     }
-    if (nomination &&
-        (lcl.ledgerVersion >= 11 && b.ext.v() != STELLAR_VALUE_SIGNED))
+    if (nomination && b.ext.v() != STELLAR_VALUE_SIGNED)
     {
-        // v11 and above use SIGNED for nomination
         CLOG(TRACE, "Herder")
             << "HerderSCPDriver::validateValue"
             << " i: " << slotIndex << " invalid value type - expected SIGNED";

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -18,13 +18,19 @@
 #include "util/Logging.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
 #include <Tracy.hpp>
+#include <algorithm>
 #include <fmt/format.h>
 #include <medida/metrics_registry.h>
+#include <numeric>
+#include <stdexcept>
 #include <xdrpp/marshal.h>
 
 namespace stellar
 {
+uint32_t const HerderSCPDriver::FIRST_PROTOCOL_WITH_TXSET_CLOSETIME_AFFINITY =
+    14;
 
 HerderSCPDriver::SCPMetrics::SCPMetrics(Application& app)
     : mEnvelopeSign(
@@ -205,17 +211,9 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
     ZoneScoped;
     if (b.ext.v() == STELLAR_VALUE_SIGNED)
     {
-        if (nomination)
+        ZoneNamedN(sigZone, "signature check", true);
+        if (!mHerder.verifyStellarValueSignature(b))
         {
-            ZoneNamedN(sigZone, "signature check", true);
-            if (!mHerder.verifyStellarValueSignature(b))
-            {
-                return SCPDriver::kInvalidValue;
-            }
-        }
-        else
-        {
-            // don't use signed values in ballot protocol
             return SCPDriver::kInvalidValue;
         }
     }
@@ -319,15 +317,16 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
         return SCPDriver::kInvalidValue;
     }
 
-    if (!nomination && b.ext.v() != STELLAR_VALUE_BASIC)
+    bool const expectSignedValue =
+        nomination || (compositeValueType() == STELLAR_VALUE_SIGNED);
+    if (!expectSignedValue && (b.ext.v() != STELLAR_VALUE_BASIC))
     {
-        // ballot protocol only supports BASIC
         CLOG(TRACE, "Herder")
             << "HerderSCPDriver::validateValue"
             << " i: " << slotIndex << " invalid value type - expected BASIC";
         return SCPDriver::kInvalidValue;
     }
-    if (nomination && b.ext.v() != STELLAR_VALUE_SIGNED)
+    if (expectSignedValue && (b.ext.v() != STELLAR_VALUE_SIGNED))
     {
         CLOG(TRACE, "Herder")
             << "HerderSCPDriver::validateValue"
@@ -340,6 +339,10 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
 
     SCPDriver::ValidationLevel res;
 
+    auto closeTimeOffset = curProtocolPreservesTxSetCloseTimeAffinity()
+                               ? (b.closeTime - lastCloseTime)
+                               : 0;
+
     if (!txSet)
     {
         CLOG(ERROR, "Herder") << "validateValue i:" << slotIndex
@@ -347,7 +350,7 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
 
         res = SCPDriver::kInvalidValue;
     }
-    else if (!txSet->checkValid(mApp, 0))
+    else if (!txSet->checkValid(mApp, closeTimeOffset, closeTimeOffset))
     {
         if (Logging::logDebug("Herder"))
             CLOG(DEBUG, "Herder")
@@ -570,8 +573,8 @@ HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
 // returns true if l < r
 // lh, rh are the hashes of l,h
 static bool
-compareTxSets(TxSetFramePtr l, TxSetFramePtr r, Hash const& lh, Hash const& rh,
-              LedgerHeader const& header, Hash const& s)
+compareTxSets(TxSetFrameConstPtr l, TxSetFrameConstPtr r, Hash const& lh,
+              Hash const& rh, LedgerHeader const& header, Hash const& s)
 {
     if (l == nullptr)
     {
@@ -629,6 +632,8 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
 
     std::vector<StellarValue> candidateValues;
 
+    TimePoint maxCloseTime = 0;
+
     for (auto const& c : candidates)
     {
         candidateValues.emplace_back();
@@ -637,10 +642,9 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
         xdr::xdr_from_opaque(c->getValue(), sv);
         candidatesHash ^= sha256(c->getValue());
 
-        // max closeTime
-        if (comp.closeTime < sv.closeTime)
+        if (maxCloseTime < sv.closeTime)
         {
-            comp.closeTime = sv.closeTime;
+            maxCloseTime = sv.closeTime;
         }
         for (auto const& upgrade : sv.upgrades)
         {
@@ -687,59 +691,42 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
     }
 
     // take the txSet with the biggest size, highest xored hash that we have
-    TxSetFramePtr bestTxSet;
     {
-        Hash highest;
-        TxSetFramePtr highestTxSet;
-        for (auto const& sv : candidateValues)
+        auto highest = candidateValues.cend();
+        TxSetFrameConstPtr highestTxSet;
+        for (auto it = candidateValues.cbegin(); it != candidateValues.cend();
+             ++it)
         {
-            TxSetFramePtr cTxSet = mPendingEnvelopes.getTxSet(sv.txSetHash);
-
-            if (cTxSet && cTxSet->previousLedgerHash() == lcl.hash)
+            auto const& sv = *it;
+            auto const cTxSet = mPendingEnvelopes.getTxSet(sv.txSetHash);
+            if (cTxSet && cTxSet->previousLedgerHash() == lcl.hash &&
+                (!highestTxSet ||
+                 compareTxSets(highestTxSet, cTxSet, highest->txSetHash,
+                               sv.txSetHash, lcl.header, candidatesHash)))
             {
-                if (compareTxSets(highestTxSet, cTxSet, highest, sv.txSetHash,
-                                  lcl.header, candidatesHash))
-                {
-                    highestTxSet = cTxSet;
-                    highest = sv.txSetHash;
-                }
+                highest = it;
+                highestTxSet = cTxSet;
             }
+        };
+        if (highest == candidateValues.cend())
+        {
+            throw std::runtime_error(
+                "No highest candidate transaction set found");
         }
-        // make a copy as we're about to modify it and we don't want to mess
-        // with the txSet cache
-        bestTxSet = std::make_shared<TxSetFrame>(*highestTxSet);
+        comp = *highest;
     }
-
+    if (!curProtocolPreservesTxSetCloseTimeAffinity())
+    {
+        comp.closeTime = maxCloseTime;
+        comp.ext.v(STELLAR_VALUE_BASIC);
+    }
+    comp.upgrades.clear();
     for (auto const& upgrade : upgrades)
     {
         Value v(xdr::xdr_to_opaque(upgrade.second));
         comp.upgrades.emplace_back(v.begin(), v.end());
     }
 
-    // just to be sure
-    auto removed = bestTxSet->trimInvalid(mApp, 0);
-    comp.txSetHash = bestTxSet->getContentsHash();
-
-    if (removed.size() != 0)
-    {
-        CLOG(WARNING, "Herder") << "Candidate set had " << removed.size()
-                                << " invalid transactions";
-
-        // learn the updated tx set
-        bestTxSet = mPendingEnvelopes.putTxSet(bestTxSet->getContentsHash(),
-                                               slotIndex, bestTxSet);
-
-        // post to avoid triggering SCP handling code recursively
-        mApp.postOnMainThread(
-            [this, bestTxSet]() {
-                mPendingEnvelopes.recvTxSet(bestTxSet->getContentsHash(),
-                                            bestTxSet);
-            },
-            "HerderSCPDriver combineCandidates");
-    }
-
-    // Ballot Protocol uses BASIC values
-    comp.ext.v(STELLAR_VALUE_BASIC);
     auto res = wrapStellarValue(comp);
     return res;
 }
@@ -839,6 +826,13 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
     {
         mHerder.valueExternalized(slotIndex, b);
     }
+}
+
+bool
+HerderSCPDriver::curProtocolPreservesTxSetCloseTimeAffinity() const
+{
+    return mLedgerManager.getLastClosedLedgerHeader().header.ledgerVersion >=
+           FIRST_PROTOCOL_WITH_TXSET_CLOSETIME_AFFINITY;
 }
 
 void
@@ -1068,6 +1062,13 @@ HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex)
     }
 
     getSCP().purgeSlots(maxSlotIndex);
+}
+
+StellarValueType
+HerderSCPDriver::compositeValueType() const
+{
+    return curProtocolPreservesTxSetCloseTimeAffinity() ? STELLAR_VALUE_SIGNED
+                                                        : STELLAR_VALUE_BASIC;
 }
 
 void

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -156,6 +156,14 @@ class HerderSCPDriver : public SCPDriver
     // clean up older slots
     void purgeSlots(uint64_t maxSlotIndex);
 
+    // Does the nomination protocol output a BASIC or a SIGNED
+    // StellarValue?
+    virtual StellarValueType compositeValueType() const;
+
+    // Does the current protocol version contain the CAP-0034 closeTime
+    // semantics change?
+    bool curProtocolPreservesTxSetCloseTimeAffinity() const;
+
   private:
     Application& mApp;
     HerderImpl& mHerder;
@@ -163,6 +171,8 @@ class HerderSCPDriver : public SCPDriver
     Upgrades const& mUpgrades;
     PendingEnvelopes& mPendingEnvelopes;
     SCP mSCP;
+
+    static uint32_t const FIRST_PROTOCOL_WITH_TXSET_CLOSETIME_AFFINITY;
 
     struct SCPMetrics
     {

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -206,7 +206,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
                          .getLastClosedLedgerHeader()
                          .header.scpValue.closeTime;
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
-    if (!tx->checkValid(ltx, seqNum,
+    if (!tx->checkValid(ltx, seqNum, 0,
                         getUpperBoundCloseTimeOffset(mApp, closeTime)))
     {
         return TransactionQueue::AddResult::ADD_STATUS_ERROR;

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -284,7 +284,8 @@ TxSetFrame::surgePricingFilter(Application& app)
 bool
 TxSetFrame::checkOrTrim(Application& app,
                         std::vector<TransactionFrameBasePtr>& trimmed,
-                        bool justCheck, uint64_t upperBoundCloseTimeOffset)
+                        bool justCheck, uint64_t lowerBoundCloseTimeOffset,
+                        uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -298,7 +299,8 @@ TxSetFrame::checkOrTrim(Application& app,
         while (iter != kv.second.end())
         {
             auto tx = *iter;
-            if (!tx->checkValid(ltx, lastSeq, upperBoundCloseTimeOffset))
+            if (!tx->checkValid(ltx, lastSeq, lowerBoundCloseTimeOffset,
+                                upperBoundCloseTimeOffset))
             {
                 if (justCheck)
                 {
@@ -367,12 +369,14 @@ TxSetFrame::checkOrTrim(Application& app,
 }
 
 std::vector<TransactionFrameBasePtr>
-TxSetFrame::trimInvalid(Application& app, uint64_t upperBoundCloseTimeOffset)
+TxSetFrame::trimInvalid(Application& app, uint64_t lowerBoundCloseTimeOffset,
+                        uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     std::vector<TransactionFrameBasePtr> trimmed;
     sortForHash();
-    checkOrTrim(app, trimmed, false, upperBoundCloseTimeOffset);
+    checkOrTrim(app, trimmed, false, lowerBoundCloseTimeOffset,
+                upperBoundCloseTimeOffset);
     return trimmed;
 }
 
@@ -380,7 +384,8 @@ TxSetFrame::trimInvalid(Application& app, uint64_t upperBoundCloseTimeOffset)
 // the fees of all the tx it has submitted in this set
 // check seq num
 bool
-TxSetFrame::checkValid(Application& app, uint64_t upperBoundCloseTimeOffset)
+TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
+                       uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     auto& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
@@ -420,7 +425,8 @@ TxSetFrame::checkValid(Application& app, uint64_t upperBoundCloseTimeOffset)
     }
 
     std::vector<TransactionFrameBasePtr> trimmed;
-    bool valid = checkOrTrim(app, trimmed, true, upperBoundCloseTimeOffset);
+    bool valid = checkOrTrim(app, trimmed, true, lowerBoundCloseTimeOffset,
+                             upperBoundCloseTimeOffset);
     mValid = make_optional<std::pair<Hash, bool>>(lcl.hash, valid);
     return valid;
 }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -18,6 +18,7 @@ class Application;
 
 class TxSetFrame;
 typedef std::shared_ptr<TxSetFrame> TxSetFramePtr;
+typedef std::shared_ptr<TxSetFrame const> TxSetFrameConstPtr;
 
 class AbstractTxSetFrameForApply
 {
@@ -52,7 +53,8 @@ class TxSetFrame : public AbstractTxSetFrameForApply
 
     bool checkOrTrim(Application& app,
                      std::vector<TransactionFrameBasePtr>& trimmed,
-                     bool justCheck, uint64_t upperBoundCloseTimeOffset);
+                     bool justCheck, uint64_t lowerBoundCloseTimeOffset,
+                     uint64_t upperBoundCloseTimeOffset);
 
     std::unordered_map<AccountID, AccountTransactionQueue>
     buildAccountTxQueues();
@@ -80,12 +82,14 @@ class TxSetFrame : public AbstractTxSetFrameForApply
 
     std::vector<TransactionFrameBasePtr> sortForApply() override;
 
-    bool checkValid(Application& app, uint64_t upperBoundCloseTimeOffset);
+    bool checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset);
 
     // remove invalid transaction from this set and return those removed
     // transactions
     std::vector<TransactionFrameBasePtr>
-    trimInvalid(Application& app, uint64_t upperBoundCloseTimeOffset);
+    trimInvalid(Application& app, uint64_t lowerBoundCloseTimeOffset,
+                uint64_t upperBoundCloseTimeOffset);
     void surgePricingFilter(Application& app);
 
     void removeTx(TransactionFrameBasePtr tx);

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1451,7 +1451,7 @@ TEST_CASE("SCP Driver", "[herder][acceptance]")
 {
     SECTION("protocol 10")
     {
-        testSCPDriver(10, 10, 10, false, false);
+        testSCPDriver(10, 10, 10, false, true);
     }
     SECTION("protocol current")
     {

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1949,7 +1949,7 @@ TEST_CASE("simulate upgrades", "[herder][upgrades][acceptance]")
                                                     {upgrade, genesis(0, 15)}};
         auto checks = std::vector<LedgerUpgradeCheck>{
             {genesis(0, 10), {noUpgrade, noUpgrade, noUpgrade}},
-            {genesis(0, 21), {upgrade, upgrade, upgrade}}};
+            {genesis(0, 28), {upgrade, upgrade, upgrade}}};
         simulateUpgrade(nodes, checks);
     }
 
@@ -1975,7 +1975,7 @@ TEST_CASE("simulate upgrades", "[herder][upgrades][acceptance]")
                                                     {upgrade, genesis(0, 30)}};
         auto checks = std::vector<LedgerUpgradeCheck>{
             {genesis(0, 20), {noUpgrade, noUpgrade, noUpgrade}},
-            {genesis(0, 36), {upgrade, upgrade, upgrade}}};
+            {genesis(0, 37), {upgrade, upgrade, upgrade}}};
         simulateUpgrade(nodes, checks);
     }
 
@@ -1986,7 +1986,7 @@ TEST_CASE("simulate upgrades", "[herder][upgrades][acceptance]")
                                                     {upgrade, genesis(0, 30)}};
         auto checks = std::vector<LedgerUpgradeCheck>{
             {genesis(0, 9), {noUpgrade, noUpgrade, noUpgrade}},
-            {genesis(0, 20), {upgrade, upgrade, upgrade}}};
+            {genesis(0, 27), {upgrade, upgrade, upgrade}}};
         simulateUpgrade(nodes, checks);
     }
 }

--- a/src/scp/test/SCPTests.cpp
+++ b/src/scp/test/SCPTests.cpp
@@ -2439,8 +2439,6 @@ TEST_CASE("ballot protocol core3", "[scp][ballotprotocol]")
     auto recvQuorumChecksEx =
         std::bind(recvQuorumChecksEx2, _1, _2, _3, _4, false);
     auto recvQuorumChecks = std::bind(recvQuorumChecksEx, _1, _2, _3, false);
-    auto recvQuorumEx = std::bind(recvQuorumChecksEx, _1, true, false, _2);
-    auto recvQuorum = std::bind(recvQuorumEx, _1, false);
 
     // no timer is set
     REQUIRE(!scp.hasBallotTimer());

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -122,7 +122,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
     AccountEntry srcAccountBefore;
     {
         LedgerTxn ltxFeeProc(ltx);
-        check = tx->checkValid(ltxFeeProc, 0, 0);
+        check = tx->checkValid(ltxFeeProc, 0, 0, 0);
         checkResult = tx->getResult();
         REQUIRE((!check || checkResult.result.code() == txSUCCESS));
 
@@ -311,7 +311,7 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
     auto shouldValidateOk = validationResult.code == txSUCCESS;
     {
         LedgerTxn ltx(app.getLedgerTxnRoot());
-        REQUIRE(tx->checkValid(ltx, 0, 0) == shouldValidateOk);
+        REQUIRE(tx->checkValid(ltx, 0, 0, 0) == shouldValidateOk);
     }
     REQUIRE(tx->getResult().result.code() == validationResult.code);
     REQUIRE(tx->getResult().feeCharged == validationResult.fee);
@@ -351,7 +351,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
     }
 
     txSet->sortForHash();
-    REQUIRE(txSet->checkValid(app, 0));
+    REQUIRE(txSet->checkValid(app, 0, 0));
 
     StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
                     emptyUpgradeSteps, STELLAR_VALUE_BASIC);

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -144,6 +144,7 @@ FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
 bool
 FeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
                                     SequenceNumber current,
+                                    uint64_t lowerBoundCloseTimeOffset,
                                     uint64_t upperBoundCloseTimeOffset)
 {
     LedgerTxn ltx(ltxOuter);
@@ -165,7 +166,8 @@ FeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
     }
 
     bool res =
-        mInnerTx->checkValid(ltx, current, false, upperBoundCloseTimeOffset);
+        mInnerTx->checkValid(ltx, current, false, lowerBoundCloseTimeOffset,
+                             upperBoundCloseTimeOffset);
     updateResult(getResult(), mInnerTx);
     return res;
 }

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -64,6 +64,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
                TransactionMeta& meta) override;
 
     bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
 
     TransactionEnvelope const& getEnvelope() const override;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -64,11 +64,13 @@ class TransactionFrame : public TransactionFrameBase
         kMaybeValid
     };
 
-    virtual bool isTooEarly(LedgerTxnHeader const& header) const;
+    virtual bool isTooEarly(LedgerTxnHeader const& header,
+                            uint64_t lowerBoundCloseTimeOffset) const;
     virtual bool isTooLate(LedgerTxnHeader const& header,
                            uint64_t upperBoundCloseTimeOffset) const;
 
     bool commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee,
+                              uint64_t lowerBoundCloseTimeOffset,
                               uint64_t upperBoundCloseTimeOffset);
 
     virtual bool isBadSeq(int64_t seqNum) const;
@@ -77,6 +79,7 @@ class TransactionFrame : public TransactionFrameBase
                                AbstractLedgerTxn& ltxOuter,
                                SequenceNumber current, bool applying,
                                bool chargeFee,
+                               uint64_t lowerBoundCloseTimeOffset,
                                uint64_t upperBoundCloseTimeOffset);
 
     virtual std::shared_ptr<OperationFrame>
@@ -171,8 +174,10 @@ class TransactionFrame : public TransactionFrameBase
                                  AccountID const& accountID);
 
     bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
-                    bool chargeFee, uint64_t upperBoundCloseTimeOffset);
+                    bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset);
     bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
 
     void insertKeysForFeeProcessing(

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -29,6 +29,7 @@ class TransactionFrameBase
                        TransactionMeta& meta) = 0;
 
     virtual bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                            uint64_t lowerBoundCloseTimeOffset,
                             uint64_t upperBoundCloseTimeOffset) = 0;
 
     virtual TransactionEnvelope const& getEnvelope() const = 0;

--- a/src/transactions/simulation/TxSimTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimTransactionFrame.cpp
@@ -60,7 +60,8 @@ TxSimTransactionFrame::makeOperation(Operation const& op, OperationResult& res,
 }
 
 bool
-TxSimTransactionFrame::isTooEarly(LedgerTxnHeader const& header) const
+TxSimTransactionFrame::isTooEarly(LedgerTxnHeader const& header,
+                                  uint64_t lowerBoundCloseTimeOffset) const
 {
     return mSimulationResult.result.code() == txTOO_EARLY;
 }

--- a/src/transactions/simulation/TxSimTransactionFrame.h
+++ b/src/transactions/simulation/TxSimTransactionFrame.h
@@ -17,7 +17,8 @@ class TxSimTransactionFrame : public TransactionFrame
     uint32_t const mCount;
 
   protected:
-    bool isTooEarly(LedgerTxnHeader const& header) const override;
+    bool isTooEarly(LedgerTxnHeader const& header,
+                    uint64_t lowerBoundCloseTimeOffset) const override;
     bool isTooLate(LedgerTxnHeader const& header,
                    uint64_t upperBoundCloseTimeOffset) const override;
 

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -80,7 +80,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee, fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txNOT_SUPPORTED);
             });
         }
@@ -91,7 +91,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee - 1, 1, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
                 REQUIRE(fb->getResult().feeCharged == 2 * fee);
             });
@@ -103,7 +103,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee + 1, 101, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
                 REQUIRE(fb->getResult().feeCharged == 2 * 101);
             });
@@ -116,7 +116,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txNO_ACCOUNT);
             });
         }
@@ -131,7 +131,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH);
             });
         }
@@ -149,7 +149,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH);
             });
         }
@@ -161,7 +161,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_BALANCE);
             });
         }
@@ -178,7 +178,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH_EXTRA);
             });
         }
@@ -192,7 +192,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_FAILED);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -209,7 +209,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, -1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0));
+                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_FAILED);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -229,7 +229,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(fb->checkValid(ltx, 0, 0));
+                REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_SUCCESS);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -273,7 +273,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 }
                 acc.merge(root);
                 {
@@ -293,7 +293,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 }
                 acc.setOptions(setMasterWeight(0));
                 {
@@ -313,7 +313,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 }
                 acc.pay(root, 2 * fee);
                 {
@@ -339,7 +339,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                     app->getNetworkID(), fbXDR);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 }
 
                 auto setOptionsTx = acc.tx({setOptions(setLowThreshold(1))});
@@ -363,7 +363,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 }
 
                 auto setOptionsOp = setOptions(setMasterWeight(0));
@@ -393,7 +393,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
                                   fee, INT64_MAX);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                 }
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -436,7 +436,7 @@ TEST_CASE("fee bump transactions", "[tx][feebump]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0));
+                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
                     REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_SUCCESS);
                 }
                 {

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -359,7 +359,7 @@ TEST_CASE("manage buy offer liabilities", "[tx][offers]")
 
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                tx->checkValid(ltx, 0, 0);
+                tx->checkValid(ltx, 0, 0, 0);
             }
 
             auto buyOp = std::static_pointer_cast<ManageBuyOfferOpFrame>(


### PR DESCRIPTION
# Description

Implements [CAP-0034](https://github.com/stellar/stellar-protocol/pull/679), and thereby resolves [stellar-protocol issue #622](https://github.com/stellar/stellar-protocol/issues/622).

For details, see that PR and issue, and the commit logs for the "State pattern" and "Upgrade protocol" commits in this PR.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
