### PR TITLE
 Give a sensible default value for operations error code

### DIFF
--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -73,7 +73,8 @@ void validateTxResults(TransactionFramePtr const& tx, Application& app,
 
 TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,
-              std::vector<TransactionFrameBasePtr> const& txs = {});
+              std::vector<TransactionFrameBasePtr> const& txs = {},
+              bool skipValid = false);
 
 SecretKey getRoot(Hash const& networkID);
 

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -106,6 +106,7 @@ OperationFrame::OperationFrame(Operation const& op, OperationResult& res,
                                TransactionFrame& parentTx)
     : mOperation(op), mParentTx(parentTx), mResult(res)
 {
+    resetResultSuccess();
 }
 
 bool
@@ -229,8 +230,7 @@ OperationFrame::checkValid(SignatureChecker& signatureChecker,
         }
     }
 
-    mResult.code(opINNER);
-    mResult.tr().type(mOperation.body.type());
+    resetResultSuccess();
 
     return doCheckValid(ledgerVersion);
 }
@@ -241,6 +241,13 @@ OperationFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
 {
     ZoneScoped;
     return mParentTx.loadAccount(ltx, header, getSourceID());
+}
+
+void
+OperationFrame::resetResultSuccess()
+{
+    mResult.code(opINNER);
+    mResult.tr().type(mOperation.body.type());
 }
 
 void

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -51,6 +51,10 @@ class OperationFrame
     LedgerTxnEntry loadSourceAccount(AbstractLedgerTxn& ltx,
                                      LedgerTxnHeader const& header);
 
+    // given an operation, gives a default value representing "success" for the
+    // result
+    void resetResultSuccess();
+
   public:
     static std::shared_ptr<OperationFrame>
     makeHelper(Operation const& op, OperationResult& res,

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -408,7 +408,7 @@ TEST_CASE("txenvelope", "[tx][envelope]")
         {
             std::string name;
             bool autoRemove;
-            std::function<SignerKey(TransactionFrame const&)> createSigner;
+            std::function<SignerKey(TransactionFrame&)> createSigner;
             std::function<void(TransactionFrame&)> sign;
         };
 
@@ -419,17 +419,17 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                                       0,   0,   'G', 'H', 'I', 'J', 'K', 'L'};
         auto alternatives = std::vector<AltSignature>{
             AltSignature{"hash tx", true,
-                         [](TransactionFrame const& tx) {
+                         [](TransactionFrame& tx) {
+                             tx.clearCached();
                              return SignerKeyUtils::preAuthTxKey(tx);
                          },
                          [](TransactionFrame&) {}},
-            AltSignature{"hash x", false,
-                         [x](TransactionFrame const&) {
-                             return SignerKeyUtils::hashXKey(x);
-                         },
-                         [x](TransactionFrame& tx) {
-                             tx.addSignature(SignatureUtils::signHashX(x));
-                         }}};
+            AltSignature{
+                "hash x", false,
+                [x](TransactionFrame&) { return SignerKeyUtils::hashXKey(x); },
+                [x](TransactionFrame& tx) {
+                    tx.addSignature(SignatureUtils::signHashX(x));
+                }}};
 
         for (auto const& alternative : alternatives)
         {
@@ -990,10 +990,10 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             tx = a1.tx({root.op(payment(a1, 100))});
                             getSignatures(tx).clear();
 
+                            setSeqNum(tx, tx->getSeqNum() + 1);
                             // add signer twice.
                             tx->addSignature(s1);
                             tx->addSignature(s1);
-                            setSeqNum(tx, tx->getSeqNum() + 1);
                             a1.setSequenceNumber(a1.getLastSequenceNumber() -
                                                  1);
 
@@ -1143,8 +1143,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                         auto setup = [&]() {
                             tx = a1.tx({payment(root, 1000)});
                             getSignatures(tx).clear();
-                            tx->addSignature(s1);
                             setSeqNum(tx, tx->getSeqNum() + 1);
+                            tx->addSignature(s1);
                             a1.setSequenceNumber(a1.getLastSequenceNumber() -
                                                  1);
 
@@ -1268,8 +1268,9 @@ TEST_CASE("txenvelope", "[tx][envelope]")
             for_versions_from(3, *app, [&] {
                 auto tx = a1.tx({payment(root, 1000)});
                 getSignatures(tx).clear();
-                tx->addSignature(s1);
+
                 setSeqNum(tx, tx->getSeqNum() + 1);
+                tx->addSignature(s1);
                 a1.setSequenceNumber(a1.getLastSequenceNumber() - 1);
 
                 SignerKey sk = SignerKeyUtils::hashXKey(x);
@@ -1568,6 +1569,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             {payment(a1.getPublicKey(), paymentAmount)});
                         setMinTime(txFrame, 1000);
                         setMaxTime(txFrame, start + 300000);
+                        getSignatures(txFrame).clear();
+                        txFrame->addSignature(root);
 
                         closeLedgerOn(*app, 3, 2, 7, 2014);
                         applyCheck(txFrame, *app);
@@ -1606,6 +1609,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                                 TimePoint const lowerBound,
                                 bool const expectSuccess) {
                                 setMinTime(txFrame, minTime);
+                                getSignatures(txFrame).clear();
+                                txFrame->addSignature(root);
                                 {
                                     LedgerTxn ltx(app->getLedgerTxnRoot());
                                     REQUIRE(txFrame->checkValid(
@@ -1660,6 +1665,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             {payment(a1.getPublicKey(), paymentAmount)});
 
                         setMinTime(txFrame, 1000);
+                        getSignatures(txFrame).clear();
+                        txFrame->addSignature(root);
 
                         closeLedgerOn(*app, 3, 3, 7, 2014);
 
@@ -1682,6 +1689,8 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             SECTION("success")
                             {
                                 setMaxTime(txFrame, upperBoundCloseTime);
+                                getSignatures(txFrame).clear();
+                                txFrame->addSignature(root);
 
                                 {
                                     LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -1933,32 +1942,76 @@ TEST_CASE("txenvelope", "[tx][envelope]")
             });
         }
 
-        SECTION("remove signer, do something")
+        SECTION("reduce auth, do something")
         {
-            a.setOptions(setSigner(makeSigner(b, 1)) | setMasterWeight(1) |
-                         setLowThreshold(2) | setMedThreshold(2) |
-                         setHighThreshold(2));
+            a.setOptions(setSigner(makeSigner(b, 2)) | setMasterWeight(3) |
+                         setLowThreshold(1) | setMedThreshold(3) |
+                         setHighThreshold(5));
 
-            for_versions({1, 2, 3, 4, 5, 6, 8, 9}, *app, [&] {
-                auto tx = a.tx({setOptions(setSigner(makeSigner(b, 0))),
-                                setOptions(setHomeDomain("stellar.org"))});
-                tx->addSignature(b);
+            SECTION("single tx")
+            {
+                SECTION("valid")
+                {
+                    for_versions({1, 2, 3, 4, 5, 6, 8, 9}, *app, [&] {
+                        auto tx =
+                            a.tx({setOptions(setSigner(makeSigner(b, 1))),
+                                  setOptions(setSigner(makeSigner(b, 2)))});
+                        tx->addSignature(b);
 
-                validateTxResults(
-                    tx, *app, {baseFee * 2, txSUCCESS},
-                    expectedResult(baseFee * 2, 2, txFAILED,
-                                   {SET_OPTIONS_SUCCESS, opBAD_AUTH}));
-            });
-            for_versions_from({7, 10}, *app, [&] {
-                auto tx = a.tx({setOptions(setSigner(makeSigner(b, 0))),
-                                setOptions(setHomeDomain("stellar.org"))});
-                tx->addSignature(b);
+                        validateTxResults(
+                            tx, *app, {baseFee * 2, txSUCCESS},
+                            expectedResult(baseFee * 2, 2, txFAILED,
+                                           {SET_OPTIONS_SUCCESS, opBAD_AUTH}));
+                    });
+                    for_versions_from({7, 10}, *app, [&] {
+                        auto tx =
+                            a.tx({setOptions(setSigner(makeSigner(b, 1))),
+                                  setOptions(setSigner(makeSigner(b, 2)))});
+                        tx->addSignature(b);
 
-                validateTxResults(
-                    tx, *app, {baseFee * 2, txSUCCESS},
-                    expectedResult(baseFee * 2, 2, txSUCCESS,
-                                   {SET_OPTIONS_SUCCESS, SET_OPTIONS_SUCCESS}));
-            });
+                        validateTxResults(
+                            tx, *app, {baseFee * 2, txSUCCESS},
+                            expectedResult(
+                                baseFee * 2, 2, txSUCCESS,
+                                {SET_OPTIONS_SUCCESS, SET_OPTIONS_SUCCESS}));
+                    });
+                }
+                SECTION("missing signature")
+                {
+                    for_versions_from(10, *app, [&] {
+                        auto tx =
+                            a.tx({payment(root, 1000),
+                                  setOptions(setSigner(makeSigner(b, 2)))});
+                        // missing b signature
+                        applyCheck(tx, *app);
+                        REQUIRE(tx->getResultCode() == txFAILED);
+                        REQUIRE(PaymentOpFrame::getInnerCode(
+                                    getFirstResult(*tx)) == PAYMENT_SUCCESS);
+                        REQUIRE(tx->getOperations()[1]->getResultCode() ==
+                                opBAD_AUTH);
+                    });
+                }
+            }
+            SECTION("multiple tx")
+            {
+                for_versions_from(10, *app, [&] {
+                    auto tx1 = a.tx({setOptions(setSigner(makeSigner(b, 1)))});
+                    tx1->addSignature(b);
+                    auto tx2 = a.tx({payment(root, 1000),
+                                     setOptions(setSigner(makeSigner(b, 2)))});
+                    tx2->addSignature(b);
+
+                    auto r =
+                        closeLedgerOn(*app, 2, 1, 2, 2016, {tx1, tx2}, true);
+
+                    REQUIRE(tx1->getResultCode() == txSUCCESS);
+                    REQUIRE(tx2->getResultCode() == txFAILED);
+                    REQUIRE(PaymentOpFrame::getInnerCode(
+                                getFirstResult(*tx2)) == PAYMENT_SUCCESS);
+                    REQUIRE(tx2->getOperations()[1]->getResultCode() ==
+                            opBAD_AUTH);
+                });
+            }
         }
 
         SECTION("add signer, increase thresholds, do something")


### PR DESCRIPTION
This PR fixes an edge case in how we apply transactions when replaying from history, that can cause nodes to fail catching up to the  latest ledger with a "hash mismatch" error.

The fix ensures that invoking `TransactionFrame::apply` yields the same error code on failure regardless of calling `TransactionFrame::checkValid` before (we don't call `checkValid` when replaying from history as we rely on hashes).
