### PR TITLE
Allow account extension v2 in tests

### DIFF
--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -138,8 +138,34 @@ makeValid(AccountEntry& a)
         a.ext.v1().liabilities.buying = std::abs(a.ext.v1().liabilities.buying);
         a.ext.v1().liabilities.selling =
             std::abs(a.ext.v1().liabilities.selling);
-        // TODO(jonjove): Make tests support v2
-        a.ext.v1().ext.v(0);
+
+        if (a.ext.v1().ext.v() == 2)
+        {
+            auto& extV2 = a.ext.v1().ext.v2();
+
+            int64_t effEntries = 2LL;
+            effEntries += a.numSubEntries;
+            effEntries += extV2.numSponsoring;
+            effEntries -= extV2.numSponsored;
+            if (effEntries < 0)
+            {
+                // This condition implies (in arbitrary precision)
+                //      2 + numSubentries + numSponsoring - numSponsored < 0
+                // which can be rearranged as
+                //      numSponsored > 2 + numSubentries + numSponsoring .
+                // Substituting this inequality yields
+                //      2 + numSubentries + numSponsored
+                //          > 4 + 2 * numSubentries + numSponsoring
+                //          > numSponsoring
+                // which can be rearranged as
+                //      2 + numSubentries + numSponsored - numSponsoring > 0 .
+                // In summary, swapping numSponsored and numSponsoring fixes the
+                // account state.
+                std::swap(extV2.numSponsored, extV2.numSponsoring);
+            }
+
+            extV2.signerSponsoringIDs.resize(a.signers.size());
+        }
     }
 }
 

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -528,7 +528,6 @@ canCreateSignerWithoutSponsorship(LedgerHeader const& lh,
         return SponsorshipResult::TOO_MANY_SUBENTRIES;
     }
 
-    // TODO(jonjove): Compare against getMinBalance
     if (getAvailableBalance(lh, acc) < lh.baseReserve)
     {
         return SponsorshipResult::LOW_RESERVE;

--- a/src/transactions/test/UpdateSponsorshipTests.cpp
+++ b/src/transactions/test/UpdateSponsorshipTests.cpp
@@ -50,7 +50,6 @@ TEST_CASE("update sponsorship", "[tx][sponsorship]")
     SECTION("entry is not sponsored")
     {
         // No-op
-        // TODO(jonjove): Consider shrinking minBal
         SECTION("account is not sponsored")
         {
             SECTION("account")


### PR DESCRIPTION
# Description
This PR makes it possible to use account extension v2 in tests, and removes all residual TODOs from CAP-33 implementation. This obsoletes portions of #2661 which will need to be rebased after this is merged.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
