### PR TITLE
Increase the timeout for the resilience tests

### DIFF
--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -152,7 +152,7 @@ resilienceTest(Simulation::pointer sim)
         targetLedger += step;
         sim->crankUntil(
             [&]() { return sim->haveAllExternalized(targetLedger, maxGap); },
-            2 * nbLedgerStep * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+            5 * nbLedgerStep * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
 
         REQUIRE(sim->haveAllExternalized(targetLedger, maxGap));
     };


### PR DESCRIPTION
# Description

Resolves #2632
tl; dr: Things seem to be behaving the way they should be, but it's taking a little longer than one might initially expect. Increasing the timeout will fix the issue.

* The only test in the resilience tests that seems to fail after trying 200 random seeds (0, 1, ..., 199) is `custom-A`.
* `custom-A` is a network with 6 nodes. It removes one node from the network, puts that node back in the network. It again removes and puts that node in the network. In other words, there are `6 * 6 = 36` possibilities.
* After iterating through all the possibilities, I found out that there seemed to be only two possible combinations that fail the test: `(5, 3)` and `(2, 3)`. They can be reproduced by
  * `src/stellar-core test '[resilience]' -c 'custom-A' --rng-seed 82`
  * `src/stellar-core test '[resilience]' -c 'custom-A' --rng-seed 174`
* By examining the log obtained through `--ll DEBUG`, the only things that take more than 5 seconds are:
  * Nominate delta such as `2020-07-30T09:22:11.108 <test> [Herder DEBUG] Nominate delta for slot 9 is 28100 ms`
  * Externalize delay such as `2020-07-30T09:22:11.242 <test> [Herder DEBUG] externalize delay (GB3X5) delta for slot 9 is 12400 ms`

1. The `Nominate delta` seems to be related to #2106.
2. All the long externalize delays happen only when a "victim" node tries to close a ledger that was closed while it was away. For instance, the `12400 ms` above is calculated by `(when GB3X5 closed slot 9) - (the earliest time slot 9 was externalized)` and the number is so big because `(the earliest time slot 9 was externalized)` happened while `GB3x5` was away from the network. Checking `steady_clock` shows that there is a very small delay between a victim re-joining and externalizing.

Therefore, I decided to increase the timeout. The multiplier of 4 still fails the custom-A test, but with 5, the resilience tests pass with 10k seeds (1, 2, ..., 10,000), which implies that the test probably has the passing rate > 99.99%.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)