### PR TITLE
Fix libc++ versions in Dockerfile.testing

### DIFF
--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -28,7 +28,7 @@ RUN make install
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-8 libc++1-8
+    apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
 
 COPY --from=buildstage /usr/local/bin/stellar-core /usr/local/bin/stellar-core
 EXPOSE 11625


### PR DESCRIPTION
looks like there was a mismatch in libc++ versions installed for building and running core, which resulted in various errors like
```
undefined symbol _ZNSt3__14__fs10filesystem8__statusERKNS1_4pathEPNS_10error_codeE
```