### PR TITLE
Fix fuzzer offer setup parameters and assertion

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1344,12 +1344,18 @@ TransactionFuzzer::storeSetupLedgerKeys(AbstractLedgerTxn& ltx)
     std::sort(init.begin(), init.end());
 
     // Setup should only create entries; there should be no dead entries, and
-    // only one "live" (modified) one:  the root account.
+    // at most one "live" (modified) one:  the root account.
     assert(dead.empty());
-    assert(live.size() == 1);
-    assert(live[0].data.type() == ACCOUNT);
-    assert(live[0].data.account().accountID ==
-           txtest::getRoot(mApp->getNetworkID()).getPublicKey());
+    if (live.size() == 1)
+    {
+        assert(live[0].data.type() == ACCOUNT);
+        assert(live[0].data.account().accountID ==
+               txtest::getRoot(mApp->getNetworkID()).getPublicKey());
+    }
+    else
+    {
+        assert(live.empty());
+    }
 
     // If we ever create more ledger entries during setup than we have room for
     // in mStoredLedgerEntries, then we will have to do something further.

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1492,11 +1492,11 @@ TransactionFuzzer::initializeOffers(AbstractLedgerTxn& ltxOuter)
     {
         auto op = param.mPassive
                       ? txtest::createPassiveOffer(
-                            param.mBid.toAsset(), param.mSell.toAsset(),
+                            param.mSell.toAsset(), param.mBid.toAsset(),
                             Price{param.mNumerator, param.mDenominator},
                             param.mAmount)
                       : txtest::manageOffer(
-                            0, param.mBid.toAsset(), param.mSell.toAsset(),
+                            0, param.mSell.toAsset(), param.mBid.toAsset(),
                             Price{param.mNumerator, param.mDenominator},
                             param.mAmount);
         PublicKey pkA;


### PR DESCRIPTION
# Fix two bugs in fuzzer setup configuration

While working on making fuzzer setup more varied, I noticed two bugs in the existing code:

- There's an assertion that tries to confirm that setup has done exactly what the configuration was intended to mean, which states that the root account is the only modified ledger entry in the setup transaction (the others should all be newly-created).  That's true for almost any configuration -- but not for the _empty_ configuration, in which case there are _no_ modified ledger entries.  We are not planning for the configuration to be empty, but technically the assertion is wrong; an empty configuration is not inherently erroneous, and nothing else in the code depends on the configuration being non-empty.
- More important, the ask and bid parameters to `txtest::manageOffer()` have been reversed ever since the first version of the order book setup code!  This hasn't mattered either because the setup has been symmetrical, but we're going to make it _not_ so, and it would cause complete confusion then.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
