### PR TITLE
Fix flaky liabilities test

### DIFF
--- a/src/invariant/test/LiabilitiesMatchOffersTests.cpp
+++ b/src/invariant/test/LiabilitiesMatchOffersTests.cpp
@@ -284,7 +284,11 @@ TEST_CASE("Create account then increase liabilities without changing balance",
     auto offer = generateOffer(native, cur1, 100, Price{1, 1});
     auto selling =
         generateSellingLiabilities(*app, offer, true, AUTHORIZED_FLAG);
-    ++selling.data.account().balance;
+
+    // we want to set the balance to the absolute minimum balance required.
+    selling.data.account().balance =
+        getMinBalance(*app, selling.data.account()) + offer.data.offer().amount;
+
     auto buying =
         generateBuyingLiabilities(*app, offer, false, AUTHORIZED_FLAG);
     std::vector<LedgerEntry> entries{offer, selling, buying};


### PR DESCRIPTION
# Description

Resolves #2730 

This test made the assumption that `generateSellingLiabilities` with `excess == true` would return an account with `balance == minBalance - 1`. This assumption is not guaranteed, and is more likely to fail due to the introduction of sponsorships.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
