### PR TITLE
Split broadcasts into multiple Scheduler Actions.

### DIFF
--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -14,6 +14,7 @@
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
 #include <Tracy.hpp>
+#include <fmt/format.h>
 
 namespace stellar
 {
@@ -111,13 +112,25 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
     auto peers = mApp.getOverlayManager().getAuthenticatedPeers();
 
     bool log = true;
+    std::shared_ptr<StellarMessage> smsg =
+        std::make_shared<StellarMessage>(msg);
     for (auto peer : peers)
     {
         assert(peer.second->isAuthenticated());
         if (peersTold.find(peer.second->toString()) == peersTold.end())
         {
             mSendFromBroadcast.Mark();
-            peer.second->sendMessage(msg, log);
+            std::weak_ptr<Peer> weak(
+                std::static_pointer_cast<Peer>(peer.second));
+            mApp.postOnMainThread(
+                [smsg, weak, log]() {
+                    auto strong = weak.lock();
+                    if (strong)
+                    {
+                        strong->sendMessage(*smsg, log);
+                    }
+                },
+                fmt::format("broadcast to {}", peer.second->toString()));
             peersTold.insert(peer.second->toString());
             log = false;
         }

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -227,6 +227,16 @@ class OverlayManagerTests
     }
 
     void
+    crank(size_t n)
+    {
+        while (n != 0)
+        {
+            clock.crank(false);
+            n--;
+        }
+    }
+
+    void
     testBroadcast()
     {
         OverlayManagerStub& pm = app->getOverlayManager();
@@ -255,12 +265,15 @@ class OverlayManagerTests
             }
         }
         pm.broadcastMessage(AtoB);
+        crank(10);
         std::vector<int> expected{1, 1, 0, 1, 1};
         REQUIRE(sentCounts(pm) == expected);
         pm.broadcastMessage(AtoB);
+        crank(10);
         REQUIRE(sentCounts(pm) == expected);
         StellarMessage CtoD = c.tx({payment(d, 10)})->toStellarMessage();
         pm.broadcastMessage(CtoD);
+        crank(10);
         std::vector<int> expectedFinal{2, 2, 1, 2, 2};
         REQUIRE(sentCounts(pm) == expectedFinal);
 
@@ -268,6 +281,7 @@ class OverlayManagerTests
         StellarMessage AtoC = a.tx({payment(c, 10)})->toStellarMessage();
         pm.updateFloodRecord(AtoB, AtoC);
         pm.broadcastMessage(AtoC);
+        crank(10);
         REQUIRE(sentCounts(pm) == expectedFinal);
     }
 };


### PR DESCRIPTION
This modifies the floodgate broadcast function to enqueue each message-send in the broadcast as a separate scheduler action (on separate, per-receiver broadcast queues). The idea here is to reduce maximum latency from broadcasts -- one broadcast can take a while when sending to a lot of peers, separately encoding and adding authentication material and writing to each.