### PR TITLE
Stop using `xdr::xdr_to_string` and `xdr_printer` everywhere

### DIFF
--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -12,10 +12,10 @@
 #include "invariant/InvariantDoesNotHold.h"
 #include "ledger/CheckpointRange.h"
 #include "ledger/LedgerManager.h"
-#include "lib/xdrpp/xdrpp/printer.h"
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
 #include "util/FileSystemException.h"
+#include "util/XDRCereal.h"
 #include <Tracy.hpp>
 #include <fmt/format.h>
 #include <medida/meter.h>
@@ -259,11 +259,10 @@ ApplyCheckpointWork::onRun()
 
                 CLOG(DEBUG, "History")
                     << "LedgerManager LCL:\n"
-                    << xdr::xdr_to_string(lm.getLastClosedLedgerHeader());
+                    << xdr_to_string(lm.getLastClosedLedgerHeader());
 
-                CLOG(DEBUG, "History")
-                    << "Replay header:\n"
-                    << xdr::xdr_to_string(mHeaderHistoryEntry);
+                CLOG(DEBUG, "History") << "Replay header:\n"
+                                       << xdr_to_string(mHeaderHistoryEntry);
                 if (lm.getLastClosedLedgerHeader().hash !=
                     mHeaderHistoryEntry.hash)
                 {

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -17,7 +17,7 @@
 #include "transactions/TransactionBridge.h"
 #include "transactions/TransactionSQL.h"
 #include "transactions/TransactionUtils.h"
-#include "xdrpp/printer.h"
+#include "util/XDRCereal.h"
 #include <fmt/format.h>
 
 namespace stellar
@@ -68,8 +68,8 @@ checkOperationResults(xdr::xvector<OperationResult> const& expected,
         {
             CLOG(ERROR, "History")
                 << fmt::format("Expected operation result {} but got {}",
-                               xdr::xdr_to_string(expected[i].code()),
-                               xdr::xdr_to_string(actual[i].code()));
+                               xdr_to_string(expected[i].code()),
+                               xdr_to_string(actual[i].code()));
             continue;
         }
 
@@ -155,11 +155,10 @@ checkOperationResults(xdr::xvector<OperationResult> const& expected,
 
         if (!match)
         {
-            CLOG(ERROR, "History")
-                << fmt::format("Expected operation result: {}",
-                               xdr::xdr_to_string(expectedOpRes));
             CLOG(ERROR, "History") << fmt::format(
-                "Actual operation result: {}", xdr::xdr_to_string(actualOpRes));
+                "Expected operation result: {}", xdr_to_string(expectedOpRes));
+            CLOG(ERROR, "History") << fmt::format("Actual operation result: {}",
+                                                  xdr_to_string(actualOpRes));
         }
     }
 }
@@ -182,8 +181,7 @@ checkResults(Application& app, uint32_t ledger,
         {
             CLOG(ERROR, "History") << fmt::format(
                 "Expected result code {} does not agree with {} for tx {}",
-                xdr::xdr_to_string(archiveRes.code()),
-                xdr::xdr_to_string(dbRes.code()),
+                xdr_to_string(archiveRes.code()), xdr_to_string(dbRes.code()),
                 binToHex(results[i].transactionHash));
         }
         else if (dbRes.code() == txFEE_BUMP_INNER_FAILED ||
@@ -196,10 +194,9 @@ checkResults(Application& app, uint32_t ledger,
                 CLOG(ERROR, "History") << fmt::format(
                     "Expected result code {} does not agree with {} for "
                     "fee-bump inner tx {}",
-                    xdr::xdr_to_string(
+                    xdr_to_string(
                         archiveRes.innerResultPair().result.result.code()),
-                    xdr::xdr_to_string(
-                        dbRes.innerResultPair().result.result.code()),
+                    xdr_to_string(dbRes.innerResultPair().result.result.code()),
                     binToHex(archiveRes.innerResultPair().transactionHash));
             }
             else if (dbRes.innerResultPair().result.result.code() == txFAILED ||

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -17,14 +17,13 @@
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/XDRCereal.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include <Tracy.hpp>
 #include <algorithm>
 #include <list>
 #include <numeric>
-
-#include "xdrpp/printer.h"
 
 namespace stellar
 {
@@ -319,7 +318,7 @@ TxSetFrame::checkOrTrim(Application& app,
                     CLOG(DEBUG, "Herder")
                         << "Got bad txSet: " << hexAbbrev(mPreviousLedgerHash)
                         << " tx invalid lastSeq:" << lastSeq
-                        << " tx: " << xdr::xdr_to_string(tx->getEnvelope())
+                        << " tx: " << xdr_to_string(tx->getEnvelope())
                         << " result: " << tx->getResultCode();
                     return false;
                 }
@@ -360,7 +359,7 @@ TxSetFrame::checkOrTrim(Application& app,
                     CLOG(DEBUG, "Herder")
                         << "Got bad txSet: " << hexAbbrev(mPreviousLedgerHash)
                         << " account can't pay fee tx: "
-                        << xdr::xdr_to_string(tx->getEnvelope());
+                        << xdr_to_string(tx->getEnvelope());
                     return false;
                 }
                 while (iter != kv.second.end())

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -11,7 +11,7 @@
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "main/Application.h"
-#include "xdrpp/printer.h"
+#include "util/XDRCereal.h"
 #include <fmt/format.h>
 
 namespace stellar
@@ -25,7 +25,7 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
     {
         std::string s{
             "Inconsistent state between objects (not found in database): "};
-        s += xdr::xdr_to_string(entry, "live");
+        s += xdr_to_string(entry, "live");
         return s;
     }
 
@@ -36,8 +36,8 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
     else
     {
         std::string s{"Inconsistent state between objects: "};
-        s += xdr::xdr_to_string(fromDb.current(), "db");
-        s += xdr::xdr_to_string(entry, "live");
+        s += xdr_to_string(fromDb.current(), "db");
+        s += xdr_to_string(entry, "live");
         return s;
     }
 }
@@ -52,7 +52,7 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerKey const& key)
     }
 
     std::string s = "Entry with type DEADENTRY found in database ";
-    s += xdr::xdr_to_string(fromDb.current(), "db");
+    s += xdr_to_string(fromDb.current(), "db");
     return s;
 }
 
@@ -93,8 +93,8 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
             if (hasPreviousEntry && !BucketEntryIdCmp{}(previousEntry, e))
             {
                 std::string s = "Bucket has out of order entries: ";
-                s += xdr::xdr_to_string(previousEntry, "previous");
-                s += xdr::xdr_to_string(e, "current");
+                s += xdr_to_string(previousEntry, "previous");
+                s += xdr_to_string(e, "current");
                 return s;
             }
             previousEntry = e;
@@ -108,7 +108,7 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
                                          " bound for this bucket ({} < {}): ",
                                          e.liveEntry().lastModifiedLedgerSeq,
                                          oldestLedger);
-                    s += xdr::xdr_to_string(e.liveEntry(), "live");
+                    s += xdr_to_string(e.liveEntry(), "live");
                     return s;
                 }
                 if (e.liveEntry().lastModifiedLedgerSeq > newestLedger)
@@ -117,7 +117,7 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
                                          " bound for this bucket ({} > {}): ",
                                          e.liveEntry().lastModifiedLedgerSeq,
                                          newestLedger);
-                    s += xdr::xdr_to_string(e.liveEntry(), "live");
+                    s += xdr_to_string(e.liveEntry(), "live");
                     return s;
                 }
 

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -13,7 +13,7 @@
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
 #include "util/Logging.h"
-#include "xdrpp/printer.h"
+#include "util/XDRCereal.h"
 #include <fmt/format.h>
 
 #include "medida/counter.h"
@@ -117,7 +117,7 @@ InvariantManagerImpl::checkOnOperationApply(Operation const& operation,
 
         auto message = fmt::format(
             R"(Invariant "{}" does not hold on operation: {}{}{})",
-            invariant->getName(), result, "\n", xdr::xdr_to_string(operation));
+            invariant->getName(), result, "\n", xdr_to_string(operation));
         onInvariantFailure(invariant, message,
                            ltxDelta.header.current.ledgerSeq);
     }

--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -9,6 +9,7 @@
 #include "main/Application.h"
 #include "transactions/OfferExchange.h"
 #include "transactions/TransactionUtils.h"
+#include "util/XDRCereal.h"
 #include "util/types.h"
 #include "xdrpp/printer.h"
 #include <fmt/format.h>
@@ -99,7 +100,7 @@ checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
                 {
                     return fmt::format(
                         "Liabilities increased on unauthorized trust line {}",
-                        xdr::xdr_to_string(trust));
+                        xdr_to_string(trust));
                 }
             }
             else
@@ -109,7 +110,7 @@ checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
                 {
                     return fmt::format(
                         "Unauthorized trust line has liabilities {}",
-                        xdr::xdr_to_string(trust));
+                        xdr_to_string(trust));
                 }
             }
         }
@@ -258,7 +259,7 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
             {
                 return fmt::format(
                     "Balance not compatible with liabilities for account {}",
-                    xdr::xdr_to_string(account));
+                    xdr_to_string(account));
             }
         }
     }
@@ -276,7 +277,7 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
         {
             return fmt::format(
                 "Balance not compatible with liabilities for trustline {}",
-                xdr::xdr_to_string(trust));
+                xdr_to_string(trust));
         }
     }
     return {};
@@ -349,8 +350,8 @@ LiabilitiesMatchOffers::checkOnOperationApply(Operation const& operation,
                         "change in total buying liabilities of "
                         "offers by {} for account {} in asset {}",
                         assetLiabilities.second.buying,
-                        xdr::xdr_to_string(accLiabilities.first),
-                        xdr::xdr_to_string(assetLiabilities.first));
+                        xdr_to_string(accLiabilities.first),
+                        xdr_to_string(assetLiabilities.first));
                 }
                 else if (assetLiabilities.second.selling != 0)
                 {
@@ -359,8 +360,8 @@ LiabilitiesMatchOffers::checkOnOperationApply(Operation const& operation,
                         "change in total selling liabilities of "
                         "offers by {} for account {} in asset {}",
                         assetLiabilities.second.selling,
-                        xdr::xdr_to_string(accLiabilities.first),
-                        xdr::xdr_to_string(assetLiabilities.first));
+                        xdr_to_string(accLiabilities.first),
+                        xdr_to_string(assetLiabilities.first));
                 }
             }
         }

--- a/src/ledger/GeneralizedLedgerEntry.cpp
+++ b/src/ledger/GeneralizedLedgerEntry.cpp
@@ -3,7 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "ledger/GeneralizedLedgerEntry.h"
-#include "util/XDROperators.h"
+#include "util/XDRCereal.h"
 #include "util/types.h"
 #include "xdrpp/printer.h"
 
@@ -288,10 +288,10 @@ GeneralizedLedgerKey::toString() const
         return xdr::xdr_to_string(ledgerKey());
     case GeneralizedLedgerEntryType::SPONSORSHIP:
         return fmt::format("{{\n  sponsoredID = {}\n}}\n",
-                           xdr_printer(sponsorshipKey().sponsoredID));
+                           xdr_to_string(sponsorshipKey().sponsoredID));
     case GeneralizedLedgerEntryType::SPONSORSHIP_COUNTER:
         return fmt::format("{{\n  sponsoringID = {}\n}}\n",
-                           xdr_printer(sponsorshipCounterKey().sponsoringID));
+                           xdr_to_string(sponsorshipCounterKey().sponsoringID));
     default:
         abort();
     }
@@ -568,12 +568,12 @@ GeneralizedLedgerEntry::toString() const
         return xdr::xdr_to_string(ledgerEntry());
     case GeneralizedLedgerEntryType::SPONSORSHIP:
         return fmt::format("{{\n  sponsoredID = {},\n  sponsoringID = {}\n}}\n",
-                           xdr_printer(sponsorshipEntry().sponsoredID),
-                           xdr_printer(sponsorshipEntry().sponsoringID));
+                           xdr_to_string(sponsorshipEntry().sponsoredID),
+                           xdr_to_string(sponsorshipEntry().sponsoringID));
     case GeneralizedLedgerEntryType::SPONSORSHIP_COUNTER:
         return fmt::format(
             "{{\n  sponsoringID = {},\n  numSponsoring = {}\n}}\n",
-            xdr_printer(sponsorshipCounterEntry().sponsoringID),
+            xdr_to_string(sponsorshipCounterEntry().sponsoringID),
             sponsorshipCounterEntry().numSponsoring);
     default:
         abort();

--- a/src/ledger/GeneralizedLedgerEntry.cpp
+++ b/src/ledger/GeneralizedLedgerEntry.cpp
@@ -5,7 +5,6 @@
 #include "ledger/GeneralizedLedgerEntry.h"
 #include "util/XDRCereal.h"
 #include "util/types.h"
-#include "xdrpp/printer.h"
 
 #include <fmt/format.h>
 
@@ -285,7 +284,7 @@ GeneralizedLedgerKey::toString() const
     switch (mType)
     {
     case GeneralizedLedgerEntryType::LEDGER_ENTRY:
-        return xdr::xdr_to_string(ledgerKey());
+        return xdr_to_string(ledgerKey());
     case GeneralizedLedgerEntryType::SPONSORSHIP:
         return fmt::format("{{\n  sponsoredID = {}\n}}\n",
                            xdr_to_string(sponsorshipKey().sponsoredID));
@@ -565,7 +564,7 @@ GeneralizedLedgerEntry::toString() const
     switch (mType)
     {
     case GeneralizedLedgerEntryType::LEDGER_ENTRY:
-        return xdr::xdr_to_string(ledgerEntry());
+        return xdr_to_string(ledgerEntry());
     case GeneralizedLedgerEntryType::SPONSORSHIP:
         return fmt::format("{{\n  sponsoredID = {},\n  sponsoringID = {}\n}}\n",
                            xdr_to_string(sponsorshipEntry().sponsoredID),

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -31,6 +31,7 @@
 #include "util/GlobalChecks.h"
 #include "util/LogSlowExecution.h"
 #include "util/Logging.h"
+#include "util/XDRCereal.h"
 #include "util/XDROperators.h"
 #include <fmt/format.h>
 
@@ -566,7 +567,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             << ", LCL is " << ledgerAbbrev(getLastClosedLedgerHeader());
 
         CLOG(ERROR, "Ledger")
-            << "Full LCL: " << xdr::xdr_to_string(getLastClosedLedgerHeader());
+            << "Full LCL: " << xdr_to_string(getLastClosedLedgerHeader());
         CLOG(ERROR, "Ledger") << POSSIBLY_CORRUPTED_LOCAL_DATA;
 
         throw std::runtime_error("txset mismatch");
@@ -634,7 +635,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         case Upgrades::UpgradeValidity::INVALID:
             throw std::runtime_error(
                 fmt::format(FMT_STRING("Invalid upgrade at index {}: {}"), i,
-                            xdr::xdr_to_string(lupgrade)));
+                            xdr_to_string(lupgrade)));
         }
 
         try

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -26,9 +26,9 @@
 
 #include "medida/reporting/json_reporter.h"
 #include "util/Decoder.h"
+#include "util/XDRCereal.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
-#include "xdrpp/printer.h"
 
 #include "ExternalQueue.h"
 
@@ -944,8 +944,7 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
             break;
         case TransactionQueue::AddResult::ADD_STATUS_ERROR:
             root["status"] = "error";
-            root["detail"] =
-                xdr::xdr_to_string(txFrame->getResult().result.code());
+            root["detail"] = xdr_to_string(txFrame->getResult().result.code());
             break;
         case TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER:
             root["status"] = "try_again_later";

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -157,10 +157,7 @@ printOneXdr(xdr::opaque_vec<> const& o, std::string const& desc, bool compact)
 {
     T tmp;
     xdr::xdr_from_opaque(o, tmp);
-    cereal::JSONOutputArchive ar(
-        std::cout, compact ? cereal::JSONOutputArchive::Options::NoIndent()
-                           : cereal::JSONOutputArchive::Options::Default());
-    ar(tmp);
+    std::cout << xdr_to_string(tmp, desc, compact) << std::endl;
 }
 
 void

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -42,29 +42,6 @@ using namespace std::placeholders;
 namespace stellar
 {
 
-std::string
-xdr_printer(PublicKey const& pk)
-{
-    return KeyUtils::toStrKey<PublicKey>(pk);
-}
-
-std::string
-xdr_printer(MuxedAccount const& muxedAccount)
-{
-    switch (muxedAccount.type())
-    {
-    case KEY_TYPE_ED25519:
-        return KeyUtils::toStrKey(toAccountID(muxedAccount));
-    case KEY_TYPE_MUXED_ED25519:
-        return fmt::format("{{ id = {}, accountID = {} }}",
-                           muxedAccount.med25519().id,
-                           KeyUtils::toStrKey(toAccountID(muxedAccount)));
-    default:
-        // this would be a bug
-        abort();
-    }
-}
-
 template <typename T>
 void
 dumpstream(XDRInputFileStream& in, bool compact)

--- a/src/overlay/StellarXDR.h
+++ b/src/overlay/StellarXDR.h
@@ -4,10 +4,3 @@
 #include "xdr/Stellar-overlay.h"
 #include "xdr/Stellar-transaction.h"
 #include "xdr/Stellar-types.h"
-
-namespace stellar
-{
-
-std::string xdr_printer(PublicKey const& pk);
-std::string xdr_printer(MuxedAccount const& ma);
-}

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -15,13 +15,13 @@
 #include "util/Logging.h"
 #include "util/Math.h"
 #include "util/Timer.h"
+#include "util/XDRCereal.h"
 #include "util/numeric.h"
 #include "util/types.h"
 
 #include "database/Database.h"
 
 #include "xdrpp/marshal.h"
-#include "xdrpp/printer.h"
 
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
@@ -652,8 +652,8 @@ LoadGenerator::TxInfo::execute(Application& app, bool isCreate,
     {
         CLOG(INFO, "LoadGen")
             << "tx rejected '" << TX_STATUS_STRING[static_cast<int>(status)]
-            << "': " << xdr::xdr_to_string(txf->getEnvelope()) << " ===> "
-            << xdr::xdr_to_string(txf->getResult());
+            << "': " << xdr_to_string(txf->getEnvelope()) << " ===> "
+            << xdr_to_string(txf->getResult());
         if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {
             code = txf->getResultCode();

--- a/src/test/TestPrinter.cpp
+++ b/src/test/TestPrinter.cpp
@@ -5,6 +5,7 @@
 #include "test/TestPrinter.h"
 #include "catchup/CatchupRange.h"
 #include "test/TestMarket.h"
+#include "util/XDRCereal.h"
 #include <fmt/format.h>
 
 namespace Catch
@@ -14,8 +15,8 @@ StringMaker<stellar::OfferState>::convert(stellar::OfferState const& os)
 {
     return fmt::format(
         "selling: {}, buying: {}, price: {}, amount: {}, type: {}",
-        xdr::xdr_to_string(os.selling), xdr::xdr_to_string(os.buying),
-        xdr::xdr_to_string(os.price), os.amount,
+        xdr_to_string(os.selling), xdr_to_string(os.buying),
+        xdr_to_string(os.price), os.amount,
         os.type == stellar::OfferType::PASSIVE ? "passive" : "active");
 }
 

--- a/src/test/TestPrinter.h
+++ b/src/test/TestPrinter.h
@@ -7,7 +7,7 @@
 #include "catchup/CatchupWork.h"
 #include "history/test/HistoryTestsUtils.h"
 #include "lib/catch.hpp"
-#include "xdrpp/printer.h"
+#include "util/XDRCereal.h"
 #include "xdrpp/types.h"
 
 namespace stellar
@@ -23,7 +23,7 @@ struct StringMaker<T, typename std::enable_if<xdr::xdr_traits<T>::valid>::type>
     static std::string
     convert(T const& val)
     {
-        return xdr::xdr_to_string(val);
+        return xdr_to_string(val);
     }
 };
 

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -25,8 +25,8 @@
 #include "transactions/TransactionUtils.h"
 #include "transactions/UpdateSponsorshipOpFrame.h"
 #include "util/Logging.h"
+#include "util/XDRCereal.h"
 #include <Tracy.hpp>
-#include <xdrpp/printer.h>
 
 namespace stellar
 {
@@ -117,7 +117,7 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
     bool res;
     if (Logging::logTrace("Tx"))
     {
-        CLOG(TRACE, "Tx") << "Operation: " << xdr::xdr_to_string(mOperation);
+        CLOG(TRACE, "Tx") << "Operation: " << xdr_to_string(mOperation);
     }
     res = checkValid(signatureChecker, ltx, true);
     if (res)
@@ -125,8 +125,7 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
         res = doApply(ltx);
         if (Logging::logTrace("Tx"))
         {
-            CLOG(TRACE, "Tx")
-                << "Operation result: " << xdr::xdr_to_string(mResult);
+            CLOG(TRACE, "Tx") << "Operation result: " << xdr_to_string(mResult);
         }
     }
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -820,14 +820,13 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
     catch (std::exception& e)
     {
         CLOG(ERROR, "Tx") << "Exception while applying operations (txHash= "
-                          << xdr::xdr_to_string(getFullHash())
-                          << "): " << e.what();
+                          << xdr_to_string(getFullHash()) << "): " << e.what();
     }
     catch (...)
     {
         CLOG(ERROR, "Tx")
             << "Unknown exception while applying operations (txHash= "
-            << xdr::xdr_to_string(getFullHash()) << ")";
+            << xdr_to_string(getFullHash()) << ")";
     }
 
     // This is only reachable if an exception is thrown

--- a/src/util/XDRCereal.cpp
+++ b/src/util/XDRCereal.cpp
@@ -1,0 +1,44 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/XDRCereal.h"
+
+void
+cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
+                const char* field)
+{
+    xdr::archive(ar, stellar::KeyUtils::toStrKey<stellar::PublicKey>(s), field);
+}
+
+void
+cereal_override(cereal::JSONOutputArchive& ar,
+                const stellar::MuxedAccount& muxedAccount, const char* field)
+{
+    switch (muxedAccount.type())
+    {
+    case stellar::KEY_TYPE_ED25519:
+        xdr::archive(ar, stellar::KeyUtils::toStrKey(toAccountID(muxedAccount)),
+                     field);
+        return;
+    case stellar::KEY_TYPE_MUXED_ED25519:
+        xdr::archive(
+            ar,
+            std::make_tuple(
+                cereal::make_nvp("id", muxedAccount.med25519().id),
+                cereal::make_nvp("accountID", stellar::KeyUtils::toStrKey(
+                                                  toAccountID(muxedAccount)))),
+            field);
+        return;
+    default:
+        // this would be a bug
+        abort();
+    }
+}
+
+void
+cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
+                const char* field)
+{
+    xdr::archive(ar, stellar::assetToString(s), field);
+}

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -51,43 +51,16 @@ cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_vec<N>& s,
     xdr::archive(ar, stellar::binToHex(stellar::ByteSlice(s.data(), s.size())),
                  field);
 }
-void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
-                const char* field)
-{
-    xdr::archive(ar, stellar::KeyUtils::toStrKey<stellar::PublicKey>(s), field);
-}
 
-void
-cereal_override(cereal::JSONOutputArchive& ar,
-                const stellar::MuxedAccount& muxedAccount, const char* field)
-{
-    switch (muxedAccount.type())
-    {
-    case stellar::KEY_TYPE_ED25519:
-        xdr::archive(ar, stellar::KeyUtils::toStrKey(toAccountID(muxedAccount)),
-                     field);
-        return;
-    case stellar::KEY_TYPE_MUXED_ED25519:
-        xdr::archive(
-            ar,
-            std::make_tuple(
-                cereal::make_nvp("id", muxedAccount.med25519().id),
-                cereal::make_nvp("accountID", stellar::KeyUtils::toStrKey(
-                                                  toAccountID(muxedAccount)))),
-            field);
-        return;
-    default:
-        // this would be a bug
-        abort();
-    }
-}
-void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
-                const char* field)
-{
-    xdr::archive(ar, stellar::assetToString(s), field);
-}
+void cereal_override(cereal::JSONOutputArchive& ar, const stellar::PublicKey& s,
+                     const char* field);
+
+void cereal_override(cereal::JSONOutputArchive& ar,
+                     const stellar::MuxedAccount& muxedAccount,
+                     const char* field);
+
+void cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
+                     const char* field);
 
 template <typename T>
 typename std::enable_if<xdr::xdr_traits<T>::is_enum>::type

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -1,3 +1,7 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
 #pragma once
 
 #ifdef _XDRPP_CEREAL_H_HEADER_INCLUDED_

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -95,3 +95,29 @@ cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
 // otherwise some interplay of name lookup and visibility
 // during the enable_if call in the cereal adaptor fails to find them.
 #include <xdrpp/cereal.h>
+
+// If name is a nonempty string, the output string begins with it.
+// If compact = true, the output string will not contain any indentation.
+template <typename T>
+std::string
+xdr_to_string(const T& t, std::string const& name = "", bool compact = false)
+{
+    std::stringstream os;
+
+    // Archives are designed to be used in an RAII manner and are guaranteed to
+    // flush their contents only on destruction.
+    {
+        cereal::JSONOutputArchive ar(
+            os, compact ? cereal::JSONOutputArchive::Options::NoIndent()
+                        : cereal::JSONOutputArchive::Options::Default());
+        if (!name.empty())
+        {
+            ar(cereal::make_nvp(name, t));
+        }
+        else
+        {
+            ar(t);
+        }
+    }
+    return os.str();
+}


### PR DESCRIPTION
# Description

Resolves Part (b) of https://github.com/stellar/stellar-core/issues/2681.

Replace all the occurrences of `xdr::xdr_to_string` and `xdr_printer` with a printing function that uses Cereal for more readable output strings. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
