### PR TITLE
Use TRACY_NO_ISA_EXTENSIONS in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ TRACY_GUI_SOURCE=$(TRACY_GUI_DIR)/src
 TRACY_GUI_BUILD=$(TRACY_GUI_DIR)/build/unix
 
 $(TRACY_GUI_BUILD)/Tracy-release: $(wildcard $(TRACY_GUI_SOURCE)/*.*)
-	$(MAKE) -C $(TRACY_GUI_BUILD) release CC="$(CC)" CXX="$(CXX)"
+	$(MAKE) -C $(TRACY_GUI_BUILD) release CC="$(CC)" CXX="$(CXX)" TRACY_NO_ISA_EXTENSIONS=1
 
 tracy-gui: $(TRACY_GUI_BUILD)/Tracy-release
 	cp -v $< $@
@@ -46,7 +46,7 @@ TRACY_CAPTURE_SOURCE=$(TRACY_CAPTURE_DIR)/src
 TRACY_CAPTURE_BUILD=$(TRACY_CAPTURE_DIR)/build/unix
 
 $(TRACY_CAPTURE_BUILD)/capture-release: $(wildcard $(TRACY_CAPTURE_SOURCE)/*.*)
-	$(MAKE) -C $(TRACY_CAPTURE_BUILD) release CC="$(CC)" CXX="$(CXX)"
+	$(MAKE) -C $(TRACY_CAPTURE_BUILD) release CC="$(CC)" CXX="$(CXX)" TRACY_NO_ISA_EXTENSIONS=1
 
 tracy-capture: $(TRACY_CAPTURE_BUILD)/capture-release
 	cp -v $< $@
@@ -60,7 +60,7 @@ TRACY_CSVEXPORT_SOURCE=$(TRACY_CSVEXPORT_DIR)/src
 TRACY_CSVEXPORT_BUILD=$(TRACY_CSVEXPORT_DIR)/build/unix
 
 $(TRACY_CSVEXPORT_BUILD)/csvexport-release: $(wildcard $(TRACY_CSVEXPORT_SOURCE)/*.*)
-	$(MAKE) -C $(TRACY_CSVEXPORT_BUILD) release CC="$(CC)" CXX="$(CXX)"
+	$(MAKE) -C $(TRACY_CSVEXPORT_BUILD) release CC="$(CC)" CXX="$(CXX)" TRACY_NO_ISA_EXTENSIONS=1
 
 tracy-csvexport: $(TRACY_CSVEXPORT_BUILD)/csvexport-release
 	cp -v $< $@


### PR DESCRIPTION
Some of the auxiliary tracy tools (`tracy-csvexport` and `tracy-capture`) get built with -mcpu=native or -mcpu=sse4.2, which can produce instructions in compiled binaries (thus packages and docker images) that can only run those tools on machines as-new-or-newer than the build host. This PR attempts to use more conservative build flags for those tools.