### PR TITLE
Shutdown fixes

### DIFF
--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -291,6 +291,11 @@ HistoryManagerImpl::takeSnapshotAndPublish(HistoryArchiveState const& has)
 size_t
 HistoryManagerImpl::publishQueuedHistory()
 {
+    if (mApp.isStopping())
+    {
+        return 0;
+    }
+
 #ifdef BUILD_TESTS
     if (!mPublicationEnabled)
     {

--- a/src/historywork/VerifyBucketWork.cpp
+++ b/src/historywork/VerifyBucketWork.cpp
@@ -60,6 +60,14 @@ VerifyBucketWork::spawnVerifier()
         [&app, filename, weak, hash]() {
             SHA256 hasher;
             asio::error_code ec;
+
+            // No point in verifying buckets if things are shutting down
+            auto self = weak.lock();
+            if (!self || self->isAborting())
+            {
+                return;
+            }
+
             try
             {
                 ZoneNamedN(verifyZone, "bucket verify", true);

--- a/src/historywork/VerifyTxResultsWork.cpp
+++ b/src/historywork/VerifyTxResultsWork.cpp
@@ -48,7 +48,7 @@ VerifyTxResultsWork::onRun()
         std::static_pointer_cast<VerifyTxResultsWork>(shared_from_this()));
     auto verify = [weak, checkpoint = mCheckpoint]() {
         auto self = weak.lock();
-        if (self)
+        if (self && !self->isAborting())
         {
             ZoneScoped;
             asio::error_code ec;

--- a/src/historywork/WriteSnapshotWork.cpp
+++ b/src/historywork/WriteSnapshotWork.cpp
@@ -36,7 +36,7 @@ WriteSnapshotWork::onRun()
 
     auto work = [weak]() {
         auto self = weak.lock();
-        if (!self)
+        if (!self || self->isAborting())
         {
             return;
         }

--- a/src/ledger/FlushAndRotateMetaDebugWork.cpp
+++ b/src/ledger/FlushAndRotateMetaDebugWork.cpp
@@ -73,6 +73,10 @@ FlushAndRotateMetaDebugWork::listMetaDebugFiles(
 bool
 FlushAndRotateMetaDebugWork::isDebugSegmentBoundary(uint32_t ledgerSeq)
 {
+    if (META_DEBUG_LEDGER_SEGMENT_SIZE == 1)
+    {
+        return true;
+    }
     return ledgerSeq % (META_DEBUG_LEDGER_SEGMENT_SIZE - 1) == 0;
 }
 

--- a/src/ledger/FlushAndRotateMetaDebugWork.cpp
+++ b/src/ledger/FlushAndRotateMetaDebugWork.cpp
@@ -110,7 +110,7 @@ FlushAndRotateMetaDebugWork::doWork()
         mApp.postOnBackgroundThread(
             [weak, file]() {
                 auto self = weak.lock();
-                if (!self)
+                if (!self || self->isAborting())
                 {
                     return;
                 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -781,11 +781,6 @@ ApplicationImpl::shutdownWorkScheduler()
     if (mWorkScheduler)
     {
         mWorkScheduler->shutdown();
-
-        while (mWorkScheduler->getState() != BasicWork::State::WORK_ABORTED)
-        {
-            mVirtualClock.crank();
-        }
     }
 }
 

--- a/src/work/BasicWork.cpp
+++ b/src/work/BasicWork.cpp
@@ -44,7 +44,7 @@ BasicWork::BasicWork(Application& app, std::string name, size_t maxRetries)
 BasicWork::~BasicWork()
 {
     // Work completed or has not started yet
-    releaseAssert(isDone() || mState == InternalState::PENDING);
+    releaseAssert(isDone() || mState == InternalState::PENDING || isAborting());
 }
 
 void

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -19,7 +19,10 @@ Work::Work(Application& app, std::string name, size_t maxRetries)
 Work::~Work()
 {
     // Work is destroyed only if in terminal state, and is properly reset
-    releaseAssert(!hasChildren());
+    if (isDone())
+    {
+        releaseAssert(!hasChildren());
+    }
 }
 
 std::string


### PR DESCRIPTION
Resolves #3163 
 
The goal of this change is to ensure asynchronous callbacks behave appropriately during application shutdown (when certain subsystems are already in shutdown state, but the application continues to crank and execute events). There are two areas I looked into: timer-based callbacks, and scheduler queues. There doesn't seem to be a problem with timers, as those are properly cancelled in `shutdown` functions. There are a couple of places where events from the scheduler queues can be executed during shutdown, but most of them seem to be already mitigated with early exits if the app is shutting down (specifically, I'm referring to `processSCPQueueSomeMore` in Herder, and message-related functions in Peer). I added on check in `HistoryManagerImpl::publishQueuedHistory`.

In addition, I updated the scheduler shutdown code to not wait until completion, and updated callbacks in related works to no-op if the work scheduler is aborting. 