### PR TITLE
Photesthesis - preliminary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 	path = lib/spdlog
 	url = https://github.com/gabime/spdlog
 	ignore = dirty
+[submodule "lib/photesthesis"]
+	path = lib/photesthesis
+	url = https://github.com/graydon/photesthesis

--- a/common.mk
+++ b/common.mk
@@ -10,7 +10,8 @@ AM_CPPFLAGS += -isystem "$(top_srcdir)/lib"             \
 	-isystem "$(top_srcdir)/lib/fmt/include"            \
 	-isystem "$(top_srcdir)/lib/soci/src/core"          \
 	-isystem "$(top_srcdir)/lib/tracy"                  \
-	-isystem "$(top_srcdir)/lib/spdlog/include"
+	-isystem "$(top_srcdir)/lib/spdlog/include"         \
+	-isystem "$(top_srcdir)/lib/photesthesis/include"
 
 if USE_POSTGRES
 AM_CPPFLAGS += -DUSE_POSTGRES=1 $(libpq_CFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,23 @@ AS_IF([test x != "x$sanitizeopts"], [
 
 ])
 
+AC_ARG_ENABLE([sancov],
+  AS_HELP_STRING([--enable-sancov],
+        [build with sanitizer-coverage instrumentation (supporting coverage-guided testing)]))
+AS_IF([test "x$enable_sancov" = "xyes"], [
+  AC_MSG_NOTICE([ enabling sanitizer-coverage, see  https://clang.llvm.org/docs/SanitizerCoverage.html])
+  sancovflags="-fsanitize-coverage=inline-8bit-counters"
+  # Further check for the allowlist/blocklist support present in clang 11 -- this is basically
+  # necessary to use the photesthesis test system effectively, as it cannot stabilize the
+  # sancov counters without selective instrumentation.
+  AX_CHECK_COMPILE_FLAG([-fsanitize-coverage-allowlist=${ac_abs_confdir}/sancov-allowlist.txt], [
+    sancovflags+=" -fsanitize-coverage-allowlist=${ac_abs_confdir}/sancov-allowlist.txt"
+    sancovflags+=" -fsanitize-coverage-blocklist=${ac_abs_confdir}/sancov-blocklist.txt"
+  ], [])
+  CFLAGS="$CFLAGS $sancovflags"
+  CXXFLAGS="$CXXFLAGS $sancovflags"
+])
+
 AC_ARG_ENABLE([extrachecks],
   AS_HELP_STRING([--enable-extrachecks],
         [build with additional debugging checks enabled]))

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -22,7 +22,7 @@ if USE_POSTGRES
 libsoci_a_SOURCES += $(SOCI_PG_FILES)
 endif # USE_POSTGRES
 
-lib3rdparty_a_SOURCES = $(UTIL_FILES) $(ASIO_CXX_FILES) $(JSON_FILES) $(SQLITE3_FILES)
+lib3rdparty_a_SOURCES = $(UTIL_FILES) $(ASIO_CXX_FILES) $(JSON_FILES) $(SQLITE3_FILES) 
 if USE_SPDLOG
 lib3rdparty_a_SOURCES += $(SPDLOG_FILES)
 endif # !USE_SPDLOG
@@ -31,6 +31,11 @@ if USE_TRACY
 lib3rdparty_a_SOURCES += $(TRACY_CXX_FILES)
 endif # USE_TRACY
 noinst_HEADERS = $(MISC_H_FILES) $(ASIO_H_FILES)
+
+if BUILD_TESTS
+lib3rdparty_a_SOURCES += $(PHOTESTHESIS_CXX_FILES)
+noinst_HEADERS += $(PHOTESTHESIS_H_FILES)
+endif # !BUILD_TESTS
 
 # Suppress any installation of SUBDIRS, which may be distributed separately
 install-data:

--- a/make-mks
+++ b/make-mks
@@ -54,6 +54,8 @@ listall() {
  echo TRACY_CXX_FILES = tracy/TracyClient.cpp
  echo JSON_FILES = $(listall json)
  echo SPDLOG_FILES = spdlog.cpp
+ echo PHOTESTHESIS_CXX_FILES = $(listall photesthesis/src)
+ echo PHOTESTHESIS_H_FILES = $(listall photesthesis/include)
 
  echo MISC_H_FILES = *.hpp $(listall autocheck cereal fmt)
 ) > lib/lib.mk

--- a/sancov-allowlist.txt
+++ b/sancov-allowlist.txt
@@ -1,0 +1,29 @@
+# This file controls instrumentation of functions using sancov, which is used to support
+# trajectory-evaluation by the photesthesis tool.
+#
+# For a function to be instrumented is must both reside in file listed in a 'src:' pattern
+# _and_ have a name listed in a 'fun:' pattern.
+
+# Instrument everything in the main stellar src directories
+src:*/bucket/*
+src:*/catchup/*
+src:*/crypto/*
+src:*/database/*
+src:*/herder/*
+src:*/history/*
+src:*/historywork/*
+src:*/invariant/*
+src:*/ledger/*
+src:*/main/*
+src:*/overlay/*
+src:*/process/*
+src:*/scp/*
+src:*/simulation/*
+src:*/test/*
+src:*/transactions/*
+src:*/util/*
+src:*/work/*
+src:*/xdr/*
+
+# Instrument everything in those files that's in the stellar:: namespace (this is matched against mangled names)
+fun:*

--- a/sancov-blocklist.txt
+++ b/sancov-blocklist.txt
@@ -1,0 +1,3 @@
+# This file lists files and functions to block from sancov instrumentation. It is applied
+# after files and functions are selected in the corresponding allowlist. A function must
+# survive both being-allowed and not-being-blocked to be instrumented.

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -121,9 +121,13 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
         }
     });
 
-    auto t = mConfig.WORKER_THREADS;
+    size_t t = static_cast<size_t>(mConfig.WORKER_THREADS);
     LOG_DEBUG(DEFAULT_LOG, "Application constructing (worker threads: {})", t);
-    while (t--)
+    if (t == 0)
+    {
+        throw std::runtime_error("WORKER_THREADS must be nonzero");
+    }
+    for (size_t i = 0; i < t; ++i)
     {
         auto thread = std::thread{[this]() {
             runCurrentThreadWithLowPriority();

--- a/src/test/TestExceptions.h
+++ b/src/test/TestExceptions.h
@@ -16,11 +16,19 @@ void throwIf(TransactionResult const& result);
 
 class ex_txException
 {
+  public:
+    virtual std::string getName() const = 0;
 };
 
 #define TEST_EXCEPTION(M) \
     class M : public ex_txException \
     { \
+      public: \
+        virtual std::string \
+        getName() const \
+        { \
+            return #M; \
+        } \
     };
 
 TEST_EXCEPTION(ex_UNKNOWN)

--- a/src/test/TestMarket.cpp
+++ b/src/test/TestMarket.cpp
@@ -245,6 +245,12 @@ TestMarket::checkCurrentOffers()
     checkState(mOffers, {});
 }
 
+std::map<OfferKey, OfferState> const&
+TestMarket::getCurrentOffers() const
+{
+    return mOffers;
+}
+
 void
 TestMarket::checkState(std::map<OfferKey, OfferState> const& offers,
                        std::vector<OfferKey> const& deletedOffers)

--- a/src/test/TestMarket.h
+++ b/src/test/TestMarket.h
@@ -109,6 +109,8 @@ class TestMarket
 
     void checkCurrentOffers();
 
+    std::map<OfferKey, OfferState> const& getCurrentOffers() const;
+
   private:
     Application& mApp;
     std::map<OfferKey, OfferState> mOffers;


### PR DESCRIPTION
This is a very preliminary sketch of wiring up the [photesthesis](github.com/graydon/photesthesis) testing library to the path payment tests of stellar-core. It's to show roughly how it might work and explore ergonomic and comprehensibility issues. 

Feedback very welcome.

The current PR here is definitely a draft -- it has much of the path-payments file commented out! -- and contains only a single parametric test. That test can do some successful payments using multiple assets, paths and market makers. Running it over 25,000 random test plans from the grammar produces about 600 distinct trajectories, which is .. probably uncomfortably many to manually review still, but not many-orders-of-magnitude too many. My next planned step is to adapti the harness to filter out pointless cases that can't obviously be filtered by the grammar context system.