### PR TITLE
Delete TmpDirs in order before shutting down in the Fuzzer

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1613,10 +1613,7 @@ TransactionFuzzer::reduceTrustLineLimitsAfterSetup(AbstractLedgerTxn& ltxOuter)
 void
 TransactionFuzzer::shutdown()
 {
-    mApp->gracefulStop();
-    while (mClock.crank(true))
-    {
-    }
+    exit(1);
 }
 
 void

--- a/src/test/fuzz.cpp
+++ b/src/test/fuzz.cpp
@@ -64,6 +64,7 @@ fuzz(std::string const& filename, std::vector<std::string> const& metrics,
     {
         fuzzer->inject(filename);
     }
+    cleanupTmpDirs();
     fuzzer->shutdown();
 }
 }

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -19,6 +19,8 @@ struct TransactionMeta;
 Config const& getTestConfig(int instanceNumber = 0,
                             Config::TestDbMode mode = Config::TESTDB_DEFAULT);
 
+void cleanupTmpDirs();
+
 // Records or checks a TxMetadata value against a persistent record
 // of metadata hashes. Each unit-test name and section has a separate
 // vector of TxMetadata hashes, containing all the txs in that


### PR DESCRIPTION
# Description

The Fuzzer was crashing on shutdown due to this issue. There might be a better way to fix this, but I'm opening the PR now get some eyes on it.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
