### PR TITLE
In memory mode wants soci transactions

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -435,6 +435,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerTxnOfferSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnTrustLineSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\InMemoryLedgerTxnRoot.cpp" />
+    <ClCompile Include="..\..\src\ledger\InMemoryLedgerTxn.cpp" />
     <ClCompile Include="..\..\lib\asio.cpp" />
     <ClCompile Include="..\..\lib\http\connection.cpp" />
     <ClCompile Include="..\..\lib\http\connection_manager.cpp" />
@@ -792,6 +793,7 @@ exit /b 0
     <ClInclude Include="..\..\src\ledger\LedgerTxnHeader.h" />
     <ClInclude Include="..\..\src\ledger\LedgerTxnImpl.h" />
     <ClInclude Include="..\..\src\ledger\InMemoryLedgerTxnRoot.h" />
+    <ClInclude Include="..\..\src\ledger\InMemoryLedgerTxn.h" />
     <ClInclude Include="..\..\src\ledger\test\LedgerTestUtils.h" />
     <ClInclude Include="..\..\src\ledger\TrustLineWrapper.h" />
     <ClInclude Include="..\..\src\main\Application.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1014,6 +1014,9 @@
     <ClCompile Include="..\..\src\ledger\InMemoryLedgerTxnRoot.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\InMemoryLedgerTxn.cpp">
+      <Filter>ledger</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp">
       <Filter>ledger\tests</Filter>
     </ClCompile>
@@ -1902,6 +1905,9 @@
       <Filter>catchup</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ledger\InMemoryLedgerTxnRoot.h">
+      <Filter>ledger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ledger\InMemoryLedgerTxn.h">
       <Filter>ledger</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\crypto\Curve25519.h">

--- a/src/ledger/InMemoryLedgerTxn.cpp
+++ b/src/ledger/InMemoryLedgerTxn.cpp
@@ -1,0 +1,87 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/InMemoryLedgerTxn.h"
+#include "ledger/LedgerTxnImpl.h"
+#include "util/GlobalChecks.h"
+
+namespace stellar
+{
+
+InMemoryLedgerTxn::InMemoryLedgerTxn(InMemoryLedgerTxnRoot& parent,
+                                     Database& db)
+    : LedgerTxn(parent), mDb(db)
+{
+}
+
+InMemoryLedgerTxn::~InMemoryLedgerTxn()
+{
+}
+
+void
+InMemoryLedgerTxn::addChild(AbstractLedgerTxn& child)
+{
+    if (mTransaction)
+    {
+        throw std::runtime_error(
+            "Adding child to already-open InMemoryLedgerTxn");
+    }
+    LedgerTxn::addChild(child);
+    mTransaction = std::make_unique<soci::transaction>(mDb.getSession());
+}
+
+void
+InMemoryLedgerTxn::commitChild(EntryIterator iter, LedgerTxnConsistency cons)
+{
+    if (!mTransaction)
+    {
+        throw std::runtime_error(
+            "Committing child to non-open InMemoryLedgerTxn");
+    }
+    try
+    {
+        LedgerTxn::commitChild(iter, cons);
+        mTransaction->commit();
+        mTransaction.reset();
+    }
+    catch (std::exception& e)
+    {
+        printErrorAndAbort("fatal error during commit to InMemoryLedgerTxn: ",
+                           e.what());
+    }
+    catch (...)
+    {
+        printErrorAndAbort(
+            "unknown fatal error during commit to InMemoryLedgerTxn");
+    }
+}
+
+void
+InMemoryLedgerTxn::rollbackChild()
+{
+    if (!mTransaction)
+    {
+        throw std::runtime_error(
+            "Rolling back child on non-open InMemoryLedgerTxn");
+    }
+    try
+    {
+        LedgerTxn::rollbackChild();
+        mTransaction->rollback();
+        mTransaction.reset();
+    }
+    catch (std::exception& e)
+    {
+        printErrorAndAbort(
+            "fatal error when rolling back child of InMemoryLedgerTxn: ",
+            e.what());
+    }
+    catch (...)
+    {
+        printErrorAndAbort(
+            "unknown fatal error when rolling back child of InMemoryLedgerTxn");
+    }
+}
+
+}

--- a/src/ledger/InMemoryLedgerTxn.h
+++ b/src/ledger/InMemoryLedgerTxn.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "database/Database.h"
+#include "ledger/InMemoryLedgerTxnRoot.h"
+#include "ledger/LedgerTxn.h"
+
+// This is a (very small) extension of LedgerTxn to help implement in-memory
+// mode. In-memory mode only holds the _ledger_ contents in memory; it still has
+// a "small" SQL database storing some additional tables, and we still want to
+// have transactional atomicity on those tables in regions of code we have a
+// LedgerTxn open. So that's the _purpose_.
+//
+// On to messy implementation details: in-memory mode is implemented by
+// replacing the normal LedgerTxnRoot with a stub class InMemoryLedgerTxnRoot
+// that never issues _any_ SQL, and then substituting a subclass of LedgerTxn as
+// a fake root that stores LEs in memory (like any other LedgerTxn) but that we
+// never commit to its parent at all -- only commit children _to_. This class is
+// that subclass of LedgerTxn used as a fake root.
+//
+// Put diagrammatically:
+//
+//        "Normal" (DB-backed) ledger         "In-memory" ledger
+//      --------------------------------+----------------------------------
+//               LedgerTxnRoot          |     InMemoryLedgerTxnRoot
+//           has soci::transaction      |   has no soci::transaction
+//                                      |
+//               LedgerTxn              |       InMemoryLedgerTxn
+//        has no soci::transaction      |      has soci::transaction
+//
+//
+// In other words, in-memory mode _moves_ the soci::transaction from the root
+// to its first (never-closing) child, and commits to the DB when children
+// of that first never-closing child commit to it.
+
+namespace stellar
+{
+
+class InMemoryLedgerTxn : public LedgerTxn
+{
+    Database& mDb;
+    std::unique_ptr<soci::transaction> mTransaction;
+
+  public:
+    InMemoryLedgerTxn(InMemoryLedgerTxnRoot& parent, Database& db);
+    virtual ~InMemoryLedgerTxn();
+
+    void addChild(AbstractLedgerTxn& child) override;
+    void commitChild(EntryIterator iter, LedgerTxnConsistency cons) override;
+    void rollbackChild() override;
+};
+
+}

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -1,3 +1,7 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
 #include "ledger/InMemoryLedgerTxnRoot.h"
 #include "ledger/LedgerRange.h"
 #include "ledger/LedgerTxn.h"

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -1,3 +1,9 @@
+#pragma once
+
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
 #include "ledger/InternalLedgerEntry.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnImpl.h"

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -606,7 +606,7 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual bool hasSponsorshipEntry() const = 0;
 };
 
-class LedgerTxn final : public AbstractLedgerTxn
+class LedgerTxn : public AbstractLedgerTxn
 {
     class Impl;
     std::unique_ptr<Impl> mImpl;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // Copyright 2018 Stellar Development Foundation and contributors. Licensed
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -30,6 +30,7 @@
 #include "invariant/LedgerEntryIsValid.h"
 #include "invariant/LiabilitiesMatchOffers.h"
 #include "invariant/SponsorshipCountIsValid.h"
+#include "ledger/InMemoryLedgerTxn.h"
 #include "ledger/InMemoryLedgerTxnRoot.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
@@ -304,13 +305,13 @@ ApplicationImpl::resetLedgerState()
     if (getConfig().MODE_USES_IN_MEMORY_LEDGER)
     {
         mNeverCommittingLedgerTxn.reset();
-        mLedgerTxnRoot = std::make_unique<InMemoryLedgerTxnRoot>(
+        mInMemoryLedgerTxnRoot = std::make_unique<InMemoryLedgerTxnRoot>(
 #ifdef BEST_OFFER_DEBUGGING
             mConfig.BEST_OFFER_DEBUGGING_ENABLED
 #endif
         );
-        mNeverCommittingLedgerTxn =
-            std::make_unique<LedgerTxn>(*mLedgerTxnRoot);
+        mNeverCommittingLedgerTxn = std::make_unique<InMemoryLedgerTxn>(
+            *mInMemoryLedgerTxnRoot, getDatabase());
     }
     else
     {

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -33,6 +33,7 @@ class CommandHandler;
 class Database;
 class LedgerTxn;
 class LedgerTxnRoot;
+class InMemoryLedgerTxn;
 class InMemoryLedgerTxnRoot;
 class LoadGenerator;
 
@@ -168,18 +169,19 @@ class ApplicationImpl : public Application
     std::unique_ptr<StatusManager> mStatusManager;
     std::unique_ptr<AbstractLedgerTxnParent> mLedgerTxnRoot;
 
-    // This exists for use in MODE_USES_IN_MEMORY_LEDGER only: the
-    // mLedgerTxnRoot will be an InMemoryLedgerTxnRoot which is a _stub_
-    // AbstractLedgerTxnParent that refuses all commits and answers null to all
-    // queries; then an inner "never-committing" sub-LedgerTxn is constructed
-    // beneath it that serves as the "effective" in-memory root transaction,
-    // is returned when a client requests the root.
+    // These two exist for use in MODE_USES_IN_MEMORY_LEDGER only: the
+    // mInMemoryLedgerTxnRoot is a _stub_ AbstractLedgerTxnParent that refuses
+    // all commits and answers null to all queries; then an inner
+    // "never-committing" sub-LedgerTxn is constructed beneath it that serves as
+    // the "effective" in-memory root transaction, is returned when a client
+    // requests the root.
     //
     // Note that using this only works when the ledger can fit in RAM -- as it
     // is held in the never-committing LedgerTxn in its entirety -- so if it
     // ever grows beyond RAM-size you need to use a mode with some sort of
     // database on secondary storage.
-    std::unique_ptr<LedgerTxn> mNeverCommittingLedgerTxn;
+    std::unique_ptr<InMemoryLedgerTxnRoot> mInMemoryLedgerTxnRoot;
+    std::unique_ptr<InMemoryLedgerTxn> mNeverCommittingLedgerTxn;
 
     std::unique_ptr<CommandHandler> mCommandHandler;
 


### PR DESCRIPTION
This shows two possible fixes for an atomicity bug on non-ledger auxiliary tables in in-memory mode. Neither is particularly pretty -- one is simpler and more local, one is uglier and more invasive but more systematic. We should only keep one.