### PR TITLE
Transaction flooding throttling

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -138,9 +138,18 @@ MAX_BATCH_WRITE_COUNT=1024
 # How many bytes can this server send at once to a peer
 MAX_BATCH_WRITE_BYTES=1048576
 
+# FLOOD_OP_RATE_PER_LEDGER (Integer) default -2
+# How many operations get flooded per ledger
+# If negative, the number is derived as:
+#  -FLOOD_OP_RATE_PER_LEDGER*<maximum number of operations per ledger>
+FLOOD_OP_RATE_PER_LEDGER = -2
+
 # FLOOD_TX_PERIOD_MS (Integer) default 0
 # Time in milliseconds between transaction flood events
-# When set to 0, flooding is not delayed
+# When non 0, transaction flooding is delayed
+#   and governed by FLOOD_OP_RATE_PER_LEDGER
+#   so that the target rate is met on a per ledger basis
+# When set to 0, transactions are flooded right away
 FLOOD_TX_PERIOD_MS=0
 
 # PREFERRED_PEERS (list of strings) default is empty

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -138,6 +138,11 @@ MAX_BATCH_WRITE_COUNT=1024
 # How many bytes can this server send at once to a peer
 MAX_BATCH_WRITE_BYTES=1048576
 
+# FLOOD_TX_PERIOD_MS (Integer) default 0
+# Time in milliseconds between transaction flood events
+# When set to 0, flooding is not delayed
+FLOOD_TX_PERIOD_MS=0
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -149,6 +149,7 @@ HerderImpl::shutdown()
                    "Shutdown interrupting quorum transitive closure analysis.");
         mLastQuorumMapIntersectionState.mInterruptFlag = true;
     }
+    mTransactionQueue.shutdown();
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1693,6 +1693,9 @@ HerderImpl::restoreState()
 {
     restoreSCPState();
     restoreUpgrades();
+    // make sure that the transaction queue is setup against
+    // the lcl that we have right now
+    mTransactionQueue.maybeVersionUpgraded();
 }
 
 void
@@ -1721,15 +1724,7 @@ HerderImpl::updateTransactionQueue(
     mTransactionQueue.removeApplied(applied);
     mTransactionQueue.shift();
 
-    // Transactions in the queue need to be updated after the protocol 13
-    // upgrade
-    auto replacedTxs = mTransactionQueue.maybeVersionUpgraded();
-    for (auto const& replacedTx : replacedTxs)
-    {
-        mApp.getOverlayManager().updateFloodRecord(
-            replacedTx.mOld->toStellarMessage(),
-            replacedTx.mNew->toStellarMessage());
-    }
+    mTransactionQueue.maybeVersionUpgraded();
 
     // Generate a transaction set from a random hash and drop invalid
     auto lhhe = mLedgerManager.getLastClosedLedgerHeader();

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1792,6 +1792,8 @@ HerderImpl::getMoreSCPState()
 
     auto low = getMinLedgerSeqToAskPeers();
 
+    CLOG_INFO(Herder, "Asking peers for SCP messages more recent than {}", low);
+
     // ask a few random peers their SCP messages
     auto r = mApp.getOverlayManager().getRandomAuthenticatedPeers();
     for (int i = 0; i < NB_PEERS_TO_ASK && i < r.size(); i++)

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -725,11 +725,9 @@ TransactionQueue::broadcastTx(AccountState& state, TimestampedTx& tx)
     }
     tx.mBroadcasted = true;
     state.mBroadcastQueueOps -= tx.mTx->getNumOperations();
-    StellarMessage msg;
-    msg.type(TRANSACTION);
-    msg.transaction() = tx.mTx->getEnvelope();
-    return mApp.getOverlayManager().broadcastMessage(msg);
-    }
+    return mApp.getOverlayManager().broadcastMessage(
+        tx.mTx->toStellarMessage());
+}
 
 bool
 TransactionQueue::broadcastSome()

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -751,6 +751,22 @@ TransactionQueue::broadcastSome()
     {
         TimestampedTransactions::iterator mCur;
         AccountState* mAccountState;
+        TxTracker(TxTracker&&) = default;
+
+        // NB: this overload seems to be necessary with most versions of
+        // libstdc++ that assert when std::move is called on self for iterators
+        // std::swap ends up calling this operator
+        // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85828
+        TxTracker&
+        operator=(TxTracker&& other)
+        {
+            if (this != &other)
+            {
+                mCur = other.mCur;
+                mAccountState = other.mAccountState;
+            }
+            return *this;
+        }
     };
     std::deque<TxTracker> iters;
     size_t totalOpsToFlood = 0;

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -687,10 +687,12 @@ TransactionQueue::rebroadcast()
             {
                 break;
             }
-            opsToFlood -= tx->getNumOperations();
 
             auto msg = tx->toStellarMessage();
-            mApp.getOverlayManager().broadcastMessage(msg);
+            if (mApp.getOverlayManager().broadcastMessage(msg))
+            {
+                opsToFlood -= tx->getNumOperations();
+            }
         }
     }
 }

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -80,6 +80,7 @@ class TransactionQueue
         SequenceNumber mMaxSeq{0};
         int64_t mTotalFees{0};
         size_t mQueueSizeOps{0};
+        size_t mBroadcastQueueOps{0};
         int32_t mAge{0};
 
         friend bool operator==(AccountTxQueueInfo const& x,
@@ -110,6 +111,7 @@ class TransactionQueue
     {
         int64_t mTotalFees{0};
         size_t mQueueSizeOps{0};
+        size_t mBroadcastQueueOps{0};
         int32_t mAge{0};
         TimestampedTransactions mTransactions;
     };

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -147,6 +147,8 @@ class TransactionQueue
 
     void rebroadcast();
 
+    void shutdown();
+
   private:
     /**
      * The AccountState for every account. As noted above, an AccountID is in
@@ -177,7 +179,11 @@ class TransactionQueue
 
     UnorderedSet<OperationType> mFilteredTypes;
 
-    void broadcast();
+    bool mShutdown{false};
+    bool mWaiting{false};
+    VirtualTimer mBroadcastTimer;
+
+    void broadcast(bool fromCallback);
 
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -101,6 +101,7 @@ class TransactionQueue
     struct TimestampedTx
     {
         TransactionFrameBasePtr mTx;
+        bool mBroadcasted;
         VirtualClock::time_point mInsertionTime;
     };
     using TimestampedTransactions = std::vector<TimestampedTx>;
@@ -175,6 +176,8 @@ class TransactionQueue
     medida::Timer& mTransactionsDelay;
 
     UnorderedSet<OperationType> mFilteredTypes;
+
+    void broadcast();
 
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -144,6 +144,8 @@ class TransactionQueue
 
     void maybeVersionUpgraded();
 
+    void rebroadcast();
+
   private:
     /**
      * The AccountState for every account. As noted above, an AccountID is in

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -183,9 +183,11 @@ class TransactionQueue
 
     bool mShutdown{false};
     bool mWaiting{false};
+    int mBroadcastSteps{0};
+    size_t mBroadcastOpCount{0};
     VirtualTimer mBroadcastTimer;
 
-    size_t getMaxOpsToFloodPerPeriod() const;
+    size_t getMaxOpsToFloodThisPeriod() const;
     bool broadcastSome();
     void broadcast(bool fromCallback);
     bool broadcastTx(AccountState& state, TimestampedTx& tx);

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -141,7 +141,8 @@ class TransactionQueue
         TransactionFrameBasePtr mOld;
         TransactionFrameBasePtr mNew;
     };
-    std::vector<ReplacedTransaction> maybeVersionUpgraded();
+
+    void maybeVersionUpgraded();
 
   private:
     /**
@@ -182,6 +183,8 @@ class TransactionQueue
     void dropTransactions(AccountStates::iterator stateIter,
                           TimestampedTransactions::iterator begin,
                           TimestampedTransactions::iterator end);
+
+    void clearAll();
 
     // size of the transaction queue, in operations
     size_t mQueueSizeOps{0};

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -183,6 +183,7 @@ class TransactionQueue
     bool mWaiting{false};
     VirtualTimer mBroadcastTimer;
 
+    size_t getMaxOpsToFloodPerPeriod() const;
     void broadcast(bool fromCallback);
 
     AddResult canAdd(TransactionFrameBasePtr tx,

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -183,8 +183,7 @@ class TransactionQueue
 
     bool mShutdown{false};
     bool mWaiting{false};
-    int mBroadcastSteps{0};
-    size_t mBroadcastOpCount{0};
+    size_t mBroadcastOpCarryover{0};
     VirtualTimer mBroadcastTimer;
 
     size_t getMaxOpsToFloodThisPeriod() const;

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -184,7 +184,9 @@ class TransactionQueue
     VirtualTimer mBroadcastTimer;
 
     size_t getMaxOpsToFloodPerPeriod() const;
+    bool broadcastSome();
     void broadcast(bool fromCallback);
+    bool broadcastTx(AccountState& state, TimestampedTx& tx);
 
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,
@@ -192,6 +194,7 @@ class TransactionQueue
 
     void releaseFeeMaybeEraseAccountState(TransactionFrameBasePtr tx);
 
+    void prepareDropTransaction(AccountState& as, TimestampedTx& tstx);
     void dropTransactions(AccountStates::iterator stateIter,
                           TimestampedTransactions::iterator begin,
                           TimestampedTransactions::iterator end);

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -176,6 +176,8 @@ class TransactionQueueTest
                     expectedFees[accountState.mAccountID]);
             REQUIRE(accountTransactionQueueInfo.mMaxSeq == seqNum);
             REQUIRE(accountTransactionQueueInfo.mAge == accountState.mAge);
+            REQUIRE(accountTransactionQueueInfo.mBroadcastQueueOps ==
+                    accountTransactionQueueInfo.mQueueSizeOps);
             totOps += accountTransactionQueueInfo.mQueueSizeOps;
 
             for (auto& tx : accountState.mAccountTransactions)
@@ -207,11 +209,12 @@ class TransactionQueueTest
 };
 }
 
-TEST_CASE("TransactionQueue", "[herder][TransactionQueue]")
+TEST_CASE("TransactionQueue", "[herder][transactionqueue]")
 {
     VirtualClock clock;
     auto cfg = getTestConfig();
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 4;
+    cfg.FLOOD_TX_PERIOD_MS = 100;
     auto app = createTestApplication(clock, cfg);
     auto const minBalance2 = app->getLedgerManager().getLastMinBalance(2);
 
@@ -763,7 +766,9 @@ TEST_CASE("transaction queue starting sequence boundary",
 TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
 {
     VirtualClock clock;
-    auto app = createTestApplication(clock, getTestConfig());
+    auto cfg = getTestConfig();
+    cfg.FLOOD_TX_PERIOD_MS = 100;
+    auto app = createTestApplication(clock, cfg);
     auto const minBalance0 = app->getLedgerManager().getLastMinBalance(0);
     auto const minBalance2 = app->getLedgerManager().getLastMinBalance(2);
 
@@ -1025,7 +1030,9 @@ TEST_CASE("transaction queue with fee-bump", "[herder][transactionqueue]")
 TEST_CASE("replace by fee", "[herder][transactionqueue]")
 {
     VirtualClock clock;
-    auto app = createTestApplication(clock, getTestConfig());
+    auto cfg = getTestConfig();
+    cfg.FLOOD_TX_PERIOD_MS = 100;
+    auto app = createTestApplication(clock, cfg);
     auto const minBalance2 = app->getLedgerManager().getLastMinBalance(2);
 
     auto root = TestAccount::createRoot(*app);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -621,14 +621,6 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
             TransactionQueue::AddResult status =
                 mApp.getHerder().recvTransaction(transaction);
 
-            if (status == TransactionQueue::AddResult::ADD_STATUS_PENDING)
-            {
-                StellarMessage msg;
-                msg.type(TRANSACTION);
-                msg.transaction() = envelope;
-                mApp.getOverlayManager().broadcastMessage(msg);
-            }
-
             output << "{"
                    << "\"status\": "
                    << "\"" << TX_STATUS_STRING[static_cast<int>(status)]

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -153,6 +153,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_TIMEOUT = 30;
     PEER_STRAGGLER_TIMEOUT = 120;
 
+    FLOOD_OP_RATE_PER_LEDGER = -2;
     FLOOD_TX_PERIOD_MS = 0;
 
     MAX_BATCH_WRITE_COUNT = 1024;
@@ -889,6 +890,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "MAX_BATCH_WRITE_BYTES")
             {
                 MAX_BATCH_WRITE_BYTES = readInt<int>(item, 1);
+            }
+            else if (item.first == "FLOOD_OP_RATE_PER_LEDGER")
+            {
+                FLOOD_OP_RATE_PER_LEDGER = readInt<int>(item);
             }
             else if (item.first == "FLOOD_TX_PERIOD_MS")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -153,6 +153,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_TIMEOUT = 30;
     PEER_STRAGGLER_TIMEOUT = 120;
 
+    FLOOD_TX_PERIOD_MS = 0;
+
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
     PREFERRED_PEERS_ONLY = false;
@@ -887,6 +889,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "MAX_BATCH_WRITE_BYTES")
             {
                 MAX_BATCH_WRITE_BYTES = readInt<int>(item, 1);
+            }
+            else if (item.first == "FLOOD_TX_PERIOD_MS")
+            {
+                FLOOD_TX_PERIOD_MS = readInt<int>(item, 0);
             }
             else if (item.first == "PREFERRED_PEERS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -311,6 +311,7 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short PEER_STRAGGLER_TIMEOUT;
     int MAX_BATCH_WRITE_COUNT;
     int MAX_BATCH_WRITE_BYTES;
+    int FLOOD_OP_RATE_PER_LEDGER;
     int FLOOD_TX_PERIOD_MS;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -311,6 +311,7 @@ class Config : public std::enable_shared_from_this<Config>
     unsigned short PEER_STRAGGLER_TIMEOUT;
     int MAX_BATCH_WRITE_COUNT;
     int MAX_BATCH_WRITE_BYTES;
+    int FLOOD_TX_PERIOD_MS;
     static constexpr auto const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr auto const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -59,7 +59,8 @@ class Floodgate
     bool addRecord(StellarMessage const& msg, Peer::pointer fromPeer,
                    Hash& msgID);
 
-    void broadcast(StellarMessage const& msg, bool force);
+    // returns true if msg was sent to at least one peer
+    bool broadcast(StellarMessage const& msg, bool force);
 
     // returns the list of peers that sent us the item with hash `msgID`
     // NB: `msgID` is the hash of a `StellarMessage`

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -64,9 +64,9 @@ class OverlayManager
     // This is called by Herder when ledger `lclSeq` closes.
     virtual void clearLedgersBelow(uint32_t ledgerSeq, uint32_t lclSeq) = 0;
 
-    // Send a given message to all peers, via the FloodGate. This is called by
-    // Herder.
-    virtual void broadcastMessage(StellarMessage const& msg,
+    // Send a given message to all peers, via the FloodGate.
+    // returns true if message was sent to at least one peer
+    virtual bool broadcastMessage(StellarMessage const& msg,
                                   bool force = false) = 0;
 
     // Make a note in the FloodGate that a given peer has provided us with a

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -900,12 +900,12 @@ OverlayManagerImpl::forgetFloodedMsg(Hash const& msgID)
     mFloodGate.forgetRecord(msgID);
 }
 
-void
+bool
 OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force)
 {
     ZoneScoped;
     mOverlayMetrics.mMessagesBroadcast.Mark();
-    mFloodGate.broadcast(msg, force);
+    return mFloodGate.broadcast(msg, force);
 }
 
 void

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -103,7 +103,7 @@ class OverlayManagerImpl : public OverlayManager
     bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
                           Hash& msgID) override;
     void forgetFloodedMsg(Hash const& msgID) override;
-    void broadcastMessage(StellarMessage const& msg,
+    bool broadcastMessage(StellarMessage const& msg,
                           bool force = false) override;
     void connectTo(PeerBareAddress const& address) override;
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -639,9 +639,7 @@ LoadGenerator::TxInfo::execute(Application& app, bool isCreate,
     }
     txm.mTxnAttempted.Mark();
 
-    StellarMessage msg;
-    msg.type(TRANSACTION);
-    msg.transaction() = txf->getEnvelope();
+    StellarMessage msg(txf->toStellarMessage());
     txm.mTxnBytes.Mark(xdr::xdr_argpack_size(msg));
 
     auto status = app.getHerder().recvTransaction(txf);

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -426,8 +426,7 @@ FeeBumpTransactionFrame::resetResults(LedgerHeader const& header,
 StellarMessage
 FeeBumpTransactionFrame::toStellarMessage() const
 {
-    StellarMessage msg;
-    msg.type(TRANSACTION);
+    StellarMessage msg(TRANSACTION);
     msg.transaction() = mEnvelope;
     return msg;
 }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -924,8 +924,7 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
 StellarMessage
 TransactionFrame::toStellarMessage() const
 {
-    StellarMessage msg;
-    msg.type(TRANSACTION);
+    StellarMessage msg(TRANSACTION);
     msg.transaction() = mEnvelope;
     return msg;
 }


### PR DESCRIPTION
This PR adds a new mode (opt-in for now) to decouple flooding transactions from receiving transactions.

When enabled, this should help smooth out the occasional traffic spikes that may interfere with other traffic.
