### PR TITLE
Tell libsodium not to download code from savannah.gnu.org in autogen.sh.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -20,6 +20,14 @@ case "$1" in
 	;;
 esac
 
+# NB: the DO_NOT_UPDATE_CONFIG_SCRIPTS variable is here to inform libsodium not
+# to download a fresh config.sub and config.guess from git.savannah.gnu.org
+# (which is sometimes offline).
+#
+# This variable was how you disable the update in libsodium up to version
+# 1.0.18; but in master they have changed this, so on the next libsodium
+# submodule bump we'll want to change the code here to the new interface
+# (running `autogen.sh -b` in the libsodium directory)
 
 case "${skip_submodules}" in
     0|no|false|"")
@@ -28,7 +36,7 @@ case "${skip_submodules}" in
             autogen=$(find . -name autogen.sh)
             if [ -x "$autogen" ]; then
                 cd $(dirname "$autogen")
-                ./autogen.sh
+                DO_NOT_UPDATE_CONFIG_SCRIPTS=1 ./autogen.sh
             fi
             '
     ;;


### PR DESCRIPTION
Libsodium's autogen.sh step automatically downloads a fresh config.guess and config.sub from savannah.gnu.org, which .. is not something we really want it to be doing. At very least because savannah.gnu.org isn't always online.

Unfortunately we'll have to change this code slightly when 1.0.19 comes out, but thems the breaks.