### PR TITLE
Special-case `LedgerKey` when fuzzing

### DIFF
--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -106,6 +106,19 @@ it might be partly hidden depending on the color scheme of your terminal, as it
 makes use of bold color highlighting. There are a lot of [interesting statistics][12]
 displayed here.
 
+When evaluating changes or posting a PR, include screenshots of the TUI
+after similar runtimes from before and after the changes.  We've seen
+~15% variability in metrics such as "total paths" after 10 minutes, so
+you should choose a time significantly longer than that.  The [user guide][13]
+documents interpretation of the many metrics.  At a minimum, we're interested
+in:
+
+- Exec speed
+- Total paths
+- Stability
+- Whether the TUI displays any metrics in red (indicating values it considers
+undesirable)
+
 While it runs, it will write new crashes to files in `fuzz-findings`; before
 pouncing on these as definite evidence of a flaw, you should confirm the crash
 by feeding it to an instance of `stellar-core fuzz` run by hand, elsewhere (in
@@ -183,4 +196,5 @@ part of staging-tests", here are some directions I think we should take fuzzing:
 [10]: https://github.com/trailofbits/deepstate
 [11]: https://llvm.org/docs/LibFuzzer.html
 [12]: https://github.com/google/AFL/blob/master/docs/status_screen.txt
+[13]: https://afl-1.readthedocs.io/en/latest/user_guide.html
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1412,19 +1412,25 @@ fuzzerModeParser(std::string& fuzzerModeArg, FuzzerMode& fuzzerMode)
 int
 runFuzz(CommandLineArgs const& args)
 {
-    LogLevel logLevel{LogLevel::LVL_INFO};
+    LogLevel logLevel{LogLevel::LVL_FATAL};
     std::vector<std::string> metrics;
     std::string fileName;
+    std::string outputFile;
     int processID = 0;
     FuzzerMode fuzzerMode{FuzzerMode::OVERLAY};
     std::string fuzzerModeArg = "overlay";
 
     return runWithHelp(args,
                        {logLevelParser(logLevel), metricsParser(metrics),
-                        fileNameParser(fileName), processIDParser(processID),
+                        fileNameParser(fileName), outputFileParser(outputFile),
+                        processIDParser(processID),
                         fuzzerModeParser(fuzzerModeArg, fuzzerMode)},
                        [&] {
                            Logging::setLogLevel(logLevel, nullptr);
+                           if (!outputFile.empty())
+                           {
+                               Logging::setLoggingToFile(outputFile);
+                           }
 
                            fuzz(fileName, metrics, processID, fuzzerMode);
                            return 0;
@@ -1434,15 +1440,25 @@ runFuzz(CommandLineArgs const& args)
 int
 runGenFuzz(CommandLineArgs const& args)
 {
+    LogLevel logLevel{LogLevel::LVL_FATAL};
     std::string fileName;
+    std::string outputFile;
     FuzzerMode fuzzerMode{FuzzerMode::OVERLAY};
     std::string fuzzerModeArg = "overlay";
     int processID = 0;
 
     return runWithHelp(
         args,
-        {fileNameParser(fileName), fuzzerModeParser(fuzzerModeArg, fuzzerMode)},
+        {logLevelParser(logLevel), fileNameParser(fileName),
+         outputFileParser(outputFile),
+         fuzzerModeParser(fuzzerModeArg, fuzzerMode)},
         [&] {
+            Logging::setLogLevel(logLevel, nullptr);
+            if (!outputFile.empty())
+            {
+                Logging::setLoggingToFile(outputFile);
+            }
+
             FuzzUtils::createFuzzer(processID, fuzzerMode)->genFuzz(fileName);
             return 0;
         });

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -78,6 +78,13 @@ makeAsset(int i)
     setShortKey(asset.alphaNum4().issuer, i);
     return asset;
 }
+
+SequenceNumber
+getSequenceNumber(AbstractLedgerTxn& ltx, PublicKey const& sourceAccountID)
+{
+    auto account = loadAccount(ltx, sourceAccountID);
+    return account.current().data.account().seqNum;
+}
 }
 }
 
@@ -451,8 +458,8 @@ class FuzzTransactionFrame : public TransactionFrame
         // reset results of operations
         resetResults(ltx.getHeader(), 0, true);
 
-        // attempt application of transaction without accounting for sequence
-        // number, processing the fee, or committing the LedgerTxn
+        // attempt application of transaction without processing the fee or
+        // committing the LedgerTxn
         SignatureChecker signatureChecker{
             ltx.loadHeader().current().ledgerVersion, getContentsHash(),
             mEnvelope.v1().signatures};
@@ -469,6 +476,7 @@ class FuzzTransactionFrame : public TransactionFrame
         // protocols < 8, this triggered buggy caching, and potentially may do
         // so in the future
         loadSourceAccount(ltx, ltx.loadHeader());
+        processSeqNum(ltx);
         TransactionMeta tm(2);
         applyOperations(signatureChecker, app, ltx, tm);
         if (getResultCode() == txINTERNAL_ERROR)
@@ -479,7 +487,8 @@ class FuzzTransactionFrame : public TransactionFrame
 };
 
 std::shared_ptr<FuzzTransactionFrame>
-createFuzzTransactionFrame(PublicKey const& sourceAccountID,
+createFuzzTransactionFrame(AbstractLedgerTxn& ltx,
+                           PublicKey const& sourceAccountID,
                            std::vector<Operation>::const_iterator begin,
                            std::vector<Operation>::const_iterator end,
                            Hash const& networkID)
@@ -492,7 +501,7 @@ createFuzzTransactionFrame(PublicKey const& sourceAccountID,
     auto& tx1 = txEnv.v1();
     tx1.tx.sourceAccount = toMuxedAccount(sourceAccountID);
     tx1.tx.fee = 0;
-    tx1.tx.seqNum = 1;
+    tx1.tx.seqNum = FuzzUtils::getSequenceNumber(ltx, sourceAccountID) + 1;
     std::copy(begin, end, std::back_inserter(tx1.tx.operations));
 
     std::shared_ptr<FuzzTransactionFrame> res =
@@ -528,7 +537,7 @@ attemptToApplyOps(LedgerTxn& ltx, PublicKey const& sourceAccount,
                                   ? end
                                   : begin + MAX_OPS_PER_TX;
         auto txFramePtr = createFuzzTransactionFrame(
-            sourceAccount, begin, endOpsInThisTx, app.getNetworkID());
+            ltx, sourceAccount, begin, endOpsInThisTx, app.getNetworkID());
         txFramePtr->attemptApplication(app, ltx);
         begin = endOpsInThisTx;
 

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -714,6 +714,7 @@ class FuzzTransactionFrame : public TransactionFrame
         if (std::any_of(mOperations.begin(), mOperations.end(),
                         isInvalidOperation))
         {
+            markResultFailed();
             return;
         }
         // while the following method's result is not captured, regardless, for

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -793,6 +793,20 @@ TransactionFuzzer::initialize()
                     distributeOp.sourceAccount.activate() =
                         toMuxedAccount(issuer);
                     ops.emplace_back(distributeOp);
+
+                    // Create a claimable balance representing the "send" part
+                    // of a payment like the above distribution.
+                    ClaimPredicate predicate;
+                    predicate.type(CLAIM_PREDICATE_UNCONDITIONAL);
+                    Claimant claimant;
+                    claimant.v0().predicate = predicate;
+                    claimant.v0().destination = account;
+                    auto claimableBalanceOp = txtest::createClaimableBalance(
+                        asset, FuzzUtils::INITIAL_ASSET_DISTRIBUTION,
+                        {claimant});
+                    claimableBalanceOp.sourceAccount.activate() =
+                        toMuxedAccount(issuer);
+                    ops.emplace_back(claimableBalanceOp);
                 }
             }
         }

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1030,7 +1030,7 @@ TransactionFuzzer::initialize()
             }
         }
 
-        applySetupOperations(ltx, root.getPublicKey(), ops.begin(), ops.end(),
+        applySetupOperations(ltx, mSourceAccountID, ops.begin(), ops.end(),
                              *mApp);
 
         ltx.commit();

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -479,7 +479,7 @@ class FuzzTransactionFrame : public TransactionFrame
 };
 
 std::shared_ptr<FuzzTransactionFrame>
-createFuzzTransactionFrame(PublicKey sourceAccountID,
+createFuzzTransactionFrame(PublicKey const& sourceAccountID,
                            std::vector<Operation>::const_iterator begin,
                            std::vector<Operation>::const_iterator end,
                            Hash const& networkID)

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -668,17 +668,17 @@ getFuzzConfig(int instanceNumber)
 }
 
 static void
-resetRandomSeed()
+resetRandomSeed(unsigned int seed)
 {
     // seed randomness
-    srand(1);
-    gRandomEngine.seed(1);
+    srand(seed);
+    gRandomEngine.seed(seed);
 }
 
 static void
 resetTxInternalState(Application& app)
 {
-    resetRandomSeed();
+    resetRandomSeed(1);
 // reset caches to clear persistent state
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     app.getLedgerTxnRoot().resetForFuzzer();
@@ -979,7 +979,7 @@ std::array<OfferParameters, 28> constexpr orderBookParameters{
 void
 TransactionFuzzer::initialize()
 {
-    resetRandomSeed();
+    resetRandomSeed(1);
     mApp = createTestApplication(mClock, getFuzzConfig(0));
     auto root = TestAccount::createRoot(*mApp);
     mSourceAccountID = root.getPublicKey();
@@ -1295,7 +1295,7 @@ TransactionFuzzer::xdrSizeLimit()
 void
 TransactionFuzzer::genFuzz(std::string const& filename)
 {
-    gRandomEngine.seed(std::random_device()());
+    resetRandomSeed(std::random_device()());
     std::ofstream out;
     out.exceptions(std::ios::failbit | std::ios::badbit);
     out.open(filename, std::ofstream::binary | std::ofstream::trunc);
@@ -1329,7 +1329,7 @@ OverlayFuzzer::shutdown()
 void
 OverlayFuzzer::initialize()
 {
-    resetRandomSeed();
+    resetRandomSeed(1);
     stellar::FuzzUtils::generateStoredLedgerKeys(mStoredLedgerKeys.begin(),
                                                  mStoredLedgerKeys.end());
     auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
@@ -1435,6 +1435,7 @@ OverlayFuzzer::xdrSizeLimit()
 void
 OverlayFuzzer::genFuzz(std::string const& filename)
 {
+    resetRandomSeed(std::random_device()());
     std::ofstream out;
     out.exceptions(std::ios::failbit | std::ios::badbit);
     out.open(filename, std::ofstream::binary | std::ofstream::trunc);

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -805,19 +805,19 @@ applySetupOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
             auto const opType = op.body.type();
 
             if ((opType == MANAGE_BUY_OFFER &&
-                 tr.manageBuyOfferResult().success().offer.effect() ==
-                     MANAGE_OFFER_DELETED) ||
+                 tr.manageBuyOfferResult().success().offer.effect() !=
+                     MANAGE_OFFER_CREATED) ||
                 (opType == MANAGE_SELL_OFFER &&
-                 tr.manageSellOfferResult().success().offer.effect() ==
-                     MANAGE_OFFER_DELETED) ||
+                 tr.manageSellOfferResult().success().offer.effect() !=
+                     MANAGE_OFFER_CREATED) ||
                 (opType == CREATE_PASSIVE_SELL_OFFER &&
-                 tr.createPassiveSellOfferResult().success().offer.effect() ==
-                     MANAGE_OFFER_DELETED))
+                 tr.createPassiveSellOfferResult().success().offer.effect() !=
+                     MANAGE_OFFER_CREATED))
             {
-                auto const msg =
-                    fmt::format(FMT_STRING("MANAGE_OFFER_DELETED while setting "
-                                           "up fuzzing -- operation is {}"),
-                                xdr_to_string(op));
+                auto const msg = fmt::format(
+                    FMT_STRING("Manage offer result {} while setting "
+                               "up fuzzing -- operation is {}"),
+                    xdr_to_string(tr), xdr_to_string(op));
                 LOG_FATAL(DEFAULT_LOG, "{}", msg);
                 throw std::runtime_error(msg);
             }

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -708,11 +708,11 @@ class FuzzTransactionFrame : public TransactionFrame
             ltx.loadHeader().current().ledgerVersion, getContentsHash(),
             mEnvelope.v1().signatures};
         // if any ill-formed Operations, do not attempt transaction application
-        auto isInvalidOperationXDR = [&](auto const& op) {
+        auto isInvalidOperation = [&](auto const& op) {
             return !op->checkValid(signatureChecker, ltx, false);
         };
         if (std::any_of(mOperations.begin(), mOperations.end(),
-                        isInvalidOperationXDR))
+                        isInvalidOperation))
         {
             return;
         }

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -4,8 +4,10 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "ledger/LedgerTxn.h"
 #include "test/Fuzzer.h"
 #include "util/Timer.h"
+#include "xdr/Stellar-ledger-entries.h"
 #include "xdr/Stellar-types.h"
 
 namespace stellar
@@ -16,6 +18,16 @@ class Simulation;
 class Application;
 struct StellarMessage;
 struct Operation;
+
+namespace FuzzUtils
+{
+size_t static constexpr NUM_STORED_LEDGER_KEYS = 0x100U;
+size_t static constexpr NUM_UNVALIDATED_LEDGER_KEYS = 0x40U;
+size_t static constexpr NUM_VALIDATED_LEDGER_KEYS =
+    NUM_STORED_LEDGER_KEYS - NUM_UNVALIDATED_LEDGER_KEYS;
+
+using StoredLedgerKeys = std::array<LedgerKey, NUM_STORED_LEDGER_KEYS>;
+}
 
 class TransactionFuzzer : public Fuzzer
 {
@@ -30,9 +42,11 @@ class TransactionFuzzer : public Fuzzer
     int xdrSizeLimit() override;
 
   private:
+    void storeSetupLedgerKeys(AbstractLedgerTxn& ltx);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;
+    FuzzUtils::StoredLedgerKeys mStoredLedgerKeys;
 };
 
 class OverlayFuzzer : public Fuzzer
@@ -52,5 +66,6 @@ class OverlayFuzzer : public Fuzzer
 
   private:
     std::shared_ptr<Simulation> mSimulation;
+    FuzzUtils::StoredLedgerKeys mStoredLedgerKeys;
 };
 }


### PR DESCRIPTION
# Special-case `LedgerKey` when fuzzing

Resolves #2896 
Part of #1376 

- Fixes the bug that fuzzer setup and testing transactions would all re-use transaction sequence number 1.
- Maps `LedgerKey` to 1 byte to limit fuzz search space.
- Creates a sponsorship and some claimable balances during fuzzer setup, as these are a couple of the main operations which are likely to require `LedgerKey` mapping to get meaningful fuzz coverage.

This PR is currently only a draft because I have not yet confirmed that it's testing everything that I want to test, only that whatever it is testing isn't crashing!  However, I think it makes sense to start getting comments on the approach and implementation while I work on the remaining validation.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v5.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
