### PR TITLE
Hash LiquidityPoolParameters instead of LiquidityPoolConstantProductParameters

### DIFF
--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1149,8 +1149,7 @@ changeTrustAssetToTrustLineAsset(ChangeTrustAsset const& ctAsset)
         tlAsset.alphaNum12() = ctAsset.alphaNum12();
         break;
     case stellar::ASSET_TYPE_POOL_SHARE:
-        tlAsset.liquidityPoolID() =
-            xdrSha256(ctAsset.liquidityPool().constantProduct());
+        tlAsset.liquidityPoolID() = xdrSha256(ctAsset.liquidityPool());
         break;
     default:
         throw std::runtime_error("Unknown asset type");


### PR DESCRIPTION
# Description

The CAP specifies that `LiquidityPoolParameters` should be hashed for the poolID.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
