### PR TITLE
Add an option to catchup to "go backwards"

### DIFF
--- a/src/database/DatabaseUtils.cpp
+++ b/src/database/DatabaseUtils.cpp
@@ -30,5 +30,15 @@ deleteOldEntriesHelper(soci::session& sess, uint32_t ledgerSeq, uint32_t count,
              << " <= " << m;
     }
 }
+
+void
+deleteNewerEntriesHelper(soci::session& sess, uint32_t ledgerSeq,
+                         std::string const& tableName,
+                         std::string const& ledgerSeqColumn)
+{
+    sess << "DELETE FROM " << tableName << " WHERE " << ledgerSeqColumn
+         << " >= " << ledgerSeq;
+}
+
 }
 }

--- a/src/database/DatabaseUtils.h
+++ b/src/database/DatabaseUtils.h
@@ -13,5 +13,9 @@ namespace DatabaseUtils
 void deleteOldEntriesHelper(soci::session& sess, uint32_t ledgerSeq,
                             uint32_t count, std::string const& tableName,
                             std::string const& ledgerSeqColumn);
+
+void deleteNewerEntriesHelper(soci::session& sess, uint32_t ledgerSeq,
+                              std::string const& tableName,
+                              std::string const& ledgerSeqColumn);
 }
 }

--- a/src/herder/HerderPersistence.h
+++ b/src/herder/HerderPersistence.h
@@ -48,6 +48,7 @@ class HerderPersistence
     static void dropAll(Database& db);
     static void deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                  uint32_t count);
+    static void deleteNewerEntries(Database& db, uint32_t ledgerSeq);
 
     static void createQuorumTrackingTable(soci::session& sess);
 };

--- a/src/herder/HerderPersistenceImpl.cpp
+++ b/src/herder/HerderPersistenceImpl.cpp
@@ -400,4 +400,14 @@ HerderPersistence::deleteOldEntries(Database& db, uint32_t ledgerSeq,
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
                                           "scpquorums", "lastledgerseq");
 }
+
+void
+HerderPersistence::deleteNewerEntries(Database& db, uint32_t ledgerSeq)
+{
+    ZoneScoped;
+    DatabaseUtils::deleteNewerEntriesHelper(db.getSession(), ledgerSeq,
+                                            "scphistory", "ledgerseq");
+    DatabaseUtils::deleteNewerEntriesHelper(db.getSession(), ledgerSeq,
+                                            "scpquorums", "lastledgerseq");
+}
 }

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -429,6 +429,14 @@ Upgrades::deleteOldEntries(Database& db, uint32_t ledgerSeq, uint32_t count)
                                           "upgradehistory", "ledgerseq");
 }
 
+void
+Upgrades::deleteNewerEntries(Database& db, uint32_t ledgerSeq)
+{
+    ZoneScoped;
+    DatabaseUtils::deleteNewerEntriesHelper(db.getSession(), ledgerSeq,
+                                            "upgradehistory", "ledgerseq");
+}
+
 static void
 addLiabilities(std::map<Asset, std::unique_ptr<int64_t>>& liabilities,
                AccountID const& accountID, Asset const& asset, int64_t delta)

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -112,6 +112,7 @@ class Upgrades
                                     int index);
     static void deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                  uint32_t count);
+    static void deleteNewerEntries(Database& db, uint32_t ledgerSeq);
 
   private:
     UpgradeParameters mParams;

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -353,6 +353,9 @@ class HistoryManager
                      std::vector<std::string> const& originalBuckets,
                      bool success) = 0;
 
+    // clear the publish queue for any ledgers more recent than ledgerSeq
+    virtual void deleteCheckpointsNewerThan(uint32_t ledgerSeq) = 0;
+
     // Return the name of the HistoryManager's tmpdir (used for storing files in
     // transit).
     virtual std::string const& getTmpDir() = 0;

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -431,6 +431,18 @@ HistoryManagerImpl::historyPublished(
                           "HistoryManagerImpl: publishQueuedHistory");
 }
 
+void
+HistoryManagerImpl::deleteCheckpointsNewerThan(uint32_t ledgerSeq)
+{
+    ZoneScoped;
+    auto prep = mApp.getDatabase().getPreparedStatement(
+        "DELETE FROM publishqueue WHERE ledger >= :lg;");
+    auto& st = prep.statement();
+    st.exchange(soci::use(ledgerSeq));
+    st.define_and_bind();
+    st.execute(true);
+}
+
 uint64_t
 HistoryManagerImpl::getPublishQueueCount() const
 {

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -75,6 +75,8 @@ class HistoryManagerImpl : public HistoryManager
                           std::vector<std::string> const& originalBuckets,
                           bool success) override;
 
+    void deleteCheckpointsNewerThan(uint32_t ledgerSeq) override;
+
     std::string const& getTmpDir() override;
 
     std::string localFilename(std::string const& basename) override;

--- a/src/ledger/LedgerHeaderUtils.cpp
+++ b/src/ledger/LedgerHeaderUtils.cpp
@@ -168,6 +168,14 @@ deleteOldEntries(Database& db, uint32_t ledgerSeq, uint32_t count)
                                           "ledgerheaders", "ledgerseq");
 }
 
+void
+deleteNewerEntries(Database& db, uint32_t ledgerSeq)
+{
+    ZoneScoped;
+    DatabaseUtils::deleteNewerEntriesHelper(db.getSession(), ledgerSeq,
+                                            "ledgerheaders", "ledgerseq");
+}
+
 size_t
 copyToStream(Database& db, soci::session& sess, uint32_t ledgerSeq,
              uint32_t ledgerCount, XDROutputFileStream& headersOut)

--- a/src/ledger/LedgerHeaderUtils.h
+++ b/src/ledger/LedgerHeaderUtils.h
@@ -25,6 +25,7 @@ std::shared_ptr<LedgerHeader> loadBySequence(Database& db, soci::session& sess,
                                              uint32_t seq);
 
 void deleteOldEntries(Database& db, uint32_t ledgerSeq, uint32_t count);
+void deleteNewerEntries(Database& db, uint32_t ledgerSeq);
 
 size_t copyToStream(Database& db, soci::session& sess, uint32_t ledgerSeq,
                     uint32_t ledgerCount, XDROutputFileStream& headersOut);

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -155,6 +155,12 @@ class LedgerManager
     virtual void deleteOldEntries(Database& db, uint32_t ledgerSeq,
                                   uint32_t count) = 0;
 
+    // cleans historical data newer than ledgerSeq
+    // as this is used when applying buckets, the data is deleted such that:
+    // ledgerheaders >= ledgerSeq
+    // everything else > ledgerSeq
+    virtual void deleteNewerEntries(Database& db, uint32_t ledgerSeq) = 0;
+
     virtual void
     setLastClosedLedger(LedgerHeaderHistoryEntry const& lastClosed) = 0;
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -122,6 +122,8 @@ class LedgerManagerImpl : public LedgerManager
     void deleteOldEntries(Database& db, uint32_t ledgerSeq,
                           uint32_t count) override;
 
+    void deleteNewerEntries(Database& db, uint32_t ledgerSeq) override;
+
     void
     setLastClosedLedger(LedgerHeaderHistoryEntry const& lastClosed) override;
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -744,6 +744,10 @@ runCatchup(CommandLineArgs const& args)
                         "Cleaning historical data (this may take a while)");
                     auto& lm = app->getLedgerManager();
                     lm.deleteNewerEntries(app->getDatabase(), range.first());
+                    // checkpoints
+                    app->getHistoryManager().deleteCheckpointsNewerThan(
+                        range.first());
+
                     // need to delete genesis ledger data (so that we can reset
                     // to it)
                     lm.deleteOldEntries(app->getDatabase(),

--- a/src/transactions/TransactionSQL.cpp
+++ b/src/transactions/TransactionSQL.cpp
@@ -289,4 +289,15 @@ deleteOldTransactionHistoryEntries(Database& db, uint32_t ledgerSeq,
     DatabaseUtils::deleteOldEntriesHelper(db.getSession(), ledgerSeq, count,
                                           "txfeehistory", "ledgerseq");
 }
+
+void
+deleteNewerTransactionHistoryEntries(Database& db, uint32_t ledgerSeq)
+{
+    ZoneScoped;
+    DatabaseUtils::deleteNewerEntriesHelper(db.getSession(), ledgerSeq,
+                                            "txhistory", "ledgerseq");
+    DatabaseUtils::deleteNewerEntriesHelper(db.getSession(), ledgerSeq,
+                                            "txfeehistory", "ledgerseq");
+}
+
 }

--- a/src/transactions/TransactionSQL.h
+++ b/src/transactions/TransactionSQL.h
@@ -36,4 +36,6 @@ void dropTransactionHistory(Database& db);
 
 void deleteOldTransactionHistoryEntries(Database& db, uint32_t ledgerSeq,
                                         uint32_t count);
+
+void deleteNewerTransactionHistoryEntries(Database& db, uint32_t ledgerSeq);
 }


### PR DESCRIPTION
# Description

This PR adds an option to catchup to start replaying from a "previous" checkpoint while preserving historical data.

Previously the only option was to run `new-db` which was forcing operators to rebuild .

example use:

```
stellar-core --conf testnet.cfg catchup  50000/100
# has history for ledgers up to 49856-50000
stellar-core --conf testnet.cfg catchup --force-back 49997/1
# has history for ledger up 49856-49997 (has to apply buckets for ledger 49983)
# rebuilds history for 49984-49997
```
