### PR TITLE
Fix the logging logic of LoadGenerator to take care of the division-by-0

### DIFF
--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -344,8 +344,8 @@ LoadGenerator::logProgress(std::chrono::nanoseconds submitTimer, bool isCreate,
     auto submitSteps = duration_cast<milliseconds>(submitTimer).count();
 
     auto remainingTxCount = isCreate ? nAccounts / batchSize : nTxs;
-    auto etaSecs =
-        (uint32_t)(((double)remainingTxCount) / applyTx.one_minute_rate());
+    auto etaSecs = (uint32_t)(((double)remainingTxCount) /
+                              max<double>(1, applyTx.one_minute_rate()));
 
     auto etaHours = etaSecs / 3600;
     auto etaMins = etaSecs % 60;


### PR DESCRIPTION
The logging logic of `LoadGenerator.cpp` doesn't handle the case when `applyTx.one_minute_rate() = 0` which leads to the division-by-0 error. This PR fixes that by replacing the `one_minute_rate()` with 1 when smaller than 1. It's used for calculating the ETA, and thus slight inaccuracy there doesn't seem like a big concern.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
