### PR TITLE
Lower scheduler latency window / overload signal threshold from 5s -> 1s

### DIFF
--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -20,7 +20,7 @@ using namespace std;
 static const uint32_t RECENT_CRANK_WINDOW = 1024;
 static const std::chrono::milliseconds CRANK_TIME_SLICE(500);
 static const size_t CRANK_EVENT_SLICE = 100;
-static const std::chrono::seconds SCHEDULER_LATENCY_WINDOW(5);
+static const std::chrono::seconds SCHEDULER_LATENCY_WINDOW(1);
 
 VirtualClock::VirtualClock(Mode mode)
     : mMode(mode)


### PR DESCRIPTION
This makes the Action Scheduler a little more aggressive about deciding it's overloaded and dropping messages.