### PR TITLE
Cleanup peer type update

### DIFF
--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -346,9 +346,7 @@ OverlayManagerImpl::storePeerList(std::vector<PeerBareAddress> const& addresses,
                                   bool setPreferred, bool startup)
 {
     ZoneScoped;
-    auto typeUpgrade = setPreferred
-                           ? PeerManager::TypeUpdate::SET_PREFERRED
-                           : PeerManager::TypeUpdate::UPDATE_TO_OUTBOUND;
+    auto type = setPreferred ? PeerType::PREFERRED : PeerType::OUTBOUND;
     if (setPreferred)
     {
         mConfigurationPreferredPeers.clear();
@@ -363,7 +361,8 @@ OverlayManagerImpl::storePeerList(std::vector<PeerBareAddress> const& addresses,
 
         if (startup)
         {
-            getPeerManager().update(peer, typeUpgrade,
+            getPeerManager().update(peer, type,
+                                    /* preferredTypeKnown */ false,
                                     PeerManager::BackOffUpdate::HARD_RESET);
         }
         else
@@ -371,7 +370,8 @@ OverlayManagerImpl::storePeerList(std::vector<PeerBareAddress> const& addresses,
             // If address is present in the DB, `update` will ensure
             // type is correctly updated. Otherwise, a new entry is created.
             // Note that this won't downgrade preferred peers back to outbound.
-            getPeerManager().update(peer, typeUpgrade);
+            getPeerManager().update(peer, type,
+                                    /* preferredTypeKnown */ false);
         }
     }
 }

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1025,11 +1025,14 @@ Peer::updatePeerRecordAfterEcho()
     assert(!getAddress().isEmpty());
 
     auto type = mApp.getOverlayManager().isPreferred(this)
-                    ? PeerManager::TypeUpdate::SET_PREFERRED
-                    : mRole == WE_CALLED_REMOTE
-                          ? PeerManager::TypeUpdate::SET_OUTBOUND
-                          : PeerManager::TypeUpdate::REMOVE_PREFERRED;
-    mApp.getOverlayManager().getPeerManager().update(getAddress(), type);
+                    ? PeerType::PREFERRED
+                    : mRole == WE_CALLED_REMOTE ? PeerType::OUTBOUND
+                                                : PeerType::INBOUND;
+    // Now that we've done authentication, we know whether this peer is
+    // preferred or not
+    mApp.getOverlayManager().getPeerManager().update(
+        getAddress(), type,
+        /* preferredTypeKnown */ true);
 }
 
 void

--- a/src/overlay/PeerManager.h
+++ b/src/overlay/PeerManager.h
@@ -64,10 +64,9 @@ class PeerManager
   public:
     enum class TypeUpdate
     {
-        SET_OUTBOUND,
+        ENSURE_OUTBOUND,
         SET_PREFERRED,
-        REMOVE_PREFERRED,
-        UPDATE_TO_OUTBOUND
+        ENSURE_NOT_PREFERRED,
     };
 
     enum class BackOffUpdate
@@ -87,9 +86,13 @@ class PeerManager
     void ensureExists(PeerBareAddress const& address);
 
     /**
-     * Update type of peer associated with given address.
+     * Update type of peer associated with given address. This function takes
+     * observed peer type, and whether the preferred type is definitely known
+     * (in some cases it is unknown whether a peer is preferred or not).
+     * Depending on the peer type stored in the DB, a new type is determined.
      */
-    void update(PeerBareAddress const& address, TypeUpdate type);
+    void update(PeerBareAddress const& address, PeerType observedType,
+                bool preferredTypeKnown);
 
     /**
      * Update "next try" of peer associated with given address - can reset
@@ -100,8 +103,8 @@ class PeerManager
     /**
      * Update both type and "next try" of peer associated with given address.
      */
-    void update(PeerBareAddress const& address, TypeUpdate type,
-                BackOffUpdate backOff);
+    void update(PeerBareAddress const& address, PeerType observedType,
+                bool preferredTypeKnown, BackOffUpdate backOff);
 
     /**
      * Load PeerRecord data for peer with given address. If not available in

--- a/src/overlay/test/PeerManagerTests.cpp
+++ b/src/overlay/test/PeerManagerTests.cpp
@@ -376,8 +376,7 @@ TEST_CASE("getPeersToSend", "[overlay][PeerManager]")
         }
         for (auto i = 0; i < normalOutboundCount; i++)
         {
-            peerManager.update(localhost(port++),
-                               PeerManager::TypeUpdate::SET_OUTBOUND);
+            peerManager.update(localhost(port++), PeerType::OUTBOUND, false);
         }
         for (auto i = 0; i < failedOutboundCount; i++)
         {


### PR DESCRIPTION
Resolves #2775 

minor cleanup. right now peer type update is really confusing as UPDATE_TO_OUTBOUND would only conditionally update the type. This is not exactly right: in the situation where we're using this, what we really want is to make sure that we're not "downgrading" preferred peers. This change aims to make this a little clearer. The downside of this is that we do an extra load per peer, but since this only happens on startup and once every 10 minutes (when we resolve peers), that doesn't seem like a significant overhead. 