### PR TITLE
Limit LogSlowExecution to one message per second (plus overflow summary).

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -361,6 +361,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\TransactionSQL.cpp" />
     <ClCompile Include="..\..\src\transactions\RevokeSponsorshipOpFrame.cpp" />
     <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
+    <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\Scheduler.cpp" />
     <ClCompile Include="..\..\src\util\test\MetricTests.cpp" />
     <ClCompile Include="..\..\src\util\test\SchedulerTests.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1137,6 +1137,9 @@
     <ClCompile Include="..\..\src\util\XDRCereal.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\LogSlowExecution.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">

--- a/src/util/LogSlowExecution.cpp
+++ b/src/util/LogSlowExecution.cpp
@@ -1,0 +1,82 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/LogSlowExecution.h"
+#include "util/Logging.h"
+#include <fmt/format.h>
+#include <mutex>
+
+namespace
+{
+std::mutex gLogSlowExecMutex;
+std::chrono::system_clock::time_point gLastLogMessage;
+size_t gDroppedLogMessagesSinceLast{0};
+}
+
+namespace stellar
+{
+LogSlowExecution::LogSlowExecution(std::string eventName, Mode mode,
+                                   std::string message,
+                                   std::chrono::milliseconds threshold)
+    : mStart(std::chrono::system_clock::now())
+    , mName(std::move(eventName))
+    , mMode(mode)
+    , mMessage(std::move(message))
+    , mThreshold(threshold){};
+
+LogSlowExecution::~LogSlowExecution()
+{
+    if (mMode == Mode::AUTOMATIC_RAII)
+    {
+        checkElapsedTime();
+    }
+}
+
+std::chrono::milliseconds
+LogSlowExecution::checkElapsedTime() const
+{
+    auto finish = std::chrono::system_clock::now();
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(finish - mStart);
+
+    if (elapsed > mThreshold)
+    {
+        std::lock_guard<std::mutex> guard(gLogSlowExecMutex);
+
+        // Only emit a new log message once-per-second (optionally preceeded
+        // by a summary of how many messages have been dropped since last time).
+        if ((finish - gLastLogMessage) > std::chrono::seconds(1))
+        {
+            if (gDroppedLogMessagesSinceLast > 0)
+            {
+                CLOG(WARNING, "Perf")
+                    << "Dropped " << gDroppedLogMessagesSinceLast
+                    << " slow-execution warning messages";
+                gDroppedLogMessagesSinceLast = 0;
+            }
+            auto msg = fmt::format("'{}' {} {} s", mName, mMessage,
+                                   static_cast<float>(elapsed.count()) / 1000);
+            // if we're 10 times over the threshold, log with INFO, otherwise
+            // use DEBUG
+            if (elapsed > mThreshold * 10)
+            {
+                CLOG(WARNING, "Perf") << msg;
+            }
+            else
+            {
+                CLOG(DEBUG, "Perf") << msg;
+            }
+            gLastLogMessage = finish;
+        }
+
+        // If we've emitted this second already, just bump a counter that
+        // will be flushed in a summary message at the next second-boundary.
+        else
+        {
+            gDroppedLogMessagesSinceLast++;
+        }
+    }
+    return elapsed;
+}
+}

--- a/src/util/LogSlowExecution.h
+++ b/src/util/LogSlowExecution.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
-#include "util/Logging.h"
 #include <chrono>
-#include <fmt/format.h>
+#include <string>
 
+namespace stellar
+{
 class LogSlowExecution
 {
   public:
@@ -21,45 +22,9 @@ class LogSlowExecution
     LogSlowExecution(
         std::string eventName, Mode mode = Mode::AUTOMATIC_RAII,
         std::string message = "took",
-        std::chrono::milliseconds threshold = std::chrono::seconds(1))
-        : mStart(std::chrono::system_clock::now())
-        , mName(std::move(eventName))
-        , mMode(mode)
-        , mMessage(std::move(message))
-        , mThreshold(threshold){};
-
-    ~LogSlowExecution()
-    {
-        if (mMode == Mode::AUTOMATIC_RAII)
-        {
-            checkElapsedTime();
-        }
-    }
-
-    std::chrono::milliseconds
-    checkElapsedTime() const
-    {
-        auto finish = std::chrono::system_clock::now();
-        auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-            finish - mStart);
-
-        if (elapsed > mThreshold)
-        {
-            auto msg = fmt::format("'{}' {} {} s", mName, mMessage,
-                                   static_cast<float>(elapsed.count()) / 1000);
-            // if we're 10 times over the threshold, log with INFO, otherwise
-            // use DEBUG
-            if (elapsed > mThreshold * 10)
-            {
-                CLOG(INFO, "Perf") << msg;
-            }
-            else
-            {
-                CLOG(DEBUG, "Perf") << msg;
-            }
-        }
-        return elapsed;
-    }
+        std::chrono::milliseconds threshold = std::chrono::seconds(1));
+    ~LogSlowExecution();
+    std::chrono::milliseconds checkElapsedTime() const;
 
   private:
     std::chrono::system_clock::time_point mStart;
@@ -68,3 +33,4 @@ class LogSlowExecution
     std::string mMessage;
     std::chrono::milliseconds mThreshold;
 };
+}


### PR DESCRIPTION
When there's a slow execution there's often a gigantic _storm_ of slow executions, producing thousands of log messages that then can be a performance problem of their own. This changes the slow-execution tracking machinery to (rather crudely) just throttle messages that occur faster than once a second, compressing them down to a summary of `Dropped <N> slow-execution warning messages` if they occur any faster.

(Ideally we'd never have such messages _and_ we'd have a fast enough logging subsystem not to care, but we're not quite living in that world yet. One step at a time.)