### PR TITLE
fix: close files after applying checkpoint

### DIFF
--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -65,12 +65,18 @@ ApplyCheckpointWork::getStatus() const
 }
 
 void
-ApplyCheckpointWork::onReset()
+ApplyCheckpointWork::closeFiles()
 {
     mHdrIn.close();
     mTxIn.close();
-    mConditionalWork.reset();
     mFilesOpen = false;
+}
+
+void
+ApplyCheckpointWork::onReset()
+{
+    mConditionalWork.reset();
+    closeFiles();
 }
 
 void
@@ -280,6 +286,7 @@ ApplyCheckpointWork::onRun()
 
     if (done)
     {
+        closeFiles();
         return State::WORK_SUCCESS;
     }
 

--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -61,6 +61,8 @@ class ApplyCheckpointWork : public BasicWork
 
     std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();
 
+    void closeFiles();
+
   public:
     ApplyCheckpointWork(Application& app, TmpDir const& downloadDir,
                         LedgerRange const& range, OnFailureCallback cb);


### PR DESCRIPTION
#3306 introduced a bug on Windows:
attempting to run a command such as `catchup 2000/200` would fail due to "files in use".

Indeed files were kept open by the `ApplyCheckpointWork` class.
