### PR TITLE
Allow to set HTTP port in config to 0 as a way to disable it

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -51,6 +51,7 @@ PREFETCH_BATCH_SIZE=1000
 
 # HTTP_PORT (integer) default 11626
 # What port stellar-core listens for commands on.
+# If set to 0, disable HTTP interface entirely
 HTTP_PORT=11626
 
 # PUBLIC_HTTP_PORT (true or false) default false

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -684,7 +684,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             }
             else if (item.first == "HTTP_PORT")
             {
-                HTTP_PORT = readInt<unsigned short>(item, 1);
+                HTTP_PORT = readInt<unsigned short>(item);
             }
             else if (item.first == "HTTP_MAX_CLIENT")
             {


### PR DESCRIPTION
The change introduced in 20acb82 introduces a dependency on setting the HTTP_PORT to a unique value.

This change allows to disable the HTTP port via configuration when core is used exclusively via command line.

Replaces #2696 
