### PR TITLE
Make stored fuzzer ledger keys deterministic

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -673,6 +673,7 @@ resetRandomSeed(unsigned int seed)
     // seed randomness
     srand(seed);
     gRandomEngine.seed(seed);
+    autocheck::rng().seed(seed);
 }
 
 static void

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1212,6 +1212,11 @@ TransactionFuzzer::storeSetupLedgerKeys(AbstractLedgerTxn& ltx)
     std::vector<LedgerKey> dead;
     ltx.getAllEntries(init, live, dead);
 
+    // getAllEntries() does not guarantee anything about the order in which
+    // entries are returned, so to minimize non-determinism in fuzzing setup, we
+    // sort them.
+    std::sort(init.begin(), init.end());
+
     // Setup should only create entries; there should be no dead entries, and
     // only one "live" (modified) one:  the root account.
     assert(dead.empty());


### PR DESCRIPTION
# Make stored fuzzer ledger keys deterministic

Part of #1376 
Follow-on to #2904 

I realize that the array of stored ledger keys created by #2904 in fuzzer setup is non-deterministic (it can vary from one `stellar-core fuzz` execution to the next) for two reasons:

- We now use `autocheck`, to generate the mix of validated and unvalidated ledger keys to fill in the room we have that's not used by setup, and `autocheck` has its own PRNG.  So we should reseed that in the same place as we reseed `gRandomEngine` (and call `srand()`).
- `getAllEntries()` is not guaranteed to return entries in the same order with each call, since it uses an `unordered_map`, which does not make any such guarantee.  So we should sort the returned entries.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
