### PR TITLE
Adjust automatic maintenance to run faster (every 6 minutes)

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -295,18 +295,18 @@ QUORUM_INTERSECTION_CHECKER=true
 # This limits the number that will be active at a time.
 MAX_CONCURRENT_SUBPROCESSES=16
 
-# AUTOMATIC_MAINTENANCE_PERIOD (integer, seconds) default 660
+# AUTOMATIC_MAINTENANCE_PERIOD (integer, seconds) default 359
 # Interval between automatic maintenance executions
 # Set to 0 to disable automatic maintenance
-AUTOMATIC_MAINTENANCE_PERIOD=660
+AUTOMATIC_MAINTENANCE_PERIOD=359
 
-# AUTOMATIC_MAINTENANCE_COUNT (integer) default 700
+# AUTOMATIC_MAINTENANCE_COUNT (integer) default 400
 # Number of unneeded ledgers in each table that will be removed during one
 # maintenance run.
 # NB: make sure that enough ledgers are deleted as to offset the growth of
 # data accumulated by closing ledgers (catchup and normal operation)
 # Set to 0 to disable automatic maintenance
-AUTOMATIC_MAINTENANCE_COUNT=700
+AUTOMATIC_MAINTENANCE_COUNT=400
 
 # AUTOMATIC_SELF_CHECK_PERIOD (integer, seconds) default 10800
 # Interval between automatic self-checks, including connectivity

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -131,15 +131,15 @@ Config::Config() : NODE_SEED(SecretKey::random())
     CATCHUP_RECENT = 0;
     EXPERIMENTAL_PRECAUTION_DELAY_META = false;
     // automatic maintenance settings:
-    // 11 minutes is relatively short and prime with 1 hour
-    // which will cause automatic maintenance to rarely conflict with any other
-    // scheduled tasks on a machine (that tend to run on a fixed schedule)
-    AUTOMATIC_MAINTENANCE_PERIOD = std::chrono::seconds{11 * 60};
+    // short and prime with 1 hour which will cause automatic maintenance to
+    // rarely conflict with any other scheduled tasks on a machine (that tend to
+    // run on a fixed schedule)
+    AUTOMATIC_MAINTENANCE_PERIOD = std::chrono::seconds{359};
     // count picked as to catchup with 1 month worth of ledgers
     // in about 1 week.
-    // (30*24*3600/5) / (700 - (11*60)/5 ) // number of periods
-    //   * (11*60) / (24*3600) = 6.97 days
-    AUTOMATIC_MAINTENANCE_COUNT = 700;
+    // (30*24*3600/5) / (400 - 359/5 ) // number of periods needed to catchup
+    //   * (359) / (24*3600) = 6.56 days
+    AUTOMATIC_MAINTENANCE_COUNT = 400;
     // automatic self-check happens once every 3 hours
     AUTOMATIC_SELF_CHECK_PERIOD = std::chrono::seconds{3 * 60 * 60};
     ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;


### PR DESCRIPTION
this avoids putting too much pressure on slower disks
