### PR TITLE
Herder: process old slots correctly

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -202,12 +202,11 @@ HerderImpl::processExternalized(uint64 slotIndex, StellarValue const& value)
 }
 
 void
-HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value)
+HerderImpl::valueExternalized(uint64 slotIndex, StellarValue const& value,
+                              bool isLatestSlot)
 {
     ZoneScoped;
     const int DUMP_SCP_TIMEOUT_SECONDS = 20;
-    // SCPDriver always updates tracking for latest slots
-    bool isLatestSlot = slotIndex == getCurrentLedgerSeq();
 
     if (isLatestSlot)
     {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -57,7 +57,8 @@ class HerderImpl : public Herder
     }
 
     void processExternalized(uint64 slotIndex, StellarValue const& value);
-    void valueExternalized(uint64 slotIndex, StellarValue const& value);
+    void valueExternalized(uint64 slotIndex, StellarValue const& value,
+                           bool isLatestSlot);
     void emitEnvelope(SCPEnvelope const& envelope);
 
     TransactionQueue::AddResult

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -789,7 +789,7 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
 
         recordSCPExecutionMetrics(slotIndex);
 
-        mHerder.valueExternalized(slotIndex, b);
+        mHerder.valueExternalized(slotIndex, b, isLatestSlot);
 
         // update externalize time so that we don't include the time spent in
         // `mHerder.valueExternalized`
@@ -797,7 +797,7 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
     }
     else
     {
-        mHerder.valueExternalized(slotIndex, b);
+        mHerder.valueExternalized(slotIndex, b, isLatestSlot);
     }
 }
 


### PR DESCRIPTION
This change fixes a bug in Herder, where older slots sometimes are processed as latest slots. The bug occurs if a node externalizes a ledger that is already closed but doesn't have messages from the network: for example, if the node is restarted with LCL=N, and receives enough messages to externalize N again.

The solution is to avoid reasoning based on `getCurrentLedgerSeq`, which is very confusing anyway, and explicitly pass `isLatestSlot` instead.