### PR TITLE
Add ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING config param (BUILD_TESTS only)

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -336,6 +336,16 @@ Database::getUpsertTimer(std::string const& entityName)
 }
 
 void
+Database::maybeArtificiallySleepForSimulatedLatency()
+{
+    auto usec = mApp.getConfig().ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING;
+    if (usec.count() != 0)
+    {
+        std::this_thread::sleep_for(usec);
+    }
+}
+
+void
 Database::setCurrentTransactionReadOnly()
 {
     if (!isSqlite())
@@ -417,6 +427,7 @@ Database::getSession()
 {
     // global session can only be used from the main thread
     assertThreadIsMain();
+    maybeArtificiallySleepForSimulatedLatency();
     return mSession;
 }
 
@@ -488,6 +499,7 @@ class SQLLogContext : NonCopyable
 StatementContext
 Database::getPreparedStatement(std::string const& query)
 {
+    maybeArtificiallySleepForSimulatedLatency();
     auto i = mStatements.find(query);
     std::shared_ptr<soci::statement> p;
     if (i == mStatements.end())

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -133,6 +133,8 @@ class Database : NonMovableOrCopyable
     medida::TimerContext getUpdateTimer(std::string const& entityName);
     medida::TimerContext getUpsertTimer(std::string const& entityName);
 
+    void maybeArtificiallySleepForSimulatedLatency();
+
     // If possible (i.e. "on postgres") issue an SQL pragma that marks
     // the current transaction as read-only. The effects of this last
     // only as long as the current SQL transaction.

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -46,6 +46,7 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING",
     "ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING",
     "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING",
+    "ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING",
     "OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING",
     "OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
     "LOADGEN_OP_COUNT_FOR_TESTING",
@@ -148,6 +149,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = false;
     ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING = false;
     ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING = false;
+    ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING = std::chrono::microseconds(0);
     ALLOW_LOCALHOST_FOR_TESTING = false;
     USE_CONFIG_FOR_GENESIS = false;
     FAILURE_SAFETY = -1;
@@ -918,6 +920,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING =
                     readBool(item);
+            }
+            else if (item.first == "ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING")
+            {
+                ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING =
+                    std::chrono::microseconds{readInt<uint32_t>(item)};
             }
             else if (item.first == "ALLOW_LOCALHOST_FOR_TESTING")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -196,6 +196,11 @@ class Config : public std::enable_shared_from_this<Config>
     // system.
     bool ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING;
 
+    // A config parameter that causes each database call to sleep for a given
+    // number of microseconds before returning. This allows simulating a slow
+    // database (or a database on a slow disk) in performance tests.
+    std::chrono::microseconds ARTIFICIAL_DATABASE_LATENCY_FOR_TESTING;
+
     // Config parameters that force transaction application during ledger
     // close to sleep for a certain amount of time.
     // The probability that it sleeps for


### PR DESCRIPTION
This is just a test utility to let us crudely simulate the effects of arbitrarily-slow databases without having to manually construct them (eg. spinning disks, slow network drives, etc.)

Compiled-out of release builds, just for testing.