### PR TITLE
Simulation: advance bucketlist level even for empty buckets

### DIFF
--- a/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
+++ b/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
@@ -124,9 +124,13 @@ TxSimGenerateBucketsWork::onRun()
         mTimer->async_wait(wakeSelfUpCallback(), &VirtualTimer::onFailureNoop);
         return BasicWork::State::WORK_WAITING;
     }
-    else if (!mIntermediateBuckets.empty())
+    else
     {
-        processGeneratedBucket();
+        if (!mIntermediateBuckets.empty())
+        {
+            processGeneratedBucket();
+        }
+
         if (mLevel < BucketList::kNumLevels - 1)
         {
             if (!mIsCurr)


### PR DESCRIPTION
Simulation bugfix, which only applies to really old (< 11) bucket versions.