### PR TITLE
Drop messages in the write queues as well when overloaded.

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -95,6 +95,7 @@ overlay.memory.flood-known               | counter   | number of known flooded e
 overlay.message.broadcast                | meter     | message broadcasted
 overlay.message.read                     | meter     | message received
 overlay.message.write                    | meter     | message sent
+overlay.message.drop                     | meter     | message dropped due to load-shedding
 overlay.outbound.attempt                 | meter     | outbound connection attempted (socket opened)
 overlay.outbound.cancel                  | meter     | outbound connection cancelled
 overlay.outbound.drop                    | meter     | outbound connection dropped

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -13,6 +13,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewMeter({"overlay", "message", "read"}, "message"))
     , mMessageWrite(
           app.getMetrics().NewMeter({"overlay", "message", "write"}, "message"))
+    , mMessageDrop(
+          app.getMetrics().NewMeter({"overlay", "message", "drop"}, "message"))
     , mAsyncRead(
           app.getMetrics().NewMeter({"overlay", "async", "read"}, "call"))
     , mAsyncWrite(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -26,6 +26,7 @@ struct OverlayMetrics
     OverlayMetrics(Application& app);
     medida::Meter& mMessageRead;
     medida::Meter& mMessageWrite;
+    medida::Meter& mMessageDrop;
     medida::Meter& mAsyncRead;
     medida::Meter& mAsyncWrite;
     medida::Meter& mByteRead;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -405,6 +405,21 @@ Peer::sendMessage(StellarMessage const& msg, bool log)
             << mApp.getConfig().PEER_PORT;
     }
 
+    // There are really _two_ layers of queues, one in Scheduler for actions and
+    // one in Peer (and its subclasses) for outgoing writes. We enforce a
+    // similar load-shedding discipline here as in Scheduler: if there is more
+    // than the scheduler latency-window worth of material in the write queue,
+    // and we're being asked to add messages that are being generated _from_ a
+    // droppable action, we drop the message rather than enqueue it. This avoids
+    // growing our queues indefinitely.
+    if (mApp.getClock().currentSchedulerActionType() ==
+            Scheduler::ActionType::DROPPABLE_ACTION &&
+        sendQueueIsOverloaded())
+    {
+        getOverlayMetrics().mMessageDrop.Mark();
+        return;
+    }
+
     switch (msg.type())
     {
     case ERROR_MSG:

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -192,6 +192,11 @@ class Peer : public std::enable_shared_from_this<Peer>,
     connected()
     {
     }
+    virtual bool
+    sendQueueIsOverloaded() const
+    {
+        return false;
+    }
 
     virtual AuthCert getAuthCert();
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -576,6 +576,14 @@ TCPPeer::connected()
     startRead();
 }
 
+bool
+TCPPeer::sendQueueIsOverloaded() const
+{
+    auto now = mApp.getClock().now();
+    return (!mWriteQueue.empty() && (now - mWriteQueue.front().mEnqueuedTime) >
+                                        SCHEDULER_LATENCY_WINDOW);
+}
+
 void
 TCPPeer::readHeaderHandler(asio::error_code const& error,
                            std::size_t bytes_transferred)

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -45,6 +45,7 @@ class TCPPeer : public Peer
     size_t getIncomingMsgLength();
     virtual void connected() override;
     void scheduleRead();
+    virtual bool sendQueueIsOverloaded() const override;
     void startRead();
 
     static constexpr size_t HDRSZ = 4;

--- a/src/util/Scheduler.cpp
+++ b/src/util/Scheduler.cpp
@@ -297,7 +297,9 @@ Scheduler::runOne()
             auto updateMaxTotalService = gsl::finally([&]() {
                 mMaxTotalService =
                     std::max(q->totalService(), mMaxTotalService);
+                mCurrentActionType = ActionType::NORMAL_ACTION;
             });
+            mCurrentActionType = q->type();
             q->runNext(mClock, minTotalService);
         }
         return 1;
@@ -321,6 +323,12 @@ Scheduler::getOverloadedDuration() const
         res = std::chrono::seconds{0};
     }
     return res;
+}
+
+Scheduler::ActionType
+Scheduler::currentActionType() const
+{
+    return mCurrentActionType;
 }
 
 #ifdef BUILD_TESTS

--- a/src/util/Scheduler.h
+++ b/src/util/Scheduler.h
@@ -201,6 +201,10 @@ class Scheduler
     // not
     std::chrono::steady_clock::time_point mOverloadedStart;
 
+    // Records the currently-executing action type, or NORMAL_ACTION when no
+    // action is running. This can be retrieved through currentActionType().
+    ActionType mCurrentActionType{ActionType::NORMAL_ACTION};
+
   public:
     Scheduler(VirtualClock& clock, std::chrono::nanoseconds latencyWindow);
 
@@ -209,6 +213,10 @@ class Scheduler
 
     // Runs 0 or 1 action from the next ActionQueue in the queue-of-queues.
     size_t runOne();
+
+    // Return the ActionType of the currently-executing action; if no action
+    // is currently running, return NORMAL_ACTION.
+    ActionType currentActionType() const;
 
     // Returns how long ActionQueues have been overloaded (0 means not
     // overloaded)

--- a/src/util/Timer.cpp
+++ b/src/util/Timer.cpp
@@ -20,7 +20,7 @@ using namespace std;
 static const uint32_t RECENT_CRANK_WINDOW = 1024;
 static const std::chrono::milliseconds CRANK_TIME_SLICE(500);
 static const size_t CRANK_EVENT_SLICE = 100;
-static const std::chrono::seconds SCHEDULER_LATENCY_WINDOW(5);
+const std::chrono::seconds SCHEDULER_LATENCY_WINDOW(5);
 
 VirtualClock::VirtualClock(Mode mode)
     : mMode(mode)
@@ -419,6 +419,12 @@ bool
 VirtualClock::actionQueueIsOverloaded() const
 {
     return mActionScheduler->getOverloadedDuration().count() != 0;
+}
+
+Scheduler::ActionType
+VirtualClock::currentSchedulerActionType() const
+{
+    return mActionScheduler->currentActionType();
 }
 
 void

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -57,6 +57,8 @@ class VirtualClockEventCompare
                     std::shared_ptr<VirtualClockEvent> b);
 };
 
+extern const std::chrono::seconds SCHEDULER_LATENCY_WINDOW;
+
 class VirtualClock
 {
   public:
@@ -197,6 +199,7 @@ class VirtualClock
 
     size_t getActionQueueSize() const;
     bool actionQueueIsOverloaded() const;
+    Scheduler::ActionType currentSchedulerActionType() const;
 };
 
 class VirtualClockEvent : public NonMovableOrCopyable


### PR DESCRIPTION
This reproduces the load-shedding behaviour of the Action Scheduler at the lower level per-peer write queues. It uses the same time threshold and only drops messages enqueued during the execution of an action itself marked as droppable.