### PR TITLE
fix apt mirroring in dev container, now requires CAs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,17 +15,19 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# setup apt / certificates
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog ca-certificates 2>&1
+
 # use mirrors instead of hardcoded location for performance
 RUN sed -i -e 's/http:\/\/us.archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
     && sed -i -e 's/http:\/\/security/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list \
     && sed -i -e 's/http:\/\/archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors.txt/' /etc/apt/sources.list
 
-# Configure apt and install packages
+# install base container packages and prep for VSCode
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog ca-certificates 2>&1 \
-    #
-    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    # Verify process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
As noticed in https://github.com/stellar/stellar-core/pull/2970 mirroring got broken somehow when pulling packages.

This PR fixes mirroring by installing certificates first.

Without mirroring, download speeds are extremely slow (3MB/s on my laptop), where as with mirroring I get speeds up to my maximum download speed (depending on packages).

There might be a better fix but this will do it for now.

I compared runs by removing all containers and cleaning docker's local caches using `docker system prune`

Before (mirroring disabled):
```


[+] Building 700.2s (13/13) FINISHED
 => [internal] load build definition from Dockerfile                                              0.1s
 => => transferring dockerfile: 3.10kB                                                            0.0s
 => [internal] load .dockerignore                                                                 0.0s
 => => transferring context: 2B                                                                   0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                   2.1s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                     0.0s
 => [1/8] FROM docker.io/library/ubuntu:focal@sha256:b4f9e18267eb98998f6130342baacaeb9553f136142  0.1s
 => => resolve docker.io/library/ubuntu:focal@sha256:b4f9e18267eb98998f6130342baacaeb9553f136142  0.0s
 => => sha256:e3d7ff9efd8431d9ef39a144c45992df5502c995b9ba3c53ff70c5b52a848d9c 943B / 943B        0.0s
 => => sha256:4dd97cefde62cf2d6bcfd8f2c0300a24fbcddbe0ebcd577cc8b420c29106869a 3.32kB / 3.32kB    0.0s
 => => sha256:b4f9e18267eb98998f6130342baacaeb9553f136142d40959a1b46d6401f0f2b 1.20kB / 1.20kB    0.0s
 => [2/8] RUN apt-get update     && apt-get -y install --no-install-recommends apt-utils dialo  135.7s
 => [3/8] RUN apt-get -y install git build-essential pkg-config autoconf automake libtool biso  181.8s
 => [4/8] RUN apt-get -y install libstdc++-7-dev clang-format-8 ccache                           54.1s
 => [5/8] RUN apt-get -y install cpp-7 gcc-7 g++-7                                               73.0s
 => [6/8] RUN apt-get -y install clang-8 llvm-8                                                 148.2s
 => [7/8] RUN apt-get -y install postgresql                                                      99.6s
 => [8/8] RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen     && locale  2.8s
```

After:
```
[+] Building 368.7s (15/15) FINISHED
 => [internal] load build definition from Dockerfile                                              0.0s
 => => transferring dockerfile: 3.13kB                                                            0.0s
 => [internal] load .dockerignore                                                                 0.1s
 => => transferring context: 2B                                                                   0.0s
 => [internal] load metadata for docker.io/library/ubuntu:focal                                   2.0s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                     0.0s
 => [ 1/10] FROM docker.io/library/ubuntu:focal@sha256:b4f9e18267eb98998f6130342baacaeb9553f1361  6.1s
 => => resolve docker.io/library/ubuntu:focal@sha256:b4f9e18267eb98998f6130342baacaeb9553f136142  0.0s
 => => sha256:b4f9e18267eb98998f6130342baacaeb9553f136142d40959a1b46d6401f0f2b 1.20kB / 1.20kB    0.0s
 => => sha256:e3d7ff9efd8431d9ef39a144c45992df5502c995b9ba3c53ff70c5b52a848d9c 943B / 943B        0.0s
 => => sha256:4dd97cefde62cf2d6bcfd8f2c0300a24fbcddbe0ebcd577cc8b420c29106869a 3.32kB / 3.32kB    0.0s
 => => sha256:5d3b2c2d21bba59850dac063bcbb574fddcb6aefb444ffcc63843355d878d54f 28.57MB / 28.57MB  3.4s
 => => sha256:3fc2062ea6672189447be7510fb7d5bc2ef2fda234a04b457d9dda4bba5cc635 850B / 850B        0.5s
 => => sha256:75adf526d75b82eb4f9981cce0b23608ebe6ab85c3e1ab2441f29b302d2f9aa8 162B / 162B        0.6s
 => => extracting sha256:5d3b2c2d21bba59850dac063bcbb574fddcb6aefb444ffcc63843355d878d54f         2.2s
 => => extracting sha256:3fc2062ea6672189447be7510fb7d5bc2ef2fda234a04b457d9dda4bba5cc635         0.0s
 => => extracting sha256:75adf526d75b82eb4f9981cce0b23608ebe6ab85c3e1ab2441f29b302d2f9aa8         0.0s
 => [ 2/10] RUN apt-get update     && apt-get -y install --no-install-recommends apt-utils dial  50.6s
 => [ 3/10] RUN sed -i -e 's/http:\/\/us.archive/mirror:\/\/mirrors/' -e 's/\/ubuntu\//\/mirrors  0.5s
 => [ 4/10] RUN apt-get update     && apt-get -y install iproute2 procps lsb-release     && gro  52.2s
 => [ 5/10] RUN apt-get -y install git build-essential pkg-config autoconf automake libtool bi  128.0s
 => [ 6/10] RUN apt-get -y install libstdc++-7-dev clang-format-8 ccache                         21.7s
 => [ 7/10] RUN apt-get -y install cpp-7 gcc-7 g++-7                                             13.3s
 => [ 8/10] RUN apt-get -y install clang-8 llvm-8                                                52.4s
 => [ 9/10] RUN apt-get -y install postgresql                                                    35.6s
 => [10/10] RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen     && loca  2.6s
```
