### PR TITLE
Create multi-operation transactions in LoadGen

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -590,6 +590,7 @@ exit /b 0
     <ClCompile Include="..\..\src\simulation\LoadGenerator.cpp" />
     <ClCompile Include="..\..\src\simulation\Simulation.cpp" />
     <ClCompile Include="..\..\src\simulation\Topologies.cpp" />
+    <ClCompile Include="..\..\src\simulation\test\LoadGeneratorTests.cpp" />
     <ClCompile Include="..\..\src\test\fuzz.cpp" />
     <ClCompile Include="..\..\src\test\test.cpp" />
     <ClCompile Include="..\..\src\test\TestAccount.cpp" />
@@ -858,6 +859,7 @@ exit /b 0
     <ClInclude Include="..\..\src\simulation\LoadGenerator.h" />
     <ClInclude Include="..\..\src\simulation\Simulation.h" />
     <ClInclude Include="..\..\src\simulation\Topologies.h" />
+    <ClInclude Include="..\..\src\simulation\test\LoadGeneratorTests.cpp" />
     <ClInclude Include="..\..\src\test\fuzz.h" />
     <ClInclude Include="..\..\src\test\SimpleTestReporter.h" />
     <ClInclude Include="..\..\src\test\test.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -252,6 +252,9 @@
     <ClCompile Include="..\..\src\simulation\Topologies.cpp">
       <Filter>simulation</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\simulation\test\LoadGeneratorTests.cpp">
+      <Filter>simulation</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\scp\SCP.cpp">
       <Filter>scp</Filter>
     </ClCompile>
@@ -1265,6 +1268,9 @@
     <ClInclude Include="..\..\src\simulation\Topologies.h">
       <Filter>simulation</Filter>
     </ClInclude>
+    <ClCompile Include="..\..\src\simulation\test\LoadGeneratorTests.cpp">
+      <Filter>simulation</Filter>
+    </ClCompile>
     <ClInclude Include="..\..\lib\json\json.h">
       <Filter>lib\json</Filter>
     </ClInclude>

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -65,6 +65,7 @@ ledger.transaction.count                 | histogram | number of transactions pe
 ledger.transaction.internal-error        | counter   | number of internal errors since start
 loadgen.account.created                  | meter     | loadgenerator: account created
 loadgen.payment.native                   | meter     | loadgenerator: native payment submitted
+loadgen.pretend.submitted                | meter     | loadgenerator: pretend ops submitted
 loadgen.run.complete                     | meter     | loadgenerator: run complete
 loadgen.step.count                       | meter     | loadgenerator: generated some transactions
 loadgen.step.submit                      | timer     | loadgenerator: time spent submiting transactions per step

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -274,13 +274,23 @@ format.
 
 ### The following HTTP commands are exposed on test instances
 * **generateload**
-  `generateload[?mode=(create|pay)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L&spikesize=S&spikeinterval=I]`<br>
+  `generateload[?mode=(create|pay|pretend)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L&spikesize=S&spikeinterval=I]`<br>
   Artificially generate load for testing; must be used with
-  `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true. Depending on the mode,
-  either creates new accounts or generates payments on accounts specified
-  (where number of accounts can be offset). Additionally, allows batching up to
-  100 account creations per transaction via 'batchsize'.
-  When a nonzero I is given, a spike will occur every I seconds injecting S transactions on top of `txrate`.
+  `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
+  * `create` mode creates new accounts.
+    Additionally, allows batching up to 100 account creations per transaction via 'batchsize'.
+  * `pay` mode generates `PaymentOp` transactions on accounts specified
+    (where the number of accounts can be offset).
+  * `pretend` mode generates transactions on accounts specified
+    (where the number of accounts can be offset). Operations in `pretend` mode are
+    designed to have a realistic size to help users "pretend" that they have real traffic.
+    You can add optional configs `LOADGEN_OP_COUNT_FOR_TESTING` and
+    `LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING` in the config file to specify
+    the # of ops / tx and how often they appear. More specifically, the probability
+    that a transaction contains `COUNT[i]` ops is
+    `DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...)`.
+
+  For `pay` and `pretend`, when a nonzero I is given, a spike will occur every I seconds injecting S transactions on top of `txrate`.
 
 * **manualclose**
   If MANUAL_CLOSE is set to true in the .cfg file, this will cause the current

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -765,14 +765,19 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     // step 4
     mApp.getBucketManager().forgetUnreferencedBuckets();
 
-    if (!mApp.getConfig().getOpApplySleepTimeForTesting().empty())
+    if (!mApp.getConfig().OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
     {
         // Sleep for a parameterized amount of time in simulation mode
+        std::discrete_distribution<uint32> distribution(
+            mApp.getConfig().OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.begin(),
+            mApp.getConfig().OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.end());
         std::chrono::microseconds sleepFor{0};
         for (size_t i = 0; i < txSet->sizeOp(); i++)
         {
             sleepFor +=
-                rand_element(mApp.getConfig().getOpApplySleepTimeForTesting());
+                mApp.getConfig()
+                    .OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[distribution(
+                        gRandomEngine)];
         }
         std::chrono::microseconds applicationTime =
             closeLedgerTime.checkElapsedTime();

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -44,6 +44,7 @@ class BanManager;
 class StatusManager;
 class AbstractLedgerTxnParent;
 class BasicWork;
+enum class LoadGenMode;
 
 #ifdef BUILD_TESTS
 class LoadGenerator;
@@ -259,7 +260,7 @@ class Application
 #ifdef BUILD_TESTS
     // If config.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true, generate some load
     // against the current application.
-    virtual void generateLoad(bool isCreate, uint32_t nAccounts,
+    virtual void generateLoad(LoadGenMode mode, uint32_t nAccounts,
                               uint32_t offset, uint32_t nTxs, uint32_t txRate,
                               uint32_t batchSize,
                               std::chrono::seconds spikeInterval,

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -993,14 +993,14 @@ ApplicationImpl::advanceToLedgerBeforeManualCloseTarget(
 
 #ifdef BUILD_TESTS
 void
-ApplicationImpl::generateLoad(bool isCreate, uint32_t nAccounts,
+ApplicationImpl::generateLoad(LoadGenMode mode, uint32_t nAccounts,
                               uint32_t offset, uint32_t nTxs, uint32_t txRate,
                               uint32_t batchSize,
                               std::chrono::seconds spikeInterval,
                               uint32_t spikeSize)
 {
     getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
-    getLoadGenerator().generateLoad(isCreate, nAccounts, offset, nTxs, txRate,
+    getLoadGenerator().generateLoad(mode, nAccounts, offset, nTxs, txRate,
                                     batchSize, spikeInterval, spikeSize);
 }
 

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -104,7 +104,7 @@ class ApplicationImpl : public Application
                 std::optional<TimePoint> const& manualCloseTime) override;
 
 #ifdef BUILD_TESTS
-    virtual void generateLoad(bool isCreate, uint32_t nAccounts,
+    virtual void generateLoad(LoadGenMode mode, uint32_t nAccounts,
                               uint32_t offset, uint32_t nTxs, uint32_t txRate,
                               uint32_t batchSize,
                               std::chrono::seconds spikeInterval,

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -34,6 +34,7 @@
 #include "ExternalQueue.h"
 
 #ifdef BUILD_TESTS
+#include "simulation/LoadGenerator.h"
 #include "test/TestAccount.h"
 #include "test/TxTests.h"
 #endif
@@ -810,21 +811,9 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         std::map<std::string, std::string> map;
         http::server::server::parseParams(params, map);
 
-        bool isCreate;
-        std::string mode =
-            parseOptionalParamOrDefault<std::string>(map, "mode", "create");
-        if (mode == std::string("create"))
-        {
-            isCreate = true;
-        }
-        else if (mode == std::string("pay") || mode == std::string("pretend"))
-        {
-            isCreate = false;
-        }
-        else
-        {
-            throw std::runtime_error("Unknown mode.");
-        }
+        LoadGenMode mode = LoadGenerator::getMode(
+            parseOptionalParamOrDefault<std::string>(map, "mode", "create"));
+        bool isCreate = mode == LoadGenMode::CREATE;
 
         uint32_t nAccounts =
             parseOptionalParamOrDefault<uint32_t>(map, "accounts", 1000);
@@ -850,7 +839,7 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             retStr = "Setting batch size to its limit of 100.";
         }
 
-        mApp.generateLoad(isCreate, nAccounts, offset, nTxs, txRate, batchSize,
+        mApp.generateLoad(mode, nAccounts, offset, nTxs, txRate, batchSize,
                           spikeInterval, spikeSize);
 
         retStr += fmt::format(" Generating load: {:d} {:s}, {:d} tx/s",

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -817,7 +817,7 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         {
             isCreate = true;
         }
-        else if (mode == std::string("pay"))
+        else if (mode == std::string("pay") || mode == std::string("pretend"))
         {
             isCreate = false;
         }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -23,7 +23,6 @@
 #include <fmt/format.h>
 #include <functional>
 #include <numeric>
-#include <random>
 #include <sstream>
 #include <type_traits>
 #include <unordered_set>
@@ -757,11 +756,11 @@ Config::verifyLoadGenOpCountForTestingConfigs()
 
     if (!std::all_of(LOADGEN_OP_COUNT_FOR_TESTING.begin(),
                      LOADGEN_OP_COUNT_FOR_TESTING.end(),
-                     [](unsigned short i) { return 0 <= i && i <= 100; }))
+                     [](unsigned short i) { return 1 <= i && i <= 100; }))
     {
         throw std::invalid_argument(
             "All elements in NUM_OPS_PER_TX_COUNT_FOR_TESTING must be "
-            "integers in [0, 100]");
+            "integers in [1, 100]");
     }
 }
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -197,13 +197,17 @@ class Config : public std::enable_shared_from_this<Config>
     bool ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING;
 
     // Config parameters that force transaction application during ledger
-    // close to sleep for OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[i]
-    // microseconds OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i]% of the time for
-    // each i. These options are only for consensus and overlay simulation
-    // testing. These two must be used together.
+    // close to sleep for a certain amount of time.
+    // The probability that it sleeps for
+    // OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING[i] microseconds is
+    // OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[i] divided by
+    // (OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[0] +
+    // OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING[1] + ...) for each i. These
+    // options are only for consensus and overlay simulation testing. These two
+    // must be used together.
     std::vector<std::chrono::microseconds>
         OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING;
-    std::vector<unsigned short> OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING;
+    std::vector<uint32> OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING;
 
     // Config parameters that LoadGen uses to decide the number of operations
     // to include in each transaction and its distribution.
@@ -463,10 +467,6 @@ class Config : public std::enable_shared_from_this<Config>
     // line arguments.
     static std::string const STDIN_SPECIAL_NAME;
 
-    std::vector<std::chrono::microseconds> const&
-    getOpApplySleepTimeForTesting() const;
-
-    std::vector<std::chrono::microseconds>
-    processOpApplySleepTimeForTestingConfigs();
+    void processOpApplySleepTimeForTestingConfigs();
 };
 }

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -101,6 +101,8 @@ class Config : public std::enable_shared_from_this<Config>
     void verifyHistoryValidatorsBlocking(
         std::vector<ValidatorEntry> const& validators);
 
+    void verifyLoadGenOpCountForTestingConfigs();
+
     std::vector<std::chrono::microseconds> mOpApplySleepTimeForTesting;
 
   public:
@@ -202,6 +204,14 @@ class Config : public std::enable_shared_from_this<Config>
     std::vector<std::chrono::microseconds>
         OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING;
     std::vector<unsigned short> OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING;
+
+    // Config parameters that LoadGen uses to decide the number of operations
+    // to include in each transaction and its distribution.
+    // The probability that transactions will contain COUNT[i] operations
+    // is DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...) for each
+    // i.
+    std::vector<unsigned short> LOADGEN_OP_COUNT_FOR_TESTING;
+    std::vector<uint32> LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING;
 
     // A config parameter that allows a node to generate buckets. This should
     // be set to `false` only for testing purposes.

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -226,7 +226,8 @@ TEST_CASE("application setup", "[applicationutils]")
 
         // Generate a bit of load, and crank for some time
         auto& loadGen = validator->getLoadGenerator();
-        loadGen.generateLoad(true, /* nAccounts */ 10, 0, 0, /*txRate*/ 1,
+        loadGen.generateLoad(LoadGenMode::CREATE, /* nAccounts */ 10, 0, 0,
+                             /*txRate*/ 1,
                              /*batchSize*/ 1, std::chrono::seconds(0), 0);
 
         auto& loadGenDone = validator->getMetrics().NewMeter(

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -394,7 +394,8 @@ TEST_CASE(
     auto& app = *nodes[0]; // pick a node to generate load
 
     auto& loadGen = app.getLoadGenerator();
-    loadGen.generateLoad(true, 3, 0, 0, 10, 100, std::chrono::seconds(0), 0);
+    loadGen.generateLoad(LoadGenMode::CREATE, 3, 0, 0, 10, 100,
+                         std::chrono::seconds(0), 0);
     try
     {
         simulation->crankUntil(
@@ -407,8 +408,8 @@ TEST_CASE(
             },
             3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
 
-        loadGen.generateLoad(false, 3, 0, 10, 10, 100, std::chrono::seconds(0),
-                             0);
+        loadGen.generateLoad(LoadGenMode::PAY, 3, 0, 10, 10, 100,
+                             std::chrono::seconds(0), 0);
         simulation->crankUntil(
             [&]() {
                 return simulation->haveAllExternalized(8, 2) &&
@@ -521,8 +522,8 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
     uint32_t numItems = 500000;
 
     // Create accounts
-    loadGen.generateLoad(true, numItems, 0, 0, 10, 100, std::chrono::seconds(0),
-                         0);
+    loadGen.generateLoad(LoadGenMode::CREATE, numItems, 0, 0, 10, 100,
+                         std::chrono::seconds(0), 0);
 
     auto& complete =
         appPtr->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
@@ -537,7 +538,7 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
     txtime.Clear();
 
     // Generate payment txs
-    loadGen.generateLoad(false, numItems, 0, numItems / 10, 10, 100,
+    loadGen.generateLoad(LoadGenMode::PAY, numItems, 0, numItems / 10, 10, 100,
                          std::chrono::seconds(0), 0);
     while (!io.stopped() && complete.count() == 1)
     {
@@ -572,8 +573,8 @@ netTopologyTest(std::string const& name,
         auto& app = *nodes[0];
 
         auto& loadGen = app.getLoadGenerator();
-        loadGen.generateLoad(true, 50, 0, 0, 10, 100, std::chrono::seconds(0),
-                             0);
+        loadGen.generateLoad(LoadGenMode::CREATE, 50, 0, 0, 10, 100,
+                             std::chrono::seconds(0), 0);
         auto& complete =
             app.getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
 

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -25,11 +25,20 @@ namespace stellar
 
 class VirtualTimer;
 
+enum class LoadGenMode
+{
+    CREATE,
+    PAY,
+    PRETEND
+};
+
 class LoadGenerator
 {
   public:
     using TestAccountPtr = std::shared_ptr<TestAccount>;
     LoadGenerator(Application& app);
+
+    static LoadGenMode getMode(std::string const& mode);
 
     // Generate one "step" worth of load (assuming 1 step per STEP_MSECS) at a
     // given target number of accounts and txs, and a given target tx/s rate.
@@ -40,7 +49,7 @@ class LoadGenerator
     //                Set this to 0 if no spikes are needed.
     // spikeSize: The number of transactions a spike injects on top of the
     // steady rate.
-    void generateLoad(bool isCreate, uint32_t nAccounts, uint32_t offset,
+    void generateLoad(LoadGenMode mode, uint32_t nAccounts, uint32_t offset,
                       uint32_t nTxs, uint32_t txRate, uint32_t batchSize,
                       std::chrono::seconds spikeInterval, uint32_t spikeSize);
 
@@ -54,6 +63,7 @@ class LoadGenerator
     {
         medida::Meter& mAccountCreated;
         medida::Meter& mNativePayment;
+        medida::Meter& mPretendOps;
         medida::Meter& mTxnAttempted;
         medida::Meter& mTxnRejected;
         medida::Meter& mTxnBytes;
@@ -62,24 +72,23 @@ class LoadGenerator
         void report();
     };
 
-    struct TxInfo
-    {
-        TestAccountPtr mFrom;
-        std::vector<Operation> mOps;
-        // There are a few scenarios where tx submission might fail:
-        // * ADD_STATUS_DUPLICATE, should be just a no-op and not count toward
-        // total tx goal.
-        // * ADD_STATUS_TRY_AGAIN_LATER, transaction is banned/dropped. This
-        // indicates that the system is getting overloaded, so loadgen fails.
-        // * ADD_STATUS_ERROR, transaction didn't pass validation checks. If
-        // failure is due to txBAD_SEQ, synchronize accounts with the DB and
-        // re-submit. Any other code points to a loadgen misconfigurations, as
-        // transactions must have valid (pre-generated) source accounts,
-        // sufficient balances etc.
-        TransactionQueue::AddResult execute(Application& app, bool isCreate,
-                                            TransactionResultCode& code,
-                                            int32_t batchSize);
-    };
+    // There are a few scenarios where tx submission might fail:
+    // * ADD_STATUS_DUPLICATE, should be just a no-op and not count toward
+    // total tx goal.
+    // * ADD_STATUS_TRY_AGAIN_LATER, transaction is banned/dropped. This
+    // indicates that the system is getting overloaded, so loadgen fails.
+    // * ADD_STATUS_ERROR, transaction didn't pass validation checks. If
+    // failure is due to txBAD_SEQ, synchronize accounts with the DB and
+    // re-submit. Any other code points to a loadgen misconfigurations, as
+    // transactions must have valid (pre-generated) source accounts,
+    // sufficient balances etc.
+    TransactionQueue::AddResult execute(TransactionFramePtr& txf,
+                                        LoadGenMode mode,
+                                        TransactionResultCode& code,
+                                        int32_t batchSize);
+    TransactionFramePtr createTransactionFramePtr(TestAccountPtr from,
+                                                  std::vector<Operation> ops,
+                                                  LoadGenMode mode);
 
     static const uint32_t STEP_MSECS;
     static const uint32_t TX_SUBMIT_MAX_TRIES;
@@ -109,7 +118,7 @@ class LoadGenerator
                          uint32_t spikeSize);
 
     // Schedule a callback to generateLoad() STEP_MSECS milliseconds from now.
-    void scheduleLoadGeneration(bool isCreate, uint32_t nAccounts,
+    void scheduleLoadGeneration(LoadGenMode mode, uint32_t nAccounts,
                                 uint32_t offset, uint32_t nTxs, uint32_t txRate,
                                 uint32_t batchSize,
                                 std::chrono::seconds spikeInterval,
@@ -124,26 +133,33 @@ class LoadGenerator
     pickAccountPair(uint32_t numAccounts, uint32_t offset, uint32_t ledgerNum,
                     uint64_t sourceAccountId);
     TestAccountPtr findAccount(uint64_t accountId, uint32_t ledgerNum);
-    LoadGenerator::TxInfo paymentTransaction(uint32_t numAccounts,
-                                             uint32_t offset,
-                                             uint32_t ledgerNum,
-                                             uint64_t sourceAccount);
+    std::pair<TestAccountPtr, TransactionFramePtr>
+    paymentTransaction(uint32_t numAccounts, uint32_t offset,
+                       uint32_t ledgerNum, uint64_t sourceAccount);
+    std::pair<TestAccountPtr, TransactionFramePtr>
+    pretendTransaction(uint32_t numAccounts, uint32_t offset,
+                       uint32_t ledgerNum, uint64_t sourceAccount,
+                       uint32_t opCount);
     void maybeHandleFailedTx(TestAccountPtr sourceAccount,
                              TransactionQueue::AddResult status,
                              TransactionResultCode code);
-    TxInfo creationTransaction(uint64_t startAccount, uint64_t numItems,
-                               uint32_t ledgerNum);
-    void logProgress(std::chrono::nanoseconds submitTimer, bool isCreate,
+    std::pair<TestAccountPtr, TransactionFramePtr>
+    creationTransaction(uint64_t startAccount, uint64_t numItems,
+                        uint32_t ledgerNum);
+    void logProgress(std::chrono::nanoseconds submitTimer, LoadGenMode mode,
                      uint32_t nAccounts, uint32_t nTxs, uint32_t batchSize,
                      uint32_t txRate);
 
     uint32_t submitCreationTx(uint32_t nAccounts, uint32_t offset,
                               uint32_t batchSize, uint32_t ledgerNum);
-    uint32_t submitPaymentTx(uint32_t nAccounts, uint32_t offset,
-                             uint32_t batchSize, uint32_t ledgerNum,
-                             uint32_t nTxs);
+    uint32_t submitPaymentOrPretendTx(uint32_t nAccounts, uint32_t offset,
+                                      uint32_t batchSize, uint32_t ledgerNum,
+                                      uint32_t nTxs, uint32_t opCount,
+                                      LoadGenMode mode);
     void waitTillComplete(bool isCreate);
 
     void updateMinBalance();
+
+    unsigned short chooseOpCount(Config const& cfg) const;
 };
 }

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/SHA.h"
+#include "crypto/SecretKey.h"
+#include "lib/catch.hpp"
+#include "main/Config.h"
+#include "scp/QuorumSetUtils.h"
+#include "simulation/LoadGenerator.h"
+#include "simulation/Topologies.h"
+#include "test/test.h"
+#include "util/Math.h"
+#include <fmt/format.h>
+
+using namespace stellar;
+
+TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
+{
+    auto cfg = getTestConfig();
+
+    // 50% of transactions contain 2 ops,
+    // and 50% of transactions contain 3 ops.
+    cfg.LOADGEN_OP_COUNT_FOR_TESTING = {2, 3};
+    cfg.LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {1, 1};
+
+    Hash networkID = sha256(cfg.NETWORK_PASSPHRASE);
+    Simulation::pointer simulation =
+        Topologies::pair(Simulation::OVER_LOOPBACK, networkID);
+
+    simulation->startAllNodes();
+    simulation->crankUntil(
+        [&]() { return simulation->haveAllExternalized(3, 1); },
+        2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    auto nodes = simulation->getNodes();
+    auto& app = *nodes[0]; // pick a node to generate load
+
+    auto& loadGen = app.getLoadGenerator();
+    loadGen.generateLoad(LoadGenMode::CREATE, 3, 0, 0, 10, 100,
+                         std::chrono::seconds(0), 0);
+    try
+    {
+        simulation->crankUntil(
+            [&]() {
+                return app.getMetrics()
+                           .NewMeter({"loadgen", "run", "complete"}, "run")
+                           .count() == 1;
+            },
+            3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+        loadGen.generateLoad(LoadGenMode::PRETEND, 3, 0, 5, 10, 100,
+                             std::chrono::seconds(0), 0);
+
+        simulation->crankUntil(
+            [&]() {
+                return app.getMetrics()
+                           .NewMeter({"loadgen", "run", "complete"}, "run")
+                           .count() == 2;
+            },
+            2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+    }
+    catch (...)
+    {
+        auto problems = loadGen.checkAccountSynced(app, false);
+        REQUIRE(problems.empty());
+    }
+
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "txn", "rejected"}, "txn")
+                .count() == 0);
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "account", "created"}, "account")
+                .count() == 100);
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "payment", "native"}, "txn")
+                .count() == 0);
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "pretend", "submitted"}, "op")
+                .count() == 5);
+}

--- a/src/transactions/TransactionBridge.cpp
+++ b/src/transactions/TransactionBridge.cpp
@@ -111,6 +111,15 @@ setFee(TransactionFramePtr tx, uint32_t fee)
 }
 
 void
+setMemo(TransactionFramePtr tx, Memo memo)
+{
+    auto& env = tx->getEnvelope();
+    Memo& m =
+        env.type() == ENVELOPE_TYPE_TX_V0 ? env.v0().tx.memo : env.v1().tx.memo;
+    m = memo;
+}
+
+void
 setMinTime(TransactionFramePtr tx, TimePoint minTime)
 {
     auto& env = tx->getEnvelope();

--- a/src/transactions/TransactionBridge.h
+++ b/src/transactions/TransactionBridge.h
@@ -30,6 +30,8 @@ void setSeqNum(TransactionFramePtr tx, int64_t seq);
 
 void setFee(TransactionFramePtr tx, uint32_t fee);
 
+void setMemo(TransactionFramePtr tx, Memo memo);
+
 void setMinTime(TransactionFramePtr tx, TimePoint minTime);
 
 void setMaxTime(TransactionFramePtr tx, TimePoint maxTime);


### PR DESCRIPTION
# Description

Add a feature to create transactions with multiple operations in LoadGen

- In the config file, use `OP_SIZE_FOR_TESTING` and `TX_OVERHEAD_FOR_TESTING` to specify the op size and tx overhead.
- In the config file, use `NUM_OPS_PER_TX_COUNT_FOR_TESTING` and `NUM_OPS_PER_TX_WEIGHT_FOR_TESTING` to specify the distribution of operations counts of transactions.
- The parameters `txrate` and `txs` for the http endpoint remain the same. In other words, `txrate` is the rate of transactions. This change makes it possible to include more than one operations in each transaction that is generated at `txrate`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
