### PR TITLE
Split reads per peer

### DIFF
--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -441,8 +441,11 @@ TCPPeer::startRead()
 
     mIncomingHeader.clear();
 
-    CLOG(DEBUG, "Overlay") << "TCPPeer::startRead " << mSocket->in_avail()
-                           << " from " << toString();
+    if (Logging::logDebug("Overlay"))
+    {
+        CLOG(DEBUG, "Overlay") << "TCPPeer::startRead " << mSocket->in_avail()
+                               << " from " << toString();
+    }
 
     mIncomingHeader.resize(HDRSZ);
 

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -44,6 +44,7 @@ class TCPPeer : public Peer
 
     size_t getIncomingMsgLength();
     virtual void connected() override;
+    void scheduleRead();
     void startRead();
 
     static constexpr size_t HDRSZ = 4;


### PR DESCRIPTION
Variant (as requested) of #2781 where we split the issuing of async reads into per-peer actions and run them through the scheduler for balance, but do not split the received message-type queues to be per-peer.

Currently doing perf evaluation / comparison of the two approaches.