### PR TITLE
devcontainer: add c/c++ extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,5 +32,7 @@
 	// "postCreateCommand": "uname -a",
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
-	"extensions": []
+	"extensions": [
+		"ms-vscode.cpptools"
+	]
 }


### PR DESCRIPTION
# Description

## What
Add the Microsoft C/C++ extension to the VSCode devcontainer configuration that is specified for this repository. When using the devcontainer this will have the C/C++ extension installed during devcontainer setup.

## Why
The extension does a decent job of providing autocompletion and code navigation features to this code base. It would be helpful for new folks using the devcontainer or anyone picking it up if the extension was installed automatically so that new folks do not need to figure out what the best extensions to install are to get navigation in VSCode.

The extension is developed by Microsoft so seemingly not a security risk to have it installed automatically since Microsoft also develop VSCode itself.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
