### PR TITLE
Make LedgerTxnEntry bool operator stricter by using a bool to hold initialization state

### DIFF
--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -72,7 +72,11 @@ store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
             REQUIRE(false);
         }
 
-        if (entry && entry.current().data.type() == ACCOUNT)
+        if (previous && !current)
+        {
+            REQUIRE_THROWS_AS(!entry, std::runtime_error);
+        }
+        else if (entry && entry.current().data.type() == ACCOUNT)
         {
             normalizeSigners(entry.current().data.account());
         }

--- a/src/ledger/LedgerTxnEntry.h
+++ b/src/ledger/LedgerTxnEntry.h
@@ -32,6 +32,8 @@ class LedgerTxnEntry
     std::shared_ptr<Impl> getImpl();
     std::shared_ptr<Impl const> getImpl() const;
 
+    bool mIsInitialized;
+
   public:
     // LedgerTxnEntry constructors do not throw
     LedgerTxnEntry();
@@ -75,6 +77,8 @@ class ConstLedgerTxnEntry
 
     std::shared_ptr<Impl> getImpl();
     std::shared_ptr<Impl const> getImpl() const;
+
+    bool mIsInitialized;
 
   public:
     // ConstLedgerTxnEntry constructors do not throw


### PR DESCRIPTION
# Description

Resolves #2342. 

This PR is an alternative to #2850. It doesn't rely on `weak_ptr:: owner_before`.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
