### PR TITLE
Use "/dev/stdin" as a special name for `stdin` in command line arguments

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -8,7 +8,7 @@ stellar-core can be controlled via the following commands.
 ## Common options
 Common options can be placed at any place in the command line.
 
-* **--conf <FILE-NAME>**: Specify a config file to use. You can use '-' and
+* **--conf <FILE-NAME>**: Specify a config file to use. You can use '/dev/stdin' and
   provide the config file via STDIN. *default 'stellar-core.cfg'*
 * **--ll <LEVEL>**: Set the log level. It is redundant with `http-command ll`
   but we need this form if you want to change the log level during test runs.

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -84,7 +84,7 @@ Command options can only by placed after command.
   envelope stored in binary format in <FILE-NAME>, and send the result to
   standard output (which should be redirected to a file or piped through a tool
   such as `base64`).  The private signing key is read from standard input,
-  unless <FILE-NAME> is "-" in which case the transaction envelope is read from
+  unless <FILE-NAME> is "/dev/stdin" in which case the transaction envelope is read from
   standard input and the signing key is read from `/dev/tty`.  In either event,
   if the signing key appears to be coming from a terminal, stellar-core
   disables echo. Note that if you do not have a STELLAR_NETWORK_ID environment

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -58,7 +58,7 @@ Command options can only by placed after command.
 * **offline-info**: Returns an output similar to `--c info` for an offline
   instance
 * **print-xdr <FILE-NAME>**:  Pretty-print a binary file containing an XDR
-  object. If FILE-NAME is "-", the XDR object is read from standard input.<br>
+  object. If FILE-NAME is "/dev/stdin", the XDR object is read from standard input.<br>
   Option **--filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**
   controls type used for printing (default: auto).<br>
   Option **--base64** alters the behavior to work on base64-encoded XDR rather than

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -254,8 +254,9 @@ configurationParser(CommandLine::ConfigOption& configOption)
     return logLevelParser(configOption.mLogLevel) |
            metricsParser(configOption.mMetrics) |
            clara::Opt{configOption.mConfigFile, "FILE-NAME"}["--conf"](
-               "specify a config file ('-' for STDIN, "
-               "default 'stellar-core.cfg')");
+               fmt::format("specify a config file ('{0}' for STDIN, default "
+                           "'stellar-core.cfg')",
+                           Config::STDIN_SPECIAL_NAME));
 }
 
 clara::Opt

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -537,7 +537,7 @@ Config::parseDomainsQuality(std::shared_ptr<cpptoml::base> domainsQuality)
 void
 Config::load(std::string const& filename)
 {
-    if (filename != "-" && !fs::exists(filename))
+    if (filename != Config::STDIN_SPECIAL_NAME && !fs::exists(filename))
     {
         std::string s;
         s = "No config file ";
@@ -548,7 +548,7 @@ Config::load(std::string const& filename)
     LOG(DEBUG) << "Loading config from: " << filename;
     try
     {
-        if (filename == "-")
+        if (filename == Config::STDIN_SPECIAL_NAME)
         {
             load(std::cin);
         }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1565,4 +1565,6 @@ Config::toString(SCPQuorumSet const& qset)
     Json::StyledWriter fw;
     return fw.write(json);
 }
+
+std::string const Config::STDIN_SPECIAL_NAME = "/dev/stdin";
 }

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -413,5 +413,9 @@ class Config : public std::enable_shared_from_this<Config>
 
     // function to stringify a quorum set
     std::string toString(SCPQuorumSet const& qset);
+
+    // A special name to be used for stdin in stead of a file name in command
+    // line arguments.
+    static std::string const STDIN_SPECIAL_NAME;
 };
 }

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -2,6 +2,7 @@
 #include "crypto/Hex.h"
 #include "crypto/SecretKey.h"
 #include "crypto/StrKey.h"
+#include "main/Config.h"
 #include "transactions/SignatureUtils.h"
 #include "transactions/TransactionBridge.h"
 #include "transactions/TransactionUtils.h"
@@ -363,7 +364,8 @@ signtxn(std::string const& filename, std::string netId, bool base64)
             throw std::runtime_error("missing --netid argument or "
                                      "STELLAR_NETWORK_ID environment variable");
 
-        const bool txn_stdin = filename == "-" || filename.empty();
+        const bool txn_stdin =
+            filename == Config::STDIN_SPECIAL_NAME || filename.empty();
 
         if (!base64 && isatty(1))
             throw std::runtime_error(

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -132,7 +132,7 @@ readFile(const std::string& filename, bool base64 = false)
 {
     using namespace std;
     ostringstream input;
-    if (filename == "-" || filename.empty())
+    if (filename == Config::STDIN_SPECIAL_NAME || filename.empty())
         input << cin.rdbuf();
     else
     {


### PR DESCRIPTION
# Description

When "/dev/stdin" is given as a special name instead of a file name, the program reads stdin instead of a file.

Resolves https://github.com/stellar/stellar-core/issues/2560

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
