### PR TITLE
Fix typo BATCH_SIZE -> BATCHSIZE in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,7 @@ The `make check` command runs tests and supports parallelization. This functiona
 * `TEST_SPEC`: Used to run just a subset of the tests (default: "~[.]")
 * `NUM_PARTITIONS`: Partitions the test suite (after applying `TEST_SPEC`) into
 `$NUM_PARTITIONS` disjoint sets (default: 1)
-* `BATCH_SIZE`: The number of tests to be batched together to reduce setup overhead. (default: 5)
+* `BATCHSIZE`: The number of tests to be batched together to reduce setup overhead. (default: 5)
 * `RUN_PARTITIONS`: Run only a subset of the partitions, indexed from 0
 (default: "$(seq 0 $((NUM_PARTITIONS-1)))")
 * `TEMP_POSTGRES`: Automatically generates temporary database clusters instead


### PR DESCRIPTION
# Description
Fixes a small typo that would effect performance of parallel test runs.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
