### PR TITLE
Bug #2722 - Remove MAX_BATCH_READ_{COUNT,PERIOD_MS}, obsoleted by VirtualClock::shouldYield

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -126,14 +126,6 @@ PEER_TIMEOUT=30
 # time when authenticated.
 PEER_STRAGGLER_TIMEOUT=120
 
-# MAX_BATCH_READ_PERIOD_MS (Integer) default 100
-# How long this server can spend processing reads from a peer at once
-MAX_BATCH_READ_PERIOD_MS=100
-
-# MAX_BATCH_READ_COUNT (Integer) default 1024
-# How many messages can this server read at once from a peer
-MAX_BATCH_READ_COUNT=1024
-
 # MAX_BATCH_WRITE_COUNT (Integer) default 1024
 # How many messages can this server send at once to a peer
 MAX_BATCH_WRITE_COUNT=1024

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -147,16 +147,6 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_TIMEOUT = 30;
     PEER_STRAGGLER_TIMEOUT = 120;
 
-    // time spent picking up items from a connection all at once, this should be
-    // picked high enough that we can pick up as many items as possible but low
-    // enough that we give a chance to cycle through all connections in a
-    // reasonable amount of time. 10ms would allow to cycle through 100
-    // connections in one second
-    MAX_BATCH_READ_PERIOD_MS = std::chrono::milliseconds(10);
-    // during transaction spikes, we want to increase the chance of picking up
-    // items behind transactions
-    MAX_BATCH_READ_COUNT = 1000;
-
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
     PREFERRED_PEERS_ONLY = false;
@@ -839,15 +829,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 PEER_STRAGGLER_TIMEOUT = readInt<unsigned short>(
                     item, 1, std::numeric_limits<unsigned short>::max());
-            }
-            else if (item.first == "MAX_BATCH_READ_PERIOD_MS")
-            {
-                MAX_BATCH_READ_PERIOD_MS =
-                    std::chrono::milliseconds(readInt<int>(item, 1));
-            }
-            else if (item.first == "MAX_BATCH_READ_COUNT")
-            {
-                MAX_BATCH_READ_COUNT = readInt<int>(item, 1);
             }
             else if (item.first == "MAX_BATCH_WRITE_COUNT")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -309,8 +309,6 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short PEER_AUTHENTICATION_TIMEOUT;
     unsigned short PEER_TIMEOUT;
     unsigned short PEER_STRAGGLER_TIMEOUT;
-    std::chrono::milliseconds MAX_BATCH_READ_PERIOD_MS;
-    int MAX_BATCH_READ_COUNT;
     int MAX_BATCH_WRITE_COUNT;
     int MAX_BATCH_WRITE_BYTES;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;


### PR DESCRIPTION
Resolves #2722 -- obsolete config setting.