### PR TITLE
Optionally use TransactionResultSets in replay, to accelerate failed txs.

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -292,6 +292,11 @@ CATCHUP_COMPLETE=false
 # new history
 CATCHUP_RECENT=0
 
+# CATCHUP_REPLAY_ALL_INCLUDING_FAILURES (boolean) default to false
+# If true will replay failed transactions as well as successful ones while
+# catching up to the network. If true, replay will be significantly slower.
+CATCHUP_REPLAY_ALL_INCLUDING_FAILURES=false
+
 # WORKER_THREADS (integer) default 11
 # Number of threads available for doing long durations jobs, like bucket
 # merging and vertification.

--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -27,6 +27,13 @@ struct LedgerHeaderHistoryEntry;
  * used to read transactions that will be used and ledger files are used to
  * check if ledger hashes are matching.
  *
+ * It may also require a third set of files -- transaction results -- to use
+ * in accelerated replay, where failed transactions are _not applied_ but their
+ * results taken directly from the results file. This is common when rejoining
+ * the network, when replaying failures is fairly pointless and if the results
+ * are corrupt / a lie we'll know fairly immediately with a consensus hash
+ * mismatch.
+ *
  * In each run it skips or applies transactions from one ledger. Skipping occurs
  * when ledger to be applied is older than LCL from local ledger. At LCL
  * boundary checks are made to confirm that ledgers from files knit up with
@@ -48,7 +55,9 @@ class ApplyCheckpointWork : public BasicWork
 
     XDRInputFileStream mHdrIn;
     XDRInputFileStream mTxIn;
+    XDRInputFileStream mTxResultIn;
     TransactionHistoryEntry mTxHistoryEntry;
+    TransactionHistoryResultEntry mTxHistoryResultEntry;
     LedgerHeaderHistoryEntry mHeaderHistoryEntry;
     OnFailureCallback mOnFailure;
 
@@ -57,6 +66,7 @@ class ApplyCheckpointWork : public BasicWork
     std::shared_ptr<ConditionalWork> mConditionalWork;
 
     TxSetFramePtr getCurrentTxSet();
+    std::optional<TransactionResultSet> getCurrentTxResultSet();
     void openInputFiles();
 
     std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -16,11 +16,13 @@ namespace stellar
 
 LedgerCloseData::LedgerCloseData(
     uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-    StellarValue const& v, std::optional<Hash> const& expectedLedgerHash)
+    StellarValue const& v, std::optional<Hash> const& expectedLedgerHash,
+    std::optional<TransactionResultSet> const& expectedResults)
     : mLedgerSeq(ledgerSeq)
     , mTxSet(txSet)
     , mValue(v)
     , mExpectedLedgerHash(expectedLedgerHash)
+    , mExpectedResults(expectedResults)
 {
     releaseAssert(txSet->getContentsHash() == mValue.txSetHash);
 }

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -26,7 +26,9 @@ class LedgerCloseData
     LedgerCloseData(
         uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
         StellarValue const& v,
-        std::optional<Hash> const& expectedLedgerHash = std::nullopt);
+        std::optional<Hash> const& expectedLedgerHash = std::nullopt,
+        std::optional<TransactionResultSet> const& expectedResults =
+            std::nullopt);
 
     uint32_t
     getLedgerSeq() const
@@ -48,12 +50,18 @@ class LedgerCloseData
     {
         return mExpectedLedgerHash;
     }
+    std::optional<TransactionResultSet> const&
+    getExpectedResults() const
+    {
+        return mExpectedResults;
+    }
 
   private:
     uint32_t mLedgerSeq;
     std::shared_ptr<AbstractTxSetFrameForApply> mTxSet;
     StellarValue mValue;
     std::optional<Hash> mExpectedLedgerHash;
+    std::optional<TransactionResultSet> mExpectedResults;
 };
 
 std::string stellarValueToString(Config const& c, StellarValue const& sv);

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -68,11 +68,12 @@ class LedgerManagerImpl : public LedgerManager
                        AbstractLedgerTxn& ltxOuter, int64_t baseFee,
                        std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta);
 
-    void
-    applyTransactions(std::vector<TransactionFrameBasePtr>& txs,
-                      AbstractLedgerTxn& ltx, TransactionResultSet& txResultSet,
-                      std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta,
-                      int64 curBaseFee);
+    void applyTransactions(
+        std::vector<TransactionFrameBasePtr>& txs, AbstractLedgerTxn& ltx,
+        TransactionResultSet& txResultSet,
+        std::optional<TransactionResultSet> const& expectedResults,
+        std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta,
+        int64 curBaseFee);
 
     void ledgerClosed(AbstractLedgerTxn& ltx);
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -132,6 +132,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MANUAL_CLOSE = false;
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
+    CATCHUP_REPLAY_ALL_INCLUDING_FAILURES = false;
     EXPERIMENTAL_PRECAUTION_DELAY_META = false;
     // automatic maintenance settings:
     // short and prime with 1 hour which will cause automatic maintenance to
@@ -961,6 +962,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "CATCHUP_RECENT")
             {
                 CATCHUP_RECENT = readInt<uint32_t>(item, 0, UINT32_MAX - 1);
+            }
+            else if (item.first == "CATCHUP_REPLAY_ALL_INCLUDING_FAILURES")
+            {
+                CATCHUP_REPLAY_ALL_INCLUDING_FAILURES = readBool(item);
             }
             else if (item.first == "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -151,6 +151,10 @@ class Config : public std::enable_shared_from_this<Config>
     // If you want, say, a week of history, set this to 120000.
     uint32_t CATCHUP_RECENT;
 
+    // Whether to replay failed transactions as well as successful transactions
+    // during catchup.
+    bool CATCHUP_REPLAY_ALL_INCLUDING_FAILURES;
+
     // Interval between automatic maintenance executions
     std::chrono::seconds AUTOMATIC_MAINTENANCE_PERIOD;
 

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -437,4 +437,14 @@ FeeBumpTransactionFrame::toStellarMessage() const
     msg.transaction() = mEnvelope;
     return msg;
 }
+
+void
+FeeBumpTransactionFrame::setReplayFailingOperationResults(
+    xdr::xvector<OperationResult> const&)
+{
+    // Currently we don't support replay-suppression on fee-bump txs.
+    // This could be enhanced in the future but it's harmless to avoid
+    // for now.
+}
+
 }

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -94,5 +94,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     static TransactionEnvelope
     convertInnerTxToV1(TransactionEnvelope const& envelope);
+
+    void setReplayFailingOperationResults(
+        xdr::xvector<OperationResult> const&) override;
 };
 }

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -52,6 +52,8 @@ class TransactionFrame : public TransactionFrameBase
     mutable Hash mFullHash;     // the hash of the contents and the sig.
 
     std::vector<std::shared_ptr<OperationFrame>> mOperations;
+    std::optional<xdr::xvector<OperationResult>> mReplayFailingOperationResults{
+        std::nullopt};
 
     LedgerTxnEntry loadSourceAccount(AbstractLedgerTxn& ltx,
                                      LedgerTxnHeader const& header);
@@ -103,6 +105,9 @@ class TransactionFrame : public TransactionFrameBase
     bool processSignatures(ValidationType cv,
                            SignatureChecker& signatureChecker,
                            AbstractLedgerTxn& ltxOuter);
+
+    void setReplayFailingOperationResults(
+        xdr::xvector<OperationResult> const&) override;
 
   public:
     TransactionFrame(Hash const& networkID,

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -57,6 +57,8 @@ class TransactionFrameBase
     virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const = 0;
 
     virtual void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) = 0;
+    virtual void
+    setReplayFailingOperationResults(xdr::xvector<OperationResult> const&) = 0;
 
     virtual StellarMessage toStellarMessage() const = 0;
 };


### PR DESCRIPTION
This is a sketch of a special mode (set to on-by-default in this PR) that accelerates replay of txsets with a lot of failed txs in them by reusing the result codes from the txresults file. If there's any discrepancy it'll diverge and halt, of course; I think the only thing this could really do _wrong_ is hide divergence in the database by supplying "correct" historical result vectors. But we aren't always able to catch divergence in the DB when it happens anyways; this might make it a little worse but it's not exactly new.