### PR TITLE
Explicitly select RNG type for gRandomEngine

### DIFF
--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -155,7 +155,7 @@ SecretKey::random()
 
 #ifdef BUILD_TESTS
 static SecretKey
-pseudoRandomForTestingFromPRNG(std::default_random_engine& engine)
+pseudoRandomForTestingFromPRNG(stellar_default_random_engine& engine)
 {
     std::vector<uint8_t> bytes;
     for (size_t i = 0; i < crypto_sign_SEEDBYTES; ++i)
@@ -180,7 +180,7 @@ SecretKey::pseudoRandomForTestingFromSeed(unsigned int seed)
     // Reminder: this is not cryptographic randomness or even particularly hard
     // to guess PRNG-ness. It's intended for _deterministic_ use, when you want
     // "slightly random-ish" keys, for test-data generation.
-    std::default_random_engine tmpEngine(seed);
+    stellar_default_random_engine tmpEngine(seed);
     return pseudoRandomForTestingFromPRNG(tmpEngine);
 }
 #endif

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -127,7 +127,7 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction, DropMode)
 }
 
 static bool
-damageMessage(default_random_engine& gen, xdr::msg_ptr& msg)
+damageMessage(stellar_default_random_engine& gen, xdr::msg_ptr& msg)
 {
     size_t bitsFlipped = 0;
     char* d = msg->raw_data();

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -14,7 +14,7 @@
 namespace stellar
 {
 
-std::default_random_engine gRandomEngine;
+stellar_default_random_engine gRandomEngine;
 std::uniform_real_distribution<double> uniformFractionDistribution(0.0, 1.0);
 
 double

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -19,7 +19,9 @@ double closest_cluster(double p, std::set<double> const& centers);
 
 bool rand_flip();
 
-extern std::default_random_engine gRandomEngine;
+typedef std::minstd_rand stellar_default_random_engine;
+
+extern stellar_default_random_engine gRandomEngine;
 
 template <typename T>
 T


### PR DESCRIPTION
# Description
 
Resolves #2736

One of a series of sources of unit test non-determinism (in some cases within a single build, in other cases only across builds against different libraries -- this bug is one of the latter kind) that @sisuresh and I discovered is that `std::default_random_engine` is not defined to the same RNG by all C++ libraries.  In particular, the one that Siddharth was using `typedef`s it to `std::minstd_rand`, whereas mine uses `std::minstd_rand0`.

The fix that I am proposing here makes our `stellar::gRandomEngine` explicitly into a `std::minstd_rand`, rather than being whatever `std::default_random_device` turns out to be.

Note that even given this fix and the fix for issue #2663 , we still have non-determinism across different libraries from other sources:  the two I know of are #2739 and #2741 .

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
