### PR TITLE
allow access to HTTP endpoint -- /info in particular -- during catchup.

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -81,29 +81,37 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
         addRoute("maintenance", &CommandHandler::maintenance);
     }
 
-    addRoute("bans", &CommandHandler::bans);
+    if (!mApp.getConfig().RUN_STANDALONE)
+    {
+        addRoute("bans", &CommandHandler::bans);
+        addRoute("connect", &CommandHandler::connect);
+        addRoute("droppeer", &CommandHandler::dropPeer);
+        addRoute("peers", &CommandHandler::peers);
+        addRoute("quorum", &CommandHandler::quorum);
+        addRoute("scp", &CommandHandler::scpInfo);
+        addRoute("stopsurvey", &CommandHandler::stopSurvey);
+#ifndef BUILD_TESTS
+        addRoute("getsurveyresult", &CommandHandler::getSurveyResult);
+        addRoute("surveytopology", &CommandHandler::surveyTopology);
+#endif
+        addRoute("unban", &CommandHandler::unban);
+    }
+
     addRoute("clearmetrics", &CommandHandler::clearMetrics);
-    addRoute("connect", &CommandHandler::connect);
-    addRoute("droppeer", &CommandHandler::dropPeer);
     addRoute("info", &CommandHandler::info);
     addRoute("ll", &CommandHandler::ll);
     addRoute("logrotate", &CommandHandler::logRotate);
     addRoute("manualclose", &CommandHandler::manualClose);
     addRoute("metrics", &CommandHandler::metrics);
-    addRoute("peers", &CommandHandler::peers);
-    addRoute("quorum", &CommandHandler::quorum);
-    addRoute("scp", &CommandHandler::scpInfo);
     addRoute("tx", &CommandHandler::tx);
-    addRoute("unban", &CommandHandler::unban);
     addRoute("upgrades", &CommandHandler::upgrades);
-    addRoute("surveytopology", &CommandHandler::surveyTopology);
-    addRoute("stopsurvey", &CommandHandler::stopSurvey);
-    addRoute("getsurveyresult", &CommandHandler::getSurveyResult);
 
 #ifdef BUILD_TESTS
     addRoute("generateload", &CommandHandler::generateLoad);
     addRoute("testacc", &CommandHandler::testAcc);
     addRoute("testtx", &CommandHandler::testTx);
+    addRoute("getsurveyresult", &CommandHandler::getSurveyResult);
+    addRoute("surveytopology", &CommandHandler::surveyTopology);
 #endif
 }
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -577,7 +577,10 @@ runCatchup(CommandLineArgs const& args)
          metadataOutputStreamParser(stream)},
         [&] {
             auto config = configOption.getConfig();
-            config.setNoListen();
+            // Don't call config.setNoListen() here as we might want to
+            // access the /info HTTP endpoint during catchup.
+            config.RUN_STANDALONE = true;
+            config.MANUAL_CLOSE = true;
             config.DISABLE_BUCKET_GC = disableBucketGC;
 
             if (config.AUTOMATIC_MAINTENANCE_PERIOD.count() > 0 &&


### PR DESCRIPTION
This very-slightly relaxes the configuration during command-line catchup so that the HTTP endpoint is enabled. Specifically so that kubernetes health checks and the like can call the /info endpoint and monitor the progress of a long catchup.

I included a couple tightenings of the HTTP endpoints that one might want to _not_ be allowed to call in such a circumstance -- disabling the /tx endpoint when not synced and the /connect endpoint when standalone -- which shouldn't change semantics as far as I can tell, but I can drop those if they're contentious.