### PR TITLE
Lower crank time slice from 500ms -> 10ms.

### DIFF
--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -18,7 +18,7 @@ namespace stellar
 using namespace std;
 
 static const uint32_t RECENT_CRANK_WINDOW = 1024;
-static const std::chrono::milliseconds CRANK_TIME_SLICE(500);
+static const std::chrono::milliseconds CRANK_TIME_SLICE(10);
 static const size_t CRANK_EVENT_SLICE = 100;
 static const std::chrono::seconds SCHEDULER_LATENCY_WINDOW(5);
 


### PR DESCRIPTION
This is intended to help balance load more fairly between peers and tighten tails on queuing delays when under load.