### PR TITLE
Dampen arb flooding

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -623,6 +623,7 @@ exit /b 0
     <ClCompile Include="..\..\src\util\test\TimerTests.cpp" />
     <ClCompile Include="..\..\src\util\test\Uint128Tests.cpp" />
     <ClCompile Include="..\..\src\util\test\XDRStreamTests.cpp" />
+    <ClCompile Include="..\..\src\util\TarjanSCCCalculator.cpp" />
     <ClCompile Include="..\..\src\util\Thread.cpp" />
     <ClCompile Include="..\..\src\util\TmpDir.cpp" />
     <ClCompile Include="..\..\src\util\Timer.cpp" />
@@ -919,6 +920,7 @@ exit /b 0
     <ClInclude Include="..\..\src\util\SecretValue.h" />
     <ClInclude Include="..\..\src\util\SociNoWarnings.h" />
     <ClInclude Include="..\..\src\util\StatusManager.h" />
+    <ClInclude Include="..\..\src\util\TarjanSCCCalculator.h" />
     <ClInclude Include="..\..\src\util\Thread.h" />
     <ClInclude Include="..\..\src\util\TmpDir.h" />
     <ClInclude Include="..\..\src\util\Timer.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -765,6 +765,9 @@
     <ClCompile Include="..\..\src\test\TxTests.cpp">
       <Filter>test</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\TarjanSCCCalculator.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\util\Thread.cpp">
       <Filter>util</Filter>
     </ClCompile>
@@ -1756,6 +1759,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\test\TxTests.h">
       <Filter>test</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\TarjanSCCCalculator.h">
+      <Filter>util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\util\Thread.h">
       <Filter>util</Filter>

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -146,6 +146,18 @@ FLOOD_OP_RATE_PER_LEDGER = 1.0
 # a per ledger basis
 FLOOD_TX_PERIOD_MS=200
 
+# FLOOD_ARB_BASE_ALLOWANCE (Integer) default 5
+# Number of cyclical path-payments (arbitrage attempts) to flood per
+# asset pair, per flood period, before appplying damping function.
+# Set to -1 to disable traffic damping on arbitrage traffic.
+FLOOD_ARB_TX_BASE_ALLOWANCE = 5
+
+# FLOOD_ARB_TX_DAMPING_FACTOR (floating point) default 0.8
+# Parameter > 0.0 and <= 1.0 that controls intensity of geometric
+# damping of cyclical path-payments (arbitrage attempts). Higher
+# numbers make for more forceful damping.
+FLOOD_ARB_TX_DAMPING_FACTOR = 0.8
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -354,8 +354,10 @@
 #include "main/Config.h"
 #include "util/BitSet.h"
 #include "util/RandomEvictionCache.h"
+#include "util/TarjanSCCCalculator.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-types.h"
+#include <functional>
 
 namespace
 {
@@ -389,27 +391,6 @@ struct QBitSet
     void log(size_t indent = 0) const;
 
     static BitSet getSuccessors(BitSet const& nodes, QGraph const& inner);
-};
-
-// Implementation of Tarjan's algorithm for SCC calculation.
-struct TarjanSCCCalculator
-{
-    struct SCCNode
-    {
-        int mIndex = {-1};
-        int mLowLink = {-1};
-        bool mOnStack = {false};
-    };
-
-    std::vector<SCCNode> mNodes;
-    std::vector<size_t> mStack;
-    int mIndex = {0};
-    std::vector<BitSet> mSCCs;
-    QGraph const& mGraph;
-
-    TarjanSCCCalculator(QGraph const& graph);
-    void calculateSCCs();
-    void scc(size_t i);
 };
 
 // A MinQuorumEnumerator is responsible to scanning the powerset of the SCC

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -6,6 +6,7 @@
 
 #include "crypto/SecretKey.h"
 #include "herder/TxSetFrame.h"
+#include "ledger/LedgerTxn.h"
 #include "transactions/TransactionFrame.h"
 #include "util/HashOfHash.h"
 #include "util/Timer.h"
@@ -121,6 +122,9 @@ class TransactionQueue
                               uint32 banDepth, uint32 poolLedgerMultiplier);
     ~TransactionQueue();
 
+    static std::vector<AssetPair>
+    findAllAssetPairsInvolvedInPaymentLoops(TransactionFrameBasePtr tx);
+
     AddResult tryAdd(TransactionFrameBasePtr tx);
     void removeApplied(Transactions const& txs);
     void ban(Transactions const& txs);
@@ -179,6 +183,8 @@ class TransactionQueue
     // counters
     std::vector<medida::Counter*> mSizeByAge;
     medida::Counter& mBannedTransactionsCounter;
+    medida::Counter& mArbTxSeenCounter;
+    medida::Counter& mArbTxDroppedCounter;
     medida::Timer& mTransactionsDelay;
 
     UnorderedSet<OperationType> mFilteredTypes;
@@ -210,6 +216,7 @@ class TransactionQueue
     bool isFiltered(TransactionFrameBasePtr tx) const;
 
     std::unique_ptr<TxQueueLimiter> mTxQueueLimiter;
+    UnorderedMap<AssetPair, uint32_t, AssetPairHash> mArbitrageFloodDamping;
 
     size_t mBroadcastSeed;
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <numeric>
 #include <sstream>
+#include <stdexcept>
 #include <type_traits>
 #include <unordered_set>
 
@@ -185,6 +186,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     FLOOD_OP_RATE_PER_LEDGER = 1.0;
     FLOOD_TX_PERIOD_MS = 200;
+    FLOOD_ARB_TX_BASE_ALLOWANCE = 5;
+    FLOOD_ARB_TX_DAMPING_FACTOR = 0.8;
 
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
@@ -1093,6 +1096,20 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "FLOOD_TX_PERIOD_MS")
             {
                 FLOOD_TX_PERIOD_MS = readInt<int>(item, 1);
+            }
+            else if (item.first == "FLOOD_ARB_TX_BASE_ALLOWANCE")
+            {
+                FLOOD_ARB_TX_BASE_ALLOWANCE = readInt<int32_t>(item, 0);
+            }
+            else if (item.first == "FLOOD_ARB_TX_DAMPING_FACTOR")
+            {
+                FLOOD_ARB_TX_DAMPING_FACTOR = readDouble(item);
+                if (FLOOD_ARB_TX_DAMPING_FACTOR <= 0.0 ||
+                    FLOOD_ARB_TX_DAMPING_FACTOR > 1.0)
+                {
+                    throw std::invalid_argument(
+                        "bad value for FLOOD_ARB_TX_DAMPING_FACTOR");
+                }
             }
             else if (item.first == "PREFERRED_PEERS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -356,6 +356,8 @@ class Config : public std::enable_shared_from_this<Config>
     int MAX_BATCH_WRITE_BYTES;
     double FLOOD_OP_RATE_PER_LEDGER;
     int FLOOD_TX_PERIOD_MS;
+    int32_t FLOOD_ARB_TX_BASE_ALLOWANCE;
+    double FLOOD_ARB_TX_DAMPING_FACTOR;
     static constexpr size_t const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr size_t const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -320,6 +320,12 @@ FeeBumpTransactionFrame::getNumOperations() const
     return mInnerTx->getNumOperations() + 1;
 }
 
+std::vector<Operation> const&
+FeeBumpTransactionFrame::getRawOperations() const
+{
+    return mInnerTx->getRawOperations();
+}
+
 TransactionResult&
 FeeBumpTransactionFrame::getResult()
 {

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -75,6 +75,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     Hash const& getInnerFullHash() const;
 
     uint32_t getNumOperations() const override;
+    std::vector<Operation> const& getRawOperations() const override;
 
     TransactionResult& getResult() override;
     TransactionResultCode getResultCode() const override;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -144,6 +144,14 @@ TransactionFrame::getNumOperations() const
                : static_cast<uint32_t>(mEnvelope.v1().tx.operations.size());
 }
 
+std::vector<Operation> const&
+TransactionFrame::getRawOperations() const
+{
+    return mEnvelope.type() == ENVELOPE_TYPE_TX_V0
+               ? mEnvelope.v0().tx.operations
+               : mEnvelope.v1().tx.operations;
+}
+
 int64_t
 TransactionFrame::getFeeBid() const
 {

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -158,6 +158,7 @@ class TransactionFrame : public TransactionFrameBase
     AccountID getSourceID() const override;
 
     uint32_t getNumOperations() const override;
+    std::vector<Operation> const& getRawOperations() const override;
 
     int64_t getFeeBid() const override;
 

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -43,6 +43,7 @@ class TransactionFrameBase
     virtual Hash const& getFullHash() const = 0;
 
     virtual uint32_t getNumOperations() const = 0;
+    virtual std::vector<Operation> const& getRawOperations() const = 0;
 
     virtual TransactionResult& getResult() = 0;
     virtual TransactionResultCode getResultCode() const = 0;

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -269,5 +269,4 @@ ChangeTrustAsset assetToChangeTrustAsset(Asset const& asset);
 
 int64_t getPoolWithdrawalAmount(int64_t amountPoolShares,
                                 int64_t totalPoolShares, int64_t reserve);
-
 }

--- a/src/util/BitSet.h
+++ b/src/util/BitSet.h
@@ -167,7 +167,7 @@ class BitSet
     void
     set(size_t i)
     {
-        ensureCapacity(i);
+        ensureCapacity(i + 1);
         bitset_set(mPtr, i);
         mCountDirty = true;
     }

--- a/src/util/TarjanSCCCalculator.cpp
+++ b/src/util/TarjanSCCCalculator.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/TarjanSCCCalculator.h"
+#include "util/Logging.h"
+
+// This is a completely stock implementation of Tarjan's algorithm for
+// calculating strongly connected components. Like "read off of wikipedia"
+// stock. Go have a look!
+//
+// https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+
+TarjanSCCCalculator::TarjanSCCCalculator()
+{
+}
+
+void
+TarjanSCCCalculator::calculateSCCs(
+    size_t graphSize,
+    std::function<BitSet const&(size_t)> const& getNodeSuccessors)
+{
+    mNodes.clear();
+    mStack.clear();
+    mIndex = 0;
+    mSCCs.clear();
+    for (size_t i = 0; i < graphSize; ++i)
+    {
+        mNodes.emplace_back(SCCNode{});
+    }
+    for (size_t i = 0; i < graphSize; ++i)
+    {
+        if (mNodes.at(i).mIndex == -1)
+        {
+            scc(i, getNodeSuccessors);
+        }
+    }
+}
+
+void
+TarjanSCCCalculator::scc(
+    size_t i, std::function<BitSet const&(size_t)> const& getNodeSuccessors)
+{
+    auto& v = mNodes.at(i);
+    v.mIndex = mIndex;
+    v.mLowLink = mIndex;
+    mIndex++;
+    mStack.push_back(i);
+    v.mOnStack = true;
+
+    BitSet const& succ = getNodeSuccessors(i);
+    for (size_t j = 0; succ.nextSet(j); ++j)
+    {
+        LOG_TRACE(DEFAULT_LOG, "TarjanSCC edge: {} -> {}", i, j);
+        SCCNode& w = mNodes.at(j);
+        if (w.mIndex == -1)
+        {
+            scc(j, getNodeSuccessors);
+            v.mLowLink = std::min(v.mLowLink, w.mLowLink);
+        }
+        else if (w.mOnStack)
+        {
+            v.mLowLink = std::min(v.mLowLink, w.mIndex);
+        }
+    }
+
+    if (v.mLowLink == v.mIndex)
+    {
+        BitSet newScc;
+        newScc.set(i);
+        size_t j = 0;
+        do
+        {
+            j = mStack.back();
+            newScc.set(j);
+            mStack.pop_back();
+            mNodes.at(j).mOnStack = false;
+        } while (j != i);
+        LOG_TRACE(DEFAULT_LOG, "TarjanSCC SCC: {}", newScc);
+        mSCCs.push_back(newScc);
+    }
+}

--- a/src/util/TarjanSCCCalculator.h
+++ b/src/util/TarjanSCCCalculator.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Copyright 2021 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "util/BitSet.h"
+
+// Implementation of Tarjan's algorithm for SCC calculation.
+struct TarjanSCCCalculator
+{
+    struct SCCNode
+    {
+        int mIndex = {-1};
+        int mLowLink = {-1};
+        bool mOnStack = {false};
+    };
+
+    std::vector<SCCNode> mNodes;
+    std::vector<size_t> mStack;
+    int mIndex = {0};
+    std::vector<BitSet> mSCCs;
+
+    TarjanSCCCalculator();
+    void calculateSCCs(
+        size_t graphSize,
+        std::function<BitSet const&(size_t)> const& getNodeSuccessors);
+    void scc(size_t i,
+             std::function<BitSet const&(size_t)> const& getNodeSuccessors);
+};

--- a/src/util/test/BitSetTests.cpp
+++ b/src/util/test/BitSetTests.cpp
@@ -193,3 +193,13 @@ TEST_CASE("BitSet symmetric difference", "[bitset]")
         REQUIRE(bs_c.count() == ref.size());
     }
 }
+
+TEST_CASE("BitSet large bitsets", "[bitset]")
+{
+    BitSet bs;
+    for (size_t i = 0; i < 10000; ++i)
+    {
+        bs.set(i);
+    }
+    REQUIRE(bs.count() == 10000);
+}


### PR DESCRIPTION
This adds a new statistical damping pass to the herder's transaction queueing/flooding machinery, to try to traffic-shape the flow of cyclical (arbitrage-attempt) path payments on a per-asset-pair basis. The network has been experiencing very high volumes of these txs (almost all of which fail); this gives validators a new tool for managing that volume. It has a controllable threshold and intensity (managed by a pair of config variables) and is set to a reasonable damping factor by default.