### PR TITLE
Actually enforce SHA256 contract

### DIFF
--- a/src/crypto/SHA.cpp
+++ b/src/crypto/SHA.cpp
@@ -69,6 +69,7 @@ SHA256::finish()
     {
         throw CryptoError("error from crypto_hash_sha256_final");
     }
+    mFinished = true;
     return out;
 }
 


### PR DESCRIPTION
This change actually ensures that we don't make broken calls to libsodium when using the SHA256 class.

I did a code review of the call sites, and right now we don't make such broken calls so this is hardening "just in case".