### PR TITLE
Fix end-transaction iterator computation in fuzzer

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -524,17 +524,15 @@ attemptToApplyOps(LedgerTxn& ltx, PublicKey const& sourceAccount,
                   xdr::xvector<Operation>::const_iterator end, Application& app,
                   bool const throwIfTxFails = true)
 {
-    for (auto beginOpsInThisTx = begin; beginOpsInThisTx != end;)
+    while (begin != end)
     {
-        auto endOpsInThisTx =
-            std::distance(beginOpsInThisTx, end) <= MAX_OPS_PER_TX
-                ? end
-                : begin + MAX_OPS_PER_TX;
-        auto txFramePtr =
-            createFuzzTransactionFrame(sourceAccount, beginOpsInThisTx,
-                                       endOpsInThisTx, app.getNetworkID());
+        auto endOpsInThisTx = std::distance(begin, end) <= MAX_OPS_PER_TX
+                                  ? end
+                                  : begin + MAX_OPS_PER_TX;
+        auto txFramePtr = createFuzzTransactionFrame(
+            sourceAccount, begin, endOpsInThisTx, app.getNetworkID());
         txFramePtr->attemptApplication(app, ltx);
-        beginOpsInThisTx = endOpsInThisTx;
+        begin = endOpsInThisTx;
 
         if (throwIfTxFails)
         {


### PR DESCRIPTION
# Fix end-transaction iterator computation in fuzzer

Resolves #2928 

Had `attemptToApplyOps()` been called with more operations than would fit in a transaction, the second transaction would have computed the wrong `endOpsInThisTx`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
