### PR TITLE
Fix several signed overflows in tests

### DIFF
--- a/src/test/TestAccount.h
+++ b/src/test/TestAccount.h
@@ -132,6 +132,11 @@ class TestAccount
     nextSequenceNumber()
     {
         updateSequenceNumber();
+        if (mSn == std::numeric_limits<SequenceNumber>::max())
+        {
+            throw std::runtime_error(
+                "Sequence number overflow in test account");
+        }
         return ++mSn;
     }
     SequenceNumber loadSequenceNumber();

--- a/src/transactions/test/BumpSequenceTests.cpp
+++ b/src/transactions/test/BumpSequenceTests.cpp
@@ -51,7 +51,12 @@ TEST_CASE("bump sequence", "[tx][bumpsequence]")
                 REQUIRE(a.loadSequenceNumber() == newSeq);
                 SECTION("no more tx when INT64_MAX is reached")
                 {
-                    REQUIRE_THROWS_AS(a.pay(root, 1), ex_txBAD_SEQ);
+                    REQUIRE_THROWS_AS(
+                        applyTx(
+                            {a.tx({payment(root, 1)},
+                                  std::numeric_limits<SequenceNumber>::min())},
+                            *app),
+                        ex_txBAD_SEQ);
                 }
             }
             SECTION("backward jump (no-op)")

--- a/src/transactions/test/ExchangeTests.cpp
+++ b/src/transactions/test/ExchangeTests.cpp
@@ -745,8 +745,9 @@ TEST_CASE("ExchangeV10", "[exchange]")
             else
             {
                 REQUIRE(res.wheatStays ==
-                        (maxWheatSend * p.n >
-                         std::min(maxSheepSend * p.d, maxWheatReceive * p.n)));
+                        bigMultiply(maxWheatSend, p.n) >
+                            std::min(bigMultiply(maxSheepSend, p.d),
+                                     bigMultiply(maxWheatReceive, p.n)));
             }
             REQUIRE(res.numWheatReceived == wheatReceive);
             REQUIRE(res.numSheepSend == sheepSend);


### PR DESCRIPTION
# Fix several signed overflows in tests

`ubsan` reveals three signed overflows in our tests, all of which I think admit small fixes:

- `TestAccount::nextSequenceNumber()` does not account for the possibility that `mSn` might already be `INT64_MAX`.  This makes it simply remain at `INT64_MAX` in that case . (The `"large bump"` test in `BumpSequenceTests.cpp`  is the one which exposes the UB.)
- The `"ExchangeV10"` test case in `ExchangeTests.cpp` has a potential overflow in a `REQUIRE()` when multiplying 64-bit numbers.  There are several other tests in the same file which avoid this by casting to `uint128_t`, so this PR does the same.  (It also adds `REQUIRE()`s that confirm that it's not casting any negative values to `uint128_t`.)
- The `"Account balances unchanged without inflation"` test in `ConservationOfLumens.cpp` increases `LedgerHeader::totalCoins` by the sum of the balances of the accounts that it's going to delete:
    ```
        int64_t balanceToDelete = getTotalBalance(toDelete);
        auto entries4 = updateBalances(entries3, *app, balanceToDelete);
    ```
  But nothing ensures that that increase can't overflow.  What this PR proposes is to check whether it would overflow and, if so, shorten the `toDelete` list until it _wouldn't_ overflow:
    ```
        while (getTotalBalance(std::vector<LedgerEntry>(
                   keepEnd, entries2.end())) > maxBalanceIncrease(*app))
        {
            ++keepEnd;
        }
    ```
  In my tests, during the 100 times through that loop, `keepEnd` had to be bumped during only 3 of the loops, so I don't think that this change is reducing the effectiveness of the test significantly.  There might be a simpler/better fix, though; I don't think I fully understand the aims of this test.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
