### PR TITLE
Emit some EXTERNALIZE messages when caught up

### DIFF
--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1964,6 +1964,21 @@ TEST_CASE("values externalized out of order", "[herder]")
             }
         }
 
+        // Ensure C sent EXTERNALIZE messages for buffered ledgers it closed
+        for (auto const& ledger : ledgers)
+        {
+            bool found = false;
+            for (auto const& msg :
+                 herderC.getSCP().getLatestMessagesSend(ledger))
+            {
+                if (msg.statement.pledges.type() == SCP_ST_EXTERNALIZE)
+                {
+                    found = true;
+                }
+            }
+            REQUIRE(found);
+        }
+
         // As we're back in sync now, ensure Herder and LM are consistent with
         // each other
         auto lcl = lmC.getLastClosedLedgerNum();

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1997,6 +1997,18 @@ BallotProtocol::validateValues(SCPStatement const& st)
 }
 
 void
+BallotProtocol::emitExternalizeMessage()
+{
+    if (mPhase == SCP_PHASE_EXTERNALIZE)
+    {
+        // sendLatestEnvelope ensures slot is validated
+        // and no-ops if last envelope has already been
+        // emitted
+        sendLatestEnvelope();
+    }
+}
+
+void
 BallotProtocol::sendLatestEnvelope()
 {
     ZoneScoped;

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -154,6 +154,9 @@ class BallotProtocol
     // returns all values referenced by a statement
     static std::set<Value> getStatementValues(SCPStatement const& st);
 
+    // Send latest envelope if phase is EXTERNALIZE and slot is fully validated
+    void emitExternalizeMessage();
+
   private:
     // attempts to make progress using the latest statement as a hint
     // calls into the various attempt* methods, emits message

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -258,6 +258,16 @@ SCP::getLatestMessage(NodeID const& id)
     return nullptr;
 }
 
+void
+SCP::sendExternalizeForSlot(uint64 slotIndex)
+{
+    auto it = mKnownSlots.find(slotIndex);
+    if (it != mKnownSlots.end())
+    {
+        it->second->sendExternalizeMessage();
+    }
+}
+
 std::vector<SCPEnvelope>
 SCP::getExternalizingState(uint64 slotIndex)
 {
@@ -383,5 +393,18 @@ SCP::envToStr(SCPStatement const& st, bool fullKeys) const
 
     oss << " }";
     return oss.str();
+}
+
+void
+SCP::setValidatedUpToIndex(uint64 slotIndex)
+{
+    for (auto const& slot : mKnownSlots)
+    {
+        if (slot.first <= slotIndex && slot.second &&
+            !slot.second->isFullyValidated())
+        {
+            slot.second->setFullyValidated(true);
+        }
+    }
 }
 }

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -94,6 +94,10 @@ class SCP
     // returns the latest messages sent for the given slot
     std::vector<SCPEnvelope> getLatestMessagesSend(uint64 slotIndex);
 
+    // Emit latest saved envelope for slotIndex if it is validated
+    // and has not been emitted yet
+    void sendExternalizeForSlot(uint64 slotIndex);
+
     // forces the state to match the one in the envelope
     // this is used when rebuilding the state after a crash for example
     void setStateFromEnvelope(uint64 slotIndex, SCPEnvelopeWrapperPtr e);
@@ -127,6 +131,10 @@ class SCP
     std::string envToStr(SCPEnvelope const& envelope,
                          bool fullKeys = false) const;
     std::string envToStr(SCPStatement const& st, bool fullKeys = false) const;
+
+    // iterates through slots up to and including slotIndex, marking them as
+    // validated
+    void setValidatedUpToIndex(uint64 slotIndex);
 
   protected:
     std::shared_ptr<LocalNode> mLocalNode;

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -57,6 +57,15 @@ Slot::getLatestMessagesSend() const
 }
 
 void
+Slot::sendExternalizeMessage()
+{
+    if (mFullyValidated)
+    {
+        mBallotProtocol.emitExternalizeMessage();
+    }
+}
+
+void
 Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
 {
     auto& e = env->getEnvelope();

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -83,6 +83,8 @@ class Slot : public std::enable_shared_from_this<Slot>
     // returns the latest messages the slot emitted
     std::vector<SCPEnvelope> getLatestMessagesSend() const;
 
+    void sendExternalizeMessage();
+
     // forces the state to match the one in the envelope
     // this is used when rebuilding the state after a crash for example
     void setStateFromEnvelope(SCPEnvelopeWrapperPtr e);


### PR DESCRIPTION
This change aims to resolve #2529 

Note that this does not cover all possible catchup cases, as nodes send limited number of EXTERNALIZE messages, so this applies to nodes that aren't too far behind.