### PR TITLE
Pass TimePoint to TransactionBridge set time methods

### DIFF
--- a/src/transactions/TransactionBridge.cpp
+++ b/src/transactions/TransactionBridge.cpp
@@ -111,7 +111,7 @@ setFee(TransactionFramePtr tx, uint32_t fee)
 }
 
 void
-setMinTime(TransactionFramePtr tx, int64_t minTime)
+setMinTime(TransactionFramePtr tx, TimePoint minTime)
 {
     auto& env = tx->getEnvelope();
     auto& tb = env.type() == ENVELOPE_TYPE_TX_V0 ? env.v0().tx.timeBounds
@@ -120,7 +120,7 @@ setMinTime(TransactionFramePtr tx, int64_t minTime)
 }
 
 void
-setMaxTime(TransactionFramePtr tx, int64_t maxTime)
+setMaxTime(TransactionFramePtr tx, TimePoint maxTime)
 {
     auto& env = tx->getEnvelope();
     auto& tb = env.type() == ENVELOPE_TYPE_TX_V0 ? env.v0().tx.timeBounds

--- a/src/transactions/TransactionBridge.h
+++ b/src/transactions/TransactionBridge.h
@@ -30,9 +30,9 @@ void setSeqNum(TransactionFramePtr tx, int64_t seq);
 
 void setFee(TransactionFramePtr tx, uint32_t fee);
 
-void setMinTime(TransactionFramePtr tx, int64_t minTime);
+void setMinTime(TransactionFramePtr tx, TimePoint minTime);
 
-void setMaxTime(TransactionFramePtr tx, int64_t maxTime);
+void setMaxTime(TransactionFramePtr tx, TimePoint maxTime);
 #endif
 }
 }


### PR DESCRIPTION
# Description

The time bounds are `TimePoint`, which is `uint64_t`, not `int64_t`. I noticed this while reviewing https://github.com/stellar/stellar-core/pull/2979.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
