### PR TITLE
Add `encode-asset` command for debugging

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -36,6 +36,8 @@ Command options can only by placed after command.
 `$ stellar-core convert-id SDQVDISRYN2JXBS7ICL7QJAEKB3HWBJFP2QECXG7GZICAHBK4UNJCWK2`
 
 * **dump-xdr <FILE-NAME>**:  Dumps the given XDR file and then exits.
+* **encode-asset --code <CODE> --issuer <ISSUER>**: Prints a base-64 encoded asset.
+  Prints the native asset if neither `code` nor `issuer` is given.
 * **fuzz <FILE-NAME>**: Run a single fuzz input and exit.
 * **gen-fuzz <FILE-NAME>**:  Generate a random fuzzer input file.
 * **gen-seed**: Generate and print a random public/private key and then exit.


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/3113

Example usage:

```
stellar-core encode-asset --code EURT --issuer GAP5LETOV6YIE62YAM56STDANPRDO7ZFDBGSNHJQIYGGKSMOZAHOOS2S
```
prints `AAAAAUVVUlQAAAAAH9WSbq+wgntYAzvpTGBr4jd/JRhNJp0wRgxlSY7IDuc=` which is the base-64 encoded asset with the specified code and issuer.

When neither `code` nor `issuer` is given, it prints the native asset. If only one of them is given or the code is longer than 12 characters, it throws.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
