### PR TITLE
Cache the results of `isAQuorum`

### DIFF
--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -478,16 +478,15 @@ QuorumIntersectionCheckerImpl::contractToMaximalQuorum(BitSet nodes) const
     }
     while (true)
     {
-        BitSet filtered(nodes.count());
+        BitSet filtered(nodes);
         for (size_t i = 0; nodes.nextSet(i); ++i)
         {
-            if (containsQuorumSliceForNode(nodes, i))
+            if (containsQuorumSliceForNode(filtered, i))
             {
                 if (mLogTrace)
                 {
                     CLOG(TRACE, "SCP") << "Have qslice for " << i;
                 }
-                filtered.set(i);
             }
             else
             {
@@ -495,6 +494,7 @@ QuorumIntersectionCheckerImpl::contractToMaximalQuorum(BitSet nodes) const
                 {
                     CLOG(TRACE, "SCP") << "Missing qslice for " << i;
                 }
+                filtered.unset(i);
             }
         }
         if (filtered.count() == nodes.count() || filtered.empty())

--- a/src/herder/QuorumIntersectionCheckerImpl.cpp
+++ b/src/herder/QuorumIntersectionCheckerImpl.cpp
@@ -346,6 +346,7 @@ QuorumIntersectionCheckerImpl::QuorumIntersectionCheckerImpl(
     , mQuiet(quiet)
     , mTSC(mGraph)
     , mInterruptFlag(interruptFlag)
+    , mCachedQuorums(MAX_CACHED_QUORUMS_SIZE)
 {
     buildGraph(qmap);
     buildSCCs();
@@ -464,7 +465,17 @@ QuorumIntersectionCheckerImpl::containsQuorumSliceForNode(BitSet const& bs,
 bool
 QuorumIntersectionCheckerImpl::isAQuorum(BitSet const& nodes) const
 {
-    return (bool)contractToMaximalQuorum(nodes);
+    bool* pRes = mCachedQuorums.maybeGet(nodes);
+    if (pRes == nullptr)
+    {
+        bool result = (bool)contractToMaximalQuorum(nodes);
+        mCachedQuorums.put(nodes, result);
+        return result;
+    }
+    else
+    {
+        return *pRes;
+    }
 }
 
 BitSet

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -353,6 +353,7 @@
 #include "QuorumIntersectionChecker.h"
 #include "main/Config.h"
 #include "util/BitSet.h"
+#include "util/RandomEvictionCache.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-types.h"
 
@@ -530,6 +531,10 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     bool containsQuorumSlice(BitSet const& bs, QBitSet const& qbs) const;
     bool containsQuorumSliceForNode(BitSet const& bs, size_t node) const;
     BitSet contractToMaximalQuorum(BitSet nodes) const;
+
+    const int MAX_CACHED_QUORUMS_SIZE = 0xffff;
+    mutable stellar::RandomEvictionCache<BitSet, bool, BitSet::HashFunction>
+        mCachedQuorums;
     bool isAQuorum(BitSet const& nodes) const;
     bool isMinimalQuorum(BitSet const& nodes) const;
     void noteFoundDisjointQuorums(BitSet const& nodes,

--- a/src/util/BitSet.h
+++ b/src/util/BitSet.h
@@ -351,6 +351,25 @@ class BitSet
     {
         streamWith(out, [](std::ostream& out, size_t i) { out << i; });
     }
+    class HashFunction
+    {
+        std::hash<uint64_t> mHasher;
+
+      public:
+        size_t
+        operator()(BitSet const& bitset) const noexcept
+        {
+            // Implementation taken from Boost.
+            // https://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+            size_t seed = 0;
+            for (size_t i = 0; i < bitset.mPtr->arraysize; i++)
+            {
+                seed ^= mHasher(bitset.mPtr->array[i]) + 0x9e3779b9 +
+                        (seed << 6) + (seed >> 2);
+            }
+            return seed;
+        }
+    };
 };
 
 inline std::ostream&


### PR DESCRIPTION
# Description

Improve the performance of the quorum intersection checker by caching the results of `isAQuorum`.

After caching results of different functions in the `QuorumIntersectionCheckerImpl.cpp` (https://github.com/stellar/stellar-core/issues/2140), `isAQuorum` seems to be the best function to cache the results for because:

- The improvement is comparable to `contractToMaximalQuorum` and is bigger than caching results of other functions.
- Caching the results of `contractToMaximalQuorum` consumes more memory because both the input and output are `BitSet`. On the other hand, `isAQuorum`'s return value is boolean, so it consumes less memory.

On top of that, I have also included a small change to `contractToMaximalQuorum` which also improves the execution time.
These two changes make the code pass `quorum intersection scaling test` roughly 10-30% faster than compared to the master branch.

* Memory consumption (`heaptrack src/stellar-core test -a 'quorum intersection scaling test'`)

Master
```
bytes allocated in total (ignoring deallocations): 3.83MB (1.18MB/s)
calls to allocation functions: 30384 (9334/s)
temporary memory allocations: 1736 (533/s)
peak heap memory consumption: 1.87MB
peak RSS (including heaptrack overhead): 71.31MB
total memory leaked: 1.28MB
```

This change
```
bytes allocated in total (ignoring deallocations): 37.92MB (8.78MB/s)
calls to allocation functions: 1663627 (385009/s)
temporary memory allocations: 1385472 (320636/s)
peak heap memory consumption: 8.70MB
peak RSS (including heaptrack overhead): 404.98MB
total memory leaked: 1.25MB
```
* `perf` shows that the function `containsQuorumSlice` takes 70% of the execution time in the master branch, but it will only take 54% with this change, which, I believe, comes from caching the results of `isAQuorum`.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
