### PR TITLE
Change internal strong hashes to BLAKE2

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -281,6 +281,7 @@ exit /b 0
     <ClCompile Include="..\..\src\catchup\test\CatchupWorkTests.cpp" />
     <ClCompile Include="..\..\src\catchup\DownloadApplyTxsWork.cpp" />
     <ClCompile Include="..\..\src\catchup\VerifyLedgerChainWork.cpp" />
+    <ClCompile Include="..\..\src\crypto\BLAKE2.cpp" />
     <ClCompile Include="..\..\src\crypto\Curve25519.cpp" />
     <ClCompile Include="..\..\src\crypto\Hex.cpp" />
     <ClCompile Include="..\..\src\crypto\KeyUtils.cpp" />
@@ -645,6 +646,7 @@ exit /b 0
     <ClInclude Include="..\..\src\catchup\simulation\TxSimApplyTransactionsWork.h" />
     <ClInclude Include="..\..\src\catchup\test\CatchupWorkTests.h" />
     <ClInclude Include="..\..\src\catchup\VerifyLedgerChainWork.h" />
+    <ClInclude Include="..\..\src\crypto\BLAKE2.h" />
     <ClInclude Include="..\..\src\crypto\ByteSlice.h" />
     <ClInclude Include="..\..\src\crypto\Curve25519.h" />
     <ClInclude Include="..\..\src\crypto\Hex.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1140,6 +1140,9 @@
     <ClCompile Include="..\..\src\util\LogSlowExecution.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\crypto\BLAKE2.cpp">
+      <Filter>crypto</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">
@@ -1966,6 +1969,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\util\XDRCereal.h">
       <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\crypto\BLAKE2.h">
+      <Filter>crypto</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/crypto/BLAKE2.cpp
+++ b/src/crypto/BLAKE2.cpp
@@ -1,0 +1,75 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/BLAKE2.h"
+#include "crypto/ByteSlice.h"
+#include "crypto/CryptoError.h"
+#include "util/NonCopyable.h"
+#include <Tracy.hpp>
+#include <sodium.h>
+
+namespace stellar
+{
+
+// Plain BLAKE2 (a.k.a. BLAKE2b)
+uint256
+blake2(ByteSlice const& bin)
+{
+    static_assert(crypto_generichash_BYTES == sizeof(uint256),
+                  "unexpected crypto_generichash_BYTES");
+    ZoneScoped;
+    uint256 out;
+    if (crypto_generichash(out.data(), out.size(), bin.data(), bin.size(),
+                           nullptr, 0) != 0)
+    {
+        throw CryptoError("error from crypto_generichash");
+    }
+    return out;
+}
+
+BLAKE2::BLAKE2()
+{
+    reset();
+}
+
+void
+BLAKE2::reset()
+{
+    if (crypto_generichash_init(&mState, nullptr, 0,
+                                crypto_generichash_BYTES) != 0)
+    {
+        throw CryptoError("error from crypto_generichash_init");
+    }
+    mFinished = false;
+}
+
+void
+BLAKE2::add(ByteSlice const& bin)
+{
+    ZoneScoped;
+    if (mFinished)
+    {
+        throw std::runtime_error("adding bytes to finished BLAKE2");
+    }
+    if (crypto_generichash_update(&mState, bin.data(), bin.size()) != 0)
+    {
+        throw CryptoError("error from crypto_generichash_update");
+    }
+}
+
+uint256
+BLAKE2::finish()
+{
+    uint256 out;
+    if (mFinished)
+    {
+        throw std::runtime_error("finishing already-finished BLAKE2");
+    }
+    if (crypto_generichash_final(&mState, out.data(), out.size()) != 0)
+    {
+        throw CryptoError("error from crypto_generichash_final");
+    }
+    return out;
+}
+}

--- a/src/crypto/BLAKE2.h
+++ b/src/crypto/BLAKE2.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/ByteSlice.h"
+#include "crypto/XDRHasher.h"
+#include "sodium/crypto_generichash.h"
+#include "xdr/Stellar-types.h"
+#include <memory>
+
+namespace stellar
+{
+
+// Plain BLAKE2 (a.k.a. BLAKE2b)
+uint256 blake2(ByteSlice const& bin);
+
+// BLAKE2 in incremental mode, for large inputs.
+class BLAKE2
+{
+    crypto_generichash_state mState;
+    bool mFinished{false};
+
+  public:
+    BLAKE2();
+    void reset();
+    void add(ByteSlice const& bin);
+    uint256 finish();
+};
+
+// Helper for xdrBlake2 below.
+struct XDRBLAKE2 : XDRHasher<XDRBLAKE2>
+{
+    BLAKE2 state;
+    void
+    hashBytes(unsigned char const* bytes, size_t size)
+    {
+        state.add(ByteSlice(bytes, size));
+    }
+};
+
+// Equivalent to `blake2(xdr_to_opaque(t))` on any XDR object `t` but
+// without allocating a temporary buffer.
+//
+// NB: This is not an overload of `blake2` to avoid ambiguity when called
+// with xdrpp-provided types like opaque_vec, which will convert to a ByteSlice
+// if demanded, but can also be passed to XDRBLAKE2.
+template <typename T>
+uint256
+xdrBlake2(T const& t)
+{
+    XDRBLAKE2 xb;
+    xdr::archive(xb, t);
+    xb.flush();
+    return xb.state.finish();
+}
+}

--- a/src/crypto/CryptoError.h
+++ b/src/crypto/CryptoError.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <exception>
+#include <stdexcept>
+#include <string>
+
+namespace stellar
+{
+class CryptoError : public std::runtime_error
+{
+  public:
+    CryptoError(std::string const& msg) : std::runtime_error(msg)
+    {
+    }
+};
+}

--- a/src/crypto/Curve25519.cpp
+++ b/src/crypto/Curve25519.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/Curve25519.h"
+#include "crypto/CryptoError.h"
 #include "crypto/SHA.h"
 #include "util/HashOfHash.h"
 #include <Tracy.hpp>

--- a/src/crypto/Curve25519.h
+++ b/src/crypto/Curve25519.h
@@ -13,13 +13,6 @@
 
 namespace stellar
 {
-class CryptoError : public std::runtime_error
-{
-  public:
-    CryptoError(std::string const& msg) : std::runtime_error(msg)
-    {
-    }
-};
 // This module contains functions for doing ECDH on Curve25519. Despite the
 // equivalence between this curve and Ed25519 (used in signatures, see
 // SecretKey.h) we use Curve25519 keys _only_ for ECDH shared-key-agreement

--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -4,6 +4,7 @@
 
 #include "crypto/SHA.h"
 #include "crypto/ByteSlice.h"
+#include "crypto/CryptoError.h"
 #include "crypto/Curve25519.h"
 #include "util/NonCopyable.h"
 #include <Tracy.hpp>

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -3,11 +3,11 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/SecretKey.h"
+#include "crypto/BLAKE2.h"
 #include "crypto/CryptoError.h"
 #include "crypto/Curve25519.h"
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
-#include "crypto/SHA.h"
 #include "crypto/StrKey.h"
 #include "main/Config.h"
 #include "transactions/SignatureUtils.h"
@@ -45,7 +45,7 @@ verifySigCacheKey(PublicKey const& key, Signature const& signature,
 {
     assert(key.type() == PUBLIC_KEY_TYPE_ED25519);
 
-    SHA256 hasher;
+    BLAKE2 hasher;
     hasher.add(key.ed25519());
     hasher.add(signature);
     hasher.add(bin);

--- a/src/crypto/SecretKey.cpp
+++ b/src/crypto/SecretKey.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/SecretKey.h"
+#include "crypto/CryptoError.h"
 #include "crypto/Curve25519.h"
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -633,7 +633,7 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope,
     mPendingEnvelopes.addTxSet(txset.getContentsHash(),
                                envelope.statement.slotIndex,
                                std::make_shared<TxSetFrame>(txset));
-    mPendingEnvelopes.addSCPQuorumSet(sha256(xdr::xdr_to_opaque(qset)), qset);
+    mPendingEnvelopes.addSCPQuorumSet(xdrSha256(qset), qset);
     return recvSCPEnvelope(envelope);
 }
 
@@ -1635,7 +1635,7 @@ HerderImpl::restoreSCPState()
             }
             for (auto const& qset : latestQSets)
             {
-                Hash hash = sha256(xdr::xdr_to_opaque(qset));
+                Hash hash = xdrSha256(qset);
                 mPendingEnvelopes.addSCPQuorumSet(hash, qset);
             }
             for (auto const& e : latestEnvs)

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -104,7 +104,7 @@ HerderPersistenceImpl::saveSCPHistory(uint32_t seq,
             // skip node if we don't have its quorum set
             continue;
         }
-        auto qSetH = sha256(xdr::xdr_to_opaque(*(p.second.mQuorumSet)));
+        auto qSetH = xdrSha256(*(p.second.mQuorumSet));
         usedQSets.insert(std::make_pair(qSetH, p.second.mQuorumSet));
 
         std::string nodeIDStrKey = KeyUtils::toStrKey(nodeID);

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -871,7 +871,7 @@ HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
     mCurrentValue = wrapStellarValue(value);
     mLedgerSeqNominating = static_cast<uint32_t>(slotIndex);
 
-    auto valueHash = sha256(xdr::xdr_to_opaque(mCurrentValue->getValue()));
+    auto valueHash = xdrSha256(mCurrentValue->getValue());
     CLOG(DEBUG, "Herder") << "HerderSCPDriver::triggerNextLedger"
                           << " txSet.size: "
                           << proposedSet->mTransactions.size()

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -336,9 +336,9 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
             {
                 CLOG(TRACE, "Perf")
                     << "Herder fetched for envelope "
-                    << hexAbbrev(sha256(xdr::xdr_to_opaque(envelope)))
-                    << " with txsets " << txSetsToStr(envelope) << " and qset "
-                    << hexAbbrev(h) << " in "
+                    << hexAbbrev(xdrSha256(envelope)) << " with txsets "
+                    << txSetsToStr(envelope) << " and qset " << hexAbbrev(h)
+                    << " in "
                     << std::chrono::duration<double>(durationNano).count()
                     << " seconds";
             }
@@ -523,9 +523,8 @@ PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
     if (Logging::logTrace("Herder"))
     {
         CLOG(TRACE, "Herder")
-            << "Envelope ready "
-            << hexAbbrev(sha256(xdr::xdr_to_opaque(envelope))) << " i:" << slot
-            << " t:" << envelope.statement.pledges.type();
+            << "Envelope ready " << hexAbbrev(xdrSha256(envelope))
+            << " i:" << slot << " t:" << envelope.statement.pledges.type();
     }
 
     // envelope has been fetched completely, but SCP has not done
@@ -583,10 +582,10 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
 
     if (needSomething && Logging::logTrace("Herder"))
     {
-        CLOG(TRACE, "Herder") << "StartFetch env "
-                              << hexAbbrev(sha256(xdr::xdr_to_opaque(envelope)))
-                              << " i:" << envelope.statement.slotIndex
-                              << " t:" << envelope.statement.pledges.type();
+        CLOG(TRACE, "Herder")
+            << "StartFetch env " << hexAbbrev(xdrSha256(envelope))
+            << " i:" << envelope.statement.slotIndex
+            << " t:" << envelope.statement.pledges.type();
     }
 }
 
@@ -604,10 +603,10 @@ PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
 
     if (Logging::logTrace("Herder"))
     {
-        CLOG(TRACE, "Herder") << "StopFetch env "
-                              << hexAbbrev(sha256(xdr::xdr_to_opaque(envelope)))
-                              << " i:" << envelope.statement.slotIndex
-                              << " t:" << envelope.statement.pledges.type();
+        CLOG(TRACE, "Herder")
+            << "StopFetch env " << hexAbbrev(xdrSha256(envelope))
+            << " i:" << envelope.statement.slotIndex
+            << " t:" << envelope.statement.pledges.type();
     }
 }
 

--- a/src/history/InferredQuorum.cpp
+++ b/src/history/InferredQuorum.cpp
@@ -20,8 +20,7 @@ InferredQuorum::InferredQuorum(QuorumTracker::QuorumMap const& qmap)
         if (pair.second.mQuorumSet)
         {
             noteQset(*(pair.second.mQuorumSet));
-            Hash qSetHash =
-                sha256(xdr::xdr_to_opaque(*(pair.second.mQuorumSet)));
+            Hash qSetHash = xdrSha256(*(pair.second.mQuorumSet));
             noteQsetHash(pair.first, qSetHash);
         }
     }
@@ -75,7 +74,7 @@ InferredQuorum::noteQsetHash(PublicKey const& pk, Hash const& qsetHash)
 void
 InferredQuorum::noteQset(SCPQuorumSet const& qset)
 {
-    Hash qSetHash = sha256(xdr::xdr_to_opaque(qset));
+    Hash qSetHash = xdrSha256(qset);
     if (mQsets.find(qSetHash) == mQsets.end())
     {
         mQsets.insert(std::make_pair(qSetHash, qset));

--- a/src/ledger/LedgerHeaderUtils.cpp
+++ b/src/ledger/LedgerHeaderUtils.cpp
@@ -117,7 +117,7 @@ loadByHash(Database& db, Hash const& hash)
     {
         auto lh = decodeFromData(headerEncoded);
         lhPtr = std::make_shared<LedgerHeader>(lh);
-        auto ledgerHash = sha256(xdr::xdr_to_opaque(lh));
+        auto ledgerHash = xdrSha256(lh);
         if (ledgerHash != hash)
         {
             throw std::runtime_error(
@@ -191,7 +191,7 @@ copyToStream(Database& db, soci::session& sess, uint32_t ledgerSeq,
     {
         LedgerHeaderHistoryEntry lhe;
         lhe.header = decodeFromData(headerEncoded);
-        lhe.hash = sha256(xdr::xdr_to_opaque(lhe.header));
+        lhe.hash = xdrSha256(lhe.header);
         CLOG(DEBUG, "Ledger")
             << "Streaming ledger-header " << lhe.header.ledgerSeq;
         headersOut.writeOne(lhe);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -87,7 +87,7 @@ LedgerManager::create(Application& app)
 std::string
 LedgerManager::ledgerAbbrev(LedgerHeader const& header)
 {
-    return ledgerAbbrev(header, sha256(xdr::xdr_to_opaque(header)));
+    return ledgerAbbrev(header, xdrSha256(header));
 }
 
 std::string
@@ -613,8 +613,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     txResultSet.results.reserve(txs.size());
     applyTransactions(txs, ltx, txResultSet, ledgerCloseMeta);
 
-    ltx.loadHeader().current().txSetResultHash =
-        sha256(xdr::xdr_to_opaque(txResultSet));
+    ltx.loadHeader().current().txSetResultHash = xdrSha256(txResultSet);
 
     // apply any upgrades that were decided during consensus
     // this must be done after applying transactions as the txset
@@ -810,7 +809,7 @@ void
 LedgerManagerImpl::advanceLedgerPointers(LedgerHeader const& header,
                                          bool debugLog)
 {
-    auto ledgerHash = sha256(xdr::xdr_to_opaque(header));
+    auto ledgerHash = xdrSha256(header);
 
     if (debugLog)
     {
@@ -1011,7 +1010,7 @@ LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header)
         LedgerHeaderUtils::storeInDatabase(mApp.getDatabase(), header);
     }
 
-    Hash hash = sha256(xdr::xdr_to_opaque(header));
+    Hash hash = xdrSha256(header);
     assert(!isZero(hash));
     mApp.getPersistentState().setState(PersistentState::kLastClosedLedger,
                                        binToHex(hash));

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -3,8 +3,8 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/Floodgate.h"
+#include "crypto/BLAKE2.h"
 #include "crypto/Hex.h"
-#include "crypto/SHA.h"
 #include "herder/Herder.h"
 #include "main/Application.h"
 #include "medida/counter.h"
@@ -58,7 +58,7 @@ bool
 Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer, Hash& index)
 {
     ZoneScoped;
-    index = sha256(xdr::xdr_to_opaque(msg));
+    index = xdrBlake2(msg);
     if (mShuttingDown)
     {
         return false;
@@ -89,7 +89,7 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
     {
         return;
     }
-    Hash index = sha256(xdr::xdr_to_opaque(msg));
+    Hash index = xdrBlake2(msg);
 
     FloodRecord::pointer fr;
     auto result = mFloodMap.find(index);
@@ -164,8 +164,8 @@ Floodgate::updateRecord(StellarMessage const& oldMsg,
                         StellarMessage const& newMsg)
 {
     ZoneScoped;
-    Hash oldHash = sha256(xdr::xdr_to_opaque(oldMsg));
-    Hash newHash = sha256(xdr::xdr_to_opaque(newMsg));
+    Hash oldHash = xdrBlake2(oldMsg);
+    Hash newHash = xdrBlake2(newMsg);
 
     auto oldIter = mFloodMap.find(oldHash);
     if (oldIter != mFloodMap.end())

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -5,6 +5,7 @@
 #include "overlay/Peer.h"
 
 #include "BanManager.h"
+#include "crypto/CryptoError.h"
 #include "crypto/Hex.h"
 #include "crypto/Random.h"
 #include "crypto/SHA.h"

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -915,7 +915,7 @@ void
 Peer::recvSCPQuorumSet(StellarMessage const& msg)
 {
     ZoneScoped;
-    Hash hash = sha256(xdr::xdr_to_opaque(msg.qSet()));
+    Hash hash = xdrSha256(msg.qSet());
     mApp.getHerder().recvSCPQuorumSet(hash, msg.qSet());
 }
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/TCPPeer.h"
+#include "crypto/CryptoError.h"
 #include "crypto/Curve25519.h"
 #include "database/Database.h"
 #include "main/Application.h"

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -240,8 +240,7 @@ Tracker::listen(const SCPEnvelope& env)
     m.envelope() = env;
 
     // NB: hash here is of StellarMessage
-    mWaitingEnvelopes.push_back(
-        std::make_pair(sha256(xdr::xdr_to_opaque(m)), env));
+    mWaitingEnvelopes.push_back(std::make_pair(xdrSha256(m), env));
 }
 
 void

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -5,8 +5,8 @@
 #include "Tracker.h"
 
 #include "OverlayMetrics.h"
+#include "crypto/BLAKE2.h"
 #include "crypto/Hex.h"
-#include "crypto/SHA.h"
 #include "herder/Herder.h"
 #include "main/Application.h"
 #include "medida/medida.h"
@@ -239,8 +239,11 @@ Tracker::listen(const SCPEnvelope& env)
     m.type(SCP_MESSAGE);
     m.envelope() = env;
 
-    // NB: hash here is of StellarMessage
-    mWaitingEnvelopes.push_back(std::make_pair(xdrSha256(m), env));
+    // NB: hash here is BLAKE2 of StellarMessage because that is
+    // what the floodmap is keyed by, and we're storing its keys
+    // in mWaitingEnvelopes, not the mItemHash that is the SHA256
+    // of the item being tracked.
+    mWaitingEnvelopes.push_back(std::make_pair(xdrBlake2(m), env));
 }
 
 void

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -284,6 +284,6 @@ CreateClaimableBalanceOpFrame::getBalanceID()
     operationID.id().seqNum = mParentTx.getSeqNum();
     operationID.id().opNum = mOpIndex;
 
-    return sha256(xdr::xdr_to_opaque(operationID));
+    return xdrSha256(operationID);
 }
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -58,7 +58,7 @@ TransactionFrame::getFullHash() const
 {
     if (isZero(mFullHash))
     {
-        mFullHash = sha256(xdr::xdr_to_opaque(mEnvelope));
+        mFullHash = xdrSha256(mEnvelope);
     }
     return (mFullHash);
 }


### PR DESCRIPTION
This switches two of the strong internal hashes (one on floodgate, one on signature checking cache, neither exposed as part of any protocol) from SHA256 to [BLAKE2b](https://www.blake2.net/), which runs about twice as fast and has equal-or-superior security properties. This also happens to be the default "generic" strong hash in libsodium, so not especially hard to hook up to.

Along the way it also changes a bunch of `sha256(xdr_to_opaque(...))` calls to the non-allocating (and very slightly faster) `xdrSha256` and `xdrBlake2` variants