### PR TITLE
More CAP-38 path payment tests

### DIFF
--- a/src/transactions/ManageBuyOfferOpFrame.cpp
+++ b/src/transactions/ManageBuyOfferOpFrame.cpp
@@ -83,13 +83,6 @@ ManageBuyOfferOpFrame::getExchangeParametersBeforeV10(int64_t& maxSheepSend,
     throw std::runtime_error("ManageBuyOffer used before protocol version 10");
 }
 
-bool
-ManageBuyOfferOpFrame::isResultSuccess()
-{
-    return mResult.tr().manageBuyOfferResult().code() ==
-           MANAGE_BUY_OFFER_SUCCESS;
-}
-
 ManageOfferSuccessResult&
 ManageBuyOfferOpFrame::getSuccessResult()
 {

--- a/src/transactions/ManageBuyOfferOpFrame.h
+++ b/src/transactions/ManageBuyOfferOpFrame.h
@@ -39,7 +39,6 @@ class ManageBuyOfferOpFrame : public ManageOfferOpFrameBase
     void getExchangeParametersBeforeV10(int64_t& maxSheepSend,
                                         int64_t& maxWheatReceive) override;
 
-    bool isResultSuccess() override;
     ManageOfferSuccessResult& getSuccessResult() override;
 
     void setResultSuccess() override;

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -345,17 +345,17 @@ ManageOfferOpFrameBase::doApply(AbstractLedgerTxn& ltxOuter)
                 if ((passive && (o.price >= maxWheatPrice)) ||
                     (o.price > maxWheatPrice))
                 {
-                    return OfferFilterResult::eStop;
+                    return OfferFilterResult::eStopBadPrice;
                 }
                 if (o.sellerID == getSourceID())
                 {
                     // we are crossing our own offer
-                    setResultCrossSelf();
-                    return OfferFilterResult::eStop;
+                    return OfferFilterResult::eStopCrossSelf;
                 }
                 return OfferFilterResult::eKeep;
             },
             offerTrail, maxOffersToCross);
+
         releaseAssertOrThrow(sheepSent >= 0);
 
         bool sheepStays;
@@ -367,13 +367,12 @@ ManageOfferOpFrameBase::doApply(AbstractLedgerTxn& ltxOuter)
         case ConvertResult::ePartial:
             sheepStays = true;
             break;
-        case ConvertResult::eFilterStop:
-            if (!isResultSuccess())
-            {
-                return false;
-            }
+        case ConvertResult::eFilterStopBadPrice:
             sheepStays = true;
             break;
+        case ConvertResult::eFilterStopCrossSelf:
+            setResultCrossSelf();
+            return false;
         case ConvertResult::eCrossedTooMany:
             mResult.code(opEXCEEDED_WORK_LIMIT);
             return false;

--- a/src/transactions/ManageOfferOpFrameBase.h
+++ b/src/transactions/ManageOfferOpFrameBase.h
@@ -57,7 +57,6 @@ class ManageOfferOpFrameBase : public OperationFrame
     virtual void getExchangeParametersBeforeV10(int64_t& maxSheepSend,
                                                 int64_t& maxWheatReceive) = 0;
 
-    virtual bool isResultSuccess() = 0;
     virtual ManageOfferSuccessResult& getSuccessResult() = 0;
 
     virtual void setResultSuccess() = 0;

--- a/src/transactions/ManageSellOfferOpFrame.cpp
+++ b/src/transactions/ManageSellOfferOpFrame.cpp
@@ -100,13 +100,6 @@ ManageSellOfferOpFrame::getExchangeParametersBeforeV10(int64_t& maxSheepSend,
         std::min({maxSheepSend, maxSheepBasedOnWheat, mManageSellOffer.amount});
 }
 
-bool
-ManageSellOfferOpFrame::isResultSuccess()
-{
-    return mResult.tr().manageSellOfferResult().code() ==
-           MANAGE_SELL_OFFER_SUCCESS;
-}
-
 ManageOfferSuccessResult&
 ManageSellOfferOpFrame::getSuccessResult()
 {

--- a/src/transactions/ManageSellOfferOpFrame.h
+++ b/src/transactions/ManageSellOfferOpFrame.h
@@ -39,7 +39,6 @@ class ManageSellOfferOpFrame : public ManageOfferOpFrameBase
     void getExchangeParametersBeforeV10(int64_t& maxSheepSend,
                                         int64_t& maxWheatReceive) override;
 
-    bool isResultSuccess() override;
     ManageOfferSuccessResult& getSuccessResult() override;
 
     void setResultSuccess() override;

--- a/src/transactions/OfferExchange.cpp
+++ b/src/transactions/OfferExchange.cpp
@@ -1514,9 +1514,19 @@ convertWithOffers(
             wheatOffer.current().ext.v1().sponsoringID.activate() = sponsorID;
         }
 
-        if (filter && filter(wheatOffer) == OfferFilterResult::eStop)
+        if (filter)
         {
-            return ConvertResult::eFilterStop;
+            switch (filter(wheatOffer))
+            {
+            case OfferFilterResult::eKeep:
+                break;
+            case OfferFilterResult::eStopBadPrice:
+                return ConvertResult::eFilterStopBadPrice;
+            case OfferFilterResult::eStopCrossSelf:
+                return ConvertResult::eFilterStopCrossSelf;
+            default:
+                throw std::runtime_error("unexpected filter result");
+            }
         }
 
         // Note: maxOffersToCross == INT64_MAX before protocol version 11

--- a/src/transactions/OfferExchange.h
+++ b/src/transactions/OfferExchange.h
@@ -291,14 +291,16 @@ bool exchangeWithPool(int64_t reservesToPool, int64_t maxSendToPool,
 enum class OfferFilterResult
 {
     eKeep,
-    eStop
+    eStopBadPrice,
+    eStopCrossSelf
 };
 
 enum class ConvertResult
 {
     eOK,
     ePartial,
-    eFilterStop,
+    eFilterStopBadPrice,
+    eFilterStopCrossSelf,
     eCrossedTooMany
 };
 

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -81,7 +81,6 @@ PathPaymentOpFrameBase::convert(AbstractLedgerTxn& ltx,
             if (offer.sellerID == getSourceID())
             {
                 // we are crossing our own offer
-                setResultOfferCrossSelf();
                 return OfferFilterResult::eStop;
             }
             return OfferFilterResult::eKeep;
@@ -96,6 +95,7 @@ PathPaymentOpFrameBase::convert(AbstractLedgerTxn& ltx,
     switch (r)
     {
     case ConvertResult::eFilterStop:
+        setResultOfferCrossSelf();
         return false;
     case ConvertResult::eOK:
         if (checkTransfer(maxSend, amountSend, maxRecv, amountRecv))

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -81,7 +81,7 @@ PathPaymentOpFrameBase::convert(AbstractLedgerTxn& ltx,
             if (offer.sellerID == getSourceID())
             {
                 // we are crossing our own offer
-                return OfferFilterResult::eStop;
+                return OfferFilterResult::eStopCrossSelf;
             }
             return OfferFilterResult::eKeep;
         },
@@ -94,7 +94,7 @@ PathPaymentOpFrameBase::convert(AbstractLedgerTxn& ltx,
 
     switch (r)
     {
-    case ConvertResult::eFilterStop:
+    case ConvertResult::eFilterStopCrossSelf:
         setResultOfferCrossSelf();
         return false;
     case ConvertResult::eOK:
@@ -109,6 +109,8 @@ PathPaymentOpFrameBase::convert(AbstractLedgerTxn& ltx,
     case ConvertResult::eCrossedTooMany:
         mResult.code(opEXCEEDED_WORK_LIMIT);
         return false;
+    default:
+        throw std::runtime_error("unexpected convert result");
     }
 
     return true;


### PR DESCRIPTION
# Description
Built on top of #3198, so that should be merged first. New code starts from "CAP-38: Fix bug with PATH_PAYMENT_STRICT_*_CROSS_SELF".

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
