### PR TITLE
Windows compile fix

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -863,7 +863,6 @@ exit /b 0
     <ClInclude Include="..\..\src\simulation\LoadGenerator.h" />
     <ClInclude Include="..\..\src\simulation\Simulation.h" />
     <ClInclude Include="..\..\src\simulation\Topologies.h" />
-    <ClInclude Include="..\..\src\simulation\test\LoadGeneratorTests.cpp" />
     <ClInclude Include="..\..\src\test\fuzz.h" />
     <ClInclude Include="..\..\src\test\SimpleTestReporter.h" />
     <ClInclude Include="..\..\src\test\test.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1280,9 +1280,6 @@
     <ClInclude Include="..\..\src\simulation\Topologies.h">
       <Filter>simulation</Filter>
     </ClInclude>
-    <ClCompile Include="..\..\src\simulation\test\LoadGeneratorTests.cpp">
-      <Filter>simulation</Filter>
-    </ClCompile>
     <ClInclude Include="..\..\lib\json\json.h">
       <Filter>lib\json</Filter>
     </ClInclude>

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -3102,7 +3102,7 @@ LedgerTxnRoot::Impl::getPoolShareTrustLinesByAccountAndAsset(
     {
         trustLines = loadPoolShareTrustLinesByAccountAndAsset(account, asset);
     }
-    catch (NonSociRelatedException& e)
+    catch (NonSociRelatedException&)
     {
         throw;
     }

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -558,7 +558,7 @@ LoadGenerator::pretendTransaction(uint32_t numAccounts, uint32_t offset,
     vector<Operation> ops;
     ops.reserve(opCount);
     auto acc = findAccount(sourceAccount, ledgerNum);
-    for (int i = 0; i < opCount; i++)
+    for (uint32 i = 0; i < opCount; i++)
     {
         auto args = SetOptionsArguments{};
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -82,12 +82,12 @@ CATCH_REGISTER_LISTENER(ReseedPRNGListener)
 
 enum class TestTxMetaMode
 {
-    IGNORE,
-    RECORD,
-    CHECK
+    META_TEST_IGNORE,
+    META_TEST_RECORD,
+    META_TEST_CHECK
 };
 
-static TestTxMetaMode gTestTxMetaMode{TestTxMetaMode::IGNORE};
+static TestTxMetaMode gTestTxMetaMode{TestTxMetaMode::META_TEST_IGNORE};
 
 struct TestContextListener : Catch::TestEventListenerBase
 {
@@ -102,7 +102,7 @@ struct TestContextListener : Catch::TestEventListenerBase
     void
     testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
-        if (gTestTxMetaMode != TestTxMetaMode::IGNORE)
+        if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
             assertThreadIsMain();
             sTestCtx.emplace_back(testInfo);
@@ -111,7 +111,7 @@ struct TestContextListener : Catch::TestEventListenerBase
     void
     testCaseEnded(Catch::TestCaseStats const& testCaseStats) override
     {
-        if (gTestTxMetaMode != TestTxMetaMode::IGNORE)
+        if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
             assertThreadIsMain();
             sTestCtx.pop_back();
@@ -120,7 +120,7 @@ struct TestContextListener : Catch::TestEventListenerBase
     void
     sectionStarting(Catch::SectionInfo const& sectionInfo) override
     {
-        if (gTestTxMetaMode != TestTxMetaMode::IGNORE)
+        if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
             assertThreadIsMain();
             sSectCtx.emplace_back(sectionInfo);
@@ -129,7 +129,7 @@ struct TestContextListener : Catch::TestEventListenerBase
     void
     sectionEnded(Catch::SectionStats const& sectionStats) override
     {
-        if (gTestTxMetaMode != TestTxMetaMode::IGNORE)
+        if (gTestTxMetaMode != TestTxMetaMode::META_TEST_IGNORE)
         {
             assertThreadIsMain();
             sSectCtx.pop_back();
@@ -347,11 +347,11 @@ runTest(CommandLineArgs const& args)
                       "are mutually exclusive");
             return 1;
         }
-        gTestTxMetaMode = TestTxMetaMode::RECORD;
+        gTestTxMetaMode = TestTxMetaMode::META_TEST_RECORD;
     }
     if (!checkTestTxMeta.empty())
     {
-        gTestTxMetaMode = TestTxMetaMode::CHECK;
+        gTestTxMetaMode = TestTxMetaMode::META_TEST_CHECK;
         loadTestTxMeta(checkTestTxMeta);
     }
 
@@ -391,7 +391,7 @@ runTest(CommandLineArgs const& args)
     {
         LOG_ERROR(DEFAULT_LOG, "Nonzero test result with --rng-seed {}", seed);
     }
-    if (gTestTxMetaMode == TestTxMetaMode::RECORD)
+    if (gTestTxMetaMode == TestTxMetaMode::META_TEST_RECORD)
     {
         saveTestTxMeta(recordTestTxMeta);
     }
@@ -563,19 +563,19 @@ getCurrentTestContext()
 void
 recordOrCheckGlobalTestTxMetadata(TransactionMeta const& txMeta)
 {
-    if (gTestTxMetaMode == TestTxMetaMode::IGNORE)
+    if (gTestTxMetaMode == TestTxMetaMode::META_TEST_IGNORE)
     {
         return;
     }
     std::string ctx = getCurrentTestContext();
     Hash gotTxMetaHash = xdrSha256(txMeta);
-    if (gTestTxMetaMode == TestTxMetaMode::RECORD)
+    if (gTestTxMetaMode == TestTxMetaMode::META_TEST_RECORD)
     {
         gTestTxMetadata[ctx].emplace_back(gotTxMetaHash);
     }
     else
     {
-        releaseAssert(gTestTxMetaMode == TestTxMetaMode::CHECK);
+        releaseAssert(gTestTxMetaMode == TestTxMetaMode::META_TEST_CHECK);
         auto i = gTestTxMetadata.find(ctx);
         CHECK(i != gTestTxMetadata.end());
         std::vector<Hash>& vec = i->second;

--- a/src/transactions/test/ChangeTrustTests.cpp
+++ b/src/transactions/test/ChangeTrustTests.cpp
@@ -339,7 +339,7 @@ TEST_CASE("change trust", "[tx][changetrust]")
 
             // this should create a LiquidityPoolEntry, and modify
             // liquidityPoolUseCount on the asset trustlines
-            auto prePoolNumSubEntries = getNumSubEntries(root);
+            // auto prePoolNumSubEntries = getNumSubEntries(root);
             root.changeTrust(poolShareAsset, 10);
 
             // TODO: This line requires the update to SponsorshipUtils

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -416,8 +416,8 @@ TEST_CASE("huge divide", "[bigdivide]")
         std::vector<int64_t> values64;
         for (size_t i = 0; i < 10; ++i)
         {
-            values32.emplace_back(i);
-            values32.emplace_back(INT32_MAX - i);
+            values32.emplace_back(static_cast<int>(i));
+            values32.emplace_back(static_cast<int>(INT32_MAX - i));
             values64.emplace_back(i);
             values64.emplace_back(INT32_MAX - i);
             values64.emplace_back(INT64_MAX - i);


### PR DESCRIPTION
Project file was referencing the same file twice and `IGNORE` is a macro defined in one of the Windows headers (and causes conflicts).