### PR TITLE
Use nullopt

### DIFF
--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -177,7 +177,7 @@ closeLedger(Application& app, std::optional<SecretKey> skToSignValue)
 static Hash
 closeLedger(Application& app)
 {
-    return closeLedger(app, std::optional<SecretKey>());
+    return closeLedger(app, std::nullopt);
 }
 }
 

--- a/src/catchup/CatchupConfiguration.cpp
+++ b/src/catchup/CatchupConfiguration.cpp
@@ -18,9 +18,7 @@ CatchupConfiguration::CatchupConfiguration(LedgerNumHashPair ledgerHashPair,
 
 CatchupConfiguration::CatchupConfiguration(uint32_t toLedger, uint32_t count,
                                            Mode mode)
-    : mCount{count}
-    , mLedgerHashPair{toLedger, std::optional<Hash>()}
-    , mMode{mode}
+    : mCount{count}, mLedgerHashPair{toLedger, std::nullopt}, mMode{mode}
 {
 }
 

--- a/src/catchup/VerifyLedgerChainWork.cpp
+++ b/src/catchup/VerifyLedgerChainWork.cpp
@@ -131,7 +131,7 @@ VerifyLedgerChainWork::onReset()
 {
     CLOG_INFO(History, "Verifying ledgers {}", mRange.toString());
 
-    mVerifiedAhead = LedgerNumHashPair(0, std::optional<Hash>());
+    mVerifiedAhead = LedgerNumHashPair(0, std::nullopt);
     mMaxVerifiedLedgerOfMinCheckpoint = {};
     mVerifiedLedgers.clear();
     mCurrCheckpoint = mRange.mCount == 0

--- a/src/database/test/DatabaseTests.cpp
+++ b/src/database/test/DatabaseTests.cpp
@@ -559,24 +559,24 @@ TEST_CASE("schema upgrade test", "[db]")
     auto testOneDBMode = [prepOldSchemaDB](Config::TestDbMode const dbMode) {
         // A vector of optional Liabilities entries, for each of which the test
         // will generate a valid account.
-        auto const accOptLiabilities = {
-            std::optional<Liabilities>(),
+        std::vector<std::optional<Liabilities>> const accOptLiabilities = {
+            std::nullopt,
             std::make_optional<Liabilities>(Liabilities{12, 17}),
             std::make_optional<Liabilities>(Liabilities{4, 0}),
-            std::optional<Liabilities>(),
+            std::nullopt,
             std::make_optional<Liabilities>(Liabilities{3, 0}),
             std::make_optional<Liabilities>(Liabilities{11, 11}),
             std::make_optional<Liabilities>(Liabilities{0, 0})};
 
         // A vector of optional Liabilities entries, for each of which the test
         // will generate a valid trustline.
-        auto const tlOptLiabilities = {
+        std::vector<std::optional<Liabilities>> const tlOptLiabilities = {
             std::make_optional<Liabilities>(Liabilities{1, 0}),
             std::make_optional<Liabilities>(Liabilities{0, 6}),
-            std::optional<Liabilities>(),
+            std::nullopt,
             std::make_optional<Liabilities>(Liabilities{0, 0}),
             std::make_optional<Liabilities>(Liabilities{5, 8}),
-            std::optional<Liabilities>()};
+            std::nullopt};
 
         // Generate from each of the optional liabilities in accOptLiabilities a
         // new valid account.

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -33,15 +33,14 @@ namespace stellar
 using namespace std;
 
 TxSetFrame::TxSetFrame(Hash const& previousLedgerHash)
-    : mHash(std::optional<Hash>())
-    , mValid(std::optional<std::pair<Hash, bool>>())
+    : mHash(std::nullopt)
+    , mValid(std::nullopt)
     , mPreviousLedgerHash(previousLedgerHash)
 {
 }
 
 TxSetFrame::TxSetFrame(Hash const& networkID, TransactionSet const& xdrSet)
-    : mHash(std::optional<Hash>())
-    , mValid(std::optional<std::pair<Hash, bool>>())
+    : mHash(std::nullopt), mValid(std::nullopt)
 {
     ZoneScoped;
     for (auto const& env : xdrSet.txs)

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1260,7 +1260,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
         // combineCandidates() and the one we compute at each step.
 
         std::vector<CandidateSpec> const specs{
-            {0, 1, 100, 10, std::optional<uint32>()},
+            {0, 1, 100, 10, std::nullopt},
             {10, 1, 100, 5, std::make_optional<uint32>(1)},
             {5, 3, 100, 20, std::make_optional<uint32>(2)},
             {7, 2, 5, 30, std::make_optional<uint32>(3)}};

--- a/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
+++ b/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
@@ -44,12 +44,12 @@ static LedgerEntry
 generateRandomSubEntry(LedgerEntry const& acc)
 {
     static auto validAccountIDGenerator =
-        autocheck::map([](AccountID&& id, size_t s) { return id; },
+        autocheck::map([](AccountID&& id, size_t s) { return std::move(id); },
                        autocheck::generator<AccountID>());
     static auto validDataNameGenerator = autocheck::map(
         [](string64&& dn, size_t s) {
             LedgerTestUtils::replaceControlCharacters(dn, 64);
-            return dn;
+            return std::move(dn);
         },
         autocheck::generator<string64>());
 
@@ -119,7 +119,7 @@ static auto validSignerGenerator = autocheck::map(
         {
             signer.weight = 100;
         }
-        return signer;
+        return std::move(signer);
     },
     autocheck::generator<Signer>());
 

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -329,42 +329,42 @@ static auto validLedgerEntryGenerator = autocheck::map(
             break;
         }
 
-        return le;
+        return std::move(le);
     },
     autocheck::generator<LedgerEntry>());
 
 static auto validAccountEntryGenerator = autocheck::map(
     [](AccountEntry&& ae, size_t s) {
         makeValid(ae);
-        return ae;
+        return std::move(ae);
     },
     autocheck::generator<AccountEntry>());
 
 static auto validTrustLineEntryGenerator = autocheck::map(
     [](TrustLineEntry&& tl, size_t s) {
         makeValid(tl);
-        return tl;
+        return std::move(tl);
     },
     autocheck::generator<TrustLineEntry>());
 
 static auto validOfferEntryGenerator = autocheck::map(
     [](OfferEntry&& o, size_t s) {
         makeValid(o);
-        return o;
+        return std::move(o);
     },
     autocheck::generator<OfferEntry>());
 
 static auto validDataEntryGenerator = autocheck::map(
     [](DataEntry&& d, size_t s) {
         makeValid(d);
-        return d;
+        return std::move(d);
     },
     autocheck::generator<DataEntry>());
 
 static auto validClaimableBalanceEntryGenerator = autocheck::map(
     [](ClaimableBalanceEntry&& c, size_t s) {
         makeValid(c);
-        return c;
+        return std::move(c);
     },
     autocheck::generator<ClaimableBalanceEntry>());
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -189,7 +189,7 @@ parseOptionalParam(std::map<std::string, std::string> const& map,
         return std::make_optional<T>(val);
     }
 
-    return std::optional<T>();
+    return std::nullopt;
 }
 
 // If the key exists and the value successfully parses, return that value.

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -297,7 +297,7 @@ maybeEnableInMemoryLedgerMode(Config& config, bool inMemory,
         {
             throw std::runtime_error("--start-at-hash requires --in-memory");
         }
-        return std::optional<CatchupConfiguration>();
+        return std::nullopt;
     }
 
     // Adjust configs for in-memory-replay mode
@@ -328,7 +328,7 @@ maybeEnableInMemoryLedgerMode(Config& config, bool inMemory,
         auto mode = CatchupConfiguration::Mode::OFFLINE_COMPLETE;
         return std::make_optional<CatchupConfiguration>(pair, count, mode);
     }
-    return std::optional<CatchupConfiguration>();
+    return std::nullopt;
 }
 
 clara::Opt
@@ -556,7 +556,7 @@ CommandLine::selectCommand(std::string const& commandName)
     {
         return std::make_optional<Command>(*command);
     }
-    return std::optional<Command>();
+    return std::nullopt;
 }
 
 void

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -268,8 +268,8 @@ TEST_CASE("manualclose", "[commandhandler]")
         commandHandler.manualClose(params, retStr);
     };
 
-    auto const noLedgerSeq = std::optional<uint32_t>();
-    auto const noCloseTime = std::optional<TimePoint>();
+    std::optional<uint32_t> noLedgerSeq;
+    std::optional<TimePoint> noCloseTime;
 
     SECTION("manual close with no parameters increments sequence number and "
             "increases close time")

--- a/src/test/TestExceptions.cpp
+++ b/src/test/TestExceptions.cpp
@@ -546,6 +546,12 @@ throwIf(TransactionResult const& result)
     case CLAIM_CLAIMABLE_BALANCE:
         throwIf(opResult.tr().claimClaimableBalanceResult());
         break;
+    case BEGIN_SPONSORING_FUTURE_RESERVES:
+    case END_SPONSORING_FUTURE_RESERVES:
+    case REVOKE_SPONSORSHIP:
+        // Sponsorship tests catch error codes at a higher level than this.
+        throw std::runtime_error("got error-result in test sponsorship tx");
+        break;
     case CLAWBACK:
         throwIf(opResult.tr().clawbackResult());
         break;

--- a/src/util/test/MetricTests.cpp
+++ b/src/util/test/MetricTests.cpp
@@ -134,7 +134,8 @@ struct Percentiles
         {
             std::ostringstream oss;
             bool first = true;
-            for (auto dbl : snap.getValues())
+            auto values = snap.getValues();
+            for (auto dbl : values)
             {
                 if (first)
                 {
@@ -146,6 +147,7 @@ struct Percentiles
                 }
                 oss << dbl;
             }
+            printDistribution(values);
             LOG_ERROR(DEFAULT_LOG, "failing samples: {}", oss.str());
         }
     }


### PR DESCRIPTION
# Description

Mainly this change shifts us from using `std::optional()` to `std::nullopt`. I introduced a bunch of the former in #3013 and having read a bit more internet lore I now think it's better to do the latter.

I also included some warning fixups, one of which might have been serious but I asked @sisuresh and it's not -- tests already handle the missing enums earlier.

No functional change.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] N/A If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
