### PR TITLE
Remove the <= and bool operators from the BitSet class

### DIFF
--- a/src/util/BitSet.h
+++ b/src/util/BitSet.h
@@ -157,12 +157,6 @@ class BitSet
         return bitset_subseteq(mPtr, other.mPtr);
     }
 
-    bool
-    operator<=(BitSet const& other) const
-    {
-        return isSubsetEq(other);
-    }
-
     size_t
     size() const
     {
@@ -209,10 +203,6 @@ class BitSet
     {
         size_t tmp = 0;
         return !nextSet(tmp);
-    }
-    operator bool() const
-    {
-        return !empty();
     }
     size_t
     min() const

--- a/src/util/test/BitSetTests.cpp
+++ b/src/util/test/BitSetTests.cpp
@@ -25,12 +25,12 @@ TEST_CASE("BitSet basics", "[bitset]")
         REQUIRE(!bs_even.get(i + 1));
         REQUIRE(bs_odd.get(i + 1));
     }
-    REQUIRE(bs_even <= (bs_even | bs_odd));
-    REQUIRE(bs_odd <= (bs_even | bs_odd));
-    REQUIRE(bs_odd <= bs_odd);
-    REQUIRE(bs_even <= bs_even);
-    REQUIRE(!(bs_odd <= bs_even));
-    REQUIRE(!(bs_even <= bs_odd));
+    REQUIRE(bs_even.isSubsetEq(bs_even | bs_odd));
+    REQUIRE(bs_odd.isSubsetEq(bs_even | bs_odd));
+    REQUIRE(bs_odd.isSubsetEq(bs_odd));
+    REQUIRE(bs_even.isSubsetEq(bs_even));
+    REQUIRE(!bs_odd.isSubsetEq(bs_even));
+    REQUIRE(!bs_even.isSubsetEq(bs_odd));
     REQUIRE((bs_even | bs_odd) == (bs_odd | bs_even));
     REQUIRE((bs_even & bs_odd).empty());
     REQUIRE((bs_even & (bs_even | bs_odd)) == bs_even);


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/2800

This PR removes the `<=` and `bool` operators from the `BitSet` class.

* The issue https://github.com/stellar/stellar-core/issues/2800 has some discussion on why we might consider removing `<=`.
* If we remove the `<=` operator but keep the `bool` operator, then `bitset1 <= bitset2` still compiles and runs (I think C++ implicitly converts each bitset into a boolean value and compare.) I felt that that might create some more confusion in the future (also the `bool` operator is defined to be `nonempty`, which may not be obvious to some people), so I decided that we might consider removing it, also.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
