### PR TITLE
Enable docker-from-docker inside devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,15 @@
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
+	// Use 'features.docker-from-docker' to setup docker inside the container
+	// for building the Docker images inside GitHub Codespaces.
+	"features": {
+		"docker-from-docker": {
+			"version": "latest",
+			"moby": true
+		}
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 


### PR DESCRIPTION
# Description

### What

Enable docker-from-docker inside devcontainer.

### Why

To support building docker images in GitHub Codespaces or VSCode when when developing using the devcontainer.

Docker-in-docker is also an option, but docker-from-docker is preferred for a few reasons unless you're developing docker itself or have other unique requirements. There's some discussion here: https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
