### PR TITLE
Harden bucket apply path

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -81,8 +81,7 @@ ApplyBucketsWork::onReset()
         // apply
         if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
         {
-            auto& lsRoot = mApp.getLedgerTxnRoot();
-            lsRoot.deleteObjectsModifiedOnOrAfterLedger(0);
+            mApp.resetLedgerState();
         }
 
         auto addBucket = [this](std::shared_ptr<Bucket const> const& bucket) {

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -79,10 +79,7 @@ ApplyBucketsWork::onReset()
     {
         // clear ledgerTxn state of all ledger entries in preparation of bucket
         // apply
-        if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
-        {
-            mApp.resetLedgerState();
-        }
+        mApp.resetLedgerState();
 
         auto addBucket = [this](std::shared_ptr<Bucket const> const& bucket) {
             if (bucket->getSize() > 0)

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -77,6 +77,14 @@ ApplyBucketsWork::onReset()
 
     if (!isAborting())
     {
+        // clear ledgerTxn state of all ledger entries in preparation of bucket
+        // apply
+        if (!mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
+        {
+            auto& lsRoot = mApp.getLedgerTxnRoot();
+            lsRoot.deleteObjectsModifiedOnOrAfterLedger(0);
+        }
+
         auto addBucket = [this](std::shared_ptr<Bucket const> const& bucket) {
             if (bucket->getSize() > 0)
             {
@@ -113,18 +121,6 @@ ApplyBucketsWork::startLevel()
 
     bool applySnap = (i.snap != binToHex(level.getSnap()->getHash()));
     bool applyCurr = (i.curr != binToHex(level.getCurr()->getHash()));
-
-    if (!mApplying && !mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER &&
-        (applySnap || applyCurr))
-    {
-        uint32_t oldestLedger = applySnap
-                                    ? BucketList::oldestLedgerInSnap(
-                                          mApplyState.currentLedger, mLevel)
-                                    : BucketList::oldestLedgerInCurr(
-                                          mApplyState.currentLedger, mLevel);
-        auto& lsRoot = mApp.getLedgerTxnRoot();
-        lsRoot.deleteObjectsModifiedOnOrAfterLedger(oldestLedger);
-    }
 
     if (mApplying || applySnap)
     {

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -740,9 +740,6 @@ TransactionQueue::getMaxOpsToFloodThisPeriod() const
         opsToFlood = opsToFloodLedger;
     }
     releaseAssertOrThrow(opsToFlood >= 0);
-    releaseAssertOrThrow(
-        opsToFlood <=
-        static_cast<int64_t>(std::numeric_limits<ssize_t>::max()));
     return static_cast<size_t>(opsToFlood);
 }
 

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -164,6 +164,10 @@ class Application
 
     virtual void initialize(bool createNewDB) = 0;
 
+    // reset the ledger state entirely
+    // (to be used before applying buckets)
+    virtual void resetLedgerState() = 0;
+
     // Return the time in seconds since the POSIX epoch, according to the
     // VirtualClock this Application is bound to. Convenience method.
     virtual uint64_t timeNow() = 0;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -221,6 +221,13 @@ ApplicationImpl::initialize(bool createNewDB)
 }
 
 void
+ApplicationImpl::resetLedgerState()
+{
+    auto& lsRoot = getLedgerTxnRoot();
+    lsRoot.deleteObjectsModifiedOnOrAfterLedger(0);
+}
+
+void
 ApplicationImpl::newDB()
 {
     mDatabase->initialize();

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -44,6 +44,8 @@ class ApplicationImpl : public Application
 
     virtual void initialize(bool newDB) override;
 
+    virtual void resetLedgerState() override;
+
     virtual uint64_t timeNow() override;
 
     virtual Config const& getConfig() override;

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -774,8 +774,7 @@ runCatchup(CommandLineArgs const& args)
                     LOG_INFO(
                         DEFAULT_LOG,
                         "Resetting ledger state to genesis before catching up");
-                    auto& lsRoot = app->getLedgerTxnRoot();
-                    lsRoot.deleteObjectsModifiedOnOrAfterLedger(0);
+                    app->resetLedgerState();
                     lm.startNewLedger();
                 }
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -22,6 +22,7 @@
 #include <fmt/chrono.h>
 #include <fmt/format.h>
 #include <functional>
+#include <numeric>
 #include <sstream>
 #include <unordered_set>
 
@@ -733,7 +734,7 @@ Config::processOpApplySleepTimeForTestingConfigs()
     ret.reserve(100);
     for (size_t i = 0; i < OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.size(); i++)
     {
-        LOG_INFO(DEFAULT_LOG, "Sleeps for {} {}\% of the time",
+        LOG_INFO(DEFAULT_LOG, "Sleeps for {} {}% of the time",
                  OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[i],
                  OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i]);
         for (size_t j = 0; j < OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i]; j++)


### PR DESCRIPTION
I noticed while investigating something that there could be situations during catchup where we do not properly clear the in memory state (this only applies to captive core).

This PR fixes that by ensuring that we rebuild the ledger every time we apply buckets.
