### PR TITLE
Bug 2634 run in memory from checkpoint

### DIFF
--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -142,7 +142,7 @@ transactions or ledger states) must be downloaded and verified sequentially. It 
 worthwhile to save and reuse such a trusted reference file multiple times before regenerating it.
 
 ##### Experimental fast "meta data generation"
-`catchup` has a command line flag `--replay-in-memory` that when combined with the
+`catchup` has a command line flag `--in-memory` that when combined with the
 `METADATA_OUTPUT_STREAM` allows a stellar-core instance to stream meta data instead
 of using a database as intermediate store.
 
@@ -151,6 +151,17 @@ of history.
 
 If you don't specify any value for stream the command will just replay transactions
 in memory and throw away all meta. This can be useful for performance testing the transaction processing subsystem.
+
+The `--in-memory` flag is also supported by the `run` command, which can be used to
+run a lightweight, stateless validator or watcher node, and this can be combined with
+`METADATA_OUTPUT_STREAM` to stream network activity to another process.
+
+By default, such a stateless node in `run` mode will catch up to the network starting from the
+network's most recent checkpoint, but this behaviour can be further modified using two flags
+(that must be used together) called `--start-at-ledger <N>` and `--start-at-hash <HEXHASH>`. These
+cause the node to start with a fast in-memory catchup to ledger `N` with hash `HEXHASH`, and then
+replay ledgers forward to the current state of the network.
+
 
 #### Publish backlog
 There is a command `publish` that allows to flush the publish backlog without starting

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -25,7 +25,7 @@ Command options can only by placed after command.
   configuration and it will perform bucket application on such a checkpoint
   that at least LEDGER-COUNT entries are present in history table afterwards.
   For instances that already have some history entries, all ledgers since last
-  closed ledger will be replayed.
+  closed ledger will be replayed.<br>
   Option **--trusted-checkpoint-hashes <FILE-NAME>** checks the destination
   ledger hash against the provided reference list of trusted hashes. See the
   command verify-checkpoints for details.
@@ -59,20 +59,27 @@ Command options can only by placed after command.
   instance
 * **print-xdr <FILE-NAME>**:  Pretty-print a binary file containing an XDR
   object. If FILE-NAME is "-", the XDR object is read from standard input.<br>
-  Option --filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**
+  Option **--filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**
   controls type used for printing (default: auto).<br>
-  Option --base64 alters the behavior to work on base64-encoded XDR rather than
+  Option **--base64** alters the behavior to work on base64-encoded XDR rather than
   raw XDR.
 * **publish**: Execute publish of all items remaining in publish queue without
   connecting to network. May not publish last checkpoint if last closed ledger
   is on checkpoint boundary.
 * **report-last-history-checkpoint**: Download and report last history
   checkpoint from a history archive.
-* **run**: Runs stellar-core service. Option --wait-for-consensus lets validators
-  wait to hear from the network before participating in consensus.
+* **run**: Runs stellar-core service.<br>
+  Option **--wait-for-consensus** lets validators wait to hear from the network
+  before participating in consensus.<br>
+  Option **--in-memory** stores the current ledger in memory rather than a
+  database.<br>
+  Option **--start-at-ledger <N>** starts **--in-memory** mode with a catchup to
+  ledger **N** then replays to the current state of the network.<br>
+  Option **--start-at-hash <HASH>** provides a (mandatory) hash for the ledger
+  **N** specified by the **--start-at-ledger** option.
 * **sec-to-pub**:  Reads a secret key on standard input and outputs the
   corresponding public key.  Both keys are in Stellar's standard
-  base-32 ASCII format. 
+  base-32 ASCII format.
 * **sign-transaction <FILE-NAME>**:  Add a digital signature to a transaction
   envelope stored in binary format in <FILE-NAME>, and send the result to
   standard output (which should be redirected to a file or piped through a tool

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -449,7 +449,10 @@ ApplicationImpl::start()
             ExternalQueue ps(*this);
             ps.setInitialCursors(mConfig.KNOWN_CURSORS);
             mMaintainer->start();
-            mOverlayManager->start();
+            if (mConfig.MODE_AUTO_STARTS_OVERLAY)
+            {
+                mOverlayManager->start();
+            }
             auto npub = mHistoryManager->publishQueuedHistory();
             if (npub != 0)
             {

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -12,7 +12,7 @@ namespace stellar
 
 class CatchupConfiguration;
 
-int runWithConfig(Config cfg);
+int runWithConfig(Config cfg, optional<CatchupConfiguration> cc);
 void setForceSCPFlag();
 void initializeDatabase(Config cfg);
 void httpCommand(std::string const& command, unsigned short port);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -93,6 +93,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MODE_USES_IN_MEMORY_LEDGER = false;
     MODE_STORES_HISTORY = true;
     MODE_DOES_CATCHUP = true;
+    MODE_AUTO_STARTS_OVERLAY = true;
     OP_APPLY_SLEEP_TIME_FOR_TESTING = 0;
 
     FORCE_SCP = false;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -215,6 +215,11 @@ class Config : public std::enable_shared_from_this<Config>
     // it is halted.
     bool MODE_DOES_CATCHUP;
 
+    // A config parameter that controls whether the application starts the
+    // overlay on startup, or waits for a later startup after performing some
+    // other pre-overlay-start operations (eg. offline catchup).
+    bool MODE_AUTO_STARTS_OVERLAY;
+
     // A config to allow connections to localhost
     // this should only be enabled when testing as it's a security issue
     bool ALLOW_LOCALHOST_FOR_TESTING;


### PR DESCRIPTION
Initial implementation of bug #2634 that allows one to run something like:

```
stellar-core --conf ~/core.cfg run --in-memory --start-at-ledger 31534975 --start-at-hash 407dc8a57ec308c12fa292f11d98080898b403fafc8dc2c12eb48d70977258bf
```
