### PR TITLE
remove extra survey routes

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -90,10 +90,8 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
         addRoute("quorum", &CommandHandler::quorum);
         addRoute("scp", &CommandHandler::scpInfo);
         addRoute("stopsurvey", &CommandHandler::stopSurvey);
-#ifndef BUILD_TESTS
         addRoute("getsurveyresult", &CommandHandler::getSurveyResult);
         addRoute("surveytopology", &CommandHandler::surveyTopology);
-#endif
         addRoute("unban", &CommandHandler::unban);
     }
 
@@ -110,8 +108,6 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
     addRoute("generateload", &CommandHandler::generateLoad);
     addRoute("testacc", &CommandHandler::testAcc);
     addRoute("testtx", &CommandHandler::testTx);
-    addRoute("getsurveyresult", &CommandHandler::getSurveyResult);
-    addRoute("surveytopology", &CommandHandler::surveyTopology);
 #endif
 }
 


### PR DESCRIPTION
those were added by accident in 20acb825832fdc2114d238211ac1833ab91d7557

fixes a minor issue: test enabled builds had survey related endpoints always enabled