### PR TITLE
Should FAILURE_SAFETY in example config be -1 (i.e. default value)?

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -9,10 +9,10 @@
 ## General admin settings
 
 
-# LOG_FILE_PATH (string) default "stellar-core.log"
+# LOG_FILE_PATH (string) default "stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"
 # Path to the file you want stellar-core to write its log to.
 # You can set to "" for no log file.
-LOG_FILE_PATH=""
+LOG_FILE_PATH="stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"
 
 # LOG_COLOR (boolean) default false
 # Whether to highlight stdout log messages with ANSI terminal colors.
@@ -46,7 +46,7 @@ DATABASE="sqlite3://stellar.db"
 #   that will be stored in the cache (default 4096)
 # - PREFETCH_BATCH_SIZE determines batch size for bulk loads used for
 #   prefetching
-ENTRY_CACHE_SIZE=4096
+ENTRY_CACHE_SIZE=100000
 PREFETCH_BATCH_SIZE=1000
 
 # HTTP_PORT (integer) default 11626
@@ -246,7 +246,7 @@ NODE_HOME_DOMAIN=""
 # A value of 0 is only allowed if UNSAFE_QUORUM is set
 # Note: The value of 1 below is the maximum number derived from the value of
 # QUORUM_SET in this configuration file
-FAILURE_SAFETY=1
+FAILURE_SAFETY=-1
 
 # UNSAFE_QUORUM (true or false) default false
 # Most people should leave this to false.
@@ -279,12 +279,12 @@ CATCHUP_COMPLETE=false
 # at least CATCHUP_RECENT number of ledger entries will be present in database
 # if "some past snapshot" is already present in database, it just replays all
 # new history
-CATCHUP_RECENT=1024
+CATCHUP_RECENT=0
 
-# WORKER_THREADS (integer) default 10
+# WORKER_THREADS (integer) default 11
 # Number of threads available for doing long durations jobs, like bucket
 # merging and vertification.
-WORKER_THREADS=10
+WORKER_THREADS=11
 
 # QUORUM_INTERSECTION_CHECKER (boolean) default true
 # Enable/disable computation of quorum intersection monitoring
@@ -293,7 +293,7 @@ QUORUM_INTERSECTION_CHECKER=true
 # MAX_CONCURRENT_SUBPROCESSES (integer) default 16
 # History catchup can potentially spawn a bunch of sub-processes.
 # This limits the number that will be active at a time.
-MAX_CONCURRENT_SUBPROCESSES=10
+MAX_CONCURRENT_SUBPROCESSES=16
 
 # AUTOMATIC_MAINTENANCE_PERIOD (integer, seconds) default 660
 # Interval between automatic maintenance executions


### PR DESCRIPTION
# Description

`FAILURE_SAFETY` is set to 1 in the example full config, while the default value is -1. As far as I can tell, the other fields are set to their default value. Should this also be the case for `FAILURE_SAFETY`?

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
