### PR TITLE
Additional tx tests

### DIFF
--- a/src/transactions/test/ChangeTrustTests.cpp
+++ b/src/transactions/test/ChangeTrustTests.cpp
@@ -263,7 +263,7 @@ TEST_CASE("change trust", "[tx][changetrust]")
         createModifyAndRemoveSponsoredEntry(
             *app, acc2, changeTrust(idr, 1000), changeTrust(idr, 999),
             changeTrust(idr, 1001), changeTrust(idr, 0),
-            trustlineKey(acc2, idr));
+            trustlineKey(acc2, idr), 14);
     }
 
     SECTION("too many")

--- a/src/transactions/test/ManageDataTests.cpp
+++ b/src/transactions/test/ManageDataTests.cpp
@@ -174,7 +174,8 @@ TEST_CASE("manage data", "[tx][managedata]")
 
         createModifyAndRemoveSponsoredEntry(
             *app, acc2, manageData(t1, &value), manageData(t1, &value2),
-            manageData(t1, &value), manageData(t1, nullptr), dataKey(acc2, t1));
+            manageData(t1, &value), manageData(t1, nullptr), dataKey(acc2, t1),
+            14);
     }
 
     SECTION("too many subentries")

--- a/src/transactions/test/OfferTests.cpp
+++ b/src/transactions/test/OfferTests.cpp
@@ -2983,7 +2983,7 @@ TEST_CASE("create offer", "[tx][offers]")
             *app, acc2, manageOffer(0, usd, idr, Price{1, 1}, 1000),
             manageOffer(1, usd, idr, Price{1, 1}, 999),
             manageOffer(1, usd, idr, Price{1, 1}, 1001),
-            manageOffer(1, usd, idr, Price{1, 1}, 0), offerKey(acc2, 1));
+            manageOffer(1, usd, idr, Price{1, 1}, 0), offerKey(acc2, 1), 14);
     }
 
     SECTION("crossed sponsored offers")

--- a/src/transactions/test/SponsorshipTestUtils.cpp
+++ b/src/transactions/test/SponsorshipTestUtils.cpp
@@ -143,6 +143,36 @@ createSponsoredEntryButSponsorHasInsufficientBalance(
     }
 }
 
+static uint32_t
+getNumReservesRequiredForOperation(Operation const& op)
+{
+    if (op.body.type() == REVOKE_SPONSORSHIP &&
+        op.body.revokeSponsorshipOp().type() ==
+            REVOKE_SPONSORSHIP_LEDGER_ENTRY &&
+        (op.body.revokeSponsorshipOp().ledgerKey().type() == ACCOUNT ||
+         (op.body.revokeSponsorshipOp().ledgerKey().type() == TRUSTLINE &&
+          op.body.revokeSponsorshipOp().ledgerKey().trustLine().asset.type() ==
+              ASSET_TYPE_POOL_SHARE)))
+    {
+        return 2;
+    }
+    else if (op.body.type() == CREATE_ACCOUNT)
+    {
+        return 2;
+    }
+    else if (op.body.type() == CHANGE_TRUST &&
+             op.body.changeTrustOp().line.type() == ASSET_TYPE_POOL_SHARE)
+    {
+        return 2;
+    }
+    else if (op.body.type() == CREATE_CLAIMABLE_BALANCE)
+    {
+        return op.body.createClaimableBalanceOp().claimants.size();
+    }
+
+    return 1;
+}
+
 static void
 createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                                     Operation const& opCreate,
@@ -203,6 +233,8 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                 }
             };
 
+            auto numReserves = getNumReservesRequiredForOperation(opCreate);
+
             {
                 LedgerTxn ltx(app.getLedgerTxnRoot());
                 TransactionMeta txm(2);
@@ -210,9 +242,9 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                 REQUIRE(tx->apply(app, ltx, txm));
 
                 check(ltx);
-                checkSponsorship(ltx, sponsoredAcc, 0, nullptr, nse + 1, 2, 0,
-                                 1);
-                checkSponsorship(ltx, root, 0, nullptr, 0, 2, 1, 0);
+                checkSponsorship(ltx, sponsoredAcc, 0, nullptr,
+                                 nse + numReserves, 2, 0, numReserves);
+                checkSponsorship(ltx, root, 0, nullptr, 0, 2, numReserves, 0);
                 ltx.commit();
             }
 
@@ -224,9 +256,9 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                 REQUIRE(tx2->apply(app, ltx2, txm2));
 
                 check(ltx2);
-                checkSponsorship(ltx2, sponsoredAcc, 0, nullptr, nse + 1, 2, 0,
-                                 1);
-                checkSponsorship(ltx2, root, 0, nullptr, 0, 2, 1, 0);
+                checkSponsorship(ltx2, sponsoredAcc, 0, nullptr,
+                                 nse + numReserves, 2, 0, numReserves);
+                checkSponsorship(ltx2, root, 0, nullptr, 0, 2, numReserves, 0);
                 ltx2.commit();
             }
 
@@ -238,9 +270,9 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                 REQUIRE(tx3->apply(app, ltx3, txm3));
 
                 check(ltx3);
-                checkSponsorship(ltx3, sponsoredAcc, 0, nullptr, nse + 1, 2, 0,
-                                 1);
-                checkSponsorship(ltx3, root, 0, nullptr, 0, 2, 1, 0);
+                checkSponsorship(ltx3, sponsoredAcc, 0, nullptr,
+                                 nse + numReserves, 2, 0, numReserves);
+                checkSponsorship(ltx3, root, 0, nullptr, 0, 2, numReserves, 0);
                 checkSponsorship(ltx3, a2, 0, nullptr, 0, 0, 0, 0);
                 ltx3.commit();
             }
@@ -320,36 +352,6 @@ getMinProtocolVersionForTooManyTestsFromOp(Operation const& op)
     }
 
     return 14;
-}
-
-static uint32_t
-getNumReservesRequiredForOperation(Operation const& op)
-{
-    if (op.body.type() == REVOKE_SPONSORSHIP &&
-        op.body.revokeSponsorshipOp().type() ==
-            REVOKE_SPONSORSHIP_LEDGER_ENTRY &&
-        (op.body.revokeSponsorshipOp().ledgerKey().type() == ACCOUNT ||
-         (op.body.revokeSponsorshipOp().ledgerKey().type() == TRUSTLINE &&
-          op.body.revokeSponsorshipOp().ledgerKey().trustLine().asset.type() ==
-              ASSET_TYPE_POOL_SHARE)))
-    {
-        return 2;
-    }
-    else if (op.body.type() == CREATE_ACCOUNT)
-    {
-        return 2;
-    }
-    else if (op.body.type() == CHANGE_TRUST &&
-             op.body.changeTrustOp().line.type() == ASSET_TYPE_POOL_SHARE)
-    {
-        return 2;
-    }
-    else if (op.body.type() == CREATE_CLAIMABLE_BALANCE)
-    {
-        return op.body.createClaimableBalanceOp().claimants.size();
-    }
-
-    return 1;
 }
 
 static void

--- a/src/transactions/test/SponsorshipTestUtils.cpp
+++ b/src/transactions/test/SponsorshipTestUtils.cpp
@@ -149,11 +149,12 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                                     Operation const& opModify1,
                                     Operation const& opModify2,
                                     Operation const& opRemove,
-                                    RevokeSponsorshipOp const& rso)
+                                    RevokeSponsorshipOp const& rso,
+                                    uint32_t ledgerVersionFrom)
 {
     SECTION("create, modify, and remove sponsored entry")
     {
-        for_versions_from(14, app, [&] {
+        for_versions_from(ledgerVersionFrom, app, [&] {
             uint32_t nse;
             {
                 LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -264,17 +265,16 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
 }
 
 void
-createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
-                                    Operation const& opCreate,
-                                    Operation const& opModify1,
-                                    Operation const& opModify2,
-                                    Operation const& opRemove,
-                                    LedgerKey const& lk)
+createModifyAndRemoveSponsoredEntry(
+    Application& app, TestAccount& sponsoredAcc, Operation const& opCreate,
+    Operation const& opModify1, Operation const& opModify2,
+    Operation const& opRemove, LedgerKey const& lk, uint32_t ledgerVersionFrom)
 {
     RevokeSponsorshipOp rso(REVOKE_SPONSORSHIP_LEDGER_ENTRY);
     rso.ledgerKey() = lk;
     createModifyAndRemoveSponsoredEntry(app, sponsoredAcc, opCreate, opModify1,
-                                        opModify2, opRemove, rso);
+                                        opModify2, opRemove, rso,
+                                        ledgerVersionFrom);
 }
 
 void
@@ -289,7 +289,7 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
     rso.signer().accountID = sponsoredAcc;
     rso.signer().signerKey = signerKey;
     createModifyAndRemoveSponsoredEntry(app, sponsoredAcc, opCreate, opModify1,
-                                        opModify2, opRemove, rso);
+                                        opModify2, opRemove, rso, 14);
 }
 
 void

--- a/src/transactions/test/SponsorshipTestUtils.h
+++ b/src/transactions/test/SponsorshipTestUtils.h
@@ -29,7 +29,7 @@ void createSponsoredEntryButSponsorHasInsufficientBalance(
 void createModifyAndRemoveSponsoredEntry(
     Application& app, TestAccount& sponsoredAcc, Operation const& opCreate,
     Operation const& opModify1, Operation const& opModify2,
-    Operation const& opRemove, LedgerKey const& lk);
+    Operation const& opRemove, LedgerKey const& lk, uint32_t ledgerVersionFrom);
 
 void createModifyAndRemoveSponsoredEntry(
     Application& app, TestAccount& sponsoredAcc, Operation const& opCreate,


### PR DESCRIPTION
# Description

1. Adds additional CAP-0038 tests.
2. Expands the `op source account last modified is updated on claim of sponsored balance` test to include clawback.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
