### PR TITLE
CAP-0029 - Do not return ALLOW_TRUST_TRUST_NOT_REQUIRED from V16

### DIFF
--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -72,9 +72,9 @@ AllowTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
         auto header = ltxSource.loadHeader();
         auto sourceAccountEntry = loadSourceAccount(ltxSource, header);
         auto const& sourceAccount = sourceAccountEntry.current().data.account();
-        if (!(sourceAccount.flags & AUTH_REQUIRED_FLAG))
-        { // this account doesn't require authorization to
-            // hold credit
+        if (header.current().ledgerVersion < 16 &&
+            !(sourceAccount.flags & AUTH_REQUIRED_FLAG))
+        {
             innerResult().code(ALLOW_TRUST_TRUST_NOT_REQUIRED);
             return false;
         }


### PR DESCRIPTION
# Description

Implements https://github.com/stellar/stellar-protocol/blob/master/core/cap-0029.md.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
