### PR TITLE
Improve instructions for installing on macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -96,13 +96,21 @@ In order to install the llvm (clang) toolchain, you may have to follow instructi
 ### OS X
 When building on OSX, here's some dependencies you'll need:
 - Install xcode
-- Install homebrew
-- brew install libsodium
-- brew install libtool
-- brew install automake
-- brew install pkg-config
-- brew install libpqxx *(If ./configure later complains about libpq missing, try PKG_CONFIG_PATH='/usr/local/lib/pkgconfig')*
-- brew install parallel (required for running tests)
+- Install [homebrew](https://brew.sh)
+- `brew install libsodium`
+- `brew install libtool`
+- `brew install autoconf`
+- `brew install automake`
+- `brew install pkg-config`
+- `brew install libpq` (required for postgres)
+- `brew install openssl` (required for postgres)
+- `brew install parallel` (required for running tests)
+
+You'll also need to configure pkg-config by adding the following to your shell (`.zshenv` or `.zshrc`):
+```zsh
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/libpq/lib/pkgconfig"
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/openssl@3/lib/pkgconfig"
+```
 
 ### Windows
 See [INSTALL-Windows.md](INSTALL-Windows.md)


### PR DESCRIPTION
# Description

Improve instructions for building on macOS to support Apple Silicon.

I recently built stellar-core on macOS and needed to install openssl as well as configure pkg-config. I forgot about it until I saw @jayz22 running into similar problems. This seems like it will be common enough of an issue onboarding that we should expand the instructions.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] ~Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)~
- [x] ~Compiles~
- [x] ~Ran all tests~
- [x] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~
