### PR TITLE
Revive fuzzer and move to compact binary form

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -684,6 +684,7 @@ exit /b 0
     <ClInclude Include="..\..\src\ledger\NonSociRelatedException.h" />
     <ClInclude Include="..\..\src\overlay\SurveyManager.h" />
     <ClInclude Include="..\..\src\overlay\SurveyMessageLimiter.h" />
+    <ClInclude Include="..\..\src\test\Fuzzer.h" />
     <ClInclude Include="..\..\src\test\FuzzerImpl.h" />
     <ClInclude Include="..\..\src\transactions\ClaimClaimableBalanceOpFrame.h" />
     <ClInclude Include="..\..\src\transactions\EndSponsoringFutureReservesOpFrame.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1988,6 +1988,9 @@
     <ClInclude Include="..\..\src\util\Backtrace.h">
       <Filter>util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\src\test\Fuzzer.h">
+      <Filter>test</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\AUTHORS" />

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -44,17 +44,45 @@ signatures. For both modes, there is still much room for improvement in regards 
 
 ## Installing AFL
 
+### Packages
+
+Pre-packaged versions of AFL may be available.
+
+For example, Ubuntu provides `AFL++` that can be installed with
+```
+  apt-get install afl++
+```
+
+### From source
+
 Go to the [AFL repo][0], download the [tarball][2], unpack and run `make`, `make -C llvm_mode`
 then `sudo make install`. This will install both `afl-fuzz`, the fuzzer itself, and `afl-gcc`,
 `afl-clang`, and `afl-clang-fast`, which are compiler-wrappers that instrument binaries they
 compile with the fuzzer's branch-tracking machinery (the later being necessary for `llvm_mode`
 improvements described above).
 
+note: you may have to provide a default clang/clang++, this can be done in many ways.
+
+For example, this makes clang-8 the default:
+
+```
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-8   81 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-8    --slave /usr/share/man/man1/clang.1.gz clang.1.gz /usr/share/man/man1/clang-8.1.gz --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-8  --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-8 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-8
+```
 
 ## Building an instrumented stellar-core
 
-Start with a clean workspace, `make clean` or cleaner; then just do `./configure
---enable-afl && make` and make sure you have not enabled `asan` and `ccache`;
+Start with a clean workspace, `make clean` or cleaner; then just do
+
+```
+# or any compile flags that you like
+export CFLAGS='-O3 -g1' ; export CXXFLAGS="$CFLAGS"
+
+# or any compiler that you want
+export CC='clang' ; export CXX='clang++'
+./autogen.sh && ./configure --enable-extrachecks --disable-postgres --enable-afl && make
+```
+
+make sure you have not enabled `asan` and `ccache`;
 the former is incompatible, and the latter doesn't interoperate with the
 compiler wrappers.
 
@@ -155,3 +183,4 @@ part of staging-tests", here are some directions I think we should take fuzzing:
 [10]: https://github.com/trailofbits/deepstate
 [11]: https://llvm.org/docs/LibFuzzer.html
 [12]: https://github.com/google/AFL/blob/master/docs/status_screen.txt
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,16 +71,20 @@ FUZZER_MODE ?= overlay
 fuzz-testcases: stellar-core
 	mkdir -p fuzz-testcases
 	for i in `seq 1 10000`; do \
-	    ./stellar-core gen-fuzz fuzz-testcases/fuzz$$i.xdr --mode=${FUZZER_MODE}; \
+	    ./stellar-core gen-fuzz --mode=${FUZZER_MODE} fuzz-testcases/fuzz$i.xdr ; \
 	done
 	mkdir -p min-testcases
-	afl-cmin -i fuzz-testcases -o min-testcases -m 250 -t 250 ./stellar-core fuzz @@ --mode=${FUZZER_MODE}
+	afl-cmin -i fuzz-testcases -o min-testcases -m 500 -t 250 ./stellar-core fuzz --ll ERROR --mode=${FUZZER_MODE} @@
 	rm -Rf fuzz-testcases
+
+# when running in parallel,
+# run the same command than below replacing `-M main` with `-S worker_N`
+# and `--process-id 0` with `--process-id N`
 
 fuzz: fuzz-testcases stellar-core
 	mkdir -p fuzz-findings
-	afl-fuzz -m 250 -t 250 -i min-testcases -o fuzz-findings \
-	    ./stellar-core fuzz @@ --mode=${FUZZER_MODE}
+	afl-fuzz -m 500 -M main -t 250 -i min-testcases -o fuzz-findings \
+	    ./stellar-core fuzz --ll ERROR --process-id 0 --mode=${FUZZER_MODE} @@
 
 fuzz-clean: always
 	rm -Rf fuzz-testcases fuzz-findings

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -215,6 +215,9 @@ void
 InvariantManagerImpl::handleInvariantFailure(
     std::shared_ptr<Invariant> invariant, std::string const& message) const
 {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    abort();
+#endif
     if (invariant->isStrict())
     {
         CLOG(FATAL, "Invariant") << message;

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -132,4 +132,12 @@ InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
 {
     return 0;
 }
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+void
+InMemoryLedgerTxnRoot::resetForFuzzer()
+{
+    abort();
+}
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -58,5 +58,8 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void dropClaimableBalances() override;
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    void resetForFuzzer() override;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 };
 }

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1572,6 +1572,14 @@ LedgerTxn::getPrefetchHitRate() const
     return getImpl()->getPrefetchHitRate();
 }
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+void
+LedgerTxn::resetForFuzzer()
+{
+    abort();
+}
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
 double
 LedgerTxn::Impl::getPrefetchHitRate() const
 {

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -449,6 +449,10 @@ class AbstractLedgerTxnParent
     // work, while still being correct. Will throw when called on anything other
     // than a (real or stub) root LedgerTxn.
     virtual uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) = 0;
+
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    virtual void resetForFuzzer() = 0;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 };
 
 // An abstraction for an object that is an AbstractLedgerTxnParent and has
@@ -696,6 +700,9 @@ class LedgerTxn final : public AbstractLedgerTxn
         AssetPairHash> const&
     getOrderBook();
 #endif
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    void resetForFuzzer() override;
+#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 };
 
 class LedgerTxnRoot : public AbstractLedgerTxnParent
@@ -726,7 +733,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     void dropClaimableBalances() override;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    void resetForFuzzer();
+    void resetForFuzzer() override;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
     UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -175,7 +175,7 @@ fileNameParser(std::string& string)
 clara::Opt
 processIDParser(int& num)
 {
-    return clara::Opt{num, "PROCESS-ID"}["--process_id"](
+    return clara::Opt{num, "PROCESS-ID"}["--process-id"](
         "for spawning multiple instances in fuzzing parallelization");
 }
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1418,8 +1418,9 @@ runFuzz(CommandLineArgs const& args)
                         fileNameParser(fileName), processIDParser(processID),
                         fuzzerModeParser(fuzzerModeArg, fuzzerMode)},
                        [&] {
-                           fuzz(fileName, logLevel, metrics, processID,
-                                fuzzerMode);
+                           Logging::setLogLevel(logLevel, nullptr);
+
+                           fuzz(fileName, metrics, processID, fuzzerMode);
                            return 0;
                        });
 }

--- a/src/test/Fuzzer.h
+++ b/src/test/Fuzzer.h
@@ -24,8 +24,9 @@ class Fuzzer
     // attempts to apply it to the state according to whatever apply may mean,
     // i.e. apply a transaction in the case of a TransactionFuzzer or send a
     // message in case of an OverlayFuzzer
-    virtual void inject(XDRInputFileStream&) = 0;
+    virtual void inject(std::string const& filename) = 0;
     virtual void initialize() = 0;
+    virtual void shutdown() = 0;
     // genFuzz randomly generates an XDR input for the given fuzzer. For the
     // TransactionFuzzer, this is a xdr::xvector of Operations, for the
     // OverlayFuzzer this is a StellarMessage

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -427,6 +427,12 @@ TransactionFuzzer::genFuzz(std::string const& filename)
     for (int i = 0; i < numops; ++i)
     {
         Operation op = gen(FUZZER_INITIAL_CORPUS_OPERATION_GEN_UPPERBOUND);
+        // include a placeholder account for the base cases as it's more likely
+        // to be useful right away
+        if (!op.sourceAccount)
+        {
+            op.sourceAccount.activate();
+        }
         ops.emplace_back(op);
     }
     auto bins = xdr::xdr_to_opaque(ops);

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -37,8 +37,8 @@ class TransactionFuzzer : public Fuzzer
 
 class OverlayFuzzer : public Fuzzer
 {
-    const int ACCEPTOR_INDEX = 0;
-    const int INITIATOR_INDEX = 1;
+    int const ACCEPTOR_INDEX = 0;
+    int const INITIATOR_INDEX = 1;
 
   public:
     OverlayFuzzer()

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -20,7 +20,7 @@ struct Operation;
 class TransactionFuzzer : public Fuzzer
 {
   public:
-    TransactionFuzzer(int numAccounts) : mNumAccounts(numAccounts)
+    TransactionFuzzer()
     {
     }
     void inject(std::string const& filename) override;
@@ -33,7 +33,6 @@ class TransactionFuzzer : public Fuzzer
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;
-    int mNumAccounts;
 };
 
 class OverlayFuzzer : public Fuzzer

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "test/Fuzzer.h"
+#include "util/Timer.h"
 #include "xdr/Stellar-types.h"
 
 namespace stellar
@@ -19,20 +20,20 @@ struct Operation;
 class TransactionFuzzer : public Fuzzer
 {
   public:
-    TransactionFuzzer(unsigned int numAccounts, int processID)
-        : mNumAccounts(numAccounts), mProcessID(processID)
+    TransactionFuzzer(int numAccounts) : mNumAccounts(numAccounts)
     {
     }
-    void inject(XDRInputFileStream&) override;
+    void inject(std::string const& filename) override;
     void initialize() override;
+    void shutdown() override;
     void genFuzz(std::string const& filename) override;
     int xdrSizeLimit() override;
 
   private:
+    VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;
-    unsigned int mNumAccounts;
-    int mProcessID;
+    int mNumAccounts;
 };
 
 class OverlayFuzzer : public Fuzzer
@@ -44,8 +45,9 @@ class OverlayFuzzer : public Fuzzer
     OverlayFuzzer()
     {
     }
-    void inject(XDRInputFileStream&) override;
+    void inject(std::string const& filename) override;
     void initialize() override;
+    void shutdown() override;
     void genFuzz(std::string const& filename) override;
     int xdrSizeLimit() override;
 

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -4,6 +4,7 @@
 
 #include "test/fuzz.h"
 #include "test/FuzzerImpl.h"
+#include "test/test.h"
 #include "util/XDRStream.h"
 #include "util/types.h"
 
@@ -28,21 +29,21 @@
 
 namespace stellar
 {
-
 namespace FuzzUtils
 {
-unsigned int const NUMBER_OF_PREGENERATED_ACCOUNTS = 16;
+int const NUMBER_OF_PREGENERATED_ACCOUNTS = 16;
 
 std::unique_ptr<Fuzzer>
 createFuzzer(int processID, FuzzerMode fuzzerMode)
 {
+    gBaseInstance = processID;
     switch (fuzzerMode)
     {
     case FuzzerMode::OVERLAY:
         return std::make_unique<OverlayFuzzer>();
     case FuzzerMode::TRANSACTION:
         return std::make_unique<TransactionFuzzer>(
-            NUMBER_OF_PREGENERATED_ACCOUNTS, processID);
+            NUMBER_OF_PREGENERATED_ACCOUNTS);
     default:
         abort();
     }
@@ -65,10 +66,8 @@ fuzz(std::string const& filename, el::Level logLevel,
     while (__AFL_LOOP(PERSIST_MAX))
 #endif // AFL_LLVM_MODE
     {
-        XDRInputFileStream in(fuzzer->xdrSizeLimit());
-        in.open(filename);
-
-        fuzzer->inject(in);
+        fuzzer->inject(filename);
     }
+    fuzzer->shutdown();
 }
 }

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -31,8 +31,6 @@ namespace stellar
 {
 namespace FuzzUtils
 {
-int const NUMBER_OF_PREGENERATED_ACCOUNTS = 16;
-
 std::unique_ptr<Fuzzer>
 createFuzzer(int processID, FuzzerMode fuzzerMode)
 {
@@ -42,8 +40,7 @@ createFuzzer(int processID, FuzzerMode fuzzerMode)
     case FuzzerMode::OVERLAY:
         return std::make_unique<OverlayFuzzer>();
     case FuzzerMode::TRANSACTION:
-        return std::make_unique<TransactionFuzzer>(
-            NUMBER_OF_PREGENERATED_ACCOUNTS);
+        return std::make_unique<TransactionFuzzer>();
     default:
         abort();
     }

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -52,9 +52,8 @@ createFuzzer(int processID, FuzzerMode fuzzerMode)
 
 #define PERSIST_MAX 1000000
 void
-fuzz(std::string const& filename, el::Level logLevel,
-     std::vector<std::string> const& metrics, int processID,
-     FuzzerMode fuzzerMode)
+fuzz(std::string const& filename, std::vector<std::string> const& metrics,
+     int processID, FuzzerMode fuzzerMode)
 {
     auto fuzzer = FuzzUtils::createFuzzer(processID, fuzzerMode);
     fuzzer->initialize();

--- a/src/test/fuzz.h
+++ b/src/test/fuzz.h
@@ -21,7 +21,6 @@ enum class FuzzerMode
 
 namespace FuzzUtils
 {
-extern int const NUMBER_OF_PREGENERATED_ACCOUNTS;
 std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode);
 }
 

--- a/src/test/fuzz.h
+++ b/src/test/fuzz.h
@@ -22,7 +22,7 @@ enum class FuzzerMode
 
 namespace FuzzUtils
 {
-extern unsigned int const NUMBER_OF_PREGENERATED_ACCOUNTS;
+extern int const NUMBER_OF_PREGENERATED_ACCOUNTS;
 std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode);
 }
 

--- a/src/test/fuzz.h
+++ b/src/test/fuzz.h
@@ -4,7 +4,6 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "util/Logging.h"
 #include <memory>
 #include <string>
 #include <vector>
@@ -26,7 +25,6 @@ extern int const NUMBER_OF_PREGENERATED_ACCOUNTS;
 std::unique_ptr<Fuzzer> createFuzzer(int processID, FuzzerMode fuzzerMode);
 }
 
-void fuzz(std::string const& filename, el::Level logLevel,
-          std::vector<std::string> const& metrics, int processID,
-          FuzzerMode fuzzerMode);
+void fuzz(std::string const& filename, std::vector<std::string> const& metrics,
+          int processID, FuzzerMode fuzzerMode);
 }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -75,7 +75,7 @@ static std::vector<std::unique_ptr<Config>> gTestCfg[Config::TESTDB_MODES];
 static std::vector<TmpDir> gTestRoots;
 static bool gTestAllVersions{false};
 static std::vector<uint32> gVersionsToTest;
-static int gBaseInstance{0};
+int gBaseInstance{0};
 
 bool force_sqlite = (std::getenv("STELLAR_FORCE_SQLITE") != nullptr);
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -20,6 +20,7 @@ Config const& getTestConfig(int instanceNumber = 0,
 
 int runTest(CommandLineArgs const& args);
 
+extern int gBaseInstance;
 extern bool force_sqlite;
 
 void for_versions_to(uint32 to, Application& app,

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -836,9 +836,6 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             << "Unknown exception while applying operations (txHash= "
             << xdr_to_string(getFullHash()) << ")";
     }
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    abort();
-#endif
     // This is only reachable if an exception is thrown
     getResult().result.code(txINTERNAL_ERROR);
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -836,7 +836,9 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             << "Unknown exception while applying operations (txHash= "
             << xdr_to_string(getFullHash()) << ")";
     }
-
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    abort();
+#endif
     // This is only reachable if an exception is thrown
     getResult().result.code(txINTERNAL_ERROR);
 


### PR DESCRIPTION
# Description

Resolves #2418 

This PR incorporates the previous fuzzer branch with various fixes so that it could run reliably.
It also moves to a "compact binary form" when fuzzing as to maximize the chances that a fuzzer would find problems.
It's a tradeoff: the "raw" form would allow to find integer overflow type of bugs, but this is at the expense of a much bigger dataset, and this does not seem to be the right tradeoff at this time (bugs that we typically run into are more around logic error where we don't expect a certain sequence of operation to take place).

In my tests, I found that with this change, afl-fuzz can build a graph in less than 4 minutes that takes over two hours to build without the compact form.

More work needs to be done on the fuzzer, but I figured this was a good place to checkpoint.
