### PR TITLE
Check for memcpy() of null in signHashX

### DIFF
--- a/src/transactions/SignatureUtils.cpp
+++ b/src/transactions/SignatureUtils.cpp
@@ -51,7 +51,14 @@ signHashX(const ByteSlice& x)
     DecoratedSignature result;
     Signature out(0, 0);
     out.resize(static_cast<uint32_t>(x.size()));
-    std::memcpy(out.data(), x.data(), x.size());
+    if (!x.empty() && x.data())
+    {
+        std::memcpy(out.data(), x.data(), x.size());
+    }
+    else
+    {
+        assert(x.empty());
+    }
     result.signature = out;
     result.hint = getHint(sha256(x));
     return result;


### PR DESCRIPTION
# Check for memcpy() of null in signHashX

`ubsan` complains about a `memcpy` on `NULL` (of 0 bytes) in `signHashX()`.  I don't think we can be getting any bad behavior in practice, but it's technically UB even to copy 0 bytes from `NULL`, and we should silence `ubsan`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
