### PR TITLE
Best-offer debugging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,7 +158,7 @@ AC_ARG_ENABLE([extrachecks],
         [build with additional debugging checks enabled]))
 AS_IF([test "x$enable_extrachecks" = "xyes"], [
   # don't try to detect which c++ library we're using
-  CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_SANITIZE_VECTOR=1 -D_LIBCPP_DEBUG=0"
+  CXXFLAGS="$CXXFLAGS -D_GLIBCXX_DEBUG=1 -D_GLIBCXX_SANITIZE_VECTOR=1 -D_LIBCPP_DEBUG=0 -DBEST_OFFER_DEBUGGING"
 ])
 
 AC_ARG_ENABLE([ccache],

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -147,4 +147,21 @@ InMemoryLedgerTxnRoot::resetForFuzzer()
     abort();
 }
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+#ifdef BEST_OFFER_DEBUGGING
+bool
+InMemoryLedgerTxnRoot::bestOfferDebuggingEnabled() const
+{
+    return mBestOfferDebuggingEnabled;
+}
+
+std::shared_ptr<LedgerEntry const>
+InMemoryLedgerTxnRoot::getBestOfferSlow(Asset const& buying,
+                                        Asset const& selling,
+                                        OfferDescriptor const* worseThan,
+                                        std::unordered_set<int64_t>& exclude)
+{
+    return nullptr;
+}
+#endif
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -10,8 +10,15 @@
 namespace stellar
 {
 
-InMemoryLedgerTxnRoot::InMemoryLedgerTxnRoot()
+InMemoryLedgerTxnRoot::InMemoryLedgerTxnRoot(
+#ifdef BEST_OFFER_DEBUGGING
+    bool bestOfferDebuggingEnabled
+#endif
+    )
     : mHeader(std::make_unique<LedgerHeader>())
+#ifdef BEST_OFFER_DEBUGGING
+    , mBestOfferDebuggingEnabled(bestOfferDebuggingEnabled)
+#endif
 {
 }
 

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -69,5 +69,14 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     void resetForFuzzer() override;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+#ifdef BEST_OFFER_DEBUGGING
+    bool bestOfferDebuggingEnabled() const override;
+
+    std::shared_ptr<LedgerEntry const>
+    getBestOfferSlow(Asset const& buying, Asset const& selling,
+                     OfferDescriptor const* worseThan,
+                     std::unordered_set<int64_t>& exclude) override;
+#endif
 };
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -21,8 +21,16 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
 {
     std::unique_ptr<LedgerHeader> mHeader;
 
+#ifdef BEST_OFFER_DEBUGGING
+    bool const mBestOfferDebuggingEnabled;
+#endif
+
   public:
-    InMemoryLedgerTxnRoot();
+    InMemoryLedgerTxnRoot(
+#ifdef BEST_OFFER_DEBUGGING
+        bool bestOfferDebuggingEnabled
+#endif
+    );
     void addChild(AbstractLedgerTxn& child) override;
     void commitChild(EntryIterator iter, LedgerTxnConsistency cons) override;
     void rollbackChild() override;

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1980,13 +1980,28 @@ LedgerTxn::Impl::WorstBestOfferIteratorImpl::clone() const
 size_t const LedgerTxnRoot::Impl::MIN_BEST_OFFERS_BATCH_SIZE = 5;
 
 LedgerTxnRoot::LedgerTxnRoot(Database& db, size_t entryCacheSize,
-                             size_t prefetchBatchSize)
-    : mImpl(std::make_unique<Impl>(db, entryCacheSize, prefetchBatchSize))
+                             size_t prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+                             ,
+                             bool bestOfferDebuggingEnabled
+#endif
+                             )
+    : mImpl(std::make_unique<Impl>(db, entryCacheSize, prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+                                   ,
+                                   bestOfferDebuggingEnabled
+#endif
+                                   ))
 {
 }
 
 LedgerTxnRoot::Impl::Impl(Database& db, size_t entryCacheSize,
-                          size_t prefetchBatchSize)
+                          size_t prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+                          ,
+                          bool bestOfferDebuggingEnabled
+#endif
+                          )
     : mMaxBestOffersBatchSize(
           std::min(std::max(prefetchBatchSize, MIN_BEST_OFFERS_BATCH_SIZE),
                    MAX_OFFERS_TO_CROSS))
@@ -1995,6 +2010,9 @@ LedgerTxnRoot::Impl::Impl(Database& db, size_t entryCacheSize,
     , mEntryCache(entryCacheSize)
     , mBulkLoadBatchSize(prefetchBatchSize)
     , mChild(nullptr)
+#ifdef BEST_OFFER_DEBUGGING
+    , mBestOfferDebuggingEnabled(bestOfferDebuggingEnabled)
+#endif
 {
 }
 

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -453,6 +453,15 @@ class AbstractLedgerTxnParent
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     virtual void resetForFuzzer() = 0;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+#ifdef BEST_OFFER_DEBUGGING
+    virtual bool bestOfferDebuggingEnabled() const = 0;
+
+    virtual std::shared_ptr<LedgerEntry const>
+    getBestOfferSlow(Asset const& buying, Asset const& selling,
+                     OfferDescriptor const* worseThan,
+                     std::unordered_set<int64_t>& exclude) = 0;
+#endif
 };
 
 // An abstraction for an object that is an AbstractLedgerTxnParent and has
@@ -710,6 +719,15 @@ class LedgerTxn final : public AbstractLedgerTxn
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     void resetForFuzzer() override;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+#ifdef BEST_OFFER_DEBUGGING
+    bool bestOfferDebuggingEnabled() const override;
+
+    std::shared_ptr<LedgerEntry const>
+    getBestOfferSlow(Asset const& buying, Asset const& selling,
+                     OfferDescriptor const* worseThan,
+                     std::unordered_set<int64_t>& exclude) override;
+#endif
 };
 
 class LedgerTxnRoot : public AbstractLedgerTxnParent
@@ -772,5 +790,14 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
     double getPrefetchHitRate() const override;
+
+#ifdef BEST_OFFER_DEBUGGING
+    bool bestOfferDebuggingEnabled() const override;
+
+    std::shared_ptr<LedgerEntry const>
+    getBestOfferSlow(Asset const& buying, Asset const& selling,
+                     OfferDescriptor const* worseThan,
+                     std::unordered_set<int64_t>& exclude) override;
+#endif
 };
 }

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -719,7 +719,12 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
   public:
     explicit LedgerTxnRoot(Database& db, size_t entryCacheSize,
-                           size_t prefetchBatchSize);
+                           size_t prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+                           ,
+                           bool bestOfferDebuggingEnabled
+#endif
+    );
 
     virtual ~LedgerTxnRoot();
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -686,6 +686,10 @@ class LedgerTxnRoot::Impl
     std::unique_ptr<soci::transaction> mTransaction;
     AbstractLedgerTxn* mChild;
 
+#ifdef BEST_OFFER_DEBUGGING
+    bool const mBestOfferDebuggingEnabled;
+#endif
+
     void throwIfChild() const;
 
     std::shared_ptr<LedgerEntry const> loadAccount(LedgerKey const& key) const;
@@ -776,7 +780,12 @@ class LedgerTxnRoot::Impl
 
   public:
     // Constructor has the strong exception safety guarantee
-    Impl(Database& db, size_t entryCacheSize, size_t prefetchBatchSize);
+    Impl(Database& db, size_t entryCacheSize, size_t prefetchBatchSize
+#ifdef BEST_OFFER_DEBUGGING
+         ,
+         bool bestOfferDebuggingEnabled
+#endif
+    );
 
     ~Impl();
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -586,6 +586,20 @@ class LedgerTxn::Impl
 #ifdef BUILD_TESTS
     MultiOrderBook const& getOrderBook();
 #endif
+
+#ifdef BEST_OFFER_DEBUGGING
+    bool bestOfferDebuggingEnabled() const;
+
+    std::shared_ptr<LedgerEntry const>
+    getBestOfferSlow(Asset const& buying, Asset const& selling,
+                     OfferDescriptor const* worseThan,
+                     std::unordered_set<int64_t>& exclude);
+
+    std::shared_ptr<LedgerEntry const>
+    checkBestOffer(Asset const& buying, Asset const& selling,
+                   OfferDescriptor const* worseThan,
+                   std::shared_ptr<LedgerEntry const> best);
+#endif
 };
 
 class LedgerTxn::Impl::EntryIteratorImpl : public EntryIterator::AbstractImpl
@@ -867,6 +881,20 @@ class LedgerTxnRoot::Impl
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
 
     double getPrefetchHitRate() const;
+
+#ifdef BEST_OFFER_DEBUGGING
+    bool bestOfferDebuggingEnabled() const;
+
+    std::shared_ptr<LedgerEntry const>
+    getBestOfferSlow(Asset const& buying, Asset const& selling,
+                     OfferDescriptor const* worseThan,
+                     std::unordered_set<int64_t>& exclude);
+
+    std::shared_ptr<LedgerEntry const>
+    checkBestOffer(Asset const& buying, Asset const& selling,
+                   OfferDescriptor const* worseThan,
+                   std::shared_ptr<LedgerEntry const> best);
+#endif
 };
 
 #ifdef USE_POSTGRES

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -151,9 +151,17 @@ ApplicationImpl::initialize(bool createNewDB)
     mBanManager = BanManager::create(*this);
     mStatusManager = std::make_unique<StatusManager>();
 
+#ifdef BEST_OFFER_DEBUGGING
+    auto const bestOfferDebuggingEnabled = mConfig.BEST_OFFER_DEBUGGING_ENABLED;
+#endif
+
     if (getConfig().MODE_USES_IN_MEMORY_LEDGER)
     {
-        mLedgerTxnRoot = std::make_unique<InMemoryLedgerTxnRoot>();
+        mLedgerTxnRoot = std::make_unique<InMemoryLedgerTxnRoot>(
+#ifdef BEST_OFFER_DEBUGGING
+            bestOfferDebuggingEnabled
+#endif
+        );
         mNeverCommittingLedgerTxn =
             std::make_unique<LedgerTxn>(*mLedgerTxnRoot);
     }
@@ -166,9 +174,13 @@ ApplicationImpl::initialize(bool createNewDB)
                         "of 20000",
                         mConfig.ENTRY_CACHE_SIZE);
         }
-
         mLedgerTxnRoot = std::make_unique<LedgerTxnRoot>(
-            *mDatabase, mConfig.ENTRY_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE);
+            *mDatabase, mConfig.ENTRY_CACHE_SIZE, mConfig.PREFETCH_BATCH_SIZE
+#ifdef BEST_OFFER_DEBUGGING
+            ,
+            bestOfferDebuggingEnabled
+#endif
+        );
     }
 
     BucketListIsConsistentWithDatabase::registerInvariant(*this);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -192,6 +192,10 @@ Config::Config() : NODE_SEED(SecretKey::random())
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
 #endif
+
+#ifdef BEST_OFFER_DEBUGGING
+    BEST_OFFER_DEBUGGING_ENABLED = false;
+#endif
 }
 
 namespace

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -385,6 +385,10 @@ class Config : public std::enable_shared_from_this<Config>
     bool TEST_CASES_ENABLED;
 #endif
 
+#ifdef BEST_OFFER_DEBUGGING
+    bool BEST_OFFER_DEBUGGING_ENABLED;
+#endif
+
     // Any transaction that reaches the TransactionQueue will be rejected if it
     // contains an operation in this list.
     std::vector<OperationType> EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -191,6 +191,9 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         // only spin up a small number of worker threads
         thisConfig.WORKER_THREADS = 2;
         thisConfig.QUORUM_INTERSECTION_CHECKER = false;
+#ifdef BEST_OFFER_DEBUGGING
+        thisConfig.BEST_OFFER_DEBUGGING_ENABLED = true;
+#endif
     }
     return *cfgs[instanceNumber];
 }


### PR DESCRIPTION
# Best-offer debugging

Updates and integrates some formerly-private debugging for `getBestOffer()` which cross-checks its return values against a much slower, simpler algorithm.

Because the debug algorithm is so slow, it is compiled in by default only when tests are compiled in (or when explicitly requested with a `configure` option), and if is compiled in, it runs by default only under the `test` and `fuzz` commands (or when explicitly requested with a command-line option; it can also be disabled for `test` and `fuzz` with a command-line option).

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
