### PR TITLE
Make apt mirror configurable in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,10 +19,21 @@ ARG USER_GID=$USER_UID
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog ca-certificates 2>&1
 
-# use mirrors instead of hardcoded location for performance
-RUN sed -i -e 's/http:\/\/us.archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
-    && sed -i -e 's/http:\/\/security/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
-    && sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list
+# use apt mirror instead of default archives if specified
+# to use, specify the build arg or as an env var on the host machine
+# e.g.:
+#   mirror://mirrors.ubuntu.com/mirrors.txt
+#   mirror://mirrors.ubuntu.com/<country-code>.txt
+#   http://<country-code>.archive.ubuntu.com/ubuntu/
+#   http://<aws-region>.ec2.archive.ubuntu.com/ubuntu
+ARG APT_MIRROR=
+RUN if [ ! -z "${APT_MIRROR}" ]; then \
+    sed -i \
+        -e "s|http://archive.ubuntu.com/ubuntu/|${APT_MIRROR}|" \
+        -e "s|http://security.ubuntu.com/ubuntu/|${APT_MIRROR}|" \
+        /etc/apt/sources.list \
+    ; fi \
+    ; grep "^[^#;]" /etc/apt/sources.list
 
 # install base container packages and prep for VSCode
 RUN apt-get update \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,11 @@
 {
 	"name": "Ubuntu 20.04 & Git",
 	"dockerFile": "Dockerfile",
+	"build": {
+		"args": {
+			"APT_MIRROR": "${localEnv:APT_MIRROR}"
+		}
+	},
 	// The optional 'runArgs' property can be used to specify additional runtime arguments.
 	"runArgs": [
 		// Uncomment the line if you will use a ptrace-based debugger like C++, Go, and Rust.


### PR DESCRIPTION
# Description

Reduce the build time of the devcontainer from 5min30sec to 1min20sec for users in San Francisco and AWS's California location by making the apt mirrors configurable.

The currently configured mirrors are insane slow from several locations I tested, compared to the default apt repositories. It's not one slow mirror being selected either, apt is selecting a different mirror for each package install.

A build arg is added that is the apt mirror that should be used. When not set the default apt repos are used. A developer may specify the mirror using a variety of options:
- `mirror://mirrors.ubuntu.com/mirrors.txt` to use the full list of all mirrors
- `mirror://mirrors.ubuntu.com/<country-code>.txt` to use country specific mirror lists directly
- `http://<country-code>.archive.ubuntu.com/ubuntu/` to use the country specific mirrors via Canonical
- `http://<aws-region>.ec2.archive.ubuntu.com/ubuntu` to use the mirrors hosted in the same AWS region

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
