### PR TITLE
Out of sync timer cleanup

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -50,6 +50,7 @@ constexpr auto const TRANSACTION_QUEUE_SIZE = 4;
 constexpr auto const TRANSACTION_QUEUE_BAN_SIZE = 10;
 constexpr auto const TRANSACTION_QUEUE_MULTIPLIER = 4;
 constexpr size_t const OPERATION_BROADCAST_MULTIPLIER = 2;
+constexpr auto const OUT_OF_SYNC_RECOVERY_TIMER = std::chrono::seconds(10);
 
 std::unique_ptr<Herder>
 Herder::create(Application& app)
@@ -330,7 +331,7 @@ HerderImpl::startOutOfSyncTimer()
         return;
     }
 
-    mOutOfSyncTimer.expires_from_now(std::chrono::seconds(2));
+    mOutOfSyncTimer.expires_from_now(OUT_OF_SYNC_RECOVERY_TIMER);
 
     mOutOfSyncTimer.async_wait(
         [&]() {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -138,8 +138,8 @@ class HerderImpl : public Herder
 
     void maybeTriggerNextLedger(bool synchronous);
 
-    void startRebroadcastTimer();
-    void rebroadcast();
+    void startOutOfSyncTimer();
+    void outOfSyncRecovery();
     void broadcast(SCPEnvelope const& e);
 
     void processSCPQueueUpToIndex(uint64 slotIndex);
@@ -184,7 +184,7 @@ class HerderImpl : public Herder
 
     VirtualTimer mTriggerTimer;
 
-    VirtualTimer mRebroadcastTimer;
+    VirtualTimer mOutOfSyncTimer;
 
     Application& mApp;
     LedgerManager& mLedgerManager;

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -1188,7 +1188,8 @@ HerderSCPDriver::reportCostOutliersForSlot(int64_t slotIndex,
             Json::Value res;
             for (auto const& t : tracked)
             {
-                auto clusterToCompare = closest_cluster(t.second, clusters);
+                auto clusterToCompare =
+                    closest_cluster(static_cast<double>(t.second), clusters);
                 auto const smallestCluster = *(clusters.begin());
                 if (shouldReportCostOutlier(clusterToCompare, smallestCluster,
                                             OUTLIER_COST_RATIO_LIMIT))

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -217,7 +217,7 @@ TEST_CASE("quorum tracker closest validators", "[quorum][herder]")
     auto makeQset = [&](std::vector<int> const& validatorIndexes,
                         int selfIndex) {
         SCPQuorumSet q;
-        q.threshold = validatorIndexes.size() + 1;
+        q.threshold = static_cast<uint32>(validatorIndexes.size()) + 1;
         std::transform(validatorIndexes.begin(), validatorIndexes.end(),
                        std::back_inserter(q.validators),
                        [&](int i) { return otherKeys[i]; });

--- a/src/invariant/test/SponsorshipCountIsValidTests.cpp
+++ b/src/invariant/test/SponsorshipCountIsValidTests.cpp
@@ -18,7 +18,7 @@ using namespace stellar::InvariantTestUtils;
 static int32_t
 getNumClaimants(LedgerEntry const& le)
 {
-    return le.data.claimableBalance().claimants.size();
+    return static_cast<int32_t>(le.data.claimableBalance().claimants.size());
 }
 
 TEST_CASE("sponsorship invariant", "[invariant][sponsorshipcountisvalid]")
@@ -46,7 +46,8 @@ TEST_CASE("sponsorship invariant", "[invariant][sponsorshipcountisvalid]")
             extV2.numSponsoring = 0;
             extV2.numSponsored = 0;
             extV2.signerSponsoringIDs.clear();
-            extV2.signerSponsoringIDs.resize(ae.signers.size());
+            extV2.signerSponsoringIDs.resize(
+                static_cast<int32_t>(ae.signers.size()));
         }
     };
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -857,8 +857,7 @@ Peer::pingIDfromTimePoint(VirtualClock::time_point const& tp)
 void
 Peer::pingPeer()
 {
-    if (!mApp.getConfig().RUN_STANDALONE && isAuthenticated() &&
-        mPingSentTime == PING_NOT_SENT)
+    if (isAuthenticated() && mPingSentTime == PING_NOT_SENT)
     {
         mPingSentTime = mApp.getClock().now();
         auto h = pingIDfromTimePoint(mPingSentTime);

--- a/src/overlay/test/ItemFetcherTests.cpp
+++ b/src/overlay/test/ItemFetcherTests.cpp
@@ -243,9 +243,12 @@ TEST_CASE("ItemFetcher fetches", "[overlay][ItemFetcher]")
 
             itemFetcher.recv(zero, timer);
 
-            while (clock.crank(false) > 0)
+            // crank for a while
+            constexpr auto elapsed = std::chrono::minutes(1);
+            auto const later = clock.now() + elapsed;
+            while (clock.crank(false) > 0 && clock.now() < later)
             {
-                std::this_thread::sleep_for(std::chrono::microseconds(1));
+                clock.sleep_for(std::chrono::milliseconds(500));
             }
 
             REQUIRE(asked.size() == 4);

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -7,6 +7,7 @@
 #include <Tracy.hpp>
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 #include <set>
 #include <unordered_map>
 


### PR DESCRIPTION
# Description

This PR changes the behavior related to re-broadcasting of SCP messages and asking peers for potential missing data:
* the main change is to associate this behavior to the "out of sync" event that is triggered when a node does not reach consensus
    * previously nodes would constantly rebroadcast SCP messages even though this should not be necessary
* a more aggressive change we can consider later on would be to remove this code entirely, but for now I left it as it can help in situations where nodes start up all at once. "pull mode" may render this obsolete anyways.

Overall this should reduce the number of duplicate SCP messages being sent in "steady state" (when the network is "in sync").
