### PR TITLE
Log content hash on txINTERNAL_ERROR

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -826,14 +826,19 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
     }
     catch (std::exception& e)
     {
-        CLOG_ERROR(Tx, "Exception while applying operations (txHash= {}): {}",
-                   xdr_to_string(getFullHash()), e.what());
+        CLOG_ERROR(Tx,
+                   "Exception while applying operations (fullHash= {}, "
+                   "contentsHash= {}): {}",
+                   xdr_to_string(getFullHash()),
+                   xdr_to_string(getContentsHash()), e.what());
     }
     catch (...)
     {
         CLOG_ERROR(Tx,
-                   "Unknown exception while applying operations (txHash= {})",
-                   xdr_to_string(getFullHash()));
+                   "Unknown exception while applying operations (fullHash= {}, "
+                   "contentsHash= {})",
+                   xdr_to_string(getFullHash()),
+                   xdr_to_string(getContentsHash()));
     }
     // This is only reachable if an exception is thrown
     getResult().result.code(txINTERNAL_ERROR);


### PR DESCRIPTION
# Description
Log content hash on `txINTERNAL_ERROR` to facilitate debugging with Horizon.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
