### PR TITLE
cancel stale GA workflows when PRs/branches get updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
       matrix:
         toolchain: [ "gcc", "clang"]
     steps:
+      - name: Cancel Stale Workflows
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       - name: Compute cache key
         # this step works around a limitation in actions/cache
         # that does not allow updating a cache


### PR DESCRIPTION
uses https://github.com/marketplace/actions/cancel-workflow-action
