### PR TITLE
Cleanup logic for checking protocol versions.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -374,6 +374,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\TrustFlagsOpFrameBase.cpp" />
     <ClCompile Include="..\..\src\util\Backtrace.cpp" />
     <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
+    <ClCompile Include="..\..\src\util\ProtocolVersion.cpp" />
     <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\RandHasher.cpp" />
     <ClCompile Include="..\..\src\util\Scheduler.cpp" />
@@ -746,6 +747,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\TrustFlagsOpFrameBase.h" />
     <ClInclude Include="..\..\src\util\Backtrace.h" />
     <ClInclude Include="..\..\src\util\Decoder.h" />
+    <ClInclude Include="..\..\src\util\ProtocolVersion.h" />
     <ClInclude Include="..\..\src\util\numeric128.h" />
     <ClInclude Include="..\..\src\util\RandHasher.h" />
     <ClInclude Include="..\..\src\util\Scheduler.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1221,6 +1221,9 @@
     <ClCompile Include="..\..\src\transactions\TrustFlagsOpFrameBase.cpp">
       <Filter>transactions</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\util\ProtocolVersion.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2125,6 +2128,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\transactions\TrustFlagsOpFrameBase.h">
       <Filter>transactions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\ProtocolVersion.h">
+      <Filter>util</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -8,6 +8,7 @@
 #include "crypto/Hex.h"
 #include "overlay/StellarXDR.h"
 #include "util/NonCopyable.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDRStream.h"
 #include <string>
 
@@ -58,9 +59,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     // At version 11, we added support for INITENTRY and METAENTRY. Before this
     // we were only supporting LIVEENTRY and DEADENTRY.
-    static constexpr uint32_t
-        FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY = 11;
-    static constexpr uint32_t FIRST_PROTOCOL_SHADOWS_REMOVED = 12;
+    static constexpr ProtocolVersion
+        FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY =
+            ProtocolVersion::V_11;
+    static constexpr ProtocolVersion FIRST_PROTOCOL_SHADOWS_REMOVED =
+        ProtocolVersion::V_12;
 
     static void checkProtocolLegality(BucketEntry const& entry,
                                       uint32_t protocolVersion);

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -103,8 +103,10 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
 
             if (e.type() == LIVEENTRY || e.type() == INITENTRY)
             {
-                if (mBucketIter.getMetadata().ledgerVersion <
-                    Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY)
+                if (protocolVersionIsBefore(
+                        mBucketIter.getMetadata().ledgerVersion,
+                        Bucket::
+                            FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY))
                 {
                     // Prior to protocol 11, INITENTRY didn't exist, so we need
                     // to check ltx to see if this is an update or a create

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -12,6 +12,7 @@
 #include "main/Application.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDRStream.h"
 #include "util/types.h"
 #include <Tracy.hpp>
@@ -164,7 +165,8 @@ BucketLevel::prepare(Application& app, uint32_t currLedger,
                     : mCurr;
 
     auto shadowsBasedOnProtocol =
-        Bucket::getBucketVersion(snap) >= Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED
+        protocolVersionStartsFrom(Bucket::getBucketVersion(snap),
+                                  Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
             ? std::vector<std::shared_ptr<Bucket>>()
             : shadows;
     mNextCurr = FutureBucket(app, curr, snap, shadowsBasedOnProtocol,
@@ -636,7 +638,8 @@ BucketList::restartMerges(Application& app, uint32_t maxProtocolVersion,
             }
 
             auto version = Bucket::getBucketVersion(snap);
-            if (version < Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+            if (protocolVersionIsBefore(version,
+                                        Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
             {
                 auto msg = fmt::format(
                     FMT_STRING("Invalid state: bucketlist level {:d} has clear "

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -53,8 +53,9 @@ BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
     // Will throw if unable to open the file
     mOut.open(mFilename);
 
-    if (meta.ledgerVersion >=
-        Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY)
+    if (protocolVersionStartsFrom(
+            meta.ledgerVersion,
+            Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY))
     {
         BucketEntry bme;
         bme.type(METAENTRY);

--- a/src/bucket/FutureBucket.cpp
+++ b/src/bucket/FutureBucket.cpp
@@ -48,8 +48,8 @@ FutureBucket::FutureBucket(Application& app,
     releaseAssert(snap);
     mInputCurrBucketHash = binToHex(curr->getHash());
     mInputSnapBucketHash = binToHex(snap->getHash());
-    if (Bucket::getBucketVersion(snap) >=
-        Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+    if (protocolVersionStartsFrom(Bucket::getBucketVersion(snap),
+                                  Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
     {
         if (!mInputShadowBuckets.empty())
         {

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -24,6 +24,7 @@
 #include "test/TestUtils.h"
 #include "test/test.h"
 #include "util/Math.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 #include "xdrpp/autocheck.h"
 
@@ -242,8 +243,9 @@ TEST_CASE("bucket list shadowing pre/post proto 12", "[bucket][bucketlist]")
                     bool hasBob =
                         (curr->containsBucketIdentity(BucketEntryBob) ||
                          snap->containsBucketIdentity(BucketEntryBob));
-                    if (app->getConfig().LEDGER_PROTOCOL_VERSION <
-                            Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED ||
+                    if (protocolVersionIsBefore(
+                            app->getConfig().LEDGER_PROTOCOL_VERSION,
+                            Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED) ||
                         j > 5)
                     {
                         CHECK(!hasAlice);
@@ -388,8 +390,9 @@ TEST_CASE("bucket tombstones mutually-annihilate init entries",
             auto const& lev = bl.getLevel(k);
             auto currSz = countEntries(lev.getCurr());
             auto snapSz = countEntries(lev.getSnap());
-            if (cfg.LEDGER_PROTOCOL_VERSION >=
-                Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY)
+            if (protocolVersionStartsFrom(
+                    cfg.LEDGER_PROTOCOL_VERSION,
+                    Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY))
             {
                 // init/dead pairs should mutually-annihilate pretty readily as
                 // they go, empirically this test peaks at buckets around 400

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -61,19 +61,27 @@ void
 for_versions_with_differing_bucket_logic(
     Config const& cfg, std::function<void(Config const&)> const& f)
 {
-    for_versions({Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY - 1,
-                  Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY,
-                  Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED},
-                 cfg, f);
+    for_versions(
+        {static_cast<uint32_t>(
+             Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY) -
+             1,
+         static_cast<uint32_t>(
+             Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY),
+         static_cast<uint32_t>(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)},
+        cfg, f);
 }
 
 void
 for_versions_with_differing_initentry_logic(
     Config const& cfg, std::function<void(Config const&)> const& f)
 {
-    for_versions({Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY - 1,
-                  Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY},
-                 cfg, f);
+    for_versions(
+        {static_cast<uint32_t>(
+             Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY) -
+             1,
+         static_cast<uint32_t>(
+             Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY)},
+        cfg, f);
 }
 
 EntryCounts::EntryCounts(std::shared_ptr<Bucket> bucket)
@@ -377,7 +385,7 @@ TEST_CASE("merges proceed old-style despite newer shadows",
     Config const& cfg = getTestConfig();
     Application::pointer app = createTestApplication(clock, cfg);
     auto& bm = app->getBucketManager();
-    auto v12 = Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED;
+    auto v12 = static_cast<uint32_t>(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED);
     auto v11 = v12 - 1;
     auto v10 = v11 - 1;
 
@@ -482,7 +490,8 @@ TEST_CASE("bucket output iterator rejects wrong-version entries",
 {
     VirtualClock clock;
     Config const& cfg = getTestConfig();
-    auto vers_new = Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY;
+    auto vers_new = static_cast<uint32_t>(
+        Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY);
     BucketMetadata meta;
     meta.ledgerVersion = vers_new - 1;
     Application::pointer app = createTestApplication(clock, cfg);
@@ -510,8 +519,8 @@ TEST_CASE("merging bucket entries with initentry", "[bucket][initentry]")
         auto vers = getAppLedgerVersion(app);
 
         // Whether we're in the era of supporting or not-supporting INITENTRY.
-        bool initEra =
-            (vers >= Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY);
+        bool initEra = protocolVersionStartsFrom(
+            vers, Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY);
 
         CLOG_INFO(Bucket, "=== finished buckets for initial account == ");
 
@@ -699,8 +708,8 @@ TEST_CASE("merging bucket entries with initentry with shadows",
         auto vers = getAppLedgerVersion(app);
 
         // Whether we're in the era of supporting or not-supporting INITENTRY.
-        bool initEra =
-            (vers >= Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY);
+        bool initEra = protocolVersionStartsFrom(
+            vers, Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY);
 
         CLOG_INFO(Bucket, "=== finished buckets for initial account == ");
 

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -17,6 +17,7 @@
 #include "scp/Slot.h"
 #include "util/Logging.h"
 #include "util/Math.h"
+#include "util/ProtocolVersion.h"
 #include "xdr/Stellar-SCP.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include "xdr/Stellar-ledger.h"
@@ -556,7 +557,7 @@ compareTxSets(TxSetFrameConstPtr l, TxSetFrameConstPtr r, Hash const& lh,
     {
         return false;
     }
-    if (header.ledgerVersion >= 11)
+    if (protocolVersionStartsFrom(header.ledgerVersion, ProtocolVersion::V_11))
     {
         auto lFee = l->getTotalFees(header);
         auto rFee = r->getTotalFees(header);

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -19,6 +19,7 @@
 #include "util/GlobalChecks.h"
 #include "util/HashOfHash.h"
 #include "util/Math.h"
+#include "util/ProtocolVersion.h"
 #include "util/TarjanSCCCalculator.h"
 #include "util/XDROperators.h"
 #include "util/numeric128.h"
@@ -815,7 +816,9 @@ void
 TransactionQueue::maybeVersionUpgraded()
 {
     auto const& lcl = mApp.getLedgerManager().getLastClosedLedgerHeader();
-    if (mLedgerVersion < 13 && lcl.header.ledgerVersion >= 13)
+    if (protocolVersionIsBefore(mLedgerVersion, ProtocolVersion::V_13) &&
+        protocolVersionStartsFrom(lcl.header.ledgerVersion,
+                                  ProtocolVersion::V_13))
     {
         clearAll();
     }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -18,6 +18,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDRCereal.h"
 #include "util/XDROperators.h"
 #include "xdrpp/marshal.h"
@@ -223,7 +224,8 @@ TxSetFrame::surgePricingFilter(Application& app)
     LedgerTxn ltx(app.getLedgerTxnRoot());
     auto header = ltx.loadHeader();
 
-    bool maxIsOps = header.current().ledgerVersion >= 11;
+    bool maxIsOps = protocolVersionStartsFrom(header.current().ledgerVersion,
+                                              ProtocolVersion::V_11);
 
     size_t opsLeft = app.getLedgerManager().getLastMaxTxSetSizeOps();
 
@@ -474,7 +476,9 @@ TxSetFrame::previousLedgerHash() const
 size_t
 TxSetFrame::size(LedgerHeader const& lh) const
 {
-    return lh.ledgerVersion >= 11 ? sizeOp() : sizeTx();
+    return protocolVersionStartsFrom(lh.ledgerVersion, ProtocolVersion::V_11)
+               ? sizeOp()
+               : sizeTx();
 }
 
 size_t
@@ -492,7 +496,7 @@ int64_t
 TxSetFrame::getBaseFee(LedgerHeader const& lh) const
 {
     int64_t baseFee = lh.baseFee;
-    if (lh.ledgerVersion >= 11)
+    if (protocolVersionStartsFrom(lh.ledgerVersion, ProtocolVersion::V_11))
     {
         size_t ops = 0;
         int64_t lowBaseFee = std::numeric_limits<int64_t>::max();

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -30,6 +30,7 @@
 #include "transactions/TransactionFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Math.h"
+#include "util/ProtocolVersion.h"
 
 #include "xdr/Stellar-ledger.h"
 #include "xdrpp/marshal.h"
@@ -151,7 +152,9 @@ TEST_CASE("standalone", "[herder][acceptance]")
                 bool hasC = false;
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    hasC = ltx.loadHeader().current().ledgerVersion >= 10;
+                    hasC = protocolVersionStartsFrom(
+                        ltx.loadHeader().current().ledgerVersion,
+                        ProtocolVersion::V_10);
                 }
                 if (hasC)
                 {

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -19,6 +19,7 @@
 #include "util/Fs.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 #include <fmt/format.h>
 
@@ -357,7 +358,8 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
             // No real buckets seen yet, move on
             continue;
         }
-        else if (prevSnapVersion >= Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+        else if (protocolVersionStartsFrom(
+                     prevSnapVersion, Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
         {
             if (!level.next.isClear())
             {
@@ -390,8 +392,9 @@ HistoryArchiveState::prepareForPublish(Application& app)
 
         auto snap =
             app.getBucketManager().getBucketByHash(hexToBin256(prev.snap));
-        if (!level.next.isClear() && Bucket::getBucketVersion(snap) >=
-                                         Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+        if (!level.next.isClear() &&
+            protocolVersionStartsFrom(Bucket::getBucketVersion(snap),
+                                      Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
         {
             level.next.clear();
         }

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -504,7 +504,8 @@ TEST_CASE("Publish works correctly post shadow removal", "[history]")
     CatchupSimulation catchupSimulation{VirtualClock::VIRTUAL_TIME,
                                         configurator};
 
-    uint32_t oldProto = Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED - 1;
+    uint32_t oldProto =
+        static_cast<uint32_t>(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED) - 1;
     catchupSimulation.generateRandomLedger(oldProto);
 
     // The next sections reflect how future buckets in HAS change, depending on
@@ -884,7 +885,8 @@ TEST_CASE("History prefix catchup", "[history][catchup]")
 
 TEST_CASE("Catchup post-shadow-removal works", "[history]")
 {
-    uint32_t newProto = Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED;
+    uint32_t newProto =
+        static_cast<uint32_t>(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED);
     uint32_t oldProto = newProto - 1;
 
     auto configurator =
@@ -959,8 +961,8 @@ TEST_CASE("Catchup post-shadow-removal works", "[history]")
 TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
           "[history][bucket][acceptance]")
 {
-    uint32_t newProto =
-        Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY;
+    uint32_t newProto = static_cast<uint32_t>(
+        Bucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY);
     uint32_t oldProto = newProto - 1;
     auto configurator =
         std::make_shared<RealGenesisTmpDirHistoryConfigurator>();

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -521,7 +521,8 @@ CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger)
         if (lcl + 1 == mTestProtocolShadowsRemovedLedgerSeq)
         {
             // Force proto 12 upgrade
-            generateRandomLedger(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED);
+            generateRandomLedger(
+                static_cast<uint32_t>(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED));
         }
         else
         {

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -13,6 +13,7 @@
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDRCereal.h"
 #include <fmt/format.h>
 
@@ -102,7 +103,8 @@ InvariantManagerImpl::checkOnOperationApply(Operation const& operation,
                                             OperationResult const& opres,
                                             LedgerTxnDelta const& ltxDelta)
 {
-    if (ltxDelta.header.current.ledgerVersion < 8)
+    if (protocolVersionIsBefore(ltxDelta.header.current.ledgerVersion,
+                                ProtocolVersion::V_8))
     {
         return;
     }

--- a/src/invariant/LiabilitiesMatchOffers.cpp
+++ b/src/invariant/LiabilitiesMatchOffers.cpp
@@ -9,6 +9,7 @@
 #include "main/Application.h"
 #include "transactions/OfferExchange.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDRCereal.h"
 #include "util/types.h"
 #include "xdrpp/printer.h"
@@ -220,7 +221,7 @@ shouldCheckAccount(LedgerEntry const* current, LedgerEntry const* previous,
     auto const& prevAcc = previous->data.account();
 
     bool didBalanceDecrease = currAcc.balance < prevAcc.balance;
-    if (ledgerVersion >= 10)
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
     {
         bool sellingLiabilitiesInc =
             getSellingLiabilities(*current) > getSellingLiabilities(*previous);
@@ -251,7 +252,7 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
         {
             auto const& account = current->data.account();
             Liabilities liabilities;
-            if (ledgerVersion >= 10)
+            if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
             {
                 liabilities.selling = getSellingLiabilities(*current);
                 liabilities.buying = getBuyingLiabilities(*current);
@@ -271,7 +272,7 @@ checkBalanceAndLimit(LedgerHeader const& header, LedgerEntry const* current,
     {
         auto const& trust = current->data.trustLine();
         Liabilities liabilities;
-        if (ledgerVersion >= 10)
+        if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
         {
             liabilities.selling = getSellingLiabilities(*current);
             liabilities.buying = getBuyingLiabilities(*current);
@@ -328,7 +329,7 @@ LiabilitiesMatchOffers::checkOnOperationApply(Operation const& operation,
                                               LedgerTxnDelta const& ltxDelta)
 {
     auto ledgerVersion = ltxDelta.header.current.ledgerVersion;
-    if (ledgerVersion >= 10)
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
     {
         LiabilitiesMap deltaLiabilities;
         for (auto const& entryDelta : ltxDelta.entry)

--- a/src/invariant/SponsorshipCountIsValid.cpp
+++ b/src/invariant/SponsorshipCountIsValid.cpp
@@ -8,6 +8,7 @@
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
+#include "util/ProtocolVersion.h"
 #include "util/UnorderedMap.h"
 #include <fmt/format.h>
 
@@ -158,7 +159,7 @@ SponsorshipCountIsValid::checkOnOperationApply(Operation const& operation,
 {
     // No sponsorships prior to protocol 14
     auto ledgerVersion = ltxDelta.header.current.ledgerVersion;
-    if (ledgerVersion < 14)
+    if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_14))
     {
         return {};
     }

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -21,6 +21,7 @@
 #include "transactions/TransactionBridge.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/StatusManager.h"
 #include <Tracy.hpp>
 #include <fmt/format.h>
@@ -669,7 +670,8 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
 
         {
             auto lhhe = mApp.getLedgerManager().getLastClosedLedgerHeader();
-            if (lhhe.header.ledgerVersion >= 13)
+            if (protocolVersionStartsFrom(lhhe.header.ledgerVersion,
+                                          ProtocolVersion::V_13))
             {
                 envelope = txbridge::convertForV13(envelope);
             }

--- a/src/transactions/AllowTrustOpFrame.cpp
+++ b/src/transactions/AllowTrustOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -108,7 +109,8 @@ AllowTrustOpFrame::isAuthRevocationValid(AbstractLedgerTxn& ltx,
 
     // Check if the source account doesn't require authorization check
     // Only valid for earlier versions.
-    if (header.current().ledgerVersion < 16 &&
+    if (protocolVersionIsBefore(header.current().ledgerVersion,
+                                ProtocolVersion::V_16) &&
         !(sourceAccount.flags & AUTH_REQUIRED_FLAG))
     {
         innerResult().code(ALLOW_TRUST_TRUST_NOT_REQUIRED);
@@ -173,7 +175,8 @@ AllowTrustOpFrame::doCheckValid(uint32_t ledgerVersion)
         return false;
     }
 
-    if (ledgerVersion > 15 && mAllowTrust.trustor == getSourceID())
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_16) &&
+        mAllowTrust.trustor == getSourceID())
     {
         innerResult().code(ALLOW_TRUST_MALFORMED);
         return false;

--- a/src/transactions/BeginSponsoringFutureReservesOpFrame.cpp
+++ b/src/transactions/BeginSponsoringFutureReservesOpFrame.cpp
@@ -7,6 +7,7 @@
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -23,7 +24,8 @@ bool
 BeginSponsoringFutureReservesOpFrame::isOpSupported(
     LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 14;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_14);
 }
 
 void

--- a/src/transactions/BumpSequenceOpFrame.cpp
+++ b/src/transactions/BumpSequenceOpFrame.cpp
@@ -7,6 +7,7 @@
 #include "database/Database.h"
 #include "main/Application.h"
 #include "transactions/TransactionFrame.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <Tracy.hpp>
 
@@ -30,7 +31,8 @@ BumpSequenceOpFrame::getThresholdLevel() const
 bool
 BumpSequenceOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 10;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_10);
 }
 
 bool

--- a/src/transactions/ChangeTrustOpFrame.cpp
+++ b/src/transactions/ChangeTrustOpFrame.cpp
@@ -12,6 +12,7 @@
 #include "main/Application.h"
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -149,7 +150,8 @@ ChangeTrustOpFrame::doApply(AbstractLedgerTxn& ltx)
         throw std::runtime_error("native asset is not valid in ChangeTrustOp");
     }
 
-    if (ltx.loadHeader().current().ledgerVersion > 2)
+    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                  ProtocolVersion::V_3))
     {
         // Note: No longer checking if issuer exists here, because if
         //     issuerID == getSourceID()
@@ -316,7 +318,7 @@ ChangeTrustOpFrame::doCheckValid(uint32_t ledgerVersion)
         innerResult().code(CHANGE_TRUST_MALFORMED);
         return false;
     }
-    if (ledgerVersion > 9)
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
     {
         if (mChangeTrust.line.type() == ASSET_TYPE_NATIVE)
         {
@@ -325,7 +327,8 @@ ChangeTrustOpFrame::doCheckValid(uint32_t ledgerVersion)
         }
     }
 
-    if (ledgerVersion > 15 && isIssuer(getSourceID(), mChangeTrust.line))
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_16) &&
+        isIssuer(getSourceID(), mChangeTrust.line))
     {
         innerResult().code(CHANGE_TRUST_MALFORMED);
         return false;

--- a/src/transactions/ClaimClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClaimClaimableBalanceOpFrame.cpp
@@ -10,6 +10,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -30,7 +31,8 @@ ClaimClaimableBalanceOpFrame::getThresholdLevel() const
 bool
 ClaimClaimableBalanceOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 14;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_14);
 }
 
 bool

--- a/src/transactions/ClawbackClaimableBalanceOpFrame.cpp
+++ b/src/transactions/ClawbackClaimableBalanceOpFrame.cpp
@@ -6,6 +6,7 @@
 #include "ledger/LedgerTxn.h"
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -21,7 +22,8 @@ ClawbackClaimableBalanceOpFrame::ClawbackClaimableBalanceOpFrame(
 bool
 ClawbackClaimableBalanceOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 17;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_17);
 }
 
 bool

--- a/src/transactions/ClawbackOpFrame.cpp
+++ b/src/transactions/ClawbackOpFrame.cpp
@@ -5,6 +5,7 @@
 #include "transactions/ClawbackOpFrame.h"
 #include "ledger/LedgerTxn.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -19,7 +20,8 @@ ClawbackOpFrame::ClawbackOpFrame(Operation const& op, OperationResult& res,
 bool
 ClawbackOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 17;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_17);
 }
 
 bool

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -13,6 +13,7 @@
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <Tracy.hpp>
 #include <algorithm>
@@ -44,7 +45,8 @@ CreateAccountOpFrame::doApplyBeforeV14(AbstractLedgerTxn& ltx)
     }
 
     bool doesAccountExist =
-        (header.current().ledgerVersion >= 8) ||
+        protocolVersionStartsFrom(header.current().ledgerVersion,
+                                  ProtocolVersion::V_8) ||
         (bool)ltx.loadWithoutRecord(accountKey(getSourceID()));
 
     auto sourceAccount = loadSourceAccount(ltx, header);
@@ -143,7 +145,8 @@ CreateAccountOpFrame::doApply(AbstractLedgerTxn& ltx)
         return false;
     }
 
-    if (ltx.loadHeader().current().ledgerVersion < 14)
+    if (protocolVersionIsBefore(ltx.loadHeader().current().ledgerVersion,
+                                ProtocolVersion::V_14))
     {
         return doApplyBeforeV14(ltx);
     }
@@ -156,7 +159,8 @@ CreateAccountOpFrame::doApply(AbstractLedgerTxn& ltx)
 bool
 CreateAccountOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
-    int64_t minStartingBalance = ledgerVersion >= 14 ? 0 : 1;
+    int64_t minStartingBalance =
+        protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_14) ? 0 : 1;
     if (mCreateAccount.startingBalance < minStartingBalance)
     {
         innerResult().code(CREATE_ACCOUNT_MALFORMED);

--- a/src/transactions/CreateClaimableBalanceOpFrame.cpp
+++ b/src/transactions/CreateClaimableBalanceOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -134,7 +135,8 @@ CreateClaimableBalanceOpFrame::CreateClaimableBalanceOpFrame(
 bool
 CreateClaimableBalanceOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 14;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_14);
 }
 
 bool
@@ -186,7 +188,8 @@ CreateClaimableBalanceOpFrame::doApply(AbstractLedgerTxn& ltx)
             return false;
         }
 
-        if (header.current().ledgerVersion >= 17)
+        if (protocolVersionStartsFrom(header.current().ledgerVersion,
+                                      ProtocolVersion::V_17))
         {
             bool enableClawback;
             if (getSourceID() == getIssuer(asset))

--- a/src/transactions/EndSponsoringFutureReservesOpFrame.cpp
+++ b/src/transactions/EndSponsoringFutureReservesOpFrame.cpp
@@ -6,6 +6,7 @@
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -20,7 +21,8 @@ bool
 EndSponsoringFutureReservesOpFrame::isOpSupported(
     LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 14;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_14);
 }
 
 bool

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -16,6 +16,7 @@
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
+#include "util/ProtocolVersion.h"
 #include "util/numeric128.h"
 #include "xdrpp/marshal.h"
 
@@ -180,7 +181,8 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
     //    (stay true regardless of other side effects)
 
     auto header = ltx.loadHeader();
-    if (header.current().ledgerVersion < 13)
+    if (protocolVersionIsBefore(header.current().ledgerVersion,
+                                ProtocolVersion::V_13))
     {
         getResult().result.code(txNOT_SUPPORTED);
         return false;

--- a/src/transactions/LiquidityPoolDepositOpFrame.cpp
+++ b/src/transactions/LiquidityPoolDepositOpFrame.cpp
@@ -7,6 +7,7 @@
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/numeric128.h"
 
 namespace stellar
@@ -22,7 +23,9 @@ LiquidityPoolDepositOpFrame::LiquidityPoolDepositOpFrame(
 bool
 LiquidityPoolDepositOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 18 && !isPoolDepositDisabled(header);
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_18) &&
+           !isPoolDepositDisabled(header);
 }
 
 static bool

--- a/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
+++ b/src/transactions/LiquidityPoolWithdrawOpFrame.cpp
@@ -7,6 +7,7 @@
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -21,7 +22,9 @@ LiquidityPoolWithdrawOpFrame::LiquidityPoolWithdrawOpFrame(
 bool
 LiquidityPoolWithdrawOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 18 && !isPoolWithdrawalDisabled(header);
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_18) &&
+           !isPoolWithdrawalDisabled(header);
 }
 
 bool

--- a/src/transactions/ManageBuyOfferOpFrame.cpp
+++ b/src/transactions/ManageBuyOfferOpFrame.cpp
@@ -9,6 +9,7 @@
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/OfferExchange.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -33,7 +34,8 @@ ManageBuyOfferOpFrame::ManageBuyOfferOpFrame(Operation const& op,
 bool
 ManageBuyOfferOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 11;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_11);
 }
 
 bool

--- a/src/transactions/ManageDataOpFrame.cpp
+++ b/src/transactions/ManageDataOpFrame.cpp
@@ -12,6 +12,7 @@
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
 #include <Tracy.hpp>
@@ -33,7 +34,8 @@ ManageDataOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
     ZoneNamedN(applyZone, "ManageDataOp apply", true);
     auto header = ltx.loadHeader();
-    if (header.current().ledgerVersion == 3)
+    if (protocolVersionEquals(header.current().ledgerVersion,
+                              ProtocolVersion::V_3))
     {
         throw std::runtime_error(
             "MANAGE_DATA not supported on ledger version 3");
@@ -101,7 +103,7 @@ ManageDataOpFrame::doApply(AbstractLedgerTxn& ltx)
 bool
 ManageDataOpFrame::doCheckValid(uint32_t ledgerVersion)
 {
-    if (ledgerVersion < 2)
+    if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_2))
     {
         innerResult().code(MANAGE_DATA_NOT_SUPPORTED_YET);
         return false;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -30,6 +30,7 @@
 #include "transactions/TransactionFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDRCereal.h"
 #include <Tracy.hpp>
 
@@ -223,7 +224,8 @@ OperationFrame::checkValid(SignatureChecker& signatureChecker,
     }
 
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
-    if (!forApply || ledgerVersion < 10)
+    if (!forApply ||
+        protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_10))
     {
         if (!checkSignature(signatureChecker, ltx, forApply))
         {

--- a/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictReceiveOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerTxnHeader.h"
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <Tracy.hpp>
 
@@ -38,7 +39,8 @@ PathPaymentStrictReceiveOpFrame::doApply(AbstractLedgerTxn& ltx)
     setResultSuccess();
 
     bool doesSourceAccountExist = true;
-    if (ltx.loadHeader().current().ledgerVersion < 8)
+    if (protocolVersionIsBefore(ltx.loadHeader().current().ledgerVersion,
+                                ProtocolVersion::V_8))
     {
         doesSourceAccountExist =
             (bool)stellar::loadAccountWithoutRecord(ltx, getSourceID());
@@ -83,8 +85,9 @@ PathPaymentStrictReceiveOpFrame::doApply(AbstractLedgerTxn& ltx)
         }
 
         int64_t maxOffersToCross = INT64_MAX;
-        if (ltx.loadHeader().current().ledgerVersion >=
-            FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS)
+        if (protocolVersionStartsFrom(
+                ltx.loadHeader().current().ledgerVersion,
+                FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS))
         {
             size_t offersCrossed = innerResult().success().offers.size();
             // offersCrossed will never be bigger than INT64_MAX because

--- a/src/transactions/PathPaymentStrictSendOpFrame.cpp
+++ b/src/transactions/PathPaymentStrictSendOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerTxnHeader.h"
 #include "ledger/TrustLineWrapper.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <Tracy.hpp>
 
@@ -24,7 +25,8 @@ PathPaymentStrictSendOpFrame::PathPaymentStrictSendOpFrame(
 bool
 PathPaymentStrictSendOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 12;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_12);
 }
 
 bool

--- a/src/transactions/PaymentOpFrame.cpp
+++ b/src/transactions/PaymentOpFrame.cpp
@@ -10,6 +10,7 @@
 #include "transactions/PathPaymentStrictReceiveOpFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/GlobalChecks.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -35,10 +36,11 @@ PaymentOpFrame::doApply(AbstractLedgerTxn& ltx)
     // in ledger version 2 it would work for any asset type
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
     auto destID = toAccountID(mPayment.destination);
-    auto instantSuccess = ledgerVersion > 2
-                              ? destID == getSourceID() &&
-                                    mPayment.asset.type() == ASSET_TYPE_NATIVE
-                              : destID == getSourceID();
+    auto instantSuccess =
+        protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_3)
+            ? destID == getSourceID() &&
+                  mPayment.asset.type() == ASSET_TYPE_NATIVE
+            : destID == getSourceID();
     if (instantSuccess)
     {
         innerResult().code(PAYMENT_SUCCESS);

--- a/src/transactions/RevokeSponsorshipOpFrame.cpp
+++ b/src/transactions/RevokeSponsorshipOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerTxnEntry.h"
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -23,7 +24,8 @@ RevokeSponsorshipOpFrame::RevokeSponsorshipOpFrame(Operation const& op,
 bool
 RevokeSponsorshipOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 14;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_14);
 }
 
 static AccountID const&

--- a/src/transactions/SetOptionsOpFrame.cpp
+++ b/src/transactions/SetOptionsOpFrame.cpp
@@ -11,6 +11,7 @@
 #include "main/Application.h"
 #include "transactions/SponsorshipUtils.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <Tracy.hpp>
 
@@ -287,12 +288,15 @@ SetOptionsOpFrame::doCheckValid(uint32_t ledgerVersion)
                       KeyUtils::convertKey<SignerKey>(getSourceID());
         auto isPublicKey =
             KeyUtils::canConvert<PublicKey>(mSetOptions.signer->key);
-        if (isSelf || (!isPublicKey && ledgerVersion < 3))
+        if (isSelf ||
+            (!isPublicKey &&
+             protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_3)))
         {
             innerResult().code(SET_OPTIONS_BAD_SIGNER);
             return false;
         }
-        if (mSetOptions.signer->weight > UINT8_MAX && ledgerVersion > 9)
+        if (mSetOptions.signer->weight > UINT8_MAX &&
+            protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
         {
             innerResult().code(SET_OPTIONS_BAD_SIGNER);
             return false;

--- a/src/transactions/SetTrustLineFlagsOpFrame.cpp
+++ b/src/transactions/SetTrustLineFlagsOpFrame.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerTxnHeader.h"
 #include "main/Application.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -26,7 +27,8 @@ SetTrustLineFlagsOpFrame::SetTrustLineFlagsOpFrame(Operation const& op,
 bool
 SetTrustLineFlagsOpFrame::isOpSupported(LedgerHeader const& header) const
 {
-    return header.ledgerVersion >= 17;
+    return protocolVersionStartsFrom(header.ledgerVersion,
+                                     ProtocolVersion::V_17);
 }
 
 void

--- a/src/transactions/SignatureChecker.cpp
+++ b/src/transactions/SignatureChecker.cpp
@@ -10,6 +10,7 @@
 #include "crypto/SignerKey.h"
 #include "transactions/SignatureUtils.h"
 #include "util/Algorithm.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <Tracy.hpp>
 
@@ -34,7 +35,7 @@ SignatureChecker::checkSignature(std::vector<Signer> const& signersV,
     return true;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
-    if (mProtocolVersion == 7)
+    if (protocolVersionEquals(mProtocolVersion, ProtocolVersion::V_7))
     {
         return true;
     }
@@ -55,7 +56,9 @@ SignatureChecker::checkSignature(std::vector<Signer> const& signersV,
         if (signerKey.key.preAuthTx() == mContentsHash)
         {
             auto w = signerKey.weight;
-            if (mProtocolVersion > 9 && w > UINT8_MAX)
+            if (protocolVersionStartsFrom(mProtocolVersion,
+                                          ProtocolVersion::V_10) &&
+                w > UINT8_MAX)
             {
                 w = UINT8_MAX;
             }
@@ -79,7 +82,9 @@ SignatureChecker::checkSignature(std::vector<Signer> const& signersV,
                 {
                     mUsedSignatures[i] = true;
                     auto w = signerKey.weight;
-                    if (mProtocolVersion > 9 && w > UINT8_MAX)
+                    if (protocolVersionStartsFrom(mProtocolVersion,
+                                                  ProtocolVersion::V_10) &&
+                        w > UINT8_MAX)
                     {
                         w = UINT8_MAX;
                     }
@@ -126,7 +131,7 @@ SignatureChecker::checkAllSignaturesUsed() const
     return true;
 #endif // FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
-    if (mProtocolVersion == 7)
+    if (protocolVersionEquals(mProtocolVersion, ProtocolVersion::V_7))
     {
         return true;
     }

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerTxnHeader.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include "util/types.h"
 
@@ -19,7 +20,7 @@ static bool
 isSponsoringSubentrySumIncreaseValid(LedgerHeader const& lh,
                                      LedgerEntry const& acc, uint32_t mult)
 {
-    return lh.ledgerVersion < 18 ||
+    return protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_18) ||
            ((uint64_t)getNumSponsoring(acc) +
             (uint64_t)acc.data.account().numSubEntries + (uint64_t)mult) <=
                UINT32_MAX;
@@ -41,7 +42,8 @@ static bool
 tooManyNumSubEntries(LedgerHeader const& lh, LedgerEntry const& acc,
                      uint32_t mult)
 {
-    if (lh.ledgerVersion >= FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS &&
+    if (protocolVersionStartsFrom(lh.ledgerVersion,
+                                  FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS) &&
         acc.data.account().numSubEntries > getAccountSubEntryLimit() - mult)
     {
         return true;
@@ -232,7 +234,7 @@ canEstablishEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
                              LedgerEntry const& sponsoringAcc,
                              LedgerEntry const* sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -250,7 +252,7 @@ canRemoveEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
                           LedgerEntry const& sponsoringAcc,
                           LedgerEntry const* sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -270,7 +272,7 @@ canTransferEntrySponsorship(LedgerHeader const& lh, LedgerEntry const& le,
                             LedgerEntry const& oldSponsoringAcc,
                             LedgerEntry const& newSponsoringAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -292,7 +294,7 @@ canEstablishSignerSponsorship(
     LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
     LedgerEntry const& sponsoringAcc, LedgerEntry const& sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -311,7 +313,7 @@ canRemoveSignerSponsorship(LedgerHeader const& lh,
                            LedgerEntry const& sponsoringAcc,
                            LedgerEntry const& sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -330,7 +332,7 @@ canTransferSignerSponsorship(
     LedgerEntry const& oldSponsoringAcc, LedgerEntry const& newSponsoringAcc,
     LedgerEntry const& sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -471,7 +473,7 @@ canCreateEntryWithoutSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
             return SponsorshipResult::TOO_MANY_SUBENTRIES;
         }
 
-        if (lh.ledgerVersion < 9)
+        if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_9))
         {
             // This is needed to handle the overflow in getMinBalance which was
             // corrected in protocol version 9
@@ -507,7 +509,7 @@ canCreateEntryWithSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
                               LedgerEntry const& sponsoringAcc,
                               LedgerEntry const* sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -543,7 +545,7 @@ canRemoveEntryWithSponsorship(LedgerHeader const& lh, LedgerEntry const& le,
                               LedgerEntry const& sponsoringAcc,
                               LedgerEntry const* sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -589,7 +591,7 @@ canCreateSignerWithSponsorship(
     LedgerHeader const& lh, std::vector<Signer>::const_iterator const& signerIt,
     LedgerEntry const& sponsoringAcc, LedgerEntry const& sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }
@@ -618,7 +620,7 @@ canRemoveSignerWithSponsorship(LedgerHeader const& lh,
                                LedgerEntry const& sponsoringAcc,
                                LedgerEntry const& sponsoredAcc)
 {
-    if (lh.ledgerVersion < 14)
+    if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_14))
     {
         throw std::runtime_error("sponsorship before version 14");
     }

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "util/NonCopyable.h"
+#include "util/ProtocolVersion.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include "xdr/Stellar-ledger.h"
 #include "xdr/Stellar-transaction.h"
@@ -61,7 +62,8 @@ LedgerKey poolShareTrustLineKey(AccountID const& accountID,
 InternalLedgerKey sponsorshipKey(AccountID const& sponsoredID);
 InternalLedgerKey sponsorshipCounterKey(AccountID const& sponsoringID);
 
-uint32_t const FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS = 11;
+ProtocolVersion const FIRST_PROTOCOL_SUPPORTING_OPERATION_LIMITS =
+    ProtocolVersion::V_11;
 
 uint32_t getAccountSubEntryLimit();
 size_t getMaxOffersToCross();

--- a/src/transactions/TrustFlagsOpFrameBase.cpp
+++ b/src/transactions/TrustFlagsOpFrameBase.cpp
@@ -5,6 +5,7 @@
 #include "transactions/TrustFlagsOpFrameBase.h"
 #include "ledger/LedgerTxn.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include <Tracy.hpp>
 
 namespace stellar
@@ -55,7 +56,7 @@ TrustFlagsOpFrameBase::doApply(AbstractLedgerTxn& ltx)
     ZoneNamedN(applyZone, "TrustFlagsOpFrameBase apply", true);
 
     auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
-    if (ledgerVersion > 2)
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_3))
     {
         // Only relevant for AllowTrust, since version 3 it is not allowed
         // to use AllowTrust on self.
@@ -117,7 +118,8 @@ TrustFlagsOpFrameBase::doApply(AbstractLedgerTxn& ltx)
     }
 
     // Remove offers, the ledgerVersion check is only relevant for AllowTrust
-    if (ledgerVersion >= 10 && shouldRemoveOffers)
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10) &&
+        shouldRemoveOffers)
     {
         if (!removeOffers(ltx))
         {

--- a/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
+++ b/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
@@ -183,7 +183,8 @@ TxSimGenerateBucketsWork::setFutureBuckets()
         auto const& prevSnapBucket = mBuckets[prevSnapHash];
 
         auto snapVersion = Bucket::getBucketVersion(prevSnapBucket);
-        if (snapVersion < Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+        if (protocolVersionIsBefore(snapVersion,
+                                    Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
         {
             auto const& currHash = mGeneratedApplyState.currentBuckets[i].curr;
             auto const& currBucket = mBuckets[currHash];

--- a/src/transactions/simulation/TxSimTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimTransactionFrame.cpp
@@ -12,6 +12,7 @@
 #include "transactions/simulation/TxSimManageBuyOfferOpFrame.h"
 #include "transactions/simulation/TxSimManageSellOfferOpFrame.h"
 #include "transactions/simulation/TxSimMergeOpFrame.h"
+#include "util/ProtocolVersion.h"
 
 namespace stellar
 {
@@ -124,7 +125,8 @@ TxSimTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
         header.current().feePool += fee;
     }
     // in v10 we update sequence numbers during apply
-    if (header.current().ledgerVersion <= 9)
+    if (protocolVersionIsBefore(header.current().ledgerVersion,
+                                ProtocolVersion::V_10))
     {
         acc.seqNum = getSeqNum();
     }
@@ -134,7 +136,8 @@ void
 TxSimTransactionFrame::processSeqNum(AbstractLedgerTxn& ltx)
 {
     auto header = ltx.loadHeader();
-    if (header.current().ledgerVersion >= 10)
+    if (protocolVersionStartsFrom(header.current().ledgerVersion,
+                                  ProtocolVersion::V_10))
     {
         auto sourceAccount = loadSourceAccount(ltx, header);
         sourceAccount.current().data.account().seqNum = getSeqNum();

--- a/src/transactions/test/ClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClaimableBalanceTests.cpp
@@ -14,6 +14,7 @@
 #include "transactions/TransactionUtils.h"
 #include "transactions/test/SponsorshipTestUtils.h"
 #include "util/Math.h"
+#include "util/ProtocolVersion.h"
 #include <fmt/format.h>
 
 using namespace stellar;
@@ -1304,7 +1305,7 @@ TEST_CASE("claimableBalance", "[tx][claimablebalance]")
                 ledgerVersion = ltx.loadHeader().current().ledgerVersion;
             }
 
-            if (ledgerVersion >= 17)
+            if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_17))
             {
                 SECTION("clawback")
                 {

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -19,6 +19,7 @@
 #include "transactions/InflationOpFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 #include "util/XDROperators.h"
 #include <functional>
@@ -136,7 +137,7 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
         // computes the share of this guy
         int64 toDoleToThis =
             bigDivideOrThrow(coinsToDole, votes.at(w), totVotes, ROUND_DOWN);
-        if (ledgerVersion >= 10)
+        if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_10))
         {
             LedgerTxn ltx(app.getLedgerTxnRoot());
             auto header = ltx.loadHeader();
@@ -148,7 +149,7 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
         if (balances[w] >= 0)
         {
             balances[w] += toDoleToThis;
-            if (ledgerVersion <= 7)
+            if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_8))
             {
                 totCoins += toDoleToThis;
             }
@@ -156,7 +157,7 @@ simulateInflation(int ledgerVersion, int nbAccounts, int64& totCoins,
         }
     }
 
-    if (ledgerVersion > 7)
+    if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_8))
     {
         totCoins += inflation;
     }

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -19,6 +19,7 @@
 #include "transactions/OperationFrame.h"
 #include "transactions/TransactionFrame.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/numeric128.h"
 #include "xdrpp/autocheck.h"
 
@@ -163,7 +164,8 @@ TEST_CASE("manage buy offer failure modes", "[tx][offers]")
 
                 SECTION("sell no issuer")
                 {
-                    if (ledgerVersion < 13)
+                    if (protocolVersionIsBefore(ledgerVersion,
+                                                ProtocolVersion::V_13))
                     {
                         REQUIRE_THROWS_AS(
                             a1.manageBuyOffer(0, cur1, native, Price{1, 1}, 1),
@@ -177,7 +179,8 @@ TEST_CASE("manage buy offer failure modes", "[tx][offers]")
 
                 SECTION("buy no issuer")
                 {
-                    if (ledgerVersion < 13)
+                    if (protocolVersionIsBefore(ledgerVersion,
+                                                ProtocolVersion::V_13))
                     {
                         REQUIRE_THROWS_AS(
                             a1.manageBuyOffer(0, native, cur1, Price{1, 1}, 1),

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -20,6 +20,7 @@
 #include "transactions/TransactionUtils.h"
 #include "transactions/test/SponsorshipTestUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 
 using namespace stellar;
@@ -720,7 +721,8 @@ TEST_CASE("merge", "[tx][merge]")
                 }
                 SECTION("into sponsoring account")
                 {
-                    if (ledgerVersion < 16)
+                    if (protocolVersionIsBefore(ledgerVersion,
+                                                ProtocolVersion::V_16))
                     {
                         REQUIRE_THROWS(a1.merge(sponsoringAcc));
                         LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -766,7 +768,8 @@ TEST_CASE("merge", "[tx][merge]")
                             acc1, 0, &sponsoringAcc.getPublicKey(), 0, 2, 3, 0);
                     }
 
-                    if (ledgerVersion < 16 &&
+                    if (protocolVersionIsBefore(ledgerVersion,
+                                                ProtocolVersion::V_16) &&
                         dest == sponsoringAcc.getPublicKey())
                     {
                         REQUIRE_THROWS(acc1.merge(dest));

--- a/src/transactions/test/OfferTests.cpp
+++ b/src/transactions/test/OfferTests.cpp
@@ -21,6 +21,7 @@
 #include "transactions/OfferExchange.h"
 #include "transactions/TransactionUtils.h"
 #include "transactions/test/SponsorshipTestUtils.h"
+#include "util/ProtocolVersion.h"
 
 using namespace stellar;
 using namespace stellar::txtest;
@@ -707,7 +708,8 @@ TEST_CASE("create offer", "[tx][offers]")
                             ltx.loadHeader().current().ledgerVersion;
                     }
 
-                    if (ledgerVersion < 13)
+                    if (protocolVersionIsBefore(ledgerVersion,
+                                                ProtocolVersion::V_13))
                     {
                         return;
                     }

--- a/src/transactions/test/PathPaymentStrictSendTests.cpp
+++ b/src/transactions/test/PathPaymentStrictSendTests.cpp
@@ -11,6 +11,7 @@
 #include "test/TxTests.h"
 #include "test/test.h"
 #include "transactions/TransactionUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 
 using namespace stellar;
@@ -582,7 +583,8 @@ TEST_CASE("pathpayment strict send", "[tx][pathpayment]")
 
             auto pathPaymentStrictSend = [&](std::vector<Asset> const& path,
                                              Asset& noIssuer) {
-                if (ledgerVersion < 13)
+                if (protocolVersionIsBefore(ledgerVersion,
+                                            ProtocolVersion::V_13))
                 {
                     REQUIRE_THROWS_AS(
                         source.pathPaymentStrictSend(destination, idr, 10, usd,
@@ -2485,7 +2487,8 @@ TEST_CASE("pathpayment strict send uses all offers in a loop",
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 ledgerVersion = ltx.loadHeader().current().ledgerVersion;
             }
-            if (issuerToDelete && ledgerVersion >= 13)
+            if (issuerToDelete &&
+                protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_13))
             {
                 closeLedgerOn(*app, 2, 1, 1, 2016);
                 // remove issuer

--- a/src/transactions/test/PathPaymentTests.cpp
+++ b/src/transactions/test/PathPaymentTests.cpp
@@ -14,6 +14,7 @@
 #include "test/test.h"
 #include "transactions/TransactionUtils.h"
 #include "transactions/test/SponsorshipTestUtils.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 
 #include <deque>
@@ -682,7 +683,8 @@ TEST_CASE("pathpayment", "[tx][pathpayment]")
 
             auto pathPayment = [&](std::vector<Asset> const& path,
                                    Asset& noIssuer) {
-                if (ledgerVersion < 13)
+                if (protocolVersionIsBefore(ledgerVersion,
+                                            ProtocolVersion::V_13))
                 {
                     REQUIRE_THROWS_AS(source.pay(destination, idr, 11, usd, 11,
                                                  path, &noIssuer),
@@ -1555,7 +1557,8 @@ TEST_CASE("pathpayment", "[tx][pathpayment]")
                     ledgerVersion = ltx.loadHeader().current().ledgerVersion;
                 }
 
-                if (ledgerVersion < 13)
+                if (protocolVersionIsBefore(ledgerVersion,
+                                            ProtocolVersion::V_13))
                 {
                     return;
                 }
@@ -4942,7 +4945,8 @@ TEST_CASE("path payment uses all offers in a loop", "[tx][pathpayment]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 ledgerVersion = ltx.loadHeader().current().ledgerVersion;
             }
-            if (issuerToDelete && ledgerVersion >= 13)
+            if (issuerToDelete &&
+                protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_13))
             {
                 closeLedgerOn(*app, 2, 1, 1, 2016);
                 // remove issuer

--- a/src/transactions/test/PaymentTests.cpp
+++ b/src/transactions/test/PaymentTests.cpp
@@ -22,6 +22,7 @@
 #include "transactions/PaymentOpFrame.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 
 using namespace stellar;
@@ -1472,7 +1473,8 @@ TEST_CASE("payment", "[tx][payment]")
                         ledgerVersion =
                             ltx.loadHeader().current().ledgerVersion;
                     }
-                    if (ledgerVersion < 13)
+                    if (protocolVersionIsBefore(ledgerVersion,
+                                                ProtocolVersion::V_13))
                     {
                         // cannot send to an account that is not the issuer
                         REQUIRE_THROWS_AS(a1.pay(b1, idr, 40),
@@ -1620,7 +1622,7 @@ TEST_CASE("payment", "[tx][payment]")
             }
             // in ledger versions 1 and 2 each of these payment succeeds
 
-            if (ledgerVersion < 3)
+            if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_3))
             {
                 payNoTrust = payOk;
                 payLineFull = payOk;
@@ -1634,7 +1636,7 @@ TEST_CASE("payment", "[tx][payment]")
             };
 
             // issuer checks were removed starting from v13
-            if (ledgerVersion < 13)
+            if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_13))
             {
                 withoutTrustLine.push_back(
                     Data{"non existing asset with non existing issuer",

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -29,6 +29,7 @@
 #include "transactions/TransactionUtils.h"
 #include "transactions/test/SponsorshipTestUtils.h"
 #include "util/Logging.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
 
 using namespace stellar;
@@ -693,8 +694,11 @@ TEST_CASE("txenvelope", "[tx][envelope]")
                             // However, if the transaction source account is
                             // missing, then signatures can only be removed if
                             // V13 or greater.
-                            if (ledgerVersion < 13 &&
-                                (txAccountMissing || ledgerVersion < 10))
+                            if (protocolVersionIsBefore(
+                                    ledgerVersion, ProtocolVersion::V_13) &&
+                                (txAccountMissing ||
+                                 protocolVersionIsBefore(
+                                     ledgerVersion, ProtocolVersion::V_10)))
                             {
                                 REQUIRE(getAccountSigners(a1, *app).size() ==
                                         1);

--- a/src/util/ProtocolVersion.cpp
+++ b/src/util/ProtocolVersion.cpp
@@ -1,0 +1,26 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ProtocolVersion.h"
+
+namespace stellar
+{
+bool
+protocolVersionIsBefore(uint32_t protocolVersion, ProtocolVersion beforeVersion)
+{
+    return protocolVersion < static_cast<uint32_t>(beforeVersion);
+}
+
+bool
+protocolVersionStartsFrom(uint32_t protocolVersion, ProtocolVersion fromVersion)
+{
+    return protocolVersion >= static_cast<uint32_t>(fromVersion);
+}
+
+bool
+protocolVersionEquals(uint32_t protocolVersion, ProtocolVersion equalsVersion)
+{
+    return protocolVersion == static_cast<uint32_t>(equalsVersion);
+}
+}

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstdint>
+namespace stellar
+{
+// This is a set of utilities for checking the ledger protocol versions in
+// expressive and searchable fashion.
+
+enum class ProtocolVersion : uint32_t
+{
+    V_0 = 0,
+    V_1,
+    V_2,
+    V_3,
+    V_4,
+    V_5,
+    V_6,
+    V_7,
+    V_8,
+    V_9,
+    V_10,
+    V_11,
+    V_12,
+    V_13,
+    V_14,
+    V_15,
+    V_16,
+    V_17,
+    V_18,
+};
+
+// Checks whether provided protocolVersion is before (i.e. strictly lower than)
+// beforeVersion.
+bool protocolVersionIsBefore(uint32_t protocolVersion,
+                             ProtocolVersion beforeVersion);
+// Checks whether provided protocolVersion starts from (i.e. is greater than or
+// equal to) fromVersion.
+bool protocolVersionStartsFrom(uint32_t protocolVersion,
+                               ProtocolVersion fromVersion);
+// Checks whether provided protocolVersion is exactly equalsVersion.
+bool protocolVersionEquals(uint32_t protocolVersion,
+                           ProtocolVersion equalsVersion);
+
+}

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -5,6 +5,7 @@
 #include "util/types.h"
 #include "lib/util/uint128_t.h"
 #include "util/GlobalChecks.h"
+#include "util/ProtocolVersion.h"
 #include "util/XDROperators.h"
 #include <fmt/format.h>
 
@@ -109,13 +110,13 @@ isPoolShareAssetValid(Asset const& asset, uint32_t ledgerVersion)
 bool
 isPoolShareAssetValid(TrustLineAsset const& asset, uint32_t ledgerVersion)
 {
-    return ledgerVersion >= 18;
+    return protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_18);
 }
 
 bool
 isPoolShareAssetValid(ChangeTrustAsset const& asset, uint32_t ledgerVersion)
 {
-    if (ledgerVersion < 18)
+    if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_18))
     {
         return false;
     }


### PR DESCRIPTION
# Description

Resolves #3182 

In order to make the protocol version-dependent code more searchable and cleaner I propose the following:
- Introduce the enum for the versions in order to avoid 'magic numbers' in code
- Introduce a limited set of functions to check the versions (all of them are relative to the version that either added or removed some feature). This way of referring to the version was the most common before
- Refactor most of the current version comparisons (all I could find) to use the new functions/enums

This should make it easy to see which code blocks became active/inactive given any version and hopefully will make it harder to make a bug in version check.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
