### PR TITLE
Overlay flow control

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -83,6 +83,8 @@ overlay.inbound.attempt                  | meter     | inbound connection attemp
 overlay.inbound.drop                     | meter     | inbound connection dropped
 overlay.inbound.establish                | meter     | inbound connection established (added to pending)
 overlay.inbound.reject                   | meter     | inbound connection rejected
+overlay.outbound-queue.scp               | timer     | time SCP traffic sits in flow-controlled queues
+overlay.outbound-queue.tx                | timer     | time tx traffic sits in flow-controlled queues
 overlay.item-fetcher.next-peer           | meter     | ask for item past the first one
 overlay.memory.flood-known               | counter   | number of known flooded entries
 overlay.message.broadcast                | meter     | message broadcasted

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -418,6 +418,27 @@ ALLOW_LOCALHOST_FOR_TESTING=false
 # before applying transactions.
 CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING=false
 
+# ENABLE_OVERLAY_FLOW_CONTROL defaults to false
+# Enables flow control when communicating with peers
+ENABLE_OVERLAY_FLOW_CONTROL=false
+
+# PEER_READING_CAPACITY defaults to 600
+# Controls how many messages from a particular peer
+# core can process simultaneously, and throttles reading from a peer when at
+# capacity. This config only takes effect if ENABLE_OVERLAY_FLOW_CONTROL=true.
+PEER_READING_CAPACITY=600
+
+# PEER_FLOOD_READING_CAPACITY defaults to 500
+# Controls how many flood messages (tx or SCP) from
+# a particular peer core can process simultaneously. This config only takes
+# effect if ENABLE_OVERLAY_FLOW_CONTROL=true. Must be strictly less than
+# PEER_READING_CAPACITY.
+PEER_FLOOD_READING_CAPACITY=500
+
+# ENABLE_OVERLAY_FLOW_CONTROL defaults to 100
+# Controls how often peers ask for more data wehn flow control is enabled.
+FLOW_CONTROL_SEND_MORE_BATCH_SIZE=100
+
 # MAXIMUM_LEDGER_CLOSETIME_DRIFT (in seconds) defaults to 50
 # Maximum drift between the local clock and the network time.
 # When joining the network for the first time, ignore SCP messages that are

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -147,6 +147,10 @@ class Herder
 
     // return the smallest ledger number we need messages for when asking peers
     virtual uint32 getMinLedgerSeqToAskPeers() const = 0;
+    virtual uint32 getMinLedgerSeqToRemember() const = 0;
+
+    virtual bool isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                             SCPStatement const& newSt) = 0;
 
     // Return the maximum sequence number for any tx (or 0 if none) from a given
     // sender in the pending or recent tx sets.

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -730,7 +730,8 @@ HerderImpl::sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer)
                 StellarMessage m;
                 m.type(SCP_MESSAGE);
                 m.envelope() = e;
-                peer->sendMessage(m, log);
+                auto mPtr = std::make_shared<StellarMessage const>(m);
+                peer->sendMessage(mPtr, log);
                 log = false;
                 slotHadData = true;
                 return true;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1891,4 +1891,12 @@ HerderImpl::makeStellarValue(Hash const& txSetHash, uint64_t closeTime,
                                   sv.txSetHash, sv.closeTime));
     return sv;
 }
+
+bool
+HerderImpl::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                        SCPStatement const& newSt)
+{
+    return getSCP().isNewerNominationOrBallotSt(oldSt, newSt);
+}
+
 }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -128,6 +128,11 @@ class HerderImpl : public Herder
 
     uint32 getMinLedgerSeqToAskPeers() const override;
 
+    uint32_t getMinLedgerSeqToRemember() const override;
+
+    bool isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                     SCPStatement const& newSt) override;
+
     SequenceNumber getMaxSeqInPendingTxs(AccountID const&) override;
 
     void triggerNextLedger(uint32_t ledgerSeqToTrigger,
@@ -291,8 +296,6 @@ class HerderImpl : public Herder
         }
     };
     QuorumMapIntersectionState mLastQuorumMapIntersectionState;
-
-    uint32_t getMinLedgerSeqToRemember() const;
 
     State mState;
     void setState(State st);

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -1035,6 +1035,23 @@ HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
     }
 
     // Compute prepare time
+    // The 'threshold' here acts as a filter to coarsely exclude from
+    // metric-recording events that occur "too close together". This
+    // happens when the current node is not actually keeping up with
+    // consensus (i.e. not participating meaningfully): it receives bursts
+    // of SCP messages that traverse all SCP states "instantly". If we
+    // record those events it gives the misleading impression of the node
+    // going "super fast", which is not really accurate: the node is
+    // actually going so slow nobody's even listening to it anymore, it's
+    // just being dragged along with its quorum.
+    //
+    // Unfortunately by excluding these "too fast" events we produce a
+    // different distortion in that case: we record so few events that the
+    // node looks like it's "going fast" from mere _sparsity of data_, the
+    // summary metric only recording a handful of samples. What you want
+    // to look at -- any time you're examining SCP phase-timing data -- is
+    // the combination of this timer _and_ the lag timers that say whether
+    // the node is so lagged that nobody's listening to it.
     if (SCPTiming.mPrepareStart)
     {
         recordLogTiming(*SCPTiming.mPrepareStart, externalizeStart,

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1440,7 +1440,14 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
             app->getConfig().NODE_SEED);
         lm.closeLedger(LedgerCloseData(ledgerSeq, txSet, sv));
         auto& bm = app->getBucketManager();
+        auto& bl = bm.getBucketList();
+        while (!bl.futuresAllResolved())
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            bl.resolveAnyReadyFutures();
+        }
         auto mc = bm.readMergeCounters();
+
         CLOG_INFO(Bucket,
                   "Ledger {} did {} old-protocol merges, {} new-protocol "
                   "merges, {} new INITENTRYs, {} old INITENTRYs",
@@ -1559,6 +1566,7 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
         auto& bl = bm.getBucketList();
         while (!bl.futuresAllResolved())
         {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
             bl.resolveAnyReadyFutures();
         }
         auto mc = bm.readMergeCounters();

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -763,13 +763,7 @@ ApplicationImpl::gracefulStop()
 void
 ApplicationImpl::shutdownMainIOContext()
 {
-    if (!mVirtualClock.getIOContext().stopped())
-    {
-        // Drain all events; things are shutting down.
-        while (mVirtualClock.cancelAllEvents())
-            ;
-        mVirtualClock.getIOContext().stop();
-    }
+    mVirtualClock.shutdown();
 }
 
 void

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -1270,6 +1270,12 @@ ApplicationImpl::postOnMainThread(std::function<void()>&& f, std::string&& name,
     mVirtualClock.postAction(
         [this, f = std::move(f), isSlow]() {
             mPostOnMainThreadDelay.Update(isSlow.checkElapsedTime());
+            auto sleepFor =
+                this->getConfig().ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING;
+            if (sleepFor > std::chrono::microseconds::zero())
+            {
+                std::this_thread::sleep_for(sleepFor);
+            }
             f();
         },
         std::move(name), type);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -52,7 +52,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "LOADGEN_OP_COUNT_FOR_TESTING",
     "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING",
     "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING",
-    "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING"};
+    "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING",
+    "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -117,6 +118,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     LOADGEN_OP_COUNT_FOR_TESTING = {};
     LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {};
     CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = false;
+    ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING =
+        std::chrono::microseconds::zero();
 
     FORCE_SCP = false;
     LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION;
@@ -1304,6 +1307,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "HALT_ON_INTERNAL_TRANSACTION_ERROR")
             {
                 HALT_ON_INTERNAL_TRANSACTION_ERROR = readBool(item);
+            }
+            else if (item.first == "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING")
+            {
+                ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING =
+                    std::chrono::microseconds(readInt<uint32_t>(item));
             }
             else
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -128,7 +128,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAXIMUM_LEDGER_CLOSETIME_DRIFT = 50;
 
     OVERLAY_PROTOCOL_MIN_VERSION = 18;
-    OVERLAY_PROTOCOL_VERSION = 19;
+    OVERLAY_PROTOCOL_VERSION = 20;
 
     VERSION_STR = STELLAR_CORE_VERSION;
 
@@ -199,6 +199,11 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
     PREFERRED_PEERS_ONLY = false;
+
+    PEER_READING_CAPACITY = 600;
+    PEER_FLOOD_READING_CAPACITY = 500;
+    ENABLE_OVERLAY_FLOW_CONTROL = false;
+    FLOW_CONTROL_SEND_MORE_BATCH_SIZE = 100;
 
     // WORKER_THREADS: setting this too low risks a form of priority inversion
     // where a long-running background task occupies all worker threads and
@@ -918,7 +923,19 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                          "node may not function properly with most networks");
             }
 
-            if (item.first == "PEER_PORT")
+            if (item.first == "PEER_READING_CAPACITY")
+            {
+                PEER_READING_CAPACITY = readInt<uint32_t>(item, 2);
+            }
+            else if (item.first == "PEER_FLOOD_READING_CAPACITY")
+            {
+                PEER_FLOOD_READING_CAPACITY = readInt<uint32_t>(item, 1);
+            }
+            else if (item.first == "ENABLE_OVERLAY_FLOW_CONTROL")
+            {
+                ENABLE_OVERLAY_FLOW_CONTROL = readBool(item);
+            }
+            else if (item.first == "PEER_PORT")
             {
                 PEER_PORT = readInt<unsigned short>(item, 1);
             }
@@ -1313,6 +1330,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING =
                     std::chrono::microseconds(readInt<uint32_t>(item));
             }
+            else if (item.first == "FLOW_CONTROL_SEND_MORE_BATCH_SIZE")
+            {
+                FLOW_CONTROL_SEND_MORE_BATCH_SIZE = readInt<uint32_t>(item, 1);
+            }
             else
             {
                 std::string err("Unknown configuration entry: '");
@@ -1326,6 +1347,22 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             !OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
         {
             processOpApplySleepTimeForTestingConfigs();
+        }
+
+        if (PEER_FLOOD_READING_CAPACITY >= PEER_READING_CAPACITY)
+        {
+            std::string msg =
+                "Invalid configuration: PEER_READING_CAPACITY must be strictly "
+                "greater than PEER_FLOOD_READING_CAPACITY";
+            throw std::runtime_error(msg);
+        }
+
+        if (FLOW_CONTROL_SEND_MORE_BATCH_SIZE > PEER_FLOOD_READING_CAPACITY)
+        {
+            std::string msg =
+                "Invalid configuration: FLOW_CONTROL_SEND_MORE_BATCH_SIZE "
+                "can't be greater than PEER_FLOOD_READING_CAPACITY";
+            throw std::runtime_error(msg);
         }
 
         verifyLoadGenOpCountForTestingConfigs();

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -230,6 +230,27 @@ class Config : public std::enable_shared_from_this<Config>
     // Waits for merges to complete before applying transactions during catchup
     bool CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING;
 
+    // A config parameter that controls how many messages from a particular peer
+    // core can process simultaneously. If core is at capacity, it temporarily
+    // stops reading from a peer until it completes processing of at least one
+    // in-flight message. This config only takes effect if
+    // ENABLE_OVERLAY_FLOW_CONTROL=true.
+    uint32_t PEER_READING_CAPACITY;
+
+    // A config parameter that controls how many flood messages (tx or SCP) from
+    // a particular peer core can process simultaneously. This config only takes
+    // effect if ENABLE_OVERLAY_FLOW_CONTROL=true. Must be strictly less than
+    // PEER_READING_CAPACITY
+    uint32_t PEER_FLOOD_READING_CAPACITY;
+
+    // A config parameter that allows core to enable or disable flow control
+    // when communicating with peers.
+    bool ENABLE_OVERLAY_FLOW_CONTROL;
+
+    // When flow control is enabled, peer asks for more data every time it
+    // processes `FLOW_CONTROL_SEND_MORE_BATCH_SIZE` messages
+    uint32_t FLOW_CONTROL_SEND_MORE_BATCH_SIZE;
+
     // A config parameter that allows a node to generate buckets. This should
     // be set to `false` only for testing purposes.
     bool MODE_ENABLES_BUCKETLIST;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -201,6 +201,11 @@ class Config : public std::enable_shared_from_this<Config>
     // during captive core fast restart.
     std::chrono::seconds ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING;
 
+    // A config parameter that forces stellar-core to sleep every time a task is
+    // picked up from the scheduler. This is useful to imitate a "slow" node.
+    // This config should only be enabled when testing.
+    std::chrono::microseconds ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING;
+
     // Config parameters that force transaction application during ledger
     // close to sleep for a certain amount of time.
     // The probability that it sleeps for

--- a/src/overlay/Floodgate.cpp
+++ b/src/overlay/Floodgate.cpp
@@ -114,8 +114,7 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
     auto peers = mApp.getOverlayManager().getAuthenticatedPeers();
 
     bool broadcasted = false;
-    std::shared_ptr<StellarMessage> smsg =
-        std::make_shared<StellarMessage>(msg);
+    auto smsg = std::make_shared<StellarMessage const>(msg);
     for (auto peer : peers)
     {
         releaseAssert(peer.second->isAuthenticated());
@@ -129,7 +128,7 @@ Floodgate::broadcast(StellarMessage const& msg, bool force)
                     auto strong = weak.lock();
                     if (strong)
                     {
-                        strong->sendMessage(*smsg, log);
+                        strong->sendMessage(smsg, log);
                     }
                 },
                 fmt::format(FMT_STRING("broadcast to {}"),

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -126,6 +126,8 @@ class OverlayManager
 
     virtual bool isPreferred(Peer* peer) const = 0;
 
+    virtual bool isFloodMessage(StellarMessage const& msg) = 0;
+
     // Return the current in-memory set of inbound pending peers.
     virtual std::vector<Peer::pointer> const&
     getInboundPendingPeers() const = 0;

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -871,6 +871,12 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
     return false;
 }
 
+bool
+OverlayManagerImpl::isFloodMessage(StellarMessage const& msg)
+{
+    return msg.type() == SCP_MESSAGE || msg.type() == TRANSACTION;
+}
+
 std::vector<Peer::pointer>
 OverlayManagerImpl::getRandomAuthenticatedPeers()
 {
@@ -1022,8 +1028,7 @@ OverlayManagerImpl::recordMessageMetric(StellarMessage const& stellarMsg,
     };
 
     bool flood = false;
-    if (stellarMsg.type() == TRANSACTION || stellarMsg.type() == SCP_MESSAGE ||
-        stellarMsg.type() == SURVEY_REQUEST ||
+    if (isFloodMessage(stellarMsg) || stellarMsg.type() == SURVEY_REQUEST ||
         stellarMsg.type() == SURVEY_RESPONSE)
     {
         flood = true;

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -115,6 +115,7 @@ class OverlayManagerImpl : public OverlayManager
 
     bool acceptAuthenticatedPeer(Peer::pointer peer) override;
     bool isPreferred(Peer* peer) const override;
+    bool isFloodMessage(StellarMessage const& msg) override;
     std::vector<Peer::pointer> const& getInboundPendingPeers() const override;
     std::vector<Peer::pointer> const& getOutboundPendingPeers() const override;
     std::vector<Peer::pointer> getPendingPeers() const override;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -57,6 +57,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "recv", "scp-message"}))
     , mRecvGetSCPStateTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "get-scp-state"}))
+    , mRecvSendMoreTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "send-more"}))
 
     , mRecvSCPPrepareTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "scp-prepare"}))
@@ -71,11 +73,14 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "recv", "survey-request"}))
     , mRecvSurveyResponseTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "survey-response"}))
-
     , mMessageDelayInWriteQueueTimer(
           app.getMetrics().NewTimer({"overlay", "delay", "write-queue"}))
     , mMessageDelayInAsyncWriteTimer(
           app.getMetrics().NewTimer({"overlay", "delay", "async-write"}))
+    , mOutboundQueueDelaySCP(
+          app.getMetrics().NewTimer({"overlay", "outbound-queue", "scp"}))
+    , mOutboundQueueDelayTxs(
+          app.getMetrics().NewTimer({"overlay", "outbound-queue", "tx"}))
 
     , mSendErrorMeter(
           app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))
@@ -103,6 +108,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
           {"overlay", "send", "scp-message"}, "message"))
     , mSendGetSCPStateMeter(app.getMetrics().NewMeter(
           {"overlay", "send", "get-scp-state"}, "message"))
+    , mSendSendMoreMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "send-more"}, "message"))
     , mSendSurveyRequestMeter(app.getMetrics().NewMeter(
           {"overlay", "send", "survey-request"}, "message"))
     , mSendSurveyResponseMeter(app.getMetrics().NewMeter(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -50,6 +50,7 @@ struct OverlayMetrics
     medida::Timer& mRecvSCPQuorumSetTimer;
     medida::Timer& mRecvSCPMessageTimer;
     medida::Timer& mRecvGetSCPStateTimer;
+    medida::Timer& mRecvSendMoreTimer;
 
     medida::Timer& mRecvSCPPrepareTimer;
     medida::Timer& mRecvSCPConfirmTimer;
@@ -61,6 +62,9 @@ struct OverlayMetrics
 
     medida::Timer& mMessageDelayInWriteQueueTimer;
     medida::Timer& mMessageDelayInAsyncWriteTimer;
+
+    medida::Timer& mOutboundQueueDelaySCP;
+    medida::Timer& mOutboundQueueDelayTxs;
 
     medida::Meter& mSendErrorMeter;
     medida::Meter& mSendHelloMeter;
@@ -75,6 +79,7 @@ struct OverlayMetrics
     medida::Meter& mSendSCPQuorumSetMeter;
     medida::Meter& mSendSCPMessageSetMeter;
     medida::Meter& mSendGetSCPStateMeter;
+    medida::Meter& mSendSendMoreMeter;
 
     medida::Meter& mSendSurveyRequestMeter;
     medida::Meter& mSendSurveyResponseMeter;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -911,7 +911,6 @@ void
 Peer::recvGetSCPQuorumSet(StellarMessage const& msg)
 {
     ZoneScoped;
-    maybeProcessPingResponse(msg.qSetHash());
 
     SCPQuorumSetPtr qset = mApp.getHerder().getQSet(msg.qSetHash());
 
@@ -931,6 +930,7 @@ Peer::recvSCPQuorumSet(StellarMessage const& msg)
 {
     ZoneScoped;
     Hash hash = xdrSha256(msg.qSet());
+    maybeProcessPingResponse(hash);
     mApp.getHerder().recvSCPQuorumSet(hash, msg.qSet());
 }
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -60,11 +60,78 @@ Peer::Peer(Application& app, PeerRole role)
     , mLastWrite(app.getClock().now())
     , mEnqueueTimeOfLastWrite(app.getClock().now())
     , mPeerMetrics(app.getClock().now())
+    , mFlowControlState(Peer::FlowControlState::DONT_KNOW)
+    , mCapacity{app.getConfig().PEER_FLOOD_READING_CAPACITY,
+                app.getConfig().PEER_READING_CAPACITY}
 {
     mPingSentTime = PING_NOT_SENT;
     mLastPing = std::chrono::hours(24); // some default very high value
     auto bytes = randomBytes(mSendNonce.size());
     std::copy(bytes.begin(), bytes.end(), mSendNonce.begin());
+}
+
+void
+Peer::beginMesssageProcessing(StellarMessage const& msg)
+{
+    // Check if flow control is enabled on the local node
+    if (flowControlEnabled() == Peer::FlowControlState::ENABLED)
+    {
+        releaseAssert(mCapacity.mTotalCapacity > 0);
+        mCapacity.mTotalCapacity--;
+
+        if (mApp.getOverlayManager().isFloodMessage(msg))
+        {
+            if (mCapacity.mFloodCapacity == 0)
+            {
+                drop("unexpected flood message, peer at capacity",
+                     Peer::DropDirection::WE_DROPPED_REMOTE,
+                     Peer::DropMode::IGNORE_WRITE_QUEUE);
+                return;
+            }
+
+            mCapacity.mFloodCapacity--;
+            if (mCapacity.mFloodCapacity == 0)
+            {
+                CLOG_TRACE(Overlay, "{}: no capacity for peer {}",
+                           mApp.getConfig().toShortString(
+                               mApp.getConfig().NODE_SEED.getPublicKey()),
+                           mApp.getConfig().toShortString(getPeerID()));
+            }
+        }
+    }
+}
+
+Peer::MsgCapacityTracker::MsgCapacityTracker(std::weak_ptr<Peer> peer,
+                                             StellarMessage const& msg)
+    : mWeakPeer(peer), mMsg(msg)
+{
+    auto self = mWeakPeer.lock();
+    if (!self)
+    {
+        throw std::runtime_error("Invalid peer");
+    }
+    self->beginMesssageProcessing(mMsg);
+}
+
+Peer::MsgCapacityTracker::~MsgCapacityTracker()
+{
+    auto self = mWeakPeer.lock();
+    if (self)
+    {
+        self->endMessageProcessing(mMsg);
+    }
+}
+
+StellarMessage const&
+Peer::MsgCapacityTracker::getMessage()
+{
+    return mMsg;
+}
+
+std::weak_ptr<Peer>
+Peer::MsgCapacityTracker::getPeer()
+{
+    return mWeakPeer;
 }
 
 void
@@ -85,7 +152,9 @@ Peer::sendHello()
     elo.peerID = cfg.NODE_SEED.getPublicKey();
     elo.cert = this->getAuthCert();
     elo.nonce = mSendNonce;
-    sendMessage(msg);
+
+    auto msgPtr = std::make_shared<StellarMessage const>(msg);
+    sendMessage(msgPtr);
 }
 
 AuthCert
@@ -190,7 +259,8 @@ Peer::sendAuth()
     ZoneScoped;
     StellarMessage msg;
     msg.type(AUTH);
-    sendMessage(msg);
+    auto msgPtr = std::make_shared<StellarMessage const>(msg);
+    sendMessage(msgPtr);
 }
 
 std::string const&
@@ -225,8 +295,8 @@ Peer::sendDontHave(MessageType type, uint256 const& itemID)
     msg.type(DONT_HAVE);
     msg.dontHave().reqHash = itemID;
     msg.dontHave().type = type;
-
-    sendMessage(msg);
+    auto msgPtr = std::make_shared<StellarMessage const>(msg);
+    sendMessage(msgPtr);
 }
 
 void
@@ -236,8 +306,8 @@ Peer::sendSCPQuorumSet(SCPQuorumSetPtr qSet)
     StellarMessage msg;
     msg.type(SCP_QUORUMSET);
     msg.qSet() = *qSet;
-
-    sendMessage(msg);
+    auto msgPtr = std::make_shared<StellarMessage const>(msg);
+    sendMessage(msgPtr);
 }
 
 void
@@ -248,7 +318,8 @@ Peer::sendGetTxSet(uint256 const& setID)
     newMsg.type(GET_TX_SET);
     newMsg.txSetHash() = setID;
 
-    sendMessage(newMsg);
+    auto msgPtr = std::make_shared<StellarMessage const>(newMsg);
+    sendMessage(msgPtr);
 }
 
 void
@@ -259,7 +330,8 @@ Peer::sendGetQuorumSet(uint256 const& setID)
     newMsg.type(GET_SCP_QUORUMSET);
     newMsg.qSetHash() = setID;
 
-    sendMessage(newMsg);
+    auto msgPtr = std::make_shared<StellarMessage const>(newMsg);
+    sendMessage(msgPtr);
 }
 
 void
@@ -268,8 +340,8 @@ Peer::sendGetPeers()
     ZoneScoped;
     StellarMessage newMsg;
     newMsg.type(GET_PEERS);
-
-    sendMessage(newMsg);
+    auto msgPtr = std::make_shared<StellarMessage const>(newMsg);
+    sendMessage(msgPtr);
 }
 
 void
@@ -279,8 +351,8 @@ Peer::sendGetScpState(uint32 ledgerSeq)
     StellarMessage newMsg;
     newMsg.type(GET_SCP_STATE);
     newMsg.getSCPLedgerSeq() = ledgerSeq;
-
-    sendMessage(newMsg);
+    auto msgPtr = std::make_shared<StellarMessage const>(newMsg);
+    sendMessage(msgPtr);
 }
 
 void
@@ -303,7 +375,8 @@ Peer::sendPeers()
         {
             newMsg.peers().push_back(toXdr(address));
         }
-        sendMessage(newMsg);
+        auto msgPtr = std::make_shared<StellarMessage const>(newMsg);
+        sendMessage(msgPtr);
     }
 }
 
@@ -315,7 +388,8 @@ Peer::sendError(ErrorCode error, std::string const& message)
     m.type(ERROR_MSG);
     m.error().code = error;
     m.error().msg = message;
-    sendMessage(m);
+    auto msgPtr = std::make_shared<StellarMessage const>(m);
+    sendMessage(msgPtr);
 }
 
 void
@@ -391,15 +465,17 @@ Peer::msgSummary(StellarMessage const& msg)
     case SURVEY_REQUEST:
     case SURVEY_RESPONSE:
         return SurveyManager::getMsgSummary(msg);
+    case SEND_MORE:
+        return "SENDMORE";
     }
     return "UNKNOWN";
 }
 
 void
-Peer::sendMessage(StellarMessage const& msg, bool log)
+Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
 {
     ZoneScoped;
-    CLOG_TRACE(Overlay, "send: {} to : {}", msgSummary(msg),
+    CLOG_TRACE(Overlay, "send: {} to : {}", msgSummary(*msg),
                mApp.getConfig().toShortString(mPeerID));
 
     // There are really _two_ layers of queues, one in Scheduler for actions and
@@ -417,7 +493,7 @@ Peer::sendMessage(StellarMessage const& msg, bool log)
         return;
     }
 
-    switch (msg.type())
+    switch (msg->type())
     {
     case ERROR_MSG:
         getOverlayMetrics().mSendErrorMeter.Mark();
@@ -464,8 +540,33 @@ Peer::sendMessage(StellarMessage const& msg, bool log)
     case SURVEY_RESPONSE:
         getOverlayMetrics().mSendSurveyResponseMeter.Mark();
         break;
+    case SEND_MORE:
+        getOverlayMetrics().mSendSendMoreMeter.Mark();
+        break;
     };
 
+    if (mApp.getOverlayManager().isFloodMessage(*msg))
+    {
+        auto flowControl = flowControlEnabled();
+        if (flowControl == Peer::FlowControlState::DONT_KNOW)
+        {
+            // Drop any flood messages while flow control is being set
+            return;
+        }
+        else if (flowControl == Peer::FlowControlState::ENABLED)
+        {
+            addMsgAndMaybeTrimQueue(msg);
+            maybeSendNextBatch();
+            return;
+        }
+    }
+
+    sendAuthenticatedMessage(*msg);
+}
+
+void
+Peer::sendAuthenticatedMessage(StellarMessage const& msg)
+{
     AuthenticatedMessage amsg;
     amsg.v0().message = msg;
     if (msg.type() != HELLO && msg.type() != ERROR_MSG)
@@ -585,10 +686,59 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
     switch (stellarMsg.type())
     {
     // group messages used during handshake, process those synchronously
-    case MessageType::HELLO:
-    case MessageType::AUTH:
+    case HELLO:
+    case AUTH:
         Peer::recvRawMessage(stellarMsg);
         return;
+    case SEND_MORE:
+    {
+        if (mRemoteOverlayVersion < Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
+        {
+            drop("Peer sent SEND_MORE that it doesn't support",
+                 Peer::DropDirection::WE_DROPPED_REMOTE,
+                 Peer::DropMode::IGNORE_WRITE_QUEUE);
+            return;
+        }
+
+        if (mApp.getConfig().OVERLAY_PROTOCOL_VERSION <
+            Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
+        {
+            drop("does not support SEND_MORE",
+                 Peer::DropDirection::WE_DROPPED_REMOTE,
+                 Peer::DropMode::IGNORE_WRITE_QUEUE);
+            return;
+        }
+
+        cat = "CTRL";
+        // Set this once: peers aren't allowed to switch between modes
+        // Either set the flow control to "off" or continue processing the
+        // message and potentially send the next batch of items
+        if (mFlowControlState == Peer::FlowControlState::DONT_KNOW)
+        {
+            if (stellarMsg.sendMoreMessage().numMessages == 0)
+            {
+                mFlowControlState = Peer::FlowControlState::DISABLED;
+                // Done with the message
+                return;
+            }
+            else
+            {
+                mFlowControlState = Peer::FlowControlState::ENABLED;
+            }
+        }
+
+        if (stellarMsg.sendMoreMessage().numMessages >
+            UINT64_MAX - mOutboundCapacity)
+        {
+            drop("Peer capacity overflow",
+                 Peer::DropDirection::WE_DROPPED_REMOTE,
+                 Peer::DropMode::IGNORE_WRITE_QUEUE);
+            return;
+        }
+
+        mOutboundCapacity += stellarMsg.sendMoreMessage().numMessages;
+        break;
+    }
 
     // control messages
     case GET_PEERS:
@@ -630,36 +780,231 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
         return;
     }
 
-    std::weak_ptr<Peer> weak(static_pointer_cast<Peer>(shared_from_this()));
+    auto self = shared_from_this();
+    std::weak_ptr<Peer> weak(static_pointer_cast<Peer>(self));
+
+    auto msgTracker = std::make_shared<MsgCapacityTracker>(weak, stellarMsg);
+
     mApp.postOnMainThread(
-        [weak, sm = StellarMessage(stellarMsg), mtype = stellarMsg.type(), cat,
-         port = mApp.getConfig().PEER_PORT]() {
-            auto self = weak.lock();
-            if (self)
+        [weak, msgTracker, cat, port = mApp.getConfig().PEER_PORT]() {
+            auto self = msgTracker->getPeer().lock();
+            if (!self)
             {
-                try
-                {
-                    self->recvRawMessage(sm);
-                }
-                catch (CryptoError const& e)
-                {
-                    std::string err = fmt::format(
-                        FMT_STRING("Error RecvMessage T:{} cat:{} {} @{:d}"),
-                        mtype, cat, self->toString(), port);
-                    CLOG_ERROR(Overlay, "Dropping connection with {}: {}", err,
-                               e.what());
-                    self->drop("Bad crypto request",
-                               Peer::DropDirection::WE_DROPPED_REMOTE,
-                               Peer::DropMode::IGNORE_WRITE_QUEUE);
-                }
+                CLOG_TRACE(Overlay, "Error RecvMessage T:{} cat:{}",
+                           msgTracker->getMessage().type(), cat);
+                return;
             }
-            else
+
+            try
             {
-                CLOG_TRACE(Overlay, "Error RecvMessage T:{} cat:{}", mtype,
-                           cat);
+                self->recvRawMessage(msgTracker->getMessage());
+            }
+            catch (CryptoError const& e)
+            {
+                std::string err = fmt::format(
+                    FMT_STRING("Error RecvMessage T:{} cat:{} {} @{:d}"),
+                    msgTracker->getMessage().type(), cat, self->toString(),
+                    port);
+                CLOG_ERROR(Overlay, "Dropping connection with {}: {}", err,
+                           e.what());
+                self->drop("Bad crypto request",
+                           Peer::DropDirection::WE_DROPPED_REMOTE,
+                           Peer::DropMode::IGNORE_WRITE_QUEUE);
             }
         },
         fmt::format(FMT_STRING("{} recvMessage"), cat), type);
+}
+
+void
+Peer::sendSendMore(uint32_t numMessages)
+{
+    ZoneScoped;
+    StellarMessage m;
+    m.type(SEND_MORE);
+    m.sendMoreMessage().numMessages = numMessages;
+    auto msgPtr = std::make_shared<StellarMessage const>(m);
+    sendMessage(msgPtr);
+}
+
+void
+Peer::recvSendMore(StellarMessage const& msg)
+{
+    ZoneScoped;
+    // Flow control must be "on"
+    auto fc = flowControlEnabled();
+    releaseAssert(fc != Peer::FlowControlState::DONT_KNOW);
+
+    if (msg.sendMoreMessage().numMessages == 0)
+    {
+        drop("unexpected SEND_MORE message",
+             Peer::DropDirection::WE_DROPPED_REMOTE,
+             Peer::DropMode::IGNORE_WRITE_QUEUE);
+        return;
+    }
+
+    CLOG_TRACE(Overlay, "Peer {} sent SEND_MORE {}",
+               mApp.getConfig().toShortString(getPeerID()),
+               msg.sendMoreMessage().numMessages);
+
+    // SEND_MORE means we can free some capacity, and dump the next batch of
+    // messages onto the writing queue
+    if (fc == Peer::FlowControlState::ENABLED)
+    {
+        maybeSendNextBatch();
+    }
+}
+
+bool
+Peer::hasReadingCapacity() const
+{
+    return flowControlEnabled() != Peer::FlowControlState::ENABLED ||
+           mCapacity.mTotalCapacity > 0;
+}
+
+Peer::FlowControlState
+Peer::flowControlEnabled() const
+{
+    if (mFlowControlState == Peer::FlowControlState::DONT_KNOW)
+    {
+        return Peer::FlowControlState::DONT_KNOW;
+    }
+    if (mApp.getConfig().OVERLAY_PROTOCOL_VERSION <
+            Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL ||
+        !mApp.getConfig().ENABLE_OVERLAY_FLOW_CONTROL)
+    {
+        return Peer::FlowControlState::DISABLED;
+    }
+    return mFlowControlState;
+}
+
+void
+Peer::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
+{
+    ZoneScoped;
+
+    releaseAssert(msg);
+    auto type = msg->type();
+    auto& queue = type == SCP_MESSAGE ? mOutboundQueues[0] : mOutboundQueues[1];
+    queue.emplace_back(QueuedOutboundMessage{msg, mApp.getClock().now()});
+
+    int dropped = 0;
+
+    if (type == TRANSACTION)
+    {
+        uint32_t limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+        if (queue.size() > limit)
+        {
+            dropped = queue.size() - limit;
+            queue.erase(queue.begin(), queue.begin() + dropped);
+        }
+    }
+    else if (type == SCP_MESSAGE)
+    {
+        // Iterate over the message queue. If we found any messages for slots we
+        // don't keep in-memory anymore, delete those. Otherwise, compare
+        // messages for the same slot and validator against the latest SCP
+        // message and drop
+        auto minSlotToRemember = mApp.getHerder().getMinLedgerSeqToRemember();
+        bool valueReplaced = false;
+
+        for (auto it = queue.begin(); it != queue.end();)
+        {
+            if (it->mMessage->envelope().statement.slotIndex <
+                minSlotToRemember)
+            {
+                it = queue.erase(it);
+                dropped++;
+            }
+            else if (!valueReplaced && it != queue.end() - 1 &&
+                     mApp.getHerder().isNewerNominationOrBallotSt(
+                         it->mMessage->envelope().statement,
+                         queue.back().mMessage->envelope().statement))
+            {
+                valueReplaced = true;
+                *it = std::move(queue.back());
+                queue.pop_back();
+                dropped++;
+                ++it;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
+    if (dropped && Logging::logTrace("Overlay"))
+    {
+        CLOG_TRACE(Overlay, "Dropped {} {} messages to peer {}", dropped,
+                   (type == TRANSACTION ? "tx" : "SCP"),
+                   mApp.getConfig().toShortString(getPeerID()));
+    }
+}
+
+void
+Peer::maybeSendNextBatch()
+{
+    ZoneScoped;
+
+    releaseAssert(flowControlEnabled() == Peer::FlowControlState::ENABLED);
+
+    auto oldOutboundCapacity = mOutboundCapacity;
+    for (int i = 0; i < mOutboundQueues.size(); i++)
+    {
+        auto& queue = mOutboundQueues[i];
+        while (!queue.empty() && mOutboundCapacity > 0)
+        {
+            auto& front = queue.front();
+            sendAuthenticatedMessage(*(front.mMessage));
+            auto& om = mApp.getOverlayManager().getOverlayMetrics();
+            auto& timer = front.mMessage->type() == SCP_MESSAGE
+                              ? om.mOutboundQueueDelaySCP
+                              : om.mOutboundQueueDelayTxs;
+            timer.Update(mApp.getClock().now() - front.mTimeEmplaced);
+            mOutboundCapacity--;
+            queue.pop_front();
+        }
+    }
+
+    CLOG_TRACE(Overlay, "Peer {}: send next flood batch of {}",
+               mApp.getConfig().toShortString(getPeerID()),
+               (oldOutboundCapacity - mOutboundCapacity));
+}
+
+void
+Peer::endMessageProcessing(StellarMessage const& msg)
+{
+    if (shouldAbort() ||
+        flowControlEnabled() != Peer::FlowControlState::ENABLED)
+    {
+        return;
+    }
+
+    mCapacity.mTotalCapacity++;
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        mCapacity.mFloodCapacity++;
+        CLOG_TRACE(Overlay, "{}: got capacity {} for peer {}",
+                   mApp.getConfig().toShortString(
+                       mApp.getConfig().NODE_SEED.getPublicKey()),
+                   mCapacity.mFloodCapacity,
+                   mApp.getConfig().toShortString(getPeerID()));
+        mFloodMsgsProcessed++;
+
+        if (mFloodMsgsProcessed ==
+            mApp.getConfig().FLOW_CONTROL_SEND_MORE_BATCH_SIZE)
+        {
+            sendSendMore(mApp.getConfig().FLOW_CONTROL_SEND_MORE_BATCH_SIZE);
+            mFloodMsgsProcessed = 0;
+        }
+    }
+
+    // Got some capacity back, can schedule more reads now
+    if (mIsPeerThrottled)
+    {
+        mIsPeerThrottled = false;
+        scheduleRead();
+    }
 }
 
 void
@@ -795,6 +1140,12 @@ Peer::recvRawMessage(StellarMessage const& stellarMsg)
         recvGetSCPState(stellarMsg);
     }
     break;
+    case SEND_MORE:
+    {
+        auto t = getOverlayMetrics().mRecvSendMoreTimer.TimeScope();
+        recvSendMore(stellarMsg);
+    }
+    break;
     }
 }
 
@@ -818,8 +1169,8 @@ Peer::recvGetTxSet(StellarMessage const& msg)
         StellarMessage newMsg;
         newMsg.type(TX_SET);
         txSet->toXDR(newMsg.txSet());
-
-        self->sendMessage(newMsg);
+        auto newMsgPtr = std::make_shared<StellarMessage const>(newMsg);
+        self->sendMessage(newMsgPtr);
     }
     else
     {
@@ -1237,6 +1588,28 @@ Peer::recvAuth(StellarMessage const& msg)
         return;
     }
 
+    // Subtle: after successful auth, must send sendMore message first to tell
+    // the other peer if this node prefers to flow control the traffic or not
+    if (mRemoteOverlayVersion >= Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL &&
+        mApp.getConfig().OVERLAY_PROTOCOL_VERSION >=
+            Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
+    {
+        if (mApp.getConfig().ENABLE_OVERLAY_FLOW_CONTROL)
+        {
+            sendSendMore(mApp.getConfig().PEER_FLOOD_READING_CAPACITY);
+        }
+        else
+        {
+            // 0 indicates peer doesn't want to use flow control
+            sendSendMore(0);
+        }
+    }
+    else
+    {
+        mFlowControlState = Peer::FlowControlState::DISABLED;
+    }
+
+    // Ask for SCP data _after_ the flow control message
     auto low = mApp.getHerder().getMinLedgerSeqToAskPeers();
     sendGetScpState(low);
 }

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -420,6 +420,14 @@ TCPPeer::scheduleRead()
     // Post to the peer-specific Scheduler a call to ::startRead below;
     // this will be throttled to try to balance input rates across peers.
     ZoneScoped;
+
+    if (mIsPeerThrottled)
+    {
+        return;
+    }
+
+    releaseAssert(hasReadingCapacity());
+
     assertThreadIsMain();
     if (shouldAbort())
     {
@@ -436,6 +444,7 @@ TCPPeer::startRead()
 {
     ZoneScoped;
     assertThreadIsMain();
+    releaseAssert(hasReadingCapacity());
     if (shouldAbort())
     {
         return;
@@ -466,6 +475,8 @@ TCPPeer::startRead()
             return;
         }
         size_t length = getIncomingMsgLength();
+
+        // in_avail = amount of unread data
         if (mSocket->in_avail() >= length)
         {
             // We can finish reading a full message here synchronously,
@@ -487,6 +498,14 @@ TCPPeer::startRead()
                 }
                 noteFullyReadBody(length);
                 recvMessage();
+                if (!hasReadingCapacity())
+                {
+                    // Break and wait until more capacity frees up
+                    CLOG_TRACE(Overlay, "Throttle reading for peer {}!",
+                               mApp.getConfig().toShortString(getPeerID()));
+                    mIsPeerThrottled = true;
+                    return;
+                }
                 if (mApp.getClock().shouldYield())
                 {
                     break;
@@ -495,6 +514,9 @@ TCPPeer::startRead()
         }
         else
         {
+            // No throttling - we just read a header, so we must have capacity
+            releaseAssert(hasReadingCapacity());
+
             // We read a header synchronously, but don't have enough data in the
             // buffered_stream to read the body synchronously. Pretend we just
             // finished reading the header asynchronously, and punt to
@@ -620,6 +642,16 @@ TCPPeer::readBodyHandler(asio::error_code const& error,
         // sequence happens after the first read of a single large input-buffer
         // worth of input. Even when we weren't preempted, we still bounce off
         // the per-peer scheduler queue here, to balance input across peers.
+        if (!hasReadingCapacity())
+        {
+            // No more capacity after processing this message
+            CLOG_TRACE(Overlay,
+                       "TCPPeer::readBodyHandler: throttle reading from {}",
+                       mApp.getConfig().toShortString(getPeerID()));
+            mIsPeerThrottled = true;
+            return;
+        }
+
         scheduleRead();
     }
 }
@@ -629,6 +661,7 @@ TCPPeer::recvMessage()
 {
     ZoneScoped;
     assertThreadIsMain();
+    releaseAssert(hasReadingCapacity());
 
     try
     {

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -44,7 +44,7 @@ class TCPPeer : public Peer
 
     size_t getIncomingMsgLength();
     virtual void connected() override;
-    void scheduleRead();
+    void scheduleRead() override;
     virtual bool sendQueueIsOverloaded() const override;
     void startRead();
 

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -45,6 +45,12 @@ LoopbackPeer::getAuthCert()
 }
 
 void
+LoopbackPeer::scheduleRead()
+{
+    processInQueue();
+}
+
+void
 LoopbackPeer::sendMessage(xdr::msg_ptr&& msg)
 {
     if (mRemote.expired())
@@ -164,6 +170,12 @@ duplicateMessage(Peer::TimestampedMessage const& msg)
 void
 LoopbackPeer::processInQueue()
 {
+    if (!hasReadingCapacity())
+    {
+        mIsPeerThrottled = true;
+        return;
+    }
+
     if (!mInQueue.empty() && mState != CLOSING)
     {
         auto const& m = mInQueue.front();
@@ -479,5 +491,11 @@ std::shared_ptr<LoopbackPeer>
 LoopbackPeerConnection::getAcceptor() const
 {
     return mAcceptor;
+}
+
+bool
+LoopbackPeer::checkCapacity(uint64_t expectedOutboundCapacity) const
+{
+    return expectedOutboundCapacity == mOutboundCapacity;
 }
 }

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -73,6 +73,8 @@ class LoopbackPeer : public Peer
     size_t getBytesQueued() const;
     size_t getMessagesQueued() const;
 
+    virtual void scheduleRead() override;
+
     Stats const& getStats() const;
 
     bool getCorked() const;
@@ -110,9 +112,27 @@ class LoopbackPeer : public Peer
         return mDropReason;
     }
 
+    std::array<std::deque<QueuedOutboundMessage>, 2>&
+    getQueues()
+    {
+        return mOutboundQueues;
+    }
+
+    uint64_t&
+    getOutboundCapacity()
+    {
+        return mOutboundCapacity;
+    }
+
+    bool checkCapacity(uint64_t expectedOutboundCapacity) const;
+
     std::string getIP() const override;
 
+    using Peer::addMsgAndMaybeTrimQueue;
+    using Peer::flowControlEnabled;
     using Peer::sendAuth;
+    using Peer::sendAuthenticatedMessage;
+    using Peer::sendSendMore;
 
     friend class LoopbackPeerConnection;
 };

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -38,6 +38,8 @@ class PeerStub : public Peer
         mPeerID = SecretKey::pseudoRandomForTesting().getPublicKey();
         mState = GOT_AUTH;
         mAddress = address;
+        mOutboundCapacity = std::numeric_limits<uint32>::max();
+        mFlowControlState = Peer::FlowControlState::ENABLED;
     }
     virtual std::string
     getIP() const override
@@ -53,6 +55,10 @@ class PeerStub : public Peer
     sendMessage(xdr::msg_ptr&& xdrBytes) override
     {
         sent++;
+    }
+    virtual void
+    scheduleRead() override
+    {
     }
 };
 

--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -155,6 +155,10 @@ class BallotProtocol
     // returns all values referenced by a statement
     static std::set<Value> getStatementValues(SCPStatement const& st);
 
+    // returns true if st is newer than oldst
+    static bool isNewerStatement(SCPStatement const& oldst,
+                                 SCPStatement const& st);
+
   private:
     // attempts to make progress using the latest statement as a hint
     // calls into the various attempt* methods, emits message
@@ -260,10 +264,6 @@ class BallotProtocol
     // returns true if the statement is newer than the one we know about
     // for a given node.
     bool isNewerStatement(NodeID const& nodeID, SCPStatement const& st);
-
-    // returns true if st is newer than oldst
-    static bool isNewerStatement(SCPStatement const& oldst,
-                                 SCPStatement const& st);
 
     // basic sanity check on statement
     bool isStatementSane(SCPStatement const& st, bool self);

--- a/src/scp/NominationProtocol.h
+++ b/src/scp/NominationProtocol.h
@@ -41,8 +41,6 @@ class NominationProtocol
     Value mPreviousValue;
 
     bool isNewerStatement(NodeID const& nodeID, SCPNomination const& st);
-    static bool isNewerStatement(SCPNomination const& oldst,
-                                 SCPNomination const& st);
 
     // returns true if 'p' is a subset of 'v'
     // also sets 'notEqual' if p and v differ
@@ -84,6 +82,9 @@ class NominationProtocol
     ValueWrapperPtr getNewValueFromNomination(SCPNomination const& nom);
 
   public:
+    static bool isNewerStatement(SCPNomination const& oldst,
+                                 SCPNomination const& st);
+
     NominationProtocol(Slot& slot);
 
     SCP::EnvelopeState processEnvelope(SCPEnvelopeWrapperPtr envelope);

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -280,6 +280,24 @@ SCP::getLatestMessage(NodeID const& id)
     return nullptr;
 }
 
+bool
+SCP::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                 SCPStatement const& newSt)
+{
+    if (oldSt.slotIndex != newSt.slotIndex || !(oldSt.nodeID == newSt.nodeID))
+    {
+        return false;
+    }
+
+    auto slot = getSlot(oldSt.slotIndex, false);
+    if (slot)
+    {
+        return slot->isNewerNominationOrBallotSt(oldSt, newSt);
+    }
+
+    return false;
+}
+
 std::vector<SCPEnvelope>
 SCP::getExternalizingState(uint64 slotIndex)
 {

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -122,6 +122,9 @@ class SCP
     // or nullptr if not found
     SCPEnvelope const* getLatestMessage(NodeID const& id);
 
+    bool isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                     SCPStatement const& newSt);
+
     // returns messages that contributed to externalizing the slot
     // (or empty if the slot didn't externalize)
     std::vector<SCPEnvelope> getExternalizingState(uint64 slotIndex);

--- a/src/scp/Slot.cpp
+++ b/src/scp/Slot.cpp
@@ -106,6 +106,40 @@ Slot::getLatestMessage(NodeID const& id) const
     return m;
 }
 
+bool
+Slot::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                  SCPStatement const& newSt)
+{
+    bool oldNomination =
+        oldSt.pledges.type() == SCPStatementType::SCP_ST_NOMINATE;
+    bool newNomination =
+        newSt.pledges.type() == SCPStatementType::SCP_ST_NOMINATE;
+
+    if (oldNomination != newNomination)
+    {
+        return false;
+    }
+
+    bool replace = false;
+    if (oldNomination)
+    {
+        if (NominationProtocol::isNewerStatement(oldSt.pledges.nominate(),
+                                                 newSt.pledges.nominate()))
+        {
+            replace = true;
+        }
+    }
+    else
+    {
+        if (BallotProtocol::isNewerStatement(oldSt, newSt))
+        {
+            replace = true;
+        }
+    }
+
+    return replace;
+}
+
 std::vector<SCPEnvelope>
 Slot::getExternalizingState() const
 {

--- a/src/scp/Slot.h
+++ b/src/scp/Slot.h
@@ -98,6 +98,10 @@ class Slot : public std::enable_shared_from_this<Slot>
     // or nullptr if not found
     SCPEnvelope const* getLatestMessage(NodeID const& id) const;
 
+    // Return true if the statement is latest for a node that sent it
+    bool isNewerNominationOrBallotSt(SCPStatement const& oldSt,
+                                     SCPStatement const& newSt);
+
     // returns messages that helped this slot externalize
     std::vector<SCPEnvelope> getExternalizingState() const;
 

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -2039,8 +2039,11 @@ OverlayFuzzer::inject(std::string const& filename)
     auto acceptor = loopbackPeerConnection->getAcceptor();
 
     initiator->getApp().getClock().postAction(
-        [initiator, msg]() { initiator->Peer::sendMessage(msg); }, "main",
-        Scheduler::ActionType::NORMAL_ACTION);
+        [initiator, msg]() {
+            initiator->Peer::sendMessage(
+                std::make_shared<StellarMessage const>(msg));
+        },
+        "main", Scheduler::ActionType::NORMAL_ACTION);
 
     mSimulation->crankForAtMost(std::chrono::milliseconds{500}, false);
 

--- a/src/util/Scheduler.cpp
+++ b/src/util/Scheduler.cpp
@@ -196,6 +196,20 @@ Scheduler::trimIdleActionQueues(VirtualClock::time_point now)
 }
 
 void
+Scheduler::shutdown()
+{
+    if (!mIsShutdown)
+    {
+        mIsShutdown = true;
+        mAllActionQueues.clear();
+        mRunnableActionQueues =
+            std::priority_queue<Qptr, std::vector<Qptr>,
+                                std::function<bool(Qptr, Qptr)>>();
+        mIdleActionQueues.clear();
+    }
+}
+
+void
 Scheduler::setOverloaded(bool overloaded)
 {
     if (overloaded)
@@ -211,6 +225,11 @@ Scheduler::setOverloaded(bool overloaded)
 void
 Scheduler::enqueue(std::string&& name, Action&& action, ActionType type)
 {
+    if (mIsShutdown)
+    {
+        return;
+    }
+
     auto key = std::make_pair(name, type);
     auto qi = mAllActionQueues.find(key);
     if (qi == mAllActionQueues.end())

--- a/src/util/Scheduler.h
+++ b/src/util/Scheduler.h
@@ -183,6 +183,8 @@ class Scheduler
     // or run.
     size_t mSize{0};
 
+    bool mIsShutdown{false};
+
     void trimSingleActionQueue(Qptr q,
                                std::chrono::steady_clock::time_point now);
     void trimIdleActionQueues(std::chrono::steady_clock::time_point now);
@@ -239,6 +241,8 @@ class Scheduler
     {
         return mStats;
     }
+
+    void shutdown();
 
 #ifdef BUILD_TESTS
     // Testing interface

--- a/src/util/Timer.h
+++ b/src/util/Timer.h
@@ -124,6 +124,9 @@ class VirtualClock
     // make progress. Use a do-while loop or break mid-loop or something.
     bool shouldYield() const;
 
+    void shutdown();
+    bool isStopped();
+
   private:
     asio::io_context mIOContext;
     Mode mMode;

--- a/src/xdr/Stellar-overlay.x
+++ b/src/xdr/Stellar-overlay.x
@@ -22,6 +22,11 @@ struct Error
     string msg<100>;
 };
 
+struct SendMore
+{
+    uint32 numMessages;
+};
+
 struct AuthCert
 {
     Curve25519Public pubkey;
@@ -93,7 +98,9 @@ enum MessageType
     HELLO = 13,
 
     SURVEY_REQUEST = 14,
-    SURVEY_RESPONSE = 15
+    SURVEY_RESPONSE = 15,
+
+    SEND_MORE = 16
 };
 
 struct DontHave
@@ -214,6 +221,8 @@ case SCP_MESSAGE:
     SCPEnvelope envelope;
 case GET_SCP_STATE:
     uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
+case SEND_MORE:
+    SendMore sendMoreMessage;
 };
 
 union AuthenticatedMessage switch (uint32 v)


### PR DESCRIPTION
Initial version of the overlay flow control change, wanted to get more eyes on it. Main changes are:
* Overlay now supports flow control via the new message type SEND_MORE
* Reading from the peers is throttled based on the available capacity
* Peers may opt-out of flow control via the config flag ENABLE_OVERLAY_FLOW_CONTROL (in which case they send SEND_MORE=0 during auth to notify the other peer that they don't want flow control)

Currently, the next things I'm working on are:
* Implementing emergency mechanisms to unblock the nodes in case there are bugs (deadlocks etc)
* Automatically calculating the "right" window size and pipeline parameters based on the connection quality
* Adding unit tests