### PR TITLE
Visual C++ fixes and warnings

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -18,6 +18,7 @@
     <ProjectGuid>{916B91AB-A300-422C-B9C2-D683924DC109}</ProjectGuid>
     <RootNamespace>stellar-core</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <UseNativeEnvironment>true</UseNativeEnvironment>
   </PropertyGroup>
   <PropertyGroup>
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -367,13 +367,14 @@ TEST_CASE("manualclose", "[commandhandler]")
         }
     }
 
+    auto const maxLedgerNum =
+        static_cast<uint32_t>(std::numeric_limits<int32_t>::max() - 1);
+
     SECTION("manual close sequence number parameter that just barely does not "
             "overflow int32_t is accepted")
     {
         std::string retStr;
         REQUIRE(lastLedgerNum() == LedgerManager::GENESIS_LEDGER_SEQ);
-        auto maxLedgerNum =
-            static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
         submitClose(std::make_optional<uint32_t>(maxLedgerNum), noCloseTime,
                     retStr);
         CAPTURE(retStr);
@@ -385,11 +386,8 @@ TEST_CASE("manualclose", "[commandhandler]")
     {
         std::string retStr;
         REQUIRE_THROWS_AS(
-            submitClose(
-                std::make_optional<uint32_t>(
-                    static_cast<uint32_t>(std::numeric_limits<int32_t>::max()) +
-                    1),
-                noCloseTime, retStr),
+            submitClose(std::make_optional<uint32_t>(maxLedgerNum + 1),
+                        noCloseTime, retStr),
             std::invalid_argument);
     }
 

--- a/src/overlay/PeerManager.cpp
+++ b/src/overlay/PeerManager.cpp
@@ -360,12 +360,15 @@ namespace
 static std::chrono::seconds
 computeBackoff(size_t numFailures)
 {
-    constexpr const size_t SECONDS_PER_BACKOFF = 10;
+    constexpr const uint32 SECONDS_PER_BACKOFF = 10;
     constexpr const size_t MAX_BACKOFF_EXPONENT = 10;
 
-    size_t backoffCount = std::min<size_t>(MAX_BACKOFF_EXPONENT, numFailures);
-    auto nsecs = std::chrono::seconds(
-        std::rand() % ((1 << backoffCount) * SECONDS_PER_BACKOFF) + 1);
+    uint32 backoffCount = static_cast<uint32>(
+        std::min<size_t>(MAX_BACKOFF_EXPONENT, numFailures));
+    auto nsecs =
+        std::chrono::seconds(static_cast<uint32>(std::rand()) %
+                                 ((1u << backoffCount) * SECONDS_PER_BACKOFF) +
+                             1);
     return nsecs;
 }
 }

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -1058,7 +1058,7 @@ TEST_CASE("inbounds nodes can be promoted to ouboundvalid",
         OUTBOUND
     };
 
-    auto getTestPeerType = [&](int i, int j) {
+    auto getTestPeerType = [&](size_t i, size_t j) {
         auto& node = nodes[i];
         auto peer =
             node->getOverlayManager().getPeerManager().load(addresses[j]);

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -772,13 +772,17 @@ getSellingLiabilities(LedgerTxnHeader const& header,
     return getSellingLiabilities(header.current(), entry.current());
 }
 
-uint64_t
+SequenceNumber
 getStartingSequenceNumber(uint32_t ledgerSeq)
 {
-    return static_cast<uint64_t>(ledgerSeq) << 32;
+    if (ledgerSeq > static_cast<uint32_t>(std::numeric_limits<int32_t>::max()))
+    {
+        throw std::runtime_error("overflowed getStartingSequenceNumber");
+    }
+    return static_cast<SequenceNumber>(ledgerSeq) << 32;
 }
 
-uint64_t
+SequenceNumber
 getStartingSequenceNumber(LedgerTxnHeader const& header)
 {
     return getStartingSequenceNumber(header.current().ledgerSeq);

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -151,8 +151,8 @@ int64_t getSellingLiabilities(LedgerHeader const& header,
 int64_t getSellingLiabilities(LedgerTxnHeader const& header,
                               LedgerTxnEntry const& offer);
 
-uint64_t getStartingSequenceNumber(uint32_t ledgerSeq);
-uint64_t getStartingSequenceNumber(LedgerTxnHeader const& header);
+SequenceNumber getStartingSequenceNumber(uint32_t ledgerSeq);
+SequenceNumber getStartingSequenceNumber(LedgerTxnHeader const& header);
 
 bool isAuthorized(LedgerEntry const& le);
 bool isAuthorized(LedgerTxnEntry const& entry);

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -3,7 +3,6 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "util/Backtrace.h"
-#include "config.h"
 #include "util/GlobalChecks.h"
 #include <cstdio>
 #include <cstdlib>

--- a/src/util/test/CacheTests.cpp
+++ b/src/util/test/CacheTests.cpp
@@ -106,7 +106,7 @@ TEST_CASE("RandomEvictionCache does not thrash",
 {
     gRandomEngine.seed(std::time(nullptr) & UINT32_MAX);
     size_t sz = 1000;
-    RandomEvictionCache<int, int> cache(sz);
+    RandomEvictionCache<size_t, size_t> cache(sz);
     auto const& ctrs = cache.getCounters();
     // Fill the cache and then over-fill it by 1, so it expires an entry. In
     // LRU-land this can be the beginning of the end.

--- a/src/work/test/WorkTests.cpp
+++ b/src/work/test/WorkTests.cpp
@@ -770,10 +770,10 @@ TEST_CASE("WorkSequence test", "[work]")
 class TestBatchWork : public BatchWork
 {
     bool mShouldFail;
-    int mTotalWorks;
+    size_t mTotalWorks;
 
   public:
-    int mCount{0};
+    size_t mCount{0};
     std::vector<std::weak_ptr<BasicWork>> mBatchedWorks;
     TestBatchWork(Application& app, std::string const& name, bool fail = false)
         : BatchWork(app, name)


### PR DESCRIPTION
This PR works around a problem when building release builds with the latest version of Visual C++ (unclear if this was introduced recently or not).

It also fixes a few warnings that were introduced in a recent commit (mismatch between signed and unsigned types).
