### PR TITLE
makeValid for claimable balance must produce v0 before protocol 16

### DIFF
--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -236,6 +236,10 @@ makeValid(ClaimableBalanceEntry& c)
     c.asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
     strToAssetCode(c.asset.alphaNum4().assetCode, "CAD");
 
+    if (Config::CURRENT_LEDGER_PROTOCOL_VERSION < 16)
+    {
+        c.ext.v(0);
+    }
     if (c.ext.v() == 1)
     {
         c.ext.v1().flags = MASK_CLAIMABLE_BALANCE_FLAGS;


### PR DESCRIPTION
# Description
Resolves #2956

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
