### PR TITLE
Change OperationID to use an AccountID instead of MuxedAccount

### DIFF
--- a/src/test/TestAccount.cpp
+++ b/src/test/TestAccount.cpp
@@ -362,7 +362,7 @@ TestAccount::getBalanceID(uint32_t opIndex, SequenceNumber sn)
 
     OperationID operationID;
     operationID.type(ENVELOPE_TYPE_OP_ID);
-    operationID.id().sourceAccount = toMuxedAccount(getPublicKey());
+    operationID.id().sourceAccount = getPublicKey();
     operationID.id().seqNum = sn;
     operationID.id().opNum = opIndex;
 

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -312,7 +312,7 @@ CreateClaimableBalanceOpFrame::getBalanceID()
 {
     OperationID operationID;
     operationID.type(ENVELOPE_TYPE_OP_ID);
-    operationID.id().sourceAccount = toMuxedAccount(mParentTx.getSourceID());
+    operationID.id().sourceAccount = mParentTx.getSourceID();
     operationID.id().seqNum = mParentTx.getSeqNum();
     operationID.id().opNum = mOpIndex;
 

--- a/src/xdr/Stellar-transaction.x
+++ b/src/xdr/Stellar-transaction.x
@@ -472,7 +472,7 @@ union OperationID switch (EnvelopeType type)
 case ENVELOPE_TYPE_OP_ID:
     struct
     {
-        MuxedAccount sourceAccount;
+        AccountID sourceAccount;
         SequenceNumber seqNum;
         uint32 opNum;
     } id;


### PR DESCRIPTION
# Description

Implements https://github.com/stellar/stellar-protocol/pull/968.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
