### PR TITLE
Print a report on archives on startup & add an http endpoint for that

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -392,6 +392,7 @@ exit /b 0
     <ClCompile Include="..\..\src\history\FileTransferInfo.cpp" />
     <ClCompile Include="..\..\src\history\HistoryArchive.cpp" />
     <ClCompile Include="..\..\src\history\HistoryArchiveManager.cpp" />
+    <ClCompile Include="..\..\src\history\HistoryArchiveReportWork.cpp" />
     <ClCompile Include="..\..\src\history\HistoryManagerImpl.cpp" />
     <ClCompile Include="..\..\src\history\InferredQuorum.cpp" />
     <ClCompile Include="..\..\src\history\InferredQuorumUtils.cpp" />
@@ -740,6 +741,7 @@ exit /b 0
     <ClInclude Include="..\..\src\history\FileTransferInfo.h" />
     <ClInclude Include="..\..\src\history\HistoryArchive.h" />
     <ClInclude Include="..\..\src\history\HistoryArchiveManager.h" />
+    <ClInclude Include="..\..\src\history\HistoryArchiveReportWork.h" />
     <ClInclude Include="..\..\src\history\HistoryManager.h" />
     <ClInclude Include="..\..\src\history\HistoryManagerImpl.h" />
     <ClInclude Include="..\..\src\history\HistoryTestsUtils.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -534,6 +534,9 @@
     <ClCompile Include="..\..\src\history\HistoryArchiveManager.cpp">
       <Filter>history</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\history\HistoryArchiveReportWork.cpp">
+      <Filter>history</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\history\HistoryManagerImpl.cpp">
       <Filter>history</Filter>
     </ClCompile>
@@ -1569,6 +1572,9 @@
       <Filter>history</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\history\HistoryArchiveManager.h">
+      <Filter>history</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\history\HistoryArchiveReportWork.h">
       <Filter>history</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\history\HistoryManager.h">

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -123,6 +123,9 @@ You can send commands to stellar-core via a web browser, curl, or using the --c
 command line option (see above). Most commands return their results in JSON
 format.
 
+* **self-check**: Perform history-related sanity checks, and it is planned
+  to support other kinds of sanity checks in the future.
+
 * **bans**
   List current active bans
 

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -80,6 +80,8 @@ Command options can only by placed after command.
 * **sec-to-pub**:  Reads a secret key on standard input and outputs the
   corresponding public key.  Both keys are in Stellar's standard
   base-32 ASCII format.
+* **self-check**: Perform history-related sanity checks, and it is planned
+  to support other kinds of sanity checks in the future.
 * **sign-transaction <FILE-NAME>**:  Add a digital signature to a transaction
   envelope stored in binary format in <FILE-NAME>, and send the result to
   standard output (which should be redirected to a file or piped through a tool

--- a/src/history/HistoryArchiveManager.cpp
+++ b/src/history/HistoryArchiveManager.cpp
@@ -4,6 +4,7 @@
 
 #include "history/HistoryArchiveManager.h"
 #include "history/HistoryArchive.h"
+#include "history/HistoryArchiveReportWork.h"
 #include "historywork/GetHistoryArchiveStateWork.h"
 #include "historywork/PutHistoryArchiveStateWork.h"
 #include "main/Application.h"
@@ -155,6 +156,20 @@ HistoryArchiveManager::selectRandomReadableHistoryArchive() const
         return archives[i];
     }
 }
+
+std::shared_ptr<HistoryArchiveReportWork>
+HistoryArchiveManager::scheduleHistoryArchiveReportWork() const
+{
+    std::vector<std::shared_ptr<GetHistoryArchiveStateWork>> hasWorks;
+    for (auto const& archive : mArchives)
+    {
+        hasWorks.push_back(std::make_shared<GetHistoryArchiveStateWork>(
+            mApp, 0, archive, "archive-report-" + archive->getName(),
+            BasicWork::RETRY_NEVER));
+    }
+    return mApp.getWorkScheduler().scheduleWork<HistoryArchiveReportWork>(
+        hasWorks);
+};
 
 bool
 HistoryArchiveManager::initializeHistoryArchive(std::string const& arch) const

--- a/src/history/HistoryArchiveManager.h
+++ b/src/history/HistoryArchiveManager.h
@@ -14,6 +14,8 @@ class Application;
 class Config;
 class HistoryArchive;
 
+class HistoryArchiveReportWork;
+
 class HistoryArchiveManager
 {
   public:
@@ -25,6 +27,9 @@ class HistoryArchiveManager
     // Select any readable history archive. If there are more than one,
     // select one at random.
     std::shared_ptr<HistoryArchive> selectRandomReadableHistoryArchive() const;
+
+    std::shared_ptr<HistoryArchiveReportWork>
+    scheduleHistoryArchiveReportWork() const;
 
     // Initialize a named history archive by writing
     // .well-known/stellar-history.json to it.

--- a/src/history/HistoryArchiveReportWork.cpp
+++ b/src/history/HistoryArchiveReportWork.cpp
@@ -1,0 +1,57 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "history/HistoryArchiveReportWork.h"
+#include "history/HistoryArchive.h"
+#include "historywork/GetHistoryArchiveStateWork.h"
+#include "util/Logging.h"
+#include "work/WorkSequence.h"
+#include <Tracy.hpp>
+#include <fmt/format.h>
+#include <iostream>
+
+namespace stellar
+{
+
+HistoryArchiveReportWork::HistoryArchiveReportWork(
+    Application& app,
+    std::vector<std::shared_ptr<GetHistoryArchiveStateWork>> const& works)
+    : WorkSequence(
+          app, "history-archive-report-work",
+          std::vector<std::shared_ptr<BasicWork>>(works.begin(), works.end()),
+          BasicWork::RETRY_NEVER)
+    , mGetHistoryArchiveStateWorks(works)
+{
+}
+
+void
+HistoryArchiveReportWork::onSuccess()
+{
+    for (auto const& work : mGetHistoryArchiveStateWorks)
+    {
+        CLOG(INFO, "History")
+            << fmt::format("Archive information: [name: {}, server: {}, "
+                           "currentLedger: "
+                           "{}]",
+                           work->getArchive()->getName(),
+                           work->getHistoryArchiveState().server,
+                           work->getHistoryArchiveState().currentLedger);
+    }
+}
+
+void
+HistoryArchiveReportWork::onFailureRaise()
+{
+    for (auto const& work : mGetHistoryArchiveStateWorks)
+    {
+        if (work->getState() != State::WORK_SUCCESS)
+        {
+            CLOG(ERROR, "History")
+                << fmt::format("Failed to obtain archive information: {}",
+                               work->getArchive()->getName());
+            return;
+        }
+    }
+}
+}

--- a/src/history/HistoryArchiveReportWork.h
+++ b/src/history/HistoryArchiveReportWork.h
@@ -1,0 +1,29 @@
+#pragma once
+
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "work/WorkSequence.h"
+
+namespace stellar
+{
+class GetHistoryArchiveStateWork;
+class HistoryArchive;
+class HistoryArchiveReportWork : public WorkSequence
+{
+  protected:
+    void onFailureRaise() override;
+    void onSuccess() override;
+
+  public:
+    HistoryArchiveReportWork(
+        Application& app,
+        std::vector<std::shared_ptr<GetHistoryArchiveStateWork>> const& works);
+    ~HistoryArchiveReportWork() = default;
+
+  private:
+    std::vector<std::shared_ptr<GetHistoryArchiveStateWork>>
+        mGetHistoryArchiveStateWorks;
+};
+}

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -64,6 +64,7 @@ runWithConfig(Config cfg, optional<CatchupConfiguration> cc)
     Application::pointer app;
     try
     {
+        cfg.COMMANDS.push_back("self-check");
         app = Application::create(clock, cfg, false);
 
         if (!app->getHistoryArchiveManager().checkSensibleConfig())

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -10,6 +10,7 @@
 #include "database/Database.h"
 #include "history/HistoryArchive.h"
 #include "history/HistoryArchiveManager.h"
+#include "history/HistoryArchiveReportWork.h"
 #include "historywork/GetHistoryArchiveStateWork.h"
 #include "ledger/LedgerManager.h"
 #include "main/ErrorMessages.h"
@@ -169,6 +170,26 @@ httpCommand(std::string const& command, unsigned short port)
     {
         LOG(INFO) << "http failed(" << code << ") port: " << port
                   << " command: " << command;
+    }
+}
+
+int
+selfCheck(Config cfg)
+{
+    VirtualClock clock;
+    cfg.setNoListen();
+    Application::pointer app = Application::create(clock, cfg, false);
+    std::shared_ptr<HistoryArchiveReportWork> w =
+        app->getHistoryArchiveManager().scheduleHistoryArchiveReportWork();
+    while (clock.crank(true) && !w->isDone())
+        ;
+    if (w->getState() == BasicWork::State::WORK_SUCCESS)
+    {
+        return 0;
+    }
+    else
+    {
+        return 1;
     }
 }
 

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -16,6 +16,7 @@ int runWithConfig(Config cfg, optional<CatchupConfiguration> cc);
 void setForceSCPFlag();
 void initializeDatabase(Config cfg);
 void httpCommand(std::string const& command, unsigned short port);
+int selfCheck(Config cfg);
 void showOfflineInfo(Config cfg);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);
 #ifdef BUILD_TESTS

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -6,6 +6,7 @@
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
 #include "herder/Herder.h"
+#include "history/HistoryArchiveManager.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
@@ -105,6 +106,7 @@ CommandHandler::CommandHandler(Application& app) : mApp(app)
     addRoute("metrics", &CommandHandler::metrics);
     addRoute("tx", &CommandHandler::tx);
     addRoute("upgrades", &CommandHandler::upgrades);
+    addRoute("self-check", &CommandHandler::selfCheck);
 
 #ifdef BUILD_TESTS
     addRoute("generateload", &CommandHandler::generateLoad);
@@ -491,6 +493,13 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
     {
         retStr = fmt::format("Unknown mode: {}", s);
     }
+}
+
+void
+CommandHandler::selfCheck(std::string const&, std::string& retStr)
+{
+    ZoneScoped;
+    mApp.getHistoryArchiveManager().scheduleHistoryArchiveReportWork();
 }
 
 void

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -48,6 +48,7 @@ class CommandHandler
     void metrics(std::string const& params, std::string& retStr);
     void clearMetrics(std::string const& params, std::string& retStr);
     void peers(std::string const& params, std::string& retStr);
+    void selfCheck(std::string const&, std::string& retStr);
     void quorum(std::string const& params, std::string& retStr);
     void setcursor(std::string const& params, std::string& retStr);
     void getcursor(std::string const& params, std::string& retStr);

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -913,6 +913,15 @@ runHttpCommand(CommandLineArgs const& args)
 }
 
 int
+runSelfCheck(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+
+    return runWithHelp(args, {configurationParser(configOption)},
+                       [&] { return selfCheck(configOption.getConfig()); });
+}
+
+int
 runInferQuorum(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -1452,6 +1461,7 @@ handleCommandLine(int argc, char* const* argv)
          {"gen-seed", "generate and print a random node seed", runGenSeed},
          {"http-command", "send a command to local stellar-core",
           runHttpCommand},
+         {"self-check", "performs sanity checks", runSelfCheck},
          {"infer-quorum", "print a quorum set inferred from history",
           runInferQuorum},
          {"new-db", "creates or restores the DB to the genesis ledger",


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/2328

With this change, the program will now print the name, server, and current ledger information on startup & as requested through the http-endpoint `archive-report`.

The output will be formatted as following:

```
2020-11-04T13:29:24.544 GBA2J [History INFO] Archive information: [name: sdftest1, server: stellar-core 15.0.1~unstable (572604757f7dd5760cb2da2b35956a83a3b34618), currentLedger: 121151]
```


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
