### PR TITLE
Rename maxTxSize to maxTxSetSize.

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -234,22 +234,24 @@ format.
     Retrieves the currently configured upgrade settings.<br>
   * `upgrades?mode=clear`<br>
     Clears any upgrade settings.<br>
-  * `upgrades?mode=set&upgradetime=DATETIME&[basefee=NUM]&[basereserve=NUM]&[maxtxsize=NUM]&[protocolversion=NUM]`<br>
-    * upgradetime is a required date (UTC) in the form `1970-01-01T00:00:00Z`. 
+  * `upgrades?mode=set&upgradetime=DATETIME&[basefee=NUM]&[basereserve=NUM]&[maxtxsetsize=NUM]&[protocolversion=NUM]`<br>
+    * `upgradetime` is a required date (UTC) in the form `1970-01-01T00:00:00Z`. 
         It is the time the upgrade will be scheduled for. If it is in the past
         by less than 12 hours, the upgrade will occur immediately. If it's more
         than 12 hours, then the upgrade will be ignored<br>
-    * fee (uint32) This is what you would prefer the base fee to be. It is in
+    * `fee` (uint32) This is what you would prefer the base fee to be. It is in
         stroops<br>
-    * basereserve (uint32) This is what you would prefer the base reserve to
+    * `basereserve` (uint32) This is what you would prefer the base reserve to
         be. It is in stroops.<br>
-    * maxtxsize (uint32) This defines the maximum number of transactions to
-        include in a ledger. When too many transactions are pending, surge
-        pricing is applied. The instance picks the top maxtxsize transactions
-        locally to be considered in the next ledger. Where transactions are
-        ordered by transaction fee(lower fee transactions are held for later).
+    * `maxtxsetsize` (uint32) This defines the maximum number of operations in 
+        the transaction set to include in a ledger. When too many transactions 
+        are pending, surge pricing is applied. The instance picks the 
+        transactions from the transaction queue locally to be considered in the 
+        next ledger until at most `maxtxsetsize` operations are accumulated.
+        Transactions are ordered by fee per operation (transactions with lower 
+        operation fees are held for later)
         <br>
-    * protocolversion (uint32) defines the protocol version to upgrade to.
+    * `protocolversion` (uint32) defines the protocol version to upgrade to.
         When specified it must match one of the protocol versions supported
         by the node and should be greater than ledgerVersion from the current
         ledger<br>

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -43,7 +43,7 @@ Upgrades are specified with:
   nominate upgrades
 * basefee - upgrades value of baseFee in ledger header, uses upgrade
   type LEDGER_UPGRADE_BASE_FEE
-* maxtxsize - upgrades value of maxTxSetSize in ledger header,
+* maxtxsetsize - upgrades value of maxTxSetSize in ledger header,
   uses upgrade type LEDGER_UPGRADE_MAX_TX_SET_SIZE
 * basereserve - upgrades value of baseReserve in ledger header, uses
   upgrade type LEDGER_UPGRADE_BASE_RESERVE

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -41,7 +41,7 @@ save(Archive& ar, stellar::Upgrades::UpgradeParameters const& p)
     ar(make_nvp("time", stellar::VirtualClock::to_time_t(p.mUpgradeTime)));
     ar(make_nvp("version", p.mProtocolVersion));
     ar(make_nvp("fee", p.mBaseFee));
-    ar(make_nvp("maxtxsize", p.mMaxTxSize));
+    ar(make_nvp("maxtxsize", p.mMaxTxSetSize));
     ar(make_nvp("reserve", p.mBaseReserve));
     ar(make_nvp("flags", p.mFlags));
 }
@@ -55,7 +55,7 @@ load(Archive& ar, stellar::Upgrades::UpgradeParameters& o)
     o.mUpgradeTime = stellar::VirtualClock::from_time_t(t);
     ar(make_nvp("version", o.mProtocolVersion));
     ar(make_nvp("fee", o.mBaseFee));
-    ar(make_nvp("maxtxsize", o.mMaxTxSize));
+    ar(make_nvp("maxtxsize", o.mMaxTxSetSize));
     ar(make_nvp("reserve", o.mBaseReserve));
 
     // the flags upgrade was added after the fields above, so it's possible for
@@ -181,10 +181,11 @@ Upgrades::createUpgradesFor(LedgerHeader const& header) const
         result.emplace_back(LEDGER_UPGRADE_BASE_FEE);
         result.back().newBaseFee() = *mParams.mBaseFee;
     }
-    if (mParams.mMaxTxSize && (header.maxTxSetSize != *mParams.mMaxTxSize))
+    if (mParams.mMaxTxSetSize &&
+        (header.maxTxSetSize != *mParams.mMaxTxSetSize))
     {
         result.emplace_back(LEDGER_UPGRADE_MAX_TX_SET_SIZE);
-        result.back().newMaxTxSetSize() = *mParams.mMaxTxSize;
+        result.back().newMaxTxSetSize() = *mParams.mMaxTxSetSize;
     }
     if (mParams.mBaseReserve && (header.baseReserve != *mParams.mBaseReserve))
     {
@@ -278,7 +279,7 @@ Upgrades::toString() const
     appendInfo("protocolversion", mParams.mProtocolVersion);
     appendInfo("basefee", mParams.mBaseFee);
     appendInfo("basereserve", mParams.mBaseReserve);
-    appendInfo("maxtxsize", mParams.mMaxTxSize);
+    appendInfo("maxtxsetsize", mParams.mMaxTxSetSize);
     appendInfo("flags", mParams.mFlags);
 
     return r.str();
@@ -308,7 +309,7 @@ Upgrades::removeUpgrades(std::vector<UpgradeType>::const_iterator beginUpdates,
 
         resetParamIfSet(res.mProtocolVersion);
         resetParamIfSet(res.mBaseFee);
-        resetParamIfSet(res.mMaxTxSize);
+        resetParamIfSet(res.mMaxTxSetSize);
         resetParamIfSet(res.mBaseReserve);
         resetParamIfSet(res.mFlags);
 
@@ -344,7 +345,7 @@ Upgrades::removeUpgrades(std::vector<UpgradeType>::const_iterator beginUpdates,
             resetParam(res.mBaseFee, lu.newBaseFee());
             break;
         case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-            resetParam(res.mMaxTxSize, lu.newMaxTxSetSize());
+            resetParam(res.mMaxTxSetSize, lu.newMaxTxSetSize());
             break;
         case LEDGER_UPGRADE_BASE_RESERVE:
             resetParam(res.mBaseReserve, lu.newBaseReserve());
@@ -423,8 +424,8 @@ Upgrades::isValidForNomination(LedgerUpgrade const& upgrade,
     case LEDGER_UPGRADE_BASE_FEE:
         return mParams.mBaseFee && (upgrade.newBaseFee() == *mParams.mBaseFee);
     case LEDGER_UPGRADE_MAX_TX_SET_SIZE:
-        return mParams.mMaxTxSize &&
-               (upgrade.newMaxTxSetSize() == *mParams.mMaxTxSize);
+        return mParams.mMaxTxSetSize &&
+               (upgrade.newMaxTxSetSize() == *mParams.mMaxTxSetSize);
     case LEDGER_UPGRADE_BASE_RESERVE:
         return mParams.mBaseReserve &&
                (upgrade.newBaseReserve() == *mParams.mBaseReserve);

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -39,7 +39,7 @@ class Upgrades
                 std::make_optional<uint32>(cfg.LEDGER_PROTOCOL_VERSION);
             mBaseFee =
                 std::make_optional<uint32>(cfg.TESTING_UPGRADE_DESIRED_FEE);
-            mMaxTxSize =
+            mMaxTxSetSize =
                 std::make_optional<uint32>(cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
             mBaseReserve =
                 std::make_optional<uint32>(cfg.TESTING_UPGRADE_RESERVE);
@@ -48,7 +48,7 @@ class Upgrades
         VirtualClock::system_time_point mUpgradeTime;
         std::optional<uint32> mProtocolVersion;
         std::optional<uint32> mBaseFee;
-        std::optional<uint32> mMaxTxSize;
+        std::optional<uint32> mMaxTxSetSize;
         std::optional<uint32> mBaseReserve;
         std::optional<uint32> mFlags;
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -655,8 +655,8 @@ TEST_CASE("txset", "[herder][txset]")
 TEST_CASE("txset base fee", "[herder][txset]")
 {
     Config cfg(getTestConfig());
-    uint32_t const maxTxSize = 112;
-    cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = maxTxSize;
+    uint32_t const maxTxSetSize = 112;
+    cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = maxTxSetSize;
 
     auto testBaseFee = [&](uint32_t protocolVersion, uint32 nbTransactions,
                            uint32 extraAccounts, size_t lim, int64_t expLowFee,
@@ -760,7 +760,8 @@ TEST_CASE("txset base fee", "[herder][txset]")
             {
                 // low = base tx
                 // high = last extra tx
-                testBaseFee(10, baseCount, v10ExtraTx, maxTxSize, 1000, 20104);
+                testBaseFee(10, baseCount, v10ExtraTx, maxTxSetSize, 1000,
+                            20104);
             }
             SECTION("protocol current")
             {
@@ -769,13 +770,14 @@ TEST_CASE("txset base fee", "[herder][txset]")
                 SECTION("maxed out surged")
                 {
                     testBaseFee(Config::CURRENT_LEDGER_PROTOCOL_VERSION,
-                                baseCount, v11ExtraTx, maxTxSize, 1000, 2000);
+                                baseCount, v11ExtraTx, maxTxSetSize, 1000,
+                                2000);
                 }
                 SECTION("smallest surged")
                 {
                     testBaseFee(Config::CURRENT_LEDGER_PROTOCOL_VERSION,
                                 baseCount + 1, v11ExtraTx - 50,
-                                maxTxSize - 100 + 1, 1000, 2000);
+                                maxTxSetSize - 100 + 1, 1000, 2000);
                 }
             }
         }
@@ -785,14 +787,14 @@ TEST_CASE("txset base fee", "[herder][txset]")
             {
                 // low = 20000+1
                 // high = 20000+112
-                testBaseFee(10, 0, v10NewCount, maxTxSize, 20001, 20112);
+                testBaseFee(10, 0, v10NewCount, maxTxSetSize, 20001, 20112);
             }
             SECTION("protocol current")
             {
                 // low = 20000+1 -> baseFee = 20001/2+ = 10001
                 // high = 10001*2
                 testBaseFee(Config::CURRENT_LEDGER_PROTOCOL_VERSION, 0,
-                            v11NewCount, maxTxSize, 20001, 20002);
+                            v11NewCount, maxTxSetSize, 20001, 20002);
             }
         }
     }
@@ -812,7 +814,7 @@ TEST_CASE("txset base fee", "[herder][txset]")
                 // high = 2*minFee
                 // highest number of ops not surged is max-100
                 testBaseFee(Config::CURRENT_LEDGER_PROTOCOL_VERSION, baseCount,
-                            v11ExtraTx - 50, maxTxSize - 100, 100, 200);
+                            v11ExtraTx - 50, maxTxSetSize - 100, 100, 200);
             }
         }
         SECTION("newOnly")
@@ -829,7 +831,7 @@ TEST_CASE("txset base fee", "[herder][txset]")
                 // high = 2*minFee
                 // highest number of ops not surged is max-100
                 testBaseFee(Config::CURRENT_LEDGER_PROTOCOL_VERSION, 0,
-                            v11NewCount - 50, maxTxSize - 100, 200, 200);
+                            v11NewCount - 50, maxTxSetSize - 100, 200, 200);
             }
         }
     }
@@ -1062,7 +1064,7 @@ TEST_CASE("surge pricing", "[herder][txset]")
 }
 
 static void
-testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
+testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
 {
     using SVUpgrades = decltype(StellarValue::upgrades);
 
@@ -1070,7 +1072,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
 
     cfg.MANUAL_CLOSE = false;
     cfg.LEDGER_PROTOCOL_VERSION = protocolVersion;
-    cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = maxTxSize;
+    cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = maxTxSetSize;
 
     VirtualClock clock;
     auto s = SecretKey::pseudoRandomForTesting();
@@ -1256,9 +1258,10 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSize, size_t expectedOps)
             std::max_element(txSetSizes.begin(), txSetSizes.end()));
         REQUIRE(txSetOpSizes[bestTxSetIndex] == expectedOps);
 
-        TxSetFramePtr txSetL = makeTransactions(lcl.hash, maxTxSize, 1, 101);
+        TxSetFramePtr txSetL = makeTransactions(lcl.hash, maxTxSetSize, 1, 101);
         addToCandidates(makeTxPair(herder, txSetL, 20));
-        TxSetFramePtr txSetL2 = makeTransactions(lcl.hash, maxTxSize, 1, 1000);
+        TxSetFramePtr txSetL2 =
+            makeTransactions(lcl.hash, maxTxSetSize, 1, 1000);
         addToCandidates(makeTxPair(herder, txSetL2, 20));
         auto v = herder.getHerderSCPDriver().combineCandidates(1, candidates);
         StellarValue sv;

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -113,7 +113,7 @@ simulateUpgrade(std::vector<LedgerUpgradeNode> const& nodes,
             Upgrades::UpgradeParameters upgrades;
             setUpgrade(upgrades.mBaseFee, du.baseFee);
             setUpgrade(upgrades.mBaseReserve, du.baseReserve);
-            setUpgrade(upgrades.mMaxTxSize, du.maxTxSetSize);
+            setUpgrade(upgrades.mMaxTxSetSize, du.maxTxSetSize);
             setUpgrade(upgrades.mProtocolVersion, du.ledgerVersion);
             upgrades.mUpgradeTime = upgradeTime;
             app->getHerder().setUpgrades(upgrades);
@@ -2296,7 +2296,7 @@ TEST_CASE("validate upgrade expiration logic", "[upgrades]")
         REQUIRE(updated);
         REQUIRE(!upgrades.mProtocolVersion);
         REQUIRE(!upgrades.mBaseFee);
-        REQUIRE(!upgrades.mMaxTxSize);
+        REQUIRE(!upgrades.mMaxTxSetSize);
         REQUIRE(!upgrades.mBaseReserve);
         REQUIRE(!upgrades.mFlags);
     }
@@ -2315,7 +2315,7 @@ TEST_CASE("validate upgrade expiration logic", "[upgrades]")
         REQUIRE(!updated);
         REQUIRE(upgrades.mProtocolVersion);
         REQUIRE(upgrades.mBaseFee);
-        REQUIRE(upgrades.mMaxTxSize);
+        REQUIRE(upgrades.mMaxTxSetSize);
         REQUIRE(upgrades.mBaseReserve);
         REQUIRE(upgrades.mFlags);
     }
@@ -2349,8 +2349,8 @@ TEST_CASE("upgrade from cpp14 serialized data", "[upgrades]")
     REQUIRE(up.mProtocolVersion.has_value());
     REQUIRE(up.mProtocolVersion.value() == 17);
     REQUIRE(!up.mBaseFee.has_value());
-    REQUIRE(up.mMaxTxSize.has_value());
-    REQUIRE(up.mMaxTxSize.value() == 10000);
+    REQUIRE(up.mMaxTxSetSize.has_value());
+    REQUIRE(up.mMaxTxSetSize.value() == 10000);
     REQUIRE(!up.mBaseReserve.has_value());
 }
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -535,7 +535,7 @@ CommandHandler::upgrades(std::string const& params, std::string& retStr)
 
         p.mBaseFee = parseOptionalParam<uint32>(retMap, "basefee");
         p.mBaseReserve = parseOptionalParam<uint32>(retMap, "basereserve");
-        p.mMaxTxSize = parseOptionalParam<uint32>(retMap, "maxtxsize");
+        p.mMaxTxSetSize = parseOptionalParam<uint32>(retMap, "maxtxsetsize");
         p.mProtocolVersion =
             parseOptionalParam<uint32>(retMap, "protocolversion");
         p.mFlags = parseOptionalParam<uint32>(retMap, "flags");


### PR DESCRIPTION
# Description

Resolves #3181 

Renamed maxTxSize to maxTxSetSize everywhere for clarity. Also updated the respective documentation and verified that http get option works as expected.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
