### PR TITLE
Remove MINIMUM_IDLE_PERCENT and TMP_DIR_PATH from core config.

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -192,14 +192,6 @@ SURVEYOR_KEYS=[
 "GBKXI3TVIFHD6QDSNMUOTJFDWHDYDVRRPWIHN4IM2YFXIUEWDTY7DSSI",
 "$eliza"]
 
-# Percentage, between 0 and 100, of system activity (measured in terms
-# of both event-loop cycles and database time) below-which the system
-# will consider itself "loaded" and attempt to shed load. Set this
-# number low and the system will be tolerant of overloading. Set it
-# high and the system will be intolerant. By default it is 0, meaning
-# totally insensitive to overloading.
-MINIMUM_IDLE_PERCENT=0
-
 # KNOWN_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # It will try to connect to these when it is below TARGET_PEER_CONNECTIONS.

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -196,8 +196,6 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
     PREFERRED_PEERS_ONLY = false;
 
-    MINIMUM_IDLE_PERCENT = 0;
-
     // WORKER_THREADS: setting this too low risks a form of priority inversion
     // where a long-running background task occupies all worker threads and
     // we're not able to do short high-priority background tasks like merging
@@ -1026,12 +1024,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 LOG_COLOR = readBool(item);
             }
-            else if (item.first == "TMP_DIR_PATH")
-            {
-                throw std::invalid_argument("TMP_DIR_PATH is not supported "
-                                            "anymore - tmp data is now kept in "
-                                            "BUCKET_DIR_PATH/tmp");
-            }
             else if (item.first == "BUCKET_DIR_PATH")
             {
                 BUCKET_DIR_PATH = readString(item);
@@ -1155,10 +1147,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "MAX_CONCURRENT_SUBPROCESSES")
             {
                 MAX_CONCURRENT_SUBPROCESSES = readInt<size_t>(item, 1);
-            }
-            else if (item.first == "MINIMUM_IDLE_PERCENT")
-            {
-                MINIMUM_IDLE_PERCENT = readInt<uint32_t>(item, 0, 100);
             }
             else if (item.first == "QUORUM_INTERSECTION_CHECKER")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -379,14 +379,6 @@ class Config : public std::enable_shared_from_this<Config>
     // Whether to exclude peers that are not preferred.
     bool PREFERRED_PEERS_ONLY;
 
-    // Percentage, between 0 and 100, of system activity (measured in terms
-    // of both event-loop cycles and database time) below-which the system
-    // will consider itself "loaded" and attempt to shed load. Set this
-    // number low and the system will be tolerant of overloading. Set it
-    // high and the system will be intolerant. By default it is 0, meaning
-    // totally insensitive to overloading.
-    uint32_t MINIMUM_IDLE_PERCENT;
-
     // thread-management config
     int WORKER_THREADS;
 


### PR DESCRIPTION
# Description

Resolves #3305

Removed MINIMUM_IDLE_PERCENT config argument as it doesn't do anything and TMP_DIR_PATH as using it throws an exception.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
