### PR TITLE
Fix deadlock in verify-checkpoints command

### DIFF
--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -17,6 +17,7 @@
 #include "main/ErrorMessages.h"
 #include "util/LogSlowExecution.h"
 #include "util/Logging.h"
+#include "util/Thread.h"
 #include <Tracy.hpp>
 #include <fmt/format.h>
 
@@ -235,8 +236,7 @@ FutureBucket::mergeComplete() const
         return true;
     }
 
-    auto status = mOutputBucketFuture.wait_for(std::chrono::nanoseconds(1));
-    return status == std::future_status::ready;
+    return futureIsReady(mOutputBucketFuture);
 }
 
 std::shared_ptr<Bucket>

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -65,7 +65,7 @@ verifyLastLedgerInCheckpoint(LedgerHeaderHistoryEntry const& ledger,
     // When max ledger in the checkpoint is reached, verify its hash against the
     // numerically-greater checkpoint (that we should have an incoming hash-link
     // from).
-    assert(ledger.header.ledgerSeq == verifiedAhead.first);
+    releaseAssert(ledger.header.ledgerSeq == verifiedAhead.first);
     auto trustedHash = verifiedAhead.second;
     if (!trustedHash)
     {
@@ -110,8 +110,8 @@ VerifyLedgerChainWork::VerifyLedgerChainWork(
           {"history", "verify-ledger-chain", "failure"}, "event"))
 {
     // LCL should be at-or-after genesis and we should have a hash.
-    assert(lastClosedLedger.first >= LedgerManager::GENESIS_LEDGER_SEQ);
-    assert(lastClosedLedger.second);
+    releaseAssert(lastClosedLedger.first >= LedgerManager::GENESIS_LEDGER_SEQ);
+    releaseAssert(lastClosedLedger.second);
 }
 
 std::string
@@ -301,8 +301,8 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
     {
         // If so, there should be no "saved" incoming hash-link value from
         // a previous iteration.
-        assert(incoming.first == 0);
-        assert(incoming.second.get() == nullptr);
+        releaseAssert(incoming.first == 0);
+        releaseAssert(incoming.second.get() == nullptr);
 
         // Instead, there _should_ be a value in the shared_future this work
         // object reads its initial trust from. If anything went wrong upstream
@@ -322,8 +322,8 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
         // to this method and the `incoming` value we read out of
         // `mVerifiedAhead` should have content, because the previous call
         // should have saved something in `mVerifiedAhead`.
-        assert(incoming.second);
-        assert(incoming.first != 0);
+        releaseAssert(incoming.second);
+        releaseAssert(incoming.first != 0);
     }
 
     // In either case, the last ledger in the checkpoint needs to agree with the
@@ -332,7 +332,7 @@ VerifyLedgerChainWork::verifyHistoryOfSingleCheckpoint()
     auto verifyTrustedHash = verifyLastLedgerInCheckpoint(curr, incoming);
     if (verifyTrustedHash != HistoryManager::VERIFY_STATUS_OK)
     {
-        assert(incoming.second);
+        releaseAssert(incoming.second);
         CLOG(ERROR, "History")
             << "Checkpoint does not agree with checkpoint ahead: "
             << "current " << LedgerManager::ledgerAbbrev(curr) << ", verified: "
@@ -464,7 +464,7 @@ VerifyLedgerChainWork::onRun()
         mVerifyLedgerChainFailure.Mark();
         return BasicWork::State::WORK_FAILURE;
     default:
-        assert(false);
+        releaseAssert(false);
         throw std::runtime_error("unexpected VerifyLedgerChainWork state");
     }
 }

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -616,6 +616,29 @@ CatchupSimulation::ensureOnlineCatchupPossible(uint32_t targetLedger,
     ensurePublishesComplete();
 }
 
+std::vector<LedgerNumHashPair>
+CatchupSimulation::getAllPublishedCheckpoints() const
+{
+    std::vector<LedgerNumHashPair> res;
+    assert(mLedgerHashes.size() == mLedgerSeqs.size());
+    auto hi = mLedgerHashes.begin();
+    auto si = mLedgerSeqs.begin();
+    auto const& hm = mApp.getHistoryManager();
+    while (si != mLedgerSeqs.end())
+    {
+        if (hm.isLastLedgerInCheckpoint(*si))
+        {
+            LedgerNumHashPair pair;
+            pair.first = *si;
+            pair.second = make_optional<Hash>(*hi);
+            res.emplace_back(pair);
+        }
+        ++hi;
+        ++si;
+    }
+    return res;
+}
+
 LedgerNumHashPair
 CatchupSimulation::getLastPublishedCheckpoint() const
 {

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -273,6 +273,7 @@ class CatchupSimulation
     void ensureOnlineCatchupPossible(uint32_t targetLedger,
                                      uint32_t bufferLedgers = 0);
 
+    std::vector<LedgerNumHashPair> getAllPublishedCheckpoints() const;
     LedgerNumHashPair getLastPublishedCheckpoint() const;
 
     Application::pointer createCatchupApplication(uint32_t count,

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -9,6 +9,7 @@
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerRange.h"
 #include "main/Application.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "work/ConditionalWork.h"
 #include <Tracy.hpp>
@@ -155,7 +156,7 @@ WriteVerifiedCheckpointHashesWork::yieldMoreWork()
         mApp, "download-verify-ledger-" + checkpointStr, seq);
 
     mTmpDirs.emplace_back(workSeq, tmpDir);
-    assert(first >= 1);
+    releaseAssert(first >= 1);
     mCurrCheckpoint = std::max(LedgerManager::GENESIS_LEDGER_SEQ, first - 1);
     mPrevVerifyWork = currWork;
     return workSeq;
@@ -164,7 +165,7 @@ WriteVerifiedCheckpointHashesWork::yieldMoreWork()
 void
 WriteVerifiedCheckpointHashesWork::startOutputFile()
 {
-    assert(!mOutputFile);
+    releaseAssert(!mOutputFile);
     auto mode = std::ios::out | std::ios::trunc;
     mOutputFile = std::make_shared<std::ofstream>(mOutputFileName, mode);
     if (!*mOutputFile)

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -54,8 +54,9 @@ WriteVerifiedCheckpointHashesWork::loadHashFromJsonOutput(
 
 WriteVerifiedCheckpointHashesWork::WriteVerifiedCheckpointHashesWork(
     Application& app, LedgerNumHashPair rangeEnd, std::string const& outputFile,
-    std::shared_ptr<HistoryArchive> archive)
+    uint32_t nestedBatchSize, std::shared_ptr<HistoryArchive> archive)
     : BatchWork(app, "write-verified-checkpoint-hashes")
+    , mNestedBatchSize(nestedBatchSize)
     , mRangeEnd(rangeEnd)
     , mRangeEndPromise()
     , mRangeEndFuture(mRangeEndPromise.get_future().share())
@@ -97,7 +98,7 @@ WriteVerifiedCheckpointHashesWork::yieldMoreWork()
     auto const lclHe = mApp.getLedgerManager().getLastClosedLedgerHeader();
     LedgerNumHashPair const lcl(lclHe.header.ledgerSeq,
                                 make_optional<Hash>(lclHe.hash));
-    uint32_t const span = NESTED_DOWNLOAD_BATCH_SIZE * freq;
+    uint32_t const span = mNestedBatchSize * freq;
     uint32_t const last = mCurrCheckpoint;
     uint32_t const first =
         last <= span ? LedgerManager::GENESIS_LEDGER_SEQ

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.h
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.h
@@ -28,6 +28,7 @@ class WriteVerifiedCheckpointHashesWork : public BatchWork
     WriteVerifiedCheckpointHashesWork(
         Application& app, LedgerNumHashPair rangeEnd,
         std::string const& outputFile,
+        uint32_t nestedBatchSize = NESTED_DOWNLOAD_BATCH_SIZE,
         std::shared_ptr<HistoryArchive> archive = nullptr);
     ~WriteVerifiedCheckpointHashesWork();
 
@@ -43,6 +44,9 @@ class WriteVerifiedCheckpointHashesWork : public BatchWork
     // latter busy we introduce an inner level of fully-parallelizable batching
     // of downloads. Empirically this seems to work well at a fixed size.
     static constexpr uint32_t NESTED_DOWNLOAD_BATCH_SIZE = 64;
+
+    // For testing purposes we'd like to be able to change this, however.
+    uint32_t const mNestedBatchSize;
 
     // We make a TmpDir for each inner WorkSequence we run, but delete them on
     // the end of each to free up disk space. Since the inner WorkSequences end

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -17,6 +17,7 @@
 #include "overlay/TCPPeer.h"
 #include "util/Logging.h"
 #include "util/Math.h"
+#include "util/Thread.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include <Tracy.hpp>
@@ -496,9 +497,7 @@ OverlayManagerImpl::tick()
 
     mLoad.maybeShedExcessLoad(mApp);
 
-    if (mResolvedPeers.valid() &&
-        mResolvedPeers.wait_for(std::chrono::nanoseconds(1)) ==
-            std::future_status::ready)
+    if (futureIsReady(mResolvedPeers))
     {
         CLOG(TRACE, "Overlay") << "Resolved peers are ready";
         auto res = mResolvedPeers.get();

--- a/src/util/Thread.h
+++ b/src/util/Thread.h
@@ -4,10 +4,36 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include <chrono>
+#include <future>
 #include <thread>
 
 namespace stellar
 {
 
 void runCurrentThreadWithLowPriority();
+
+template <typename T>
+bool
+futureIsReady(std::future<T> const& fut)
+{
+    if (!fut.valid())
+    {
+        return false;
+    }
+    auto status = fut.wait_for(std::chrono::nanoseconds(1));
+    return status == std::future_status::ready;
+}
+
+template <typename T>
+bool
+futureIsReady(std::shared_future<T> const& fut)
+{
+    if (!fut.valid())
+    {
+        return false;
+    }
+    auto status = fut.wait_for(std::chrono::nanoseconds(1));
+    return status == std::future_status::ready;
+}
 }


### PR DESCRIPTION
# Description

The deadlock in bug #2757 was just mistakenly treating `.valid()` as meaning "future is ready" when guarding an assert.

Existing testcase didn't trap this because while I _thought_ it did 5 inner works because it did 5 checkpoints (and thus exercised the inter-work propagation code) I forgot that I also did batching for parallelism inside the outer work (to keep the network saturated with downloads) and so all 5 checkpoints were verified by a single inner work, this actually wasn't testing the inter-work propagation code on the inner works at all. So I changed the outer work to allow changing the batching factor (to avoid having to make the test run a long time) and then fixed the test to run 5 * the batching factor.

Once the test is corrected, the fix is straightforward: just add a helper called `futureIsReady` that does the (honesty somewhat silly) wait-for-a-nanosecond thing one has to do to check future readiness, and use it instead. Also replace other places in the code we do the same silly wait.