### PR TITLE
Github Actions: work around stale cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,12 +12,26 @@ jobs:
       matrix:
         toolchain: [ "gcc", "clang"]
     steps:
+      - name: Compute cache key
+        # this step works around a limitation in actions/cache
+        # that does not allow updating a cache
+        # so what we do here instead is
+        #  1. generate a new id that gets refreshed every hour
+        #   the limit is to reduce the chance of hitting the
+        #   global 5GB limit per repo
+        #  2. use that id as part of the cache identifier
+        #  3. fallback (restore-keys) to the most recent cache
+        id: cache_extra_id
+        run: |
+          echo "::set-output name=id::$(( $(date +'%s') / 60 / 60 ))"
       - name: Cache
         uses: actions/cache@v2
         with:
           path: |
             /home/runner/.ccache
-          key: ${{ runner.os }}-${{ matrix.toolchain }}-cacheID
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-cacheID-${{ steps.cache_extra_id.outputs.id }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.toolchain }}-cacheID-
       - uses: actions/checkout@v2
         with:
            fetch-depth: 200

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,4 +65,4 @@ jobs:
             export CXX='clang++'
           fi
           echo Build with $CC and $CXX
-          ./travis-build.sh --use-temp-db
+          ./ci-build.sh --use-temp-db

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
 before_script:
   - ulimit -c unlimited -S
 
-script: ./travis-build.sh
+script: ./ci-build.sh
 
 after_failure:
   - COREFILE=$(find . -maxdepth 1 -name "core*" | head -n 1)
@@ -62,8 +62,8 @@ matrix:
   include:
     - stage: compile
       compiler: clang
-      script: ./travis-build.sh --disable-tests
+      script: ./ci-build.sh --disable-tests
     - stage: compile
       compiler: gcc
-      script: ./travis-build.sh --disable-tests
+      script: ./ci-build.sh --disable-tests
 

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -1071,7 +1071,7 @@ exit /b 0
     <None Include="..\..\src\overlay\readme.md" />
     <None Include="..\..\src\scp\readme.md" />
     <None Include="..\..\src\transactions\readme.md" />
-    <None Include="..\..\travis-build.sh" />
+    <None Include="..\..\ci-build.sh" />
     <None Include="libmedida\libmedida.vcxproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -2037,7 +2037,7 @@
     </None>
     <None Include="..\..\CONTRIBUTING.md" />
     <None Include="..\..\README" />
-    <None Include="..\..\travis-build.sh" />
+    <None Include="..\..\ci-build.sh" />
     <None Include="..\..\src\history\serialize-tests\stellar-history.livenet.15686975.json">
       <Filter>history\tests\serialize-tests</Filter>
     </None>

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# This is just a slightly more-debuggable script that does our travis build
+# this script performs a build & test pass
+# it depends on the CC and CXX environment variables
 
 set -ev
 
@@ -152,4 +153,3 @@ time make check
 echo All done
 date
 exit 0
-

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -4,6 +4,9 @@
 
 set -ev
 
+# max age of cache before force purging
+CACHE_MAX_DAYS=30
+
 WITH_TESTS=1
 export TEMP_POSTGRES=0
 
@@ -89,10 +92,17 @@ export LSAN_OPTIONS=detect_leaks=0
 echo "config_flags = $config_flags"
 
 #### ccache config
+export CCACHE_DIR=$HOME/.ccache
 export CCACHE_COMPRESS=true
 export CCACHE_COMPILERCHECK="string:$CXX"
 export CCACHE_MAXSIZE=900M
 export CCACHE_CPP2=true
+
+# purge cache if it's too old
+if [ -n "$(find $CCACHE_DIR -mtime +$CACHE_MAX_DAYS -print -quit)" ] ; then
+    echo Purging old cache $CCACHE_DIR
+    rm -rf $CCACHE_DIR
+fi
 
 ccache -p
 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -95,7 +95,9 @@ echo "config_flags = $config_flags"
 export CCACHE_DIR=$HOME/.ccache
 export CCACHE_COMPRESS=true
 export CCACHE_COMPILERCHECK="string:$CXX"
-export CCACHE_MAXSIZE=900M
+export CCACHE_COMPRESSLEVEL=9
+# cache size should be large enough for a full build
+export CCACHE_MAXSIZE=300M
 export CCACHE_CPP2=true
 
 # purge cache if it's too old

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -94,7 +94,6 @@ echo "config_flags = $config_flags"
 #### ccache config
 export CCACHE_DIR=$HOME/.ccache
 export CCACHE_COMPRESS=true
-export CCACHE_COMPILERCHECK="string:$CXX"
 export CCACHE_COMPRESSLEVEL=9
 # cache size should be large enough for a full build
 export CCACHE_MAXSIZE=300M


### PR DESCRIPTION
This PR changes how build caches work:
* it actually makes caching work by working around a limitation of `actions/cache@v2` that does not update the cache it used (there is a PR open in their repo)
* it changes our cache size
   * there is a limit of 5GB for caches **project wide** - and the previous limit was 900MB, which means that with a few PRs, we would trash important caches like the one for the `auto` branch
   * we reduce the limit to 300MB - a build only needs about 200MB, so this allows to go slightly over that
* it changes the policy for caching
   * we switch back to using the default behavior for compiler signature `Hash(mtime + size)`
   * we force purge caches that are more than 1 month old. This acts as a safety net in case something else (standard library headers, etc) gets modified but is not tracked by ccache.
