### PR TITLE
Subprocess shutdown fixes

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -365,7 +365,8 @@ ApplicationImpl::~ApplicationImpl()
     }
     catch (std::exception const& e)
     {
-        LOG_ERROR(DEFAULT_LOG, "While shutting down {}", e.what());
+        LOG_ERROR(DEFAULT_LOG, "Exception occurred while shutting down: {}",
+                  e.what());
     }
     reportCfgMetrics();
     shutdownMainIOContext();

--- a/src/process/ProcessManager.h
+++ b/src/process/ProcessManager.h
@@ -51,12 +51,27 @@ class ProcessManager : public std::enable_shared_from_this<ProcessManager>,
     static std::shared_ptr<ProcessManager> create(Application& app);
     virtual std::weak_ptr<ProcessExitEvent>
     runProcess(std::string const& cmdLine, std::string outputFile) = 0;
+
+    // Return the number or processes we started and have not yet seen exits
+    // for, _excluding_ those we're attempting to shut down / are shortly
+    // expecting to see an exit for (which are likely already dead, just not yet
+    // reaped). This number will decrement as soon as the associated
+    // ProcessExitEvent is fired.
     virtual size_t getNumRunningProcesses() = 0;
     virtual bool isShutdown() const = 0;
     virtual void shutdown() = 0;
 
-    // Depending on the state of the process, either kill the process nicely
-    // or force shutdown it
+    // Synchronously cancels the provided ProcessExitEvent (firing its event
+    // handler with ABORT_ERROR_CODE) and attempts to terminate the associated
+    // process if it is running. Returns true if the attempt was successful --
+    // in the sense of succesfully sending a SIGTERM for example -- though this
+    // does not guarantee that the process _has exited_ yet.
+    //
+    // Since the event is cancelled, there is no further way for clients to be
+    // certain the process has exited using this interface. If a process that
+    // has been sent a termination signal does _not_ exit, however, it will
+    // remain tracked by the ProcessManager, and be forcibly killed when
+    // the ProcessManager is destructed.
     virtual bool tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe) = 0;
     virtual ~ProcessManager()
     {

--- a/src/process/ProcessManager.h
+++ b/src/process/ProcessManager.h
@@ -58,6 +58,13 @@ class ProcessManager : public std::enable_shared_from_this<ProcessManager>,
     // reaped). This number will decrement as soon as the associated
     // ProcessExitEvent is fired.
     virtual size_t getNumRunningProcesses() = 0;
+
+    // Return the number of processes we started and have not yet seen exits
+    // for, _including_ those we're in the process of shutting down. This number
+    // may remain higher than expected for a while after a ProcessExitEvent is
+    // fired.
+    virtual size_t getNumRunningOrShuttingDownProcesses() = 0;
+
     virtual bool isShutdown() const = 0;
     virtual void shutdown() = 0;
 

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -876,14 +876,20 @@ ProcessManagerImpl::maybeRunPendingProcesses()
         {
             CLOG_DEBUG(Process, "Running: {}", i->mImpl->mCmdLine);
 
-            if (fs::exists(i->mImpl->mOutFile))
+            if (!i->mImpl->mOutFile.empty() && fs::exists(i->mImpl->mOutFile))
             {
                 throw std::runtime_error(fmt::format(
                     "output file {} already exists", i->mImpl->mOutFile));
             }
 
             i->mImpl->run();
-            mProcesses[i->mImpl->getProcessId()] = i;
+            auto pid = i->mImpl->getProcessId();
+            if (mProcesses.find(pid) != mProcesses.end())
+            {
+                throw std::runtime_error(
+                    fmt::format("process {} already exists", pid));
+            }
+            mProcesses[pid] = i;
         }
         catch (std::runtime_error& e)
         {

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -15,6 +15,7 @@
 #include "process/ProcessManager.h"
 #include "process/ProcessManagerImpl.h"
 #include "util/Fs.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/Timer.h"
 #include <Tracy.hpp>
@@ -40,19 +41,88 @@
 extern char** environ;
 #endif
 
+namespace
+{
+enum ProcessLifecycle
+{
+    PENDING = 0,
+    RUNNING = 1,
+    TRIED_POLITE_SHUTDOWN = 2,
+    TRIED_FORCED_SHUTDOWN = 3,
+    TERMINATED = 5
+};
+}
+
 namespace stellar
 {
 
 static const asio::error_code ABORT_ERROR_CODE(asio::error::operation_aborted,
                                                asio::system_category());
 
+static asio::error_code
+mapExitStatusToErrorCode(std::string const& cmdLine, int pid, int status)
+{
+// On windows, an exit status is just an exit status. On unix it's
+// got some flags incorporated into it.
+#ifdef _WIN32
+    return asio::error_code(status, asio::system_category());
+#else
+    if (WIFEXITED(status))
+    {
+        if (WEXITSTATUS(status) == 0)
+        {
+            CLOG_DEBUG(Process, "process {} exited {}: {}", pid,
+                       WEXITSTATUS(status), cmdLine);
+        }
+        else
+        {
+            CLOG_WARNING(Process, "process {} exited {}: {}", pid,
+                         WEXITSTATUS(status), cmdLine);
+        }
+#ifdef __linux__
+        // Linux posix_spawnp does not fault on file-not-found in the
+        // parent process at the point of invocation, as BSD does; so
+        // rather than a fatal error / throw we get an ambiguous and
+        // easily-overlooked shell-like 'exit 127' on waitpid.
+        if (WEXITSTATUS(status) == 127)
+        {
+            CLOG_WARNING(Process, "");
+            CLOG_WARNING(Process, "************");
+            CLOG_WARNING(Process, "");
+            CLOG_WARNING(Process, "  likely 'missing command':");
+            CLOG_WARNING(Process, "");
+            CLOG_WARNING(Process, "    {}", cmdLine);
+            CLOG_WARNING(Process, "");
+            CLOG_WARNING(Process, "************");
+            CLOG_WARNING(Process, "");
+        }
+#endif
+        // FIXME: this doesn't _quite_ do the right thing; it conveys
+        // the exit status back to the caller but it puts it in "system
+        // category" which on POSIX means if you call .message() on it
+        // you'll get perror(value()), which is not correct. Errno has
+        // nothing to do with process exit values. We could make a new
+        // error_category to tighten this up, but it's a bunch of work
+        // just to convey the meaningless string "exited" to the user.
+        return asio::error_code(WEXITSTATUS(status), asio::system_category());
+    }
+    else
+    {
+        // FIXME: for now we also collapse all non-WIFEXITED exits on
+        // posix into a single "exit 1" error_code. This is enough
+        // for most callers; we can enrich it if anyone really wants
+        // to differentiate various signals that might have killed
+        // the child.
+        return asio::error_code(1, asio::system_category());
+    }
+#endif
+}
+
 std::shared_ptr<ProcessManager>
 ProcessManager::create(Application& app)
 {
     return std::make_shared<ProcessManagerImpl>(app);
 }
-
-std::atomic<size_t> ProcessManagerImpl::gNumProcessesActive{0};
 
 class ProcessExitEvent::Impl
     : public std::enable_shared_from_this<ProcessExitEvent::Impl>
@@ -63,7 +133,7 @@ class ProcessExitEvent::Impl
     std::string const mCmdLine;
     std::string const mOutFile;
     std::string const mTempFile;
-    bool mRunning{false};
+    ProcessLifecycle mLifecycle{ProcessLifecycle::PENDING};
 #ifdef _WIN32
     asio::windows::object_handle mProcessHandle;
 #endif
@@ -90,6 +160,7 @@ class ProcessExitEvent::Impl
     finish()
     {
         ZoneScoped;
+        releaseAssertOrThrow(mLifecycle == ProcessLifecycle::TERMINATED);
         if (!mOutFile.empty())
         {
             if (fs::exists(mOutFile))
@@ -97,8 +168,7 @@ class ProcessExitEvent::Impl
                 CLOG_WARNING(Process, "Outfile already exists: {}", mOutFile);
                 return false;
             }
-            else if (mRunning &&
-                     std::rename(mTempFile.c_str(), mOutFile.c_str()))
+            else if (std::rename(mTempFile.c_str(), mOutFile.c_str()))
             {
                 CLOG_ERROR(Process, "{} -> {} rename failed, error: {}",
                            mTempFile, mOutFile, errno);
@@ -126,7 +196,18 @@ class ProcessExitEvent::Impl
 size_t
 ProcessManagerImpl::getNumRunningProcesses()
 {
-    return gNumProcessesActive;
+    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
+    size_t n = 0;
+    for (auto const& pe : mProcesses)
+    {
+        if (pe.second->mImpl->mLifecycle == ProcessLifecycle::RUNNING)
+        {
+            ++n;
+        }
+    }
+    return n;
+}
+
 size_t
 ProcessManagerImpl::getNumRunningOrShuttingDownProcesses()
 {
@@ -210,6 +291,9 @@ bool
 ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
+    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
+    checkInvariants();
+
     if (!pe)
     {
         CLOG_ERROR(
@@ -218,54 +302,102 @@ ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
         throw std::runtime_error("Invalid ProcessExitEvent");
     }
 
-    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
-    auto ec = ABORT_ERROR_CODE;
     auto impl = pe->mImpl;
-
-    // If we already tried nice kill, force shutdown and return success.
-    auto killableIt = find(mKillable.begin(), mKillable.end(), pe);
-    if (killableIt != mKillable.end())
+    switch (impl->mLifecycle)
     {
-        CLOG_DEBUG(Process, "Shutting down (forced): {}", impl->mCmdLine);
-        forceShutdown(*pe);
-        return true;
-    }
-
-    // Otherwise, there are three possible scenarios for process shutdown:
-    // 1. Process is in pending queue, and hasn't run yet
-    // 2. Process is currently running, in which case we try to kill it nicely
-    // 3. Process didn't get killed correctly, so we issue a force kill
-
-    CLOG_DEBUG(Process, "Shutting down (nicely): {}", impl->mCmdLine);
-    auto pendingIt = find(mPending.begin(), mPending.end(), pe);
-    if (pendingIt != mPending.end())
+    case ProcessLifecycle::PENDING:
     {
-        (*pendingIt)->mImpl->cancel(ec);
-        mPending.erase(pendingIt);
-    }
-    else
-    {
-        // Process is running, so issue a `kill` command
-        // and remove from the list of running processes
-        auto pid = impl->getProcessId();
-        auto runningIt = mProcesses.find(pid);
-        if (runningIt != mProcesses.end())
+        auto pendingIt = find(mPending.begin(), mPending.end(), pe);
+        if (pendingIt == mPending.end())
         {
-            // Mark it as "ready to be killed"
-            mKillable.push_back(runningIt->second);
-            impl->cancel(ec);
-            auto res = cleanShutdown(*runningIt->second);
-            mProcesses.erase(pid);
-            gNumProcessesActive--;
-            return res;
+            CLOG_WARNING(Process, "Pending process not found in queue: {}",
+                         impl->mCmdLine);
+            return false;
         }
         else
         {
-            CLOG_DEBUG(Process, "failed to find pending or running process");
+            releaseAssertOrThrow(*pendingIt == pe);
+            CLOG_DEBUG(Process, "Cancelling pending: {}", impl->mCmdLine);
+            impl->cancel(ABORT_ERROR_CODE);
+            mPending.erase(pendingIt);
+        }
+        break;
+    }
+
+    case ProcessLifecycle::TRIED_FORCED_SHUTDOWN:
+    case ProcessLifecycle::TERMINATED:
+        // Either we've already tried forcefully to shut it down, or else it
+        // fully terminated and we're in the process of cleaning up; either way
+        // there's nothing more to try to do here.
+        break;
+
+    default:
+    {
+        auto pid = impl->getProcessId();
+        auto i = mProcesses.find(pid);
+        if (i == mProcesses.end())
+        {
+            CLOG_WARNING(Process, "Attempt to shut down unknown process: {}",
+                         impl->mCmdLine);
             return false;
         }
+        releaseAssertOrThrow(i->second == pe);
+        if (impl->mLifecycle == ProcessLifecycle::TRIED_POLITE_SHUTDOWN)
+        {
+            CLOG_DEBUG(Process, "Shutting down (forced): {}", impl->mCmdLine);
+            return forcedShutdown(pe);
+        }
+        else
+        {
+            CLOG_DEBUG(Process, "Shutting down (polite): {}", impl->mCmdLine);
+            return politeShutdown(pe);
+        }
+        break;
     }
+    }
+
     return true;
+}
+
+asio::error_code
+ProcessManagerImpl::handleProcessTermination(int pid, int status)
+{
+    ZoneScoped;
+    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
+    checkInvariants();
+
+    auto pair = mProcesses.find(pid);
+    if (pair == mProcesses.end())
+    {
+        CLOG_DEBUG(Process, "failed to find process with pid {}", pid);
+        return mapExitStatusToErrorCode("", pid, status);
+    }
+    auto impl = pair->second->mImpl;
+    releaseAssertOrThrow(impl->mLifecycle != ProcessLifecycle::TERMINATED);
+    impl->mLifecycle = ProcessLifecycle::TERMINATED;
+
+    auto ec = mapExitStatusToErrorCode(impl->mCmdLine, pid, status);
+
+    if (!impl->finish())
+    {
+        // We can only transmit one ec to the callback, so if
+        // we already have a nonzero (failure) ec, don't overwrite
+        // it.
+        if (!ec)
+        {
+            ec = asio::error_code(asio::error::try_again,
+                                  asio::system_category());
+        }
+    }
+
+    mProcesses.erase(pair);
+
+    // Fire off any new processes we've made room for before we
+    // trigger the callback.
+    maybeRunPendingProcesses();
+
+    impl->cancel(ec);
+    return ec;
 }
 
 #ifdef _WIN32
@@ -360,12 +492,8 @@ ProcessExitEvent::Impl::run()
 {
     ZoneScoped;
     auto manager = mProcManagerImpl.lock();
-    assert(manager && !manager->isShutdown());
-    if (mRunning)
-    {
-        CLOG_ERROR(Process, "ProcessExitEvent::Impl already running");
-        throw std::runtime_error("ProcessExitEvent::Impl already running");
-    }
+    releaseAssertOrThrow(manager && !manager->isShutdown());
+    releaseAssertOrThrow(mLifecycle == ProcessLifecycle::PENDING);
 
     PROCESS_INFORMATION pi;
     ZeroMemory(&pi, sizeof(pi));
@@ -457,12 +585,6 @@ ProcessExitEvent::Impl::run()
             return;
         }
 
-        --ProcessManagerImpl::gNumProcessesActive;
-
-        // Fire off any new processes we've made room for before we
-        // trigger the callback.
-        manager->maybeRunPendingProcesses();
-
         if (ec)
         {
             // We can only transmit one ec to the callback, so if we
@@ -483,56 +605,53 @@ ProcessExitEvent::Impl::run()
             ec = manager->handleProcessTermination(sf->mProcessId,
                                                    static_cast<int>(exitCode));
         }
-        sf->cancel(ec);
     });
-    mRunning = true;
-}
-
-asio::error_code
-ProcessManagerImpl::handleProcessTermination(int pid, int /*status*/)
-{
-    ZoneScoped;
-    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
-    auto ec = asio::error_code();
-    auto process = mProcesses.find(pid);
-    if (process != mProcesses.end() && !process->second->mImpl->finish())
-    {
-        ec = asio::error_code(asio::error::try_again, asio::system_category());
-    }
-    mProcesses.erase(pid);
-    return ec;
+    mLifecycle = ProcessLifecycle::RUNNING;
 }
 
 bool
-ProcessManagerImpl::cleanShutdown(ProcessExitEvent& pe)
+ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
-    if (!GenerateConsoleCtrlEvent(CTRL_C_EVENT, pe.mImpl->getProcessId()))
+    checkInvariants();
+    if (pe->mImpl->mLifecycle >= ProcessLifecycle::TRIED_POLITE_SHUTDOWN)
+    {
+        return true;
+    }
+    pe->mImpl->mLifecycle = ProcessLifecycle::TRIED_POLITE_SHUTDOWN;
+    pe->mImpl->cancel(ABORT_ERROR_CODE);
+    if (!GenerateConsoleCtrlEvent(CTRL_C_EVENT, pe->mImpl->getProcessId()))
     {
         CLOG_WARNING(
             Process,
-            "failed to cleanly shutdown process with pid {}, error code {}",
-            pe.mImpl->getProcessId(), GetLastError());
+            "failed to politely shutdown process with pid {}, error code {}",
+            pe->mImpl->getProcessId(), GetLastError());
         return false;
     }
     return true;
 }
 
 bool
-ProcessManagerImpl::forceShutdown(ProcessExitEvent& pe)
+ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
-    if (!TerminateProcess(pe.mImpl->mProcessHandle.native_handle(), 1))
+    checkInvariants();
+    if (pe->mImpl->mLifecycle >= ProcessLifecycle::TRIED_FORCED_SHUTDOWN)
+    {
+        return true;
+    }
+    pe->mImpl->mLifecycle = ProcessLifecycle::TRIED_FORCED_SHUTDOWN;
+    if (!TerminateProcess(pe->mImpl->mProcessHandle.native_handle(), 1))
     {
         CLOG_WARNING(
             Process,
-            "failed to force shutdown of process with pid {}, error code {}",
-            pe.mImpl->getProcessId(), GetLastError());
+            "failed to forcibly shutdown process with pid {}, error code {}",
+            pe->mImpl->getProcessId(), GetLastError());
         return false;
     }
     // Cancel any pending events on the handle. Ignore error code
     asio::error_code dummy;
-    pe.mImpl->mProcessHandle.cancel(dummy);
+    pe->mImpl->mProcessHandle.cancel(dummy);
     return true;
 }
 
@@ -603,109 +722,44 @@ ProcessManagerImpl::reapChildren()
     }
 }
 
-asio::error_code
-ProcessManagerImpl::handleProcessTermination(int pid, int status)
-{
-    ZoneScoped;
-    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
-    auto ec = asio::error_code();
-
-    auto pair = mProcesses.find(pid);
-    if (pair == mProcesses.end())
-    {
-        CLOG_DEBUG(Process, "failed to find process with pid {}", pid);
-        return ec;
-    }
-    auto impl = pair->second->mImpl;
-
-    if (WIFEXITED(status))
-    {
-        if (WEXITSTATUS(status) == 0)
-        {
-            CLOG_DEBUG(Process, "process {} exited {}: {}", pid,
-                       WEXITSTATUS(status), impl->mCmdLine);
-        }
-        else
-        {
-            CLOG_WARNING(Process, "process {} exited {}: {}", pid,
-                         WEXITSTATUS(status), impl->mCmdLine);
-        }
-#ifdef __linux__
-        // Linux posix_spawnp does not fault on file-not-found in the
-        // parent process at the point of invocation, as BSD does; so
-        // rather than a fatal error / throw we get an ambiguous and
-        // easily-overlooked shell-like 'exit 127' on waitpid.
-        if (WEXITSTATUS(status) == 127)
-        {
-            CLOG_WARNING(Process, "");
-            CLOG_WARNING(Process, "************");
-            CLOG_WARNING(Process, "");
-            CLOG_WARNING(Process, "  likely 'missing command':");
-            CLOG_WARNING(Process, "");
-            CLOG_WARNING(Process, "    {}", impl->mCmdLine);
-            CLOG_WARNING(Process, "");
-            CLOG_WARNING(Process, "************");
-            CLOG_WARNING(Process, "");
-        }
-#endif
-        // FIXME: this doesn't _quite_ do the right thing; it conveys
-        // the exit status back to the caller but it puts it in "system
-        // category" which on POSIX means if you call .message() on it
-        // you'll get perror(value()), which is not correct. Errno has
-        // nothing to do with process exit values. We could make a new
-        // error_category to tighten this up, but it's a bunch of work
-        // just to convey the meaningless string "exited" to the user.
-        ec = asio::error_code(WEXITSTATUS(status), asio::system_category());
-    }
-    else
-    {
-        // FIXME: for now we also collapse all non-WIFEXITED exits on
-        // posix into a single "exit 1" error_code. This is enough
-        // for most callers; we can enrich it if anyone really wants
-        // to differentiate various signals that might have killed
-        // the child.
-        ec = asio::error_code(1, asio::system_category());
-    }
-
-    if (!impl->finish())
-    {
-        ec = asio::error_code(asio::error::try_again, asio::system_category());
-    }
-
-    --gNumProcessesActive;
-    mProcesses.erase(pair);
-
-    // Fire off any new processes we've made room for before we
-    // trigger the callback.
-    maybeRunPendingProcesses();
-
-    impl->cancel(ec);
-    return ec;
-}
-
 bool
-ProcessManagerImpl::cleanShutdown(ProcessExitEvent& pe)
+ProcessManagerImpl::politeShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
-    const int pid = pe.mImpl->getProcessId();
-    if (kill(pid, SIGINT) != 0)
+    checkInvariants();
+    if (pe->mImpl->mLifecycle >= ProcessLifecycle::TRIED_POLITE_SHUTDOWN)
     {
-        CLOG_WARNING(Process, "kill (SIGINT) failed for pid {}, errno {}", pid,
-                     errno);
+        return true;
+    }
+    pe->mImpl->mLifecycle = ProcessLifecycle::TRIED_POLITE_SHUTDOWN;
+    pe->mImpl->cancel(ABORT_ERROR_CODE);
+    const int pid = pe->mImpl->getProcessId();
+    if (kill(pid, SIGTERM) != 0)
+    {
+        CLOG_WARNING(Process,
+                     "kill (SIGTERM) failed for pid {}, errno {} = '{}'", pid,
+                     errno, strerror(errno));
         return false;
     }
     return true;
 }
 
 bool
-ProcessManagerImpl::forceShutdown(ProcessExitEvent& pe)
+ProcessManagerImpl::forcedShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {
     ZoneScoped;
-    const int pid = pe.mImpl->getProcessId();
+    checkInvariants();
+    if (pe->mImpl->mLifecycle >= ProcessLifecycle::TRIED_FORCED_SHUTDOWN)
+    {
+        return true;
+    }
+    pe->mImpl->mLifecycle = ProcessLifecycle::TRIED_FORCED_SHUTDOWN;
+    const int pid = pe->mImpl->getProcessId();
     if (kill(pid, SIGKILL) != 0)
     {
-        CLOG_WARNING(Process, "kill (SIGKILL) failed for pid {}, errno {}", pid,
-                     errno);
+        CLOG_WARNING(Process,
+                     "kill (SIGKILL) failed for pid {}, errno {} = '{}'", pid,
+                     errno, strerror(errno));
         return false;
     }
     return true;
@@ -726,12 +780,9 @@ ProcessExitEvent::Impl::run()
 {
     ZoneScoped;
     auto manager = mProcManagerImpl.lock();
-    assert(manager && !manager->isShutdown());
-    if (mRunning)
-    {
-        CLOG_ERROR(Process, "ProcessExitEvent::Impl already running");
-        throw std::runtime_error("ProcessExitEvent::Impl already running");
-    }
+    releaseAssertOrThrow(manager && !manager->isShutdown());
+    releaseAssertOrThrow(mLifecycle == ProcessLifecycle::PENDING);
+
     std::vector<std::string> args = split(mCmdLine);
     std::vector<char*> argv;
     for (auto& a : args)
@@ -779,7 +830,7 @@ ProcessExitEvent::Impl::run()
         throw std::runtime_error("posix_spawn() failed");
     }
 
-    mRunning = true;
+    mLifecycle = ProcessLifecycle::RUNNING;
 }
 
 #endif
@@ -810,12 +861,14 @@ void
 ProcessManagerImpl::maybeRunPendingProcesses()
 {
     ZoneScoped;
+    checkInvariants();
     if (mIsShutdown)
     {
         return;
     }
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
-    while (!mPending.empty() && gNumProcessesActive < mMaxProcesses)
+    while (!mPending.empty() &&
+           getNumRunningOrShuttingDownProcesses() < mMaxProcesses)
     {
         auto i = mPending.front();
         mPending.pop_front();
@@ -831,7 +884,6 @@ ProcessManagerImpl::maybeRunPendingProcesses()
 
             i->mImpl->run();
             mProcesses[i->mImpl->getProcessId()] = i;
-            ++gNumProcessesActive;
         }
         catch (std::runtime_error& e)
         {
@@ -839,6 +891,27 @@ ProcessManagerImpl::maybeRunPendingProcesses()
             CLOG_ERROR(Process, "Error starting process: {}", e.what());
             CLOG_ERROR(Process, "When running: {}", i->mImpl->mCmdLine);
         }
+    }
+}
+
+void
+ProcessManagerImpl::checkInvariants()
+{
+    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
+    if (mIsShutdown)
+    {
+        releaseAssertOrThrow(mPending.empty());
+    }
+    for (auto const& pe : mPending)
+    {
+        releaseAssertOrThrow(pe->mImpl->mLifecycle ==
+                             ProcessLifecycle::PENDING);
+    }
+    for (auto const& pair : mProcesses)
+    {
+        auto const& impl = pair.second->mImpl;
+        releaseAssertOrThrow(impl->mLifecycle != ProcessLifecycle::PENDING);
+        releaseAssertOrThrow(impl->getProcessId() == pair.first);
     }
 }
 

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -279,6 +279,13 @@ ProcessManagerImpl::handleSignalChild()
 {
     // No-op on windows, uses waitable object handles
 }
+
+void
+ProcessManagerImpl::reapChildren()
+{
+    // No-op on windows, uses waitable object handles
+}
+
 namespace
 {
 struct InfoHelper
@@ -548,6 +555,12 @@ ProcessManagerImpl::handleSignalChild()
         return;
     }
     startWaitingForSignalChild();
+    reapChildren();
+}
+
+void
+ProcessManagerImpl::reapChildren()
+{
     // Store tuples (pid, status)
     std::vector<std::tuple<int, int>> signaledChildren;
     std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -193,6 +193,16 @@ ProcessManagerImpl::shutdown()
     }
 }
 
+void
+ProcessManagerImpl::tryProcessShutdownAll()
+{
+    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
+    for (auto const& pe : mProcesses)
+    {
+        tryProcessShutdown(pe.second);
+    }
+}
+
 bool
 ProcessManagerImpl::tryProcessShutdown(std::shared_ptr<ProcessExitEvent> pe)
 {

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -127,6 +127,11 @@ size_t
 ProcessManagerImpl::getNumRunningProcesses()
 {
     return gNumProcessesActive;
+size_t
+ProcessManagerImpl::getNumRunningOrShuttingDownProcesses()
+{
+    std::lock_guard<std::recursive_mutex> guard(mProcessesMutex);
+    return mProcesses.size();
 }
 
 ProcessManagerImpl::~ProcessManagerImpl()

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -39,6 +39,7 @@ class ProcessManagerImpl : public ProcessManager
 
     void startWaitingForSignalChild();
     void handleSignalChild();
+    void reapChildren();
     asio::error_code handleProcessTermination(int pid, int status);
     bool cleanShutdown(ProcessExitEvent& pe);
     bool forceShutdown(ProcessExitEvent& pe);

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -37,8 +37,8 @@ class ProcessManagerImpl : public ProcessManager
     std::deque<std::shared_ptr<ProcessExitEvent>> mKillable;
     void maybeRunPendingProcesses();
 
-    void startSignalWait();
-    void handleSignalWait();
+    void startWaitingForSignalChild();
+    void handleSignalChild();
     asio::error_code handleProcessTermination(int pid, int status);
     bool cleanShutdown(ProcessExitEvent& pe);
     bool forceShutdown(ProcessExitEvent& pe);

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -16,17 +16,17 @@ namespace stellar
 
 class ProcessManagerImpl : public ProcessManager
 {
-    // On windows we use a simple global counter to throttle the
-    // number of processes we run at once.
-    static std::atomic<size_t> gNumProcessesActive;
-
     // Subprocesses will be removed asynchronously, hence the lock on
-    // just this member
+    // just the mProcesses member.
     std::recursive_mutex mProcessesMutex;
+
+    // Stores a map from pid to running-or-shutting-down processes.
+    // Any ProcessExitEvent should be stored either in mProcesses
+    // or in mPending (before it's launched).
     std::map<int, std::shared_ptr<ProcessExitEvent>> mProcesses;
 
     bool mIsShutdown{false};
-    size_t mMaxProcesses;
+    size_t const mMaxProcesses;
     asio::io_context& mIOContext;
     // These are only used on POSIX, but they're harmless here.
     asio::signal_set mSigChild;
@@ -34,15 +34,15 @@ class ProcessManagerImpl : public ProcessManager
     uint64_t mTempFileCount{0};
 
     std::deque<std::shared_ptr<ProcessExitEvent>> mPending;
-    std::deque<std::shared_ptr<ProcessExitEvent>> mKillable;
     void maybeRunPendingProcesses();
+    void checkInvariants();
 
     void startWaitingForSignalChild();
     void handleSignalChild();
     void reapChildren();
     asio::error_code handleProcessTermination(int pid, int status);
-    bool cleanShutdown(ProcessExitEvent& pe);
-    bool forceShutdown(ProcessExitEvent& pe);
+    bool politeShutdown(std::shared_ptr<ProcessExitEvent> pe);
+    bool forcedShutdown(std::shared_ptr<ProcessExitEvent> pe);
     void tryProcessShutdownAll();
 
     friend class ProcessExitEvent::Impl;

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -50,6 +50,7 @@ class ProcessManagerImpl : public ProcessManager
     std::weak_ptr<ProcessExitEvent> runProcess(std::string const& cmdLine,
                                                std::string outFile) override;
     size_t getNumRunningProcesses() override;
+    size_t getNumRunningOrShuttingDownProcesses() override;
 
     bool isShutdown() const override;
     void shutdown() override;

--- a/src/process/ProcessManagerImpl.h
+++ b/src/process/ProcessManagerImpl.h
@@ -43,6 +43,7 @@ class ProcessManagerImpl : public ProcessManager
     asio::error_code handleProcessTermination(int pid, int status);
     bool cleanShutdown(ProcessExitEvent& pe);
     bool forceShutdown(ProcessExitEvent& pe);
+    void tryProcessShutdownAll();
 
     friend class ProcessExitEvent::Impl;
 


### PR DESCRIPTION
Third, slightly wider but still narrow attempt at this PR. I've attempted to integrate all review comments so far. There's one fairly large chunk of inter-dependent refactoring in the last commit; unfortunately it proved hard to separate out further while rebasing, but I _think_ it's still fairly comprehensible.

There should be no contract changes here, only improved internal book-keeping and interaction with external processes shutting down. There are two main things happening:

  - The motivating change: making all the SIGTERM and SIGKILL'ed processes route into the same child-reaping path that we use for normal (non-killing) process exit, so we actually reap them, and making sure we do this on shutdown and destruction. This is to avoid producing orphan zombies if we're running in a container. Containers don't always have init processes and so they can accumulate orphan zombies if we don't do this. (see horizon bug https://github.com/stellar/go/issues/3217). This mostly happens in the second-last change 04e0c26 though there's some setup before it.
  - Refactoring and cleanup:
    - Merging and reusing more code where possible, making some platform-specific stuff platform-generic.
    - Fixing minor and probably-never-exercised bugs in error-routing and locking.
    - Reporting errors with strerror.
    - Renaming things that were misnamed or inconsistently named.
    - Adding comments.
    - Adding an invariant-checking helper.
