### PR TITLE
Move to `FMT_STRING` in production code

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -201,7 +201,7 @@ Bucket::checkProtocolLegality(BucketEntry const& entry,
         (entry.type() == INITENTRY || entry.type() == METAENTRY))
     {
         throw std::runtime_error(fmt::format(
-            "unsupported entry type {} in protocol {} bucket",
+            FMT_STRING("unsupported entry type {} in protocol {:d} bucket"),
             (entry.type() == INITENTRY ? "INIT" : "META"), protocolVersion));
     }
 }
@@ -383,7 +383,8 @@ calculateMergeProtocolVersion(
     if (protocolVersion > maxProtocolVersion)
     {
         throw std::runtime_error(fmt::format(
-            "bucket protocol version {} exceeds maxProtocolVersion {}",
+            FMT_STRING(
+                "bucket protocol version {:d} exceeds maxProtocolVersion {:d}"),
             protocolVersion, maxProtocolVersion));
     }
 

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -28,7 +28,8 @@ BucketApplicator::BucketApplicator(Application& app,
     if (protocolVersion > mMaxProtocolVersion)
     {
         throw std::runtime_error(fmt::format(
-            "bucket protocol version {} exceeds maxProtocolVersion {}",
+            FMT_STRING(
+                "bucket protocol version {:d} exceeds maxProtocolVersion {:d}"),
             protocolVersion, mMaxProtocolVersion));
     }
 }

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -638,10 +638,10 @@ BucketList::restartMerges(Application& app, uint32_t maxProtocolVersion,
             auto version = Bucket::getBucketVersion(snap);
             if (version < Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
             {
-                auto msg =
-                    fmt::format("Invalid state: bucketlist level {} has clear "
-                                "future bucket but version {} snap",
-                                i, version);
+                auto msg = fmt::format(
+                    FMT_STRING("Invalid state: bucketlist level {:d} has clear "
+                               "future bucket but version {:d} snap"),
+                    i, version);
                 throw std::runtime_error(msg);
             }
 

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -73,10 +73,10 @@ BucketManagerImpl::initialize()
     }
     catch (std::exception const& e)
     {
-        throw std::runtime_error(
-            fmt::format("{}. This can be caused by access rights issues or "
-                        "another stellar-core process already running",
-                        e.what()));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("{}. This can be caused by access rights issues or "
+                       "another stellar-core process already running"),
+            e.what()));
     }
 
     mLockedBucketDir = std::make_unique<std::string>(d);
@@ -898,9 +898,9 @@ loadEntriesFromBucket(std::shared_ptr<Bucket> b, std::string const& name,
                 size_t erased = map.erase(e.deadEntry());
                 if (erased != 1)
                 {
-                    std::string err =
-                        fmt::format("DEADENTRY does not exist in ledger: {}",
-                                    xdr::xdr_to_string(e.deadEntry(), "entry"));
+                    std::string err = fmt::format(
+                        FMT_STRING("DEADENTRY does not exist in ledger: {}"),
+                        xdr::xdr_to_string(e.deadEntry(), "entry"));
                     CLOG_ERROR(Bucket, "{}", err);
                     throw std::runtime_error(err);
                 }
@@ -925,9 +925,9 @@ BucketManagerImpl::loadCompleteLedgerState(HistoryArchiveState const& has)
     {
         HistoryStateBucket const& hsb = has.currentBuckets.at(i - 1);
         hashes.emplace_back(hexToBin256(hsb.snap),
-                            fmt::format("snap {}", i - 1));
+                            fmt::format(FMT_STRING("snap {:d}"), i - 1));
         hashes.emplace_back(hexToBin256(hsb.curr),
-                            fmt::format("curr {}", i - 1));
+                            fmt::format(FMT_STRING("curr {:d}"), i - 1));
     }
     for (auto const& pair : hashes)
     {
@@ -980,8 +980,8 @@ BucketManagerImpl::scheduleVerifyReferencedBucketsWork()
         auto b = getBucketByHash(h);
         if (!b)
         {
-            throw std::runtime_error(
-                fmt::format("Missing referenced bucket {}", binToHex(h)));
+            throw std::runtime_error(fmt::format(
+                FMT_STRING("Missing referenced bucket {}"), binToHex(h)));
         }
         seq.emplace_back(std::make_shared<VerifyBucketWork>(
             mApp, b->getFilename(), b->getHash(), nullptr));

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -386,8 +386,8 @@ FutureBucket::startMerge(Application& app, uint32_t maxProtocolVersion,
             catch (std::exception const& e)
             {
                 throw std::runtime_error(fmt::format(
-                    "Error merging bucket curr={} with snap={}: "
-                    "{}. {}",
+                    FMT_STRING("Error merging bucket curr={} with snap={}: "
+                               "{}. {}"),
                     hexAbbrev(curr->getHash()), hexAbbrev(snap->getHash()),
                     e.what(), POSSIBLY_CORRUPTED_LOCAL_FS));
             };

--- a/src/bucket/MergeKey.cpp
+++ b/src/bucket/MergeKey.cpp
@@ -49,7 +49,7 @@ operator<<(std::ostream& out, MergeKey const& b)
         first = false;
         out << hexAbbrev(s);
     }
-    out << fmt::format("], keep={}]", b.mKeepDeadEntries);
+    out << fmt::format(FMT_STRING("], keep={}]"), b.mKeepDeadEntries);
     return out;
 }
 }

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -306,7 +306,8 @@ ApplyBucketsWork::isLevelComplete()
 std::string
 ApplyBucketsWork::getStatus() const
 {
-    return fmt::format("Applying buckets {}%. Currently on level {}",
-                       (100 * mAppliedSize / mTotalSize), mLevel);
+    return fmt::format(
+        FMT_STRING("Applying buckets {:d}%. Currently on level {:d}"),
+        (100 * mAppliedSize / mTotalSize), mLevel);
 }
 }

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -78,8 +78,9 @@ ApplyBufferedLedgersWork::onRun()
 
     mConditionalWork = std::make_shared<ConditionalWork>(
         mApp,
-        fmt::format("apply-buffered-ledger-conditional ledger({})",
-                    lcd.getLedgerSeq()),
+        fmt::format(
+            FMT_STRING("apply-buffered-ledger-conditional ledger({:d})"),
+            lcd.getLedgerSeq()),
         predicate, applyLedger, std::chrono::milliseconds(500));
 
     mConditionalWork->startWork(wakeSelfUpCallback());
@@ -90,7 +91,7 @@ ApplyBufferedLedgersWork::onRun()
 std::string
 ApplyBufferedLedgersWork::getStatus() const
 {
-    return fmt::format("Applying buffered ledgers: {}",
+    return fmt::format(FMT_STRING("Applying buffered ledgers: {}"),
                        mConditionalWork ? mConditionalWork->getStatus()
                                         : BasicWork::getStatus());
 }

--- a/src/catchup/ApplyLedgerWork.cpp
+++ b/src/catchup/ApplyLedgerWork.cpp
@@ -36,6 +36,7 @@ ApplyLedgerWork::onAbort()
 std::string
 ApplyLedgerWork::getStatus() const
 {
-    return fmt::format("apply ledger {}", mLedgerCloseData.getLedgerSeq());
+    return fmt::format(FMT_STRING("apply ledger {:d}"),
+                       mLedgerCloseData.getLedgerSeq());
 }
 }

--- a/src/catchup/CatchupConfiguration.cpp
+++ b/src/catchup/CatchupConfiguration.cpp
@@ -46,7 +46,7 @@ parseLedger(std::string const& str)
     if (pos < str.length() || result < 2)
     {
         throw std::runtime_error(
-            fmt::format("{} is not a valid ledger number", str));
+            fmt::format(FMT_STRING("{} is not a valid ledger number"), str));
     }
 
     return result;
@@ -65,7 +65,7 @@ parseLedgerCount(std::string const& str)
     if (pos < str.length())
     {
         throw std::runtime_error(
-            fmt::format("{} is not a valid ledger count", str));
+            fmt::format(FMT_STRING("{} is not a valid ledger count"), str));
     }
 
     return result;

--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -177,9 +177,10 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
     if (mApp.getConfig().MODE_DOES_CATCHUP && it != mSyncingLedgers.end() &&
         it->first < lastLedgerInBuffer)
     {
-        message = fmt::format("Starting catchup after ensuring checkpoint "
-                              "ledger {} was closed on network",
-                              lastLedgerInBuffer);
+        message =
+            fmt::format(FMT_STRING("Starting catchup after ensuring checkpoint "
+                                   "ledger {:d} was closed on network"),
+                        lastLedgerInBuffer);
 
         // We only need ledgers starting from the checkpoint. We can
         // remove all ledgers before this
@@ -205,14 +206,15 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
         {
             auto eta = (catchupTriggerLedger - lastLedgerInBuffer) *
                        mApp.getConfig().getExpectedLedgerCloseTime();
-            message = fmt::format("Waiting for trigger ledger: {}/{}, ETA: {}s",
-                                  lastLedgerInBuffer, catchupTriggerLedger,
-                                  eta.count());
+            message = fmt::format(
+                FMT_STRING("Waiting for trigger ledger: {:d}/{:d}, ETA: {:d}s"),
+                lastLedgerInBuffer, catchupTriggerLedger, eta.count());
         }
         else
         {
             message = fmt::format(
-                "Waiting for out-of-order ledger(s). Trigger ledger: {}",
+                FMT_STRING(
+                    "Waiting for out-of-order ledger(s). Trigger ledger: {:d}"),
                 catchupTriggerLedger);
         }
     }
@@ -275,7 +277,7 @@ CatchupManagerImpl::logAndUpdateCatchupStatus(bool contiguous,
     {
         auto contiguousString =
             contiguous ? "" : " (discontiguous; will fail and restart): ";
-        auto state = fmt::format("{}{}", contiguousString, message);
+        auto state = fmt::format(FMT_STRING("{}{}"), contiguousString, message);
         auto existing = mApp.getStatusManager().getStatusMessage(
             StatusCategory::HISTORY_CATCHUP);
         if (existing != state)
@@ -483,7 +485,9 @@ CatchupManagerImpl::fileDownloaded(std::string type, uint32_t num)
     else if (type != HISTORY_FILE_TYPE_RESULTS && type != HISTORY_FILE_TYPE_SCP)
     {
         throw std::runtime_error(fmt::format(
-            "CatchupManagerImpl::fileDownloaded unknown file type {}", type));
+            FMT_STRING(
+                "CatchupManagerImpl::fileDownloaded unknown file type {}"),
+            type));
     }
 }
 

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -113,7 +113,7 @@ CatchupWork::getStatus() const
         toLedger = std::to_string(mCatchupConfiguration.toLedger());
     }
 
-    return fmt::format("Catching up to ledger {}: {}", toLedger,
+    return fmt::format(FMT_STRING("Catching up to ledger {}: {}"), toLedger,
                        mCurrentWork ? mCurrentWork->getStatus()
                                     : Work::getStatus());
 }
@@ -247,11 +247,11 @@ CatchupWork::assertBucketState()
     auto lcl = mApp.getLedgerManager().getLastClosedLedgerHeader();
     if (mVerifiedLedgerRangeStart.header.ledgerSeq < lcl.header.ledgerSeq)
     {
-        throw std::runtime_error(
-            fmt::format("Catchup MINIMAL applying ledger earlier than local "
-                        "LCL: {:s} < {:s}",
-                        LedgerManager::ledgerAbbrev(mVerifiedLedgerRangeStart),
-                        LedgerManager::ledgerAbbrev(lcl)));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("Catchup MINIMAL applying ledger earlier than local "
+                       "LCL: {:s} < {:s}"),
+            LedgerManager::ledgerAbbrev(mVerifiedLedgerRangeStart),
+            LedgerManager::ledgerAbbrev(lcl)));
     }
 }
 

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -186,9 +186,10 @@ DownloadApplyTxsWork::getStatus() const
     auto checkpointsApplied = checkpointsStarted - getNumWorksInBatch();
 
     auto totalCheckpoints = (last - first) / hm.getCheckpointFrequency() + 1;
-    return fmt::format("Download & apply checkpoints: num checkpoints left to "
-                       "apply:{} ({}% done)",
-                       totalCheckpoints - checkpointsApplied,
-                       100 * checkpointsApplied / totalCheckpoints);
+    return fmt::format(
+        FMT_STRING("Download & apply checkpoints: num checkpoints left to "
+                   "apply:{:d} ({:d}% done)"),
+        totalCheckpoints - checkpointsApplied,
+        100 * checkpointsApplied / totalCheckpoints);
 }
 }

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -633,7 +633,8 @@ TxSimApplyTransactionsWork::onRun()
 
     mApplyLedgerWork = std::make_shared<ConditionalWork>(
         mApp,
-        fmt::format("simulation-apply-ledger-{}", closeData.getLedgerSeq()),
+        fmt::format(FMT_STRING("simulation-apply-ledger-{:d}"),
+                    closeData.getLedgerSeq()),
         condition, applyLedger);
 
     mApplyLedgerWork->startWork(wakeSelfUpCallback());

--- a/src/crypto/Curve25519.h
+++ b/src/crypto/Curve25519.h
@@ -59,7 +59,8 @@ curve25519Encrypt(Curve25519Public const& remotePublic, ByteSlice const& bin)
     if (CIPHERTEXT_LEN > N)
     {
         throw std::runtime_error(fmt::format(
-            "CIPHERTEXT_LEN({}) is greater than N({})", CIPHERTEXT_LEN, N));
+            FMT_STRING("CIPHERTEXT_LEN({:d}) is greater than N({:d})"),
+            CIPHERTEXT_LEN, N));
     }
 
     xdr::opaque_vec<N> ciphertext(CIPHERTEXT_LEN, 0);

--- a/src/crypto/ShortHash.cpp
+++ b/src/crypto/ShortHash.cpp
@@ -33,10 +33,11 @@ seed(unsigned int s)
     {
         if (gExplicitSeed != s)
         {
-            throw std::runtime_error(
-                fmt::format("re-seeding shortHash with {} after having already "
-                            "hashed with seed {}",
-                            s, gExplicitSeed));
+            throw std::runtime_error(fmt::format(
+                FMT_STRING(
+                    "re-seeding shortHash with {:d} after having already "
+                    "hashed with seed {:d}"),
+                s, gExplicitSeed));
         }
     }
     gExplicitSeed = s;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -151,9 +151,9 @@ HerderImpl::setState(State st)
     if (initState && (mState == HERDER_TRACKING_NETWORK_STATE ||
                       mState == HERDER_SYNCING_STATE))
     {
-        throw std::runtime_error(
-            fmt::format("Invalid state transition in Herder: {} -> {}",
-                        getStateHuman(mState), getStateHuman(st)));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("Invalid state transition in Herder: {} -> {}"),
+            getStateHuman(mState), getStateHuman(st)));
     }
     mState = st;
 }
@@ -1175,7 +1175,8 @@ HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
 
     if (!desc.empty())
     {
-        auto message = fmt::format("Armed with network upgrades: {}", desc);
+        auto message =
+            fmt::format(FMT_STRING("Armed with network upgrades: {}"), desc);
         auto prev = mApp.getStatusManager().getStatusMessage(
             StatusCategory::REQUIRES_UPGRADES);
         if (prev != message)

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -116,10 +116,10 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
         mQSet = mHerder.getQSet(qSetH);
         if (!mQSet)
         {
-            throw std::runtime_error(
-                fmt::format("SCPHerderEnvelopeWrapper: Wrapping an unknown "
-                            "qset {} from envelope",
-                            hexAbbrev(qSetH)));
+            throw std::runtime_error(fmt::format(
+                FMT_STRING("SCPHerderEnvelopeWrapper: Wrapping an unknown "
+                           "qset {} from envelope"),
+                hexAbbrev(qSetH)));
         }
         auto txSets = getTxSetHashes(e);
         for (auto const& txSetH : txSets)
@@ -131,10 +131,10 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
             }
             else
             {
-                throw std::runtime_error(
-                    fmt::format("SCPHerderEnvelopeWrapper: Wrapping an unknown "
-                                "tx set {} from envelope",
-                                hexAbbrev(txSetH)));
+                throw std::runtime_error(fmt::format(
+                    FMT_STRING("SCPHerderEnvelopeWrapper: Wrapping an unknown "
+                               "tx set {} from envelope"),
+                    hexAbbrev(txSetH)));
             }
         }
     }
@@ -968,16 +968,17 @@ HerderSCPDriver::recordSCPExternalizeEvent(uint64_t slotIndex, NodeID const& id,
             recordLogTiming(
                 *timing.mSelfExternalize, now,
                 mSCPMetrics.mSelfToOthersExternalizeLag,
-                fmt::format("self to {} externalize lag", toShortString(id)),
+                fmt::format(FMT_STRING("self to {} externalize lag"),
+                            toShortString(id)),
                 std::chrono::nanoseconds::zero(), slotIndex);
         }
 
         // Record lag for other nodes
         auto& lag = mQSetLag[id];
-        recordLogTiming(
-            *timing.mFirstExternalize, now, lag,
-            fmt::format("first to {} externalize lag", toShortString(id)),
-            std::chrono::nanoseconds::zero(), slotIndex);
+        recordLogTiming(*timing.mFirstExternalize, now, lag,
+                        fmt::format(FMT_STRING("first to {} externalize lag"),
+                                    toShortString(id)),
+                        std::chrono::nanoseconds::zero(), slotIndex);
     }
 }
 
@@ -1076,7 +1077,8 @@ class SCPHerderValueWrapper : public ValueWrapper
         if (!mTxSet)
         {
             throw std::runtime_error(fmt::format(
-                "SCPHerderValueWrapper tried to bind an unknown tx set {}",
+                FMT_STRING(
+                    "SCPHerderValueWrapper tried to bind an unknown tx set {}"),
                 hexAbbrev(sv.txSetHash)));
         }
     }
@@ -1089,8 +1091,9 @@ HerderSCPDriver::wrapValue(Value const& val)
     auto b = mHerder.getHerderSCPDriver().toStellarValue(val, sv);
     if (!b)
     {
-        throw std::runtime_error(fmt::format(
-            "Invalid value in SCPHerderValueWrapper {}", binToHex(val)));
+        throw std::runtime_error(
+            fmt::format(FMT_STRING("Invalid value in SCPHerderValueWrapper {}"),
+                        binToHex(val)));
     }
     auto res = std::make_shared<SCPHerderValueWrapper>(sv, val, mHerder);
     return res;

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -54,7 +54,7 @@ TransactionQueue::TransactionQueue(Application& app, uint32 pendingDepth,
     for (uint32 i = 0; i < pendingDepth; i++)
     {
         mSizeByAge.emplace_back(&app.getMetrics().NewCounter(
-            {"herder", "pending-txs", fmt::format("age{}", i)}));
+            {"herder", "pending-txs", fmt::format(FMT_STRING("age{:d}"), i)}));
     }
 
     auto const& filteredTypes =

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -147,9 +147,10 @@ Upgrades::setParameters(UpgradeParameters const& params, Config const& cfg)
     if (params.mProtocolVersion &&
         *params.mProtocolVersion > cfg.LEDGER_PROTOCOL_VERSION)
     {
-        throw std::invalid_argument(fmt::format(
-            "Protocol version error: supported is up to {}, passed is {}",
-            cfg.LEDGER_PROTOCOL_VERSION, *params.mProtocolVersion));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("Protocol version error: supported is up to "
+                                   "{:d}, passed is {:d}"),
+                        cfg.LEDGER_PROTOCOL_VERSION, *params.mProtocolVersion));
     }
     mParams = params;
 }
@@ -224,7 +225,8 @@ Upgrades::applyTo(LedgerUpgrade const& upgrade, AbstractLedgerTxn& ltx)
         break;
     default:
     {
-        auto s = fmt::format("Unknown upgrade type: {0}", upgrade.type());
+        auto s =
+            fmt::format(FMT_STRING("Unknown upgrade type: {}"), upgrade.type());
         throw std::runtime_error(s);
     }
     }
@@ -236,15 +238,18 @@ Upgrades::toString(LedgerUpgrade const& upgrade)
     switch (upgrade.type())
     {
     case LEDGER_UPGRADE_VERSION:
-        return fmt::format("protocolversion={0}", upgrade.newLedgerVersion());
+        return fmt::format(FMT_STRING("protocolversion={:d}"),
+                           upgrade.newLedgerVersion());
     case LEDGER_UPGRADE_BASE_FEE:
-        return fmt::format("basefee={0}", upgrade.newBaseFee());
+        return fmt::format(FMT_STRING("basefee={:d}"), upgrade.newBaseFee());
     case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-        return fmt::format("maxtxsetsize={0}", upgrade.newMaxTxSetSize());
+        return fmt::format(FMT_STRING("maxtxsetsize={:d}"),
+                           upgrade.newMaxTxSetSize());
     case LEDGER_UPGRADE_BASE_RESERVE:
-        return fmt::format("basereserve={0}", upgrade.newBaseReserve());
+        return fmt::format(FMT_STRING("basereserve={:d}"),
+                           upgrade.newBaseReserve());
     case LEDGER_UPGRADE_FLAGS:
-        return fmt::format("flags={0}", upgrade.newFlags());
+        return fmt::format(FMT_STRING("flags={:d}"), upgrade.newFlags());
     default:
         return "<unsupported>";
     }
@@ -263,11 +268,11 @@ Upgrades::toString() const
             if (first)
             {
                 r << fmt::format(
-                    "upgradetime={}",
+                    FMT_STRING("upgradetime={}"),
                     VirtualClock::systemPointToISOString(mParams.mUpgradeTime));
                 first = false;
             }
-            r << fmt::format(", {}={}", s, *o);
+            r << fmt::format(FMT_STRING(", {}={:d}"), s, *o);
         }
     };
     appendInfo("protocolversion", mParams.mProtocolVersion);

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -137,7 +137,8 @@ HistoryArchiveState::load(std::string const& inFile)
     std::ifstream in(inFile);
     if (!in)
     {
-        throw std::runtime_error(fmt::format("Error opening file {}", inFile));
+        throw std::runtime_error(
+            fmt::format(FMT_STRING("Error opening file {}"), inFile));
     }
     in.exceptions(std::ios::badbit);
     cereal::JSONInputArchive ar(in);

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -18,8 +18,9 @@ BatchDownloadWork::BatchDownloadWork(Application& app, CheckpointRange range,
                                      std::string const& type,
                                      TmpDir const& downloadDir,
                                      std::shared_ptr<HistoryArchive> archive)
-    : BatchWork(app, fmt::format("batch-download-{:s}-{:08x}-{:08x}", type,
-                                 range.mFirst, range.limit()))
+    : BatchWork(app,
+                fmt::format(FMT_STRING("batch-download-{:s}-{:08x}-{:08x}"),
+                            type, range.mFirst, range.limit()))
     , mRange(range)
     , mNext(range.mFirst)
     , mFileType(type)
@@ -33,7 +34,8 @@ BatchDownloadWork::getStatus() const
 {
     if (!isDone() && !isAborting())
     {
-        auto task = fmt::format("downloading {:s} files", mFileType);
+        auto task =
+            fmt::format(FMT_STRING("downloading {:s} files"), mFileType);
         return fmtProgress(mApp, task, mRange.getLedgerRange(), mNext);
     }
     return BatchWork::getStatus();

--- a/src/historywork/CheckSingleLedgerHeaderWork.cpp
+++ b/src/historywork/CheckSingleLedgerHeaderWork.cpp
@@ -19,7 +19,7 @@ CheckSingleLedgerHeaderWork::CheckSingleLedgerHeaderWork(
     Application& app, std::shared_ptr<HistoryArchive> archive,
     LedgerHeaderHistoryEntry const& expected)
     : Work(app,
-           fmt::format("check-single-ledger-header-{}",
+           fmt::format(FMT_STRING("check-single-ledger-header-{:d}"),
                        expected.header.ledgerSeq),
            BasicWork::RETRY_NEVER)
     , mArchive(archive)

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -41,8 +41,9 @@ DownloadBucketsWork::getStatus() const
             auto total = static_cast<uint32_t>(mHashes.size());
             auto pct = (100 * numDone) / total;
             return fmt::format(
-                "downloading and verifying buckets: {:d}/{:d} ({:d}%)", numDone,
-                total, pct);
+                FMT_STRING(
+                    "downloading and verifying buckets: {:d}/{:d} ({:d}%)"),
+                numDone, total, pct);
         }
     }
     return Work::getStatus();

--- a/src/historywork/DownloadVerifyTxResultsWork.cpp
+++ b/src/historywork/DownloadVerifyTxResultsWork.cpp
@@ -32,8 +32,9 @@ DownloadVerifyTxResultsWork::getStatus() const
 {
     if (!isDone() && !isAborting())
     {
-        auto task = fmt::format("Downloading and verifying {:s} files",
-                                HISTORY_FILE_TYPE_RESULTS);
+        auto task =
+            fmt::format(FMT_STRING("Downloading and verifying {:s} files"),
+                        HISTORY_FILE_TYPE_RESULTS);
         return fmtProgress(mApp, task, mRange.getLedgerRange(),
                            mCurrCheckpoint);
     }
@@ -69,7 +70,8 @@ DownloadVerifyTxResultsWork::yieldMoreWork()
     std::vector<std::shared_ptr<BasicWork>> seq{w1, w2};
     auto w3 = std::make_shared<WorkSequence>(
         mApp,
-        fmt::format(FMT_STRING("download-verify-results-{}"), mCurrCheckpoint),
+        fmt::format(FMT_STRING("download-verify-results-{:d}"),
+                    mCurrCheckpoint),
         seq);
 
     mCurrCheckpoint += mApp.getHistoryManager().getCheckpointFrequency();

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -120,7 +120,7 @@ std::string
 GetHistoryArchiveStateWork::getStatus() const
 {
     std::string ledgerString = mSeq == 0 ? "current" : std::to_string(mSeq);
-    return fmt::format("Downloading state file {} for ledger {}",
+    return fmt::format(FMT_STRING("Downloading state file {} for ledger {}"),
                        getRemoteName(), ledgerString);
 }
 }

--- a/src/historywork/Progress.cpp
+++ b/src/historywork/Progress.cpp
@@ -21,7 +21,7 @@ fmtProgress(Application& app, std::string const& task, LedgerRange const& range,
     releaseAssert(step != 0);
     if (range.mCount == 0)
     {
-        return fmt::format("{:s} 0/0 (100%)", task);
+        return fmt::format(FMT_STRING("{:s} 0/0 (100%)"), task);
     }
     auto first = range.mFirst;
     auto last = range.last();
@@ -40,6 +40,7 @@ fmtProgress(Application& app, std::string const& task, LedgerRange const& range,
     auto done = 1 + ((curr - first) / step);
     auto total = 1 + ((last - first) / step);
     auto pct = (100 * done) / total;
-    return fmt::format("{:s} {:d}/{:d} ({:d}%)", task, done, total, pct);
+    return fmt::format(FMT_STRING("{:s} {:d}/{:d} ({:d}%)"), task, done, total,
+                       pct);
 }
 }

--- a/src/historywork/PublishWork.cpp
+++ b/src/historywork/PublishWork.cpp
@@ -18,10 +18,10 @@ PublishWork::PublishWork(Application& app,
                          std::shared_ptr<StateSnapshot> snapshot,
                          std::vector<std::shared_ptr<BasicWork>> seq,
                          std::vector<std::string> const& bucketHashes)
-    : WorkSequence(
-          app,
-          fmt::format("publish-{:08x}", snapshot->mLocalState.currentLedger),
-          seq, BasicWork::RETRY_NEVER)
+    : WorkSequence(app,
+                   fmt::format(FMT_STRING("publish-{:08x}"),
+                               snapshot->mLocalState.currentLedger),
+                   seq, BasicWork::RETRY_NEVER)
     , mSnapshot(snapshot)
     , mOriginalBuckets(bucketHashes)
 {

--- a/src/historywork/PutSnapshotFilesWork.cpp
+++ b/src/historywork/PutSnapshotFilesWork.cpp
@@ -21,7 +21,7 @@ namespace stellar
 PutSnapshotFilesWork::PutSnapshotFilesWork(
     Application& app, std::shared_ptr<StateSnapshot> snapshot)
     : Work(app,
-           fmt::format("update-archives-{:08x}",
+           fmt::format(FMT_STRING("update-archives-{:08x}"),
                        snapshot->mLocalState.currentLedger),
            // Each put-snapshot-sequence will retry correctly
            BasicWork::RETRY_NEVER)
@@ -132,17 +132,17 @@ PutSnapshotFilesWork::getStatus() const
 {
     if (!mUploadSeqs.empty())
     {
-        return fmt::format("{}:uploading files", getName());
+        return fmt::format(FMT_STRING("{}:uploading files"), getName());
     }
 
     if (!mGzipFilesWorks.empty())
     {
-        return fmt::format("{}:zipping files", getName());
+        return fmt::format(FMT_STRING("{}:zipping files"), getName());
     }
 
     if (!mGetStateWorks.empty())
     {
-        return fmt::format("{}:getting archives", getName());
+        return fmt::format(FMT_STRING("{}:getting archives"), getName());
     }
 
     return BasicWork::getStatus();

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -70,8 +70,8 @@ VerifyBucketWork::spawnVerifier()
                 std::ifstream in(filename, std::ifstream::binary);
                 if (!in)
                 {
-                    throw std::runtime_error(
-                        fmt::format("Error opening file {}", filename));
+                    throw std::runtime_error(fmt::format(
+                        FMT_STRING("Error opening file {}"), filename));
                 }
                 in.exceptions(std::ios::badbit);
                 char buf[4096];

--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -158,8 +158,8 @@ AccountSubEntriesCountIsValid::checkOnOperationApply(
         if (change.numSubEntries != change.calculatedSubEntries)
         {
             return fmt::format(
-                "Change in Account {} numSubEntries ({}) does not"
-                " match change in number of subentries ({})",
+                FMT_STRING("Change in Account {} numSubEntries ({:d}) does not"
+                           " match change in number of subentries ({:d})"),
                 KeyUtils::toStrKey(kv.first), change.numSubEntries,
                 change.calculatedSubEntries);
         }
@@ -192,8 +192,9 @@ AccountSubEntriesCountIsValid::checkOnOperationApply(
                     static_cast<int32_t>(account.numSubEntries) -
                     static_cast<int32_t>(account.signers.size());
                 return fmt::format(
-                    "Deleted Account {} has {} subentries other than"
-                    " signers",
+                    FMT_STRING(
+                        "Deleted Account {} has {:d} subentries other than"
+                        " signers"),
                     KeyUtils::toStrKey(account.accountID), otherSubEntries);
             }
         }

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -123,7 +123,7 @@ struct EntryCounts
             break;
         default:
             throw std::runtime_error(
-                fmt::format("unknown ledger entry type: {}",
+                fmt::format(FMT_STRING("unknown ledger entry type: {:d}"),
                             static_cast<uint32_t>(e.data.type())));
         }
     }
@@ -141,7 +141,8 @@ struct EntryCounts
                 if (numInDb != numInBucket)
                 {
                     msg = fmt::format(
-                        "Incorrect {} count: Bucket = {} Database = {}",
+                        FMT_STRING("Incorrect {} count: Bucket = {:d} Database "
+                                   "= {:d}"),
                         xdr::xdr_traits<LedgerEntryType>::enum_name(let),
                         numInBucket, numInDb);
                     return false;
@@ -238,19 +239,19 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
             {
                 if (e.liveEntry().lastModifiedLedgerSeq < oldestLedger)
                 {
-                    auto s = fmt::format("lastModifiedLedgerSeq beneath lower"
-                                         " bound for this bucket ({} < {}): ",
-                                         e.liveEntry().lastModifiedLedgerSeq,
-                                         oldestLedger);
+                    auto s = fmt::format(
+                        FMT_STRING("lastModifiedLedgerSeq beneath lower"
+                                   " bound for this bucket ({:d} < {:d}): "),
+                        e.liveEntry().lastModifiedLedgerSeq, oldestLedger);
                     s += xdr_to_string(e.liveEntry(), "live");
                     return s;
                 }
                 if (e.liveEntry().lastModifiedLedgerSeq > newestLedger)
                 {
-                    auto s = fmt::format("lastModifiedLedgerSeq above upper"
-                                         " bound for this bucket ({} > {}): ",
-                                         e.liveEntry().lastModifiedLedgerSeq,
-                                         newestLedger);
+                    auto s = fmt::format(
+                        FMT_STRING("lastModifiedLedgerSeq above upper"
+                                   " bound for this bucket ({:d} > {:d}): "),
+                        e.liveEntry().lastModifiedLedgerSeq, newestLedger);
                     s += xdr_to_string(e.liveEntry(), "live");
                     return s;
                 }

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -134,36 +134,41 @@ ConservationOfLumens::checkOnOperationApply(Operation const& operation,
         if (deltaTotalCoins != inflationPayouts + deltaFeePool)
         {
             return fmt::format(
-                "LedgerHeader totalCoins change ({}) did not match"
-                " feePool change ({}) plus inflation payouts ({})",
+                FMT_STRING(
+                    "LedgerHeader totalCoins change ({:d}) did not match"
+                    " feePool change ({:d}) plus inflation payouts ({:d})"),
                 deltaTotalCoins, deltaFeePool, inflationPayouts);
         }
         if (deltaBalances != inflationPayouts)
         {
-            return fmt::format("LedgerEntry account balances change ({}) "
-                               "did not match inflation payouts ({})",
-                               deltaBalances, inflationPayouts);
+            return fmt::format(
+                FMT_STRING("LedgerEntry account balances change ({:d}) "
+                           "did not match inflation payouts ({:d})"),
+                deltaBalances, inflationPayouts);
         }
     }
     else
     {
         if (deltaTotalCoins != 0)
         {
-            return fmt::format("LedgerHeader totalCoins changed from {} to"
-                               " {} without inflation",
-                               lhPrev.totalCoins, lhCurr.totalCoins);
+            return fmt::format(
+                FMT_STRING("LedgerHeader totalCoins changed from {:d} to"
+                           " {:d} without inflation"),
+                lhPrev.totalCoins, lhCurr.totalCoins);
         }
         if (deltaFeePool != 0)
         {
-            return fmt::format("LedgerHeader feePool changed from {} to"
-                               " {} without inflation",
-                               lhPrev.feePool, lhCurr.feePool);
+            return fmt::format(
+                FMT_STRING("LedgerHeader feePool changed from {:d} to"
+                           " {:d} without inflation"),
+                lhPrev.feePool, lhCurr.feePool);
         }
         if (deltaBalances != 0)
         {
-            return fmt::format("LedgerEntry account balances changed by"
-                               " {} without inflation",
-                               deltaBalances);
+            return fmt::format(
+                FMT_STRING("LedgerEntry account balances changed by"
+                           " {:d} without inflation"),
+                deltaBalances);
         }
     }
     return {};

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -89,7 +89,8 @@ InvariantManagerImpl::checkOnBucketApply(
         }
 
         auto message = fmt::format(
-            R"(invariant "{}" does not hold on bucket {}[{}] = {}: {})",
+            FMT_STRING(
+                R"(invariant "{}" does not hold on bucket {}[{}] = {}: {})"),
             invariant->getName(), isCurr ? "Curr" : "Snap", level,
             binToHex(bucket->getHash()), result);
         onInvariantFailure(invariant, message, ledger);
@@ -115,10 +116,10 @@ InvariantManagerImpl::checkOnOperationApply(Operation const& operation,
             continue;
         }
 
-        auto message =
-            fmt::format(R"(Invariant "{}" does not hold on operation: {}{}{})",
-                        invariant->getName(), result, "\n",
-                        xdr_to_string(operation, "Operation"));
+        auto message = fmt::format(
+            FMT_STRING(R"(Invariant "{}" does not hold on operation: {}{}{})"),
+            invariant->getName(), result, "\n",
+            xdr_to_string(operation, "Operation"));
         onInvariantFailure(invariant, message,
                            ltxDelta.header.current.ledgerSeq);
     }
@@ -155,8 +156,9 @@ InvariantManagerImpl::enableInvariant(std::string const& invPattern)
     }
     catch (std::regex_error& e)
     {
-        throw std::invalid_argument(fmt::format(
-            "Invalid invariant pattern '{}': {}", invPattern, e.what()));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("Invalid invariant pattern '{}': {}"),
+                        invPattern, e.what()));
     }
 
     bool enabledSome = false;
@@ -182,7 +184,8 @@ InvariantManagerImpl::enableInvariant(std::string const& invPattern)
     if (!enabledSome)
     {
         std::string message = fmt::format(
-            "Invariant pattern '{}' did not match any invariants.", invPattern);
+            FMT_STRING("Invariant pattern '{}' did not match any invariants."),
+            invPattern);
         if (mInvariants.size() > 0)
         {
             using value_type = decltype(mInvariants)::value_type;

--- a/src/invariant/LedgerEntryIsValid.cpp
+++ b/src/invariant/LedgerEntryIsValid.cpp
@@ -44,8 +44,9 @@ LedgerEntryIsValid::checkOnOperationApply(Operation const& operation,
     uint32_t currLedgerSeq = ltxDelta.header.current.ledgerSeq;
     if (currLedgerSeq > INT32_MAX)
     {
-        return fmt::format("LedgerHeader ledgerSeq ({}) exceeds limits ({})",
-                           currLedgerSeq, INT32_MAX);
+        return fmt::format(
+            FMT_STRING("LedgerHeader ledgerSeq ({:d}) exceeds limits ({:d})"),
+            currLedgerSeq, INT32_MAX);
     }
 
     auto ver = ltxDelta.header.current.ledgerVersion;
@@ -87,9 +88,10 @@ LedgerEntryIsValid::checkIsValid(LedgerEntry const& le,
 {
     if (le.lastModifiedLedgerSeq != ledgerSeq)
     {
-        return fmt::format("LedgerEntry lastModifiedLedgerSeq ({}) does not"
-                           " equal LedgerHeader ledgerSeq ({})",
-                           le.lastModifiedLedgerSeq, ledgerSeq);
+        return fmt::format(
+            FMT_STRING("LedgerEntry lastModifiedLedgerSeq ({:d}) does not"
+                       " equal LedgerHeader ledgerSeq ({:d})"),
+            le.lastModifiedLedgerSeq, ledgerSeq);
     }
 
     if (version < 14 && le.ext.v() == 1)
@@ -129,16 +131,19 @@ LedgerEntryIsValid::checkIsValid(AccountEntry const& ae, uint32 version) const
 {
     if (ae.balance < 0)
     {
-        return fmt::format("Account balance ({}) is negative", ae.balance);
+        return fmt::format(FMT_STRING("Account balance ({:d}) is negative"),
+                           ae.balance);
     }
     if (ae.seqNum < 0)
     {
-        return fmt::format("Account seqNum ({}) is negative", ae.seqNum);
+        return fmt::format(FMT_STRING("Account seqNum ({:d}) is negative"),
+                           ae.seqNum);
     }
     if (ae.numSubEntries > INT32_MAX)
     {
-        return fmt::format("Account numSubEntries ({}) exceeds limit ({})",
-                           ae.numSubEntries, INT32_MAX);
+        return fmt::format(
+            FMT_STRING("Account numSubEntries ({:d}) exceeds limit ({:d})"),
+            ae.numSubEntries, INT32_MAX);
     }
 
     if (!accountFlagIsValid(ae.flags, version))
@@ -221,16 +226,19 @@ LedgerEntryIsValid::checkIsValid(TrustLineEntry const& tl,
     }
     if (tl.balance < 0)
     {
-        return fmt::format("TrustLine balance ({}) is negative", tl.balance);
+        return fmt::format(FMT_STRING("TrustLine balance ({:d}) is negative"),
+                           tl.balance);
     }
     if (tl.limit <= 0)
     {
-        return fmt::format("TrustLine limit ({}) is not positive", tl.limit);
+        return fmt::format(FMT_STRING("TrustLine limit ({:d}) is not positive"),
+                           tl.limit);
     }
     if (tl.balance > tl.limit)
     {
-        return fmt::format("TrustLine balance ({}) exceeds limit ({})",
-                           tl.balance, tl.limit);
+        return fmt::format(
+            FMT_STRING("TrustLine balance ({:d}) exceeds limit ({:d})"),
+            tl.balance, tl.limit);
     }
     if (!trustLineFlagIsValid(tl.flags, version))
     {
@@ -249,7 +257,8 @@ LedgerEntryIsValid::checkIsValid(OfferEntry const& oe, uint32 version) const
 {
     if (oe.offerID <= 0)
     {
-        return fmt::format("Offer offerID ({}) must be positive", oe.offerID);
+        return fmt::format(FMT_STRING("Offer offerID ({:d}) must be positive"),
+                           oe.offerID);
     }
     if (!isAssetValid(oe.selling, version))
     {
@@ -265,8 +274,8 @@ LedgerEntryIsValid::checkIsValid(OfferEntry const& oe, uint32 version) const
     }
     if (oe.price.n <= 0 || oe.price.d < 1)
     {
-        return fmt::format("Offer price ({} / {}) is invalid", oe.price.n,
-                           oe.price.d);
+        return fmt::format(FMT_STRING("Offer price ({:d} / {:d}) is invalid"),
+                           oe.price.n, oe.price.d);
     }
     if ((oe.flags & ~MASK_OFFERENTRY_FLAGS) != 0)
     {

--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -101,9 +101,9 @@ checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
 
                 if (sellingLiabilitiesInc || buyingLiabilitiesInc)
                 {
-                    return fmt::format(
-                        "Liabilities increased on unauthorized trust line {}",
-                        xdr_to_string(trust, "TrustLineEntry"));
+                    return fmt::format(FMT_STRING("Liabilities increased on "
+                                                  "unauthorized trust line {}"),
+                                       xdr_to_string(trust, "TrustLineEntry"));
                 }
             }
             else
@@ -112,7 +112,8 @@ checkAuthorized(LedgerEntry const* current, LedgerEntry const* previous)
                     getBuyingLiabilities(*current) > 0)
                 {
                     return fmt::format(
-                        "Unauthorized trust line has liabilities {}",
+                        FMT_STRING(
+                            "Unauthorized trust line has liabilities {}"),
                         xdr_to_string(trust, "TrustLineEntry"));
                 }
             }
@@ -260,7 +261,8 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
                 (INT64_MAX - account.balance < liabilities.buying))
             {
                 return fmt::format(
-                    "Balance not compatible with liabilities for {}",
+                    FMT_STRING(
+                        "Balance not compatible with liabilities for {}"),
                     xdr_to_string(account, "AccountEntry"));
             }
         }
@@ -277,8 +279,9 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
         if ((trust.balance < liabilities.selling) ||
             (trust.limit - trust.balance < liabilities.buying))
         {
-            return fmt::format("Balance not compatible with liabilities for {}",
-                               xdr_to_string(trust, "TrustLineEntry"));
+            return fmt::format(
+                FMT_STRING("Balance not compatible with liabilities for {}"),
+                xdr_to_string(trust, "TrustLineEntry"));
         }
     }
     return {};
@@ -347,9 +350,9 @@ LiabilitiesMatchOffers::checkOnOperationApply(Operation const& operation,
                 if (assetLiabilities.second.buying != 0)
                 {
                     return fmt::format(
-                        "Change in buying liabilities differed from "
-                        "change in total buying liabilities of "
-                        "offers by {} for {} in {}",
+                        FMT_STRING("Change in buying liabilities differed from "
+                                   "change in total buying liabilities of "
+                                   "offers by {:d} for {} in {}"),
                         assetLiabilities.second.buying,
                         xdr_to_string(accLiabilities.first, "account"),
                         xdr_to_string(assetLiabilities.first, "asset"));
@@ -357,9 +360,10 @@ LiabilitiesMatchOffers::checkOnOperationApply(Operation const& operation,
                 else if (assetLiabilities.second.selling != 0)
                 {
                     return fmt::format(
-                        "Change in selling liabilities differed from "
-                        "change in total selling liabilities of "
-                        "offers by {} for {} in {}",
+                        FMT_STRING(
+                            "Change in selling liabilities differed from "
+                            "change in total selling liabilities of "
+                            "offers by {:d} for {} in {}"),
                         assetLiabilities.second.selling,
                         xdr_to_string(accLiabilities.first, "account"),
                         xdr_to_string(assetLiabilities.first, "asset"));

--- a/src/invariant/SponsorshipCountIsValid.cpp
+++ b/src/invariant/SponsorshipCountIsValid.cpp
@@ -194,16 +194,18 @@ SponsorshipCountIsValid::checkOnOperationApply(Operation const& operation,
         if (numSponsoring[accountID] != deltaNumSponsoring)
         {
             return fmt::format(
-                "Change in Account {} numSponsoring ({}) does not"
-                " match change in number of sponsored entries ({})",
+                FMT_STRING(
+                    "Change in Account {} numSponsoring ({:d}) does not"
+                    " match change in number of sponsored entries ({:d})"),
                 KeyUtils::toStrKey(accountID), deltaNumSponsoring,
                 numSponsoring[accountID]);
         }
         if (numSponsored[accountID] != deltaNumSponsored)
         {
             return fmt::format(
-                "Change in Account {} numSponsored ({}) does not"
-                " match change in number of sponsored entries ({})",
+                FMT_STRING(
+                    "Change in Account {} numSponsored ({:d}) does not"
+                    " match change in number of sponsored entries ({:d})"),
                 KeyUtils::toStrKey(accountID), deltaNumSponsored,
                 numSponsored[accountID]);
         }
@@ -218,8 +220,9 @@ SponsorshipCountIsValid::checkOnOperationApply(Operation const& operation,
         if (kv.second != 0)
         {
             return fmt::format(
-                "Change in Account {} numSponsoring (0) does not"
-                " match change in number of sponsored entries ({})",
+                FMT_STRING(
+                    "Change in Account {} numSponsoring (0) does not"
+                    " match change in number of sponsored entries ({:d})"),
                 KeyUtils::toStrKey(kv.first), kv.second);
         }
     }
@@ -228,8 +231,9 @@ SponsorshipCountIsValid::checkOnOperationApply(Operation const& operation,
         if (kv.second != 0)
         {
             return fmt::format(
-                "Change in Account {} numSponsored (0) does not"
-                " match change in number of sponsored entries ({})",
+                FMT_STRING(
+                    "Change in Account {} numSponsored (0) does not"
+                    " match change in number of sponsored entries ({:d})"),
                 KeyUtils::toStrKey(kv.first), kv.second);
         }
     }

--- a/src/ledger/CheckpointRange.cpp
+++ b/src/ledger/CheckpointRange.cpp
@@ -56,7 +56,7 @@ CheckpointRange::CheckpointRange(LedgerRange const& ledgerRange,
 std::string
 CheckpointRange::toString() const
 {
-    return fmt::format("[{},{})", mFirst, limit());
+    return fmt::format(FMT_STRING("[{:d},{:d})"), mFirst, limit());
 }
 
 bool

--- a/src/ledger/InternalLedgerEntry.cpp
+++ b/src/ledger/InternalLedgerEntry.cpp
@@ -340,10 +340,10 @@ InternalLedgerKey::toString() const
 
     case InternalLedgerEntryType::SPONSORSHIP:
         return fmt::format(
-            "{{\n  {}\n}}\n",
+            FMT_STRING("{{\n  {}\n}}\n"),
             xdr_to_string(sponsorshipKey().sponsoredID, "sponsoredID"));
     case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
-        return fmt::format("{{\n  {}\n}}\n",
+        return fmt::format(FMT_STRING("{{\n  {}\n}}\n"),
                            xdr_to_string(sponsorshipCounterKey().sponsoringID,
                                          "sponsoringID"));
     default:
@@ -623,11 +623,11 @@ InternalLedgerEntry::toString() const
         return xdr_to_string(ledgerEntry(), "LedgerEntry");
     case InternalLedgerEntryType::SPONSORSHIP:
         return fmt::format(
-            "{{\n  {},\n  {}\n}}\n",
+            FMT_STRING("{{\n  {},\n  {}\n}}\n"),
             xdr_to_string(sponsorshipEntry().sponsoredID, "sponsoredID"),
             xdr_to_string(sponsorshipEntry().sponsoringID, "sponsoringID"));
     case InternalLedgerEntryType::SPONSORSHIP_COUNTER:
-        return fmt::format("{{\n  {},\n  numSponsoring = {}\n}}\n",
+        return fmt::format(FMT_STRING("{{\n  {},\n  numSponsoring = {}\n}}\n"),
                            xdr_to_string(sponsorshipCounterEntry().sponsoringID,
                                          "sponsoringID"),
                            sponsorshipCounterEntry().numSponsoring);

--- a/src/ledger/LedgerHeaderUtils.cpp
+++ b/src/ledger/LedgerHeaderUtils.cpp
@@ -128,8 +128,8 @@ loadByHash(Database& db, Hash const& hash)
         if (ledgerHash != hash)
         {
             throw std::runtime_error(
-                fmt::format("Wrong hash in ledger header database: "
-                            "loaded ledger {} contains {}",
+                fmt::format(FMT_STRING("Wrong hash in ledger header database: "
+                                       "loaded ledger {} contains {}"),
                             binToHex(ledgerHash), binToHex(hash)));
         }
     }
@@ -157,10 +157,10 @@ loadBySequence(Database& db, soci::session& sess, uint32_t seq)
 
         if (lh.ledgerSeq != seq)
         {
-            throw std::runtime_error(
-                fmt::format("Wrong sequence number in ledger header database: "
-                            "loaded ledger {} contains {}",
-                            seq, lh.ledgerSeq));
+            throw std::runtime_error(fmt::format(
+                FMT_STRING("Wrong sequence number in ledger header database: "
+                           "loaded ledger {:d} contains {:d}"),
+                seq, lh.ledgerSeq));
         }
     }
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -594,9 +594,9 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         CLOG_ERROR(Ledger, "Unknown ledger version: {}",
                    header.current().ledgerVersion);
         CLOG_ERROR(Ledger, "{}", UPGRADE_STELLAR_CORE);
-        throw std::runtime_error(
-            fmt::format("cannot apply ledger with not supported version: {}",
-                        header.current().ledgerVersion));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("cannot apply ledger with not supported version: {:d}"),
+            header.current().ledgerVersion));
     }
 
     if (txSet->previousLedgerHash() != getLastClosedLedgerHeader().hash)
@@ -682,10 +682,10 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             break;
         case Upgrades::UpgradeValidity::XDR_INVALID:
             throw std::runtime_error(
-                fmt::format(FMT_STRING("Unknown upgrade at index {}"), i));
+                fmt::format(FMT_STRING("Unknown upgrade at index {:d}"), i));
         case Upgrades::UpgradeValidity::INVALID:
             throw std::runtime_error(
-                fmt::format(FMT_STRING("Invalid upgrade at index {}: {}"), i,
+                fmt::format(FMT_STRING("Invalid upgrade at index {:d}: {}"), i,
                             xdr_to_string(lupgrade, "LedgerUpgrade")));
         }
 

--- a/src/ledger/LedgerRange.cpp
+++ b/src/ledger/LedgerRange.cpp
@@ -19,7 +19,7 @@ LedgerRange::LedgerRange(uint32_t first, uint32_t count)
 std::string
 LedgerRange::toString() const
 {
-    return fmt::format("[{},{})", mFirst, mFirst + mCount);
+    return fmt::format(FMT_STRING("[{:d},{:d})"), mFirst, mFirst + mCount);
 }
 
 bool

--- a/src/main/Application.cpp
+++ b/src/main/Application.cpp
@@ -31,8 +31,8 @@ validateNetworkPassphrase(Application::pointer app)
     else if (networkPassphrase != prevNetworkPassphrase)
     {
         throw std::invalid_argument(
-            fmt::format("NETWORK_PASSPHRASE \"{}\" does not match"
-                        " previous NETWORK_PASSPHRASE \"{}\"",
+            fmt::format(FMT_STRING("NETWORK_PASSPHRASE \"{}\" does not match"
+                                   " previous NETWORK_PASSPHRASE \"{}\""),
                         networkPassphrase, prevNetworkPassphrase));
     }
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -849,13 +849,13 @@ ApplicationImpl::manualClose(std::optional<uint32_t> const& manualLedgerSeq,
                 throw std::runtime_error(fmt::format(
                     FMT_STRING(
                         "Standalone manual close failed to produce expected "
-                        "sequence number increment (expected {}; got {})"),
+                        "sequence number increment (expected {:d}; got {:d})"),
                     targetLedgerSeq, newLedgerSeq));
             }
 
             return fmt::format(
                 FMT_STRING("Manually closed ledger with sequence "
-                           "number {} and closeTime {}"),
+                           "number {:d} and closeTime {:d}"),
                 targetLedgerSeq,
                 getLedgerManager()
                     .getLastClosedLedgerHeader()
@@ -864,7 +864,7 @@ ApplicationImpl::manualClose(std::optional<uint32_t> const& manualLedgerSeq,
 
         return fmt::format(
             FMT_STRING("Manually triggered a ledger close with sequence "
-                       "number {}"),
+                       "number {:d}"),
             targetLedgerSeq);
     }
     else if (!mConfig.FORCE_SCP)
@@ -895,7 +895,7 @@ ApplicationImpl::targetManualCloseLedgerSeqNum(
     {
         throw std::invalid_argument(
             fmt::format(FMT_STRING("Manually closed ledger sequence number "
-                                   "({}) already at max ({})"),
+                                   "({:d}) already at max ({:d})"),
                         startLedgerSeq, maxLedgerSeq));
     }
 
@@ -906,17 +906,17 @@ ApplicationImpl::targetManualCloseLedgerSeqNum(
         if (*explicitlyProvidedSeqNum > maxLedgerSeq)
         {
             // The "scphistory" stores ledger sequence numbers as INTs.
-            throw std::invalid_argument(fmt::format(
-                FMT_STRING(
-                    "Manual close ledger sequence number {} beyond max ({})"),
-                *explicitlyProvidedSeqNum, maxLedgerSeq));
+            throw std::invalid_argument(
+                fmt::format(FMT_STRING("Manual close ledger sequence number "
+                                       "{:d} beyond max ({:d})"),
+                            *explicitlyProvidedSeqNum, maxLedgerSeq));
         }
 
         if (*explicitlyProvidedSeqNum <= startLedgerSeq)
         {
             throw std::invalid_argument(fmt::format(
-                FMT_STRING("Invalid manual close ledger sequence number {} "
-                           "(must exceed current sequence number {})"),
+                FMT_STRING("Invalid manual close ledger sequence number {:d} "
+                           "(must exceed current sequence number {:d})"),
                 *explicitlyProvidedSeqNum, startLedgerSeq));
         }
     }
@@ -955,8 +955,8 @@ ApplicationImpl::setManualCloseVirtualTime(
         if (*explicitlyProvidedCloseTime < nextCloseTime)
         {
             throw std::invalid_argument(
-                fmt::format(FMT_STRING("Manual close time {} too early (last "
-                                       "close time={}, now={})"),
+                fmt::format(FMT_STRING("Manual close time {:d} too early (last "
+                                       "close time={:d}, now={:d})"),
                             *explicitlyProvidedCloseTime, lastCloseTime, now));
         }
         nextCloseTime = *explicitlyProvidedCloseTime;
@@ -973,9 +973,9 @@ ApplicationImpl::setManualCloseVirtualTime(
 
     if (nextCloseTime > maxCloseTime)
     {
-        throw std::invalid_argument(
-            fmt::format(FMT_STRING("New close time {} would exceed max ({})"),
-                        nextCloseTime, maxCloseTime));
+        throw std::invalid_argument(fmt::format(
+            FMT_STRING("New close time {:d} would exceed max ({:d})"),
+            nextCloseTime, maxCloseTime));
     }
 
     getClock().setCurrentVirtualTime(VirtualClock::from_time_t(nextCloseTime));

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -662,6 +662,7 @@ publish(Application::pointer app)
 std::string
 minimalDBForInMemoryMode(Config const& cfg)
 {
-    return fmt::format("sqlite3://{}/minimal.db", cfg.BUCKET_DIR_PATH);
+    return fmt::format(FMT_STRING("sqlite3://{}/minimal.db"),
+                       cfg.BUCKET_DIR_PATH);
 }
 }

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -137,7 +137,7 @@ CommandHandler::safeRouter(CommandHandler::HandlerRoute route,
     }
     catch (std::exception const& e)
     {
-        retStr = fmt::format(R"({{"exception": "{}"}})", e.what());
+        retStr = fmt::format(FMT_STRING(R"({{"exception": "{}"}})"), e.what());
     }
     catch (...)
     {
@@ -184,7 +184,7 @@ parseOptionalParam(std::map<std::string, std::string> const& map,
         if (str.fail() || !str.eof())
         {
             std::string errorMsg =
-                fmt::format("Failed to parse '{}' argument", key);
+                fmt::format(FMT_STRING("Failed to parse '{}' argument"), key);
             throw std::runtime_error(errorMsg);
         }
         return std::make_optional<T>(val);
@@ -222,7 +222,8 @@ parseRequiredParam(std::map<std::string, std::string> const& map,
     auto res = parseOptionalParam<T>(map, key);
     if (!res)
     {
-        std::string errorMsg = fmt::format("'{}' argument is required!", key);
+        std::string errorMsg =
+            fmt::format(FMT_STRING("'{}' argument is required!"), key);
         throw std::runtime_error(errorMsg);
     }
     return *res;
@@ -526,8 +527,8 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
         }
         catch (std::exception&)
         {
-            retStr =
-                fmt::format("could not parse upgradetime: '{}'", upgradeTime);
+            retStr = fmt::format(
+                FMT_STRING("could not parse upgradetime: '{}'"), upgradeTime);
             return;
         }
         p.mUpgradeTime = VirtualClock::tmToSystemPoint(tm);
@@ -548,7 +549,7 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
     }
     else
     {
-        retStr = fmt::format("Unknown mode: {}", s);
+        retStr = fmt::format(FMT_STRING("Unknown mode: {}"), s);
     }
 }
 
@@ -812,7 +813,7 @@ CommandHandler::clearMetrics(std::string const& params, std::string& retStr)
 
     mApp.clearMetrics(domain);
 
-    retStr = fmt::format("Cleared {} metrics!", domain);
+    retStr = fmt::format(FMT_STRING("Cleared {} metrics!"), domain);
 }
 
 void
@@ -905,8 +906,9 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         mApp.generateLoad(mode, nAccounts, offset, nTxs, txRate, batchSize,
                           spikeInterval, spikeSize);
 
-        retStr += fmt::format(" Generating load: {:d} {:s}, {:d} tx/s",
-                              numItems, itemType, txRate);
+        retStr +=
+            fmt::format(FMT_STRING(" Generating load: {:d} {:s}, {:d} tx/s"),
+                        numItems, itemType, txRate);
     }
     else
     {

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -275,10 +275,11 @@ configurationParser(CommandLine::ConfigOption& configOption)
 {
     return logLevelParser(configOption.mLogLevel) |
            metricsParser(configOption.mMetrics) |
-           clara::Opt{configOption.mConfigFile, "FILE-NAME"}["--conf"](
-               fmt::format("specify a config file ('{0}' for STDIN, default "
-                           "'stellar-core.cfg')",
-                           Config::STDIN_SPECIAL_NAME));
+           clara::Opt{configOption.mConfigFile,
+                      "FILE-NAME"}["--conf"](fmt::format(
+               FMT_STRING("specify a config file ('{}' for STDIN, default "
+                          "'stellar-core.cfg')"),
+               Config::STDIN_SPECIAL_NAME));
 }
 
 clara::Opt
@@ -1698,7 +1699,8 @@ handleCommandLine(int argc, char* const* argv)
     bool didDefaultToHelp = command->name() != adjustedCommandLine.first;
 
     auto exeName = "stellar-core";
-    auto commandName = fmt::format("{0} {1}", exeName, command->name());
+    auto commandName =
+        fmt::format(FMT_STRING("{0} {1}"), exeName, command->name());
     auto args = CommandLineArgs{exeName, commandName, command->description(),
                                 adjustedCommandLine.second};
     if (command->name() == "run" || command->name() == "fuzz")

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -230,7 +230,8 @@ readBool(ConfigItem const& item)
 {
     if (!item.second->as<bool>())
     {
-        throw std::invalid_argument(fmt::format("invalid '{}'", item.first));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("invalid '{}'"), item.first));
     }
     return item.second->as<bool>()->get();
 }
@@ -240,7 +241,8 @@ readDouble(ConfigItem const& item)
 {
     if (!item.second->as<double>())
     {
-        throw std::invalid_argument(fmt::format("invalid '{}'", item.first));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("invalid '{}'"), item.first));
     }
     return item.second->as<double>()->get();
 }
@@ -250,7 +252,8 @@ readString(ConfigItem const& item)
 {
     if (!item.second->as<std::string>())
     {
-        throw std::invalid_argument(fmt::format("invalid '{}'", item.first));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("invalid '{}'"), item.first));
     }
     return item.second->as<std::string>()->get();
 }
@@ -263,14 +266,14 @@ readArray(ConfigItem const& item)
     if (!item.second->is_array())
     {
         throw std::invalid_argument(
-            fmt::format("'{}' must be an array", item.first));
+            fmt::format(FMT_STRING("'{}' must be an array"), item.first));
     }
     for (auto v : item.second->as_array()->get())
     {
         if (!v->as<T>())
         {
             throw std::invalid_argument(
-                fmt::format("invalid element of '{}'", item.first));
+                fmt::format(FMT_STRING("invalid element of '{}'"), item.first));
         }
         result.push_back(v->as<T>()->get());
     }
@@ -283,7 +286,7 @@ castInt(int64_t v, std::string const& name, T min, T max)
 {
     if (v < min || v > max)
     {
-        throw std::invalid_argument(fmt::format("bad '{}'", name));
+        throw std::invalid_argument(fmt::format(FMT_STRING("bad '{}'"), name));
     }
     return static_cast<T>(v);
 }
@@ -294,13 +297,14 @@ castInt(int64_t v, std::string const& name, T min, T max)
 {
     if (v < 0)
     {
-        throw std::invalid_argument(fmt::format("bad '{}'", name));
+        throw std::invalid_argument(fmt::format(FMT_STRING("bad '{}'"), name));
     }
     else
     {
         if (static_cast<T>(v) < min || static_cast<T>(v) > max)
         {
-            throw std::invalid_argument(fmt::format("bad '{}'", name));
+            throw std::invalid_argument(
+                fmt::format(FMT_STRING("bad '{}'"), name));
         }
     }
     return static_cast<T>(v);
@@ -313,7 +317,8 @@ readInt(ConfigItem const& item, T min = std::numeric_limits<T>::min(),
 {
     if (!item.second->as<int64_t>())
     {
-        throw std::invalid_argument(fmt::format("invalid '{}'", item.first));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("invalid '{}'"), item.first));
     }
     return castInt<T>(item.second->as<int64_t>()->get(), item.first, min, max);
 }
@@ -349,21 +354,21 @@ readXdrEnumArray(ConfigItem const& item)
     if (!item.second->is_array())
     {
         throw std::invalid_argument(
-            fmt::format("'{}' must be an array", item.first));
+            fmt::format(FMT_STRING("'{}' must be an array"), item.first));
     }
     for (auto v : item.second->as_array()->get())
     {
         if (!v->as<std::string>())
         {
             throw std::invalid_argument(
-                fmt::format("invalid element of '{}'", item.first));
+                fmt::format(FMT_STRING("invalid element of '{}'"), item.first));
         }
 
         auto name = v->as<std::string>()->get();
         if (enumNames.find(name) == enumNames.end())
         {
             throw std::invalid_argument(
-                fmt::format("invalid element of '{}'", item.first));
+                fmt::format(FMT_STRING("invalid element of '{}'"), item.first));
         }
         result.push_back(enumNames[name]);
     }
@@ -459,7 +464,7 @@ Config::addHistoryArchive(std::string const& name, std::string const& get,
     if (!r.second)
     {
         throw std::invalid_argument(
-            fmt::format("Conflicting archive name '{}'", name));
+            fmt::format(FMT_STRING("Conflicting archive name '{}'"), name));
     }
 }
 
@@ -486,7 +491,8 @@ Config::parseQuality(std::string const& q) const
     }
     else
     {
-        throw std::invalid_argument(fmt::format("Unknown QUALITY '{}'", q));
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("Unknown QUALITY '{}'"), q));
     }
     return res;
 }
@@ -545,7 +551,8 @@ Config::parseValidators(
             else
             {
                 throw std::invalid_argument(fmt::format(
-                    "malformed VALIDATORS entry, unknown element '{}'",
+                    FMT_STRING(
+                        "malformed VALIDATORS entry, unknown element '{}'"),
                     f.first));
             }
         }
@@ -556,18 +563,18 @@ Config::parseValidators(
         }
         if (pubKey.empty() || ve.mHomeDomain.empty())
         {
-            throw std::invalid_argument(
-                fmt::format("malformed VALIDATORS entry '{}'", ve.mName));
+            throw std::invalid_argument(fmt::format(
+                FMT_STRING("malformed VALIDATORS entry '{}'"), ve.mName));
         }
         auto globQualityIt = domainQualityMap.find(ve.mHomeDomain);
         if (globQualityIt != domainQualityMap.end())
         {
             if (qualitySet)
             {
-                throw std::invalid_argument(
-                    fmt::format("malformed VALIDATORS entry '{}': quality "
-                                "already defined in home domain '{}'",
-                                ve.mName, ve.mHomeDomain));
+                throw std::invalid_argument(fmt::format(
+                    FMT_STRING("malformed VALIDATORS entry '{}': quality "
+                               "already defined in home domain '{}'"),
+                    ve.mName, ve.mHomeDomain));
             }
             else
             {
@@ -578,7 +585,8 @@ Config::parseValidators(
         if (!qualitySet)
         {
             throw std::invalid_argument(fmt::format(
-                "malformed VALIDATORS entry '{}' (missing quality)", ve.mName));
+                FMT_STRING("malformed VALIDATORS entry '{}' (missing quality)"),
+                ve.mName));
         }
         addValidatorName(pubKey, ve.mName);
         ve.mKey = KeyUtils::fromStrKey<PublicKey>(pubKey);
@@ -591,10 +599,10 @@ Config::parseValidators(
              ve.mQuality == ValidatorQuality::VALIDATOR_CRITICAL_QUALITY) &&
             hist.empty())
         {
-            throw std::invalid_argument(
-                fmt::format("malformed VALIDATORS entry '{}' (critical and "
-                            "high quality must have an archive)",
-                            ve.mName));
+            throw std::invalid_argument(fmt::format(
+                FMT_STRING("malformed VALIDATORS entry '{}' (critical and "
+                           "high quality must have an archive)"),
+                ve.mName));
         }
         res.emplace_back(ve);
     }
@@ -634,20 +642,20 @@ Config::parseDomainsQuality(std::shared_ptr<cpptoml::base> domainsQuality)
             }
             else
             {
-                throw std::invalid_argument(
-                    fmt::format("Unknown field '{}' in HOME_DOMAINS", f.first));
+                throw std::invalid_argument(fmt::format(
+                    FMT_STRING("Unknown field '{}' in HOME_DOMAINS"), f.first));
             }
         }
         if (!qualitySet || domain.empty())
         {
             throw std::invalid_argument(
-                fmt::format("Malformed HOME_DOMAINS '{}'", domain));
+                fmt::format(FMT_STRING("Malformed HOME_DOMAINS '{}'"), domain));
         }
         auto p = res.emplace(std::make_pair(domain, quality));
         if (!p.second)
         {
-            throw std::invalid_argument(
-                fmt::format("Malformed HOME_DOMAINS: duplicate '{}'", domain));
+            throw std::invalid_argument(fmt::format(
+                FMT_STRING("Malformed HOME_DOMAINS: duplicate '{}'"), domain));
         }
     }
     return res;
@@ -676,8 +684,8 @@ Config::load(std::string const& filename)
             std::ifstream ifs(filename);
             if (!ifs)
             {
-                throw std::runtime_error(
-                    fmt::format("Error opening file '{}'", filename));
+                throw std::runtime_error(fmt::format(
+                    FMT_STRING("Error opening file '{}'"), filename));
             }
             ifs.exceptions(std::ios::badbit);
             load(ifs);
@@ -725,10 +733,10 @@ Config::addSelfToValidators(
     }
     else
     {
-        throw std::invalid_argument(
-            fmt::format("Validator configured with NODE_HOME_DOMAIN='{}' "
-                        "but there is no matching HOME_DOMAINS",
-                        NODE_HOME_DOMAIN));
+        throw std::invalid_argument(fmt::format(
+            FMT_STRING("Validator configured with NODE_HOME_DOMAIN='{}' "
+                       "but there is no matching HOME_DOMAINS"),
+            NODE_HOME_DOMAIN));
     }
     validators.emplace_back(self);
 }
@@ -934,8 +942,8 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 {
                     if (!ExternalQueue::validateResourceID(c))
                     {
-                        throw std::invalid_argument(
-                            fmt::format("invalid cursor: \"{}\"", c));
+                        throw std::invalid_argument(fmt::format(
+                            FMT_STRING("invalid cursor: \"{}\""), c));
                     }
                 }
             }
@@ -1811,7 +1819,8 @@ Config::generateQuorumSetHelper(
             if (it2->mQuality != it->mQuality)
             {
                 throw std::invalid_argument(fmt::format(
-                    "Validators '{}' and '{}' must have same quality",
+                    FMT_STRING(
+                        "Validators '{}' and '{}' must have same quality"),
                     it->mName, it2->mName));
             }
             vals.emplace_back(it2->mKey);
@@ -1820,10 +1829,10 @@ Config::generateQuorumSetHelper(
             (it->mQuality == ValidatorQuality::VALIDATOR_HIGH_QUALITY ||
              it->mQuality == ValidatorQuality::VALIDATOR_CRITICAL_QUALITY))
         {
-            throw std::invalid_argument(
-                fmt::format("Critical and High quality validators for '{}' "
-                            "must have redundancy of at least 3",
-                            it->mHomeDomain));
+            throw std::invalid_argument(fmt::format(
+                FMT_STRING("Critical and High quality validators for '{}' "
+                           "must have redundancy of at least 3"),
+                it->mHomeDomain));
         }
         innerSet.threshold = computeDefaultThreshold(
             innerSet, ValidationThresholdLevels::SIMPLE_MAJORITY);
@@ -1836,7 +1845,8 @@ Config::generateQuorumSetHelper(
         if (it->mQuality > curQuality)
         {
             throw std::invalid_argument(fmt::format(
-                "invalid validator quality for '{}' (must be ascending)",
+                FMT_STRING(
+                    "invalid validator quality for '{}' (must be ascending)"),
                 it->mName));
         }
         auto lowQ = generateQuorumSetHelper(it, end, it->mQuality);

--- a/src/main/Maintainer.cpp
+++ b/src/main/Maintainer.cpp
@@ -35,11 +35,13 @@ Maintainer::start()
             c.getExpectedLedgerCloseTime().count(), Rounding::ROUND_UP);
         if (c.AUTOMATIC_MAINTENANCE_COUNT <= ledgersPerMaintenancePeriod)
         {
-            LOG_WARNING(DEFAULT_LOG, "{}",
-                        fmt::format("Maintenance may not be able to keep up: "
-                                    "AUTOMATIC_MAINTENANCE_COUNT={} <= {}",
-                                    c.AUTOMATIC_MAINTENANCE_COUNT,
-                                    ledgersPerMaintenancePeriod));
+            LOG_WARNING(
+                DEFAULT_LOG, "{}",
+                fmt::format(
+                    FMT_STRING("Maintenance may not be able to keep up: "
+                               "AUTOMATIC_MAINTENANCE_COUNT={:d} <= {:d}"),
+                    c.AUTOMATIC_MAINTENANCE_COUNT,
+                    ledgersPerMaintenancePeriod));
         }
         scheduleMaintenance();
     }

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -312,8 +312,8 @@ printXdr(std::string const& filename, std::string const& filetype, bool base64,
                 }
                 else
                 {
-                    throw std::invalid_argument(
-                        fmt::format("unknown filetype {}", filetype));
+                    throw std::invalid_argument(fmt::format(
+                        FMT_STRING("unknown filetype {}"), filetype));
                 }
             }
         });
@@ -479,7 +479,8 @@ signtxn(std::string const& filename, std::string netId, bool base64)
                     "Envelope already contains maximum number of signatures");
 
             SecretKey sk(SecretKey::fromStrKeySeed(readSecret(
-                fmt::format("Secret key seed [network id: '{}']: ", netId),
+                fmt::format(FMT_STRING("Secret key seed [network id: '{}']: "),
+                            netId),
                 txn_stdin)));
             TransactionSignaturePayload payload;
             payload.networkId = sha256(netId);

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -132,7 +132,8 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
                         strong->sendMessage(*smsg, log);
                     }
                 },
-                fmt::format("broadcast to {}", peer.second->toString()));
+                fmt::format(FMT_STRING("broadcast to {}"),
+                            peer.second->toString()));
             broadcasted = true;
         }
     }

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -339,15 +339,16 @@ Peer::msgSummary(StellarMessage const& msg)
     case AUTH:
         return "AUTH";
     case DONT_HAVE:
-        return fmt::format("DONTHAVE {}:{}", msg.dontHave().type,
+        return fmt::format(FMT_STRING("DONTHAVE {}:{}"), msg.dontHave().type,
                            hexAbbrev(msg.dontHave().reqHash));
     case GET_PEERS:
         return "GETPEERS";
     case PEERS:
-        return fmt::format("PEERS {}", msg.peers().size());
+        return fmt::format(FMT_STRING("PEERS {:d}"), msg.peers().size());
 
     case GET_TX_SET:
-        return fmt::format("GETTXSET {}", hexAbbrev(msg.txSetHash()));
+        return fmt::format(FMT_STRING("GETTXSET {}"),
+                           hexAbbrev(msg.txSetHash()));
     case TX_SET:
         return "TXSET";
 
@@ -355,7 +356,8 @@ Peer::msgSummary(StellarMessage const& msg)
         return "TRANSACTION";
 
     case GET_SCP_QUORUMSET:
-        return fmt::format("GET_SCP_QSET {}", hexAbbrev(msg.qSetHash()));
+        return fmt::format(FMT_STRING("GET_SCP_QSET {}"),
+                           hexAbbrev(msg.qSetHash()));
     case SCP_QUORUMSET:
         return "SCP_QSET";
     case SCP_MESSAGE:
@@ -379,11 +381,12 @@ Peer::msgSummary(StellarMessage const& msg)
             t = "unknown";
         }
         return fmt::format(
-            "{} ({})", t,
+            FMT_STRING("{} ({})"), t,
             mApp.getConfig().toShortString(msg.envelope().statement.nodeID));
     }
     case GET_SCP_STATE:
-        return fmt::format("GET_SCP_STATE {}", msg.getSCPLedgerSeq());
+        return fmt::format(FMT_STRING("GET_SCP_STATE {:d}"),
+                           msg.getSCPLedgerSeq());
 
     case SURVEY_REQUEST:
     case SURVEY_RESPONSE:
@@ -633,9 +636,9 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
                 }
                 catch (CryptoError const& e)
                 {
-                    std::string err =
-                        fmt::format("Error RecvMessage T:{} cat:{} {} @{}",
-                                    mtype, cat, self->toString(), port);
+                    std::string err = fmt::format(
+                        FMT_STRING("Error RecvMessage T:{} cat:{} {} @{:d}"),
+                        mtype, cat, self->toString(), port);
                     CLOG_ERROR(Overlay, "Dropping connection with {}: {}", err,
                                e.what());
                     self->drop("Bad crypto request",
@@ -649,7 +652,7 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
                            cat);
             }
         },
-        fmt::format("{} recvMessage", cat), type);
+        fmt::format(FMT_STRING("{} recvMessage"), cat), type);
 }
 
 void
@@ -667,7 +670,7 @@ Peer::recvRawMessage(StellarMessage const& stellarMsg)
     if (!isAuthenticated() && (stellarMsg.type() != HELLO) &&
         (stellarMsg.type() != AUTH) && (stellarMsg.type() != ERROR_MSG))
     {
-        drop(fmt::format("received {} before completed handshake",
+        drop(fmt::format(FMT_STRING("received {} before completed handshake"),
                          stellarMsg.type()),
              Peer::DropDirection::WE_DROPPED_REMOTE,
              Peer::DropMode::IGNORE_WRITE_QUEUE);
@@ -1011,7 +1014,7 @@ Peer::recvError(StellarMessage const& msg)
                    std::back_inserter(msgStr),
                    [](char c) { return (isalnum(c) || c == ' ') ? c : '*'; });
 
-    drop(fmt::format("{} ({})", codeStr, msgStr),
+    drop(fmt::format(FMT_STRING("{} ({})"), codeStr, msgStr),
          Peer::DropDirection::REMOTE_DROPPED_US,
          Peer::DropMode::IGNORE_WRITE_QUEUE);
 }

--- a/src/overlay/PeerBareAddress.cpp
+++ b/src/overlay/PeerBareAddress.cpp
@@ -24,7 +24,7 @@ PeerBareAddress::PeerBareAddress(std::string ip, unsigned short port)
     : mType{Type::IPv4}
     , mIP{std::move(ip)}
     , mPort{port}
-    , mStringValue{fmt::format("{}:{}", mIP, mPort)}
+    , mStringValue{fmt::format(FMT_STRING("{}:{:d}"), mIP, mPort)}
 {
     if (mIP.empty())
     {
@@ -35,12 +35,12 @@ PeerBareAddress::PeerBareAddress(std::string ip, unsigned short port)
 PeerBareAddress::PeerBareAddress(PeerAddress const& pa)
     : mType{Type::IPv4}
     , mIP{pa.ip.type() == IPv4
-              ? fmt::format("{}.{}.{}.{}", (int)pa.ip.ipv4()[0],
-                            (int)pa.ip.ipv4()[1], (int)pa.ip.ipv4()[2],
-                            (int)pa.ip.ipv4()[3])
+              ? fmt::format(FMT_STRING("{:d}.{:d}.{:d}.{:d}"),
+                            (int)pa.ip.ipv4()[0], (int)pa.ip.ipv4()[1],
+                            (int)pa.ip.ipv4()[2], (int)pa.ip.ipv4()[3])
               : throw std::runtime_error("IPv6 addresses not supported")}
     , mPort{static_cast<unsigned short>(pa.port)}
-    , mStringValue{fmt::format("{}:{}", mIP, mPort)}
+    , mStringValue{fmt::format(FMT_STRING("{}:{:d}"), mIP, mPort)}
 {
 }
 
@@ -56,7 +56,7 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
     if (!std::regex_search(ipPort, m, re) || m.empty())
     {
         throw std::runtime_error(
-            fmt::format("Cannot parse peer address '{}'", ipPort));
+            fmt::format(FMT_STRING("Cannot parse peer address '{}'"), ipPort));
     }
 
     asio::ip::tcp::resolver::query::flags resolveflags;
@@ -81,8 +81,8 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
     {
         LOG_DEBUG(DEFAULT_LOG, "Could not resolve '{}' : {}", ipPort,
                   ec.message());
-        throw std::runtime_error(
-            fmt::format("Could not resolve '{}': {}", ipPort, ec.message()));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("Could not resolve '{}': {}"), ipPort, ec.message()));
     }
 
     std::string ip;
@@ -98,8 +98,8 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
     }
     if (ip.empty())
     {
-        throw std::runtime_error(
-            fmt::format("Could not resolve '{}': {}", ipPort, ec.message()));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("Could not resolve '{}': {}"), ipPort, ec.message()));
     }
 
     unsigned short port = defaultPort;
@@ -108,8 +108,9 @@ PeerBareAddress::resolve(std::string const& ipPort, Application& app,
         int parsedPort = atoi(m[3].str().c_str());
         if (parsedPort <= 0 || parsedPort > UINT16_MAX)
         {
-            throw std::runtime_error(fmt::format("Could not resolve '{}': {}",
-                                                 ipPort, ec.message()));
+            throw std::runtime_error(
+                fmt::format(FMT_STRING("Could not resolve '{}': {}"), ipPort,
+                            ec.message()));
         }
         port = static_cast<unsigned short>(parsedPort);
     }

--- a/src/overlay/SurveyManager.cpp
+++ b/src/overlay/SurveyManager.cpp
@@ -568,7 +568,8 @@ SurveyManager::commandTypeName(SurveyMessageCommandType type)
     case SURVEY_TOPOLOGY:
         return "SURVEY_TOPOLOGY";
     default:
-        throw std::runtime_error(fmt::format("Unknown commandType={}", type));
+        throw std::runtime_error(
+            fmt::format(FMT_STRING("Unknown commandType={}"), type));
     }
 }
 }

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -428,7 +428,7 @@ TCPPeer::scheduleRead()
     auto self = static_pointer_cast<TCPPeer>(shared_from_this());
     self->getApp().postOnMainThread(
         [self]() { self->startRead(); },
-        fmt::format("TCPPeer::startRead for {}", toString()));
+        fmt::format(FMT_STRING("TCPPeer::startRead for {}"), toString()));
 }
 
 void

--- a/src/process/ProcessManagerImpl.cpp
+++ b/src/process/ProcessManagerImpl.cpp
@@ -879,16 +879,17 @@ ProcessManagerImpl::maybeRunPendingProcesses()
 
             if (!i->mImpl->mOutFile.empty() && fs::exists(i->mImpl->mOutFile))
             {
-                throw std::runtime_error(fmt::format(
-                    "output file {} already exists", i->mImpl->mOutFile));
+                throw std::runtime_error(
+                    fmt::format(FMT_STRING("output file {} already exists"),
+                                i->mImpl->mOutFile));
             }
 
             i->mImpl->run();
             auto pid = i->mImpl->getProcessId();
             if (mProcesses.find(pid) != mProcesses.end())
             {
-                throw std::runtime_error(
-                    fmt::format("process {} already exists", pid));
+                throw std::runtime_error(fmt::format(
+                    FMT_STRING("process {:d} already exists"), pid));
             }
             mProcesses[pid] = i;
         }

--- a/src/util/FileSystemException.cpp
+++ b/src/util/FileSystemException.cpp
@@ -27,7 +27,7 @@ FileSystemException::getLastErrorString()
                                     FORMAT_MESSAGE_IGNORE_INSERTS,
                                 NULL, dw, 0, (LPTSTR)buf, bufSize, NULL);
     buf[sz] = 0;
-    res = fmt::format("Error {:#X} - {}", dw, buf);
+    res = fmt::format(FMT_STRING("Error {:#X} - {}"), dw, buf);
     return res;
 }
 

--- a/src/util/Fs.cpp
+++ b/src/util/Fs.cpp
@@ -350,7 +350,7 @@ mkpath(const std::string& path)
 std::string
 hexStr(uint32_t checkpointNum)
 {
-    return fmt::format("{:08x}", checkpointNum);
+    return fmt::format(FMT_STRING("{:08x}"), checkpointNum);
 }
 
 std::string

--- a/src/util/LogSlowExecution.cpp
+++ b/src/util/LogSlowExecution.cpp
@@ -54,7 +54,7 @@ LogSlowExecution::checkElapsedTime() const
                              gDroppedLogMessagesSinceLast);
                 gDroppedLogMessagesSinceLast = 0;
             }
-            auto msg = fmt::format("'{}' {} {} s", mName, mMessage,
+            auto msg = fmt::format(FMT_STRING("'{}' {} {} s"), mName, mMessage,
                                    static_cast<float>(elapsed.count()) / 1000);
             // if we're 10 times over the threshold, log with INFO, otherwise
             // use DEBUG

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -147,7 +147,8 @@ Logging::init(bool truncate)
             if (out.fail())
             {
                 throw std::runtime_error(fmt::format(
-                    "Could not open log file {}, check access rights",
+                    FMT_STRING(
+                        "Could not open log file {}, check access rights"),
                     filename));
             }
             else

--- a/src/util/TmpDir.cpp
+++ b/src/util/TmpDir.cpp
@@ -77,7 +77,7 @@ TmpDirManager::TmpDirManager(std::string const& root) : mRoot(root)
     if (!fs::mkpath(root))
     {
         throw std::runtime_error(
-            fmt::format("Could not create directory {}", mRoot));
+            fmt::format(FMT_STRING("Could not create directory {}"), mRoot));
     }
 }
 

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -85,24 +85,25 @@ BasicWork::getStatus() const
     switch (state)
     {
     case InternalState::PENDING:
-        return fmt::format("Ready to run: {:s}", getName());
+        return fmt::format(FMT_STRING("Ready to run: {}"), getName());
     case InternalState::RUNNING:
-        return fmt::format("Running: {:s}", getName());
+        return fmt::format(FMT_STRING("Running: {}"), getName());
     case InternalState::WAITING:
-        return fmt::format("Waiting: {:s}", getName());
+        return fmt::format(FMT_STRING("Waiting: {}"), getName());
     case InternalState::SUCCESS:
-        return fmt::format("Succeeded: {:s}", getName());
+        return fmt::format(FMT_STRING("Succeeded: {}"), getName());
     case InternalState::RETRYING:
     {
         auto eta = getRetryETA();
-        return fmt::format("Retrying in {:d} sec: {:s}", eta, getName());
+        return fmt::format(FMT_STRING("Retrying in {:d} sec: {}"), eta,
+                           getName());
     }
     case InternalState::FAILURE:
-        return fmt::format("Failed: {:s}", getName());
+        return fmt::format(FMT_STRING("Failed: {}"), getName());
     case InternalState::ABORTING:
-        return fmt::format("Aborting: {:s}", getName());
+        return fmt::format(FMT_STRING("Aborting: {}"), getName());
     case InternalState::ABORTED:
-        return fmt::format("Aborted: {:s}", getName());
+        return fmt::format(FMT_STRING("Aborted: {}"), getName());
     default:
         abort();
     }
@@ -176,8 +177,8 @@ BasicWork::waitForRetry()
 {
     if (mRetryTimer)
     {
-        throw std::runtime_error(
-            fmt::format("Retry timer for {} already exists!", getName()));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("Retry timer for {} already exists!"), getName()));
     }
 
     mRetryTimer = std::make_unique<VirtualTimer>(mApp.getClock());
@@ -418,9 +419,9 @@ BasicWork::assertValidTransition(Transition const& t) const
 {
     if (ALLOWED_TRANSITIONS.find(t) == ALLOWED_TRANSITIONS.end())
     {
-        throw std::runtime_error(
-            fmt::format("BasicWork error: illegal state transition {} -> {}",
-                        stateName(t.first), stateName(t.second)));
+        throw std::runtime_error(fmt::format(
+            FMT_STRING("BasicWork error: illegal state transition {} -> {}"),
+            stateName(t.first), stateName(t.second)));
     }
 }
 

--- a/src/work/ConditionalWork.cpp
+++ b/src/work/ConditionalWork.cpp
@@ -93,7 +93,8 @@ ConditionalWork::onReset()
 std::string
 ConditionalWork::getStatus() const
 {
-    return fmt::format("{}{}", mWorkStarted ? "" : "Waiting before starting ",
+    return fmt::format(FMT_STRING("{}{}"),
+                       mWorkStarted ? "" : "Waiting before starting ",
                        mConditionedWork->getStatus());
 }
 }

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -28,8 +28,8 @@ Work::getStatus() const
     auto status = BasicWork::getStatus();
     if (mTotalChildren)
     {
-        status += fmt::format(" : {:d}/{:d} children completed", mDoneChildren,
-                              mTotalChildren);
+        status += fmt::format(FMT_STRING(" : {:d}/{:d} children completed"),
+                              mDoneChildren, mTotalChildren);
     }
     return status;
 }


### PR DESCRIPTION
Using `fmt::format` runtime checks triggers annoying warnings from static analyzers.
