### PR TITLE
Delete temporary files while catching up

### DIFF
--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -141,10 +141,20 @@ DownloadApplyTxsWork::yieldMoreWork()
     seq.push_back(std::make_shared<WorkWithCallback>(
         mApp, "delete-transactions-" + std::to_string(mCheckpointToQueue),
         [ft](Application& app) {
-            CLOG_DEBUG(History, "Deleting transactions {}",
-                       ft.localPath_nogz());
-            std::filesystem::remove(std::filesystem::path(ft.localPath_nogz()));
-            return true;
+            try
+            {
+                std::filesystem::remove(
+                    std::filesystem::path(ft.localPath_nogz()));
+                CLOG_DEBUG(History, "Deleted transactions {}",
+                           ft.localPath_nogz());
+                return true;
+            }
+            catch (std::filesystem::filesystem_error const& e)
+            {
+                CLOG_ERROR(History, "Could not delete transactions {}: {}",
+                           ft.localPath_nogz(), e.what());
+                return false;
+            }
         }));
 
     auto nextWork = std::make_shared<WorkSequence>(


### PR DESCRIPTION
This limits temporary disk space used during catchup by deleting tx files as soon as we're done with them. It will still store MAX_CONCURRENT_SUBPROCESSES (default 16) worth of tx files at any time -- and since it verifies the entire header chain before starting it will download and keep that all up front -- but that's comparatively small.