### PR TITLE
change local history location in configs

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -527,9 +527,9 @@ HISTORY="curl -sf http://history.stellar.org/prd/core-testnet/core_testnet_003/{
 # NB: this is an example, in general you should probably not do this as
 #   archives grow indefinitely
 [HISTORY.local]
-get="cp /tmp/stellar-core/history/vs/{0} {1}"
-put="cp {0} /tmp/stellar-core/history/vs/{1}"
-mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
+get="cp /var/lib/stellar-core/history/vs/{0} {1}"
+put="cp {0} /var/lib/stellar-core/history/vs/{1}"
+mkdir="mkdir -p /var/lib/stellar-core/history/vs/{0}"
 
 # other examples:
 # [HISTORY.stellar]

--- a/docs/stellar-core_standalone.cfg
+++ b/docs/stellar-core_standalone.cfg
@@ -25,6 +25,6 @@ THRESHOLD_PERCENT=100
 VALIDATORS=["$self"]
 
 [HISTORY.vs]
-get="cp /tmp/stellar-core/history/vs/{0} {1}"
-put="cp {0} /tmp/stellar-core/history/vs/{1}"
-mkdir="mkdir -p /tmp/stellar-core/history/vs/{0}"
+get="cp /var/lib/stellar-core/history/vs/{0} {1}"
+put="cp {0} /var/lib/stellar-core/history/vs/{1}"
+mkdir="mkdir -p /var/lib/stellar-core/history/vs/{0}"


### PR DESCRIPTION
# Description

Prevents people from losing their archives

Every now and then I see people (on stellar.stackexchange for example) actually storing their archives in /tmp and I think it would be better to have a different location in the example configs.

# Checklist
- [X] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [X] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
