### PR TITLE
Set fail and/or badbit exception masks on fstreams.

### DIFF
--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -36,6 +36,7 @@ fileSize(std::string const& name)
 {
     assert(fs::exists(name));
     std::ifstream in(name, std::ifstream::ate | std::ifstream::binary);
+    in.exceptions(std::ios::badbit);
     return in.tellg();
 }
 

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -109,6 +109,7 @@ HistoryArchiveState::save(std::string const& outFile) const
 {
     ZoneScoped;
     std::ofstream out(outFile);
+    out.exceptions(std::ios::failbit | std::ios::badbit);
     cereal::JSONOutputArchive ar(out);
     serialize(ar);
 }
@@ -133,6 +134,7 @@ HistoryArchiveState::load(std::string const& inFile)
 {
     ZoneScoped;
     std::ifstream in(inFile);
+    in.exceptions(std::ios::badbit);
     cereal::JSONInputArchive ar(in);
     serialize(ar);
     if (version != HISTORY_ARCHIVE_STATE_VERSION)

--- a/src/history/InferredQuorumUtils.cpp
+++ b/src/history/InferredQuorumUtils.cpp
@@ -87,6 +87,7 @@ writeQuorumGraph(Config const& cfg, std::string const& outputFile,
     else
     {
         std::ofstream out(filename);
+        out.exceptions(std::ios::failbit | std::ios::badbit);
         iq.writeQuorumGraph(cfg2, out);
         LOG(INFO) << "*";
         LOG(INFO) << "* Wrote quorum graph to " << filename;

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -86,6 +86,7 @@ TEST_CASE("HistoryManager compress", "[history]")
     std::string fname = hm.localFilename("compressme");
     {
         std::ofstream out(fname, std::ofstream::binary);
+        out.exceptions(std::ios::failbit | std::ios::badbit);
         out.write(s.data(), s.size());
     }
     std::string compressed = fname + ".gz";

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -205,6 +205,7 @@ TestBucketGenerator::generateBucket(TestBucketState state)
         else
         {
             std::ofstream out(filename + ".gz");
+            out.exceptions(std::ios::failbit | std::ios::badbit);
             out.close();
             seq = {mkdir, put};
         }

--- a/src/history/test/SerializeTests.cpp
+++ b/src/history/test/SerializeTests.cpp
@@ -22,6 +22,7 @@ TEST_CASE("Serialization round trip", "[history]")
         SECTION("Serialize " + fnPath)
         {
             std::ifstream in(fnPath);
+            in.exceptions(std::ios::badbit);
             std::string fromFile((std::istreambuf_iterator<char>(in)),
                                  std::istreambuf_iterator<char>());
 

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -89,6 +89,7 @@ VerifyBucketWork::spawnVerifier()
                 // ensure that the stream gets its own scope to avoid race with
                 // main thread
                 std::ifstream in(filename, std::ifstream::binary);
+                in.exceptions(std::ios::badbit);
                 char buf[4096];
                 while (in)
                 {

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -319,6 +319,7 @@ writeCatchupInfo(Json::Value const& catchupInfo, std::string const& outputFile)
     else
     {
         std::ofstream out{};
+        out.exceptions(std::ios::failbit | std::ios::badbit);
         out.open(filename);
         out.write(content.c_str(), content.size());
         out.close();

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -558,6 +558,7 @@ Config::load(std::string const& filename)
             {
                 throw std::runtime_error("could not open file");
             }
+            ifs.exceptions(std::ios::badbit);
             load(ifs);
         }
     }

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -216,6 +216,7 @@ readFile(const std::string& filename, bool base64 = false)
         ifstream file(filename.c_str());
         if (!file)
             throw_perror(filename);
+        file.exceptions(std::ios::badbit);
         input << file.rdbuf();
     }
     string ret;

--- a/src/process/test/ProcessTests.cpp
+++ b/src/process/test/ProcessTests.cpp
@@ -100,6 +100,7 @@ TEST_CASE("subprocess redirect to file", "[process]")
 
     std::ifstream in(filename);
     CHECK(in);
+    in.exceptions(std::ios::badbit);
     std::string s;
     in >> s;
     CLOG(DEBUG, "Process") << "opened redirect file, read: " << s;
@@ -129,6 +130,7 @@ TEST_CASE("subprocess storm", "[process]")
         CLOG(INFO, "Process") << "making file " << src;
         {
             std::ofstream out(src);
+            out.exceptions(std::ios::failbit | std::ios::badbit);
             out << i;
         }
         auto evt = app.getProcessManager()

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -442,6 +442,7 @@ class ScaleReporter
                                 std::time(nullptr)))
         , mOut(mFilename)
     {
+        mOut.exceptions(std::ios::failbit | std::ios::badbit);
         LOG(INFO) << "Opened " << mFilename << " for writing";
         mOut << join(columns, ",") << std::endl;
     }

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -567,6 +567,7 @@ size(std::string const& filename)
     ifs.open(filename, std::ifstream::binary);
     if (ifs)
     {
+        ifs.exceptions(std::ios::badbit);
         return size(ifs);
     }
     else

--- a/src/util/XDRStream.h
+++ b/src/util/XDRStream.h
@@ -60,7 +60,7 @@ class XDRInputFileStream
             CLOG(ERROR, "Fs") << msg;
             throw FileSystemException(msg);
         }
-
+        mIn.exceptions(std::ios::badbit);
         mSize = fs::size(mIn);
     }
 


### PR DESCRIPTION
This just sets badbit on ifstream exception masks, and failbit|badbit on ofstreams.

Failbit is not set on ifstreams because read operations typically signal _completion_ by reading at-the-end and failing, setting both failbit and eof. Yet more magic and beauty of the iostreams library.