### PR TITLE
Only define gExplicitSeed when BUILD_TEST is

### DIFF
--- a/src/crypto/ShortHash.cpp
+++ b/src/crypto/ShortHash.cpp
@@ -14,7 +14,9 @@ namespace shortHash
 static unsigned char gKey[crypto_shorthash_KEYBYTES];
 static std::mutex gKeyMutex;
 static bool gHaveHashed{false};
+#ifdef BUILD_TESTS
 static unsigned int gExplicitSeed{0};
+#endif
 
 void
 initialize()


### PR DESCRIPTION
Avoids an 'unused variable' warning that might trigger with some compilers.