### PR TITLE
Fix some formatting issues when printing XDR

### DIFF
--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -19,6 +19,14 @@ using namespace std::placeholders;
 
 template <uint32_t N>
 void
+cereal_override(cereal::JSONOutputArchive& ar, const xdr::xstring<N>& s,
+                const char* field)
+{
+    xdr::archive(ar, static_cast<std::string const&>(s), field);
+}
+
+template <uint32_t N>
+void
 cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_array<N>& s,
                 const char* field)
 {


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/2749

This PR fixes some issues with printing XDR as described in https://github.com/stellar/stellar-core/issues/2749 by implementing `cereal_override` for `xstring` and `Memo`.

`AAAAAgAAAAAfpR7UY4+Podv9E4/IgUImlA8y6OKEQi8lJ8rRR8wMiAAAAGQAAAAAAodXoAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAACgAAAA50aGlzaXNkYXRhbmFtZQAAAAAAAQAAAA90aGlzaXNkYXRhdmFsdWUAAAAAAAAAAAA=` contains `xstring` and this will be printed as `"dataName": "thisisdataname",`.

Similarly, `AAAAAAGUcmKO5465JxTSLQOQljwk2SfqAJmZSG6JH6wtqpwhAAABLAAAAAAAAAABAAAAAAAAAAEAAAALaGVsbG8gd29ybGQAAAAAAwAAAAAAAAAAAAAAABbxCy3mLg3hiTqX4VUEEp60pFOrJNxYM1JtxXTwXhY2AAAAAAvrwgAAAAAAAAAAAQAAAAAW8Qst5i4N4Yk6l+FVBBKetKRTqyTcWDNSbcV08F4WNgAAAAAN4Lazj4x61AAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABLaqcIQAAAEBKwqWy3TaOxoGnfm9eUjfTRBvPf34dvDA0Nf+B8z4zBob90UXtuCqmQqwMCyH+okOI3c05br3khkH0yP4kCwcE` contains `Memo` and it will be printed as `"text": "hello world"`.


 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
