### PR TITLE
Return early in updateEntryIfRecorded if entry is not an offer

### DIFF
--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2089,6 +2089,19 @@ void
 LedgerTxn::Impl::updateEntryIfRecorded(InternalLedgerKey const& key,
                                        bool effectiveActive)
 {
+    // This early return is just an optimization. updateEntryIfRecorded does not
+    // end up modifying mEntry because it loads the entry here, and then
+    // attempts to update that same entry in updateEntry using the identical one
+    // that was loaded. It just refreshes mMultiOrderBook in updateEntry, so
+    // there's nothing to do if the entry is not an offer. If updateEntry is
+    // updated in the future to maintain additional state outside of mEntry,
+    // this optimization might have to be modified.
+    if (key.type() != InternalLedgerEntryType::LEDGER_ENTRY ||
+        key.ledgerKey().type() != OFFER)
+    {
+        return;
+    }
+
     auto entryIter = mEntry.find(key);
     // If loadWithoutRecord was used, then key may not be in mEntry. But if key
     // is not in mEntry, then there is no reason to have an entry in the order

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2115,15 +2115,6 @@ LedgerTxn::Impl::updateEntryIfRecorded(InternalLedgerKey const& key,
 void
 LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
                              EntryMap::iterator const* keyHint,
-                             LedgerEntryPtr lePtr)
-{
-    bool effectiveActive = mActive.find(key) != mActive.end();
-    updateEntry(key, keyHint, lePtr, effectiveActive);
-}
-
-void
-LedgerTxn::Impl::updateEntry(InternalLedgerKey const& key,
-                             EntryMap::iterator const* keyHint,
                              LedgerEntryPtr lePtr,
                              bool effectiveActive) noexcept
 {

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -386,8 +386,6 @@ class LedgerTxn::Impl
     void updateEntryIfRecorded(InternalLedgerKey const& key,
                                bool effectiveActive);
     void updateEntry(InternalLedgerKey const& key,
-                     EntryMap::iterator const* keyHint, LedgerEntryPtr lePtr);
-    void updateEntry(InternalLedgerKey const& key,
                      EntryMap::iterator const* keyHint, LedgerEntryPtr lePtr,
                      bool effectiveActive) noexcept;
 


### PR DESCRIPTION
# Description

This change is an optimization to reduce unnecessary hash lookups in `updateEntryIfRecorded` calls. For example, every time a `LedgerTxnEntry` goes out of scope, (like in the bottom of `LedgerTxn::Impl::load` and `LedgerTxn::Impl::create`), we end up calling `deactivate`, which calls `updateEntryIfRecorded`, leading to some unnecessary work.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
