### PR TITLE
Introduce a mode to delay streaming meta by one ledger

### DIFF
--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -167,6 +167,22 @@ network's most recent checkpoint, but this behaviour can be further modified usi
 cause the node to start with a fast in-memory catchup to ledger `N` with hash `HEXHASH`, and then
 replay ledgers forward to the current state of the network.
 
+A stateless and meta-streaming node can additionally be configured with
+`UNSAFE_EMIT_META_EARLY=false` (if unspecified, the default is `true`).  If
+`UNSAFE_EMIT_META_EARLY` is `false`, then the node will defer emitting meta for
+a ledger `<N>` until the _next_ ledger, `<N+1>`, closes.  The idea is that if a
+node suffers local corruption in a ledger because of a software bug or hardware
+fault, it will be unable to close the _next_ ledger because it won't be able to
+reach consensus with other nodes. Therefore, the meta for the corrupted ledger
+will never be emitted.  With `UNSAFE_EMIT_META_EARLY` set to `true`, local
+corruption could cause a node to emit meta that were inconsistent with what the
+network reached consensus on.  Setting `UNSAFE_EMIT_META_EARLY` to `false` does
+have a cost, though:  clients waiting for the meta to determine the result of a
+transaction will have to wait for an extra ledger close duration.
+
+During catchup from history archives, a stateless node can emit meta for the
+latest ledger replayed even if `UNSAFE_EMIT_META_EARLY` is `false`, because it
+can validate the latest ledger's hash from the history archive.
 
 #### Publish backlog
 There is a command `publish` that allows to flush the publish backlog without starting

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -168,21 +168,23 @@ cause the node to start with a fast in-memory catchup to ledger `N` with hash `H
 replay ledgers forward to the current state of the network.
 
 A stateless and meta-streaming node can additionally be configured with
-`UNSAFE_EMIT_META_EARLY=false` (if unspecified, the default is `true`).  If
-`UNSAFE_EMIT_META_EARLY` is `false`, then the node will defer emitting meta for
-a ledger `<N>` until the _next_ ledger, `<N+1>`, closes.  The idea is that if a
-node suffers local corruption in a ledger because of a software bug or hardware
-fault, it will be unable to close the _next_ ledger because it won't be able to
-reach consensus with other nodes. Therefore, the meta for the corrupted ledger
-will never be emitted.  With `UNSAFE_EMIT_META_EARLY` set to `true`, local
-corruption could cause a node to emit meta that were inconsistent with what the
-network reached consensus on.  Setting `UNSAFE_EMIT_META_EARLY` to `false` does
-have a cost, though:  clients waiting for the meta to determine the result of a
-transaction will have to wait for an extra ledger close duration.
+`EXPERIMENTAL_PRECAUTION_DELAY_META=true` (if unspecified, the default is
+`false`).  If `EXPERIMENTAL_PRECAUTION_DELAY_META` is `true`, then the node will
+delay emitting meta for a ledger `<N>` until the _next_ ledger, `<N+1>`, closes.
+The idea is that if a node suffers local corruption in a ledger because of a
+software bug or hardware fault, it will be unable to close the _next_ ledger
+because it won't be able to reach consensus with other nodes on the input state
+of the next ledger. Therefore, the meta for the corrupted ledger will never be
+emitted.  With `EXPERIMENTAL_PRECAUTION_DELAY_META` set to `false`, a local
+corruption bug could cause a node to emit meta that is inconsistent with that of
+other nodes on the network. Setting `EXPERIMENTAL_PRECAUTION_DELAY_META` to
+`true` does have a cost, though: clients waiting for the meta to determine the
+result of a transaction will have to wait for an extra ledger close duration.
 
-During catchup from history archives, a stateless node can emit meta for the
-latest ledger replayed even if `UNSAFE_EMIT_META_EARLY` is `false`, because it
-can validate the latest ledger's hash from the history archive.
+During catchup from history archives, a stateless node will emit meta for any
+historical ledger without delay, even if `EXPERIMENTAL_PRECAUTION_DELAY_META` is
+`true`, because the ledger's results are already part of the validated consensus
+history.
 
 #### Publish backlog
 There is a command `publish` that allows to flush the publish backlog without starting

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -441,17 +441,18 @@ MAX_SLOTS_TO_REMEMBER=12
 # only a passive "watcher" node.
 METADATA_OUTPUT_STREAM=""
 
-# Setting UNSAFE_EMIT_META_EARLY to false causes a stateless node which is
-# streaming # meta to defer streaming the meta from one ledger until it closes
-# the next ledger.  This ensures that if a local bug had corrupted the previous
-# ledger, then the meta for the corrupted ledger will never be emitted, as the
-# node will not be able to reach consensus with the network on the next ledger.
+# Setting EXPERIMENTAL_PRECAUTION_DELAY_META to true causes a stateless node
+# which is streaming meta to delay streaming the meta for a given ledger until
+# it closes the next ledger. This ensures that if a local bug had corrupted the
+# given ledger, then the meta for the corrupted ledger will never be emitted, as
+# the node will not be able to reach consensus with the network on the next
+# ledger.
 #
-# Setting UNSAFE_EMIT_META_EARLY to false in combination with a non-empty
-# METADATA_OUTPUT_STREAM (which can be configured on the command line as well
-# as in the config file) requires an in-memory database (specified by using
-# --in-memory on the command line).
-UNSAFE_EMIT_META_EARLY=true
+# Setting EXPERIMENTAL_PRECAUTION_DELAY_META to true in combination with a
+# non-empty METADATA_OUTPUT_STREAM (which can be configured on the command line
+# as well as in the config file) requires an in-memory database (specified by
+# using --in-memory on the command line).
+EXPERIMENTAL_PRECAUTION_DELAY_META=false
 
 # EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE (list of strings) default is empty
 # Setting this will cause the node to reject transactions that it receives if

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -441,6 +441,18 @@ MAX_SLOTS_TO_REMEMBER=12
 # only a passive "watcher" node.
 METADATA_OUTPUT_STREAM=""
 
+# Setting UNSAFE_EMIT_META_EARLY to false causes a stateless node which is
+# streaming # meta to defer streaming the meta from one ledger until it closes
+# the next ledger.  This ensures that if a local bug had corrupted the previous
+# ledger, then the meta for the corrupted ledger will never be emitted, as the
+# node will not be able to reach consensus with the network on the next ledger.
+#
+# Setting UNSAFE_EMIT_META_EARLY to false in combination with a non-empty
+# METADATA_OUTPUT_STREAM (which can be configured on the command line as well
+# as in the config file) requires an in-memory database (specified by using
+# --in-memory on the command line).
+UNSAFE_EMIT_META_EARLY=true
+
 # EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE (list of strings) default is empty
 # Setting this will cause the node to reject transactions that it receives if
 # they contain any operation in this list. It will not, however, stop the node

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -20,6 +20,7 @@
 #include <fmt/format.h>
 #include <medida/meter.h>
 #include <medida/metrics_registry.h>
+#include <optional>
 
 namespace stellar
 {
@@ -241,7 +242,7 @@ ApplyCheckpointWork::getNextLedgerCloseData()
 
     return std::make_shared<LedgerCloseData>(
         header.ledgerSeq, txset, header.scpValue,
-        make_optional<Hash>(mHeaderHistoryEntry.hash));
+        std::make_optional<Hash>(mHeaderHistoryEntry.hash));
 }
 
 BasicWork::State

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -239,8 +239,9 @@ ApplyCheckpointWork::getNextLedgerCloseData()
     }
 #endif
 
-    return std::make_shared<LedgerCloseData>(header.ledgerSeq, txset,
-                                             header.scpValue);
+    return std::make_shared<LedgerCloseData>(
+        header.ledgerSeq, txset, header.scpValue,
+        make_optional<Hash>(mHeaderHistoryEntry.hash));
 }
 
 BasicWork::State

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -15,10 +15,20 @@ namespace stellar
 
 LedgerCloseData::LedgerCloseData(
     uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-    StellarValue const& v)
-    : mLedgerSeq(ledgerSeq), mTxSet(txSet), mValue(v)
+    StellarValue const& v, optional<Hash> const& expectedLedgerHash)
+    : mLedgerSeq(ledgerSeq)
+    , mTxSet(txSet)
+    , mValue(v)
+    , mExpectedLedgerHash(expectedLedgerHash)
 {
     assert(txSet->getContentsHash() == mValue.txSetHash);
+}
+
+LedgerCloseData::LedgerCloseData(
+    uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
+    StellarValue const& v)
+    : LedgerCloseData(ledgerSeq, txSet, v, nullopt<Hash>())
+{
 }
 
 std::string

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -15,20 +15,13 @@ namespace stellar
 
 LedgerCloseData::LedgerCloseData(
     uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-    StellarValue const& v, optional<Hash> const& expectedLedgerHash)
+    StellarValue const& v, std::optional<Hash> const& expectedLedgerHash)
     : mLedgerSeq(ledgerSeq)
     , mTxSet(txSet)
     , mValue(v)
     , mExpectedLedgerHash(expectedLedgerHash)
 {
     assert(txSet->getContentsHash() == mValue.txSetHash);
-}
-
-LedgerCloseData::LedgerCloseData(
-    uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-    StellarValue const& v)
-    : LedgerCloseData(ledgerSeq, txSet, v, nullopt<Hash>())
-{
 }
 
 std::string

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -7,7 +7,7 @@
 #include "TxSetFrame.h"
 #include "main/Config.h"
 #include "overlay/StellarXDR.h"
-#include "util/optional.h"
+#include <optional>
 #include <string>
 
 namespace stellar
@@ -23,14 +23,10 @@ namespace stellar
 class LedgerCloseData
 {
   public:
-    LedgerCloseData(uint32_t ledgerSeq,
-                    std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-                    StellarValue const& v,
-                    optional<Hash> const& expectedLedgerHash);
-
-    LedgerCloseData(uint32_t ledgerSeq,
-                    std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-                    StellarValue const& v);
+    LedgerCloseData(
+        uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
+        StellarValue const& v,
+        std::optional<Hash> const& expectedLedgerHash = std::nullopt);
 
     uint32_t
     getLedgerSeq() const
@@ -47,7 +43,7 @@ class LedgerCloseData
     {
         return mValue;
     }
-    optional<Hash> const&
+    std::optional<Hash> const&
     getExpectedHash() const
     {
         return mExpectedLedgerHash;
@@ -57,7 +53,7 @@ class LedgerCloseData
     uint32_t mLedgerSeq;
     std::shared_ptr<AbstractTxSetFrameForApply> mTxSet;
     StellarValue mValue;
-    optional<Hash> mExpectedLedgerHash;
+    std::optional<Hash> mExpectedLedgerHash;
 };
 
 std::string stellarValueToString(Config const& c, StellarValue const& sv);

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -7,6 +7,7 @@
 #include "TxSetFrame.h"
 #include "main/Config.h"
 #include "overlay/StellarXDR.h"
+#include "util/optional.h"
 #include <string>
 
 namespace stellar
@@ -22,6 +23,11 @@ namespace stellar
 class LedgerCloseData
 {
   public:
+    LedgerCloseData(uint32_t ledgerSeq,
+                    std::shared_ptr<AbstractTxSetFrameForApply> txSet,
+                    StellarValue const& v,
+                    optional<Hash> const& expectedLedgerHash);
+
     LedgerCloseData(uint32_t ledgerSeq,
                     std::shared_ptr<AbstractTxSetFrameForApply> txSet,
                     StellarValue const& v);
@@ -41,11 +47,17 @@ class LedgerCloseData
     {
         return mValue;
     }
+    optional<Hash> const&
+    getExpectedHash() const
+    {
+        return mExpectedLedgerHash;
+    }
 
   private:
     uint32_t mLedgerSeq;
     std::shared_ptr<AbstractTxSetFrameForApply> mTxSet;
     StellarValue mValue;
+    optional<Hash> mExpectedLedgerHash;
 };
 
 std::string stellarValueToString(Config const& c, StellarValue const& sv);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -689,7 +689,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         mNextMetaToEmit->v0().ledgerHeader = mLastClosedLedger;
         // If the LedgerCloseData provided an expected hash, then we validated
         // it above.
-        if (mApp.getConfig().UNSAFE_EMIT_META_EARLY ||
+        if (!mApp.getConfig().EXPERIMENTAL_PRECAUTION_DELAY_META ||
             ledgerData.getExpectedHash())
         {
             emitNextMeta();

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -55,6 +55,8 @@ class LedgerManagerImpl : public LedgerManager
     std::unique_ptr<VirtualClock::time_point> mStartCatchup;
     medida::Timer& mCatchupDuration;
 
+    std::unique_ptr<LedgerCloseMeta> mNextMetaToEmit;
+
     void
     processFeesSeqNums(std::vector<TransactionFrameBasePtr>& txs,
                        AbstractLedgerTxn& ltxOuter, int64_t baseFee,
@@ -74,6 +76,8 @@ class LedgerManagerImpl : public LedgerManager
 
     State mState;
     void setState(State s);
+
+    void emitNextMeta();
 
   protected:
     virtual void transferLedgerEntriesToBucketList(AbstractLedgerTxn& ltx,

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -92,8 +92,7 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - LIVE_NODE",
 
         cfg4.UNSAFE_EMIT_META_EARLY = true;
         cfg5.UNSAFE_EMIT_META_EARLY = false;
-        cfg5.MODE_USES_IN_MEMORY_LEDGER =
-            true; // required by !UNSAFE_EMIT_META_EARLY
+        cfg5.setInMemoryMode(); // required by !UNSAFE_EMIT_META_EARLY
 
         // Step 3: Run simulation a few steps to stream metadata.
         auto app1 = simulation->addNode(vNode1SecretKey, qSet, &cfg1);
@@ -252,13 +251,7 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - REPLAY_IN_MEMORY",
         cfg.NODE_IS_VALIDATOR = false;
         cfg.FORCE_SCP = false;
         cfg.RUN_STANDALONE = true;
-        // Replay-in-memory configs
-        cfg.DISABLE_XDR_FSYNC = true;
-        cfg.DATABASE = SecretValue{"sqlite3://:memory:"};
-        cfg.MODE_STORES_HISTORY = false;
-        cfg.MODE_USES_IN_MEMORY_LEDGER = false;
-        cfg.MODE_ENABLES_BUCKETLIST = true;
-        cfg.MODE_KEEPS_BUCKETS = false;
+        cfg.setInMemoryMode();
         cfg.UNSAFE_EMIT_META_EARLY = unsafeEmitMeta;
         VirtualClock clock;
         auto app = createTestApplication(clock, cfg, /*newdb=*/false);
@@ -313,7 +306,10 @@ TEST_CASE("UNSAFE_EMIT_META_EARLY configuration",
         auto const unsafeEmitMeta = GENERATE(false, true);
         auto const inMemory = GENERATE(false, true);
         cfg.UNSAFE_EMIT_META_EARLY = unsafeEmitMeta;
-        cfg.MODE_USES_IN_MEMORY_LEDGER = inMemory;
+        if (inMemory)
+        {
+            cfg.setInMemoryMode();
+        }
         REQUIRE_NOTHROW(createTestApplication(clock, cfg)->start());
     }
 
@@ -338,7 +334,10 @@ TEST_CASE("UNSAFE_EMIT_META_EARLY configuration",
         auto const unsafeEmitMeta = GENERATE(false, true);
         auto const inMemory = GENERATE(false, true);
         cfg.UNSAFE_EMIT_META_EARLY = unsafeEmitMeta;
-        cfg.MODE_USES_IN_MEMORY_LEDGER = inMemory;
+        if (inMemory)
+        {
+            cfg.setInMemoryMode();
+        }
         if (!unsafeEmitMeta && !inMemory)
         {
             REQUIRE_THROWS_AS(createTestApplication(clock, cfg)->start(),

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -6,6 +6,8 @@
 #include "crypto/Random.h"
 #include "history/HistoryArchiveManager.h"
 #include "history/test/HistoryTestsUtils.h"
+#include "ledger/LedgerTxn.h"
+#include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
 #include "main/Application.h"
 #include "main/ApplicationUtils.h"
@@ -25,15 +27,28 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - LIVE_NODE",
     // Live reqires a multinode simulation, as we're not allowed to run a
     // validator and record metadata streams at the same time (to avoid the
     // unbounded-latency stream-write step): N nodes participating in consensus,
-    // and one watching and streamnig metadata.
+    // and two watching and streaming metadata -- the second one using
+    // !UNSAFE_EMIT_META_EARLY.
 
-    Hash hash;
+    Hash expectedLastUnsafeHash, expectedLastSafeHash;
     TmpDirManager tdm(std::string("streamtmp-") + binToHex(randomBytes(8)));
     TmpDir td = tdm.tmpDir("streams");
     std::string path = td.getName() + "/stream.xdr";
+    std::string pathSafe = td.getName() + "/streamSafe.xdr";
+
+    auto const ledgerToWaitFor = 10;
+
+    bool const induceOneLedgerFork = GENERATE(false, true);
+    CAPTURE(induceOneLedgerFork);
+    auto const ledgerToCorrupt = 5;
+    static_assert(ledgerToCorrupt < ledgerToWaitFor,
+                  "must wait beyond corrupt ledger");
+
+    auto const expectedLastWatcherLedger =
+        induceOneLedgerFork ? ledgerToCorrupt : ledgerToWaitFor;
 
     {
-        // Step 1: Set up a 4 node simulation with 3 validators and 1 watcher.
+        // Step 1: Set up a 5 node simulation with 3 validators and 2 watchers.
         auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
         auto simulation =
             std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
@@ -42,7 +57,8 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - LIVE_NODE",
         SIMULATION_CREATE_NODE(Node2); // Validator
         SIMULATION_CREATE_NODE(Node3); // Validator
 
-        SIMULATION_CREATE_NODE(Node4); // Watcher
+        SIMULATION_CREATE_NODE(Node4); // Watcher, UNSAFE_EMIT_META_EARLY
+        SIMULATION_CREATE_NODE(Node5); // Watcher, !UNSAFE_EMIT_META_EARLY
 
         SCPQuorumSet qSet;
         qSet.threshold = 3;
@@ -54,51 +70,132 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - LIVE_NODE",
         Config const& cfg2 = getTestConfig(2);
         Config const& cfg3 = getTestConfig(3);
         Config cfg4 = getTestConfig(4);
+        Config cfg5 = getTestConfig(5);
 
-        // Step 2: open a writable file and pass it to config 4 (watcher).
+        // Step 2: open writable files and pass them to configs 4 and 5
+        // (watchers).
         cfg4.NODE_IS_VALIDATOR = false;
         cfg4.FORCE_SCP = false;
+        cfg5.NODE_IS_VALIDATOR = false;
+        cfg5.FORCE_SCP = false;
 #ifdef _WIN32
         cfg4.METADATA_OUTPUT_STREAM = path;
+        cfg5.METADATA_OUTPUT_STREAM = pathSafe;
 #else
         int fd = ::open(path.c_str(), O_CREAT | O_WRONLY, 0644);
         REQUIRE(fd != -1);
         cfg4.METADATA_OUTPUT_STREAM = fmt::format("fd:{}", fd);
+        int fdSafe = ::open(pathSafe.c_str(), O_CREAT | O_WRONLY, 0644);
+        REQUIRE(fdSafe != -1);
+        cfg5.METADATA_OUTPUT_STREAM = fmt::format("fd:{}", fdSafe);
 #endif
+
+        cfg4.UNSAFE_EMIT_META_EARLY = true;
+        cfg5.UNSAFE_EMIT_META_EARLY = false;
+        cfg5.MODE_USES_IN_MEMORY_LEDGER =
+            true; // required by !UNSAFE_EMIT_META_EARLY
 
         // Step 3: Run simulation a few steps to stream metadata.
         auto app1 = simulation->addNode(vNode1SecretKey, qSet, &cfg1);
         auto app2 = simulation->addNode(vNode2SecretKey, qSet, &cfg2);
         auto app3 = simulation->addNode(vNode3SecretKey, qSet, &cfg3);
         auto app4 = simulation->addNode(vNode4SecretKey, qSet, &cfg4);
+        auto app5 = simulation->addNode(vNode5SecretKey, qSet, &cfg5);
 
         simulation->addPendingConnection(vNode1NodeID, vNode2NodeID);
         simulation->addPendingConnection(vNode1NodeID, vNode3NodeID);
         simulation->addPendingConnection(vNode1NodeID, vNode4NodeID);
+        simulation->addPendingConnection(vNode1NodeID, vNode5NodeID);
 
         simulation->startAllNodes();
+        bool watchersAreCorrupted = false;
         simulation->crankUntil(
             [&]() {
-                return app4->getLedgerManager().getLastClosedLedgerNum() == 10;
+                // As long as the watchers are in sync, wait for them to get the
+                // news of all the ledgers closed by the validators.  But once
+                // the watchers are corrupt, they won't be able to close more
+                // ledgers, so at that point we start waiting only for the
+                // validators to do so.
+                if (watchersAreCorrupted)
+                {
+                    return app1->getLedgerManager().getLastClosedLedgerNum() ==
+                           ledgerToWaitFor;
+                }
+
+                auto const lastClosedLedger =
+                    app4->getLedgerManager().getLastClosedLedgerNum();
+                REQUIRE(app5->getLedgerManager().getLastClosedLedgerNum() ==
+                        lastClosedLedger);
+
+                if (lastClosedLedger == expectedLastWatcherLedger - 1)
+                {
+                    expectedLastSafeHash = app5->getLedgerManager()
+                                               .getLastClosedLedgerHeader()
+                                               .hash;
+
+                    if (induceOneLedgerFork)
+                    {
+                        for (auto& app : {app4, app5})
+                        {
+                            txtest::closeLedgerOn(
+                                *app, ledgerToCorrupt,
+                                app->getLedgerManager()
+                                        .getLastClosedLedgerHeader()
+                                        .header.scpValue.closeTime +
+                                    1);
+                        }
+
+                        expectedLastUnsafeHash =
+                            app4->getLedgerManager()
+                                .getLastClosedLedgerHeader()
+                                .hash;
+
+                        watchersAreCorrupted = true;
+                        return false;
+                    }
+                }
+
+                return lastClosedLedger == ledgerToWaitFor;
             },
             std::chrono::seconds{200}, false);
 
-        REQUIRE(app4->getLedgerManager().getLastClosedLedgerNum() == 10);
-        hash = app4->getLedgerManager().getLastClosedLedgerHeader().hash;
+        REQUIRE(app4->getLedgerManager().getLastClosedLedgerNum() ==
+                expectedLastWatcherLedger);
+        REQUIRE(app5->getLedgerManager().getLastClosedLedgerNum() ==
+                expectedLastWatcherLedger);
+
+        if (!induceOneLedgerFork)
+        {
+            expectedLastUnsafeHash =
+                app4->getLedgerManager().getLastClosedLedgerHeader().hash;
+        }
     }
 
-    // Step 4: reopen the file as an XDR stream and read back the LCMs
+    // Step 4: reopen the files as XDR streams and read back the LCMs
     // and check they have the expected content.
-    XDRInputFileStream stream;
-    stream.open(path);
-    LedgerCloseMeta lcm;
-    size_t nLcm = 1;
-    while (stream && stream.readOne(lcm))
-    {
-        ++nLcm;
-    }
-    REQUIRE(nLcm == 10);
-    REQUIRE(lcm.v0().ledgerHeader.hash == hash);
+    auto readLcms = [](std::string const& lcmPath) {
+        std::vector<LedgerCloseMeta> lcms;
+        XDRInputFileStream stream;
+        stream.open(lcmPath);
+        LedgerCloseMeta lcm;
+        while (stream && stream.readOne(lcm))
+        {
+            lcms.push_back(lcm);
+        }
+        return lcms;
+    };
+
+    auto lcms = readLcms(path);
+    auto lcmsSafe = readLcms(pathSafe);
+    // The "- 1" is because we don't stream meta for the genesis ledger.
+    REQUIRE(lcms.size() == expectedLastWatcherLedger - 1);
+    REQUIRE(lcms.back().v0().ledgerHeader.hash == expectedLastUnsafeHash);
+    // The node with !UNSAFE_EMIT_META_EARLY should not have streamed the meta
+    // for the latest ledger (or the latest ledger before the corrupt one) yet.
+    REQUIRE(lcmsSafe.size() == lcms.size() - 1);
+    REQUIRE(lcmsSafe.back().v0().ledgerHeader.hash == expectedLastSafeHash);
+    REQUIRE(lcmsSafe ==
+            std::vector<LedgerCloseMeta>(lcms.begin(), lcms.end() - 1));
 }
 
 TEST_CASE("LedgerCloseMetaStream file descriptor - REPLAY_IN_MEMORY",

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -432,6 +432,18 @@ ApplicationImpl::start()
             "RUN_STANDALONE is not set");
     }
 
+    // UNSAFE_EMIT_META_EARLY is only meaningful when there's a
+    // METADATA_OUTPUT_STREAM.  We only allow !UNSAFE_EMIT_META_EARLY on a
+    // captive core, without a persistent database; old-style ingestion which
+    // reads from the core database could do the delaying itself.
+    if (mConfig.METADATA_OUTPUT_STREAM != "" &&
+        !mConfig.UNSAFE_EMIT_META_EARLY && !mConfig.MODE_USES_IN_MEMORY_LEDGER)
+    {
+        throw std::invalid_argument("Using a METADATA_OUTPUT_STREAM with "
+                                    "UNSAFE_EMIT_META_EARLY set to false "
+                                    "requires --in-memory");
+    }
+
     if (isNetworkedValidator)
     {
         bool inMemory = mConfig.DATABASE.value == "sqlite3://:memory:" &&

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -432,16 +432,17 @@ ApplicationImpl::start()
             "RUN_STANDALONE is not set");
     }
 
-    // UNSAFE_EMIT_META_EARLY is only meaningful when there's a
-    // METADATA_OUTPUT_STREAM.  We only allow !UNSAFE_EMIT_META_EARLY on a
-    // captive core, without a persistent database; old-style ingestion which
-    // reads from the core database could do the delaying itself.
+    // EXPERIMENTAL_PRECAUTION_DELAY_META is only meaningful when there's a
+    // METADATA_OUTPUT_STREAM.  We only allow EXPERIMENTAL_PRECAUTION_DELAY_META
+    // on a captive core, without a persistent database; old-style ingestion
+    // which reads from the core database could do the delaying itself.
     if (mConfig.METADATA_OUTPUT_STREAM != "" &&
-        !mConfig.UNSAFE_EMIT_META_EARLY && !mConfig.isInMemoryMode())
+        mConfig.EXPERIMENTAL_PRECAUTION_DELAY_META && !mConfig.isInMemoryMode())
     {
-        throw std::invalid_argument("Using a METADATA_OUTPUT_STREAM with "
-                                    "UNSAFE_EMIT_META_EARLY set to false "
-                                    "requires --in-memory");
+        throw std::invalid_argument(
+            "Using a METADATA_OUTPUT_STREAM with "
+            "EXPERIMENTAL_PRECAUTION_DELAY_META set to true "
+            "requires --in-memory");
     }
 
     if (isNetworkedValidator && mConfig.isInMemoryMode())

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -437,24 +437,18 @@ ApplicationImpl::start()
     // captive core, without a persistent database; old-style ingestion which
     // reads from the core database could do the delaying itself.
     if (mConfig.METADATA_OUTPUT_STREAM != "" &&
-        !mConfig.UNSAFE_EMIT_META_EARLY && !mConfig.MODE_USES_IN_MEMORY_LEDGER)
+        !mConfig.UNSAFE_EMIT_META_EARLY && !mConfig.isInMemoryMode())
     {
         throw std::invalid_argument("Using a METADATA_OUTPUT_STREAM with "
                                     "UNSAFE_EMIT_META_EARLY set to false "
                                     "requires --in-memory");
     }
 
-    if (isNetworkedValidator)
+    if (isNetworkedValidator && mConfig.isInMemoryMode())
     {
-        bool inMemory = mConfig.DATABASE.value == "sqlite3://:memory:" &&
-                        !mConfig.MODE_STORES_HISTORY &&
-                        !mConfig.MODE_KEEPS_BUCKETS;
-        if (inMemory)
-        {
-            throw std::invalid_argument(
-                "In-memory mode is set, NODE_IS_VALIDATOR is set, "
-                "and RUN_STANDALONE is not set");
-        }
+        throw std::invalid_argument(
+            "In-memory mode is set, NODE_IS_VALIDATOR is set, "
+            "and RUN_STANDALONE is not set");
     }
 
     if (getHistoryArchiveManager().hasAnyWritableHistoryArchive())

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -301,14 +301,7 @@ maybeEnableInMemoryLedgerMode(Config& config, bool inMemory,
     }
 
     // Adjust configs for in-memory-replay mode
-    config.DATABASE = SecretValue{"sqlite3://:memory:"};
-    config.MODE_STORES_HISTORY = false;
-    config.MODE_USES_IN_MEMORY_LEDGER = false;
-    config.MODE_ENABLES_BUCKETLIST = true;
-    config.MODE_KEEPS_BUCKETS = false;
-    // And don't bother fsyncing buckets without a DB,
-    // they're temporary anyways.
-    config.DISABLE_XDR_FSYNC = true;
+    config.setInMemoryMode();
 
     if (startAtLedger != 0 && startAtHash.empty())
     {
@@ -814,13 +807,8 @@ runWriteVerifiedCheckpointHashes(CommandLineArgs const& args)
 
             // Set up for quick in-memory no-catchup mode.
             cfg.QUORUM_INTERSECTION_CHECKER = false;
-            cfg.DATABASE = SecretValue{"sqlite3://:memory:"};
-            cfg.MODE_STORES_HISTORY = false;
+            cfg.setInMemoryMode();
             cfg.MODE_DOES_CATCHUP = false;
-            cfg.MODE_USES_IN_MEMORY_LEDGER = false;
-            cfg.MODE_ENABLES_BUCKETLIST = true;
-            cfg.MODE_KEEPS_BUCKETS = false;
-            cfg.DISABLE_XDR_FSYNC = true;
 
             auto app = Application::create(clock, cfg, false);
             app->start();

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -119,6 +119,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MANUAL_CLOSE = false;
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
+    UNSAFE_EMIT_META_EARLY = true;
     // automatic maintenance settings:
     // 11 minutes is relatively short and prime with 1 hour
     // which will cause automatic maintenance to rarely conflict with any other
@@ -779,6 +780,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "METADATA_OUTPUT_STREAM")
             {
                 METADATA_OUTPUT_STREAM = readString(item);
+            }
+            else if (item.first == "UNSAFE_EMIT_META_EARLY")
+            {
+                UNSAFE_EMIT_META_EARLY = readBool(item);
             }
             else if (item.first == "KNOWN_CURSORS")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -119,7 +119,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MANUAL_CLOSE = false;
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
-    UNSAFE_EMIT_META_EARLY = true;
+    EXPERIMENTAL_PRECAUTION_DELAY_META = false;
     // automatic maintenance settings:
     // 11 minutes is relatively short and prime with 1 hour
     // which will cause automatic maintenance to rarely conflict with any other
@@ -781,9 +781,9 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 METADATA_OUTPUT_STREAM = readString(item);
             }
-            else if (item.first == "UNSAFE_EMIT_META_EARLY")
+            else if (item.first == "EXPERIMENTAL_PRECAUTION_DELAY_META")
             {
-                UNSAFE_EMIT_META_EARLY = readBool(item);
+                EXPERIMENTAL_PRECAUTION_DELAY_META = readBool(item);
             }
             else if (item.first == "KNOWN_CURSORS")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1555,6 +1555,29 @@ Config::getExpectedLedgerCloseTime() const
 }
 
 void
+Config::setInMemoryMode()
+{
+    // For the time being, --in-memory mode on the command line does not enable
+    // MODE_USES_IN_MEMORY_LEDGER; rather it uses in-memory sqlite. This change
+    // happened when mitigating the protocol 16 issue, funneling all database
+    // access through the sqlite layer; it may be reverted once a different
+    // workaround for that issue is in place.
+    MODE_USES_IN_MEMORY_LEDGER = false;
+    DATABASE = SecretValue{"sqlite3://:memory:"};
+    MODE_STORES_HISTORY = false;
+    MODE_ENABLES_BUCKETLIST = true;
+    MODE_KEEPS_BUCKETS = false;
+}
+
+bool
+Config::isInMemoryMode() const
+{
+    return ((MODE_USES_IN_MEMORY_LEDGER ||
+             DATABASE.value == "sqlite3://:memory:") &&
+            !MODE_STORES_HISTORY && !MODE_KEEPS_BUCKETS);
+}
+
+void
 Config::setNoListen()
 {
     // prevent opening up a port for other peers

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -421,6 +421,9 @@ class Config : public std::enable_shared_from_this<Config>
 
     std::chrono::seconds getExpectedLedgerCloseTime() const;
 
+    void setInMemoryMode();
+    bool isInMemoryMode() const;
+
     void logBasicInfo();
     void setNoListen();
     void setNoPublish();

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -204,6 +204,10 @@ class Config : public std::enable_shared_from_this<Config>
     // production validators.
     bool MODE_USES_IN_MEMORY_LEDGER;
 
+    // A config parameter that can be set to false (in a captive-core
+    // configuration) to defer emitting metadata by one ledger.
+    bool UNSAFE_EMIT_META_EARLY;
+
     // A config parameter that stores historical data, such as transactions,
     // fees, and scp history in the database
     bool MODE_STORES_HISTORY;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -204,9 +204,9 @@ class Config : public std::enable_shared_from_this<Config>
     // production validators.
     bool MODE_USES_IN_MEMORY_LEDGER;
 
-    // A config parameter that can be set to false (in a captive-core
-    // configuration) to defer emitting metadata by one ledger.
-    bool UNSAFE_EMIT_META_EARLY;
+    // A config parameter that can be set to true (in a captive-core
+    // configuration) to delay emitting metadata by one ledger.
+    bool EXPERIMENTAL_PRECAUTION_DELAY_META;
 
     // A config parameter that stores historical data, such as transactions,
     // fees, and scp history in the database


### PR DESCRIPTION
# Introduce a mode to delay streaming meta by one ledger

Resolves #2925

Introduce a config option affecting streaming metadata (characterized by a non-empty `METADATA_OUTPUT_STREAM`), `UNSAFE_EMIT_META`, which defaults to `true` for now, in which case `stellar-core`'s current behavior does not change.  If `UNSAFE_EMIT_META` is set to `false` (our intended long-term default), which may be done only in conjunction with `--in-memory` (in particular, we intend for this to be used by captive core watcher nodes that stream meta for Horizon), then, while streaming meta online, `stellar-core` defers streaming the meta for ledger `N` until ledger `N+1` closes.  The idea is that in case of a local fault which corrupts a ledger, incorrect meta will never be streamed, as the following ledger will never close on that node, since it will not be able to reach consensus with the network given its corrupt previous ledger.

When streaming meta from the replay of a history archive, `stellar-core` will still emit meta for the latest ledger replayed, as the archive will contain a hash against which that ledger can be validated.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
