### PR TITLE
Use txbridge in tests to mutate time bounds

### DIFF
--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -12,6 +12,7 @@
 #include "test/TxTests.h"
 #include "test/test.h"
 #include "transactions/SignatureUtils.h"
+#include "transactions/TransactionBridge.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Decoder.h"
 #include "util/Math.h"
@@ -23,6 +24,7 @@
 #include <stdexcept>
 
 using namespace stellar;
+using namespace stellar::txbridge;
 using namespace stellar::txtest;
 
 TEST_CASE("transaction envelope bridge", "[commandhandler]")
@@ -462,12 +464,11 @@ TEST_CASE("manualclose", "[commandhandler]")
             auto dataOp = txtest::manageData(de.dataName, &de.dataValue);
             auto txFrame = root.tx({dataOp});
             REQUIRE(txFrame->getEnvelope().type() == stellar::ENVELOPE_TYPE_TX);
-            txFrame->getEnvelope().v1().tx.timeBounds.activate();
-            txFrame->getEnvelope().v1().tx.timeBounds->minTime = 0;
+            setMinTime(txFrame, 0);
             TimePoint const maxTime =
                 lastCloseTime() + defaultManualCloseTimeInterval +
                 getUpperBoundCloseTimeOffset(*app, lastCloseTime());
-            txFrame->getEnvelope().v1().tx.timeBounds->maxTime = maxTime;
+            setMaxTime(txFrame, maxTime);
             txFrame->getEnvelope().v1().signatures.clear();
             txFrame->addSignature(root);
 


### PR DESCRIPTION
# Description

Use txbridge in tests to mutate time bounds.

While working on CAP-21 XDR changes I noticed that some tests use the txbridge `setMinTime` and `setMaxTime`, and then a few don't. This change is non-functional and only updates those tests that don't to use them. It makes it easier to update the bridging logic required to change for CAP-21 if tests use the helpers consistently. This change seems mildly beneficial regardless of whether CAP-21 lands or not.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
