### PR TITLE
Prevent `mSyncingLedgers` from growing indefinitely

### DIFF
--- a/src/catchup/CatchupManager.h
+++ b/src/catchup/CatchupManager.h
@@ -86,11 +86,17 @@ class CatchupManager
     // work item.
     virtual void logAndUpdateCatchupStatus(bool contiguous) = 0;
 
-    // popBufferedLedger will throw if there are no buffered ledgers
-    virtual bool hasBufferedLedger() const = 0;
-    virtual LedgerCloseData const& getFirstBufferedLedger() const = 0;
-    virtual LedgerCloseData const& getLastBufferedLedger() const = 0;
-    virtual void popBufferedLedger() = 0;
+    // This returns the ledger that comes immediately after the LCL (i.e., LCL +
+    // 1) if CatchupManager has it in its buffer. If not, it doesn’t return any
+    // ledger. This method doesn’t tell if the buffer is empty or if it's ever
+    // heard of LCL + 1. It only tells if CatchupManager has LCL + 1 in its
+    // buffer right now.
+    virtual std::optional<LedgerCloseData>
+    maybeGetNextBufferedLedgerToApply() = 0;
+
+    // This returns the largest ledger sequence that CatchupManager has ever
+    // heard of.
+    virtual uint32_t getLargestLedgerSeqHeard() const = 0;
 
     // Ensure any metrics that are "current state" gauge-like counters reflect
     // the current reality as best as possible.

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -87,6 +87,7 @@ CatchupManagerImpl::CatchupManagerImpl(Application& app)
     , mCatchupWork(nullptr)
     , mSyncingLedgersSize(
           app.getMetrics().NewCounter({"ledger", "memory", "queued-ledgers"}))
+    , mLargestLedgerSeqHeard(0)
 {
 }
 
@@ -108,10 +109,13 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
     ZoneScoped;
     if (mCatchupWork && mCatchupWork->isDone())
     {
-        trimAndReset();
+        mCatchupWork.reset();
+        logAndUpdateCatchupStatus(true);
     }
 
     uint32_t lastReceivedLedgerSeq = ledgerData.getLedgerSeq();
+    mLargestLedgerSeqHeard =
+        std::max(mLargestLedgerSeqHeard, lastReceivedLedgerSeq);
 
     // 1. CatchupWork is not running yet
     // 2. CatchupManager received  ledger that was immediately applied by
@@ -153,14 +157,14 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
             return;
         }
 
-        addToSyncingLedgers(ledgerData);
+        addAndTrimSyncingLedgers(ledgerData);
         logAndUpdateCatchupStatus(true);
         return;
     }
 
     // Next, we buffer every out of sync ledger to allow us to get back in sync
     // in case the ledgers we're missing are received.
-    addToSyncingLedgers(ledgerData);
+    addAndTrimSyncingLedgers(ledgerData);
 
     // Finally we wait some number of ledgers beyond the smallest buffered
     // checkpoint ledger before we trigger the CatchupWork. This could be any
@@ -169,28 +173,23 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
     // we just check for any ledger larger than the checkpoint
 
     auto& hm = mApp.getHistoryManager();
-    auto it =
-        findFirstCheckpoint(mSyncingLedgers.begin(), mSyncingLedgers.end(), hm);
 
     std::string message;
+    uint32_t firstLedgerInBuffer = mSyncingLedgers.begin()->first;
     uint32_t lastLedgerInBuffer = mSyncingLedgers.crbegin()->first;
-    if (mApp.getConfig().MODE_DOES_CATCHUP && it != mSyncingLedgers.end() &&
-        it->first < lastLedgerInBuffer)
+    if (mApp.getConfig().MODE_DOES_CATCHUP &&
+        hm.isFirstLedgerInCheckpoint(firstLedgerInBuffer) &&
+        firstLedgerInBuffer < lastLedgerInBuffer)
     {
         message = fmt::format("Starting catchup after ensuring checkpoint "
                               "ledger {} was closed on network",
                               lastLedgerInBuffer);
-
-        // We only need ledgers starting from the checkpoint. We can
-        // remove all ledgers before this
-        mSyncingLedgers.erase(mSyncingLedgers.begin(), it);
 
         startOnlineCatchup();
     }
     else
     {
         // get the smallest checkpoint we need to start catchup
-        uint32_t firstLedgerInBuffer = mSyncingLedgers.cbegin()->first;
         uint32_t requiredFirstLedgerInCheckpoint =
             hm.isFirstLedgerInCheckpoint(firstLedgerInBuffer)
                 ? firstLedgerInBuffer
@@ -228,7 +227,9 @@ CatchupManagerImpl::startCatchup(CatchupConfiguration configuration,
     if ((configuration.toLedger() != CatchupConfiguration::CURRENT) &&
         (configuration.toLedger() <= lastClosedLedger))
     {
-        throw std::invalid_argument("Target ledger is not newer than LCL");
+        throw std::invalid_argument(fmt::format(
+            FMT_STRING("Target ledger({:d}) is not newer than LCL({:d})"),
+            configuration.toLedger(), lastClosedLedger));
     }
 
     auto offlineCatchup = configuration.offline();
@@ -298,46 +299,27 @@ CatchupManagerImpl::logAndUpdateCatchupStatus(bool contiguous)
     logAndUpdateCatchupStatus(contiguous, getStatus());
 }
 
-bool
-CatchupManagerImpl::hasBufferedLedger() const
+std::optional<LedgerCloseData>
+CatchupManagerImpl::maybeGetNextBufferedLedgerToApply()
 {
-    return !mSyncingLedgers.empty();
+    trimSyncingLedgers();
+    if (!mSyncingLedgers.empty() &&
+        mSyncingLedgers.begin()->first ==
+            mApp.getLedgerManager().getLastClosedLedgerNum() + 1)
+    {
+        return std::make_optional<LedgerCloseData>(
+            mSyncingLedgers.begin()->second);
+    }
+    else
+    {
+        return {};
+    }
 }
 
-LedgerCloseData const&
-CatchupManagerImpl::getFirstBufferedLedger() const
+uint32_t
+CatchupManagerImpl::getLargestLedgerSeqHeard() const
 {
-    if (!hasBufferedLedger())
-    {
-        throw std::runtime_error(
-            "getFirstBufferedLedger called when mSyncingLedgers is empty!");
-    }
-
-    return mSyncingLedgers.cbegin()->second;
-}
-
-LedgerCloseData const&
-CatchupManagerImpl::getLastBufferedLedger() const
-{
-    if (!hasBufferedLedger())
-    {
-        throw std::runtime_error(
-            "getLastBufferedLedger called when mSyncingLedgers is empty!");
-    }
-
-    return mSyncingLedgers.crbegin()->second;
-}
-
-void
-CatchupManagerImpl::popBufferedLedger()
-{
-    if (!hasBufferedLedger())
-    {
-        throw std::runtime_error(
-            "popBufferedLedger called when mSyncingLedgers is empty!");
-    }
-
-    mSyncingLedgers.erase(mSyncingLedgers.cbegin());
+    return mLargestLedgerSeqHeard;
 }
 
 void
@@ -347,21 +329,14 @@ CatchupManagerImpl::syncMetrics()
 }
 
 void
-CatchupManagerImpl::trimAndReset()
-{
-    releaseAssert(mCatchupWork);
-    mCatchupWork.reset();
-
-    logAndUpdateCatchupStatus(true);
-    trimSyncingLedgers();
-}
-
-void
-CatchupManagerImpl::addToSyncingLedgers(LedgerCloseData const& ledgerData)
+CatchupManagerImpl::addAndTrimSyncingLedgers(LedgerCloseData const& ledgerData)
 {
     mSyncingLedgers.emplace(ledgerData.getLedgerSeq(), ledgerData);
+    trimSyncingLedgers();
 
-    CLOG_INFO(Ledger, "Close of ledger {} buffered", ledgerData.getLedgerSeq());
+    CLOG_INFO(Ledger,
+              "Close of ledger {} buffered. mSyncingLedgers has {} ledgers",
+              ledgerData.getLedgerSeq(), mSyncingLedgers.size());
 }
 
 void
@@ -383,26 +358,39 @@ CatchupManagerImpl::startOnlineCatchup()
 void
 CatchupManagerImpl::trimSyncingLedgers()
 {
-    // Look for newest checkpoint ledger by using a reverse iterator
-    auto rit =
-        findFirstCheckpoint(mSyncingLedgers.rbegin(), mSyncingLedgers.rend(),
-                            mApp.getHistoryManager());
 
-    // only keep ledgers after start of the latest checkpoint. If no checkpoint
-    // exists, then do nothing. We don't want to erase mSyncingLedgers in case
-    // we receive the missing ledgers and recover
-    if (rit != mSyncingLedgers.rend())
+    auto removeLedgersLessThan = [&](uint32_t ledger) {
+        // lower_bound returns an iterator pointing to the first element whose
+        // key is not considered to go before k. Thus we get the iterator to
+        // `ledger` if exists, or the first one after `ledger`.
+        auto it = mSyncingLedgers.lower_bound(ledger);
+        // This erases [begin, it).
+        mSyncingLedgers.erase(mSyncingLedgers.begin(), it);
+    };
+    removeLedgersLessThan(mApp.getLedgerManager().getLastClosedLedgerNum() + 1);
+    auto& hm = mApp.getHistoryManager();
+    if (!mSyncingLedgers.empty())
     {
-        // rit points to a ledger that's the first in a checkpoint, like 64 or
-        // 128; rit.base() is the underlying forward iterator one _past_ (in
-        // forward-order) the value pointed-to by rit. In other words
-        // (++rit).base() is the forward iterator pointing to the same ledger 64
-        // or 128 or such.
-        //
-        // We then erase the half-open range [begin, (++rit).base()) which is
-        // like [..., 64) or [..., 128), which leaves us with the checkpoint
-        // range [64, ...) or [128, ...) in mSyncingLedgers.
-        mSyncingLedgers.erase(mSyncingLedgers.begin(), (++rit).base());
+        auto const lastBufferedLedger = mSyncingLedgers.rbegin()->first;
+        if (hm.isFirstLedgerInCheckpoint(lastBufferedLedger))
+        {
+            // The last ledger is the first ledger in the checkpoint.
+            // This means that nodes may not have started publishing
+            // the checkpoint of lastBufferedLedger.
+            // We should only keep lastBufferedLedger _and_ the checkpoint
+            // before that.
+            removeLedgersLessThan(
+                hm.firstLedgerInCheckpointContaining(lastBufferedLedger - 1));
+        }
+        else
+        {
+            // The last ledger isn't the first ledger in the checkpoint.
+            // This means that nodes must have started publishing
+            // the checkpoint of lastBufferedLedger.
+            // Therefore, we will delete all ledgers before the checkpoint.
+            removeLedgersLessThan(
+                hm.firstLedgerInCheckpointContaining(lastBufferedLedger));
+        }
     }
 }
 

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -380,6 +380,10 @@ CatchupWork::runCatchupStep()
             // Step 4.4: Apply buffered ledgers
             if (mApplyBufferedLedgersWork)
             {
+                // ApplyBufferedLedgersWork will try to apply
+                // as many ledgers in mSyncingLedgers as possible.
+                // Note that it's not always possible to apply
+                // _all_ the ledgers in mSyncingLedgers due to gaps.
                 if (mApplyBufferedLedgersWork->getState() ==
                     State::WORK_SUCCESS)
                 {
@@ -393,7 +397,7 @@ CatchupWork::runCatchupStep()
                 }
             }
             // see if we need to apply buffered ledgers
-            if (mApp.getCatchupManager().hasBufferedLedger())
+            if (mApp.getCatchupManager().maybeGetNextBufferedLedgerToApply())
             {
                 mApplyBufferedLedgersWork = addWork<ApplyBufferedLedgersWork>();
                 mCurrentWork = mApplyBufferedLedgersWork;
@@ -515,7 +519,7 @@ CatchupWork::doWork()
 
     if (nextState == BasicWork::State::WORK_SUCCESS)
     {
-        releaseAssert(!cm.hasBufferedLedger());
+        releaseAssert(!cm.maybeGetNextBufferedLedgerToApply());
     }
 
     cm.logAndUpdateCatchupStatus(true);

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1791,7 +1791,7 @@ static void
 checkSynced(Application& app)
 {
     REQUIRE(app.getLedgerManager().isSynced());
-    REQUIRE(!app.getCatchupManager().hasBufferedLedger());
+    REQUIRE(!app.getCatchupManager().maybeGetNextBufferedLedgerToApply());
 }
 
 void

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -207,11 +207,6 @@ class CatchupSimulation
 
     uint32_t mTestProtocolShadowsRemovedLedgerSeq{0};
 
-    CatchupPerformedWork computeCatchupPerformedWork(
-        uint32_t lastClosedLedger,
-        CatchupConfiguration const& catchupConfiguration, Application& app);
-    void validateCatchup(Application::pointer app);
-
   public:
     explicit CatchupSimulation(
         VirtualClock::Mode mode = VirtualClock::VIRTUAL_TIME,
@@ -237,6 +232,12 @@ class CatchupSimulation
     {
         return *mHistoryConfigurator.get();
     }
+
+    CatchupMetrics getCatchupMetrics(Application::pointer app);
+    CatchupPerformedWork computeCatchupPerformedWork(
+        uint32_t lastClosedLedger,
+        CatchupConfiguration const& catchupConfiguration, Application& app);
+    void validateCatchup(Application::pointer app);
 
     uint32_t getLastCheckpointLedger(uint32_t checkpointIndex) const;
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -451,9 +451,9 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
 
     cm.processLedger(ledgerData);
 
-    // Invariant: if catchup is running or waiting to run, buffered ledgers are
-    // never empty
-    if (!cm.hasBufferedLedger())
+    // We set the state to synced
+    // if we have closed the latest ledger we have heard of.
+    if (cm.getLargestLedgerSeqHeard() == getLastClosedLedgerNum())
     {
         setState(LM_SYNCED_STATE);
         // New ledger(s) got closed, notify Herder

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -888,13 +888,6 @@ runWriteVerifiedCheckpointHashes(CommandLineArgs const& args)
                     auto const& lhe = lm.getLastClosedLedgerHeader();
                     tryCheckpoint(lhe.header.ledgerSeq, lhe.hash);
                 }
-                else if (cm.hasBufferedLedger())
-                {
-                    auto const& lcd = cm.getLastBufferedLedger();
-                    uint32_t seq = lcd.getLedgerSeq() - 1;
-                    Hash hash = lcd.getTxSet()->previousLedgerHash();
-                    tryCheckpoint(seq, hash);
-                }
             }
             if (authPair.second)
             {


### PR DESCRIPTION
# Description

Resolves #3157 

This PR updates the online catchup mechanism such that
- `mSyncingLedgers` is the list of buffered ledgers, but it only keeps track of ledgers for the latest checkpoint.
- `CatchupWork` is triggered to catch up to the ledger before the oldest ledger in `mSyncingLedgers`. (This is the same as before)
- It is possible that, by the time `CatchupWork` finishes, `mSyncingLedgers` may have popped some elements. In such a case, `processLedger` will re-trigger `CatchupWork`.

 
# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
