### PR TITLE
Sync filesystem changes after subprocess exit

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -410,6 +410,20 @@ MAXIMUM_LEDGER_CLOSETIME_DRIFT=50
 # you want to make that trade.
 DISABLE_XDR_FSYNC=false
 
+# DISABLE_SUBPROCESS_SYNC (true or false) defaults to false.
+# If set to true, running a subprocess (typically: to get or decompress a data
+# file from an archive) will not be followed by a sync(2) call to flush dirty
+# pages and make filesystem changes durable. This in turn means that there may
+# be a spike in dirty page memory pressure (which can cause a linux "oom-kill"
+# in rare circumstances, such as running as a burstable job under kubernetes),
+# and may also risk leaving corrupt data files on durable storage should there
+# be an operating system crash or sudden power loss, which may in turn may cause
+# a node to diverge or get stuck. This option only exists as an escape hatch if
+# the local filesystem is so unusably slow that you prefer operating without
+# durability guarantees. Do not set it to true unless you're very certain you
+# want to make that trade.
+DISABLE_SUBPROCESS_SYNC=false
+
 # MAX_SLOTS_TO_REMEMBER (in ledgers) defaults to 12
 # Most people should leave this to 12
 # Number of most recent ledgers keep in memory. Storing more ledgers allows other

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -410,9 +410,9 @@ MAXIMUM_LEDGER_CLOSETIME_DRIFT=50
 # you want to make that trade.
 DISABLE_XDR_FSYNC=false
 
-# DISABLE_SUBPROCESS_SYNC (true or false) defaults to false.
-# If set to true, running a subprocess (typically: to get or decompress a data
-# file from an archive) will not be followed by a sync(2) call to flush dirty
+# DISABLE_SUBPROCESS_FSYNC (true or false) defaults to false.
+# If set to true, running a subprocess that fetches or decompresses a file from
+# an archive will not be followed by an fsync() call on the file to flush dirty
 # pages and make filesystem changes durable. This in turn means that there may
 # be a spike in dirty page memory pressure (which can cause a linux "oom-kill"
 # in rare circumstances, such as running as a burstable job under kubernetes),
@@ -422,7 +422,7 @@ DISABLE_XDR_FSYNC=false
 # the local filesystem is so unusably slow that you prefer operating without
 # durability guarantees. Do not set it to true unless you're very certain you
 # want to make that trade.
-DISABLE_SUBPROCESS_SYNC=false
+DISABLE_SUBPROCESS_FSYNC=false
 
 # MAX_SLOTS_TO_REMEMBER (in ledgers) defaults to 12
 # Most people should leave this to 12

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -38,6 +38,12 @@ GetRemoteFileWork::getCommand()
     return CommandInfo{cmdLine, std::string()};
 }
 
+std::vector<std::string>
+GetRemoteFileWork::getFilesToFlush() const
+{
+    return {mLocal};
+}
+
 void
 GetRemoteFileWork::onReset()
 {

--- a/src/historywork/GetRemoteFileWork.h
+++ b/src/historywork/GetRemoteFileWork.h
@@ -18,6 +18,7 @@ class GetRemoteFileWork : public RunCommandWork
     std::shared_ptr<HistoryArchive> mArchive;
     std::shared_ptr<HistoryArchive> mCurrentArchive;
     CommandInfo getCommand() override;
+    std::vector<std::string> getFilesToFlush() const override;
 
   public:
     // Passing `nullptr` for the archive argument will cause the work to

--- a/src/historywork/GunzipFileWork.h
+++ b/src/historywork/GunzipFileWork.h
@@ -12,8 +12,10 @@ namespace stellar
 class GunzipFileWork : public RunCommandWork
 {
     std::string const mFilenameGz;
+    std::string const mFilenameNoGz;
     bool const mKeepExisting;
     CommandInfo getCommand() override;
+    std::vector<std::string> getFilesToFlush() const override;
 
   public:
     GunzipFileWork(Application& app, std::string const& filenameGz,

--- a/src/historywork/RunCommandWork.h
+++ b/src/historywork/RunCommandWork.h
@@ -26,6 +26,7 @@ class RunCommandWork : public BasicWork
     bool mDone{false};
     asio::error_code mEc;
     virtual CommandInfo getCommand() = 0;
+    virtual std::vector<std::string> getFilesToFlush() const;
     std::weak_ptr<ProcessExitEvent> mExitEvent;
 
   public:

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -124,7 +124,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     UNSAFE_QUORUM = false;
     DISABLE_BUCKET_GC = false;
     DISABLE_XDR_FSYNC = false;
-    DISABLE_SUBPROCESS_SYNC = false;
+    DISABLE_SUBPROCESS_FSYNC = false;
     MAX_SLOTS_TO_REMEMBER = 12;
     METADATA_OUTPUT_STREAM = "";
 
@@ -708,9 +708,9 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 DISABLE_XDR_FSYNC = readBool(item);
             }
-            else if (item.first == "DISABLE_SUBPROCESS_SYNC")
+            else if (item.first == "DISABLE_SUBPROCESS_FSYNC")
             {
-                DISABLE_SUBPROCESS_SYNC = readBool(item);
+                DISABLE_SUBPROCESS_FSYNC = readBool(item);
             }
             else if (item.first == "METADATA_OUTPUT_STREAM")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -124,6 +124,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     UNSAFE_QUORUM = false;
     DISABLE_BUCKET_GC = false;
     DISABLE_XDR_FSYNC = false;
+    DISABLE_SUBPROCESS_SYNC = false;
     MAX_SLOTS_TO_REMEMBER = 12;
     METADATA_OUTPUT_STREAM = "";
 
@@ -706,6 +707,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "DISABLE_XDR_FSYNC")
             {
                 DISABLE_XDR_FSYNC = readBool(item);
+            }
+            else if (item.first == "DISABLE_SUBPROCESS_SYNC")
+            {
+                DISABLE_SUBPROCESS_SYNC = readBool(item);
             }
             else if (item.first == "METADATA_OUTPUT_STREAM")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -253,6 +253,20 @@ class Config : public std::enable_shared_from_this<Config>
     // you want to make that trade.
     bool DISABLE_XDR_FSYNC;
 
+    // If set to true, running a subprocess (typically: to get or decompress a
+    // data file from an archive) will not be followed by a sync(2) call to
+    // flush dirty pages and make filesystem changes durable. This in turn means
+    // that there may be a spike in dirty page memory pressure (which can cause
+    // a linux "oom-kill" in rare circumstances, such as running as a burstable
+    // job under kubernetes), and may also risk leaving corrupt data files on
+    // durable storage should there be an operating system crash or sudden power
+    // loss, which may in turn may cause a node to diverge or get stuck. This
+    // option only exists as an escape hatch if the local filesystem is so
+    // unusably slow that you prefer operating without durability guarantees. Do
+    // not set it to true unless you're very certain you want to make that
+    // trade.
+    bool DISABLE_SUBPROCESS_SYNC;
+
     // Number of most recent ledgers to remember. Defaults to 12, or
     // approximately ~1 min of network activity.
     uint32 MAX_SLOTS_TO_REMEMBER;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -253,8 +253,8 @@ class Config : public std::enable_shared_from_this<Config>
     // you want to make that trade.
     bool DISABLE_XDR_FSYNC;
 
-    // If set to true, running a subprocess (typically: to get or decompress a
-    // data file from an archive) will not be followed by a sync(2) call to
+    // If set to true, running a subprocess that fetches or decompresses a file
+    // from an archive will not be followed by an fsync() call on the file to
     // flush dirty pages and make filesystem changes durable. This in turn means
     // that there may be a spike in dirty page memory pressure (which can cause
     // a linux "oom-kill" in rare circumstances, such as running as a burstable
@@ -265,7 +265,7 @@ class Config : public std::enable_shared_from_this<Config>
     // unusably slow that you prefer operating without durability guarantees. Do
     // not set it to true unless you're very certain you want to make that
     // trade.
-    bool DISABLE_SUBPROCESS_SYNC;
+    bool DISABLE_SUBPROCESS_FSYNC;
 
     // Number of most recent ledgers to remember. Defaults to 12, or
     // approximately ~1 min of network activity.

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -259,7 +259,6 @@ ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
 
 ProcessManagerImpl::ProcessManagerImpl(Application& app)
     : mMaxProcesses(app.getConfig().MAX_CONCURRENT_SUBPROCESSES)
-    , mSyncFilesystemOnProcessExit(!app.getConfig().DISABLE_SUBPROCESS_SYNC)
     , mIOContext(app.getClock().getIOContext())
     , mSigChild(mIOContext)
     , mTmpDir(
@@ -516,7 +515,6 @@ ProcessManagerImpl::forceShutdown(ProcessExitEvent& pe)
 
 ProcessManagerImpl::ProcessManagerImpl(Application& app)
     : mMaxProcesses(app.getConfig().MAX_CONCURRENT_SUBPROCESSES)
-    , mSyncFilesystemOnProcessExit(!app.getConfig().DISABLE_SUBPROCESS_SYNC)
     , mIOContext(app.getClock().getIOContext())
     , mSigChild(mIOContext, SIGCHLD)
     , mTmpDir(
@@ -566,11 +564,6 @@ ProcessManagerImpl::handleSignalWait()
             const int pid = std::get<0>(pidStatus);
             const int status = std::get<1>(pidStatus);
             handleProcessTermination(pid, status);
-        }
-        if (mSyncFilesystemOnProcessExit)
-        {
-            // Sync filesystem changes caused by processes.
-            sync();
         }
     }
     startSignalWait();

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -26,7 +26,8 @@ class ProcessManagerImpl : public ProcessManager
     std::map<int, std::shared_ptr<ProcessExitEvent>> mProcesses;
 
     bool mIsShutdown{false};
-    size_t mMaxProcesses;
+    size_t const mMaxProcesses;
+    bool const mSyncFilesystemOnProcessExit;
     asio::io_context& mIOContext;
     // These are only used on POSIX, but they're harmless here.
     asio::signal_set mSigChild;

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -27,7 +27,6 @@ class ProcessManagerImpl : public ProcessManager
 
     bool mIsShutdown{false};
     size_t const mMaxProcesses;
-    bool const mSyncFilesystemOnProcessExit;
     asio::io_context& mIOContext;
     // These are only used on POSIX, but they're harmless here.
     asio::signal_set mSigChild;

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -46,6 +46,9 @@ void unlockFile(std::string const& path);
 // Call fsync() on POSIX or FlushFileBuffers() on Win32.
 void flushFileChanges(native_handle_t h);
 
+// Open a file by name, flushFileChanges on it, and close it again.
+void flushFileChanges(std::string const& path);
+
 // For completely preposterous reasons, on windows an asio "stream"
 // type wrapping a win32 HANDLE is always written-to using an OVERLAPPED
 // structure with offset zero, meaning that when you write to a
@@ -57,6 +60,9 @@ bool shouldUseRandomAccessHandle(std::string const& path);
 
 // Open a native handle (fd or HANDLE) for writing.
 native_handle_t openFileToWrite(std::string const& path);
+
+// Close a native handle (fd or HANDLE).
+void closeFile(native_handle_t);
 
 // On POSIX, do rename(src, dst) then open dir and fsync() it
 // too: a necessary second step for ensuring durability.


### PR DESCRIPTION
This changes the behaviour of the process manager to call `sync(2)` when a subprocess exits.

There are two purposes to this:

  - First -- the motivating purpose -- is to reduce spikes in dirty pages (still being written to disk) that happen when running large-ish test workloads on kubernetes; these spikes seem to provoke oom-kill events from the underlying kernel at unfortunate frequency.
  - Second, it may also close a small node-local data corruption gap should there be a power loss or node reboot during such a period of transient data. This is unlikely (we only usually run a slew of `get` commands once during catchup) but it's a possible failure mode and it's always nice to remove a few more of those.

As with the fsync-on-xdr-stream-close change, this change is accompanied by a config variable you can use to disable the behaviour should you need to (eg. on a super-slow spinning disk) but it seems even less likely to ever be needed here.