### PR TITLE
Add `maintainer::shutdown()` and stop maintenance after a crash

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -741,6 +741,10 @@ ApplicationImpl::gracefulStop()
     {
         mHerder->shutdown();
     }
+    if (mMaintainer)
+    {
+        mMaintainer->shutdown();
+    }
 
     mStoppingTimer.expires_from_now(
         std::chrono::seconds(SHUTDOWN_DELAY_SECONDS));

--- a/src/main/Maintainer.h
+++ b/src/main/Maintainer.h
@@ -24,9 +24,12 @@ class Maintainer
     // removes maximum count entries from tables like txhistory or scphistory
     void performMaintenance(uint32_t count);
 
+    void shutdown();
+
   private:
     Application& mApp;
     VirtualTimer mTimer;
+    bool mShuttingDown;
 
     void scheduleMaintenance();
     void tick();


### PR DESCRIPTION
# Description

Resolves #3106 

The message `got signal 15, shutting down` mentioned in #3106 comes from `gracefulStop`. This PR adds the `shutdown()` method in `Maintainer` and call it from `gracefulStop` to prevent it from performing any maintenance after `shutdown`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
