### PR TITLE
Log root account address when starting new ledger

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -218,6 +218,7 @@ LedgerManagerImpl::startNewLedger(LedgerHeader const& genesisLedger)
     ltx.create(rootEntry);
 
     CLOG_INFO(Ledger, "Established genesis ledger, closing");
+    CLOG_INFO(Ledger, "Root account: {}", skey.getStrKeyPublic());
     CLOG_INFO(Ledger, "Root account seed: {}", skey.getStrKeySeed().value);
     ledgerClosed(ltx);
     ltx.commit();


### PR DESCRIPTION
# Description
## What
Log the root account's public key in strkey format when starting a new
ledger.

## Why
When debugging and testing locally on standalone ledgers the developer needs
to know the root account seed to prefund test accounts. The seed is
conveniently outputted when running the `new-db` command when the new ledger
is being created, but the account public key / address is not. This is
inconvenient because the developer needs both. The developer can derive the
public key from the secret key using tools such as stc but it would be more
convenient if the address was logged alongside the seed.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [ ] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
