### PR TITLE
make quorum tracker use only what it needs

### DIFF
--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -33,7 +33,7 @@ PendingEnvelopes::PendingEnvelopes(Application& app, HerderImpl& herder)
                                 Hash hash) { peer->sendGetQuorumSet(hash); })
     , mTxSetCache(TXSET_CACHE_SIZE)
     , mRebuildQuorum(true)
-    , mQuorumTracker(mHerder.getSCP())
+    , mQuorumTracker(mApp.getConfig().NODE_SEED.getPublicKey())
     , mProcessedCount(
           app.getMetrics().NewCounter({"scp", "pending", "processed"}))
     , mDiscardedCount(

--- a/src/herder/QuorumTracker.cpp
+++ b/src/herder/QuorumTracker.cpp
@@ -8,7 +8,8 @@
 
 namespace stellar
 {
-QuorumTracker::QuorumTracker(SCP& scp) : mSCP(scp)
+QuorumTracker::QuorumTracker(NodeID const& localNodeID)
+    : mLocalNodeID(localNodeID)
 {
 }
 
@@ -49,9 +50,8 @@ QuorumTracker::rebuild(std::function<SCPQuorumSetPtr(NodeID const&)> lookup)
 {
     ZoneScoped;
     mQuorum.clear();
-    auto local = mSCP.getLocalNode();
     std::set<NodeID> backlog;
-    backlog.insert(local->getNodeID());
+    backlog.insert(mLocalNodeID);
     while (!backlog.empty())
     {
         auto n = *backlog.begin();

--- a/src/herder/QuorumTracker.h
+++ b/src/herder/QuorumTracker.h
@@ -24,11 +24,11 @@ class QuorumTracker : public NonMovableOrCopyable
     using QuorumMap = std::unordered_map<NodeID, SCPQuorumSetPtr>;
 
   private:
-    SCP& mSCP;
+    NodeID const mLocalNodeID;
     QuorumMap mQuorum;
 
   public:
-    QuorumTracker(SCP& scp);
+    QuorumTracker(NodeID const& localNodeID);
 
     // returns true if id is in transitive quorum for sure
     bool isNodeDefinitelyInQuorum(NodeID const& id);


### PR DESCRIPTION
This PR fixes a small issue in how herder is initialized.

Approach taken here is to simply not use members that may not be fully initialized