### PR TITLE
Add --enable-tracy-csvexport

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 ## Process this file with automake to produce Makefile.in
 
+bin_PROGRAMS =
 SUBDIRS = lib src
 AM_EXTRA_RECURSIVE_TARGETS = check-valgrind
 ACLOCAL_AMFLAGS = -I m4
@@ -35,6 +36,8 @@ $(TRACY_GUI_BUILD)/Tracy-release: $(wildcard $(TRACY_GUI_SOURCE)/*.*)
 
 tracy-gui: $(TRACY_GUI_BUILD)/Tracy-release
 	cp -v $< $@
+
+bin_PROGRAMS += tracy-gui
 endif # USE_TRACY_GUI
 
 if USE_TRACY_CAPTURE
@@ -47,6 +50,8 @@ $(TRACY_CAPTURE_BUILD)/capture-release: $(wildcard $(TRACY_CAPTURE_SOURCE)/*.*)
 
 tracy-capture: $(TRACY_CAPTURE_BUILD)/capture-release
 	cp -v $< $@
+
+bin_PROGRAMS += tracy-capture
 endif # USE_TRACY_CAPTURE
 
 if USE_TRACY_CSVEXPORT
@@ -59,6 +64,8 @@ $(TRACY_CSVEXPORT_BUILD)/csvexport-release: $(wildcard $(TRACY_CSVEXPORT_SOURCE)
 
 tracy-csvexport: $(TRACY_CSVEXPORT_BUILD)/csvexport-release
 	cp -v $< $@
+
+bin_PROGRAMS += tracy-csvexport
 endif # USE_TRACY_CSVEXPORT
 
 EXTRA_DIST = stellar-core.supp test/testnet/multitail.conf	\

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,18 @@ tracy-capture: $(TRACY_CAPTURE_BUILD)/capture-release
 	cp -v $< $@
 endif # USE_TRACY_CAPTURE
 
+if USE_TRACY_CSVEXPORT
+TRACY_CSVEXPORT_DIR=$(top_srcdir)/lib/tracy/csvexport
+TRACY_CSVEXPORT_SOURCE=$(TRACY_CSVEXPORT_DIR)/src
+TRACY_CSVEXPORT_BUILD=$(TRACY_CSVEXPORT_DIR)/build/unix
+
+$(TRACY_CSVEXPORT_BUILD)/csvexport-release: $(wildcard $(TRACY_CSVEXPORT_SOURCE)/*.*)
+	$(MAKE) -C $(TRACY_CSVEXPORT_BUILD) release CC="$(CC)" CXX="$(CXX)"
+
+tracy-csvexport: $(TRACY_CSVEXPORT_BUILD)/csvexport-release
+	cp -v $< $@
+endif # USE_TRACY_CSVEXPORT
+
 EXTRA_DIST = stellar-core.supp test/testnet/multitail.conf	\
 	test/testnet/run-test.sh README.md make-mks
 

--- a/configure.ac
+++ b/configure.ac
@@ -355,6 +355,11 @@ AC_ARG_ENABLE(tracy-capture,
         [Enable 'tracy' profiler/tracer capture program]))
 AM_CONDITIONAL(USE_TRACY_CAPTURE, [test x$enable_tracy_capture = xyes])
 
+AC_ARG_ENABLE(tracy-csvexport,
+    AS_HELP_STRING([--enable-tracy-csvexport],
+        [Enable 'tracy' profiler/tracer csvexport program]))
+AM_CONDITIONAL(USE_TRACY_CSVEXPORT, [test x$enable_tracy_csvexport = xyes])
+
 AC_ARG_ENABLE(spdlog,
     AS_HELP_STRING([--disable-spdlog],
         [Disable spdlog]))

--- a/scripts/DiffTracyCSV.py
+++ b/scripts/DiffTracyCSV.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+import sys
+if sys.version_info < (3, 4):
+    raise "must use python 3.4 or greater"
+
+import csv
+import statistics
+import argparse
+from collections import namedtuple
+
+Measure = namedtuple("Measure", ["old", "new", "diff", "pct", "flag"])
+Measures = namedtuple("Measures", ["median", "p90", "sum", "events"])
+Changes = namedtuple("Changes", ["zone", "measures"])
+
+
+def read_file(filename):
+    data = dict()
+    with open(filename, newline='', encoding='utf-8') as f:
+        reader = csv.reader(f)
+        next(reader, None)  # skip header
+        rows = 0
+        for (name, src_file, src_line, _, exec_time_ns) in reader:
+            rows += 1
+            key = (name, src_file, src_line)
+            if key in data:
+                data[key].append(float(exec_time_ns))
+            else:
+                data[key] = [float(exec_time_ns)]
+    print("  - read {} rows about {} zones from {}".format(rows, len(data),
+                                                           filename))
+    return data
+
+
+def chk_diff(old, new, pct_lim, abs_lim):
+    diff = int(new - old)
+    pct = (diff / (1.0 + old)) * 100.0
+    flag = (new >= abs_lim and pct >= pct_lim)
+    return Measure(old=int(old), new=int(new), flag=flag,
+                   diff=diff, pct=int(pct))
+
+
+def filter_zone_changes(old, new, pct_lim, zone_lim, sum_lim, evt_lim):
+    print(("  - showing all zones with pct_lim={:,d}, zone_lim={:s}, " +
+           "sum_lim={:s} and evt_lim={:,d}\n")
+          .format(pct_lim, fmt_time(zone_lim), fmt_time(sum_lim), evt_lim))
+    out = []
+    for (zone, new_data) in new.items():
+        if zone in old.keys():
+            old_data = old[zone]
+            old_evt = len(old_data)
+            new_evt = len(new_data)
+            if old_evt > 2 and new_evt > 2:
+                if old_evt < evt_lim and new_evt < evt_lim:
+                    continue
+                old_sum = sum(old_data)
+                new_sum = sum(new_data)
+                if old_sum < sum_lim and new_sum < sum_lim:
+                    continue
+                # Quantiles returns an n-1 cutpoint list qq, so median is
+                # at qq[4] and p90 is at qq[8].
+                old_qq = statistics.quantiles(old_data, n=10)
+                new_qq = statistics.quantiles(new_data, n=10)
+                m1 = chk_diff(old_qq[4], new_qq[4], pct_lim, zone_lim)
+                m2 = chk_diff(old_qq[8], new_qq[8], pct_lim, zone_lim)
+                m3 = chk_diff(old_sum, new_sum, pct_lim, sum_lim)
+                m4 = chk_diff(old_evt, new_evt, pct_lim, evt_lim)
+                if m1.flag or m2.flag or m3.flag or m4.flag:
+                    ms = Measures(median=m1, p90=m2, sum=m3, events=m4)
+                    z = "{} @ {}:{}".format(*zone)
+                    out.append(Changes(zone=z, measures=ms))
+    return out
+
+
+def fmt_time(ns):
+    thousand = 1000
+    million = thousand * thousand
+    billion = million * thousand
+    ans = int(abs(ns))
+    if ans >= billion:
+        return "{:n} sec".format(int(ns / billion))
+    elif ans >= million:
+        return "{:n} msec".format(int(ns / million))
+    elif ans >= thousand:
+        return "{:n} usec".format(int(ns / thousand))
+    else:
+        return "{:n} nsec".format(int(ns))
+
+
+def fmt_flag(flag):
+    if flag:
+        return "🛑"
+    else:
+        return "✅"
+
+
+def main():
+
+    # construct the argument parse and parse the arguments
+    argument_parser = argparse.ArgumentParser()
+    argument_parser.add_argument("--old", required=True,
+                                 help="old CSV file")
+    argument_parser.add_argument("--new", required=True,
+                                 help="new CSV file")
+    argument_parser.add_argument("--pct-lim", default=10, type=int,
+                                 help="limit to deltas >= given percent")
+    argument_parser.add_argument("--zone-lim", default=1000, type=int,
+                                 help="limit to zone delta >= given nsecs")
+    argument_parser.add_argument("--sum-lim", default=100000000, type=int,
+                                 help="limit to sum delta >= given nsecs")
+    argument_parser.add_argument("--evt-lim", default=1000, type=int,
+                                 help="limit to event delta >= given count")
+
+    args = argument_parser.parse_args()
+
+    print("\n### Tracy zone-timing comparison\n")
+
+    old = read_file(args.old)
+    new = read_file(args.new)
+    out = filter_zone_changes(old, new, args.pct_lim, args.zone_lim,
+                              args.sum_lim, args.evt_lim)
+
+    if len(out) == 0:
+        print("**No zone changes exceed limits**")
+    else:
+        out.sort(key=lambda v: v.measures.sum.pct)
+        for c in out:
+            print("\n### {}".format(c.zone))
+            print(("| {:>8s} | {:>15s} | {:>15s} " +
+                   "| {:>15s} | {:>15s} | {:<5s} ").format(
+                       "measure", "old", "new",
+                       "diff", "diff %", "flag"))
+            print("|---------:|----------------:|----------------:" +
+                  "|----------------:|----------------:|:------|")
+            for k, m in c.measures._asdict().items():
+                if k == "events":
+                    print(("| {:>8.8s} | {:15n} | {:15n} " +
+                           "| {:15n} | {:14n}% | {:<5s} |").format(
+                               k, m.old, m.new, m.diff,
+                               m.pct, fmt_flag(m.flag)))
+                else:
+                    print(("| {:>8.8s} | {:>15s} | {:>15s} " +
+                           "| {:>15s} | {:14n}% | {:<5s} |").format(
+                                k, fmt_time(m.old), fmt_time(m.new),
+                                fmt_time(m.diff), m.pct, fmt_flag(m.flag)))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,6 +3,7 @@ This folder is for storing any scripts that may be helpful for using stellar-cor
 
 ## List of scripts
 - [Overlay survey](#overlay-survey)
+- [Diff Tracy CSV](#diff-tracy-csv)
 
 ### Overlay survey 
 - Name - `OverlaySurvey.py`
@@ -24,6 +25,11 @@ This folder is for storing any scripts that may be helpful for using stellar-cor
     - sub command `flatten` - Take a graphml file containing a bidrectional graph (possibly augmented with StellarBeat data) and flatten it into an undirected graph in JSON.
         - `-gmli GRAPHMLINPUT` - input graphml file
         - `-json JSONOUTPUT` - output json file
+
+### Diff Tracy CSV
+- Name - `DiffTracyCSV.py`
+- Description - A Python script that compares two CSV files produced by `tracy-csvexport` (which in turn reads output from `tracy-capture`). The purpose of this script is to detect significant performance impacts of changes to stellar-core by capturing before-and-after traces.
+- Usage - Ex. `tracy-capture -o old.tracy -s 10 -a 127.0.0.1` to capture a 10 second trace of stellar-core running on the local machine. Then run `tracy-csvexport -u old.tracy >old.csv`. Then make a change to stellar-core and repeat the process to capture `new.tracy` and `new.csv`. Finally, run `DiffTracyCSV.py --old old.csv --new new.csv` and inspect the differences.
 
 ## Style guide
 We follow [PEP-0008](https://www.python.org/dev/peps/pep-0008/).


### PR DESCRIPTION
This is a few pieces of tracy infrastructure:

  - Enables the `tracy-csvexport` tool, that converts a `tracy-capture` file to CSV
  - Adds `scripts/DiffTracyCSV.py` that does a high-level statistical filter-and-comparison between two CSV files
  - Bumps the tracy submodule to get a change I submitted upstream to allow time-limited runs of `tracy-capture`
  - Adds the `tracy-{capture,csvexport,gui}` programs to `bin_PROGRAMS` in `Makefile.am` which (I think) means they will be both automatically built and installed and, more importantly, included in any debian package that is built with them enabled.
