### PR TITLE
fix: captive core crashes with all invariants enabled

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -274,9 +274,10 @@ ApplicationImpl::initialize(bool createNewDB, bool forceRebuild)
             mConfig.BEST_OFFER_DEBUGGING_ENABLED
 #endif
         );
+
+        BucketListIsConsistentWithDatabase::registerInvariant(*this);
     }
 
-    BucketListIsConsistentWithDatabase::registerInvariant(*this);
     AccountSubEntriesCountIsValid::registerInvariant(*this);
     ConservationOfLumens::registerInvariant(*this);
     LedgerEntryIsValid::registerInvariant(*this);


### PR DESCRIPTION
disable bucketlist check invariant that relies on SQL
