### PR TITLE
Clawback - Change AssetCode parameter to Asset

### DIFF
--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -456,20 +456,6 @@ TestAccount::pathPaymentStrictSend(PublicKey const& destination,
 void
 TestAccount::clawback(PublicKey const& from, Asset const& asset, int64_t amount)
 {
-    REQUIRE(asset.type() != ASSET_TYPE_NATIVE);
-
-    AssetCode assetCode;
-    if (asset.type() == ASSET_TYPE_CREDIT_ALPHANUM4)
-    {
-        assetCode.type(ASSET_TYPE_CREDIT_ALPHANUM4);
-        assetCode.assetCode4() = asset.alphaNum4().assetCode;
-    }
-    else if (asset.type() == ASSET_TYPE_CREDIT_ALPHANUM12)
-    {
-        assetCode.type(ASSET_TYPE_CREDIT_ALPHANUM12);
-        assetCode.assetCode12() = asset.alphaNum12().assetCode;
-    }
-
-    applyTx(tx({txtest::clawback(from, assetCode, amount)}), mApp);
+    applyTx(tx({txtest::clawback(from, asset, amount)}), mApp);
 }
 };

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -1191,13 +1191,13 @@ revokeSponsorship(AccountID const& accID, SignerKey const& key)
 }
 
 Operation
-clawback(AccountID const& from, AssetCode const& assetCode, int64_t amount)
+clawback(AccountID const& from, Asset const& asset, int64_t amount)
 {
     Operation op;
     op.body.type(CLAWBACK);
     op.body.clawbackOp().from = toMuxedAccount(from);
     op.body.clawbackOp().amount = amount;
-    op.body.clawbackOp().asset = assetCode;
+    op.body.clawbackOp().asset = asset;
 
     return op;
 }

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -196,8 +196,7 @@ Operation endSponsoringFutureReserves();
 Operation revokeSponsorship(LedgerKey const& key);
 Operation revokeSponsorship(AccountID const& accID, SignerKey const& key);
 
-Operation clawback(AccountID const& from, AssetCode const& assetCode,
-                   int64_t amount);
+Operation clawback(AccountID const& from, Asset const& asset, int64_t amount);
 
 Asset makeNativeAsset();
 Asset makeInvalidAsset();

--- a/src/transactions/ClawbackOpFrame.h
+++ b/src/transactions/ClawbackOpFrame.h
@@ -20,7 +20,6 @@ class ClawbackOpFrame : public OperationFrame
     }
 
     ClawbackOp const& mClawback;
-    Asset const mAsset;
 
   public:
     ClawbackOpFrame(Operation const& op, OperationResult& res,

--- a/src/transactions/test/ClawbackTests.cpp
+++ b/src/transactions/test/ClawbackTests.cpp
@@ -165,6 +165,14 @@ TEST_CASE("clawback", "[tx][clawback]")
                         REQUIRE_THROWS_AS(gateway.clawback(a1, asset, 75),
                                           ex_CLAWBACK_MALFORMED);
                     }
+
+                    // native asset
+                    REQUIRE_THROWS_AS(gateway.clawback(a1, native, 75),
+                                      ex_CLAWBACK_MALFORMED);
+
+                    // source account is not the issuer
+                    REQUIRE_THROWS_AS(a1.clawback(gateway, idr, 75),
+                                      ex_CLAWBACK_MALFORMED);
                 }
                 SECTION("apply")
                 {

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -373,7 +373,7 @@ case REVOKE_SPONSORSHIP_SIGNER:
 */
 struct ClawbackOp
 {
-    AssetCode asset;
+    Asset asset;
     MuxedAccount from;
     int64 amount;
 };


### PR DESCRIPTION
# Description

This PR changes the type of the `asset` parameter for the `ClawbackOp` from `AssetCode` to `Asset`. This reflects the updates specified under https://github.com/stellar/stellar-protocol/blob/master/core/cap-0035.md#xdr-changes. 

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
