### PR TITLE
Store LedgerEntry in trustline table

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -62,7 +62,7 @@ bool Database::gDriversRegistered = false;
 
 // smallest schema version supported
 static unsigned long const MIN_SCHEMA_VERSION = 13;
-static unsigned long const SCHEMA_VERSION = 14;
+static unsigned long const SCHEMA_VERSION = 15;
 
 // These should always match our compiled version precisely, since we are
 // using a bundled version to get access to carray(). But in case someone
@@ -207,6 +207,9 @@ Database::applySchemaUpgrade(unsigned long vers)
     {
     case 14:
         mApp.getPersistentState().setRebuildForType(OFFER);
+        break;
+    case 15:
+        mApp.getPersistentState().setRebuildForType(TRUSTLINE);
         break;
     default:
         throw std::runtime_error("Unknown DB schema version");

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -338,9 +338,7 @@ class WorstBestOfferIterator
     std::shared_ptr<OfferDescriptor const> const& offerDescriptor() const;
 };
 
-void getTrustLineStrings(AccountID const& accountID, Asset const& asset,
-                         std::string& accountIDStr, std::string& issuerStr,
-                         std::string& assetCodeStr, uint32_t ledgerVersion);
+void validateTrustLineKey(uint32_t ledgerVersion, LedgerKey const& key);
 
 // An abstraction for an object that can be the parent of an AbstractLedgerTxn
 // (discussed below). Allows children to commit atomically to the parent. Has no

--- a/src/ledger/LedgerTxnClaimableBalanceSQL.cpp
+++ b/src/ledger/LedgerTxnClaimableBalanceSQL.cpp
@@ -3,27 +3,10 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "ledger/LedgerTxnImpl.h"
-#include "util/Decoder.h"
 #include "util/types.h"
 
 namespace stellar
 {
-
-template <typename T>
-std::string
-toOpaqueBase64(T const& input)
-{
-    return decoder::encode_b64(xdr::xdr_to_opaque(input));
-}
-
-template <typename T>
-void
-fromOpaqueBase64(T& res, std::string const& opaqueBase64)
-{
-    std::vector<uint8_t> opaque;
-    decoder::decode_b64(opaqueBase64, opaque);
-    xdr::xdr_from_opaque(opaque, res);
-}
 
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::loadClaimableBalance(LedgerKey const& key) const

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -898,6 +898,22 @@ class LedgerTxnRoot::Impl
 #endif
 };
 
+template <typename T>
+std::string
+toOpaqueBase64(T const& input)
+{
+    return decoder::encode_b64(xdr::xdr_to_opaque(input));
+}
+
+template <typename T>
+void
+fromOpaqueBase64(T& res, std::string const& opaqueBase64)
+{
+    std::vector<uint8_t> opaque;
+    decoder::decode_b64(opaqueBase64, opaque);
+    xdr::xdr_from_opaque(opaque, res);
+}
+
 #ifdef USE_POSTGRES
 template <typename T>
 inline void

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -1355,9 +1355,7 @@ TEST_CASE("LedgerTxn load", "[ledgertxn]")
                         auto key = trustlineKey(acc2.getPublicKey(), asset);
 
                         // verify that this doesn't throw before V15
-                        getTrustLineStrings(key.trustLine().accountID,
-                                            key.trustLine().asset, accountIDStr,
-                                            issuerStr, assetCodeStr, 14);
+                        validateTrustLineKey(14, key);
 
                         REQUIRE_THROWS_AS(ltx1.load(key),
                                           NonSociRelatedException);


### PR DESCRIPTION
# Description

This PR stores the full `LedgerEntry` instead of the individual fields into the trustlines table. This is the first step to storing different kinds of trustlines (like trustlines for pool shares).

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
