### PR TITLE
Use a randomized hasher in unordered sets/maps

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -611,7 +611,6 @@ exit /b 0
     <ClCompile Include="..\..\src\work\Work.cpp" />
     <ClCompile Include="..\..\src\work\WorkScheduler.cpp" />
     <ClCompile Include="..\..\src\work\WorkSequence.cpp" />
-    <ClCompile Include="Source.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\catch.hpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -611,6 +611,7 @@ exit /b 0
     <ClCompile Include="..\..\src\work\Work.cpp" />
     <ClCompile Include="..\..\src\work\WorkScheduler.cpp" />
     <ClCompile Include="..\..\src\work\WorkSequence.cpp" />
+    <ClCompile Include="Source.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\catch.hpp" />
@@ -708,7 +709,10 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\TransactionSQL.h" />
     <ClInclude Include="..\..\src\transactions\RevokeSponsorshipOpFrame.h" />
     <ClInclude Include="..\..\src\util\Decoder.h" />
+    <ClInclude Include="..\..\src\util\RandHasher.h" />
     <ClInclude Include="..\..\src\util\Scheduler.h" />
+    <ClInclude Include="..\..\src\util\UnorderedMap.h" />
+    <ClInclude Include="..\..\src\util\UnorderedSet.h" />
     <ClInclude Include="..\..\src\util\XDRCereal.h" />
     <ClInclude Include="..\..\src\util\XDROperators.h" />
     <ClInclude Include="..\..\src\work\BatchWork.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1137,6 +1137,9 @@
     <ClCompile Include="..\..\src\ledger\InternalLedgerEntry.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="Source.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">
@@ -1966,6 +1969,15 @@
     </ClInclude>
     <ClInclude Include="..\..\src\ledger\NonSociRelatedException.h">
       <Filter>ledger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\RandHasher.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\UnorderedMap.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\UnorderedSet.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1137,9 +1137,6 @@
     <ClCompile Include="..\..\src\ledger\InternalLedgerEntry.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
-    <ClCompile Include="Source.cpp">
-      <Filter>util</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\easylogging++.h">

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -55,7 +55,7 @@ class BucketManagerImpl : public BucketManager
     // FutureBucket being resolved). Entries in this map will be cleared when
     // the FutureBucket is _cleared_ (typically when the owning BucketList level
     // is committed).
-    std::unordered_map<MergeKey, std::shared_future<std::shared_ptr<Bucket>>>
+    UnorderedMap<MergeKey, std::shared_future<std::shared_ptr<Bucket>>>
         mLiveFutures;
 
     // Records bucket-merges that are _finished_, i.e. have been adopted as

--- a/src/bucket/BucketMergeMap.cpp
+++ b/src/bucket/BucketMergeMap.cpp
@@ -9,11 +9,11 @@
 
 namespace
 {
-std::unordered_set<stellar::Hash>
+stellar::UnorderedSet<stellar::Hash>
 getMergeKeyHashes(stellar::MergeKey const& key)
 {
     ZoneScoped;
-    std::unordered_set<stellar::Hash> hashes;
+    stellar::UnorderedSet<stellar::Hash> hashes;
     hashes.emplace(key.mInputCurrBucket);
     hashes.emplace(key.mInputSnapBucket);
     for (auto const& in : key.mInputShadowBuckets)
@@ -41,11 +41,11 @@ BucketMergeMap::recordMerge(MergeKey const& input, Hash const& output)
     }
 }
 
-std::unordered_set<MergeKey>
+UnorderedSet<MergeKey>
 BucketMergeMap::forgetAllMergesProducing(Hash const& outputBeingDropped)
 {
     ZoneScoped;
-    std::unordered_set<MergeKey> ret;
+    UnorderedSet<MergeKey> ret;
     auto mergesProducingOutput =
         mOutputToMergeKey.equal_range(outputBeingDropped);
     for (auto mergeProducingOutput = mergesProducingOutput.first;

--- a/src/bucket/BucketMergeMap.h
+++ b/src/bucket/BucketMergeMap.h
@@ -2,10 +2,10 @@
 
 #include "bucket/MergeKey.h"
 #include "util/HashOfHash.h"
+#include "util/UnorderedSet.h"
 #include "xdr/Stellar-types.h"
 #include <set>
 #include <unordered_map>
-#include <unordered_set>
 
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
@@ -42,7 +42,7 @@ class BucketMergeMap
 
   public:
     void recordMerge(MergeKey const& input, Hash const& output);
-    std::unordered_set<MergeKey> forgetAllMergesProducing(Hash const& output);
+    UnorderedSet<MergeKey> forgetAllMergesProducing(Hash const& output);
     bool findMergeFor(MergeKey const& input, Hash& output);
     void getOutputsUsingInput(Hash const& input, std::set<Hash>& outputs) const;
 };

--- a/src/bucket/BucketMergeMap.h
+++ b/src/bucket/BucketMergeMap.h
@@ -2,10 +2,10 @@
 
 #include "bucket/MergeKey.h"
 #include "util/HashOfHash.h"
+#include "util/UnorderedMap.h"
 #include "util/UnorderedSet.h"
 #include "xdr/Stellar-types.h"
 #include <set>
-#include <unordered_map>
 
 // Copyright 2019 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
@@ -25,7 +25,7 @@ class BucketMergeMap
     // not -- they just showed up from catchup or state reloading). Entries in
     // this map will be cleared when their _output_ is dropped from the owning
     // BucketManager's mSharedBuckets, typically due to being unreferenced.
-    std::unordered_map<MergeKey, Hash> mMergeKeyToOutput;
+    UnorderedMap<MergeKey, Hash> mMergeKeyToOutput;
 
     // Unfortunately to use this correctly in the bucket GC path, we also need
     // a different version of the same map, keyed by each input separately. And

--- a/src/bucket/MergeKey.cpp
+++ b/src/bucket/MergeKey.cpp
@@ -4,6 +4,7 @@
 
 #include "bucket/MergeKey.h"
 #include "crypto/Hex.h"
+#include "fmt/format.h"
 #include <sstream>
 
 namespace stellar
@@ -48,7 +49,7 @@ operator<<(std::ostream& out, MergeKey const& b)
         first = false;
         out << hexAbbrev(s);
     }
-    out << "]]";
+    out << fmt::format("], keep={}]", b.mKeepDeadEntries);
     return out;
 }
 }

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -101,23 +101,23 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     REQUIRE(outs == std::set<Hash>{out1->getHash()});
 
     REQUIRE(bmm.forgetAllMergesProducing(out1->getHash()) ==
-            std::unordered_set<MergeKey>{m1});
+            UnorderedSet<MergeKey>{m1});
     REQUIRE(!bmm.findMergeFor(m1, t));
     outs.clear();
     bmm.getOutputsUsingInput(in1a->getHash(), outs);
     REQUIRE(outs == std::set<Hash>{out6->getHash()});
 
     REQUIRE(bmm.forgetAllMergesProducing(out2->getHash()) ==
-            std::unordered_set<MergeKey>{m2, m3});
+            UnorderedSet<MergeKey>{m2, m3});
     REQUIRE(!bmm.findMergeFor(m2, t));
     REQUIRE(!bmm.findMergeFor(m3, t));
 
     REQUIRE(bmm.forgetAllMergesProducing(out4->getHash()) ==
-            std::unordered_set<MergeKey>{m4});
+            UnorderedSet<MergeKey>{m4});
     REQUIRE(!bmm.findMergeFor(m4, t));
 
     REQUIRE(bmm.forgetAllMergesProducing(out6->getHash()) ==
-            std::unordered_set<MergeKey>{m6});
+            UnorderedSet<MergeKey>{m6});
     REQUIRE(!bmm.findMergeFor(m6, t));
     outs.clear();
     bmm.getOutputsUsingInput(in6a->getHash(), outs);
@@ -128,5 +128,5 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
 
     // Second forget produces empty set.
     REQUIRE(bmm.forgetAllMergesProducing(out1->getHash()) ==
-            std::unordered_set<MergeKey>{});
+            UnorderedSet<MergeKey>{});
 }

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -398,7 +398,7 @@ TxSimApplyTransactionsWork::getNextLedgerFromHistoryArchive()
                                mResultHistory))
     {
         // Derive transaction apply order from the results
-        std::unordered_map<Hash, TransactionEnvelope> transactions;
+        UnorderedMap<Hash, TransactionEnvelope> transactions;
         for (auto const& tx : mTransactionHistory.txSet.txs)
         {
             auto txFrame = TransactionFrameBase::makeTransactionFromWire(

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1298,7 +1298,7 @@ HerderImpl::getJsonTransitiveQuorumInfo(NodeID const& rootID, bool summary,
     std::map<Value, int> knownValues;
 
     // walk the quorum graph, starting at id
-    std::unordered_set<NodeID> visited;
+    UnorderedSet<NodeID> visited;
     std::vector<NodeID> next;
     next.push_back(rootID);
     visited.emplace(rootID);

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -10,10 +10,10 @@
 #include "herder/TransactionQueue.h"
 #include "herder/Upgrades.h"
 #include "util/Timer.h"
+#include "util/UnorderedMap.h"
 #include "util/XDROperators.h"
 #include <deque>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 namespace medida

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -44,7 +44,7 @@ HerderPersistenceImpl::saveSCPHistory(uint32_t seq,
         return;
     }
 
-    auto usedQSets = std::unordered_map<Hash, SCPQuorumSetPtr>{};
+    auto usedQSets = UnorderedMap<Hash, SCPQuorumSetPtr>{};
     auto& db = mApp.getDatabase();
 
     soci::transaction txscope(db.getSession());
@@ -221,7 +221,7 @@ HerderPersistence::copySCPHistoryToStream(Database& db, soci::session& sess,
     size_t n = 0;
 
     // all known quorum sets
-    std::unordered_map<Hash, SCPQuorumSet> qSets;
+    UnorderedMap<Hash, SCPQuorumSet> qSets;
 
     for (uint32_t curLedgerSeq = begin; curLedgerSeq < end; curLedgerSeq++)
     {

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -210,7 +210,7 @@ class HerderSCPDriver : public SCPDriver
     medida::Histogram& mPrepareTimeout;
 
     // Externalize lag tracking for nodes in qset
-    std::unordered_map<NodeID, medida::Timer> mQSetLag;
+    UnorderedMap<NodeID, medida::Timer> mQSetLag;
 
     struct SCPTiming
     {

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -833,7 +833,7 @@ PendingEnvelopes::envelopeProcessed(SCPEnvelope const& env)
     }
 }
 
-std::unordered_map<NodeID, size_t>
+UnorderedMap<NodeID, size_t>
 PendingEnvelopes::getCostPerValidator(uint64 slotIndex) const
 {
     auto found = mEnvelopes.find(slotIndex);

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -11,8 +11,8 @@
 #include "scp/QuorumSetUtils.h"
 #include "scp/Slot.h"
 #include "util/Logging.h"
+#include "util/UnorderedSet.h"
 #include <Tracy.hpp>
-#include <unordered_set>
 #include <xdrpp/marshal.h>
 
 using namespace std;
@@ -262,7 +262,7 @@ static std::string
 txSetsToStr(SCPEnvelope const& envelope)
 {
     auto hashes = getTxSetHashes(envelope);
-    std::unordered_set<Hash> hashesSet(hashes.begin(), hashes.end());
+    UnorderedSet<Hash> hashesSet(hashes.begin(), hashes.end());
     std::string res = "[";
     for (auto const& s : hashesSet)
     {

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -41,7 +41,7 @@ struct SlotEnvelopes
     //   * txsets `NodeID` introduces either itself or via its
     //     quorum (our transitive quorum)
     //   * qsets
-    std::unordered_map<NodeID, size_t> mReceivedCost;
+    UnorderedMap<NodeID, size_t> mReceivedCost;
 };
 
 class PendingEnvelopes
@@ -55,7 +55,7 @@ class PendingEnvelopes
     // recent quorum sets
     RandomEvictionCache<Hash, SCPQuorumSetPtr> mQsetCache;
     // weak references to all known qsets
-    std::unordered_map<Hash, std::weak_ptr<SCPQuorumSet>> mKnownQSets;
+    UnorderedMap<Hash, std::weak_ptr<SCPQuorumSet>> mKnownQSets;
 
     ItemFetcher mTxSetFetcher;
     ItemFetcher mQuorumSetFetcher;
@@ -64,7 +64,7 @@ class PendingEnvelopes
     // recent txsets
     RandomEvictionCache<Hash, TxSetFramCacheItem> mTxSetCache;
     // weak references to all known txsets
-    std::unordered_map<Hash, std::weak_ptr<TxSetFrame>> mKnownTxSets;
+    UnorderedMap<Hash, std::weak_ptr<TxSetFrame>> mKnownTxSets;
 
     // keep track of txset/qset hash -> size pairs for quick access
     RandomEvictionCache<Hash, size_t> mValueSizeCache;
@@ -109,8 +109,7 @@ class PendingEnvelopes
 
     void recordReceivedCost(SCPEnvelope const& env);
 
-    std::unordered_map<NodeID, size_t>
-    getCostPerValidator(uint64 slotIndex) const;
+    UnorderedMap<NodeID, size_t> getCostPerValidator(uint64 slotIndex) const;
 
     // stops all pending downloads for slots strictly below `slotIndex`
     // counts partially downloaded data towards the cost for that slot

--- a/src/herder/QuorumTracker.h
+++ b/src/herder/QuorumTracker.h
@@ -6,10 +6,10 @@
 
 #include "scp/SCP.h"
 #include "util/NonCopyable.h"
+#include "util/UnorderedSet.h"
 #include <deque>
 #include <set>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace stellar
 {

--- a/src/herder/QuorumTracker.h
+++ b/src/herder/QuorumTracker.h
@@ -6,10 +6,10 @@
 
 #include "scp/SCP.h"
 #include "util/NonCopyable.h"
+#include "util/UnorderedMap.h"
 #include "util/UnorderedSet.h"
 #include <deque>
 #include <set>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -40,7 +40,7 @@ class QuorumTracker : public NonMovableOrCopyable
         std::set<NodeID> mClosestValidators;
     };
 
-    using QuorumMap = std::unordered_map<NodeID, NodeInfo>;
+    using QuorumMap = UnorderedMap<NodeID, NodeInfo>;
 
   private:
     NodeID const mLocalNodeID;

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -333,7 +333,7 @@ TransactionQueue::removeApplied(Transactions const& appliedTxs)
     ZoneScoped;
     // Find the highest sequence number that was applied for each source account
     std::map<AccountID, int64_t> seqByAccount;
-    std::unordered_set<Hash> appliedHashes;
+    UnorderedSet<Hash> appliedHashes;
     appliedHashes.reserve(appliedTxs.size());
     for (auto const& tx : appliedTxs)
     {
@@ -584,7 +584,7 @@ TransactionQueue::isBanned(Hash const& hash) const
 {
     return std::any_of(
         std::begin(mBannedTransactions), std::end(mBannedTransactions),
-        [&](std::unordered_set<Hash> const& transactions) {
+        [&](UnorderedSet<Hash> const& transactions) {
             return transactions.find(hash) != std::end(transactions);
         });
 }
@@ -667,9 +667,8 @@ TransactionQueue::maxQueueSizeOps() const
 }
 
 static bool
-containsFilteredOperation(
-    std::vector<Operation> const& ops,
-    std::unordered_set<OperationType> const& filteredTypes)
+containsFilteredOperation(std::vector<Operation> const& ops,
+                          UnorderedSet<OperationType> const& filteredTypes)
 {
     return std::any_of(ops.begin(), ops.end(), [&](auto const& op) {
         return filteredTypes.find(op.body.type()) != filteredTypes.end();

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -12,11 +12,11 @@
 #include "util/XDROperators.h"
 #include "xdr/Stellar-transaction.h"
 
+#include "util/UnorderedMap.h"
 #include "util/UnorderedSet.h"
 #include <chrono>
 #include <deque>
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 namespace medida
@@ -151,7 +151,7 @@ class TransactionQueue
      * - AccountState.mTotalFees > 0
      * - !AccountState.mTransactions.empty()
      */
-    using AccountStates = std::unordered_map<AccountID, AccountState>;
+    using AccountStates = UnorderedMap<AccountID, AccountState>;
 
     /**
      * Banned transactions are stored in deque of depth banDepth, so it is easy

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -12,11 +12,11 @@
 #include "util/XDROperators.h"
 #include "xdr/Stellar-transaction.h"
 
+#include "util/UnorderedSet.h"
 #include <chrono>
 #include <deque>
 #include <memory>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace medida
@@ -157,7 +157,7 @@ class TransactionQueue
      * Banned transactions are stored in deque of depth banDepth, so it is easy
      * to unban all transactions that were banned for long enough.
      */
-    using BannedTransactions = std::deque<std::unordered_set<Hash>>;
+    using BannedTransactions = std::deque<UnorderedSet<Hash>>;
 
     Application& mApp;
     int const mPendingDepth;
@@ -171,7 +171,7 @@ class TransactionQueue
     medida::Counter& mBannedTransactionsCounter;
     medida::Timer& mTransactionsDelay;
 
-    std::unordered_set<OperationType> mFilteredTypes;
+    UnorderedSet<OperationType> mFilteredTypes;
 
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -205,11 +205,11 @@ struct SurgeCompare
     }
 };
 
-std::unordered_map<AccountID, TxSetFrame::AccountTransactionQueue>
+UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
 TxSetFrame::buildAccountTxQueues()
 {
     ZoneScoped;
-    std::unordered_map<AccountID, AccountTransactionQueue> actTxQueueMap;
+    UnorderedMap<AccountID, AccountTransactionQueue> actTxQueueMap;
     for (auto& tx : mTransactions)
     {
         auto id = tx->getSourceID();
@@ -301,7 +301,7 @@ TxSetFrame::checkOrTrim(Application& app,
     ZoneScoped;
     LedgerTxn ltx(app.getLedgerTxnRoot());
 
-    std::unordered_map<AccountID, int64_t> accountFeeMap;
+    UnorderedMap<AccountID, int64_t> accountFeeMap;
     auto accountTxMap = buildAccountTxQueues();
     for (auto& kv : accountTxMap)
     {

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -7,10 +7,10 @@
 #include "ledger/LedgerHashUtils.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrame.h"
+#include "util/UnorderedMap.h"
 #include "util/optional.h"
 #include <deque>
 #include <functional>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -56,8 +56,7 @@ class TxSetFrame : public AbstractTxSetFrameForApply
                      bool justCheck, uint64_t lowerBoundCloseTimeOffset,
                      uint64_t upperBoundCloseTimeOffset);
 
-    std::unordered_map<AccountID, AccountTransactionQueue>
-    buildAccountTxQueues();
+    UnorderedMap<AccountID, AccountTransactionQueue> buildAccountTxQueues();
     friend struct SurgeCompare;
 
   public:

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -611,12 +611,12 @@ updateOffer(
     return res;
 }
 
-static std::unordered_map<AccountID, int64_t>
+static UnorderedMap<AccountID, int64_t>
 getOfferAccountMinBalances(
     AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
     std::map<AccountID, std::vector<LedgerTxnEntry>> const& offersByAccount)
 {
-    std::unordered_map<AccountID, int64_t> minBalanceMap;
+    UnorderedMap<AccountID, int64_t> minBalanceMap;
     for (auto const& accountOffers : offersByAccount)
     {
         auto const& accountID = accountOffers.first;

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -635,10 +635,11 @@ getOfferAccountMinBalances(
 }
 
 static void
-eraseOfferWithPossibleSponsorship(
-    AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,
-    LedgerTxnEntry& offerEntry, LedgerTxnEntry& accountEntry,
-    std::unordered_set<AccountID>& changedAccounts)
+eraseOfferWithPossibleSponsorship(AbstractLedgerTxn& ltx,
+                                  LedgerTxnHeader const& header,
+                                  LedgerTxnEntry& offerEntry,
+                                  LedgerTxnEntry& accountEntry,
+                                  UnorderedSet<AccountID>& changedAccounts)
 {
     LedgerEntry::_ext_t extension = offerEntry.current().ext;
     bool isSponsored = extension.v() == 1 && extension.v1().sponsoringID;
@@ -682,7 +683,7 @@ prepareLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header)
 
     auto offersByAccount = ltx.loadAllOffers();
 
-    std::unordered_set<AccountID> changedAccounts;
+    UnorderedSet<AccountID> changedAccounts;
     uint64_t nChangedTrustLines = 0;
 
     std::map<UpdateOfferResult, uint64_t> nUpdatedOffers;

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -35,8 +35,7 @@ class HistoryManagerImpl : public HistoryManager
     medida::Meter& mPublishFailure;
 
     medida::Timer& mEnqueueToPublishTimer;
-    std::unordered_map<uint32_t, std::chrono::steady_clock::time_point>
-        mEnqueueTimes;
+    UnorderedMap<uint32_t, std::chrono::steady_clock::time_point> mEnqueueTimes;
 
     PublishQueueBuckets::BucketCount loadBucketsReferencedByPublishQueue();
 #ifdef BUILD_TESTS

--- a/src/history/InferredQuorum.h
+++ b/src/history/InferredQuorum.h
@@ -9,8 +9,8 @@
 #include "main/Config.h"
 #include "overlay/StellarXDR.h"
 #include "util/HashOfHash.h"
+#include "util/UnorderedMap.h"
 #include <string>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -19,9 +19,9 @@ struct InferredQuorum
 {
     InferredQuorum();
     InferredQuorum(QuorumTracker::QuorumMap const& qmap);
-    std::unordered_map<Hash, SCPQuorumSet> mQsets;
-    std::unordered_map<PublicKey, std::vector<Hash>> mQsetHashes;
-    std::unordered_map<PublicKey, size_t> mPubKeys;
+    UnorderedMap<Hash, SCPQuorumSet> mQsets;
+    UnorderedMap<PublicKey, std::vector<Hash>> mQsetHashes;
+    UnorderedMap<PublicKey, size_t> mPubKeys;
     void noteSCPHistory(SCPHistoryEntry const& hist);
     void noteQset(SCPQuorumSet const& qset);
     void noteQsetHash(PublicKey const& pk, Hash const& hash);

--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -104,7 +104,7 @@ PutSnapshotFilesWork::doReset()
     mUploadSeqs.clear();
 }
 
-std::unordered_set<std::string>
+UnorderedSet<std::string>
 PutSnapshotFilesWork::getFilesToZip()
 {
     // Sanity check: there are states for all archives
@@ -114,7 +114,7 @@ PutSnapshotFilesWork::getFilesToZip()
         throw std::runtime_error("Corrupted GetHistoryArchiveStateWork");
     }
 
-    std::unordered_set<std::string> filesToZip{};
+    UnorderedSet<std::string> filesToZip{};
     for (auto const& getState : mGetStateWorks)
     {
         for (auto const& f :

--- a/src/historywork/PutSnapshotFilesWork.h
+++ b/src/historywork/PutSnapshotFilesWork.h
@@ -6,6 +6,7 @@
 
 #include "history/FileTransferInfo.h"
 #include "history/HistoryArchive.h"
+#include "util/UnorderedSet.h"
 #include "work/Work.h"
 
 namespace stellar
@@ -23,7 +24,7 @@ class PutSnapshotFilesWork : public Work
     std::list<std::shared_ptr<BasicWork>> mGzipFilesWorks;
     std::list<std::shared_ptr<BasicWork>> mUploadSeqs;
 
-    std::unordered_set<std::string> getFilesToZip();
+    UnorderedSet<std::string> getFilesToZip();
 
   public:
     PutSnapshotFilesWork(Application& app,

--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -7,8 +7,8 @@
 #include "ledger/LedgerTxn.h"
 #include "main/Application.h"
 #include "util/Logging.h"
+#include "util/UnorderedMap.h"
 #include <fmt/format.h>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -30,7 +30,7 @@ calculateDelta(LedgerEntry const* current, LedgerEntry const* previous)
 
 static void
 updateChangedSubEntriesCount(
-    std::unordered_map<AccountID, SubEntriesChange>& subEntriesChange,
+    UnorderedMap<AccountID, SubEntriesChange>& subEntriesChange,
     LedgerEntry const* current, LedgerEntry const* previous)
 {
     auto valid = current ? current : previous;
@@ -84,7 +84,7 @@ updateChangedSubEntriesCount(
 
 static void
 updateChangedSubEntriesCount(
-    std::unordered_map<AccountID, SubEntriesChange>& subEntriesChange,
+    UnorderedMap<AccountID, SubEntriesChange>& subEntriesChange,
     std::shared_ptr<InternalLedgerEntry const> const& genCurrent,
     std::shared_ptr<InternalLedgerEntry const> const& genPrevious)
 {
@@ -121,7 +121,7 @@ AccountSubEntriesCountIsValid::checkOnOperationApply(
     Operation const& operation, OperationResult const& result,
     LedgerTxnDelta const& ltxDelta)
 {
-    std::unordered_map<AccountID, SubEntriesChange> subEntriesChange;
+    UnorderedMap<AccountID, SubEntriesChange> subEntriesChange;
     for (auto const& entryDelta : ltxDelta.entry)
     {
         updateChangedSubEntriesCount(subEntriesChange,

--- a/src/invariant/AccountSubEntriesCountIsValid.h
+++ b/src/invariant/AccountSubEntriesCountIsValid.h
@@ -5,8 +5,8 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "invariant/Invariant.h"
+#include "util/UnorderedMap.h"
 #include <memory>
-#include <unordered_map>
 
 namespace stellar
 {

--- a/src/invariant/SponsorshipCountIsValid.cpp
+++ b/src/invariant/SponsorshipCountIsValid.cpp
@@ -7,8 +7,8 @@
 #include "ledger/LedgerTxn.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
+#include "util/UnorderedMap.h"
 #include <fmt/format.h>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -69,8 +69,8 @@ getAccountID(LedgerEntry const& le)
 
 static void
 updateCounters(LedgerEntry const& le,
-               std::unordered_map<AccountID, int64_t>& numSponsoring,
-               std::unordered_map<AccountID, int64_t>& numSponsored,
+               UnorderedMap<AccountID, int64_t>& numSponsoring,
+               UnorderedMap<AccountID, int64_t>& numSponsored,
                int64_t& claimableBalanceReserve, int64_t sign)
 {
     if (le.ext.v() == 1 && le.ext.v1().sponsoringID)
@@ -109,8 +109,8 @@ static void
 updateChangedSponsorshipCounts(
     std::shared_ptr<InternalLedgerEntry const> current,
     std::shared_ptr<InternalLedgerEntry const> previous,
-    std::unordered_map<AccountID, int64_t>& numSponsoring,
-    std::unordered_map<AccountID, int64_t>& numSponsored,
+    UnorderedMap<AccountID, int64_t>& numSponsoring,
+    UnorderedMap<AccountID, int64_t>& numSponsored,
     int64_t& claimableBalanceReserve)
 {
     if (current && current->type() == InternalLedgerEntryType::LEDGER_ENTRY)
@@ -157,8 +157,8 @@ SponsorshipCountIsValid::checkOnOperationApply(Operation const& operation,
     }
 
     // Get changes in numSponsoring and numSponsored based on extensions
-    std::unordered_map<AccountID, int64_t> numSponsoring;
-    std::unordered_map<AccountID, int64_t> numSponsored;
+    UnorderedMap<AccountID, int64_t> numSponsoring;
+    UnorderedMap<AccountID, int64_t> numSponsored;
     int64_t claimableBalanceReserve = 0;
     for (auto const& kv : ltxDelta.entry)
     {

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -18,10 +18,10 @@
 #include "transactions/TransactionUtils.h"
 #include "util/Decoder.h"
 #include "util/Math.h"
+#include "util/UnorderedSet.h"
 #include "util/XDROperators.h"
 #include "work/WorkScheduler.h"
 #include <random>
-#include <unordered_set>
 #include <vector>
 
 using namespace stellar;
@@ -36,7 +36,7 @@ struct BucketListGenerator
     Application::pointer mAppGenerate;
     Application::pointer mAppApply;
     uint32_t mLedgerSeq;
-    std::unordered_set<LedgerKey> mLiveKeys;
+    UnorderedSet<LedgerKey> mLiveKeys;
 
   public:
     BucketListGenerator()
@@ -133,7 +133,7 @@ struct BucketListGenerator
     virtual std::vector<LedgerKey>
     generateDeadEntries(AbstractLedgerTxn& ltx)
     {
-        std::unordered_set<LedgerKey> live(mLiveKeys);
+        UnorderedSet<LedgerKey> live(mLiveKeys);
         std::vector<LedgerKey> dead;
         while (dead.size() < 2 && !live.empty())
         {
@@ -234,7 +234,7 @@ struct SelectBucketListGenerator : public BucketListGenerator
     {
         if (mLedgerSeq == mSelectLedger)
         {
-            std::unordered_set<LedgerKey> filteredKeys(mLiveKeys.size());
+            UnorderedSet<LedgerKey> filteredKeys(mLiveKeys.size());
             std::copy_if(
                 mLiveKeys.begin(), mLiveKeys.end(),
                 std::inserter(filteredKeys, filteredKeys.end()),

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -128,7 +128,7 @@ InMemoryLedgerTxnRoot::getPrefetchHitRate() const
 }
 
 uint32_t
-InMemoryLedgerTxnRoot::prefetch(std::unordered_set<LedgerKey> const& keys)
+InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return 0;
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -32,10 +32,10 @@ InMemoryLedgerTxnRoot::rollbackChild()
 {
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 InMemoryLedgerTxnRoot::getAllOffers()
 {
-    return std::unordered_map<LedgerKey, LedgerEntry>();
+    return UnorderedMap<LedgerKey, LedgerEntry>();
 }
 
 std::shared_ptr<LedgerEntry const>
@@ -51,11 +51,11 @@ InMemoryLedgerTxnRoot::getBestOffer(Asset const& buying, Asset const& selling,
     return nullptr;
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 InMemoryLedgerTxnRoot::getOffersByAccountAndAsset(AccountID const& account,
                                                   Asset const& asset)
 {
-    return std::unordered_map<LedgerKey, LedgerEntry>();
+    return UnorderedMap<LedgerKey, LedgerEntry>();
 }
 
 LedgerHeader const&

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -1,10 +1,10 @@
 #include "ledger/InternalLedgerEntry.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnImpl.h"
+#include "util/UnorderedMap.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include <map>
 #include <set>
-#include <unordered_map>
 #include <vector>
 
 // This is a stub helper class that pretends to implements a "root"
@@ -27,13 +27,13 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void commitChild(EntryIterator iter, LedgerTxnConsistency cons) override;
     void rollbackChild() override;
 
-    std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
+    UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;
     std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) override;
     std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling,
                  OfferDescriptor const& worseThan) override;
-    std::unordered_map<LedgerKey, LedgerEntry>
+    UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,
                                Asset const& asset) override;
 

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -57,6 +57,6 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void dropTrustLines() override;
     void dropClaimableBalances() override;
     double getPrefetchHitRate() const override;
-    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) override;
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
 };
 }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -875,7 +875,7 @@ LedgerManagerImpl::prefetchTxSourceIds(
     ZoneScoped;
     if (mApp.getConfig().PREFETCH_BATCH_SIZE > 0)
     {
-        std::unordered_set<LedgerKey> keys;
+        UnorderedSet<LedgerKey> keys;
         for (auto const& tx : txs)
         {
             tx->insertKeysForFeeProcessing(keys);
@@ -891,7 +891,7 @@ LedgerManagerImpl::prefetchTransactionData(
     ZoneScoped;
     if (mApp.getConfig().PREFETCH_BATCH_SIZE > 0)
     {
-        std::unordered_set<LedgerKey> keys;
+        UnorderedSet<LedgerKey> keys;
         for (auto const& tx : txs)
         {
             tx->insertKeysForTxApply(keys);

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -25,7 +25,7 @@ namespace stellar
 {
 
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-populateLoadedEntries(std::unordered_set<LedgerKey> const& keys,
+populateLoadedEntries(UnorderedSet<LedgerKey> const& keys,
                       std::vector<LedgerEntry> const& entries)
 {
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>> res;
@@ -1579,13 +1579,13 @@ LedgerTxn::Impl::getPrefetchHitRate() const
 }
 
 uint32_t
-LedgerTxn::prefetch(std::unordered_set<LedgerKey> const& keys)
+LedgerTxn::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return getImpl()->prefetch(keys);
 }
 
 uint32_t
-LedgerTxn::Impl::prefetch(std::unordered_set<LedgerKey> const& keys)
+LedgerTxn::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return mParent.prefetch(keys);
 }
@@ -2305,22 +2305,22 @@ LedgerTxnRoot::dropClaimableBalances()
 }
 
 uint32_t
-LedgerTxnRoot::prefetch(std::unordered_set<LedgerKey> const& keys)
+LedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return mImpl->prefetch(keys);
 }
 
 uint32_t
-LedgerTxnRoot::Impl::prefetch(std::unordered_set<LedgerKey> const& keys)
+LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     ZoneScoped;
     uint32_t total = 0;
 
-    std::unordered_set<LedgerKey> accounts;
-    std::unordered_set<LedgerKey> offers;
-    std::unordered_set<LedgerKey> trustlines;
-    std::unordered_set<LedgerKey> data;
-    std::unordered_set<LedgerKey> claimablebalance;
+    UnorderedSet<LedgerKey> accounts;
+    UnorderedSet<LedgerKey> offers;
+    UnorderedSet<LedgerKey> trustlines;
+    UnorderedSet<LedgerKey> data;
+    UnorderedSet<LedgerKey> claimablebalance;
 
     auto cacheResult =
         [&](std::unordered_map<LedgerKey,
@@ -2332,7 +2332,7 @@ LedgerTxnRoot::Impl::prefetch(std::unordered_set<LedgerKey> const& keys)
             }
         };
 
-    auto insertIfNotLoaded = [&](std::unordered_set<LedgerKey>& keys,
+    auto insertIfNotLoaded = [&](UnorderedSet<LedgerKey>& keys,
                                  LedgerKey const& key) {
         if (!mEntryCache.exists(key, false))
         {
@@ -2534,7 +2534,7 @@ LedgerTxnRoot::Impl::populateEntryCacheFromBestOffers(
     std::deque<LedgerEntry>::const_iterator iter,
     std::deque<LedgerEntry>::const_iterator const& end)
 {
-    std::unordered_set<LedgerKey> toPrefetch;
+    UnorderedSet<LedgerKey> toPrefetch;
     for (; iter != end; ++iter)
     {
         auto const& oe = iter->data.offer();

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -24,11 +24,11 @@
 namespace stellar
 {
 
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 populateLoadedEntries(UnorderedSet<LedgerKey> const& keys,
                       std::vector<LedgerEntry> const& entries)
 {
-    std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>> res;
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>> res;
 
     for (auto const& le : entries)
     {
@@ -613,13 +613,13 @@ LedgerTxn::Impl::eraseWithoutLoading(InternalLedgerKey const& key)
     mConsistency = LedgerTxnConsistency::EXTRA_DELETES;
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxn::getAllOffers()
 {
     return getImpl()->getAllOffers();
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxn::Impl::getAllOffers()
 {
     auto offers = mParent.getAllOffers();
@@ -1151,14 +1151,14 @@ LedgerTxn::Impl::getNewestVersion(InternalLedgerKey const& key) const
     return mParent.getNewestVersion(key);
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxn::getOffersByAccountAndAsset(AccountID const& account,
                                       Asset const& asset)
 {
     return getImpl()->getOffersByAccountAndAsset(account, asset);
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxn::Impl::getOffersByAccountAndAsset(AccountID const& account,
                                             Asset const& asset)
 {
@@ -1699,9 +1699,9 @@ LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
                              bool effectiveActive, bool eraseIfNull)
 {
     // recordEntry has the strong exception safety guarantee because
-    // - std::unordered_map<...>::erase has the strong exception safety
+    // - UnorderedMap<...>::erase has the strong exception safety
     //   guarantee
-    // - std::unordered_map<...>::operator[] has the strong exception safety
+    // - UnorderedMap<...>::operator[] has the strong exception safety
     //   guarantee
     // - std::shared_ptr<...>::operator= does not throw
     auto recordEntry = [&]() {
@@ -1770,7 +1770,7 @@ LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
         else
         {
             // mMultiOrderBook is a MultiOrderBook, which is a typedef for
-            // std::unordered_map<...>. std::unordered_map<...> may invalidate
+            // UnorderedMap<...>. UnorderedMap<...> may invalidate
             // all iterators on insertion if a rehash is required, but pointers
             // are guaranteed to remain valid so obOld is still valid after
             // this insertion. From the standard:
@@ -1821,7 +1821,7 @@ LedgerTxn::Impl::updateWorstBestOffer(
     auto iter = mWorstBestOffer.find(assets);
     if (iter == mWorstBestOffer.end() || isWorseThan(offerDesc, iter->second))
     {
-        // std::unordered_map<...>::operator[] has the strong exception safety
+        // UnorderedMap<...>::operator[] has the strong exception safety
         // guarantee
         // std::shared_ptr<...>::operator= does not throw
         mWorstBestOffer[assets] = offerDesc;
@@ -1843,10 +1843,9 @@ LedgerTxn::Impl::getWorstBestOfferIterator()
 }
 
 #ifdef BUILD_TESTS
-std::unordered_map<
-    AssetPair,
-    std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
-    AssetPairHash> const&
+UnorderedMap<AssetPair,
+             std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
+             AssetPairHash> const&
 LedgerTxn::getOrderBook()
 {
     return getImpl()->getOrderBook();
@@ -2323,8 +2322,8 @@ LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
     UnorderedSet<LedgerKey> claimablebalance;
 
     auto cacheResult =
-        [&](std::unordered_map<LedgerKey,
-                               std::shared_ptr<LedgerEntry const>> const& res) {
+        [&](UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>> const&
+                res) {
             for (auto const& item : res)
             {
                 putInEntryCache(item.first, item.second, LoadType::PREFETCH);
@@ -2420,13 +2419,13 @@ LedgerTxnRoot::Impl::getPrefetchHitRate() const
            (mPrefetchMisses + mPrefetchHits);
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxnRoot::getAllOffers()
 {
     return mImpl->getAllOffers();
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxnRoot::Impl::getAllOffers()
 {
     ZoneScoped;
@@ -2447,7 +2446,7 @@ LedgerTxnRoot::Impl::getAllOffers()
             "unknown fatal error when getting all offers from LedgerTxnRoot");
     }
 
-    std::unordered_map<LedgerKey, LedgerEntry> offersByKey(offers.size());
+    UnorderedMap<LedgerKey, LedgerEntry> offersByKey(offers.size());
     for (auto const& offer : offers)
     {
         offersByKey.emplace(LedgerEntryKey(offer), offer);
@@ -2599,14 +2598,14 @@ LedgerTxnRoot::Impl::getBestOffer(Asset const& buying, Asset const& selling,
     return nullptr;
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxnRoot::getOffersByAccountAndAsset(AccountID const& account,
                                           Asset const& asset)
 {
     return mImpl->getOffersByAccountAndAsset(account, asset);
 }
 
-std::unordered_map<LedgerKey, LedgerEntry>
+UnorderedMap<LedgerKey, LedgerEntry>
 LedgerTxnRoot::Impl::getOffersByAccountAndAsset(AccountID const& account,
                                                 Asset const& asset)
 {
@@ -2628,7 +2627,7 @@ LedgerTxnRoot::Impl::getOffersByAccountAndAsset(AccountID const& account,
                            "and asset from LedgerTxnRoot");
     }
 
-    std::unordered_map<LedgerKey, LedgerEntry> res(offers.size());
+    UnorderedMap<LedgerKey, LedgerEntry> res(offers.size());
     for (auto const& offer : offers)
     {
         res.emplace(LedgerEntryKey(offer), offer);

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -7,6 +7,7 @@
 #include "ledger/InternalLedgerEntry.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
+#include "util/UnorderedSet.h"
 #include "xdr/Stellar-ledger.h"
 #include <functional>
 #include <ledger/LedgerHashUtils.h>
@@ -14,7 +15,6 @@
 #include <memory>
 #include <set>
 #include <unordered_map>
-#include <unordered_set>
 
 /////////////////////////////////////////////////////////////////////////////
 //  Overview
@@ -448,7 +448,7 @@ class AbstractLedgerTxnParent
     // This is purely advisory and can be a no-op, or do any level of actual
     // work, while still being correct. Will throw when called on anything other
     // than a (real or stub) root LedgerTxn.
-    virtual uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) = 0;
+    virtual uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) = 0;
 };
 
 // An abstraction for an object that is an AbstractLedgerTxnParent and has
@@ -687,7 +687,7 @@ class LedgerTxn final : public AbstractLedgerTxn
     void dropTrustLines() override;
     void dropClaimableBalances() override;
     double getPrefetchHitRate() const override;
-    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) override;
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
 
 #ifdef BUILD_TESTS
     std::unordered_map<
@@ -751,7 +751,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     void rollbackChild() override;
 
-    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys) override;
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
     double getPrefetchHitRate() const override;
 };
 }

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -7,6 +7,7 @@
 #include "ledger/InternalLedgerEntry.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
+#include "util/UnorderedMap.h"
 #include "util/UnorderedSet.h"
 #include "xdr/Stellar-ledger.h"
 #include <functional>
@@ -14,7 +15,6 @@
 #include <map>
 #include <memory>
 #include <set>
-#include <unordered_map>
 
 /////////////////////////////////////////////////////////////////////////////
 //  Overview
@@ -276,7 +276,7 @@ struct LedgerTxnDelta
         LedgerHeader previous;
     };
 
-    std::unordered_map<InternalLedgerKey, EntryDelta> entry;
+    UnorderedMap<InternalLedgerKey, EntryDelta> entry;
     HeaderDelta header;
 };
 
@@ -376,13 +376,13 @@ class AbstractLedgerTxnParent
     // - getOffersByAccountAndAsset
     //     Get XDR for every offer owned by the specified account that is either
     //     buying or selling the specified asset.
-    virtual std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() = 0;
+    virtual UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() = 0;
     virtual std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) = 0;
     virtual std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling,
                  OfferDescriptor const& worseThan) = 0;
-    virtual std::unordered_map<LedgerKey, LedgerEntry>
+    virtual UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,
                                Asset const& asset) = 0;
 
@@ -618,7 +618,7 @@ class LedgerTxn final : public AbstractLedgerTxn
 
     void erase(InternalLedgerKey const& key) override;
 
-    std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
+    UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;
 
     std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) override;
@@ -632,7 +632,7 @@ class LedgerTxn final : public AbstractLedgerTxn
 
     LedgerTxnDelta getDelta() override;
 
-    std::unordered_map<LedgerKey, LedgerEntry>
+    UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,
                                Asset const& asset) override;
 
@@ -690,7 +690,7 @@ class LedgerTxn final : public AbstractLedgerTxn
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
 
 #ifdef BUILD_TESTS
-    std::unordered_map<
+    UnorderedMap<
         AssetPair,
         std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
         AssetPairHash> const&
@@ -729,7 +729,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     void resetForFuzzer();
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
-    std::unordered_map<LedgerKey, LedgerEntry> getAllOffers() override;
+    UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;
 
     std::shared_ptr<LedgerEntry const>
     getBestOffer(Asset const& buying, Asset const& selling) override;
@@ -737,7 +737,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     getBestOffer(Asset const& buying, Asset const& selling,
                  OfferDescriptor const& worseThan) override;
 
-    std::unordered_map<LedgerKey, LedgerEntry>
+    UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,
                                Asset const& asset) override;
 

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -582,8 +582,7 @@ class BulkLoadAccountsOperation
     }
 
   public:
-    BulkLoadAccountsOperation(Database& db,
-                              std::unordered_set<LedgerKey> const& keys)
+    BulkLoadAccountsOperation(Database& db, UnorderedSet<LedgerKey> const& keys)
         : mDb(db)
     {
         mAccountIDs.reserve(keys.size());
@@ -651,8 +650,7 @@ class BulkLoadAccountsOperation
 };
 
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-LedgerTxnRoot::Impl::bulkLoadAccounts(
-    std::unordered_set<LedgerKey> const& keys) const
+LedgerTxnRoot::Impl::bulkLoadAccounts(UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(keys.size()));

--- a/src/ledger/LedgerTxnAccountSQL.cpp
+++ b/src/ledger/LedgerTxnAccountSQL.cpp
@@ -649,7 +649,7 @@ class BulkLoadAccountsOperation
 #endif
 };
 
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadAccounts(UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;

--- a/src/ledger/LedgerTxnClaimableBalanceSQL.cpp
+++ b/src/ledger/LedgerTxnClaimableBalanceSQL.cpp
@@ -151,7 +151,7 @@ class BulkLoadClaimableBalanceOperation
 #endif
 };
 
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadClaimableBalance(
     UnorderedSet<LedgerKey> const& keys) const
 {

--- a/src/ledger/LedgerTxnClaimableBalanceSQL.cpp
+++ b/src/ledger/LedgerTxnClaimableBalanceSQL.cpp
@@ -88,7 +88,7 @@ class BulkLoadClaimableBalanceOperation
 
   public:
     BulkLoadClaimableBalanceOperation(Database& db,
-                                      std::unordered_set<LedgerKey> const& keys)
+                                      UnorderedSet<LedgerKey> const& keys)
         : mDb(db)
     {
         mBalanceIDs.reserve(keys.size());
@@ -153,7 +153,7 @@ class BulkLoadClaimableBalanceOperation
 
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadClaimableBalance(
-    std::unordered_set<LedgerKey> const& keys) const
+    UnorderedSet<LedgerKey> const& keys) const
 {
     if (!keys.empty())
     {

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -394,8 +394,7 @@ class BulkLoadDataOperation
     }
 
   public:
-    BulkLoadDataOperation(Database& db,
-                          std::unordered_set<LedgerKey> const& keys)
+    BulkLoadDataOperation(Database& db, UnorderedSet<LedgerKey> const& keys)
         : mDb(db)
     {
         mAccountIDs.reserve(keys.size());
@@ -480,8 +479,7 @@ class BulkLoadDataOperation
 };
 
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-LedgerTxnRoot::Impl::bulkLoadData(
-    std::unordered_set<LedgerKey> const& keys) const
+LedgerTxnRoot::Impl::bulkLoadData(UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(keys.size()));

--- a/src/ledger/LedgerTxnDataSQL.cpp
+++ b/src/ledger/LedgerTxnDataSQL.cpp
@@ -478,7 +478,7 @@ class BulkLoadDataOperation
 #endif
 };
 
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadData(UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -18,7 +18,7 @@ namespace stellar
 
 // Precondition: The keys associated with entries are unique and constitute a
 // subset of keys
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 populateLoadedEntries(UnorderedSet<LedgerKey> const& keys,
                       std::vector<LedgerEntry> const& entries);
 
@@ -166,8 +166,8 @@ class LedgerTxn::Impl
     class EntryIteratorImpl;
     class WorstBestOfferIteratorImpl;
 
-    typedef std::unordered_map<InternalLedgerKey,
-                               std::shared_ptr<InternalLedgerEntry>>
+    typedef UnorderedMap<InternalLedgerKey,
+                         std::shared_ptr<InternalLedgerEntry>>
         EntryMap;
 
     AbstractLedgerTxnParent& mParent;
@@ -175,8 +175,7 @@ class LedgerTxn::Impl
     std::unique_ptr<LedgerHeader> mHeader;
     std::shared_ptr<LedgerTxnHeader::Impl> mActiveHeader;
     EntryMap mEntry;
-    std::unordered_map<InternalLedgerKey, std::shared_ptr<EntryImplBase>>
-        mActive;
+    UnorderedMap<InternalLedgerKey, std::shared_ptr<EntryImplBase>> mActive;
     bool const mShouldUpdateLastModified;
     bool mIsSealed;
     LedgerTxnConsistency mConsistency;
@@ -188,8 +187,7 @@ class LedgerTxn::Impl
     // have multiple elements with the same key.
     typedef std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>
         OrderBook;
-    typedef std::unordered_map<AssetPair, OrderBook, AssetPairHash>
-        MultiOrderBook;
+    typedef UnorderedMap<AssetPair, OrderBook, AssetPairHash> MultiOrderBook;
     // mMultiOrderbook is an in-memory representation of the order book that
     // contains an entry if and only if it is live, and recorded in this
     // LedgerTxn, and not active. It is grouped by asset pair, and for each
@@ -318,8 +316,8 @@ class LedgerTxn::Impl
     // parent, and finally _used_ when that parent asks _its_ parent to
     // getBestOffer.
 
-    typedef std::unordered_map<
-        AssetPair, std::shared_ptr<OfferDescriptor const>, AssetPairHash>
+    typedef UnorderedMap<AssetPair, std::shared_ptr<OfferDescriptor const>,
+                         AssetPairHash>
         WorstBestOfferMap;
     // The exact definition / invariant of the WorstBestOfferMap's data is
     // unfortunately a bit subtle.
@@ -448,7 +446,7 @@ class LedgerTxn::Impl
     // exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified.
-    std::unordered_map<LedgerKey, LedgerEntry> getAllOffers();
+    UnorderedMap<LedgerKey, LedgerEntry> getAllOffers();
 
     // getBestOffer has the basic exception safety guarantee. If it throws an
     // exception, then
@@ -485,7 +483,7 @@ class LedgerTxn::Impl
     // it throws an exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
-    std::unordered_map<LedgerKey, LedgerEntry>
+    UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account, Asset const& asset);
 
     // getHeader does not throw
@@ -759,15 +757,15 @@ class LedgerTxnRoot::Impl
     BestOffersCacheEntryPtr getFromBestOffersCache(Asset const& buying,
                                                    Asset const& selling) const;
 
-    std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
     bulkLoadAccounts(UnorderedSet<LedgerKey> const& keys) const;
-    std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
     bulkLoadTrustLines(UnorderedSet<LedgerKey> const& keys) const;
-    std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
     bulkLoadOffers(UnorderedSet<LedgerKey> const& keys) const;
-    std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
     bulkLoadData(UnorderedSet<LedgerKey> const& keys) const;
-    std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
     bulkLoadClaimableBalance(UnorderedSet<LedgerKey> const& keys) const;
 
     std::deque<LedgerEntry>::const_iterator
@@ -814,7 +812,7 @@ class LedgerTxnRoot::Impl
     // exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified.
-    std::unordered_map<LedgerKey, LedgerEntry> getAllOffers();
+    UnorderedMap<LedgerKey, LedgerEntry> getAllOffers();
 
     // getBestOffer has the basic exception safety guarantee. If it throws an
     // exception, then
@@ -832,7 +830,7 @@ class LedgerTxnRoot::Impl
     // it throws an exception, then
     // - the prepared statement cache may be, but is not guaranteed to be,
     //   modified
-    std::unordered_map<LedgerKey, LedgerEntry>
+    UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account, Asset const& asset);
 
     // getHeader does not throw

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -19,7 +19,7 @@ namespace stellar
 // Precondition: The keys associated with entries are unique and constitute a
 // subset of keys
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-populateLoadedEntries(std::unordered_set<LedgerKey> const& keys,
+populateLoadedEntries(UnorderedSet<LedgerKey> const& keys,
                       std::vector<LedgerEntry> const& entries);
 
 // A defensive heuristic to ensure prefetching stops if entry cache is filling
@@ -582,7 +582,7 @@ class LedgerTxn::Impl
     // unsealHeader has the same exception safety guarantee as f
     void unsealHeader(LedgerTxn& self, std::function<void(LedgerHeader&)> f);
 
-    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys);
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
 
     double getPrefetchHitRate() const;
 
@@ -760,15 +760,15 @@ class LedgerTxnRoot::Impl
                                                    Asset const& selling) const;
 
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-    bulkLoadAccounts(std::unordered_set<LedgerKey> const& keys) const;
+    bulkLoadAccounts(UnorderedSet<LedgerKey> const& keys) const;
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-    bulkLoadTrustLines(std::unordered_set<LedgerKey> const& keys) const;
+    bulkLoadTrustLines(UnorderedSet<LedgerKey> const& keys) const;
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-    bulkLoadOffers(std::unordered_set<LedgerKey> const& keys) const;
+    bulkLoadOffers(UnorderedSet<LedgerKey> const& keys) const;
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-    bulkLoadData(std::unordered_set<LedgerKey> const& keys) const;
+    bulkLoadData(UnorderedSet<LedgerKey> const& keys) const;
     std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-    bulkLoadClaimableBalance(std::unordered_set<LedgerKey> const& keys) const;
+    bulkLoadClaimableBalance(UnorderedSet<LedgerKey> const& keys) const;
 
     std::deque<LedgerEntry>::const_iterator
     loadNextBestOffersIntoCache(BestOffersCacheEntryPtr cached,
@@ -859,7 +859,7 @@ class LedgerTxnRoot::Impl
     // Prefetch some or all of given keys in batches. Note that no prefetching
     // could occur if the cache is at its fill ratio. Returns number of keys
     // prefetched.
-    uint32_t prefetch(std::unordered_set<LedgerKey> const& keys);
+    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
 
     double getPrefetchHitRate() const;
 };

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -715,7 +715,7 @@ class BulkLoadOffersOperation
 {
     Database& mDb;
     std::vector<int64_t> mOfferIDs;
-    std::unordered_set<LedgerKey> mKeys;
+    UnorderedSet<LedgerKey> mKeys;
 
     std::vector<LedgerEntry>
     executeAndFetch(soci::statement& st)
@@ -778,8 +778,7 @@ class BulkLoadOffersOperation
     }
 
   public:
-    BulkLoadOffersOperation(Database& db,
-                            std::unordered_set<LedgerKey> const& keys)
+    BulkLoadOffersOperation(Database& db, UnorderedSet<LedgerKey> const& keys)
         : mDb(db)
     {
         mOfferIDs.reserve(keys.size());
@@ -840,8 +839,7 @@ class BulkLoadOffersOperation
 };
 
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
-LedgerTxnRoot::Impl::bulkLoadOffers(
-    std::unordered_set<LedgerKey> const& keys) const
+LedgerTxnRoot::Impl::bulkLoadOffers(UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(keys.size()));

--- a/src/ledger/LedgerTxnOfferSQL.cpp
+++ b/src/ledger/LedgerTxnOfferSQL.cpp
@@ -838,7 +838,7 @@ class BulkLoadOffersOperation
 #endif
 };
 
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadOffers(UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -646,7 +646,7 @@ class BulkLoadTrustLinesOperation
 #endif
 };
 
-std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadTrustLines(
     UnorderedSet<LedgerKey> const& keys) const
 {

--- a/src/ledger/LedgerTxnTrustLineSQL.cpp
+++ b/src/ledger/LedgerTxnTrustLineSQL.cpp
@@ -526,7 +526,7 @@ class BulkLoadTrustLinesOperation
 
   public:
     BulkLoadTrustLinesOperation(Database& db,
-                                std::unordered_set<LedgerKey> const& keys)
+                                UnorderedSet<LedgerKey> const& keys)
         : mDb(db)
     {
         mAccountIDs.reserve(keys.size());
@@ -648,7 +648,7 @@ class BulkLoadTrustLinesOperation
 
 std::unordered_map<LedgerKey, std::shared_ptr<LedgerEntry const>>
 LedgerTxnRoot::Impl::bulkLoadTrustLines(
-    std::unordered_set<LedgerKey> const& keys) const
+    UnorderedSet<LedgerKey> const& keys) const
 {
     ZoneScoped;
     ZoneValue(static_cast<int64_t>(keys.size()));

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -345,9 +345,9 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
     auto generateErase =
         [&](AbstractLedgerTxn& ltx,
             std::unordered_map<LedgerKey, LedgerEntry>& entries,
-            std::unordered_set<LedgerKey>& dead) {
+            UnorderedSet<LedgerKey>& dead) {
             size_t const ERASE_ENTRIES = 25;
-            std::unordered_set<LedgerKey> eraseBatch;
+            UnorderedSet<LedgerKey> eraseBatch;
             std::uniform_int_distribution<size_t> dist(0, entries.size() - 1);
             while (eraseBatch.size() < ERASE_ENTRIES)
             {
@@ -367,7 +367,7 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
     auto checkLedger =
         [](AbstractLedgerTxnParent& ltxParent,
            std::unordered_map<LedgerKey, LedgerEntry> const& entries,
-           std::unordered_set<LedgerKey> const& dead) {
+           UnorderedSet<LedgerKey> const& dead) {
             LedgerTxn ltx(ltxParent);
             for (auto const& kv : entries)
             {
@@ -387,14 +387,14 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
 
     auto runTest = [&](AbstractLedgerTxnParent& ltxParent) {
         std::unordered_map<LedgerKey, LedgerEntry> entries;
-        std::unordered_set<LedgerKey> dead;
+        UnorderedSet<LedgerKey> dead;
         size_t const NUM_BATCHES = 10;
         for (size_t k = 0; k < NUM_BATCHES; ++k)
         {
             checkLedger(ltxParent, entries, dead);
 
             std::unordered_map<LedgerKey, LedgerEntry> updatedEntries = entries;
-            std::unordered_set<LedgerKey> updatedDead = dead;
+            UnorderedSet<LedgerKey> updatedDead = dead;
             LedgerTxn ltx1(ltxParent);
             generateNew(ltx1, updatedEntries);
             generateModify(ltx1, updatedEntries);
@@ -2430,7 +2430,7 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
         cfg.ENTRY_CACHE_SIZE = 1000;
         cfg.PREFETCH_BATCH_SIZE = cfg.ENTRY_CACHE_SIZE / 10;
 
-        std::unordered_set<LedgerKey> keysToPrefetch;
+        UnorderedSet<LedgerKey> keysToPrefetch;
         auto app = createTestApplication(clock, cfg);
         app->start();
         auto& root = app->getLedgerTxnRoot();
@@ -2447,7 +2447,7 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
         SECTION("prefetch normally")
         {
             LedgerTxn ltx2(root);
-            std::unordered_set<LedgerKey> smallSet;
+            UnorderedSet<LedgerKey> smallSet;
             for (auto const& k : keysToPrefetch)
             {
                 smallSet.emplace(k);
@@ -2622,7 +2622,7 @@ TEST_CASE("Bulk load batch size benchmark", "[!hide][bulkbatchsizebench]")
     auto runTest = [&](Config::TestDbMode mode) {
         for (; floor <= ceiling; floor += 1000)
         {
-            std::unordered_set<LedgerKey> keys;
+            UnorderedSet<LedgerKey> keys;
             VirtualClock clock;
             Config cfg(getTestConfig(0, mode));
             cfg.PREFETCH_BATCH_SIZE = floor;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -246,7 +246,7 @@ template <typename T>
 std::vector<T>
 readXdrEnumArray(ConfigItem const& item)
 {
-    std::unordered_map<std::string, T> enumNames;
+    UnorderedMap<std::string, T> enumNames;
     for (auto enumVal : xdr::xdr_traits<T>::enum_values())
     {
         auto enumNameCharPtr =
@@ -404,7 +404,7 @@ Config::parseQuality(std::string const& q) const
 std::vector<Config::ValidatorEntry>
 Config::parseValidators(
     std::shared_ptr<cpptoml::base> validators,
-    std::unordered_map<std::string, ValidatorQuality> const& domainQualityMap)
+    UnorderedMap<std::string, ValidatorQuality> const& domainQualityMap)
 {
     std::vector<ValidatorEntry> res;
 
@@ -511,10 +511,10 @@ Config::parseValidators(
     return res;
 }
 
-std::unordered_map<std::string, Config::ValidatorQuality>
+UnorderedMap<std::string, Config::ValidatorQuality>
 Config::parseDomainsQuality(std::shared_ptr<cpptoml::base> domainsQuality)
 {
-    std::unordered_map<std::string, ValidatorQuality> res;
+    UnorderedMap<std::string, ValidatorQuality> res;
     auto tarr = domainsQuality->as_table_array();
     if (!tarr)
     {
@@ -615,7 +615,7 @@ Config::load(std::istream& in)
 void
 Config::addSelfToValidators(
     std::vector<ValidatorEntry>& validators,
-    std::unordered_map<std::string, ValidatorQuality> const& domainQualityMap)
+    UnorderedMap<std::string, ValidatorQuality> const& domainQualityMap)
 {
     auto it = domainQualityMap.find(NODE_HOME_DOMAIN);
     ValidatorEntry self;
@@ -690,7 +690,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             throw std::runtime_error("Could not parse toml");
         }
         std::vector<ValidatorEntry> validators;
-        std::unordered_map<std::string, ValidatorQuality> domainQualityMap;
+        UnorderedMap<std::string, ValidatorQuality> domainQualityMap;
 
         // cpptoml returns the items in non-deterministic order
         // so we need to process items that are potential dependencies first

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -18,6 +18,7 @@
 #include "util/XDROperators.h"
 #include "util/types.h"
 
+#include "util/UnorderedSet.h"
 #include <fmt/format.h>
 #include <functional>
 #include <sstream>
@@ -1079,7 +1080,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             QUORUM_SET = autoQSet;
             verifyHistoryValidatorsBlocking(validators);
             // count the number of domains
-            std::unordered_set<std::string> domains;
+            UnorderedSet<std::string> domains;
             for (auto const& v : validators)
             {
                 domains.insert(v.mHomeDomain);

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -8,6 +8,7 @@
 #include "overlay/StellarXDR.h"
 #include "util/SecretValue.h"
 #include "util/Timer.h"
+#include "util/UnorderedMap.h"
 #include "util/optional.h"
 
 #include <map>
@@ -76,12 +77,11 @@ class Config : public std::enable_shared_from_this<Config>
     std::string toString(ValidatorQuality q) const;
     ValidatorQuality parseQuality(std::string const& q) const;
 
-    std::vector<ValidatorEntry>
-    parseValidators(std::shared_ptr<cpptoml::base> validators,
-                    std::unordered_map<std::string, ValidatorQuality> const&
-                        domainQualityMap);
+    std::vector<ValidatorEntry> parseValidators(
+        std::shared_ptr<cpptoml::base> validators,
+        UnorderedMap<std::string, ValidatorQuality> const& domainQualityMap);
 
-    std::unordered_map<std::string, ValidatorQuality>
+    UnorderedMap<std::string, ValidatorQuality>
     parseDomainsQuality(std::shared_ptr<cpptoml::base> domainsQuality);
 
     static SCPQuorumSet
@@ -92,10 +92,9 @@ class Config : public std::enable_shared_from_this<Config>
     static SCPQuorumSet
     generateQuorumSet(std::vector<ValidatorEntry> const& validators);
 
-    void
-    addSelfToValidators(std::vector<ValidatorEntry>& validators,
-                        std::unordered_map<std::string, ValidatorQuality> const&
-                            domainQualityMap);
+    void addSelfToValidators(
+        std::vector<ValidatorEntry>& validators,
+        UnorderedMap<std::string, ValidatorQuality> const& domainQualityMap);
 
     void verifyHistoryValidatorsBlocking(
         std::vector<ValidatorEntry> const& validators);

--- a/src/overlay/SurveyManager.h
+++ b/src/overlay/SurveyManager.h
@@ -9,6 +9,7 @@
 #include "overlay/StellarXDR.h"
 #include "overlay/SurveyMessageLimiter.h"
 #include "util/Timer.h"
+#include "util/UnorderedSet.h"
 #include <lib/json/json.h>
 
 namespace stellar
@@ -76,12 +77,12 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
     Curve25519Public mCurve25519PublicKey;
     SurveyMessageLimiter mMessageLimiter;
 
-    std::unordered_set<NodeID> mPeersToSurvey;
+    UnorderedSet<NodeID> mPeersToSurvey;
     std::queue<NodeID> mPeersToSurveyQueue;
 
     std::chrono::seconds const SURVEY_THROTTLE_TIMEOUT_SEC;
 
-    std::unordered_set<NodeID> mBadResponseNodes;
+    UnorderedSet<NodeID> mBadResponseNodes;
     Json::Value mResults;
 };
 }

--- a/src/overlay/SurveyMessageLimiter.h
+++ b/src/overlay/SurveyMessageLimiter.h
@@ -5,9 +5,9 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/StellarXDR.h"
+#include "util/UnorderedMap.h"
 #include <functional>
 #include <map>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -39,10 +39,9 @@ class SurveyMessageLimiter
   private:
     bool surveyLedgerNumValid(uint32_t ledgerNum);
 
-    typedef std::unordered_map<NodeID /*surveyedNodeId*/, bool /*responseSeen*/>
+    typedef UnorderedMap<NodeID /*surveyedNodeId*/, bool /*responseSeen*/>
         SurveyedMap;
-    typedef std::unordered_map<NodeID /*surveyorNodeId*/, SurveyedMap>
-        SurveyorMap;
+    typedef UnorderedMap<NodeID /*surveyorNodeId*/, SurveyedMap> SurveyorMap;
 
     std::map<uint32_t /*ledgerNum*/, SurveyorMap> mRecordMap;
 

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -207,7 +207,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
         // a valid transaction set
 
         std::vector<SecretKey> keys;
-        std::unordered_map<PublicKey, SecretKey> keysMap;
+        UnorderedMap<PublicKey, SecretKey> keysMap;
         for (int i = 0; i < nbTx; i++)
         {
             keys.emplace_back(SecretKey::pseudoRandomForTesting());

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -16,7 +16,6 @@
 #include <Tracy.hpp>
 #include <algorithm>
 #include <functional>
-#include <unordered_set>
 
 namespace stellar
 {

--- a/src/transactions/ClaimClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.cpp
@@ -144,7 +144,7 @@ ClaimClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion)
 
 void
 ClaimClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(claimableBalanceKey(mClaimClaimableBalance.balanceID));
 }

--- a/src/transactions/ClaimClaimableBalanceOpFrame.h
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.h
@@ -30,8 +30,8 @@ class ClaimClaimableBalanceOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     static ClaimClaimableBalanceResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -173,7 +173,7 @@ CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion)
 
 void
 CreateAccountOpFrame::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(accountKey(mCreateAccount.destination));
 }

--- a/src/transactions/CreateAccountOpFrame.h
+++ b/src/transactions/CreateAccountOpFrame.h
@@ -33,8 +33,8 @@ class CreateAccountOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     static CreateAccountResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -240,7 +240,7 @@ CreateClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion)
     }
 
     // check for duplicates
-    std::unordered_set<AccountID> dests;
+    UnorderedSet<AccountID> dests;
     for (auto const& claimant : claimants)
     {
         auto const& dest = claimant.v0().destination;
@@ -265,7 +265,7 @@ CreateClaimableBalanceOpFrame::doCheckValid(uint32_t ledgerVersion)
 
 void
 CreateClaimableBalanceOpFrame::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     // Prefetch trustline for non-native assets
     if (mCreateClaimableBalance.asset.type() != ASSET_TYPE_NATIVE)

--- a/src/transactions/CreateClaimableBalanceOpFrame.h
+++ b/src/transactions/CreateClaimableBalanceOpFrame.h
@@ -32,8 +32,8 @@ class CreateClaimableBalanceOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     static CreateClaimableBalanceResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -352,7 +352,7 @@ FeeBumpTransactionFrame::getSourceID() const
 
 void
 FeeBumpTransactionFrame::insertKeysForFeeProcessing(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(accountKey(getFeeSourceID()));
     mInnerTx->insertKeysForFeeProcessing(keys);
@@ -360,7 +360,7 @@ FeeBumpTransactionFrame::insertKeysForFeeProcessing(
 
 void
 FeeBumpTransactionFrame::insertKeysForTxApply(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     mInnerTx->insertKeysForTxApply(keys);
 }

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -83,10 +83,9 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     AccountID getFeeSourceID() const override;
     AccountID getSourceID() const override;
 
-    void insertKeysForFeeProcessing(
-        std::unordered_set<LedgerKey>& keys) const override;
     void
-    insertKeysForTxApply(std::unordered_set<LedgerKey>& keys) const override;
+    insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
 

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -119,7 +119,7 @@ ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion)
 
 void
 ManageDataOpFrame::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(dataKey(getSourceID(), mManageData.dataName));
 }

--- a/src/transactions/ManageDataOpFrame.h
+++ b/src/transactions/ManageDataOpFrame.h
@@ -27,8 +27,8 @@ class ManageDataOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     static ManageDataResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -599,7 +599,7 @@ ManageOfferOpFrameBase::doCheckValid(uint32_t ledgerVersion)
 
 void
 ManageOfferOpFrameBase::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     // Prefetch existing offer
     if (mOfferID)

--- a/src/transactions/ManageOfferOpFrameBase.h
+++ b/src/transactions/ManageOfferOpFrameBase.h
@@ -41,8 +41,8 @@ class ManageOfferOpFrameBase : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     bool doApply(AbstractLedgerTxn& lsOuter) override;
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     virtual bool isAmountValid() const = 0;
     virtual bool isDeleteOffer() const = 0;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -252,8 +252,7 @@ OperationFrame::resetResultSuccess()
 }
 
 void
-OperationFrame::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+OperationFrame::insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const
 {
     // Do nothing by default
     return;

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -89,6 +89,6 @@ class OperationFrame
     }
 
     virtual void
-    insertLedgerKeysToPrefetch(std::unordered_set<LedgerKey>& keys) const;
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const;
 };
 }

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -28,7 +28,7 @@ PathPaymentOpFrameBase::getDestID() const
 
 void
 PathPaymentOpFrameBase::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     auto destID = getDestID();
     keys.emplace(accountKey(destID));

--- a/src/transactions/PathPaymentOpFrameBase.h
+++ b/src/transactions/PathPaymentOpFrameBase.h
@@ -34,8 +34,8 @@ class PathPaymentOpFrameBase : public OperationFrame
     PathPaymentOpFrameBase(Operation const& op, OperationResult& res,
                            TransactionFrame& parentTx);
 
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     virtual bool checkTransfer(int64_t maxSend, int64_t amountSend,
                                int64_t maxRecv, int64_t amountRecv) const = 0;

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -131,8 +131,7 @@ PaymentOpFrame::doCheckValid(uint32_t ledgerVersion)
 }
 
 void
-PaymentOpFrame::insertLedgerKeysToPrefetch(
-    std::unordered_set<LedgerKey>& keys) const
+PaymentOpFrame::insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const
 {
     auto destID = toAccountID(mPayment.destination);
     keys.emplace(accountKey(destID));

--- a/src/transactions/PaymentOpFrame.h
+++ b/src/transactions/PaymentOpFrame.h
@@ -25,8 +25,8 @@ class PaymentOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
-    void insertLedgerKeysToPrefetch(
-        std::unordered_set<LedgerKey>& keys) const override;
+    void
+    insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
     static PaymentResultCode
     getInnerCode(OperationResult const& res)

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -599,7 +599,7 @@ TransactionFrame::removeOneTimeSignerFromAllSourceAccounts(
         return;
     }
 
-    std::unordered_set<AccountID> accounts{getSourceID()};
+    UnorderedSet<AccountID> accounts{getSourceID()};
     for (auto& op : mOperations)
     {
         accounts.emplace(op->getSourceID());
@@ -692,14 +692,13 @@ TransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
 
 void
 TransactionFrame::insertKeysForFeeProcessing(
-    std::unordered_set<LedgerKey>& keys) const
+    UnorderedSet<LedgerKey>& keys) const
 {
     keys.emplace(accountKey(getSourceID()));
 }
 
 void
-TransactionFrame::insertKeysForTxApply(
-    std::unordered_set<LedgerKey>& keys) const
+TransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const
 {
     for (auto const& op : mOperations)
     {

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -181,10 +181,9 @@ class TransactionFrame : public TransactionFrameBase
                     uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
 
-    void insertKeysForFeeProcessing(
-        std::unordered_set<LedgerKey>& keys) const override;
     void
-    insertKeysForTxApply(std::unordered_set<LedgerKey>& keys) const override;
+    insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
     // collect fee, consume sequence number
     void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -6,7 +6,7 @@
 
 #include "ledger/LedgerHashUtils.h"
 #include "overlay/StellarXDR.h"
-#include <unordered_set>
+#include "util/UnorderedSet.h"
 
 namespace stellar
 {
@@ -52,9 +52,8 @@ class TransactionFrameBase
     virtual AccountID getSourceID() const = 0;
 
     virtual void
-    insertKeysForFeeProcessing(std::unordered_set<LedgerKey>& keys) const = 0;
-    virtual void
-    insertKeysForTxApply(std::unordered_set<LedgerKey>& keys) const = 0;
+    insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const = 0;
+    virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const = 0;
 
     virtual void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) = 0;
 

--- a/src/util/HashOfHash.cpp
+++ b/src/util/HashOfHash.cpp
@@ -1,3 +1,7 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
 #include "HashOfHash.h"
 #include "crypto/ShortHash.h"
 

--- a/src/util/Math.cpp
+++ b/src/util/Math.cpp
@@ -4,12 +4,12 @@
 
 #include "Math.h"
 #include "util/GlobalChecks.h"
+#include "util/UnorderedMap.h"
 #include <Tracy.hpp>
 #include <algorithm>
 #include <cmath>
 #include <numeric>
 #include <set>
-#include <unordered_map>
 
 namespace stellar
 {
@@ -125,7 +125,7 @@ k_means(std::vector<double> const& points, uint32_t k)
     // Run until convergence or iteration depth exhaustion
     while (recalculate && iteration++ < MAX_RECOMPUTE_ITERATIONS)
     {
-        std::unordered_map<double, std::vector<double>> assignment;
+        UnorderedMap<double, std::vector<double>> assignment;
         assignment.reserve(points.size());
         recalculate = false;
         // centroid -> assigned points

--- a/src/util/RandHasher.h
+++ b/src/util/RandHasher.h
@@ -1,0 +1,24 @@
+// Copyright 2020 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+#include "util/Math.h"
+#include <functional>
+#include <limits>
+
+namespace std
+{
+template <class T, class Hasher = std::hash<T>> class RandHasher
+{
+  public:
+    size_t
+    operator()(T const& t) const
+    {
+        static size_t mixer =
+            stellar::rand_uniform<size_t>(std::numeric_limits<size_t>::min(),
+                                          std::numeric_limits<size_t>::max());
+        return Hasher()(t) ^ mixer;
+    }
+};
+}

--- a/src/util/UnorderedMap.h
+++ b/src/util/UnorderedMap.h
@@ -3,12 +3,12 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #pragma once
-#include <xdr/Stellar-types.h>
+#include "util/RandHasher.h"
+#include <unordered_map>
 
-namespace std
+namespace stellar
 {
-template <> struct hash<stellar::uint256>
-{
-    size_t operator()(stellar::uint256 const& x) const noexcept;
-};
+template <class KeyT, class ValT, class Hasher = std::hash<KeyT>>
+using UnorderedMap =
+    std::unordered_map<KeyT, ValT, std::RandHasher<KeyT, Hasher>>;
 }

--- a/src/util/UnorderedSet.h
+++ b/src/util/UnorderedSet.h
@@ -3,12 +3,11 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #pragma once
-#include <xdr/Stellar-types.h>
+#include "util/RandHasher.h"
+#include <unordered_set>
 
-namespace std
+namespace stellar
 {
-template <> struct hash<stellar::uint256>
-{
-    size_t operator()(stellar::uint256 const& x) const noexcept;
-};
+template <class KeyT, class Hasher = std::hash<KeyT>>
+using UnorderedSet = std::unordered_set<KeyT, std::RandHasher<KeyT, Hasher>>;
 }

--- a/src/util/test/BitSetTests.cpp
+++ b/src/util/test/BitSetTests.cpp
@@ -5,9 +5,8 @@
 #include "lib/catch.hpp"
 #include "util/BitSet.h"
 #include "util/Math.h"
-
+#include "util/UnorderedSet.h"
 #include <set>
-#include <unordered_set>
 
 using namespace stellar;
 
@@ -63,7 +62,7 @@ TEST_CASE("BitSet union", "[bitset]")
 {
     for (size_t loop = 0; loop < 100; ++loop)
     {
-        std::unordered_set<size_t> ref;
+        UnorderedSet<size_t> ref;
         BitSet bs_a, bs_b;
         for (size_t i = 0; i < rand_uniform<size_t>(size_t(1), size_t(100));
              ++i)
@@ -95,7 +94,7 @@ TEST_CASE("BitSet intersection", "[bitset]")
 {
     for (size_t loop = 0; loop < 100; ++loop)
     {
-        std::unordered_set<size_t> ref;
+        UnorderedSet<size_t> ref;
         BitSet bs_a, bs_b;
         for (size_t i = 0; i < rand_uniform<size_t>(size_t(1), size_t(100));
              ++i)
@@ -125,7 +124,7 @@ TEST_CASE("BitSet difference", "[bitset]")
 {
     for (size_t loop = 0; loop < 100; ++loop)
     {
-        std::unordered_set<size_t> ref;
+        UnorderedSet<size_t> ref;
         BitSet bs_a, bs_b;
         for (size_t i = 0; i < rand_uniform<size_t>(size_t(1), size_t(100));
              ++i)
@@ -158,7 +157,7 @@ TEST_CASE("BitSet symmetric difference", "[bitset]")
 {
     for (size_t loop = 0; loop < 100; ++loop)
     {
-        std::unordered_set<size_t> ref;
+        UnorderedSet<size_t> ref;
         BitSet bs_a, bs_b;
         for (size_t i = 0; i < rand_uniform<size_t>(size_t(1), size_t(100));
              ++i)


### PR DESCRIPTION
# Description

Resolves #2809

The only real change is the first commit, rest is search/replace.

PR for now has this always enabled.
We could enable this on builds with `--enable-extrachecks` enabled, but having this always on gives better confidence that mitigations are in place in production environments.