### PR TITLE
fix crash on shutdown (as to get the proper error message)

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -348,14 +348,21 @@ ApplicationImpl::getNetworkID() const
 ApplicationImpl::~ApplicationImpl()
 {
     LOG(INFO) << "Application destructing";
-    shutdownWorkScheduler();
-    if (mProcessManager)
+    try
     {
-        mProcessManager->shutdown();
+        shutdownWorkScheduler();
+        if (mProcessManager)
+        {
+            mProcessManager->shutdown();
+        }
+        if (mBucketManager)
+        {
+            mBucketManager->shutdown();
+        }
     }
-    if (mBucketManager)
+    catch (std::exception const& e)
     {
-        mBucketManager->shutdown();
+        LOG(ERROR) << "While shutting down " << e.what();
     }
     reportCfgMetrics();
     shutdownMainIOContext();


### PR DESCRIPTION
Fixes a crash on shutdown occurring when running `new-hist` without a database

This was introduced by #2622 : when there is no database, `shutdown` throws, which bypasses joining threads (and deleting a thread object when a thread is running violates spec).
