### PR TITLE
Update SponsorshipUtils to handle pool share trustlines

### DIFF
--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -14,17 +14,38 @@
 namespace stellar
 {
 
+static bool
+isPoolShareTrustline(LedgerEntry const& le)
+{
+    return le.data.type() == TRUSTLINE &&
+           le.data.trustLine().asset.type() == ASSET_TYPE_POOL_SHARE;
+}
+
 static int32_t
 calculateDelta(LedgerEntry const* current, LedgerEntry const* previous)
 {
     int32_t delta = 0;
     if (current)
     {
-        ++delta;
+        if (isPoolShareTrustline(*current))
+        {
+            delta += 2;
+        }
+        else
+        {
+            ++delta;
+        }
     }
     if (previous)
     {
-        --delta;
+        if (isPoolShareTrustline(*previous))
+        {
+            delta -= 2;
+        }
+        else
+        {
+            --delta;
+        }
     }
     return delta;
 }

--- a/src/invariant/LedgerEntryIsValid.cpp
+++ b/src/invariant/LedgerEntryIsValid.cpp
@@ -179,6 +179,12 @@ LedgerEntryIsValid::checkIsValid(AccountEntry const& ae, uint32 version) const
         {
             return "Account signers not paired with signerSponsoringIDs";
         }
+
+        if (version >= 18 &&
+            ae.numSubEntries > UINT32_MAX - extV2.numSponsoring)
+        {
+            return "Account numSubEntries + numSponsoring is > UINT32_MAX";
+        }
     }
     return {};
 }

--- a/src/invariant/SponsorshipCountIsValid.cpp
+++ b/src/invariant/SponsorshipCountIsValid.cpp
@@ -39,6 +39,8 @@ getMult(LedgerEntry const& le)
     case ACCOUNT:
         return 2;
     case TRUSTLINE:
+        return le.data.trustLine().asset.type() == ASSET_TYPE_POOL_SHARE ? 2
+                                                                         : 1;
     case OFFER:
     case DATA:
         return 1;

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -38,6 +38,7 @@ std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);
 
+TrustLineEntry generateNonPoolShareValidTrustLineEntry(size_t b = 3);
 TrustLineEntry generateValidTrustLineEntry(size_t b = 3);
 std::vector<TrustLineEntry> generateValidTrustLineEntries(size_t n);
 

--- a/src/ledger/test/LiabilitiesTests.cpp
+++ b/src/ledger/test/LiabilitiesTests.cpp
@@ -541,7 +541,8 @@ TEST_CASE("liabilities", "[ledger][liabilities]")
         auto addSellingLiabilities = [&](int64_t initLimit, int64_t initBalance,
                                          int64_t initSellingLiabilities,
                                          int64_t deltaLiabilities) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.flags = AUTHORIZED_FLAG;
             tl.balance = initBalance;
             tl.limit = initLimit;
@@ -581,7 +582,7 @@ TEST_CASE("liabilities", "[ledger][liabilities]")
             [&](int64_t initLimit, int64_t initBalance,
                 int64_t deltaLiabilities) {
                 TrustLineEntry tl =
-                    LedgerTestUtils::generateValidTrustLineEntry();
+                    LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
                 tl.flags = AUTHORIZED_FLAG;
                 tl.balance = initBalance;
                 tl.limit = initLimit;
@@ -683,7 +684,8 @@ TEST_CASE("liabilities", "[ledger][liabilities]")
         auto addBuyingLiabilities = [&](int64_t initLimit, int64_t initBalance,
                                         int64_t initBuyingLiabilities,
                                         int64_t deltaLiabilities) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.flags = AUTHORIZED_FLAG;
             tl.balance = initBalance;
             tl.limit = initLimit;
@@ -722,7 +724,8 @@ TEST_CASE("liabilities", "[ledger][liabilities]")
         auto addBuyingLiabilitiesUninitialized = [&](int64_t initLimit,
                                                      int64_t initBalance,
                                                      int64_t deltaLiabilities) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.flags = AUTHORIZED_FLAG;
             tl.balance = initBalance;
             tl.limit = initLimit;
@@ -1154,7 +1157,8 @@ TEST_CASE("balance with liabilities", "[ledger][liabilities]")
         auto addBalance = [&](int64_t initLimit, int64_t initBalance,
                               Liabilities initLiabilities,
                               int64_t deltaBalance) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.balance = initBalance;
             tl.limit = initLimit;
             tl.flags = AUTHORIZED_FLAG;
@@ -1443,7 +1447,8 @@ TEST_CASE("available balance and limit", "[ledger][liabilities]")
     {
         auto checkAvailableBalance = [&](int64_t initLimit, int64_t initBalance,
                                          int64_t initSellingLiabilities) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.flags = AUTHORIZED_FLAG;
             tl.balance = initBalance;
             tl.limit = initLimit;
@@ -1488,7 +1493,8 @@ TEST_CASE("available balance and limit", "[ledger][liabilities]")
     {
         auto checkAvailableLimit = [&](int64_t initLimit, int64_t initBalance,
                                        int64_t initBuyingLiabilities) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.flags = AUTHORIZED_FLAG;
             tl.balance = initBalance;
             tl.limit = initLimit;
@@ -1536,7 +1542,8 @@ TEST_CASE("available balance and limit", "[ledger][liabilities]")
     {
         auto checkMinimumLimit = [&](int64_t initBalance,
                                      int64_t initBuyingLiabilities) {
-            TrustLineEntry tl = LedgerTestUtils::generateValidTrustLineEntry();
+            TrustLineEntry tl =
+                LedgerTestUtils::generateNonPoolShareValidTrustLineEntry();
             tl.flags = AUTHORIZED_FLAG;
             tl.balance = initBalance;
             tl.limit = INT64_MAX;

--- a/src/transactions/test/ChangeTrustTests.cpp
+++ b/src/transactions/test/ChangeTrustTests.cpp
@@ -266,6 +266,24 @@ TEST_CASE("change trust", "[tx][changetrust]")
             trustlineKey(acc2, idr));
     }
 
+    SECTION("too many")
+    {
+        auto acc1 =
+            root.create("acc1", app->getLedgerManager().getLastMinBalance(0));
+        auto usd = makeAsset(gateway, "USD");
+
+        SECTION("too many sponsoring")
+        {
+            tooManySponsoring(*app, acc1, acc1.op(changeTrust(idr, 1)),
+                              acc1.op(changeTrust(usd, 1)));
+        }
+        SECTION("too many subentries")
+        {
+            tooManySubentries(*app, acc1, changeTrust(idr, 1),
+                              changeTrust(usd, 1));
+        }
+    }
+
     SECTION("pool trustline")
     {
         auto getNumSubEntries = [&](AccountID const& accountID) {
@@ -548,6 +566,29 @@ TEST_CASE("change trust", "[tx][changetrust]")
             {
                 poolShareTest(makeAsset(root, "IDR"), makeAsset(root, "USD"),
                               true);
+            }
+            SECTION("too many")
+            {
+                auto acc1 = root.create(
+                    "acc1", app->getLedgerManager().getLastMinBalance(3));
+                auto native = makeNativeAsset();
+                auto shareNative1 = makeChangeTrustAssetPoolShare(
+                    native, idr, LIQUIDITY_POOL_FEE_V18);
+
+                acc1.changeTrust(idr, 1);
+                acc1.changeTrust(usd, 1);
+
+                SECTION("too many sponsoring")
+                {
+                    tooManySponsoring(*app, acc1,
+                                      acc1.op(changeTrust(idrUsd, 1)),
+                                      acc1.op(changeTrust(shareNative1, 1)));
+                }
+                SECTION("too many subentries")
+                {
+                    tooManySubentries(*app, acc1, changeTrust(idrUsd, 1),
+                                      changeTrust(shareNative1, 1));
+                }
             }
         });
     }

--- a/src/transactions/test/ClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClaimableBalanceTests.cpp
@@ -1198,6 +1198,19 @@ TEST_CASE("claimableBalance", "[tx][claimablebalance]")
                 acc1.op(createClaimableBalance(native, 1, validClaimants)));
         }
 
+        SECTION("too many sponsoring multiple claimants")
+        {
+            validClaimants.emplace_back(
+                makeClaimant(root, makeSimplePredicate(1)));
+            validClaimants.emplace_back(
+                makeClaimant(acc1, makeSimplePredicate(1)));
+
+            tooManySponsoring(
+                *app, acc1,
+                acc1.op(createClaimableBalance(native, 1, validClaimants)),
+                acc1.op(createClaimableBalance(native, 1, validClaimants)));
+        }
+
         SECTION("source account is issuer")
         {
             auto eur = makeAsset(issuer, "EUR");

--- a/src/transactions/test/LiquidityPoolDepositTests.cpp
+++ b/src/transactions/test/LiquidityPoolDepositTests.cpp
@@ -212,7 +212,7 @@ TEST_CASE("liquidity pool deposit", "[tx][liquiditypool]")
             root.setOptions(setFlags(AUTH_REQUIRED_FLAG));
 
             // This section is all about depositing into an empty pool
-            auto a1 = root.create("a1", minBal(2) + 6 * 100);
+            auto a1 = root.create("a1", minBal(3) + 6 * 100);
 
             // No trust
             REQUIRE_THROWS_AS(a1.liquidityPoolDeposit(poolNative1, 1, INT32_MAX,
@@ -260,7 +260,7 @@ TEST_CASE("liquidity pool deposit", "[tx][liquiditypool]")
             checkLiquidityPool(*app, poolNative1, 1, INT32_MAX, 46341);
 
             // This section is all about depositing into a non-empty pool
-            auto a2 = root.create("a2", minBal(2) + 6 * 100);
+            auto a2 = root.create("a2", minBal(3) + 6 * 100);
 
             // No trust
             REQUIRE_THROWS_AS(a2.liquidityPoolDeposit(poolNative1, 1, INT32_MAX,

--- a/src/transactions/test/ManageDataTests.cpp
+++ b/src/transactions/test/ManageDataTests.cpp
@@ -176,4 +176,12 @@ TEST_CASE("manage data", "[tx][managedata]")
             *app, acc2, manageData(t1, &value), manageData(t1, &value2),
             manageData(t1, &value), manageData(t1, nullptr), dataKey(acc2, t1));
     }
+
+    SECTION("too many subentries")
+    {
+        auto acc1 =
+            root.create("acc1", app->getLedgerManager().getLastMinBalance(0));
+        tooManySubentries(*app, acc1, manageData(t1, &value),
+                          manageData(t2, &value2));
+    }
 }

--- a/src/transactions/test/SetOptionsTests.cpp
+++ b/src/transactions/test/SetOptionsTests.cpp
@@ -325,6 +325,15 @@ TEST_CASE("set options", "[tx][setoptions]")
                               a1.op(setOptions(setSigner(signer2))));
         }
 
+        SECTION("too many subentries")
+        {
+            auto signer1 = makeSigner(getAccount("S1"), 1);
+            auto signer2 = makeSigner(getAccount("S2"), 1);
+
+            tooManySubentries(*app, a1, setOptions(setSigner(signer1)),
+                              setOptions(setSigner(signer2)));
+        }
+
         SECTION("delete signer that does not exist with sponsorships")
         {
             for_versions_from(14, *app, [&]() {

--- a/src/transactions/test/SponsorshipTestUtils.cpp
+++ b/src/transactions/test/SponsorshipTestUtils.cpp
@@ -298,16 +298,111 @@ tooManySponsoring(Application& app, TestAccount& sponsoredAcc,
 {
     tooManySponsoring(app, sponsoredAcc, sponsoredAcc, successfulOp, failOp);
 }
+
+static uint32_t
+getMinProtocolVersionForTooManyTestsFromOp(Operation const& op)
+{
+    if (op.body.type() == CHANGE_TRUST &&
+        op.body.changeTrustOp().line.type() == ASSET_TYPE_POOL_SHARE)
+    {
+        return 18;
+    }
+    else if (op.body.type() == REVOKE_SPONSORSHIP &&
+             op.body.revokeSponsorshipOp().type() ==
+                 REVOKE_SPONSORSHIP_LEDGER_ENTRY &&
+             op.body.revokeSponsorshipOp().ledgerKey().type() == TRUSTLINE &&
+             op.body.revokeSponsorshipOp()
+                     .ledgerKey()
+                     .trustLine()
+                     .asset.type() == ASSET_TYPE_POOL_SHARE)
+    {
+        return 18;
+    }
+
+    return 14;
+}
+
+static uint32_t
+getNumReservesRequiredForOperation(Operation const& op)
+{
+    if (op.body.type() == REVOKE_SPONSORSHIP &&
+        op.body.revokeSponsorshipOp().type() ==
+            REVOKE_SPONSORSHIP_LEDGER_ENTRY &&
+        (op.body.revokeSponsorshipOp().ledgerKey().type() == ACCOUNT ||
+         (op.body.revokeSponsorshipOp().ledgerKey().type() == TRUSTLINE &&
+          op.body.revokeSponsorshipOp().ledgerKey().trustLine().asset.type() ==
+              ASSET_TYPE_POOL_SHARE)))
+    {
+        return 2;
+    }
+    else if (op.body.type() == CREATE_ACCOUNT)
+    {
+        return 2;
+    }
+    else if (op.body.type() == CHANGE_TRUST &&
+             op.body.changeTrustOp().line.type() == ASSET_TYPE_POOL_SHARE)
+    {
+        return 2;
+    }
+    else if (op.body.type() == CREATE_CLAIMABLE_BALANCE)
+    {
+        return op.body.createClaimableBalanceOp().claimants.size();
+    }
+
+    return 1;
+}
+
+static void
+submitTooManySponsoringTxs(Application& app, TestAccount& successfulOpAcc,
+                           TestAccount& failOpAcc,
+                           Operation const& successfulOp,
+                           Operation const& failOp)
+{
+    auto root = TestAccount::createRoot(app);
+    {
+        auto tx1 = transactionFrameFromOps(
+            app.getNetworkID(), root,
+            {root.op(beginSponsoringFutureReserves(successfulOpAcc)),
+             successfulOp, successfulOpAcc.op(endSponsoringFutureReserves())},
+            {successfulOpAcc});
+
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        TransactionMeta txm1(2);
+        REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx1->apply(app, ltx, txm1));
+        ltx.commit();
+    }
+
+    {
+        auto tx2 = transactionFrameFromOps(
+            app.getNetworkID(), root,
+            {root.op(beginSponsoringFutureReserves(failOpAcc)), failOp,
+             failOpAcc.op(endSponsoringFutureReserves())},
+            {failOpAcc});
+
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        TransactionMeta txm2(2);
+        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+        REQUIRE(!tx2->apply(app, ltx, txm2));
+        REQUIRE(tx2->getResult().result.results()[1].code() ==
+                opTOO_MANY_SPONSORING);
+    }
+}
+
 void
 tooManySponsoring(Application& app, TestAccount& successfulOpAcc,
                   TestAccount& failOpAcc, Operation const& successfulOp,
                   Operation const& failOp)
 {
+    REQUIRE(failOp.body.type() == successfulOp.body.type());
+
     // root is the sponsoring account
     auto root = TestAccount::createRoot(app);
+    auto minVersion = getMinProtocolVersionForTooManyTestsFromOp(successfulOp);
+
     SECTION("too many sponsoring")
     {
-        for_versions_from(14, app, [&] {
+        for_versions_from(minVersion, app, [&] {
             {
                 LedgerTxn ltx(app.getLedgerTxnRoot());
                 auto acc = stellar::loadAccount(ltx, root.getPublicKey());
@@ -316,56 +411,159 @@ tooManySponsoring(Application& app, TestAccount& successfulOpAcc,
                 ae.ext.v(1);
                 ae.ext.v1().ext.v(2);
 
-                uint32_t offset = 1;
                 // we want to be able to do one successful op before the fail op
-                if (successfulOp.body.type() == REVOKE_SPONSORSHIP &&
-                    successfulOp.body.revokeSponsorshipOp().type() ==
-                        REVOKE_SPONSORSHIP_LEDGER_ENTRY &&
-                    successfulOp.body.revokeSponsorshipOp()
-                            .ledgerKey()
-                            .type() == ACCOUNT)
-                {
-                    ++offset;
-                }
-                else if (successfulOp.body.type() == CREATE_ACCOUNT)
-                {
-                    ++offset;
-                }
-
-                ae.ext.v1().ext.v2().numSponsoring = UINT32_MAX - offset;
+                ae.ext.v1().ext.v2().numSponsoring =
+                    UINT32_MAX -
+                    getNumReservesRequiredForOperation(successfulOp);
                 ltx.commit();
             }
 
+            submitTooManySponsoringTxs(app, successfulOpAcc, failOpAcc,
+                                       successfulOp, failOp);
+        });
+    }
+    SECTION("too many sponsoring but not due to subentries")
+    {
+        for_versions(minVersion, 17, app, [&] {
             {
-                auto tx1 = transactionFrameFromOps(
-                    app.getNetworkID(), root,
-                    {root.op(beginSponsoringFutureReserves(successfulOpAcc)),
-                     successfulOp,
-                     successfulOpAcc.op(endSponsoringFutureReserves())},
-                    {successfulOpAcc});
-
                 LedgerTxn ltx(app.getLedgerTxnRoot());
-                TransactionMeta txm1(2);
-                REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
-                REQUIRE(tx1->apply(app, ltx, txm1));
+                auto acc = stellar::loadAccount(ltx, root.getPublicKey());
+                auto& le = acc.current();
+                auto& ae = le.data.account();
+                ae.ext.v(1);
+                ae.ext.v1().ext.v(2);
+
+                // we want to be able to do one successful op before the fail op
+                ae.ext.v1().ext.v2().numSponsoring =
+                    UINT32_MAX -
+                    getNumReservesRequiredForOperation(successfulOp);
+
+                // make sure numSubEntry + numSponsoring limit doesn't exist pre
+                // 18
+                ae.numSubEntries = 50;
+
                 ltx.commit();
             }
 
+            submitTooManySponsoringTxs(app, successfulOpAcc, failOpAcc,
+                                       successfulOp, failOp);
+        });
+    }
+    SECTION("too many sponsoring but due to subentries")
+    {
+        for_versions_from(18, app, [&] {
             {
-                auto tx2 = transactionFrameFromOps(
-                    app.getNetworkID(), root,
-                    {root.op(beginSponsoringFutureReserves(failOpAcc)), failOp,
-                     failOpAcc.op(endSponsoringFutureReserves())},
-                    {failOpAcc});
-
                 LedgerTxn ltx(app.getLedgerTxnRoot());
-                TransactionMeta txm2(2);
-                REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
-                REQUIRE(!tx2->apply(app, ltx, txm2));
-                REQUIRE(tx2->getResult().result.results()[1].code() ==
-                        opTOO_MANY_SPONSORING);
+                auto acc = stellar::loadAccount(ltx, root.getPublicKey());
+                auto& le = acc.current();
+                auto& ae = le.data.account();
+                ae.ext.v(1);
+                ae.ext.v1().ext.v(2);
+
+                // Set numSponsoring close to UINT32_MAX and set numSubEntries
+                // high enough so only the successfulOp will succeed. This
+                // should validate the numSponsoring + numSubEntries <=
+                // UINT32_MAX protocol v18 check.
+                ae.ext.v1().ext.v2().numSponsoring =
+                    UINT32_MAX -
+                    getNumReservesRequiredForOperation(successfulOp) - 50;
+
+                ae.numSubEntries = 50;
+
                 ltx.commit();
             }
+
+            submitTooManySponsoringTxs(app, successfulOpAcc, failOpAcc,
+                                       successfulOp, failOp);
+        });
+    }
+}
+
+static void
+submitTooManyNumSubEntries(Application& app, TestAccount& testAcc,
+                           Operation const& successfulOp,
+                           Operation const& failOp)
+{
+    {
+        auto tx1 = transactionFrameFromOps(app.getNetworkID(), testAcc,
+                                           {successfulOp}, {});
+
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        TransactionMeta txm1(2);
+        REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx1->apply(app, ltx, txm1));
+        ltx.commit();
+    }
+
+    {
+        auto tx2 =
+            transactionFrameFromOps(app.getNetworkID(), testAcc, {failOp}, {});
+
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        TransactionMeta txm2(2);
+        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+        REQUIRE(!tx2->apply(app, ltx, txm2));
+        REQUIRE(tx2->getResult().result.results()[0].code() ==
+                opTOO_MANY_SUBENTRIES);
+    }
+}
+
+void
+tooManySubentries(Application& app, TestAccount& testAcc,
+                  Operation const& successfulOp, Operation const& failOp)
+{
+    REQUIRE(failOp.body.type() == successfulOp.body.type());
+
+    // testAcc needs a high balance
+    auto root = TestAccount::createRoot(app);
+    root.pay(testAcc, root.getAvailableBalance() - 100);
+
+    auto minVersion = getMinProtocolVersionForTooManyTestsFromOp(successfulOp);
+
+    SECTION("too many subentries")
+    {
+        for_versions_from(minVersion, app, [&] {
+            {
+                LedgerTxn ltx(app.getLedgerTxnRoot());
+                auto acc = stellar::loadAccount(ltx, testAcc.getPublicKey());
+                auto& le = acc.current();
+                auto& ae = le.data.account();
+
+                ae.numSubEntries =
+                    ACCOUNT_SUBENTRY_LIMIT -
+                    getNumReservesRequiredForOperation(successfulOp);
+
+                ltx.commit();
+            }
+
+            submitTooManyNumSubEntries(app, testAcc, successfulOp, failOp);
+        });
+    }
+    SECTION("too many subentries due to numSponsoring")
+    {
+        for_versions_from(18, app, [&] {
+            {
+                LedgerTxn ltx(app.getLedgerTxnRoot());
+                auto acc = stellar::loadAccount(ltx, testAcc.getPublicKey());
+                auto& le = acc.current();
+                auto& ae = le.data.account();
+
+                // Set numSponsoring close to UINT32_MAX and set numSubEntries
+                // high enough so only the successfulOp will succeed. This
+                // should validate the numSponsoring + numSubEntries <=
+                // UINT32_MAX protocol v18 check.
+                ae.ext.v(1);
+                ae.ext.v1().ext.v(2);
+                ae.ext.v1().ext.v2().numSponsoring =
+                    UINT32_MAX -
+                    getNumReservesRequiredForOperation(successfulOp) - 50;
+
+                ae.numSubEntries = 50;
+
+                ltx.commit();
+            }
+
+            submitTooManyNumSubEntries(app, testAcc, successfulOp, failOp);
         });
     }
 }

--- a/src/transactions/test/SponsorshipTestUtils.h
+++ b/src/transactions/test/SponsorshipTestUtils.h
@@ -42,4 +42,7 @@ void tooManySponsoring(Application& app, TestAccount& sponsoredAcc,
 void tooManySponsoring(Application& app, TestAccount& successfulOpAcc,
                        TestAccount& failOpAcc, Operation const& successfulOp,
                        Operation const& failOp);
+
+void tooManySubentries(Application& app, TestAccount& testAcc,
+                       Operation const& opCreate1, Operation const& opCreate2);
 }


### PR DESCRIPTION
# Description

Resolves #3107 and #3156

This PR adds the limit described at the bottom of https://github.com/stellar/stellar-protocol/blob/master/core/cap-0038.md#trustlineentry-with-asset-of-type-asset_type_pool_share-takes-two-base-reserves, and also makes sure that pool share trustlines are accounted for correctly.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
