### PR TITLE
add missing include file

### DIFF
--- a/lib/util/basen.h
+++ b/lib/util/basen.h
@@ -29,6 +29,7 @@
 #include <cctype>
 #include <cassert>
 #include <cstring>
+#include <limits>
 
 namespace bn
 {


### PR DESCRIPTION
needed when build with clang-10 + GNU-11
