### PR TITLE
Use random hashes for temp filenames

### DIFF
--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -191,9 +191,10 @@ HistoryArchiveState::remoteName(uint32_t snapshotNumber)
 }
 
 std::string
-HistoryArchiveState::localName(Application& app, std::string const& archiveName)
+HistoryArchiveState::localName(Application& app,
+                               std::string const& uniquePrefix)
 {
-    return app.getHistoryManager().localFilename(archiveName + "-" +
+    return app.getHistoryManager().localFilename(uniquePrefix + "-" +
                                                  baseName());
 }
 

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -3,6 +3,8 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "historywork/GetHistoryArchiveStateWork.h"
+#include "crypto/Hex.h"
+#include "crypto/Random.h"
 #include "history/HistoryArchive.h"
 #include "historywork/GetRemoteFileWork.h"
 #include "ledger/LedgerManager.h"
@@ -24,9 +26,7 @@ GetHistoryArchiveStateWork::GetHistoryArchiveStateWork(
     , mArchive(archive)
     , mRetries(maxRetries)
     , mLocalFilename(
-          archive ? HistoryArchiveState::localName(app, archive->getName())
-                  : app.getHistoryManager().localFilename(
-                        HistoryArchiveState::baseName()))
+          HistoryArchiveState::localName(app, binToHex(randomBytes(8))))
     , mGetHistoryArchiveStateSuccess(app.getMetrics().NewMeter(
           {"history", "download-history-archive-state" + std::move(mode),
            "success"},

--- a/src/historywork/GetHistoryArchiveStateWork.h
+++ b/src/historywork/GetHistoryArchiveStateWork.h
@@ -26,7 +26,7 @@ class GetHistoryArchiveStateWork : public Work
     uint32_t mSeq;
     std::shared_ptr<HistoryArchive> mArchive;
     size_t mRetries;
-    std::string mLocalFilename;
+    std::string const mLocalFilename;
 
     medida::Meter& mGetHistoryArchiveStateSuccess;
 

--- a/src/historywork/PutHistoryArchiveStateWork.cpp
+++ b/src/historywork/PutHistoryArchiveStateWork.cpp
@@ -3,6 +3,8 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "historywork/PutHistoryArchiveStateWork.h"
+#include "crypto/Hex.h"
+#include "crypto/Random.h"
 #include "history/HistoryArchive.h"
 #include "historywork/MakeRemoteDirWork.h"
 #include "historywork/PutRemoteFileWork.h"
@@ -21,7 +23,8 @@ PutHistoryArchiveStateWork::PutHistoryArchiveStateWork(
     : Work(app, "put-history-archive-state", BasicWork::RETRY_ONCE)
     , mState(state)
     , mArchive(archive)
-    , mLocalFilename(HistoryArchiveState::localName(app, archive->getName()))
+    , mLocalFilename(
+          HistoryArchiveState::localName(app, binToHex(randomBytes(8))))
 {
     if (!mState.containsValidBuckets(mApp))
     {

--- a/src/historywork/PutHistoryArchiveStateWork.h
+++ b/src/historywork/PutHistoryArchiveStateWork.h
@@ -17,7 +17,7 @@ class PutHistoryArchiveStateWork : public Work
 {
     HistoryArchiveState const& mState;
     std::shared_ptr<HistoryArchive> mArchive;
-    std::string mLocalFilename;
+    std::string const mLocalFilename;
     std::shared_ptr<WorkSequence> mPutRemoteFileWork;
 
     void spawnPublishWork();


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core/issues/2976

This change improves the naming of local temp files during catchup and publish. Specifically, it avoids dependencies on node's config. These temp files are contained within the works that use it, and are not exposed outside. On retry, we re-use the same filename (which is what happens in master as well, although this is not critical for correctness).