### PR TITLE
Minor doc fixup: Link to the referenced file

### DIFF
--- a/src/overlay/readme.md
+++ b/src/overlay/readme.md
@@ -9,5 +9,5 @@ Within the local process, the overlay subsystem primarily delivers messages to,
 and accepts them from, the [Herder](../herder), as well as propagating through
 the network any transactions injected from public API servers.
 
-Good reading entry points are `OverlayManager.h`, as well as the implementation of
+Good reading entry points are [`OverlayManager.h`](./OverlayManager.h), as well as the implementation of
 `OverlayManagerImpl::tick`, and `OverlayManagerImpl::broadcastMessage`.


### PR DESCRIPTION
# Description

Minor enhancement: Add link to OverlayManager.h instead of just mentioning it in plain text in the sub-readme.
Makes it just a tad easier to open the file, esp. when viewing the README on GitHub.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist

The last 4 items are not really applicable, since it's only a doc change.

- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
