### PR TITLE
Use HashOfHash in LedgerHashUtils and InternalLedgerEntry

### DIFF
--- a/src/ledger/InternalLedgerEntry.cpp
+++ b/src/ledger/InternalLedgerEntry.cpp
@@ -5,6 +5,7 @@
 #include "ledger/InternalLedgerEntry.h"
 #include "ledger/LedgerHashUtils.h"
 #include "util/GlobalChecks.h"
+#include "util/HashOfHash.h"
 #include "util/XDRCereal.h"
 #include "util/types.h"
 
@@ -162,12 +163,12 @@ InternalLedgerKey::hash() const
         res = std::hash<stellar::LedgerKey>()(ledgerKey());
         break;
     case stellar::InternalLedgerEntryType::SPONSORSHIP:
-        res = shortHash::computeHash(stellar::ByteSlice(
-            sponsorshipKey().sponsoredID.ed25519().data(), 8));
+        res = std::hash<stellar::uint256>()(
+            sponsorshipKey().sponsoredID.ed25519());
         break;
     case stellar::InternalLedgerEntryType::SPONSORSHIP_COUNTER:
-        res = shortHash::computeHash(stellar::ByteSlice(
-            sponsorshipCounterKey().sponsoringID.ed25519().data(), 8));
+        res = std::hash<stellar::uint256>()(
+            sponsorshipCounterKey().sponsoringID.ed25519());
         break;
     default:
         abort();

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -6,6 +6,7 @@
 
 #include "crypto/ShortHash.h"
 #include "ledger/InternalLedgerEntry.h"
+#include "util/HashOfHash.h"
 #include "xdr/Stellar-ledger.h"
 #include <functional>
 
@@ -48,8 +49,7 @@ getAssetHash(T const& asset)
     case stellar::ASSET_TYPE_CREDIT_ALPHANUM4:
     {
         auto& a4 = asset.alphaNum4();
-        hashMix(res, stellar::shortHash::computeHash(
-                         stellar::ByteSlice(a4.issuer.ed25519().data(), 8)));
+        hashMix(res, std::hash<stellar::uint256>()(a4.issuer.ed25519()));
         hashMix(res, stellar::shortHash::computeHash(stellar::ByteSlice(
                          a4.assetCode.data(), a4.assetCode.size())));
         break;
@@ -57,16 +57,14 @@ getAssetHash(T const& asset)
     case stellar::ASSET_TYPE_CREDIT_ALPHANUM12:
     {
         auto& a12 = asset.alphaNum12();
-        hashMix(res, stellar::shortHash::computeHash(
-                         stellar::ByteSlice(a12.issuer.ed25519().data(), 8)));
+        hashMix(res, std::hash<stellar::uint256>()(a12.issuer.ed25519()));
         hashMix(res, stellar::shortHash::computeHash(stellar::ByteSlice(
                          a12.assetCode.data(), a12.assetCode.size())));
         break;
     }
     case stellar::ASSET_TYPE_POOL_SHARE:
     {
-        hashMix(res, stellar::shortHash::computeHash(stellar::ByteSlice(
-                         getLiquidityPoolID(asset).data(), 8)));
+        hashMix(res, std::hash<stellar::uint256>()(getLiquidityPoolID(asset)));
         break;
     }
     default:
@@ -110,23 +108,20 @@ template <> class hash<stellar::LedgerKey>
         switch (lk.type())
         {
         case stellar::ACCOUNT:
-            stellar::hashMix(res,
-                             stellar::shortHash::computeHash(stellar::ByteSlice(
-                                 lk.account().accountID.ed25519().data(), 8)));
+            stellar::hashMix(res, std::hash<stellar::uint256>()(
+                                      lk.account().accountID.ed25519()));
             break;
         case stellar::TRUSTLINE:
         {
             auto& tl = lk.trustLine();
             stellar::hashMix(
-                res, stellar::shortHash::computeHash(
-                         stellar::ByteSlice(tl.accountID.ed25519().data(), 8)));
+                res, std::hash<stellar::uint256>()(tl.accountID.ed25519()));
             stellar::hashMix(res, hash<stellar::TrustLineAsset>()(tl.asset));
             break;
         }
         case stellar::DATA:
-            stellar::hashMix(res,
-                             stellar::shortHash::computeHash(stellar::ByteSlice(
-                                 lk.data().accountID.ed25519().data(), 8)));
+            stellar::hashMix(res, std::hash<stellar::uint256>()(
+                                      lk.data().accountID.ed25519()));
             stellar::hashMix(
                 res,
                 stellar::shortHash::computeHash(stellar::ByteSlice(
@@ -138,14 +133,12 @@ template <> class hash<stellar::LedgerKey>
                          &lk.offer().offerID, sizeof(lk.offer().offerID))));
             break;
         case stellar::CLAIMABLE_BALANCE:
-            stellar::hashMix(
-                res, stellar::shortHash::computeHash(stellar::ByteSlice(
-                         lk.claimableBalance().balanceID.v0().data(), 8)));
+            stellar::hashMix(res, std::hash<stellar::uint256>()(
+                                      lk.claimableBalance().balanceID.v0()));
             break;
         case stellar::LIQUIDITY_POOL:
-            stellar::hashMix(
-                res, stellar::shortHash::computeHash(stellar::ByteSlice(
-                         lk.liquidityPool().liquidityPoolID.data(), 8)));
+            stellar::hashMix(res, std::hash<stellar::uint256>()(
+                                      lk.liquidityPool().liquidityPoolID));
             break;
         default:
             abort();


### PR DESCRIPTION
# Description

Resolves #3120

Uses HashOfHash function instead of the `shortHash::computeHash` to compute hash for an hash object (ed25519), in LedgerHashUtils and InternalLedgerEntry.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
