### PR TITLE
Bug 2874 flaky bucketlist invariant test

### DIFF
--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -133,6 +133,9 @@ void clearVerifySigCache();
 void flushVerifySigCacheCounts(uint64_t& hits, uint64_t& misses);
 
 PublicKey random();
+#ifdef BUILD_TESTS
+PublicKey pseudoRandomForTesting();
+#endif
 }
 
 namespace StrKeyUtils
@@ -145,6 +148,9 @@ void logKey(std::ostream& s, std::string const& key);
 namespace HashUtils
 {
 Hash random();
+#ifdef BUILD_TESTS
+Hash pseudoRandomForTesting();
+#endif
 }
 }
 

--- a/src/crypto/ShortHash.h
+++ b/src/crypto/ShortHash.h
@@ -17,6 +17,9 @@ namespace stellar
 namespace shortHash
 {
 void initialize();
+#ifdef BUILD_TESTS
+void seed(unsigned int);
+#endif
 uint64_t computeHash(stellar::ByteSlice const& b);
 
 struct XDRShortHasher : XDRHasher<XDRShortHasher>

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -674,6 +674,12 @@ TEST_CASE("BucketListIsConsistentWithDatabase bucket bounds",
             }
             return entries;
         }
+
+        virtual std::vector<LedgerKey>
+        generateDeadEntries(AbstractLedgerTxn& ltx)
+        {
+            return {};
+        }
     };
 
     for (uint32_t level = 0; level < BucketList::kNumLevels; ++level)

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -109,7 +109,7 @@ makeValid(AccountEntry& a)
 
     if (a.inflationDest)
     {
-        *a.inflationDest = PubKeyUtils::random();
+        *a.inflationDest = PubKeyUtils::pseudoRandomForTesting();
     }
 
     std::sort(
@@ -262,7 +262,8 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
                 lh.header.ledgerVersion += 1;
                 break;
             case HistoryManager::VERIFY_STATUS_ERR_BAD_HASH:
-                lh.header.previousLedgerHash = HashUtils::random();
+                lh.header.previousLedgerHash =
+                    HashUtils::pseudoRandomForTesting();
                 break;
             case HistoryManager::VERIFY_STATUS_ERR_UNDERSHOT:
                 lh.header.ledgerSeq -= 1;
@@ -278,7 +279,7 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
         if (i == randomIndex &&
             state == HistoryManager::VERIFY_STATUS_ERR_BAD_HASH && rand_flip())
         {
-            lh.hash = HashUtils::random();
+            lh.hash = HashUtils::pseudoRandomForTesting();
         }
         else
         {

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -56,6 +56,7 @@ struct ReseedPRNGListener : Catch::TestEventListenerBase
     {
         srand(sCommandLineSeed);
         gRandomEngine.seed(sCommandLineSeed);
+        shortHash::seed(sCommandLineSeed);
         Catch::rng().seed(sCommandLineSeed);
         autocheck::rng().seed(sCommandLineSeed);
     }


### PR DESCRIPTION
# Description

Resolves #2874

There are two things going on in 2874, this PR fixes both of them (and does a little auxiliary improvement along the way):

First: the (sometimes) failing test checks that an invariant detects a type of malformed `LIVEENTRY` the test generates and applies from a bucket; but this invariant did not _always_ detect that type of `LIVEENTRY` because _sometimes_ (due to some nondeterminism) the test would also produce a `DEADENTRY` that annihilated the malformed `LIVEENTRY` during a merge before it was detected by the invariant. So the main fix is the last commit, to just "not make `DEADENTRY`s in the test anymore". This causes the `LIVEENTRY`s to always make it through to the point where they're detected by the test, so the test will always pass.

Second: the test was failing _nondeterministically_ because it stored live and dead `LedgerKey`s in a hashtable (and decided which entries to kill by selecting entries by hashtable order) and the _entire infrastructure_ of hashing using `shortHash::*` was just .. always nondeterministic: it had never been retrofit to key its hash with seeded-pseudorandom data  during tests, at all. So this change fixes that: the key material used in `shortHash` is now seeded along with all the other seedable PRNGs from the test seed, when testing. This is the middle commit.

Finally: a few other sources of nondeterminism-in-testing-that-should-be-deterministic were fixed while investigating. This is the first commit, and while it doesn't change the determinism of the test passing or failing, it does change its output at high trace levels (and the contents of buckets). So I included it as cleanup.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
