### PR TITLE
tests: create databases with a random UTF encoding if possible

### DIFF
--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -63,9 +63,14 @@ runpg() {
 
     trap cleanup 0 2 15
 
-    echo Creating temporary PostgreSQL database cluster in "$PGDATA"
+    # pick a random utf locale if we can as to increase
+    # detection of encoding issues
+    DB_LOC=`locale -a | grep -i utf | shuf | head -1`
+    if [ -z "$DB_LOC" ] ; then DB_LOC="--no-locale" ; else DB_LOC="--locale=$DB_LOC" ; fi
 
-    $PGCTL init -s -o "--no-locale -U ${PGUSER-postgres} -A trust" \
+    echo Creating temporary PostgreSQL database cluster in "$PGDATA" with $DB_LOC
+
+    $PGCTL init -s -o "$DB_LOC -U ${PGUSER-postgres} -A trust" \
         || return 1
     conf="$PGDATA/postgresql.conf"
     usd=$(sed -ne '/#\(unix_socket_director[^ ]*\) =.*/{


### PR DESCRIPTION
this increases the chances of finding encoding issues