### PR TITLE
Log as much uncaught-exception info as we can, fixes #3155.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -385,10 +385,11 @@ AM_CONDITIONAL(ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION,
 AC_ARG_ENABLE(libunwind,
     AS_HELP_STRING([--disable-libunwind],
         [Disable backtraces using libunwind]))
-if test x"$enable_libunwind" = xyes; then
+if test x"$enable_libunwind" != xno; then
     case "${host_os}" in
         *darwin*)
             # libunwind comes standard with the command-line tools on macos
+            AC_MSG_NOTICE([using platform-native libunwind])
             AC_DEFINE([HAVE_LIBUNWIND], [1],
                 [Define to 1 if you have the <libunwind.h> header file])
             ;;
@@ -417,6 +418,8 @@ if test x"$enable_libunwind" = xyes; then
             esac
             ;;
     esac
+else
+  AC_MSG_NOTICE([not using libunwind as it was not requested])
 fi
 
 # Need this to pass through ccache for xdrpp, libsodium

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -239,19 +239,11 @@ runApp(Application::pointer app)
         return 1;
     }
 
-    try
+    auto& io = app->getClock().getIOContext();
+    asio::io_context::work mainWork(io);
+    while (!io.stopped())
     {
-        auto& io = app->getClock().getIOContext();
-        asio::io_context::work mainWork(io);
-        while (!io.stopped())
-        {
-            app->getClock().crank();
-        }
-    }
-    catch (std::exception const& e)
-    {
-        LOG_FATAL(DEFAULT_LOG, "Got an exception: {}", e.what());
-        throw; // propagate exception (core dump, etc)
+        app->getClock().crank();
     }
     return 0;
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -2,22 +2,134 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "crypto/CryptoError.h"
+#include "invariant/InvariantDoesNotHold.h"
+#include "ledger/NonSociRelatedException.h"
 #include "main/CommandLine.h"
 #include "util/Backtrace.h"
+#include "util/FileSystemException.h"
 #include "util/Logging.h"
 
 #include "crypto/ShortHash.h"
 #include "util/RandHasher.h"
 #include <cstdlib>
 #include <exception>
+#include <filesystem>
 #include <sodium/core.h>
+#include <system_error>
 #include <xdrpp/marshal.h>
 
 namespace stellar
 {
 static void
+printCurrentException()
+{
+    std::exception_ptr eptr = std::current_exception();
+    if (eptr)
+    {
+        try
+        {
+            std::rethrow_exception(eptr);
+        }
+        catch (NonSociRelatedException const& e)
+        {
+            fprintf(stderr,
+                    "current exception: NonSociRelatedException(\"%s\")\n",
+                    e.what());
+        }
+        catch (CryptoError const& e)
+        {
+            fprintf(stderr, "current exception: CryptoError(\"%s\")\n",
+                    e.what());
+        }
+        catch (FileSystemException const& e)
+        {
+            fprintf(stderr, "current exception: FileSystemException(\"%s\")\n",
+                    e.what());
+        }
+        catch (InvariantDoesNotHold const& e)
+        {
+            fprintf(stderr, "current exception: InvariantDoesNotHold(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::filesystem::filesystem_error const& e)
+        {
+            fprintf(stderr,
+                    "current exception: std::filesystem::filesystem_error(%d, "
+                    "\"%s\", \"%s\", \"%s\", \"%s\")\n",
+                    e.code().value(), e.code().message().c_str(), e.what(),
+                    e.path1().c_str(), e.path2().c_str());
+        }
+        catch (std::system_error const& e)
+        {
+            fprintf(
+                stderr,
+                "current exception: std::system_error(%d, \"%s\", \"%s\")\n",
+                e.code().value(), e.code().message().c_str(), e.what());
+        }
+        catch (std::logic_error const& e)
+        {
+            fprintf(stderr, "current exception: std::logic_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::domain_error const& e)
+        {
+            fprintf(stderr, "current exception: std::domain_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::invalid_argument const& e)
+        {
+            fprintf(stderr,
+                    "current exception: std::invalid_argument(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::length_error const& e)
+        {
+            fprintf(stderr, "current exception: std::length_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::out_of_range const& e)
+        {
+            fprintf(stderr, "current exception: std::out_of_range(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::runtime_error const& e)
+        {
+            fprintf(stderr, "current exception: std::runtime_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::range_error const& e)
+        {
+            fprintf(stderr, "current exception: std::range_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::overflow_error const& e)
+        {
+            fprintf(stderr, "current exception: std::overflow_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::underflow_error const& e)
+        {
+            fprintf(stderr, "current exception: std::underflow_error(\"%s\")\n",
+                    e.what());
+        }
+        catch (std::exception const& e)
+        {
+            fprintf(stderr, "current exception: std::exception(\"%s\")\n",
+                    e.what());
+        }
+        catch (...)
+        {
+            fprintf(stderr, "current exception: unknown\n");
+        }
+        fflush(stderr);
+    }
+}
+
+static void
 printBacktraceAndAbort()
 {
+    printCurrentException();
     printCurrentBacktrace();
     std::abort();
 }


### PR DESCRIPTION
This just adds some additional reporting in the case where we call `std::terminate` with an uncaught exception. Especially bad when backtraces aren't working (as they don't on many configs).

I also added a change that makes the libunwind-based backtracing machinery turn on a little more automatically when we are able to use it. But I re-tested various configs and it is still only able to work reliably on gcc-only builds (or possibly clangs that you build yourself with a specific choice of libunwind, but not stock / platform clangs).