### PR TITLE
Add a new command to gather information on any given bucket

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -328,6 +328,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerTxnClaimableBalanceSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp" />
+    <ClCompile Include="..\..\src\main\Diagnostics.cpp" />
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\SurveyManager.cpp" />
     <ClCompile Include="..\..\src\overlay\SurveyMessageLimiter.cpp" />
@@ -706,6 +707,7 @@ exit /b 0
     <ClInclude Include="..\..\src\historywork\WriteVerifiedCheckpointHashesWork.h" />
     <ClInclude Include="..\..\src\ledger\InternalLedgerEntry.h" />
     <ClInclude Include="..\..\src\ledger\NonSociRelatedException.h" />
+    <ClInclude Include="..\..\src\main\Diagnostics.h" />
     <ClInclude Include="..\..\src\overlay\SurveyManager.h" />
     <ClInclude Include="..\..\src\overlay\SurveyMessageLimiter.h" />
     <ClInclude Include="..\..\src\test\Fuzzer.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1209,6 +1209,9 @@
     <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\main\Diagnostics.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2095,6 +2098,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.h">
       <Filter>historyWork</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\Diagnostics.h">
+      <Filter>main</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -14,6 +14,7 @@
 #include "main/Application.h"
 #include "main/ApplicationUtils.h"
 #include "main/Config.h"
+#include "main/Diagnostics.h"
 #include "main/ErrorMessages.h"
 #include "main/PersistentState.h"
 #include "main/StellarCoreVersion.h"
@@ -604,6 +605,23 @@ CommandLine::writeToStream(std::string const& exeName, std::ostream& os) const
         os << row << std::endl;
     }
 }
+}
+
+int
+diagBucketStats(CommandLineArgs const& args)
+{
+    std::string bucketFile;
+    bool aggAccountStats = false;
+
+    return runWithHelp(
+        args,
+        {fileNameParser(bucketFile),
+         clara::Opt{aggAccountStats}["--aggregate-account-stats"](
+             "aggregate entries on a per account basis")},
+        [&] {
+            diagnostics::bucketStats(bucketFile, aggAccountStats);
+            return 0;
+        });
 }
 
 int
@@ -1608,6 +1626,8 @@ handleCommandLine(int argc, char* const* argv)
          {"verify-checkpoints", "write verified checkpoint ledger hashes",
           runWriteVerifiedCheckpointHashes},
          {"convert-id", "displays ID in all known forms", runConvertId},
+         {"diag-bucket-stats", "reports statistics on the content of a bucket",
+          diagBucketStats},
          {"dump-xdr", "dump an XDR file, for debugging", runDumpXDR},
          {"encode-asset", "Print an encoded asset in base 64 for debugging",
           runEncodeAsset},

--- a/src/main/Diagnostics.cpp
+++ b/src/main/Diagnostics.cpp
@@ -1,0 +1,147 @@
+#include "main/Diagnostics.h"
+#include "json/json.h"
+#include "util/Decoder.h"
+#include "util/XDROperators.h"
+#include "util/XDRStream.h"
+
+#include <map>
+#include <numeric>
+
+namespace stellar
+{
+namespace diagnostics
+{
+
+void
+bucketStats(std::string const& filename, bool aggregateAccounts)
+{
+    XDRInputFileStream in;
+    in.open(filename);
+
+    BucketEntry tmp;
+    std::map<LedgerEntryType, size_t> ledgerEntriesSizeBytes,
+        ledgerEntriesCount, deadEntryCount;
+    std::map<BucketEntryType, size_t> bucketEntriesCount;
+    std::map<AccountID, size_t> perAccountBytes, perAccountCount;
+    Json::Value root;
+
+    while (in && in.readOne(tmp))
+    {
+        ++bucketEntriesCount[tmp.type()];
+        switch (tmp.type())
+        {
+        case LIVEENTRY:
+        case INITENTRY:
+        {
+            auto const& le = tmp.liveEntry().data;
+            auto t = le.type();
+            auto bytes = xdr::xdr_to_opaque(tmp).size();
+            ledgerEntriesSizeBytes[t] += bytes;
+            ++ledgerEntriesCount[t];
+
+            if (aggregateAccounts)
+            {
+                AccountID const* k = nullptr;
+                switch (t)
+                {
+                case ACCOUNT:
+                    k = &le.account().accountID;
+                    break;
+                case TRUSTLINE:
+                    k = &le.trustLine().accountID;
+                    break;
+                case OFFER:
+                    k = &le.offer().sellerID;
+                    break;
+                case DATA:
+                    k = &le.data().accountID;
+                    break;
+                default:
+                    break;
+                }
+                if (k)
+                {
+                    perAccountBytes[*k] += bytes;
+                    ++perAccountCount[*k];
+                }
+            }
+        }
+        break;
+        case DEADENTRY:
+            ++deadEntryCount[tmp.deadEntry().type()];
+            break;
+        case METAENTRY:
+            root["LEDGER_VERSION"] = tmp.metaEntry().ledgerVersion;
+        }
+    }
+    Json::Value& be = root["BUCKET_ENTRIES"];
+    for (auto const& kv : bucketEntriesCount)
+    {
+        be[xdr::xdr_traits<BucketEntryType>::enum_name(kv.first)] =
+            static_cast<Json::Int64>(kv.second);
+    }
+    Json::Value& le = root["LEDGER_ENTRIES"];
+    for (auto const& kv : ledgerEntriesCount)
+    {
+        auto t = kv.first;
+        auto n = kv.second;
+        auto totalBytes = ledgerEntriesSizeBytes[t];
+        auto avgBytes = totalBytes / n;
+        size_t deadCount = 0;
+        auto deadIt = deadEntryCount.find(t);
+        if (deadIt != deadEntryCount.end())
+        {
+            deadCount = deadIt->second;
+        }
+        Json::Value& o =
+            le[xdr::xdr_traits<LedgerEntryType>::enum_name(kv.first)];
+        o["count"] = static_cast<Json::Int64>(n);
+        o["dead_count"] = static_cast<Json::Int64>(deadCount);
+        o["avg"] = static_cast<Json::Int64>(avgBytes);
+    }
+    if (aggregateAccounts)
+    {
+        // compute per account stats
+        std::vector<size_t> bytes, entries;
+        bytes.reserve(perAccountBytes.size());
+        entries.reserve(perAccountBytes.size());
+
+        size_t totalBytes = 0;
+        size_t totalEntries = 0;
+
+        for (auto const& kv : perAccountCount)
+        {
+            auto n = kv.second;
+            auto kvTotalBytes = perAccountBytes[kv.first];
+
+            bytes.emplace_back(kvTotalBytes);
+            totalBytes += kvTotalBytes;
+
+            entries.emplace_back(n);
+            totalEntries += n;
+        }
+        std::sort(bytes.begin(), bytes.end());
+        std::sort(entries.begin(), entries.end());
+
+        auto addStats = [&](Json::Value& o, std::vector<size_t> const& v,
+                            size_t total) {
+            auto vMin = v[0];
+            auto vMax = v[v.size() - 1];
+            o["count"] = static_cast<Json::Int64>(v.size());
+            o["total"] = static_cast<Json::Int64>(total);
+            o["min"] = static_cast<Json::Int64>(vMin);
+            o["max"] = static_cast<Json::Int64>(vMax);
+            o["avg"] = static_cast<Json::Int64>(total / v.size());
+            o["P50"] = static_cast<Json::Int64>(v[v.size() / 2]);
+            o["P99"] = static_cast<Json::Int64>(v[v.size() * 99 / 100]);
+        };
+
+        Json::Value& agg = root["AGG_ACCOUNT"];
+        addStats(agg["BYTES"], bytes, totalBytes);
+        addStats(agg["ENTRIES"], entries, totalEntries);
+    }
+
+    fmt::print("{}\n", root.toStyledString());
+}
+}
+}

--- a/src/main/Diagnostics.h
+++ b/src/main/Diagnostics.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/StellarXDR.h"
+
+namespace stellar
+{
+namespace diagnostics
+{
+void bucketStats(std::string const& filename, bool aggregateAccounts);
+}
+}


### PR DESCRIPTION
As I found myself writing the same kind of code every few months while debugging issues or just trying to understand recent activity better, I figured we should just have this in the tree:
at a minimum this is handy to get information on a bucket file, and it's a good starting point to customize it to gather different information on buckets.

When invoking the command on a bucket, the output looks like something like this:
```
) stellar-core diag-bucket-stats --aggregate-account-stats bucket-4bece439ef4685bb06212fc44e3549b4ae192b5e33602379eb0b8a7c23f94207.xdr

{
   "AGG_ACCOUNT" : {
      "BYTES" : {
         "P50" : 96,
         "P99" : 696,
         "avg" : 172,
         "count" : 5219458,
         "max" : 1066668,
         "min" : 96,
         "total" : 899107812
      },
      "ENTRIES" : {
         "P50" : 1,
         "P99" : 5,
         "avg" : 1,
         "count" : 5219458,
         "max" : 6838,
         "min" : 1,
         "total" : 8197760
      }
   },
   "BUCKET_ENTRIES" : {
      "INITENTRY" : 4228999,
      "LIVEENTRY" : 3968761,
      "METAENTRY" : 1
   },
   "LEDGER_ENTRIES" : {
      "ACCOUNT" : {
         "avg" : 101,
         "count" : 5219458,
         "dead_count" : 0
      },
      "CLAIMABLE_BALANCE" : {
         "avg" : 202,
         "count" : 222,
         "dead_count" : 0
      },
      "DATA" : {
         "avg" : 144,
         "count" : 27731,
         "dead_count" : 0
      },
      "OFFER" : {
         "avg" : 147,
         "count" : 69239,
         "dead_count" : 0
      },
      "TRUSTLINE" : {
         "avg" : 122,
         "count" : 2881110,
         "dead_count" : 0
      }
   },
   "LEDGER_VERSION" : 16
}
```
