### PR TITLE
Diagnostic tools

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -508,8 +508,10 @@ exit /b 0
     <ClCompile Include="..\..\src\main\Maintainer.cpp" />
     <ClCompile Include="..\..\src\main\PersistentState.cpp" />
     <ClCompile Include="..\..\src\main\StellarCoreVersion.cpp" />
+    <ClCompile Include="..\..\src\main\test\ApplicationUtilsTests.cpp" />
     <ClCompile Include="..\..\src\main\test\ConfigTests.cpp" />
     <ClCompile Include="..\..\src\main\test\ExternalQueueTests.cpp" />
+    <ClCompile Include="..\..\src\main\test\SelfCheckTests.cpp" />
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp" />
     <ClCompile Include="..\..\src\overlay\Floodgate.cpp" />
     <ClCompile Include="..\..\src\overlay\ItemFetcher.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -376,6 +376,7 @@ exit /b 0
     <ClCompile Include="..\..\src\util\test\SchedulerTests.cpp" />
     <ClCompile Include="..\..\src\util\XDRCereal.cpp" />
     <ClCompile Include="..\..\src\work\BatchWork.cpp" />
+    <ClCompile Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.cpp" />
     <ClCompile Include="..\..\src\historywork\DownloadBucketsWork.cpp" />
     <ClCompile Include="..\..\src\historywork\DownloadVerifyTxResultsWork.cpp" />
     <ClCompile Include="..\..\src\historywork\FetchRecentQsetsWork.cpp" />
@@ -733,6 +734,7 @@ exit /b 0
     <ClInclude Include="..\..\src\util\XDRCereal.h" />
     <ClInclude Include="..\..\src\util\XDROperators.h" />
     <ClInclude Include="..\..\src\work\BatchWork.h" />
+    <ClInclude Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.h" />
     <ClInclude Include="..\..\src\historywork\DownloadBucketsWork.h" />
     <ClInclude Include="..\..\src\historywork\DownloadVerifyTxResultsWork.h" />
     <ClInclude Include="..\..\src\historywork\FetchRecentQsetsWork.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1173,6 +1173,9 @@
     <ClCompile Include="..\..\src\herder\SurgePricingUtils.cpp">
       <Filter>herder</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.cpp">
+      <Filter>historyWork</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2044,6 +2047,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\herder\SurgePricingUtils.h">
       <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.h">
+      <Filter>historyWork</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -693,6 +693,9 @@
     <ClCompile Include="..\..\src\ledger\test\LiabilitiesTests.cpp">
       <Filter>ledger\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\test\ApplicationUtilsTests.cpp">
+      <Filter>main\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp">
       <Filter>main\tests</Filter>
     </ClCompile>
@@ -700,6 +703,9 @@
       <Filter>main\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\main\test\ExternalQueueTests.cpp">
+      <Filter>main\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\test\SelfCheckTests.cpp">
       <Filter>main\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\util\test\CacheTests.cpp">

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,29 @@ AS_IF([test "x$enable_afl" = "xyes"], [
 ])
 AM_CONDITIONAL([USE_AFL_FUZZ], [test "x$enable_afl" == "xyes"])
 
+# check to see if we need to append -lstdc++fs or -lc++fs to access
+# functionality from <filesystem> (for some reason this was thought
+# a good idea in gcc 8 and clang 8)
+AC_MSG_CHECKING([to see if <filesystem> works without any extra libs])
+AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+                               [[std::filesystem::path test("hello");]])],
+              [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+              [AC_MSG_RESULT([no]); FS_WORKS=no])
+for testlib in -lstdc++fs -lc++fs; do
+    if test "$FS_WORKS" = "no"; then
+        fs_save_LIBS="$LIBS"
+        LIBS="$testlib $LIBS"
+        AC_MSG_CHECKING([to see if <filesystem> works with $testlib])
+        AC_RUN_IFELSE([AC_LANG_PROGRAM([[#include <filesystem>]],
+                                   [[std::filesystem::path test("hello");]])],
+                  [AC_MSG_RESULT([yes]); FS_WORKS=yes],
+                  [AC_MSG_RESULT([no]); FS_WORKS=no; LIBS="$fs_save_LIBS"])
+    fi
+done
+if test "$FS_WORKS" = "no"; then
+   AC_MSG_ERROR([C++17 <filesystem> does not work with any known linker flags])
+fi
+
 # prefer 10 as it's the one we use
 AC_CHECK_PROGS(CLANG_FORMAT, [clang-format-10 clang-format])
 AM_CONDITIONAL([USE_CLANG_FORMAT], [test "x$CLANG_FORMAT" != "x"])

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -40,8 +40,6 @@ herder.pending-txs.age2                  | counter   | number of gen2 pending tr
 herder.pending-txs.age3                  | counter   | number of gen3 pending transactions
 herder.pending-txs.banned                | counter   | number of transactions that got banned
 herder.pending-txs.delay                 | timer     | time for transactions to be included in a ledger
-history-archive.<X>.failure              | meter     | accessing history archive <X> failed
-history-archive.<X>.success              | meter     | accessing history archive <X> succeeded
 history.apply-ledger-chain.failure       | meter     | apply ledger chain failed
 history.apply-ledger-chain.success       | meter     | apply ledger chain completed successfully
 history.download-<X>.failure             | meter     | download of <X> failed
@@ -49,9 +47,9 @@ history.download-<X>.success             | meter     | download of <X> completed
 history.publish.failure                  | meter     | published failed
 history.publish.success                  | meter     | published completed successfully
 history.publish.time                     | timer     | time to successfully publish history
-history.verify-<X>.failure               | meter     | verification of <X> failed
-history.verify-<X>.success               | meter     | verification of <X> succeeded
-ledger.age.closed                        | bucket     | time between ledgers
+history.verify-<X>.failure               | meter     | verification of file from archive <X> failed
+history.verify-<X>.success               | meter     | verification of file from archive <X> succeeded
+ledger.age.closed                        | bucket    | time between ledgers
 ledger.age.current-seconds               | counter   | gap between last close ledger time and current time
 ledger.catchup.duration                  | timer     | time between entering LM_CATCHING_UP_STATE and entering LM_SYNCED_STATE
 ledger.invariant.failure                 | counter   | number of times invariants failed

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,6 +44,8 @@ history.apply-ledger-chain.failure       | meter     | apply ledger chain failed
 history.apply-ledger-chain.success       | meter     | apply ledger chain completed successfully
 history.download-<X>.failure             | meter     | download of <X> failed
 history.download-<X>.success             | meter     | download of <X> completed successfully
+history.check.failure                    | meter     | history archive status checks failed
+history.check.success                    | meter     | history archive status checks succeeded
 history.publish.failure                  | meter     | published failed
 history.publish.success                  | meter     | published completed successfully
 history.publish.time                     | timer     | time to successfully publish history

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -634,7 +634,6 @@ The output will look something like
 ```json
 {
       "build" : "v11.1.0",
-      "history_failure_rate" : "0",
       "ledger" : {
          "age" : 3,
          "baseFee" : 100,

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -308,6 +308,12 @@ AUTOMATIC_MAINTENANCE_PERIOD=660
 # Set to 0 to disable automatic maintenance
 AUTOMATIC_MAINTENANCE_COUNT=700
 
+# AUTOMATIC_SELF_CHECK_PERIOD (integer, seconds) default 10800
+# Interval between automatic self-checks, including connectivity
+# and consistency checking against configured history archives.
+# Set to zero to disable automatic self-checks.
+AUTOMATIC_SELF_CHECK_PERIOD=10800
+
 ###############################
 ## The following options should probably never be set. They are used primarily
 ##  for testing.

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -8,6 +8,7 @@
 #include "overlay/StellarXDR.h"
 #include "util/NonCopyable.h"
 #include <future>
+#include <map>
 #include <memory>
 #include <set>
 
@@ -22,6 +23,7 @@ class TmpDirManager;
 struct LedgerHeader;
 struct MergeKey;
 struct HistoryArchiveState;
+class BasicWork;
 
 // A fine-grained merge-operation-counter structure for tracking various
 // events during merges. These are not medida counters because we do not
@@ -211,5 +213,27 @@ class BucketManager : NonMovableOrCopyable
     virtual void shutdown() = 0;
 
     virtual bool isShutdown() const = 0;
+
+    // Load the complete state of the ledger from the provided HAS. Throws if
+    // any of the buckets referenced in the HAS do not exist.
+    //
+    // Note: this returns an _ordered_ map because we want to enable writing it
+    // straight to a single "merged bucket" with a canonical order for debugging
+    // purposes.
+    //
+    // Also note: this returns a large map -- likely multiple GB of memory on
+    // public nodes. The whole ledger. Call carefully, and only offline.
+    virtual std::map<LedgerKey, LedgerEntry>
+    loadCompleteLedgerState(HistoryArchiveState const& has) = 0;
+
+    // Merge the bucket list of the provided HAS into a single "super bucket"
+    // consisting of only live entries, and return it.
+    virtual std::shared_ptr<Bucket>
+    mergeBuckets(HistoryArchiveState const& has) = 0;
+
+    // Schedule a Work class that verifies the hashes of all referenced buckets
+    // on background threads.
+    virtual std::shared_ptr<BasicWork>
+    scheduleVerifyReferencedBucketsWork() = 0;
 };
 }

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -136,6 +136,14 @@ class BucketManagerImpl : public BucketManager
     void shutdown() override;
 
     bool isShutdown() const override;
+
+    std::map<LedgerKey, LedgerEntry>
+    loadCompleteLedgerState(HistoryArchiveState const& has) override;
+
+    std::shared_ptr<Bucket>
+    mergeBuckets(HistoryArchiveState const& has) override;
+
+    std::shared_ptr<BasicWork> scheduleVerifyReferencedBucketsWork() override;
 };
 
 #define SKIP_1 50

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -68,8 +68,9 @@ ApplyBufferedLedgersWork::onRun()
 
     auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, lcd);
 
-    auto predicate = [&]() {
-        auto& bl = mApp.getBucketManager().getBucketList();
+    auto predicate = [](Application& app) {
+        auto& bl = app.getBucketManager().getBucketList();
+        auto& lm = app.getLedgerManager();
         bl.resolveAnyReadyFutures();
         return bl.futuresAllResolved(
             bl.getMaxMergeLevel(lm.getLastClosedLedgerNum() + 1));

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -306,8 +306,9 @@ ApplyCheckpointWork::onRun()
 
         auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, *lcd);
 
-        auto predicate = [&]() {
-            auto& bl = mApp.getBucketManager().getBucketList();
+        auto predicate = [](Application& app) {
+            auto& bl = app.getBucketManager().getBucketList();
+            auto& lm = app.getLedgerManager();
             bl.resolveAnyReadyFutures();
             return bl.futuresAllResolved(
                 bl.getMaxMergeLevel(lm.getLastClosedLedgerNum() + 1));

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -80,8 +80,8 @@ DownloadApplyTxsWork::yieldMoreWork()
     {
         auto prev = mLastYieldedWork;
         bool pqFellBehind = false;
-        auto predicate = [prev, pqFellBehind, waitForPublish = mWaitForPublish,
-                          &hm]() mutable {
+        auto predicate = [prev, pqFellBehind, waitForPublish = mWaitForPublish](
+                             Application& app) mutable {
             if (!prev)
             {
                 throw std::runtime_error("Download and apply txs: related Work "
@@ -98,6 +98,7 @@ DownloadApplyTxsWork::yieldMoreWork()
             bool res = true;
             if (waitForPublish)
             {
+                auto& hm = app.getHistoryManager();
                 auto length = hm.publishQueueLength();
                 if (length <= CatchupWork::PUBLISH_QUEUE_UNBLOCK_APPLICATION)
                 {

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -595,10 +595,11 @@ TxSimApplyTransactionsWork::onRun()
     LedgerCloseData closeData(header.ledgerSeq + 1, txSet, sv);
     auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, closeData);
 
-    auto const& ham = mApp.getHistoryArchiveManager();
-    auto const& hm = mApp.getHistoryManager();
     bool waitForPublish = false;
-    auto condition = [&lm, &ham, &hm, waitForPublish]() mutable {
+    auto condition = [waitForPublish](Application& app) mutable {
+        auto const& lm = app.getLedgerManager();
+        auto const& ham = app.getHistoryArchiveManager();
+        auto const& hm = app.getHistoryManager();
         auto proceed = true;
         if (ham.hasAnyWritableHistoryArchive())
         {

--- a/src/crypto/SecretKey.h
+++ b/src/crypto/SecretKey.h
@@ -58,6 +58,11 @@ class SecretKey
     // Create a new, random secret key.
     static SecretKey random();
 
+    // Measure the speed of sign-and-verify ops.
+    static void benchmarkOpsPerSecond(size_t& sign, size_t& verify,
+                                      size_t iterations,
+                                      size_t cachedVerifyPasses = 1);
+
 #ifdef BUILD_TESTS
     // Create a new, pseudo-random secret key drawn from the global weak
     // non-cryptographic PRNG (which itself is seeded from command-line or

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -447,10 +447,6 @@ HistoryArchiveState::HistoryArchiveState(uint32_t ledgerSeq,
 HistoryArchive::HistoryArchive(Application& app,
                                HistoryArchiveConfiguration const& config)
     : mConfig(config)
-    , mSuccessMeter(app.getMetrics().NewMeter(
-          {"history-archive", config.mName, "success"}, "event"))
-    , mFailureMeter(app.getMetrics().NewMeter(
-          {"history-archive", config.mName, "failure"}, "event"))
 {
 }
 
@@ -506,29 +502,5 @@ HistoryArchive::mkdirCmd(std::string const& remoteDir) const
     if (mConfig.mMkdirCmd.empty())
         return "";
     return formatString(mConfig.mMkdirCmd, remoteDir);
-}
-
-void
-HistoryArchive::markSuccess()
-{
-    mSuccessMeter.Mark();
-}
-
-void
-HistoryArchive::markFailure()
-{
-    mFailureMeter.Mark();
-}
-
-uint64_t
-HistoryArchive::getSuccessCount() const
-{
-    return mSuccessMeter.count();
-}
-
-uint64_t
-HistoryArchive::getFailureCount() const
-{
-    return mFailureMeter.count();
 }
 }

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -166,15 +166,7 @@ class HistoryArchive : public std::enable_shared_from_this<HistoryArchive>
                            std::string const& remote) const;
     std::string mkdirCmd(std::string const& remoteDir) const;
 
-    void markSuccess();
-    void markFailure();
-
-    uint64_t getSuccessCount() const;
-    uint64_t getFailureCount() const;
-
   private:
     HistoryArchiveConfiguration mConfig;
-    medida::Meter& mSuccessMeter;
-    medida::Meter& mFailureMeter;
 };
 }

--- a/src/history/HistoryArchiveManager.cpp
+++ b/src/history/HistoryArchiveManager.cpp
@@ -252,27 +252,4 @@ HistoryArchiveManager::getWritableHistoryArchives() const
                  });
     return result;
 }
-
-double
-HistoryArchiveManager::getFailureRate() const
-{
-    uint64_t successCount{0};
-    uint64_t failureCount{0};
-
-    for (auto archive : mArchives)
-    {
-        successCount += archive->getSuccessCount();
-        failureCount += archive->getFailureCount();
-    }
-
-    auto total = successCount + failureCount;
-    if (total == 0)
-    {
-        return 0.0;
-    }
-    else
-    {
-        return static_cast<double>(failureCount) / total;
-    }
-}
 }

--- a/src/history/HistoryArchiveManager.h
+++ b/src/history/HistoryArchiveManager.h
@@ -14,7 +14,8 @@ class Application;
 class Config;
 class HistoryArchive;
 
-class HistoryArchiveReportWork;
+class BasicWork;
+struct LedgerHeaderHistoryEntry;
 
 class HistoryArchiveManager
 {
@@ -28,8 +29,13 @@ class HistoryArchiveManager
     // select one at random.
     std::shared_ptr<HistoryArchive> selectRandomReadableHistoryArchive() const;
 
-    std::shared_ptr<HistoryArchiveReportWork>
-    scheduleHistoryArchiveReportWork() const;
+    // Returns a work that reports the last-published checkpoint on each
+    // archive.
+    std::shared_ptr<BasicWork> getHistoryArchiveReportWork() const;
+
+    // Returns a work that checks a given LHHE's content against each archive.
+    std::shared_ptr<BasicWork>
+    getCheckLedgerHeaderWork(LedgerHeaderHistoryEntry const&) const;
 
     // Initialize a named history archive by writing
     // .well-known/stellar-history.json to it.

--- a/src/history/HistoryArchiveManager.h
+++ b/src/history/HistoryArchiveManager.h
@@ -48,8 +48,6 @@ class HistoryArchiveManager
     std::vector<std::shared_ptr<HistoryArchive>>
     getWritableHistoryArchives() const;
 
-    double getFailureRate() const;
-
   private:
     Application& mApp;
     std::vector<std::shared_ptr<HistoryArchive>> mArchives;

--- a/src/historywork/CheckSingleLedgerHeaderWork.cpp
+++ b/src/historywork/CheckSingleLedgerHeaderWork.cpp
@@ -1,0 +1,157 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "historywork/CheckSingleLedgerHeaderWork.h"
+#include "history/FileTransferInfo.h"
+#include "history/HistoryArchive.h"
+#include "history/HistoryManager.h"
+#include "historywork/GetAndUnzipRemoteFileWork.h"
+#include "util/GlobalChecks.h"
+#include "util/Logging.h"
+#include "util/TmpDir.h"
+#include "xdrpp/printer.h"
+
+namespace stellar
+{
+
+CheckSingleLedgerHeaderWork::CheckSingleLedgerHeaderWork(
+    Application& app, std::shared_ptr<HistoryArchive> archive,
+    LedgerHeaderHistoryEntry const& expected)
+    : Work(app,
+           fmt::format("check-single-ledger-header-{}",
+                       expected.header.ledgerSeq),
+           BasicWork::RETRY_NEVER)
+    , mArchive(archive)
+    , mExpected(expected)
+    , mCheckSuccess(
+          app.getMetrics().NewMeter({"history", "check", "success"}, "event"))
+    , mCheckFailed(
+          app.getMetrics().NewMeter({"history", "check", "failure"}, "event"))
+{
+    // LedgerSeq 0 is never valid.
+    releaseAssertOrThrow(expected.header.ledgerSeq != 0);
+}
+
+CheckSingleLedgerHeaderWork::~CheckSingleLedgerHeaderWork()
+{
+}
+
+void
+CheckSingleLedgerHeaderWork::onSuccess()
+{
+    mCheckSuccess.Mark();
+    Work::onSuccess();
+}
+
+void
+CheckSingleLedgerHeaderWork::onFailureRaise()
+{
+    mCheckFailed.Mark();
+    Work::onFailureRaise();
+}
+
+void
+CheckSingleLedgerHeaderWork::doReset()
+{
+    mGetLedgerFileWork.reset();
+    mDownloadDir =
+        std::make_unique<TmpDir>(mApp.getTmpDirManager().tmpDir(getName()));
+    uint32_t checkpoint = mApp.getHistoryManager().checkpointContainingLedger(
+        mExpected.header.ledgerSeq);
+    mFt = std::make_unique<FileTransferInfo>(
+        *mDownloadDir, HISTORY_FILE_TYPE_LEDGER, checkpoint);
+}
+
+BasicWork::State
+CheckSingleLedgerHeaderWork::doWork()
+{
+    if (!mGetLedgerFileWork)
+    {
+        CLOG_INFO(History, "Downloading ledger checkpoint {} from archive {}",
+                  mFt->baseName_gz(), mArchive->getName());
+        mGetLedgerFileWork = addWork<GetAndUnzipRemoteFileWork>(
+            *mFt, mArchive, BasicWork::RETRY_NEVER);
+        return State::WORK_RUNNING;
+    }
+    else if (!mGetLedgerFileWork->isDone())
+    {
+        return mGetLedgerFileWork->getState();
+    }
+    else if (mGetLedgerFileWork->getState() != State::WORK_SUCCESS)
+    {
+        CLOG_ERROR(History,
+                   "Failed to download ledger checkpoint {} from archive {}",
+                   mFt->baseName_gz(), mArchive->getName());
+        return mGetLedgerFileWork->getState();
+    }
+
+    // Theoretically we could do this scan in multiple steps with state
+    // transitions, but a ledger header file is 30kb: reading it synchronously
+    // is nearly instant.
+    XDRInputFileStream in;
+    in.open(mFt->localPath_nogz());
+    LedgerHeaderHistoryEntry lhhe;
+    size_t headersToRead = mApp.getHistoryManager().getCheckpointFrequency();
+    try
+    {
+        while (in && in.readOne<LedgerHeaderHistoryEntry>(lhhe))
+        {
+            if (headersToRead == 0)
+            {
+                CLOG_ERROR(History,
+                           "Read too many headers from file {} from archive {}",
+                           mFt->localPath_nogz(), mArchive->getName());
+                return State::WORK_FAILURE;
+            }
+            --headersToRead;
+            if (lhhe.header.ledgerSeq == mExpected.header.ledgerSeq)
+            {
+                if (lhhe == mExpected)
+                {
+                    CLOG_INFO(History,
+                              "Local ledger header {} matches archive {}",
+                              mExpected.header.ledgerSeq, mArchive->getName());
+                    mApp.getMetrics()
+                        .NewMeter({"history", "ledger-check", "success"},
+                                  "event")
+                        .Mark();
+                    return State::WORK_SUCCESS;
+                }
+                else
+                {
+                    CLOG_ERROR(
+                        History,
+                        "Local ledger header {} does not match archive {}",
+                        mExpected.header.ledgerSeq, mArchive->getName());
+                    CLOG_ERROR(History, "Expected: {}",
+                               xdr::xdr_to_string(mExpected, "Local Header"));
+                    CLOG_ERROR(History, "Found: {}",
+                               xdr::xdr_to_string(lhhe, "Archive Header"));
+                    mApp.getMetrics()
+                        .NewMeter({"history", "ledger-check", "failure"},
+                                  "event")
+                        .Mark();
+                    return State::WORK_FAILURE;
+                }
+            }
+        }
+    }
+    catch (xdr::xdr_runtime_error& e)
+    {
+        CLOG_ERROR(History, "XDR error decoding {} from archive {}: {}",
+                   mFt->localPath_nogz(), mArchive->getName(), e.what());
+        return State::WORK_FAILURE;
+    }
+    catch (FileSystemException& e)
+    {
+        CLOG_ERROR(History, "Error opening {} from archive {}: {}",
+                   mFt->localPath_nogz(), mArchive->getName(), e.what());
+        return State::WORK_FAILURE;
+    }
+    CLOG_ERROR(History, "Failed to find ledger header {} in archive {}",
+               mExpected.header.ledgerSeq, mArchive->getName());
+    return State::WORK_FAILURE;
+}
+
+}

--- a/src/historywork/CheckSingleLedgerHeaderWork.h
+++ b/src/historywork/CheckSingleLedgerHeaderWork.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "work/Work.h"
+#include <medida/meter.h>
+
+namespace stellar
+{
+class FileTransferInfo;
+class GetAndUnzipRemoteFileWork;
+class HistoryArchive;
+class TmpDir;
+
+// This class takes an LHHE for a given point in history (likely the LCL),
+// downloads the containing checkpoint file from an archive and checks that the
+// archive agrees with it. It exists for use by the offline self-check command.
+class CheckSingleLedgerHeaderWork : public Work
+{
+  protected:
+    void doReset() override;
+    BasicWork::State doWork() override;
+    void onFailureRaise() override;
+    void onSuccess() override;
+
+  public:
+    CheckSingleLedgerHeaderWork(Application& app,
+                                std::shared_ptr<HistoryArchive> archive,
+                                LedgerHeaderHistoryEntry const& entry);
+    ~CheckSingleLedgerHeaderWork();
+
+  private:
+    std::shared_ptr<HistoryArchive> const mArchive;
+    LedgerHeaderHistoryEntry const mExpected;
+    std::unique_ptr<TmpDir> mDownloadDir;
+    std::unique_ptr<FileTransferInfo> mFt;
+    std::shared_ptr<GetAndUnzipRemoteFileWork> mGetLedgerFileWork;
+    medida::Meter& mCheckSuccess;
+    medida::Meter& mCheckFailed;
+};
+}

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -3,11 +3,13 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "historywork/DownloadBucketsWork.h"
+#include "bucket/BucketManager.h"
 #include "catchup/CatchupManager.h"
 #include "history/FileTransferInfo.h"
 #include "history/HistoryArchive.h"
 #include "historywork/GetAndUnzipRemoteFileWork.h"
 #include "historywork/VerifyBucketWork.h"
+#include "work/WorkWithCallback.h"
 #include <Tracy.hpp>
 #include <fmt/format.h>
 
@@ -72,7 +74,7 @@ DownloadBucketsWork::yieldMoreWork()
     auto w1 = std::make_shared<GetAndUnzipRemoteFileWork>(mApp, ft, mArchive);
 
     auto getFileWeak = std::weak_ptr<GetAndUnzipRemoteFileWork>(w1);
-    OnFailureCallback cb = [getFileWeak, hash]() {
+    OnFailureCallback failureCb = [getFileWeak, hash]() {
         auto getFile = getFileWeak.lock();
         if (getFile)
         {
@@ -84,14 +86,30 @@ DownloadBucketsWork::yieldMoreWork()
             }
         }
     };
-
-    auto w2 = std::make_shared<VerifyBucketWork>(
-        mApp, mBuckets, ft.localPath_nogz(), hexToBin256(hash), cb);
-    std::vector<std::shared_ptr<BasicWork>> seq{w1, w2};
-    auto w3 = std::make_shared<WorkSequence>(
+    std::weak_ptr<DownloadBucketsWork> weak(
+        std::static_pointer_cast<DownloadBucketsWork>(shared_from_this()));
+    auto successCb = [weak, ft, hash](Application& app) -> bool {
+        auto self = weak.lock();
+        if (self)
+        {
+            auto bucketPath = ft.localPath_nogz();
+            auto b = app.getBucketManager().adoptFileAsBucket(bucketPath,
+                                                              hexToBin256(hash),
+                                                              /*objectsPut=*/0,
+                                                              /*bytesPut=*/0);
+            self->mBuckets[hash] = b;
+        }
+        return true;
+    };
+    auto w2 = std::make_shared<VerifyBucketWork>(mApp, ft.localPath_nogz(),
+                                                 hexToBin256(hash), failureCb);
+    auto w3 = std::make_shared<WorkWithCallback>(mApp, "adopt-verified-bucket",
+                                                 successCb);
+    std::vector<std::shared_ptr<BasicWork>> seq{w1, w2, w3};
+    auto w4 = std::make_shared<WorkSequence>(
         mApp, "download-verify-sequence-" + hash, seq);
 
     ++mNextBucketIter;
-    return w3;
+    return w4;
 }
 }

--- a/src/historywork/GetAndUnzipRemoteFileWork.cpp
+++ b/src/historywork/GetAndUnzipRemoteFileWork.cpp
@@ -15,9 +15,9 @@ namespace stellar
 
 GetAndUnzipRemoteFileWork::GetAndUnzipRemoteFileWork(
     Application& app, FileTransferInfo ft,
-    std::shared_ptr<HistoryArchive> archive)
+    std::shared_ptr<HistoryArchive> archive, size_t retry)
     : Work(app, std::string("get-and-unzip-remote-file ") + ft.remoteName(),
-           BasicWork::RETRY_A_LOT)
+           retry)
     , mFt(std::move(ft))
     , mArchive(archive)
     , mDownloadStart(app.getMetrics().NewMeter(

--- a/src/historywork/GetAndUnzipRemoteFileWork.h
+++ b/src/historywork/GetAndUnzipRemoteFileWork.h
@@ -33,9 +33,9 @@ class GetAndUnzipRemoteFileWork : public Work
     // Passing `nullptr` for the archive argument will cause the work to
     // select a new readable history archive at random each time it runs /
     // retries.
-    GetAndUnzipRemoteFileWork(
-        Application& app, FileTransferInfo ft,
-        std::shared_ptr<HistoryArchive> archive = nullptr);
+    GetAndUnzipRemoteFileWork(Application& app, FileTransferInfo ft,
+                              std::shared_ptr<HistoryArchive> archive = nullptr,
+                              size_t retry = BasicWork::RETRY_A_LOT);
     ~GetAndUnzipRemoteFileWork() = default;
     std::string getStatus() const override;
     std::shared_ptr<HistoryArchive> getArchive() const;

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -51,7 +51,6 @@ void
 GetRemoteFileWork::onSuccess()
 {
     assert(mCurrentArchive);
-    mCurrentArchive->markSuccess();
     RunCommandWork::onSuccess();
 }
 
@@ -62,7 +61,6 @@ GetRemoteFileWork::onFailureRaise()
     CLOG_ERROR(History,
                "Could not download file: archive {} maybe missing file {}",
                mCurrentArchive->getName(), mRemote);
-    mCurrentArchive->markFailure();
     RunCommandWork::onFailureRaise();
 }
 

--- a/src/historywork/MakeRemoteDirWork.cpp
+++ b/src/historywork/MakeRemoteDirWork.cpp
@@ -29,17 +29,4 @@ MakeRemoteDirWork::getCommand()
     }
     return CommandInfo{cmdLine, std::string()};
 }
-
-void
-MakeRemoteDirWork::onSuccess()
-{
-    mArchive->markSuccess();
-}
-
-void
-MakeRemoteDirWork::onFailureRaise()
-{
-    mArchive->markFailure();
-    RunCommandWork::onFailureRaise();
-}
 }

--- a/src/historywork/MakeRemoteDirWork.h
+++ b/src/historywork/MakeRemoteDirWork.h
@@ -21,8 +21,5 @@ class MakeRemoteDirWork : public RunCommandWork
     MakeRemoteDirWork(Application& app, std::string const& dir,
                       std::shared_ptr<HistoryArchive> archive);
     ~MakeRemoteDirWork() = default;
-
-    void onSuccess() override;
-    void onFailureRaise() override;
 };
 }

--- a/src/historywork/PutRemoteFileWork.cpp
+++ b/src/historywork/PutRemoteFileWork.cpp
@@ -27,18 +27,4 @@ PutRemoteFileWork::getCommand()
     auto cmdLine = mArchive->putFileCmd(mLocal, mRemote);
     return CommandInfo{cmdLine, std::string()};
 }
-
-void
-PutRemoteFileWork::onSuccess()
-{
-    mArchive->markSuccess();
-    RunCommandWork::onSuccess();
-}
-
-void
-PutRemoteFileWork::onFailureRaise()
-{
-    mArchive->markFailure();
-    RunCommandWork::onFailureRaise();
-}
 }

--- a/src/historywork/PutRemoteFileWork.h
+++ b/src/historywork/PutRemoteFileWork.h
@@ -23,9 +23,5 @@ class PutRemoteFileWork : public RunCommandWork
                       std::string const& remote,
                       std::shared_ptr<HistoryArchive> archive);
     ~PutRemoteFileWork() = default;
-
-  protected:
-    void onSuccess() override;
-    void onFailureRaise() override;
 };
 }

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -19,13 +19,11 @@ class Bucket;
 
 class VerifyBucketWork : public BasicWork
 {
-    std::map<std::string, std::shared_ptr<Bucket>>& mBuckets;
     std::string mBucketFile;
     uint256 mHash;
     bool mDone{false};
     std::error_code mEc;
 
-    void adoptBucket();
     void spawnVerifier();
 
     OnFailureCallback mOnFailure;
@@ -34,10 +32,8 @@ class VerifyBucketWork : public BasicWork
     medida::Meter& mVerifyBucketFailure;
 
   public:
-    VerifyBucketWork(Application& app,
-                     std::map<std::string, std::shared_ptr<Bucket>>& buckets,
-                     std::string const& bucketFile, uint256 const& hash,
-                     OnFailureCallback cb);
+    VerifyBucketWork(Application& app, std::string const& bucketFile,
+                     uint256 const& hash, OnFailureCallback failureCb);
     ~VerifyBucketWork() = default;
 
   protected:

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -140,7 +140,7 @@ WriteVerifiedCheckpointHashesWork::yieldMoreWork()
     auto currWork = std::make_shared<VerifyLedgerChainWork>(
         mApp, *tmpDir, ledgerRange, lcl, prevTrusted, mOutputFile);
     auto prevWork = mPrevVerifyWork;
-    auto predicate = [prevWork]() {
+    auto predicate = [prevWork](Application&) {
         if (!prevWork)
         {
             return true;

--- a/src/historywork/test/HistoryWorkTests.cpp
+++ b/src/historywork/test/HistoryWorkTests.cpp
@@ -4,6 +4,7 @@
 
 #include "history/HistoryArchiveManager.h"
 #include "history/test/HistoryTestsUtils.h"
+#include "historywork/CheckSingleLedgerHeaderWork.h"
 #include "historywork/WriteVerifiedCheckpointHashesWork.h"
 #include "test/TestUtils.h"
 #include "test/test.h"
@@ -52,4 +53,21 @@ TEST_CASE("write verified checkpoint hashes", "[historywork]")
             p.first, file);
         REQUIRE(h == *p.second);
     }
+}
+
+TEST_CASE("check single ledger header work", "[historywork]")
+{
+    CatchupSimulation catchupSimulation{};
+    auto l1 = catchupSimulation.getLastCheckpointLedger(2);
+    auto l2 = catchupSimulation.getLastCheckpointLedger(4);
+    catchupSimulation.ensureOfflineCatchupPossible(l1);
+    auto& app = catchupSimulation.getApp();
+    auto& lm = app.getLedgerManager();
+    auto lhhe = lm.getLastClosedLedgerHeader();
+    catchupSimulation.ensureOfflineCatchupPossible(l2);
+    auto arch =
+        app.getHistoryArchiveManager().selectRandomReadableHistoryArchive();
+    auto& wm = app.getWorkScheduler();
+    auto w = wm.executeWork<CheckSingleLedgerHeaderWork>(arch, lhhe);
+    REQUIRE(w->getState() == BasicWork::State::WORK_SUCCESS);
 }

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -5,14 +5,21 @@
 #include "invariant/BucketListIsConsistentWithDatabase.h"
 #include "bucket/Bucket.h"
 #include "bucket/BucketInputIterator.h"
+#include "bucket/BucketManager.h"
 #include "crypto/Hex.h"
+#include "history/HistoryArchive.h"
 #include "invariant/InvariantManager.h"
+#include "ledger/LedgerManager.h"
 #include "ledger/LedgerRange.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "main/Application.h"
+#include "medida/timer.h"
 #include "util/XDRCereal.h"
+#include <chrono>
+#include <fmt/chrono.h>
 #include <fmt/format.h>
+#include <map>
 
 namespace stellar
 {
@@ -75,13 +82,137 @@ BucketListIsConsistentWithDatabase::getName() const
     return "BucketListIsConsistentWithDatabase";
 }
 
+struct EntryCounts
+{
+    uint64_t mAccounts{0};
+    uint64_t mTrustLines{0};
+    uint64_t mOffers{0};
+    uint64_t mData{0};
+    uint64_t mClaimableBalance{0};
+
+    uint64_t
+    totalEntries() const
+    {
+        return mAccounts + mTrustLines + mOffers + mData + mClaimableBalance;
+    }
+
+    void
+    countLiveEntry(LedgerEntry const& e)
+    {
+        switch (e.data.type())
+        {
+        case ACCOUNT:
+            ++mAccounts;
+            break;
+        case TRUSTLINE:
+            ++mTrustLines;
+            break;
+        case OFFER:
+            ++mOffers;
+            break;
+        case DATA:
+            ++mData;
+            break;
+        case CLAIMABLE_BALANCE:
+            ++mClaimableBalance;
+            break;
+        default:
+            throw std::runtime_error(
+                fmt::format("unknown ledger entry type: {}",
+                            static_cast<uint32_t>(e.data.type())));
+        }
+    }
+
+    std::string
+    checkDbEntryCounts(Application& app, LedgerRange const& range)
+    {
+        std::string countFormat =
+            "Incorrect {} count: Bucket = {} Database = {}";
+        auto& ltxRoot = app.getLedgerTxnRoot();
+        uint64_t nAccountsInDb = ltxRoot.countObjects(ACCOUNT, range);
+        if (nAccountsInDb != mAccounts)
+        {
+            return fmt::format(countFormat, "Account", mAccounts,
+                               nAccountsInDb);
+        }
+        uint64_t nTrustLinesInDb = ltxRoot.countObjects(TRUSTLINE, range);
+        if (nTrustLinesInDb != mTrustLines)
+        {
+            return fmt::format(countFormat, "TrustLine", mTrustLines,
+                               nTrustLinesInDb);
+        }
+        uint64_t nOffersInDb = ltxRoot.countObjects(OFFER, range);
+        if (nOffersInDb != mOffers)
+        {
+            return fmt::format(countFormat, "Offer", mOffers, nOffersInDb);
+        }
+        uint64_t nDataInDb = ltxRoot.countObjects(DATA, range);
+        if (nDataInDb != mData)
+        {
+            return fmt::format(countFormat, "Data", mData, nDataInDb);
+        }
+        uint64_t nClaimableBalanceInDb =
+            ltxRoot.countObjects(CLAIMABLE_BALANCE, range);
+        if (nClaimableBalanceInDb != mClaimableBalance)
+        {
+            return fmt::format(countFormat, "ClaimableBalance",
+                               mClaimableBalance, nClaimableBalanceInDb);
+        }
+        return {};
+    }
+};
+
+void
+BucketListIsConsistentWithDatabase::checkEntireBucketlist()
+{
+    auto& lm = mApp.getLedgerManager();
+    auto& bm = mApp.getBucketManager();
+    HistoryArchiveState has = lm.getLastClosedLedgerHAS();
+    std::map<LedgerKey, LedgerEntry> bucketLedgerMap =
+        bm.loadCompleteLedgerState(has);
+    EntryCounts counts;
+    medida::Timer timer(std::chrono::microseconds(1));
+
+    {
+        LedgerTxn ltx(mApp.getLedgerTxnRoot());
+        for (auto const& pair : bucketLedgerMap)
+        {
+            counts.countLiveEntry(pair.second);
+            std::string s;
+            timer.Time([&]() { s = checkAgainstDatabase(ltx, pair.second); });
+            if (!s.empty())
+            {
+                throw std::runtime_error(s);
+            }
+            auto i = counts.totalEntries();
+            if ((i & 0x7ffff) == 0)
+            {
+                using namespace std::chrono;
+                nanoseconds ns = timer.duration_unit() *
+                                 static_cast<nanoseconds::rep>(timer.mean());
+                microseconds us = duration_cast<microseconds>(ns);
+                CLOG_INFO(Ledger,
+                          "Checked bucket-vs-DB consistency for "
+                          "{} entries (mean {}/entry)",
+                          i, us);
+            }
+        }
+    }
+    auto range = LedgerRange::inclusive(LedgerManager::GENESIS_LEDGER_SEQ,
+                                        has.currentLedger);
+    auto s = counts.checkDbEntryCounts(mApp, range);
+    if (!s.empty())
+    {
+        throw std::runtime_error(s);
+    }
+}
+
 std::string
 BucketListIsConsistentWithDatabase::checkOnBucketApply(
     std::shared_ptr<Bucket const> bucket, uint32_t oldestLedger,
     uint32_t newestLedger)
 {
-    uint64_t nAccounts = 0, nTrustLines = 0, nOffers = 0, nData = 0,
-             nClaimableBalance = 0;
+    EntryCounts counts;
     {
         LedgerTxn ltx(mApp.getLedgerTxnRoot());
 
@@ -121,26 +252,7 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
                     return s;
                 }
 
-                switch (e.liveEntry().data.type())
-                {
-                case ACCOUNT:
-                    ++nAccounts;
-                    break;
-                case TRUSTLINE:
-                    ++nTrustLines;
-                    break;
-                case OFFER:
-                    ++nOffers;
-                    break;
-                case DATA:
-                    ++nData;
-                    break;
-                case CLAIMABLE_BALANCE:
-                    ++nClaimableBalance;
-                    break;
-                default:
-                    abort();
-                }
+                counts.countLiveEntry(e.liveEntry());
                 auto s = checkAgainstDatabase(ltx, e.liveEntry());
                 if (!s.empty())
                 {
@@ -159,37 +271,6 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
     }
 
     auto range = LedgerRange::inclusive(oldestLedger, newestLedger);
-    std::string countFormat = "Incorrect {} count: Bucket = {} Database = {}";
-    auto& ltxRoot = mApp.getLedgerTxnRoot();
-    uint64_t nAccountsInDb = ltxRoot.countObjects(ACCOUNT, range);
-    if (nAccountsInDb != nAccounts)
-    {
-        return fmt::format(countFormat, "Account", nAccounts, nAccountsInDb);
-    }
-    uint64_t nTrustLinesInDb = ltxRoot.countObjects(TRUSTLINE, range);
-    if (nTrustLinesInDb != nTrustLines)
-    {
-        return fmt::format(countFormat, "TrustLine", nTrustLines,
-                           nTrustLinesInDb);
-    }
-    uint64_t nOffersInDb = ltxRoot.countObjects(OFFER, range);
-    if (nOffersInDb != nOffers)
-    {
-        return fmt::format(countFormat, "Offer", nOffers, nOffersInDb);
-    }
-    uint64_t nDataInDb = ltxRoot.countObjects(DATA, range);
-    if (nDataInDb != nData)
-    {
-        return fmt::format(countFormat, "Data", nData, nDataInDb);
-    }
-    uint64_t nClaimableBalanceInDb =
-        ltxRoot.countObjects(CLAIMABLE_BALANCE, range);
-    if (nClaimableBalanceInDb != nClaimableBalance)
-    {
-        return fmt::format(countFormat, "ClaimableBalance", nClaimableBalance,
-                           nClaimableBalanceInDb);
-    }
-
-    return {};
+    return counts.checkDbEntryCounts(mApp, range);
 }
 }

--- a/src/invariant/BucketListIsConsistentWithDatabase.h
+++ b/src/invariant/BucketListIsConsistentWithDatabase.h
@@ -37,6 +37,10 @@ class BucketListIsConsistentWithDatabase : public Invariant
                                            uint32_t oldestLedger,
                                            uint32_t newestLedger) override;
 
+    // Secondary entrypoint to database-vs-bucket consistency checking, designed
+    // to be run offline via self-check. Throws an exception on any error.
+    void checkEntireBucketlist();
+
   private:
     Application& mApp;
 };

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -43,6 +43,7 @@ class WorkScheduler;
 class BanManager;
 class StatusManager;
 class AbstractLedgerTxnParent;
+class BasicWork;
 
 #ifdef BUILD_TESTS
 class LoadGenerator;
@@ -282,6 +283,11 @@ class Application
 
     // Report information about the instance to standard logging
     virtual void reportInfo() = 0;
+
+    // Schedule background work to do some (basic, online) self-checks.
+    // Returns a WorkSequence that can be monitored for completion.
+    virtual std::shared_ptr<BasicWork>
+    scheduleSelfCheck(bool waitUntilNextCheckpoint) = 0;
 
     // Returns the hash of the passphrase, used to separate various network
     // instances

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -462,9 +462,6 @@ ApplicationImpl::getJsonInfo()
         info["invariant_failures"] = invariantFailures;
     }
 
-    info["history_failure_rate"] =
-        fmt::format("{:.2}", getHistoryArchiveManager().getFailureRate());
-
     return root;
 }
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -120,6 +120,9 @@ class ApplicationImpl : public Application
 
     virtual void reportInfo() override;
 
+    virtual std::shared_ptr<BasicWork>
+    scheduleSelfCheck(bool waitUntilNextCheckpoint) override;
+
     virtual Hash const& getNetworkID() const override;
 
     virtual AbstractLedgerTxnParent& getLedgerTxnRoot() override;
@@ -191,6 +194,7 @@ class ApplicationImpl : public Application
     bool mStopping;
 
     VirtualTimer mStoppingTimer;
+    VirtualTimer mSelfCheckTimer;
 
     std::unique_ptr<medida::MetricsRegistry> mMetrics;
     medida::Counter& mAppStateCurrent;
@@ -199,6 +203,10 @@ class ApplicationImpl : public Application
     VirtualClock::system_time_point mStartedOn;
 
     Hash mNetworkID;
+
+    // A handle to any running self-check, to avoid scheduling
+    // more than one concurrently.
+    std::weak_ptr<BasicWork> mRunningSelfCheck;
 
     void newDB();
 

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -353,7 +353,14 @@ selfCheck(Config cfg)
         blcOk = false;
     }
 
-    if (seq->getState() == BasicWork::State::WORK_SUCCESS && blcOk)
+    LOG_INFO(DEFAULT_LOG, "Self-check phase 4: crypto benchmarking");
+    size_t signPerSec = 0, verifyPerSec = 0;
+    SecretKey::benchmarkOpsPerSecond(signPerSec, verifyPerSec, 10000);
+    LOG_INFO(DEFAULT_LOG, "Benchmarked {} signatures / sec", signPerSec);
+    LOG_INFO(DEFAULT_LOG, "Benchmarked {} verifications / sec", verifyPerSec);
+
+    if (seq1->getState() == BasicWork::State::WORK_SUCCESS &&
+        seq2->getState() == BasicWork::State::WORK_SUCCESS && blcOk)
     {
         LOG_INFO(DEFAULT_LOG, "Self-check succeeded");
         return 0;

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -22,6 +22,7 @@ void setForceSCPFlag();
 void initializeDatabase(Config cfg);
 void httpCommand(std::string const& command, unsigned short port);
 int selfCheck(Config cfg);
+int mergeBucketList(Config cfg, std::string const& outputDir);
 void showOfflineInfo(Config cfg);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);
 #ifdef BUILD_TESTS

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -500,7 +500,12 @@ void
 CommandHandler::selfCheck(std::string const&, std::string& retStr)
 {
     ZoneScoped;
-    mApp.getHistoryArchiveManager().scheduleHistoryArchiveReportWork();
+    // NB: this only runs the online "self-check" routine; running the
+    // offline "self-check" from command-line will also do an expensive,
+    // synchronous database-vs-bucketlist consistency check. We can't do
+    // that online since it would block for so long that the node would
+    // lose sync. So we just omit it here.
+    mApp.scheduleSelfCheck(true);
 }
 
 void

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1111,7 +1111,6 @@ run(CommandLineArgs const& args)
                 maybeSetMetadataOutputStream(cfg, stream);
                 cfg.FORCE_SCP =
                     cfg.NODE_IS_VALIDATOR ? !waitForConsensus : false;
-                cfg.COMMANDS.push_back("self-check");
 
                 if (cfg.MANUAL_CLOSE)
                 {

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -189,6 +189,12 @@ outputFileParser(std::string& string)
 }
 
 clara::Opt
+outputDirParser(std::string& string)
+{
+    return clara::Opt{string, "DIR-NAME"}["--output-dir"]("output dir");
+}
+
+clara::Opt
 logLevelParser(LogLevel& value)
 {
     return clara::Opt{
@@ -961,6 +967,19 @@ runSelfCheck(CommandLineArgs const& args)
 }
 
 int
+runMergeBucketList(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    std::string outputDir{"."};
+
+    return runWithHelp(
+        args,
+        {configurationParser(configOption),
+         outputDirParser(outputDir).required()},
+        [&] { return mergeBucketList(configOption.getConfig(), outputDir); });
+}
+
+int
 runNewDB(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -1551,7 +1570,9 @@ handleCommandLine(int argc, char* const* argv)
          {"gen-seed", "generate and print a random node seed", runGenSeed},
          {"http-command", "send a command to local stellar-core",
           runHttpCommand},
-         {"self-check", "performs sanity checks", runSelfCheck},
+         {"self-check", "performs diagnostic checks", runSelfCheck},
+         {"merge-bucketlist", "writes diagnostic merged bucket list",
+          runMergeBucketList},
          {"new-db", "creates or restores the DB to the genesis ledger",
           runNewDB},
          {"new-hist", "initialize history archives", runNewHist},

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -135,6 +135,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     // (30*24*3600/5) / (700 - (11*60)/5 ) // number of periods
     //   * (11*60) / (24*3600) = 6.97 days
     AUTOMATIC_MAINTENANCE_COUNT = 700;
+    // automatic self-check happens once every 3 hours
+    AUTOMATIC_SELF_CHECK_PERIOD = std::chrono::seconds{3 * 60 * 60};
     ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
     ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
     ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = 0;
@@ -899,6 +901,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "AUTOMATIC_MAINTENANCE_COUNT")
             {
                 AUTOMATIC_MAINTENANCE_COUNT = readInt<uint32_t>(item);
+            }
+            else if (item.first == "AUTOMATIC_SELF_CHECK_PERIOD")
+            {
+                AUTOMATIC_SELF_CHECK_PERIOD =
+                    std::chrono::seconds{readInt<uint32_t>(item)};
             }
             else if (item.first == "MANUAL_CLOSE")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -156,6 +156,9 @@ class Config : public std::enable_shared_from_this<Config>
     // maintenance run
     uint32_t AUTOMATIC_MAINTENANCE_COUNT;
 
+    // Interval between automatic invocations of self-check.
+    std::chrono::seconds AUTOMATIC_SELF_CHECK_PERIOD;
+
     // A config parameter that enables synthetic load generation on demand,
     // using the `generateload` runtime command (see CommandHandler.cpp). This
     // option only exists for stress-testing and should not be enabled in

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -1,0 +1,148 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "history/test/HistoryTestsUtils.h"
+#include "ledger/LedgerTxn.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "main/ApplicationUtils.h"
+#include "main/CommandHandler.h"
+#include "main/Config.h"
+#include "test/TestUtils.h"
+#include "test/TxTests.h"
+#include "test/test.h"
+#include "transactions/TransactionUtils.h"
+#include "util/Logging.h"
+#include <filesystem>
+#include <fstream>
+
+using namespace stellar;
+using namespace stellar::historytestutils;
+
+class TemporaryFileDamager
+{
+  protected:
+    std::filesystem::path mVictim;
+    std::filesystem::path mVictimSaved;
+
+  public:
+    TemporaryFileDamager(std::filesystem::path victim) : mVictim(victim)
+    {
+        mVictimSaved = mVictim;
+        mVictimSaved.replace_filename(mVictim.filename().string() + "-saved");
+        std::filesystem::copy_file(mVictim, mVictimSaved);
+    }
+    virtual void
+    damageVictim()
+    {
+        // Default damage just truncates the file.
+        std::ofstream out(mVictim);
+    }
+    ~TemporaryFileDamager()
+    {
+        std::filesystem::remove(mVictim);
+        std::filesystem::rename(mVictimSaved, mVictim);
+    }
+};
+
+class TemporarySQLiteDBDamager : public TemporaryFileDamager
+{
+    Config mConfig;
+    static std::filesystem::path
+    getSQLiteDBPath(Config const& cfg)
+    {
+        auto str = cfg.DATABASE.value;
+        std::string prefix = "sqlite3://";
+        REQUIRE(str.find(prefix) == 0);
+        str = str.substr(prefix.size());
+        REQUIRE(!str.empty());
+        std::filesystem::path path(str);
+        REQUIRE(std::filesystem::exists(path));
+        return path;
+    }
+
+  public:
+    TemporarySQLiteDBDamager(Config const& cfg)
+        : TemporaryFileDamager(getSQLiteDBPath(cfg)), mConfig(cfg)
+    {
+    }
+    void
+    damageVictim() override
+    {
+        // Damage a database by bumping the root account's last-modified.
+        VirtualClock clock;
+        auto app = createTestApplication(clock, mConfig, /*newDB=*/false);
+        LedgerTxn ltx(app->getLedgerTxnRoot(),
+                      /*shouldUpdateLastModified=*/false);
+        {
+            auto rootKey = accountKey(
+                stellar::txtest::getRoot(app->getNetworkID()).getPublicKey());
+            auto rootLe = ltx.load(rootKey);
+            rootLe.current().lastModifiedLedgerSeq += 1;
+        }
+        ltx.commit();
+    }
+};
+TEST_CASE("offline self-check works", "[applicationutils][selfcheck]")
+{
+    // Step 1: set up history archives and publish to them.
+    Config chkConfig;
+    CatchupSimulation catchupSimulation{};
+    auto l1 = catchupSimulation.getLastCheckpointLedger(2);
+    auto l2 = catchupSimulation.getLastCheckpointLedger(4);
+    catchupSimulation.ensureOfflineCatchupPossible(l2);
+    std::filesystem::path victimBucketPath;
+    {
+        // Step 2: make a new application and catch it up part-way to the
+        // archives (but behind).
+        auto app = catchupSimulation.createCatchupApplication(
+            std::numeric_limits<uint32_t>::max(), Config::TESTDB_ON_DISK_SQLITE,
+            "client");
+        catchupSimulation.catchupOffline(app, l1);
+        chkConfig = app->getConfig();
+        victimBucketPath = app->getBucketManager()
+                               .getBucketList()
+                               .getLevel(0)
+                               .getCurr()
+                               ->getFilename();
+    }
+
+    // Step 3: run offline self-check on that application's state, see that it's
+    // agreeable.
+    REQUIRE(selfCheck(chkConfig) == 0);
+
+    std::filesystem::path archPath =
+        catchupSimulation.getHistoryConfigurator().getArchiveDirName();
+
+    // Step 4: require various self-check failures are caught.
+    {
+        // Damage the well-known HAS path in the archive.
+        auto path = archPath;
+        path /= HistoryArchiveState::wellKnownRemoteName();
+        TemporaryFileDamager damage(path);
+        damage.damageVictim();
+        REQUIRE(selfCheck(chkConfig) == 1);
+    }
+    {
+        // Damage the target ledger in the archive.
+        auto path = archPath;
+        path /=
+            fs::remoteName(HISTORY_FILE_TYPE_LEDGER, fs::hexStr(l1), "xdr.gz");
+        TemporaryFileDamager damage(path);
+        damage.damageVictim();
+        REQUIRE(selfCheck(chkConfig) == 1);
+    }
+    {
+        // Damage a bucket file.
+        TemporaryFileDamager damage(victimBucketPath);
+        damage.damageVictim();
+        REQUIRE(selfCheck(chkConfig) == 1);
+    }
+    {
+        // Damage the SQL ledger.
+        TemporarySQLiteDBDamager damage(chkConfig);
+        damage.damageVictim();
+        REQUIRE(selfCheck(chkConfig) == 1);
+    }
+}

--- a/src/main/test/SelfCheckTests.cpp
+++ b/src/main/test/SelfCheckTests.cpp
@@ -1,0 +1,63 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "history/HistoryArchiveManager.h"
+#include "history/test/HistoryTestsUtils.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "main/ApplicationUtils.h"
+#include "main/Config.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+#include "util/Logging.h"
+#include "work/WorkScheduler.h"
+
+using namespace stellar;
+using namespace stellar::historytestutils;
+
+// More extensive self-check tests (that check for caught damage) are in the
+// ApplicationUtilsTests.cpp file, since they run the more extensive _offline_
+// self-check mode. This file just tests that self-check mode runs periodically.
+
+class SelfCheckMultiArchiveHistoryConfigurator
+    : public TmpDirHistoryConfigurator
+{
+  public:
+    Config&
+    configure(Config& cfg, bool writable) const override
+    {
+        REQUIRE(writable);
+        TmpDirHistoryConfigurator::configure(cfg, writable);
+        // In accelerated-time mode we close every 1s and checkpoint every 8s.
+        cfg.ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = true;
+        // In this test config we'll run self-check every 4 checkpoints (32s).
+        cfg.AUTOMATIC_SELF_CHECK_PERIOD = std::chrono::seconds(32);
+        return cfg;
+    }
+};
+
+TEST_CASE("online self-check runs on a schedule", "[selfcheck]")
+{
+    Config chkConfig;
+    size_t n = 5;
+    auto configurator =
+        std::make_shared<SelfCheckMultiArchiveHistoryConfigurator>();
+    CatchupSimulation catchupSimulation{VirtualClock::VIRTUAL_TIME,
+                                        configurator};
+    auto& app = catchupSimulation.getApp();
+    auto& clock = app.getClock();
+    auto last = clock.now();
+    auto& meter =
+        app.getMetrics().NewMeter({"history", "check", "success"}, "event");
+    while (meter.count() < n)
+    {
+        catchupSimulation.getClock().crank(false);
+        if ((clock.now() - last) > std::chrono::seconds(1))
+        {
+            catchupSimulation.generateRandomLedger();
+            last = clock.now();
+        }
+    }
+    REQUIRE(meter.count() == n);
+}

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -188,6 +188,8 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.REPORT_METRICS = gTestMetrics;
         // disable maintenance
         thisConfig.AUTOMATIC_MAINTENANCE_COUNT = 0;
+        // disable self-check
+        thisConfig.AUTOMATIC_SELF_CHECK_PERIOD = std::chrono::seconds(0);
         // only spin up a small number of worker threads
         thisConfig.WORKER_THREADS = 2;
         thisConfig.QUORUM_INTERSECTION_CHECKER = false;

--- a/src/work/ConditionalWork.cpp
+++ b/src/work/ConditionalWork.cpp
@@ -43,7 +43,7 @@ ConditionalWork::onRun()
     }
 
     // Work is not started, so check the condition
-    if (!mCondition())
+    if (!mCondition(mApp))
     {
         CLOG_TRACE(Work, "Condition for {} is not satisfied: sleeping {} ms",
                    getName(), mSleepDelay.count());

--- a/src/work/ConditionalWork.h
+++ b/src/work/ConditionalWork.h
@@ -15,7 +15,7 @@ namespace stellar
 // once). ConditionalWork makes its own lifecycle transitions and may call
 // ConditionFn repeatedly; ConditionFn should not make any assumptions about the
 // number of times or order in which it's called.
-using ConditionFn = std::function<bool()>;
+using ConditionFn = std::function<bool(Application&)>;
 
 // A `ConditionalWork` is a work _gated_ on some arbitrary (and monotonic: see
 // above) `ConditionFn`. It will remain in `WORK_WAITING` state polling the

--- a/src/work/WorkSequence.h
+++ b/src/work/WorkSequence.h
@@ -19,11 +19,13 @@ class WorkSequence : public BasicWork
     std::vector<std::shared_ptr<BasicWork>> mSequenceOfWork;
     std::vector<std::shared_ptr<BasicWork>>::const_iterator mNextInSequence;
     std::shared_ptr<BasicWork> mCurrentExecuting;
+    bool const mStopAtFirstFailure;
 
   public:
     WorkSequence(Application& app, std::string name,
                  std::vector<std::shared_ptr<BasicWork>> sequence,
-                 size_t maxRetries = RETRY_A_FEW);
+                 size_t maxRetries = RETRY_A_FEW,
+                 bool stopAtFirstFailure = true);
     ~WorkSequence() = default;
 
     std::string getStatus() const override;


### PR DESCRIPTION
This PR contains a set of enhancements to `stellar-core self-check` to do more thorough analysis of local state:
   - Comparing the expected bucketlist to the buckets found in the bucket directory
   - Checking bucket hashes
   - Decoding all bucket contents and comparing to all database ledger contents
   - Benchmarking the IO speeds, DB latency and cryptography speeds of the node
   - Checking that all history archives have a ledger header that is identical with the local database LCL header
 
These enhancements are divided into a small set that run online, during startup or when triggered by the HTTP endpoint (those that probe the history archive) and a larger set that run offline when the `self-check` command-line is run (all the IO intensive and database/bucket tests).