### PR TITLE
make static arrays safe (old style doesn't enforce proper size at compile time)

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -118,8 +118,8 @@ HerderImpl::syncMetrics()
 std::string
 HerderImpl::getStateHuman() const
 {
-    static const char* stateStrings[HERDER_NUM_STATE] = {
-        "HERDER_SYNCING_STATE", "HERDER_TRACKING_STATE"};
+    static std::array<const char*, HERDER_NUM_STATE> stateStrings =
+        std::array{"HERDER_SYNCING_STATE", "HERDER_TRACKING_STATE"};
     return std::string(stateStrings[getState()]);
 }
 

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -29,9 +29,10 @@ namespace stellar
 {
 const uint64_t TransactionQueue::FEE_MULTIPLIER = 10;
 
-const char* TX_STATUS_STRING[static_cast<int>(
-    TransactionQueue::AddResult::ADD_STATUS_COUNT)] = {
-    "PENDING", "DUPLICATE", "ERROR", "TRY_AGAIN_LATER", "FILTERED"};
+std::array<const char*,
+           static_cast<int>(TransactionQueue::AddResult::ADD_STATUS_COUNT)>
+    TX_STATUS_STRING = std::array{"PENDING", "DUPLICATE", "ERROR",
+                                  "TRY_AGAIN_LATER", "FILTERED"};
 
 TransactionQueue::TransactionQueue(Application& app, uint32 pendingDepth,
                                    uint32 banDepth, uint32 poolLedgerMultiplier)

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -222,7 +222,9 @@ class TransactionQueue
 #endif
 };
 
-extern const char* TX_STATUS_STRING[static_cast<int>(
-    TransactionQueue::AddResult::ADD_STATUS_COUNT)];
+extern std::array<const char*,
+                  static_cast<int>(
+                      TransactionQueue::AddResult::ADD_STATUS_COUNT)>
+    TX_STATUS_STRING;
 
 }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -182,7 +182,7 @@ LedgerManagerImpl::getState() const
 std::string
 LedgerManagerImpl::getStateHuman() const
 {
-    static const char* stateStrings[LM_NUM_STATE] = {
+    static std::array<const char*, LM_NUM_STATE> stateStrings = std::array{
         "LM_BOOTING_STATE", "LM_SYNCED_STATE", "LM_CATCHING_UP_STATE"};
     return std::string(stateStrings[getState()]);
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -994,9 +994,9 @@ ApplicationImpl::getState() const
 std::string
 ApplicationImpl::getStateHuman() const
 {
-    static const char* stateStrings[APP_NUM_STATE] = {
-        "Booting",     "Joining SCP", "Connected",
-        "Catching up", "Synced!",     "Stopping"};
+    static std::array<const char*, APP_NUM_STATE> stateStrings =
+        std::array{"Booting",     "Joining SCP", "Connected",
+                   "Catching up", "Synced!",     "Stopping"};
     return std::string(stateStrings[getState()]);
 }
 

--- a/src/scp/BallotProtocol.cpp
+++ b/src/scp/BallotProtocol.cpp
@@ -1994,8 +1994,8 @@ BallotProtocol::sendLatestEnvelope()
     }
 }
 
-const char* BallotProtocol::phaseNames[SCP_PHASE_NUM] = {"PREPARE", "FINISH",
-                                                         "EXTERNALIZE"};
+std::array<const char*, BallotProtocol::SCP_PHASE_NUM>
+    BallotProtocol::phaseNames = std::array{"PREPARE", "FINISH", "EXTERNALIZE"};
 
 Json::Value
 BallotProtocol::getJsonInfo()

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -39,7 +39,7 @@ class BallotProtocol
         SCP_PHASE_NUM
     };
     // human readable names matching SCPPhase
-    static const char* phaseNames[];
+    static std::array<const char*, SCP_PHASE_NUM> phaseNames;
 
     class SCPBallotWrapper
     {


### PR DESCRIPTION
This compiles, but we really don't want it to be the case:
```
   std::array<int, 2> foo = { 100 }; // 1 element initialized!
   int bar[2] = { 100 }; // 1 element initialized!
```

We can force size checking by using C++17's type deduction that lets the compiler figure out the parameters to `std::array` .
