### PR TITLE
normalize meta when using printXDR subcommand

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1024,15 +1024,18 @@ runPrintXdr(CommandLineArgs const& args)
     std::string fileType{"auto"};
     auto base64 = false;
     auto compact = false;
+    auto rawMode = false;
 
     auto fileTypeOpt = clara::Opt(fileType, "FILE-TYPE")["--filetype"](
         "[auto|ledgerheader|meta|result|resultpair|tx|txfee]");
 
     return runWithHelp(args,
                        {fileNameParser(xdr), fileTypeOpt, base64Parser(base64),
-                        compactParser(compact)},
+                        compactParser(compact),
+                        clara::Opt{rawMode}["--raw"](
+                            "raw mode, do not normalize some objects")},
                        [&] {
-                           printXdr(xdr, fileType, base64, compact);
+                           printXdr(xdr, fileType, base64, compact, rawMode);
                            return 0;
                        });
 }

--- a/src/main/dumpxdr.h
+++ b/src/main/dumpxdr.h
@@ -11,7 +11,7 @@ namespace stellar
 
 void dumpXdrStream(std::string const& filename, bool json);
 void printXdr(std::string const& filename, std::string const& filetype,
-              bool base64, bool compact);
+              bool base64, bool compact, bool rawMode);
 void signtxn(std::string const& filename, std::string netId, bool base64);
 void priv2pub();
 }


### PR DESCRIPTION
# Description

This PR fixes a long annoyance when printing `TransactionMeta`:
it now normalizes changes, so that it's possible to diff meta captured during debugging sessions.

I added an optional `raw` mode so that we can still inspect data "as-is".