### PR TITLE
Escape shell variable in Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,7 @@ FUZZER_MODE ?= overlay
 fuzz-testcases: stellar-core
 	mkdir -p fuzz-testcases
 	for i in `seq 1 10000`; do \
-	    ./stellar-core gen-fuzz --mode=${FUZZER_MODE} fuzz-testcases/fuzz$i.xdr ; \
+	    ./stellar-core gen-fuzz --mode=${FUZZER_MODE} fuzz-testcases/fuzz$$i.xdr ; \
 	done
 	mkdir -p min-testcases
 	afl-cmin -i fuzz-testcases -o min-testcases -m 500 -t 250 ./stellar-core fuzz --ll ERROR --mode=${FUZZER_MODE} @@


### PR DESCRIPTION
# Description

`make fuzz` uses a shell script, inlined in `Makefile.am`, which loops over a shell variable `$i`.  It's used as `fuzz$i.xdr` and is intended to generate numbered filenames.  But it should be (and used to be) `fuzz$$i.xdr`; as it is the `$i` is being treated as an unset Makefile variable, so instead of generating 10,000 files, the script generates `fuzz.xdr` and then overwrites it 9,999 times.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
