### PR TITLE
run automatic maintenance more often with smaller counts

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -416,6 +416,13 @@ By default, stellar-core will perform this automatic maintenance, so be sure to 
 
 If you need to regenerate the meta data, the simplest way is to replay ledgers for the range you're interested in after (optionally) clearing the database with `newdb`.
 
+Note that in some cases automatic maintenance has just too much work to do in order to get back to the nominal state.
+This can occur following large catchup operations such as when performing a full catchup that may create a backlog of 10s of millions of ledgers.
+
+If this happens, database performance can be restored; the node will take some downtime while performing the following recovery commands:
+1. run the `maintenance` http command manually with a large number of ledgers,
+2. perform a database maintenance operation such as `VACUUM FULL` to reclaim/rebuild the database as needed
+
 ##### Meta data snapshots and restoration
 
 Some deployments of stellar-core and Horizon will want to retain meta data for the _entire history_ of the network. This meta data can be quite large and computationally expensive to regenerate anew by replaying ledgers in stellar-core from an empty initial database state, as described in the previous section.

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -294,18 +294,18 @@ QUORUM_INTERSECTION_CHECKER=true
 # This limits the number that will be active at a time.
 MAX_CONCURRENT_SUBPROCESSES=10
 
-# AUTOMATIC_MAINTENANCE_PERIOD (integer, seconds) default 14400
+# AUTOMATIC_MAINTENANCE_PERIOD (integer, seconds) default 660
 # Interval between automatic maintenance executions
 # Set to 0 to disable automatic maintenance
-AUTOMATIC_MAINTENANCE_PERIOD=14400
+AUTOMATIC_MAINTENANCE_PERIOD=660
 
-# AUTOMATIC_MAINTENANCE_COUNT (integer) default 50000
+# AUTOMATIC_MAINTENANCE_COUNT (integer) default 700
 # Number of unneeded ledgers in each table that will be removed during one
 # maintenance run.
 # NB: make sure that enough ledgers are deleted as to offset the growth of
 # data accumulated by closing ledgers (catchup and normal operation)
 # Set to 0 to disable automatic maintenance
-AUTOMATIC_MAINTENANCE_COUNT=50000
+AUTOMATIC_MAINTENANCE_COUNT=700
 
 ###############################
 ## The following options should probably never be set. They are used primarily

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -116,8 +116,16 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MANUAL_CLOSE = false;
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
-    AUTOMATIC_MAINTENANCE_PERIOD = std::chrono::seconds{14400};
-    AUTOMATIC_MAINTENANCE_COUNT = 50000;
+    // automatic maintenance settings:
+    // 11 minutes is relatively short and prime with 1 hour
+    // which will cause automatic maintenance to rarely conflict with any other
+    // scheduled tasks on a machine (that tend to run on a fixed schedule)
+    AUTOMATIC_MAINTENANCE_PERIOD = std::chrono::seconds{11 * 60};
+    // count picked as to catchup with 1 month worth of ledgers
+    // in about 1 week.
+    // (30*24*3600/5) / (700 - (11*60)/5 ) // number of periods
+    //   * (11*60) / (24*3600) = 6.97 days
+    AUTOMATIC_MAINTENANCE_COUNT = 700;
     ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
     ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
     ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = 0;

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -6,8 +6,10 @@
 #include "main/Config.h"
 #include "main/ExternalQueue.h"
 #include "util/GlobalChecks.h"
+#include "util/LogSlowExecution.h"
 #include "util/Logging.h"
 #include "util/numeric.h"
+
 #include <Tracy.hpp>
 #include <fmt/format.h>
 
@@ -63,6 +65,11 @@ Maintainer::performMaintenance(uint32_t count)
 {
     ZoneScoped;
     LOG_INFO(DEFAULT_LOG, "Performing maintenance");
+    auto logSlow = LogSlowExecution(
+        "Performing maintenance", LogSlowExecution::Mode::AUTOMATIC_RAII,
+        "performance issue: check database or perform a large manual "
+        "maintenance followed by database maintenance. Maintenance took",
+        std::chrono::seconds{2});
     ExternalQueue ps{mApp};
     ps.deleteOldEntries(count);
 }


### PR DESCRIPTION
Old defaults tend to create too many changes at once as it was running only every 4 hours, or ~2,880 ledgers which may translate (with full ledgers) up to 2.8M transactions. As each transaction corresponds to 2 rows (`txhistory` and `txfeehistory`) it potentially deletes 5.6M rows.

The new defaults make it run more often: every 11 minutes, or 132 ledgers which translates to up to 132k transactions.

As for "maintenance debt":
* the old default had a "count" set to 50,000 which means that it would delete up to 50M transactions at a time. The default was picked as to make it possible to "pay back" debt of 30M ledgers in 3 months
* new default is picked so that nominal performance from a 30 days downtime/backlog is recovered in one week.
