### PR TITLE
Add a new config to wait for merges to complete when catching up

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -403,6 +403,11 @@ ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING=0
 # as this is a security threat.
 ALLOW_LOCALHOST_FOR_TESTING=false
 
+# CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING defaults to false
+# When set, during catchup, waits for bucket merges to complete
+# before applying transactions.
+CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING=false
+
 # MAXIMUM_LEDGER_CLOSETIME_DRIFT (in seconds) defaults to 50
 # Maximum drift between the local clock and the network time.
 # When joining the network for the first time, ignore SCP messages that are
@@ -651,5 +656,3 @@ mkdir="mkdir -p /var/lib/stellar-core/history/vs/{0}"
 #     "GAWOEMG7DQDWHCFDTPJEBYWRKUUZTX2M2HLMNABM42G7C7IAPU54GL6X K_from_above",
 #     "GDZAJNUUDJFKTZX3YWZSOAS4S4NGCJ5RQAY7JPYBG5CUFL3JZ5C3ECOH L_from_above"
 # ]
-
-

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -3,6 +3,8 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "catchup/DownloadApplyTxsWork.h"
+#include "bucket/BucketList.h"
+#include "bucket/BucketManager.h"
 #include "catchup/ApplyCheckpointWork.h"
 #include "history/FileTransferInfo.h"
 #include "history/HistoryManager.h"
@@ -10,6 +12,7 @@
 #include "ledger/LedgerManager.h"
 #include "work/ConditionalWork.h"
 #include "work/WorkSequence.h"
+
 #include <Tracy.hpp>
 #include <fmt/format.h>
 
@@ -76,12 +79,25 @@ DownloadApplyTxsWork::yieldMoreWork()
 
     std::vector<std::shared_ptr<BasicWork>> seq{getAndUnzip};
 
+    auto maybeWaitForMerges = [](Application& app) {
+        if (app.getConfig().CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING)
+        {
+            auto& bl = app.getBucketManager().getBucketList();
+            bl.resolveAnyReadyFutures();
+            return bl.futuresAllResolved();
+        }
+        else
+        {
+            return true;
+        }
+    };
+
     if (mLastYieldedWork)
     {
         auto prev = mLastYieldedWork;
         bool pqFellBehind = false;
-        auto predicate = [prev, pqFellBehind, waitForPublish = mWaitForPublish](
-                             Application& app) mutable {
+        auto predicate = [prev, pqFellBehind, waitForPublish = mWaitForPublish,
+                          maybeWaitForMerges](Application& app) mutable {
             if (!prev)
             {
                 throw std::runtime_error("Download and apply txs: related Work "
@@ -110,14 +126,15 @@ DownloadApplyTxsWork::yieldMoreWork()
                 }
                 res = !pqFellBehind;
             }
-            return res;
+            return res && maybeWaitForMerges(app);
         };
         seq.push_back(std::make_shared<ConditionalWork>(
             mApp, "conditional-" + apply->getName(), predicate, apply));
     }
     else
     {
-        seq.push_back(apply);
+        seq.push_back(std::make_shared<ConditionalWork>(
+            mApp, "wait-merges" + apply->getName(), maybeWaitForMerges, apply));
     }
 
     auto nextWork = std::make_shared<WorkSequence>(

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -49,7 +49,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "OP_APPLY_SLEEP_TIME_DURATION_FOR_TESTING",
     "OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
     "LOADGEN_OP_COUNT_FOR_TESTING",
-    "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING"};
+    "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING",
+    "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -113,6 +114,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = std::vector<uint32>();
     LOADGEN_OP_COUNT_FOR_TESTING = {};
     LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {};
+    CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = false;
 
     FORCE_SCP = false;
     LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION;
@@ -1240,6 +1242,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING =
                     readIntArray<uint32>(item);
+            }
+            else if (item.first == "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING")
+            {
+                CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = readBool(item);
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -217,6 +217,9 @@ class Config : public std::enable_shared_from_this<Config>
     std::vector<unsigned short> LOADGEN_OP_COUNT_FOR_TESTING;
     std::vector<uint32> LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING;
 
+    // Waits for merges to complete before applying transactions during catchup
+    bool CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING;
+
     // A config parameter that allows a node to generate buckets. This should
     // be set to `false` only for testing purposes.
     bool MODE_ENABLES_BUCKETLIST;


### PR DESCRIPTION
Very useful when performance testing as it allows to isolate merges from the transaction apply phase.