### PR TITLE
Update maxCommit for possible quorum intersection check performance improvements 

### DIFF
--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -182,7 +182,7 @@ MinQuorumEnumerator::pickSplitNode() const
 size_t
 MinQuorumEnumerator::maxCommit() const
 {
-    return (mScanSCC.count() / 2) + 1;
+    return mScanSCC.count() / 2;
 }
 
 MinQuorumEnumerator::MinQuorumEnumerator(

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -172,7 +172,7 @@
 // ======================================================
 //
 // The first early exit is easy: just stop expanding when you get half-way
-// through the space (or precisely: at sets larger than MAXSZ = (#N/2) + 1)
+// through the space (or precisely: at sets larger than MAXSZ = #N/2)
 // because the problem is symmetric: any potential failing subset C with size
 // greater than MAXSZ discovered in the branching subtree ahead will satisfy
 //

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -47,6 +47,61 @@ TEST_CASE("quorum intersection basic 4-node", "[herder][quorumintersection]")
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
+TEST_CASE("quorum non intersection basic 4-node",
+          "[herder][quorumintersection]")
+{
+    QuorumTracker::QuorumMap qm;
+
+    PublicKey pkA = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkB = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkC = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkD = SecretKey::pseudoRandomForTesting().getPublicKey();
+
+    qm[pkA] = QuorumTracker::NodeInfo{
+        make_shared<QS>(1, VK({pkB, pkC, pkD}), VQ{}), 0};
+    qm[pkB] = QuorumTracker::NodeInfo{
+        make_shared<QS>(1, VK({pkA, pkC, pkD}), VQ{}), 0};
+    qm[pkC] = QuorumTracker::NodeInfo{
+        make_shared<QS>(1, VK({pkA, pkB, pkD}), VQ{}), 0};
+    qm[pkD] = QuorumTracker::NodeInfo{
+        make_shared<QS>(1, VK({pkA, pkB, pkC}), VQ{}), 0};
+
+    Config cfg(getTestConfig());
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    REQUIRE(!qic->networkEnjoysQuorumIntersection());
+}
+
+TEST_CASE("quorum non intersection 6-node", "[herder][quorumintersection]")
+{
+    QuorumTracker::QuorumMap qm;
+
+    PublicKey pkA = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkB = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkC = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkD = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkE = SecretKey::pseudoRandomForTesting().getPublicKey();
+    PublicKey pkF = SecretKey::pseudoRandomForTesting().getPublicKey();
+
+    qm[pkA] =
+        QuorumTracker::NodeInfo{make_shared<QS>(2, VK{pkB, pkC}, VQ{}), 0};
+    qm[pkB] =
+        QuorumTracker::NodeInfo{make_shared<QS>(2, VK{pkA, pkC}, VQ{}), 0};
+    qm[pkC] =
+        QuorumTracker::NodeInfo{make_shared<QS>(2, VK{pkA, pkB}, VQ{}), 0};
+    qm[pkD] =
+        QuorumTracker::NodeInfo{make_shared<QS>(2, VK{pkE, pkF}, VQ{}), 0};
+    qm[pkE] =
+        QuorumTracker::NodeInfo{make_shared<QS>(2, VK{pkD, pkF}, VQ{}), 0};
+    qm[pkF] =
+        QuorumTracker::NodeInfo{make_shared<QS>(2, VK{pkD, pkE}, VQ{}), 0};
+
+    Config cfg(getTestConfig());
+    std::atomic<bool> flag{false};
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    REQUIRE(!qic->networkEnjoysQuorumIntersection());
+}
+
 TEST_CASE("quorum intersection 6-node with subquorums",
           "[herder][quorumintersection]")
 {


### PR DESCRIPTION
# Description

This PR will reduce maxCommit by 1 in the quorum intersection check algorithm.

## Correctness
Given a network with `N` nodes, the quorum intersection check algorithm essentially enumerates all the subsets of size `<= (N/2) + 1` and checks

* if the subset is a quorum, and
* if the complement contains a quorum.

It actually suffices to enumerate all the subsets of size `<= N / 2` because if there's a pair of disjoint quorums `A, B` with `|A| <= |B|`, then `|A| <= floor(N/2)`. (Otherwise, `|B| >= |A| >= floor(N/2) + 1` which implies `|A| + |B| >= 2 * (floor(N/2) + 1) = 2 * floor(N/2) + 2 > N`, which is a contradiction.)


## Possible performance improvements

This change will not make the program slower as we are reducing the search space.

Given a network of `N` nodes, our search space consists of

* `choose(N, 1)` subsets with 1 element,
* `choose(N, 2)` subsets with 2 elements,
* `choose(N, 3)` subsets with 3 elements,
* ...
* `choose(N, N/2 + 1)` subsets with `N/2 + 1` elements.

This change will get rid of the necessity of checking `choose(N, N/2 + 1)`. This could potentially be huge. For instance, when `N = 30`, the search space contains 759,852,346 sets, and this change would remove 145,422,675 sets, which is roughly 19%.

Furthermore, I did a quick verification in https://github.com/stellar/stellar-core/commit/94bbeebee2aca906bbeaeff58f00c16054966030, which shows that in one of the existing tests, we explore 40,310 sets, but this change would remove 17,722(=43.9643%) of them. (This number doesn't exactly match with the number above for any `N` because we have other early exits.)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
