### PR TITLE
Add the command to simplify the master graph in OverlaySurvey.py

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,9 @@ This folder is for storing any scripts that may be helpful for using stellar-cor
     - sub command `augment` - analyze an existing graph
         - `-gmli GRAPHMLINPUT` - input graphml file
         - `-gmlo GRAPHMLOUTPUT` - output graphml file
+    - sub command `flatten` - Take a graphml file containing a bidrectional graph (possibly augmented with StellarBeat data) and flatten it into an undirected graph in JSON.
+        - `-gmli GRAPHMLINPUT` - input graphml file
+        - `-json JSONOUTPUT` - output json file
 
 ## Style guide
 We follow [PEP-0008](https://www.python.org/dev/peps/pep-0008/).


### PR DESCRIPTION
# Description

The `simplify` command takes the "master" graph with all the information, and simplifies it and outputs it in a JSON file.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
