### PR TITLE
Small Dockerfile tweaks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,3 +22,6 @@ RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
 RUN echo "deb https://apt.stellar.org ${DISTRO} unstable" | tee -a /etc/apt/sources.list.d/SDF-unstable.list
 RUN apt-get update
 RUN apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
+
+WORKDIR "/etc/stellar"
+ENTRYPOINT ["/usr/bin/stellar-core"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,9 @@ It uses the official stellar-core deb package for two reasons:
 To build set `STELLAR_CORE_VERSION` to deb package version you want installed.
 For example:
 ```
-STELLAR_CORE_VERSION=17.0.0-557.096f6a7.focal make docker-build
+export STELLAR_CORE_VERSION=17.0.0-557.096f6a7.focal
+export TAG=${USER}/stellar-core:${STELLAR_CORE_VERSION}
+make docker-build
 ```
 
 ## Dockerfile.testing


### PR DESCRIPTION
# Description

* set `WORKDIR` and `ENTRYPOINT` for convenience. This will allow us to use:
  `docker run -v "/path/to/config/dir:/etc/stellar/" stellar/stellar-core:latest run`
* clarify documentation

# Checklist
- [x] Rebased on top of master (no merge commits)
