### PR TITLE
BucketManager: move garbage collection out of shutdown

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -207,7 +207,6 @@ class BucketManager : NonMovableOrCopyable
     virtual void assumeState(HistoryArchiveState const& has,
                              uint32_t maxProtocolVersion) = 0;
 
-    // Ensure all needed buckets are retained
     virtual void shutdown() = 0;
 
     virtual bool isShutdown() const = 0;

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -853,17 +853,13 @@ BucketManagerImpl::assumeState(HistoryArchiveState const& has,
 void
 BucketManagerImpl::shutdown()
 {
-    ZoneScoped;
-
-    if (!mIsShutdown)
+    if (mIsShutdown)
     {
-        mIsShutdown = true;
-
-        // This call happens in shutdown -- before destruction -- so that we
-        // can be sure other subsystems (ledger etc.) are still alive and we
-        // can call into them to figure out which buckets _are_ referenced.
-        forgetUnreferencedBuckets();
+        CLOG_WARNING(Bucket,
+                     "BucketManager: shutdown is called more than once");
     }
+
+    mIsShutdown = true;
 }
 
 bool

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -491,9 +491,7 @@ ApplicationImpl::~ApplicationImpl()
         {
             mProcessManager->shutdown();
         }
-        // As garbage collection performed on shutdown depends on LedgerManager
-        // and HistoryManager, ensure those are alive before calling `shutdown`
-        if (mBucketManager && mLedgerManager && mHistoryManager)
+        if (mBucketManager)
         {
             mBucketManager->shutdown();
         }
@@ -659,6 +657,10 @@ ApplicationImpl::gracefulStop()
     }
     if (mBucketManager)
     {
+        // This call happens in shutdown -- before destruction -- so that we can
+        // be sure other subsystems (ledger etc.) are still alive and we can
+        // call into them to figure out which buckets _are_ referenced.
+        mBucketManager->forgetUnreferencedBuckets();
         mBucketManager->shutdown();
     }
     if (mHerder)


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core/issues/3054

This change removes GC call from shutdown, making the app explicitly call it in `gracefulStop` instead. This prevents issues when destructing the app that is not fully initialized. 

Note: we still need to call shutdown in graceful stop and in the destructor, as we use BucketManager's state to determine if we need to stop merges in-progress.