### PR TITLE
Add stale content hash detector for TransactionFrame

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -66,6 +66,12 @@ TransactionFrame::getFullHash() const
 Hash const&
 TransactionFrame::getContentsHash() const
 {
+#ifdef _DEBUG
+    // force recompute
+    Hash oldHash;
+    std::swap(mContentsHash, oldHash);
+#endif
+
     if (isZero(mContentsHash))
     {
         if (mEnvelope.type() == ENVELOPE_TYPE_TX_V0)
@@ -79,6 +85,9 @@ TransactionFrame::getContentsHash() const
                 mNetworkID, ENVELOPE_TYPE_TX, mEnvelope.v1().tx));
         }
     }
+#ifdef _DEBUG
+    assert(isZero(oldHash) || (oldHash == mContentsHash));
+#endif
     return (mContentsHash);
 }
 


### PR DESCRIPTION
Allows to systematically catch illegal use of `TransactionFrame`.

In prod code we (should) never modify envelopes, but in test it's a common pattern that can produce bad tests, sequences such as:

1. create a tx
2. sign tx
3. modify tx (like change the sequence number is a typical one)
4. check tx's validity -- this step uses the stale hash from step 2, and signatures are considered valid (which is incorrect)

I enabled this under `_DEBUG`
*  it's a typical macro that people use to enable "code that may be a lot slower",  but maybe we could use a (safer?) macro name that allows for more granular activation. It's "friend" `NDEBUG` is typically *not* set and not setting it typically has minimal performance implications (but still causes `assert` to crash the app).
* we can also enable it with "extrachecks" so that checked builds have this safeguard enabled as well.
