### PR TITLE
Factor remaining fuzzer setup parameters into constexpr arrays

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -874,23 +874,31 @@ applyFuzzOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
 // Unlike Asset, this can be a constexpr.
 struct AssetID
 {
-    constexpr AssetID() : mIsNative(true), mId(0)
+    constexpr AssetID() : mIsNative(true), mIssuer(0), mSuffixDigit(0)
     {
     }
 
-    constexpr AssetID(int id) : mIsNative(false), mId(id)
+    constexpr AssetID(int id) : AssetID(id, id)
     {
+    }
+
+    constexpr AssetID(int issuer, int digit)
+        : mIsNative(false), mIssuer(issuer), mSuffixDigit(digit)
+    {
+        assert(mSuffixDigit != 0); // id 0 is for native asset
+        assert(mSuffixDigit < FuzzUtils::NUMBER_OF_ASSETS_TO_USE);
     }
 
     Asset
     toAsset() const
     {
         return mIsNative ? txtest::makeNativeAsset()
-                         : FuzzUtils::makeAsset(mId);
+                         : FuzzUtils::makeAsset(mIssuer, mSuffixDigit);
     }
 
     bool const mIsNative;
-    int const mId; // meaningful only if !isNative
+    int const mIssuer;      // non-zero only if !isNative
+    int const mSuffixDigit; // non-zero only if !isNative
 };
 
 struct AccountParameters

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -871,6 +871,28 @@ applyFuzzOperations(LedgerTxn& ltx, PublicKey const& sourceAccount,
     txFramePtr->attemptApplication(app, ltx);
 }
 
+// Unlike Asset, this can be a constexpr.
+struct AssetID
+{
+    constexpr AssetID() : mIsNative(true), mId(0)
+    {
+    }
+
+    constexpr AssetID(int id) : mIsNative(false), mId(id)
+    {
+    }
+
+    Asset
+    toAsset() const
+    {
+        return mIsNative ? txtest::makeNativeAsset()
+                         : FuzzUtils::makeAsset(mId);
+    }
+
+    bool const mIsNative;
+    int const mId; // meaningful only if !isNative
+};
+
 struct AccountParameters
 {
     constexpr AccountParameters(int64_t assetAvailableForTestActivity,
@@ -905,28 +927,6 @@ std::array<
      {DEFAULT_ASSET_AVAILABLE_FOR_TEST_ACTIVITY, false},
      {DEFAULT_ASSET_AVAILABLE_FOR_TEST_ACTIVITY, false},
      {DEFAULT_ASSET_AVAILABLE_FOR_TEST_ACTIVITY, false}}};
-
-// Unlike Asset, this can be a constexpr.
-struct AssetID
-{
-    constexpr AssetID() : mIsNative(true), mId(0)
-    {
-    }
-
-    constexpr AssetID(int id) : mIsNative(false), mId(id)
-    {
-    }
-
-    Asset
-    toAsset() const
-    {
-        return mIsNative ? txtest::makeNativeAsset()
-                         : FuzzUtils::makeAsset(mId);
-    }
-
-    bool const mIsNative;
-    int const mId; // meaningful only if !isNative
-};
 
 struct OfferParameters
 {

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -901,6 +901,27 @@ struct AssetID
     int const mSuffixDigit; // non-zero only if !isNative
 };
 
+struct SponsoredEntryParameters
+{
+    constexpr SponsoredEntryParameters() : SponsoredEntryParameters(false, 0)
+    {
+    }
+
+    constexpr SponsoredEntryParameters(int sponsorKey)
+        : SponsoredEntryParameters(true, sponsorKey)
+    {
+    }
+
+    bool const mSponsored;
+    int const mSponsorKey; // meaningful only if mSponsored is true
+
+  private:
+    constexpr SponsoredEntryParameters(bool sponsored, int sponsorKey)
+        : mSponsored(sponsored), mSponsorKey(sponsorKey)
+    {
+    }
+};
+
 struct AccountParameters
 {
     constexpr AccountParameters(int64_t assetAvailableForTestActivity,

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -659,12 +659,17 @@ template <>
 void
 generator_t::operator()(stellar::PublicKey& t) const
 {
-    // note that we include NUMBER_OF_PREGENERATED_ACCOUNTS as to also cover the
-    // case of non existing accounts
+    // Generate account IDs in a somewhat larger range than the number of
+    // accounts created during setup, so that the fuzzer can generate some
+    // unused accounts (and also generate operation sequences in which it
+    // creates a new account and then uses it in a later operation).
+    uint8_t constexpr NUMBER_OF_ACCOUNT_IDS_TO_GENERATE = 32;
+    static_assert(NUMBER_OF_ACCOUNT_IDS_TO_GENERATE >
+                      stellar::FuzzUtils::NUMBER_OF_PREGENERATED_ACCOUNTS,
+                  "Range of generated accounts too small");
     stellar::FuzzUtils::setShortKey(
-        t.ed25519(),
-        static_cast<uint8_t>(stellar::rand_uniform<int>(
-            0, stellar::FuzzUtils::NUMBER_OF_PREGENERATED_ACCOUNTS)));
+        t.ed25519(), static_cast<uint8_t>(stellar::rand_uniform<int>(
+                         0, NUMBER_OF_ACCOUNT_IDS_TO_GENERATE - 1)));
 }
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 }

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -44,6 +44,7 @@ class TransactionFuzzer : public Fuzzer
   private:
     void storeSetupLedgerKeys(AbstractLedgerTxn& ltx);
     void initializeAccounts(AbstractLedgerTxn& ltxOuter);
+    void initializeTrustLines(AbstractLedgerTxn& ltxOuter);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -45,6 +45,7 @@ class TransactionFuzzer : public Fuzzer
     void storeSetupLedgerKeys(AbstractLedgerTxn& ltx);
     void initializeAccounts(AbstractLedgerTxn& ltxOuter);
     void initializeTrustLines(AbstractLedgerTxn& ltxOuter);
+    void initializeClaimableBalances(AbstractLedgerTxn& ltxOuter);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -46,6 +46,7 @@ class TransactionFuzzer : public Fuzzer
     void initializeAccounts(AbstractLedgerTxn& ltxOuter);
     void initializeTrustLines(AbstractLedgerTxn& ltxOuter);
     void initializeClaimableBalances(AbstractLedgerTxn& ltxOuter);
+    void initializeOffers(AbstractLedgerTxn& ltxOuter);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -48,6 +48,8 @@ class TransactionFuzzer : public Fuzzer
     void initializeClaimableBalances(AbstractLedgerTxn& ltxOuter);
     void initializeOffers(AbstractLedgerTxn& ltxOuter);
     void reduceNativeBalancesAfterSetup(AbstractLedgerTxn& ltxOuter);
+    void reduceTrustLineBalancesAfterSetup(AbstractLedgerTxn& ltxOuter);
+    void reduceTrustLineLimitsAfterSetup(AbstractLedgerTxn& ltxOuter);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -47,6 +47,7 @@ class TransactionFuzzer : public Fuzzer
     void initializeTrustLines(AbstractLedgerTxn& ltxOuter);
     void initializeClaimableBalances(AbstractLedgerTxn& ltxOuter);
     void initializeOffers(AbstractLedgerTxn& ltxOuter);
+    void reduceNativeBalancesAfterSetup(AbstractLedgerTxn& ltxOuter);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;

--- a/src/test/FuzzerImpl.h
+++ b/src/test/FuzzerImpl.h
@@ -43,6 +43,7 @@ class TransactionFuzzer : public Fuzzer
 
   private:
     void storeSetupLedgerKeys(AbstractLedgerTxn& ltx);
+    void initializeAccounts(AbstractLedgerTxn& ltxOuter);
     VirtualClock mClock;
     std::shared_ptr<Application> mApp;
     PublicKey mSourceAccountID;


### PR DESCRIPTION
# Factor remaining fuzzer setup parameters into constexpr arrays

Part of #1376

Follow-on from #2904 
Follow-on from #2927 
Follow-on from #2897

Complete the factoring out of fuzzer setup configuration into `constexpr` arrays which are separate from the implementation of the operations that perform that setup.  The idea is that it should be possible to examine the state of the ledger after fuzzer setup by looking only at the arrays, and modify the state by modifying only the arrays.

The new configuration supports enhancements to fuzzer setup such as:

- A single account may issue multiple assets
- Accounts may have different post-setup balances of different assets
- All ledger entries may be sponsored
- Trust line limits are reduced (to values specified in the array) after setup
- Account options (authorization flags) may be set
- Trust line authorization flags may be set
- A single trust line may have multiple claimable balances

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
