### PR TITLE
do not cancel Workflows in Github Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
         toolchain: [ "gcc", "clang"]
         protocol: ["current", "next"]
     steps:
-      - name: Cancel Stale Workflows
-        uses: styfle/cancel-workflow-action@0.8.0
-        with:
-          access_token: ${{ github.token }}
       - name: Compute cache key
         # this step works around a limitation in actions/cache
         # that does not allow updating a cache


### PR DESCRIPTION
instead, just let the script fail later.

Our CI bot resets the `auto` branch to `master`, then merges the PR to test into it as two separate events.
The problem is that it looks like Github actions are not being queued in that order all the time, so we can't just cancel "older builds".