### PR TITLE
Rework slot tracking

### DIFF
--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -7,6 +7,8 @@ namespace stellar
 std::chrono::seconds const Herder::EXP_LEDGER_TIMESPAN_SECONDS(5);
 std::chrono::seconds const Herder::MAX_SCP_TIMEOUT_SECONDS(240);
 std::chrono::seconds const Herder::CONSENSUS_STUCK_TIMEOUT_SECONDS(35);
+std::chrono::seconds const Herder::OUT_OF_SYNC_RECOVERY_TIMER =
+    std::chrono::seconds(10);
 std::chrono::seconds constexpr Herder::MAX_TIME_SLIP_SECONDS;
 std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 // the value of LEDGER_VALIDITY_BRACKET should be in the order of

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -43,6 +43,9 @@ class Herder
     // timeout before considering the node out of sync
     static std::chrono::seconds const CONSENSUS_STUCK_TIMEOUT_SECONDS;
 
+    // timeout before triggering out of sync recovery
+    static std::chrono::seconds const OUT_OF_SYNC_RECOVERY_TIMER;
+
     // Maximum time slip between nodes.
     static std::chrono::seconds constexpr MAX_TIME_SLIP_SECONDS =
         std::chrono::seconds{60};

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1282,7 +1282,7 @@ HerderImpl::getJsonQuorumInfo(NodeID const& id, bool summary, bool fullKeys,
         ret["qset"]["lag_ms"] =
             getHerderSCPDriver().getQsetLagInfo(summary, fullKeys);
         ret["qset"]["cost"] =
-            mHerderSCPDriver.getJsonValidatorCost(summary, fullKeys, index);
+            mPendingEnvelopes.getJsonValidatorCost(summary, fullKeys, index);
     }
     return ret;
 }
@@ -1787,7 +1787,7 @@ HerderImpl::herderOutOfSync()
     auto trackingData = mHerderSCPDriver.lastTrackingSCP();
     if (trackingData)
     {
-        mHerderSCPDriver.reportCostOutliersForSlot(
+        mPendingEnvelopes.reportCostOutliersForSlot(
             trackingData->mConsensusIndex, false);
     }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -872,9 +872,7 @@ HerderImpl::ledgerClosed(bool synchronous)
         mApp.getOverlayManager().clearLedgersBelow(minSlotToRemember,
                                                    lastIndex);
     }
-
-    mPendingEnvelopes.slotClosed(lastIndex);
-
+    mPendingEnvelopes.forceRebuildQuorum();
     maybeTriggerNextLedger(synchronous);
 }
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -866,13 +866,13 @@ HerderImpl::ledgerClosed(bool synchronous)
         }
         getHerderSCPDriver().purgeSlots(minSlotToRemember);
         mPendingEnvelopes.eraseBelow(minSlotToRemember);
+
+        auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
+        mApp.getOverlayManager().clearLedgersBelow(minSlotToRemember,
+                                                   lastIndex);
     }
 
-    auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
-
     mPendingEnvelopes.slotClosed(lastIndex);
-
-    mApp.getOverlayManager().ledgerClosed(lastIndex);
 
     maybeTriggerNextLedger(synchronous);
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -861,12 +861,13 @@ HerderImpl::ledgerClosed(bool synchronous)
         // report any outliers for the most recent slot to purge
         if (mLedgerManager.isSynced())
         {
+            // stop early as to properly update cost for slots
+            mPendingEnvelopes.stopAllBelow(minSlotToRemember);
             getHerderSCPDriver().reportCostOutliersForSlot(
                 minSlotToRemember - 1, true);
         }
         getHerderSCPDriver().purgeSlots(minSlotToRemember);
         mPendingEnvelopes.eraseBelow(minSlotToRemember);
-
         auto lastIndex = mHerderSCPDriver.lastConsensusLedgerIndex();
         mApp.getOverlayManager().clearLedgersBelow(minSlotToRemember,
                                                    lastIndex);

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -844,16 +844,8 @@ HerderImpl::maybeTriggerNextLedger(bool synchronous)
 void
 HerderImpl::eraseBelow(uint32 ledgerSeq)
 {
-    // report any outliers for the most recent slot to purge
-    if (mLedgerManager.isSynced())
-    {
-        // stop early as to properly update cost for slots
-        mPendingEnvelopes.stopAllBelow(ledgerSeq);
-        getHerderSCPDriver().reportCostOutliersForSlot(ledgerSeq - 1, true);
-    }
     getHerderSCPDriver().purgeSlots(ledgerSeq);
     mPendingEnvelopes.eraseBelow(ledgerSeq);
-
     auto lastIndex = getCurrentLedgerSeq();
     mApp.getOverlayManager().clearLedgersBelow(ledgerSeq, lastIndex);
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -50,7 +50,6 @@ constexpr auto const TRANSACTION_QUEUE_SIZE = 4;
 constexpr auto const TRANSACTION_QUEUE_BAN_SIZE = 10;
 constexpr auto const TRANSACTION_QUEUE_MULTIPLIER = 4;
 constexpr size_t const OPERATION_BROADCAST_MULTIPLIER = 2;
-constexpr auto const OUT_OF_SYNC_RECOVERY_TIMER = std::chrono::seconds(10);
 
 std::unique_ptr<Herder>
 Herder::create(Application& app)
@@ -331,7 +330,7 @@ HerderImpl::startOutOfSyncTimer()
         return;
     }
 
-    mOutOfSyncTimer.expires_from_now(OUT_OF_SYNC_RECOVERY_TIMER);
+    mOutOfSyncTimer.expires_from_now(Herder::OUT_OF_SYNC_RECOVERY_TIMER);
 
     mOutOfSyncTimer.async_wait(
         [&]() {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -213,6 +213,9 @@ class HerderImpl : public Herder
     // run a background job that re-analyzes the current quorum map.
     void checkAndMaybeReanalyzeQuorumMap();
 
+    // erase all data for ledgers strictly less than ledgerSeq
+    void eraseBelow(uint32 ledgerSeq);
+
     struct QuorumMapIntersectionState
     {
         uint32_t mLastCheckLedger{0};

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -171,11 +171,6 @@ class HerderSCPDriver : public SCPDriver
 
     Json::Value getQsetLagInfo(bool summary, bool fullKeys);
 
-    void reportCostOutliersForSlot(int64_t slotIndex, bool updateMetrics);
-
-    Json::Value getJsonValidatorCost(bool summary, bool fullKeys,
-                                     uint64 index) const;
-
   private:
     Application& mApp;
     HerderImpl& mHerder;
@@ -203,9 +198,6 @@ class HerderSCPDriver : public SCPDriver
         // Timers tracking externalize messages
         medida::Timer& mExternalizeLag;
         medida::Timer& mExternalizeDelay;
-
-        // Tracked cost per slot
-        medida::Histogram& mCostPerSlot;
 
         SCPMetrics(Application& app);
     };

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -658,7 +658,7 @@ PendingEnvelopes::readySlots()
 void
 PendingEnvelopes::eraseBelow(uint64 slotIndex)
 {
-    stopAllBelow(slotIndex + 1);
+    stopAllBelow(slotIndex);
 
     for (auto iter = mEnvelopes.begin(); iter != mEnvelopes.end();)
     {

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -661,6 +661,9 @@ PendingEnvelopes::eraseBelow(uint64 slotIndex)
 {
     stopAllBelow(slotIndex);
 
+    // report only for the highest slot that we're purging
+    reportCostOutliersForSlot(slotIndex - 1, true);
+
     for (auto iter = mEnvelopes.begin(); iter != mEnvelopes.end();)
     {
         if (iter->first < slotIndex)

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -45,6 +45,7 @@ PendingEnvelopes::PendingEnvelopes(Application& app, HerderImpl& herder)
     , mFetchDuration(app.getMetrics().NewTimer({"scp", "fetch", "envelope"}))
     , mFetchTxSetTimer(app.getMetrics().NewTimer({"overlay", "fetch", "txset"}))
     , mFetchQsetTimer(app.getMetrics().NewTimer({"overlay", "fetch", "qset"}))
+    , mCostPerSlot(app.getMetrics().NewHistogram({"scp", "cost", "per-slot"}))
 {
 }
 
@@ -831,7 +832,7 @@ PendingEnvelopes::envelopeProcessed(SCPEnvelope const& env)
 }
 
 std::unordered_map<NodeID, size_t>
-PendingEnvelopes::getCostPerValidator(uint64 slotIndex)
+PendingEnvelopes::getCostPerValidator(uint64 slotIndex) const
 {
     auto found = mEnvelopes.find(slotIndex);
     if (found != mEnvelopes.end())
@@ -839,5 +840,141 @@ PendingEnvelopes::getCostPerValidator(uint64 slotIndex)
         return found->second.mReceivedCost;
     }
     return {};
+}
+
+static bool
+shouldReportCostOutlier(double possibleOutlierCost, double expectedCost,
+                        double ratioLimit)
+{
+    if (possibleOutlierCost <= 0 || expectedCost <= 0)
+    {
+        CLOG(ERROR, "SCP") << "Unexpected k-means value: must be positive";
+        return false;
+    }
+
+    if (possibleOutlierCost / expectedCost > ratioLimit)
+    {
+        // If we're off by too much from the selected cluster, report the value
+        return true;
+    }
+    return false;
+}
+
+void
+PendingEnvelopes::reportCostOutliersForSlot(int64_t slotIndex,
+                                            bool updateMetrics) const
+{
+    ZoneScoped;
+
+    const uint32_t K_MEAN_NUM_CLUSTERS = 3;
+    const double OUTLIER_COST_RATIO_LIMIT = 10;
+
+    auto tracked = getCostPerValidator(slotIndex);
+    if (tracked.empty())
+    {
+        return;
+    }
+
+    std::vector<double> myValidatorsTrackedCost;
+    double totalCost = 0;
+
+    for (auto const& t : tracked)
+    {
+        if (t.second > 0)
+        {
+            double cost = static_cast<double>(t.second);
+            myValidatorsTrackedCost.push_back(cost);
+            totalCost += cost;
+        }
+    }
+
+    // Compare each node to other nodes we heard from for this slot
+    // Note: do not include cost from self as it's much smaller and will
+    // likely skew the data
+    if (myValidatorsTrackedCost.size() > 1)
+    {
+        auto numClusters =
+            std::min(static_cast<uint32_t>(myValidatorsTrackedCost.size()),
+                     K_MEAN_NUM_CLUSTERS);
+        auto clusters = k_means(myValidatorsTrackedCost, numClusters);
+
+        if (clusters.empty() || *(clusters.begin()) <= 0)
+        {
+            CLOG(ERROR, "SCP")
+                << "Expected non-empty set of positive cluster centers";
+        }
+        else
+        {
+            Json::Value res;
+            for (auto const& t : tracked)
+            {
+                auto clusterToCompare =
+                    closest_cluster(static_cast<double>(t.second), clusters);
+                auto const smallestCluster = *(clusters.begin());
+                if (shouldReportCostOutlier(clusterToCompare, smallestCluster,
+                                            OUTLIER_COST_RATIO_LIMIT))
+                {
+                    res[mApp.getConfig().toShortString(t.first)] =
+                        static_cast<Json::UInt64>(t.second);
+                }
+            }
+
+            Json::FastWriter fw;
+            if (!res.empty())
+            {
+                CLOG(WARNING, "SCP") << "High validator costs for slot "
+                                     << slotIndex << ": " << fw.write(res);
+            }
+        }
+    }
+
+    if (updateMetrics && totalCost > 0)
+    {
+        mCostPerSlot.Update(static_cast<int64_t>(totalCost));
+    }
+}
+
+Json::Value
+PendingEnvelopes::getJsonValidatorCost(bool summary, bool fullKeys,
+                                       uint64 index) const
+{
+    Json::Value res;
+
+    auto computeTotalAndMaybeFillJson = [&](Json::Value& res, uint64 slot) {
+        auto tracked = getCostPerValidator(slot);
+        size_t total = 0;
+        for (auto const& t : tracked)
+        {
+            if (!summary)
+            {
+                res[std::to_string(slot)]
+                   [mApp.getConfig().toStrKey(t.first, fullKeys)] =
+                       static_cast<Json::UInt64>(t.second);
+            }
+            total += t.second;
+        }
+        return total;
+    };
+
+    // Total for one or all slots
+    size_t summaryTotal = 0;
+    if (index == 0)
+    {
+        for (auto const& s : mEnvelopes)
+        {
+            auto slotTotal = computeTotalAndMaybeFillJson(res, s.first);
+            summaryTotal += slotTotal;
+        }
+    }
+    else
+    {
+        summaryTotal = computeTotalAndMaybeFillJson(res, index);
+    }
+
+    if (summary)
+    {
+        res = static_cast<Json::UInt64>(summaryTotal);
+    }
+    return res;
 }
 }

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -699,7 +699,7 @@ PendingEnvelopes::stopAllBelow(uint64 slotIndex)
 }
 
 void
-PendingEnvelopes::slotClosed(uint64 slotIndex)
+PendingEnvelopes::forceRebuildQuorum()
 {
     // force recomputing the transitive quorum
     mRebuildQuorum = true;

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -169,7 +169,12 @@ class PendingEnvelopes
 
     SCPEnvelopeWrapperPtr pop(uint64 slotIndex);
 
+    // erases data for all slots strictly below `slotIndex`
     void eraseBelow(uint64 slotIndex);
+
+    // stops all pending downloads for slots strictly below `slotIndex`
+    // counts partially downloaded data towards the cost for that slot
+    void stopAllBelow(uint64 slotIndex);
 
     void slotClosed(uint64 slotIndex);
 

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -112,6 +112,10 @@ class PendingEnvelopes
     std::unordered_map<NodeID, size_t>
     getCostPerValidator(uint64 slotIndex) const;
 
+    // stops all pending downloads for slots strictly below `slotIndex`
+    // counts partially downloaded data towards the cost for that slot
+    void stopAllBelow(uint64 slotIndex);
+
   public:
     PendingEnvelopes(Application& app, HerderImpl& herder);
     ~PendingEnvelopes();
@@ -176,10 +180,6 @@ class PendingEnvelopes
 
     // erases data for all slots strictly below `slotIndex`
     void eraseBelow(uint64 slotIndex);
-
-    // stops all pending downloads for slots strictly below `slotIndex`
-    // counts partially downloaded data towards the cost for that slot
-    void stopAllBelow(uint64 slotIndex);
 
     void forceRebuildQuorum();
 

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -176,7 +176,7 @@ class PendingEnvelopes
     // counts partially downloaded data towards the cost for that slot
     void stopAllBelow(uint64 slotIndex);
 
-    void slotClosed(uint64 slotIndex);
+    void forceRebuildQuorum();
 
     std::vector<uint64> readySlots();
 

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -79,6 +79,8 @@ class PendingEnvelopes
     medida::Timer& mFetchDuration;
     medida::Timer& mFetchTxSetTimer;
     medida::Timer& mFetchQsetTimer;
+    // Tracked cost per slot
+    medida::Histogram& mCostPerSlot;
 
     // discards all SCP envelopes thats use QSet with given hash,
     // as it is not sane QSet
@@ -106,6 +108,9 @@ class PendingEnvelopes
     void cleanKnownData();
 
     void recordReceivedCost(SCPEnvelope const& env);
+
+    std::unordered_map<NodeID, size_t>
+    getCostPerValidator(uint64 slotIndex) const;
 
   public:
     PendingEnvelopes(Application& app, HerderImpl& herder);
@@ -195,6 +200,8 @@ class PendingEnvelopes
     // updates internal state when an envelope was successfully processed
     void envelopeProcessed(SCPEnvelope const& env);
 
-    std::unordered_map<NodeID, size_t> getCostPerValidator(uint64 slotIndex);
+    void reportCostOutliersForSlot(int64_t slotIndex, bool updateMetrics) const;
+    Json::Value getJsonValidatorCost(bool summary, bool fullKeys,
+                                     uint64 index) const;
 };
 }

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2401,3 +2401,148 @@ TEST_CASE("do not flood too many transactions", "[herder]")
         test(100);
     }
 }
+
+TEST_CASE("slot herder policy", "[herder]")
+{
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+    SIMULATION_CREATE_NODE(3);
+
+    Config cfg(getTestConfig());
+
+    // start in sync
+    cfg.FORCE_SCP = true;
+    cfg.MANUAL_CLOSE = false;
+    cfg.NODE_SEED = v0SecretKey;
+    cfg.MAX_SLOTS_TO_REMEMBER = 5;
+    cfg.NODE_IS_VALIDATOR = false;
+
+    cfg.QUORUM_SET.threshold = 3; // 3 out of 4
+    cfg.QUORUM_SET.validators.push_back(v1NodeID);
+    cfg.QUORUM_SET.validators.push_back(v2NodeID);
+    cfg.QUORUM_SET.validators.push_back(v3NodeID);
+
+    VirtualClock clock;
+    Application::pointer app = createTestApplication(clock, cfg);
+
+    auto& herder = static_cast<HerderImpl&>(app->getHerder());
+
+    auto qSet = herder.getSCP().getLocalQuorumSet();
+    auto qsetHash = sha256(xdr::xdr_to_opaque(qSet));
+
+    auto recvExternalize = [&](SecretKey const& sk, uint64_t slotIndex,
+                               Hash const& prevHash) {
+        auto envelope = SCPEnvelope{};
+        envelope.statement.slotIndex = slotIndex;
+        envelope.statement.pledges.type(SCP_ST_EXTERNALIZE);
+        auto& ext = envelope.statement.pledges.externalize();
+        TxSetFramePtr txSet = std::make_shared<TxSetFrame>(prevHash);
+
+        StellarValue sv{txSet->getContentsHash(), (TimePoint)slotIndex,
+                        xdr::xvector<UpgradeType, 6>{}, STELLAR_VALUE_BASIC};
+        if (herder.getHerderSCPDriver().compositeValueType() ==
+            STELLAR_VALUE_SIGNED)
+        {
+            // sign values with the same secret key
+            herder.signStellarValue(v1SecretKey, sv);
+        }
+        ext.commit.counter = 1;
+        ext.commit.value = xdr::xdr_to_opaque(sv);
+        ext.commitQuorumSetHash = qsetHash;
+        ext.nH = 1;
+        envelope.statement.nodeID = sk.getPublicKey();
+        herder.signEnvelope(sk, envelope);
+        auto res = herder.recvSCPEnvelope(envelope, qSet, *txSet);
+        REQUIRE(res == Herder::ENVELOPE_STATUS_READY);
+    };
+
+    auto const LIMIT = cfg.MAX_SLOTS_TO_REMEMBER;
+
+    auto recvExternPeers = [&](uint32 seq, Hash const& prev, bool quorum) {
+        recvExternalize(v1SecretKey, seq, prev);
+        recvExternalize(v2SecretKey, seq, prev);
+        if (quorum)
+        {
+            recvExternalize(v3SecretKey, seq, prev);
+        }
+    };
+    // first, close a few ledgers, see if we actually retain the right
+    // number of ledgers
+    auto timeout = clock.now() + std::chrono::minutes(10);
+    for (uint32 i = 0; i < LIMIT * 2; ++i)
+    {
+        auto seq = app->getLedgerManager().getLastClosedLedgerNum() + 1;
+        auto prev = app->getLedgerManager().getLastClosedLedgerHeader().hash;
+        recvExternPeers(seq, prev, true);
+        while (app->getLedgerManager().getLastClosedLedgerNum() < seq)
+        {
+            clock.crank(true);
+            REQUIRE(clock.now() < timeout);
+        }
+    }
+    REQUIRE(herder.getState() == Herder::HERDER_TRACKING_STATE);
+    REQUIRE(herder.getSCP().getKnownSlotsCount() == LIMIT);
+    auto const PARTIAL = LIMIT * 4;
+
+    // create a gap
+    auto newSeq = app->getLedgerManager().getLastClosedLedgerNum() + 2;
+    for (uint32 i = 0; i < PARTIAL; ++i)
+    {
+        auto prev = app->getLedgerManager().getLastClosedLedgerHeader().hash;
+        recvExternPeers(newSeq++, prev, false);
+    }
+    auto oneSec = std::chrono::seconds(1);
+    // let the node go out of sync, it should reach the desired state
+    timeout = clock.now() + Herder::CONSENSUS_STUCK_TIMEOUT_SECONDS + oneSec;
+    while (herder.getState() == Herder::HERDER_TRACKING_STATE)
+    {
+        clock.crank(false);
+        REQUIRE(clock.now() < timeout);
+    }
+    REQUIRE(herder.getSCP().getKnownSlotsCount() == (LIMIT + PARTIAL));
+
+    timeout = clock.now() + Herder::OUT_OF_SYNC_RECOVERY_TIMER + oneSec;
+    while (herder.getSCP().getKnownSlotsCount() != (2 * LIMIT + 1))
+    {
+        clock.sleep_for(std::chrono::seconds(1));
+        clock.crank(false);
+        REQUIRE(clock.now() < timeout);
+    }
+
+    Hash prevHash;
+    // add a bunch more - not v-blocking
+    for (uint32 i = 0; i < PARTIAL; ++i)
+    {
+        recvExternalize(v1SecretKey, newSeq++, prevHash);
+    }
+    // policy here is to not do anything
+    auto waitForRecovery = [&]() {
+        timeout = clock.now() + Herder::OUT_OF_SYNC_RECOVERY_TIMER + oneSec;
+        while (clock.now() < timeout)
+        {
+            clock.sleep_for(std::chrono::seconds(1));
+            clock.crank(false);
+        }
+    };
+
+    waitForRecovery();
+    auto const FULLSLOTS = 2 * LIMIT + 1 + PARTIAL;
+    REQUIRE(herder.getSCP().getKnownSlotsCount() == FULLSLOTS);
+
+    // now inject a few more, policy should apply here, with
+    // partial in between
+    // lower slots getting dropped so the total number of slots in memory is
+    // constant
+    auto cutOff = 2 * LIMIT;
+    for (uint32 i = 0; i < cutOff; ++i)
+    {
+        recvExternPeers(newSeq++, prevHash, false);
+        waitForRecovery();
+        REQUIRE(herder.getSCP().getKnownSlotsCount() == FULLSLOTS);
+    }
+    // adding one more, should get rid of the partial slots
+    recvExternPeers(newSeq++, prevHash, false);
+    waitForRecovery();
+    REQUIRE(herder.getSCP().getKnownSlotsCount() == (2 * LIMIT + 1));
+}

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -37,13 +37,12 @@ Floodgate::Floodgate(Application& app)
 
 // remove old flood records
 void
-Floodgate::clearBelow(uint32_t currentLedger)
+Floodgate::clearBelow(uint32_t maxLedger)
 {
     ZoneScoped;
     for (auto it = mFloodMap.cbegin(); it != mFloodMap.cend();)
     {
-        // give one ledger of leeway
-        if (it->second->mLedgerSeq + 10 < currentLedger)
+        if (it->second->mLedgerSeq < maxLedger)
         {
             it = mFloodMap.erase(it);
         }

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -52,8 +52,8 @@ class Floodgate
 
   public:
     Floodgate(Application& app);
-    // Floodgate will be cleared after every ledger close
-    void clearBelow(uint32_t currentLedger);
+    // forget data strictly older than `maxLedger`
+    void clearBelow(uint32_t maxLedger);
     // returns true if this is a new record
     // fills msgID with msg's hash
     bool addRecord(StellarMessage const& msg, Peer::pointer fromPeer,

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -61,9 +61,9 @@ class OverlayManager
     static void dropAll(Database& db);
 
     // Flush all FloodGate and ItemFetcher state for ledgers older than
-    // `ledger`.
-    // This is called by LedgerManager when a ledger closes.
-    virtual void ledgerClosed(uint32_t lastClosedledgerSeq) = 0;
+    // `ledgerSeq`.
+    // This is called by Herder when ledger `lclSeq` closes.
+    virtual void clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq) = 0;
 
     // Send a given message to all peers, via the FloodGate. This is called by
     // Herder.

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -619,10 +619,10 @@ OverlayManagerImpl::getConnectedPeer(PeerBareAddress const& address)
 }
 
 void
-OverlayManagerImpl::ledgerClosed(uint32_t lastClosedledgerSeq)
+OverlayManagerImpl::clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq)
 {
-    mFloodGate.clearBelow(lastClosedledgerSeq);
-    mSurveyManager->clearOldLedgers(lastClosedledgerSeq);
+    mFloodGate.clearBelow(ledgerSeq);
+    mSurveyManager->clearOldLedgers(lclSeq);
 }
 
 void

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -100,7 +100,7 @@ class OverlayManagerImpl : public OverlayManager
     OverlayManagerImpl(Application& app);
     ~OverlayManagerImpl();
 
-    void ledgerClosed(uint32_t lastClosedledgerSeq) override;
+    void clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq) override;
     bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
                           Hash& msgID) override;
     void forgetFloodedMsg(Hash const& msgID) override;

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -74,16 +74,9 @@ void
 SCP::purgeSlots(uint64 maxSlotIndex)
 {
     auto it = mKnownSlots.begin();
-    while (it != mKnownSlots.end())
+    while (it != mKnownSlots.end() && it->first < maxSlotIndex)
     {
-        if (it->first < maxSlotIndex)
-        {
-            it = mKnownSlots.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
+        it = mKnownSlots.erase(it);
     }
 }
 

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -244,6 +244,21 @@ SCP::processSlotsAscendingFrom(uint64 startingSlot,
     }
 }
 
+void
+SCP::processSlotsDescendingFrom(uint64 startingSlot,
+                                std::function<bool(uint64)> const& f)
+{
+    auto iter = mKnownSlots.upper_bound(startingSlot);
+    while (iter != mKnownSlots.begin())
+    {
+        --iter;
+        if (!f(iter->first))
+        {
+            break;
+        }
+    }
+}
+
 SCPEnvelope const*
 SCP::getLatestMessage(NodeID const& id)
 {

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -174,6 +174,20 @@ SCP::isSlotFullyValidated(uint64 slotIndex)
     }
 }
 
+bool
+SCP::gotVBlocking(uint64 slotIndex)
+{
+    auto slot = getSlot(slotIndex, false);
+    if (slot)
+    {
+        return slot->gotVBlocking();
+    }
+    else
+    {
+        return false;
+    }
+}
+
 size_t
 SCP::getKnownSlotsCount() const
 {

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -86,6 +86,9 @@ class SCP
     // returns the validation state of the given slot
     bool isSlotFullyValidated(uint64 slotIndex);
 
+    // returns if we received messages from a v-blocking set
+    bool gotVBlocking(uint64 slotIndex);
+
     // Helpers for monitoring and reporting the internal memory-usage of the SCP
     // protocol to system metric reporters.
     size_t getKnownSlotsCount() const;

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -108,9 +108,13 @@ class SCP
                              std::function<bool(SCPEnvelope const&)> const& f,
                              bool forceSelf);
 
-    // iterates through slots, starting from ledgerSeq
+    // iterates through slots, starting from slot startIndex
     void processSlotsAscendingFrom(uint64 startIndex,
                                    std::function<bool(uint64)> const& f);
+
+    // iterates through slots, starting from slot startIndex
+    void processSlotsDescendingFrom(uint64 startIndex,
+                                    std::function<bool(uint64)> const& f);
 
     // returns the latest message from a node
     // or nullptr if not found

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -9,6 +9,7 @@
 #include "lib/json/json.h"
 #include "main/ErrorMessages.h"
 #include "scp/LocalNode.h"
+#include "scp/QuorumSetUtils.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/XDROperators.h"
@@ -26,6 +27,7 @@ Slot::Slot(uint64 slotIndex, SCP& scp)
     , mBallotProtocol(*this)
     , mNominationProtocol(*this)
     , mFullyValidated(scp.getLocalNode()->isValidator())
+    , mGotVBlocking(false)
 {
 }
 
@@ -63,6 +65,8 @@ Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
     if (e.statement.nodeID == getSCP().getLocalNodeID() &&
         e.statement.slotIndex == mSlotIndex)
     {
+        auto prev = getLatestMessage(e.statement.nodeID) != nullptr;
+
         if (e.statement.pledges.type() == SCPStatementType::SCP_ST_NOMINATE)
         {
             mNominationProtocol.setStateFromEnvelope(env);
@@ -70,6 +74,11 @@ Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
         else
         {
             mBallotProtocol.setStateFromEnvelope(env);
+        }
+
+        if (!prev)
+        {
+            maybeSetGotVBlocking();
         }
     }
     else
@@ -131,15 +140,21 @@ Slot::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
 
     try
     {
+        auto& st = envelope->getStatement();
+        auto prev = getLatestMessage(st.nodeID) != nullptr;
 
-        if (envelope->getStatement().pledges.type() ==
-            SCPStatementType::SCP_ST_NOMINATE)
+        if (st.pledges.type() == SCPStatementType::SCP_ST_NOMINATE)
         {
             res = mNominationProtocol.processEnvelope(envelope);
         }
         else
         {
             res = mBallotProtocol.processEnvelope(envelope, self);
+        }
+
+        if (!prev && res == SCP::VALID)
+        {
+            maybeSetGotVBlocking();
         }
     }
     catch (...)
@@ -398,5 +413,34 @@ Slot::getEntireCurrentState()
         },
         true);
     return res;
+}
+
+void
+Slot::maybeSetGotVBlocking()
+{
+    if (mGotVBlocking)
+    {
+        // was already set
+        return;
+    }
+    std::vector<NodeID> nodes;
+
+    auto& qSet = getLocalNode()->getQuorumSet();
+
+    LocalNode::forAllNodes(qSet, [&](NodeID const& id) {
+        auto latest = getLatestMessage(id);
+        if (latest)
+        {
+            nodes.emplace_back(id);
+        }
+        return true;
+    });
+
+    mGotVBlocking = LocalNode::isVBlocking(qSet, nodes);
+
+    if (mGotVBlocking)
+    {
+        CLOG(TRACE, "SCP") << "Got v-blocking for " << mSlotIndex;
+    }
 }
 }

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -45,6 +45,9 @@ class Slot : public std::enable_shared_from_this<Slot>
     // true if the Slot was fully validated
     bool mFullyValidated;
 
+    // true if we heard from a v-blocking set
+    bool mGotVBlocking;
+
   public:
     Slot(uint64 slotIndex, SCP& SCP);
 
@@ -137,6 +140,12 @@ class Slot : public std::enable_shared_from_this<Slot>
         return mStatementsHistory.size();
     }
 
+    bool
+    gotVBlocking() const
+    {
+        return mGotVBlocking;
+    }
+
     // returns information about the local state in JSON format
     // including historical statements if available
     Json::Value getJsonInfo(bool fullKeys = false);
@@ -182,6 +191,7 @@ class Slot : public std::enable_shared_from_this<Slot>
 
   protected:
     std::vector<SCPEnvelope> getEntireCurrentState();
+    void maybeSetGotVBlocking();
     friend class TestSCP;
 };
 }


### PR DESCRIPTION
This PR fixes issues related to how we keep track of slots, in particular it cleans up how we reason about slot related information between systems (bringing consistency) and erases old slots more aggressively when out of sync.
