### PR TITLE
logging:do not use reserved names (Windows)

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -58,7 +58,7 @@ class CommandLine
         using Common = std::pair<std::string, bool>;
         static const std::vector<Common> COMMON_OPTIONS;
 
-        LogLevel mLogLevel{LogLevel::Info};
+        LogLevel mLogLevel{LogLevel::LVL_INFO};
         std::vector<std::string> mMetrics;
         std::string mConfigFile;
 
@@ -1412,7 +1412,7 @@ fuzzerModeParser(std::string& fuzzerModeArg, FuzzerMode& fuzzerMode)
 int
 runFuzz(CommandLineArgs const& args)
 {
-    LogLevel logLevel{LogLevel::Info};
+    LogLevel logLevel{LogLevel::LVL_INFO};
     std::vector<std::string> metrics;
     std::string fileName;
     int processID = 0;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -198,7 +198,7 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
 int
 runTest(CommandLineArgs const& args)
 {
-    LogLevel logLevel{LogLevel::Info};
+    LogLevel logLevel{LogLevel::LVL_INFO};
 
     Catch::Session session{};
 

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -25,7 +25,7 @@ std::array<std::string const, 14> const Logging::kPartitionNames = {
 #undef LOG_PARTITION
 };
 
-LogLevel Logging::mGlobalLogLevel = LogLevel::INFO;
+LogLevel Logging::mGlobalLogLevel = LogLevel::LVL_INFO;
 std::map<std::string, LogLevel> Logging::mPartitionLogLevels;
 
 #if defined(USE_SPDLOG)
@@ -55,22 +55,22 @@ convert_loglevel(LogLevel level)
     auto slev = spdlog::level::info;
     switch (level)
     {
-    case LogLevel::FATAL:
+    case LogLevel::LVL_FATAL:
         slev = spdlog::level::critical;
         break;
-    case LogLevel::ERROR:
+    case LogLevel::LVL_ERROR:
         slev = spdlog::level::err;
         break;
-    case LogLevel::WARNING:
+    case LogLevel::LVL_WARNING:
         slev = spdlog::level::warn;
         break;
-    case LogLevel::INFO:
+    case LogLevel::LVL_INFO:
         slev = spdlog::level::info;
         break;
-    case LogLevel::DEBUG:
+    case LogLevel::LVL_DEBUG:
         slev = spdlog::level::debug;
         break;
-    case LogLevel::TRACE:
+    case LogLevel::LVL_TRACE:
         slev = spdlog::level::trace;
         break;
     default:
@@ -256,30 +256,30 @@ Logging::getLLfromString(std::string const& levelName)
 {
     if (iequals(levelName, "fatal"))
     {
-        return LogLevel::FATAL;
+        return LogLevel::LVL_FATAL;
     }
 
     if (iequals(levelName, "error"))
     {
-        return LogLevel::ERROR;
+        return LogLevel::LVL_ERROR;
     }
 
     if (iequals(levelName, "warning"))
     {
-        return LogLevel::WARNING;
+        return LogLevel::LVL_WARNING;
     }
 
     if (iequals(levelName, "debug"))
     {
-        return LogLevel::DEBUG;
+        return LogLevel::LVL_DEBUG;
     }
 
     if (iequals(levelName, "trace"))
     {
-        return LogLevel::TRACE;
+        return LogLevel::LVL_TRACE;
     }
 
-    return LogLevel::INFO;
+    return LogLevel::LVL_INFO;
 }
 
 LogLevel
@@ -299,17 +299,17 @@ Logging::getStringFromLL(LogLevel level)
 {
     switch (level)
     {
-    case LogLevel::FATAL:
+    case LogLevel::LVL_FATAL:
         return "Fatal";
-    case LogLevel::ERROR:
+    case LogLevel::LVL_ERROR:
         return "Error";
-    case LogLevel::WARNING:
+    case LogLevel::LVL_WARNING:
         return "Warning";
-    case LogLevel::INFO:
+    case LogLevel::LVL_INFO:
         return "Info";
-    case LogLevel::DEBUG:
+    case LogLevel::LVL_DEBUG:
         return "Debug";
-    case LogLevel::TRACE:
+    case LogLevel::LVL_TRACE:
         return "Trace";
     }
     return "????";
@@ -319,14 +319,14 @@ bool
 Logging::logDebug(std::string const& partition)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
-    return mGlobalLogLevel <= LogLevel::DEBUG;
+    return mGlobalLogLevel <= LogLevel::LVL_DEBUG;
 }
 
 bool
 Logging::logTrace(std::string const& partition)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
-    return mGlobalLogLevel <= LogLevel::TRACE;
+    return mGlobalLogLevel <= LogLevel::LVL_TRACE;
 }
 
 void

--- a/src/util/Logging.h
+++ b/src/util/Logging.h
@@ -84,31 +84,34 @@ typedef std::shared_ptr<spdlog::logger> LogPtr;
 // No spdlog either: delegate back to old logging interface, which will
 // in turn use stellar::CoutLogger.
 
+#define CLOG(LEVEL, ...) stellar::CoutLogger(stellar::LogLevel::LEVEL)
+#define LOG(LEVEL) CLOG(LEVEL)
+
 #define CLOG_TRACE(partition, f, ...) \
-    CLOG(TRACE, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_TRACE, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
 #define CLOG_DEBUG(partition, f, ...) \
-    CLOG(DEBUG, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_DEBUG, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
 #define CLOG_INFO(partition, f, ...) \
-    CLOG(INFO, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_INFO, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
 #define CLOG_WARNING(partition, f, ...) \
-    CLOG(WARNING, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_WARNING, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
 #define CLOG_ERROR(partition, f, ...) \
-    CLOG(ERROR, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_ERROR, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
 #define CLOG_FATAL(partition, f, ...) \
-    CLOG(FATAL, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
+    CLOG(LVL_FATAL, #partition) << fmt::format(FMT_STRING(f), ##__VA_ARGS__)
 
 #define LOG_TRACE(logger, f, ...) \
-    CLOG(TRACE, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_TRACE, logger) << fmt::format(f, ##__VA_ARGS__)
 #define LOG_DEBUG(logger, f, ...) \
-    CLOG(DEBUG, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_DEBUG, logger) << fmt::format(f, ##__VA_ARGS__)
 #define LOG_INFO(logger, f, ...) \
-    CLOG(INFO, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_INFO, logger) << fmt::format(f, ##__VA_ARGS__)
 #define LOG_WARNING(logger, f, ...) \
-    CLOG(WARNING, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_WARNING, logger) << fmt::format(f, ##__VA_ARGS__)
 #define LOG_ERROR(logger, f, ...) \
-    CLOG(ERROR, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_ERROR, logger) << fmt::format(f, ##__VA_ARGS__)
 #define LOG_FATAL(logger, f, ...) \
-    CLOG(FATAL, logger) << fmt::format(f, ##__VA_ARGS__)
+    CLOG(LVL_FATAL, logger) << fmt::format(f, ##__VA_ARGS__)
 #define GET_LOG(name) name
 #define DEFAULT_LOG nullptr
 namespace stellar
@@ -118,23 +121,17 @@ typedef void* LogPtr;
 
 #endif
 
-#define CLOG(LEVEL, ...) stellar::CoutLogger(stellar::LogLevel::LEVEL)
-#define LOG(LEVEL) CLOG(LEVEL)
-
 namespace stellar
 {
 
 enum class LogLevel
 {
-    FATAL = 0,
-    ERROR = 1,
-    WARNING = 2,
-    INFO = 3,
-    DEBUG = 4,
-    TRACE = 5,
-
-    // Needed for some existing code
-    Info = 3
+    LVL_FATAL = 0,
+    LVL_ERROR = 1,
+    LVL_WARNING = 2,
+    LVL_INFO = 3,
+    LVL_DEBUG = 4,
+    LVL_TRACE = 5
 };
 
 class CoutLogger


### PR DESCRIPTION
`ERROR` is `#define`'d in some headers and conflicts with the change from #2906 