### PR TITLE
Replace an unordered_set in SurveyManager with a queue

### DIFF
--- a/src/overlay/SurveyManager.h
+++ b/src/overlay/SurveyManager.h
@@ -77,6 +77,7 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
     SurveyMessageLimiter mMessageLimiter;
 
     std::unordered_set<NodeID> mPeersToSurvey;
+    std::queue<NodeID> mPeersToSurveyQueue;
 
     std::chrono::seconds const SURVEY_THROTTLE_TIMEOUT_SEC;
 


### PR DESCRIPTION
# Description

https://github.com/stellar/stellar-core/issues/2481

This change allows survey requests to be processed in FIFO order

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
