### PR TITLE
Make validators from the same home domain preferred peers

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -528,6 +528,7 @@ Config::parseValidators(
         ValidatorEntry ve;
         std::string pubKey, hist;
         bool qualitySet = false;
+        std::string address;
         for (auto const& f : *validator)
         {
             if (f.first == "NAME")
@@ -550,8 +551,7 @@ Config::parseValidators(
             }
             else if (f.first == "ADDRESS")
             {
-                auto address = readString(f);
-                KNOWN_PEERS.emplace_back(address);
+                address = readString(f);
             }
             else if (f.first == "HISTORY")
             {
@@ -612,6 +612,17 @@ Config::parseValidators(
                 FMT_STRING("malformed VALIDATORS entry '{}' (critical and "
                            "high quality must have an archive)"),
                 ve.mName));
+        }
+        if (!address.empty())
+        {
+            if (NODE_HOME_DOMAIN == ve.mHomeDomain)
+            {
+                PREFERRED_PEERS.emplace_back(address);
+            }
+            else
+            {
+                KNOWN_PEERS.emplace_back(address);
+            }
         }
         res.emplace_back(ve);
     }

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -213,7 +213,8 @@ TEST_CASE("load validators config", "[config]")
 )";
 
     REQUIRE(actualS == expected);
-    REQUIRE(c.KNOWN_PEERS.size() == 15);
+    REQUIRE(c.KNOWN_PEERS.size() == 13);
+    REQUIRE(c.PREFERRED_PEERS.size() == 2); // 2 other "domainA" validators
     REQUIRE(c.HISTORY.size() == 20);
 }
 


### PR DESCRIPTION
This PR implements a best practice for entities that operate multiple validators by upgrading the peer type for other validators in the same home domain from just "known" to "preferred" peers.

This allows an organization to better take advantage of their internal bandwidth while providing better guarantees to other nodes on the network as they will receive an organization's SCP messages in batch.