### PR TITLE
Fix logging issues

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -159,12 +159,8 @@ HerderImpl::processExternalized(uint64 slotIndex, StellarValue const& value)
     ZoneScoped;
     bool validated = getSCP().isSlotFullyValidated(slotIndex);
 
-    if (Logging::logDebug("Herder"))
-    {
-        CLOG_DEBUG(Herder,
-                   "HerderSCPDriver::valueExternalized index: {} txSet: {}",
-                   slotIndex, hexAbbrev(value.txSetHash));
-    }
+    CLOG_DEBUG(Herder, "HerderSCPDriver::valueExternalized index: {} txSet: {}",
+               slotIndex, hexAbbrev(value.txSetHash));
 
     if (getSCP().isValidator() && !validated)
     {
@@ -351,10 +347,9 @@ HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
     ZoneScoped;
     uint64 slotIndex = envelope.statement.slotIndex;
 
-    if (Logging::logDebug("Herder"))
-        CLOG_DEBUG(Herder, "emitEnvelope s:{} i:{} a:{}",
-                   envelope.statement.pledges.type(), slotIndex,
-                   mApp.getStateHuman());
+    CLOG_DEBUG(Herder, "emitEnvelope s:{} i:{} a:{}",
+               envelope.statement.pledges.type(), slotIndex,
+               mApp.getStateHuman());
 
     persistSCPState(slotIndex);
 
@@ -368,10 +363,9 @@ HerderImpl::recvTransaction(TransactionFrameBasePtr tx)
     auto result = mTransactionQueue.tryAdd(tx);
     if (result == TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
-        if (Logging::logTrace("Herder"))
-            CLOG_TRACE(Herder, "recv transaction {} for {}",
-                       hexAbbrev(tx->getFullHash()),
-                       KeyUtils::toShortString(tx->getSourceID()));
+        CLOG_TRACE(Herder, "recv transaction {} for {}",
+                   hexAbbrev(tx->getFullHash()),
+                   KeyUtils::toShortString(tx->getSourceID()));
     }
     return result;
 }
@@ -473,7 +467,7 @@ HerderImpl::checkCloseTime(SCPEnvelope const& envelope, bool enforceRecent)
         abort();
     }
 
-    if (!b && Logging::logTrace("Herder"))
+    if (!b)
     {
         CLOG_TRACE(Herder, "Invalid close time processing {}",
                    getSCP().envToStr(st));
@@ -586,14 +580,10 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
     {
         std::string txt("READY");
         ZoneText(txt.c_str(), txt.size());
-        if (Logging::logDebug("Herder"))
-        {
-            CLOG_DEBUG(
-                Herder, "recvSCPEnvelope (ready) from: {} s:{} i:{} a:{}",
-                mApp.getConfig().toShortString(envelope.statement.nodeID),
-                envelope.statement.pledges.type(), envelope.statement.slotIndex,
-                mApp.getStateHuman());
-        }
+        CLOG_DEBUG(Herder, "recvSCPEnvelope (ready) from: {} s:{} i:{} a:{}",
+                   mApp.getConfig().toShortString(envelope.statement.nodeID),
+                   envelope.statement.pledges.type(),
+                   envelope.statement.slotIndex, mApp.getStateHuman());
 
         processSCPQueue();
     }
@@ -609,14 +599,11 @@ HerderImpl::recvSCPEnvelope(SCPEnvelope const& envelope)
             std::string txt("PROCESSED");
             ZoneText(txt.c_str(), txt.size());
         }
-        if (Logging::logTrace("Herder"))
-        {
-            CLOG_TRACE(
-                Herder, "recvSCPEnvelope ({}) from: {} s:{} i:{} a:{}", status,
-                mApp.getConfig().toShortString(envelope.statement.nodeID),
-                envelope.statement.pledges.type(), envelope.statement.slotIndex,
-                mApp.getStateHuman());
-        }
+        CLOG_TRACE(Herder, "recvSCPEnvelope ({}) from: {} s:{} i:{} a:{}",
+                   status,
+                   mApp.getConfig().toShortString(envelope.statement.nodeID),
+                   envelope.statement.pledges.type(),
+                   envelope.statement.slotIndex, mApp.getStateHuman());
     }
     return status;
 }

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -274,11 +274,8 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
         {
             // if we're not tracking, there is not much more we can do to
             // validate
-            if (Logging::logTrace("Herder"))
-            {
-                CLOG_TRACE(Herder, "MaybeValidValue (not tracking) for slot {}",
-                           slotIndex);
-            }
+            CLOG_TRACE(Herder, "MaybeValidValue (not tracking) for slot {}",
+                       slotIndex);
             return SCPDriver::kMaybeValidValue;
         }
 
@@ -287,13 +284,9 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
         {
             // we already moved on from this slot
             // still send it through for emitting the final messages
-            if (Logging::logTrace("Herder"))
-            {
-                CLOG_TRACE(
-                    Herder,
-                    "MaybeValidValue (already moved on) for slot {}, at {}",
-                    slotIndex, nextConsensusLedgerIndex());
-            }
+            CLOG_TRACE(Herder,
+                       "MaybeValidValue (already moved on) for slot {}, at {}",
+                       slotIndex, nextConsensusLedgerIndex());
             return SCPDriver::kMaybeValidValue;
         }
         if (nextConsensusLedgerIndex() < slotIndex)
@@ -317,12 +310,9 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
         }
 
         // this is as far as we can go if we don't have the state
-        if (Logging::logTrace("Herder"))
-        {
-            CLOG_TRACE(Herder,
-                       "Can't validate locally, value may be valid for slot {}",
-                       slotIndex);
-        }
+        CLOG_TRACE(Herder,
+                   "Can't validate locally, value may be valid for slot {}",
+                   slotIndex);
         return SCPDriver::kMaybeValidValue;
     }
 
@@ -349,18 +339,16 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
     }
     else if (!txSet->checkValid(mApp, closeTimeOffset, closeTimeOffset))
     {
-        if (Logging::logDebug("Herder"))
-            CLOG_DEBUG(Herder,
-                       "HerderSCPDriver::validateValue i: {} invalid txSet {}",
-                       slotIndex, hexAbbrev(txSetHash));
+        CLOG_DEBUG(Herder,
+                   "HerderSCPDriver::validateValue i: {} invalid txSet {}",
+                   slotIndex, hexAbbrev(txSetHash));
         res = SCPDriver::kInvalidValue;
     }
     else
     {
-        if (Logging::logDebug("Herder"))
-            CLOG_DEBUG(Herder,
-                       "HerderSCPDriver::validateValue i: {} valid txSet {}",
-                       slotIndex, hexAbbrev(txSetHash));
+        CLOG_DEBUG(Herder,
+                   "HerderSCPDriver::validateValue i: {} valid txSet {}",
+                   slotIndex, hexAbbrev(txSetHash));
         res = SCPDriver::kFullyValidatedValue;
     }
     return res;
@@ -863,9 +851,8 @@ HerderSCPDriver::ballotDidHearFromQuorum(uint64_t, SCPBallot const&)
 void
 HerderSCPDriver::nominatingValue(uint64_t slotIndex, Value const& value)
 {
-    if (Logging::logDebug("Herder"))
-        CLOG_DEBUG(Herder, "nominatingValue i:{} v: {}", slotIndex,
-                   getValueString(value));
+    CLOG_DEBUG(Herder, "nominatingValue i:{} v: {}", slotIndex,
+               getValueString(value));
 }
 
 void
@@ -1031,14 +1018,9 @@ HerderSCPDriver::recordLogTiming(VirtualClock::time_point start,
 {
     auto delta =
         std::chrono::duration_cast<std::chrono::nanoseconds>(end - start);
-    if (Logging::logDebug("Herder"))
-    {
-        auto msCount =
-            std::chrono::duration_cast<std::chrono::milliseconds>(delta)
-                .count();
-        CLOG_DEBUG(Herder, "{} delta for slot {} is {} ms", logStr, slotIndex,
-                   msCount);
-    }
+    CLOG_DEBUG(
+        Herder, "{} delta for slot {} is {} ms", logStr, slotIndex,
+        std::chrono::duration_cast<std::chrono::milliseconds>(delta).count());
     if (delta >= threshold)
     {
         timer.Update(delta);

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -331,15 +331,12 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
             mFetchDuration.Update(durationNano);
             Hash h = Slot::getCompanionQuorumSetHashFromStatement(
                 envelope.statement);
-            if (Logging::logTrace("Perf"))
-            {
-                CLOG_TRACE(Perf,
-                           "Herder fetched for envelope {} with txsets {} and "
-                           "qset {} in {} seconds",
-                           hexAbbrev(xdrSha256(envelope)),
-                           txSetsToStr(envelope), hexAbbrev(h),
-                           std::chrono::duration<double>(durationNano).count());
-            }
+            CLOG_TRACE(Perf,
+                       "Herder fetched for envelope {} with txsets {} and "
+                       "qset {} in {} seconds",
+                       hexAbbrev(xdrSha256(envelope)), txSetsToStr(envelope),
+                       hexAbbrev(h),
+                       std::chrono::duration<double>(durationNano).count());
 
             // move the item from fetching to processed
             processed.emplace(envelope);
@@ -519,12 +516,9 @@ PendingEnvelopes::envelopeReady(SCPEnvelope const& envelope)
 {
     ZoneScoped;
     auto slot = envelope.statement.slotIndex;
-    if (Logging::logTrace("Herder"))
-    {
-        CLOG_TRACE(Herder, "Envelope ready {} i:{} t:{}",
-                   hexAbbrev(xdrSha256(envelope)), slot,
-                   envelope.statement.pledges.type());
-    }
+    CLOG_TRACE(Herder, "Envelope ready {} i:{} t:{}",
+               hexAbbrev(xdrSha256(envelope)), slot,
+               envelope.statement.pledges.type());
 
     // envelope has been fetched completely, but SCP has not done
     // any validation on values yet. Regardless, record cost of this
@@ -579,7 +573,7 @@ PendingEnvelopes::startFetch(SCPEnvelope const& envelope)
         }
     }
 
-    if (needSomething && Logging::logTrace("Herder"))
+    if (needSomething)
     {
         CLOG_TRACE(Herder, "StartFetch env {} i:{} t:{}",
                    hexAbbrev(xdrSha256(envelope)), envelope.statement.slotIndex,
@@ -599,12 +593,9 @@ PendingEnvelopes::stopFetch(SCPEnvelope const& envelope)
         mTxSetFetcher.stopFetch(h2, envelope);
     }
 
-    if (Logging::logTrace("Herder"))
-    {
-        CLOG_TRACE(Herder, "StopFetch env {} i:{} t:{}",
-                   hexAbbrev(xdrSha256(envelope)), envelope.statement.slotIndex,
-                   envelope.statement.pledges.type());
-    }
+    CLOG_TRACE(Herder, "StopFetch env {} i:{} t:{}",
+               hexAbbrev(xdrSha256(envelope)), envelope.statement.slotIndex,
+               envelope.statement.pledges.type());
 }
 
 void

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -976,14 +976,11 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
 {
     ZoneScoped;
     auto logMessage = [&](bool unique, std::string const& msgType) {
-        if (Logging::logTrace("Overlay"))
-        {
-            CLOG_TRACE(Overlay, "recv: {} {} ({}) of size: {} from: {}",
-                       (unique ? "unique" : "duplicate"),
-                       peer->msgSummary(stellarMsg), msgType,
-                       xdr::xdr_argpack_size(stellarMsg),
-                       mApp.getConfig().toShortString(peer->getPeerID()));
-        }
+        CLOG_TRACE(Overlay, "recv: {} {} ({}) of size: {} from: {}",
+                   (unique ? "unique" : "duplicate"),
+                   peer->msgSummary(stellarMsg), msgType,
+                   xdr::xdr_argpack_size(stellarMsg),
+                   mApp.getConfig().toShortString(peer->getPeerID()));
     };
 
     bool flood = false;

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -87,8 +87,7 @@ void
 OverlayManagerImpl::PeersList::removePeer(Peer* peer)
 {
     ZoneScoped;
-    CLOG_TRACE(Overlay, "Removing peer {} @{}", peer->toString(),
-               mOverlayManager.mApp.getConfig().PEER_PORT);
+    CLOG_TRACE(Overlay, "Removing peer {}", peer->toString());
     assert(peer->getState() == Peer::CLOSING);
 
     auto pendingIt =
@@ -122,9 +121,8 @@ bool
 OverlayManagerImpl::PeersList::moveToAuthenticated(Peer::pointer peer)
 {
     ZoneScoped;
-    CLOG_TRACE(Overlay, "Moving peer {} to authenticated  state: {} @{}",
-               peer->toString(), peer->getState(),
-               mOverlayManager.mApp.getConfig().PEER_PORT);
+    CLOG_TRACE(Overlay, "Moving peer {} to authenticated  state: {}",
+               peer->toString(), peer->getState());
     auto pendingIt = std::find(std::begin(mPending), std::end(mPending), peer);
     if (pendingIt == std::end(mPending))
     {
@@ -161,8 +159,8 @@ bool
 OverlayManagerImpl::PeersList::acceptAuthenticatedPeer(Peer::pointer peer)
 {
     ZoneScoped;
-    CLOG_TRACE(Overlay, "Trying to promote peer to authenticated {} @{}",
-               peer->toString(), mOverlayManager.mApp.getConfig().PEER_PORT);
+    CLOG_TRACE(Overlay, "Trying to promote peer to authenticated {}",
+               peer->toString());
     if (mOverlayManager.isPreferred(peer.get()))
     {
         if (mAuthenticated.size() < mMaxAuthenticatedCount)
@@ -310,8 +308,7 @@ bool
 OverlayManagerImpl::connectToImpl(PeerBareAddress const& address,
                                   bool forceoutbound)
 {
-    CLOG_TRACE(Overlay, "Connect to {} @{}", address.toString(),
-               mApp.getConfig().PEER_PORT);
+    CLOG_TRACE(Overlay, "Connect to {}", address.toString());
     auto currentConnection = getConnectedPeer(address);
     if (!currentConnection || (forceoutbound && currentConnection->getRole() ==
                                                     Peer::REMOTE_CALLED_US))
@@ -320,9 +317,8 @@ OverlayManagerImpl::connectToImpl(PeerBareAddress const& address,
         {
             CLOG_DEBUG(Overlay,
                        "Peer rejected - all outbound pending connections "
-                       "taken: {} @{}",
-                       currentConnection->toString(),
-                       mApp.getConfig().PEER_PORT);
+                       "taken: {}",
+                       currentConnection->toString());
             return false;
         }
         getPeerManager().update(address, PeerManager::BackOffUpdate::INCREASE);
@@ -504,8 +500,7 @@ void
 OverlayManagerImpl::tick()
 {
     ZoneScoped;
-    CLOG_TRACE(Overlay, "OverlayManagerImpl tick  @{}",
-               mApp.getConfig().PEER_PORT);
+    CLOG_TRACE(Overlay, "OverlayManagerImpl tick");
 
     if (futureIsReady(mResolvedPeers))
     {
@@ -683,8 +678,7 @@ OverlayManagerImpl::addInboundConnection(Peer::pointer peer)
                    Peer::DropMode::IGNORE_WRITE_QUEUE);
         return;
     }
-    CLOG_DEBUG(Overlay, "New (inbound) connected peer {} @{}", peer->toString(),
-               mApp.getConfig().PEER_PORT);
+    CLOG_DEBUG(Overlay, "New (inbound) connected peer {}", peer->toString());
     mInboundPeers.mConnectionsEstablished.Mark();
     mInboundPeers.mPending.push_back(peer);
     updateSizeCounters();
@@ -711,8 +705,8 @@ OverlayManagerImpl::addOutboundConnection(Peer::pointer peer)
         if (!mShuttingDown)
         {
             CLOG_DEBUG(Overlay,
-                       "Peer rejected - all outbound connections taken: {} @{}",
-                       peer->toString(), mApp.getConfig().PEER_PORT);
+                       "Peer rejected - all outbound connections taken: {}",
+                       peer->toString());
             CLOG_DEBUG(Overlay, "If you wish to allow for more pending "
                                 "outbound connections, please update "
                                 "your MAX_PENDING_CONNECTIONS setting in "
@@ -725,8 +719,7 @@ OverlayManagerImpl::addOutboundConnection(Peer::pointer peer)
                    Peer::DropMode::IGNORE_WRITE_QUEUE);
         return false;
     }
-    CLOG_DEBUG(Overlay, "New (outbound) connected peer {} @{}",
-               peer->toString(), mApp.getConfig().PEER_PORT);
+    CLOG_DEBUG(Overlay, "New (outbound) connected peer {}", peer->toString());
     mOutboundPeers.mConnectionsEstablished.Mark();
     mOutboundPeers.mPending.push_back(peer);
     updateSizeCounters();
@@ -822,8 +815,7 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
     if (mConfigurationPreferredPeers.find(peer->getAddress()) !=
         mConfigurationPreferredPeers.end())
     {
-        CLOG_DEBUG(Overlay, "Peer {} is preferred  @{}", pstr,
-                   mApp.getConfig().PEER_PORT);
+        CLOG_DEBUG(Overlay, "Peer {} is preferred", pstr);
         return true;
     }
 
@@ -831,15 +823,13 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
     {
         if (mApp.getConfig().PREFERRED_PEER_KEYS.count(peer->getPeerID()) != 0)
         {
-            CLOG_DEBUG(Overlay, "Peer key {} is preferred @{}",
-                       mApp.getConfig().toShortString(peer->getPeerID()),
-                       mApp.getConfig().PEER_PORT);
+            CLOG_DEBUG(Overlay, "Peer key {} is preferred",
+                       mApp.getConfig().toShortString(peer->getPeerID()));
             return true;
         }
     }
 
-    CLOG_TRACE(Overlay, "Peer {} is not preferred @{}", pstr,
-               mApp.getConfig().PEER_PORT);
+    CLOG_TRACE(Overlay, "Peer {} is not preferred", pstr);
     return false;
 }
 
@@ -988,12 +978,11 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
     auto logMessage = [&](bool unique, std::string const& msgType) {
         if (Logging::logTrace("Overlay"))
         {
-            CLOG_TRACE(Overlay, "recv: {} {} ({}) of size: {} from: {} @{}",
+            CLOG_TRACE(Overlay, "recv: {} {} ({}) of size: {} from: {}",
                        (unique ? "unique" : "duplicate"),
                        peer->msgSummary(stellarMsg), msgType,
                        xdr::xdr_argpack_size(stellarMsg),
-                       mApp.getConfig().toShortString(peer->getPeerID()),
-                       mApp.getConfig().PEER_PORT);
+                       mApp.getConfig().toShortString(peer->getPeerID()));
         }
     };
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -70,8 +70,7 @@ void
 Peer::sendHello()
 {
     ZoneScoped;
-    CLOG_DEBUG(Overlay, "Peer::sendHello to {} @{}", toString(),
-               mApp.getConfig().PEER_PORT);
+    CLOG_DEBUG(Overlay, "Peer::sendHello to {}", toString());
     StellarMessage msg;
     msg.type(HELLO);
     Hello& elo = msg.hello();
@@ -210,8 +209,7 @@ Peer::connectHandler(asio::error_code const& error)
     }
     else
     {
-        CLOG_DEBUG(Overlay, "Connected to {} @{}", toString(),
-                   mApp.getConfig().PEER_PORT);
+        CLOG_DEBUG(Overlay, "Connected to {}", toString());
         connected();
         mState = CONNECTED;
         sendHello();
@@ -397,12 +395,8 @@ void
 Peer::sendMessage(StellarMessage const& msg, bool log)
 {
     ZoneScoped;
-    //    if (log && Logging::logTrace("Overlay"))
-    //    {
-    CLOG_TRACE(Overlay, "send: {} to : {} @{}", msgSummary(msg),
-               mApp.getConfig().toShortString(mPeerID),
-               mApp.getConfig().PEER_PORT);
-    //    }
+    CLOG_TRACE(Overlay, "send: {} to : {}", msgSummary(msg),
+               mApp.getConfig().toShortString(mPeerID));
 
     // There are really _two_ layers of queues, one in Scheduler for actions and
     // one in Peer (and its subclasses) for outgoing writes. We enforce a
@@ -1107,8 +1101,7 @@ Peer::recvHello(Hello const& elo)
     mAddress =
         PeerBareAddress{ip, static_cast<unsigned short>(elo.listeningPort)};
 
-    CLOG_DEBUG(Overlay, "recvHello from {} @{}", toString(),
-               mApp.getConfig().PEER_PORT);
+    CLOG_DEBUG(Overlay, "recvHello from {}", toString());
 
     auto dropMode = Peer::DropMode::IGNORE_WRITE_QUEUE;
     if (mRole == REMOTE_CALLED_US)

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -910,8 +910,7 @@ Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
     }
     else
     {
-        if (Logging::logTrace("Overlay"))
-            CLOG_TRACE(Overlay, "No quorum set: {}", hexAbbrev(msg.qSetHash()));
+        CLOG_TRACE(Overlay, "No quorum set: {}", hexAbbrev(msg.qSetHash()));
         sendDontHave(SCP_QUORUMSET, msg.qSetHash());
         // do we want to ask other people for it?
     }

--- a/src/overlay/PeerDoor.cpp
+++ b/src/overlay/PeerDoor.cpp
@@ -72,8 +72,7 @@ PeerDoor::acceptNextPeer()
 void
 PeerDoor::handleKnock(shared_ptr<TCPPeer::SocketType> socket)
 {
-    CLOG_DEBUG(Overlay, "PeerDoor handleKnock() @{}",
-               mApp.getConfig().PEER_PORT);
+    CLOG_DEBUG(Overlay, "PeerDoor handleKnock()");
     Peer::pointer peer = TCPPeer::accept(mApp, socket);
     if (peer)
     {

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -405,8 +405,7 @@ PeerManager::ensureExists(PeerBareAddress const& address)
     auto peer = load(address);
     if (!peer.second)
     {
-        CLOG_TRACE(Overlay, "Learned peer {} @{}", address.toString(),
-                   mApp.getConfig().PEER_PORT);
+        CLOG_TRACE(Overlay, "Learned peer {}", address.toString());
         store(address, peer.first, peer.second);
     }
 }

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -270,11 +270,8 @@ TCPPeer::messageSender()
             break;
     }
 
-    if (Logging::logDebug("Overlay"))
-    {
-        CLOG_DEBUG(Overlay, "messageSender {} - b:{} n:{}/{}", toString(),
-                   expected_length, mWriteBuffers.size(), mWriteQueue.size());
-    }
+    CLOG_DEBUG(Overlay, "messageSender {} - b:{} n:{}/{}", toString(),
+               expected_length, mWriteBuffers.size(), mWriteQueue.size());
     getOverlayMetrics().mAsyncWrite.Mark();
     auto self = static_pointer_cast<TCPPeer>(shared_from_this());
     asio::async_write(*(mSocket.get()), mWriteBuffers,
@@ -451,11 +448,8 @@ TCPPeer::startRead()
 
     mIncomingHeader.clear();
 
-    if (Logging::logDebug("Overlay"))
-    {
-        CLOG_DEBUG(Overlay, "TCPPeer::startRead {} from {}",
-                   mSocket->in_avail(), toString());
-    }
+    CLOG_DEBUG(Overlay, "TCPPeer::startRead {} from {}", mSocket->in_avail(),
+               toString());
 
     mIncomingHeader.resize(HDRSZ);
 

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -83,15 +83,14 @@ TCPPeer::accept(Application& app, shared_ptr<TCPPeer::SocketType> socket)
 
     if (!ec)
     {
-        CLOG_DEBUG(Overlay, "TCPPeer:accept@{}", app.getConfig().PEER_PORT);
+        CLOG_DEBUG(Overlay, "TCPPeer:accept");
         result = make_shared<TCPPeer>(app, REMOTE_CALLED_US, socket);
         result->startRecurrentTimer();
         result->startRead();
     }
     else
     {
-        CLOG_DEBUG(Overlay, "TCPPeer:accept@{} error {}",
-                   app.getConfig().PEER_PORT, ec.message());
+        CLOG_DEBUG(Overlay, "TCPPeer:accept error {}", ec.message());
     }
 
     return result;

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -375,9 +375,8 @@ BallotProtocol::bumpState(Value const& value, uint32 n)
         newb.value = value;
     }
 
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "BallotProtocol::bumpState i: {} v: {}",
-                   mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(newb));
+    CLOG_TRACE(SCP, "BallotProtocol::bumpState i: {} v: {}",
+               mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(newb));
 
     bool updated = updateCurrentValue(newb);
 
@@ -452,9 +451,8 @@ BallotProtocol::bumpToBallot(SCPBallot const& ballot, bool check)
     ZoneValue(static_cast<int64_t>(mSlot.getSlotIndex()));
     ZoneValue(static_cast<int64_t>(ballot.counter));
 
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "BallotProtocol::bumpToBallot i: {} b: {}",
-                   mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(ballot));
+    CLOG_TRACE(SCP, "BallotProtocol::bumpToBallot i: {} b: {}",
+               mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(ballot));
 
     // `bumpToBallot` should be never called once we committed.
     dbgAssert(mPhase != SCP_PHASE_EXTERNALIZE);
@@ -891,9 +889,8 @@ bool
 BallotProtocol::setAcceptPrepared(SCPBallot const& ballot)
 {
     ZoneScoped;
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "BallotProtocol::setAcceptPrepared i: {} b: {}",
-                   mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(ballot));
+    CLOG_TRACE(SCP, "BallotProtocol::setAcceptPrepared i: {} b: {}",
+               mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(ballot));
 
     // update our state
     bool didWork = setPrepared(ballot);
@@ -1049,9 +1046,8 @@ bool
 BallotProtocol::setConfirmPrepared(SCPBallot const& newC, SCPBallot const& newH)
 {
     ZoneScoped;
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "BallotProtocol::setConfirmPrepared i: {} h: {}",
-                   mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(newH));
+    CLOG_TRACE(SCP, "BallotProtocol::setConfirmPrepared i: {} h: {}",
+               mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(newH));
 
     bool didWork = false;
 
@@ -1311,11 +1307,9 @@ bool
 BallotProtocol::setAcceptCommit(SCPBallot const& c, SCPBallot const& h)
 {
     ZoneScoped;
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP,
-                   "BallotProtocol::setAcceptCommit i: {} new c: {} new h: {}",
-                   mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(c),
-                   mSlot.getSCP().ballotToStr(h));
+    CLOG_TRACE(SCP, "BallotProtocol::setAcceptCommit i: {} new c: {} new h: {}",
+               mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(c),
+               mSlot.getSCP().ballotToStr(h));
 
     bool didWork = false;
 
@@ -1514,11 +1508,10 @@ bool
 BallotProtocol::setConfirmCommit(SCPBallot const& c, SCPBallot const& h)
 {
     ZoneScoped;
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP,
-                   "BallotProtocol::setConfirmCommit i: {} new c: {} new h: {}",
-                   mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(c),
-                   mSlot.getSCP().ballotToStr(h));
+    CLOG_TRACE(SCP,
+               "BallotProtocol::setConfirmCommit i: {} new c: {} new h: {}",
+               mSlot.getSlotIndex(), mSlot.getSCP().ballotToStr(c),
+               mSlot.getSCP().ballotToStr(h));
 
     mCommit = makeBallot(c);
     mHighBallot = makeBallot(h);
@@ -1870,9 +1863,8 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
 {
     ZoneScoped;
     mCurrentMessageLevel++;
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "BallotProtocol::advanceSlot {} {}",
-                   mCurrentMessageLevel, getLocalState());
+    CLOG_TRACE(SCP, "BallotProtocol::advanceSlot {} {}", mCurrentMessageLevel,
+               getLocalState());
 
     if (mCurrentMessageLevel >= MAX_ADVANCE_SLOT_RECURSION)
     {
@@ -1911,9 +1903,8 @@ BallotProtocol::advanceSlot(SCPStatement const& hint)
         checkHeardFromQuorum();
     }
 
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "BallotProtocol::advanceSlot {} - exiting {}",
-                   mCurrentMessageLevel, getLocalState());
+    CLOG_TRACE(SCP, "BallotProtocol::advanceSlot {} - exiting {}",
+               mCurrentMessageLevel, getLocalState());
 
     --mCurrentMessageLevel;
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -500,9 +500,8 @@ NominationProtocol::nominate(ValueWrapperPtr value, Value const& previousValue,
                              bool timedout)
 {
     ZoneScoped;
-    if (Logging::logDebug("SCP"))
-        CLOG_DEBUG(SCP, "NominationProtocol::nominate ({}) {}", mRoundNumber,
-                   mSlot.getSCP().getValueString(value->getValue()));
+    CLOG_DEBUG(SCP, "NominationProtocol::nominate ({}) {}", mRoundNumber,
+               mSlot.getSCP().getValueString(value->getValue()));
 
     bool updated = false;
 

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -83,10 +83,8 @@ Slot::setStateFromEnvelope(SCPEnvelopeWrapperPtr env)
     }
     else
     {
-        if (Logging::logTrace("SCP"))
-            CLOG_TRACE(SCP,
-                       "Slot::setStateFromEnvelope invalid envelope i: {} {}",
-                       getSlotIndex(), mSCP.envToStr(e));
+        CLOG_TRACE(SCP, "Slot::setStateFromEnvelope invalid envelope i: {} {}",
+                   getSlotIndex(), mSCP.envToStr(e));
     }
 }
 
@@ -130,9 +128,8 @@ Slot::processEnvelope(SCPEnvelopeWrapperPtr envelope, bool self)
 {
     dbgAssert(envelope->getStatement().slotIndex == mSlotIndex);
 
-    if (Logging::logTrace("SCP"))
-        CLOG_TRACE(SCP, "Slot::processEnvelope i: {} {}", getSlotIndex(),
-                   mSCP.envToStr(envelope->getEnvelope()));
+    CLOG_TRACE(SCP, "Slot::processEnvelope i: {} {}", getSlotIndex(),
+               mSCP.envToStr(envelope->getEnvelope()));
 
     SCP::EnvelopeState res;
 

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -14,6 +14,7 @@
 #include "test/test.h"
 #include "util/Logging.h"
 #include "util/Math.h"
+#include "util/finally.h"
 #include "util/types.h"
 
 #include <fmt/format.h>
@@ -378,6 +379,14 @@ Simulation::crankAllNodes(int nbTicks)
 
     VirtualTimer mainQuantumTimer(*mIdleApp);
 
+    bool debugFmt = Logging::logDebug("Process");
+
+    auto h = gsl::finally([&]() {
+        if (debugFmt)
+        {
+            Logging::setFmt("<test>");
+        }
+    });
     int i = 0;
     do
     {
@@ -435,6 +444,11 @@ Simulation::crankAllNodes(int nbTicks)
                         // node caught up, don't give it any compute
                         continue;
                     }
+                }
+                if (debugFmt)
+                {
+                    Logging::setFmt(fmt::format(
+                        "<test-{}>", p.second.mApp->getConfig().PEER_PORT));
                 }
                 crankNode(p.first, nextTime);
             }

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -126,18 +126,12 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
 {
     ZoneScoped;
     bool res;
-    if (Logging::logTrace("Tx"))
-    {
-        CLOG_TRACE(Tx, "{}", xdr_to_string(mOperation, "Operation"));
-    }
+    CLOG_TRACE(Tx, "{}", xdr_to_string(mOperation, "Operation"));
     res = checkValid(signatureChecker, ltx, true);
     if (res)
     {
         res = doApply(ltx);
-        if (Logging::logTrace("Tx"))
-        {
-            CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
-        }
+        CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
     }
 
     return res;

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -350,14 +350,24 @@ bool
 Logging::logDebug(std::string const& partition)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
-    return mGlobalLogLevel <= LogLevel::LVL_DEBUG;
+    auto it = mPartitionLogLevels.find(partition);
+    if (it != mPartitionLogLevels.end())
+    {
+        return it->second >= LogLevel::LVL_DEBUG;
+    }
+    return mGlobalLogLevel >= LogLevel::LVL_DEBUG;
 }
 
 bool
 Logging::logTrace(std::string const& partition)
 {
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
-    return mGlobalLogLevel <= LogLevel::LVL_TRACE;
+    auto it = mPartitionLogLevels.find(partition);
+    if (it != mPartitionLogLevels.end())
+    {
+        return it->second >= LogLevel::LVL_TRACE;
+    }
+    return mGlobalLogLevel >= LogLevel::LVL_TRACE;
 }
 
 void

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -209,11 +209,15 @@ void
 Logging::setFmt(std::string const& peerID, bool timestamps)
 {
 #if defined(USE_SPDLOG)
+    auto pattern =
+        fmt::format("%Y-%m-%dT%H:%M:%S.%e {} [%^%n %l%$] %v", peerID);
     std::lock_guard<std::recursive_mutex> guard(mLogMutex);
-    init();
-    mLastPattern = std::string("%Y-%m-%dT%H:%M:%S.%e ") + peerID +
-                   std::string(" [%^%n %l%$] %v");
-    spdlog::set_pattern(mLastPattern);
+    if (pattern != mLastPattern)
+    {
+        init();
+        mLastPattern = std::move(pattern);
+        spdlog::set_pattern(mLastPattern);
+    }
 #endif
 }
 


### PR DESCRIPTION
# Description

Resolves #2752

This PR makes logging easier to follow when running simulation by setting the log format string based off  the node in the simulation.

I also fixed a couple bugs in `logDebug` and `logTrace` (were checking conditions backward and were broken when setting log levels in partitions) as well as removed using them (this was made obsolete with the switch to spdlog)
