### PR TITLE
SCP: Remove unused includes of crypto/SHA.h

### DIFF
--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -6,7 +6,6 @@
 
 #include "Slot.h"
 #include "crypto/Hex.h"
-#include "crypto/SHA.h"
 #include "lib/json/json.h"
 #include "scp/LocalNode.h"
 #include "scp/QuorumSetUtils.h"

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -6,7 +6,6 @@
 
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
-#include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
 #include "lib/json/json.h"
 #include "scp/QuorumSetUtils.h"

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -6,7 +6,6 @@
 
 #include "Slot.h"
 #include "crypto/Hex.h"
-#include "crypto/SHA.h"
 #include "lib/json/json.h"
 #include "scp/LocalNode.h"
 #include "scp/QuorumSetUtils.h"

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -4,7 +4,6 @@
 
 #include "scp/SCP.h"
 #include "crypto/Hex.h"
-#include "crypto/SHA.h"
 #include "scp/LocalNode.h"
 #include "scp/Slot.h"
 #include "util/GlobalChecks.h"

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -5,7 +5,6 @@
 #include "Slot.h"
 
 #include "crypto/Hex.h"
-#include "crypto/SHA.h"
 #include "lib/json/json.h"
 #include "main/ErrorMessages.h"
 #include "scp/LocalNode.h"


### PR DESCRIPTION
SCP was made mostly independent of the underlying crypto implementation,
so those includes are just leftovers.
