### PR TITLE
Set "fail" bit on streams

### DIFF
--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -38,6 +38,7 @@ fileSize(std::string const& name)
 {
     assert(fs::exists(name));
     std::ifstream in(name, std::ifstream::ate | std::ifstream::binary);
+    REQUIRE(!!in);
     in.exceptions(std::ios::badbit);
     return in.tellg();
 }

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -108,8 +108,9 @@ void
 HistoryArchiveState::save(std::string const& outFile) const
 {
     ZoneScoped;
-    std::ofstream out(outFile);
+    std::ofstream out;
     out.exceptions(std::ios::failbit | std::ios::badbit);
+    out.open(outFile);
     cereal::JSONOutputArchive ar(out);
     serialize(ar);
 }
@@ -134,6 +135,10 @@ HistoryArchiveState::load(std::string const& inFile)
 {
     ZoneScoped;
     std::ifstream in(inFile);
+    if (!in)
+    {
+        throw std::runtime_error(fmt::format("Error opening file {}", inFile));
+    }
     in.exceptions(std::ios::badbit);
     cereal::JSONInputArchive ar(in);
     serialize(ar);

--- a/src/history/InferredQuorumUtils.cpp
+++ b/src/history/InferredQuorumUtils.cpp
@@ -86,8 +86,9 @@ writeQuorumGraph(Config const& cfg, std::string const& outputFile,
     }
     else
     {
-        std::ofstream out(filename);
+        std::ofstream out;
         out.exceptions(std::ios::failbit | std::ios::badbit);
+        out.open(filename);
         iq.writeQuorumGraph(cfg2, out);
         LOG(INFO) << "*";
         LOG(INFO) << "* Wrote quorum graph to " << filename;

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -85,8 +85,9 @@ TEST_CASE("HistoryManager compress", "[history]")
     HistoryManager& hm = catchupSimulation.getApp().getHistoryManager();
     std::string fname = hm.localFilename("compressme");
     {
-        std::ofstream out(fname, std::ofstream::binary);
+        std::ofstream out;
         out.exceptions(std::ios::failbit | std::ios::badbit);
+        out.open(fname, std::ofstream::binary);
         out.write(s.data(), s.size());
     }
     std::string compressed = fname + ".gz";

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -204,8 +204,9 @@ TestBucketGenerator::generateBucket(TestBucketState state)
         }
         else
         {
-            std::ofstream out(filename + ".gz");
+            std::ofstream out;
             out.exceptions(std::ios::failbit | std::ios::badbit);
+            out.open(filename + ".gz");
             out.close();
             seq = {mkdir, put};
         }

--- a/src/history/test/SerializeTests.cpp
+++ b/src/history/test/SerializeTests.cpp
@@ -23,6 +23,7 @@ TEST_CASE("Serialization round trip", "[history]")
         SECTION("Serialize " + testFilePath)
         {
             std::ifstream in(testFilePath);
+            REQUIRE(in);
             in.exceptions(std::ios::badbit);
             std::string hasString((std::istreambuf_iterator<char>(in)),
                                   std::istreambuf_iterator<char>());

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -81,6 +81,7 @@ VerifyBucketWork::spawnVerifier()
         [&app, filename, weak, hash]() {
             SHA256 hasher;
             asio::error_code ec;
+            try
             {
                 ZoneNamedN(verifyZone, "bucket verify", true);
                 CLOG(INFO, "History")
@@ -89,6 +90,11 @@ VerifyBucketWork::spawnVerifier()
                 // ensure that the stream gets its own scope to avoid race with
                 // main thread
                 std::ifstream in(filename, std::ifstream::binary);
+                if (!in)
+                {
+                    throw std::runtime_error(
+                        fmt::format("Error opening file {}", filename));
+                }
                 in.exceptions(std::ios::badbit);
                 char buf[4096];
                 while (in)
@@ -114,6 +120,12 @@ VerifyBucketWork::spawnVerifier()
                     CLOG(WARNING, "History") << POSSIBLY_CORRUPTED_HISTORY;
                     ec = std::make_error_code(std::errc::io_error);
                 }
+            }
+            catch (std::exception const& e)
+            {
+                CLOG(WARNING, "History")
+                    << "Failed verification : " << e.what();
+                ec = std::make_error_code(std::errc::io_error);
             }
 
             // Not ideal, but needed to prevent race conditions with

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -633,7 +633,8 @@ ApplicationImpl::targetManualCloseLedgerSeqNum(
     auto const startLedgerSeq = getLedgerManager().getLastClosedLedgerNum();
 
     // The "scphistory" stores ledger sequence numbers as INTs.
-    if (startLedgerSeq >= std::numeric_limits<int32_t>::max())
+    if (startLedgerSeq >=
+        static_cast<uint32>(std::numeric_limits<int32_t>::max()))
     {
         throw std::invalid_argument(fmt::format(
             FMT_STRING(
@@ -645,7 +646,8 @@ ApplicationImpl::targetManualCloseLedgerSeqNum(
 
     if (explicitlyProvidedSeqNum)
     {
-        if (*explicitlyProvidedSeqNum > std::numeric_limits<int32_t>::max())
+        if (*explicitlyProvidedSeqNum >
+            static_cast<uint32>(std::numeric_limits<int32_t>::max()))
         {
             // The "scphistory" stores ledger sequence numbers as INTs.
             throw std::invalid_argument(fmt::format(

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -555,9 +555,10 @@ Config::load(std::string const& filename)
         else
         {
             std::ifstream ifs(filename);
-            if (!ifs.is_open())
+            if (!ifs)
             {
-                throw std::runtime_error("could not open file");
+                throw std::runtime_error(
+                    fmt::format("Error opening file {}", filename));
             }
             ifs.exceptions(std::ios::badbit);
             load(ifs);

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -137,7 +137,9 @@ readFile(const std::string& filename, bool base64 = false)
     {
         ifstream file(filename.c_str());
         if (!file)
+        {
             throw_perror(filename);
+        }
         file.exceptions(std::ios::badbit);
         input << file.rdbuf();
     }

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -322,7 +322,8 @@ TEST_CASE("manualclose", "[commandhandler]")
             REQUIRE(lastLedgerNum() == curLedgerSeq + 1);
             REQUIRE(lastCloseTime() == expectedNewCloseTime);
             REQUIRE(lastCloseTime() ==
-                    VirtualClock::to_time_t(app->getClock().system_now()));
+                    static_cast<TimePoint>(
+                        VirtualClock::to_time_t(app->getClock().system_now())));
         }
     }
 
@@ -331,11 +332,11 @@ TEST_CASE("manualclose", "[commandhandler]")
     {
         std::string retStr;
         REQUIRE(lastLedgerNum() == LedgerManager::GENESIS_LEDGER_SEQ);
-        submitClose(make_optional<uint32_t>(static_cast<uint32_t>(
-                        std::numeric_limits<int32_t>::max())),
-                    noCloseTime, retStr);
+        auto maxLedgerNum =
+            static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+        submitClose(make_optional<uint32_t>(maxLedgerNum), noCloseTime, retStr);
         CAPTURE(retStr);
-        REQUIRE(lastLedgerNum() == std::numeric_limits<int32_t>::max());
+        REQUIRE(lastLedgerNum() == maxLedgerNum);
     }
 
     SECTION("manual close sequence number parameter that overflows int32_t is "

--- a/src/process/test/ProcessTests.cpp
+++ b/src/process/test/ProcessTests.cpp
@@ -129,8 +129,9 @@ TEST_CASE("subprocess storm", "[process]")
         std::string dst(fmt::format("{:s}/dst/{:d}", dir, i));
         CLOG(INFO, "Process") << "making file " << src;
         {
-            std::ofstream out(src);
+            std::ofstream out;
             out.exceptions(std::ios::failbit | std::ios::badbit);
+            out.open(src);
             out << i;
         }
         auto evt = app.getProcessManager()

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -440,9 +440,9 @@ class ScaleReporter
         : mColumns(columns)
         , mFilename(fmt::format("{:s}-{:d}.csv", join(columns, "-vs-"),
                                 std::time(nullptr)))
-        , mOut(mFilename)
     {
         mOut.exceptions(std::ios::failbit | std::ios::badbit);
+        mOut.open(mFilename);
         LOG(INFO) << "Opened " << mFilename << " for writing";
         mOut << join(columns, ",") << std::endl;
     }

--- a/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
+++ b/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
@@ -11,6 +11,7 @@
 #include "crypto/SecretKey.h"
 #include "crypto/SignerKey.h"
 #include "history/HistoryArchive.h"
+#include "main/ErrorMessages.h"
 #include "src/transactions/simulation/TxSimUtils.h"
 
 namespace stellar
@@ -140,7 +141,19 @@ TxSimGenerateBucketsWork::onRun()
         }
         else
         {
-            return State::WORK_SUCCESS;
+            try
+            {
+                // Persist HAS file to avoid re-generating same buckets
+                getGeneratedHAS().save("simulate-" +
+                                       HistoryArchiveState::baseName());
+                return State::WORK_SUCCESS;
+            }
+            catch (std::exception const& e)
+            {
+                CLOG(ERROR, "History") << "Error saving HAS file: " << e.what();
+                CLOG(ERROR, "History") << POSSIBLY_CORRUPTED_LOCAL_FS;
+                return State::WORK_FAILURE;
+            }
         }
 
         mIsCurr = !mIsCurr;
@@ -260,13 +273,6 @@ TxSimGenerateBucketsWork::startBucketGeneration(
     }
 
     checkOrStartMerges();
-}
-
-void
-TxSimGenerateBucketsWork::onSuccess()
-{
-    // Persist HAS file to avoid re-generating same buckets
-    getGeneratedHAS().save("simulate-" + HistoryArchiveState::baseName());
 }
 }
 }

--- a/src/transactions/simulation/TxSimGenerateBucketsWork.h
+++ b/src/transactions/simulation/TxSimGenerateBucketsWork.h
@@ -68,8 +68,6 @@ class TxSimGenerateBucketsWork : public BasicWork
     {
         return true;
     }
-
-    void onSuccess() override;
 };
 }
 }


### PR DESCRIPTION
In a few places we were not enabling `failbit` checks.
This causes all sorts of unexpected behavior: in particular, if the file cannot be opened, trying to read from it will just return "no data" and the failure will be silent.
