### PR TITLE
Add src/archtmp-* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ compile_commands.json
 
 /INSTALL
 
+/src/archtmp-*
 /src/main/StellarCoreVersion.cpp
 /src/testdata
 /src/xdr/*.h


### PR DESCRIPTION
# Description

Add `src/archtmp-*` to `.gitignore`.

Folders matching that glob keep appearing after test runs and it's annoying to have them appear as untracked files.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
