### PR TITLE
Configure error if ccache enabled but not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,9 @@ AC_ARG_ENABLE([ccache],
               AS_HELP_STRING([--enable-ccache], [build with ccache]))
 AS_IF([test "x$enable_ccache" = "xyes"], [
   AC_CHECK_PROGS([CCACHE], [ccache])
+  AS_IF([test -z "$CCACHE"], [
+    AC_MSG_ERROR([ccache enabled but not found])
+  ])
   case "$CC" in
   *ccache\ *)
       ;;


### PR DESCRIPTION
# Description

Error when running `./configure --enable-ccache` when ccache is not found.

Some macOS devs have noticed recently that when running configure with `--enable-ccache` they see the following error:

```
checking for ccache... no
checking to see if <filesystem> works without any extra libs... no
checking to see if <filesystem> works with -lstdc++fs... no
checking to see if <filesystem> works with -lc++fs... no
configure: error: C++17 <filesystem> does not work with any known linker flags
```

The error is misleading, suggesting that there is a problem with finding `<filesystem>`.

Actually what's happening, at least what I see on my own system where this occurred, is that ccache isn't being found but the configure script continues having prepended `ccache` to `CC` and `CXX`.

It seems to me like if a dependency can't be found when we run `AC_CHECK_PROG`, we should stop at that point rather than let the script continue and error at some later point that is easily misunderstood.

cc @jayz22 @jonjove 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
