### PR TITLE
Small reordering of protocol 18 behavior in ChangeTrust

### DIFF
--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -224,13 +224,6 @@ ChangeTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
 
         if (mChangeTrust.limit == 0)
         { // we are deleting a trustline
-
-            // line gets deleted. first release reserves
-            auto header = ltx.loadHeader();
-            auto sourceAccount = loadSourceAccount(ltx, header);
-            removeEntryWithPossibleSponsorship(ltx, header, trustLine.current(),
-                                               sourceAccount);
-
             // use a lambda so we don't hold a reference to the TrustLineEntry
             auto tlEntry = [&]() -> TrustLineEntry const& {
                 return trustLine.current().data.trustLine();
@@ -245,6 +238,11 @@ ChangeTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
                 return false;
             }
 
+            // line gets deleted. first release reserves
+            auto header = ltx.loadHeader();
+            auto sourceAccount = loadSourceAccount(ltx, header);
+            removeEntryWithPossibleSponsorship(ltx, header, trustLine.current(),
+                                               sourceAccount);
             trustLine.erase();
 
             // this will create a child LedgerTxn and deactivate all loaded


### PR DESCRIPTION
# Description

Related to #3169 

Refactoring sponsorships will be easier if `removeEntryWithPossibleSponsorship` is immediately followed by `erase`, which is what we do in most places. It is safe to reorder this because the interleaved code is only used in protocol 18, which has not been released yet.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
