### PR TITLE
Initialize CommandHandler last

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -239,7 +239,6 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
     mHistoryManager = HistoryManager::create(*this);
     mInvariantManager = createInvariantManager();
     mMaintainer = std::make_unique<Maintainer>(*this);
-    mCommandHandler = std::make_unique<CommandHandler>(*this);
     mWorkScheduler = WorkScheduler::create(*this);
     mBanManager = BanManager::create(*this);
     mStatusManager = std::make_unique<StatusManager>();
@@ -287,6 +286,10 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
     // initialization and newDB run, as it relies on tmp dir created in the
     // constructor
     mProcessManager = ProcessManager::create(*this);
+
+    // After everything is initialized, start accepting HTTP commands
+    mCommandHandler = std::make_unique<CommandHandler>(*this);
+
     LOG_DEBUG(DEFAULT_LOG, "Application constructed");
 }
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -159,7 +159,6 @@ class ApplicationImpl : public Application
     std::unique_ptr<InvariantManager> mInvariantManager;
     std::unique_ptr<Maintainer> mMaintainer;
     std::shared_ptr<ProcessManager> mProcessManager;
-    std::unique_ptr<CommandHandler> mCommandHandler;
     std::shared_ptr<WorkScheduler> mWorkScheduler;
     std::unique_ptr<PersistentState> mPersistentState;
     std::unique_ptr<BanManager> mBanManager;
@@ -178,6 +177,8 @@ class ApplicationImpl : public Application
     // ever grows beyond RAM-size you need to use a mode with some sort of
     // database on secondary storage.
     std::unique_ptr<LedgerTxn> mNeverCommittingLedgerTxn;
+
+    std::unique_ptr<CommandHandler> mCommandHandler;
 
 #ifdef BUILD_TESTS
     std::unique_ptr<LoadGenerator> mLoadGenerator;


### PR DESCRIPTION
This change fixes #3076 by initializing CommandHandler last, so the user can't issue HTTP commands until all of the Application components are fully initialized.