### PR TITLE
Rename isString32Valid to isStringValid

### DIFF
--- a/src/invariant/LedgerEntryIsValid.cpp
+++ b/src/invariant/LedgerEntryIsValid.cpp
@@ -151,7 +151,7 @@ LedgerEntryIsValid::checkIsValid(AccountEntry const& ae, uint32 version) const
         return "Account flags are invalid";
     }
 
-    if (!isString32Valid(ae.homeDomain))
+    if (!isStringValid(ae.homeDomain))
     {
         return "Account homeDomain is invalid";
     }
@@ -291,7 +291,7 @@ LedgerEntryIsValid::checkIsValid(DataEntry const& de, uint32 version) const
     {
         return "Data dataName is empty";
     }
-    if (!isString32Valid(de.dataName))
+    if (!isStringValid(de.dataName))
     {
         return "Data dataName is invalid";
     }

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -108,7 +108,7 @@ ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion)
     }
 
     if ((mManageData.dataName.size() < 1) ||
-        (!isString32Valid(mManageData.dataName)))
+        (!isStringValid(mManageData.dataName)))
     {
         innerResult().code(MANAGE_DATA_INVALID_NAME);
         return false;

--- a/src/transactions/RevokeSponsorshipOpFrame.cpp
+++ b/src/transactions/RevokeSponsorshipOpFrame.cpp
@@ -419,7 +419,7 @@ RevokeSponsorshipOpFrame::doCheckValid(uint32_t ledgerVersion)
         case DATA:
         {
             auto const& name = lk.data().dataName;
-            if ((name.size() < 1) || !isString32Valid(name))
+            if ((name.size() < 1) || !isStringValid(name))
             {
                 innerResult().code(REVOKE_SPONSORSHIP_MALFORMED);
                 return false;

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -301,7 +301,7 @@ SetOptionsOpFrame::doCheckValid(uint32_t ledgerVersion)
 
     if (mSetOptions.homeDomain)
     {
-        if (!isString32Valid(*mSetOptions.homeDomain))
+        if (!isStringValid(*mSetOptions.homeDomain))
         {
             innerResult().code(SET_OPTIONS_INVALID_HOME_DOMAIN);
             return false;

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -87,7 +87,7 @@ lessThanXored(Hash const& l, Hash const& r, Hash const& x)
 }
 
 bool
-isString32Valid(std::string const& str)
+isStringValid(std::string const& str)
 {
     auto& loc = std::locale::classic();
     for (auto c : str)

--- a/src/util/types.h
+++ b/src/util/types.h
@@ -23,8 +23,8 @@ Hash& operator^=(Hash& l, Hash const& r);
 // returns true if ( l ^ x ) < ( r ^ x)
 bool lessThanXored(Hash const& l, Hash const& r, Hash const& x);
 
-// returns true if the passed string32 is valid
-bool isString32Valid(std::string const& str);
+// returns true if the passed string is valid
+bool isStringValid(std::string const& str);
 
 // returns true if the currencies are the same
 bool compareAsset(Asset const& first, Asset const& second);


### PR DESCRIPTION
# Description

Rename isString32Valid to isStringValid.

isString32Valid is named with 32 in the name which implies that it is
validating 32 byte strings, but it is used to validate strings of both 32 bytes
and 64 bytes in length. For example, it is used to validate 32 byte home
domains, and 64 byte data entry names. When perusing the code this initially
confused me and I thought the data entry names must also be 32 bytes. On closer
inspection I discovered that the isString32Valid does not check if the string
is valid for the string32 type as specified in the Stellar XDR, but rather that
the string is valid for specific string fields in the XDR, namely the home
domain and the data entry name.

It would be less misleading if this function didn't specify the string size in
the name when it is not relevant to the functions behavior or intended scope of
use.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~

Note: I ran `make format` with `clang-format version 13.0.1` and it modified hundreds of files, so I discarded those changes and have not run format. I'm unable to install clang-format v8.0.0 on macOS, so I'm not sure if that is the cause of the difference.