### PR TITLE
Reduce default fuzz-testing account balances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,8 @@ compile_commands.json
 # test output
 stellar-core-test-*
 test-partitions.*
-/fuzz-findings/
+fuzz-findings/
+min-testcases/
 /my-history/
 
 # Windows specific

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -779,6 +779,7 @@ TransactionFuzzer::xdrSizeLimit()
 void
 TransactionFuzzer::genFuzz(std::string const& filename)
 {
+    gRandomEngine.seed(std::random_device()());
     std::ofstream out;
     out.exceptions(std::ios::failbit | std::ios::badbit);
     out.open(filename, std::ofstream::binary | std::ofstream::trunc);


### PR DESCRIPTION
# Description

Part of #1376

- Reduce default account balances while fuzzing to try to reduce the space that the fuzzer needs to explore.
- Correspondingly, reduce fees and reserves.
- Log some debug information when setup transactions fail.
- Don't crash when _non_-setup transactions fail -- we expect (or at least, hope) that the fuzzer will find some invalid-but-interesting inputs.

I have not given much thought yet to what really good numbers would be; I just shrank them by "a lot" and added some symbolic constants to try to clarify where some numbers were coming from (as well as fixing a bug that would make the fuzzer think that it had found a crash whenever it submitted an invalid transaction, such as one with a "too early" timestamp).  So I'm not sure whether we should accept this as is before I think more about the numbers we _really_ want, or whether we should wait to merge until after I have.  But I'm creating a PR at least to invite commentary on the structural changes / bug fix, as well as any suggestions about how to zero in on what numbers we should choose.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
