### PR TITLE
Ensure docker builds don't use cached layers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,7 @@ ARG STELLAR_CORE_VERSION
 #install stellar-core
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -
 RUN echo "deb https://apt.stellar.org ${DISTRO} unstable" | tee -a /etc/apt/sources.list.d/SDF-unstable.list
-RUN apt-get update
-RUN apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
+RUN apt-get update && apt-get install -y stellar-core=${STELLAR_CORE_VERSION}
 
 WORKDIR "/etc/stellar"
 ENTRYPOINT ["/usr/bin/stellar-core"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -23,7 +23,7 @@ endif
 ifndef TAG
 	TAG = stellar/stellar-core:$(STELLAR_CORE_VERSION)
 endif
-	$(SUDO)  docker build --pull \
+	$(SUDO)  docker build --pull --no-cache \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION} \
 	--build-arg DISTRO=${DISTRO} \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -23,7 +23,7 @@ endif
 ifndef TAG
 	TAG = stellar/stellar-core:$(STELLAR_CORE_VERSION)
 endif
-	$(SUDO)  docker build --pull --no-cache \
+	$(SUDO)  docker build --pull \
 	--label org.opencontainers.image.created="$(BUILD_DATE)" \
 	--build-arg STELLAR_CORE_VERSION=${STELLAR_CORE_VERSION} \
 	--build-arg DISTRO=${DISTRO} \


### PR DESCRIPTION
In some circumstances docker will use cached layers during buidls. This can
cause problems as we depend on the external repository that may change at any
time. This change will disable layer cache.