### PR TITLE
enable GH actions on auto branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 on:
   pull_request:
+  push:
+    branches:
+      - auto
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Runs GH action for default build on "auto" branch.

See https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestbranchestags for reference on how it's done.
