### PR TITLE
Do not enforce bucket oldest versions check

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -1074,10 +1074,6 @@ This section contains information that is useful to know but that should not sto
 [testnet.md](./testnet.md) is a short tutorial demonstrating how to
   configure and run a short-lived, isolated test network.
 
-### Considerations when bootstrapping a private network
-
-In order to generate valid state when running a private network, it must be upgraded to the latest protocol version. The protocol upgrade must occur before the network starts accepting any transactions. See "Example upgrade command" section for an example command.
-
 ### Runtime information: start and stop
 
 Stellar-core can be started directly from the command line, or through a supervision 

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -286,7 +286,6 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
     ZoneScoped;
     // This function assumes presence of required buckets to verify state
     uint32_t minBucketVersion = 0;
-    uint32_t oldestBucketVersion = 0;
     bool nonEmptySeen = false;
     Hash const emptyHash;
 
@@ -315,7 +314,6 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
             if (!nonEmptySeen)
             {
                 nonEmptySeen = true;
-                oldestBucketVersion = version;
             }
         }
         return version;
@@ -370,18 +368,6 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
                        "Invalid HAS: future must have resolved output");
             return false;
         }
-    }
-
-    // By protocol "Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED + 1", all buckets
-    // must be at least of version "Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED"
-    if (minBucketVersion >= Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED + 1 &&
-        oldestBucketVersion < Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
-    {
-        CLOG_ERROR(History,
-                   "Invalid HAS: bucketlist contains bucket version {} that is "
-                   "too old",
-                   oldestBucketVersion);
-        return false;
     }
 
     return true;


### PR DESCRIPTION
Introduced by #2843, this check breaks private networks that do not upgrade fast enough