### PR TITLE
Allow storing SPEEDEX configuration in the ledger

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -328,6 +328,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\InternalLedgerEntry.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnClaimableBalanceSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp" />
+    <ClCompile Include="..\..\src\ledger\LedgerTxnSpeedexConfigSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp" />
     <ClCompile Include="..\..\src\main\Diagnostics.cpp" />
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1224,6 +1224,9 @@
     <ClCompile Include="..\..\src\util\ProtocolVersion.cpp">
       <Filter>util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\LedgerTxnSpeedexConfigSQL.cpp">
+      <Filter>ledger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -47,12 +47,13 @@ class BucketApplicator
         uint64_t mClaimableBalanceDelete;
         uint64_t mLiquidityPoolUpsert;
         uint64_t mLiquidityPoolDelete;
+        uint64_t mSpeedexConfigurationUpsert;
         void getRates(VirtualClock::time_point now, uint64_t& au_sec,
                       uint64_t& ad_sec, uint64_t& tu_sec, uint64_t& td_sec,
                       uint64_t& ou_sec, uint64_t& od_sec, uint64_t& du_sec,
                       uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
-                      uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& T_sec,
-                      uint64_t& total);
+                      uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& sc_sec,
+                      uint64_t& T_sec, uint64_t& total);
 
       public:
         Counters(VirtualClock::time_point now);

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -82,6 +82,8 @@ struct LedgerEntryIdCmp
         case LIQUIDITY_POOL:
             return a.liquidityPool().liquidityPoolID <
                    b.liquidityPool().liquidityPoolID;
+        case SPEEDEX_CONFIGURATION:
+            return false;
         }
         return false;
     }

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -346,16 +346,21 @@ TEST_CASE("bucket tombstones mutually-annihilate init entries",
     Config const& cfg = getTestConfig();
 
     for_versions_with_differing_bucket_logic(cfg, [&](Config const& cfg) {
+        int const BatchCount = 512;
+        int const BatchSize = 8;
         Application::pointer app = createTestApplication(clock, cfg);
         BucketList bl;
         auto vers = getAppLedgerVersion(app);
         autocheck::generator<bool> flip;
         std::deque<LedgerEntry> entriesToModify;
-        for (uint32_t i = 1; i < 512; ++i)
+        std::vector<LedgerEntry> allEntries =
+            LedgerTestUtils::generateValidUniqueLedgerEntries(BatchCount *
+                                                              BatchSize);
+        for (uint32_t i = 1; i <= BatchCount; ++i)
         {
-            std::vector<LedgerEntry> initEntries =
-                LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
-                    {SPEEDEX_CONFIGURATION}, 8);
+            std::vector<LedgerEntry> initEntries(
+                allEntries.begin() + (i - 1) * BatchSize,
+                allEntries.begin() + i * BatchSize);
             std::vector<LedgerEntry> liveEntries;
             std::vector<LedgerKey> deadEntries;
             for (auto const& e : initEntries)

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -1408,7 +1408,7 @@ TEST_CASE("bucket persistence over app restart",
         auto batch_entries =
             LedgerTestUtils::generateValidUniqueLedgerEntries(110);
         std::vector<std::vector<LedgerEntry>> batches;
-        for (const auto& batch_entry : batch_entries)
+        for (auto const& batch_entry : batch_entries)
         {
             batches.emplace_back().push_back(batch_entry);
         }

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -19,11 +19,8 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     Application::pointer app = createTestApplication(clock, cfg);
 
     auto getValidBucket = [&](int numEntries = 10) {
-        std::vector<LedgerEntry> live(numEntries);
-        for (auto& e : live)
-        {
-            e = LedgerTestUtils::generateValidLedgerEntry(3);
-        }
+        std::vector<LedgerEntry> live =
+            LedgerTestUtils::generateValidUniqueLedgerEntries(numEntries);
         std::shared_ptr<Bucket> b1 =
             Bucket::fresh(app->getBucketManager(),
                           BucketTests::getAppLedgerVersion(app), {}, live, {},

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -132,12 +132,10 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
 
         autocheck::generator<LedgerKey> deadGen;
         CLOG_DEBUG(Bucket, "Generating 10000 random ledger entries");
-        std::vector<LedgerEntry> live(9000);
-        std::vector<LedgerKey> dead(1000);
-        for (auto& e : live)
-            e = LedgerTestUtils::generateValidLedgerEntry(3);
-        for (auto& e : dead)
-            e = deadGen(3);
+        auto live = LedgerTestUtils::generateValidUniqueLedgerEntries(9000);
+        auto dead = LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+            {SPEEDEX_CONFIGURATION}, 1000);
+
         CLOG_DEBUG(Bucket, "Hashing entries");
         std::shared_ptr<Bucket> b1 = Bucket::fresh(
             app->getBucketManager(), getAppLedgerVersion(app), {}, live, dead,
@@ -148,10 +146,10 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
             CLOG_DEBUG(Bucket,
                        "Merging 10000 new ledger entries into {} entry bucket",
                        (i * 10000));
-            for (auto& e : live)
-                e = LedgerTestUtils::generateValidLedgerEntry(3);
-            for (auto& e : dead)
-                e = deadGen(3);
+            live = LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                {SPEEDEX_CONFIGURATION}, 9000);
+            dead = LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                {SPEEDEX_CONFIGURATION}, 1000);
             {
                 b1 = Bucket::merge(
                     app->getBucketManager(),
@@ -248,7 +246,8 @@ TEST_CASE("merging bucket entries", "[bucket]")
             std::vector<LedgerKey> dead;
             for (auto& e : live)
             {
-                e = LedgerTestUtils::generateValidLedgerEntry(10);
+                e = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                    {SPEEDEX_CONFIGURATION});
                 if (rand_flip())
                 {
                     dead.push_back(LedgerEntryKey(e));
@@ -276,12 +275,10 @@ TEST_CASE("merging bucket entries", "[bucket]")
 
         SECTION("random live entries overwrite live entries in any order")
         {
-            std::vector<LedgerEntry> live(100);
+            std::vector<LedgerEntry> live =
+                LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                    {SPEEDEX_CONFIGURATION}, 100);
             std::vector<LedgerKey> dead;
-            for (auto& e : live)
-            {
-                e = LedgerTestUtils::generateValidLedgerEntry(10);
-            }
             std::shared_ptr<Bucket> b1 = Bucket::fresh(
                 app->getBucketManager(), getAppLedgerVersion(app), {}, live,
                 dead, /*countMergeEvents=*/true, clock.getIOContext(),
@@ -309,7 +306,8 @@ TEST_CASE("merging bucket entries", "[bucket]")
             {
                 if (rand_flip())
                 {
-                    e = LedgerTestUtils::generateValidLedgerEntry(10);
+                    e = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                        {SPEEDEX_CONFIGURATION}, 100);
                     ++liveCount;
                 }
             }

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -146,8 +146,7 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
             CLOG_DEBUG(Bucket,
                        "Merging 10000 new ledger entries into {} entry bucket",
                        (i * 10000));
-            live = LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
-                {SPEEDEX_CONFIGURATION}, 9000);
+            live = LedgerTestUtils::generateValidUniqueLedgerEntries(9000);
             dead = LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
                 {SPEEDEX_CONFIGURATION}, 1000);
             {
@@ -242,13 +241,12 @@ TEST_CASE("merging bucket entries", "[bucket]")
 
         SECTION("random dead entries annihilates live entries")
         {
-            std::vector<LedgerEntry> live(100);
+            std::vector<LedgerEntry> live =
+                LedgerTestUtils::generateValidUniqueLedgerEntries(100);
             std::vector<LedgerKey> dead;
             for (auto& e : live)
             {
-                e = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-                    {SPEEDEX_CONFIGURATION});
-                if (rand_flip())
+                if (rand_flip() && e.data.type() != SPEEDEX_CONFIGURATION)
                 {
                     dead.push_back(LedgerEntryKey(e));
                 }
@@ -276,8 +274,7 @@ TEST_CASE("merging bucket entries", "[bucket]")
         SECTION("random live entries overwrite live entries in any order")
         {
             std::vector<LedgerEntry> live =
-                LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
-                    {SPEEDEX_CONFIGURATION}, 100);
+                LedgerTestUtils::generateValidUniqueLedgerEntries(100);
             std::vector<LedgerKey> dead;
             std::shared_ptr<Bucket> b1 = Bucket::fresh(
                 app->getBucketManager(), getAppLedgerVersion(app), {}, live,

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1141,8 +1141,9 @@ TEST_CASE("HAS in publishqueue remains in pristine state until publish",
             while (hm.getPublishQueueCount() != 1)
             {
                 uint32_t ledger = lm.getLastClosedLedgerNum() + 1;
-                bl.addBatch(*app, ledger, cfg.LEDGER_PROTOCOL_VERSION, {},
-                            LedgerTestUtils::generateValidLedgerEntries(8), {});
+                bl.addBatch(
+                    *app, ledger, cfg.LEDGER_PROTOCOL_VERSION, {},
+                    LedgerTestUtils::generateValidUniqueLedgerEntries(8), {});
                 clock.crank(true);
             }
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -136,7 +136,7 @@ std::pair<std::string, uint256>
 BucketOutputIteratorForTesting::writeTmpTestBucket()
 {
     auto ledgerEntries =
-        LedgerTestUtils::generateValidLedgerEntries(NUM_ITEMS_PER_BUCKET);
+        LedgerTestUtils::generateValidUniqueLedgerEntries(NUM_ITEMS_PER_BUCKET);
     auto bucketEntries =
         Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
     for (auto const& bucketEntry : bucketEntries)

--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -96,8 +96,10 @@ updateChangedSubEntriesCount(
     }
     case CLAIMABLE_BALANCE:
     case LIQUIDITY_POOL:
+    case SPEEDEX_CONFIGURATION:
     {
-        // claimable balance and liquidity pools are not subentries
+        // claimable balance, liquidity pools and speedex configuration are not
+        // subentries.
         break;
     }
     default:

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -159,7 +159,8 @@ struct EntryCounts
         check(ACCOUNT, mAccounts) && check(TRUSTLINE, mTrustLines) &&
             check(OFFER, mOffers) && check(DATA, mData) &&
             check(CLAIMABLE_BALANCE, mClaimableBalance) &&
-            check(LIQUIDITY_POOL, mLiquidityPool);
+            check(LIQUIDITY_POOL, mLiquidityPool) &&
+            check(SPEEDEX_CONFIGURATION, mSpeedexConfiguration);
         return msg;
     }
 };

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -90,12 +90,13 @@ struct EntryCounts
     uint64_t mData{0};
     uint64_t mClaimableBalance{0};
     uint64_t mLiquidityPool{0};
+    uint64_t mSpeedexConfiguration{0};
 
     uint64_t
     totalEntries() const
     {
         return mAccounts + mTrustLines + mOffers + mData + mClaimableBalance +
-               mLiquidityPool;
+               mLiquidityPool + mSpeedexConfiguration;
     }
 
     void
@@ -120,6 +121,9 @@ struct EntryCounts
             break;
         case LIQUIDITY_POOL:
             ++mLiquidityPool;
+            break;
+        case SPEEDEX_CONFIGURATION:
+            ++mSpeedexConfiguration;
             break;
         default:
             throw std::runtime_error(

--- a/src/invariant/ConservationOfLumens.cpp
+++ b/src/invariant/ConservationOfLumens.cpp
@@ -69,6 +69,8 @@ calculateDeltaBalance(LedgerEntry const* current, LedgerEntry const* previous)
         }
         return delta;
     }
+    case SPEEDEX_CONFIGURATION:
+        break;
     }
     return 0;
 }

--- a/src/invariant/LedgerEntryIsValid.cpp
+++ b/src/invariant/LedgerEntryIsValid.cpp
@@ -123,6 +123,9 @@ LedgerEntryIsValid::checkIsValid(LedgerEntry const& le,
             return "LiquidityPool is sponsored";
         }
         return checkIsValid(le.data.liquidityPool(), previous, version);
+    case SPEEDEX_CONFIGURATION:
+        // Speedex configuration doesn't have content to be validated yet.
+        return "";
     default:
         return "LedgerEntry has invalid type";
     }

--- a/src/invariant/SponsorshipCountIsValid.cpp
+++ b/src/invariant/SponsorshipCountIsValid.cpp
@@ -48,6 +48,7 @@ getMult(LedgerEntry const& le)
     case CLAIMABLE_BALANCE:
         return le.data.claimableBalance().claimants.size();
     case LIQUIDITY_POOL:
+    case SPEEDEX_CONFIGURATION:
         throw std::runtime_error("invalid LedgerEntry type");
     default:
         abort();

--- a/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
+++ b/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
@@ -58,8 +58,8 @@ generateRandomSubEntry(LedgerEntry const& acc)
     do
     {
         le = LedgerTestUtils::generateValidLedgerEntry(5);
-    } while (le.data.type() == ACCOUNT || le.data.type() == CLAIMABLE_BALANCE ||
-             le.data.type() == LIQUIDITY_POOL);
+    } while (le.data.type() != OFFER && le.data.type() != TRUSTLINE &&
+             le.data.type() != DATA);
     le.lastModifiedLedgerSeq = acc.lastModifiedLedgerSeq;
 
     switch (le.data.type())
@@ -87,9 +87,6 @@ generateRandomSubEntry(LedgerEntry const& acc)
         le.data.data().accountID = acc.data.account().accountID;
         le.data.data().dataName = validDataNameGenerator(64);
         break;
-    case CLAIMABLE_BALANCE:
-    case ACCOUNT:
-    case LIQUIDITY_POOL:
     default:
         abort();
     }

--- a/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
+++ b/src/invariant/test/AccountSubEntriesCountIsValidTests.cpp
@@ -107,6 +107,7 @@ generateRandomModifiedSubEntry(LedgerEntry const& acc, LedgerEntry const& se)
     case ACCOUNT:
     case CLAIMABLE_BALANCE:
     case LIQUIDITY_POOL:
+    case SPEEDEX_CONFIGURATION:
         break;
     case OFFER:
         res.data.offer().offerID = se.data.offer().offerID;

--- a/src/invariant/test/SponsorshipCountIsValidTests.cpp
+++ b/src/invariant/test/SponsorshipCountIsValidTests.cpp
@@ -72,6 +72,7 @@ TEST_CASE("sponsorship invariant", "[invariant][sponsorshipcountisvalid]")
             le.data.claimableBalance() =
                 LedgerTestUtils::generateValidClaimableBalanceEntry();
             break;
+        case LIQUIDITY_POOL:
         case SPEEDEX_CONFIGURATION:
         default:
             abort();

--- a/src/invariant/test/SponsorshipCountIsValidTests.cpp
+++ b/src/invariant/test/SponsorshipCountIsValidTests.cpp
@@ -72,6 +72,7 @@ TEST_CASE("sponsorship invariant", "[invariant][sponsorshipcountisvalid]")
             le.data.claimableBalance() =
                 LedgerTestUtils::generateValidClaimableBalanceEntry();
             break;
+        case SPEEDEX_CONFIGURATION:
         default:
             abort();
         }

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -144,6 +144,11 @@ InMemoryLedgerTxnRoot::dropLiquidityPools()
 {
 }
 
+void
+InMemoryLedgerTxnRoot::dropSpeedexConfiguration()
+{
+}
+
 double
 InMemoryLedgerTxnRoot::getPrefetchHitRate() const
 {

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -76,6 +76,8 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void dropTrustLines() override;
     void dropClaimableBalances() override;
     void dropLiquidityPools() override;
+    void dropSpeedexConfiguration() override;
+
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
     void prepareNewObjects(size_t s) override;

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -140,6 +140,12 @@ template <> class hash<stellar::LedgerKey>
             stellar::hashMix(res, std::hash<stellar::uint256>()(
                                       lk.liquidityPool().liquidityPoolID));
             break;
+        case stellar::SPEEDEX_CONFIGURATION:
+            // As there is only a single speedex configuration entry, just
+            // add the hash of the key type itself.
+            stellar::hashMix(res, stellar::shortHash::computeHash(
+                                      stellar::ByteSlice(&res, sizeof(res))));
+            break;
         default:
             abort();
         }

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -141,10 +141,8 @@ template <> class hash<stellar::LedgerKey>
                                       lk.liquidityPool().liquidityPoolID));
             break;
         case stellar::SPEEDEX_CONFIGURATION:
-            // As there is only a single speedex configuration entry, just
-            // add the hash of the key type itself.
-            stellar::hashMix(res, stellar::shortHash::computeHash(
-                                      stellar::ByteSlice(&res, sizeof(res))));
+            // As there is only a single speedex configuration entry, don't add
+            // anything else.
             break;
         default:
             abort();

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -755,6 +755,11 @@ LedgerTxn::Impl::eraseWithoutLoading(InternalLedgerKey const& key)
 {
     throwIfSealed();
     throwIfChild();
+    if (key.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
+        key.ledgerKey().type() == SPEEDEX_CONFIGURATION)
+    {
+        throw std::runtime_error("Speedex configuration cannot be erased.");
+    }
 
     auto activeIter = mActive.find(key);
     bool isActive = activeIter != mActive.end();
@@ -2523,6 +2528,7 @@ BulkLedgerEntryChangeAccumulator::accumulate(EntryIterator const& iter)
     case SPEEDEX_CONFIGURATION:
         // Speedex configuration can not be deleted.
         releaseAssert(iter.entryExists());
+        releaseAssert(!mSpeedexConfigurationToUpsert);
         mSpeedexConfigurationToUpsert.emplace(iter);
         break;
     default:

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -473,6 +473,10 @@ class AbstractLedgerTxnParent
     // anything other than a (real or stub) root LedgerTxn.
     virtual void dropLiquidityPools() = 0;
 
+    // Delete all (at most one) speedex configuration ledger entries. Will throw
+    // when called on anything other than a (real or stub) root LedgerTxn.
+    virtual void dropSpeedexConfiguration() = 0;
+
     // Return the current cache hit rate for prefetched ledger entries, as a
     // fraction from 0.0 to 1.0. Will throw when called on anything other than a
     // (real or stub) root LedgerTxn.
@@ -770,6 +774,8 @@ class LedgerTxn : public AbstractLedgerTxn
     void dropTrustLines() override;
     void dropClaimableBalances() override;
     void dropLiquidityPools() override;
+    void dropSpeedexConfiguration() override;
+
     double getPrefetchHitRate() const override;
     uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
     void prepareNewObjects(size_t s) override;
@@ -828,6 +834,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     void dropTrustLines() override;
     void dropClaimableBalances() override;
     void dropLiquidityPools() override;
+    void dropSpeedexConfiguration() override;
 
 #ifdef BUILD_TESTS
     void resetForFuzzer() override;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -12,6 +12,7 @@
 #include <iomanip>
 #include <libpq-fe.h>
 #include <limits>
+#include <optional>
 #include <sstream>
 #endif
 
@@ -69,6 +70,7 @@ class BulkLedgerEntryChangeAccumulator
     std::vector<EntryIterator> mTrustLinesToDelete;
     std::vector<EntryIterator> mLiquidityPoolToUpsert;
     std::vector<EntryIterator> mLiquidityPoolToDelete;
+    std::optional<EntryIterator> mSpeedexConfigurationToUpsert;
 
   public:
     std::vector<EntryIterator>&
@@ -141,6 +143,12 @@ class BulkLedgerEntryChangeAccumulator
     getLiquidityPoolToDelete()
     {
         return mLiquidityPoolToDelete;
+    }
+
+    std::optional<EntryIterator>&
+    getSpeedexConfigurationToUpsert()
+    {
+        return mSpeedexConfigurationToUpsert;
     }
 
     void accumulate(EntryIterator const& iter);
@@ -724,6 +732,7 @@ class LedgerTxnRoot::Impl
     loadClaimableBalance(LedgerKey const& key) const;
     std::shared_ptr<LedgerEntry const>
     loadLiquidityPool(LedgerKey const& key) const;
+    std::shared_ptr<LedgerEntry const> loadSpeedexConfiguration() const;
 
     void bulkApply(BulkLedgerEntryChangeAccumulator& bleca,
                    size_t bufferThreshold, LedgerTxnConsistency cons);
@@ -745,6 +754,7 @@ class LedgerTxnRoot::Impl
     void bulkUpsertLiquidityPool(std::vector<EntryIterator> const& entries);
     void bulkDeleteLiquidityPool(std::vector<EntryIterator> const& entries,
                                  LedgerTxnConsistency cons);
+    void upsertSpeedexConfiguration(EntryIterator const& entry);
 
     static std::string tableFromLedgerEntryType(LedgerEntryType let);
 
@@ -824,6 +834,7 @@ class LedgerTxnRoot::Impl
     void dropTrustLines();
     void dropClaimableBalances();
     void dropLiquidityPools();
+    void dropSpeedexConfiguration();
 
 #ifdef BUILD_TESTS
     void resetForFuzzer();

--- a/src/ledger/LedgerTxnSpeedexConfigSQL.cpp
+++ b/src/ledger/LedgerTxnSpeedexConfigSQL.cpp
@@ -1,0 +1,94 @@
+// Copyright 2018 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerTxnImpl.h"
+#include "util/GlobalChecks.h"
+
+namespace stellar
+{
+namespace
+{
+
+const std::string CREATE_SPEEDEX_CONFIGURATION_TABLE_SQL = R"(
+    CREATE TABLE speedexconfiguration (
+        dummykey     INT PRIMARY KEY,
+        ledgerentry  TEXT NOT NULL,
+        lastmodified INT NOT NULL);
+)";
+
+const std::string DROP_SPEEDEX_CONFIGURATION_TABLE_SQL =
+    "DROP TABLE IF EXISTS speedexconfiguration;";
+
+const std::string LOAD_SPEEDEX_CONFIGURATION_SQL = R"(
+    SELECT ledgerentry
+    FROM speedexconfiguration
+    LIMIT 1;)";
+
+const std::string INSERT_SPEEDEX_CONFIGURATION_SQL = R"(
+    INSERT INTO speedexconfiguration
+    VALUES ( 
+        1, :ledgerentry, :lastmodified 
+    )
+    ON CONFLICT (dummykey) DO UPDATE SET
+        ledgerentry = excluded.ledgerentry,
+        lastmodified = excluded.lastmodified;
+)";
+
+}
+
+std::shared_ptr<LedgerEntry const>
+LedgerTxnRoot::Impl::loadSpeedexConfiguration() const
+{
+    std::string speedexConfigStr;
+
+    auto prep = mDatabase.getPreparedStatement(LOAD_SPEEDEX_CONFIGURATION_SQL);
+    auto& st = prep.statement();
+    st.exchange(soci::into(speedexConfigStr));
+    st.define_and_bind();
+    st.execute(true);
+    if (!st.got_data())
+    {
+        return nullptr;
+    }
+
+    LedgerEntry speedexConfigEntry;
+    fromOpaqueBase64(speedexConfigEntry, speedexConfigStr);
+    releaseAssert(speedexConfigEntry.data.type() == SPEEDEX_CONFIGURATION);
+
+    return std::make_shared<LedgerEntry const>(std::move(speedexConfigEntry));
+}
+
+void
+LedgerTxnRoot::Impl::upsertSpeedexConfiguration(EntryIterator const& entry)
+{
+    auto prep =
+        mDatabase.getPreparedStatement(INSERT_SPEEDEX_CONFIGURATION_SQL);
+    auto& st = prep.statement();
+    auto const& ledgerEntry = entry.entry().ledgerEntry();
+    auto ledgerEntryStr = toOpaqueBase64(ledgerEntry);
+    st.exchange(soci::use(ledgerEntryStr));
+    st.exchange(soci::use(ledgerEntry.lastModifiedLedgerSeq));
+    st.define_and_bind();
+    {
+        auto timer = mDatabase.getUpsertTimer("speedexconfiguration");
+        st.execute(true);
+    }
+    if (static_cast<size_t>(st.get_affected_rows()) != 1)
+    {
+        throw std::runtime_error(
+            "Could not update speedex configuration data in SQL");
+    }
+}
+
+void
+LedgerTxnRoot::Impl::dropSpeedexConfiguration()
+{
+    throwIfChild();
+    mEntryCache.clear();
+    mBestOffers.clear();
+
+    mDatabase.getSession() << DROP_SPEEDEX_CONFIGURATION_TABLE_SQL;
+    mDatabase.getSession() << CREATE_SPEEDEX_CONFIGURATION_TABLE_SQL;
+}
+}

--- a/src/ledger/LedgerTxnSpeedexConfigSQL.cpp
+++ b/src/ledger/LedgerTxnSpeedexConfigSQL.cpp
@@ -10,26 +10,24 @@ namespace stellar
 namespace
 {
 
-const std::string CREATE_SPEEDEX_CONFIGURATION_TABLE_SQL = R"(
+std::string const CREATE_SPEEDEX_CONFIGURATION_TABLE_SQL = R"(
     CREATE TABLE speedexconfiguration (
         dummykey     INT PRIMARY KEY,
         ledgerentry  TEXT NOT NULL,
         lastmodified INT NOT NULL);
 )";
 
-const std::string DROP_SPEEDEX_CONFIGURATION_TABLE_SQL =
+std::string const DROP_SPEEDEX_CONFIGURATION_TABLE_SQL =
     "DROP TABLE IF EXISTS speedexconfiguration;";
 
-const std::string LOAD_SPEEDEX_CONFIGURATION_SQL = R"(
+std::string const LOAD_SPEEDEX_CONFIGURATION_SQL = R"(
     SELECT ledgerentry
     FROM speedexconfiguration
     LIMIT 1;)";
 
-const std::string INSERT_SPEEDEX_CONFIGURATION_SQL = R"(
-    INSERT INTO speedexconfiguration
-    VALUES ( 
-        1, :ledgerentry, :lastmodified 
-    )
+std::string const INSERT_SPEEDEX_CONFIGURATION_SQL = R"(
+    INSERT INTO speedexconfiguration (dummykey, ledgerentry, lastmodified)
+    VALUES (1, :ledgerentry, :lastmodified)
     ON CONFLICT (dummykey) DO UPDATE SET
         ledgerentry = excluded.ledgerentry,
         lastmodified = excluded.lastmodified;

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -486,12 +486,12 @@ generateValidUniqueLedgerEntries(size_t n)
 
 LedgerEntry
 generateValidLedgerEntryWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excluded_types, size_t b)
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b)
 {
     while (true)
     {
         auto entry = generateValidLedgerEntry(b);
-        if (excluded_types.find(entry.data.type()) == excluded_types.end())
+        if (excludedTypes.find(entry.data.type()) == excludedTypes.end())
         {
             return entry;
         }
@@ -500,23 +500,23 @@ generateValidLedgerEntryWithExclusions(
 
 std::vector<LedgerEntry>
 generateValidLedgerEntriesWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n)
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
     std::vector<LedgerEntry> res;
     res.reserve(n);
     for (int i = 0; i < n; ++i)
     {
-        res.push_back(generateValidLedgerEntryWithExclusions(excluded_types));
+        res.push_back(generateValidLedgerEntryWithExclusions(excludedTypes));
     }
     return res;
 }
 
 std::vector<LedgerKey>
 generateValidLedgerEntryKeysWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n)
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
     auto entries = LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
-        excluded_types, n);
+        excludedTypes, n);
     std::vector<LedgerKey> keys;
     keys.reserve(entries.size());
     for (auto const& entry : entries)

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -107,6 +107,10 @@ randomlyModifyEntry(LedgerEntry& e)
             autocheck::generator<int64>{}();
         makeValid(e.data.liquidityPool());
         break;
+    case SPEEDEX_CONFIGURATION:
+        e.data.speedexConfiguration() =
+            generateValidSpeedexConfigurationEntry();
+        break;
     }
 }
 
@@ -292,7 +296,7 @@ makeValid(LiquidityPoolEntry& lp)
 void
 makeValid(SpeedexConfigurationEntry& sc)
 {
-    // Currently the is no speedex configuration entry content is not defined.
+    // Currently there is no speedex configuration entry content to be defined.
 }
 
 void
@@ -482,7 +486,7 @@ generateValidUniqueLedgerEntries(size_t n)
 
 LedgerEntry
 generateValidLedgerEntryWithExclusions(
-    const std::unordered_set<LedgerEntryType>& excluded_types, size_t b)
+    std::unordered_set<LedgerEntryType> const& excluded_types, size_t b)
 {
     while (true)
     {
@@ -496,25 +500,26 @@ generateValidLedgerEntryWithExclusions(
 
 std::vector<LedgerEntry>
 generateValidLedgerEntriesWithExclusions(
-    const std::unordered_set<LedgerEntryType>& excluded_types, size_t n)
+    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n)
 {
-    std::vector<LedgerEntry> res(n);
+    std::vector<LedgerEntry> res;
+    res.reserve(n);
     for (int i = 0; i < n; ++i)
     {
-        res[i] = generateValidLedgerEntryWithExclusions(excluded_types);
+        res.push_back(generateValidLedgerEntryWithExclusions(excluded_types));
     }
     return res;
 }
 
 std::vector<LedgerKey>
 generateValidLedgerEntryKeysWithExclusions(
-    const std::unordered_set<LedgerEntryType>& excluded_types, size_t n)
+    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n)
 {
     auto entries = LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
         excluded_types, n);
     std::vector<LedgerKey> keys;
     keys.reserve(entries.size());
-    for (const auto& entry : entries)
+    for (auto const& entry : entries)
     {
         keys.push_back(LedgerEntryKey(entry));
     }

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -33,7 +33,17 @@ void makeValid(LedgerHeaderHistoryEntry& lh,
                HistoryManager::LedgerVerificationStatus state);
 
 LedgerEntry generateValidLedgerEntry(size_t b = 3);
+LedgerEntry generateValidLedgerEntryOfType(LedgerEntryType type);
 std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
+std::vector<LedgerEntry> generateValidUniqueLedgerEntries(size_t n);
+
+std::vector<LedgerKey> generateValidLedgerEntryKeysWithExclusions(
+    const std::unordered_set<LedgerEntryType>& excluded_types, size_t n);
+
+LedgerEntry generateValidLedgerEntryWithExclusions(
+    const std::unordered_set<LedgerEntryType>& excluded_types, size_t b = 3);
+std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(
+    const std::unordered_set<LedgerEntryType>& excluded_types, size_t n);
 
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);
@@ -54,6 +64,8 @@ generateValidClaimableBalanceEntries(size_t n);
 
 LiquidityPoolEntry generateValidLiquidityPoolEntry(size_t b = 3);
 std::vector<LiquidityPoolEntry> generateValidLiquidityPoolEntries(size_t n);
+
+SpeedexConfigurationEntry generateValidSpeedexConfigurationEntry(size_t b = 3);
 
 std::vector<LedgerHeaderHistoryEntry> generateLedgerHeadersForCheckpoint(
     LedgerHeaderHistoryEntry firstLedger, uint32_t size,

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -38,12 +38,12 @@ std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
 std::vector<LedgerEntry> generateValidUniqueLedgerEntries(size_t n);
 
 std::vector<LedgerKey> generateValidLedgerEntryKeysWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n);
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
 
 LedgerEntry generateValidLedgerEntryWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excluded_types, size_t b = 3);
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b = 3);
 std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(
-    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n);
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
 
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -38,12 +38,12 @@ std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
 std::vector<LedgerEntry> generateValidUniqueLedgerEntries(size_t n);
 
 std::vector<LedgerKey> generateValidLedgerEntryKeysWithExclusions(
-    const std::unordered_set<LedgerEntryType>& excluded_types, size_t n);
+    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n);
 
 LedgerEntry generateValidLedgerEntryWithExclusions(
-    const std::unordered_set<LedgerEntryType>& excluded_types, size_t b = 3);
+    std::unordered_set<LedgerEntryType> const& excluded_types, size_t b = 3);
 std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(
-    const std::unordered_set<LedgerEntryType>& excluded_types, size_t n);
+    std::unordered_set<LedgerEntryType> const& excluded_types, size_t n);
 
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -523,7 +523,8 @@ TEST_CASE("LedgerTxn create", "[ledgertxn]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
 
-    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
+    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+        {SPEEDEX_CONFIGURATION});
     le.lastModifiedLedgerSeq = 1;
     LedgerKey key = LedgerEntryKey(le);
 
@@ -1452,7 +1453,8 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
 
-    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
+    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+        {SPEEDEX_CONFIGURATION});
     le.lastModifiedLedgerSeq = 1;
     LedgerKey key = LedgerEntryKey(le);
 

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -149,8 +149,7 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
 
-    LedgerEntry le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-        {SPEEDEX_CONFIGURATION});
+    LedgerEntry le1 = LedgerTestUtils::generateValidLedgerEntry();
     le1.lastModifiedLedgerSeq = 1;
     LedgerKey key = LedgerEntryKey(le1);
 
@@ -203,6 +202,11 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
 
         SECTION("erased in child")
         {
+            le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                {SPEEDEX_CONFIGURATION});
+            key = LedgerEntryKey(le1);
+            le2 = generateLedgerEntryWithSameKey(le1);
+
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le1));
 
@@ -221,9 +225,7 @@ TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgertxn]")
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le1 =
-            LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-                {SPEEDEX_CONFIGURATION});
+        LedgerEntry le1 = LedgerTestUtils::generateValidLedgerEntry();
         le1.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le1);
 
@@ -276,6 +278,12 @@ TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgertxn]")
 
             SECTION("erased in child")
             {
+                le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                    {SPEEDEX_CONFIGURATION});
+                le1.lastModifiedLedgerSeq = 1;
+                key = LedgerEntryKey(le1);
+                le2 = generateLedgerEntryWithSameKey(le1);
+
                 LedgerTxn ltx1(app->getLedgerTxnRoot());
                 REQUIRE(ltx1.create(le1));
 
@@ -523,8 +531,7 @@ TEST_CASE("LedgerTxn create", "[ledgertxn]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
 
-    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-        {SPEEDEX_CONFIGURATION});
+    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
     le.lastModifiedLedgerSeq = 1;
     LedgerKey key = LedgerEntryKey(le);
 
@@ -564,6 +571,11 @@ TEST_CASE("LedgerTxn create", "[ledgertxn]")
 
     SECTION("when key exists in grandparent, erased in parent")
     {
+        le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+            {SPEEDEX_CONFIGURATION});
+        le.lastModifiedLedgerSeq = 1;
+        key = LedgerEntryKey(le);
+
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         REQUIRE(ltx1.create(le));
 
@@ -585,9 +597,7 @@ TEST_CASE("LedgerTxn createWithoutLoading and updateWithoutLoading",
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le =
-            LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-                {SPEEDEX_CONFIGURATION});
+        LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
         le.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le);
 
@@ -647,6 +657,11 @@ TEST_CASE("LedgerTxn createWithoutLoading and updateWithoutLoading",
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                {SPEEDEX_CONFIGURATION});
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
+
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -791,6 +806,18 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
             ltx1.getAllEntries(init, live, dead);
             REQUIRE_THROWS_AS(ltx1.eraseWithoutLoading(key),
                               std::runtime_error);
+        }
+
+        SECTION("fails for speedex configuration")
+        {
+            auto speedexLe = LedgerTestUtils::generateValidLedgerEntryOfType(
+                SPEEDEX_CONFIGURATION);
+            speedexLe.lastModifiedLedgerSeq = 1;
+            LedgerTxn ltx1(app->getLedgerTxnRoot());
+            REQUIRE(ltx1.create(speedexLe));
+            REQUIRE_THROWS_AS(
+                ltx1.eraseWithoutLoading(LedgerEntryKey(speedexLe)),
+                std::runtime_error);
         }
 
         SECTION("when key does not exist")
@@ -1300,9 +1327,7 @@ TEST_CASE("LedgerTxn load", "[ledgertxn]")
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le =
-            LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-                {SPEEDEX_CONFIGURATION});
+        LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
         le.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le);
 
@@ -1342,6 +1367,11 @@ TEST_CASE("LedgerTxn load", "[ledgertxn]")
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                {SPEEDEX_CONFIGURATION});
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
+
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -1453,8 +1483,7 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
 
-    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
-        {SPEEDEX_CONFIGURATION});
+    LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
     le.lastModifiedLedgerSeq = 1;
     LedgerKey key = LedgerEntryKey(le);
 
@@ -1491,6 +1520,11 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
 
     SECTION("when key exists in grandparent, erased in parent")
     {
+        le = LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+            {SPEEDEX_CONFIGURATION});
+        le.lastModifiedLedgerSeq = 1;
+        key = LedgerEntryKey(le);
+
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         REQUIRE(ltx1.create(le));
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -194,6 +194,10 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
                 LOG_INFO(DEFAULT_LOG, "Dropping liquiditypools");
                 app.getLedgerTxnRoot().dropLiquidityPools();
                 break;
+            case SPEEDEX_CONFIGURATION:
+                LOG_INFO(DEFAULT_LOG, "Dropping speedexconfiguration");
+                app.getLedgerTxnRoot().dropSpeedexConfiguration();
+                break;
             default:
                 abort();
             }

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -159,6 +159,8 @@ getShortKey(LedgerKey const& key)
         return getShortKey(key.claimableBalance().balanceID);
     case LIQUIDITY_POOL:
         return getShortKey(key.liquidityPool().liquidityPoolID);
+    case SPEEDEX_CONFIGURATION:
+        return SPEEDEX_CONFIGURATION;
     }
     throw std::runtime_error("Unknown key type");
 }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -117,6 +117,7 @@ computeMultiplier(LedgerEntry const& le)
     case CLAIMABLE_BALANCE:
         return static_cast<uint32_t>(
             le.data.claimableBalance().claimants.size());
+    case SPEEDEX_CONFIGURATION:
     default:
         throw std::runtime_error("Unexpected LedgerEntry type");
     }

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -117,6 +117,7 @@ computeMultiplier(LedgerEntry const& le)
     case CLAIMABLE_BALANCE:
         return static_cast<uint32_t>(
             le.data.claimableBalance().claimants.size());
+    case LIQUIDITY_POOL:
     case SPEEDEX_CONFIGURATION:
     default:
         throw std::runtime_error("Unexpected LedgerEntry type");

--- a/src/transactions/RevokeSponsorshipOpFrame.cpp
+++ b/src/transactions/RevokeSponsorshipOpFrame.cpp
@@ -43,6 +43,7 @@ getAccountID(LedgerEntry const& le)
         return le.data.data().accountID;
     case CLAIMABLE_BALANCE:
         return *le.ext.v1().sponsoringID;
+    case SPEEDEX_CONFIGURATION:
     default:
         abort();
     }
@@ -431,6 +432,7 @@ RevokeSponsorshipOpFrame::doCheckValid(uint32_t ledgerVersion)
         case CLAIMABLE_BALANCE:
             break;
         case LIQUIDITY_POOL:
+        case SPEEDEX_CONFIGURATION:
             innerResult().code(REVOKE_SPONSORSHIP_MALFORMED);
             return false;
         default:

--- a/src/transactions/RevokeSponsorshipOpFrame.cpp
+++ b/src/transactions/RevokeSponsorshipOpFrame.cpp
@@ -44,6 +44,8 @@ getAccountID(LedgerEntry const& le)
     case CLAIMABLE_BALANCE:
         return *le.ext.v1().sponsoringID;
     case SPEEDEX_CONFIGURATION:
+        throw std::runtime_error(
+            "Speedex configuration doesn't have accountId.");
     default:
         abort();
     }

--- a/src/transactions/SponsorshipUtils.cpp
+++ b/src/transactions/SponsorshipUtils.cpp
@@ -202,8 +202,9 @@ computeMultiplier(LedgerEntry const& le)
         return static_cast<uint32_t>(
             le.data.claimableBalance().claimants.size());
     case LIQUIDITY_POOL:
+    case SPEEDEX_CONFIGURATION:
         throw std::runtime_error(
-            "LIQUIDITY_POOL is not valid in SponsorshipUtils");
+            "Invalid ledger entry type in SponsorshipUtils");
     default:
         throw std::runtime_error("Unknown LedgerEntry type");
     }
@@ -222,8 +223,9 @@ isSubentry(LedgerEntry const& le)
     case DATA:
         return true;
     case LIQUIDITY_POOL:
+    case SPEEDEX_CONFIGURATION:
         throw std::runtime_error(
-            "LIQUIDITY_POOL is not valid in SponsorshipUtils");
+            "Invalid ledger entry type in SponsorshipUtils");
     default:
         throw std::runtime_error("Unknown LedgerEntry type");
     }

--- a/src/transactions/simulation/TxSimUtils.cpp
+++ b/src/transactions/simulation/TxSimUtils.cpp
@@ -387,6 +387,7 @@ generateScaledLiveEntries(
 
             break;
         }
+        case SPEEDEX_CONFIGURATION:
         default:
             abort();
         }
@@ -423,6 +424,7 @@ scaleNonPoolLedgerKey(LedgerKey& key, uint32_t partition)
             generateScaledClaimableBalanceID(
                 key.claimableBalance().balanceID.v0(), partition);
         break;
+    case SPEEDEX_CONFIGURATION:
     default:
         throw std::runtime_error("invalid ledger key type");
     }

--- a/src/transactions/simulation/TxSimUtils.cpp
+++ b/src/transactions/simulation/TxSimUtils.cpp
@@ -388,6 +388,8 @@ generateScaledLiveEntries(
             break;
         }
         case SPEEDEX_CONFIGURATION:
+            // Currently there is no actual configuration to modify.
+            break;
         default:
             abort();
         }
@@ -424,6 +426,7 @@ scaleNonPoolLedgerKey(LedgerKey& key, uint32_t partition)
             generateScaledClaimableBalanceID(
                 key.claimableBalance().balanceID.v0(), partition);
         break;
+    case LIQUIDITY_POOL:
     case SPEEDEX_CONFIGURATION:
     default:
         throw std::runtime_error("invalid ledger key type");

--- a/src/transactions/test/RevokeSponsorshipTests.cpp
+++ b/src/transactions/test/RevokeSponsorshipTests.cpp
@@ -1335,5 +1335,10 @@ TEST_CASE("update sponsorship", "[tx][sponsorship]")
                 revoke(poolShareTrustLineKey(a1, PoolID{}));
             });
         }
+        SECTION("speedex configuration")
+        {
+            for_versions_from(
+                19, *app, [&]() { revoke(LedgerKey(SPEEDEX_CONFIGURATION)); });
+        }
     }
 }

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -49,7 +49,10 @@ LedgerEntryKey(LedgerEntry const& e)
     case LIQUIDITY_POOL:
         k.liquidityPool().liquidityPoolID = d.liquidityPool().liquidityPoolID;
         break;
-
+    case SPEEDEX_CONFIGURATION:
+        // Speedex configuration key contains no payload as there exists is
+        // only a single configuration.
+        break;
     default:
         abort();
     }

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -50,8 +50,8 @@ LedgerEntryKey(LedgerEntry const& e)
         k.liquidityPool().liquidityPoolID = d.liquidityPool().liquidityPoolID;
         break;
     case SPEEDEX_CONFIGURATION:
-        // Speedex configuration key contains no payload as there exists is
-        // only a single configuration.
+        // Speedex configuration key contains no payload as there exists only
+        // a single configuration.
         break;
     default:
         abort();

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -474,8 +474,6 @@ struct LiquidityPoolEntry
     body;
 };
 
-
-
 struct LedgerEntryExtensionV1
 {
     SponsorshipDescriptor sponsoringID;

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -97,7 +97,8 @@ enum LedgerEntryType
     OFFER = 2,
     DATA = 3,
     CLAIMABLE_BALANCE = 4,
-    LIQUIDITY_POOL = 5
+    LIQUIDITY_POOL = 5,
+    SPEEDEX_CONFIGURATION = 6
 };
 
 struct Signer
@@ -473,10 +474,24 @@ struct LiquidityPoolEntry
     body;
 };
 
+
+
 struct LedgerEntryExtensionV1
 {
     SponsorshipDescriptor sponsoringID;
 
+    union switch (int v)
+    {
+    case 0:
+        void;
+    }
+    ext;
+};
+
+struct SpeedexConfigurationEntry
+{
+    Asset asset<>;
+    uint32 dummyParam;
     union switch (int v)
     {
     case 0:
@@ -503,6 +518,8 @@ struct LedgerEntry
         ClaimableBalanceEntry claimableBalance;
     case LIQUIDITY_POOL:
         LiquidityPoolEntry liquidityPool;
+    case SPEEDEX_CONFIGURATION:
+        SpeedexConfigurationEntry speedexConfiguration;
     }
     data;
 
@@ -557,6 +574,9 @@ case LIQUIDITY_POOL:
     {
         PoolID liquidityPoolID;
     } liquidityPool;
+
+case SPEEDEX_CONFIGURATION:
+    void;
 };
 
 // list of all envelope types used in the application

--- a/src/xdr/Stellar-ledger-entries.x
+++ b/src/xdr/Stellar-ledger-entries.x
@@ -491,7 +491,6 @@ struct LedgerEntryExtensionV1
 struct SpeedexConfigurationEntry
 {
     Asset asset<>;
-    uint32 dummyParam;
     union switch (int v)
     {
     case 0:

--- a/test-tx-meta-baseline-current/RevokeSponsorshipTests.json
+++ b/test-tx-meta-baseline-current/RevokeSponsorshipTests.json
@@ -31,6 +31,7 @@
 		"FJYdrTZVmAE=",
 		"FJYdrTZVmAE=",
 		"FJYdrTZVmAE=",
+		"FJYdrTZVmAE=",
 		"FJYdrTZVmAE="
 	],
 	"update sponsorship|invalid input|invalid trustline keys" : [ "WN8efkyHAzM=", "WN8efkyHAzM=", "WN8efkyHAzM=", "WN8efkyHAzM=" ],

--- a/test-tx-meta-baseline-next/RevokeSponsorshipTests.json
+++ b/test-tx-meta-baseline-next/RevokeSponsorshipTests.json
@@ -36,6 +36,7 @@
 		"FJYdrTZVmAE=",
 		"FJYdrTZVmAE=",
 		"FJYdrTZVmAE=",
+		"FJYdrTZVmAE=",
 		"FJYdrTZVmAE="
 	],
 	"update sponsorship|invalid input|invalid trustline keys" : 


### PR DESCRIPTION
# Description

Resolves #3341 

This adds a new SpeedexConfigurationEntry to the ledger and allows storing it in the SQL database. I've used the XDR from the 
[CAP-44](https://github.com/stellar/stellar-protocol/blob/master/core/cap-0044.md), but the only relevant part for this PR is really just the new entry type and the entry itself. The entry just has a dummy field that makes it usable with tests.

Since this is a configuration entry, it differs from the regular entries:
- The entry can be created just once and then only be updated and never deleted
- The entry cannot be prefetched as prefetch assumes bulk operations

While these operations could be implemented, I think it's more appropriate to only allow the operations that make sense semantically (also deleting the configuration doesn't seem like the right thing to do).

This led to some updates in the tests:
- A lot of the bucket list-related tests rely on the uniqueness of the random ledger entries, but with this type we always have one same key, hence I force uniqueness in these tests
- Some bucket list tests delete randomly generated entries, so they have to exclude SpeedexConfigurationEntry from generation
- Made the respective changes for the excluded functionality (delete/prefetch in LedgerTxn)

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
