### PR TITLE
Add test for LedgerTxnRoot best offers cache eviction

### DIFF
--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -3707,3 +3707,66 @@ TEST_CASE("LedgerTxn generalized ledger entries", "[ledgertxn]")
         }
     }
 }
+
+TEST_CASE("LedgerTxn best offers cache eviction", "[ledgertxn]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig(0);
+    auto app = createTestApplication(clock, cfg);
+    app->start();
+
+    auto buying = autocheck::generator<Asset>()(UINT32_MAX);
+    auto selling = autocheck::generator<Asset>()(UINT32_MAX);
+    while (buying == selling)
+    {
+        selling = autocheck::generator<Asset>()(UINT32_MAX);
+    }
+
+    // Populate the database with two offers involving the same asset pair
+    {
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+
+        LedgerEntry le;
+        le.data.type(OFFER);
+        auto& oe = le.data.offer();
+        oe.offerID = 1;
+        oe.price = Price{1, 1};
+        oe.buying = buying;
+        oe.selling = selling;
+        ltx.create(le);
+
+        oe.offerID = 2;
+        ltx.create(le);
+
+        ltx.commit();
+    }
+
+    {
+        LedgerTxn ltx1(app->getLedgerTxnRoot());
+
+        // If the implementation involves caching, try to churn the cache
+        {
+            LedgerTxn ltx2(ltx1);
+            auto ltxe1 = ltx2.loadBestOffer(buying, selling);
+            REQUIRE(ltxe1.current().data.offer().offerID == 1);
+            ltxe1.erase();
+
+            for (size_t i = 0; i < 100; ++i)
+            {
+                auto a1 = autocheck::generator<Asset>()(UINT32_MAX);
+                auto a2 = autocheck::generator<Asset>()(UINT32_MAX);
+                if (!(a1 == a2))
+                {
+                    ltx2.loadBestOffer(a1, a2);
+                }
+            }
+
+            auto ltxe2 = ltx2.loadBestOffer(buying, selling);
+            REQUIRE(ltxe2.current().data.offer().offerID == 2);
+        }
+
+        // Access the cache to check if it is valid
+        auto ltxe = ltx1.loadBestOffer(buying, selling);
+        REQUIRE(ltxe.current().data.offer().offerID == 1);
+    }
+}


### PR DESCRIPTION
# Description
This is an old test that I wrote before we stopped evicting from the best offers cache, but might still have value in preventing future regressions.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
