### PR TITLE
Improve print xdr

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -61,7 +61,7 @@ Command options can only by placed after command.
   Option **--filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**
   controls type used for printing (default: auto).<br>
   Option **--base64** alters the behavior to work on base64-encoded XDR rather than
-  raw XDR.
+  raw XDR, and converts a stream of encoded objects separated by space/newline.
 * **publish**: Execute publish of all items remaining in publish queue without
   connecting to network. May not publish last checkpoint if last closed ledger
   is on checkpoint boundary.

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -8,7 +8,7 @@ stellar-core can be controlled via the following commands.
 ## Common options
 Common options can be placed at any place in the command line.
 
-* **--conf <FILE-NAME>**: Specify a config file to use. You can use '/dev/stdin' and
+* **--conf <FILE-NAME>**: Specify a config file to use. You can use 'stdin' and
   provide the config file via STDIN. *default 'stellar-core.cfg'*
 * **--ll <LEVEL>**: Set the log level. It is redundant with `http-command ll`
   but we need this form if you want to change the log level during test runs.
@@ -57,7 +57,7 @@ Command options can only by placed after command.
 * **offline-info**: Returns an output similar to `--c info` for an offline
   instance
 * **print-xdr <FILE-NAME>**:  Pretty-print a binary file containing an XDR
-  object. If FILE-NAME is "/dev/stdin", the XDR object is read from standard input.<br>
+  object. If FILE-NAME is "stdin", the XDR object is read from standard input.<br>
   Option **--filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**
   controls type used for printing (default: auto).<br>
   Option **--base64** alters the behavior to work on base64-encoded XDR rather than
@@ -85,7 +85,7 @@ Command options can only by placed after command.
   envelope stored in binary format in <FILE-NAME>, and send the result to
   standard output (which should be redirected to a file or piped through a tool
   such as `base64`).  The private signing key is read from standard input,
-  unless <FILE-NAME> is "/dev/stdin" in which case the transaction envelope is read from
+  unless <FILE-NAME> is "stdin" in which case the transaction envelope is read from
   standard input and the signing key is read from `/dev/tty`.  In either event,
   if the signing key appears to be coming from a terminal, stellar-core
   disables echo. Note that if you do not have a STELLAR_NETWORK_ID environment

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -219,7 +219,7 @@ compactParser(bool& compact)
 clara::Opt
 base64Parser(bool& base64)
 {
-    return clara::Opt{base64}["--base64"]("use base64");
+    return clara::Opt{base64}["--base64"]("batch process base64 encoded input");
 }
 
 clara::Opt

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1119,7 +1119,7 @@ runPrintXdr(CommandLineArgs const& args)
     auto rawMode = false;
 
     auto fileTypeOpt = clara::Opt(fileType, "FILE-TYPE")["--filetype"](
-        "[auto|ledgerheader|meta|result|resultpair|tx|txfee]");
+        "[auto|ledgerentry|ledgerheader|meta|result|resultpair|tx|txfee]");
 
     return runWithHelp(args,
                        {fileNameParser(xdr), fileTypeOpt, base64Parser(base64),

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1119,7 +1119,8 @@ runPrintXdr(CommandLineArgs const& args)
     auto rawMode = false;
 
     auto fileTypeOpt = clara::Opt(fileType, "FILE-TYPE")["--filetype"](
-        "[auto|ledgerentry|ledgerheader|meta|result|resultpair|tx|txfee]");
+        "[auto|asset|ledgerentry|ledgerheader|meta|result|resultpair|tx|"
+        "txfee]");
 
     return runWithHelp(args,
                        {fileNameParser(xdr), fileTypeOpt, base64Parser(base64),

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1874,6 +1874,5 @@ Config::toString(SCPQuorumSet const& qset)
     return fw.write(json);
 }
 
-std::string const Config::STDIN_SPECIAL_NAME = "/dev/stdin";
-
+std::string const Config::STDIN_SPECIAL_NAME = "stdin";
 }

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -246,6 +246,7 @@ printXdr(std::string const& filename, std::string const& filetype, bool base64,
                 : printerFunc(std::bind(printTransactionMeta, _1, compact));
 
     auto dumpMap = std::map<std::string, printerFunc>{
+        {"asset", PRINTONEXDR(Asset)},
         {"ledgerentry", PRINTONEXDR(LedgerEntry)},
         {"ledgerheader", PRINTONEXDR(LedgerHeader)},
         {"meta", metaPrinter},

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -246,6 +246,7 @@ printXdr(std::string const& filename, std::string const& filetype, bool base64,
                 : printerFunc(std::bind(printTransactionMeta, _1, compact));
 
     auto dumpMap = std::map<std::string, printerFunc>{
+        {"ledgerentry", PRINTONEXDR(LedgerEntry)},
         {"ledgerheader", PRINTONEXDR(LedgerHeader)},
         {"meta", metaPrinter},
         {"result", PRINTONEXDR(TransactionResult)},

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -1515,10 +1515,10 @@ depositTradeWithdrawTest(Application& app, TestAccount& root, int depositSize,
     // withdraw in reverse order
     for (auto rit = deposits.rbegin(); rit != deposits.rend(); ++rit)
     {
-        auto& deposit = *rit;
-        deposit.acc.liquidityPoolWithdraw(pool12, deposit.numPoolShares, 0, 0);
+        auto& d = *rit;
+        d.acc.liquidityPoolWithdraw(pool12, d.numPoolShares, 0, 0);
 
-        total -= deposit.numPoolShares;
+        total -= d.numPoolShares;
     }
 
     checkLiquidityPool(app, pool12, 0, 0, 0, 2);

--- a/src/transactions/test/ChangeTrustTests.cpp
+++ b/src/transactions/test/ChangeTrustTests.cpp
@@ -799,9 +799,6 @@ TEST_CASE("change trust pool share trustline",
                             .baseReserve == newReserve);
                 };
 
-                auto usd = makeAsset(gateway, "USD");
-                auto idrUsd = makeChangeTrustAssetPoolShare(
-                    idr, usd, LIQUIDITY_POOL_FEE_V18);
                 auto acc1 = root.create("acc1", lm.getLastMinBalance(5));
 
                 auto deletePoolTl = [&]() {

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -99,7 +99,8 @@ static uint32_t
 getNumOffers(Application& app, TestAccount const& account, Asset const& asset)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
-    return ltx.getOffersByAccountAndAsset(account, asset).size();
+    auto s = ltx.getOffersByAccountAndAsset(account, asset).size();
+    return static_cast<uint32_t>(s);
 }
 
 TEST_CASE("set trustline flags", "[tx][settrustlineflags]")


### PR DESCRIPTION
This PR makes a few improvements to the `print-xdr` subcommand:

* it allows printing `LedgerEntry` and `Asset`
* it allows printing multiple entries when using the `base64` option (batch mode), so that we can use `print-xdr` when piping from sql queries (see below).

With those changes, it's now possible to run a command such as:
```
    sqlite3 database.db 'select ledgerentry from trustlines' | stellar-core print-xdr  --base64 --filetype ledgerentry stdin | jq ' . | .LedgerEntry.data.trustLine | select(.balance >= 0 and (.asset.assetCode | contains("USD"))) | {id: .accountID, a:.asset}''

{
  "id": "GAAC4HY6OLTVC63MI5GF334ZXB6GAR2RLTXU7BXTB5UXLQZEAEGVAOKR",
  "a": {
    "assetCode": "USD1",
    "issuer": "GCIEGKAZ4ZUM4PEBTDXUMG6N4ZXOTCCK3UMSJCJ33QE5SVMCTTBKCVNY"
  }
}
{
  "id": "GAAC6CKP63PO3KGUS5PCTMKYYHX7K4CE7VVBKAKKKCIXFZCRP7WYPUPG",
  "a": {
    "assetCode": "USDC",
    "issuer": "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
  }
}
{
  "id": "GAAC6MQSD7PMGPTJBOVVFUZQ4THT6VTHNB2B72IY2KGPRAID4KY4IGNM",
  "a": {
    "assetCode": "USD",
    "issuer": "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX"
  }
}
...
```
