### PR TITLE
Captive core buffers ledgers on startup

### DIFF
--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -306,8 +306,9 @@ ApplyBucketsWork::isLevelComplete()
 std::string
 ApplyBucketsWork::getStatus() const
 {
+    auto size = mTotalSize == 0 ? 0 : (100 * mAppliedSize / mTotalSize);
     return fmt::format(
-        FMT_STRING("Applying buckets {:d}%. Currently on level {:d}"),
-        (100 * mAppliedSize / mTotalSize), mLevel);
+        FMT_STRING("Applying buckets {:d}%. Currently on level {:d}"), size,
+        mLevel);
 }
 }

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -10,9 +10,9 @@
 #include "catchup/CatchupManager.h"
 #include "crypto/Hex.h"
 #include "crypto/SecretKey.h"
-#include "history/HistoryArchive.h"
 #include "historywork/Progress.h"
 #include "invariant/InvariantManager.h"
+#include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
@@ -153,6 +153,7 @@ ApplyBucketsWork::onReset()
 
     mLevel = BucketList::kNumLevels - 1;
     mApplying = false;
+    mDelayChecked = false;
 
     mSnapBucket.reset();
     mCurrBucket.reset();
@@ -197,6 +198,20 @@ BasicWork::State
 ApplyBucketsWork::onRun()
 {
     ZoneScoped;
+
+    if (mApp.getLedgerManager().rebuildingInMemoryState() && !mDelayChecked)
+    {
+        mDelayChecked = true;
+        auto delay =
+            mApp.getConfig().ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING;
+        if (delay != std::chrono::seconds::zero())
+        {
+            CLOG_INFO(History, "Delay bucket application by {} seconds",
+                      delay.count());
+            setupWaitingCallback(delay);
+            return State::WORK_WAITING;
+        }
+    }
 
     // Check if we're at the beginning of the new level
     if (isLevelComplete())

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -45,6 +45,8 @@ class ApplyBucketsWork : public BasicWork
     void startLevel();
     bool isLevelComplete();
 
+    bool mDelayChecked{false};
+
   public:
     ApplyBucketsWork(
         Application& app,

--- a/src/catchup/CatchupConfiguration.cpp
+++ b/src/catchup/CatchupConfiguration.cpp
@@ -10,27 +10,58 @@
 namespace stellar
 {
 
+void
+CatchupConfiguration::checkInvariants() const
+{
+    if (mMode == CatchupConfiguration::Mode::LOCAL_BUCKETS_ONLY)
+    {
+        releaseAssert(mHAS && mHistoryEntry);
+        releaseAssert(toLedger() != CatchupConfiguration::CURRENT);
+        releaseAssert(count() == 0);
+    }
+    else
+    {
+        releaseAssert(!mHAS && !mHistoryEntry);
+    }
+}
+
 CatchupConfiguration::CatchupConfiguration(LedgerNumHashPair ledgerHashPair,
                                            uint32_t count, Mode mode)
     : mCount{count}, mLedgerHashPair{ledgerHashPair}, mMode{mode}
 {
+    checkInvariants();
+}
+
+CatchupConfiguration::CatchupConfiguration(HistoryArchiveState has,
+                                           LedgerHeaderHistoryEntry lhhe)
+    : mCount(0)
+    , mLedgerHashPair(LedgerNumHashPair(lhhe.header.ledgerSeq,
+                                        std::make_optional(lhhe.hash)))
+    , mMode(CatchupConfiguration::Mode::LOCAL_BUCKETS_ONLY)
+    , mHAS(std::make_optional(has))
+    , mHistoryEntry(std::make_optional(lhhe))
+{
+    checkInvariants();
 }
 
 CatchupConfiguration::CatchupConfiguration(uint32_t toLedger, uint32_t count,
                                            Mode mode)
     : mCount{count}, mLedgerHashPair{toLedger, std::nullopt}, mMode{mode}
 {
+    checkInvariants();
 }
 
 CatchupConfiguration
 CatchupConfiguration::resolve(uint32_t remoteCheckpoint) const
 {
+    checkInvariants();
+    auto cfg = *this;
     if (toLedger() == CatchupConfiguration::CURRENT)
     {
-        return CatchupConfiguration{remoteCheckpoint, count(), mMode};
+        cfg.mLedgerHashPair.first = remoteCheckpoint;
+        return cfg;
     }
-    return CatchupConfiguration{LedgerNumHashPair(toLedger(), hash()), count(),
-                                mode()};
+    return cfg;
 }
 
 uint32_t

--- a/src/catchup/CatchupConfiguration.h
+++ b/src/catchup/CatchupConfiguration.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "history/HistoryArchive.h"
 #include "ledger/LedgerRange.h"
 #include <cstdint>
 #include <optional>
@@ -46,13 +47,19 @@ class CatchupConfiguration
         // Do validity checks on all history archive file types for a given
         // range, regardless of whether files are used or not
         OFFLINE_COMPLETE,
-        ONLINE
+        ONLINE,
+        // Similar to online catchup, except in this mode there is no archive
+        // lookup and validation, rebuild local state present on disk, while
+        // buffering ledgers
+        LOCAL_BUCKETS_ONLY
     };
     static const uint32_t CURRENT = 0;
 
     CatchupConfiguration(uint32_t toLedger, uint32_t count, Mode mode);
     CatchupConfiguration(LedgerNumHashPair ledgerHashPair, uint32_t count,
                          Mode mode);
+    CatchupConfiguration(HistoryArchiveState has,
+                         LedgerHeaderHistoryEntry lhhe);
 
     /**
      * If toLedger() == CatchupConfiguration::CURRENT it replaces it with
@@ -96,10 +103,31 @@ class CatchupConfiguration
         return mMode == Mode::ONLINE;
     }
 
+    bool
+    localBucketsOnly() const
+    {
+        return mMode == Mode::LOCAL_BUCKETS_ONLY;
+    }
+
+    std::optional<HistoryArchiveState>
+    getHAS() const
+    {
+        return mHAS;
+    }
+
+    std::optional<LedgerHeaderHistoryEntry>
+    getHistoryEntry() const
+    {
+        return mHistoryEntry;
+    }
+
   private:
     uint32_t mCount;
     LedgerNumHashPair mLedgerHashPair;
     Mode mMode;
+    std::optional<HistoryArchiveState> mHAS;
+    std::optional<LedgerHeaderHistoryEntry> mHistoryEntry;
+    void checkInvariants() const;
 };
 
 uint32_t parseLedger(std::string const& str);

--- a/src/catchup/CatchupManager.h
+++ b/src/catchup/CatchupManager.h
@@ -60,8 +60,10 @@ class CatchupManager
     // LedgerManager detects it is desynchronized from SCP's consensus ledger.
     // This method is present in the public interface to permit testing and
     // offline catchups.
-    virtual void startCatchup(CatchupConfiguration configuration,
-                              std::shared_ptr<HistoryArchive> archive) = 0;
+    virtual void
+    startCatchup(CatchupConfiguration configuration,
+                 std::shared_ptr<HistoryArchive> archive,
+                 std::set<std::shared_ptr<Bucket>> bucketsToRetain) = 0;
 
     // Return status of catchup for or empty string, if no catchup in progress
     virtual std::string getStatus() const = 0;

--- a/src/catchup/CatchupManagerImpl.h
+++ b/src/catchup/CatchupManagerImpl.h
@@ -57,8 +57,10 @@ class CatchupManagerImpl : public CatchupManager
     ~CatchupManagerImpl() override;
 
     void processLedger(LedgerCloseData const& ledgerData) override;
-    void startCatchup(CatchupConfiguration configuration,
-                      std::shared_ptr<HistoryArchive> archive) override;
+    void
+    startCatchup(CatchupConfiguration configuration,
+                 std::shared_ptr<HistoryArchive> archive,
+                 std::set<std::shared_ptr<Bucket>> bucketsToRetain) override;
 
     std::string getStatus() const override;
 

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -75,6 +75,7 @@ setHerderStateTo(FileTransferInfo const& ft, uint32_t ledger, Application& app)
 
 CatchupWork::CatchupWork(Application& app,
                          CatchupConfiguration catchupConfiguration,
+                         std::set<std::shared_ptr<Bucket>> bucketsToRetain,
                          std::shared_ptr<HistoryArchive> archive)
     : Work(app, "catchup", BasicWork::RETRY_NEVER)
     , mLocalState{app.getLedgerManager().getLastClosedLedgerHAS()}
@@ -82,12 +83,17 @@ CatchupWork::CatchupWork(Application& app,
           mApp.getTmpDirManager().tmpDir(getName()))}
     , mCatchupConfiguration{catchupConfiguration}
     , mArchive{archive}
+    , mRetainedBuckets{bucketsToRetain}
 {
     if (mArchive)
     {
         CLOG_INFO(History, "CatchupWork: selected archive {}",
                   mArchive->getName());
     }
+
+    // Local catchup is only valid if core is rebuilding state
+    releaseAssert(mCatchupConfiguration.localBucketsOnly() ==
+                  mApp.getLedgerManager().rebuildingInMemoryState());
 }
 
 CatchupWork::~CatchupWork()
@@ -139,23 +145,17 @@ CatchupWork::doReset()
     mVerifyLedgers.reset();
     mLastApplied = mApp.getLedgerManager().getLastClosedLedgerHeader();
     mCurrentWork.reset();
-}
-
-bool
-CatchupWork::hasAnyLedgersToCatchupTo() const
-{
-    releaseAssert(mGetHistoryArchiveStateWork);
-    releaseAssert(mGetHistoryArchiveStateWork->getState() ==
-                  State::WORK_SUCCESS);
-
-    return mLastClosedLedgerHashPair.first <=
-           mGetHistoryArchiveStateWork->getHistoryArchiveState().currentLedger;
+    mHAS.reset();
+    mBucketHAS.reset();
+    mRetainedBuckets.clear();
 }
 
 void
 CatchupWork::downloadVerifyLedgerChain(CatchupRange const& catchupRange,
                                        LedgerNumHashPair rangeEnd)
 {
+    releaseAssert(!mCatchupConfiguration.localBucketsOnly());
+
     ZoneScoped;
     auto verifyRange = catchupRange.getFullRangeIncludingBucketApply();
     releaseAssert(verifyRange.mCount != 0);
@@ -190,35 +190,46 @@ CatchupWork::downloadVerifyTxResults(CatchupRange const& catchupRange)
 bool
 CatchupWork::alreadyHaveBucketsHistoryArchiveState(uint32_t atCheckpoint) const
 {
-    return atCheckpoint ==
-           mGetHistoryArchiveStateWork->getHistoryArchiveState().currentLedger;
+    return mCatchupConfiguration.localBucketsOnly() ||
+           atCheckpoint == mGetHistoryArchiveStateWork->getHistoryArchiveState()
+                               .currentLedger;
 }
 
 WorkSeqPtr
 CatchupWork::downloadApplyBuckets()
 {
     ZoneScoped;
-    auto const& has = mGetBucketStateWork->getHistoryArchiveState();
-    std::vector<std::string> hashes = has.differingBuckets(mLocalState);
 
-    auto getBuckets = std::make_shared<DownloadBucketsWork>(
-        mApp, mBuckets, hashes, *mDownloadDir, mArchive);
+    std::vector<std::shared_ptr<BasicWork>> seq;
+    auto version = Config::CURRENT_LEDGER_PROTOCOL_VERSION;
 
-    auto verifyHASCallback = [has](Application& app) {
-        if (!has.containsValidBuckets(app))
-        {
-            CLOG_ERROR(History, "Malformed HAS: invalid buckets");
-            return false;
-        }
-        return true;
-    };
-    auto verifyHAS = std::make_shared<WorkWithCallback>(mApp, "verify-has",
-                                                        verifyHASCallback);
+    // Download buckets, or skip if catchup is local
+    if (!mCatchupConfiguration.localBucketsOnly())
+    {
+        std::vector<std::string> hashes =
+            mBucketHAS->differingBuckets(mLocalState);
+        auto getBuckets = std::make_shared<DownloadBucketsWork>(
+            mApp, mBuckets, hashes, *mDownloadDir, mArchive);
+        seq.push_back(getBuckets);
+
+        auto verifyHASCallback = [has = *mBucketHAS](Application& app) {
+            if (!has.containsValidBuckets(app))
+            {
+                CLOG_ERROR(History, "Malformed HAS: invalid buckets");
+                return false;
+            }
+            return true;
+        };
+        auto verifyHAS = std::make_shared<WorkWithCallback>(mApp, "verify-has",
+                                                            verifyHASCallback);
+        seq.push_back(verifyHAS);
+        version = mVerifiedLedgerRangeStart.header.ledgerVersion;
+    }
+
     auto applyBuckets = std::make_shared<ApplyBucketsWork>(
-        mApp, mBuckets, has, mVerifiedLedgerRangeStart.header.ledgerVersion);
+        mApp, mBuckets, *mBucketHAS, version);
 
-    std::vector<std::shared_ptr<BasicWork>> seq{getBuckets, verifyHAS,
-                                                applyBuckets};
+    seq.push_back(applyBuckets);
     return std::make_shared<WorkSequence>(mApp, "download-verify-apply-buckets",
                                           seq, RETRY_NEVER);
 }
@@ -226,19 +237,21 @@ CatchupWork::downloadApplyBuckets()
 void
 CatchupWork::assertBucketState()
 {
-    auto const& has = mGetBucketStateWork->getHistoryArchiveState();
+    releaseAssert(mBucketHAS);
+    releaseAssert(mBucketHAS->currentLedger >
+                  LedgerManager::GENESIS_LEDGER_SEQ);
 
     // Consistency check: remote state and mVerifiedLedgerRangeStart should
     // point to the same ledger and the same BucketList.
-    if (has.currentLedger != mVerifiedLedgerRangeStart.header.ledgerSeq)
+    if (mBucketHAS->currentLedger != mVerifiedLedgerRangeStart.header.ledgerSeq)
     {
         CLOG_ERROR(History, "Caught up to wrong ledger: wanted {}, got {}",
-                   has.currentLedger,
+                   mBucketHAS->currentLedger,
                    mVerifiedLedgerRangeStart.header.ledgerSeq);
     }
-    releaseAssert(has.currentLedger ==
+    releaseAssert(mBucketHAS->currentLedger ==
                   mVerifiedLedgerRangeStart.header.ledgerSeq);
-    releaseAssert(has.getBucketListHash() ==
+    releaseAssert(mBucketHAS->getBucketListHash() ==
                   mVerifiedLedgerRangeStart.header.bucketListHash);
 
     // Consistency check: LCL should be in the _past_ from
@@ -266,41 +279,61 @@ CatchupWork::downloadApplyTransactions(CatchupRange const& catchupRange)
 }
 
 BasicWork::State
-CatchupWork::runCatchupStep()
+CatchupWork::getAndMaybeSetHistoryArchiveState()
 {
-    ZoneScoped;
-    // Step 1: Get history archive state
-    if (!mGetHistoryArchiveStateWork)
-    {
-        auto toLedger = mCatchupConfiguration.toLedger() == 0
-                            ? "CURRENT"
-                            : std::to_string(mCatchupConfiguration.toLedger());
-        CLOG_INFO(History,
-                  "Starting catchup with configuration:\n  lastClosedLedger: "
-                  "{}\n  toLedger: {}\n  count: {}",
-                  mApp.getLedgerManager().getLastClosedLedgerNum(), toLedger,
-                  mCatchupConfiguration.count());
+    // First, retrieve the HAS
 
-        auto toCheckpoint =
-            mCatchupConfiguration.toLedger() == CatchupConfiguration::CURRENT
-                ? CatchupConfiguration::CURRENT
-                : mApp.getHistoryManager().checkpointContainingLedger(
-                      mCatchupConfiguration.toLedger());
-        mGetHistoryArchiveStateWork =
-            addWork<GetHistoryArchiveStateWork>(toCheckpoint, mArchive, true);
-        mCurrentWork = mGetHistoryArchiveStateWork;
-        return State::WORK_RUNNING;
-    }
-    else if (mGetHistoryArchiveStateWork->getState() != State::WORK_SUCCESS)
+    // If we're just doing local catchup, set HAS right away
+    if (mCatchupConfiguration.localBucketsOnly())
     {
-        return mGetHistoryArchiveStateWork->getState();
+        mHAS = getCatchupConfiguration().getHAS();
+        releaseAssert(mHAS.has_value());
+    }
+    else
+    {
+        // Otherwise, continue with the normal catchup flow: download and verify
+        // HAS from history archive
+        if (!mGetHistoryArchiveStateWork)
+        {
+            auto toLedger =
+                mCatchupConfiguration.toLedger() == 0
+                    ? "CURRENT"
+                    : std::to_string(mCatchupConfiguration.toLedger());
+            CLOG_INFO(
+                History,
+                "Starting catchup with configuration:\n  lastClosedLedger: "
+                "{}\n  toLedger: {}\n  count: {}",
+                mApp.getLedgerManager().getLastClosedLedgerNum(), toLedger,
+                mCatchupConfiguration.count());
+
+            auto toCheckpoint =
+                mCatchupConfiguration.toLedger() ==
+                        CatchupConfiguration::CURRENT
+                    ? CatchupConfiguration::CURRENT
+                    : mApp.getHistoryManager().checkpointContainingLedger(
+                          mCatchupConfiguration.toLedger());
+            mGetHistoryArchiveStateWork = addWork<GetHistoryArchiveStateWork>(
+                toCheckpoint, mArchive, true);
+            mCurrentWork = mGetHistoryArchiveStateWork;
+            return State::WORK_RUNNING;
+        }
+        else if (mGetHistoryArchiveStateWork->getState() != State::WORK_SUCCESS)
+        {
+            return mGetHistoryArchiveStateWork->getState();
+        }
+        else
+        {
+            mHAS = std::make_optional<HistoryArchiveState>(
+                mGetHistoryArchiveStateWork->getHistoryArchiveState());
+        }
     }
 
-    auto const& has = mGetHistoryArchiveStateWork->getHistoryArchiveState();
+    // Second, perform some validation
+
     // If the HAS is a newer version and contains networkPassphrase,
     // we should make sure that it matches the config's networkPassphrase.
-    if (!has.networkPassphrase.empty() &&
-        has.networkPassphrase != mApp.getConfig().NETWORK_PASSPHRASE)
+    if (!mHAS->networkPassphrase.empty() &&
+        mHAS->networkPassphrase != mApp.getConfig().NETWORK_PASSPHRASE)
     {
         CLOG_ERROR(History, "The network passphrase of the "
                             "application does not match that of the "
@@ -308,15 +341,14 @@ CatchupWork::runCatchupStep()
         return State::WORK_FAILURE;
     }
 
-    // Step 2: Compare local and remote states
-    if (!hasAnyLedgersToCatchupTo())
+    if (mLastClosedLedgerHashPair.first >= mHAS->currentLedger)
     {
         CLOG_INFO(History, "*");
         CLOG_INFO(
             History,
             "* Target ledger {} is not newer than last closed ledger {} - "
             "nothing to do",
-            has.currentLedger, mLastClosedLedgerHashPair.first);
+            mHAS->currentLedger, mLastClosedLedgerHashPair.first);
 
         if (mCatchupConfiguration.toLedger() == CatchupConfiguration::CURRENT)
         {
@@ -337,8 +369,54 @@ CatchupWork::runCatchupStep()
         return State::WORK_FAILURE;
     }
 
+    return State::WORK_SUCCESS;
+}
+
+BasicWork::State
+CatchupWork::getAndMaybeSetBucketHistoryArchiveState(uint32_t applyBucketsAt)
+{
+    if (!alreadyHaveBucketsHistoryArchiveState(applyBucketsAt))
+    {
+        if (!mGetBucketStateWork)
+        {
+            mGetBucketStateWork = addWork<GetHistoryArchiveStateWork>(
+                applyBucketsAt, mArchive, true);
+            mCurrentWork = mGetBucketStateWork;
+        }
+        if (mGetBucketStateWork->getState() != State::WORK_SUCCESS)
+        {
+            return mGetBucketStateWork->getState();
+        }
+        else
+        {
+            mBucketHAS = mGetBucketStateWork->getHistoryArchiveState();
+        }
+    }
+    else
+    {
+        mBucketHAS = mHAS;
+    }
+
+    return State::WORK_SUCCESS;
+}
+
+BasicWork::State
+CatchupWork::runCatchupStep()
+{
+    ZoneScoped;
+
+    // Step 1: Get and validate history archive state
+    auto res = getAndMaybeSetHistoryArchiveState();
+    if (res != State::WORK_SUCCESS)
+    {
+        return res;
+    }
+
+    // HAS is fetched and validated at this point
+    releaseAssert(mHAS->currentLedger > LedgerManager::GENESIS_LEDGER_SEQ);
+
     auto resolvedConfiguration =
-        mCatchupConfiguration.resolve(has.currentLedger);
+        mCatchupConfiguration.resolve(mHAS->currentLedger);
     auto catchupRange =
         CatchupRange{mLastClosedLedgerHashPair.first, resolvedConfiguration,
                      mApp.getHistoryManager()};
@@ -346,23 +424,11 @@ CatchupWork::runCatchupStep()
     // Step 3: If needed, download archive state for buckets
     if (catchupRange.applyBuckets())
     {
-        auto applyBucketsAt = catchupRange.getBucketApplyLedger();
-        if (!alreadyHaveBucketsHistoryArchiveState(applyBucketsAt))
+        res = getAndMaybeSetBucketHistoryArchiveState(
+            catchupRange.getBucketApplyLedger());
+        if (res != State::WORK_SUCCESS)
         {
-            if (!mGetBucketStateWork)
-            {
-                mGetBucketStateWork = addWork<GetHistoryArchiveStateWork>(
-                    applyBucketsAt, mArchive, true);
-                mCurrentWork = mGetBucketStateWork;
-            }
-            if (mGetBucketStateWork->getState() != State::WORK_SUCCESS)
-            {
-                return mGetBucketStateWork->getState();
-            }
-        }
-        else
-        {
-            mGetBucketStateWork = mGetHistoryArchiveStateWork;
+            return res;
         }
     }
 
@@ -371,7 +437,8 @@ CatchupWork::runCatchupStep()
     // Bucket and transaction processing has started
     if (mCatchupSeq)
     {
-        releaseAssert(mDownloadVerifyLedgersSeq);
+        releaseAssert(mDownloadVerifyLedgersSeq ||
+                      mCatchupConfiguration.localBucketsOnly());
         releaseAssert(mTransactionsVerifyApplySeq ||
                       !catchupRange.replayLedgers());
 
@@ -412,7 +479,8 @@ CatchupWork::runCatchupStep()
                 !mBucketsAppliedEmitted)
             {
                 mApp.getLedgerManager().setLastClosedLedger(
-                    mVerifiedLedgerRangeStart);
+                    mVerifiedLedgerRangeStart,
+                    !mCatchupConfiguration.localBucketsOnly());
                 mBucketsAppliedEmitted = true;
                 mBuckets.clear();
                 mLastApplied =
@@ -438,8 +506,25 @@ CatchupWork::runCatchupStep()
         }
         return mCatchupSeq->getState();
     }
-    // Still waiting for ledger headers
-    else if (mDownloadVerifyLedgersSeq)
+
+    // If we're just doing local catchup, setup bucket application and exit
+    if (mCatchupConfiguration.localBucketsOnly())
+    {
+        releaseAssert(catchupRange.applyBuckets());
+        auto lhhe = mCatchupConfiguration.getHistoryEntry();
+        releaseAssert(lhhe);
+        mVerifiedLedgerRangeStart = *lhhe;
+
+        mBucketVerifyApplySeq = downloadApplyBuckets();
+        std::vector<std::shared_ptr<BasicWork>> seq{mBucketVerifyApplySeq};
+
+        mCatchupSeq = addWork<WorkSequence>("catchup-seq", seq, RETRY_NEVER);
+        mCurrentWork = mCatchupSeq;
+        return State::WORK_RUNNING;
+    }
+
+    // Otherwise, proceed with normal flow. Still waiting for ledger headers
+    if (mDownloadVerifyLedgersSeq)
     {
         if (mDownloadVerifyLedgersSeq->getState() == State::WORK_SUCCESS)
         {
@@ -531,6 +616,10 @@ CatchupWork::onFailureRaise()
 {
     CLOG_WARNING(History, "Catchup failed");
     Work::onFailureRaise();
+    if (mCatchupConfiguration.localBucketsOnly())
+    {
+        throw std::runtime_error("Unable to rebuild local state");
+    }
 }
 
 void

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -312,8 +312,10 @@ CatchupWork::getAndMaybeSetHistoryArchiveState()
                     ? CatchupConfiguration::CURRENT
                     : mApp.getHistoryManager().checkpointContainingLedger(
                           mCatchupConfiguration.toLedger());
+            // Set retries to 10 to ensure we retry enough in case current
+            // checkpoint isn't published yet
             mGetHistoryArchiveStateWork = addWork<GetHistoryArchiveStateWork>(
-                toCheckpoint, mArchive, true);
+                toCheckpoint, mArchive, true, 10);
             mCurrentWork = mGetHistoryArchiveStateWork;
             return State::WORK_RUNNING;
         }

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -64,6 +64,7 @@ class CatchupWork : public Work
     static uint32_t const PUBLISH_QUEUE_MAX_SIZE;
 
     CatchupWork(Application& app, CatchupConfiguration catchupConfiguration,
+                std::set<std::shared_ptr<Bucket>> bucketsToRetain,
                 std::shared_ptr<HistoryArchive> archive = nullptr);
     virtual ~CatchupWork();
     std::string getStatus() const override;
@@ -98,7 +99,6 @@ class CatchupWork : public Work
 
     std::shared_ptr<BasicWork> mCurrentWork;
 
-    bool hasAnyLedgersToCatchupTo() const;
     bool alreadyHaveBucketsHistoryArchiveState(uint32_t atCheckpoint) const;
     void assertBucketState();
 
@@ -108,5 +108,13 @@ class CatchupWork : public Work
     void downloadApplyTransactions(CatchupRange const& catchupRange);
     void downloadVerifyTxResults(CatchupRange const& catchupRange);
     BasicWork::State runCatchupStep();
+
+    BasicWork::State getAndMaybeSetHistoryArchiveState();
+    BasicWork::State
+    getAndMaybeSetBucketHistoryArchiveState(uint32_t applyBucketsAt);
+
+    std::optional<HistoryArchiveState> mHAS;
+    std::optional<HistoryArchiveState> mBucketHAS;
+    std::set<std::shared_ptr<Bucket>> mRetainedBuckets;
 };
 }

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -674,7 +674,7 @@ CatchupSimulation::catchupOffline(Application::pointer app, uint32_t toLedger,
                                 : CatchupConfiguration::Mode::OFFLINE_BASIC;
     auto catchupConfiguration =
         CatchupConfiguration{toLedger, app->getConfig().CATCHUP_RECENT, mode};
-    lm.startCatchup(catchupConfiguration, nullptr);
+    lm.startCatchup(catchupConfiguration, nullptr, {});
     REQUIRE(!app->getClock().getIOContext().stopped());
 
     auto& cm = app->getCatchupManager();

--- a/src/historywork/CheckSingleLedgerHeaderWork.cpp
+++ b/src/historywork/CheckSingleLedgerHeaderWork.cpp
@@ -29,8 +29,6 @@ CheckSingleLedgerHeaderWork::CheckSingleLedgerHeaderWork(
     , mCheckFailed(
           app.getMetrics().NewMeter({"history", "check", "failure"}, "event"))
 {
-    // LedgerSeq 0 is never valid.
-    releaseAssertOrThrow(expected.header.ledgerSeq != 0);
 }
 
 CheckSingleLedgerHeaderWork::~CheckSingleLedgerHeaderWork()
@@ -66,6 +64,11 @@ CheckSingleLedgerHeaderWork::doReset()
 BasicWork::State
 CheckSingleLedgerHeaderWork::doWork()
 {
+    if (mExpected.header.ledgerSeq == 0)
+    {
+        return State::WORK_SUCCESS;
+    }
+
     if (!mGetLedgerFileWork)
     {
         CLOG_INFO(History, "Downloading ledger checkpoint {} from archive {}",

--- a/src/historywork/GetHistoryArchiveStateWork.cpp
+++ b/src/historywork/GetHistoryArchiveStateWork.cpp
@@ -85,8 +85,8 @@ GetHistoryArchiveStateWork::doWork()
     {
         auto name = getRemoteName();
         CLOG_INFO(History, "Downloading history archive state: {}", name);
-        mGetRemoteFile = addWork<GetRemoteFileWork>(name, mLocalFilename,
-                                                    mArchive, mRetries);
+        mGetRemoteFile = addWork<GetRemoteFileWork>(
+            name, mLocalFilename, mArchive, BasicWork::RETRY_NEVER);
         return State::WORK_RUNNING;
     }
 }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -57,6 +57,7 @@ class LedgerManagerImpl : public LedgerManager
     medida::Counter& mLedgerAge;
     medida::Timer& mMetaStreamWriteTime;
     VirtualClock::time_point mLastClose;
+    bool mRebuildInMemoryState{false};
 
     std::unique_ptr<VirtualClock::time_point> mStartCatchup;
     medida::Timer& mCatchupDuration;
@@ -76,7 +77,7 @@ class LedgerManagerImpl : public LedgerManager
 
     void ledgerClosed(AbstractLedgerTxn& ltx);
 
-    void storeCurrentLedger(LedgerHeader const& header);
+    void storeCurrentLedger(LedgerHeader const& header, bool storeHeader);
     void prefetchTransactionData(std::vector<TransactionFrameBasePtr>& txs);
     void prefetchTxSourceIds(std::vector<TransactionFrameBasePtr>& txs);
     void closeLedgerIf(LedgerCloseData const& ledgerData);
@@ -117,8 +118,9 @@ class LedgerManagerImpl : public LedgerManager
 
     void startNewLedger(LedgerHeader const& genesisLedger);
     void startNewLedger() override;
-    void loadLastKnownLedger(
-        std::function<void(asio::error_code const& ec)> handler) override;
+    void loadLastKnownLedger(std::function<void()> handler) override;
+    virtual bool rebuildingInMemoryState() override;
+    virtual void setupInMemoryStateRebuild() override;
 
     LedgerHeaderHistoryEntry const& getLastClosedLedgerHeader() const override;
 
@@ -126,8 +128,10 @@ class LedgerManagerImpl : public LedgerManager
 
     Database& getDatabase() override;
 
-    void startCatchup(CatchupConfiguration configuration,
-                      std::shared_ptr<HistoryArchive> archive) override;
+    void
+    startCatchup(CatchupConfiguration configuration,
+                 std::shared_ptr<HistoryArchive> archive,
+                 std::set<std::shared_ptr<Bucket>> bucketsToRetain) override;
 
     void closeLedger(LedgerCloseData const& ledgerData) override;
     void deleteOldEntries(Database& db, uint32_t ledgerSeq,
@@ -135,8 +139,8 @@ class LedgerManagerImpl : public LedgerManager
 
     void deleteNewerEntries(Database& db, uint32_t ledgerSeq) override;
 
-    void
-    setLastClosedLedger(LedgerHeaderHistoryEntry const& lastClosed) override;
+    void setLastClosedLedger(LedgerHeaderHistoryEntry const& lastClosed,
+                             bool storeInDB) override;
 
     void manuallyAdvanceLedgerHeader(LedgerHeader const& header) override;
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -681,14 +681,7 @@ ApplicationImpl::start()
     }
 
     bool done = false;
-    mLedgerManager->loadLastKnownLedger([this,
-                                         &done](asio::error_code const& ec) {
-        if (ec)
-        {
-            throw std::runtime_error(
-                "Unable to restore last-known ledger state");
-        }
-
+    mLedgerManager->loadLastKnownLedger([this, &done]() {
         // restores Herder's state before starting overlay
         mHerder->start();
         // set known cursors before starting maintenance job

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -852,7 +852,6 @@ runWriteVerifiedCheckpointHashes(CommandLineArgs const& args)
             app->start();
             auto const& lm = app->getLedgerManager();
             auto const& hm = app->getHistoryManager();
-            auto const& cm = app->getCatchupManager();
             auto& io = clock.getIOContext();
             asio::io_context::work mainWork(io);
             LedgerNumHashPair authPair;
@@ -1531,7 +1530,7 @@ runSimulateBuckets(CommandLineArgs const& args)
 
                 LOG_INFO(DEFAULT_LOG, "Assuming state for ledger {}",
                          curr.header.ledgerSeq);
-                app->getLedgerManager().setLastClosedLedger(curr);
+                app->getLedgerManager().setLastClosedLedger(curr, true);
                 app->getBucketManager().forgetUnreferencedBuckets();
             }
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -51,7 +51,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
     "LOADGEN_OP_COUNT_FOR_TESTING",
     "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING",
-    "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING"};
+    "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING",
+    "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING"};
 
 // Options that should only be used for testing
 static const std::unordered_set<std::string> TESTING_SUGGESTED_OPTIONS = {
@@ -151,6 +152,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = false;
     ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING = false;
     ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING = false;
+    ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING =
+        std::chrono::seconds::zero();
     ALLOW_LOCALHOST_FOR_TESTING = false;
     USE_CONFIG_FOR_GENESIS = false;
     FAILURE_SAFETY = -1;
@@ -984,6 +987,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING =
                     readBool(item);
+            }
+            else if (item.first ==
+                     "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING")
+            {
+                ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING =
+                    std::chrono::seconds(readInt<uint32_t>(item));
             }
             else if (item.first == "ALLOW_LOCALHOST_FOR_TESTING")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -196,6 +196,11 @@ class Config : public std::enable_shared_from_this<Config>
     // system.
     bool ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING;
 
+    // A config parameter that forces a delay in state rebuild via buckets in
+    // captive core. This is useful for testing how stellar-core buffers ledgers
+    // during captive core fast restart.
+    std::chrono::seconds ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING;
+
     // Config parameters that force transaction application during ledger
     // close to sleep for a certain amount of time.
     // The probability that it sleeps for

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -623,6 +623,13 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
         cat = "MISC";
     }
 
+    if (!mApp.getLedgerManager().isSynced() && stellarMsg.type() == TRANSACTION)
+    {
+        // For transactions, exit early during the state rebuild, as we can't
+        // properly verify them
+        return;
+    }
+
     std::weak_ptr<Peer> weak(static_pointer_cast<Peer>(shared_from_this()));
     mApp.postOnMainThread(
         [weak, sm = StellarMessage(stellarMsg), mtype = stellarMsg.type(), cat,

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -19,6 +19,7 @@
 
 #include <fmt/format.h>
 
+#include "main/ApplicationUtils.h"
 #include "medida/medida.h"
 #include "medida/reporting/console_reporter.h"
 
@@ -81,7 +82,8 @@ Simulation::setCurrentVirtualTime(VirtualClock::system_time_point t)
 
 Application::pointer
 Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
-                    bool newDB)
+                    bool newDB, uint32_t startAtLedger,
+                    std::string const& startAtHash)
 {
     auto cfg = cfg2 ? std::make_shared<Config>(*cfg2)
                     : std::make_shared<Config>(newConfig());
@@ -111,7 +113,15 @@ Simulation::addNode(SecretKey nodeKey, SCPQuorumSet qSet, Config const* cfg2,
         clock->setCurrentVirtualTime(mClock.now());
     }
 
-    auto app = Application::create(*clock, *cfg, newDB);
+    Application::pointer app;
+    if (newDB)
+    {
+        app = Application::create(*clock, *cfg, newDB);
+    }
+    else
+    {
+        app = setupApp(*cfg, *clock, startAtLedger, startAtHash);
+    }
     mNodes.emplace(nodeKey.getPublicKey(), Node{clock, app});
 
     return app;

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -46,8 +46,9 @@ class Simulation
     void setCurrentVirtualTime(VirtualClock::system_time_point t);
 
     Application::pointer addNode(SecretKey nodeKey, SCPQuorumSet qSet,
-                                 Config const* cfg = nullptr,
-                                 bool newDB = true);
+                                 Config const* cfg = nullptr, bool newDB = true,
+                                 uint32_t startAtLedger = 0,
+                                 std::string const& startAtHash = "");
     Application::pointer getNode(NodeID nodeID);
     std::vector<Application::pointer> getNodes();
     std::vector<NodeID> getNodeIDs();

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -393,8 +393,9 @@ VirtualClock::duration
 BasicWork::getRetryDelay() const
 {
     // Cap to 512 sec or ~8 minutes
-    uint64_t m = 2ULL << std::min(uint64_t(8), uint64_t(mRetries));
-    return std::chrono::seconds(rand_uniform<uint64_t>(1ULL, m));
+    uint64_t upperBound = 1ULL << std::min(uint64_t(9), uint64_t(mRetries));
+    uint64_t lowerBound = upperBound < 2 ? uint64_t(1) : (upperBound / 2 + 1);
+    return std::chrono::seconds(rand_uniform<uint64_t>(lowerBound, upperBound));
 }
 
 uint64_t


### PR DESCRIPTION
Resolves #3237 

This change starts captive core and bucket application simultaneously, which allows core to buffer and save any new ledgers, which can be later replayed. While core is replaying state, certain paths that use the state are inhibited. This includes transactions processing, slot validation etc. 

I tested this by setting the config ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING to a high value (like 2 minutes), and verifying that captive core was able to join the network right away after applying buckets. 

One thing that worries me is that core is running and interacting with the network while its state is not ready, which can be potentially dangerous, so I'd love to get more eyes on this change, and see if there are additional ways to make this safer. I considered temporarily setting LCL to genesis while we're replaying buckets, but that doesn't seem that much better since we still need to handle all the places where LCL and the ledger state potentially mismatch. 