### PR TITLE
Improve performance of bucket apply for captive core

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -204,3 +204,11 @@ lib/spdlog
   (https://github.com/gabime/spdlog)
   Licensed under the MIT license
   (http://opensource.org/licenses/MIT)
+
+src/ledger/LedgerHashUtils.h
+
+    Portion copied from fast-hash
+    Copyright (C) Zilong Tan (eric.zltan@gmail.com)
+    ( https://github.com/ztanml/fast-hash )
+    Licensed under the MIT license
+    (http://opensource.org/licenses/MIT)

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -88,6 +88,7 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
     {
         innerLtx = std::make_unique<LedgerTxn>(root, false);
         ltx = innerLtx.get();
+        ltx->prepareNewObjects(LEDGER_ENTRY_BATCH_COMMIT_SIZE);
     }
 
     for (; mBucketIter; ++mBucketIter)

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -73,7 +73,23 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
     size_t count = 0;
 
     auto& root = mApp.getLedgerTxnRoot();
-    LedgerTxn ltx(root, false);
+    AbstractLedgerTxn* ltx;
+    std::unique_ptr<LedgerTxn> innerLtx;
+
+    // when running in memory mode, make changes to the in memory ledger
+    // directly instead of creating a temporary inner LedgerTxn
+    // as "advance" commits changes during each step this does not introduce any
+    // new failure mode
+    if (mApp.getConfig().MODE_USES_IN_MEMORY_LEDGER)
+    {
+        ltx = static_cast<AbstractLedgerTxn*>(&root);
+    }
+    else
+    {
+        innerLtx = std::make_unique<LedgerTxn>(root, false);
+        ltx = innerLtx.get();
+    }
+
     for (; mBucketIter; ++mBucketIter)
     {
         BucketEntry const& e = *mBucketIter;
@@ -85,11 +101,11 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
 
             if (e.type() == LIVEENTRY || e.type() == INITENTRY)
             {
-                ltx.createOrUpdateWithoutLoading(e.liveEntry());
+                ltx->createOrUpdateWithoutLoading(e.liveEntry());
             }
             else
             {
-                ltx.eraseWithoutLoading(e.deadEntry());
+                ltx->eraseWithoutLoading(e.deadEntry());
             }
 
             if ((++count > LEDGER_ENTRY_BATCH_COMMIT_SIZE))
@@ -98,7 +114,10 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
             }
         }
     }
-    ltx.commit();
+    if (innerLtx)
+    {
+        ltx->commit();
+    }
 
     mCount += count;
     return count;

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -119,6 +119,15 @@ ApplyBucketsWork::onReset()
             addBucket(getBucket(hsb.snap));
             addBucket(getBucket(hsb.curr));
         }
+        // estimate the number of ledger entries contained in those buckets
+        // use accounts as a rough approximator as to overestimate a bit
+        // (default BucketEntry contains a default AccountEntry)
+        size_t const estimatedLedgerEntrySize =
+            xdr::xdr_traits<BucketEntry>::serial_size(BucketEntry{});
+        size_t const totalLECount = mTotalSize / estimatedLedgerEntrySize;
+        CLOG_INFO(History, "ApplyBuckets estimated {} ledger entries",
+                  totalLECount);
+        mApp.getLedgerTxnRoot().prepareNewObjects(totalLECount);
     }
 
     mLevel = BucketList::kNumLevels - 1;

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -156,6 +156,10 @@ InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const& keys)
     return 0;
 }
 
+void InMemoryLedgerTxnRoot::prepareNewObjects(size_t)
+{
+}
+
 #ifdef BUILD_TESTS
 void
 InMemoryLedgerTxnRoot::resetForFuzzer()

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -77,6 +77,8 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void dropLiquidityPools() override;
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
+    void prepareNewObjects(size_t s) override;
+
 #ifdef BUILD_TESTS
     void resetForFuzzer() override;
 #endif // BUILD_TESTS

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2125,6 +2125,28 @@ LedgerTxn::Impl::hasSponsorshipEntry() const
     return false;
 }
 
+void
+LedgerTxn::prepareNewObjects(size_t s)
+{
+    getImpl()->prepareNewObjects(s);
+}
+
+void
+LedgerTxn::Impl::prepareNewObjects(size_t s)
+{
+    size_t newSize = mEntry.size();
+    auto constexpr m = std::numeric_limits<size_t>::max();
+    if (newSize >= m - s)
+    {
+        newSize = m;
+    }
+    else
+    {
+        newSize += s;
+    }
+    mEntry.reserve(newSize);
+}
+
 #ifdef BUILD_TESTS
 UnorderedMap<AssetPair,
              std::multimap<OfferDescriptor, LedgerKey, IsBetterOfferComparator>,
@@ -2744,6 +2766,16 @@ LedgerTxnRoot::Impl::getPrefetchHitRate() const
     }
     return static_cast<double>(mPrefetchHits) /
            (mPrefetchMisses + mPrefetchHits);
+}
+
+void
+LedgerTxnRoot::prepareNewObjects(size_t s)
+{
+    mImpl->prepareNewObjects(s);
+}
+
+void LedgerTxnRoot::Impl::prepareNewObjects(size_t)
+{
 }
 
 UnorderedMap<LedgerKey, LedgerEntry>

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -3039,11 +3039,10 @@ LedgerTxnRoot::Impl::getBestOffer(Asset const& buying, Asset const& selling,
             populateEntryCacheFromBestOffers(iter, lastOfferIter);
         }
 
-        putInEntryCache(LedgerEntryKey(*iter),
-                        std::make_shared<LedgerEntry const>(*iter),
-                        LoadType::IMMEDIATE);
+        auto le = std::make_shared<LedgerEntry const>(*iter);
+        putInEntryCache(LedgerEntryKey(*iter), le, LoadType::IMMEDIATE);
 
-        return std::make_shared<LedgerEntry const>(*iter);
+        return le;
     }
     return nullptr;
 }

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -458,6 +458,9 @@ class AbstractLedgerTxnParent
     // than a (real or stub) root LedgerTxn.
     virtual uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) = 0;
 
+    // prepares to increase the capacity of pending changes by up to "s" changes
+    virtual void prepareNewObjects(size_t s) = 0;
+
 #ifdef BUILD_TESTS
     virtual void resetForFuzzer() = 0;
 #endif // BUILD_TESTS
@@ -730,6 +733,7 @@ class LedgerTxn : public AbstractLedgerTxn
     void dropLiquidityPools() override;
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
+    void prepareNewObjects(size_t s) override;
 
     bool hasSponsorshipEntry() const override;
 
@@ -818,6 +822,8 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
     double getPrefetchHitRate() const override;
+
+    void prepareNewObjects(size_t s) override;
 
 #ifdef BEST_OFFER_DEBUGGING
     bool bestOfferDebuggingEnabled() const override;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -614,6 +614,8 @@ class LedgerTxn::Impl
 
     double getPrefetchHitRate() const;
 
+    void prepareNewObjects(size_t s);
+
     // hasSponsorshipEntry has the strong exception safety guarantee
     bool hasSponsorshipEntry() const;
 
@@ -934,6 +936,8 @@ class LedgerTxnRoot::Impl
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
 
     double getPrefetchHitRate() const;
+
+    void prepareNewObjects(size_t s);
 
 #ifdef BEST_OFFER_DEBUGGING
     bool bestOfferDebuggingEnabled() const;


### PR DESCRIPTION
# Description

This PR makes some performance improvements to captive core.

On my test machine (Intel Xeon 3.1GHz), the time to apply buckets when running the command
`stellar-core catchup --in-memory 36939003/0`
goes from 1 minute to 34 seconds with this PR.

List of changes:
* Adjusted hash function used with ledger entries to reduce chance of rehashing
* Do not use an intermediate `LedgerTxn` when using in memory mode
* Guesstimate the size of dictionaries ahead of time to reduce chance of rehashing
    * this one only yields a small (5 seconds) improvement, the main benefit is that it removes pauses caused by rehashing while applying buckets
