### PR TITLE
Remove getDelta call after operations are applied

### DIFF
--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1850,6 +1850,34 @@ LedgerTxn::Impl::getWorstBestOfferIterator()
     return WorstBestOfferIterator(std::move(iterImpl));
 }
 
+bool
+LedgerTxn::hasSponsorshipEntry() const
+{
+    return getImpl()->hasSponsorshipEntry();
+}
+
+bool
+LedgerTxn::Impl::hasSponsorshipEntry() const
+{
+    throwIfNotExactConsistency();
+    throwIfChild();
+
+    for (auto const& kv : mEntry)
+    {
+        auto glk = kv.first;
+        switch (glk.type())
+        {
+        case InternalLedgerEntryType::SPONSORSHIP:
+        case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
+            return true;
+        default:
+            break;
+        }
+    }
+
+    return false;
+}
+
 #ifdef BUILD_TESTS
 UnorderedMap<AssetPair,
              std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -592,6 +592,11 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     // which can only be done after getDeadEntries and getLiveEntries have been
     // called.
     virtual void unsealHeader(std::function<void(LedgerHeader&)> f) = 0;
+
+    // returns true if mEntry has any record of a SPONSORSHIP or
+    // SPONSORSHIP_COUNTER entry type. Throws if the AbstractLedgerTxn has a
+    // child.
+    virtual bool hasSponsorshipEntry() const = 0;
 };
 
 class LedgerTxn final : public AbstractLedgerTxn
@@ -692,6 +697,8 @@ class LedgerTxn final : public AbstractLedgerTxn
     void dropClaimableBalances() override;
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
+
+    bool hasSponsorshipEntry() const override;
 
 #ifdef BUILD_TESTS
     UnorderedMap<

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -584,6 +584,9 @@ class LedgerTxn::Impl
 
     double getPrefetchHitRate() const;
 
+    // hasSponsorshipEntry has the strong exception safety guarantee
+    bool hasSponsorshipEntry() const;
+
 #ifdef BUILD_TESTS
     MultiOrderBook const& getOrderBook();
 #endif

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -786,22 +786,10 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                 newMeta.v2().txChangesAfter = ltxAfter.getChanges();
                 ltxAfter.commit();
             }
-            else if (ledgerVersion >= 14)
+            else if (ledgerVersion >= 14 && ltxTx.hasSponsorshipEntry())
             {
-                auto delta = ltxTx.getDelta();
-                for (auto const& kv : delta.entry)
-                {
-                    auto glk = kv.first;
-                    switch (glk.type())
-                    {
-                    case InternalLedgerEntryType::SPONSORSHIP:
-                    case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
-                        getResult().result.code(txBAD_SPONSORSHIP);
-                        return false;
-                    default:
-                        break;
-                    }
-                }
+                getResult().result.code(txBAD_SPONSORSHIP);
+                return false;
             }
 
             ltxTx.commit();


### PR DESCRIPTION
# Description

This PR adds a `HasSponsorshipEntry` method to use in place of the removed `getDelta` call.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
