### PR TITLE
Fix typo in LedgerTxn::getImpl error message

### DIFF
--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -233,7 +233,7 @@ LedgerTxn::getImpl() const
 {
     if (!mImpl)
     {
-        throw std::runtime_error("LedgerTxnEntry was handled");
+        throw std::runtime_error("LedgerTxn was handled");
     }
     return mImpl;
 }


### PR DESCRIPTION
# Description
Fixes a minor typo in an error message

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
