### PR TITLE
RunCommandWork: avoid modifying work's state after completion

### DIFF
--- a/src/historywork/RunCommandWork.cpp
+++ b/src/historywork/RunCommandWork.cpp
@@ -42,7 +42,7 @@ RunCommandWork::onRun()
                 std::static_pointer_cast<RunCommandWork>(shared_from_this()));
             exit->async_wait([weak](asio::error_code const& ec) {
                 auto self = weak.lock();
-                if (self)
+                if (self && !self->isDone())
                 {
                     self->mEc = ec;
                     self->mDone = true;


### PR DESCRIPTION
The issue came up during the review of process shutdown change: https://github.com/stellar/stellar-core/pull/2801#discussion_r524841404

Note that `basic_waitable_timer::async_wait` fires the callback regardless of whether the timer has expired or it has been cancelled, so we have to handle this case within the callback itself. 