### PR TITLE
overlay: message processing metrics

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -124,13 +124,16 @@ class Herder
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // We are learning about a new envelope.
-    virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) = 0;
+    virtual EnvelopeStatus
+    recvSCPEnvelope(SCPEnvelope const& envelope,
+                    Peer::TimeToProcessMessagePtr cb) = 0;
 
 #ifdef BUILD_TESTS
     // We are learning about a new fully-fetched envelope.
-    virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
-                                           const SCPQuorumSet& qset,
-                                           TxSetFrame txset) = 0;
+    virtual EnvelopeStatus
+    recvSCPEnvelope(SCPEnvelope const& envelope, const SCPQuorumSet& qset,
+                    TxSetFrame txset,
+                    Peer::TimeToProcessMessagePtr cb = nullptr) = 0;
 
     virtual void
     externalizeValue(std::shared_ptr<TxSetFrame> txSet, uint32_t ledgerSeq,
@@ -141,7 +144,8 @@ class Herder
     virtual VirtualTimer const& getTriggerTimer() const = 0;
 #endif
     // a peer needs our SCP state
-    virtual void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) = 0;
+    virtual void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer,
+                                    Peer::TimeToProcessMessagePtr) = 0;
 
     virtual uint32_t trackingConsensusLedgerIndex() const = 0;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -96,11 +96,13 @@ class HerderImpl : public Herder
     TransactionQueue::AddResult
     recvTransaction(TransactionFrameBasePtr tx) override;
 
-    EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
-#ifdef BUILD_TESTS
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
-                                   const SCPQuorumSet& qset,
-                                   TxSetFrame txset) override;
+                                   Peer::TimeToProcessMessagePtr cb) override;
+#ifdef BUILD_TESTS
+    EnvelopeStatus
+    recvSCPEnvelope(SCPEnvelope const& envelope, const SCPQuorumSet& qset,
+                    TxSetFrame txset,
+                    Peer::TimeToProcessMessagePtr cb = nullptr) override;
 
     void externalizeValue(std::shared_ptr<TxSetFrame> txSet, uint32_t ledgerSeq,
                           uint64_t closeTime,
@@ -115,7 +117,8 @@ class HerderImpl : public Herder
 
     uint32_t mTriggerNextLedgerSeq{0};
 #endif
-    void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) override;
+    void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer,
+                            Peer::TimeToProcessMessagePtr cb) override;
 
     bool recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset) override;
     bool recvTxSet(Hash const& hash, const TxSetFrame& txset) override;

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -88,10 +88,12 @@ class PendingEnvelopes
 
     void updateMetrics();
 
-    void envelopeReady(SCPEnvelope const& envelope);
+    void envelopeReady(SCPEnvelope const& envelope,
+                       Peer::TimeToProcessMessagePtr cb);
     void discardSCPEnvelope(SCPEnvelope const& envelope);
     bool isFullyFetched(SCPEnvelope const& envelope);
-    void startFetch(SCPEnvelope const& envelope);
+    void startFetch(SCPEnvelope const& envelope,
+                    Peer::TimeToProcessMessagePtr cb);
     void stopFetch(SCPEnvelope const& envelope);
     void touchFetchCache(SCPEnvelope const& envelope);
     bool isDiscarded(SCPEnvelope const& envelope) const;
@@ -128,7 +130,8 @@ class PendingEnvelopes
      *
      * Return status of received envelope.
      */
-    Herder::EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope);
+    Herder::EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
+                                           Peer::TimeToProcessMessagePtr cb);
 
     /**
      * Add @p qset identified by @p hash to local cache. Notifies
@@ -202,5 +205,7 @@ class PendingEnvelopes
     void reportCostOutliersForSlot(int64_t slotIndex, bool updateMetrics) const;
     Json::Value getJsonValidatorCost(bool summary, bool fullKeys,
                                      uint64 index) const;
+
+    void shutdown();
 };
 }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -743,8 +743,8 @@ TransactionQueue::broadcastTx(AccountState& state, TimestampedTx& tx)
 #endif
     tx.mBroadcasted = true;
     state.mBroadcastQueueOps -= tx.mTx->getNumOperations();
-    return mApp.getOverlayManager().broadcastMessage(
-        tx.mTx->toStellarMessage());
+    return mApp.getOverlayManager().broadcastMessage(tx.mTx->toStellarMessage(),
+                                                     nullptr);
 }
 
 struct TxQueueTracker

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -69,7 +69,12 @@ testQuorumTracker()
         envelope.statement.nodeID = k.getPublicKey();
         envelope.signature = k.sign(xdr::xdr_to_opaque(
             app->getNetworkID(), ENVELOPE_TYPE_SCP, envelope.statement));
-        herder->recvSCPEnvelope(envelope);
+
+        StellarMessage msg;
+        msg.type(SCP_MESSAGE);
+        msg.envelope() = envelope;
+        auto t = std::make_shared<Peer::MetricTracker>(msg, *app);
+        herder->recvSCPEnvelope(envelope, t);
         herder->recvSCPQuorumSet(qSetH, qSet);
         for (auto& p : pp)
         {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -568,6 +568,10 @@ ApplicationImpl::~ApplicationImpl()
     LOG_INFO(DEFAULT_LOG, "Application destructing");
     try
     {
+        if (mOverlayManager)
+        {
+            mOverlayManager->shutdown();
+        }
         shutdownWorkScheduler();
         if (mProcessManager)
         {
@@ -576,6 +580,10 @@ ApplicationImpl::~ApplicationImpl()
         if (mBucketManager)
         {
             mBucketManager->shutdown();
+        }
+        if (mHerder)
+        {
+            mHerder->shutdown();
         }
     }
     catch (std::exception const& e)

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -84,7 +84,8 @@ Floodgate::addRecord(StellarMessage const& msg, Peer::pointer peer, Hash& index)
 
 // send message to anyone you haven't gotten it from
 bool
-Floodgate::broadcast(StellarMessage const& msg, bool force)
+Floodgate::broadcast(StellarMessage const& msg, bool force,
+                     Peer::TimeToProcessMessagePtr cb)
 {
     ZoneScoped;
     if (mShuttingDown)
@@ -125,11 +126,11 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
             std::weak_ptr<Peer> weak(
                 std::static_pointer_cast<Peer>(peer.second));
             mApp.postOnMainThread(
-                [smsg, weak, log = !broadcasted]() {
+                [smsg, weak, log = !broadcasted, cb]() {
                     auto strong = weak.lock();
                     if (strong)
                     {
-                        strong->sendMessage(*smsg, log);
+                        strong->sendMessage(*smsg, cb, log);
                     }
                 },
                 fmt::format("broadcast to {}", peer.second->toString()));

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -60,7 +60,8 @@ class Floodgate
                    Hash& msgID);
 
     // returns true if msg was sent to at least one peer
-    bool broadcast(StellarMessage const& msg, bool force);
+    bool broadcast(StellarMessage const& msg, bool force,
+                   Peer::TimeToProcessMessagePtr cb);
 
     // returns the list of peers that sent us the item with hash `msgID`
     // NB: `msgID` is the hash of a `StellarMessage`

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -52,7 +52,8 @@ class ItemFetcher : private NonMovableOrCopyable
      * Fetch data identified by @p hash and needed by @p envelope. Multiple
      * envelopes may require one set of data.
      */
-    void fetch(Hash const& itemHash, SCPEnvelope const& envelope);
+    void fetch(Hash const& itemHash, SCPEnvelope const& envelope,
+               Peer::TimeToProcessMessagePtr cb = nullptr);
 
     /**
      * Stops fetching data identified by @p hash for @p envelope. If other
@@ -91,6 +92,8 @@ class ItemFetcher : private NonMovableOrCopyable
      * to Herder, matching @see Tracker will be cleaned up.
      */
     void recv(Hash itemHash, medida::Timer& timer);
+
+    void shutdown();
 
 #ifdef BUILD_TESTS
     std::shared_ptr<Tracker> getTracker(Hash const& h);

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -67,6 +67,7 @@ class OverlayManager
     // Send a given message to all peers, via the FloodGate.
     // returns true if message was sent to at least one peer
     virtual bool broadcastMessage(StellarMessage const& msg,
+                                  Peer::TimeToProcessMessagePtr cb,
                                   bool force = false) = 0;
 
     // Make a note in the FloodGate that a given peer has provided us with a

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -936,10 +936,12 @@ OverlayManagerImpl::forgetFloodedMsg(Hash const& msgID)
 }
 
 bool
-OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force)
+OverlayManagerImpl::broadcastMessage(StellarMessage const& msg,
+                                     Peer::TimeToProcessMessagePtr cb,
+                                     bool force)
 {
     ZoneScoped;
-    auto res = mFloodGate.broadcast(msg, force);
+    auto res = mFloodGate.broadcast(msg, force, cb);
     if (res)
     {
         mOverlayMetrics.mMessagesBroadcast.Mark();

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -104,6 +104,7 @@ class OverlayManagerImpl : public OverlayManager
                           Hash& msgID) override;
     void forgetFloodedMsg(Hash const& msgID) override;
     bool broadcastMessage(StellarMessage const& msg,
+                          Peer::TimeToProcessMessagePtr cb,
                           bool force = false) override;
     void connectTo(PeerBareAddress const& address) override;
 

--- a/src/overlay/SurveyManager.cpp
+++ b/src/overlay/SurveyManager.cpp
@@ -327,7 +327,7 @@ SurveyManager::processTopologyRequest(SurveyRequestMessage const& request) const
 void
 SurveyManager::broadcast(StellarMessage const& msg) const
 {
-    mApp.getOverlayManager().broadcastMessage(msg, false);
+    mApp.getOverlayManager().broadcastMessage(msg, nullptr, false);
 }
 
 void

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -32,13 +32,15 @@ class TCPPeer : public Peer
     std::vector<uint8_t> mIncomingBody;
 
     std::vector<asio::const_buffer> mWriteBuffers;
-    std::deque<TimestampedMessage> mWriteQueue;
+    std::deque<std::pair<TimestampedMessage, Peer::TimeToProcessMessagePtr>>
+        mWriteQueue;
     bool mWriting{false};
     bool mDelayedShutdown{false};
     bool mShutdownScheduled{false};
 
     void recvMessage();
-    void sendMessage(xdr::msg_ptr&& xdrBytes) override;
+    void sendMessage(xdr::msg_ptr&& xdrBytes,
+                     Peer::TimeToProcessMessagePtr) override;
 
     void messageSender();
 

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -147,7 +147,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             auto msg = tx1->toStellarMessage();
             auto res = inApp->getHerder().recvTransaction(tx1);
             REQUIRE(res == TransactionQueue::AddResult::ADD_STATUS_PENDING);
-            inApp->getOverlayManager().broadcastMessage(msg);
+            inApp->getOverlayManager().broadcastMessage(msg, nullptr);
         };
 
         auto ackedTransactions = [&](std::shared_ptr<Application> app) {

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -45,7 +45,7 @@ LoopbackPeer::getAuthCert()
 }
 
 void
-LoopbackPeer::sendMessage(xdr::msg_ptr&& msg)
+LoopbackPeer::sendMessage(xdr::msg_ptr&& msg, Peer::TimeToProcessMessagePtr cb)
 {
     if (mRemote.expired())
     {

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -52,7 +52,8 @@ class LoopbackPeer : public Peer
 
     Stats mStats;
 
-    void sendMessage(xdr::msg_ptr&& xdrBytes) override;
+    void sendMessage(xdr::msg_ptr&& xdrBytes,
+                     Peer::TimeToProcessMessagePtr cb) override;
     AuthCert getAuthCert() override;
 
     void processInQueue();

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -50,7 +50,8 @@ class PeerStub : public Peer
     {
     }
     virtual void
-    sendMessage(xdr::msg_ptr&& xdrBytes) override
+    sendMessage(xdr::msg_ptr&& xdrBytes,
+                Peer::TimeToProcessMessagePtr cb) override
     {
         sent++;
     }
@@ -264,15 +265,15 @@ class OverlayManagerTests
                 pm.recvFloodedMsg(AtoB, p.second);
             }
         }
-        pm.broadcastMessage(AtoB);
+        pm.broadcastMessage(AtoB, nullptr);
         crank(10);
         std::vector<int> expected{1, 1, 0, 1, 1};
         REQUIRE(sentCounts(pm) == expected);
-        pm.broadcastMessage(AtoB);
+        pm.broadcastMessage(AtoB, nullptr);
         crank(10);
         REQUIRE(sentCounts(pm) == expected);
         StellarMessage CtoD = c.tx({payment(d, 10)})->toStellarMessage();
-        pm.broadcastMessage(CtoD);
+        pm.broadcastMessage(CtoD, nullptr);
         crank(10);
         std::vector<int> expectedFinal{2, 2, 1, 2, 2};
         REQUIRE(sentCounts(pm) == expectedFinal);
@@ -280,7 +281,7 @@ class OverlayManagerTests
         // Test that we updating a flood record actually prevents re-broadcast
         StellarMessage AtoC = a.tx({payment(c, 10)})->toStellarMessage();
         pm.updateFloodRecord(AtoB, AtoC);
-        pm.broadcastMessage(AtoC);
+        pm.broadcastMessage(AtoC, nullptr);
         crank(10);
         REQUIRE(sentCounts(pm) == expectedFinal);
     }

--- a/src/overlay/test/TrackerTests.cpp
+++ b/src/overlay/test/TrackerTests.cpp
@@ -48,12 +48,12 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
     {
         Tracker t{*app, hash, nullAskPeer};
         auto env1 = makeEnvelope(1);
-        t.listen(env1);
+        t.listen(env1, nullptr);
 
         REQUIRE(t.size() == 1);
         REQUIRE(!t.empty());
         REQUIRE(t.getLastSeenSlotIndex() == 1);
-        REQUIRE(env1 == t.pop());
+        REQUIRE(env1 == t.pop().first);
         REQUIRE(t.size() == 0);
         REQUIRE(t.empty());
         REQUIRE(t.getLastSeenSlotIndex() == 1);
@@ -65,12 +65,12 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
     {
         Tracker t{*app, hash, nullAskPeer};
         auto env1 = makeEnvelope(1);
-        t.listen(env1);
+        t.listen(env1, nullptr);
         // this should no-op (idempotent)
-        t.listen(env1);
+        t.listen(env1, nullptr);
         REQUIRE(t.getLastSeenSlotIndex() == 1);
 
-        REQUIRE(env1 == t.pop());
+        REQUIRE(env1 == t.pop().first);
         REQUIRE(t.empty());
     }
 
@@ -79,13 +79,13 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
         Tracker t{*app, hash, nullAskPeer};
         auto env1 = makeEnvelope(1);
         auto env2 = makeEnvelope(2);
-        t.listen(env1);
+        t.listen(env1, nullptr);
         REQUIRE(t.getLastSeenSlotIndex() == 1);
-        t.listen(env2);
+        t.listen(env2, nullptr);
         REQUIRE(t.getLastSeenSlotIndex() == 2);
 
-        REQUIRE(env2 == t.pop());
-        REQUIRE(env1 == t.pop());
+        REQUIRE(env2 == t.pop().first);
+        REQUIRE(env1 == t.pop().first);
     }
 
     SECTION("properly removes old envelopes")
@@ -96,11 +96,11 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
         auto env3 = makeEnvelope(3);
         auto env4 = makeEnvelope(4);
         auto env5 = makeEnvelope(5);
-        t.listen(env5);
-        t.listen(env3);
-        t.listen(env1);
-        t.listen(env2);
-        t.listen(env4);
+        t.listen(env5, nullptr);
+        t.listen(env3, nullptr);
+        t.listen(env1, nullptr);
+        t.listen(env2, nullptr);
+        t.listen(env4, nullptr);
 
         REQUIRE(t.size() == 5);
         REQUIRE(t.getLastSeenSlotIndex() == 5);
@@ -109,8 +109,8 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
         {
             REQUIRE(t.clearEnvelopesBelow(4));
             REQUIRE(t.size() == 2);
-            REQUIRE(env4 == t.pop());
-            REQUIRE(env5 == t.pop());
+            REQUIRE(env4 == t.pop().first);
+            REQUIRE(env5 == t.pop().first);
         }
 
         SECTION("properly removes all old envelopes")

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -763,7 +763,7 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
     }
     else
     {
-        mApp.getOverlayManager().broadcastMessage(msg);
+        mApp.getOverlayManager().broadcastMessage(msg, nullptr);
     }
 
     return status;


### PR DESCRIPTION
Initial implementation of the message processing metrics in overlay. The main two metrics are: how long each message type sits in the scheduler queue before getting dispatched, and how long it takes to completely process certain message types. "completely process" here includes actions like writing to the network, fetching values etc. This should give us a better picture of the consensus round impact.

This is a preliminary implementation, and as it touches a lot of areas in the codebase, it still requires more testing. There's also a TODO to ensure proper shutdown of TCPPeer given that we now store callbacks that update metrics once messages are popped from the write queue. But I wanted to push this change anyway so we can start reviewing it. 