### PR TITLE
Additional Sequence Number Validation

### DIFF
--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -595,23 +595,11 @@ TransactionQueue::toTxSet(LedgerHeaderHistoryEntry const& lcl) const
     ZoneScoped;
     auto result = std::make_shared<TxSetFrame>(lcl.hash);
 
-    uint32_t const nextLedgerSeq = lcl.header.ledgerSeq + 1;
-    int64_t const startingSeq = getStartingSequenceNumber(nextLedgerSeq);
     for (auto const& m : mAccountStates)
     {
         for (auto const& tx : m.second.mTransactions)
         {
             result->add(tx.mTx);
-            // This condition implements the following constraint: there may be
-            // any number of transactions for a given source account, but all
-            // transactions must satisfy one of the following mutually exclusive
-            // conditions
-            // - sequence number <= startingSeq - 1
-            // - sequence number >= startingSeq
-            if (tx.mTx->getSeqNum() == startingSeq - 1)
-            {
-                break;
-            }
         }
     }
 

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -705,33 +705,37 @@ TEST_CASE("transaction queue starting sequence boundary",
     closeLedgerOn(*app, 2, 1, 1, 2020);
     closeLedgerOn(*app, 3, 1, 1, 2020);
 
-    int64_t startingSeq = static_cast<int64_t>(4) << 32;
-    REQUIRE(acc1.loadSequenceNumber() < startingSeq);
-    acc1.bumpSequence(startingSeq - 3);
-    REQUIRE(acc1.loadSequenceNumber() == startingSeq - 3);
-
-    TransactionQueue tq(*app, 4, 10, 4);
-    for (size_t i = 1; i <= 4; ++i)
+    SECTION("below")
     {
-        REQUIRE(tq.tryAdd(transaction(*app, acc1, i, 1, 100)) ==
+        int64_t startingSeq = static_cast<int64_t>(4) << 32;
+        REQUIRE(acc1.loadSequenceNumber() < startingSeq);
+        acc1.bumpSequence(startingSeq - 3);
+        REQUIRE(acc1.loadSequenceNumber() == startingSeq - 3);
+
+        TransactionQueue tq(*app, 4, 10, 4);
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 1, 1, 100)) ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 2, 1, 100)) ==
+                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 3, 1, 100)) ==
+                TransactionQueue::AddResult::ADD_STATUS_ERROR);
     }
 
-    auto checkTxSet = [&](uint32_t ledgerSeq, size_t size) {
-        auto lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-        lcl.header.ledgerSeq = ledgerSeq;
-        auto txSet = tq.toTxSet(lcl);
-        REQUIRE(txSet->mTransactions.size() == size);
-        for (size_t i = 1; i <= size; ++i)
-        {
-            REQUIRE(txSet->mTransactions[i - 1]->getSeqNum() ==
-                    static_cast<int64_t>(startingSeq - 3 + i));
-        }
-    };
+    SECTION("above")
+    {
+        int64_t startingSeq = static_cast<int64_t>(4) << 32;
+        REQUIRE(acc1.loadSequenceNumber() < startingSeq - 1);
+        acc1.bumpSequence(startingSeq - 1);
+        REQUIRE(acc1.loadSequenceNumber() == startingSeq - 1);
 
-    checkTxSet(2, 4);
-    checkTxSet(3, 2);
-    checkTxSet(4, 4);
+        TransactionQueue tq(*app, 4, 10, 4);
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 1, 1, 100)) ==
+                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 2, 1, 100)) ==
+                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 3, 1, 100)) ==
+                TransactionQueue::AddResult::ADD_STATUS_PENDING);
+    }
 }
 
 TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -74,11 +74,13 @@ class TransactionFrame : public TransactionFrameBase
                               uint64_t lowerBoundCloseTimeOffset,
                               uint64_t upperBoundCloseTimeOffset);
 
-    virtual bool isBadSeq(int64_t seqNum) const;
+    virtual bool isBadSeq(LedgerTxnHeader const& header,
+                          LedgerTxnEntry const& sourceAccount, int64_t seqNum,
+                          bool applying) const;
 
     ValidationType commonValid(SignatureChecker& signatureChecker,
                                AbstractLedgerTxn& ltxOuter,
-                               SequenceNumber current, bool applying,
+                               SequenceNumber seqNum, bool applying,
                                bool chargeFee,
                                uint64_t lowerBoundCloseTimeOffset,
                                uint64_t upperBoundCloseTimeOffset);

--- a/src/transactions/simulation/TxSimTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimTransactionFrame.cpp
@@ -79,7 +79,9 @@ TxSimTransactionFrame::isTooLate(LedgerTxnHeader const& header,
 }
 
 bool
-TxSimTransactionFrame::isBadSeq(int64_t seqNum) const
+TxSimTransactionFrame::isBadSeq(LedgerTxnHeader const& header,
+                                LedgerTxnEntry const& sourceAccount,
+                                int64_t seqNum, bool applying) const
 {
     return mSimulationResult.result.code() == txBAD_SEQ;
 }

--- a/src/transactions/simulation/TxSimTransactionFrame.h
+++ b/src/transactions/simulation/TxSimTransactionFrame.h
@@ -26,7 +26,9 @@ class TxSimTransactionFrame : public TransactionFrame
                                                   OperationResult& res,
                                                   size_t index) override;
 
-    bool isBadSeq(int64_t seqNum) const override;
+    bool isBadSeq(LedgerTxnHeader const& header,
+                  LedgerTxnEntry const& sourceAccount, int64_t seqNum,
+                  bool applying) const override;
 
     int64_t getFee(LedgerHeader const& header, int64_t baseFee,
                    bool applying) const override;


### PR DESCRIPTION
# Description
This PR moves some sequence number validation from `TransactionQueue` to `TransactionFrame`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
