### PR TITLE
Use sort -R instead of shuf in run-selftest-pg

### DIFF
--- a/src/test/run-selftest-pg
+++ b/src/test/run-selftest-pg
@@ -65,7 +65,7 @@ runpg() {
 
     # pick a random utf locale if we can as to increase
     # detection of encoding issues
-    DB_LOC=`locale -a | grep -i utf | shuf | head -1`
+    DB_LOC=`locale -a | grep -i utf | sort -R | head -1`
     if [ -z "$DB_LOC" ] ; then DB_LOC="--no-locale" ; else DB_LOC="--locale=$DB_LOC" ; fi
 
     echo Creating temporary PostgreSQL database cluster in "$PGDATA" with $DB_LOC


### PR DESCRIPTION
# Description
`shuf` is not always available on Mac, but `sort -R` seems to be more universal.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
