### PR TITLE
Add *.o.tmp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.a
 *.o
+*.o.tmp
 *.obj
 *.la
 *.lo


### PR DESCRIPTION
# Description

Instruct git to ignore `*.o.tmp` files.

I've noticed when compiling that the version control tab in VSCode updates frequently with untracked files that have the `.o.tmp` extension. These look like temporary files that shouldn't be committed.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [ ] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
