### PR TITLE
Add backtrace-printing machinery and use it in GlobalChecks asserts.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -45,7 +45,7 @@ RUN sudo apt-get update \
     && sudo apt-get update
 
 # Install common compilation tools
-RUN sudo apt-get -y install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel
+RUN sudo apt-get -y install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev
 
 # Update compiler tools
 RUN sudo apt-get -y install gcc-6 g++-6 cpp-6 libstdc++6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
             sudo apt-get -y install clang-5.0 llvm-5.0
           fi
       - name: install dependencies
-        run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel
+        run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev
       - name: Build
         run: |
           if test "${{ matrix.toolchain }}" = "gcc" ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ addons:
     - perl
     - parallel
     - gdb
+    - libunwind-dev
 
 before_script:
   - ulimit -c unlimited -S

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -361,6 +361,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\TransactionFrameBase.cpp" />
     <ClCompile Include="..\..\src\transactions\TransactionSQL.cpp" />
     <ClCompile Include="..\..\src\transactions\RevokeSponsorshipOpFrame.cpp" />
+    <ClCompile Include="..\..\src\util\Backtrace.cpp" />
     <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
     <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\Scheduler.cpp" />
@@ -707,6 +708,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\TransactionFrameBase.h" />
     <ClInclude Include="..\..\src\transactions\TransactionSQL.h" />
     <ClInclude Include="..\..\src\transactions\RevokeSponsorshipOpFrame.h" />
+    <ClInclude Include="..\..\src\util\Backtrace.h" />
     <ClInclude Include="..\..\src\util\Decoder.h" />
     <ClInclude Include="..\..\src\util\RandHasher.h" />
     <ClInclude Include="..\..\src\util\Scheduler.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1137,6 +1137,9 @@
     <ClCompile Include="..\..\src\ledger\InternalLedgerEntry.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\Backtrace.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">
@@ -1974,6 +1977,9 @@
       <Filter>util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\UnorderedSet.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\Backtrace.h">
       <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -43,6 +43,7 @@ See the [dev container's README](.devcontainer/README.md) for more detail.
 - 64-bit system
 - `clang-format-5.0` (for `make format` to work)
 - `perl`
+- `libunwind-dev`
 
 ### Ubuntu
 
@@ -72,7 +73,7 @@ After installing packages, head to [building with clang and libc++](#building-wi
 
 #### Installing packages
     # common packages
-    sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel
+    sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev libunwind-dev parallel
     # if using clang
     sudo apt-get install clang-5.0
     # clang with libstdc++

--- a/common.mk
+++ b/common.mk
@@ -2,7 +2,7 @@
 
 AM_CPPFLAGS = -isystem "$(top_srcdir)" -I"$(top_srcdir)/src" -I"$(top_builddir)/src"
 AM_CPPFLAGS += $(libsodium_CFLAGS) $(xdrpp_CFLAGS) $(libmedida_CFLAGS)	\
-	$(soci_CFLAGS) $(sqlite3_CFLAGS) $(libasio_CFLAGS)
+	$(soci_CFLAGS) $(sqlite3_CFLAGS) $(libasio_CFLAGS) $(libunwind_CFLAGS)
 AM_CPPFLAGS += -isystem "$(top_srcdir)/lib"             \
 	-isystem "$(top_srcdir)/lib/autocheck/include"      \
 	-isystem "$(top_srcdir)/lib/cereal/include"         \

--- a/configure.ac
+++ b/configure.ac
@@ -337,6 +337,19 @@ AC_ARG_ENABLE(easylogging,
         [Disable easylogging]))
 AM_CONDITIONAL(USE_EASYLOGGING, [test x$enable_easylogging != xno])
 
+case "${host_os}" in
+    *darwin*)
+        # libunwind comes standard with the command-line tools on macos
+        AC_DEFINE([HAVE_LIBUNWIND], [1],
+            [Define to 1 if you have the <libunwind.h> header file])
+        ;;
+    *)
+        PKG_CHECK_MODULES(libunwind, libunwind,
+            AC_DEFINE([HAVE_LIBUNWIND], [1],
+                [Define to 1 if you have the <libunwind.h> header file]))
+        ;;
+esac
+
 # Need this to pass through ccache for xdrpp, libsodium
 esc() {
     out=

--- a/configure.ac
+++ b/configure.ac
@@ -344,9 +344,28 @@ case "${host_os}" in
             [Define to 1 if you have the <libunwind.h> header file])
         ;;
     *)
-        PKG_CHECK_MODULES(libunwind, libunwind,
-            AC_DEFINE([HAVE_LIBUNWIND], [1],
-                [Define to 1 if you have the <libunwind.h> header file]))
+        # Unfortunately libunwind seems to interfere with clang-compiled
+        # exception-handling, at least when linked with libgcc (which is the
+        # default of libcxx and a requirement for libstdc++). I think this is
+        # roughly caused by both libgcc and libunwind providing the C++ EH ABI
+        # symbols but, evidently, interacting with clang-compiled code slightly
+        # differently when ELF-interposed with one another, in the same binary.
+        #
+        # Haven't been able to make a reduced testcase that works. You can check
+        # that this is still a problem by running the stellar-core Catch2-based
+        # unit test suite: many of the tests do REQUIRE_THROWS_AS(...) and
+        # that crashes with libunwind+clang.  Haven't been able to figure out a
+        # workaround either.
+        case "${CXX}" in
+            *clang*)
+                AC_MSG_NOTICE([backtraces disabled due to clang interaction with libunwind])
+            ;;
+            *)
+                PKG_CHECK_MODULES(libunwind, libunwind,
+                    AC_DEFINE([HAVE_LIBUNWIND], [1],
+                              [Define to 1 if you have the <libunwind.h> header file]))
+           ;;
+        esac
         ;;
 esac
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,7 @@ endif # !BUILD_TESTS
 
 stellar_core_LDADD = $(soci_LIBS) $(libmedida_LIBS)		\
 	$(top_builddir)/lib/lib3rdparty.a $(sqlite3_LIBS)	\
-	$(libpq_LIBS) $(xdrpp_LIBS) $(libsodium_LIBS)
+	$(libpq_LIBS) $(xdrpp_LIBS) $(libsodium_LIBS) $(libunwind_LIBS)
 
 TESTDATA_DIR = testdata
 TEST_FILES = $(TESTDATA_DIR)/stellar-core_example.cfg $(TESTDATA_DIR)/stellar-core_standalone.cfg \

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -8,6 +8,7 @@
 
 #include "crypto/ShortHash.h"
 #include <cstdlib>
+#include <exception>
 #include <sodium/core.h>
 #include <xdrpp/marshal.h>
 
@@ -16,11 +17,18 @@ INITIALIZE_EASYLOGGINGPP
 namespace stellar
 {
 static void
+printBacktraceAndAbort()
+{
+    printCurrentBacktrace();
+    std::abort();
+}
+
+static void
 outOfMemory()
 {
     std::fprintf(stderr, "Unable to allocate memory\n");
     std::fflush(stderr);
-    std::abort();
+    printBacktraceAndAbort();
 }
 }
 
@@ -28,10 +36,13 @@ int
 main(int argc, char* const* argv)
 {
     using namespace stellar;
+    BacktraceManager btGuard;
 
     // Abort when out of memory
     std::set_new_handler(outOfMemory);
-    BacktraceManager btGuard;
+    // At least print a backtrace in any circumstance
+    // that would call std::terminate
+    std::set_terminate(printBacktraceAndAbort);
 
     Logging::init();
     if (sodium_init() != 0)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/CommandLine.h"
+#include "util/Backtrace.h"
 #include "util/Logging.h"
 
 #include "crypto/ShortHash.h"
@@ -30,6 +31,7 @@ main(int argc, char* const* argv)
 
     // Abort when out of memory
     std::set_new_handler(outOfMemory);
+    BacktraceManager btGuard;
 
     Logging::init();
     if (sodium_init() != 0)

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -1,0 +1,152 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/Backtrace.h"
+#include "config.h"
+#include <cstdio>
+#include <cstdlib>
+#include <stdexcept>
+
+namespace
+{
+
+// The abi::__cxa_demangle call in printCurrentBacktrace below uses a buffer
+// that must be a _malloc()_ memory-region, so that it can realloc() if the
+// region is too small. To avoid calling malloc() in the middle of unwinding
+// (which might mess with already-corrupt state) we pre-malloc() a fairly large
+// buffer using BacktraceManager, with hope that it is enough for any symbol we
+// encounter.
+//
+// The BacktraceManager class is idempotent and printCurrentBacktrace sets one
+// up locally itself, in case nobody has done so yet. This minimizes the number
+// of malloc/free calls and ensures we don't leak (except in a memory-allocation
+// error path below where .. we really don't know what the right recovery is).
+char* demangleBuf = nullptr;
+size_t demangleBufSz = 4096;
+}
+
+namespace stellar
+{
+
+BacktraceManager::BacktraceManager()
+{
+    if (!demangleBuf)
+    {
+        demangleBuf = static_cast<char*>(malloc(demangleBufSz));
+        if (demangleBuf)
+        {
+            doFree = true;
+        }
+        else
+        {
+            char const* msg = "BacktraceManager failed to malloc";
+            fprintf(stderr, "error: %s\n", msg);
+            throw std::runtime_error(msg);
+        }
+    }
+}
+
+BacktraceManager::~BacktraceManager()
+{
+    if (demangleBuf && doFree)
+    {
+        free(demangleBuf);
+        demangleBuf = nullptr;
+    }
+}
+}
+
+#ifdef HAVE_LIBUNWIND
+
+#define UNW_LOCAL_ONLY
+#include <cxxabi.h>
+#include <libunwind.h>
+
+namespace stellar
+{
+
+void
+printCurrentBacktrace()
+{
+    fprintf(stderr, "backtrace:\n");
+
+    unw_context_t ctxt;
+    if (unw_getcontext(&ctxt) != 0)
+    {
+        return;
+    }
+
+    unw_cursor_t curs;
+    if (unw_init_local(&curs, &ctxt) != 0)
+    {
+        return;
+    }
+
+    char buf[1024];
+    unw_word_t off;
+    int i = 0;
+    BacktraceManager guard;
+
+    while (unw_step(&curs) > 0)
+    {
+        if (unw_get_proc_name(&curs, buf, sizeof(buf), &off) != UNW_ESUCCESS)
+        {
+            fprintf(stderr, "  %4d: <failed to get function name>\n", i++);
+            continue;
+        }
+        int res = 0;
+        size_t dsz = demangleBufSz;
+        char* d = abi::__cxa_demangle(buf, demangleBuf, &dsz, &res);
+        switch (res)
+        {
+        case 0:
+            // Demangling succceeded, might or might-not have realloc'ed
+            if (d != demangleBuf || dsz != demangleBufSz)
+            {
+                // Did realloc successfully; save the new realloc'ed
+                // pointer and size. BacktraceManager will free it.
+                demangleBuf = d;
+                demangleBufSz = dsz;
+            }
+            // Print the demangled buffer.
+            fprintf(stderr, "  %4d: %s\n", i++, d);
+            break;
+        case -1:
+            // Memory-allocation failure occurred; not sure what
+            // the fate of demangling buffer is, we'll leak and zero
+            // them and hope the next iteration can recover.
+            demangleBufSz = 0;
+            demangleBuf = nullptr;
+            // And print the _mangled_ buffer, best we can do.
+            fprintf(stderr, "  %4d: %s\n", i++, buf);
+            break;
+        case -2:
+            // Mangled name doesn't follow proper C++ mangling rules,
+            // print mangled name and continue.
+            fprintf(stderr, "  %4d: %s\n", i++, buf);
+            break;
+        case -3:
+        default:
+            // One of the arguments was invalid or some other error
+            // that isn't in the spec. Skip this iteration.
+            fprintf(stderr, "  %4d: <failed to demangle function name>\n", i++);
+            break;
+        }
+        fflush(stderr);
+    }
+}
+}
+
+#else
+namespace stellar
+{
+
+void
+printCurrentBacktrace()
+{
+    fprintf(stderr, "backtrace unavailable\n");
+    fflush(stderr);
+}
+}
+#endif

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -4,6 +4,7 @@
 
 #include "util/Backtrace.h"
 #include "config.h"
+#include "util/GlobalChecks.h"
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept>
@@ -69,6 +70,11 @@ namespace stellar
 void
 printCurrentBacktrace()
 {
+    if (!threadIsMain())
+    {
+        return;
+    }
+
     if (getenv("STELLAR_NO_BACKTRACE") != nullptr)
     {
         return;

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -69,6 +69,11 @@ namespace stellar
 void
 printCurrentBacktrace()
 {
+    if (getenv("STELLAR_NO_BACKTRACE") != nullptr)
+    {
+        return;
+    }
+
     fprintf(stderr, "backtrace:\n");
 
     unw_context_t ctxt;

--- a/src/util/Backtrace.h
+++ b/src/util/Backtrace.h
@@ -1,0 +1,25 @@
+#pragma once
+
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+namespace stellar
+{
+
+// Idempotent RAII guard object that sets up and tears down a static
+// malloc-buffer used for backtrace-printing. Should establish one of these
+// before calling printCurrentBacktrace(), though it will do so itself if you
+// forget to. If missing there's a slightly larger chance of backtrace failure
+// because of malloc() happening during a backtrace.
+class BacktraceManager
+{
+    bool doFree{false};
+
+  public:
+    BacktraceManager();
+    ~BacktraceManager();
+};
+
+void printCurrentBacktrace();
+}

--- a/src/util/GlobalChecks.cpp
+++ b/src/util/GlobalChecks.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "GlobalChecks.h"
+#include "Backtrace.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -38,6 +39,7 @@ printErrorAndAbort(const char* s1)
 {
     std::fprintf(stderr, "%s\n", s1);
     std::fflush(stderr);
+    printCurrentBacktrace();
     dbgAbort();
     std::abort();
 }
@@ -47,6 +49,7 @@ printErrorAndAbort(const char* s1, const char* s2)
 {
     std::fprintf(stderr, "%s%s\n", s1, s2);
     std::fflush(stderr);
+    printCurrentBacktrace();
     dbgAbort();
     std::abort();
 }
@@ -56,6 +59,7 @@ printAssertFailureAndAbort(const char* s1, const char* file, int line)
 {
     std::fprintf(stderr, "%s at %s:%d\n", s1, file, line);
     std::fflush(stderr);
+    printCurrentBacktrace();
     dbgAbort();
     std::abort();
 }
@@ -65,6 +69,7 @@ printAssertFailureAndThrow(const char* s1, const char* file, int line)
 {
     std::fprintf(stderr, "%s at %s:%d\n", s1, file, line);
     std::fflush(stderr);
+    printCurrentBacktrace();
     throw std::runtime_error(s1);
 }
 }

--- a/src/util/GlobalChecks.cpp
+++ b/src/util/GlobalChecks.cpp
@@ -18,10 +18,16 @@ namespace stellar
 {
 static std::thread::id mainThread = std::this_thread::get_id();
 
+bool
+threadIsMain()
+{
+    return mainThread == std::this_thread::get_id();
+}
+
 void
 assertThreadIsMain()
 {
-    dbgAssert(mainThread == std::this_thread::get_id());
+    dbgAssert(threadIsMain());
 }
 
 void

--- a/src/util/GlobalChecks.h
+++ b/src/util/GlobalChecks.h
@@ -20,6 +20,7 @@ void dbgAbort();
 // This is like `assert()` but it is _not_ sensitive to the presence of
 // NDEBUG. We don't compile with NDEBUG but "compiling out important asserts" is
 // enough of a footgun that we want to avoid even the possibility.
+// It will also print a backtrace (at least on unix platforms with libunwind).
 #define releaseAssert(e) \
     (static_cast<bool>(e) \
          ? void(0) \

--- a/src/util/GlobalChecks.h
+++ b/src/util/GlobalChecks.h
@@ -6,6 +6,7 @@
 
 namespace stellar
 {
+bool threadIsMain();
 void assertThreadIsMain();
 
 void dbgAbort();


### PR DESCRIPTION
This adds a backtrace-gathering function and wires it in to the assert functions in GlobalChecks.h so that when a `releaseAssert` or a `releaseAssertOrThrow` check fails, we get something like this (as an synthetic example of adding `releaseAssertOrThrow(false)`):

~~~
false at herder/QuorumTracker.cpp:38
backtrace:
     0: (anonymous namespace)::printBacktrace()
     1: stellar::printAssertFailureAndThrow(char const*, char const*, int)
     2: stellar::QuorumTracker::expand(stellar::PublicKey const&, std::shared_ptr<stellar::SCPQuorumSet>)
     3: stellar::QuorumTracker::rebuild(std::function<std::shared_ptr<stellar::SCPQuorumSet> (stellar::PublicKey const&)>)
     4: stellar::PendingEnvelopes::isNodeDefinitelyInQuorum(stellar::PublicKey const&)
     5: stellar::PendingEnvelopes::recvSCPEnvelope(stellar::SCPEnvelope const&)
     6: stellar::HerderImpl::recvSCPEnvelope(stellar::SCPEnvelope const&)
     7: stellar::Peer::recvSCPMessage(stellar::StellarMessage const&)
     8: stellar::Peer::recvRawMessage(stellar::StellarMessage const&)
     9: std::_Function_handler<void (), stellar::Peer::recvMessage(stellar::StellarMessage const&)::$_1>::_M_invoke(std::_Any_data const&)
    10: stellar::Scheduler::ActionQueue::runNext(stellar::VirtualClock&, std::chrono::duration<long, std::ratio<1l, 1000000000l> >)
    11: stellar::Scheduler::runOne()
    12: stellar::VirtualClock::crank(bool)
    13: stellar::runWithConfig(stellar::Config, std::shared_ptr<stellar::CatchupConfiguration>)
    14: std::_Function_handler<int (), stellar::run(stellar::CommandLineArgs const&)::$_22>::_M_invoke(std::_Any_data const&)
    15: stellar::(anonymous namespace)::runWithHelp(stellar::CommandLineArgs const&, std::vector<stellar::(anonymous namespace)::ParserWithValidation, std::allocator<stellar::(anonymous namespace)::ParserWithValidation> >, std::function<int ()>)
    16: stellar::run(stellar::CommandLineArgs const&)
    17: stellar::handleCommandLine(int, char* const*)
    18: __libc_start_main
    19: _start
2020-10-21T17:52:50.181 GBUPX [default FATAL] Got an exception: false [ApplicationUtils.cpp:121]
terminate called after throwing an instance of 'std::runtime_error'
  what():  false
Aborted (core dumped)
~~~

This does add a _requirement_ for libunwind to the build on macos and linux -- I could do a little more configury to make it optional but it seemed to me like we probably want to make it mandatory as it's quite useful and readily available. Up to reviewers to decide, I'm happy either way. Will need to update the package-building scripts if we accept it as mandatory (or merely want to ship it commonly, either way).