### PR TITLE
Add CONFIGURE_FLAGS argument to Dockerfile.testing

### DIFF
--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -17,9 +17,10 @@ ARG CC=clang-10
 ARG CXX=clang++-10
 ARG CFLAGS='-O3 -g1 -fno-omit-frame-pointer'
 ARG CXXFLAGS='-O3 -g1 -fno-omit-frame-pointer -stdlib=libc++'
+ARG CONFIGURE_FLAGS
 
 RUN ./autogen.sh
-RUN ./configure CC="${CC}" CXX="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}"
+RUN ./configure CC="${CC}" CXX="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" ${CONFIGURE_FLAGS}
 RUN sh -c 'make -j $(nproc)'
 RUN make install
 


### PR DESCRIPTION
For next-protocol testing with Horizon, we need to build core with
--enable-next-protocol-version-unsafe-for-production , for which it's
handy to be able to provide the argument to `docker build`.