### PR TITLE
overlay: properly connect to preferred peers

### DIFF
--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -540,14 +540,16 @@ OverlayManagerImpl::tick()
     }
 
     auto availableAuthenticatedSlots = availableOutboundAuthenticatedSlots();
-    bool allOutboundArePreferred = nonPreferredAuthenticatedCount() == 0;
 
-    // First, attempt to replace all connections with preferred peers
-    if (!allOutboundArePreferred)
+    // First, connect to preferred peers
     {
-        auto preferredToConnect = std::min(
-            availablePendingSlots,
-            static_cast<int>(mApp.getConfig().TARGET_PEER_CONNECTIONS));
+        // in that context, an available slot is either a free slot or a non
+        // preferred one
+        int preferredToConnect =
+            availableAuthenticatedSlots + nonPreferredAuthenticatedCount();
+        preferredToConnect =
+            std::min(availablePendingSlots, preferredToConnect);
+
         auto pendingUsedByPreferred =
             connectTo(preferredToConnect, PeerType::PREFERRED);
 


### PR DESCRIPTION
The change in b11afcc51e56d76ca63032445a46b67da156359c ended up breaking preferred peer logic:
in that change, preferred peers would only get connected to as replacement for existing connections.

This change re-introduces the proper behavior (and I think this version is easier to understand than the original one).

This was caught by our acceptance test: all known peers were set as "preferred" in those tests.
