### PR TITLE
remove obsolete tx flooding code

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -141,10 +141,9 @@ FLOOD_OP_RATE_PER_LEDGER = 1.0
 
 # FLOOD_TX_PERIOD_MS (Integer) default 200
 # Time in milliseconds between transaction flood events
-# When non 0, transaction flooding is delayed
-#   and governed by FLOOD_OP_RATE_PER_LEDGER
-#   so that the target rate is met on a per ledger basis
-# When set to 0, transactions are flooded right away
+# Transaction flooding is delayed and governed by
+# FLOOD_OP_RATE_PER_LEDGER so that the target rate is met on
+# a per ledger basis
 FLOOD_TX_PERIOD_MS=200
 
 # PREFERRED_PEERS (list of strings) default is empty

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1078,7 +1078,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             }
             else if (item.first == "FLOOD_TX_PERIOD_MS")
             {
-                FLOOD_TX_PERIOD_MS = readInt<int>(item, 0);
+                FLOOD_TX_PERIOD_MS = readInt<int>(item, 1);
             }
             else if (item.first == "PREFERRED_PEERS")
             {

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -168,54 +168,42 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             return res;
         };
 
-        auto txFloodingTests = [&](bool delayed) {
-            auto cfgGen2 = [&](int n) {
-                auto cfg = cfgGen(n);
-                // adjust delayed tx flooding
-                cfg.FLOOD_TX_PERIOD_MS = delayed ? 10 : 0;
-                return cfg;
-            };
-            SECTION("core")
-            {
-                SECTION("loopback")
-                {
-                    simulation =
-                        Topologies::core(4, .666f, Simulation::OVER_LOOPBACK,
-                                         networkID, cfgGen2);
-                    test(injectTransaction, ackedTransactions);
-                }
-                SECTION("tcp")
-                {
-                    simulation = Topologies::core(
-                        4, .666f, Simulation::OVER_TCP, networkID, cfgGen2);
-                    test(injectTransaction, ackedTransactions);
-                }
-            }
-
-            SECTION("outer nodes")
-            {
-                SECTION("loopback")
-                {
-                    simulation = Topologies::hierarchicalQuorumSimplified(
-                        5, 10, Simulation::OVER_LOOPBACK, networkID, cfgGen2);
-                    test(injectTransaction, ackedTransactions);
-                }
-                SECTION("tcp")
-                {
-                    simulation = Topologies::hierarchicalQuorumSimplified(
-                        5, 10, Simulation::OVER_TCP, networkID, cfgGen2);
-                    test(injectTransaction, ackedTransactions);
-                }
-            }
+        auto cfgGen2 = [&](int n) {
+            auto cfg = cfgGen(n);
+            // adjust delayed tx flooding
+            cfg.FLOOD_TX_PERIOD_MS = 10;
+            return cfg;
         };
-
-        SECTION("direct tx broadcast")
+        SECTION("core")
         {
-            txFloodingTests(false);
+            SECTION("loopback")
+            {
+                simulation = Topologies::core(
+                    4, .666f, Simulation::OVER_LOOPBACK, networkID, cfgGen2);
+                test(injectTransaction, ackedTransactions);
+            }
+            SECTION("tcp")
+            {
+                simulation = Topologies::core(4, .666f, Simulation::OVER_TCP,
+                                              networkID, cfgGen2);
+                test(injectTransaction, ackedTransactions);
+            }
         }
-        SECTION("delayed tx broadcast")
+
+        SECTION("outer nodes")
         {
-            txFloodingTests(true);
+            SECTION("loopback")
+            {
+                simulation = Topologies::hierarchicalQuorumSimplified(
+                    5, 10, Simulation::OVER_LOOPBACK, networkID, cfgGen2);
+                test(injectTransaction, ackedTransactions);
+            }
+            SECTION("tcp")
+            {
+                simulation = Topologies::hierarchicalQuorumSimplified(
+                    5, 10, Simulation::OVER_TCP, networkID, cfgGen2);
+                test(injectTransaction, ackedTransactions);
+            }
         }
     }
 


### PR DESCRIPTION
Delayed flooding code has been the default for a while. There is no need to maintain the legacy synchronous code at this point.