### PR TITLE
Don't generate operation meta if an operation has already failed

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -758,11 +758,14 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             {
                 app.getInvariantManager().checkOnOperationApply(
                     op->getOperation(), op->getResult(), ltxOp.getDelta());
+
+                // The operation meta will be empty if the transaction doesn't
+                // succeed so we may as well not do any work in that case
+                newMeta.v2().operations.emplace_back(ltxOp.getChanges());
             }
 
             if (txRes || ledgerVersion < 14)
             {
-                newMeta.v2().operations.emplace_back(ltxOp.getChanges());
                 ltxOp.commit();
             }
         }


### PR DESCRIPTION
# Description
This is a slight optimization to the way we currently generate meta. I think the new version is also easier to understand. This originally caught my attention because I was wondering why we were generating meta differently prior to protocol version 14.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
