### PR TITLE
When RUN_STANDALONE = true, archives should be optional

### DIFF
--- a/docs/stellar-core_standalone.cfg
+++ b/docs/stellar-core_standalone.cfg
@@ -23,8 +23,3 @@ UNSAFE_QUORUM=true
 [QUORUM_SET]
 THRESHOLD_PERCENT=100
 VALIDATORS=["$self"]
-
-[HISTORY.vs]
-get="cp /var/lib/stellar-core/history/vs/{0} {1}"
-put="cp {0} /var/lib/stellar-core/history/vs/{1}"
-mkdir="mkdir -p /var/lib/stellar-core/history/vs/{0}"

--- a/src/history/HistoryArchiveManager.cpp
+++ b/src/history/HistoryArchiveManager.cpp
@@ -96,9 +96,16 @@ HistoryArchiveManager::checkSensibleConfig() const
 
     if (readOnlyArchives.empty() && readWriteArchives.empty())
     {
-        CLOG_FATAL(History,
-                   "No readable archives configured, catchup will fail.");
-        badArchives = true;
+        if (mApp.getConfig().RUN_STANDALONE)
+        {
+            CLOG_INFO(History, "No readable archives configured.");
+        }
+        else
+        {
+            CLOG_FATAL(History,
+                       "No readable archives configured, catchup will fail.");
+            badArchives = true;
+        }
     }
 
     if (readWriteArchives.empty())


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/2345

This change ensures that Stellar Core can run without archives when `RUN_STANDALONE = true`.

More specifically, it prevents Stellar Core from throwing when there is no archive. It will still throw when there are invalid archives (e.g., archives that have neither 'get' nor 'put') since I imagine that _if_ a user did put an archive in the config, it'd be better to make sure of its validity.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
