### PR TITLE
Set MAX_BEST_OFFERS_BATCH_SIZE to PREFETCH_BATCH_SIZE

### DIFF
--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1941,7 +1941,6 @@ LedgerTxn::Impl::WorstBestOfferIteratorImpl::clone() const
 
 // Implementation of LedgerTxnRoot ------------------------------------------
 size_t const LedgerTxnRoot::Impl::MIN_BEST_OFFERS_BATCH_SIZE = 5;
-size_t const LedgerTxnRoot::Impl::MAX_BEST_OFFERS_BATCH_SIZE = 1024;
 
 LedgerTxnRoot::LedgerTxnRoot(Database& db, size_t entryCacheSize,
                              size_t bestOfferCacheSize,
@@ -2493,6 +2492,9 @@ LedgerTxnRoot::Impl::loadNextBestOffersIntoCache(BestOffersCacheEntryPtr cached,
     {
         return offers.cend();
     }
+
+    size_t const MAX_BEST_OFFERS_BATCH_SIZE =
+        std::max(mBulkLoadBatchSize, MIN_BEST_OFFERS_BATCH_SIZE);
 
     size_t const BATCH_SIZE =
         std::min(MAX_BEST_OFFERS_BATCH_SIZE,

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -677,7 +677,6 @@ class LedgerTxnRoot::Impl
         BestOffersCache;
 
     static size_t const MIN_BEST_OFFERS_BATCH_SIZE;
-    static size_t const MAX_BEST_OFFERS_BATCH_SIZE;
 
     Database& mDatabase;
     std::unique_ptr<LedgerHeader> mHeader;


### PR DESCRIPTION
# Description

`MAX_BEST_OFFERS_BATCH_SIZE` is 1024, while the default `PREFETCH_BATCH_SIZE` is 1000. This is unnecessary and can be inefficient since 1024 offers can result in 1024 accounts and 2048 trustlines being prefetched. Because `PREFETCH_BATCH_SIZE` is 1000, small bulk loads will be done for the final 24 accounts and 48 trustlines. Instead, we should just load `PREFETCH_BATCH_SIZE` number of offers to make the loads even.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
