### PR TITLE
Uint128_t native

### DIFF
--- a/lib/util/uint128_t.cpp
+++ b/lib/util/uint128_t.cpp
@@ -1,5 +1,7 @@
 #include "uint128_t.h"
 #include <cstring>
+namespace libu128
+{
 
 const uint128_t uint128_0(0u);
 const uint128_t uint128_1(1u);
@@ -543,4 +545,5 @@ std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs){
         stream << rhs.str(16);
     }
     return stream;
+}
 }

--- a/lib/util/uint128_t.h
+++ b/lib/util/uint128_t.h
@@ -1,8 +1,13 @@
+#pragma once
+#include <cstdint>
 /*
 uint128_t.h
 An unsigned 128 bit integer type for C++
 
 Copyright (c) 2013 - 2017 Jason Lee @ calccrypto at gmail.com
+
+Minor modifications
+Copyright (c) 2021 Stellar Development Foundation and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -43,9 +48,6 @@ char x = uint128_t(y);
 auto x = 2 * uint128_t(y);
 */
 
-#ifndef __UINT128_T__
-#define __UINT128_T__
-
 #include <cstdint>
 #include <ostream>
 #include <stdexcept>
@@ -81,13 +83,16 @@ auto x = 2 * uint128_t(y);
 // We're not building a shared library, skip dllimport/dllexport stuff.
 #define UINT128_T_EXTERN
 
-class UINT128_T_EXTERN uint128_t;
+namespace libu128
+{
+    class uint128_t;
+}
 
 // Give uint128_t type traits
 namespace std {  // This is probably not a good idea
-    template <> struct is_arithmetic <uint128_t> : std::true_type {};
-    template <> struct is_integral   <uint128_t> : std::true_type {};
-    template <> struct is_unsigned   <uint128_t> : std::true_type {};
+    template <> struct is_arithmetic <libu128::uint128_t> : std::true_type {};
+    template <> struct is_integral   <libu128::uint128_t> : std::true_type {};
+    template <> struct is_unsigned   <libu128::uint128_t> : std::true_type {};
 }
 
 #ifdef UNSAFE_UINT128_OPS
@@ -95,6 +100,9 @@ namespace std {  // This is probably not a good idea
 #else
 #define IMPLICIT_UNSAFE_UINT128_OPS explicit
 #endif
+
+namespace libu128
+{
 
 class uint128_t{
     private:
@@ -549,4 +557,39 @@ T & operator%=(T & lhs, const uint128_t & rhs){
 
 // IO Operator
 UINT128_T_EXTERN std::ostream & operator<<(std::ostream & stream, const uint128_t & rhs);
+}
+
+
+namespace stellar
+{
+#if defined(__SIZEOF_INT128__) || defined(_GLIBCXX_USE_INT128)
+
+typedef __uint128_t uint128_t;
+
+inline uint128_t uint128_max() {
+    return ~uint128_t(0);
+}
+
+inline int uint128_bits(__uint128_t const& x) {
+    uint64_t hi = uint64_t(x >> 64);
+    if (hi) {
+        return 128 - __builtin_clzll(hi);
+    } else {
+        uint64_t lo = uint64_t(x);
+        return 64 - __builtin_clzll(lo);
+    }
+}
+
+#else
+
+using uint128_t = libu128::uint128_t;
+
+inline uint128_t uint128_max() {
+    return ~libu128::uint128_0;
+}
+
+inline int uint128_bits(libu128::uint128_t const& x) {
+    return x.bits();
+}
 #endif
+}

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -500,9 +500,9 @@ TxSetFrame::getBaseFee(LedgerHeader const& lh) const
         {
             auto txOps = txPtr->getNumOperations();
             ops += txOps;
-            int64_t txBaseFee =
-                bigDivide(txPtr->getFeeBid(), 1, static_cast<int64_t>(txOps),
-                          Rounding::ROUND_UP);
+            int64_t txBaseFee = bigDivideOrThrow(txPtr->getFeeBid(), 1,
+                                                 static_cast<int64_t>(txOps),
+                                                 Rounding::ROUND_UP);
             lowBaseFee = std::min(lowBaseFee, txBaseFee);
         }
         // if surge pricing was in action, use the lowest base fee bid from the

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -814,9 +814,9 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
         };
         auto getBaseFeeRate = [](TxQueueLimiter const& limiter) {
             auto fr = limiter.getMinFeeNeeded();
-            return fr.second == 0
-                       ? 0ll
-                       : bigDivide(fr.first, 1, fr.second, Rounding::ROUND_UP);
+            return fr.second == 0 ? 0ll
+                                  : bigDivideOrThrow(fr.first, 1, fr.second,
+                                                     Rounding::ROUND_UP);
         };
 
         SECTION("evict nothing")

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -30,7 +30,7 @@ Maintainer::start()
     {
         // compare number of ledgers deleted per maintenance cycle with actual
         // number
-        int64 ledgersPerMaintenancePeriod = bigDivide(
+        int64 ledgersPerMaintenancePeriod = bigDivideOrThrow(
             c.AUTOMATIC_MAINTENANCE_PERIOD.count(), 1,
             c.getExpectedLedgerCloseTime().count(), Rounding::ROUND_UP);
         if (c.AUTOMATIC_MAINTENANCE_COUNT <= ledgersPerMaintenancePeriod)

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -16,6 +16,7 @@
 #include <Tracy.hpp>
 #include <algorithm>
 #include <functional>
+#include <uint128_t.h>
 
 namespace stellar
 {
@@ -94,7 +95,11 @@ LocalNode::computeWeight(uint64 m, uint64 total, uint64 threshold)
 {
     uint64 res;
     releaseAssert(threshold <= total);
-    bigDivide(res, m, threshold, total, ROUND_UP);
+    // Since threshold <= total, calculating res=m*threshold/total will always
+    // produce res <= m, and we do not need to handle the possibility of this
+    // call returning false (indicating overflow).
+    bool noOverflow = bigDivideUnsigned(res, m, threshold, total, ROUND_UP);
+    releaseAssert(noOverflow);
     return res;
 }
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -130,14 +130,15 @@ LoadGenerator::getTxPerStep(uint32_t txRate, std::chrono::seconds spikeInterval,
     auto now = mApp.getClock().now();
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
         now - *mStartTime);
-    auto txs = bigDivide(elapsed.count(), txRate, 1000, Rounding::ROUND_DOWN);
+    auto txs =
+        bigDivideOrThrow(elapsed.count(), txRate, 1000, Rounding::ROUND_DOWN);
     if (spikeInterval.count() > 0)
     {
-        txs +=
-            bigDivide(std::chrono::duration_cast<std::chrono::seconds>(elapsed)
-                          .count(),
-                      1, spikeInterval.count(), Rounding::ROUND_DOWN) *
-            spikeSize;
+        txs += bigDivideOrThrow(
+                   std::chrono::duration_cast<std::chrono::seconds>(elapsed)
+                       .count(),
+                   1, spikeInterval.count(), Rounding::ROUND_DOWN) *
+               spikeSize;
     }
 
     if (txs <= mTotalSubmitted)

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -192,12 +192,12 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
     }
 
     auto const& lh = header.current();
-    auto v1 = bigMultiply(getFeeBid(), mInnerTx->getMinFee(lh));
-    auto v2 = bigMultiply(mInnerTx->getFeeBid(), getMinFee(lh));
+    uint128_t v1 = bigMultiply(getFeeBid(), mInnerTx->getMinFee(lh));
+    uint128_t v2 = bigMultiply(mInnerTx->getFeeBid(), getMinFee(lh));
     if (v1 < v2)
     {
-        if (!bigDivide(getResult().feeCharged, v2, mInnerTx->getMinFee(lh),
-                       Rounding::ROUND_UP))
+        if (!bigDivide128(getResult().feeCharged, v2, mInnerTx->getMinFee(lh),
+                          Rounding::ROUND_UP))
         {
             getResult().feeCharged = INT64_MAX;
         }

--- a/src/transactions/InflationOpFrame.cpp
+++ b/src/transactions/InflationOpFrame.cpp
@@ -52,13 +52,13 @@ InflationOpFrame::doApply(AbstractLedgerTxn& ltx)
     */
 
     int64_t totalVotes = lh.totalCoins;
-    int64_t minBalance =
-        bigDivide(totalVotes, INFLATION_WIN_MIN_PERCENT, TRILLION, ROUND_DOWN);
+    int64_t minBalance = bigDivideOrThrow(totalVotes, INFLATION_WIN_MIN_PERCENT,
+                                          TRILLION, ROUND_DOWN);
 
     auto winners = ltx.queryInflationWinners(INFLATION_NUM_WINNERS, minBalance);
 
-    auto inflationAmount = bigDivide(lh.totalCoins, INFLATION_RATE_TRILLIONTHS,
-                                     TRILLION, ROUND_DOWN);
+    auto inflationAmount = bigDivideOrThrow(
+        lh.totalCoins, INFLATION_RATE_TRILLIONTHS, TRILLION, ROUND_DOWN);
     auto amountToDole = inflationAmount + lh.feePool;
 
     lh.feePool = 0;
@@ -73,7 +73,7 @@ InflationOpFrame::doApply(AbstractLedgerTxn& ltx)
     for (auto const& w : winners)
     {
         int64_t toDoleThisWinner =
-            bigDivide(amountToDole, w.votes, totalVotes, ROUND_DOWN);
+            bigDivideOrThrow(amountToDole, w.votes, totalVotes, ROUND_DOWN);
         if (toDoleThisWinner == 0)
             continue;
 

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -138,7 +138,7 @@ exchangeV2(int64_t wheatReceived, Price price, int64_t maxWheatReceive,
     result.numSheepSend = std::min(result.numSheepSend, maxSheepSend);
     // bias towards seller (this cannot overflow at this point)
     result.numWheatReceived =
-        bigDivide(result.numSheepSend, price.d, price.n, ROUND_DOWN);
+        bigDivideOrThrow(result.numSheepSend, price.d, price.n, ROUND_DOWN);
 
     return result;
 }
@@ -646,32 +646,36 @@ exchangeV10WithoutPriceErrorThresholds(Price price, int64_t maxWheatSend,
     {
         if (round == RoundingType::PATH_PAYMENT_STRICT_SEND)
         {
-            wheatReceive = bigDivide(sheepValue, price.n, ROUND_DOWN);
+            wheatReceive = bigDivideOrThrow128(sheepValue, price.n, ROUND_DOWN);
             sheepSend = std::min({maxSheepSend, maxSheepReceive});
         }
         else if (price.n > price.d || // Wheat is more valuable
                  round == RoundingType::PATH_PAYMENT_STRICT_RECEIVE)
         {
-            wheatReceive = bigDivide(sheepValue, price.n, ROUND_DOWN);
-            sheepSend = bigDivide(wheatReceive, price.n, price.d, ROUND_UP);
+            wheatReceive = bigDivideOrThrow128(sheepValue, price.n, ROUND_DOWN);
+            sheepSend =
+                bigDivideOrThrow(wheatReceive, price.n, price.d, ROUND_UP);
         }
         else // Sheep is more valuable
         {
-            sheepSend = bigDivide(sheepValue, price.d, ROUND_DOWN);
-            wheatReceive = bigDivide(sheepSend, price.d, price.n, ROUND_DOWN);
+            sheepSend = bigDivideOrThrow128(sheepValue, price.d, ROUND_DOWN);
+            wheatReceive =
+                bigDivideOrThrow(sheepSend, price.d, price.n, ROUND_DOWN);
         }
     }
     else
     {
         if (price.n > price.d) // Wheat is more valuable
         {
-            wheatReceive = bigDivide(wheatValue, price.n, ROUND_DOWN);
-            sheepSend = bigDivide(wheatReceive, price.n, price.d, ROUND_DOWN);
+            wheatReceive = bigDivideOrThrow128(wheatValue, price.n, ROUND_DOWN);
+            sheepSend =
+                bigDivideOrThrow(wheatReceive, price.n, price.d, ROUND_DOWN);
         }
         else // Sheep is more valuable
         {
-            sheepSend = bigDivide(wheatValue, price.d, ROUND_DOWN);
-            wheatReceive = bigDivide(sheepSend, price.d, price.n, ROUND_UP);
+            sheepSend = bigDivideOrThrow128(wheatValue, price.d, ROUND_DOWN);
+            wheatReceive =
+                bigDivideOrThrow(sheepSend, price.d, price.n, ROUND_UP);
         }
     }
 

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1698,7 +1698,8 @@ getPoolWithdrawalAmount(int64_t amountPoolShares, int64_t totalPoolShares,
         throw std::runtime_error("Invalid amountPoolShares");
     }
 
-    return bigDivide(amountPoolShares, reserve, totalPoolShares, ROUND_DOWN);
+    return bigDivideOrThrow(amountPoolShares, reserve, totalPoolShares,
+                            ROUND_DOWN);
 }
 
 namespace detail

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -127,7 +127,7 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
 
     // 1% annual inflation on a weekly basis
     // 0.000190721
-    auto inflation = bigDivide(totCoins, 190721, 1000000000, ROUND_DOWN);
+    auto inflation = bigDivideOrThrow(totCoins, 190721, 1000000000, ROUND_DOWN);
     auto coinsToDole = inflation + totFees;
     int64 leftToDole = coinsToDole;
 
@@ -135,7 +135,7 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
     {
         // computes the share of this guy
         int64 toDoleToThis =
-            bigDivide(coinsToDole, votes.at(w), totVotes, ROUND_DOWN);
+            bigDivideOrThrow(coinsToDole, votes.at(w), totVotes, ROUND_DOWN);
         if (ledgerVersion >= 10)
         {
             LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -463,7 +463,8 @@ TEST_CASE("inflation", "[tx][inflation]")
     // minVote to participate in inflation
     const int64 minVote = 1000000000LL;
     // .05% of all coins
-    const int64 winnerVote = bigDivide(getTotalCoins(), 5, 10000, ROUND_DOWN);
+    const int64 winnerVote =
+        bigDivideOrThrow(getTotalCoins(), 5, 10000, ROUND_DOWN);
 
     SECTION("inflation scenarios")
     {
@@ -538,7 +539,8 @@ TEST_CASE("inflation", "[tx][inflation]")
                 const int midPoint = nbAccounts / 2;
 
                 const int64 each =
-                    bigDivide(winnerVote, 2, nbAccounts, ROUND_DOWN) + minVote;
+                    bigDivideOrThrow(winnerVote, 2, nbAccounts, ROUND_DOWN) +
+                    minVote;
 
                 voteFunc = [&](int n) { return (n < midPoint) ? 0 : 1; };
                 balanceFunc = [&](int n) { return each; };
@@ -559,7 +561,8 @@ TEST_CASE("inflation", "[tx][inflation]")
                 const int midPoint = nbAccounts / 2;
 
                 const int64 each =
-                    bigDivide(winnerVote, 2, nbAccounts, ROUND_DOWN) + minVote;
+                    bigDivideOrThrow(winnerVote, 2, nbAccounts, ROUND_DOWN) +
+                    minVote;
 
                 voteFunc = [&](int n) { return (n < midPoint) ? 0 : 1; };
                 balanceFunc = [&](int n) {
@@ -600,7 +603,7 @@ TEST_CASE("inflation", "[tx][inflation]")
         };
 
         int64_t maxPayout =
-            bigDivide(getTotalCoins(), 190721, 1000000000, ROUND_DOWN) +
+            bigDivideOrThrow(getTotalCoins(), 190721, 1000000000, ROUND_DOWN) +
             getFeePool();
 
         SECTION("no available balance")

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -417,12 +417,14 @@ TEST_CASE("manage buy offer liabilities", "[tx][offers]")
             {
                 checkLiabilities(
                     "buy one for two", INT64_MAX, Price{2, 1},
-                    bigDivide(static_cast<uint64_t>(INT64_MAX), 2, ROUND_DOWN),
+                    bigDivideOrThrow128(static_cast<uint64_t>(INT64_MAX), 2,
+                                        ROUND_DOWN),
                     INT64_MAX - 1);
-                checkLiabilities("buy two for five", INT64_MAX, Price{5, 2},
-                                 bigDivide(static_cast<uint64_t>(INT64_MAX), 2,
-                                           5, ROUND_DOWN),
-                                 INT64_MAX - 2);
+                checkLiabilities(
+                    "buy two for five", INT64_MAX, Price{5, 2},
+                    bigDivideOrThrow(static_cast<uint64_t>(INT64_MAX), 2, 5,
+                                     ROUND_DOWN),
+                    INT64_MAX - 2);
             }
         }
 

--- a/src/transactions/test/OfferTests.cpp
+++ b/src/transactions/test/OfferTests.cpp
@@ -3974,7 +3974,8 @@ TEST_CASE("liabilities match created offer", "[tx][offers]")
         // -> price.d * X > price.n * oe.amount
         //    X > oe.amount * price.n / price.d
         //    X = ceil(oe.amount * price.n / price.d) + 1
-        int64_t crossAmount = bigDivide(amount, price.n, price.d, ROUND_UP);
+        int64_t crossAmount =
+            bigDivideOrThrow(amount, price.n, price.d, ROUND_UP);
         if (crossAmount < INT64_MAX)
         {
             ++crossAmount;

--- a/src/transactions/test/PathPaymentStrictSendTests.cpp
+++ b/src/transactions/test/PathPaymentStrictSendTests.cpp
@@ -23,7 +23,8 @@ int64_t
 operator*(int64_t x, const Price& y)
 {
     bool xNegative = (x < 0);
-    int64_t m = bigDivide(xNegative ? -x : x, y.n, y.d, Rounding::ROUND_DOWN);
+    int64_t m =
+        bigDivideOrThrow(xNegative ? -x : x, y.n, y.d, Rounding::ROUND_DOWN);
     return xNegative ? -m : m;
 }
 

--- a/src/transactions/test/PathPaymentTests.cpp
+++ b/src/transactions/test/PathPaymentTests.cpp
@@ -29,7 +29,8 @@ int64_t
 operator*(int64_t x, const Price& y)
 {
     bool xNegative = (x < 0);
-    int64_t m = bigDivide(xNegative ? -x : x, y.n, y.d, Rounding::ROUND_DOWN);
+    int64_t m =
+        bigDivideOrThrow(xNegative ? -x : x, y.n, y.d, Rounding::ROUND_DOWN);
     return xNegative ? -m : m;
 }
 

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -85,7 +85,7 @@ bigDivide(uint64_t& result, uint128_t a, uint64_t B, Rounding rounding)
     //         = (UINT64_MAX * UINT64_MAX + 2 * UINT64_MAX) / UINT64_MAX
     //         = UINT64_MAX + 2
     // which would have overflowed uint64_t anyway.
-    uint128_t const UINT128_MAX = ~uint128_0;
+    uint128_t const UINT128_MAX = uint128_max();
     if ((rounding == ROUND_UP) && (a > UINT128_MAX - (b - 1u)))
     {
         return false;
@@ -219,7 +219,7 @@ bigSquareRootCeil(uint64_t a, uint64_t b)
     uint128_t R = bigMultiply(a, b) - 1u;
 
     // Seed the result with a reasonable estimate x >= ceil(sqrt(R+1))
-    uint8_t numBits = R.bits() / 2 + 1;
+    uint8_t numBits = uint128_bits(R) / 2 + 1;
     uint64_t x = numBits >= 64 ? UINT64_MAX : (1ull << numBits);
 
     uint64_t prev = 0;

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -16,7 +16,8 @@ bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C, Rounding rounding)
     bool res;
     releaseAssertOrThrow((A >= 0) && (B >= 0) && (C > 0));
     uint64_t r2;
-    res = bigDivide(r2, (uint64_t)A, (uint64_t)B, (uint64_t)C, rounding);
+    res =
+        bigDivideUnsigned(r2, (uint64_t)A, (uint64_t)B, (uint64_t)C, rounding);
     if (res)
     {
         res = r2 <= INT64_MAX;
@@ -26,9 +27,11 @@ bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C, Rounding rounding)
 }
 
 bool
-bigDivide(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
-          Rounding rounding)
+bigDivideUnsigned(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
+                  Rounding rounding)
 {
+    releaseAssertOrThrow(C > 0);
+
     // update when moving to (signed) int128
     uint128_t a(A);
     uint128_t b(B);
@@ -40,7 +43,7 @@ bigDivide(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
 }
 
 int64_t
-bigDivide(int64_t A, int64_t B, int64_t C, Rounding rounding)
+bigDivideOrThrow(int64_t A, int64_t B, int64_t C, Rounding rounding)
 {
     int64_t res;
     if (!bigDivide(res, A, B, C, rounding))
@@ -51,12 +54,12 @@ bigDivide(int64_t A, int64_t B, int64_t C, Rounding rounding)
 }
 
 bool
-bigDivide(int64_t& result, uint128_t a, int64_t B, Rounding rounding)
+bigDivide128(int64_t& result, uint128_t a, int64_t B, Rounding rounding)
 {
     releaseAssertOrThrow(B > 0);
 
     uint64_t r2;
-    bool res = bigDivide(r2, a, (uint64_t)B, rounding);
+    bool res = bigDivideUnsigned128(r2, a, (uint64_t)B, rounding);
     if (res)
     {
         res = r2 <= INT64_MAX;
@@ -66,7 +69,8 @@ bigDivide(int64_t& result, uint128_t a, int64_t B, Rounding rounding)
 }
 
 bool
-bigDivide(uint64_t& result, uint128_t a, uint64_t B, Rounding rounding)
+bigDivideUnsigned128(uint64_t& result, uint128_t a, uint64_t B,
+                     Rounding rounding)
 {
     releaseAssertOrThrow(B != 0);
 
@@ -99,10 +103,10 @@ bigDivide(uint64_t& result, uint128_t a, uint64_t B, Rounding rounding)
 }
 
 int64_t
-bigDivide(uint128_t a, int64_t B, Rounding rounding)
+bigDivideOrThrow128(uint128_t a, int64_t B, Rounding rounding)
 {
     int64_t res;
-    if (!bigDivide(res, a, B, rounding))
+    if (!bigDivide128(res, a, B, rounding))
     {
         throw std::overflow_error("overflow while performing bigDivide");
     }
@@ -110,7 +114,7 @@ bigDivide(uint128_t a, int64_t B, Rounding rounding)
 }
 
 uint128_t
-bigMultiply(uint64_t a, uint64_t b)
+bigMultiplyUnsigned(uint64_t a, uint64_t b)
 {
     uint128_t A(a);
     uint128_t B(b);
@@ -121,7 +125,7 @@ uint128_t
 bigMultiply(int64_t a, int64_t b)
 {
     releaseAssertOrThrow((a >= 0) && (b >= 0));
-    return bigMultiply((uint64_t)a, (uint64_t)b);
+    return bigMultiplyUnsigned((uint64_t)a, (uint64_t)b);
 }
 
 // Fix R >= 0. Consider the modified Babylonian method that operates only on
@@ -216,7 +220,7 @@ bigSquareRootCeil(uint64_t a, uint64_t b)
     {
         return 0;
     }
-    uint128_t R = bigMultiply(a, b) - 1u;
+    uint128_t R = bigMultiplyUnsigned(a, b) - 1u;
 
     // Seed the result with a reasonable estimate x >= ceil(sqrt(R+1))
     uint8_t numBits = uint128_bits(R) / 2 + 1;
@@ -228,7 +232,7 @@ bigSquareRootCeil(uint64_t a, uint64_t b)
         prev = x;
 
         uint64_t y = 0;
-        bool res = bigDivide(y, R, x, ROUND_UP);
+        bool res = bigDivideUnsigned128(y, R, x, ROUND_UP);
         if (!res)
         {
             throw std::runtime_error("Overflow during bigSquareRoot");
@@ -259,7 +263,7 @@ bigSquareRoot(uint64_t a, uint64_t b)
     // sqrtCeil * sqrtCeil >= a * b so
     //     sqrtCeil * sqrtCeil <= a * b
     // implies sqrtCeil * sqrtCeil = a * b.
-    if (bigMultiply(sqrtCeil, sqrtCeil) <= bigMultiply(a, b))
+    if (bigMultiplyUnsigned(sqrtCeil, sqrtCeil) <= bigMultiplyUnsigned(a, b))
     {
         return sqrtCeil;
     }

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -41,20 +41,23 @@ isRepresentableAsInt64(double d)
 }
 
 // calculates A*B/C when A*B overflows 64bits
-int64_t bigDivide(int64_t A, int64_t B, int64_t C, Rounding rounding);
+int64_t bigDivideOrThrow(int64_t A, int64_t B, int64_t C, Rounding rounding);
 // no throw version, returns true if result is valid
 bool bigDivide(int64_t& result, int64_t A, int64_t B, int64_t C,
                Rounding rounding);
 
 // no throw version, returns true if result is valid
-bool bigDivide(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
-               Rounding rounding);
+bool bigDivideUnsigned(uint64_t& result, uint64_t A, uint64_t B, uint64_t C,
+                       Rounding rounding);
 
-bool bigDivide(int64_t& result, uint128_t a, int64_t B, Rounding rounding);
-bool bigDivide(uint64_t& result, uint128_t a, uint64_t B, Rounding rounding);
-int64_t bigDivide(uint128_t a, int64_t B, Rounding rounding);
+// same 3 cases as above, but each taking a uint128_t numerator instead of 2
+// 64-bit numerator-factors
+bool bigDivide128(int64_t& result, uint128_t a, int64_t B, Rounding rounding);
+bool bigDivideUnsigned128(uint64_t& result, uint128_t a, uint64_t B,
+                          Rounding rounding);
+int64_t bigDivideOrThrow128(uint128_t a, int64_t B, Rounding rounding);
 
-uint128_t bigMultiply(uint64_t a, uint64_t b);
+uint128_t bigMultiplyUnsigned(uint64_t a, uint64_t b);
 uint128_t bigMultiply(int64_t a, int64_t b);
 
 // This only implements ROUND_DOWN

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -337,7 +337,7 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
     SECTION("upper limits")
     {
         uint128_t const unsignedLimit = bigMultiply(UINT64_MAX, UINT64_MAX);
-        uint128_t const UINT128_MAX(UINT64_MAX, UINT64_MAX);
+        uint128_t const UINT128_MAX = uint128_max();
         REQUIRE(UINT128_MAX + 1u == 0u);
 
         verifyUnsigned(UINT128_MAX, UINT64_MAX, ROUND_UP);
@@ -455,7 +455,7 @@ TEST_CASE("huge divide", "[bigdivide]")
 
     SECTION("uint128 values")
     {
-        uint128_t const UINT128_MAX(UINT64_MAX, UINT64_MAX);
+        uint128_t const UINT128_MAX = uint128_max();
         uint128_t maxC =
             uint128_t((uint32_t)INT32_MAX) * uint128_t((uint64_t)INT64_MAX);
 

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -51,7 +51,7 @@ TEST_CASE("big divide", "[bigDivide]")
 {
     auto verifySignedUp = [](int64_t a, int64_t b, int64_t c,
                              int64_t expectedResult) {
-        REQUIRE(bigDivide(a, b, c, ROUND_UP) == expectedResult);
+        REQUIRE(bigDivideOrThrow(a, b, c, ROUND_UP) == expectedResult);
         auto signedResult = int64_t{};
         REQUIRE(bigDivide(signedResult, a, b, c, ROUND_UP));
         REQUIRE(signedResult == expectedResult);
@@ -59,7 +59,7 @@ TEST_CASE("big divide", "[bigDivide]")
 
     auto verifySignedDown = [](int64_t a, int64_t b, int64_t c,
                                int64_t expectedResult) {
-        REQUIRE(bigDivide(a, b, c, ROUND_DOWN) == expectedResult);
+        REQUIRE(bigDivideOrThrow(a, b, c, ROUND_DOWN) == expectedResult);
         auto signedResult = int64_t{};
         REQUIRE(bigDivide(signedResult, a, b, c, ROUND_DOWN));
         REQUIRE(signedResult == expectedResult);
@@ -73,13 +73,15 @@ TEST_CASE("big divide", "[bigDivide]")
     };
 
     auto verifySignedUpOverflow = [](int64_t a, int64_t b, int64_t c) {
-        REQUIRE_THROWS_AS(bigDivide(a, b, c, ROUND_UP), std::overflow_error);
+        REQUIRE_THROWS_AS(bigDivideOrThrow(a, b, c, ROUND_UP),
+                          std::overflow_error);
         auto x = int64_t{};
         REQUIRE(!bigDivide(x, a, b, c, ROUND_UP));
     };
 
     auto verifySignedDownOverflow = [](int64_t a, int64_t b, int64_t c) {
-        REQUIRE_THROWS_AS(bigDivide(a, b, c, ROUND_DOWN), std::overflow_error);
+        REQUIRE_THROWS_AS(bigDivideOrThrow(a, b, c, ROUND_DOWN),
+                          std::overflow_error);
         auto x = int64_t{};
         REQUIRE(!bigDivide(x, a, b, c, ROUND_DOWN));
     };
@@ -92,14 +94,14 @@ TEST_CASE("big divide", "[bigDivide]")
     auto verifyUnsignedUp = [](uint64_t a, uint64_t b, uint64_t c,
                                uint64_t expectedResult) {
         auto unsignedResult = uint64_t{};
-        REQUIRE(bigDivide(unsignedResult, a, b, c, ROUND_UP));
+        REQUIRE(bigDivideUnsigned(unsignedResult, a, b, c, ROUND_UP));
         REQUIRE(unsignedResult == expectedResult);
     };
 
     auto verifyUnsignedDown = [](uint64_t a, uint64_t b, uint64_t c,
                                  uint64_t expectedResult) {
         auto unsignedResult = uint64_t{};
-        REQUIRE(bigDivide(unsignedResult, a, b, c, ROUND_DOWN));
+        REQUIRE(bigDivideUnsigned(unsignedResult, a, b, c, ROUND_DOWN));
         REQUIRE(unsignedResult == expectedResult);
     };
 
@@ -112,12 +114,12 @@ TEST_CASE("big divide", "[bigDivide]")
 
     auto verifyUnsignedUpOverflow = [](uint64_t a, uint64_t b, uint64_t c) {
         auto x = uint64_t{};
-        REQUIRE(!bigDivide(x, a, b, c, ROUND_UP));
+        REQUIRE(!bigDivideUnsigned(x, a, b, c, ROUND_UP));
     };
 
     auto verifyUnsignedDownOverflow = [](uint64_t a, uint64_t b, uint64_t c) {
         auto x = uint64_t{};
-        REQUIRE(!bigDivide(x, a, b, c, ROUND_DOWN));
+        REQUIRE(!bigDivideUnsigned(x, a, b, c, ROUND_DOWN));
     };
 
     auto verifyUnsignedOverflow = [&](uint64_t a, uint64_t b, uint64_t c) {
@@ -189,25 +191,26 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
 {
     auto verifySigned = [](uint128_t a, int64_t b, Rounding rounding) {
         int64_t res;
-        REQUIRE(!bigDivide(res, a, b, rounding));
-        REQUIRE_THROWS_AS(bigDivide(a, b, rounding), std::overflow_error);
+        REQUIRE(!bigDivide128(res, a, b, rounding));
+        REQUIRE_THROWS_AS(bigDivideOrThrow128(a, b, rounding),
+                          std::overflow_error);
     };
     auto verifySignedValue = [](uint128_t a, int64_t b, Rounding rounding,
                                 int64_t expected) {
         int64_t res;
-        REQUIRE(bigDivide(res, a, b, rounding));
+        REQUIRE(bigDivide128(res, a, b, rounding));
         REQUIRE(res == expected);
-        REQUIRE(bigDivide(a, b, rounding) == expected);
+        REQUIRE(bigDivideOrThrow128(a, b, rounding) == expected);
     };
 
     auto verifyUnsigned = [](uint128_t a, uint64_t b, Rounding rounding) {
         uint64_t res;
-        REQUIRE(!bigDivide(res, a, b, rounding));
+        REQUIRE(!bigDivideUnsigned128(res, a, b, rounding));
     };
     auto verifyUnsignedValue = [](uint128_t a, uint64_t b, Rounding rounding,
                                   uint64_t expected) {
         uint64_t res;
-        REQUIRE(bigDivide(res, a, b, rounding));
+        REQUIRE(bigDivideUnsigned128(res, a, b, rounding));
         REQUIRE(res == expected);
     };
 
@@ -306,9 +309,9 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
             {
                 if (val2 > 0)
                 {
-                    verifyUnsignedValue(bigMultiply(val1, val2), val2, ROUND_UP,
-                                        val1);
-                    verifyUnsignedValue(bigMultiply(val1, val2), val2,
+                    verifyUnsignedValue(bigMultiplyUnsigned(val1, val2), val2,
+                                        ROUND_UP, val1);
+                    verifyUnsignedValue(bigMultiplyUnsigned(val1, val2), val2,
                                         ROUND_DOWN, val1);
                 }
             }
@@ -325,7 +328,7 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
         verifySignedValue(twiceSignedMax, 2, ROUND_UP, INT64_MAX);
         verifySignedValue(twiceSignedMax, 2, ROUND_DOWN, INT64_MAX);
 
-        uint128_t const twiceUnsignedMax = bigMultiply(UINT64_MAX, 2);
+        uint128_t const twiceUnsignedMax = bigMultiplyUnsigned(UINT64_MAX, 2);
         verifyUnsigned(twiceUnsignedMax + 2u, 2, ROUND_UP);
         verifyUnsigned(twiceUnsignedMax + 2u, 2, ROUND_DOWN);
         verifyUnsigned(twiceUnsignedMax + 1u, 2, ROUND_UP);
@@ -336,7 +339,8 @@ TEST_CASE("bigDivide 128bit by 64bit", "[bigdivide]")
 
     SECTION("upper limits")
     {
-        uint128_t const unsignedLimit = bigMultiply(UINT64_MAX, UINT64_MAX);
+        uint128_t const unsignedLimit =
+            bigMultiplyUnsigned(UINT64_MAX, UINT64_MAX);
         uint128_t const UINT128_MAX = uint128_max();
         REQUIRE(UINT128_MAX + 1u == 0u);
 

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -7,6 +7,8 @@
 #include "lib/util/uint128_t.h"
 #include "test/test.h"
 #include "util/Logging.h"
+#include <chrono>
+#include <fmt/chrono.h>
 #include <limits>
 #include <ostream>
 
@@ -57,6 +59,41 @@ operator<<(std::ostream& out, unsigned __int128 const& x)
 {
     return out << std::hex << "0x" << uint64_t(x >> 64) << uint64_t(x);
 }
+}
+
+TEST_CASE("uint128_t bench", "[bench][uint128][!hide]")
+{
+    gen128 g;
+    size_t const n = 1000000;
+    uint128_t res1{0};
+    __uint128_t res2{0};
+
+    std::vector<__uint128_t> native;
+    std::vector<uint128_t> lib;
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        __uint128_t n = g();
+        n |= 1; // ensure nonzero
+        native.emplace_back(n);
+        lib.emplace_back(fromNative(n));
+    }
+
+    auto start = std::chrono::high_resolution_clock::now();
+    for (auto k : lib)
+    {
+        res1 = res1 + (k * (k + k)) / k;
+    }
+    auto step1 = std::chrono::high_resolution_clock::now();
+    for (auto k : native)
+    {
+        res2 = res2 + (k * (k + k)) / k;
+    }
+    auto step2 = std::chrono::high_resolution_clock::now();
+    assert(res1 == fromNative(res2));
+    LOG_INFO(DEFAULT_LOG, "library time: {} per iteration",
+             (step1 - start) / n);
+    LOG_INFO(DEFAULT_LOG, "native time: {} per iteration", (step2 - step1) / n);
 }
 
 TEST_CASE("uint128_t", "[uint128]")

--- a/src/util/test/Uint128Tests.cpp
+++ b/src/util/test/Uint128Tests.cpp
@@ -20,6 +20,7 @@
 #if defined(__SIZEOF_INT128__) || defined(_GLIBCXX_USE_INT128)
 
 const uint64_t full = std::numeric_limits<uint64_t>::max();
+using libu128::uint128_t;
 
 uint128_t
 fromNative(unsigned __int128 x)


### PR DESCRIPTION
This is an experiment in using compiler-native uint128_t types when they are available (on gcc and clang), as a possible performance improvement over the library type. Need to discuss a bit, but it seems to work.