### PR TITLE
reduce the number of historical SCP messages we ask from peers

### DIFF
--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -13,4 +13,5 @@ std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 // how many ledgers can close ahead given CONSENSUS_STUCK_TIMEOUT_SECONDS
 uint32 const Herder::LEDGER_VALIDITY_BRACKET = 100;
 std::chrono::nanoseconds const Herder::TIMERS_THRESHOLD_NANOSEC(5000000);
+uint32 const Herder::SCP_EXTRA_LOOKBACK_LEDGERS = 3u;
 }

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -121,6 +121,9 @@ class Herder
     // and local state
     virtual uint32_t getCurrentLedgerSeq() const = 0;
 
+    // return the smallest ledger number we need messages for when asking peers
+    virtual uint32 getMinLedgerSeqToAskPeers() const = 0;
+
     // Return the maximum sequence number for any tx (or 0 if none) from a given
     // sender in the pending or recent tx sets.
     virtual SequenceNumber getMaxSeqInPendingTxs(AccountID const&) = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -58,6 +58,10 @@ class Herder
 
     static std::unique_ptr<Herder> create(Application& app);
 
+    // number of additional ledgers we retrieve from peers before our own lcl,
+    // this is to help recover potential missing SCP messages for other nodes
+    static uint32 const SCP_EXTRA_LOOKBACK_LEDGERS;
+
     enum State
     {
         HERDER_SYNCING_STATE,

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -471,7 +471,7 @@ HerderImpl::checkCloseTime(SCPEnvelope const& envelope, bool enforceRecent)
 }
 
 uint32_t
-HerderImpl::getMinLedgerSeqToRemember()
+HerderImpl::getMinLedgerSeqToRemember() const
 {
     auto maxSlotsToRemember = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
     auto currSlot = getCurrentLedgerSeq();
@@ -913,6 +913,10 @@ HerderImpl::getMinLedgerSeqToAskPeers() const
     {
         low = LedgerManager::GENESIS_LEDGER_SEQ;
     }
+
+    // do not ask for slots we'd be dropping anyways
+    auto herderLow = getMinLedgerSeqToRemember();
+    low = std::max<uint32>(low, herderLow);
 
     return low;
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -37,6 +37,7 @@
 #include "xdrpp/marshal.h"
 #include <Tracy.hpp>
 
+#include <algorithm>
 #include <ctime>
 #include <fmt/format.h>
 
@@ -900,7 +901,10 @@ HerderImpl::getMinLedgerSeqToAskPeers() const
     // we ask for messages older than lcl in case they have SCP
     // messages needed by other peers
     auto low = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
-    auto maxSlots = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
+
+    auto maxSlots = std::min<uint32>(mApp.getConfig().MAX_SLOTS_TO_REMEMBER,
+                                     SCP_EXTRA_LOOKBACK_LEDGERS);
+
     if (low > maxSlots)
     {
         low -= maxSlots;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -80,6 +80,7 @@ class HerderImpl : public Herder
     void processSCPQueue();
 
     uint32_t getCurrentLedgerSeq() const override;
+    uint32 getMinLedgerSeqToAskPeers() const override;
 
     SequenceNumber getMaxSeqInPendingTxs(AccountID const&) override;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -240,6 +240,6 @@ class HerderImpl : public Herder
     };
     QuorumMapIntersectionState mLastQuorumMapIntersectionState;
 
-    uint32_t getMinLedgerSeqToRemember();
+    uint32_t getMinLedgerSeqToRemember() const;
 };
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -444,6 +444,7 @@ OverlayManagerImpl::resolvePeers(std::vector<string> const& peers)
 {
     ZoneScoped;
     std::vector<PeerBareAddress> addresses;
+    addresses.reserve(peers.size());
     for (auto const& peer : peers)
     {
         try
@@ -860,7 +861,9 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
 std::vector<Peer::pointer>
 OverlayManagerImpl::getRandomAuthenticatedPeers()
 {
-    auto result = std::vector<Peer::pointer>{};
+    std::vector<Peer::pointer> result;
+    result.reserve(mInboundPeers.mAuthenticated.size() +
+                   mOutboundPeers.mAuthenticated.size());
     extractPeersFromMap(mInboundPeers.mAuthenticated, result);
     extractPeersFromMap(mOutboundPeers.mAuthenticated, result);
     shufflePeerList(result);
@@ -870,7 +873,8 @@ OverlayManagerImpl::getRandomAuthenticatedPeers()
 std::vector<Peer::pointer>
 OverlayManagerImpl::getRandomInboundAuthenticatedPeers()
 {
-    auto result = std::vector<Peer::pointer>{};
+    std::vector<Peer::pointer> result;
+    result.reserve(mInboundPeers.mAuthenticated.size());
     extractPeersFromMap(mInboundPeers.mAuthenticated, result);
     shufflePeerList(result);
     return result;
@@ -879,7 +883,8 @@ OverlayManagerImpl::getRandomInboundAuthenticatedPeers()
 std::vector<Peer::pointer>
 OverlayManagerImpl::getRandomOutboundAuthenticatedPeers()
 {
-    auto result = std::vector<Peer::pointer>{};
+    std::vector<Peer::pointer> result;
+    result.reserve(mOutboundPeers.mAuthenticated.size());
     extractPeersFromMap(mOutboundPeers.mAuthenticated, result);
     shufflePeerList(result);
     return result;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1216,20 +1216,7 @@ Peer::recvAuth(StellarMessage const& msg)
         return;
     }
 
-    // ask for SCP state if not synced
-    // this requests data for slots lcl-window ... latest consensus (if
-    // possible) we need to ask for older slots in case other peers need
-    // messages we didn't need ourself
-    auto low = mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
-    auto maxSlots = mApp.getConfig().MAX_SLOTS_TO_REMEMBER;
-    if (low > maxSlots)
-    {
-        low -= maxSlots;
-    }
-    else
-    {
-        low = 1;
-    }
+    auto low = mApp.getHerder().getMinLedgerSeqToAskPeers();
     sendGetScpState(low);
 }
 


### PR DESCRIPTION
This PR changes how many historical SCP messages (that a node doesn't directly need) get fetched from new peers.

Before this change, we would ask `MAX_SLOTS_TO_REMEMBER` older slots which can be arbitrary large, instead:
* we only ask for a few ledgers before lcl. basic assumptions here are that
   * either the local node has been in sync for a while, and as it receives SCP messages to externalize (so the extra data is unlikely to help).
   * or the local node is behind/was restarted recently
       * in that case other nodes that need those messages are likely connected to other peers that have not been restarted recently or are in sync (so the extra data again doesn't help them).
       * we're left with an edge case where many nodes get restarted in a short period of time, and for this we just need to have a reasonable estimate of how far behind those nodes are behind the quorum.
* we also avoid asking for data for ledgers that are too old
   * the old code made no effort to avoid asking for data that is clearly out of bound. This is mitigated by the smaller window, but I've added an extra guard in there. Note: we can probably still ask for out of bound messages as there is an inherent race where we can potentially close ledgers faster than the roundtrip lag to retrieve historical data from peers, but at least this should reduce the noise.
