### PR TITLE
Update docker image build timestamp format

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -2,7 +2,7 @@
 SUDO := $(shell docker version >/dev/null 2>&1 || echo "sudo")
 
 # https://github.com/opencontainers/image-spec/blob/master/annotations.md
-BUILD_DATE := $(shell date --utc --rfc-3339=seconds)
+BUILD_DATE := $(shell date -u +%FT%TZ)
 
 # Base image, defaults to ubuntu 20.04 focal
 DISTRO ?= focal


### PR DESCRIPTION
Golang time parser is not compatible with format rendered by the GNU date,
even though both claim to be RFC3339. This change replaces space separator
between date and time with "T" which will allow golang to parse it.
It also switches from `--utc` to `-u` that's supported by both GNU and BSD
date commands.
