### PR TITLE
Only truncate log on logrotate, not startup. Fixes #2868.

### DIFF
--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -80,7 +80,7 @@ convert_loglevel(LogLevel level)
 #endif
 
 void
-Logging::init()
+Logging::init(bool truncate)
 {
 #if defined(USE_SPDLOG)
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
@@ -105,7 +105,7 @@ Logging::init()
                 fmt::format(mLastFilenamePattern,
                             fmt::arg("datetime", fmt::localtime(time)));
             sinks.emplace_back(
-                make_shared<basic_file_sink_mt>(filename, /*truncate=*/true));
+                make_shared<basic_file_sink_mt>(filename, truncate));
         }
 
         auto makeLogger =
@@ -298,7 +298,7 @@ Logging::rotate()
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
     deinit();
-    init();
+    init(/*truncate=*/true);
 }
 
 // throws if partition name is not recognized

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -174,7 +174,7 @@ class Logging
 #endif
 
   public:
-    static void init();
+    static void init(bool truncate = false);
     static void deinit();
     static void setFmt(std::string const& peerID, bool timestamps = true);
     static void setLoggingToFile(std::string const& filename);


### PR DESCRIPTION
Resolves #2868 -- only truncate log file when we're rotating (as easylogging did) but not when starting up.
