### PR TITLE
Big square root

### DIFF
--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -56,4 +56,7 @@ int64_t bigDivide(uint128_t a, int64_t B, Rounding rounding);
 
 uint128_t bigMultiply(uint64_t a, uint64_t b);
 uint128_t bigMultiply(int64_t a, int64_t b);
+
+// This only implements ROUND_UP
+uint64_t bigSquareRoot(uint64_t a, uint64_t b);
 }

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -371,3 +371,37 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
                      ROUND_DOWN);
     }
 }
+
+TEST_CASE("bigSquareRoot tests", "[bigdivide]")
+{
+    // Test small values, including 0
+    std::vector<uint64_t> roots;
+    roots.emplace_back(0);
+    for (uint64_t i = 1; i <= 10; ++i)
+    {
+        for (uint64_t j = 1; j <= 2 * i - 1; ++j)
+        {
+            roots.emplace_back(i);
+        }
+    }
+    for (uint64_t i = 0; i <= 10; ++i)
+    {
+        for (uint64_t j = 0; j <= 10; ++j)
+        {
+            REQUIRE(bigSquareRoot(i, j) == roots[i * j]);
+        }
+    }
+
+    // Test large values
+    REQUIRE(bigSquareRoot(UINT64_MAX, 1) == 1ull << 32);
+    REQUIRE(bigSquareRoot(UINT32_MAX, 1) == 1ull << 16);
+    REQUIRE(bigSquareRoot(UINT64_MAX, UINT64_MAX) == UINT64_MAX);
+    REQUIRE(bigSquareRoot(UINT32_MAX, UINT32_MAX) == UINT32_MAX);
+
+    // UINT64_MAX * UINT32_MAX = ((1 << 32) + 1) * UINT32_MAX * UINT32_MAX
+    // but
+    // ceil(sqrt(UINT64_MAX * UINT32_MAX)) != ((1 << 16) + 1) * UINT32_MAX
+    // because the ceil occurs after the multiplication
+    REQUIRE(bigSquareRoot(UINT64_MAX, UINT32_MAX) == 281474976677888);
+    REQUIRE(((1ull << 16) + 1) * ((1ull << 32) - 1) != 281474976677888);
+}


### PR DESCRIPTION
# Description
Adds a function to compute `ceil(sqrt(a*b))` using only integer arithmetic.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
