### PR TITLE
Nomination leader fast timeout

### DIFF
--- a/src/scp/test/SCPUnitTests.cpp
+++ b/src/scp/test/SCPUnitTests.cpp
@@ -301,16 +301,17 @@ TEST_CASE("nomination two nodes win stats", "[scp][!hide]")
     auto nominationLeaders = [&](int maxRounds, SCPQuorumSet qSetNode0,
                                  SCPQuorumSet qSetNode1) {
         TestNominationSCP nomSCP0(v0NodeID, qSetNode0);
-        Slot slot0(0, nomSCP0.mSCP);
-        NominationTestHandler nom0(slot0);
-
         TestNominationSCP nomSCP1(v1NodeID, qSetNode1);
-        Slot slot1(0, nomSCP1.mSCP);
-        NominationTestHandler nom1(slot1);
 
         int tot = 0;
         for (int g = 0; g < totalIter; g++)
         {
+            Slot slot0(0, nomSCP0.mSCP);
+            NominationTestHandler nom0(slot0);
+
+            Slot slot1(0, nomSCP1.mSCP);
+            NominationTestHandler nom1(slot1);
+
             Value v;
             v.emplace_back(uint8_t(g));
             nom0.setPreviousValue(v);


### PR DESCRIPTION
# High level description

This PR resolves #2106

## Approach in this PR

The change in itself is fairly simple. We change the leader selection such that when nomination times out, we ensure that a new leader is added to the set of known leaders for the local node.

To ensure progress, we skip the current nomination round by incrementing the round number, without actually waiting for the timeout for that specific round to happen:
* this is strictly better than master, in that "no-op" rounds are just skipped by nodes and it introduces values that would be introduced by master anyways (but later).
* the nomination protocol (unlike the ballot protocol) doesn't make any assumption across nodes on round numbers or the overall timeout duration of individual nodes
* timeouts continue to grow relatively fast, so the risk of introducing too many values too fast stays low
* the new property that we have is that if a node has N validators in its quorum set, it will take at most N timeouts to add all N validators (but the total time to get there depends on the weight of those validators)

I included data that shows the chance of success of nomination after a number of timeouts (compared with master) to help support the claims from above.

## Alternative approach

Another way to fix this issue is to try to change the priority function. #1820 attempted to do this.
The challenge when designing a new priority function is that it needs to balance a global property (different nodes pick the same leader), without being vulnerable to sybil attacks.

Improving the way leaders are selected is still something we should look into as to reduce the number of values and number of timeouts.

# Supporting data

## stellar-core test "nomination two nodes win stats" -c "flat quorum" -c "2 out of 3"

### master

```
Filters: nomination two nodes win stats
2020-08-01T15:45:47.289 <test> [SCP INFO] Win rate for 1 : 37.08
2020-08-01T15:45:54.563 <test> [SCP INFO] Win rate for 2 : 65.6
2020-08-01T15:46:03.108 <test> [SCP INFO] Win rate for 3 : 82.41
2020-08-01T15:46:12.355 <test> [SCP INFO] Win rate for 4 : 90.61
2020-08-01T15:46:24.659 <test> [SCP INFO] Win rate for 5 : 94.14
2020-08-01T15:46:36.142 <test> [SCP INFO] Win rate for 6 : 95.31
2020-08-01T15:46:47.318 <test> [SCP INFO] Win rate for 7 : 96.48
2020-08-01T15:46:59.853 <test> [SCP INFO] Win rate for 8 : 98.44
2020-08-01T15:47:11.168 <test> [SCP INFO] Win rate for 9 : 99.22
```

### this PR

```
Filters: nomination two nodes win stats
2020-08-01T15:44:15.777 <test> [SCP INFO] Win rate for 1 : 37.08
2020-08-01T15:44:25.140 <test> [SCP INFO] Win rate for 2 : 80.05
2020-08-01T15:44:38.118 <test> [SCP INFO] Win rate for 3 : 100
```

## stellar-core test "nomination two nodes win stats" -c "flat quorum" -c "3 out of 5"

### master

```
Filters: nomination two nodes win stats
2020-08-01T15:50:01.353 <test> [SCP INFO] Win rate for 1 : 29.28
2020-08-01T15:50:10.672 <test> [SCP INFO] Win rate for 2 : 53.12
2020-08-01T15:50:22.539 <test> [SCP INFO] Win rate for 3 : 71.49
2020-08-01T15:50:35.817 <test> [SCP INFO] Win rate for 4 : 81.64
2020-08-01T15:50:50.149 <test> [SCP INFO] Win rate for 5 : 86.33
2020-08-01T15:51:05.708 <test> [SCP INFO] Win rate for 6 : 89.84
2020-08-01T15:51:21.911 <test> [SCP INFO] Win rate for 7 : 92.57
2020-08-01T15:51:38.564 <test> [SCP INFO] Win rate for 8 : 94.53
2020-08-01T15:51:55.346 <test> [SCP INFO] Win rate for 9 : 96.49
```

### this PR

```
Filters: nomination two nodes win stats
2020-08-01T15:53:23.250 <test> [SCP INFO] Win rate for 1 : 29.28
2020-08-01T15:53:33.831 <test> [SCP INFO] Win rate for 2 : 57.8
2020-08-01T15:53:49.028 <test> [SCP INFO] Win rate for 3 : 82.04
2020-08-01T15:54:07.200 <test> [SCP INFO] Win rate for 4 : 92.57
2020-08-01T15:54:28.411 <test> [SCP INFO] Win rate for 5 : 100
```

## stellar-core.exe test "nomination two nodes win stats" -c "hierarchy" -c "same qSet"

### master

```
Filters: nomination two nodes win stats
2020-08-01T16:06:05.093 <test> [SCP INFO] Win rate for 1 : 23.42
2020-08-01T16:06:21.568 <test> [SCP INFO] Win rate for 2 : 49.61
2020-08-01T16:06:42.370 <test> [SCP INFO] Win rate for 3 : 64.85
2020-08-01T16:07:06.976 <test> [SCP INFO] Win rate for 4 : 76.17
2020-08-01T16:07:33.116 <test> [SCP INFO] Win rate for 5 : 80.46
2020-08-01T16:08:01.117 <test> [SCP INFO] Win rate for 6 : 84.76
2020-08-01T16:08:30.307 <test> [SCP INFO] Win rate for 7 : 87.49
2020-08-01T16:09:02.508 <test> [SCP INFO] Win rate for 8 : 91.4
2020-08-01T16:09:33.333 <test> [SCP INFO] Win rate for 9 : 94.54
```

### this PR

```
Filters: nomination two nodes win stats
2020-08-01T15:56:53.730 <test> [SCP INFO] Win rate for 1 : 23.42
2020-08-01T15:57:12.917 <test> [SCP INFO] Win rate for 2 : 53.12
2020-08-01T15:57:39.870 <test> [SCP INFO] Win rate for 3 : 72.66
2020-08-01T15:58:13.071 <test> [SCP INFO] Win rate for 4 : 82.81
2020-08-01T15:58:51.163 <test> [SCP INFO] Win rate for 5 : 93.36
2020-08-01T15:59:33.360 <test> [SCP INFO] Win rate for 6 : 97.66
2020-08-01T16:00:19.920 <test> [SCP INFO] Win rate for 7 : 100
```

## stellar-core.exe test "nomination two nodes win stats" -c "hierarchy" -c "v0 is inner node for v1"

### master

```
Filters: nomination two nodes win stats
2020-08-01T16:10:33.432 <test> [SCP INFO] Win rate for 1 : 17.96
2020-08-01T16:10:57.875 <test> [SCP INFO] Win rate for 2 : 38.68
2020-08-01T16:11:31.297 <test> [SCP INFO] Win rate for 3 : 55.09
2020-08-01T16:12:12.692 <test> [SCP INFO] Win rate for 4 : 67.59
2020-08-01T16:12:59.229 <test> [SCP INFO] Win rate for 5 : 71.49
2020-08-01T16:13:48.438 <test> [SCP INFO] Win rate for 6 : 78.52
2020-08-01T16:14:41.829 <test> [SCP INFO] Win rate for 7 : 82.03
2020-08-01T16:15:35.048 <test> [SCP INFO] Win rate for 8 : 85.16
2020-08-01T16:16:32.835 <test> [SCP INFO] Win rate for 9 : 90.25
```


### this PR

```
Filters: nomination two nodes win stats
2020-08-01T16:00:54.565 <test> [SCP INFO] Win rate for 1 : 17.96
2020-08-01T16:01:13.898 <test> [SCP INFO] Win rate for 2 : 42.97
2020-08-01T16:01:43.277 <test> [SCP INFO] Win rate for 3 : 62.91
2020-08-01T16:02:23.248 <test> [SCP INFO] Win rate for 4 : 75.78
2020-08-01T16:03:10.336 <test> [SCP INFO] Win rate for 5 : 89.46
2020-08-01T16:04:03.086 <test> [SCP INFO] Win rate for 6 : 96.1
2020-08-01T16:04:59.817 <test> [SCP INFO] Win rate for 7 : 100
```
