### PR TITLE
Fix force broadcast in herder

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -515,8 +515,10 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
         maxLedgerSeq = mHerderSCPDriver.nextConsensusLedgerIndex() +
                        LEDGER_VALIDITY_BRACKET;
     }
-    else if (!checkCloseTime(envelope,
-                             minLedgerSeq <= LedgerManager::GENESIS_LEDGER_SEQ))
+    else if (!checkCloseTime(
+                 envelope,
+                 (mHerderSCPDriver.lastTrackingSCP() == nullptr) &&
+                     (minLedgerSeq <= LedgerManager::GENESIS_LEDGER_SEQ)))
     {
         // if we've never been in sync, we can be more aggressive in how we
         // filter messages: we can ignore messages that are unlikely to be


### PR DESCRIPTION
This PR fixes a couple issues.

First is a major issue with how SCP messages are broadcasted: broadcast has a `force` flag to force sending the latest SCP message to peers, but from what I can tell, that flag never worked.
  * Impact of this is that the function `HerderImpl::rebroadcast()` was actually not doing anything, which in turn may cause various issues like peers potentially missing SCP messages or connections getting idle (if SCP rounds take too long, an issue mostly in test cases as real networks have transactions flowing)

The second issue is minor, in that it doesn't really impact production/testnet and only test cases:
In test cases we have situations where we bootstrap a new network, and lose sync within the first few ledgers (before MAX_SLOTS_TO_REMEMBER=12 ledgers).

When this happens, we want to ensure that we continue to process SCP messages, regardless of their timestamp.
    
The old code was approximating "never been in sync" by just looking at the ledger window, which is inaccurate.
