### PR TITLE
Improve invariance in Herder

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -104,7 +104,7 @@ class Herder
     virtual void shutdown() = 0;
 
     // restores Herder's state from disk
-    virtual void restoreState() = 0;
+    virtual void start() = 0;
 
     virtual bool recvSCPQuorumSet(Hash const& hash,
                                   SCPQuorumSet const& qset) = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -106,6 +106,9 @@ class Herder
     // restores Herder's state from disk
     virtual void start() = 0;
 
+    virtual void setTrackingSCPState(uint64_t index,
+                                     StellarValue const& value) = 0;
+
     virtual bool recvSCPQuorumSet(Hash const& hash,
                                   SCPQuorumSet const& qset) = 0;
     virtual bool recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
@@ -134,9 +137,7 @@ class Herder
     // a peer needs our SCP state
     virtual void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) = 0;
 
-    // returns the latest known ledger seq using consensus information
-    // and local state
-    virtual uint32_t getCurrentLedgerSeq() const = 0;
+    virtual uint32_t trackingConsensusLedgerIndex() const = 0;
 
     // return the smallest ledger number we need messages for when asking peers
     virtual uint32 getMinLedgerSeqToAskPeers() const = 0;

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -106,8 +106,9 @@ class Herder
     // restores Herder's state from disk
     virtual void start() = 0;
 
-    virtual void setTrackingSCPState(uint64_t index,
-                                     StellarValue const& value) = 0;
+    // Setup Herder's state to fully participate in consensus
+    virtual void setTrackingSCPState(uint64_t index, StellarValue const& value,
+                                     bool isTrackingNetwork) = 0;
 
     virtual bool recvSCPQuorumSet(Hash const& hash,
                                   SCPQuorumSet const& qset) = 0;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -69,7 +69,7 @@ class HerderImpl : public Herder
     void bootstrap() override;
     void shutdown() override;
 
-    void restoreState() override;
+    void start() override;
 
     SCP& getSCP();
     HerderSCPDriver&

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -41,10 +41,12 @@ class HerderImpl : public Herder
         TimePoint mConsensusCloseTime{0};
     };
 
-    void setTrackingSCPState(uint64_t index, StellarValue const& value);
+    void setTrackingSCPState(uint64_t index,
+                             StellarValue const& value) override;
 
-    // the ledger index that was last externalized
-    uint32 trackingConsensusLedgerIndex() const;
+    // returns the latest known ledger from the network, requires Herder to be
+    // in fully booted state
+    uint32 trackingConsensusLedgerIndex() const override;
 
     TimePoint trackingConsensusCloseTime() const;
 
@@ -114,7 +116,6 @@ class HerderImpl : public Herder
 
     void processSCPQueue();
 
-    uint32_t getCurrentLedgerSeq() const override;
     uint32 getMinLedgerSeqToAskPeers() const override;
 
     SequenceNumber getMaxSeqInPendingTxs(AccountID const&) override;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -41,8 +41,8 @@ class HerderImpl : public Herder
         TimePoint mConsensusCloseTime{0};
     };
 
-    void setTrackingSCPState(uint64_t index,
-                             StellarValue const& value) override;
+    void setTrackingSCPState(uint64_t index, StellarValue const& value,
+                             bool isTrackingNetwork) override;
 
     // returns the latest known ledger from the network, requires Herder to be
     // in fully booted state

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -507,7 +507,7 @@ HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
                             std::function<void()> cb)
 {
     // don't setup timers for old slots
-    if (slotIndex <= mApp.getHerder().getCurrentLedgerSeq())
+    if (slotIndex <= mApp.getHerder().trackingConsensusLedgerIndex())
     {
         mSCPTimers.erase(slotIndex);
         return;
@@ -724,7 +724,8 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
     //  * when getting back in sync (a gap potentially opened)
     // in both cases do limited processing on older slots; more importantly,
     // deliver externalize events to LedgerManager
-    bool isLatestSlot = slotIndex > mApp.getHerder().getCurrentLedgerSeq();
+    bool isLatestSlot =
+        slotIndex > mApp.getHerder().trackingConsensusLedgerIndex();
 
     // Only update tracking state when newer slot comes in
     if (isLatestSlot)

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -753,7 +753,7 @@ HerderSCPDriver::valueExternalized(uint64_t slotIndex, Value const& value)
             stateChanged();
         }
 
-        mHerder.setTrackingSCPState(slotIndex, b);
+        mHerder.setTrackingSCPState(slotIndex, b, /* isTrackingNetwork */ true);
 
         // record lag
         recordSCPExternalizeEvent(slotIndex, mSCP.getLocalNodeID(), false);

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1145,7 +1145,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
 
         auto addToCandidates = [&](TxPair const& p) {
             auto envelope = makeEnvelope(
-                herder, p, {}, herder.getCurrentLedgerSeq() + 1, true);
+                herder, p, {}, herder.trackingConsensusLedgerIndex() + 1, true);
             REQUIRE(herder.recvSCPEnvelope(envelope) ==
                     Herder::ENVELOPE_STATUS_FETCHING);
             REQUIRE(herder.recvTxSet(p.second->getContentsHash(), *p.second));
@@ -1271,7 +1271,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
     {
         auto& herder = static_cast<HerderImpl&>(app->getHerder());
         auto& scp = herder.getHerderSCPDriver();
-        auto seq = herder.getCurrentLedgerSeq() + 1;
+        auto seq = herder.trackingConsensusLedgerIndex() + 1;
         auto ct = app->timeNow() + 1;
 
         TxSetFramePtr txSet0 = makeTransactions(lcl.hash, 0, 1, 100);
@@ -1375,7 +1375,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
                 // Build a StellarValue containing the transaction set we just
                 // built and the given next closeTime.
                 auto val = makeTxPair(herder, txSet, nextCloseTime);
-                auto const seq = herder.getCurrentLedgerSeq() + 1;
+                auto const seq = herder.trackingConsensusLedgerIndex() + 1;
                 auto envelope = makeEnvelope(herder, val, {}, seq, true);
                 REQUIRE(herder.recvSCPEnvelope(envelope) ==
                         Herder::ENVELOPE_STATUS_FETCHING);
@@ -1457,7 +1457,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
         auto p1 = makeTxPair(herder, transactions1, 10);
         auto p2 = makeTxPair(herder, transactions1, 10);
         // use current + 1 to allow for any value (old values get filtered more)
-        auto lseq = herder.getCurrentLedgerSeq() + 1;
+        auto lseq = herder.trackingConsensusLedgerIndex() + 1;
         auto saneEnvelopeQ1T1 =
             makeEnvelope(herder, p1, saneQSet1Hash, lseq, true);
         auto saneEnvelopeQ1T2 =
@@ -2026,7 +2026,7 @@ TEST_CASE("herder externalizes values", "[herder]")
         // As we're back in sync now, ensure Herder and LM are consistent with
         // each other
         auto lcl = lmC.getLastClosedLedgerNum();
-        REQUIRE(lcl == herderC.getCurrentLedgerSeq());
+        REQUIRE(lcl == herderC.trackingConsensusLedgerIndex());
 
         // Ensure that C sent out a nomination message for the next consensus
         // round

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -452,11 +452,16 @@ ApplicationImpl::getJsonInfo()
 
     // Try to get quorum set info for the previous ledger closed by the
     // network.
-    if (herder.getCurrentLedgerSeq() > 1)
+    auto ledgerSeq = lcl.header.ledgerSeq;
+    if (herder.getState() != Herder::HERDER_BOOTING_STATE)
     {
-        quorumInfo =
-            herder.getJsonQuorumInfo(getConfig().NODE_SEED.getPublicKey(), true,
-                                     false, herder.getCurrentLedgerSeq() - 1);
+        ledgerSeq = herder.trackingConsensusLedgerIndex();
+    }
+
+    if (ledgerSeq > 1)
+    {
+        quorumInfo = herder.getJsonQuorumInfo(
+            getConfig().NODE_SEED.getPublicKey(), true, false, ledgerSeq - 1);
     }
 
     // If the quorum set info for the previous ledger is missing, use the
@@ -464,9 +469,8 @@ ApplicationImpl::getJsonInfo()
     auto qset = quorumInfo.get("qset", "");
     if (quorumInfo.empty() || qset.empty())
     {
-        quorumInfo =
-            herder.getJsonQuorumInfo(getConfig().NODE_SEED.getPublicKey(), true,
-                                     false, herder.getCurrentLedgerSeq());
+        quorumInfo = herder.getJsonQuorumInfo(
+            getConfig().NODE_SEED.getPublicKey(), true, false, ledgerSeq);
     }
 
     auto invariantFailures = getInvariantManager().getJsonInfo();

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -678,7 +678,7 @@ ApplicationImpl::start()
         }
 
         // restores Herder's state before starting overlay
-        mHerder->restoreState();
+        mHerder->start();
         // set known cursors before starting maintenance job
         ExternalQueue ps(*this);
         ps.setInitialCursors(mConfig.KNOWN_CURSORS);

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -182,7 +182,6 @@ runApp(Application::pointer app)
     {
         if (!app->getConfig().MODE_AUTO_STARTS_OVERLAY)
         {
-            app->getHerder().start();
             app->getOverlayManager().start();
         }
 

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -182,7 +182,7 @@ runApp(Application::pointer app)
     {
         if (!app->getConfig().MODE_AUTO_STARTS_OVERLAY)
         {
-            app->getHerder().restoreState();
+            app->getHerder().start();
             app->getOverlayManager().start();
         }
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -763,6 +763,14 @@ void
 CommandHandler::surveyTopology(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
+
+    if (mApp.getState() == Application::APP_CREATED_STATE ||
+        mApp.getHerder().getState() == Herder::HERDER_BOOTING_STATE)
+    {
+        throw std::runtime_error(
+            "Application is not fully booted, try again later");
+    }
+
     std::map<std::string, std::string> map;
     http::server::server::parseParams(params, map);
 

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -69,7 +69,7 @@ Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer, Hash& index)
     if (result == mFloodMap.end())
     { // we have never seen this message
         mFloodMap[index] = std::make_shared<FloodRecord>(
-            msg, mApp.getHerder().getCurrentLedgerSeq(), peer);
+            msg, mApp.getHerder().trackingConsensusLedgerIndex(), peer);
         mFloodMapSize.set_count(mFloodMap.size());
         TracyPlot("overlay.memory.flood-known",
                   static_cast<int64_t>(mFloodMap.size()));
@@ -98,7 +98,8 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
     if (result == mFloodMap.end() || force)
     { // no one has sent us this message / start from scratch
         fr = std::make_shared<FloodRecord>(
-            msg, mApp.getHerder().getCurrentLedgerSeq(), Peer::pointer());
+            msg, mApp.getHerder().trackingConsensusLedgerIndex(),
+            Peer::pointer());
         mFloodMap[index] = fr;
         mFloodMapSize.set_count(mFloodMap.size());
     }

--- a/src/overlay/SurveyManager.cpp
+++ b/src/overlay/SurveyManager.cpp
@@ -229,7 +229,7 @@ SurveyManager::makeSurveyRequest(NodeID const& nodeToSurvey) const
     auto& signedRequest = newMsg.signedSurveyRequestMessage();
 
     auto& request = signedRequest.request;
-    request.ledgerNum = mApp.getHerder().getCurrentLedgerSeq();
+    request.ledgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
     request.surveyorPeerID = mApp.getConfig().NODE_SEED.getPublicKey();
 
     request.surveyedPeerID = nodeToSurvey;

--- a/src/overlay/SurveyMessageLimiter.cpp
+++ b/src/overlay/SurveyMessageLimiter.cpp
@@ -142,7 +142,7 @@ SurveyMessageLimiter::recordAndValidateResponse(
 bool
 SurveyMessageLimiter::surveyLedgerNumValid(uint32_t ledgerNum)
 {
-    uint32_t curLedgerNum = mApp.getHerder().getCurrentLedgerSeq();
+    uint32_t curLedgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
     return ledgerNum + mNumLedgersBeforeIgnore >= curLedgerNum &&
            ledgerNum <= curLedgerNum + 1;
 }

--- a/src/overlay/test/SurveyMessageLimiterTests.cpp
+++ b/src/overlay/test/SurveyMessageLimiterTests.cpp
@@ -27,13 +27,13 @@ TEST_CASE("messagelimiter", "[overlay][survey][messagelimiter]")
 
     // we need to pass a lower ledgerNum into the rate limiter to test the
     // window,  so make sure this is not 0
-    REQUIRE(app->getHerder().getCurrentLedgerSeq() == 1);
+    REQUIRE(app->getHerder().trackingConsensusLedgerIndex() == 1);
 
     const uint32_t ledgerNumWindow = 0;
     const uint32_t surveyorRequestLimit = 2;
     SurveyMessageLimiter rm(*app, ledgerNumWindow, surveyorRequestLimit);
 
-    auto ledgerNum = app->getHerder().getCurrentLedgerSeq();
+    auto ledgerNum = app->getHerder().trackingConsensusLedgerIndex();
     SurveyRequestMessage firstRequest(v0SecretKey.getPublicKey(),
                                       v1SecretKey.getPublicKey(), ledgerNum,
                                       temp, SURVEY_TOPOLOGY);


### PR DESCRIPTION
Depends on https://github.com/stellar/stellar-core/pull/3068

This change introduces stronger invariance in Herder. Specifically, querying "tracking" now requires Herder to be fully booted. Additionally, tracking must always be ahead of or equal to LCL. Note that this is not the case currently in master, as when we run offline/captive core catchup, Herder ends up behind. As part of this change, catchup now ensures that Herder state is properly setup before we start applying ledgers. 