### PR TITLE
More CAP-0035 tests

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -27,7 +27,7 @@
 
 namespace stellar
 {
-const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 16
+const uint32 Config::CURRENT_LEDGER_PROTOCOL_VERSION = 17
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
                                                        + 1
 #endif

--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -149,7 +149,7 @@ AllowTrustOpFrame::doCheckValid(uint32_t ledgerVersion)
         return false;
     }
 
-    if ((mAllowTrust.authorize & TRUSTLINE_CLAWBACK_ENABLED_FLAG) != 0)
+    if (mAllowTrust.authorize > AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG)
     {
         innerResult().code(ALLOW_TRUST_MALFORMED);
         return false;

--- a/src/transactions/test/AllowTrustTests.cpp
+++ b/src/transactions/test/AllowTrustTests.cpp
@@ -507,6 +507,11 @@ template <int V> struct TestStub
                             idr, a1,
                             AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG + 1),
                         ex_ALLOW_TRUST_MALFORMED);
+
+                    REQUIRE_THROWS_AS(
+                        gateway.allowTrust(idr, a1,
+                                           TRUSTLINE_CLAWBACK_ENABLED_FLAG),
+                        ex_ALLOW_TRUST_MALFORMED);
                 }
                 SECTION("do not set revocable flag")
                 {
@@ -686,6 +691,50 @@ template <int V> struct TestStub
                         [&] { gateway.denyTrust(idr, a1, flagOp); });
                 });
             }
+        }
+
+        SECTION("with clawback")
+        {
+            for_versions_from(17, *app, [&] {
+                auto toSet = static_cast<uint32_t>(AUTH_CLAWBACK_ENABLED_FLAG |
+                                                   AUTH_REVOCABLE_FLAG);
+                gateway.setOptions(setFlags(toSet));
+                a1.changeTrust(idr, trustLineLimit);
+
+                SECTION(
+                    "remove offers by pulling auth while clawback is enabled")
+                {
+                    auto market = TestMarket{*app};
+                    auto native = makeNativeAsset();
+
+                    auto offer = market.requireChangesWithOffer({}, [&] {
+                        return market.addOffer(a1,
+                                               {native, idr, Price{1, 1}, 1});
+                    });
+
+                    market.requireChanges(
+                        {{offer.key, OfferState::DELETED}},
+                        [&] { gateway.denyTrust(idr, a1, flagOp); });
+
+                    REQUIRE(
+                        isClawbackEnabledOnTrustline(a1.loadTrustLine(idr)));
+                }
+
+                SECTION("trustline auth changes while clawback is enabled")
+                {
+                    gateway.allowMaintainLiabilities(idr, a1, flagOp);
+                    REQUIRE(
+                        isClawbackEnabledOnTrustline(a1.loadTrustLine(idr)));
+
+                    gateway.denyTrust(idr, a1, flagOp);
+                    REQUIRE(
+                        isClawbackEnabledOnTrustline(a1.loadTrustLine(idr)));
+
+                    gateway.allowTrust(idr, a1, flagOp);
+                    REQUIRE(
+                        isClawbackEnabledOnTrustline(a1.loadTrustLine(idr)));
+                }
+            });
         }
     }
 };

--- a/src/transactions/test/ClawbackClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClawbackClaimableBalanceTests.cpp
@@ -83,6 +83,18 @@ TEST_CASE("clawbackClaimableBalance", "[tx][clawback][claimablebalance]")
             gateway.clawbackClaimableBalance(balanceID);
         }
 
+        SECTION("clawback when issuer already has INT64_MAX liabilities")
+        {
+            auto usd = makeAsset(gateway, "USD");
+            gateway.manageOffer(0, usd, idr, Price{1, 1}, INT64_MAX);
+
+            validClaimant.v0().destination = a1;
+            auto balanceID =
+                a1.createClaimableBalance(idr, 99, {validClaimant});
+
+            gateway.clawbackClaimableBalance(balanceID);
+        }
+
         SECTION("clawback sponsored claimable balance")
         {
             auto sponsoredClaimableBalance = [&](TestAccount& account) {

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -224,6 +224,15 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
                     gateway.setTrustLineFlags(native, a1, emptyFlag),
                     ex_SET_TRUST_LINE_FLAGS_MALFORMED);
 
+                // invalid asset
+                auto invalidAssets = testutil::getInvalidAssets(gateway);
+                for (auto const& asset : invalidAssets)
+                {
+                    REQUIRE_THROWS_AS(
+                        gateway.setTrustLineFlags(asset, a1, emptyFlag),
+                        ex_SET_TRUST_LINE_FLAGS_MALFORMED);
+                }
+
                 {
                     // set and clear flags can't overlap
                     auto setFlag = setTrustLineFlags(AUTHORIZED_FLAG);

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -91,22 +91,6 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
                               ex_PAYMENT_SRC_NOT_AUTHORIZED);
         }
 
-        SECTION("remove offers by pulling auth while clawback is enabled")
-        {
-            auto market = TestMarket{*app};
-
-            gateway.setOptions(setFlags(AUTH_CLAWBACK_ENABLED_FLAG));
-            a2.changeTrust(idr, trustLineLimit);
-
-            auto offer = market.requireChangesWithOffer({}, [&] {
-                return market.addOffer(a2, {native, idr, Price{1, 1}, 1});
-            });
-
-            market.requireChanges({{offer.key, OfferState::DELETED}}, [&] {
-                gateway.denyTrust(idr, a2, TrustFlagOp::SET_TRUST_LINE_FLAGS);
-            });
-        }
-
         SECTION("empty flags")
         {
             // verify that the setTrustLineFlags call is a noop

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -55,6 +55,27 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
     }
 
     for_versions_from(17, *app, [&] {
+        // this lambda is used to verify offers are not pulled in non-revoke
+        // scenarios
+        auto market = TestMarket{*app};
+        auto setFlagAndCheckOffer =
+            [&](Asset const& asset, TestAccount& trustor,
+                txtest::SetTrustLineFlagsArguments const& arguments,
+                bool addOffer = true) {
+                if (addOffer)
+                {
+                    auto offer = market.requireChangesWithOffer({}, [&] {
+                        return market.addOffer(trustor,
+                                               {native, asset, Price{1, 1}, 1});
+                    });
+                }
+
+                // no offer should be deleted
+                market.requireChanges({}, [&] {
+                    gateway.setTrustLineFlags(asset, trustor, arguments);
+                });
+            };
+
         SECTION("small test")
         {
             gateway.pay(a1, idr, 5);
@@ -63,7 +84,8 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
             auto flags =
                 setTrustLineFlags(AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG) |
                 clearTrustLineFlags(AUTHORIZED_FLAG);
-            gateway.setTrustLineFlags(idr, a1, flags);
+
+            setFlagAndCheckOffer(idr, a1, flags);
 
             REQUIRE_THROWS_AS(a1.pay(gateway, idr, trustLineStartingBalance),
                               ex_PAYMENT_SRC_NOT_AUTHORIZED);
@@ -89,7 +111,7 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
         {
             // verify that the setTrustLineFlags call is a noop
             auto flag = a1.getTrustlineFlags(idr);
-            gateway.setTrustLineFlags(idr, a1, emptyFlag);
+            setFlagAndCheckOffer(idr, a1, emptyFlag);
             REQUIRE(flag == a1.getTrustlineFlags(idr));
         }
 
@@ -102,7 +124,7 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
             gateway.clawback(a2, idr, 25);
 
             // clear the clawback flag and then try to clawback
-            gateway.setTrustLineFlags(
+            setFlagAndCheckOffer(
                 idr, a2, clearTrustLineFlags(TRUSTLINE_CLAWBACK_ENABLED_FLAG));
             REQUIRE_THROWS_AS(gateway.clawback(a2, idr, 25),
                               ex_CLAWBACK_NOT_CLAWBACK_ENABLED);
@@ -110,13 +132,24 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
 
         SECTION("upgrade auth when not revocable")
         {
-            SECTION("authorized to maintain liabilities -> authorized")
+            SECTION("authorized -> authorized to maintain liabilities -> "
+                    "authorized - with offers")
             {
-                gateway.allowMaintainLiabilities(
-                    idr, a1, TrustFlagOp::SET_TRUST_LINE_FLAGS);
+                // authorized -> authorized to maintain liabilities
+                auto maintainLiabilitiesflags =
+                    setTrustLineFlags(AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG) |
+                    clearTrustLineFlags(AUTHORIZED_FLAG);
+
+                setFlagAndCheckOffer(idr, a1, maintainLiabilitiesflags);
+
                 gateway.setOptions(clearFlags(AUTH_REVOCABLE_FLAG));
 
-                gateway.allowTrust(idr, a1, TrustFlagOp::SET_TRUST_LINE_FLAGS);
+                // authorized to maintain liabilities -> authorized
+                auto authorizedFlags =
+                    setTrustLineFlags(AUTHORIZED_FLAG) |
+                    clearTrustLineFlags(
+                        AUTHORIZED_TO_MAINTAIN_LIABILITIES_FLAG);
+                setFlagAndCheckOffer(idr, a1, authorizedFlags, false);
             }
 
             SECTION("0 -> authorized")

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -63,8 +63,9 @@ TEST_CASE("txset - correct apply order", "[tx][envelope]")
     auto tx1 = b1.tx({accountMerge(a1)});
     auto tx2 = a1.tx({b1.op(payment(root, 110)), root.op(payment(a1, 101))});
 
-    auto txSet = std::make_shared<TxSetFrame>(
-        app->getLedgerManager().getLastClosedLedgerHeader().hash);
+    Hash h;
+    h[0] = 2;
+    auto txSet = std::make_shared<TxSetFrame>(h);
     txSet->add(tx1);
     txSet->add(tx2);
 


### PR DESCRIPTION
# Description

1. Improved one of the AllowTrust validation checks.
2. Added some more CAP-0035 related tests.
3. Bumps protocol version to 17.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
