### PR TITLE
Introduce "order book not crossed" invariant (for fuzzing only)

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -410,6 +410,7 @@ exit /b 0
     <ClCompile Include="..\..\src\invariant\InvariantManagerImpl.cpp" />
     <ClCompile Include="..\..\src\invariant\LedgerEntryIsValid.cpp" />
     <ClCompile Include="..\..\src\invariant\LiabilitiesMatchOffers.cpp" />
+    <ClCompile Include="..\..\src\invariant\OrderBookIsNotCrossed.cpp" />
     <ClCompile Include="..\..\src\invariant\SponsorshipCountIsValid.cpp" />
     <ClCompile Include="..\..\src\invariant\test\AccountSubEntriesCountIsValidTests.cpp" />
     <ClCompile Include="..\..\src\invariant\test\BucketListIsConsistentWithDatabaseTests.cpp" />
@@ -417,6 +418,7 @@ exit /b 0
     <ClCompile Include="..\..\src\invariant\test\InvariantTests.cpp" />
     <ClCompile Include="..\..\src\invariant\test\InvariantTestUtils.cpp" />
     <ClCompile Include="..\..\src\invariant\test\LiabilitiesMatchOffersTests.cpp" />
+    <ClCompile Include="..\..\src\invariant\test\OrderBookIsNotCrossedTests.cpp" />
     <ClCompile Include="..\..\src\invariant\test\SponsorshipCountIsValidTests.cpp" />
     <ClCompile Include="..\..\src\ledger\CheckpointRange.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderUtils.cpp" />
@@ -766,6 +768,7 @@ exit /b 0
     <ClInclude Include="..\..\src\invariant\InvariantManagerImpl.h" />
     <ClInclude Include="..\..\src\invariant\LedgerEntryIsValid.h" />
     <ClInclude Include="..\..\src\invariant\LiabilitiesMatchOffers.h" />
+    <ClInclude Include="..\..\src\invariant\OrderBookIsNotCrossed.h" />
     <ClInclude Include="..\..\src\invariant\SponsorshipCountIsValid.h" />
     <ClInclude Include="..\..\src\invariant\test\InvariantTestUtils.h" />
     <ClInclude Include="..\..\src\ledger\CheckpointRange.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -345,6 +345,9 @@
     <ClCompile Include="..\..\src\invariant\LiabilitiesMatchOffers.cpp">
       <Filter>invariant</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\invariant\OrderBookIsNotCrossed.cpp">
+      <Filter>invariant</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\invariant\SponsorshipCountIsValid.cpp">
       <Filter>invariant</Filter>
     </ClCompile>
@@ -664,6 +667,9 @@
       <Filter>invariant\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\invariant\test\LiabilitiesMatchOffersTests.cpp">
+      <Filter>invariant\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\invariant\test\OrderBookIsNotCrossedTests.cpp">
       <Filter>invariant\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\invariant\test\SponsorshipCountIsValidTests.cpp">
@@ -1374,6 +1380,9 @@
       <Filter>invariant</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\invariant\LiabilitiesMatchOffers.h">
+      <Filter>invariant</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\invariant\OrderBookIsNotCrossed.h">
       <Filter>invariant</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\invariant\SponsorshipCountIsValid.h">

--- a/src/invariant/Invariant.h
+++ b/src/invariant/Invariant.h
@@ -53,5 +53,17 @@ class Invariant
     {
         return std::string{};
     }
+
+#ifdef BUILD_TESTS
+    virtual void
+    snapshotForFuzzer()
+    {
+    }
+
+    virtual void
+    resetForFuzzer()
+    {
+    }
+#endif // BUILD_TESTS
 };
 }

--- a/src/invariant/InvariantManager.h
+++ b/src/invariant/InvariantManager.h
@@ -48,6 +48,11 @@ class InvariantManager
 
     virtual void enableInvariant(std::string const& name) = 0;
 
+#ifdef BUILD_TESTS
+    virtual void snapshotForFuzzer() = 0;
+    virtual void resetForFuzzer() = 0;
+#endif // BUILD_TESTS
+
     template <typename T, typename... Args>
     std::shared_ptr<T>
     registerInvariant(Args&&... args)

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -231,4 +231,24 @@ InvariantManagerImpl::handleInvariantFailure(
         CLOG_ERROR(Invariant, "{}", REPORT_INTERNAL_BUG);
     }
 }
+
+#ifdef BUILD_TESTS
+void
+InvariantManagerImpl::snapshotForFuzzer()
+{
+    for (auto const& invariant : mEnabled)
+    {
+        invariant->snapshotForFuzzer();
+    }
+}
+
+void
+InvariantManagerImpl::resetForFuzzer()
+{
+    for (auto const& invariant : mEnabled)
+    {
+        invariant->resetForFuzzer();
+    }
+}
+#endif // BUILD_TESTS
 }

--- a/src/invariant/InvariantManagerImpl.h
+++ b/src/invariant/InvariantManagerImpl.h
@@ -50,6 +50,11 @@ class InvariantManagerImpl : public InvariantManager
 
     virtual void enableInvariant(std::string const& name) override;
 
+#ifdef BUILD_TESTS
+    void snapshotForFuzzer() override;
+    void resetForFuzzer() override;
+#endif // BUILD_TESTS
+
   private:
     void onInvariantFailure(std::shared_ptr<Invariant> invariant,
                             std::string const& message, uint32_t ledger);

--- a/src/invariant/OrderBookIsNotCrossed.cpp
+++ b/src/invariant/OrderBookIsNotCrossed.cpp
@@ -1,0 +1,230 @@
+#ifdef BUILD_TESTS
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "invariant/OrderBookIsNotCrossed.h"
+#include "invariant/InvariantManager.h"
+#include "ledger/InternalLedgerEntry.h"
+#include "ledger/LedgerTxn.h"
+#include "main/Application.h"
+#include "util/Logging.h"
+#include "util/XDROperators.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include <fmt/format.h>
+#include <functional>
+#include <xdrpp/printer.h>
+
+namespace stellar
+{
+namespace
+{
+double
+priceAsDouble(Price const& price)
+{
+    return static_cast<double>(price.n) / static_cast<double>(price.d);
+}
+
+OrderBookIsNotCrossed::AssetPairSet
+extractAssetPairs(LedgerTxnDelta const& ltxd)
+{
+    OrderBookIsNotCrossed::AssetPairSet assets;
+    for (auto const& entry : ltxd.entry)
+    {
+        if (entry.first.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
+            entry.first.ledgerKey().type() == OFFER && entry.second.current)
+        {
+            auto const& offer =
+                entry.second.current->ledgerEntry().data.offer();
+            auto const assetPair =
+                offer.selling < offer.buying
+                    ? std::make_pair(offer.selling, offer.buying)
+                    : std::make_pair(offer.buying, offer.selling);
+
+            assets.insert(assetPair);
+        }
+    }
+
+    return assets;
+}
+
+std::string
+checkCrossed(Asset const& a, Asset const& b,
+             OrderBookIsNotCrossed::OrderBook const& orderBook)
+{
+    // If either side of the order book for this asset pair is empty or does not
+    // yet exist, then the order book cannot be crossed.
+    auto const iterAB = orderBook.find({a, b});
+    auto const iterBA = orderBook.find({b, a});
+    if (iterAB == orderBook.end() || iterBA == orderBook.end())
+    {
+        return {};
+    }
+
+    auto const& asks = iterAB->second;
+    auto const& bids = iterBA->second;
+    if (asks.empty() || bids.empty())
+    {
+        return {};
+    }
+
+    // check if crossed
+    auto lowestAsk = priceAsDouble(asks.cbegin()->price);
+    auto highestBidInverse = bids.cbegin()->price;
+    auto highestBid =
+        priceAsDouble(Price{highestBidInverse.d, highestBidInverse.n});
+
+    if (lowestAsk <= highestBid)
+    {
+        if (lowestAsk == highestBid)
+        {
+            // We ordered non-passive offers before passive offers so that if
+            // the first offer at this price in the list is passive, then we
+            // know that all offers at this price in the list are passive.
+            if (((asks.cbegin()->flags & PASSIVE_FLAG) != 0) ||
+                ((bids.cbegin()->flags & PASSIVE_FLAG) != 0))
+            {
+                // In at least one of the lists, all the offers at this price
+                // are passive, so the equal-price crossing does not represent a
+                // bug.
+                return {};
+            }
+
+            // There is at least one non-passive offer in each list, so at least
+            // one of them should have crossed with an offer on the other list,
+            // so we fall through to the invariant failure.
+        }
+
+        return fmt::format(
+            FMT_STRING(
+                "Order book is in a crossed state for {} - {} "
+                "asset pair.\nTop of the book is:\n\tAsk price: {}\n\tBid "
+                "price: {}\n\nWhere {} >= {}!"),
+            xdr::xdr_to_string(a), xdr::xdr_to_string(b), lowestAsk, highestBid,
+            highestBid, lowestAsk);
+    }
+    return {};
+}
+}
+
+bool
+OrderBookIsNotCrossed::OfferEntryCmp::operator()(OfferEntry const& a,
+                                                 OfferEntry const& b) const
+{
+    auto const priceA = priceAsDouble(a.price);
+    auto const priceB = priceAsDouble(b.price);
+
+    if (priceA < priceB)
+    {
+        return true;
+    }
+    if (priceA == priceB)
+    {
+        // We order non-passive offers before passive offers so that we
+        // can find any non-passive offer at a given price at the front
+        // of the list of offers at that price.
+        if ((a.flags & PASSIVE_FLAG) != (b.flags & PASSIVE_FLAG))
+        {
+            return (a.flags & PASSIVE_FLAG) == 0;
+        }
+        return a.offerID < b.offerID;
+    }
+    return false;
+}
+
+void
+OrderBookIsNotCrossed::updateOrderBook(LedgerTxnDelta const& ltxd)
+{
+    for (auto const& entry : ltxd.entry)
+    {
+        // there are three possible "deltas" for an offer:
+        //      CREATED:  (nil)     -> LedgerKey
+        //      MODIFIED: LedgerKey -> LedgerKey
+        //      DELETED:  LedgerKey -> (nil)
+        if (entry.first.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
+            entry.first.ledgerKey().type() == OFFER)
+        {
+            if (mRestoreBeforeNextUpdate)
+            {
+                mOrderBook = mOrderBookSnapshot;
+                mRestoreBeforeNextUpdate = false;
+            }
+            if (entry.second.previous)
+            {
+                auto const& oe =
+                    entry.second.previous->ledgerEntry().data.offer();
+                mOrderBook[{oe.selling, oe.buying}].erase(oe);
+            }
+            if (entry.second.current)
+            {
+                auto const& oe =
+                    entry.second.current->ledgerEntry().data.offer();
+                mOrderBook[{oe.selling, oe.buying}].emplace(oe);
+            }
+        }
+    }
+}
+
+std::string
+OrderBookIsNotCrossed::check(AssetPairSet const& assetPairs)
+{
+    assert(!mRestoreBeforeNextUpdate);
+    for (auto const& assetPair : assetPairs)
+    {
+        auto checkCrossedResult =
+            checkCrossed(assetPair.first, assetPair.second, mOrderBook);
+        if (!checkCrossedResult.empty())
+        {
+            return checkCrossedResult;
+        }
+    }
+
+    return std::string{};
+}
+
+std::shared_ptr<Invariant>
+OrderBookIsNotCrossed::registerAndEnableInvariant(Application& app)
+{
+    auto invariant =
+        app.getInvariantManager().registerInvariant<OrderBookIsNotCrossed>();
+    app.getInvariantManager().enableInvariant(invariant->getName());
+    return invariant;
+}
+
+std::string
+OrderBookIsNotCrossed::getName() const
+{
+    return "OrderBookIsNotCrossed";
+}
+
+std::string
+OrderBookIsNotCrossed::checkOnOperationApply(Operation const& operation,
+                                             OperationResult const& result,
+                                             LedgerTxnDelta const& ltxDelta)
+{
+    updateOrderBook(ltxDelta);
+    auto assetPairs = extractAssetPairs(ltxDelta);
+    return assetPairs.size() > 0 ? check(assetPairs) : std::string{};
+}
+
+void
+OrderBookIsNotCrossed::snapshotForFuzzer()
+{
+    mOrderBookSnapshot = mOrderBook;
+}
+
+void
+OrderBookIsNotCrossed::resetForFuzzer()
+{
+    // This call indicates that the fuzzer has completed one test and its next
+    // call to `checkOnOperationApply` will be in the context of the order book
+    // state immediately after the completion of setup (`mOrderBookSnapshot`).
+    // However, it's possible that the next one or more fuzz tests won't
+    // generate any operations involving orders, in which case it wouldn't
+    // matter if `mOrderBook` were stale.  Therefore, we defer copying the map
+    // until we need it to be up to date.
+    mOrderBook.clear();
+    mRestoreBeforeNextUpdate = true;
+}
+}
+#endif // BUILD_TESTS

--- a/src/invariant/OrderBookIsNotCrossed.h
+++ b/src/invariant/OrderBookIsNotCrossed.h
@@ -1,0 +1,79 @@
+#ifdef BUILD_TESTS
+#pragma once
+
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "invariant/Invariant.h"
+#include "ledger/LedgerHashUtils.h"
+#include "ledger/LedgerTxn.h"
+#include "main/Application.h"
+#include "xdr/Stellar-ledger-entries.h"
+#include "xdr/Stellar-ledger.h"
+
+#include <set>
+#include <unordered_map>
+
+namespace stellar
+{
+// compare two OfferEntry's by price
+class OrderBookIsNotCrossed : public Invariant
+{
+  public:
+    struct OfferEntryCmp
+    {
+        bool operator()(OfferEntry const& a, OfferEntry const& b) const;
+    };
+
+    using Orders = std::set<OfferEntry, OfferEntryCmp>;
+    using OrderBook = std::unordered_map<AssetPair, Orders, AssetPairHash>;
+    using AssetPairSet = std::set<std::pair<Asset, Asset>>;
+
+    explicit OrderBookIsNotCrossed()
+        : Invariant(true), mRestoreBeforeNextUpdate(false)
+    {
+    }
+
+    // The order-book-not-crossed invariant relies on maintaining state across
+    // checkOnOperationApply() calls, and there is no general mechanism in the
+    // InvariantManager to notify an invariant if an operation was later rolled
+    // back.  Therefore, we can reliably check the order-book-not-crossed
+    // invariant only when either the calling code uses the
+    // snapshotForFuzzer()/resetForFuzzer() mechanism, which currently only the
+    // fuzzer does, or in a test specifically of the OrderBookIsNotCrossed
+    // invariant, which is aware of its maintaining state.  Therefore, we
+    // register and enable the invariant only explicitly, from those places:
+    // fuzzing and the invariant's own tests.
+    static std::shared_ptr<Invariant>
+    registerAndEnableInvariant(Application& app);
+
+    virtual std::string getName() const override;
+
+    virtual std::string
+    checkOnOperationApply(Operation const& operation,
+                          OperationResult const& result,
+                          LedgerTxnDelta const& ltxDelta) override;
+
+    OrderBook const&
+    getOrderBook() const
+    {
+        return mOrderBook;
+    }
+
+    void snapshotForFuzzer() override;
+    void resetForFuzzer() override;
+
+  private:
+    // as of right now, since this is only used in fuzzing, the mOrderBook will
+    // be empty to start. If used in production, since invariants are
+    // configurable, it is likely that this invariant will be enabled with
+    // pre-existing ledger and thus the mOrderBook will need a way to sync
+    OrderBook mOrderBook;
+    OrderBook mOrderBookSnapshot;
+    bool mRestoreBeforeNextUpdate;
+    void updateOrderBook(LedgerTxnDelta const& ltxd);
+    std::string check(AssetPairSet const& assetPairs);
+};
+}
+#endif // BUILD_TESTS

--- a/src/invariant/test/InvariantTestUtils.cpp
+++ b/src/invariant/test/InvariantTestUtils.cpp
@@ -34,6 +34,27 @@ generateRandomAccount(uint32_t ledgerSeq)
     return le;
 }
 
+LedgerEntry
+generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
+              Price price)
+{
+    REQUIRE(!(selling == buying));
+    REQUIRE(amount >= 1);
+
+    LedgerEntry le;
+    le.lastModifiedLedgerSeq = 2;
+    le.data.type(OFFER);
+
+    auto offer = LedgerTestUtils::generateValidOfferEntry();
+    offer.amount = amount;
+    offer.price = price;
+    offer.selling = selling;
+    offer.buying = buying;
+
+    le.data.offer() = offer;
+    return le;
+}
+
 bool
 store(Application& app, UpdateList const& apply, AbstractLedgerTxn* ltxPtr,
       OperationResult const* resPtr)

--- a/src/invariant/test/InvariantTestUtils.h
+++ b/src/invariant/test/InvariantTestUtils.h
@@ -12,14 +12,18 @@ namespace stellar
 
 class Application;
 class AbstractLedgerTxn;
+struct Asset;
 struct AccountEntry;
 struct LedgerEntry;
 struct OperationResult;
+struct Price;
 
 namespace InvariantTestUtils
 {
 
 LedgerEntry generateRandomAccount(uint32_t ledgerSeq);
+LedgerEntry generateOffer(Asset const& selling, Asset const& buying,
+                          int64_t amount, Price price);
 
 typedef std::vector<
     std::tuple<std::shared_ptr<LedgerEntry>, std::shared_ptr<LedgerEntry>>>

--- a/src/invariant/test/LiabilitiesMatchOffersTests.cpp
+++ b/src/invariant/test/LiabilitiesMatchOffersTests.cpp
@@ -145,27 +145,6 @@ TEST_CASE("Account below minimum balance decreases",
 }
 
 static LedgerEntry
-generateOffer(Asset const& selling, Asset const& buying, int64_t amount,
-              Price price)
-{
-    REQUIRE(!(selling == buying));
-    REQUIRE(amount >= 1);
-
-    LedgerEntry le;
-    le.lastModifiedLedgerSeq = 2;
-    le.data.type(OFFER);
-
-    auto offer = LedgerTestUtils::generateValidOfferEntry();
-    offer.amount = amount;
-    offer.price = price;
-    offer.selling = selling;
-    offer.buying = buying;
-
-    le.data.offer() = offer;
-    return le;
-}
-
-static LedgerEntry
 generateSellingLiabilities(Application& app, LedgerEntry offer, bool excess,
                            uint32_t authorized)
 {

--- a/src/invariant/test/OrderBookIsNotCrossedTests.cpp
+++ b/src/invariant/test/OrderBookIsNotCrossedTests.cpp
@@ -1,0 +1,376 @@
+#ifdef BUILD_TESTS
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "invariant/OrderBookIsNotCrossed.h"
+#include "invariant/test/InvariantTestUtils.h"
+#include "ledger/LedgerTxn.h"
+#include "lib/catch.hpp"
+#include "test/TestAccount.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "test/test.h"
+
+namespace stellar
+{
+
+namespace
+{
+void
+applyCheck(Application& app, std::vector<LedgerEntry> const& current,
+           std::vector<LedgerEntry> const& previous, bool shouldPass)
+{
+    stellar::InvariantTestUtils::UpdateList updates;
+
+    if (previous.empty())
+    {
+        updates = InvariantTestUtils::makeUpdateList(current, nullptr);
+    }
+    else if (current.empty())
+    {
+        updates = InvariantTestUtils::makeUpdateList(nullptr, previous);
+    }
+    else
+    {
+        std::vector<LedgerKey> curKeys;
+        std::vector<LedgerKey> prevKeys;
+        std::transform(current.begin(), current.end(),
+                       std::back_inserter(curKeys), LedgerEntryKey);
+        std::transform(previous.begin(), previous.end(),
+                       std::back_inserter(prevKeys), LedgerEntryKey);
+        REQUIRE(curKeys == prevKeys);
+        updates = InvariantTestUtils::makeUpdateList(current, previous);
+    }
+
+    REQUIRE(InvariantTestUtils::store(app, updates, nullptr, nullptr) ==
+            shouldPass);
+}
+
+LedgerEntry
+createOffer(Asset const& ask, Asset const& bid, int64 amount,
+            Price const& price, bool passive = false)
+{
+    auto offer = InvariantTestUtils::generateOffer(ask, bid, amount, price);
+    offer.data.offer().flags = passive ? PASSIVE_FLAG : 0;
+    return offer;
+}
+
+LedgerEntry
+modifyOffer(LedgerEntry offer, bool passive)
+{
+    offer.data.offer().flags = passive ? PASSIVE_FLAG : 0;
+    return offer;
+}
+
+LedgerEntry
+modifyOffer(LedgerEntry offer, int64 amount, Price const& price)
+{
+    offer.data.offer().amount = amount;
+    offer.data.offer().price = price;
+    return offer;
+}
+
+LedgerEntry
+modifyOffer(LedgerEntry offer, Asset const& ask, Asset const& bid, int64 amount,
+            Price const& price)
+{
+    offer.data.offer().selling = ask;
+    offer.data.offer().buying = bid;
+    return modifyOffer(offer, amount, price);
+}
+}
+
+TEST_CASE("Comparison of offers meets ordering requirements",
+          "[invariant][OrderBookIsNotCrossed]")
+{
+    OrderBookIsNotCrossed::OfferEntryCmp cmp;
+    OfferEntry l, r;
+
+    l.price = Price{1, 1};
+    l.flags = PASSIVE_FLAG;
+    r.price = Price{2, 1};
+    r.flags = 0;
+    REQUIRE(cmp(l, r));
+    REQUIRE(!cmp(r, l));
+
+    l.price = Price{1, 1};
+    l.flags = 0;
+    l.offerID = 2;
+    r.price = Price{1, 1};
+    r.flags = PASSIVE_FLAG;
+    r.offerID = 1;
+    REQUIRE(cmp(l, r));
+    REQUIRE(!cmp(r, l));
+}
+
+TEST_CASE("OrderBookIsNotCrossed in-memory order book is consistent with "
+          "application behaviour",
+          "[invariant][OrderBookIsNotCrossed]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig(0);
+    // When testing the order book not crossed invariant, enable it and no other
+    // invariants (these tests do things which violate other invariants).
+    cfg.INVARIANT_CHECKS = {};
+    auto app = createTestApplication(clock, cfg);
+    OrderBookIsNotCrossed::registerAndEnableInvariant(*app);
+    app->start();
+
+    auto root = TestAccount::createRoot(*app);
+
+    auto const cur1 = root.asset("CUR1");
+    auto const cur2 = root.asset("CUR2");
+
+    LedgerTxn ltxOuter{app->getLedgerTxnRoot()};
+
+    auto const invariant = std::make_shared<OrderBookIsNotCrossed>();
+    auto offer = InvariantTestUtils::generateOffer(cur1, cur2, 3, Price{3, 2});
+
+    // create
+    {
+        LedgerTxn ltx{ltxOuter};
+        ltx.create(offer);
+
+        invariant->checkOnOperationApply({}, OperationResult{}, ltx.getDelta());
+        auto const& orders = invariant->getOrderBook().at({cur1, cur2});
+
+        REQUIRE(orders.size() == 1);
+
+        auto const& offerToCheck = *orders.cbegin();
+
+        REQUIRE(offerToCheck.amount == 3);
+        REQUIRE(offerToCheck.price.n == 3);
+        REQUIRE(offerToCheck.price.d == 2);
+
+        ltx.commit();
+    }
+
+    // modify
+    {
+        LedgerTxn ltx{ltxOuter};
+
+        offer.data.offer().amount = 2;
+        offer.data.offer().price = Price{5, 3};
+        auto entry = ltx.load(LedgerEntryKey(offer));
+        entry.current() = offer;
+
+        invariant->checkOnOperationApply({}, OperationResult{}, ltx.getDelta());
+        auto const& orders = invariant->getOrderBook().at({cur1, cur2});
+
+        REQUIRE(orders.size() == 1);
+
+        auto const& offerToCheck = *orders.cbegin();
+
+        REQUIRE(offerToCheck.amount == 2);
+        REQUIRE(offerToCheck.price.n == 5);
+
+        ltx.commit();
+    }
+
+    // delete
+    {
+        LedgerTxn ltx{ltxOuter};
+
+        auto entry = ltx.load(LedgerEntryKey(offer));
+        entry.erase();
+
+        invariant->checkOnOperationApply({}, OperationResult{}, ltx.getDelta());
+
+        REQUIRE(invariant->getOrderBook().at({cur1, cur2}).size() == 0);
+    }
+}
+
+TEST_CASE("OrderBookIsNotCrossed properly throws if order book is crossed",
+          "[invariant][OrderBookIsNotCrossed]")
+{
+
+    VirtualClock clock;
+    auto cfg = getTestConfig(0);
+    // When testing the order book not crossed invariant, enable it and no other
+    // invariants (these tests do things which violate other invariants).
+    cfg.INVARIANT_CHECKS = {};
+    auto app = createTestApplication(clock, cfg);
+    OrderBookIsNotCrossed::registerAndEnableInvariant(*app);
+    app->start();
+
+    auto root = TestAccount::createRoot(*app);
+
+    auto const cur1 = root.asset("CUR1");
+    auto const cur2 = root.asset("CUR2");
+    auto const cur3 = root.asset("CUR3");
+    auto const cur4 = root.asset("CUR4");
+    auto const cur5 = root.asset("CUR5");
+
+    // the initial set up for the order book follows where:
+    // A = cur1, B = cur2, and C = cur3
+    // A against B
+    //     offer1: 3 A @  3/2 (B/A)
+    //     offer2: 2 A @  5/3 (B/A)
+    auto const offer1 = createOffer(cur1, cur2, 3, Price{3, 2});
+    auto const offer2 = createOffer(cur1, cur2, 2, Price{5, 3});
+    // B against A
+    //     offer3: 4 B @  3/4 (A/B)
+    //     offer4: 1 B @  4/5 (A/B)
+    auto const offer3 = createOffer(cur2, cur1, 4, Price{3, 4});
+    auto const offer4 = createOffer(cur2, cur1, 1, Price{4, 5});
+    // B against C
+    //     offer5: 3 B @  3/2 (C/B)
+    //     offer6: 2 B @  5/3 (C/B)
+    auto const offer5 = createOffer(cur2, cur3, 3, Price{3, 2});
+    auto const offer6 = createOffer(cur2, cur3, 2, Price{5, 3});
+    // C against B
+    //     offer7: 4 C @  3/4 (B/C)
+    //     offer8: 1 C @  4/5 (B/C)
+    auto const offer7 = createOffer(cur3, cur2, 4, Price{3, 4});
+    auto const offer8 = createOffer(cur3, cur2, 1, Price{4, 5});
+
+    applyCheck(*app,
+               {offer1, offer2, offer3, offer4, offer5, offer6, offer7, offer8},
+               {}, true);
+
+    SECTION("Not crossed when highest bid < lowest ask")
+    {
+        // Create - Offer 9: 7 A @  8/5 (B/A)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{8, 5});
+        applyCheck(*app, {offer9}, {}, true);
+
+        // Modify - Offer 10: 7 A @  16/11 (B/A)
+        auto const offer10 = modifyOffer(offer9, 7, Price{16, 11});
+        applyCheck(*app, {offer10}, {offer9}, true);
+
+        // Delete - Offer 10
+        applyCheck(*app, {}, {offer10}, true);
+    }
+
+    SECTION("Change an asset without crossing book")
+    {
+        auto const offer9 = modifyOffer(offer7, cur1, cur2, 4, Price{13, 10});
+        applyCheck(*app, {offer9}, {offer7}, false);
+    }
+
+    SECTION("Cross book by changing an asset")
+    {
+        auto const offer9 = modifyOffer(offer7, cur1, cur2, 4, Price{3, 4});
+        applyCheck(*app, {offer9}, {offer7}, false);
+    }
+
+    SECTION("Swap assets without crossing book")
+    {
+        auto const offer9 = modifyOffer(offer7, cur2, cur3, 4, Price{4, 3});
+        applyCheck(*app, {offer9}, {offer7}, true);
+    }
+
+    SECTION("Cross book by swapping assets")
+    {
+        auto const offer9 = modifyOffer(offer8, cur2, cur3, 1, Price{5, 4});
+        applyCheck(*app, {offer9}, {offer8}, false);
+    }
+
+    SECTION("Crossed where highest bid = lowest ask")
+    {
+        // Create - Offer 9: 7 A @  4/3 (B/A)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{4, 3});
+        applyCheck(*app, {offer9}, {}, false);
+
+        // Modify - Offer 10: 3 A @ 4/3 (B/A)
+        auto const offer10 = modifyOffer(offer9, 3, Price{4, 3});
+        applyCheck(*app, {offer10}, {offer9}, false);
+
+        // Delete - Offer 10
+        applyCheck(*app, {}, {offer10}, true);
+    }
+
+    SECTION("Not crossed where highest bid = lowest ask but only because of "
+            "passive offer(s)")
+    {
+        // Create - Offer 9: 7 A @  4/3 (B/A) (passive)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{4, 3}, true);
+        applyCheck(*app, {offer9}, {}, true);
+
+        // Modify - Offer 10: 3 A @ 4/3 (B/A)
+        auto const offer10 = modifyOffer(offer9, 3, Price{4, 3});
+        applyCheck(*app, {offer10}, {offer9}, true);
+
+        SECTION("Cross book by making an offer non-passive")
+        {
+            auto const offer11 = modifyOffer(offer10, false);
+            applyCheck(*app, {offer11}, {offer10}, false);
+        }
+
+        // Create - Offer 11: 7 A @  1/1 (B/A) (passive)
+        // This offer should cross even though it's passive, because the price
+        // ratio between the ask and the bid is not exactly 1.
+        auto const offer11 = createOffer(cur1, cur2, 7, Price{1, 1}, true);
+        applyCheck(*app, {offer11}, {}, false);
+
+        // Delete - Offer 10
+        applyCheck(*app, {}, {offer10}, true);
+    }
+
+    SECTION("Crossed where highest bid > lowest ask")
+    {
+        // Create - Offer 9: 7 A @  1/1 (B/A)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{1, 1});
+        applyCheck(*app, {offer9}, {}, false);
+
+        // Modify - Offer 6: 3 A @ 100/76 (B/A)
+        auto const offer10 = modifyOffer(offer9, 3, Price{100, 76});
+        applyCheck(*app, {offer10}, {offer9}, false);
+
+        // Delete - Offer 10
+        applyCheck(*app, {}, {offer10}, true);
+    }
+
+    SECTION("Multiple assets not crossed (PathPayment)")
+    {
+        // Create - Offer 9: 7 A @  8/5 (B/A)
+        // Create - Offer 10: 7 B @  8/5 (C/B)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{8, 5});
+        auto const offer10 = createOffer(cur2, cur3, 7, Price{8, 5});
+        applyCheck(*app, {offer9, offer10}, {}, true);
+
+        // Modify - Offer 11: 7 A @  16/11 (B/A)
+        // Modify - Offer 12: 7 B @  16/11 (C/B)
+        auto const offer11 = modifyOffer(offer9, 7, Price{16, 11});
+        auto const offer12 = modifyOffer(offer10, 7, Price{16, 11});
+        applyCheck(*app, {offer11, offer12}, {offer9, offer10}, true);
+
+        // Delete - Offer 11
+        // Delete - Offer 12
+        applyCheck(*app, {}, {offer11, offer12}, true);
+    }
+
+    SECTION("Multiple assets crossed where only one crosses (PathPayment)")
+    {
+        // Create - Offer 9: 7 A @  4/3 (B/A) - CROSSED
+        // Create - Offer 10: 7 B @  8/5 (C/B)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{4, 3});
+        auto const offer10 = createOffer(cur2, cur3, 7, Price{8, 5});
+        applyCheck(*app, {offer9, offer10}, {}, false);
+
+        // Modify - Offer 11: 3 A @  16/11 (B/A)
+        // Modify - Offer 12: 3 B @  100/76 (C/B) - CROSSED
+        auto const offer11 = modifyOffer(offer9, 3, Price{16, 11});
+        auto const offer12 = modifyOffer(offer10, 3, Price{100, 76});
+        applyCheck(*app, {offer11, offer12}, {offer9, offer10}, false);
+    }
+
+    SECTION("Multiple assets crossed where both crossed (PathPayment)")
+    {
+        // Create - Offer 9: 7 A @  4/3 (B/A)
+        // Create - Offer 10: 7 B @  4/3 (C/B)
+        auto const offer9 = createOffer(cur1, cur2, 7, Price{4, 3});
+        auto const offer10 = createOffer(cur2, cur3, 7, Price{4, 3});
+        applyCheck(*app, {offer9, offer10}, {}, false);
+    }
+
+    SECTION("Multiple assets not crossed when deleting offers with allow trust")
+    {
+        // Delete both of offer3 and offer5, as if, for example, their creator's
+        // trustline to B had been revoked.
+        applyCheck(*app, {}, {offer3, offer5}, true);
+    }
+}
+}
+#endif // BUILD_TESTS

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -140,13 +140,13 @@ InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
     return 0;
 }
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
 void
 InMemoryLedgerTxnRoot::resetForFuzzer()
 {
     abort();
 }
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
 #ifdef BEST_OFFER_DEBUGGING
 bool

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -66,9 +66,9 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void dropClaimableBalances() override;
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
     void resetForFuzzer() override;
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
 #ifdef BEST_OFFER_DEBUGGING
     bool bestOfferDebuggingEnabled() const override;

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1711,13 +1711,13 @@ LedgerTxn::getPrefetchHitRate() const
     return getImpl()->getPrefetchHitRate();
 }
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
 void
 LedgerTxn::resetForFuzzer()
 {
     abort();
 }
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
 double
 LedgerTxn::Impl::getPrefetchHitRate() const
@@ -2165,7 +2165,7 @@ LedgerTxnRoot::Impl::~Impl()
     }
 }
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
 void
 LedgerTxnRoot::Impl::resetForFuzzer()
 {
@@ -2178,7 +2178,7 @@ LedgerTxnRoot::resetForFuzzer()
 {
     mImpl->resetForFuzzer();
 }
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
 void
 LedgerTxnRoot::addChild(AbstractLedgerTxn& child)

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -450,9 +450,9 @@ class AbstractLedgerTxnParent
     // than a (real or stub) root LedgerTxn.
     virtual uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) = 0;
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
     virtual void resetForFuzzer() = 0;
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
 #ifdef BEST_OFFER_DEBUGGING
     virtual bool bestOfferDebuggingEnabled() const = 0;
@@ -715,10 +715,9 @@ class LedgerTxn final : public AbstractLedgerTxn
         std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
         AssetPairHash> const&
     getOrderBook();
-#endif
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
     void resetForFuzzer() override;
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
 #ifdef BEST_OFFER_DEBUGGING
     bool bestOfferDebuggingEnabled() const override;
@@ -762,9 +761,9 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     void dropTrustLines() override;
     void dropClaimableBalances() override;
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
     void resetForFuzzer() override;
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
     UnorderedMap<LedgerKey, LedgerEntry> getAllOffers() override;
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -825,9 +825,9 @@ class LedgerTxnRoot::Impl
     void dropTrustLines();
     void dropClaimableBalances();
 
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
     void resetForFuzzer();
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#endif // BUILD_TESTS
 
     // getAllOffers has the basic exception safety guarantee. If it throws an
     // exception, then

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -3,6 +3,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "test/FuzzerImpl.h"
+#include "invariant/OrderBookIsNotCrossed.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/TrustLineWrapper.h"
 #include "ledger/test/LedgerTestUtils.h"
@@ -1303,6 +1304,7 @@ TransactionFuzzer::initialize()
 {
     resetRandomSeed(1);
     mApp = createTestApplication(mClock, getFuzzConfig(0));
+    OrderBookIsNotCrossed::registerAndEnableInvariant(*mApp);
     auto root = TestAccount::createRoot(*mApp);
     mSourceAccountID = root.getPublicKey();
 

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -741,9 +741,10 @@ resetTxInternalState(Application& app)
 {
     resetRandomSeed(1);
 // reset caches to clear persistent state
-#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#ifdef BUILD_TESTS
     app.getLedgerTxnRoot().resetForFuzzer();
-#endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+    app.getInvariantManager().resetForFuzzer();
+#endif // BUILD_TESTS
     app.getDatabase().clearPreparedStatementCache();
 }
 
@@ -1327,6 +1328,10 @@ TransactionFuzzer::initialize()
     // commit this to the ledger so that we have a starting, persistent
     // state to fuzz test against
     ltxOuter.commit();
+
+#ifdef BUILD_TESTS
+    mApp->getInvariantManager().snapshotForFuzzer();
+#endif // BUILD_TESTS
 }
 
 void


### PR DESCRIPTION
# Introduce "order book not crossed" invariant

Resolves #2417 

This PR introduces a new invariant which keeps track of the state of the order book as operations are applied, and asserts that it is not crossed.

There is currently no mechanism by which an invariant can be informed that an operation application for which its `checkOnOperationApply()` method had been called is being rolled back.  Hence, we can not in general support an invariant such as this which maintains state across method calls.  But we can when fuzzing, where setup operations are never rolled back and where we can explicitly tell invariants when to snapshot state (that is, after setup completes) and when to reset it to that state (after each fuzz test).

Therefore, this invariant is compiled in when fuzzing is configured, and not otherwise.

This PR updates #2210 to current code, adapting to some changes such as the introduction of `InternalLedgerEntry` and the rearranging of the fuzzing code, and adds support for passive offers.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
