### PR TITLE
Record and check TxMeta produced by tests.

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -328,6 +328,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
             }
         }
         ltxTx.commit();
+        recordOrCheckGlobalTestTxMetadata(tm);
     }
 
     // Undo the increment from the beginning of this function. Note that if this

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -14,9 +14,16 @@ namespace stellar
 class Application;
 class Config;
 struct CommandLineArgs;
+struct TransactionMeta;
 
 Config const& getTestConfig(int instanceNumber = 0,
                             Config::TestDbMode mode = Config::TESTDB_DEFAULT);
+
+// Records or checks a TxMetadata value against a persistent record
+// of metadata hashes. Each unit-test name and section has a separate
+// vector of TxMetadata hashes, containing all the txs in that
+// test-and-section.
+void recordOrCheckGlobalTestTxMetadata(TransactionMeta const& txMeta);
 
 int runTest(CommandLineArgs const& args);
 


### PR DESCRIPTION
# Description

Resolves #1926

Adds a mechanism for recording and comparing TxMeta across test runs:
  - adds a global Catch2 event-listener to track when we enter and leave testcases and sections, establishing a notion of the global "current test context" (just a string)
  - adds a new global method `recordOrCheckGlobalTestTxMetadata(TransactionMeta const&)` that either -- depending on a mode flag -- pushes the hash of the provided meta onto a vector associated with the current test context in a global map, or checks that the meta matches the next expected value in that vector (tracked with an adjacent counter).
  - calls this global function from a single spot -- `applyCheck` -- in TxTests.cpp
  - adds command line functionality `--record-test-tx-meta <filename>` and `--check-test-tx-meta <filename>` that record and check the hashes against a reference file

The reference file looks like this:

~~~
# File 'transactions/test/MergeTests.cpp', Test 'merge', Section 'merge', Section 'Account has static auth flag set', Section 'protocol version 17'
        4089244b61572b430ee6bb12c7b122b8b51b9f69079282f2ace577b12179785a
        7f1a6d42d12fd3538e20e1ff7d98705a75b48dee2b7193d71cb7ea71882ef2aa
# File 'transactions/test/MergeTests.cpp', Test 'merge', Section 'merge', Section 'With sub entries', Section 'account has data', Section 'protocol version 17'
        cc7460d78170314329db03c504753c21e5e561990f53d67c10cadee2032a94dc
        2027fb7c5562d1800303377f5cf9dd419978a3426dccd8c94945dd1fbe4f4ada
# File 'transactions/test/MergeTests.cpp', Test 'merge', Section 'merge', Section 'With sub entries', Section 'account has signer', Section 'protocol version 17'
        db9cfe7914e2aa96d03f87059e87e43c7a6c4b6a8d8acdcd50a848c2b18c3297
        756ae3805ce14576b3e1a02cd0a282c4d8795d4936b130f8c52c0ed46ee0901d
# File 'transactions/test/MergeTests.cpp', Test 'merge', Section 'merge', Section 'With sub entries', Section 'with trustline'
        0da9cb83d345ec1be6913ca5e17b78e245ce74904c2ea452ccd16178e4205385
        0da9cb83d345ec1be6913ca5e17b78e245ce74904c2ea452ccd16178e4205385
# File 'transactions/test/MergeTests.cpp', Test 'merge', Section 'merge', Section 'With sub entries', Section 'with trustline', Section 'account has offer', Section 'protocol version 17'
        ac2ab83b1e184d8e1edac6947bb7c488ea000627db4de708600b85fa6a7d58da
        b7bd6542a3c856fbba21ac69b5c1d08b3c52856dabdb70955ed10d3856fb032c
        f697970f21f20a5034d95400ecde88663319727e9cb4f16229716ca8eefe520b
        c8cb6f93c8b255d6ea8b1c8ed26f7f6db69a3ca3af92ccd7896e3f969ea21d98
        c8742a56e3ad3dbad1d76cf13aaa0490974d1c9f10dd008fe44987fd1742591c
        42b3f5fca3b274fa1c9a8292c8d4b7e07d233e287de746057ef731a2b8dcc23d
~~~

and a check-error looks like this:

~~~
-------------------------------------------------------------------------------
merge
-------------------------------------------------------------------------------
transactions/test/MergeTests.cpp:34
...............................................................................

test/TestAccount.cpp:136: FAILED:
  {Unknown expression after the reported line}
due to unexpected exception with message:
  Mismatched TxMeta hash: expected
  8e3a10b6a189b982555f060dc3732c25bab8c23836190ccf60abd3b133085b62, got
  9e3a10b6a189b982555f060dc3732c25bab8c23836190ccf60abd3b133085b62, at tx #4,
  in File 'transactions/test/MergeTests.cpp', Test 'merge', Section 'merge'

===============================================================================
test cases:   1 |   0 passed | 1 failed
assertions: 120 | 119 passed | 1 failed
~~~
