### PR TITLE
Increase reliability when fetching SCP envelopes

### DIFF
--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -346,7 +346,13 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
             envelopeReady(envelope);
             updateMetrics();
             return Herder::ENVELOPE_STATUS_READY;
-        } // else just keep waiting for it to come in
+        }
+        else
+        {
+            // else just keep waiting for it to come in
+            // and refresh fetchers as needed
+            startFetch(envelope);
+        }
 
         return Herder::ENVELOPE_STATUS_FETCHING;
     }

--- a/src/overlay/test/TrackerTests.cpp
+++ b/src/overlay/test/TrackerTests.cpp
@@ -61,16 +61,17 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
         REQUIRE(t.getLastSeenSlotIndex() == 0);
     }
 
-    SECTION("can listen twice on the same envelope")
+    SECTION("listen twice on the same envelope")
     {
         Tracker t{*app, hash, nullAskPeer};
         auto env1 = makeEnvelope(1);
         t.listen(env1);
+        // this should no-op (idempotent)
         t.listen(env1);
         REQUIRE(t.getLastSeenSlotIndex() == 1);
 
         REQUIRE(env1 == t.pop());
-        REQUIRE(env1 == t.pop());
+        REQUIRE(t.empty());
     }
 
     SECTION("can listen on different envelopes")


### PR DESCRIPTION
This PR makes a small adjustment to the way we manage envelopes that are still in "fetching" state:
when in that state, we ensure that we always fetch data. Old behavior may in some rare occasion leave envelopes in a "half fetch" state with no fetchers.