### PR TITLE
Round down in bigSquareRoot

### DIFF
--- a/src/transactions/test/LiquidityPoolDepositTests.cpp
+++ b/src/transactions/test/LiquidityPoolDepositTests.cpp
@@ -255,8 +255,8 @@ TEST_CASE("liquidity pool deposit", "[tx][liquiditypool]")
                                     Price{1, INT32_MAX}, Price{1, INT32_MAX});
             REQUIRE(a1.getBalance() == balance - 100 - 1);
             REQUIRE(a1.getTrustlineBalance(cur1) == INT64_MAX - INT32_MAX);
-            REQUIRE(a1.getTrustlineBalance(poolNative1) == 46341);
-            checkLiquidityPool(*app, poolNative1, 1, INT32_MAX, 46341, 1);
+            REQUIRE(a1.getTrustlineBalance(poolNative1) == 46340);
+            checkLiquidityPool(*app, poolNative1, 1, INT32_MAX, 46340, 1);
 
             // This section is all about depositing into a non-empty pool
             auto a2 = root.create("a2", minBal(3) + 6 * 100);
@@ -309,9 +309,9 @@ TEST_CASE("liquidity pool deposit", "[tx][liquiditypool]")
                                     Price{1, INT32_MAX}, Price{INT32_MAX, 1});
             REQUIRE(a2.getBalance() == balance - 100 - 1);
             REQUIRE(a2.getTrustlineBalance(cur1) == INT64_MAX - INT32_MAX);
-            REQUIRE(a2.getTrustlineBalance(poolNative1) == 46341);
+            REQUIRE(a2.getTrustlineBalance(poolNative1) == 46340);
             checkLiquidityPool(*app, poolNative1, 2, 2 * (int64_t)INT32_MAX,
-                               92682, 2);
+                               92680, 2);
         });
     }
 

--- a/src/transactions/test/LiquidityPoolTradeTests.cpp
+++ b/src/transactions/test/LiquidityPoolTradeTests.cpp
@@ -668,7 +668,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                                   ex_PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);
                 a1.pathPaymentStrictSend(a2, cur1, 100, cur2, 256,
                                          {cur2, cur3, cur1});
-                checkLiquidityPool12(1281, 1563, 1415, 1);
+                checkLiquidityPool12(1281, 1563, 1414, 1);
             }
 
             SECTION("strict receive")
@@ -687,7 +687,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pay(a2, cur1, 106, cur2, 256, {cur2, cur3, cur1}),
                     ex_PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);
                 a1.pay(a2, cur1, 107, cur2, 256, {cur2, cur3, cur1});
-                checkLiquidityPool12(1255, 1596, 1415, 1);
+                checkLiquidityPool12(1255, 1596, 1414, 1);
             }
         }
 
@@ -742,7 +742,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pay(a2, cur1, INT64_MAX, cur2, 999, {cur2, cur3, cur1}),
                     ex_PATH_PAYMENT_STRICT_RECEIVE_TOO_FEW_OFFERS);
                 a1.pay(a2, cur1, INT64_MAX, cur2, 998, {cur2, cur3, cur1});
-                checkLiquidityPool12(1005010, 2, 1415, 1);
+                checkLiquidityPool12(1005010, 2, 1414, 1);
             }
         }
 
@@ -768,7 +768,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                                   ex_PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);
                 a1.pathPaymentStrictSend(a2, cur1, 100, cur2, 329,
                                          {cur2, cur3, cur1});
-                checkLiquidityPool12(1100, 1819, 1415, 1);
+                checkLiquidityPool12(1100, 1819, 1414, 1);
             }
 
             SECTION("strict receive")
@@ -786,7 +786,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pay(a2, cur1, 99, cur2, 329, {cur2, cur3, cur1}),
                     ex_PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);
                 a1.pay(a2, cur1, 100, cur2, 329, {cur2, cur3, cur1});
-                checkLiquidityPool12(1100, 1819, 1415, 1);
+                checkLiquidityPool12(1100, 1819, 1414, 1);
             }
         }
 
@@ -812,7 +812,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                                   ex_PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);
                 a1.pathPaymentStrictSend(a2, cur1, 100, cur2, 327,
                                          {cur2, cur3, cur1});
-                checkLiquidityPool12(1100, 1819, 1415, 1);
+                checkLiquidityPool12(1100, 1819, 1414, 1);
             }
 
             SECTION("strict receive")
@@ -830,7 +830,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pay(a2, cur1, 99, cur2, 327, {cur2, cur3, cur1}),
                     ex_PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);
                 a1.pay(a2, cur1, 100, cur2, 327, {cur2, cur3, cur1});
-                checkLiquidityPool12(1100, 1819, 1415, 1);
+                checkLiquidityPool12(1100, 1819, 1414, 1);
             }
         }
 
@@ -858,7 +858,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                                   ex_PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);
                 a1.pathPaymentStrictSend(a2, cur1, 100, cur2, 332,
                                          {cur2, cur3, cur1});
-                checkLiquidityPool12(1200, 1668, 1415, 1);
+                checkLiquidityPool12(1200, 1668, 1414, 1);
             }
 
             SECTION("strict receive")
@@ -876,7 +876,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pay(a2, cur1, 90, cur2, 332, {cur2, cur3, cur1}),
                     ex_PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);
                 a1.pay(a2, cur1, 91, cur2, 332, {cur2, cur3, cur1});
-                checkLiquidityPool12(1091, 1834, 1415, 1);
+                checkLiquidityPool12(1091, 1834, 1414, 1);
             }
         }
 
@@ -900,7 +900,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                                   ex_PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);
                 a1.pathPaymentStrictSend(a2, cur1, 100, cur2, 400,
                                          {cur2, cur3, cur1});
-                checkLiquidityPool12(1000, 2000, 1415, 1);
+                checkLiquidityPool12(1000, 2000, 1414, 1);
             }
 
             SECTION("strict receive")
@@ -917,7 +917,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pay(a2, cur1, 99, cur2, 400, {cur2, cur3, cur1}),
                     ex_PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);
                 a1.pay(a2, cur1, 100, cur2, 400, {cur2, cur3, cur1});
-                checkLiquidityPool12(1000, 2000, 1415, 1);
+                checkLiquidityPool12(1000, 2000, 1414, 1);
             }
         }
     }
@@ -956,7 +956,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                     a1.pathPaymentStrictSend(a2, cur1, 100, cur1, 100, {cur2}),
                     ex_PATH_PAYMENT_STRICT_SEND_UNDER_DESTMIN);
                 a1.pathPaymentStrictSend(a2, cur1, 100, cur1, 99, {cur2});
-                checkLiquidityPool12(1001, 2000, 1415, 1);
+                checkLiquidityPool12(1001, 2000, 1414, 1);
             }
 
             SECTION("strict receive")
@@ -973,7 +973,7 @@ testLiquidityPoolTrading(Application& app, Asset const& cur1, Asset const& cur2)
                 REQUIRE_THROWS_AS(a1.pay(a2, cur1, 100, cur1, 100, {cur2}),
                                   ex_PATH_PAYMENT_STRICT_RECEIVE_OVER_SENDMAX);
                 a1.pay(a2, cur1, 100, cur1, 99, {cur2});
-                checkLiquidityPool12(1001, 2000, 1415, 1);
+                checkLiquidityPool12(1001, 2000, 1414, 1);
             }
         }
     }

--- a/src/transactions/test/LiquidityPoolWithdrawTests.cpp
+++ b/src/transactions/test/LiquidityPoolWithdrawTests.cpp
@@ -129,24 +129,24 @@ TEST_CASE("liquidity pool withdraw", "[tx][liquiditypool]")
             root.allowTrust(cur1, acc1);
             root.allowTrust(cur2, acc1);
 
-            // sqrt(90*24) = is ~46.48, which should get rounded up to 47
+            // sqrt(90*24) = is ~46.48, which should get rounded down to 46
             acc1.liquidityPoolDeposit(pool12, 90, 24, Price{90, 24},
                                       Price{90, 24});
             REQUIRE(acc1.getTrustlineBalance(cur1) == 110);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 26);
-            REQUIRE(acc1.getTrustlineBalance(pool12) == 47);
-            checkLiquidityPool(*app, pool12, 90, 24, 47, 2);
+            REQUIRE(acc1.getTrustlineBalance(pool12) == 46);
+            checkLiquidityPool(*app, pool12, 90, 24, 46, 2);
 
-            // floor(2/47*90) = 3
-            // floor(2/47*24) = 1
+            // floor(2/46*90) = 3
+            // floor(2/46*24) = 1
             acc1.liquidityPoolWithdraw(pool12, 2, 0, 0);
             REQUIRE(acc1.getTrustlineBalance(cur1) == 113);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 27);
-            REQUIRE(acc1.getTrustlineBalance(pool12) == 45);
-            checkLiquidityPool(*app, pool12, 87, 23, 45, 2);
+            REQUIRE(acc1.getTrustlineBalance(pool12) == 44);
+            checkLiquidityPool(*app, pool12, 87, 23, 44, 2);
 
             // empty the pool
-            acc1.liquidityPoolWithdraw(pool12, 45, 0, 0);
+            acc1.liquidityPoolWithdraw(pool12, 44, 0, 0);
             REQUIRE(acc1.getTrustlineBalance(cur1) == 200);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 50);
             REQUIRE(acc1.getTrustlineBalance(pool12) == 0);
@@ -285,13 +285,13 @@ TEST_CASE("liquidity pool withdraw", "[tx][liquiditypool]")
                                       Price{1, 10});
             REQUIRE(acc1.getTrustlineBalance(cur1) == 0);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 0);
-            REQUIRE(acc1.getTrustlineBalance(pool12) == 4);
-            checkLiquidityPool(*app, pool12, 1, 10, 4, 1);
+            REQUIRE(acc1.getTrustlineBalance(pool12) == 3);
+            checkLiquidityPool(*app, pool12, 1, 10, 3, 1);
 
-            acc1.liquidityPoolWithdraw(pool12, 3, 0, 7);
-            checkLiquidityPool(*app, pool12, 1, 3, 1, 1);
+            acc1.liquidityPoolWithdraw(pool12, 2, 0, 6);
+            checkLiquidityPool(*app, pool12, 1, 4, 1, 1);
 
-            acc1.liquidityPoolWithdraw(pool12, 1, 1, 3);
+            acc1.liquidityPoolWithdraw(pool12, 1, 1, 4);
             REQUIRE(acc1.getTrustlineBalance(cur1) == 1);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 10);
             REQUIRE(acc1.getTrustlineBalance(pool12) == 0);
@@ -305,13 +305,13 @@ TEST_CASE("liquidity pool withdraw", "[tx][liquiditypool]")
                                       Price{10, 1});
             REQUIRE(acc1.getTrustlineBalance(cur1) == 0);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 0);
-            REQUIRE(acc1.getTrustlineBalance(pool12) == 4);
-            checkLiquidityPool(*app, pool12, 10, 1, 4, 1);
+            REQUIRE(acc1.getTrustlineBalance(pool12) == 3);
+            checkLiquidityPool(*app, pool12, 10, 1, 3, 1);
 
-            acc1.liquidityPoolWithdraw(pool12, 3, 7, 0);
-            checkLiquidityPool(*app, pool12, 3, 1, 1, 1);
+            acc1.liquidityPoolWithdraw(pool12, 2, 6, 0);
+            checkLiquidityPool(*app, pool12, 4, 1, 1, 1);
 
-            acc1.liquidityPoolWithdraw(pool12, 1, 3, 1);
+            acc1.liquidityPoolWithdraw(pool12, 1, 4, 1);
             REQUIRE(acc1.getTrustlineBalance(cur1) == 10);
             REQUIRE(acc1.getTrustlineBalance(cur2) == 1);
             REQUIRE(acc1.getTrustlineBalance(pool12) == 0);
@@ -329,14 +329,14 @@ TEST_CASE("liquidity pool withdraw", "[tx][liquiditypool]")
                                       Price{1, 10});
             REQUIRE(acc1.getBalance() == balance - 100 - 1);
             REQUIRE(acc1.getTrustlineBalance(cur1) == 0);
-            REQUIRE(acc1.getTrustlineBalance(poolNative1) == 4);
-            checkLiquidityPool(*app, poolNative1, 1, 10, 4, 1);
+            REQUIRE(acc1.getTrustlineBalance(poolNative1) == 3);
+            checkLiquidityPool(*app, poolNative1, 1, 10, 3, 1);
 
-            acc1.liquidityPoolWithdraw(poolNative1, 3, 0, 7);
-            checkLiquidityPool(*app, poolNative1, 1, 3, 1, 1);
+            acc1.liquidityPoolWithdraw(poolNative1, 2, 0, 6);
+            checkLiquidityPool(*app, poolNative1, 1, 4, 1, 1);
 
             balance = acc1.getBalance();
-            acc1.liquidityPoolWithdraw(poolNative1, 1, 1, 3);
+            acc1.liquidityPoolWithdraw(poolNative1, 1, 1, 4);
             REQUIRE(acc1.getBalance() == balance - 100 + 1);
             REQUIRE(acc1.getTrustlineBalance(cur1) == 10);
             REQUIRE(acc1.getTrustlineBalance(poolNative1) == 0);

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -208,8 +208,8 @@ bigMultiply(int64_t a, int64_t b)
 // Now that we have an algorithm to compute ceil(sqrt(R+1)) then we can simply
 // use R-1 instead of R in the definition of the sequence to compute
 // ceil(sqrt(R)). This requires handling R=0 as a special case.
-uint64_t
-bigSquareRoot(uint64_t a, uint64_t b)
+static uint64_t
+bigSquareRootCeil(uint64_t a, uint64_t b)
 {
     // a * b = 0 is a special-case because we can't compute a * b - 1
     if (a == 0 || b == 0)
@@ -248,6 +248,32 @@ bigSquareRoot(uint64_t a, uint64_t b)
     }
 
     return x;
+}
+
+// Find x such that x * x <= a * b < (x+1) * (x+1).
+uint64_t
+bigSquareRoot(uint64_t a, uint64_t b)
+{
+    uint64_t sqrtCeil = bigSquareRootCeil(a, b);
+
+    // sqrtCeil * sqrtCeil >= a * b so
+    //     sqrtCeil * sqrtCeil <= a * b
+    // implies sqrtCeil * sqrtCeil = a * b.
+    if (bigMultiply(sqrtCeil, sqrtCeil) <= bigMultiply(a, b))
+    {
+        return sqrtCeil;
+    }
+
+    // sqrtCeil > 0 because
+    //     0 * 0 <= a * b
+    // for all a, b.
+    //
+    // sqrtCeil * sqrtCeil > a * b implies that
+    //     (sqrtCeil - 1) * (sqrtCeil - 1) = a * b - 2 * sqrtCeil + 1
+    //                                     < a * b
+    // because
+    //     1 - 2 * sqrtCeil < 0 .
+    return sqrtCeil - 1;
 }
 
 bool

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -57,7 +57,7 @@ int64_t bigDivide(uint128_t a, int64_t B, Rounding rounding);
 uint128_t bigMultiply(uint64_t a, uint64_t b);
 uint128_t bigMultiply(int64_t a, int64_t b);
 
-// This only implements ROUND_UP
+// This only implements ROUND_DOWN
 uint64_t bigSquareRoot(uint64_t a, uint64_t b);
 
 // Compute a * B / C when C < INT32_MAX * INT64_MAX.

--- a/src/util/test/BigDivideTests.cpp
+++ b/src/util/test/BigDivideTests.cpp
@@ -379,7 +379,7 @@ TEST_CASE("bigSquareRoot tests", "[bigdivide]")
     roots.emplace_back(0);
     for (uint64_t i = 1; i <= 10; ++i)
     {
-        for (uint64_t j = 1; j <= 2 * i - 1; ++j)
+        for (uint64_t j = 1; j <= 2 * i + 1; ++j)
         {
             roots.emplace_back(i);
         }
@@ -393,17 +393,17 @@ TEST_CASE("bigSquareRoot tests", "[bigdivide]")
     }
 
     // Test large values
-    REQUIRE(bigSquareRoot(UINT64_MAX, 1) == 1ull << 32);
-    REQUIRE(bigSquareRoot(UINT32_MAX, 1) == 1ull << 16);
+    REQUIRE(bigSquareRoot(UINT64_MAX, 1) == (1ull << 32) - 1);
+    REQUIRE(bigSquareRoot(UINT32_MAX, 1) == (1ull << 16) - 1);
     REQUIRE(bigSquareRoot(UINT64_MAX, UINT64_MAX) == UINT64_MAX);
     REQUIRE(bigSquareRoot(UINT32_MAX, UINT32_MAX) == UINT32_MAX);
 
     // UINT64_MAX * UINT32_MAX = ((1 << 32) + 1) * UINT32_MAX * UINT32_MAX
     // but
-    // ceil(sqrt(UINT64_MAX * UINT32_MAX)) != ((1 << 16) + 1) * UINT32_MAX
-    // because the ceil occurs after the multiplication
-    REQUIRE(bigSquareRoot(UINT64_MAX, UINT32_MAX) == 281474976677888);
-    REQUIRE(((1ull << 16) + 1) * ((1ull << 32) - 1) != 281474976677888);
+    // floor(sqrt(UINT64_MAX * UINT32_MAX)) != (1 << 16) * UINT32_MAX
+    // because the floor occurs after the multiplication
+    REQUIRE(bigSquareRoot(UINT64_MAX, UINT32_MAX) == 281474976677887);
+    REQUIRE((1ull << 16) * ((1ull << 32) - 1) != 281474976677887);
 }
 
 TEST_CASE("huge divide", "[bigdivide]")


### PR DESCRIPTION
# Description
Change the implementation of `bigSquareRoot` to round down, avoiding certain edge cases in other parts of the implementation.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
