### PR TITLE
Bug 2607 stream debug meta files

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -423,6 +423,7 @@ exit /b 0
     <ClCompile Include="..\..\src\invariant\test\OrderBookIsNotCrossedTests.cpp" />
     <ClCompile Include="..\..\src\invariant\test\SponsorshipCountIsValidTests.cpp" />
     <ClCompile Include="..\..\src\ledger\CheckpointRange.cpp" />
+    <ClCompile Include="..\..\src\ledger\FlushAndRotateMetaDebugWork.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerHeaderUtils.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerManagerImpl.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerRange.cpp" />
@@ -780,6 +781,7 @@ exit /b 0
     <ClInclude Include="..\..\src\invariant\SponsorshipCountIsValid.h" />
     <ClInclude Include="..\..\src\invariant\test\InvariantTestUtils.h" />
     <ClInclude Include="..\..\src\ledger\CheckpointRange.h" />
+    <ClInclude Include="..\..\src\ledger\FlushAndRotateMetaDebugWork.h" />
     <ClInclude Include="..\..\src\ledger\LedgerHashUtils.h" />
     <ClInclude Include="..\..\src\ledger\LedgerHeaderUtils.h" />
     <ClInclude Include="..\..\src\ledger\LedgerManager.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -552,6 +552,9 @@
     <ClCompile Include="..\..\src\ledger\CheckpointRange.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\FlushAndRotateMetaDebugWork.cpp">
+      <Filter>ledger</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ledger\LedgerHeaderUtils.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
@@ -1629,6 +1632,9 @@
       <Filter>history</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ledger\CheckpointRange.h">
+      <Filter>ledger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ledger\FlushAndRotateMetaDebugWork.h">
       <Filter>ledger</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ledger\LedgerHashUtils.h">

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -460,6 +460,12 @@ METADATA_OUTPUT_STREAM=""
 # using --in-memory on the command line).
 EXPERIMENTAL_PRECAUTION_DELAY_META=false
 
+# Number of ledgers worth of transaction metadata to preserve on disk for
+# debugging purposes. These records are automatically maintained and rotated
+# during processing, and are helpful for recovery in case of a serious error;
+# they should only be reduced or disabled if disk space is at a premium.
+METADATA_DEBUG_LEDGERS=0
+
 # EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE (list of strings) default is empty
 # Setting this will cause the node to reject transactions that it receives if
 # they contain any operation in this list. It will not, however, stop the node

--- a/src/ledger/FlushAndRotateMetaDebugWork.cpp
+++ b/src/ledger/FlushAndRotateMetaDebugWork.cpp
@@ -1,0 +1,201 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/FlushAndRotateMetaDebugWork.h"
+#include "bucket/BucketManager.h"
+#include "crypto/Hex.h"
+#include "crypto/Random.h"
+#include "util/Fs.h"
+#include "util/GlobalChecks.h"
+#include <filesystem>
+#include <memory>
+#include <regex>
+#include <stdexcept>
+#include <system_error>
+
+namespace
+{
+const std::string META_DEBUG_DIRNAME{"meta-debug"};
+const std::string META_DEBUG_FILE_FMT_STR{"meta-debug-{:08x}-{}.xdr"};
+const std::regex META_DEBUG_FILE_REGEX{
+    "meta-debug-[[:xdigit:]]+-[[:xdigit:]]+\\.xdr(\\.gz)?"};
+
+// This number can be changed in the future without any coordination,
+// it just controls the granularity of new meta-debug XDR segments.
+//
+// 256 ledgers == ~21 minutes. At time of writing, ~5mb meta / minute
+// gives ~105mb meta / segment, which should compress to ~20mb.
+const uint32_t META_DEBUG_LEDGER_SEGMENT_SIZE = 256;
+}
+
+namespace stellar
+{
+
+FlushAndRotateMetaDebugWork::FlushAndRotateMetaDebugWork(
+    Application& app, std::filesystem::path const& metaDebugPath,
+    std::unique_ptr<XDROutputFileStream> metaDebugFile, uint32_t ledgersToKeep)
+    : Work(app, "flush and rotate meta-debug", BasicWork::RETRY_NEVER)
+    , mMetaDebugPath(metaDebugPath)
+    , mMetaDebugFile(std::move(metaDebugFile))
+    , mLedgersToKeep(ledgersToKeep)
+{
+}
+
+std::filesystem::path
+FlushAndRotateMetaDebugWork::getMetaDebugDirPath(
+    std::filesystem::path const& bucketDir)
+{
+    return bucketDir / META_DEBUG_DIRNAME;
+}
+
+std::filesystem::path
+FlushAndRotateMetaDebugWork::getMetaDebugFilePath(
+    std::filesystem::path const& bucketDir, uint32_t seqNum)
+{
+    auto file =
+        fmt::format(META_DEBUG_FILE_FMT_STR, seqNum, binToHex(randomBytes(8)));
+    return getMetaDebugDirPath(bucketDir) / file;
+}
+
+std::vector<std::filesystem::path>
+FlushAndRotateMetaDebugWork::listMetaDebugFiles(
+    std::filesystem::path const& bucketDir)
+{
+    auto dir = getMetaDebugDirPath(bucketDir);
+    auto files = fs::findfiles(dir.string(), [](std::string const& file) {
+        return std::regex_match(file, META_DEBUG_FILE_REGEX);
+    });
+    std::sort(files.begin(), files.end());
+    return std::vector<std::filesystem::path>(files.begin(), files.end());
+}
+
+bool
+FlushAndRotateMetaDebugWork::isDebugSegmentBoundary(uint32_t ledgerSeq)
+{
+    return ledgerSeq % (META_DEBUG_LEDGER_SEGMENT_SIZE - 1) == 0;
+}
+
+size_t
+FlushAndRotateMetaDebugWork::getNumberOfDebugFilesToKeep(uint32_t numLedgers)
+{
+    size_t segLen = META_DEBUG_LEDGER_SEGMENT_SIZE;
+    return (numLedgers + segLen - 1) / segLen;
+}
+
+BasicWork::State
+FlushAndRotateMetaDebugWork::doWork()
+{
+    // Step 1: transfer ownership of mMetaDebugFile to background thread
+    // and flush/fsync it. When that completes, it will post an action
+    // back to the main thread that unblocks this work to continue with
+    // gzip'ing and rotating.
+    if (mMetaDebugFile)
+    {
+        std::weak_ptr<FlushAndRotateMetaDebugWork> weak =
+            std::static_pointer_cast<FlushAndRotateMetaDebugWork>(
+                shared_from_this());
+
+        // This is a little silly, but we have ownership of a non-copyable
+        // unique_ptr here, and we want to transfer that ownership into a
+        // closure held by a std::function -- which unfortunately requires
+        // its body to be copy-constructable. So we double-indirect through
+        // something copy-constructble: a shared_ptr<unique_ptr<...>>.
+        using OwnedStream = std::unique_ptr<XDROutputFileStream>;
+        auto file = std::make_shared<OwnedStream>(std::move(mMetaDebugFile));
+        mApp.postOnBackgroundThread(
+            [weak, file]() {
+                auto self = weak.lock();
+                if (!self)
+                {
+                    return;
+                }
+
+                // First close() here, which will call fsync(), which blocks.
+                CLOG_DEBUG(Ledger, "closing meta-debug file {}",
+                           self->mMetaDebugPath.string());
+                try
+                {
+                    (*file)->close();
+                }
+                catch (std::runtime_error& e)
+                {
+                    // If we fail to close here, we're going to just eat the
+                    // error and carry on to trying to gzip. Hopefully this
+                    // doesn't cause a filehandle leak or something similarly
+                    // horrible.
+                    CLOG_WARNING(Ledger,
+                                 "Failed to close debug metadata stream: {}",
+                                 e.what());
+                }
+
+                // Then post back to main thread.
+                self->mApp.postOnMainThread(
+                    [weak]() {
+                        auto self = weak.lock();
+                        if (self)
+                        {
+                            self->wakeUp();
+                        }
+                    },
+                    "wake up gzip and rotate meta-debug");
+            },
+            "close and fsync meta-debug");
+        return BasicWork::State::WORK_WAITING;
+    }
+
+    // Step 2: wait for the creation and completion of mGzipFileWork.
+    if (!mGzipFileWork)
+    {
+        CLOG_DEBUG(Ledger, "compressing meta-debug file {}",
+                   mMetaDebugPath.string());
+        mGzipFileWork = addWork<GzipFileWork>(mMetaDebugPath.string());
+        return BasicWork::State::WORK_RUNNING;
+    }
+    if (!mGzipFileWork->isDone())
+    {
+        return mGzipFileWork->getState();
+    }
+    if (mGzipFileWork->getState() == State::WORK_SUCCESS)
+    {
+        CLOG_DEBUG(Ledger, "compressed meta-debug file {}",
+                   mMetaDebugPath.string());
+    }
+    else
+    {
+        CLOG_ERROR(Ledger, "failed to compress meta-debug file {}",
+                   mMetaDebugPath.string());
+        return State::WORK_FAILURE;
+    }
+
+    // Step 3: synchronously rotate the meta files in the directory, whether
+    // gzipped or not -- non-gzipped ones are left behind when users kill or
+    // restart core processes.
+    auto bucketDir = mApp.getBucketManager().getBucketDir();
+    auto dir = getMetaDebugDirPath(bucketDir);
+    auto files = listMetaDebugFiles(bucketDir);
+    auto keep = getNumberOfDebugFilesToKeep(mLedgersToKeep);
+    if (files.size() > keep)
+    {
+        // Forget about the most-recent (highest-sorting) keep files -- they get
+        // to survive.
+        files.resize(files.size() - keep);
+
+        // Delete all (size()-keep) younger (lower-sorting) files not forgotten
+        // above.
+        for (auto const& file : files)
+        {
+            releaseAssert(
+                std::regex_match(file.string(), META_DEBUG_FILE_REGEX));
+            auto f = dir / file;
+            CLOG_DEBUG(Ledger, "trimming old meta-debug file {}", f.string());
+            std::error_code ec;
+            std::filesystem::remove(f, ec);
+            // Ignore errors: there's nothing we can do to "try harder" and
+            // failing the work is not helpful. We'll just try again.
+        }
+    }
+    return State::WORK_SUCCESS;
+}
+
+}

--- a/src/ledger/FlushAndRotateMetaDebugWork.h
+++ b/src/ledger/FlushAndRotateMetaDebugWork.h
@@ -1,0 +1,45 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "historywork/GzipFileWork.h"
+#include "util/XDRStream.h"
+#include <filesystem>
+
+namespace stellar
+{
+
+class FlushAndRotateMetaDebugWork : public Work
+{
+    std::filesystem::path mMetaDebugPath;
+    std::unique_ptr<XDROutputFileStream> mMetaDebugFile;
+    std::shared_ptr<GzipFileWork> mGzipFileWork;
+    uint32_t mLedgersToKeep;
+
+  public:
+    FlushAndRotateMetaDebugWork(
+        Application& app, std::filesystem::path const& metaDebugPath,
+        std::unique_ptr<XDROutputFileStream> metaDebugFile,
+        uint32_t ledgersToKeep);
+    ~FlushAndRotateMetaDebugWork() = default;
+
+    static std::filesystem::path
+    getMetaDebugFilePath(std::filesystem::path const& bucketDir,
+                         uint32_t seqNum);
+
+    static std::filesystem::path
+    getMetaDebugDirPath(std::filesystem::path const& bucketDir);
+
+    static std::vector<std::filesystem::path>
+    listMetaDebugFiles(std::filesystem::path const& bucketDir);
+
+    static bool isDebugSegmentBoundary(uint32_t ledgerSeq);
+
+    static size_t getNumberOfDebugFilesToKeep(uint32_t ledgersToKeep);
+
+  protected:
+    BasicWork::State doWork() override;
+};
+}

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -11,6 +11,7 @@
 #include "transactions/TransactionFrame.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
+#include <filesystem>
 #include <string>
 
 /*
@@ -33,6 +34,7 @@ class AbstractLedgerTxn;
 class Application;
 class Database;
 class LedgerTxnHeader;
+class BasicWork;
 
 class LedgerManagerImpl : public LedgerManager
 {
@@ -41,6 +43,9 @@ class LedgerManagerImpl : public LedgerManager
   protected:
     Application& mApp;
     std::unique_ptr<XDROutputFileStream> mMetaStream;
+    std::unique_ptr<XDROutputFileStream> mMetaDebugStream;
+    std::weak_ptr<BasicWork> mFlushAndRotateMetaDebugWork;
+    std::filesystem::path mMetaDebugPath;
 
   private:
     medida::Timer& mTransactionApply;
@@ -135,5 +140,6 @@ class LedgerManagerImpl : public LedgerManager
     void manuallyAdvanceLedgerHeader(LedgerHeader const& header) override;
 
     void setupLedgerCloseMetaStream();
+    void maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq);
 };
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -151,6 +151,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     DISABLE_XDR_FSYNC = false;
     MAX_SLOTS_TO_REMEMBER = 12;
     METADATA_OUTPUT_STREAM = "";
+    METADATA_DEBUG_LEDGERS = 0;
 
     LOG_FILE_PATH = "stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log";
     BUCKET_DIR_PATH = "buckets";
@@ -841,6 +842,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "EXPERIMENTAL_PRECAUTION_DELAY_META")
             {
                 EXPERIMENTAL_PRECAUTION_DELAY_META = readBool(item);
+            }
+            else if (item.first == "METADATA_DEBUG_LEDGERS")
+            {
+                METADATA_DEBUG_LEDGERS = readInt<uint32_t>(item);
             }
             else if (item.first == "KNOWN_CURSORS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -291,6 +291,13 @@ class Config : public std::enable_shared_from_this<Config>
     // in consensus, only a passive "watcher" node.
     std::string METADATA_OUTPUT_STREAM;
 
+    // Number of ledgers worth of transaction metadata to preserve on disk for
+    // debugging purposes. These records are automatically maintained and
+    // rotated during processing, and are helpful for recovery in case of a
+    // serious error; they should only be reduced or disabled if disk space is
+    // at a premium.
+    uint32_t METADATA_DEBUG_LEDGERS;
+
     // Set of cursors added at each startup with value '1'.
     std::vector<std::string> KNOWN_CURSORS;
 

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -62,8 +62,7 @@ dumpstream(XDRInputFileStream& in, bool compact)
 void
 dumpXdrStream(std::string const& filename, bool compact)
 {
-    std::regex rx(
-        ".*(ledger|bucket|transactions|results|scp)-[[:xdigit:]]+\\.xdr");
+    std::regex rx(".*(ledger|bucket|transactions|results|meta|scp)-.+\\.xdr");
     std::smatch sm;
     if (std::regex_match(filename, sm, rx))
     {
@@ -85,6 +84,10 @@ dumpXdrStream(std::string const& filename, bool compact)
         else if (sm[1] == "results")
         {
             dumpstream<TransactionHistoryResultEntry>(in, compact);
+        }
+        else if (sm[1] == "meta")
+        {
+            dumpstream<LedgerCloseMeta>(in, compact);
         }
         else
         {

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -193,6 +193,7 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         // only spin up a small number of worker threads
         thisConfig.WORKER_THREADS = 2;
         thisConfig.QUORUM_INTERSECTION_CHECKER = false;
+        thisConfig.METADATA_DEBUG_LEDGERS = 0;
 #ifdef BEST_OFFER_DEBUGGING
         thisConfig.BEST_OFFER_DEBUGGING_ENABLED = true;
 #endif

--- a/src/util/Fs.h
+++ b/src/util/Fs.h
@@ -6,6 +6,7 @@
 
 #include "util/asio.h"
 
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <string>
@@ -64,20 +65,22 @@ native_handle_t openFileToWrite(std::string const& path);
 bool durableRename(std::string const& src, std::string const& dst,
                    std::string const& dir);
 
-// Whether a path exists
+// Return whether a path exists.
 bool exists(std::string const& path);
 
-// Delete a path and everything inside it (if a dir)
+// Delete a path and everything inside it (if a dir).
 void deltree(std::string const& path);
 
-// Make a single dir; not mkdir -p, i.e. non-recursive
+// Make a single dir; not mkdir -p, i.e. non-recursive. Returns true
+// if a directory was created (but false if it already existed).
 bool mkdir(std::string const& path);
 
-// Make a dir path like mkdir -p, i.e. recursive, uses '/' as dir separator
+// Make a dir path like mkdir -p, i.e. recursive, uses '/' as dir separator.
+// Returns true iff at the end of the call, the path exists and is a directory.
 bool mkpath(std::string const& path);
 
-// Get list of all files with names matching predicate
-// Returned names are relative to path
+// Get list of all files with names matching predicate in the provided directory
+// (but not its subdirectories). Returned names are relative to path.
 std::vector<std::string>
 findfiles(std::string const& path,
           std::function<bool(std::string const& name)> predicate);
@@ -85,19 +88,6 @@ findfiles(std::string const& path,
 size_t size(std::ifstream& ifs);
 
 size_t size(std::string const& path);
-
-class PathSplitter
-{
-  public:
-    explicit PathSplitter(std::string path);
-
-    std::string next();
-    bool hasNext() const;
-
-  private:
-    std::string mPath;
-    std::string::size_type mPos;
-};
 
 ////
 // Utility functions for constructing path names

--- a/src/util/test/FsTests.cpp
+++ b/src/util/test/FsTests.cpp
@@ -2,57 +2,70 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "crypto/Random.h"
+#include "history/FileTransferInfo.h"
 #include "lib/catch.hpp"
+#include "util/FileSystemException.h"
 #include "util/Fs.h"
-#include <tuple>
+#include "util/TmpDir.h"
 
-using namespace stellar::fs;
+using namespace stellar;
+namespace stdfs = std::filesystem;
+namespace fs = stellar::fs;
 
-TEST_CASE("path splitter", "[fs]")
+TEST_CASE("filesystem locks", "[fs]")
 {
-    using DataValue =
-        std::tuple<std::string, std::string, std::vector<std::string>>;
-    auto data = std::vector<DataValue>{
-        DataValue{"root", "/", {"/"}},
-        DataValue{"simple dir", "simple", {"simple"}},
-        DataValue{
-            "nested dir", "nested1/nested2/", {"nested1", "nested1/nested2"}},
-        DataValue{"nested dir with multiple slashes",
-                  "nested1///nested2/",
-                  {"nested1", "nested1/nested2"}},
-        DataValue{"nested dir starting at root",
-                  "/nested1/nested2/",
-                  {"/", "/nested1", "/nested1/nested2"}},
-        DataValue{"nested dir starting at rootwith multiple slashes",
-                  "/nested1///nested2/",
-                  {"/", "/nested1", "/nested1/nested2"}}};
+    TmpDir tmp("fstests");
+    stdfs::path root(tmp.getName());
+    stdfs::path lockfile = root / "file.lock";
+    fs::lockFile(lockfile.string());
+    REQUIRE(fs::exists(lockfile.string()));
+    REQUIRE_THROWS_AS(fs::lockFile(lockfile.string()), std::runtime_error);
+    fs::unlockFile(lockfile.string());
+    REQUIRE_THROWS_AS(fs::unlockFile(lockfile.string()), std::runtime_error);
+    fs::lockFile(lockfile.string());
+    fs::unlockFile(lockfile.string());
+    stdfs::remove(lockfile);
+}
 
-    using ExtensionValue = std::pair<std::string, std::string>;
-    auto extensions = std::vector<ExtensionValue>{
-        ExtensionValue{"without slash at end", ""},
-        ExtensionValue{"with slash at end", "/"},
-        ExtensionValue{"with multiple slashes at end", "//"}};
-
-    SECTION("empty")
+TEST_CASE("filesystem durable rename", "[fs]")
+{
+    TmpDir tmp("fstests");
+    stdfs::path root(tmp.getName());
+    stdfs::path fileA = root / "fileA.txt";
+    stdfs::path fileB = root / "fileB.txt";
     {
-        auto ps = PathSplitter{""};
-        REQUIRE(!ps.hasNext());
+        std::ofstream out(fileA.string());
+        out << "hi";
     }
+    REQUIRE(fs::durableRename(fileA.string(), fileB.string(), root.string()));
+    REQUIRE(!fs::exists(fileA.string()));
+    REQUIRE(fs::exists(fileB.string()));
+}
 
-    for (auto const& i : data)
+TEST_CASE("filesystem findfiles", "[fs]")
+{
+    TmpDir tmp("fstests");
+    stdfs::path root(tmp.getName());
+    stdfs::path textFile = root / "file.txt";
+    stdfs::path docFile = root / "file.doc";
     {
-        for (auto const& e : extensions)
-        {
-            SECTION(std::get<0>(i) + " " + e.first)
-            {
-                auto ps = PathSplitter{std::get<1>(i) + e.second};
-                for (auto const& p : std::get<2>(i))
-                {
-                    REQUIRE(ps.hasNext());
-                    REQUIRE(ps.next() == p);
-                }
-                REQUIRE(!ps.hasNext());
-            }
-        }
+        std::ofstream out(textFile.string());
+        out << "hi";
     }
+    stdfs::copy_file(textFile, docFile);
+    REQUIRE(stdfs::exists(textFile));
+    REQUIRE(stdfs::exists(docFile));
+    auto files =
+        fs::findfiles(root.string(), [](std::string const& name) -> bool {
+            return stdfs::path(name).extension().string() == ".doc";
+        });
+    REQUIRE(files == std::vector<std::string>{docFile.filename().string()});
+}
+
+TEST_CASE("filesystem remoteName", "[fs]")
+{
+    REQUIRE(fs::remoteName(HISTORY_FILE_TYPE_LEDGER, fs::hexStr(0x0abbccdd),
+                           "xdr.gz") ==
+            "ledger/0a/bb/cc/ledger-0abbccdd.xdr.gz");
 }

--- a/src/work/BasicWork.h
+++ b/src/work/BasicWork.h
@@ -105,9 +105,11 @@ class BasicWork : public std::enable_shared_from_this<BasicWork>,
     // Publicly exposed state of work
     enum class State
     {
-        // Work has been created and is currently in progress.
-        // Implementers return RUNNING when work needs to be scheduled to run
-        // more.
+        // Work has been created and is currently in progress. Implementers
+        // return RUNNING when work needs to be scheduled to run more.
+        //
+        // See Work::addWork for a subtle distinction about when to return
+        // RUNNING vs. WAITING when adding children to (hierarchical) Work.
         WORK_RUNNING,
         // Work should not be scheduled to run, as it's waiting
         // for some event (process exit, retry timeout, etc)

--- a/src/work/Work.h
+++ b/src/work/Work.h
@@ -83,6 +83,17 @@ class Work : public BasicWork
         return child;
     }
 
+    // addWork adds a child work and wires it up to call the current (parent)
+    // work's wakeUp method when the child completes.
+    //
+    // One subtle note: addWork transitions the child to WORK_RUNNING state, but
+    // does _not run the child's onRun method_, so in a parent's onRun method
+    // that calls addWork to add a child, the parent should return WORK_RUNNING
+    // (or the child's status), not WORK_WAITING. The parent will then be
+    // rescheduled and in its _next_ run will call through to the child's onRun,
+    // which will wire up callbacks / start running the child. The parent's
+    // onRun method should only return WORK_WAITING if it observes an _existing_
+    // child running or waiting.
     void
     addWork(std::function<void()> cb, std::shared_ptr<BasicWork> child)
     {


### PR DESCRIPTION
# Description

This adds a new debugging facility to core: a fixed-size set of metadata streams kept on-disk in the buckets directory, gzipped once closed, and rotated out once they get too old. By default it's set to 64k ledgers which is 3.8 days. Long enough to notice and fetch a copy of the offending ledger metadata from any node in the network if there's a serious fault.

Along the way I fixed a (potential) deadlock in posting work back from background threads to foreground, if it happens when foreground is blocked waiting for futurebucket merges and the merge work is itself blocked behind too much background thread work that's posting-back results to main thread. This is a fairly subtle condition to arrange and I don't think anything in the existing code triggers it, but this new code could and it's a footgun to leave it in, so I eliminated it.

The performance costs of the new meta streams (at current pubnet rates) are:
  - TIme spent writing meta on ledger close.
  - Running fsync on background thread then gzip on a ~100MB file once every ~20 min. Gzip takes about 5s of CPU time -- could degrade with a ledger close on a heavily-loaded machine. Also an IO spike, potentially interfering.
  - An extra ~5GB of storage in the bucket dir for the 256 preserved files.

Rebased on top of #3030 to correctly support `<filesystem>` on gcc 8 and clang 8. That one should land before this one.

I'll also try to quantify this PR's costs a bit more tomorrow. Meanwhile review of the logic is welcome.

Resolves #2607

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
