### PR TITLE
overlay:only mark broadcast metric if a message was actually sent

### DIFF
--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -904,8 +904,12 @@ bool
 OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force)
 {
     ZoneScoped;
-    mOverlayMetrics.mMessagesBroadcast.Mark();
-    return mFloodGate.broadcast(msg, force);
+    auto res = mFloodGate.broadcast(msg, force);
+    if (res)
+    {
+        mOverlayMetrics.mMessagesBroadcast.Mark();
+    }
+    return res;
 }
 
 void


### PR DESCRIPTION
I noticed that in some cases (when we receive messages before hitting the "broadcast" path), that we're over-counting the number of messages broadcasted.