### PR TITLE
Test code refactoring and other tiny cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,7 +78,8 @@ compile_commands.json
 /scripts/*.json
 
 # test output
-/stellar-core-test-*
+stellar-core-test-*
+test-partitions.*
 /fuzz-findings/
 /my-history/
 

--- a/src/historywork/DownloadVerifyTxResultsWork.cpp
+++ b/src/historywork/DownloadVerifyTxResultsWork.cpp
@@ -68,7 +68,8 @@ DownloadVerifyTxResultsWork::yieldMoreWork()
                                                     mCurrCheckpoint);
     std::vector<std::shared_ptr<BasicWork>> seq{w1, w2};
     auto w3 = std::make_shared<WorkSequence>(
-        mApp, "download-verify-results-" + std::to_string(mCurrCheckpoint),
+        mApp,
+        fmt::format(FMT_STRING("download-verify-results-{}"), mCurrCheckpoint),
         seq);
 
     mCurrCheckpoint += mApp.getHistoryManager().getCheckpointFrequency();

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -629,12 +629,12 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         case Upgrades::UpgradeValidity::VALID:
             break;
         case Upgrades::UpgradeValidity::XDR_INVALID:
-            throw std::runtime_error("Unknown upgrade at index " +
-                                     std::to_string(i));
+            throw std::runtime_error(
+                fmt::format(FMT_STRING("Unknown upgrade at index {}"), i));
         case Upgrades::UpgradeValidity::INVALID:
-            throw std::runtime_error("Invalid upgrade at index " +
-                                     std::to_string(i) + ": " +
-                                     xdr::xdr_to_string(lupgrade));
+            throw std::runtime_error(
+                fmt::format(FMT_STRING("Invalid upgrade at index {}: {}"), i,
+                            xdr::xdr_to_string(lupgrade)));
         }
 
         try

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -398,6 +398,14 @@ TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
               std::vector<TransactionFrameBasePtr> const& txs, bool skipValid)
 {
+    return closeLedgerOn(app, ledgerSeq, getTestDate(day, month, year), txs,
+                         skipValid);
+}
+
+TxSetResultMeta
+closeLedgerOn(Application& app, uint32 ledgerSeq, time_t closeTime,
+              std::vector<TransactionFrameBasePtr> const& txs, bool skipValid)
+{
     auto txSet = std::make_shared<TxSetFrame>(
         app.getLedgerManager().getLastClosedLedgerHeader().hash);
 
@@ -412,8 +420,8 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
         REQUIRE(txSet->checkValid(app, 0, 0));
     }
 
-    StellarValue sv(txSet->getContentsHash(), getTestDate(day, month, year),
-                    emptyUpgradeSteps, STELLAR_VALUE_BASIC);
+    StellarValue sv(txSet->getContentsHash(), closeTime, emptyUpgradeSteps,
+                    STELLAR_VALUE_BASIC);
     LedgerCloseData ledgerData(ledgerSeq, txSet, sv);
     app.getLedgerManager().closeLedger(ledgerData);
 

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -72,6 +72,11 @@ void validateTxResults(TransactionFramePtr const& tx, Application& app,
                        TransactionResult const& applyResult = {});
 
 TxSetResultMeta
+closeLedgerOn(Application& app, uint32 ledgerSeq, time_t closeTime,
+              std::vector<TransactionFrameBasePtr> const& txs = {},
+              bool skipValid = false);
+
+TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
               std::vector<TransactionFrameBasePtr> const& txs = {},
               bool skipValid = false);

--- a/src/test/run-selftest-nopg
+++ b/src/test/run-selftest-nopg
@@ -7,8 +7,11 @@
 BASE_INSTANCE="$1"
 TESTS="$2"
 
+STELLAR_CORE_DEFAULT_TEST_PARAMS="--ll fatal -w NoTests -a -r simple"
 if [[ "$ALL_VERSIONS" != "" ]]; then
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
-else
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
+    STELLAR_CORE_DEFAULT_TEST_PARAMS="$STELLAR_CORE_DEFAULT_TEST_PARAMS --all-versions"
 fi
+
+: ${STELLAR_CORE_TEST_PARAMS=$STELLAR_CORE_DEFAULT_TEST_PARAMS}
+
+./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS" 2> /dev/null

--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -10,6 +10,13 @@ if [[ -z "$TEMP_POSTGRES" ]]; then
     TEMP_POSTGRES=1
 fi
 
+STELLAR_CORE_DEFAULT_TEST_PARAMS="--ll fatal -w NoTests -a -r simple"
+if [[ "$ALL_VERSIONS" != "" ]]; then
+    STELLAR_CORE_DEFAULT_TEST_PARAMS="$STELLAR_CORE_DEFAULT_TEST_PARAMS --all-versions"
+fi
+
+: ${STELLAR_CORE_TEST_PARAMS=$STELLAR_CORE_DEFAULT_TEST_PARAMS}
+
 PGDIRS=$(exec 2>/dev/null; cd /usr/lib/postgresql && ls -1d */bin | sort -rn | xargs realpath)
 
 findpg() {
@@ -93,8 +100,5 @@ if test "$TEMP_POSTGRES" != 0; then
 else
     echo "PostgreSQL enabled for tests using existing database cluster"
 fi
-if [ "$ALL_VERSIONS" != "" ]; then
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE --all-versions -w NoTests -a -r simple "$TESTS" 2> /dev/null
-else                                 
-    ./stellar-core test --ll fatal --base-instance $BASE_INSTANCE -w NoTests -a -r simple "$TESTS" 2> /dev/null
-fi
+
+./stellar-core test $STELLAR_CORE_TEST_PARAMS --base-instance $BASE_INSTANCE "$TESTS" 2> /dev/null

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -1557,7 +1557,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         setMinTime(txFrame, start + 1000);
                         setMaxTime(txFrame, start + 10000);
 
-                        closeLedgerOn(*app, 3, 1, 7, 2014);
+                        closeLedgerOn(*app, 3, start + 1);
                         applyCheck(txFrame, *app);
 
                         REQUIRE(txFrame->getResultCode() == txTOO_EARLY);
@@ -1572,7 +1572,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         getSignatures(txFrame).clear();
                         txFrame->addSignature(root);
 
-                        closeLedgerOn(*app, 3, 2, 7, 2014);
+                        closeLedgerOn(*app, 3, start + 1);
                         applyCheck(txFrame, *app);
                         REQUIRE(txFrame->getResultCode() == txSUCCESS);
                     }
@@ -1584,7 +1584,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         setMinTime(txFrame, 1000);
                         setMaxTime(txFrame, start);
 
-                        closeLedgerOn(*app, 3, 3, 7, 2014);
+                        closeLedgerOn(*app, 3, start + 1);
                         applyCheck(txFrame, *app);
                         REQUIRE(txFrame->getResultCode() == txTOO_LATE);
                     }
@@ -1596,11 +1596,9 @@ TEST_CASE("txenvelope", "[tx][envelope]")
 
                         setMaxTime(txFrame, 0);
 
-                        closeLedgerOn(*app, 3, 1, 1, 2020);
+                        TimePoint lastClose = getTestDate(1, 1, 2020);
+                        closeLedgerOn(*app, 3, lastClose);
 
-                        auto const lastClose = app->getLedgerManager()
-                                                   .getLastClosedLedgerHeader()
-                                                   .header.scpValue.closeTime;
                         TimePoint const nextOffset = 2;
                         auto const nextClose = lastClose + nextOffset;
 

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -123,7 +123,7 @@ class XDRInputFileStream
     }
 };
 
-// XDROutputStream needs access to a file descriptor to do fsync, so we use
+// XDROutputFileStream needs access to a file descriptor to do fsync, so we use
 // asio's synchronous stream types here rather than fstreams.
 class XDROutputFileStream
 {


### PR DESCRIPTION
# Description

A couple of test script enhancements, some more git ignores,
some refactoring of time-related test utility functions to
allow more time precision in some tests, some avoidance of
operator+(const char*, std::to_string(XXX)) (see
https://bugs.llvm.org/show_bug.cgi?id=46625), and a comment
fix.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
