### PR TITLE
Make print-xdr and dump-xdr use Cereal to print

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -201,6 +201,12 @@ metricsParser(std::vector<std::string>& value)
 }
 
 clara::Opt
+compactParser(bool& compact)
+{
+    return clara::Opt{compact}["--compact"]("no indent");
+}
+
+clara::Opt
 base64Parser(bool& base64)
 {
     return clara::Opt{base64}["--base64"]("use base64");
@@ -853,13 +859,13 @@ int
 runDumpXDR(CommandLineArgs const& args)
 {
     std::string xdr;
-    bool json = false;
-    auto jsonOption = clara::Opt{json}["--json"]("dump json");
+    bool compact = false;
 
-    return runWithHelp(args, {jsonOption, fileNameParser(xdr)}, [&] {
-        dumpXdrStream(xdr, json);
-        return 0;
-    });
+    return runWithHelp(args, {compactParser(compact), fileNameParser(xdr)},
+                       [&] {
+                           dumpXdrStream(xdr, compact);
+                           return 0;
+                       });
 }
 
 int
@@ -976,15 +982,18 @@ runPrintXdr(CommandLineArgs const& args)
     std::string xdr;
     std::string fileType{"auto"};
     auto base64 = false;
+    auto compact = false;
 
     auto fileTypeOpt = clara::Opt(fileType, "FILE-TYPE")["--filetype"](
         "[auto|ledgerheader|meta|result|resultpair|tx|txfee]");
 
-    return runWithHelp(
-        args, {fileNameParser(xdr), fileTypeOpt, base64Parser(base64)}, [&] {
-            printXdr(xdr, fileType, base64);
-            return 0;
-        });
+    return runWithHelp(args,
+                       {fileNameParser(xdr), fileTypeOpt, base64Parser(base64),
+                        compactParser(compact)},
+                       [&] {
+                           printXdr(xdr, fileType, base64, compact);
+                           return 0;
+                       });
 }
 
 int

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -7,6 +7,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/Decoder.h"
 #include "util/Fs.h"
+#include "util/XDRCereal.h"
 #include "util/XDROperators.h"
 #include "util/XDRStream.h"
 #include "util/types.h"
@@ -37,104 +38,6 @@ extern "C" {
 #endif // _WIN32
 
 using namespace std::placeholders;
-
-template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_array<N>& s,
-                const char* field)
-{
-    xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
-                 field);
-}
-
-// We still need one explicit composite-container override because cereal
-// appears to process arrays-of-arrays internally, without calling back through
-// an NVP adaptor.
-template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar,
-                const xdr::xarray<stellar::Hash, N>& s, const char* field)
-{
-    std::vector<std::string> tmp;
-    for (auto const& h : s)
-    {
-        tmp.emplace_back(
-            stellar::binToHex(stellar::ByteSlice(h.data(), h.size())));
-    }
-    xdr::archive(ar, tmp, field);
-}
-
-template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_vec<N>& s,
-                const char* field)
-{
-    xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
-                 field);
-}
-void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
-                const char* field)
-{
-    xdr::archive(ar, stellar::KeyUtils::toStrKey<stellar::PublicKey>(s), field);
-}
-
-void
-cereal_override(cereal::JSONOutputArchive& ar,
-                const stellar::MuxedAccount& muxedAccount, const char* field)
-{
-    switch (muxedAccount.type())
-    {
-    case stellar::KEY_TYPE_ED25519:
-        xdr::archive(ar, stellar::KeyUtils::toStrKey(toAccountID(muxedAccount)),
-                     field);
-        return;
-    case stellar::KEY_TYPE_MUXED_ED25519:
-        xdr::archive(
-            ar,
-            std::make_tuple(
-                cereal::make_nvp("id", muxedAccount.med25519().id),
-                cereal::make_nvp("accountID", stellar::KeyUtils::toStrKey(
-                                                  toAccountID(muxedAccount)))),
-            field);
-        return;
-    default:
-        // this would be a bug
-        abort();
-    }
-}
-
-void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
-                const char* field)
-{
-    xdr::archive(ar, stellar::assetToString(s), field);
-}
-
-template <typename T>
-void
-cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
-                const char* field)
-{
-    // We tolerate a little information-loss here collapsing *T into T for
-    // the non-null case, and use JSON 'null' for the null case. This reads
-    // much better than the thing JSONOutputArchive does with PtrWrapper.
-    if (t)
-    {
-        xdr::archive(ar, *t, field);
-    }
-    else
-    {
-        ar.setNextName(field);
-        ar.writeName();
-        ar.saveValue(nullptr);
-    }
-}
-
-// This has to be included _after_ the cereal_override overloads above,
-// otherwise some interplay of name lookup and visibility during the
-// enable_if call in the cereal adaptor fails to find them.
-#include <xdrpp/cereal.h>
 
 namespace stellar
 {

--- a/src/main/dumpxdr.h
+++ b/src/main/dumpxdr.h
@@ -11,7 +11,7 @@ namespace stellar
 
 void dumpXdrStream(std::string const& filename, bool json);
 void printXdr(std::string const& filename, std::string const& filetype,
-              bool base64);
+              bool base64, bool compact);
 void signtxn(std::string const& filename, std::string netId, bool base64);
 void priv2pub();
 }

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -86,6 +86,14 @@ cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
 }
 
 template <typename T>
+typename std::enable_if<xdr::xdr_traits<T>::is_enum>::type
+cereal_override(cereal::JSONOutputArchive& ar, const T& t, const char* field)
+{
+    std::string name = xdr::xdr_traits<T>::enum_name(t);
+    xdr::archive(ar, name, field);
+}
+
+template <typename T>
 void
 cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
                 const char* field)

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#ifdef _XDRPP_CEREAL_H_HEADER_INCLUDED_
+#error This header includes xdrpp/cereal.h after necessary definitions \
+       so include this file instead of directly including xdrpp/cereal.h.
+#endif
+
+#include "crypto/Hex.h"
+#include "crypto/SecretKey.h"
+#include "transactions/TransactionUtils.h"
+#include "util/types.h"
+#include <cereal/archives/json.hpp>
+
+using namespace std::placeholders;
+
+template <uint32_t N>
+void
+cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_array<N>& s,
+                const char* field)
+{
+    xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
+                 field);
+}
+
+// We still need one explicit composite-container override because cereal
+// appears to process arrays-of-arrays internally, without calling back through
+// an NVP adaptor.
+template <uint32_t N>
+void
+cereal_override(cereal::JSONOutputArchive& ar,
+                const xdr::xarray<stellar::Hash, N>& s, const char* field)
+{
+    std::vector<std::string> tmp;
+    for (auto const& h : s)
+    {
+        tmp.emplace_back(
+            stellar::binToHex(stellar::ByteSlice(h.data(), h.size())));
+    }
+    xdr::archive(ar, tmp, field);
+}
+
+template <uint32_t N>
+void
+cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_vec<N>& s,
+                const char* field)
+{
+    xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
+                 field);
+}
+void
+cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
+                const char* field)
+{
+    xdr::archive(ar, stellar::KeyUtils::toStrKey<stellar::PublicKey>(s), field);
+}
+
+void
+cereal_override(cereal::JSONOutputArchive& ar,
+                const stellar::MuxedAccount& muxedAccount, const char* field)
+{
+    switch (muxedAccount.type())
+    {
+    case stellar::KEY_TYPE_ED25519:
+        xdr::archive(ar, stellar::KeyUtils::toStrKey(toAccountID(muxedAccount)),
+                     field);
+        return;
+    case stellar::KEY_TYPE_MUXED_ED25519:
+        xdr::archive(
+            ar,
+            std::make_tuple(
+                cereal::make_nvp("id", muxedAccount.med25519().id),
+                cereal::make_nvp("accountID", stellar::KeyUtils::toStrKey(
+                                                  toAccountID(muxedAccount)))),
+            field);
+        return;
+    default:
+        // this would be a bug
+        abort();
+    }
+}
+void
+cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
+                const char* field)
+{
+    xdr::archive(ar, stellar::assetToString(s), field);
+}
+
+template <typename T>
+void
+cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
+                const char* field)
+{
+    // We tolerate a little information-loss here collapsing *T into T for
+    // the non-null case, and use JSON 'null' for the null case. This reads
+    // much better than the thing JSONOutputArchive does with PtrWrapper.
+    if (t)
+    {
+        xdr::archive(ar, *t, field);
+    }
+    else
+    {
+        ar.setNextName(field);
+        ar.writeName();
+        ar.saveValue(nullptr);
+    }
+}
+
+// NOTE: Nothing else should include xdrpp/cereal.h directly.
+// cereal_override's have to be defined before xdrpp/cereal.h,
+// otherwise some interplay of name lookup and visibility
+// during the enable_if call in the cereal adaptor fails to find them.
+#include <xdrpp/cereal.h>


### PR DESCRIPTION
# Description

Resolves Part (a) of #2681.

This PR makes print-xdr and dump-xdr use Cereal to improve readability such as multiline printing, and also adds the `compact` flag which removes all indentation.

After:
```
{
    "value0": {
        "type": "ENVELOPE_TYPE_TX",
        "v1": {
            "tx": {
                "sourceAccount": "GAY6WPTYIMNRRFEFOKUE3KRRKIMAWRB3XLSO2M6HNMIABBPDR5DTA3IY",
                "fee": 100,
                "seqNum": 903274572021761,
                "timeBounds": null,
                "memo": {
                    "type": "MEMO_NONE"
                },
                "operations": [
                    {
                        "sourceAccount": {
                            "id": 0,
                            "accountID": "GAY6WPTYIMNRRFEFOKUE3KRRKIMAWRB3XLSO2M6HNMIABBPDR5DTA3IY"
                        },
                        "body": {
                            "type": "PAYMENT",
                            "paymentOp": {
                                "destination": {
                                    "id": 123,
                                    "accountID": "GD5FAOMDOCXDYNNY3QHGRQZIJ42FWYJBFW7OJQMUWCHIFJMDW6RFS6XQ"
                                },
                                "asset": "XLM",
                                "amount": 1000
                            }
                        }
                    }
                ],
                "ext": {
                    "v": 0
                }
            },
            "signatures": [
                {
                    "hint": "e38f4730",
                    "signature": "39344833d02394318b530efbfbc9c7d7e7ace3d6910ee21ca37cafcaa38d1fc87cb2dfb4a142ee2ccf79b23b99266449f82c8f388cc0b05c263271f8319f1308"
                }
            ]
        }
    }
}
```

Before:
```
TransactionEnvelope = {
  type = ENVELOPE_TYPE_TX,
  v1 = {
    tx = {
      sourceAccount = GAY6WPTYIMNRRFEFOKUE3KRRKIMAWRB3XLSO2M6HNMIABBPDR5DTA3IY,
      fee = 100,
      seqNum = 903274572021761,
      timeBounds = NULL,
      memo = {
        type = MEMO_NONE
      },
      operations = [
        { sourceAccount = { id = 0, accountID = GAY6WPTYIMNRRFEFOKUE3KRRKIMAWRB3XLSO2M6HNMIABBPDR5DTA3IY },
          body = {
            type = PAYMENT,
            paymentOp = {
              destination = { id = 123, accountID = GD5FAOMDOCXDYNNY3QHGRQZIJ42FWYJBFW7OJQMUWCHIFJMDW6RFS6XQ },
              asset = {
                type = ASSET_TYPE_NATIVE
              },
              amount = 1000
            }
          } }
      ],
      ext = {
        v = 0
      }
    },
    signatures = [
      { hint = e38f4730,
        signature = 39344833d02394318b530efbfbc9c7d7e7ace3d6910ee21ca37cafcaa38d1fc87cb2dfb4a142ee2ccf79b23b99266449f82c8f388cc0b05c263271f8319f1308 }
    ]
  }
}
```

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
