### PR TITLE
fix flaky herder test

### DIFF
--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1386,6 +1386,11 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps,
                            : tx->getEnvelope().v1().tx.timeBounds.activate();
             tb.minTime = minTime;
             tb.maxTime = maxTime;
+            auto& sig = tx->getEnvelope().type() == ENVELOPE_TYPE_TX_V0
+                            ? tx->getEnvelope().v0().signatures
+                            : tx->getEnvelope().v1().signatures;
+            sig.clear();
+            tx->addSignature(root.getSecretKey());
             auto txSet = std::make_shared<TxSetFrame>(
                 app->getLedgerManager().getLastClosedLedgerHeader().hash);
             txSet->add(tx);

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -455,7 +455,11 @@ testTxSetWithFeeBumps(uint32 protocolVersion)
     auto checkTrimCheck = [&](std::vector<TransactionFrameBasePtr> const& txs) {
         txSet->sortForHash();
         REQUIRE(!txSet->checkValid(*app, 0, 0));
-        REQUIRE(txSet->trimInvalid(*app, 0, 0) == txs);
+        auto trimmedSet = txSet->trimInvalid(*app, 0, 0);
+        std::sort(trimmedSet.begin(), trimmedSet.end());
+        auto txsNormalized = txs;
+        std::sort(txsNormalized.begin(), txsNormalized.end());
+        REQUIRE(trimmedSet == txsNormalized);
         REQUIRE(txSet->checkValid(*app, 0, 0));
     };
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -184,7 +184,6 @@ TransactionFrame::getFee(LedgerHeader const& header, int64_t baseFee,
 void
 TransactionFrame::addSignature(SecretKey const& secretKey)
 {
-    clearCached();
     auto sig = SignatureUtils::sign(secretKey, getContentsHash());
     addSignature(sig);
 }
@@ -192,6 +191,7 @@ TransactionFrame::addSignature(SecretKey const& secretKey)
 void
 TransactionFrame::addSignature(DecoratedSignature const& signature)
 {
+    clearCached();
     getSignatures(mEnvelope).push_back(signature);
 }
 

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -372,6 +372,8 @@ TEST_CASE("inflation", "[tx][inflation]")
 
         auto voter1tx = root.tx({createAccount(voter1, rootBalance / 6)});
         voter1tx->getEnvelope().v0().tx.fee = 999999999;
+        voter1tx->getEnvelope().v0().signatures.clear();
+        voter1tx->addSignature(root.getSecretKey());
         auto voter2tx = root.tx({createAccount(voter2, rootBalance / 3)});
         auto target1tx = root.tx({createAccount(target1, minBalance)});
         auto target2tx = root.tx({createAccount(target2, minBalance)});


### PR DESCRIPTION
The test had a dependency on the hash function / std::unordered_map
