### PR TITLE
Stricter offline info

### DIFF
--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -225,9 +225,12 @@ consistent.
 #### Offline info
 
 The command `offline-info` fetches information similar to what `info` returns but
-without starting the node.
+without starting the node, writing it directly to standard output.
 
 This allows to quickly see information about the last loaded ledger, supported protocol version etc.
+
+Combine this with logging control flags like `--ll fatal` to suppress informational
+logging output and retrieve a plain JSON object representing the node's state.
 
 #### Testing around a snapshot
 If you want to replay transactions in a specific ledger, you can run a command

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -596,14 +596,14 @@ When the node is done catching up, its state will change to
 ```
 
 ## Logging
-Stellar-core sends logs to standard output and `stellar-core.log` by default, 
+Stellar-core sends logs to standard error and `stellar-core.log` by default,
 configurable as `LOG_FILE_PATH`.
 
  Log messages are classified by progressive _priority levels_:
   `TRACE`, `DEBUG`, `INFO`, `WARNING`, `ERROR` and `FATAL`.
    The logging system only emits those messages at or above its configured logging level.
 
-Log messages at different priority levels can be color-coded on standard output
+Log messages at different priority levels can be color-coded on standard error
 by setting `LOG_COLOR=true` in the config file. By default they are not color-coded.
 
 The log level can be controlled by configuration, the `-ll` command-line flag 

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -55,7 +55,7 @@ Command options can only by placed after command.
   specified in the stellar-core.cfg. This will write a
   `.well-known/stellar-history.json` file in the archive root.
 * **offline-info**: Returns an output similar to `--c info` for an offline
-  instance
+  instance, but written directly to standard output (ignoring log levels).
 * **print-xdr <FILE-NAME>**:  Pretty-print a binary file containing an XDR
   object. If FILE-NAME is "stdin", the XDR object is read from standard input.<br>
   Option **--filetype [auto|ledgerheader|meta|result|resultpair|tx|txfee]**

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -498,7 +498,8 @@ void
 ApplicationImpl::reportInfo()
 {
     mLedgerManager->loadLastKnownLedger(nullptr);
-    LOG_INFO(DEFAULT_LOG, "info -> {}", getJsonInfo().toStyledString());
+    LOG_INFO(DEFAULT_LOG, "Reporting application info");
+    std::cout << getJsonInfo().toStyledString() << std::endl;
 }
 
 std::shared_ptr<BasicWork>

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -477,10 +477,9 @@ CommandLine::ConfigOption::getConfig(bool logToFile) const
     auto configFile =
         mConfigFile.empty() ? std::string{"stellar-core.cfg"} : mConfigFile;
 
-    LOG_INFO(DEFAULT_LOG, "Config from {}", configFile);
-
     // yes you really have to do this 3 times
     Logging::setLogLevel(mLogLevel, nullptr);
+    LOG_INFO(DEFAULT_LOG, "Config from {}", configFile);
     config.load(configFile);
 
     Logging::setFmt(KeyUtils::toShortString(config.NODE_SEED.getPublicKey()));

--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -92,9 +92,9 @@ Logging::init(bool truncate)
         using std::shared_ptr;
 
         auto console = (mColor ? static_cast<shared_ptr<sink>>(
-                                     make_shared<stdout_color_sink_mt>())
+                                     make_shared<stderr_color_sink_mt>())
                                : static_cast<shared_ptr<sink>>(
-                                     make_shared<stdout_sink_mt>()));
+                                     make_shared<stderr_sink_mt>()));
 
         std::vector<shared_ptr<sink>> sinks{console};
 


### PR DESCRIPTION
This changes (very slightly) the way `offline-info` works:

 - Bypasses the logging stream, writes directly to stdout.
 - Avoids a single (I think stray / unintentional) pre-logging-config log-write.
 - Allows user to run `stellar-core --ll fatal offline-info` to get a machine-readable JSON blob.

This is something horizon wanted to be able to programmatically query a core database when running us captive.

cc @paulbellamy 