### PR TITLE
Only git clean ignored files in Dockerfile.testing

### DIFF
--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -10,8 +10,8 @@ RUN apt-get update && \
 
 COPY . stellar-core/
 WORKDIR stellar-core
-RUN git clean -dxf
-RUN git submodule foreach --recursive git clean -dxf
+RUN git clean -dXf
+RUN git submodule foreach --recursive git clean -dXf
 
 ARG CC=clang-10
 ARG CXX=clang++-10


### PR DESCRIPTION
# Description

## Problem
It appears that Dockerfile.testing `git clean`s all untracked or ignored files that are not staged. It does not clean staged files.

This creates a counter-intuitive experience for a developer. If I build an image locally from my working copy, the built image will contain files staged but not in a commit, but it won't contain files not staged. This is counter-intuitive and confusing, at least to me, because most Dockerfiles don't use git to decide what is and isn't included in the image.

My understanding talking to @graydon is the intent is two fold:

1. To get rid of any files from the local workstation that we don't want to pollute the image. 

2. To have any image built correspond to a specific commit. It doesn't appear that the code does that today because any staged files are not removed and staged files are not in a commit. 

@graydon Please let me know if I've misunderstood or misrepresented anything here.

## Proposal (this change)

I propose `git clean`ing only files that are ignored by git.

This reduces the surprise for developers who start using the image and find their code not in the built image, while retaining the intended behavior in point 1 above. As a bonus, it resolves the inconsistent behavior that staged files are not removed while non-staged files are.

This should clean away any files that are generated by the build process while leaving other untracked files that a developer may have created.

For point 2 I think there are other ways to achieve that outside of the Dockerfile, either by always running `git stash` before hand, or erroring if `git status --porcelain` returns any changes before running docker build. 

## Alternatives
If the preferred behavior is to preserve point 2 – that the docker image only ever builds committed state – a different change should probably be proposed to ensure that files that are staged get cleaned too. Or, that the docker image fails to build if there are any staged or untracked files.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
