### PR TITLE
Use `CKMSSample` in Core

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -129,6 +129,15 @@ lib/libmedida:
   Licensed under the Apache License, Version 2.0
   (https://www.apache.org/licenses/LICENSE-2.0)
 
+lib/libmedida/src/medida/stats/ckms.{cpp,h}
+
+  CKMS implementation from https://github.com/jupp0r/prometheus-cpp
+  Local modifications made by Stellar Development Foundation
+  Copyright 2016-2019 Jupp Mueller
+  Copyright 2017-2019 Gregor Jasny
+  Licensed under the MIT license
+  (http://opensource.org/licenses/MIT)
+
 lib/util/uint128_t.h
 
   large_int implementation from https://github.com/zhanhb/int128

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -18,6 +18,12 @@ LOG_FILE_PATH="stellar-core-{datetime:%Y-%m-%d_%H-%M-%S}.log"
 # Whether to highlight stdout log messages with ANSI terminal colors.
 LOG_COLOR=false
 
+# HISTOGRAM_WINDOW_SIZE (integer) default 30
+# The size of a histogram window for metrics in seconds.
+# Core reports percentiles based on the previous
+# HISTOGRAM_WINDOW_SIZE-second window.
+HISTOGRAM_WINDOW_SIZE=30
+
 # BUCKET_DIR_PATH (string) default "buckets"
 # Specifies the directory where stellar-core should store the bucket list.
 # This will get written to a lot and will grow as the size of the ledger grows.

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -86,7 +86,8 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     , mStopping(false)
     , mStoppingTimer(*this)
     , mSelfCheckTimer(*this)
-    , mMetrics(std::make_unique<medida::MetricsRegistry>())
+    , mMetrics(
+          std::make_unique<medida::MetricsRegistry>(cfg.HISTOGRAM_WINDOW_SIZE))
     , mPostOnMainThreadDelay(
           mMetrics->NewTimer({"app", "post-on-main-thread", "delay"}))
     , mPostOnBackgroundThreadDelay(

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -474,5 +474,7 @@ class Config : public std::enable_shared_from_this<Config>
     static std::string const STDIN_SPECIAL_NAME;
 
     void processOpApplySleepTimeForTestingConfigs();
+
+    std::chrono::seconds HISTOGRAM_WINDOW_SIZE;
 };
 }

--- a/src/util/test/MetricTests.cpp
+++ b/src/util/test/MetricTests.cpp
@@ -5,6 +5,7 @@
 #include "lib/catch.hpp"
 #include "lib/util/stdrandom.h"
 #include "medida/histogram.h"
+#include "medida/stats/ckms_sample.h"
 #include "medida/stats/sliding_window_sample.h"
 #include "medida/stats/snapshot.h"
 #include "util/Logging.h"
@@ -14,6 +15,7 @@
 #include <iostream>
 #include <random>
 #include <sstream>
+#include <thread>
 
 // These tests just check that medida's math is roughly sensible.
 namespace
@@ -527,4 +529,79 @@ TEST_CASE("sums of nanoseconds do not overflow", "[medida_math]")
         REQUIRE(hist.mean() >= 0);
         REQUIRE(hist.std_dev() >= 0);
     }
+}
+
+template <typename Dist, typename... Args>
+void
+testCKMSSample(int const count, Args... args)
+{
+    auto const windowSize = std::chrono::seconds(1);
+    medida::Histogram hist{medida::SamplingInterface::kCKMS, windowSize};
+
+    double const error = 0.001;
+    auto const percentiles = {0.5, 0.75, 0.9, 0.99};
+
+    std::vector<int64_t> values;
+    values.reserve(count);
+    Dist dist(std::forward<Args>(args)...);
+    for (int i = 0; i < count; i++)
+    {
+        auto x = static_cast<int64_t>(dist(stellar::gRandomEngine));
+        values.push_back(x);
+        hist.Update(x);
+    }
+
+    {
+        // We haven't moved to the next time window.
+        // Therefore, all values must be 0.
+        auto s = hist.GetSnapshot();
+        for (auto const q : percentiles)
+        {
+            auto got = s.getValue(q);
+            REQUIRE(got == 0);
+        }
+    }
+
+    // There is no easy way to fast-forward time in Medida.
+    // We need to wait for 1 second so that the window with `count`
+    // samples are in the previous window, not in the current window.
+    std::this_thread::sleep_for(windowSize);
+    {
+        // Now all the samples we added are in the previous window
+        // which CKMSSample reports.
+        std::sort(values.begin(), values.end());
+        auto s = hist.GetSnapshot();
+        for (auto const q : percentiles)
+        {
+            auto lowerbound = values[int((1 - error) * q * count)];
+            auto upperbound = values[int((1 + error) * q * count)];
+            auto got = s.getValue(q);
+            REQUIRE(lowerbound <= got);
+            REQUIRE(got <= upperbound);
+        }
+    }
+
+    std::this_thread::sleep_for(windowSize);
+
+    {
+        // Now all the samples are two windows ago.
+        // In other words, they must have been thrown out.
+        auto s = hist.GetSnapshot();
+        for (auto const q : percentiles)
+        {
+            auto got = s.getValue(q);
+            REQUIRE(got == 0);
+        }
+    }
+}
+
+TEST_CASE("CKMSSample uniform distribution", "[medida_math]")
+{
+    testCKMSSample<uniform_u64>(10000, 0, 1e9);
+}
+
+TEST_CASE("CKMSSample gamma distribution", "[medida_math]")
+{
+    testCKMSSample<gamma_dbl>(10000, 4, 100);
+    testCKMSSample<gamma_dbl>(20000, 20, 20);
 }


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/3251

This PR updates the medida submodule in order to use the new `CKMSSample` for histograms and timers. With this PR,

- We will use CKMS to estimate percentiles.
    - CKMS is very accurate when there's a large number of samples (e.g., >= 1000)
    - It can be off by a little when the sample set is small (e.g., <= 10 samples), but it only reports a sample that it has heard of.
- Reported percentiles will be based on the previous 30-second window. (e.g., At 11:00:50, the percentiles will be from [11:00:00, 11:00:30].)
- The size of the window can be configured through `HISTOGRAM_WINDOW_SIZE`.
- It reports `100%` along with other percentiles, which is the maximum value in the 30-second time window. `max` continues to be the all-time maximum value.

I didn't add too many test cases since the CKMS implementation comes from the Prometheus project as denoted in COPYING.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
