### PR TITLE
Remove herder bogus recovery timer

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1701,8 +1701,6 @@ HerderImpl::restoreSCPState()
         }
         mPendingEnvelopes.rebuildQuorumTrackerState();
     }
-
-    startOutOfSyncTimer();
 }
 
 void

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -52,10 +52,9 @@ getAssetHash(T const& asset)
     }
     case stellar::ASSET_TYPE_POOL_SHARE:
     {
-        size_t res = asset.type();
         res ^= stellar::shortHash::computeHash(
             stellar::ByteSlice(getLiquidityPoolID(asset).data(), 8));
-        return res;
+        break;
     }
     default:
         throw std::runtime_error("unknown Asset type");


### PR DESCRIPTION
I am seeing warnings on latest master. not a big deal, just confusing for people:
`HerderImpl::outOfSyncRecovery called when tracking`
until the node sees consensus from the network.

That's because we call `startOutOfSyncTimer` in `restoreSCPState`, even though it's not needed n(node is initialized as "tracking a few lines above").

We used to setup at that location the broadcast timer before I got rid of it in #2756 and I just forgot to remove it.