### PR TITLE
mark build as failed if there is nothing to do

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -51,7 +51,7 @@ echo $HEAD
 if [ $HEAD == $MASTER ]
 then
     echo "HEAD SHA1 equals master; probably just establishing merge, exiting build early"
-    exit 0
+    exit 1
 fi
 
 # Try to ensure we're using the real g++ and clang++ versions we want


### PR DESCRIPTION
This fixes an issue where the transient build triggered by our CI robot is kicked off at the same time than the other build, and as it "succeeds in doing nothing", it creates a conflict with the build cache (we use the timestamp to uniquely identify a build for a given branch).

As added benefit, this avoids using cache capacity (currently 5GB for the entire project) for no good reason.
