### PR TITLE
Un-inline Bucket::checkProtocolLegality()

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -189,7 +189,7 @@ countShadowedEntryType(MergeCounters& mc, BucketEntry const& e)
     }
 }
 
-inline void
+void
 Bucket::checkProtocolLegality(BucketEntry const& entry,
                               uint32_t protocolVersion)
 {


### PR DESCRIPTION
It's referenced from translation units other than the one
in which it's defined.

# Description

Resolves #2704 

Fixes build in some configurations.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [N/A] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
