### PR TITLE
Update V16 flags to V17

### DIFF
--- a/src/invariant/test/LedgerEntryIsValidTests.cpp
+++ b/src/invariant/test/LedgerEntryIsValidTests.cpp
@@ -30,14 +30,14 @@ TEST_CASE("Trigger validity check for each entry type",
     {
         le.data.type(ACCOUNT);
         le.data.account() = LedgerTestUtils::generateValidAccountEntry(5);
-        le.data.account().flags = MASK_ACCOUNT_FLAGS_V16 + 1;
+        le.data.account().flags = MASK_ACCOUNT_FLAGS_V17 + 1;
         REQUIRE(!store(*app, makeUpdateList({le}, nullptr)));
     }
     SECTION("trustline")
     {
         le.data.type(TRUSTLINE);
         le.data.trustLine() = LedgerTestUtils::generateValidTrustLineEntry(5);
-        le.data.trustLine().flags = MASK_TRUSTLINE_FLAGS_V16 + 1;
+        le.data.trustLine().flags = MASK_TRUSTLINE_FLAGS_V17 + 1;
         REQUIRE(!store(*app, makeUpdateList({le}, nullptr)));
     }
     SECTION("offer")

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -131,7 +131,7 @@ makeValid(AccountEntry& a)
     {
         a.seqNum = -a.seqNum;
     }
-    a.flags = a.flags & MASK_ACCOUNT_FLAGS_V16;
+    a.flags = a.flags & MASK_ACCOUNT_FLAGS_V17;
 
     if (a.ext.v() == 1)
     {
@@ -182,7 +182,7 @@ makeValid(TrustLineEntry& tl)
     tl.asset.type(ASSET_TYPE_CREDIT_ALPHANUM4);
     strToAssetCode(tl.asset.alphaNum4().assetCode, "USD");
     clampHigh<int64_t>(tl.limit, tl.balance);
-    tl.flags = tl.flags & MASK_TRUSTLINE_FLAGS_V16;
+    tl.flags = tl.flags & MASK_TRUSTLINE_FLAGS_V17;
 
     if (tl.ext.v() == 1)
     {

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -917,7 +917,7 @@ trustLineFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
     }
     else
     {
-        return (flag & ~MASK_TRUSTLINE_FLAGS_V16) == 0;
+        return (flag & ~MASK_TRUSTLINE_FLAGS_V17) == 0;
     }
 }
 
@@ -948,7 +948,7 @@ accountFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion)
         return (flag & ~MASK_ACCOUNT_FLAGS) == 0;
     }
 
-    return (flag & ~MASK_ACCOUNT_FLAGS_V16) == 0;
+    return (flag & ~MASK_ACCOUNT_FLAGS_V17) == 0;
 }
 
 AccountID

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -269,12 +269,12 @@ TEST_CASE("set trustline flags", "[tx][settrustlineflags]")
                 REQUIRE_THROWS_AS(
                     gateway.setTrustLineFlags(
                         idr, a1,
-                        setTrustLineFlags(MASK_TRUSTLINE_FLAGS_V16 + 1)),
+                        setTrustLineFlags(MASK_TRUSTLINE_FLAGS_V17 + 1)),
                     ex_SET_TRUST_LINE_FLAGS_MALFORMED);
                 REQUIRE_THROWS_AS(
                     gateway.setTrustLineFlags(
                         idr, a1,
-                        clearTrustLineFlags(MASK_TRUSTLINE_FLAGS_V16 + 1)),
+                        clearTrustLineFlags(MASK_TRUSTLINE_FLAGS_V17 + 1)),
                     ex_SET_TRUST_LINE_FLAGS_MALFORMED);
 
                 // can't operate on self

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -119,7 +119,7 @@ enum AccountFlags
 
 // mask for all valid flags
 const MASK_ACCOUNT_FLAGS = 0x7;
-const MASK_ACCOUNT_FLAGS_V16 = 0xF;
+const MASK_ACCOUNT_FLAGS_V17 = 0xF;
 
 // maximum number of signers
 const MAX_SIGNERS = 20;
@@ -212,7 +212,7 @@ enum TrustLineFlags
 // mask for all trustline flags
 const MASK_TRUSTLINE_FLAGS = 1;
 const MASK_TRUSTLINE_FLAGS_V13 = 3;
-const MASK_TRUSTLINE_FLAGS_V16 = 7;
+const MASK_TRUSTLINE_FLAGS_V17 = 7;
 
 struct TrustLineEntry
 {


### PR DESCRIPTION
# Description

`MASK_ACCOUNT_FLAGS_V16` and `MASK_TRUSTLINE_FLAGS_V16` are now incorrectly named after the V16 update. This PR just updates the flag names.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
