### PR TITLE
Uint128 t misuse prevention

### DIFF
--- a/lib/util/uint128_t.cpp
+++ b/lib/util/uint128_t.cpp
@@ -1,8 +1,8 @@
 #include "uint128_t.h"
 #include <cstring>
 
-const uint128_t uint128_0(0);
-const uint128_t uint128_1(1);
+const uint128_t uint128_0(0u);
+const uint128_t uint128_1(1u);
 
 uint128_t::uint128_t(std::string const& s) {
     init(s.c_str());
@@ -42,11 +42,11 @@ void uint128_t::_init_hex(const char *s) {
         }
         else if ('A' <= *s && *s <= 'F'){
             LOWER *= 16;
-            LOWER += *s + (10 - 'A');
+            LOWER += (*s - 'A') + 10;
         }
         else if ('a' <= *s && *s <= 'f'){
             LOWER *= 16;
-            LOWER += *s + (10 - 'a');
+            LOWER += (*s - 'a') + 10;
         }
         else{
             return;
@@ -54,16 +54,16 @@ void uint128_t::_init_hex(const char *s) {
     }
     for (; *s && i < 32; ++s, ++i){
         if ('0' <= *s && *s <= '9'){
-            *this *= 16;
-            *this += *s - '0';
+            *this *= 16u;
+            *this += static_cast<unsigned char>(*s - '0');
         }
         else if ('A' <= *s && *s <= 'F'){
-            *this *= 16;
-            *this += *s + (10 - 'A');
+            *this *= 16u;
+            *this += static_cast<unsigned char>((*s - 'A') + 10);
         }
         else if ('a' <= *s && *s <= 'f'){
-            *this *= 16;
-            *this += *s + (10 - 'a');
+            *this *= 16u;
+            *this += static_cast<unsigned char>((*s - 'a') + 10);
         }
         else{
             return;
@@ -75,8 +75,8 @@ void uint128_t::_init_dec(const char *s){
     // 2**128 = 340282366920938463463374607431768211456.
     LOWER = UPPER = 0;
     for (int i = 0; '0' <= *s && *s <= '9' && i < 39; ++s, ++i){
-        *this *= 10;
-        *this += *s - '0';
+        *this *= 10u;
+        *this += static_cast<unsigned char>(*s - '0');
     }
 }
 
@@ -84,8 +84,8 @@ void uint128_t::_init_oct(const char *s){
     // 2**128 = 0o4000000000000000000000000000000000000000000.
     LOWER = UPPER = 0;
     for (int i = 0; '0' <= *s && *s <= '7' && i < 43; ++s, ++i){
-        *this *= 8;
-        *this += *s - '0';
+        *this *= 8u;
+        *this += static_cast<unsigned char>(*s - '0');
     }
 }
 
@@ -149,7 +149,7 @@ uint128_t uint128_t::operator<<(const uint128_t & rhs) const{
         return uint128_0;
     }
     else if (shift == 64){
-        return uint128_t(LOWER, 0);
+        return uint128_t(LOWER, 0u);
     }
     else if (shift == 0){
         return *this;
@@ -158,7 +158,7 @@ uint128_t uint128_t::operator<<(const uint128_t & rhs) const{
         return uint128_t((UPPER << shift) + (LOWER >> (64 - shift)), LOWER << shift);
     }
     else if ((128 > shift) && (shift > 64)){
-        return uint128_t(LOWER << (shift - 64), 0);
+        return uint128_t(LOWER << (shift - 64), 0u);
     }
     else{
         return uint128_0;
@@ -176,7 +176,7 @@ uint128_t uint128_t::operator>>(const uint128_t & rhs) const{
         return uint128_0;
     }
     else if (shift == 64){
-        return uint128_t(0, UPPER);
+        return uint128_t(0u, UPPER);
     }
     else if (shift == 0){
         return *this;
@@ -185,7 +185,7 @@ uint128_t uint128_t::operator>>(const uint128_t & rhs) const{
         return uint128_t(UPPER >> shift, (UPPER << (64 - shift)) + (LOWER >> shift));
     }
     else if ((128 > shift) && (shift > 64)){
-        return uint128_t(0, (UPPER >> (shift - 64)));
+        return uint128_t(0u, (UPPER >> (shift - 64)));
     }
     else{
         return uint128_0;
@@ -345,7 +345,7 @@ std::pair <uint128_t, uint128_t> uint128_t::divmod(const uint128_t & lhs, const 
         qr.first  <<= uint128_1;
         qr.second <<= uint128_1;
 
-        if ((lhs >> (x - 1U)) & 1){
+        if ((lhs >> (x - 1u)) & 1u){
             ++qr.second;
         }
 
@@ -472,6 +472,9 @@ uint128_t operator<<(const uint64_t & lhs, const uint128_t & rhs){
     return uint128_t(lhs) << rhs;
 }
 
+// Here We disable signed-lhs operators but leave the code
+// in place to assist future merges from upstream.
+#if 0
 uint128_t operator<<(const int8_t & lhs, const uint128_t & rhs){
     return uint128_t(lhs) << rhs;
 }
@@ -487,6 +490,7 @@ uint128_t operator<<(const int32_t & lhs, const uint128_t & rhs){
 uint128_t operator<<(const int64_t & lhs, const uint128_t & rhs){
     return uint128_t(lhs) << rhs;
 }
+#endif
 
 uint128_t operator>>(const bool & lhs, const uint128_t & rhs){
     return uint128_t(lhs) >> rhs;
@@ -508,6 +512,9 @@ uint128_t operator>>(const uint64_t & lhs, const uint128_t & rhs){
     return uint128_t(lhs) >> rhs;
 }
 
+// Here We disable signed-lhs operators but leave the code
+// in place to assist future merges from upstream.
+#if 0
 uint128_t operator>>(const int8_t & lhs, const uint128_t & rhs){
     return uint128_t(lhs) >> rhs;
 }
@@ -523,6 +530,7 @@ uint128_t operator>>(const int32_t & lhs, const uint128_t & rhs){
 uint128_t operator>>(const int64_t & lhs, const uint128_t & rhs){
     return uint128_t(lhs) >> rhs;
 }
+#endif
 
 std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs){
     if (stream.flags() & stream.oct){

--- a/lib/util/uint128_t.cpp
+++ b/lib/util/uint128_t.cpp
@@ -1,36 +1,96 @@
 #include "uint128_t.h"
+#include <cstring>
 
 const uint128_t uint128_0(0);
 const uint128_t uint128_1(1);
-const uint128_t uint128_64(64);
-const uint128_t uint128_128(128);
 
-uint128_t::uint128_t(){
-    UPPER = 0;
-    LOWER = 0;
+uint128_t::uint128_t(std::string & s) {
+    init(s.c_str());
 }
 
-uint128_t::uint128_t(const uint128_t & rhs){
-    UPPER = rhs.UPPER;
-    LOWER = rhs.LOWER;
+uint128_t::uint128_t(const char *s) {
+    init(s);
 }
 
-uint128_t uint128_t::operator=(const uint128_t & rhs){
-    UPPER = rhs.UPPER;
-    LOWER = rhs.LOWER;
-    return *this;
+void uint128_t::init(const char *s) {
+    if (s == NULL || s[0] == 0){
+        LOWER = UPPER = 0;
+        return;
+    }
+
+    while (*s == ' ') ++s;
+
+    if (std::memcmp(s, "0x", 2) == 0){
+        _init_hex(&s[2]);
+    }
+    else if (std::memcmp(s, "0o", 2) == 0){
+        _init_oct(&s[2]);
+    }
+    else{
+        _init_dec(s);
+    }
+}
+
+void uint128_t::_init_hex(const char *s) {
+    // 2**128 = 0x100000000000000000000000000000000.
+    LOWER = UPPER = 0;
+    int i;
+    for (i = 0; *s && i < 16; ++s, ++i){
+        if ('0' <= *s && *s <= '9'){
+            LOWER *= 16;
+            LOWER += *s - '0';
+        }
+        else if ('A' <= *s && *s <= 'F'){
+            LOWER *= 16;
+            LOWER += *s + (10 - 'A');
+        }
+        else if ('a' <= *s && *s <= 'f'){
+            LOWER *= 16;
+            LOWER += *s + (10 - 'a');
+        }
+        else{
+            return;
+        }
+    }
+    for (; *s && i < 32; ++s, ++i){
+        if ('0' <= *s && *s <= '9'){
+            *this *= 16;
+            *this += *s - '0';
+        }
+        else if ('A' <= *s && *s <= 'F'){
+            *this *= 16;
+            *this += *s + (10 - 'A');
+        }
+        else if ('a' <= *s && *s <= 'f'){
+            *this *= 16;
+            *this += *s + (10 - 'a');
+        }
+        else{
+            return;
+        }
+    }
+}
+
+void uint128_t::_init_dec(const char *s){
+    // 2**128 = 340282366920938463463374607431768211456.
+    LOWER = UPPER = 0;
+    for (int i = 0; '0' <= *s && *s <= '9' && i < 39; ++s, ++i){
+        *this *= 10;
+        *this += *s - '0';
+    }
+}
+
+void uint128_t::_init_oct(const char *s){
+    // 2**128 = 0o4000000000000000000000000000000000000000000.
+    LOWER = UPPER = 0;
+    for (int i = 0; '0' <= *s && *s <= '7' && i < 43; ++s, ++i){
+        *this *= 8;
+        *this += *s - '0';
+    }
 }
 
 uint128_t::operator bool() const{
-    return ((UPPER | LOWER) != 0);
-}
-
-uint128_t::operator char() const{
-    return (char) LOWER;
-}
-
-uint128_t::operator int() const{
-    return (int) LOWER;
+    return (bool) (UPPER | LOWER);
 }
 
 uint128_t::operator uint8_t() const{
@@ -50,30 +110,30 @@ uint128_t::operator uint64_t() const{
 }
 
 uint128_t uint128_t::operator&(const uint128_t & rhs) const{
-return uint128_t(UPPER & rhs.UPPER, LOWER & rhs.LOWER);
+    return uint128_t(UPPER & rhs.UPPER, LOWER & rhs.LOWER);
+}
+
+uint128_t & uint128_t::operator&=(const uint128_t & rhs){
+    UPPER &= rhs.UPPER;
+    LOWER &= rhs.LOWER;
+    return *this;
 }
 
 uint128_t uint128_t::operator|(const uint128_t & rhs) const{
     return uint128_t(UPPER | rhs.UPPER, LOWER | rhs.LOWER);
 }
 
-uint128_t uint128_t::operator^(const uint128_t & rhs) const{
-    return uint128_t(UPPER ^ rhs.UPPER, LOWER ^ rhs.LOWER);
-}
-
-uint128_t uint128_t::operator&=(const uint128_t & rhs){
-    UPPER &= rhs.UPPER;
-    LOWER &= rhs.LOWER;
-    return *this;
-}
-
-uint128_t uint128_t::operator|=(const uint128_t & rhs){
+uint128_t & uint128_t::operator|=(const uint128_t & rhs){
     UPPER |= rhs.UPPER;
     LOWER |= rhs.LOWER;
     return *this;
 }
 
-uint128_t uint128_t::operator^=(const uint128_t & rhs){
+uint128_t uint128_t::operator^(const uint128_t & rhs) const{
+    return uint128_t(UPPER ^ rhs.UPPER, LOWER ^ rhs.LOWER);
+}
+
+uint128_t & uint128_t::operator^=(const uint128_t & rhs){
     UPPER ^= rhs.UPPER;
     LOWER ^= rhs.LOWER;
     return *this;
@@ -84,8 +144,8 @@ uint128_t uint128_t::operator~() const{
 }
 
 uint128_t uint128_t::operator<<(const uint128_t & rhs) const{
-    uint64_t shift = rhs.LOWER;
-    if ((rhs.UPPER != 0) || (shift >= 128)){
+    const uint64_t shift = rhs.LOWER;
+    if (((bool) rhs.UPPER) || (shift >= 128)){
         return uint128_0;
     }
     else if (shift == 64){
@@ -105,9 +165,14 @@ uint128_t uint128_t::operator<<(const uint128_t & rhs) const{
     }
 }
 
+uint128_t & uint128_t::operator<<=(const uint128_t & rhs){
+    *this = *this << rhs;
+    return *this;
+}
+
 uint128_t uint128_t::operator>>(const uint128_t & rhs) const{
-    uint64_t shift = rhs.LOWER;
-    if ((rhs.UPPER != 0) || (shift >= 128)){
+    const uint64_t shift = rhs.LOWER;
+    if (((bool) rhs.UPPER) || (shift >= 128)){
         return uint128_0;
     }
     else if (shift == 64){
@@ -127,18 +192,13 @@ uint128_t uint128_t::operator>>(const uint128_t & rhs) const{
     }
 }
 
-uint128_t uint128_t::operator<<=(const uint128_t & rhs){
-    *this = *this << rhs;
-    return *this;
-}
-
-uint128_t uint128_t::operator>>=(const uint128_t & rhs){
+uint128_t & uint128_t::operator>>=(const uint128_t & rhs){
     *this = *this >> rhs;
     return *this;
 }
 
 bool uint128_t::operator!() const{
-    return (UPPER | LOWER) == 0;
+    return !(bool) (UPPER | LOWER);
 }
 
 bool uint128_t::operator&&(const uint128_t & rhs) const{
@@ -183,8 +243,8 @@ uint128_t uint128_t::operator+(const uint128_t & rhs) const{
     return uint128_t(UPPER + rhs.UPPER + ((LOWER + rhs.LOWER) < LOWER), LOWER + rhs.LOWER);
 }
 
-uint128_t uint128_t::operator+=(const uint128_t & rhs){
-    UPPER = rhs.UPPER + UPPER + ((LOWER + rhs.LOWER) < LOWER);
+uint128_t & uint128_t::operator+=(const uint128_t & rhs){
+    UPPER += rhs.UPPER + ((LOWER + rhs.LOWER) < LOWER);
     LOWER += rhs.LOWER;
     return *this;
 }
@@ -193,54 +253,82 @@ uint128_t uint128_t::operator-(const uint128_t & rhs) const{
     return uint128_t(UPPER - rhs.UPPER - ((LOWER - rhs.LOWER) > LOWER), LOWER - rhs.LOWER);
 }
 
-uint128_t uint128_t::operator-=(const uint128_t & rhs){
+uint128_t & uint128_t::operator-=(const uint128_t & rhs){
     *this = *this - rhs;
     return *this;
 }
 
 uint128_t uint128_t::operator*(const uint128_t & rhs) const{
     // split values into 4 32-bit parts
-    uint64_t top[4] ={UPPER >> 32, UPPER & 0xffffffff, LOWER >> 32, LOWER & 0xffffffff};
-    uint64_t bottom[4] ={rhs.UPPER >> 32, rhs.UPPER & 0xffffffff, rhs.LOWER >> 32, rhs.LOWER & 0xffffffff};
+    uint64_t top[4] = {UPPER >> 32, UPPER & 0xffffffff, LOWER >> 32, LOWER & 0xffffffff};
+    uint64_t bottom[4] = {rhs.UPPER >> 32, rhs.UPPER & 0xffffffff, rhs.LOWER >> 32, rhs.LOWER & 0xffffffff};
     uint64_t products[4][4];
 
+    // multiply each component of the values
     for(int y = 3; y > -1; y--){
         for(int x = 3; x > -1; x--){
             products[3 - x][y] = top[x] * bottom[y];
         }
     }
 
-    // initial row
-    uint64_t fourth32 = products[0][3] & 0xffffffff;
-    uint64_t third32 = (products[0][2] & 0xffffffff) + (products[0][3] >> 32);
+    // first row
+    uint64_t fourth32 = (products[0][3] & 0xffffffff);
+    uint64_t third32  = (products[0][2] & 0xffffffff) + (products[0][3] >> 32);
     uint64_t second32 = (products[0][1] & 0xffffffff) + (products[0][2] >> 32);
-    uint64_t first32 = (products[0][0] & 0xffffffff) + (products[0][1] >> 32);
+    uint64_t first32  = (products[0][0] & 0xffffffff) + (products[0][1] >> 32);
 
     // second row
-    third32 += products[1][3] & 0xffffffff;
+    third32  += (products[1][3] & 0xffffffff);
     second32 += (products[1][2] & 0xffffffff) + (products[1][3] >> 32);
-    first32 += (products[1][1] & 0xffffffff) + (products[1][2] >> 32);
+    first32  += (products[1][1] & 0xffffffff) + (products[1][2] >> 32);
 
     // third row
-    second32 += products[2][3] & 0xffffffff;
-    first32 += (products[2][2] & 0xffffffff) + (products[2][3] >> 32);
+    second32 += (products[2][3] & 0xffffffff);
+    first32  += (products[2][2] & 0xffffffff) + (products[2][3] >> 32);
 
     // fourth row
-    first32 += products[3][3] & 0xffffffff;
+    first32  += (products[3][3] & 0xffffffff);
 
-    // combines the values, taking care of carry over
-    return uint128_t(first32 << 32, 0) + uint128_t(third32 >> 32, third32 << 32) + uint128_t(second32, 0) + uint128_t(fourth32);
+    // move carry to next digit
+    third32  += fourth32 >> 32;
+    second32 += third32  >> 32;
+    first32  += second32 >> 32;
+
+    // remove carry from current digit
+    fourth32 &= 0xffffffff;
+    third32  &= 0xffffffff;
+    second32 &= 0xffffffff;
+    first32  &= 0xffffffff;
+
+    // combine components
+    return uint128_t((first32 << 32) | second32, (third32 << 32) | fourth32);
 }
 
-uint128_t uint128_t::operator*=(const uint128_t & rhs){
+uint128_t & uint128_t::operator*=(const uint128_t & rhs){
     *this = *this * rhs;
     return *this;
+}
+
+void uint128_t::ConvertToVector(std::vector<uint8_t> & ret, const uint64_t & val) const {
+    ret.push_back(static_cast<uint8_t>(val >> 56));
+    ret.push_back(static_cast<uint8_t>(val >> 48));
+    ret.push_back(static_cast<uint8_t>(val >> 40));
+    ret.push_back(static_cast<uint8_t>(val >> 32));
+    ret.push_back(static_cast<uint8_t>(val >> 24));
+    ret.push_back(static_cast<uint8_t>(val >> 16));
+    ret.push_back(static_cast<uint8_t>(val >> 8));
+    ret.push_back(static_cast<uint8_t>(val));
+}
+
+void uint128_t::export_bits(std::vector<uint8_t> &ret) const {
+    ConvertToVector(ret, const_cast<const uint64_t&>(UPPER));
+    ConvertToVector(ret, const_cast<const uint64_t&>(LOWER));
 }
 
 std::pair <uint128_t, uint128_t> uint128_t::divmod(const uint128_t & lhs, const uint128_t & rhs) const{
     // Save some calculations /////////////////////
     if (rhs == uint128_0){
-        throw std::runtime_error("Error: division or modulus by 0");
+        throw std::domain_error("Error: division or modulus by 0");
     }
     else if (rhs == uint128_1){
         return std::pair <uint128_t, uint128_t> (lhs, uint128_0);
@@ -252,20 +340,19 @@ std::pair <uint128_t, uint128_t> uint128_t::divmod(const uint128_t & lhs, const 
         return std::pair <uint128_t, uint128_t> (uint128_0, lhs);
     }
 
-    std::pair <uint128_t, uint128_t> qr(uint128_0, lhs);
-    uint128_t copyd = rhs << (lhs.bits() - rhs.bits());
-    uint128_t adder = uint128_1 << (lhs.bits() - rhs.bits());
-    if (copyd > qr.second){
-        copyd >>= uint128_1;
-        adder >>= uint128_1;
-    }
-    while (qr.second >= rhs){
-        if (qr.second >= copyd){
-            qr.second -= copyd;
-            qr.first |= adder;
+    std::pair <uint128_t, uint128_t> qr (uint128_0, uint128_0);
+    for(uint8_t x = lhs.bits(); x > 0; x--){
+        qr.first  <<= uint128_1;
+        qr.second <<= uint128_1;
+
+        if ((lhs >> (x - 1U)) & 1){
+            ++qr.second;
         }
-        copyd >>= uint128_1;
-        adder >>= uint128_1;
+
+        if (qr.second >= rhs){
+            qr.second -= rhs;
+            ++qr.first;
+        }
     }
     return qr;
 }
@@ -274,23 +361,22 @@ uint128_t uint128_t::operator/(const uint128_t & rhs) const{
     return divmod(*this, rhs).first;
 }
 
-uint128_t uint128_t::operator/=(const uint128_t & rhs){
+uint128_t & uint128_t::operator/=(const uint128_t & rhs){
     *this = *this / rhs;
     return *this;
 }
 
 uint128_t uint128_t::operator%(const uint128_t & rhs) const{
-    return *this - (rhs * (*this / rhs));
+    return divmod(*this, rhs).second;
 }
 
-uint128_t uint128_t::operator%=(const uint128_t & rhs){
+uint128_t & uint128_t::operator%=(const uint128_t & rhs){
     *this = *this % rhs;
     return *this;
 }
 
-uint128_t uint128_t::operator++(){
-    *this += uint128_1;
-    return *this;
+uint128_t & uint128_t::operator++(){
+    return *this += uint128_1;
 }
 
 uint128_t uint128_t::operator++(int){
@@ -299,9 +385,8 @@ uint128_t uint128_t::operator++(int){
     return temp;
 }
 
-uint128_t uint128_t::operator--(){
-    *this -= uint128_1;
-    return *this;
+uint128_t & uint128_t::operator--(){
+    return *this -= uint128_1;
 }
 
 uint128_t uint128_t::operator--(int){
@@ -310,11 +395,19 @@ uint128_t uint128_t::operator--(int){
     return temp;
 }
 
-uint64_t uint128_t::upper() const{
+uint128_t uint128_t::operator+() const{
+    return *this;
+}
+
+uint128_t uint128_t::operator-() const{
+    return ~*this + uint128_1;
+}
+
+const uint64_t & uint128_t::upper() const{
     return UPPER;
 }
 
-uint64_t uint128_t::lower() const{
+const uint64_t & uint128_t::lower() const{
     return LOWER;
 }
 
@@ -340,7 +433,7 @@ uint8_t uint128_t::bits() const{
 
 std::string uint128_t::str(uint8_t base, const unsigned int & len) const{
     if ((base < 2) || (base > 16)){
-        throw std::invalid_argument("Base must be in th range 2-16");
+        throw std::invalid_argument("Base must be in the range [2, 16]");
     }
     std::string out = "";
     if (!(*this)){
@@ -349,7 +442,7 @@ std::string uint128_t::str(uint8_t base, const unsigned int & len) const{
     else{
         std::pair <uint128_t, uint128_t> qr(*this, uint128_0);
         do{
-            qr = divmod(qr.first, uint128_t(base));
+            qr = divmod(qr.first, base);
             out = "0123456789abcdef"[(uint8_t) qr.second] + out;
         } while (qr.first);
     }
@@ -357,6 +450,78 @@ std::string uint128_t::str(uint8_t base, const unsigned int & len) const{
         out = std::string(len - out.size(), '0') + out;
     }
     return out;
+}
+
+uint128_t operator<<(const bool & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const uint8_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const uint16_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const uint32_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const uint64_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const int8_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const int16_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const int32_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator<<(const int64_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) << rhs;
+}
+
+uint128_t operator>>(const bool & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const uint8_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const uint16_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const uint32_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const uint64_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const int8_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const int16_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const int32_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
+}
+
+uint128_t operator>>(const int64_t & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) >> rhs;
 }
 
 std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs){

--- a/lib/util/uint128_t.cpp
+++ b/lib/util/uint128_t.cpp
@@ -4,7 +4,7 @@
 const uint128_t uint128_0(0);
 const uint128_t uint128_1(1);
 
-uint128_t::uint128_t(std::string & s) {
+uint128_t::uint128_t(std::string const& s) {
     init(s.c_str());
 }
 

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -1,7 +1,8 @@
 /*
 uint128_t.h
 An unsigned 128 bit integer type for C++
-Copyright (c) 2014 Jason Lee @ calccrypto at gmail.com
+
+Copyright (c) 2013 - 2017 Jason Lee @ calccrypto at gmail.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -23,136 +24,208 @@ THE SOFTWARE.
 
 With much help from Auston Sterling
 
-Thanks to Stefan Deigm�ller for finding
+Thanks to Stefan Deigmüller for finding
 a bug in operator*.
 
-Thanks to Fran�ois Dessenne for convincing me
+Thanks to François Dessenne for convincing me
 to do a general rewrite of this class.
-
-when defining UNSAFE_UINT128_OPS additional behaviors are enabled.
-
-for example:
-// implicit typecast Operators,
-// short for (short)uint128_t(y).lower()
-// or (char)uint128_t(y)
-char x = uint128_t(y);
-
-// arithmetic operators with short type as lhs,
-// short for 2 * uint128_t(y).lower()
-auto x = 2 * uint128_t(y);
 */
 
 #ifndef __UINT128_T__
 #define __UINT128_T__
 
-#include <iostream>
+#include <cstdint>
+#include <ostream>
 #include <stdexcept>
-#include <stdint.h>
-#include <utility>
 #include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
-#ifdef UNSAFE_UINT128_OPS
-#define IMPLICIT_UNSAFE_UINT128_OPS
-#else
-#define IMPLICIT_UNSAFE_UINT128_OPS explicit
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+    defined(__BIG_ENDIAN__) ||                               \
+    defined(__ARMEB__) ||                                    \
+    defined(__THUMBEB__) ||                                  \
+    defined(__AARCH64EB__) ||                                \
+    defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__)
+#ifndef __BIG_ENDIAN__
+#define __BIG_ENDIAN__
 #endif
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+    defined(__LITTLE_ENDIAN__) ||                                 \
+    defined(__ARMEL__) ||                                         \
+    defined(__THUMBEL__) ||                                       \
+    defined(__AARCH64EL__) ||                                     \
+    defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || \
+    defined(_WIN32) || defined(__i386__) || defined(__x86_64__) || \
+    defined(_X86_) || defined(_IA64_)
+#ifndef __LITTLE_ENDIAN__
+#define __LITTLE_ENDIAN__
+#endif
+#else
+#error "I don't know what architecture this is!"
+#endif
+
+// We're not building a shared library, skip dllimport/dllexport stuff.
+#define UINT128_T_EXTERN
+
+class UINT128_T_EXTERN uint128_t;
+
+// Give uint128_t type traits
+namespace std {  // This is probably not a good idea
+    template <> struct is_arithmetic <uint128_t> : std::true_type {};
+    template <> struct is_integral   <uint128_t> : std::true_type {};
+    template <> struct is_unsigned   <uint128_t> : std::true_type {};
+}
 
 class uint128_t{
     private:
+#ifdef __BIG_ENDIAN__
         uint64_t UPPER, LOWER;
+#endif
+#ifdef __LITTLE_ENDIAN__
+        uint64_t LOWER, UPPER;
+#endif
 
     public:
         // Constructors
-        uint128_t();
-        uint128_t(const uint128_t & rhs);
+        uint128_t() = default;
+        uint128_t(const uint128_t & rhs) = default;
+        uint128_t(uint128_t && rhs) = default;
+        uint128_t(std::string & s);
+        uint128_t(const char *s);
 
-        template <typename T> explicit uint128_t(const T & rhs){
-            UPPER = 0;
-            LOWER = rhs;
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t(const T & rhs)
+#ifdef __BIG_ENDIAN__
+            : UPPER(0), LOWER(rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(rhs), UPPER(0)
+#endif
+        {
+            if (std::is_signed<T>::value) {
+                if (rhs < 0) {
+                    UPPER = -1;
+                }
+            }
         }
 
-        template <typename S, typename T> uint128_t(const S & upper_rhs, const T & lower_rhs){
-            UPPER = upper_rhs;
-            LOWER = lower_rhs;
-        }
+        template <typename S, typename T, typename = typename std::enable_if <std::is_integral<S>::value && std::is_integral<T>::value, void>::type>
+        uint128_t(const S & upper_rhs, const T & lower_rhs)
+#ifdef __BIG_ENDIAN__
+            : UPPER(upper_rhs), LOWER(lower_rhs)
+#endif
+#ifdef __LITTLE_ENDIAN__
+            : LOWER(lower_rhs), UPPER(upper_rhs)
+#endif
+        {}
 
         //  RHS input args only
 
         // Assignment Operator
-        uint128_t operator=(const uint128_t & rhs);
+        uint128_t & operator=(const uint128_t & rhs) = default;
+        uint128_t & operator=(uint128_t && rhs) = default;
 
-        template <typename T> uint128_t operator=(const T & rhs){
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator=(const T & rhs){
             UPPER = 0;
+
+            if (std::is_signed<T>::value) {
+                if (rhs < 0) {
+                    UPPER = -1;
+                }
+            }
+
             LOWER = rhs;
             return *this;
         }
 
         // Typecast Operators
-        IMPLICIT_UNSAFE_UINT128_OPS operator bool() const;
-        IMPLICIT_UNSAFE_UINT128_OPS operator char() const;
-        IMPLICIT_UNSAFE_UINT128_OPS operator int() const;
-        IMPLICIT_UNSAFE_UINT128_OPS operator uint8_t() const;
-        IMPLICIT_UNSAFE_UINT128_OPS operator uint16_t() const;
-        IMPLICIT_UNSAFE_UINT128_OPS operator uint32_t() const;
-        IMPLICIT_UNSAFE_UINT128_OPS operator uint64_t() const;
+        operator bool() const;
+        operator uint8_t() const;
+        operator uint16_t() const;
+        operator uint32_t() const;
+        operator uint64_t() const;
 
         // Bitwise Operators
         uint128_t operator&(const uint128_t & rhs) const;
-        uint128_t operator|(const uint128_t & rhs) const;
-        uint128_t operator^(const uint128_t & rhs) const;
-        uint128_t operator&=(const uint128_t & rhs);
-        uint128_t operator|=(const uint128_t & rhs);
-        uint128_t operator^=(const uint128_t & rhs);
-        uint128_t operator~() const;
 
-        template <typename T> uint128_t operator&(const T & rhs) const{
+        void export_bits(std::vector<uint8_t> & ret) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator&(const T & rhs) const{
             return uint128_t(0, LOWER & (uint64_t) rhs);
         }
 
-        template <typename T> uint128_t operator|(const T & rhs) const{
-            return uint128_t(UPPER, LOWER | (uint64_t) rhs);
-        }
+        uint128_t & operator&=(const uint128_t & rhs);
 
-        template <typename T> uint128_t operator^(const T & rhs) const{
-            return uint128_t(UPPER, LOWER ^ (uint64_t) rhs);
-        }
-
-        template <typename T> uint128_t operator&=(const T & rhs){
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator&=(const T & rhs){
             UPPER = 0;
             LOWER &= rhs;
             return *this;
         }
 
-        template <typename T> uint128_t operator|=(const T & rhs){
+        uint128_t operator|(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator|(const T & rhs) const{
+            return uint128_t(UPPER, LOWER | (uint64_t) rhs);
+        }
+
+        uint128_t & operator|=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator|=(const T & rhs){
             LOWER |= (uint64_t) rhs;
             return *this;
         }
 
-        template <typename T> uint128_t operator^=(const T & rhs){
+        uint128_t operator^(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator^(const T & rhs) const{
+            return uint128_t(UPPER, LOWER ^ (uint64_t) rhs);
+        }
+
+        uint128_t & operator^=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator^=(const T & rhs){
             LOWER ^= (uint64_t) rhs;
             return *this;
         }
 
+        uint128_t operator~() const;
+
         // Bit Shift Operators
         uint128_t operator<<(const uint128_t & rhs) const;
-        uint128_t operator>>(const uint128_t & rhs) const;
-        uint128_t operator<<=(const uint128_t & rhs);
-        uint128_t operator>>=(const uint128_t & rhs);
 
-        template <typename T>uint128_t operator<<(const T & rhs) const{
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator<<(const T & rhs) const{
             return *this << uint128_t(rhs);
         }
 
-        template <typename T>uint128_t operator>>(const T & rhs) const{
-            return *this >> uint128_t(rhs);
-        }
+        uint128_t & operator<<=(const uint128_t & rhs);
 
-        template <typename T>uint128_t operator<<=(const T & rhs){
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator<<=(const T & rhs){
             *this = *this << uint128_t(rhs);
             return *this;
         }
 
-        template <typename T>uint128_t operator>>=(const T & rhs){
+        uint128_t operator>>(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator>>(const T & rhs) const{
+            return *this >> uint128_t(rhs);
+        }
+
+        uint128_t & operator>>=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator>>=(const T & rhs){
             *this = *this >> uint128_t(rhs);
             return *this;
         }
@@ -162,120 +235,156 @@ class uint128_t{
         bool operator&&(const uint128_t & rhs) const;
         bool operator||(const uint128_t & rhs) const;
 
-        template <typename T> bool operator&&(const T & rhs){
-            return ((bool) *this && rhs);
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator&&(const T & rhs){
+            return static_cast <bool> (*this && rhs);
         }
 
-        template <typename T> bool operator||(const T & rhs){
-            return ((bool) *this || rhs);
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator||(const T & rhs){
+            return static_cast <bool> (*this || rhs);
         }
 
         // Comparison Operators
         bool operator==(const uint128_t & rhs) const;
-        bool operator!=(const uint128_t & rhs) const;
-        bool operator>(const uint128_t & rhs) const;
-        bool operator<(const uint128_t & rhs) const;
-        bool operator>=(const uint128_t & rhs) const;
-        bool operator<=(const uint128_t & rhs) const;
 
-        template <typename T> bool operator==(const T & rhs) const{
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator==(const T & rhs) const{
             return (!UPPER && (LOWER == (uint64_t) rhs));
         }
 
-        template <typename T> bool operator!=(const T & rhs) const{
+        bool operator!=(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator!=(const T & rhs) const{
             return (UPPER | (LOWER != (uint64_t) rhs));
         }
 
-        template <typename T> bool operator>(const T & rhs) const{
+        bool operator>(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator>(const T & rhs) const{
             return (UPPER || (LOWER > (uint64_t) rhs));
         }
 
-        template <typename T> bool operator<(const T & rhs) const{
+        bool operator<(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator<(const T & rhs) const{
             return (!UPPER)?(LOWER < (uint64_t) rhs):false;
         }
 
-        template <typename T> bool operator>=(const T & rhs) const{
+        bool operator>=(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator>=(const T & rhs) const{
             return ((*this > rhs) | (*this == rhs));
         }
 
-        template <typename T> bool operator<=(const T & rhs) const{
+        bool operator<=(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        bool operator<=(const T & rhs) const{
             return ((*this < rhs) | (*this == rhs));
         }
 
         // Arithmetic Operators
         uint128_t operator+(const uint128_t & rhs) const;
-        uint128_t operator+=(const uint128_t & rhs);
-        uint128_t operator-(const uint128_t & rhs) const;
-        uint128_t operator-=(const uint128_t & rhs);
-        uint128_t operator*(const uint128_t & rhs) const;
-        uint128_t operator*=(const uint128_t & rhs);
 
-    private:
-        std::pair <uint128_t, uint128_t> divmod(const uint128_t & lhs, const uint128_t & rhs) const;
-
-    public:
-		uint128_t operator/(const uint128_t & rhs) const;
-        uint128_t operator/=(const uint128_t & rhs);
-        uint128_t operator%(const uint128_t & rhs) const;
-        uint128_t operator%=(const uint128_t & rhs);
-
-        template <typename T> uint128_t operator+(const T & rhs) const{
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator+(const T & rhs) const{
             return uint128_t(UPPER + ((LOWER + (uint64_t) rhs) < LOWER), LOWER + (uint64_t) rhs);
         }
 
-        template <typename T> uint128_t operator+=(const T & rhs){
-            UPPER = UPPER + ((LOWER + rhs) < LOWER);
-            LOWER = LOWER + rhs;
-            return *this;
+        uint128_t & operator+=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator+=(const T & rhs){
+            return *this += uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator-(const T & rhs) const{
+        uint128_t operator-(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator-(const T & rhs) const{
             return uint128_t((uint64_t) (UPPER - ((LOWER - rhs) > LOWER)), (uint64_t) (LOWER - rhs));
         }
 
-        template <typename T> uint128_t operator-=(const T & rhs){
-            *this = *this - rhs;
-            return *this;
+        uint128_t & operator-=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator-=(const T & rhs){
+            return *this = *this - uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator*(const T & rhs) const{
-            return (*this) * (uint128_t(rhs));
+        uint128_t operator*(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator*(const T & rhs) const{
+            return *this * uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator*=(const T & rhs){
-            *this = *this * uint128_t(rhs);
-            return *this;
+        uint128_t & operator*=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator*=(const T & rhs){
+            return *this = *this * uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator/(const T & rhs) const{
+    private:
+        std::pair <uint128_t, uint128_t> divmod(const uint128_t & lhs, const uint128_t & rhs) const;
+        void init(const char * s);
+        void ConvertToVector(std::vector<uint8_t> & current, const uint64_t & val) const;
+        void _init_hex(const char *s);
+        void _init_dec(const char *s);
+        void _init_oct(const char *s);
+
+    public:
+        uint128_t operator/(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator/(const T & rhs) const{
             return *this / uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator/=(const T & rhs){
-            *this = *this / uint128_t(rhs);
-            return *this;
+        uint128_t & operator/=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator/=(const T & rhs){
+            return *this = *this / uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator%(const T & rhs) const{
-            return *this - (rhs * (*this / rhs));
+        uint128_t operator%(const uint128_t & rhs) const;
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator%(const T & rhs) const{
+            return *this % uint128_t(rhs);
         }
 
-        template <typename T> uint128_t operator%=(const T & rhs){
-            *this = *this % uint128_t(rhs);
-            return *this;
+        uint128_t & operator%=(const uint128_t & rhs);
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator%=(const T & rhs){
+            return *this = *this % uint128_t(rhs);
         }
 
         // Increment Operator
-        uint128_t operator++();
+        uint128_t & operator++();
         uint128_t operator++(int);
 
         // Decrement Operator
-        uint128_t operator--();
+        uint128_t & operator--();
         uint128_t operator--(int);
 
+        // Nothing done since promotion doesn't work here
+        uint128_t operator+() const;
+
+        // two's complement
+        uint128_t operator-() const;
+
         // Get private values
-        uint64_t upper() const;
-        uint64_t lower() const;
+        const uint64_t & upper() const;
+        const uint64_t & lower() const;
 
         // Get bitsize of value
         uint8_t bits() const;
@@ -284,122 +393,166 @@ class uint128_t{
         std::string str(uint8_t base = 10, const unsigned int & len = 0) const;
 };
 
-// Useful values
-extern const uint128_t uint128_0;
-extern const uint128_t uint128_1;
-extern const uint128_t uint128_64;
-extern const uint128_t uint128_128;
+// useful values
+UINT128_T_EXTERN extern const uint128_t uint128_0;
+UINT128_T_EXTERN extern const uint128_t uint128_1;
 
 // lhs type T as first arguemnt
 // If the output is not a bool, casts to type T
 
 // Bitwise Operators
-template <typename T> T operator&(const T & lhs, const uint128_t & rhs){
-    return (T) (lhs & (T) rhs.lower());
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator&(const T & lhs, const uint128_t & rhs){
+    return rhs & lhs;
 }
 
-template <typename T> T operator|(const T & lhs, const uint128_t & rhs){
-    return (T) (lhs | (T) rhs.lower());
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator&=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (rhs & lhs);
 }
 
-template <typename T> T operator^(const T & lhs, const uint128_t & rhs){
-    return (T) (lhs ^ (T) rhs.lower());
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator|(const T & lhs, const uint128_t & rhs){
+    return rhs | lhs;
 }
 
-template <typename T> T operator&=(T & lhs, const uint128_t & rhs){
-    lhs &= (T) rhs.lower(); return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator|=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (rhs | lhs);
 }
 
-template <typename T> T operator|=(T & lhs, const uint128_t & rhs){
-    lhs |= (T) rhs.lower(); return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator^(const T & lhs, const uint128_t & rhs){
+    return rhs ^ lhs;
 }
 
-template <typename T> T operator^=(T & lhs, const uint128_t & rhs){
-    lhs ^= (T) rhs.lower(); return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator^=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (rhs ^ lhs);
+}
+
+// Bitshift operators
+UINT128_T_EXTERN uint128_t operator<<(const bool     & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const uint8_t  & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const uint16_t & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const uint32_t & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const uint64_t & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const int8_t   & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const int16_t  & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const int32_t  & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator<<(const int64_t  & lhs, const uint128_t & rhs);
+
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator<<=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (uint128_t(lhs) << rhs);
+}
+
+UINT128_T_EXTERN uint128_t operator>>(const bool     & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const uint8_t  & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const uint16_t & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const uint32_t & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const uint64_t & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const int8_t   & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const int16_t  & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const int32_t  & lhs, const uint128_t & rhs);
+UINT128_T_EXTERN uint128_t operator>>(const int64_t  & lhs, const uint128_t & rhs);
+
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator>>=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (uint128_t(lhs) >> rhs);
 }
 
 // Comparison Operators
-template <typename T> bool operator==(const T & lhs, const uint128_t & rhs){
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+bool operator==(const T & lhs, const uint128_t & rhs){
     return (!rhs.upper() && ((uint64_t) lhs == rhs.lower()));
 }
 
-template <typename T> bool operator!=(const T & lhs, const uint128_t & rhs){
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+bool operator!=(const T & lhs, const uint128_t & rhs){
     return (rhs.upper() | ((uint64_t) lhs != rhs.lower()));
 }
 
-template <typename T> bool operator>(const T & lhs, const uint128_t & rhs){
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+bool operator>(const T & lhs, const uint128_t & rhs){
     return (!rhs.upper()) && ((uint64_t) lhs > rhs.lower());
 }
 
-template <typename T> bool operator<(const T & lhs, const uint128_t & rhs){
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+bool operator<(const T & lhs, const uint128_t & rhs){
     if (rhs.upper()){
         return true;
     }
     return ((uint64_t) lhs < rhs.lower());
 }
 
-template <typename T> bool operator>=(const T & lhs, const uint128_t & rhs){
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+bool operator>=(const T & lhs, const uint128_t & rhs){
     if (rhs.upper()){
-            return false;
+        return false;
     }
     return ((uint64_t) lhs >= rhs.lower());
 }
 
-template <typename T> bool operator<=(const T & lhs, const uint128_t & rhs){
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+bool operator<=(const T & lhs, const uint128_t & rhs){
     if (rhs.upper()){
-            return true;
+        return true;
     }
     return ((uint64_t) lhs <= rhs.lower());
 }
 
-#ifdef UNSAFE_UINT128_OPS
 // Arithmetic Operators
-template <typename T> T operator+(const T & lhs, const uint128_t & rhs){
-    return (T) (rhs + lhs);
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator+(const T & lhs, const uint128_t & rhs){
+    return rhs + lhs;
 }
 
-template <typename T> T & operator+=(T & lhs, const uint128_t & rhs){
-    lhs = (T) (rhs + lhs);
-    return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator+=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (rhs + lhs);
 }
 
-template <typename T> T operator-(const T & lhs, const uint128_t & rhs){
-    return (T) (uint128_t(lhs) - rhs);
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator-(const T & lhs, const uint128_t & rhs){
+    return -(rhs - lhs);
 }
 
-template <typename T> T & operator-=(T & lhs, const uint128_t & rhs){
-    lhs = (T) (uint128_t(lhs) - rhs);
-    return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator-=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (-(rhs - lhs));
 }
 
-template <typename T> T operator*(const T & lhs, const uint128_t & rhs){
-    return lhs * (T) rhs.lower();
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator*(const T & lhs, const uint128_t & rhs){
+    return rhs * lhs;
 }
 
-template <typename T> T & operator*=(T & lhs, const uint128_t & rhs){
-    lhs *= (T) rhs.lower();
-    return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator*=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (rhs * lhs);
 }
 
-template <typename T> T operator/(const T & lhs, const uint128_t & rhs){
-    return (T) (uint128_t(lhs) / rhs);
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator/(const T & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) / rhs;
 }
 
-template <typename T> T & operator/=(T & lhs, const uint128_t & rhs){
-    lhs = (T) (uint128_t(lhs) / rhs);
-    return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator/=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (uint128_t(lhs) / rhs);
 }
 
-template <typename T> T operator%(const T & lhs, const uint128_t & rhs){
-    return (T) (uint128_t(lhs) % rhs);
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+uint128_t operator%(const T & lhs, const uint128_t & rhs){
+    return uint128_t(lhs) % rhs;
 }
 
-template <typename T> T & operator%=(T & lhs, const uint128_t & rhs){
-    lhs = (T) (uint128_t(lhs) % rhs);
-    return lhs;
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+T & operator%=(T & lhs, const uint128_t & rhs){
+    return lhs = static_cast <T> (uint128_t(lhs) % rhs);
 }
-#endif
 
 // IO Operator
-std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs);
+UINT128_T_EXTERN std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs);
 #endif

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -29,6 +29,18 @@ a bug in operator*.
 
 Thanks to François Dessenne for convincing me
 to do a general rewrite of this class.
+
+when defining UNSAFE_UINT128_OPS additional behaviors are enabled.
+
+for example:
+// implicit typecast Operators,
+// short for (short)uint128_t(y).lower()
+// or (char)uint128_t(y)
+char x = uint128_t(y);
+
+// arithmetic operators with short type as lhs,
+// short for 2 * uint128_t(y).lower()
+auto x = 2 * uint128_t(y);
 */
 
 #ifndef __UINT128_T__
@@ -77,6 +89,12 @@ namespace std {  // This is probably not a good idea
     template <> struct is_integral   <uint128_t> : std::true_type {};
     template <> struct is_unsigned   <uint128_t> : std::true_type {};
 }
+
+#ifdef UNSAFE_UINT128_OPS
+#define IMPLICIT_UNSAFE_UINT128_OPS
+#else
+#define IMPLICIT_UNSAFE_UINT128_OPS explicit
+#endif
 
 class uint128_t{
     private:
@@ -142,11 +160,11 @@ class uint128_t{
         }
 
         // Typecast Operators
-        operator bool() const;
-        operator uint8_t() const;
-        operator uint16_t() const;
-        operator uint32_t() const;
-        operator uint64_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator bool() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint8_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint16_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint32_t() const;
+        IMPLICIT_UNSAFE_UINT128_OPS operator uint64_t() const;
 
         // Bitwise Operators
         uint128_t operator&(const uint128_t & rhs) const;
@@ -286,46 +304,68 @@ class uint128_t{
 
         // Arithmetic Operators
         uint128_t operator+(const uint128_t & rhs) const;
+        uint128_t & operator+=(const uint128_t & rhs);
+        uint128_t operator-(const uint128_t & rhs) const;
+        uint128_t & operator-=(const uint128_t & rhs);
+        uint128_t operator*(const uint128_t & rhs) const;
+        uint128_t & operator*=(const uint128_t & rhs);
+        uint128_t operator/(const uint128_t & rhs) const;
+        uint128_t & operator/=(const uint128_t & rhs);
+        uint128_t operator%(const uint128_t & rhs) const;
+        uint128_t & operator%=(const uint128_t & rhs);
 
+#ifdef UNSAFE_UINT128_OPS
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator+(const T & rhs) const{
             return *this + uint128_t(rhs);
         }
-
-        uint128_t & operator+=(const uint128_t & rhs);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator+=(const T & rhs){
             return *this += uint128_t(rhs);
         }
 
-        uint128_t operator-(const uint128_t & rhs) const;
-
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator-(const T & rhs) const{
             return *this - uint128_t(rhs);
         }
-
-        uint128_t & operator-=(const uint128_t & rhs);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator-=(const T & rhs){
             return *this = *this - uint128_t(rhs);
         }
 
-        uint128_t operator*(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator*(const T & rhs) const{
             return *this * uint128_t(rhs);
         }
 
-        uint128_t & operator*=(const uint128_t & rhs);
-
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator*=(const T & rhs){
             return *this = *this * uint128_t(rhs);
         }
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator/(const T & rhs) const{
+            return *this / uint128_t(rhs);
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator/=(const T & rhs){
+            return *this = *this / uint128_t(rhs);
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t operator%(const T & rhs) const{
+            return *this % uint128_t(rhs);
+        }
+
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        uint128_t & operator%=(const T & rhs){
+            return *this = *this % uint128_t(rhs);
+        }
+#endif
 
     private:
         std::pair <uint128_t, uint128_t> divmod(const uint128_t & lhs, const uint128_t & rhs) const;
@@ -336,33 +376,6 @@ class uint128_t{
         void _init_oct(const char *s);
 
     public:
-        uint128_t operator/(const uint128_t & rhs) const;
-
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        uint128_t operator/(const T & rhs) const{
-            return *this / uint128_t(rhs);
-        }
-
-        uint128_t & operator/=(const uint128_t & rhs);
-
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        uint128_t & operator/=(const T & rhs){
-            return *this = *this / uint128_t(rhs);
-        }
-
-        uint128_t operator%(const uint128_t & rhs) const;
-
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        uint128_t operator%(const T & rhs) const{
-            return *this % uint128_t(rhs);
-        }
-
-        uint128_t & operator%=(const uint128_t & rhs);
-
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        uint128_t & operator%=(const T & rhs){
-            return *this = *this % uint128_t(rhs);
-        }
 
         // Increment Operator
         uint128_t & operator++();

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -155,46 +155,42 @@ class uint128_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator&(const T & rhs) const{
-            return uint128_t(0, LOWER & (uint64_t) rhs);
+            return *this & uint128_t(rhs);
         }
 
         uint128_t & operator&=(const uint128_t & rhs);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator&=(const T & rhs){
-            UPPER = 0;
-            LOWER &= rhs;
-            return *this;
+            return *this &= uint128_t(rhs);
         }
 
         uint128_t operator|(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator|(const T & rhs) const{
-            return uint128_t(UPPER, LOWER | (uint64_t) rhs);
+            return *this | uint128_t(rhs);
         }
 
         uint128_t & operator|=(const uint128_t & rhs);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator|=(const T & rhs){
-            LOWER |= (uint64_t) rhs;
-            return *this;
+            return *this |= uint128_t(rhs);
         }
 
         uint128_t operator^(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator^(const T & rhs) const{
-            return uint128_t(UPPER, LOWER ^ (uint64_t) rhs);
+            return *this ^ uint128_t(rhs);
         }
 
         uint128_t & operator^=(const uint128_t & rhs);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t & operator^=(const T & rhs){
-            LOWER ^= (uint64_t) rhs;
-            return *this;
+            return *this ^= uint128_t(rhs);
         }
 
         uint128_t operator~() const;
@@ -237,12 +233,12 @@ class uint128_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator&&(const T & rhs) const{
-            return static_cast <bool> (*this && rhs);
+            return *this && uint128_t(rhs);
         }
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator||(const T & rhs) const{
-            return static_cast <bool> (*this || rhs);
+            return *this || uint128_t(rhs);
         }
 
         // Comparison Operators
@@ -250,42 +246,42 @@ class uint128_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator==(const T & rhs) const{
-            return (!UPPER && (LOWER == (uint64_t) rhs));
+            return *this == uint128_t(rhs);
         }
 
         bool operator!=(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator!=(const T & rhs) const{
-            return (UPPER | (LOWER != (uint64_t) rhs));
+            return *this != uint128_t(rhs);
         }
 
         bool operator>(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator>(const T & rhs) const{
-            return (UPPER || (LOWER > (uint64_t) rhs));
+            return *this > uint128_t(rhs);
         }
 
         bool operator<(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator<(const T & rhs) const{
-            return (!UPPER)?(LOWER < (uint64_t) rhs):false;
+            return *this < uint128_t(rhs);
         }
 
         bool operator>=(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator>=(const T & rhs) const{
-            return ((*this > rhs) | (*this == rhs));
+            return *this >= uint128_t(rhs);
         }
 
         bool operator<=(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         bool operator<=(const T & rhs) const{
-            return ((*this < rhs) | (*this == rhs));
+            return *this <= uint128_t(rhs);
         }
 
         // Arithmetic Operators
@@ -293,7 +289,7 @@ class uint128_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator+(const T & rhs) const{
-            return uint128_t(UPPER + ((LOWER + (uint64_t) rhs) < LOWER), LOWER + (uint64_t) rhs);
+            return *this + uint128_t(rhs);
         }
 
         uint128_t & operator+=(const uint128_t & rhs);
@@ -307,7 +303,7 @@ class uint128_t{
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
         uint128_t operator-(const T & rhs) const{
-            return uint128_t((uint64_t) (UPPER - ((LOWER - rhs) > LOWER)), (uint64_t) (LOWER - rhs));
+            return *this - uint128_t(rhs);
         }
 
         uint128_t & operator-=(const uint128_t & rhs);
@@ -465,41 +461,32 @@ T & operator>>=(T & lhs, const uint128_t & rhs){
 // Comparison Operators
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
 bool operator==(const T & lhs, const uint128_t & rhs){
-    return (!rhs.upper() && ((uint64_t) lhs == rhs.lower()));
+    return rhs == lhs;
 }
 
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
 bool operator!=(const T & lhs, const uint128_t & rhs){
-    return (rhs.upper() | ((uint64_t) lhs != rhs.lower()));
+    return rhs != lhs;
 }
 
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
 bool operator>(const T & lhs, const uint128_t & rhs){
-    return (!rhs.upper()) && ((uint64_t) lhs > rhs.lower());
+    return rhs < lhs;
 }
 
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
 bool operator<(const T & lhs, const uint128_t & rhs){
-    if (rhs.upper()){
-        return true;
-    }
-    return ((uint64_t) lhs < rhs.lower());
+    return rhs > lhs;
 }
 
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
 bool operator>=(const T & lhs, const uint128_t & rhs){
-    if (rhs.upper()){
-        return false;
-    }
-    return ((uint64_t) lhs >= rhs.lower());
+    return rhs <= lhs;
 }
 
 template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
 bool operator<=(const T & lhs, const uint128_t & rhs){
-    if (rhs.upper()){
-        return true;
-    }
-    return ((uint64_t) lhs <= rhs.lower());
+    return rhs >= lhs;
 }
 
 // Arithmetic Operators

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -110,7 +110,7 @@ class uint128_t{
         uint128_t() = default;
         uint128_t(const uint128_t & rhs) = default;
         uint128_t(uint128_t && rhs) = default;
-        uint128_t(std::string & s);
+        uint128_t(std::string const& s);
         uint128_t(const char *s);
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -124,7 +124,11 @@ class uint128_t{
         {
             if (std::is_signed<T>::value) {
                 if (rhs < 0) {
+#ifdef ALLOW_UINT128_FROM_NEGATIVE_NUMBERS
                     UPPER = -1;
+#else
+                    throw std::invalid_argument("uint128_t initialized from negative number");
+#endif
                 }
             }
         }
@@ -137,7 +141,14 @@ class uint128_t{
 #ifdef __LITTLE_ENDIAN__
             : LOWER(lower_rhs), UPPER(upper_rhs)
 #endif
-        {}
+        {
+#ifndef ALLOW_UINT128_FROM_NEGATIVE_NUMBERS
+            if ((std::is_signed<S>::value && upper_rhs < 0) ||
+                (std::is_signed<T>::value && lower_rhs < 0)) {
+                throw std::invalid_argument("uint128_t initialized from negative number");
+            }
+#endif
+        }
 
         //  RHS input args only
 
@@ -151,7 +162,11 @@ class uint128_t{
 
             if (std::is_signed<T>::value) {
                 if (rhs < 0) {
+#ifdef ALLOW_UINT128_FROM_NEGATIVE_NUMBERS
                     UPPER = -1;
+#else
+                    throw std::invalid_argument("uint128_t assigned from negative number");
+#endif
                 }
             }
 

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -236,12 +236,12 @@ class uint128_t{
         bool operator||(const uint128_t & rhs) const;
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        bool operator&&(const T & rhs){
+        bool operator&&(const T & rhs) const{
             return static_cast <bool> (*this && rhs);
         }
 
         template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
-        bool operator||(const T & rhs){
+        bool operator||(const T & rhs) const{
             return static_cast <bool> (*this || rhs);
         }
 

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -113,7 +113,8 @@ class uint128_t{
         uint128_t(std::string const& s);
         uint128_t(const char *s);
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value &&
+                                                                 std::is_unsigned<T>::value, T>::type >
         uint128_t(const T & rhs)
 #ifdef __BIG_ENDIAN__
             : UPPER(0), LOWER(rhs)
@@ -121,19 +122,13 @@ class uint128_t{
 #ifdef __LITTLE_ENDIAN__
             : LOWER(rhs), UPPER(0)
 #endif
-        {
-            if (std::is_signed<T>::value) {
-                if (rhs < 0) {
-#ifdef ALLOW_UINT128_FROM_NEGATIVE_NUMBERS
-                    UPPER = -1;
-#else
-                    throw std::invalid_argument("uint128_t initialized from negative number");
-#endif
-                }
-            }
-        }
+        {}
 
-        template <typename S, typename T, typename = typename std::enable_if <std::is_integral<S>::value && std::is_integral<T>::value, void>::type>
+        template <typename S, typename T, typename = typename std::enable_if <std::is_integral<S>::value &&
+                                                                              std::is_integral<T>::value &&
+                                                                              std::is_unsigned<S>::value &&
+                                                                              std::is_unsigned<T>::value
+                                                                              , void>::type>
         uint128_t(const S & upper_rhs, const T & lower_rhs)
 #ifdef __BIG_ENDIAN__
             : UPPER(upper_rhs), LOWER(lower_rhs)
@@ -142,12 +137,6 @@ class uint128_t{
             : LOWER(lower_rhs), UPPER(upper_rhs)
 #endif
         {
-#ifndef ALLOW_UINT128_FROM_NEGATIVE_NUMBERS
-            if ((std::is_signed<S>::value && upper_rhs < 0) ||
-                (std::is_signed<T>::value && lower_rhs < 0)) {
-                throw std::invalid_argument("uint128_t initialized from negative number");
-            }
-#endif
         }
 
         //  RHS input args only
@@ -156,20 +145,10 @@ class uint128_t{
         uint128_t & operator=(const uint128_t & rhs) = default;
         uint128_t & operator=(uint128_t && rhs) = default;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value &&
+                                                                 std::is_unsigned<T>::value, T>::type >
         uint128_t & operator=(const T & rhs){
             UPPER = 0;
-
-            if (std::is_signed<T>::value) {
-                if (rhs < 0) {
-#ifdef ALLOW_UINT128_FROM_NEGATIVE_NUMBERS
-                    UPPER = -1;
-#else
-                    throw std::invalid_argument("uint128_t assigned from negative number");
-#endif
-                }
-            }
-
             LOWER = rhs;
             return *this;
         }
@@ -186,42 +165,42 @@ class uint128_t{
 
         void export_bits(std::vector<uint8_t> & ret) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator&(const T & rhs) const{
             return *this & uint128_t(rhs);
         }
 
         uint128_t & operator&=(const uint128_t & rhs);
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator&=(const T & rhs){
             return *this &= uint128_t(rhs);
         }
 
         uint128_t operator|(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator|(const T & rhs) const{
             return *this | uint128_t(rhs);
         }
 
         uint128_t & operator|=(const uint128_t & rhs);
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator|=(const T & rhs){
             return *this |= uint128_t(rhs);
         }
 
         uint128_t operator^(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator^(const T & rhs) const{
             return *this ^ uint128_t(rhs);
         }
 
         uint128_t & operator^=(const uint128_t & rhs);
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator^=(const T & rhs){
             return *this ^= uint128_t(rhs);
         }
@@ -231,14 +210,14 @@ class uint128_t{
         // Bit Shift Operators
         uint128_t operator<<(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator<<(const T & rhs) const{
             return *this << uint128_t(rhs);
         }
 
         uint128_t & operator<<=(const uint128_t & rhs);
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator<<=(const T & rhs){
             *this = *this << uint128_t(rhs);
             return *this;
@@ -246,14 +225,14 @@ class uint128_t{
 
         uint128_t operator>>(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator>>(const T & rhs) const{
             return *this >> uint128_t(rhs);
         }
 
         uint128_t & operator>>=(const uint128_t & rhs);
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator>>=(const T & rhs){
             *this = *this >> uint128_t(rhs);
             return *this;
@@ -264,12 +243,12 @@ class uint128_t{
         bool operator&&(const uint128_t & rhs) const;
         bool operator||(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator&&(const T & rhs) const{
             return *this && uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator||(const T & rhs) const{
             return *this || uint128_t(rhs);
         }
@@ -277,42 +256,42 @@ class uint128_t{
         // Comparison Operators
         bool operator==(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator==(const T & rhs) const{
             return *this == uint128_t(rhs);
         }
 
         bool operator!=(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator!=(const T & rhs) const{
             return *this != uint128_t(rhs);
         }
 
         bool operator>(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator>(const T & rhs) const{
             return *this > uint128_t(rhs);
         }
 
         bool operator<(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator<(const T & rhs) const{
             return *this < uint128_t(rhs);
         }
 
         bool operator>=(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator>=(const T & rhs) const{
             return *this >= uint128_t(rhs);
         }
 
         bool operator<=(const uint128_t & rhs) const;
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         bool operator<=(const T & rhs) const{
             return *this <= uint128_t(rhs);
         }
@@ -330,53 +309,53 @@ class uint128_t{
         uint128_t & operator%=(const uint128_t & rhs);
 
 #ifdef UNSAFE_UINT128_OPS
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator+(const T & rhs) const{
             return *this + uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator+=(const T & rhs){
             return *this += uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator-(const T & rhs) const{
             return *this - uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator-=(const T & rhs){
             return *this = *this - uint128_t(rhs);
         }
 
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator*(const T & rhs) const{
             return *this * uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator*=(const T & rhs){
             return *this = *this * uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator/(const T & rhs) const{
             return *this / uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator/=(const T & rhs){
             return *this = *this / uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t operator%(const T & rhs) const{
             return *this % uint128_t(rhs);
         }
 
-        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+        template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
         uint128_t & operator%=(const T & rhs){
             return *this = *this % uint128_t(rhs);
         }
@@ -425,32 +404,32 @@ UINT128_T_EXTERN extern const uint128_t uint128_1;
 // If the output is not a bool, casts to type T
 
 // Bitwise Operators
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator&(const T & lhs, const uint128_t & rhs){
     return rhs & lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator&=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (rhs & lhs);
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator|(const T & lhs, const uint128_t & rhs){
     return rhs | lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator|=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (rhs | lhs);
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator^(const T & lhs, const uint128_t & rhs){
     return rhs ^ lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator^=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (rhs ^ lhs);
 }
@@ -466,7 +445,7 @@ UINT128_T_EXTERN uint128_t operator<<(const int16_t  & lhs, const uint128_t & rh
 UINT128_T_EXTERN uint128_t operator<<(const int32_t  & lhs, const uint128_t & rhs);
 UINT128_T_EXTERN uint128_t operator<<(const int64_t  & lhs, const uint128_t & rhs);
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator<<=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (uint128_t(lhs) << rhs);
 }
@@ -481,89 +460,89 @@ UINT128_T_EXTERN uint128_t operator>>(const int16_t  & lhs, const uint128_t & rh
 UINT128_T_EXTERN uint128_t operator>>(const int32_t  & lhs, const uint128_t & rhs);
 UINT128_T_EXTERN uint128_t operator>>(const int64_t  & lhs, const uint128_t & rhs);
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator>>=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (uint128_t(lhs) >> rhs);
 }
 
 // Comparison Operators
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 bool operator==(const T & lhs, const uint128_t & rhs){
     return rhs == lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 bool operator!=(const T & lhs, const uint128_t & rhs){
     return rhs != lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 bool operator>(const T & lhs, const uint128_t & rhs){
     return rhs < lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 bool operator<(const T & lhs, const uint128_t & rhs){
     return rhs > lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 bool operator>=(const T & lhs, const uint128_t & rhs){
     return rhs <= lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 bool operator<=(const T & lhs, const uint128_t & rhs){
     return rhs >= lhs;
 }
 
 // Arithmetic Operators
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator+(const T & lhs, const uint128_t & rhs){
     return rhs + lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator+=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (rhs + lhs);
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator-(const T & lhs, const uint128_t & rhs){
     return -(rhs - lhs);
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator-=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (-(rhs - lhs));
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator*(const T & lhs, const uint128_t & rhs){
     return rhs * lhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator*=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (rhs * lhs);
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator/(const T & lhs, const uint128_t & rhs){
     return uint128_t(lhs) / rhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator/=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (uint128_t(lhs) / rhs);
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 uint128_t operator%(const T & lhs, const uint128_t & rhs){
     return uint128_t(lhs) % rhs;
 }
 
-template <typename T, typename = typename std::enable_if<std::is_integral<T>::value, T>::type >
+template <typename T, typename = typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, T>::type >
 T & operator%=(T & lhs, const uint128_t & rhs){
     return lhs = static_cast <T> (uint128_t(lhs) % rhs);
 }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -27,7 +27,7 @@
 
 namespace stellar
 {
-const int64_t TransactionQueue::FEE_MULTIPLIER = 10;
+const uint64_t TransactionQueue::FEE_MULTIPLIER = 10;
 
 TransactionQueue::TransactionQueue(Application& app, uint32 pendingDepth,
                                    uint32 banDepth, uint32 poolLedgerMultiplier)

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -717,13 +717,16 @@ TransactionQueue::maybeVersionUpgraded()
 size_t
 TransactionQueue::getMaxOpsToFloodThisPeriod() const
 {
-    size_t opsToFloodLedger;
     auto& cfg = mApp.getConfig();
-    auto const opRatePerLedger = cfg.FLOOD_OP_RATE_PER_LEDGER;
-    size_t maxOps = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
-    opsToFloodLedger = static_cast<size_t>(opRatePerLedger * maxOps);
+    double opRatePerLedger = cfg.FLOOD_OP_RATE_PER_LEDGER;
 
-    size_t opsToFlood;
+    size_t maxOps = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+    double opsToFloodLedgerDbl = opRatePerLedger * maxOps;
+    releaseAssertOrThrow(opsToFloodLedgerDbl >= 0.0);
+    releaseAssertOrThrow(isRepresentableAsInt64(opsToFloodLedgerDbl));
+    int64_t opsToFloodLedger = static_cast<int64_t>(opsToFloodLedgerDbl);
+
+    int64_t opsToFlood;
     if (mApp.getConfig().FLOOD_TX_PERIOD_MS != 0)
     {
         opsToFlood = mBroadcastOpCarryover +
@@ -736,7 +739,11 @@ TransactionQueue::getMaxOpsToFloodThisPeriod() const
         // else, flood the target at once
         opsToFlood = opsToFloodLedger;
     }
-    return opsToFlood;
+    releaseAssertOrThrow(opsToFlood >= 0);
+    releaseAssertOrThrow(
+        opsToFlood <=
+        static_cast<int64_t>(std::numeric_limits<ssize_t>::max()));
+    return static_cast<size_t>(opsToFlood);
 }
 
 bool

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -59,7 +59,7 @@ class TxQueueLimiter;
 class TransactionQueue
 {
   public:
-    static int64_t const FEE_MULTIPLIER;
+    static uint64_t const FEE_MULTIPLIER;
 
     enum class AddResult
     {

--- a/src/transactions/test/ExchangeTests.cpp
+++ b/src/transactions/test/ExchangeTests.cpp
@@ -23,40 +23,53 @@ TEST_CASE("Exchange", "[exchange]")
         REQUIRE(x.numWheatReceived == y.numWheatReceived);
         REQUIRE(x.numSheepSend == y.numSheepSend);
     };
-    auto validateV2 =
-        [&compare](int64_t wheatToReceive, Price price, int64_t maxWheatReceive,
-                   int64_t maxSheepSend, ExchangeResult const& expected,
-                   ReducedCheckV2 reducedCheck = REDUCED_CHECK_V2_STRICT) {
-            auto actualV2 = exchangeV2(wheatToReceive, price, maxWheatReceive,
-                                       maxSheepSend);
-            compare(actualV2, expected);
-            REQUIRE(uint128_t{actualV2.numWheatReceived} * uint128_t{price.n} <=
-                    uint128_t{expected.numSheepSend} * uint128_t{price.d});
-            REQUIRE(actualV2.numSheepSend <= maxSheepSend);
-            if (reducedCheck == REDUCED_CHECK_V2_RELAXED)
+    auto validateV2 = [&compare](int64_t wheatToReceive, Price price,
+                                 int64_t maxWheatReceive, int64_t maxSheepSend,
+                                 ExchangeResult const& expected,
+                                 ReducedCheckV2 reducedCheck =
+                                     REDUCED_CHECK_V2_STRICT) {
+        auto actualV2 =
+            exchangeV2(wheatToReceive, price, maxWheatReceive, maxSheepSend);
+        compare(actualV2, expected);
+        REQUIRE(actualV2.numWheatReceived >= 0);
+        REQUIRE(price.n >= 0);
+        REQUIRE(expected.numSheepSend >= 0);
+        REQUIRE(price.d >= 0);
+        REQUIRE(uint128_t{static_cast<uint64_t>(actualV2.numWheatReceived)} *
+                    uint128_t{static_cast<uint32_t>(price.n)} <=
+                uint128_t{static_cast<uint64_t>(expected.numSheepSend)} *
+                    uint128_t{static_cast<uint32_t>(price.d)});
+        REQUIRE(actualV2.numSheepSend <= maxSheepSend);
+        if (reducedCheck == REDUCED_CHECK_V2_RELAXED)
+        {
+            REQUIRE(actualV2.numWheatReceived <= wheatToReceive);
+        }
+        else
+        {
+            if (actualV2.reduced)
             {
-                REQUIRE(actualV2.numWheatReceived <= wheatToReceive);
+                REQUIRE(actualV2.numWheatReceived < wheatToReceive);
             }
             else
             {
-                if (actualV2.reduced)
-                {
-                    REQUIRE(actualV2.numWheatReceived < wheatToReceive);
-                }
-                else
-                {
-                    REQUIRE(actualV2.numWheatReceived == wheatToReceive);
-                }
+                REQUIRE(actualV2.numWheatReceived == wheatToReceive);
             }
-        };
+        }
+    };
     auto validateV3 = [&compare](int64_t wheatToReceive, Price price,
                                  int64_t maxWheatReceive, int64_t maxSheepSend,
                                  ExchangeResult const& expected) {
         auto actualV3 =
             exchangeV3(wheatToReceive, price, maxWheatReceive, maxSheepSend);
         compare(actualV3, expected);
-        REQUIRE(uint128_t{actualV3.numWheatReceived} * uint128_t{price.n} <=
-                uint128_t{expected.numSheepSend} * uint128_t{price.d});
+        REQUIRE(actualV3.numWheatReceived >= 0);
+        REQUIRE(price.n >= 0);
+        REQUIRE(expected.numSheepSend >= 0);
+        REQUIRE(price.d >= 0);
+        REQUIRE(uint128_t{static_cast<uint64_t>(actualV3.numWheatReceived)} *
+                    uint128_t{static_cast<uint32_t>(price.n)} <=
+                uint128_t{static_cast<uint64_t>(expected.numSheepSend)} *
+                    uint128_t{static_cast<uint32_t>(price.d)});
         REQUIRE(actualV3.numSheepSend <= maxSheepSend);
         if (actualV3.reduced)
         {

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -417,11 +417,13 @@ TEST_CASE("manage buy offer liabilities", "[tx][offers]")
 
             SECTION("with rounding")
             {
-                checkLiabilities("buy one for two", INT64_MAX, Price{2, 1},
-                                 bigDivide((uint128_t)INT64_MAX, 2, ROUND_DOWN),
-                                 INT64_MAX - 1);
+                checkLiabilities(
+                    "buy one for two", INT64_MAX, Price{2, 1},
+                    bigDivide(static_cast<uint64_t>(INT64_MAX), 2, ROUND_DOWN),
+                    INT64_MAX - 1);
                 checkLiabilities("buy two for five", INT64_MAX, Price{5, 2},
-                                 bigDivide(INT64_MAX, 2, 5, ROUND_DOWN),
+                                 bigDivide(static_cast<uint64_t>(INT64_MAX), 2,
+                                           5, ROUND_DOWN),
                                  INT64_MAX - 2);
             }
         }

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -32,7 +32,7 @@ bigDivide(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
     uint128_t a(A);
     uint128_t b(B);
     uint128_t c(C);
-    uint128_t x = rounding == ROUND_DOWN ? (a * b) / c : (a * b + c - 1) / c;
+    uint128_t x = rounding == ROUND_DOWN ? (a * b) / c : (a * b + c - 1u) / c;
 
     result = (uint64_t)x;
 
@@ -86,12 +86,12 @@ bigDivide(uint64_t& result, uint128_t a, uint64_t B, Rounding rounding)
     //         = UINT64_MAX + 2
     // which would have overflowed uint64_t anyway.
     uint128_t const UINT128_MAX = ~uint128_0;
-    if ((rounding == ROUND_UP) && (a > UINT128_MAX - (b - 1)))
+    if ((rounding == ROUND_UP) && (a > UINT128_MAX - (b - 1u)))
     {
         return false;
     }
 
-    uint128_t x = rounding == ROUND_DOWN ? a / b : (a + b - 1) / b;
+    uint128_t x = rounding == ROUND_DOWN ? a / b : (a + b - 1u) / b;
 
     result = (uint64_t)x;
 

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -6,6 +6,7 @@
 
 #include "lib/util/uint128_t.h"
 #include <cstdint>
+#include <limits>
 
 namespace stellar
 {
@@ -14,6 +15,30 @@ enum Rounding
     ROUND_DOWN,
     ROUND_UP
 };
+
+inline bool
+isRepresentableAsInt64(double d)
+{
+    // Subtle: the min value here is a power-of-two and is exactly representable
+    // as a double, so any double equal-or-greater can be rounded-up to an
+    // int64_t without triggering UB.
+    //
+    // The max value here is one-less-than a power-of-two, but converting it to
+    // a double will round _up_ to the next power-of-two (as doubles are spaced
+    // 1024 integers apart out there) and so the only doubles that can be safely
+    // represented as int64_t are those strictly _less_ than the resulting
+    // double.
+    //
+    // Concretely: the max int64_t is 0x7fff_ffff_ffff_ffff which rounds up to
+    // the double representing the integer 0x8000_0000_0000_0000, which is now
+    // strictly too big to fix back in int64_t; the next-lower double is the one
+    // representing the integer 1024 integers lower, at 0x7fff_ffff_ffff_fc00.
+    //
+    // The max int64_t that will round-down to that double, rather than up to
+    // the too-large one, is 0x7fff_ffff_ffff_fdff or 9,223,372,036,854,775,295.
+    return (d >= static_cast<double>(std::numeric_limits<int64_t>::min())) &&
+           (d < static_cast<double>(std::numeric_limits<int64_t>::max()));
+}
 
 // calculates A*B/C when A*B overflows 64bits
 int64_t bigDivide(int64_t A, int64_t B, int64_t C, Rounding rounding);

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -25,9 +25,15 @@ template <typename T> class BigDivideTester
     void
     test(P const& p, R const& downResult, R const& upResult)
     {
-        for (auto a : mValues)
-            for (auto b : mValues)
-                for (auto c : mValues)
+        std::vector<uint64_t> values;
+        for (auto v : mValues)
+        {
+            REQUIRE(v >= 0);
+            values.emplace_back(static_cast<uint64_t>(v));
+        }
+        for (auto a : values)
+            for (auto b : values)
+                for (auto c : values)
                     if (c != 0 && p(uint128_t{a}, uint128_t{b}, uint128_t{c}))
                         mVerify(a, b, c,
                                 static_cast<uint64_t>(downResult(
@@ -146,14 +152,16 @@ TEST_CASE("big divide", "[bigDivide]")
         unsignedTester.test(WHEN(when) DOWN_IS(down) UP_IS(up)); \
     }
 
-    TEST(a == 0, 0, 0)
-    TEST(b == 0, 0, 0)
-    TEST(a <= INT32_MAX && b <= INT32_MAX && c == 1, a * b, a * b)
-    TEST(b == 1 && c == 2, a / 2, (a + 1) / 2)
-    TEST(b == 1 && c == 3, a / 3, (a + 2) / 3)
-    TEST(a == 1 && b > 0 && b < c, 0, 1)
-    TEST(a == 1 && b == c, 1, 1)
-    TEST(a == c && b > 0, b, b);
+    TEST(a == 0u, 0u, 0u)
+    TEST(b == 0u, 0u, 0u)
+    TEST(a <= static_cast<uint32_t>(INT32_MAX) &&
+             b <= static_cast<uint32_t>(INT32_MAX) && c == 1u,
+         a * b, a * b)
+    TEST(b == 1u && c == 2u, a / 2u, (a + 1u) / 2u)
+    TEST(b == 1u && c == 3u, a / 3u, (a + 2u) / 3u)
+    TEST(a == 1u && b > 0u && b < c, 0u, 1u)
+    TEST(a == 1u && b == c, 1u, 1u)
+    TEST(a == c && b > 0u, b, b);
 
     SECTION("upper limits")
     {
@@ -210,21 +218,22 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
             INT64_MAX};
         for (auto value : signedValues)
         {
-            uint128_t value128(value);
+            REQUIRE(value >= 0);
+            uint128_t value128(static_cast<uint64_t>(value));
 
             verifySignedValue(value128, 1, ROUND_UP, value);
             verifySignedValue(value128, 1, ROUND_DOWN, value);
 
             if (value != 0)
             {
-                verifySignedValue(value128 + 1, value, ROUND_UP, 2);
-                verifySignedValue(value128 + 1, value, ROUND_DOWN,
+                verifySignedValue(value128 + 1u, value, ROUND_UP, 2);
+                verifySignedValue(value128 + 1u, value, ROUND_DOWN,
                                   (value == 1) ? 2 : 1);
                 verifySignedValue(value128, value, ROUND_UP, 1);
                 verifySignedValue(value128, value, ROUND_DOWN, 1);
-                verifySignedValue(value128 - 1, value, ROUND_UP,
+                verifySignedValue(value128 - 1u, value, ROUND_UP,
                                   (value == 1) ? 0 : 1);
-                verifySignedValue(value128 - 1, value, ROUND_DOWN, 0);
+                verifySignedValue(value128 - 1u, value, ROUND_DOWN, 0);
 
                 if (value > 1)
                 {
@@ -269,14 +278,14 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
 
             if (value != 0)
             {
-                verifyUnsignedValue(value128 + 1, value, ROUND_UP, 2);
-                verifyUnsignedValue(value128 + 1, value, ROUND_DOWN,
-                                    (value == 1) ? 2 : 1);
+                verifyUnsignedValue(value128 + 1u, value, ROUND_UP, 2);
+                verifyUnsignedValue(value128 + 1u, value, ROUND_DOWN,
+                                    (value == 1u) ? 2 : 1);
                 verifyUnsignedValue(value128, value, ROUND_UP, 1);
                 verifyUnsignedValue(value128, value, ROUND_DOWN, 1);
-                verifyUnsignedValue(value128 - 1, value, ROUND_UP,
+                verifyUnsignedValue(value128 - 1u, value, ROUND_UP,
                                     (value == 1) ? 0 : 1);
-                verifyUnsignedValue(value128 - 1, value, ROUND_DOWN, 0);
+                verifyUnsignedValue(value128 - 1u, value, ROUND_DOWN, 0);
 
                 if (value > 1)
                 {
@@ -309,18 +318,18 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
     SECTION("overflow threshold")
     {
         uint128_t const twiceSignedMax = bigMultiply(INT64_MAX, 2);
-        verifySigned(twiceSignedMax + 2, 2, ROUND_UP);
-        verifySigned(twiceSignedMax + 2, 2, ROUND_DOWN);
-        verifySigned(twiceSignedMax + 1, 2, ROUND_UP);
-        verifySignedValue(twiceSignedMax + 1, 2, ROUND_DOWN, INT64_MAX);
+        verifySigned(twiceSignedMax + 2u, 2, ROUND_UP);
+        verifySigned(twiceSignedMax + 2u, 2, ROUND_DOWN);
+        verifySigned(twiceSignedMax + 1u, 2, ROUND_UP);
+        verifySignedValue(twiceSignedMax + 1u, 2, ROUND_DOWN, INT64_MAX);
         verifySignedValue(twiceSignedMax, 2, ROUND_UP, INT64_MAX);
         verifySignedValue(twiceSignedMax, 2, ROUND_DOWN, INT64_MAX);
 
         uint128_t const twiceUnsignedMax = bigMultiply(UINT64_MAX, 2);
-        verifyUnsigned(twiceUnsignedMax + 2, 2, ROUND_UP);
-        verifyUnsigned(twiceUnsignedMax + 2, 2, ROUND_DOWN);
-        verifyUnsigned(twiceUnsignedMax + 1, 2, ROUND_UP);
-        verifyUnsignedValue(twiceUnsignedMax + 1, 2, ROUND_DOWN, UINT64_MAX);
+        verifyUnsigned(twiceUnsignedMax + 2u, 2, ROUND_UP);
+        verifyUnsigned(twiceUnsignedMax + 2u, 2, ROUND_DOWN);
+        verifyUnsigned(twiceUnsignedMax + 1u, 2, ROUND_UP);
+        verifyUnsignedValue(twiceUnsignedMax + 1u, 2, ROUND_DOWN, UINT64_MAX);
         verifyUnsignedValue(twiceUnsignedMax, 2, ROUND_UP, UINT64_MAX);
         verifyUnsignedValue(twiceUnsignedMax, 2, ROUND_DOWN, UINT64_MAX);
     }
@@ -329,15 +338,15 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
     {
         uint128_t const unsignedLimit = bigMultiply(UINT64_MAX, UINT64_MAX);
         uint128_t const UINT128_MAX(UINT64_MAX, UINT64_MAX);
-        REQUIRE(UINT128_MAX + 1 == 0);
+        REQUIRE(UINT128_MAX + 1u == 0u);
 
         verifyUnsigned(UINT128_MAX, UINT64_MAX, ROUND_UP);
         verifyUnsigned(UINT128_MAX, UINT64_MAX, ROUND_DOWN);
         verifyUnsigned(unsignedLimit + UINT64_MAX, UINT64_MAX, ROUND_DOWN);
-        verifyUnsignedValue(unsignedLimit + UINT64_MAX - 1, UINT64_MAX,
+        verifyUnsignedValue(unsignedLimit + UINT64_MAX - 1u, UINT64_MAX,
                             ROUND_DOWN, UINT64_MAX);
-        verifyUnsigned(unsignedLimit + 1, UINT64_MAX, ROUND_UP);
-        verifyUnsignedValue(unsignedLimit + 1, UINT64_MAX, ROUND_DOWN,
+        verifyUnsigned(unsignedLimit + 1u, UINT64_MAX, ROUND_UP);
+        verifyUnsignedValue(unsignedLimit + 1u, UINT64_MAX, ROUND_DOWN,
                             UINT64_MAX);
         verifyUnsignedValue(unsignedLimit, UINT64_MAX, ROUND_UP, UINT64_MAX);
         verifyUnsignedValue(unsignedLimit, UINT64_MAX, ROUND_DOWN, UINT64_MAX);
@@ -345,17 +354,20 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
         uint128_t const signedLimit = bigMultiply(INT64_MAX, INT64_MAX);
         verifySigned(UINT128_MAX, INT64_MAX, ROUND_UP);
         verifySigned(UINT128_MAX, INT64_MAX, ROUND_DOWN);
-        verifySigned(signedLimit + INT64_MAX, INT64_MAX, ROUND_DOWN);
-        verifySignedValue(signedLimit + INT64_MAX - 1, INT64_MAX, ROUND_DOWN,
-                          INT64_MAX);
-        verifySigned(signedLimit + 1, INT64_MAX, ROUND_UP);
-        verifySignedValue(signedLimit + 1, INT64_MAX, ROUND_DOWN, INT64_MAX);
+        verifySigned(signedLimit + static_cast<uint64_t>(INT64_MAX), INT64_MAX,
+                     ROUND_DOWN);
+        verifySignedValue(signedLimit + static_cast<uint64_t>(INT64_MAX) - 1u,
+                          INT64_MAX, ROUND_DOWN, INT64_MAX);
+        verifySigned(signedLimit + 1u, INT64_MAX, ROUND_UP);
+        verifySignedValue(signedLimit + 1u, INT64_MAX, ROUND_DOWN, INT64_MAX);
         verifySignedValue(signedLimit, INT64_MAX, ROUND_UP, INT64_MAX);
         verifySignedValue(signedLimit, INT64_MAX, ROUND_DOWN, INT64_MAX);
 
         verifyUnsigned(UINT128_MAX - UINT64_MAX, UINT64_MAX, ROUND_UP);
         verifyUnsigned(UINT128_MAX - UINT64_MAX, UINT64_MAX, ROUND_DOWN);
-        verifySigned(UINT128_MAX - INT64_MAX, INT64_MAX, ROUND_UP);
-        verifySigned(UINT128_MAX - INT64_MAX, INT64_MAX, ROUND_DOWN);
+        verifySigned(UINT128_MAX - static_cast<uint64_t>(INT64_MAX), INT64_MAX,
+                     ROUND_UP);
+        verifySigned(UINT128_MAX - static_cast<uint64_t>(INT64_MAX), INT64_MAX,
+                     ROUND_DOWN);
     }
 }

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -89,3 +89,86 @@ TEST_CASE("uint128_t", "[uint128]")
 }
 
 #endif
+
+TEST_CASE("uint128_t carry tests with positive arg")
+{
+    SECTION("subtraction")
+    {
+        SECTION("carry lower")
+        {
+            uint128_t x(0, 100);
+            x -= 1;
+            REQUIRE(x.lower() == 99);
+            REQUIRE(x.upper() == 0);
+        }
+        SECTION("carry upper")
+        {
+            uint128_t x(2, 0);
+            x -= 1;
+            REQUIRE(x.lower() == UINT64_MAX);
+            REQUIRE(x.upper() == 1);
+        }
+    }
+    SECTION("addition")
+    {
+        SECTION("carry lower")
+        {
+            uint128_t x(0, 100);
+            x += 1;
+            REQUIRE(x.lower() == 101);
+            REQUIRE(x.upper() == 0);
+        }
+        SECTION("carry upper")
+        {
+            uint128_t x(1, UINT64_MAX);
+            x += 1;
+            REQUIRE(x.lower() == 0);
+            REQUIRE(x.upper() == 2);
+        }
+    }
+}
+
+TEST_CASE("uint128_t carry tests with negative arg")
+{
+    SECTION("addition")
+    {
+        SECTION("bad carry lower")
+        {
+            uint128_t x(0, 100);
+            x += -1;
+            REQUIRE(x.lower() == 99);
+            REQUIRE(x.upper() == 0);
+        }
+        SECTION("bad carry upper")
+        {
+            uint128_t x(2, 0);
+            x += -1;
+            REQUIRE(x.lower() == UINT64_MAX);
+            REQUIRE(x.upper() == 1);
+        }
+    }
+    SECTION("subtraction")
+    {
+        SECTION("bad carry lower")
+        {
+            uint128_t x(0, 100);
+            x -= -1;
+            REQUIRE(x.lower() == 101);
+            REQUIRE(x.upper() == 0);
+        }
+        SECTION("bad carry upper")
+        {
+            uint128_t x(1, UINT64_MAX);
+            x -= -1;
+            REQUIRE(x.lower() == 0);
+            REQUIRE(x.upper() == 2);
+        }
+    }
+}
+
+TEST_CASE("uint128_t general negative tests")
+{
+    uint128_t x(0);
+    REQUIRE_THROWS_AS(x = uint128_t(-1, 0), std::invalid_argument);
+    REQUIRE_THROWS_AS(x = uint128_t(0, -1), std::invalid_argument);
+}

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -96,15 +96,15 @@ TEST_CASE("uint128_t carry tests with positive arg")
     {
         SECTION("carry lower")
         {
-            uint128_t x(0, 100);
-            x -= 1;
+            uint128_t x(0u, 100u);
+            x -= 1u;
             REQUIRE(x.lower() == 99);
             REQUIRE(x.upper() == 0);
         }
         SECTION("carry upper")
         {
-            uint128_t x(2, 0);
-            x -= 1;
+            uint128_t x(2u, 0u);
+            x -= 1u;
             REQUIRE(x.lower() == UINT64_MAX);
             REQUIRE(x.upper() == 1);
         }
@@ -113,54 +113,17 @@ TEST_CASE("uint128_t carry tests with positive arg")
     {
         SECTION("carry lower")
         {
-            uint128_t x(0, 100);
-            x += 1;
+            uint128_t x(0u, 100u);
+            x += 1u;
             REQUIRE(x.lower() == 101);
             REQUIRE(x.upper() == 0);
         }
         SECTION("carry upper")
         {
-            uint128_t x(1, UINT64_MAX);
-            x += 1;
+            uint128_t x(1u, UINT64_MAX);
+            x += 1u;
             REQUIRE(x.lower() == 0);
             REQUIRE(x.upper() == 2);
         }
     }
-}
-
-TEST_CASE("uint128_t carry tests with negative arg")
-{
-    SECTION("addition")
-    {
-        SECTION("bad carry lower")
-        {
-            uint128_t x(0, 100);
-            REQUIRE_THROWS_AS(x += -1, std::invalid_argument);
-        }
-        SECTION("bad carry upper")
-        {
-            uint128_t x(2, 0);
-            REQUIRE_THROWS_AS(x += -1, std::invalid_argument);
-        }
-    }
-    SECTION("subtraction")
-    {
-        SECTION("bad carry lower")
-        {
-            uint128_t x(0, 100);
-            REQUIRE_THROWS_AS(x -= -1, std::invalid_argument);
-        }
-        SECTION("bad carry upper")
-        {
-            uint128_t x(1, UINT64_MAX);
-            REQUIRE_THROWS_AS(x -= -1, std::invalid_argument);
-        }
-    }
-}
-
-TEST_CASE("uint128_t general negative tests")
-{
-    uint128_t x(0);
-    REQUIRE_THROWS_AS(x = uint128_t(-1, 0), std::invalid_argument);
-    REQUIRE_THROWS_AS(x = uint128_t(0, -1), std::invalid_argument);
 }

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -135,16 +135,12 @@ TEST_CASE("uint128_t carry tests with negative arg")
         SECTION("bad carry lower")
         {
             uint128_t x(0, 100);
-            x += -1;
-            REQUIRE(x.lower() == 99);
-            REQUIRE(x.upper() == 0);
+            REQUIRE_THROWS_AS(x += -1, std::invalid_argument);
         }
         SECTION("bad carry upper")
         {
             uint128_t x(2, 0);
-            x += -1;
-            REQUIRE(x.lower() == UINT64_MAX);
-            REQUIRE(x.upper() == 1);
+            REQUIRE_THROWS_AS(x += -1, std::invalid_argument);
         }
     }
     SECTION("subtraction")
@@ -152,16 +148,12 @@ TEST_CASE("uint128_t carry tests with negative arg")
         SECTION("bad carry lower")
         {
             uint128_t x(0, 100);
-            x -= -1;
-            REQUIRE(x.lower() == 101);
-            REQUIRE(x.upper() == 0);
+            REQUIRE_THROWS_AS(x -= -1, std::invalid_argument);
         }
         SECTION("bad carry upper")
         {
             uint128_t x(1, UINT64_MAX);
-            x -= -1;
-            REQUIRE(x.lower() == 0);
-            REQUIRE(x.upper() == 2);
+            REQUIRE_THROWS_AS(x -= -1, std::invalid_argument);
         }
     }
 }

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -22,7 +22,7 @@ const uint64_t full = std::numeric_limits<uint64_t>::max();
 uint128_t
 fromNative(unsigned __int128 x)
 {
-    return uint128_t(x >> 64, x & full);
+    return uint128_t(uint64_t(x >> 64), uint64_t(x & full));
 }
 
 unsigned __int128

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -4,6 +4,7 @@
 
 #include "util/types.h"
 #include "lib/util/uint128_t.h"
+#include "util/GlobalChecks.h"
 #include "util/XDROperators.h"
 #include <fmt/format.h>
 
@@ -268,20 +269,28 @@ iequals(std::string const& a, std::string const& b)
 bool
 operator>=(Price const& a, Price const& b)
 {
-    uint128_t l(a.n);
-    uint128_t r(a.d);
-    l *= b.d;
-    r *= b.n;
+    releaseAssertOrThrow(a.n >= 0);
+    releaseAssertOrThrow(a.d >= 0);
+    releaseAssertOrThrow(b.n >= 0);
+    releaseAssertOrThrow(b.d >= 0);
+    uint128_t l(static_cast<uint32_t>(a.n));
+    uint128_t r(static_cast<uint32_t>(a.d));
+    l *= static_cast<uint32_t>(b.d);
+    r *= static_cast<uint32_t>(b.n);
     return l >= r;
 }
 
 bool
 operator>(Price const& a, Price const& b)
 {
-    uint128_t l(a.n);
-    uint128_t r(a.d);
-    l *= b.d;
-    r *= b.n;
+    releaseAssertOrThrow(a.n >= 0);
+    releaseAssertOrThrow(a.d >= 0);
+    releaseAssertOrThrow(b.n >= 0);
+    releaseAssertOrThrow(b.d >= 0);
+    uint128_t l(static_cast<uint32_t>(a.n));
+    uint128_t r(static_cast<uint32_t>(a.d));
+    l *= static_cast<uint32_t>(b.d);
+    r *= static_cast<uint32_t>(b.n);
     return l > r;
 }
 


### PR DESCRIPTION
This updates uint128_t from upstream primarily to incorporate a bit more-reasonable code to deal with cases where a uint128_t is initialized from a negative number. Previously it would initialize to a (perhaps surprising!) UINT64_MAX -- that is, sign-extending only to the width of the lower of its two fields -- whereas the probably-more-sensible thing to do is sign extend across both fields.

For even-more-safety sake, I've also made the entire behaviour of sign-extending when given a negative signed input throw by default, as it's very likely an error: nothing in core does so currently, and we _should_ already have checks on all paths converting from signed types that we're dealing with non-negative inputs. This just firms it up a bit.
