### PR TITLE
Adding an option to halt on txINTERNAL_ERROR.

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -509,6 +509,14 @@ OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING=[]
 LOADGEN_OP_COUNT_FOR_TESTING=[]
 LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING=[]
 
+# HALT_ON_INTERNAL_TRANSACTION_ERROR defaults to false.
+# If set to true, the application will halt when an internal error is
+# encountered during applying a transaction. Otherwise, the txINTERNAL_ERROR 
+# transaction is created but not applied.
+# Enabling this is useful for debugging the transaction errors caused by
+# the core's internal errors via catching them early.
+HALT_ON_INTERNAL_TRANSACTION_ERROR=false
+
 #####################
 ##  Tables must come at the end. (TOML you are almost perfect!)
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -217,6 +217,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     HISTOGRAM_WINDOW_SIZE = std::chrono::seconds(30);
 
+    HALT_ON_INTERNAL_TRANSACTION_ERROR = false;
+
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
 #endif
@@ -1286,6 +1288,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                         "HISTOGRAM_WINDOW_SIZE must divide 300 evenly");
                 }
                 HISTOGRAM_WINDOW_SIZE = std::chrono::seconds(s);
+            }
+            else if (item.first == "HALT_ON_INTERNAL_TRANSACTION_ERROR")
+            {
+                HALT_ON_INTERNAL_TRANSACTION_ERROR = readBool(item);
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -420,6 +420,14 @@ class Config : public std::enable_shared_from_this<Config>
     // the entry cache
     size_t PREFETCH_BATCH_SIZE;
 
+    // If set to true, the application will halt when an internal error is
+    // encountered during applying a transaction. Otherwise, the
+    // txINTERNAL_ERROR transaction is created but not applied.
+    // Enabling this is useful for debugging the transaction errors caused by
+    // the core's internal errors via catching them early.
+    // The default value is false.
+    bool HALT_ON_INTERNAL_TRANSACTION_ERROR;
+
 #ifdef BUILD_TESTS
     // If set to true, the application will be aware this run is for a test
     // case.  This is used right now in the signal handler to exit() instead of

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -836,6 +836,11 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                    xdr_to_string(getFullHash(), "fullHash"),
                    xdr_to_string(getContentsHash(), "contentsHash"));
     }
+    if (app.getConfig().HALT_ON_INTERNAL_TRANSACTION_ERROR)
+    {
+        printErrorAndAbort("Encountered an exception while applying "
+                           "operations, see logs for details.");
+    }
     // This is only reachable if an exception is thrown
     getResult().result.code(txINTERNAL_ERROR);
 


### PR DESCRIPTION
# Description

Resolves #2609 

With HALT_ON_INTERNAL_TRANSACTION_ERROR setting enabled the core will crash when an internal error is encountered during transaction processing.

Testing: as Catch2 doesn't seem to support death tests, I don't see a good way to cover this. I've checked locally that the old version of protocol cause the crash. I also checked that this testnet/pubnet configs work with the option enabled.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
