### PR TITLE
Work shouldn't be scheduled once WorkScheduler is done

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -724,6 +724,7 @@ ApplicationImpl::gracefulStop()
     {
         mOverlayManager->shutdown();
     }
+    mSelfCheckTimer.cancel();
     shutdownWorkScheduler();
     if (mProcessManager)
     {

--- a/src/work/WorkScheduler.h
+++ b/src/work/WorkScheduler.h
@@ -47,7 +47,7 @@ class WorkScheduler : public Work
     std::shared_ptr<T>
     scheduleWork(Args&&... args)
     {
-        if (isAborting())
+        if (isAborting() || isDone())
         {
             return nullptr;
         }

--- a/src/work/test/WorkTests.cpp
+++ b/src/work/test/WorkTests.cpp
@@ -409,6 +409,10 @@ TEST_CASE("work with children", "[work]")
         REQUIRE(w2->getState() == TestBasicWork::State::WORK_ABORTED);
         REQUIRE(l1->getState() == TestBasicWork::State::WORK_ABORTED);
         REQUIRE(l2->getState() == TestBasicWork::State::WORK_ABORTED);
+
+        // no work can be scheduled
+        REQUIRE(wm.scheduleWork<TestBasicWork>("cannot-be-scheduled") ==
+                nullptr);
     }
 }
 


### PR DESCRIPTION
# Description

Resolves #3106. This issue says that the application crashed after `got signal 15, shutting down`. The stack trace posted there shows that the crash happened because the work class had children when `~Work()` was called.

Explanation of the change in this PR: The `WorkScheduler` class refuses to schedule any work when it's aborting, which makes sense. But there's a small window of time after `shutdownWorkScheduler()` has been called and before the program terminates. During that time window, `mState = ABORTED` and thus `WorkScheduler` continues to schedule new works. This would lead to a crash since the destructor `~Work()` asserts`!hasChildren()` which fails if `WorkScheduler` has scheduled new works. This PR makes sure that `WorkScheduler` won't schedule anything as long as `isAborting()` _or_ `isDone()`.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
