### PR TITLE
AMM exchange functions

### DIFF
--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -1215,6 +1215,63 @@ crossOfferV10(AbstractLedgerTxn& ltx, LedgerTxnEntry& sellingWheatOffer,
     return res;
 }
 
+bool
+exchangeWithPool(int64_t reservesToPool, int64_t maxSendToPool, int64_t& toPool,
+                 int64_t reservesFromPool, int64_t maxReceiveFromPool,
+                 int64_t& fromPool, int32_t feeBps, RoundingType round)
+{
+    ZoneScoped;
+
+    int32_t const maxBps = 10000;
+    if (feeBps < 0 || maxBps <= feeBps)
+    {
+        throw std::runtime_error("Liquidity pool fee out of range");
+    }
+
+    switch (round)
+    {
+    case RoundingType::PATH_PAYMENT_STRICT_SEND:
+    {
+        if (maxSendToPool > INT64_MAX - reservesToPool)
+        {
+            return false;
+        }
+        toPool = maxSendToPool;
+
+        uint128_t denominator = bigMultiply(maxBps, reservesToPool) +
+                                bigMultiply(maxBps - feeBps, toPool);
+        bool res = hugeDivide(fromPool, maxBps - feeBps,
+                              bigMultiply(reservesFromPool, toPool),
+                              denominator, ROUND_DOWN);
+        if (res)
+        {
+            fromPool = std::min(fromPool, maxReceiveFromPool);
+        }
+        return res;
+    }
+    case RoundingType::PATH_PAYMENT_STRICT_RECEIVE:
+    {
+        if (maxReceiveFromPool >= reservesFromPool)
+        {
+            return false;
+        }
+        fromPool = maxReceiveFromPool;
+
+        bool res = hugeDivide(
+            toPool, maxBps, bigMultiply(reservesToPool, fromPool),
+            bigMultiply(reservesFromPool - fromPool, maxBps - feeBps),
+            ROUND_UP);
+        if (res)
+        {
+            toPool = std::min(toPool, maxSendToPool);
+        }
+        return res;
+    }
+    default:
+        throw std::runtime_error("Invalid rounding type");
+    }
+}
+
 ConvertResult
 convertWithOffers(
     AbstractLedgerTxn& ltxOuter, Asset const& sheep, int64_t maxSheepSend,

--- a/src/transactions/OfferExchange.h
+++ b/src/transactions/OfferExchange.h
@@ -283,6 +283,11 @@ int64_t adjustOffer(Price const& price, int64_t maxWheatSend,
 bool checkPriceErrorBound(Price price, int64_t wheatReceive, int64_t sheepSend,
                           bool canFavorWheat);
 
+bool exchangeWithPool(int64_t reservesToPool, int64_t maxSendToPool,
+                      int64_t& toPool, int64_t reservesFromPool,
+                      int64_t maxReceiveFromPool, int64_t& fromPool,
+                      int32_t feeInBps, RoundingType round);
+
 enum class OfferFilterResult
 {
     eKeep,

--- a/src/transactions/test/ExchangeTests.cpp
+++ b/src/transactions/test/ExchangeTests.cpp
@@ -935,3 +935,99 @@ TEST_CASE("Check price error bounds", "[exchange]")
         }
     }
 }
+
+TEST_CASE("Exchange with liquidity pools", "[exchange]")
+{
+    auto validate = [](int64_t reservesToPool, int64_t maxSendToPool,
+                       int64_t reservesFromPool, int64_t maxReceiveFromPool,
+                       int32_t feeInBps, RoundingType round, bool success,
+                       int64_t expToPool, int64_t expFromPool) {
+        int64_t toPool = 0;
+        int64_t fromPool = 0;
+        bool res = exchangeWithPool(reservesToPool, maxSendToPool, toPool,
+                                    reservesFromPool, maxReceiveFromPool,
+                                    fromPool, feeInBps, round);
+        REQUIRE(res == success);
+        if (res)
+        {
+            REQUIRE(toPool == expToPool);
+            REQUIRE(fromPool == expFromPool);
+        }
+    };
+
+    SECTION("Error conditions")
+    {
+        RoundingType const send = RoundingType::PATH_PAYMENT_STRICT_SEND;
+        RoundingType const recv = RoundingType::PATH_PAYMENT_STRICT_RECEIVE;
+        REQUIRE_THROWS(validate(100, 50, 100, 50, -1, send, false, 0, 0));
+        REQUIRE_THROWS(validate(100, 50, 100, 50, -1, recv, false, 0, 0));
+
+        REQUIRE_THROWS(validate(100, 50, 100, 50, 10000, send, false, 0, 0));
+        REQUIRE_THROWS(validate(100, 50, 100, 50, 10000, recv, false, 0, 0));
+
+        REQUIRE_THROWS(
+            validate(100, 50, 100, 50, 0, RoundingType::NORMAL, false, 0, 0));
+    }
+
+    SECTION("No fees")
+    {
+        SECTION("Strict send")
+        {
+            RoundingType const round = RoundingType::PATH_PAYMENT_STRICT_SEND;
+
+            // Works exactly
+            validate(100, 100, 100, 49, 0, round, true, 100, 49);
+            validate(100, 100, 100, 50, 0, round, true, 100, 50);
+            validate(100, 100, 100, 51, 0, round, true, 100, 50);
+
+            // Requires rounding
+            validate(100, 50, 100, 32, 0, round, true, 50, 32);
+            validate(100, 50, 100, 33, 0, round, true, 50, 33);
+            validate(100, 50, 100, 34, 0, round, true, 50, 33);
+
+            // Sending 0 or receiving 0
+            validate(100, 0, 100, 50, 0, round, true, 0, 0);
+            validate(100, 50, 100, 0, 0, round, true, 50, 0);
+
+            // Sending the maximum
+            validate(100, INT64_MAX - 100, 100, 98, 0, round, true,
+                     INT64_MAX - 100, 98);
+            validate(100, INT64_MAX - 100, 100, 99, 0, round, true,
+                     INT64_MAX - 100, 99);
+            validate(100, INT64_MAX - 100, 100, 100, 0, round, true,
+                     INT64_MAX - 100, 99);
+
+            // Sending too much
+            validate(100, INT64_MAX - 99, 100, INT64_MAX, 0, round, false, 0,
+                     0);
+        }
+
+        SECTION("Strict receive")
+        {
+            RoundingType const round =
+                RoundingType::PATH_PAYMENT_STRICT_RECEIVE;
+
+            // Works exactly
+            validate(100, 99, 100, 50, 0, round, true, 99, 50);
+            validate(100, 100, 100, 50, 0, round, true, 100, 50);
+            validate(100, 101, 100, 50, 0, round, true, 100, 50);
+
+            // Requires rounding
+            validate(100, 49, 100, 33, 0, round, true, 49, 33);
+            validate(100, 50, 100, 33, 0, round, true, 50, 33);
+            validate(100, 51, 100, 33, 0, round, true, 50, 33);
+
+            // Sending 0 or receiving 0
+            validate(100, 0, 100, 50, 0, round, true, 0, 50);
+            validate(100, 50, 100, 0, 0, round, true, 0, 0);
+
+            // Receiving the maximum
+            validate(100, 9899, 100, 99, 0, round, true, 9899, 99);
+            validate(100, 9900, 100, 99, 0, round, true, 9900, 99);
+            validate(100, 9901, 100, 99, 0, round, true, 9900, 99);
+
+            // Receiving too much
+            validate(100, INT64_MAX, 100, 100, 0, round, false, 0, 0);
+        }
+    }
+}

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -123,4 +123,53 @@ bigMultiply(int64_t a, int64_t b)
     assert((a >= 0) && (b >= 0));
     return bigMultiply((uint64_t)a, (uint64_t)b);
 }
+
+bool
+hugeDivide(int64_t& result, int32_t a, uint128_t B, uint128_t C,
+           Rounding rounding)
+{
+    static uint128_t const i32_max((uint32_t)INT32_MAX);
+    static uint128_t const i64_max((uint64_t)INT64_MAX);
+
+    assert(C != 0);
+    assert(C <= i32_max * i64_max);
+
+    // Use the remainder theorem to yield B = QC + R with R < C
+    uint128_t Q(B / C);
+    uint128_t R(B % C);
+
+    // Result never fits if Q is too big
+    if (Q > i64_max)
+    {
+        return false;
+    }
+
+    // We can evaluate A * Q because
+    //     A * Q <= INT64_MAX * INT32_MAX
+    //           <  INT128_MAX .
+    // We can evaluate A * R because
+    //     A * R < A * C
+    //           < INT32_MAX * (INT32_MAX * INT64_MAX)
+    //           < INT128_MAX
+    // and A * R + C - 1 because
+    //     A * R + C < (INT32_MAX + 1) * (INT32_MAX * INT64_MAX)
+    //               < INT128_MAX .
+    // Combining these results, we can evaluate
+    //     A * Q + A * R / C < 2 * INT128_MAX < UINT128_MAX
+    // and
+    //     A * Q + (A * R + C - 1) / C < 2 * INT128_MAX < UINT128_MAX .
+    uint128_t A((uint32_t)a);
+    uint128_t res = (rounding == ROUND_DOWN) ? A * Q + A * R / C
+                                             : A * Q + (A * R + C - 1u) / C;
+
+    if (res <= i64_max)
+    {
+        // There is no conversion uint128_t to int64_t so have to go through an
+        // intermediate type.
+        result = (int64_t)(uint64_t)res;
+        return true;
+    }
+    return false;
+}
+
 }

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -56,4 +56,8 @@ int64_t bigDivide(uint128_t a, int64_t B, Rounding rounding);
 
 uint128_t bigMultiply(uint64_t a, uint64_t b);
 uint128_t bigMultiply(int64_t a, int64_t b);
+
+// Compute a * B / C when C < INT32_MAX * INT64_MAX.
+bool hugeDivide(int64_t& result, int32_t a, uint128_t B, uint128_t C,
+                Rounding rounding);
 }


### PR DESCRIPTION
# Description
This is an early step toward updating OfferExchange for AMMs. It introduces `hugeDivide` and `exchangeWithPool` to facilitate the necessary calculations, without actually using those functions. Tests still need to be added for `hugeDivide`, but it is at least being lightly exercised by the simple `exchangeWithPool` tests.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
