### PR TITLE
Bump tracy submodule and build with -DTRACY_ONLY_IPV4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,7 +298,7 @@ AC_ARG_ENABLE(tracy,
     AS_HELP_STRING([--enable-tracy],
         [Enable 'tracy' profiler/tracer client stub]))
 AM_CONDITIONAL(USE_TRACY, [test x$enable_tracy = xyes])
-tracy_CFLAGS='-DTRACY_ENABLE -DTRACY_ON_DEMAND -DTRACY_NO_BROADCAST -DTRACY_ONLY_LOCALHOST'
+tracy_CFLAGS='-DTRACY_ENABLE -DTRACY_ON_DEMAND -DTRACY_NO_BROADCAST -DTRACY_ONLY_LOCALHOST -DTRACY_ONLY_IPV4'
 if test x"$enable_tracy" = xyes; then
     case "${host_os}" in
         *darwin*)


### PR DESCRIPTION
The goal here is to have tracy only listen on IPv4 interfaces so that we can talk to it through the IPv4-only kubernetes port-forwarding system.

The submodule bump includes tracy v0.7 => v0.7.1 because the latter is the version the patch to upstream is made against.