### PR TITLE
Resize ccache in ci-build.sh

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -115,7 +115,7 @@ export CCACHE_DIR=$HOME/.ccache
 export CCACHE_COMPRESS=true
 export CCACHE_COMPRESSLEVEL=9
 # cache size should be large enough for a full build
-export CCACHE_MAXSIZE=300M
+export CCACHE_MAXSIZE=500M
 export CCACHE_CPP2=true
 
 # purge cache if it's too old


### PR DESCRIPTION
# Description
ci-build.sh specifies a `CCACHE_MAXSIZE` that is too small. I did some testing about this locally and I can see that the ccache size is about 376.8 MB (without extrachecks, since I was testing this on Mac) using the ccache compression settings from ci-build.sh without the max size. Unfortunately, the max size is set to 300 MB and ccache evicts down to 20% below max by default to avoid repetitive clean up. So the cache is approximately a factor of 2 too small. From my testing, this makes caching much more effective and improves build time by more than 50%.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
