### PR TITLE
Set MIN_SCHEMA_VERSION to 12

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -61,7 +61,7 @@ using namespace std;
 bool Database::gDriversRegistered = false;
 
 // smallest schema version supported
-static unsigned long const MIN_SCHEMA_VERSION = 11;
+static unsigned long const MIN_SCHEMA_VERSION = 12;
 static unsigned long const SCHEMA_VERSION = 13;
 
 // These should always match our compiled version precisely, since we are
@@ -209,42 +209,6 @@ Database::applySchemaUpgrade(unsigned long vers)
     soci::transaction tx(mSession);
     switch (vers)
     {
-    case 12:
-        if (!isSqlite())
-        {
-            // Set column collations to "C" if postgres; sqlite doesn't support
-            // altering them at all (and the defaults are correct anyways).
-            mSession << "ALTER TABLE accounts "
-                     << "ALTER COLUMN accountid "
-                     << "TYPE VARCHAR(56) COLLATE \"C\"";
-
-            mSession << "ALTER TABLE accountdata "
-                     << "ALTER COLUMN accountid "
-                     << "TYPE VARCHAR(56) COLLATE \"C\", "
-                     << "ALTER COLUMN dataname "
-                     << "TYPE VARCHAR(88) COLLATE \"C\"";
-
-            mSession << "ALTER TABLE offers "
-                     << "ALTER COLUMN sellerid "
-                     << "TYPE VARCHAR(56) COLLATE \"C\", "
-                     << "ALTER COLUMN buyingasset "
-                     << "TYPE TEXT COLLATE \"C\", "
-                     << "ALTER COLUMN sellingasset "
-                     << "TYPE TEXT COLLATE \"C\"";
-
-            mSession << "ALTER TABLE trustlines "
-                     << "ALTER COLUMN accountid "
-                     << "TYPE VARCHAR(56) COLLATE \"C\", "
-                     << "ALTER COLUMN issuer "
-                     << "TYPE VARCHAR(56) COLLATE \"C\", "
-                     << "ALTER COLUMN assetcode "
-                     << "TYPE VARCHAR(12) COLLATE \"C\"";
-        }
-
-        // With inflation disabled, it's not worth keeping
-        // the accountbalances index around.
-        mSession << "DROP INDEX IF EXISTS accountbalances";
-        break;
     case 13:
         if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
         {

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -61,7 +61,7 @@ using namespace std;
 bool Database::gDriversRegistered = false;
 
 // smallest schema version supported
-static unsigned long const MIN_SCHEMA_VERSION = 9;
+static unsigned long const MIN_SCHEMA_VERSION = 10;
 static unsigned long const SCHEMA_VERSION = 13;
 
 // These should always match our compiled version precisely, since we are
@@ -209,10 +209,6 @@ Database::applySchemaUpgrade(unsigned long vers)
     soci::transaction tx(mSession);
     switch (vers)
     {
-    case 10:
-        // add tracking table information
-        mApp.getHerderPersistence().createQuorumTrackingTable(mSession);
-        break;
     case 11:
         if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
         {
@@ -666,6 +662,7 @@ Database::initialize()
     HerderPersistence::dropAll(*this);
     BanManager::dropAll(*this);
     putSchemaVersion(MIN_SCHEMA_VERSION);
+    mApp.getHerderPersistence().createQuorumTrackingTable(mSession);
 
     LOG(INFO) << "* ";
     LOG(INFO) << "* The database has been initialized";

--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -61,7 +61,7 @@ using namespace std;
 bool Database::gDriversRegistered = false;
 
 // smallest schema version supported
-static unsigned long const MIN_SCHEMA_VERSION = 10;
+static unsigned long const MIN_SCHEMA_VERSION = 11;
 static unsigned long const SCHEMA_VERSION = 13;
 
 // These should always match our compiled version precisely, since we are
@@ -209,14 +209,6 @@ Database::applySchemaUpgrade(unsigned long vers)
     soci::transaction tx(mSession);
     switch (vers)
     {
-    case 11:
-        if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
-        {
-            mSession << "DROP INDEX IF EXISTS bestofferindex;";
-            mSession << "CREATE INDEX bestofferindex ON offers "
-                        "(sellingasset,buyingasset,price,offerid);";
-        }
-        break;
     case 12:
         if (!isSqlite())
         {

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -484,6 +484,12 @@ LedgerTxnRoot::Impl::dropAccounts()
            "signers            TEXT,"
            "lastmodified       INT          NOT NULL"
            ");";
+    if (!mDatabase.isSqlite())
+    {
+        mDatabase.getSession() << "ALTER TABLE accounts "
+                               << "ALTER COLUMN accountid "
+                               << "TYPE VARCHAR(56) COLLATE \"C\"";
+    }
 }
 
 class BulkLoadAccountsOperation

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -333,6 +333,14 @@ LedgerTxnRoot::Impl::dropData()
                               "lastmodified INT          NOT NULL,"
                               "PRIMARY KEY  (accountid, dataname)"
                               ");";
+    if (!mDatabase.isSqlite())
+    {
+        mDatabase.getSession() << "ALTER TABLE accountdata "
+                               << "ALTER COLUMN accountid "
+                               << "TYPE VARCHAR(56) COLLATE \"C\", "
+                               << "ALTER COLUMN dataname "
+                               << "TYPE VARCHAR(88) COLLATE \"C\"";
+    }
 }
 
 class BulkLoadDataOperation

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -699,6 +699,16 @@ LedgerTxnRoot::Impl::dropOffers()
            ");";
     mDatabase.getSession() << "CREATE INDEX bestofferindex ON offers "
                               "(sellingasset,buyingasset,price,offerid);";
+    if (!mDatabase.isSqlite())
+    {
+        mDatabase.getSession() << "ALTER TABLE offers "
+                               << "ALTER COLUMN sellerid "
+                               << "TYPE VARCHAR(56) COLLATE \"C\", "
+                               << "ALTER COLUMN buyingasset "
+                               << "TYPE TEXT COLLATE \"C\", "
+                               << "ALTER COLUMN sellingasset "
+                               << "TYPE TEXT COLLATE \"C\"";
+    }
 }
 
 class BulkLoadOffersOperation

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -698,7 +698,7 @@ LedgerTxnRoot::Impl::dropOffers()
            "PRIMARY KEY      (offerid)"
            ");";
     mDatabase.getSession() << "CREATE INDEX bestofferindex ON offers "
-                              "(sellingasset,buyingasset,price);";
+                              "(sellingasset,buyingasset,price,offerid);";
 }
 
 class BulkLoadOffersOperation

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -429,6 +429,16 @@ LedgerTxnRoot::Impl::dropTrustLines()
            "lastmodified INT             NOT NULL,"
            "PRIMARY KEY  (accountid, issuer, assetcode)"
            ");";
+    if (!mDatabase.isSqlite())
+    {
+        mDatabase.getSession() << "ALTER TABLE trustlines "
+                               << "ALTER COLUMN accountid "
+                               << "TYPE VARCHAR(56) COLLATE \"C\", "
+                               << "ALTER COLUMN issuer "
+                               << "TYPE VARCHAR(56) COLLATE \"C\", "
+                               << "ALTER COLUMN assetcode "
+                               << "TYPE VARCHAR(12) COLLATE \"C\"";
+    }
 }
 
 class BulkLoadTrustLinesOperation


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/2601

This change will bump MIN_SCHEMA_VERSION to 12.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
