### PR TITLE
Make ApplyBucketsWork independent of merges in progress

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -621,6 +621,7 @@ exit /b 0
     <ClCompile Include="..\..\src\work\Work.cpp" />
     <ClCompile Include="..\..\src\work\WorkScheduler.cpp" />
     <ClCompile Include="..\..\src\work\WorkSequence.cpp" />
+    <ClCompile Include="..\..\src\work\WorkWithCallback.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\catch.hpp" />
@@ -907,6 +908,7 @@ exit /b 0
     <ClInclude Include="..\..\src\work\Work.h" />
     <ClInclude Include="..\..\src\work\WorkScheduler.h" />
     <ClInclude Include="..\..\src\work\WorkSequence.h" />
+    <ClInclude Include="..\..\src\work\WorkWithCallback.h" />
     <ClInclude Include="src\generated\xdr\Stellar-ledger-entries.h" />
     <ClInclude Include="src\generated\xdr\Stellar-ledger.h" />
     <ClInclude Include="src\generated\xdr\Stellar-overlay.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -300,6 +300,9 @@
     <ClCompile Include="..\..\src\work\WorkSequence.cpp">
       <Filter>work</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\work\WorkWithCallback.cpp">
+      <Filter>work</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\util\StatusManager.cpp">
       <Filter>util</Filter>
     </ClCompile>
@@ -1326,6 +1329,9 @@
       <Filter>work</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\work\WorkSequence.h">
+      <Filter>work</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\work\WorkWithCallback.h">
       <Filter>work</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\StatusManager.h">

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -152,15 +152,6 @@ BasicWork::State
 ApplyBucketsWork::onRun()
 {
     ZoneScoped;
-    if (!mHaveCheckedApplyStateValidity && mLevel == BucketList::kNumLevels - 1)
-    {
-        if (!mApplyState.containsValidBuckets(mApp))
-        {
-            CLOG_ERROR(History, "Malformed HAS: unable to apply buckets");
-            return State::WORK_FAILURE;
-        }
-        mHaveCheckedApplyStateValidity = true;
-    }
 
     // Check if we're at the beginning of the new level
     if (isLevelComplete())

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -25,7 +25,6 @@ class ApplyBucketsWork : public BasicWork
 {
     std::map<std::string, std::shared_ptr<Bucket>> const& mBuckets;
     HistoryArchiveState const& mApplyState;
-    bool mHaveCheckedApplyStateValidity{false};
 
     bool mApplying{false};
     size_t mTotalBuckets{0};

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -59,7 +59,6 @@ struct BucketListGenerator
     {
         std::map<std::string, std::shared_ptr<Bucket>> buckets;
         auto has = getHistoryArchiveState();
-        has.prepareForPublish(*mAppApply);
         auto& wm = mAppApply->getWorkScheduler();
         wm.executeWork<T>(buckets, has,
                           mAppApply->getConfig().LEDGER_PROTOCOL_VERSION,

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -202,10 +202,6 @@ applyBucketsForLCL(Application& app)
     auto lclHash =
         app.getPersistentState().getState(PersistentState::kLastClosedLedger);
 
-    // As the local HAS might have merges in progress, let
-    // `prepareForPublish` convert it into a "valid historical HAS".
-    has.prepareForPublish(app);
-
     auto maxProtocolVersion = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
     auto currentLedger =
         LedgerHeaderUtils::loadByHash(app.getDatabase(), hexToBin256(lclHash));

--- a/src/work/WorkWithCallback.cpp
+++ b/src/work/WorkWithCallback.cpp
@@ -1,0 +1,48 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "work/WorkWithCallback.h"
+#include "util/Logging.h"
+
+namespace stellar
+{
+
+WorkWithCallback::WorkWithCallback(
+    Application& app, std::string name,
+    std::function<bool(Application& app)> callback)
+    : BasicWork(app, std::move(name), BasicWork::RETRY_NEVER)
+    , mCallback(callback)
+{
+    if (!mCallback)
+    {
+        throw std::invalid_argument("Must provide a valid function. Use "
+                                    "BasicWork if a callback is not needed.");
+    }
+}
+
+BasicWork::State
+WorkWithCallback::onRun()
+{
+    bool res;
+    try
+    {
+        res = mCallback(mApp);
+    }
+    catch (std::runtime_error const& er)
+    {
+        CLOG_ERROR(Work,
+                   "WorkWithCallback {} error: cannot execute callback, {}",
+                   getName(), er.what());
+        return BasicWork::State::WORK_FAILURE;
+    }
+
+    if (!res)
+    {
+        CLOG_ERROR(Work, "WorkWithCallback {} error: callback failed",
+                   getName());
+        return BasicWork::State::WORK_FAILURE;
+    }
+    return BasicWork::State::WORK_SUCCESS;
+}
+}

--- a/src/work/WorkWithCallback.h
+++ b/src/work/WorkWithCallback.h
@@ -1,0 +1,27 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+#pragma once
+
+#include "work/BasicWork.h"
+
+namespace stellar
+{
+
+class WorkWithCallback : public BasicWork
+{
+    std::function<bool(Application& app)> const mCallback;
+
+  public:
+    WorkWithCallback(Application& app, std::string name,
+                     std::function<bool(Application& app)> callback);
+
+  protected:
+    BasicWork::State onRun() override;
+    bool
+    onAbort() override
+    {
+        return true;
+    };
+};
+}


### PR DESCRIPTION
Resolves #3044

This change removes the dependency on future buckets state from ApplyBucketsWork. Previously, ApplyBucketsWork would expect the future buckets in HAS to be either resolved or clear, as it expected HAS from an untrusted archive. This has changed, since we now use the local HAS in ApplyBucketsWork as well (in captive core startup, for example), which may have merges in progress. So this change moves the HAS validation into DownloadBucketsWork instead.

Note that it also fixes the race condition that impacts older (before protocol 12) buckets: the HAS validation expects some merges to be resolved, however `prepareForPublish` restarts the merges in progress, but does not necessarily wait for them to finish.