### PR TITLE
Fix the rendering issues of some XDR fields

### DIFF
--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -257,11 +257,12 @@ ApplyCheckpointWork::onRun()
             {
                 auto& lm = mApp.getLedgerManager();
 
-                CLOG_DEBUG(History, "LedgerManager LCL:\n{}",
-                           xdr_to_string(lm.getLastClosedLedgerHeader()));
+                CLOG_DEBUG(History, "{}",
+                           xdr_to_string(lm.getLastClosedLedgerHeader(),
+                                         "LedgerManager LCL"));
 
-                CLOG_DEBUG(History, "Replay header:\n{}",
-                           xdr_to_string(mHeaderHistoryEntry));
+                CLOG_DEBUG(History, "{}",
+                           xdr_to_string(mHeaderHistoryEntry, "Replay header"));
                 if (lm.getLastClosedLedgerHeader().hash !=
                     mHeaderHistoryEntry.hash)
                 {

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -66,9 +66,9 @@ checkOperationResults(xdr::xvector<OperationResult> const& expected,
     {
         if (expected[i].code() != actual[i].code())
         {
-            CLOG_ERROR(History, "Expected operation result {} but got {}",
-                       xdr_to_string(expected[i].code()),
-                       xdr_to_string(actual[i].code()));
+            CLOG_ERROR(History, "Expected {} but got {}",
+                       xdr_to_string(expected[i].code(), "OperationResultCode"),
+                       xdr_to_string(actual[i].code(), "OperationResultCode"));
             continue;
         }
 
@@ -154,10 +154,10 @@ checkOperationResults(xdr::xvector<OperationResult> const& expected,
 
         if (!match)
         {
-            CLOG_ERROR(History, "Expected operation result: {}",
-                       xdr_to_string(expectedOpRes));
-            CLOG_ERROR(History, "Actual operation result: {}",
-                       xdr_to_string(actualOpRes));
+            CLOG_ERROR(History, "Expected {}",
+                       xdr_to_string(expectedOpRes, "OperationResult"));
+            CLOG_ERROR(History, "Actual {}",
+                       xdr_to_string(actualOpRes, "OperationResult"));
         }
     }
 }
@@ -179,9 +179,9 @@ checkResults(Application& app, uint32_t ledger,
         if (dbRes.code() != archiveRes.code())
         {
             CLOG_ERROR(
-                History,
-                "Expected result code {} does not agree with {} for tx {}",
-                xdr_to_string(archiveRes.code()), xdr_to_string(dbRes.code()),
+                History, "Expected {} does not agree with {} for tx {}",
+                xdr_to_string(archiveRes.code(), "TransactionResultCode"),
+                xdr_to_string(dbRes.code(), "TransactionResultCode"),
                 binToHex(results[i].transactionHash));
         }
         else if (dbRes.code() == txFEE_BUMP_INNER_FAILED ||
@@ -193,11 +193,13 @@ checkResults(Application& app, uint32_t ledger,
             {
                 CLOG_ERROR(
                     History,
-                    "Expected result code {} does not agree with {} for "
+                    "Expected {} does not agree with {} for "
                     "fee-bump inner tx {}",
                     xdr_to_string(
-                        archiveRes.innerResultPair().result.result.code()),
-                    xdr_to_string(dbRes.innerResultPair().result.result.code()),
+                        archiveRes.innerResultPair().result.result.code(),
+                        "TransactionResultCode"),
+                    xdr_to_string(dbRes.innerResultPair().result.result.code(),
+                                  "TransactionResultCode"),
                     binToHex(archiveRes.innerResultPair().transactionHash));
             }
             else if (dbRes.innerResultPair().result.result.code() == txFAILED ||

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -298,12 +298,13 @@ TxSetFrame::checkOrTrim(Application& app,
             {
                 if (justCheck)
                 {
-                    CLOG_DEBUG(Herder,
-                               "Got bad txSet: {} tx invalid lastSeq:{} tx: {} "
-                               "result: {}",
-                               hexAbbrev(mPreviousLedgerHash), lastSeq,
-                               xdr_to_string(tx->getEnvelope()),
-                               tx->getResultCode());
+                    CLOG_DEBUG(
+                        Herder,
+                        "Got bad txSet: {} tx invalid lastSeq:{} tx: {} "
+                        "result: {}",
+                        hexAbbrev(mPreviousLedgerHash), lastSeq,
+                        xdr_to_string(tx->getEnvelope(), "TransactionEnvelope"),
+                        tx->getResultCode());
                     return false;
                 }
                 trimmed.emplace_back(tx);
@@ -343,7 +344,8 @@ TxSetFrame::checkOrTrim(Application& app,
                     CLOG_DEBUG(Herder,
                                "Got bad txSet: {} account can't pay fee tx: {}",
                                hexAbbrev(mPreviousLedgerHash),
-                               xdr_to_string(tx->getEnvelope()));
+                               xdr_to_string(tx->getEnvelope(),
+                                             "TransactionEnvelope"));
                     return false;
                 }
                 while (iter != kv.second.end())

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -115,9 +115,10 @@ InvariantManagerImpl::checkOnOperationApply(Operation const& operation,
             continue;
         }
 
-        auto message = fmt::format(
-            R"(Invariant "{}" does not hold on operation: {}{}{})",
-            invariant->getName(), result, "\n", xdr_to_string(operation));
+        auto message =
+            fmt::format(R"(Invariant "{}" does not hold on operation: {}{}{})",
+                        invariant->getName(), result, "\n",
+                        xdr_to_string(operation, "Operation"));
         onInvariantFailure(invariant, message,
                            ltxDelta.header.current.ledgerSeq);
     }

--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -100,7 +100,7 @@ checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
                 {
                     return fmt::format(
                         "Liabilities increased on unauthorized trust line {}",
-                        xdr_to_string(trust));
+                        xdr_to_string(trust, "TrustLineEntry"));
                 }
             }
             else
@@ -110,7 +110,7 @@ checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
                 {
                     return fmt::format(
                         "Unauthorized trust line has liabilities {}",
-                        xdr_to_string(trust));
+                        xdr_to_string(trust, "TrustLineEntry"));
                 }
             }
         }
@@ -256,8 +256,8 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
                 (INT64_MAX - account.balance < liabilities.buying))
             {
                 return fmt::format(
-                    "Balance not compatible with liabilities for account {}",
-                    xdr_to_string(account));
+                    "Balance not compatible with liabilities for {}",
+                    xdr_to_string(account, "AccountEntry"));
             }
         }
     }
@@ -273,9 +273,8 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
         if ((trust.balance < liabilities.selling) ||
             (trust.limit - trust.balance < liabilities.buying))
         {
-            return fmt::format(
-                "Balance not compatible with liabilities for trustline {}",
-                xdr_to_string(trust));
+            return fmt::format("Balance not compatible with liabilities for {}",
+                               xdr_to_string(trust, "TrustLineEntry"));
         }
     }
     return {};
@@ -346,20 +345,20 @@ LiabilitiesMatchOffers::checkOnOperationApply(Operation const& operation,
                     return fmt::format(
                         "Change in buying liabilities differed from "
                         "change in total buying liabilities of "
-                        "offers by {} for account {} in asset {}",
+                        "offers by {} for {} in {}",
                         assetLiabilities.second.buying,
-                        xdr_to_string(accLiabilities.first),
-                        xdr_to_string(assetLiabilities.first));
+                        xdr_to_string(accLiabilities.first, "account"),
+                        xdr_to_string(assetLiabilities.first, "asset"));
                 }
                 else if (assetLiabilities.second.selling != 0)
                 {
                     return fmt::format(
                         "Change in selling liabilities differed from "
                         "change in total selling liabilities of "
-                        "offers by {} for account {} in asset {}",
+                        "offers by {} for {} in {}",
                         assetLiabilities.second.selling,
-                        xdr_to_string(accLiabilities.first),
-                        xdr_to_string(assetLiabilities.first));
+                        xdr_to_string(accLiabilities.first, "account"),
+                        xdr_to_string(assetLiabilities.first, "asset"));
                 }
             }
         }

--- a/src/ledger/InternalLedgerEntry.cpp
+++ b/src/ledger/InternalLedgerEntry.cpp
@@ -282,13 +282,16 @@ InternalLedgerKey::toString() const
     switch (mType)
     {
     case InternalLedgerEntryType::LEDGER_ENTRY:
-        return xdr_to_string(ledgerKey());
+        return xdr_to_string(ledgerKey(), "LedgerKey");
+
     case InternalLedgerEntryType::SPONSORSHIP:
-        return fmt::format("{{\n  sponsoredID = {}\n}}\n",
-                           xdr_to_string(sponsorshipKey().sponsoredID));
+        return fmt::format(
+            "{{\n  {}\n}}\n",
+            xdr_to_string(sponsorshipKey().sponsoredID, "sponsoredID"));
     case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
-        return fmt::format("{{\n  sponsoringID = {}\n}}\n",
-                           xdr_to_string(sponsorshipCounterKey().sponsoringID));
+        return fmt::format("{{\n  {}\n}}\n",
+                           xdr_to_string(sponsorshipCounterKey().sponsoringID,
+                                         "sponsoringID"));
     default:
         abort();
     }
@@ -558,16 +561,17 @@ InternalLedgerEntry::toString() const
     switch (mType)
     {
     case InternalLedgerEntryType::LEDGER_ENTRY:
-        return xdr_to_string(ledgerEntry());
+        return xdr_to_string(ledgerEntry(), "LedgerEntry");
     case InternalLedgerEntryType::SPONSORSHIP:
-        return fmt::format("{{\n  sponsoredID = {},\n  sponsoringID = {}\n}}\n",
-                           xdr_to_string(sponsorshipEntry().sponsoredID),
-                           xdr_to_string(sponsorshipEntry().sponsoringID));
-    case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
         return fmt::format(
-            "{{\n  sponsoringID = {},\n  numSponsoring = {}\n}}\n",
-            xdr_to_string(sponsorshipCounterEntry().sponsoringID),
-            sponsorshipCounterEntry().numSponsoring);
+            "{{\n  {},\n  {}\n}}\n",
+            xdr_to_string(sponsorshipEntry().sponsoredID, "sponsoredID"),
+            xdr_to_string(sponsorshipEntry().sponsoringID, "sponsoringID"));
+    case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
+        return fmt::format("{{\n  {},\n  numSponsoring = {}\n}}\n",
+                           xdr_to_string(sponsorshipCounterEntry().sponsoringID,
+                                         "sponsoringID"),
+                           sponsorshipCounterEntry().numSponsoring);
     default:
         abort();
     }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -555,8 +555,8 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
                                 txSet->previousLedgerHash()),
                    ledgerAbbrev(getLastClosedLedgerHeader()));
 
-        CLOG_ERROR(Ledger, "Full LCL: {}",
-                   xdr_to_string(getLastClosedLedgerHeader()));
+        CLOG_ERROR(Ledger, "{}",
+                   xdr_to_string(getLastClosedLedgerHeader(), "Full LCL"));
         CLOG_ERROR(Ledger, "{}", POSSIBLY_CORRUPTED_LOCAL_DATA);
 
         throw std::runtime_error("txset mismatch");
@@ -623,7 +623,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         case Upgrades::UpgradeValidity::INVALID:
             throw std::runtime_error(
                 fmt::format(FMT_STRING("Invalid upgrade at index {}: {}"), i,
-                            xdr_to_string(lupgrade)));
+                            xdr_to_string(lupgrade, "LedgerUpgrade")));
         }
 
         try

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -951,7 +951,8 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
         root["status"] = TX_STATUS_STRING[static_cast<int>(status)];
         if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {
-            root["detail"] = xdr_to_string(txFrame->getResult().result.code());
+            root["detail"] = xdr_to_string(txFrame->getResult().result.code(),
+                                           "TransactionResultCode");
         }
     }
     else

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -647,8 +647,8 @@ LoadGenerator::TxInfo::execute(Application& app, bool isCreate,
     {
         CLOG_INFO(LoadGen, "tx rejected '{}': {} ===> {}",
                   TX_STATUS_STRING[static_cast<int>(status)],
-                  xdr_to_string(txf->getEnvelope()),
-                  xdr_to_string(txf->getResult()));
+                  xdr_to_string(txf->getEnvelope(), "TransactionEnvelope"),
+                  xdr_to_string(txf->getResult(), "TransactionResult"));
         if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {
             code = txf->getResultCode();

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -789,11 +789,11 @@ applySetupOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
 
         if (txFramePtr->getResultCode() != txSUCCESS)
         {
-            auto const msg =
-                fmt::format(FMT_STRING("Error {} while setting up fuzzing -- "
-                                       "transaction result {}"),
-                            txFramePtr->getResultCode(),
-                            xdr_to_string(txFramePtr->getResult()));
+            auto const msg = fmt::format(
+                FMT_STRING("Error {} while setting up fuzzing -- "
+                           "{}"),
+                txFramePtr->getResultCode(),
+                xdr_to_string(txFramePtr->getResult(), "TransactionResult"));
             LOG_FATAL(DEFAULT_LOG, "{}", msg);
             throw std::runtime_error(msg);
         }
@@ -816,8 +816,9 @@ applySetupOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
             {
                 auto const msg = fmt::format(
                     FMT_STRING("Manage offer result {} while setting "
-                               "up fuzzing -- operation is {}"),
-                    xdr_to_string(tr), xdr_to_string(op));
+                               "up fuzzing -- {}"),
+                    xdr_to_string(tr, "Operation"),
+                    xdr_to_string(op, "Operation"));
                 LOG_FATAL(DEFAULT_LOG, "{}", msg);
                 throw std::runtime_error(msg);
             }
@@ -1280,7 +1281,9 @@ TransactionFuzzer::inject(std::string const& filename)
     }
 
     resetTxInternalState(*mApp);
-    LOG_TRACE(DEFAULT_LOG, "Fuzz ops ({}): {}", ops.size(), xdr_to_string(ops));
+    LOG_TRACE(DEFAULT_LOG, "{}",
+              xdr_to_string(ops, fmt::format("Fuzz ops ({})", ops.size())));
+
     LedgerTxn ltx(mApp->getLedgerTxnRoot());
     applyFuzzOperations(ltx, mSourceAccountID, ops.begin(), ops.end(), *mApp);
 }

--- a/src/test/TestPrinter.cpp
+++ b/src/test/TestPrinter.cpp
@@ -13,11 +13,12 @@ namespace Catch
 std::string
 StringMaker<stellar::OfferState>::convert(stellar::OfferState const& os)
 {
-    return fmt::format(
-        "selling: {}, buying: {}, price: {}, amount: {}, type: {}",
-        xdr_to_string(os.selling), xdr_to_string(os.buying),
-        xdr_to_string(os.price), os.amount,
-        os.type == stellar::OfferType::PASSIVE ? "passive" : "active");
+    return fmt::format("{}, {}, {}, amount: {}, type: {}",
+                       xdr_to_string(os.selling, "selling"),
+                       xdr_to_string(os.buying, "buying"),
+                       xdr_to_string(os.price, "price"), os.amount,
+                       os.type == stellar::OfferType::PASSIVE ? "passive"
+                                                              : "active");
 }
 
 std::string

--- a/src/test/TestPrinter.h
+++ b/src/test/TestPrinter.h
@@ -23,7 +23,7 @@ struct StringMaker<T, typename std::enable_if<xdr::xdr_traits<T>::valid>::type>
     static std::string
     convert(T const& val)
     {
-        return xdr_to_string(val);
+        return xdr_to_string(val, "value");
     }
 };
 

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -122,7 +122,7 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
     bool res;
     if (Logging::logTrace("Tx"))
     {
-        CLOG_TRACE(Tx, "Operation: {}", xdr_to_string(mOperation));
+        CLOG_TRACE(Tx, "{}", xdr_to_string(mOperation, "Operation"));
     }
     res = checkValid(signatureChecker, ltx, true);
     if (res)
@@ -130,7 +130,7 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
         res = doApply(ltx);
         if (Logging::logTrace("Tx"))
         {
-            CLOG_TRACE(Tx, "Operation result: {}", xdr_to_string(mResult));
+            CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
         }
     }
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -817,19 +817,15 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
     }
     catch (std::exception& e)
     {
-        CLOG_ERROR(Tx,
-                   "Exception while applying operations (fullHash= {}, "
-                   "contentsHash= {}): {}",
-                   xdr_to_string(getFullHash()),
-                   xdr_to_string(getContentsHash()), e.what());
+        CLOG_ERROR(Tx, "Exception while applying operations ({}, {}): {}",
+                   xdr_to_string(getFullHash(), "fullHash"),
+                   xdr_to_string(getContentsHash(), "contentsHash"), e.what());
     }
     catch (...)
     {
-        CLOG_ERROR(Tx,
-                   "Unknown exception while applying operations (fullHash= {}, "
-                   "contentsHash= {})",
-                   xdr_to_string(getFullHash()),
-                   xdr_to_string(getContentsHash()));
+        CLOG_ERROR(Tx, "Unknown exception while applying operations ({}, {})",
+                   xdr_to_string(getFullHash(), "fullHash"),
+                   xdr_to_string(getContentsHash(), "contentsHash"));
     }
     // This is only reachable if an exception is thrown
     getResult().result.code(txINTERNAL_ERROR);

--- a/src/util/XDRCereal.cpp
+++ b/src/util/XDRCereal.cpp
@@ -37,8 +37,19 @@ cereal_override(cereal::JSONOutputArchive& ar,
 }
 
 void
-cereal_override(cereal::JSONOutputArchive& ar, const stellar::Asset& s,
-                const char* field)
+cereal_override(cereal::JSONOutputArchive& ar, stellar::Asset const& asset,
+                char const* field)
 {
-    xdr::archive(ar, stellar::assetToString(s), field);
+    if (asset.type() == stellar::ASSET_TYPE_NATIVE)
+    {
+        xdr::archive(ar, std::string("NATIVE"), field);
+    }
+    else
+    {
+        ar.setNextName(field);
+        ar.startNode();
+        xdr::archive(ar, stellar::assetToString(asset), "assetCode");
+        xdr::archive(ar, stellar::getIssuer(asset), "issuer");
+        ar.finishNode();
+    }
 }

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -132,7 +132,7 @@ xdr_to_string(const T& t, std::string const& name, bool compact = false)
         cereal::JSONOutputArchive ar(
             os, compact ? cereal::JSONOutputArchive::Options::NoIndent()
                         : cereal::JSONOutputArchive::Options::Default());
-        ar(cereal::make_nvp(name, t));
+        xdr::archive(ar, t, name.c_str());
     }
     return os.str();
 }

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -119,11 +119,10 @@ cereal_override(cereal::JSONOutputArchive& ar, const xdr::pointer<T>& t,
 // during the enable_if call in the cereal adaptor fails to find them.
 #include <xdrpp/cereal.h>
 
-// If name is a nonempty string, the output string begins with it.
 // If compact = true, the output string will not contain any indentation.
 template <typename T>
 std::string
-xdr_to_string(const T& t, std::string const& name = "", bool compact = false)
+xdr_to_string(const T& t, std::string const& name, bool compact = false)
 {
     std::stringstream os;
 
@@ -133,14 +132,7 @@ xdr_to_string(const T& t, std::string const& name = "", bool compact = false)
         cereal::JSONOutputArchive ar(
             os, compact ? cereal::JSONOutputArchive::Options::NoIndent()
                         : cereal::JSONOutputArchive::Options::Default());
-        if (!name.empty())
-        {
-            ar(cereal::make_nvp(name, t));
-        }
-        else
-        {
-            ar(t);
-        }
+        ar(cereal::make_nvp(name, t));
     }
     return os.str();
 }

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -34,21 +34,36 @@ cereal_override(cereal::JSONOutputArchive& ar, const xdr::opaque_array<N>& s,
                  field);
 }
 
-// We still need one explicit composite-container override because cereal
-// appears to process arrays-of-arrays internally, without calling back through
-// an NVP adaptor.
-template <uint32_t N>
-void
-cereal_override(cereal::JSONOutputArchive& ar,
-                const xdr::xarray<stellar::Hash, N>& s, const char* field)
+template <typename T>
+std::enable_if_t<xdr::xdr_traits<T>::is_container>
+cereal_override(cereal::JSONOutputArchive& ar, T const& t, const char* field)
 {
-    std::vector<std::string> tmp;
-    for (auto const& h : s)
+    // CEREAL_SAVE_FUNCTION_NAME in include/cereal/archives/json.hpp runs
+    // ar.setNextName() and ar(). ar() in turns calls process() in
+    // include/cereal/cereal.hpp which calls prologue(), processImpl(),
+    // epilogue(). We are imitating this behavior here by creating a sub-object
+    // using prologue(), printing the content with xdr::archive, and finally
+    // calling epilogue(). We must use xdr::archive instead of ar() because we
+    // need to access the nested cereal_overrides.
+    //
+    // tl;dr This does what ar(cereal::make_nvp(...)) does while using nested
+    // cereal_overrides.
+    ar.setNextName(field);
+    cereal::prologue(ar, t);
+
+    // It does not matter what value we pass here to cereal::make_size_tag
+    // since it will be ignored. See the comment
+    //
+    // > SizeTags are strictly ignored for JSON, they just indicate
+    // > that the current node should be made into an array
+    //
+    // in include/cereal/archives/json.hpp
+    ar(cereal::make_size_tag(0));
+    for (auto const& element : t)
     {
-        tmp.emplace_back(
-            stellar::binToHex(stellar::ByteSlice(h.data(), h.size())));
+        xdr::archive(ar, element);
     }
-    xdr::archive(ar, tmp, field);
+    cereal::epilogue(ar, t);
 }
 
 template <uint32_t N>


### PR DESCRIPTION
# Description

Resolves #2869

- The "value0" issue. This seems like a feature rather than a bug (for instance, see this [cereal issue](https://github.com/USCiLab/cereal/issues/303) ) Long story short, it's there to support multi-entry outputs such as  
```
{          
    "value0": {
        "x": 1,
        "y": 2,
        "z": 3
    },    
    "value1": {           
        "x": 4,                
        "y": 5,
        "z": 6
    },
    "value2": {
        "x": 7,
        "y": 8,
        "z": 9
    }
}
```
- `xdr_to_string` has an optional field name argument. When that's not passed, Cereal uses the word "value0". This PR will make the argument mandatory, so we will print a descriptive name given by a caller, instead of "value0". We already use this in multiple places, and this PR updates the usage of `xdr_to_string` when the field name argument is not passed.
- I used the following XDR to make sure that the asset list is rendered correctly. With this PR, the XDR will be rendered as following:

```
...                             "destAsset": "XLM",
                                "destAmount": 2000000000,
                                "path": [
                                    "CENTUS",
                                    "USD"
                                ]
...
```
instead of
```
...
                                "path": [
                                    {
                                        "type": "ASSET_TYPE_CREDIT_ALPHANUM12",
                                        "alphaNum12": {
                                            "assetCode": "43454e545553000000000000",
                                            "issuer": "GCD5VCGHNLC46D5O2SAZCFFP3ZF7JRBQZGSFINXWNY5HCEOE42PH3XH5"
                                        }
                                    },
                                    {
                                        "type": "ASSET_TYPE_CREDIT_ALPHANUM4",
                                        "alphaNum4": {
                                            "assetCode": "55534400",
                                            "issuer": "GDJAG52BJUFI6RBKFTNUEJBDZODJPZBLIHN3SXMR7QIXNRAOJK3XL6P3"
                                        }
                                    }
                                ]
...
```

`AAAAAgAAAACJCjEa69Jmm5xInlCSLmzEAf8u1q/AeXUbhoZQFHOsoQAAAGQAAAAcvpkaFAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAQAAABx0aGlzIGlzIGEgbWVtbyBmb3IgZGVidWdnaW5nAAAAAQAAAAAAAAACAAAAAAAAAAA7msoAAAAAANhWYalldqwqmK2G0p/IIaS+64sMI9nfPeBe5RlS2NDCAAAAAAAAAAB3NZQAAAAAAgAAAAJDRU5UVVMAAAAAAAAAAAAAh9qIx2rFzw+u1IGRFK/eS/TEMMmkVDb2bjpxEcTmnn0AAAABVVNEAAAAAADSA3dBTQqPRCos20IkI8uGl+QrQdu5XZH8EXbEDkq3dQAAAAAAAAAA`



# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
