### PR TITLE
Reseed autocheck::rng() along with other RNGs

### DIFF
--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -5,6 +5,7 @@
 #define CATCH_CONFIG_RUNNER
 
 #include "util/asio.h"
+#include <autocheck/autocheck.hpp>
 
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnHeader.h"
@@ -56,6 +57,7 @@ struct ReseedPRNGListener : Catch::TestEventListenerBase
         srand(sCommandLineSeed);
         gRandomEngine.seed(sCommandLineSeed);
         Catch::rng().seed(sCommandLineSeed);
+        autocheck::rng().seed(sCommandLineSeed);
     }
     virtual void
     testCaseStarting(Catch::TestCaseInfo const& testInfo) override


### PR DESCRIPTION
Make ReseedPRNGListener::reseed() reseed autocheck's
mt19937 RNG along with the others that it already
reseeds (std::rand, gRandomEngine, and Catch::rng()), to
remove a source of non-determinism (one which we first
noticed because it made issue #2641 intermittent).

# Description

Resolves #2663 

We originally noticed the non-determinism resulting from our use of `autocheck` to generate pseudo-random `LedgerEntry` structures when we found that issue #2641 was intermittent.  The problem is that `autocheck::rng()` is seeded from a `std::random_device` which has no connection with `stellar-core`'s `--rng-seed`.

I originally thought that we might need to make `autocheck` share our internal RNG, `gRandomEngine`, but it occurs to me that all we need to do to make it deterministic is to seed `autocheck::rng()` at the same time as we seed `gRandomEngine`.

That's what this code does.  However, I'm actually mystified that it works, because I'd have expected the `inline` `autocheck::rng()` to have a separate instance in each translation unit, and consequently one Meyers "singleton" per translation unit.  But dumping the address of it from different translation units shows that they all use the same instance, and wrapping that instance in a class that logs in the constructor shows that it's only constructed once.

So this is, embarrassingly, a smaller change than I expected because of something that I'm misunderstanding about the C++ standard.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
