### PR TITLE
Adds EXPERIMENTAL_BUCKET_STORE flag to manage bucket files in an alternative sort order

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -809,10 +809,4 @@ Bucket::getBucketVersion(std::shared_ptr<Bucket const> bucket)
     BucketInputIterator it(bucket, type);
     return it.getMetadata().ledgerVersion;
 }
-
-uint256
-Bucket::extractFromFilename(std::filesystem::path const& path)
-{
-    return hexToBin256(path.filename().string().substr(7, 64));
-};
 }

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -79,20 +79,40 @@ Bucket::addFile(std::filesystem::path const& file, Hash const& hash,
     }
 }
 
-Hash const
+std::optional<Hash const> const&
 Bucket::getHash(BucketSortOrder type) const
 {
-    return type == BucketSortOrder::SortByType
-               ? mSortByTypeHash.value_or(Hash{})
-               : mSortByAccountHash.value_or(Hash{});
+    return type == BucketSortOrder::SortByType ? mSortByTypeHash
+                                               : mSortByAccountHash;
 }
 
-std::filesystem::path const
+std::optional<std::filesystem::path const> const&
 Bucket::getFilename(BucketSortOrder type) const
 {
-    return type == BucketSortOrder::SortByType
-               ? mSortByTypeFilename.value_or(std::filesystem::path{})
-               : mSortByAccountFilename.value_or(std::filesystem::path{});
+    return type == BucketSortOrder::SortByType ? mSortByTypeFilename
+                                               : mSortByAccountFilename;
+}
+
+Hash const
+Bucket::getPrimaryHash() const
+{
+    if (mSortByAccountHash.has_value())
+    {
+        return *mSortByAccountHash;
+    }
+
+    if (mSortByTypeHash.has_value())
+    {
+        return *mSortByTypeHash;
+    }
+
+    return {};
+}
+
+bool
+Bucket::isEmpty() const
+{
+    return !mSortByAccountHash.has_value() && !mSortByTypeHash.has_value();
 }
 
 size_t

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -188,6 +188,23 @@ Bucket::convertToBucketEntry(bool useInit,
     return bucket;
 }
 
+BucketSortOrder
+Bucket::getFileType(std::filesystem::path filename)
+{
+    // Dummy bucket for convenience
+    auto bucket = std::make_shared<Bucket>(filename, Hash{});
+    BucketInputIterator it(bucket);
+    if (protocolVersionIsBefore(it.getMetadata().ledgerVersion,
+                                FIRST_PROTOCOL_SORTED_BY_ACCOUNT))
+    {
+        return BucketSortOrder::SortByType;
+    }
+    else
+    {
+        return BucketSortOrder::SortByAccount;
+    }
+}
+
 std::shared_ptr<Bucket>
 Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
               std::vector<LedgerEntry> const& initEntries,
@@ -793,11 +810,9 @@ Bucket::getBucketVersion(std::shared_ptr<Bucket const> bucket)
     return it.getMetadata().ledgerVersion;
 }
 
-std::string
-Bucket::getExperimentalFilename(std::string const& filename)
+uint256
+Bucket::extractFromFilename(std::filesystem::path const& path)
 {
-    // If primary filename is empty, so should the experimental filename
-    return filename.empty() ? std::string()
-                            : filename + Bucket::EXPERIMENTAL_FILE_EXT;
-}
+    return hexToBin256(path.filename().string().substr(7, 64));
+};
 }

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -93,8 +93,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
                          std::vector<LedgerKey> const& deadEntries);
 
     static BucketSortOrder getFileType(std::filesystem::path filename);
-
-    static uint256 extractFromFilename(std::filesystem::path const& path);
 #ifdef BUILD_TESTS
     // "Applies" the bucket to the database. For each entry in the bucket,
     // if the entry is init or live, creates or updates the corresponding

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -15,12 +15,6 @@
 namespace stellar
 {
 
-enum class BucketSortOrder
-{
-    SortByType,
-    SortByAccount
-};
-
 /**
  * Bucket is an immutable container for a sorted set of "Entries" (object ID,
  * hash, xdr-message tuples) which is designed to be held in a shared_ptr<>

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -92,9 +92,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     // Get experimental filename for bucket backed by the given file.
     static std::string getExperimentalFilename(std::string const& filename);
-
-    // Returns true is filename ends in experimental file extension
-    static bool isExperimentalFile(std::string const& filename);
 #ifdef BUILD_TESTS
     // "Applies" the bucket to the database. For each entry in the bucket,
     // if the entry is init or live, creates or updates the corresponding

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -34,8 +34,11 @@ class Database;
 class Bucket : public std::enable_shared_from_this<Bucket>,
                public NonMovableOrCopyable
 {
+    // File extension for bucket files sorted with experimental cmp function
+    inline static std::string const EXPERIMENTAL_FILE_EXT = ".v2";
 
     std::string const mFilename;
+    bool mIsExperimental;
     Hash const mHash;
     size_t mSize{0};
 
@@ -44,10 +47,19 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     // filename is the empty string.
     Bucket();
 
+    // Associates a file sorted using the experimental sort order with this
+    // bucket. Caller must make sure file exists and is properly sorted.
+    void addExperimentalFile();
+
+    // Returns true if Bucket has an experimental file backing it, false
+    // otherwise.
+    bool isExperimental() const;
+
     // Construct a bucket with a given filename and hash. Asserts that the file
     // exists, but does not check that the hash is the bucket's hash. Caller
     // needs to ensure that.
-    Bucket(std::string const& filename, Hash const& hash);
+    Bucket(std::string const& filename, Hash const& hash,
+           bool useExperimental = false);
 
     Hash const& getHash() const;
     std::string const& getFilename() const;
@@ -74,6 +86,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
                          std::vector<LedgerEntry> const& liveEntries,
                          std::vector<LedgerKey> const& deadEntries);
 
+    // Get experimental filename for bucket backed by the given file.
+    static std::string getExperimentalFilename(std::string const& filename);
+
+    // Returns true is filename ends in experimental file extension
+    static bool isExperimentalFile(std::string const& filename);
 #ifdef BUILD_TESTS
     // "Applies" the bucket to the database. For each entry in the bucket,
     // if the entry is init or live, creates or updates the corresponding
@@ -111,6 +128,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
           bool keepDeadEntries, bool countMergeEvents, asio::io_context& ctx,
           bool doFsync);
 
-    static uint32_t getBucketVersion(std::shared_ptr<Bucket> const& bucket);
+    static uint32_t getBucketVersion(std::shared_ptr<Bucket const> bucket);
 };
 }

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -41,9 +41,6 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     size_t mSize{0};
 
   public:
-    // File extension for bucket files sorted with experimental cmp function
-    inline static std::string const EXPERIMENTAL_FILE_EXT = ".v2";
-
     // Create an empty bucket. The empty bucket has hash '000000...' and its
     // filename is the empty string.
     Bucket();
@@ -81,6 +78,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     static constexpr ProtocolVersion FIRST_PROTOCOL_SHADOWS_REMOVED =
         ProtocolVersion::V_12;
 
+    // Buckets with protocol version 20 and higher are sorted by account instead
+    // of by type
+    static constexpr ProtocolVersion FIRST_PROTOCOL_SORTED_BY_ACCOUNT =
+        ProtocolVersion::V_20;
+
     static void checkProtocolLegality(BucketEntry const& entry,
                                       uint32_t protocolVersion);
 
@@ -90,8 +92,9 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
                          std::vector<LedgerEntry> const& liveEntries,
                          std::vector<LedgerKey> const& deadEntries);
 
-    // Get experimental filename for bucket backed by the given file.
-    static std::string getExperimentalFilename(std::string const& filename);
+    static BucketSortOrder getFileType(std::filesystem::path filename);
+
+    static uint256 extractFromFilename(std::filesystem::path const& path);
 #ifdef BUILD_TESTS
     // "Applies" the bucket to the database. For each entry in the bucket,
     // if the entry is init or live, creates or updates the corresponding

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -41,6 +41,9 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     size_t mSize{0};
 
   public:
+    static constexpr BucketSortOrder LEDGER_HASH_SORT_ORDER =
+        BucketSortOrder::SortByType;
+
     // Create an empty bucket. The empty bucket has hash '000000...' and its
     // filename is the empty string.
     Bucket();
@@ -58,10 +61,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     void addFile(std::filesystem::path const& filename, Hash const& hash,
                  BucketSortOrder type);
 
-    Hash const
-    getHash(BucketSortOrder type = BucketSortOrder::SortByType) const;
-    std::filesystem::path const
-    getFilename(BucketSortOrder type = BucketSortOrder::SortByType) const;
+    std::optional<Hash const> const& getHash(BucketSortOrder type) const;
+    std::optional<std::filesystem::path const> const&
+    getFilename(BucketSortOrder type) const;
+    Hash const getPrimaryHash() const;
+    bool isEmpty() const;
 
     size_t getSize() const;
     bool hasFileWithSortOrder(BucketSortOrder type) const;

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -21,7 +21,7 @@ BucketApplicator::BucketApplicator(Application& app,
                                    std::function<bool(LedgerEntryType)> filter)
     : mApp(app)
     , mMaxProtocolVersion(maxProtocolVersion)
-    , mBucketIter(bucket)
+    , mBucketIter(bucket, Bucket::getBucketVersion(bucket))
     , mEntryTypeFilter(filter)
 {
     auto protocolVersion = mBucketIter.getMetadata().ledgerVersion;

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -87,7 +87,8 @@ BucketInputIterator::getMetadata() const
     return mMetadata;
 }
 
-BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket)
+BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket,
+                                         std::string const& inFilename)
     : mBucket(bucket), mEntryPtr(nullptr), mSeenMetadata(false)
 {
     // In absence of metadata, we treat every bucket as though it is from ledger
@@ -97,11 +98,13 @@ BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket)
     // protocol of a pre-protocol-11 bucket, and we have to use as conservative
     // a default as possible to avoid spurious attempted-downgrade errors.
     mMetadata.ledgerVersion = 0;
-    if (!mBucket->getFilename().empty())
+    std::string const& filename =
+        inFilename.empty() ? mBucket->getFilename() : inFilename;
+    if (!filename.empty())
     {
         CLOG_TRACE(Bucket, "BucketInputIterator opening file to read: {}",
-                   mBucket->getFilename());
-        mIn.open(mBucket->getFilename());
+                   filename);
+        mIn.open(filename);
         loadEntry();
     }
 }

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -88,7 +88,7 @@ BucketInputIterator::getMetadata() const
 }
 
 BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket,
-                                         std::string const& inFilename)
+                                         BucketSortOrder type)
     : mBucket(bucket), mEntryPtr(nullptr), mSeenMetadata(false)
 {
     // In absence of metadata, we treat every bucket as though it is from ledger
@@ -98,8 +98,7 @@ BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket,
     // protocol of a pre-protocol-11 bucket, and we have to use as conservative
     // a default as possible to avoid spurious attempted-downgrade errors.
     mMetadata.ledgerVersion = 0;
-    std::string const& filename =
-        inFilename.empty() ? mBucket->getFilename() : inFilename;
+    auto filename = bucket->getFilename(type);
     if (!filename.empty())
     {
         CLOG_TRACE(Bucket, "BucketInputIterator opening file to read: {}",

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -98,12 +98,12 @@ BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket,
     // protocol of a pre-protocol-11 bucket, and we have to use as conservative
     // a default as possible to avoid spurious attempted-downgrade errors.
     mMetadata.ledgerVersion = 0;
-    auto filename = bucket->getFilename(type);
-    if (!filename.empty())
+    auto const& filename = bucket->getFilename(type);
+    if (filename)
     {
         CLOG_TRACE(Bucket, "BucketInputIterator opening file to read: {}",
-                   filename);
-        mIn.open(filename);
+                   *filename);
+        mIn.open(*filename);
         loadEntry();
     }
 }

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -108,6 +108,12 @@ BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket,
     }
 }
 
+BucketInputIterator::BucketInputIterator(std::shared_ptr<Bucket const> bucket,
+                                         uint32_t protocolVersion)
+    : BucketInputIterator(bucket, Bucket::protocolSortOrder(protocolVersion))
+{
+}
+
 BucketInputIterator::~BucketInputIterator()
 {
     mIn.close();

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/Bucket.h"
 #include "bucket/LedgerCmp.h"
 #include "util/XDRStream.h"
 #include "xdr/Stellar-ledger.h"
@@ -49,7 +50,7 @@ class BucketInputIterator
     // If no filename given, creates iterator for mFilename associated with
     // the bucket (i.e. the non-experimental file).
     BucketInputIterator(std::shared_ptr<Bucket const> bucket,
-                        std::string const& filename = {});
+                        BucketSortOrder type = BucketSortOrder::SortByType);
 
     ~BucketInputIterator();
 

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -47,8 +47,7 @@ class BucketInputIterator
 
     BucketEntry const& operator*();
 
-    // If no filename given, creates iterator for mFilename associated with
-    // the bucket (i.e. the non-experimental file).
+    // Creates iterator for file of given sort order associated with the bucket
     BucketInputIterator(std::shared_ptr<Bucket const> bucket,
                         BucketSortOrder type = BucketSortOrder::SortByType);
 

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -49,7 +49,11 @@ class BucketInputIterator
 
     // Creates iterator for file of given sort order associated with the bucket
     BucketInputIterator(std::shared_ptr<Bucket const> bucket,
-                        BucketSortOrder type = BucketSortOrder::SortByType);
+                        BucketSortOrder type);
+
+    // Creates iterator for file of given sort order based on protocol version
+    BucketInputIterator(std::shared_ptr<Bucket const> bucket,
+                        uint32_t protocolVersion);
 
     ~BucketInputIterator();
 

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -46,7 +46,10 @@ class BucketInputIterator
 
     BucketEntry const& operator*();
 
-    BucketInputIterator(std::shared_ptr<Bucket const> bucket);
+    // If no filename given, creates iterator for mFilename associated with
+    // the bucket (i.e. the non-experimental file).
+    BucketInputIterator(std::shared_ptr<Bucket const> bucket,
+                        std::string const& filename = {});
 
     ~BucketInputIterator();
 

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -29,15 +29,15 @@ BucketLevel::BucketLevel(uint32_t i)
 }
 
 uint256
-BucketLevel::getHash() const
+BucketLevel::getHash(uint32_t protocolVersion) const
 {
     SHA256 hsh;
-    auto const& curr = mCurr->getHash(Bucket::LEDGER_HASH_SORT_ORDER);
-    auto const& snap = mSnap->getHash(Bucket::LEDGER_HASH_SORT_ORDER);
+    auto curr = mCurr->getHashByProtocol(protocolVersion);
+    auto snap = mSnap->getHashByProtocol(protocolVersion);
 
     // Empty bucket effects hash, so add empty hash if option is null
-    hsh.add(curr.value_or(Hash{}));
-    hsh.add(snap.value_or(Hash{}));
+    hsh.add(curr);
+    hsh.add(snap);
 
     return hsh.finish();
 }
@@ -365,13 +365,13 @@ BucketList::oldestLedgerInSnap(uint32_t ledger, uint32_t level)
 }
 
 uint256
-BucketList::getHash() const
+BucketList::getHash(uint32_t portocolVersion) const
 {
     ZoneScoped;
     SHA256 hsh;
     for (auto const& lev : mLevels)
     {
-        hsh.add(lev.getHash());
+        hsh.add(lev.getHash(portocolVersion));
     }
     return hsh.finish();
 }

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -310,7 +310,7 @@ class BucketLevel
 
   public:
     BucketLevel(uint32_t i);
-    uint256 getHash() const;
+    uint256 getHash(uint32_t protocolVersion) const;
     FutureBucket const& getNext() const;
     FutureBucket& getNext();
     std::shared_ptr<Bucket> getCurr() const;
@@ -400,7 +400,7 @@ class BucketList
     // Return a cumulative hash of the entire bucketlist; this is the hash of
     // the concatenation of each level's hash, each of which in turn is the hash
     // of the concatenation of the hashes of the `curr` and `snap` buckets.
-    Hash getHash() const;
+    Hash getHash(uint32_t protocolVersion) const;
 
     // Restart any merges that might be running on background worker threads,
     // merging buckets between levels. This needs to be called after forcing a

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -102,9 +102,9 @@ class BucketManager : NonMovableOrCopyable
     }
     virtual void initialize() = 0;
     virtual void dropAll() = 0;
-    virtual std::string const& getTmpDir() = 0;
+    virtual std::filesystem::path const getTmpDir() = 0;
     virtual TmpDirManager& getTmpDirManager() = 0;
-    virtual std::string const& getBucketDir() const = 0;
+    virtual std::filesystem::path const& getBucketDir() const = 0;
     virtual BucketList& getBucketList() = 0;
     virtual Config const& getConfig() const = 0;
 

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -18,6 +18,7 @@ namespace stellar
 {
 
 class Application;
+class Config;
 class BucketList;
 class TmpDirManager;
 struct LedgerHeader;
@@ -105,6 +106,7 @@ class BucketManager : NonMovableOrCopyable
     virtual TmpDirManager& getTmpDirManager() = 0;
     virtual std::string const& getBucketDir() const = 0;
     virtual BucketList& getBucketList() = 0;
+    virtual Config const& getConfig() const = 0;
 
     virtual medida::Timer& getMergeTimer() = 0;
 
@@ -127,7 +129,8 @@ class BucketManager : NonMovableOrCopyable
     virtual std::shared_ptr<Bucket>
     adoptFileAsBucket(std::string const& filename, uint256 const& hash,
                       size_t nObjects, size_t nBytes,
-                      MergeKey* mergeKey = nullptr) = 0;
+                      MergeKey* mergeKey = nullptr,
+                      std::string const& expFilename = {}) = 0;
 
     // Companion method to `adoptFileAsBucket` also called from the
     // `BucketOutputIterator::getBucket` merge-completion path. This method

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -142,7 +142,8 @@ class BucketManager : NonMovableOrCopyable
     // sort order. Returns path to newly sorted file.
     virtual std::filesystem::path resortFile(std::shared_ptr<Bucket> b,
                                              BucketSortOrder oldType,
-                                             BucketSortOrder newType) = 0;
+                                             BucketSortOrder newType,
+                                             Hash& hash) = 0;
 
     // Companion method to `adoptFileAsBucket` also called from the
     // `BucketOutputIterator::getBucket` merge-completion path. This method

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -127,10 +127,22 @@ class BucketManager : NonMovableOrCopyable
     // BucketManager mid-call -- and is intended to be called from both main and
     // worker threads. Very carefully.
     virtual std::shared_ptr<Bucket>
-    adoptFileAsBucket(std::string const& filename, uint256 const& hash,
-                      size_t nObjects, size_t nBytes,
-                      MergeKey* mergeKey = nullptr,
-                      std::string const& expFilename = {}) = 0;
+    adoptFileAsBucket(std::filesystem::path const& filename,
+                      uint256 const& hash, size_t nObjects, size_t nBytes,
+                      BucketSortOrder type, MergeKey* mergeKey = nullptr) = 0;
+
+    // Associates a file with the given sort order and hash to the bucket.
+    // Asserts that the file exists, but does not check that the hash is the
+    // bucket's hash. Caller needs to ensure that.
+    virtual void addFileToBucket(std::shared_ptr<Bucket> b,
+                                 std::filesystem::path const& filename,
+                                 uint256 const& hash, BucketSortOrder type) = 0;
+
+    // Resorts the file of type oldType associated with bucket b with newType
+    // sort order. Returns path to newly sorted file.
+    virtual std::filesystem::path resortFile(std::shared_ptr<Bucket> b,
+                                             BucketSortOrder oldType,
+                                             BucketSortOrder newType) = 0;
 
     // Companion method to `adoptFileAsBucket` also called from the
     // `BucketOutputIterator::getBucket` merge-completion path. This method

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -7,6 +7,7 @@
 #include "bucket/Bucket.h"
 #include "overlay/StellarXDR.h"
 #include "util/NonCopyable.h"
+#include "util/UnorderedMap.h"
 #include <future>
 #include <map>
 #include <memory>
@@ -209,6 +210,9 @@ class BucketManager : NonMovableOrCopyable
     // This interface exists only for checking that the BucketDir isn't
     // leaking buckets, in tests.
     virtual std::set<Hash> getBucketHashesInBucketDirForTesting() const = 0;
+
+    virtual UnorderedMap<Hash, Hash> const&
+    getAccountToTypeHashesForTesting() const = 0;
 #endif
 
     // Return the set of buckets referenced by the BucketList, LCL HAS,

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -143,7 +143,6 @@ class BucketManager : NonMovableOrCopyable
     // sort order. Returns path to newly sorted file.
     virtual std::filesystem::path resortFile(std::shared_ptr<Bucket> b,
                                              BucketSortOrder oldType,
-                                             BucketSortOrder newType,
                                              Hash& hash) = 0;
 
     // Companion method to `adoptFileAsBucket` also called from the
@@ -155,7 +154,7 @@ class BucketManager : NonMovableOrCopyable
     virtual void noteEmptyMergeOutput(MergeKey const& mergeKey) = 0;
 
     // Return a bucket by hash if we have it, else return nullptr.
-    virtual std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) = 0;
+    virtual std::shared_ptr<Bucket> getBucketByHashID(HashID const& hash) = 0;
 
     // Get a reference to a merge-future that's either running (or finished
     // somewhat recently) from either a map of the std::shared_futures doing the
@@ -211,13 +210,13 @@ class BucketManager : NonMovableOrCopyable
     // leaking buckets, in tests.
     virtual std::set<Hash> getBucketHashesInBucketDirForTesting() const = 0;
 
-    virtual UnorderedMap<Hash, Hash> const&
+    virtual UnorderedMap<HashID, HashID> const&
     getAccountToTypeHashesForTesting() const = 0;
 #endif
 
     // Return the set of buckets referenced by the BucketList, LCL HAS,
     // and publish queue.
-    virtual std::set<Hash> getReferencedBuckets() const = 0;
+    virtual std::set<HashID> getReferencedBuckets() const = 0;
 
     // Check for missing bucket files that would prevent `assumeState` from
     // succeeding

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -33,10 +33,8 @@ struct HistoryArchiveState;
 
 class BucketManagerImpl : public BucketManager
 {
-    typedef std::map<std::filesystem::path, std::filesystem::path>
-        BucketFileMap;
-
-    inline static std::string const ACCOUNT_TO_TYPE_JSON_KEY = "AccountToType";
+    inline static std::string const ACCOUNT_TO_TYPE_JSON_KEY =
+        "AccountToTypeHashes";
 
     static std::string const kLockFilename;
 
@@ -52,7 +50,7 @@ class BucketManagerImpl : public BucketManager
     medida::Timer& mBucketSnapMerge;
     medida::Counter& mSharedBucketsSize;
     MergeCounters mMergeCounters;
-    BucketFileMap mAccountToTypeFileMap;
+    UnorderedMap<Hash, Hash> mAccountToTypeHashes;
 
     bool const mDeleteEntireBucketDirInDtor;
 
@@ -147,6 +145,9 @@ class BucketManagerImpl : public BucketManager
                                               uint256 const& hash) override;
 
     std::set<Hash> getBucketHashesInBucketDirForTesting() const override;
+
+    UnorderedMap<Hash, Hash> const&
+    getAccountToTypeHashesForTesting() const override;
 #endif
 
     std::set<Hash> getReferencedBuckets() const override;

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -97,10 +97,17 @@ class BucketManagerImpl : public BucketManager
     void incrMergeCounters(MergeCounters const&) override;
     TmpDirManager& getTmpDirManager() override;
     std::shared_ptr<Bucket>
-    adoptFileAsBucket(std::string const& filename, uint256 const& hash,
-                      size_t nObjects, size_t nBytes,
-                      MergeKey* mergeKey = nullptr,
-                      std::string const& expFilename = {}) override;
+    adoptFileAsBucket(std::filesystem::path const& filename,
+                      uint256 const& hash, size_t nObjects, size_t nBytes,
+                      BucketSortOrder type,
+                      MergeKey* mergeKey = nullptr) override;
+    void addFileToBucket(std::shared_ptr<Bucket> b,
+                         std::filesystem::path const& filename,
+                         uint256 const& hash, BucketSortOrder type) override;
+
+    std::filesystem::path resortFile(std::shared_ptr<Bucket> b,
+                                     BucketSortOrder oldType,
+                                     BucketSortOrder newType) override;
     void noteEmptyMergeOutput(MergeKey const& mergeKey) override;
     std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) override;
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -70,7 +70,7 @@ class BucketManagerImpl : public BucketManager
     void cleanupStaleFiles();
     void deleteTmpDirAndUnlockBucketDir();
     void deleteEntireBucketDir();
-    bool renameBucket(std::string const& src, std::string const& dst);
+    void renameBucket(std::string const& src, std::string const& dst);
 
 #ifdef BUILD_TESTS
     bool mUseFakeTestValuesForNextClose{false};
@@ -91,6 +91,7 @@ class BucketManagerImpl : public BucketManager
     std::string const& getTmpDir() override;
     std::string const& getBucketDir() const override;
     BucketList& getBucketList() override;
+    Config const& getConfig() const override;
     medida::Timer& getMergeTimer() override;
     MergeCounters readMergeCounters() override;
     void incrMergeCounters(MergeCounters const&) override;
@@ -98,7 +99,8 @@ class BucketManagerImpl : public BucketManager
     std::shared_ptr<Bucket>
     adoptFileAsBucket(std::string const& filename, uint256 const& hash,
                       size_t nObjects, size_t nBytes,
-                      MergeKey* mergeKey = nullptr) override;
+                      MergeKey* mergeKey = nullptr,
+                      std::string const& expFilename = {}) override;
     void noteEmptyMergeOutput(MergeKey const& mergeKey) override;
     std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) override;
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -118,7 +118,8 @@ class BucketManagerImpl : public BucketManager
 
     std::filesystem::path resortFile(std::shared_ptr<Bucket> b,
                                      BucketSortOrder oldType,
-                                     BucketSortOrder newType) override;
+                                     BucketSortOrder newType,
+                                     Hash& hash) override;
     void noteEmptyMergeOutput(MergeKey const& mergeKey) override;
     std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) override;
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -42,7 +42,7 @@ class BucketManagerImpl : public BucketManager
     std::unique_ptr<BucketList> mBucketList;
     std::unique_ptr<TmpDirManager> mTmpDirManager;
     std::unique_ptr<TmpDir> mWorkDir;
-    std::map<Hash, std::shared_ptr<Bucket>> mSharedBuckets;
+    std::map<HashID, std::shared_ptr<Bucket>> mSharedBuckets;
     mutable std::recursive_mutex mBucketMutex;
     std::unique_ptr<std::filesystem::path> mLockedBucketDir;
     medida::Meter& mBucketObjectInsertBatch;
@@ -50,7 +50,7 @@ class BucketManagerImpl : public BucketManager
     medida::Timer& mBucketSnapMerge;
     medida::Counter& mSharedBucketsSize;
     MergeCounters mMergeCounters;
-    UnorderedMap<Hash, Hash> mAccountToTypeHashes;
+    UnorderedMap<HashID, HashID> mAccountToTypeHashes;
 
     bool const mDeleteEntireBucketDirInDtor;
 
@@ -116,10 +116,9 @@ class BucketManagerImpl : public BucketManager
 
     std::filesystem::path resortFile(std::shared_ptr<Bucket> b,
                                      BucketSortOrder oldType,
-                                     BucketSortOrder newType,
                                      Hash& hash) override;
     void noteEmptyMergeOutput(MergeKey const& mergeKey) override;
-    std::shared_ptr<Bucket> getBucketByHash(uint256 const& hash) override;
+    std::shared_ptr<Bucket> getBucketByHashID(HashID const& hash) override;
 
     std::shared_future<std::shared_ptr<Bucket>>
     getMergeFuture(MergeKey const& key) override;
@@ -146,11 +145,11 @@ class BucketManagerImpl : public BucketManager
 
     std::set<Hash> getBucketHashesInBucketDirForTesting() const override;
 
-    UnorderedMap<Hash, Hash> const&
+    UnorderedMap<HashID, HashID> const&
     getAccountToTypeHashesForTesting() const override;
 #endif
 
-    std::set<Hash> getReferencedBuckets() const override;
+    std::set<HashID> getReferencedBuckets() const override;
     std::vector<std::string>
     checkForMissingBucketsFiles(HistoryArchiveState const& has) override;
     void assumeState(HistoryArchiveState const& has,

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -70,7 +70,9 @@ class BucketManagerImpl : public BucketManager
     void cleanupStaleFiles();
     void deleteTmpDirAndUnlockBucketDir();
     void deleteEntireBucketDir();
-    void renameBucket(std::string const& src, std::string const& dst);
+    bool renameBucket(std::string const& src, std::string const& dst);
+    void renameBucketWithOneRetry(std::string const& src,
+                                  std::string const& dst);
 
 #ifdef BUILD_TESTS
     bool mUseFakeTestValuesForNextClose{false};

--- a/src/bucket/BucketMergeMap.h
+++ b/src/bucket/BucketMergeMap.h
@@ -25,12 +25,12 @@ class BucketMergeMap
     // not -- they just showed up from catchup or state reloading). Entries in
     // this map will be cleared when their _output_ is dropped from the owning
     // BucketManager's mSharedBuckets, typically due to being unreferenced.
-    UnorderedMap<MergeKey, Hash> mMergeKeyToOutput;
+    UnorderedMap<MergeKey, HashID> mMergeKeyToOutput;
 
     // Unfortunately to use this correctly in the bucket GC path, we also need
     // a different version of the same map, keyed by each input separately. And
     // since one input may be used in _many_ merges, it has to be a multimap.
-    std::unordered_multimap<Hash, Hash> mInputToOutput;
+    std::unordered_multimap<HashID, HashID> mInputToOutput;
 
     // Finally we need _another_ map, the opposite direction, to allow us to
     // erase entries from the previous two maps when we finally decide to drop
@@ -38,12 +38,13 @@ class BucketMergeMap
     //
     // This also has to be a multimap because the same output can be produced
     // by multiple MergeKeys.
-    std::unordered_multimap<Hash, MergeKey> mOutputToMergeKey;
+    std::unordered_multimap<HashID, MergeKey> mOutputToMergeKey;
 
   public:
-    void recordMerge(MergeKey const& input, Hash const& output);
-    UnorderedSet<MergeKey> forgetAllMergesProducing(Hash const& output);
-    bool findMergeFor(MergeKey const& input, Hash& output);
-    void getOutputsUsingInput(Hash const& input, std::set<Hash>& outputs) const;
+    void recordMerge(MergeKey const& input, HashID const& output);
+    UnorderedSet<MergeKey> forgetAllMergesProducing(HashID const& output);
+    bool findMergeFor(MergeKey const& input, HashID& output);
+    void getOutputsUsingInput(HashID const& input,
+                              std::set<HashID>& outputs) const;
 };
 }

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -54,15 +54,14 @@ BucketOutputIterator::BucketOutputIterator(std::string const& tmpDir,
                                            bool keepDeadEntries,
                                            BucketMetadata const& meta,
                                            MergeCounters& mc,
-                                           asio::io_context& ctx, bool doFsync,
-                                           BucketSortOrder type)
+                                           asio::io_context& ctx, bool doFsync)
     : mFilename(randomBucketName(tmpDir))
     , mOut(ctx, doFsync)
     , mBuf(nullptr)
     , mKeepDeadEntries(keepDeadEntries)
     , mMeta(meta)
     , mMergeCounters(mc)
-    , mType(type)
+    , mType(Bucket::protocolSortOrder(meta.ledgerVersion))
 {
     ZoneScoped;
     CLOG_TRACE(Bucket, "BucketOutputIterator opening file to write: {}",

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -156,7 +156,7 @@ BucketOutputIterator::getBucket(BucketManager& bucketManager,
     if (auxFileIter)
     {
         bucketManager.addFileToBucket(b, auxFileIter->getFilename(),
-                                      auxFileIter->mHasher.finish(),
+                                      auxFileIter->getHash(),
                                       auxFileIter->mType);
     }
 
@@ -181,6 +181,12 @@ BucketOutputIterator::close()
         CLOG_DEBUG(Bucket, "Deleting empty bucket file {}", mFilename);
         std::remove(mFilename.c_str());
     }
+}
+
+Hash
+BucketOutputIterator::getHash()
+{
+    return mHasher.finish();
 }
 
 std::filesystem::path

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -62,7 +62,7 @@ class BucketOutputIterator
     getBucket(BucketManager& bucketManager, MergeKey* mergeKey = nullptr,
               BucketOutputIterator* auxFileIter = nullptr);
 
-    std::string getFilename() const;
+    std::filesystem::path getFilename() const;
 
     // Returns true if no objects have been written, false otherwise
     bool empty() const;

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -23,7 +23,7 @@ class BucketManager;
 class BucketOutputIterator
 {
   protected:
-    std::string mFilename;
+    std::filesystem::path mFilename;
     XDROutputFileStream mOut;
     std::unique_ptr<BucketEntry> mBuf;
     SHA256 mHasher;
@@ -33,7 +33,7 @@ class BucketOutputIterator
     BucketMetadata mMeta;
     bool mPutMeta{false};
     MergeCounters& mMergeCounters;
-    bool mIsExperimental;
+    BucketSortOrder mType;
 
     // Either uses BucketEntryIdCmp or BucketEntryIdCmpExp depending on file
     bool cmp(BucketEntry const& a, BucketEntry const& b) const;
@@ -49,7 +49,7 @@ class BucketOutputIterator
     BucketOutputIterator(std::string const& tmpDir, bool keepDeadEntries,
                          BucketMetadata const& meta, MergeCounters& mc,
                          asio::io_context& ctx, bool doFsync,
-                         bool isExperimental = false);
+                         BucketSortOrder type = BucketSortOrder::SortByType);
 
     void put(BucketEntry const& e);
 
@@ -60,7 +60,7 @@ class BucketOutputIterator
     getBucket(BucketManager& bucketManager, MergeKey* mergeKey = nullptr,
               BucketOutputIterator* expFileIter = nullptr);
 
-    std::string const& getFilename() const;
+    std::string getFilename() const;
 
     // Returns true if no objects have been written, false otherwise
     bool empty() const;

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -49,8 +49,7 @@ class BucketOutputIterator
     // (or forget to do), it's handled automatically.
     BucketOutputIterator(std::string const& tmpDir, bool keepDeadEntries,
                          BucketMetadata const& meta, MergeCounters& mc,
-                         asio::io_context& ctx, bool doFsync,
-                         BucketSortOrder type = BucketSortOrder::SortByType);
+                         asio::io_context& ctx, bool doFsync);
 
     void put(BucketEntry const& e);
 

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -69,5 +69,7 @@ class BucketOutputIterator
 
     // Flushes changes to file and closes file.
     void close();
+
+    Hash getHash();
 };
 }

--- a/src/bucket/BucketOutputIterator.h
+++ b/src/bucket/BucketOutputIterator.h
@@ -35,7 +35,8 @@ class BucketOutputIterator
     MergeCounters& mMergeCounters;
     BucketSortOrder mType;
 
-    // Either uses BucketEntryIdCmp or BucketEntryIdCmpExp depending on file
+    // Either uses BucketEntryIdCmp<BucketSortOrder::SortByType> or
+    // BucketEntryIdCmp<BucketSortOrder::SortByAccount> depending on file
     bool cmp(BucketEntry const& a, BucketEntry const& b) const;
 
   public:
@@ -54,11 +55,12 @@ class BucketOutputIterator
     void put(BucketEntry const& e);
 
     // Publishes constructed bucket to BucketManager and returns constructed
-    // bucket. If expFileIter is given, the file associated with expFileIter
-    // will be added to the bucket as the experimental file.
+    // bucket. If auxFileIter is given, the file associated with auxFileIter
+    // will be added to the bucket aswell. Caller must assure that calling
+    // iterator and auxFileIter are of different types
     std::shared_ptr<Bucket>
     getBucket(BucketManager& bucketManager, MergeKey* mergeKey = nullptr,
-              BucketOutputIterator* expFileIter = nullptr);
+              BucketOutputIterator* auxFileIter = nullptr);
 
     std::string getFilename() const;
 

--- a/src/bucket/HashID.h
+++ b/src/bucket/HashID.h
@@ -1,0 +1,96 @@
+#pragma once
+
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/Hex.h"
+#include "util/types.h"
+#include "xdr/Stellar-types.h"
+
+#include <cereal/cereal.hpp>
+#include <iosfwd>
+#include <string>
+
+namespace stellar
+{
+// Type wrapper around Hash. Internally, buckets are refered to and managed by
+// hash. Since there are multiple possible hashes associated with a bucket
+// depending on file sort order, this wrapper class helps clarify a consistent
+// identifying hash.
+class HashID
+{
+    friend class std::hash<HashID>;
+    Hash mHash;
+
+  public:
+    HashID() : mHash()
+    {
+    }
+
+    HashID(Hash const& hash) : mHash(hash)
+    {
+    }
+
+    HashID(std::string const& hash) : mHash(hexToBin256(hash))
+    {
+    }
+
+    bool
+    operator==(HashID const& rhs) const
+    {
+        return this->mHash == rhs.mHash;
+    }
+
+    bool
+    operator<(HashID const& rhs) const
+    {
+        return this->mHash < rhs.mHash;
+    }
+
+    bool
+    operator()(HashID const& rhs) const
+    {
+        return *this < rhs;
+    }
+
+    // Returns hex encoded string of hash
+    std::string
+    toHex() const
+    {
+        return binToHex(mHash);
+    }
+
+    // Returns 6 character prefix of hex encoded Hash for logging
+    std::string
+    toLogString() const
+    {
+        return hexAbbrev(mHash);
+    }
+
+    bool
+    isZero() const
+    {
+        return ::stellar::isZero(mHash);
+    }
+
+    inline Hash const&
+    raw() const
+    {
+        return mHash;
+    }
+};
+}
+
+namespace std
+{
+template <> struct hash<stellar::HashID>
+{
+    size_t
+    operator()(stellar::HashID const& k) const noexcept
+    {
+        std::hash<string> h;
+        return h(k.toHex());
+    }
+};
+}

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -46,8 +46,11 @@ lexCompare(T&& lhs1, T&& rhs1, U&&... args)
  * corresponding LedgerKeys are exactly equal. This operator _could_ be
  * implemented in terms of extracting 2 LedgerKeys from 2 LedgerEntries and
  * doing operator< on them, but that would be comparatively inefficient.
+ *
+ * Entries are first ordered by LedgerEntryType, then by key/key pair for the
+ * given type.
  */
-struct LedgerEntryIdCmp
+struct LedgerEntryCmp
 {
     template <typename T, typename U>
     auto
@@ -88,62 +91,198 @@ struct LedgerEntryIdCmp
 };
 
 /**
+ * Compare two LedgerEntries or LedgerKeys for 'identity', not content.
+ *
+ * LedgerEntries are identified iff they have:
+ *
+ *   - The same type
+ *     - If accounts, then with same accountID
+ *     - If trustlines, then with same (accountID, asset) pair
+ *     - If offers, then with same (sellerID, sequence) pair
+ *
+ * Equivalently: Two LedgerEntries have the same 'identity' iff their
+ * corresponding LedgerKeys are exactly equal. This operator _could_ be
+ * implemented in terms of extracting 2 LedgerKeys from 2 LedgerEntries and
+ * doing operator< on them, but that would be comparatively inefficient.
+ *
+ * Entries that are accounts or account subentries are ordered first, followed
+ * by non-account related entries. Account subentries that have
+ * the same accountID are grouped together. If two entries have the same
+ * accountID, they are then sorted by LedgerEntryType and then by the associated
+ * key/key pair for the given type.
+ */
+struct LedgerEntryCmpExp
+{
+    template <typename T, typename U>
+    auto
+    operator()(T const& a, U const& b) const
+        -> decltype(a.type(), b.type(), bool())
+    {
+        LedgerEntryType aty = a.type();
+        LedgerEntryType bty = b.type();
+
+        // If at least one account is not associated with an account or
+        // account subentry
+        if (aty >= CLAIMABLE_BALANCE || bty >= CLAIMABLE_BALANCE)
+        {
+            // Order by type if types differ
+            if (aty < bty)
+                return true;
+
+            if (aty > bty)
+                return false;
+
+            // Order by ID if types are the same
+            switch (aty)
+            {
+            case CLAIMABLE_BALANCE:
+                return a.claimableBalance().balanceID <
+                       b.claimableBalance().balanceID;
+            case LIQUIDITY_POOL:
+                return a.liquidityPool().liquidityPoolID <
+                       b.liquidityPool().liquidityPoolID;
+            default:
+                throw std::runtime_error("Unexpected entry type.");
+            }
+            return false;
+        }
+
+        // Else if both entries are associated with an account or account
+        // subentry
+        auto getAccountID = [](auto const& e, LedgerEntryType const& et) {
+            switch (et)
+            {
+            case ACCOUNT:
+                return e.account().accountID;
+            case TRUSTLINE:
+                return e.trustLine().accountID;
+            case OFFER:
+                return e.offer().sellerID;
+            case DATA:
+                return e.data().accountID;
+            default:
+                throw std::runtime_error("Unexpected entry type.");
+            }
+        };
+
+        // Order by AccountID if they are different
+        auto aid = getAccountID(a, aty);
+        auto bid = getAccountID(b, bty);
+        if (aid < bid)
+            return true;
+
+        if (bid < aid)
+            return false;
+
+        // Else if order by type
+        if (aty < bty)
+            return true;
+
+        if (bty < aty)
+            return false;
+
+        // Else if both entries are assocaited with the same accountID and
+        // are the same type
+        switch (aty)
+        {
+        case ACCOUNT:
+            // Entries are identical
+            return false;
+        case TRUSTLINE:
+            return lexCompare(aid, bid, a.trustLine().asset,
+                              b.trustLine().asset);
+        case OFFER:
+            return lexCompare(aid, bid, a.offer().offerID, b.offer().offerID);
+        case DATA:
+            return lexCompare(aid, bid, a.data().dataName, b.data().dataName);
+        default:
+            throw std::runtime_error("Unexpected entry type.");
+        }
+        return false;
+    }
+};
+
+namespace
+{
+
+// Compares BucketEntry's using given LedgerCmp function.
+template <class LedgerCmp>
+bool
+bucketEntryIdCmpInternal(BucketEntry const& a, BucketEntry const& b)
+{
+    BucketEntryType aty = a.type();
+    BucketEntryType bty = b.type();
+
+    // METAENTRY sorts below all other entries, comes first in buckets.
+    if (aty == METAENTRY || bty == METAENTRY)
+    {
+        return aty < bty;
+    }
+
+    if (aty == LIVEENTRY || aty == INITENTRY)
+    {
+        if (bty == LIVEENTRY || bty == INITENTRY)
+        {
+            return LedgerCmp{}(a.liveEntry().data, b.liveEntry().data);
+        }
+        else
+        {
+            if (bty != DEADENTRY)
+            {
+                throw std::runtime_error("Malformed bucket: unexpected "
+                                         "non-INIT/LIVE/DEAD entry.");
+            }
+            return LedgerCmp{}(a.liveEntry().data, b.deadEntry());
+        }
+    }
+    else
+    {
+        if (aty != DEADENTRY)
+        {
+            throw std::runtime_error(
+                "Malformed bucket: unexpected non-INIT/LIVE/DEAD entry.");
+        }
+        if (bty == LIVEENTRY || bty == INITENTRY)
+        {
+            return LedgerCmp{}(a.deadEntry(), b.liveEntry().data);
+        }
+        else
+        {
+            if (bty != DEADENTRY)
+            {
+                throw std::runtime_error("Malformed bucket: unexpected "
+                                         "non-INIT/LIVE/DEAD entry.");
+            }
+            return LedgerCmp{}(a.deadEntry(), b.deadEntry());
+        }
+    }
+}
+}
+
+/**
  * Compare two BucketEntries for identity by comparing their respective
- * LedgerEntries (ignoring their hashes, as the LedgerEntryIdCmp ignores their
+ * LedgerEntries (ignoring their hashes, as the LedgerEntryCmp ignores their
  * bodies).
  */
 struct BucketEntryIdCmp
 {
-    bool
+    virtual bool
     operator()(BucketEntry const& a, BucketEntry const& b) const
     {
-        BucketEntryType aty = a.type();
-        BucketEntryType bty = b.type();
+        return bucketEntryIdCmpInternal<LedgerEntryCmp>(a, b);
+    }
+};
 
-        // METAENTRY sorts below all other entries, comes first in buckets.
-        if (aty == METAENTRY || bty == METAENTRY)
-        {
-            return aty < bty;
-        }
-
-        if (aty == LIVEENTRY || aty == INITENTRY)
-        {
-            if (bty == LIVEENTRY || bty == INITENTRY)
-            {
-                return LedgerEntryIdCmp{}(a.liveEntry().data,
-                                          b.liveEntry().data);
-            }
-            else
-            {
-                if (bty != DEADENTRY)
-                {
-                    throw std::runtime_error("Malformed bucket: unexpected "
-                                             "non-INIT/LIVE/DEAD entry.");
-                }
-                return LedgerEntryIdCmp{}(a.liveEntry().data, b.deadEntry());
-            }
-        }
-        else
-        {
-            if (aty != DEADENTRY)
-            {
-                throw std::runtime_error(
-                    "Malformed bucket: unexpected non-INIT/LIVE/DEAD entry.");
-            }
-            if (bty == LIVEENTRY || bty == INITENTRY)
-            {
-                return LedgerEntryIdCmp{}(a.deadEntry(), b.liveEntry().data);
-            }
-            else
-            {
-                if (bty != DEADENTRY)
-                {
-                    throw std::runtime_error("Malformed bucket: unexpected "
-                                             "non-INIT/LIVE/DEAD entry.");
-                }
-                return LedgerEntryIdCmp{}(a.deadEntry(), b.deadEntry());
-            }
-        }
+/**
+ * Compare two BucketEntries for identity by comparing their respective
+ * LedgerEntries using LedgerEntryCmpExp.
+ */
+struct BucketEntryIdCmpExp : public BucketEntryIdCmp
+{
+    virtual bool
+    operator()(BucketEntry const& a, BucketEntry const& b) const override
+    {
+        return bucketEntryIdCmpInternal<LedgerEntryCmpExp>(a, b);
     }
 };
 }

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -189,12 +189,11 @@ struct LedgerEntryCmpByAccount
             // Entries are identical
             return false;
         case TRUSTLINE:
-            return lexCompare(aid, bid, a.trustLine().asset,
-                              b.trustLine().asset);
+            return a.trustLine().asset < b.trustLine().asset;
         case OFFER:
-            return lexCompare(aid, bid, a.offer().offerID, b.offer().offerID);
+            return a.offer().offerID < b.offer().offerID;
         case DATA:
-            return lexCompare(aid, bid, a.data().dataName, b.data().dataName);
+            return a.data().dataName < b.data().dataName;
         default:
             throw std::runtime_error("Unexpected entry type.");
         }

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -6,6 +6,7 @@
 
 #include "overlay/StellarXDR.h"
 #include "util/XDROperators.h"
+#include <functional>
 
 namespace stellar
 {

--- a/src/bucket/MergeKey.cpp
+++ b/src/bucket/MergeKey.cpp
@@ -15,13 +15,13 @@ MergeKey::MergeKey(bool keepDeadEntries,
                    std::shared_ptr<Bucket> const& inputSnap,
                    std::vector<std::shared_ptr<Bucket>> const& inputShadows)
     : mKeepDeadEntries(keepDeadEntries)
-    , mInputCurrBucket(inputCurr->getHash())
-    , mInputSnapBucket(inputSnap->getHash())
+    , mInputCurrBucket(inputCurr->getPrimaryHash())
+    , mInputSnapBucket(inputSnap->getPrimaryHash())
 {
     mInputShadowBuckets.reserve(inputShadows.size());
     for (auto const& s : inputShadows)
     {
-        mInputShadowBuckets.emplace_back(s->getHash());
+        mInputShadowBuckets.emplace_back(s->getPrimaryHash());
     }
 }
 

--- a/src/bucket/MergeKey.h
+++ b/src/bucket/MergeKey.h
@@ -23,9 +23,9 @@ struct MergeKey
              std::vector<std::shared_ptr<Bucket>> const& inputShadows);
 
     bool mKeepDeadEntries;
-    Hash mInputCurrBucket;
-    Hash mInputSnapBucket;
-    std::vector<Hash> mInputShadowBuckets;
+    HashID mInputCurrBucket;
+    HashID mInputSnapBucket;
+    std::vector<HashID> mInputShadowBuckets;
     bool operator==(MergeKey const& other) const;
 };
 

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -132,7 +132,7 @@ binarySearchForLedger(uint32_t lbound, uint32_t ubound,
 bool
 isExpFileSorted(std::shared_ptr<Bucket> bucket, std::string const& filename)
 {
-    BucketInputIterator in(bucket, filename);
+    BucketInputIterator in(bucket, BucketSortOrder::SortByAccount);
 
     // Edge case if file is empty
     if (!in)
@@ -171,7 +171,7 @@ areFilesConsistent(std::shared_ptr<Bucket> bucket, std::string const& filename,
     }
 
     std::set<BucketEntry> fileEntries;
-    for (BucketInputIterator in(bucket, filename); in; ++in)
+    for (BucketInputIterator in(bucket); in; ++in)
     {
         // Check for duplicate entries in file
         if (fileEntries.find(*in) != fileEntries.end())
@@ -181,7 +181,8 @@ areFilesConsistent(std::shared_ptr<Bucket> bucket, std::string const& filename,
     }
 
     std::set<BucketEntry> expFileEntries;
-    for (BucketInputIterator in(bucket, expFilename); in; ++in)
+    for (BucketInputIterator in(bucket, BucketSortOrder::SortByAccount); in;
+         ++in)
     {
         // Check for duplicate entries in file
         if (expFileEntries.find(*in) != expFileEntries.end())
@@ -218,7 +219,8 @@ checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
         // Check that experimental file exists iff non-experimental file exists
         if (bucket->getFilename().empty())
         {
-            CHECK(!bucket->isExperimental());
+            CHECK(
+                !bucket->hasFileWithSortOrder(BucketSortOrder::SortByAccount));
             CHECK(expFilename.empty());
         }
         else
@@ -226,7 +228,7 @@ checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
             // If non-experimental file exists, check that the bucket is in
             // experimental mode, that the experimental file exists, and that it
             // is valid and consistent with the non-experimental file
-            CHECK(bucket->isExperimental());
+            CHECK(bucket->hasFileWithSortOrder(BucketSortOrder::SortByType));
             CHECK(!expFilename.empty());
             CHECK(fs::exists(expFilename));
             CHECK(isExpFileSorted(bucket, expFilename));
@@ -238,7 +240,7 @@ checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
     {
         // If experimental buckets not enabled, ensure bucket is in the correct
         // mode and that no experimental files have been created
-        CHECK(!bucket->isExperimental());
+        CHECK(!bucket->hasFileWithSortOrder(BucketSortOrder::SortByAccount));
         CHECK(!fs::exists(expFilename));
     }
 }

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -231,15 +231,17 @@ checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
             // experimental mode, that the experimental file exists, and that it
             // is valid and consistent with the non-experimental file
             CHECK(bucket->hasFileWithSortOrder(BucketSortOrder::SortByType));
-            auto sortByAccountFilename =
+            auto const& sortByAccountFilename =
                 bucket->getFilename(BucketSortOrder::SortByAccount);
-            CHECK(!sortByAccountFilename.empty());
-            CHECK(fs::exists(sortByAccountFilename));
+            REQUIRE(sortByAccountFilename);
+            CHECK(fs::exists(*sortByAccountFilename));
             CHECK(isFileSorted<BucketSortOrder::SortByAccount>(
-                bucket, sortByAccountFilename));
+                bucket, *sortByAccountFilename));
+            auto const& sortByTypeFilename = bucket->getFilename(BucketSortOrder::SortByType);
+            REQUIRE(sortByTypeFilename);
             CHECK(areFilesConsistent(
-                bucket, bucket->getFilename(BucketSortOrder::SortByType),
-                sortByAccountFilename));
+                bucket, *sortByTypeFilename,
+                *sortByAccountFilename));
         }
     }
     else

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -217,7 +217,6 @@ areFilesConsistent(std::shared_ptr<Bucket> bucket,
 void
 checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
 {
-    auto expFilename = Bucket::getExperimentalFilename(bucket->getFilename());
     if (cfg.EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT)
     {
         // Check that experimental file exists iff non-experimental file exists
@@ -225,7 +224,6 @@ checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
         {
             CHECK(
                 !bucket->hasFileWithSortOrder(BucketSortOrder::SortByAccount));
-            CHECK(expFilename.empty());
         }
         else
         {
@@ -233,20 +231,22 @@ checkValidBucket(std::shared_ptr<Bucket> bucket, Config const& cfg)
             // experimental mode, that the experimental file exists, and that it
             // is valid and consistent with the non-experimental file
             CHECK(bucket->hasFileWithSortOrder(BucketSortOrder::SortByType));
-            CHECK(!expFilename.empty());
-            CHECK(fs::exists(expFilename));
-            CHECK(isFileSorted<BucketSortOrder::SortByAccount>(bucket,
-                                                               expFilename));
-            CHECK(
-                areFilesConsistent(bucket, bucket->getFilename(), expFilename));
+            auto sortByAccountFilename =
+                bucket->getFilename(BucketSortOrder::SortByAccount);
+            CHECK(!sortByAccountFilename.empty());
+            CHECK(fs::exists(sortByAccountFilename));
+            CHECK(isFileSorted<BucketSortOrder::SortByAccount>(
+                bucket, sortByAccountFilename));
+            CHECK(areFilesConsistent(
+                bucket, bucket->getFilename(BucketSortOrder::SortByType),
+                sortByAccountFilename));
         }
     }
     else
     {
         // If experimental buckets not enabled, ensure bucket is in the correct
-        // mode and that no experimental files have been created
+        // mode
         CHECK(!bucket->hasFileWithSortOrder(BucketSortOrder::SortByAccount));
-        CHECK(!fs::exists(expFilename));
     }
 }
 

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -68,66 +68,65 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     MergeKey m5{true, in5a, in5b, {}};
     MergeKey m6{true, in6a, in6b, {in1a}};
 
-    bmm.recordMerge(m1, out1->getPrimaryHash());
-    bmm.recordMerge(m2, out2->getPrimaryHash());
+    bmm.recordMerge(m1, out1->getHashID());
+    bmm.recordMerge(m2, out2->getHashID());
     // m3 produces same as m2
-    bmm.recordMerge(m3, out2->getPrimaryHash());
-    bmm.recordMerge(m4, out4->getPrimaryHash());
+    bmm.recordMerge(m3, out2->getHashID());
+    bmm.recordMerge(m4, out4->getHashID());
     // m5 isn't recorded
     // m6 reuses an input from m1
-    bmm.recordMerge(m6, out6->getPrimaryHash());
+    bmm.recordMerge(m6, out6->getHashID());
 
-    Hash t;
+    HashID t;
     REQUIRE(bmm.findMergeFor(m1, t));
-    REQUIRE(t == out1->getPrimaryHash());
+    REQUIRE(t == out1->getHashID());
     REQUIRE(bmm.findMergeFor(m2, t));
-    REQUIRE(t == out2->getPrimaryHash());
+    REQUIRE(t == out2->getHashID());
     REQUIRE(bmm.findMergeFor(m3, t));
-    REQUIRE(t == out2->getPrimaryHash());
+    REQUIRE(t == out2->getHashID());
     REQUIRE(bmm.findMergeFor(m4, t));
-    REQUIRE(t == out4->getPrimaryHash());
+    REQUIRE(t == out4->getHashID());
     REQUIRE(!bmm.findMergeFor(m5, t));
     REQUIRE(bmm.findMergeFor(m6, t));
-    REQUIRE(t == out6->getPrimaryHash());
+    REQUIRE(t == out6->getHashID());
 
-    std::set<Hash> outs;
-    bmm.getOutputsUsingInput(in1a->getPrimaryHash(), outs);
-    REQUIRE(outs ==
-            std::set<Hash>{out1->getPrimaryHash(), out6->getPrimaryHash()});
+    std::set<HashID> outs;
+    bmm.getOutputsUsingInput(in1a->getHashID(), outs);
+    REQUIRE(outs == std::set<HashID>{out1->getHashID(), out6->getHashID()});
     outs.clear();
-    bmm.getOutputsUsingInput(in1b->getPrimaryHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out1->getPrimaryHash()});
+    bmm.getOutputsUsingInput(in1b->getHashID(), outs);
+    REQUIRE(outs == std::set<HashID>{out1->getHashID()});
     outs.clear();
-    bmm.getOutputsUsingInput(in1c->getPrimaryHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out1->getPrimaryHash()});
+    bmm.getOutputsUsingInput(in1c->getHashID(), outs);
+    REQUIRE(outs == std::set<HashID>{out1->getHashID()});
 
-    REQUIRE(bmm.forgetAllMergesProducing(out1->getPrimaryHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out1->getHashID()) ==
             UnorderedSet<MergeKey>{m1});
     REQUIRE(!bmm.findMergeFor(m1, t));
     outs.clear();
-    bmm.getOutputsUsingInput(in1a->getPrimaryHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out6->getPrimaryHash()});
+    bmm.getOutputsUsingInput(in1a->getHashID(), outs);
+    REQUIRE(outs == std::set<HashID>{out6->getHashID()});
 
-    REQUIRE(bmm.forgetAllMergesProducing(out2->getPrimaryHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out2->getHashID()) ==
             UnorderedSet<MergeKey>{m2, m3});
     REQUIRE(!bmm.findMergeFor(m2, t));
     REQUIRE(!bmm.findMergeFor(m3, t));
 
-    REQUIRE(bmm.forgetAllMergesProducing(out4->getPrimaryHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out4->getHashID()) ==
             UnorderedSet<MergeKey>{m4});
     REQUIRE(!bmm.findMergeFor(m4, t));
 
-    REQUIRE(bmm.forgetAllMergesProducing(out6->getPrimaryHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out6->getHashID()) ==
             UnorderedSet<MergeKey>{m6});
     REQUIRE(!bmm.findMergeFor(m6, t));
     outs.clear();
-    bmm.getOutputsUsingInput(in6a->getPrimaryHash(), outs);
-    REQUIRE(outs == std::set<Hash>{});
+    bmm.getOutputsUsingInput(in6a->getHashID(), outs);
+    REQUIRE(outs == std::set<HashID>{});
     outs.clear();
-    bmm.getOutputsUsingInput(in1a->getPrimaryHash(), outs);
-    REQUIRE(outs == std::set<Hash>{});
+    bmm.getOutputsUsingInput(in1a->getHashID(), outs);
+    REQUIRE(outs == std::set<HashID>{});
 
     // Second forget produces empty set.
-    REQUIRE(bmm.forgetAllMergesProducing(out1->getPrimaryHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out1->getHashID()) ==
             UnorderedSet<MergeKey>{});
 }

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -68,65 +68,66 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     MergeKey m5{true, in5a, in5b, {}};
     MergeKey m6{true, in6a, in6b, {in1a}};
 
-    bmm.recordMerge(m1, out1->getHash());
-    bmm.recordMerge(m2, out2->getHash());
+    bmm.recordMerge(m1, out1->getPrimaryHash());
+    bmm.recordMerge(m2, out2->getPrimaryHash());
     // m3 produces same as m2
-    bmm.recordMerge(m3, out2->getHash());
-    bmm.recordMerge(m4, out4->getHash());
+    bmm.recordMerge(m3, out2->getPrimaryHash());
+    bmm.recordMerge(m4, out4->getPrimaryHash());
     // m5 isn't recorded
     // m6 reuses an input from m1
-    bmm.recordMerge(m6, out6->getHash());
+    bmm.recordMerge(m6, out6->getPrimaryHash());
 
     Hash t;
     REQUIRE(bmm.findMergeFor(m1, t));
-    REQUIRE(t == out1->getHash());
+    REQUIRE(t == out1->getPrimaryHash());
     REQUIRE(bmm.findMergeFor(m2, t));
-    REQUIRE(t == out2->getHash());
+    REQUIRE(t == out2->getPrimaryHash());
     REQUIRE(bmm.findMergeFor(m3, t));
-    REQUIRE(t == out2->getHash());
+    REQUIRE(t == out2->getPrimaryHash());
     REQUIRE(bmm.findMergeFor(m4, t));
-    REQUIRE(t == out4->getHash());
+    REQUIRE(t == out4->getPrimaryHash());
     REQUIRE(!bmm.findMergeFor(m5, t));
     REQUIRE(bmm.findMergeFor(m6, t));
-    REQUIRE(t == out6->getHash());
+    REQUIRE(t == out6->getPrimaryHash());
 
     std::set<Hash> outs;
-    bmm.getOutputsUsingInput(in1a->getHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out1->getHash(), out6->getHash()});
+    bmm.getOutputsUsingInput(in1a->getPrimaryHash(), outs);
+    REQUIRE(outs ==
+            std::set<Hash>{out1->getPrimaryHash(), out6->getPrimaryHash()});
     outs.clear();
-    bmm.getOutputsUsingInput(in1b->getHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out1->getHash()});
+    bmm.getOutputsUsingInput(in1b->getPrimaryHash(), outs);
+    REQUIRE(outs == std::set<Hash>{out1->getPrimaryHash()});
     outs.clear();
-    bmm.getOutputsUsingInput(in1c->getHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out1->getHash()});
+    bmm.getOutputsUsingInput(in1c->getPrimaryHash(), outs);
+    REQUIRE(outs == std::set<Hash>{out1->getPrimaryHash()});
 
-    REQUIRE(bmm.forgetAllMergesProducing(out1->getHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out1->getPrimaryHash()) ==
             UnorderedSet<MergeKey>{m1});
     REQUIRE(!bmm.findMergeFor(m1, t));
     outs.clear();
-    bmm.getOutputsUsingInput(in1a->getHash(), outs);
-    REQUIRE(outs == std::set<Hash>{out6->getHash()});
+    bmm.getOutputsUsingInput(in1a->getPrimaryHash(), outs);
+    REQUIRE(outs == std::set<Hash>{out6->getPrimaryHash()});
 
-    REQUIRE(bmm.forgetAllMergesProducing(out2->getHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out2->getPrimaryHash()) ==
             UnorderedSet<MergeKey>{m2, m3});
     REQUIRE(!bmm.findMergeFor(m2, t));
     REQUIRE(!bmm.findMergeFor(m3, t));
 
-    REQUIRE(bmm.forgetAllMergesProducing(out4->getHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out4->getPrimaryHash()) ==
             UnorderedSet<MergeKey>{m4});
     REQUIRE(!bmm.findMergeFor(m4, t));
 
-    REQUIRE(bmm.forgetAllMergesProducing(out6->getHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out6->getPrimaryHash()) ==
             UnorderedSet<MergeKey>{m6});
     REQUIRE(!bmm.findMergeFor(m6, t));
     outs.clear();
-    bmm.getOutputsUsingInput(in6a->getHash(), outs);
+    bmm.getOutputsUsingInput(in6a->getPrimaryHash(), outs);
     REQUIRE(outs == std::set<Hash>{});
     outs.clear();
-    bmm.getOutputsUsingInput(in1a->getHash(), outs);
+    bmm.getOutputsUsingInput(in1a->getPrimaryHash(), outs);
     REQUIRE(outs == std::set<Hash>{});
 
     // Second forget produces empty set.
-    REQUIRE(bmm.forgetAllMergesProducing(out1->getHash()) ==
+    REQUIRE(bmm.forgetAllMergesProducing(out1->getPrimaryHash()) ==
             UnorderedSet<MergeKey>{});
 }

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -86,7 +86,8 @@ for_versions_with_differing_initentry_logic(
 
 EntryCounts::EntryCounts(std::shared_ptr<Bucket> bucket)
 {
-    BucketInputIterator iter(bucket);
+    // Type of file doesn't matter
+    BucketInputIterator iter(bucket, bucket->getValidType());
     if (iter.seenMetadata())
     {
         ++nMeta;
@@ -167,7 +168,7 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
                     /*doFsync=*/true);
             }
         }
-        auto pathOp = b1->getFilename(BucketSortOrder::SortByType);
+        auto pathOp = b1->getFilename(b1->getValidType());
         REQUIRE(pathOp.has_value());
         auto sz = static_cast<size_t>(fileSize(*pathOp));
         CLOG_DEBUG(Bucket, "Spill file size: {}", sz);

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -167,7 +167,9 @@ TEST_CASE("file backed buckets", "[bucket][bucketbench]")
                     /*doFsync=*/true);
             }
         }
-        auto sz = static_cast<size_t>(fileSize(b1->getFilename()));
+        auto pathOp = b1->getFilename(BucketSortOrder::SortByType);
+        REQUIRE(pathOp.has_value());
+        auto sz = static_cast<size_t>(fileSize(*pathOp));
         CLOG_DEBUG(Bucket, "Spill file size: {}", sz);
     });
 }

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -171,8 +171,8 @@ ApplyBucketsWork::startLevel()
     auto& level = getBucketLevel(mLevel);
     HistoryStateBucket const& i = mApplyState.currentBuckets.at(mLevel);
 
-    bool applySnap = (i.snap != binToHex(level.getSnap()->getHash()));
-    bool applyCurr = (i.curr != binToHex(level.getCurr()->getHash()));
+    bool applySnap = (i.snap != binToHex(level.getSnap()->getPrimaryHash()));
+    bool applyCurr = (i.curr != binToHex(level.getCurr()->getPrimaryHash()));
 
     if (mApplying || applySnap)
     {

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1495,21 +1495,18 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
             BucketTests::EntryCounts lev0CurrCounts(lev0Curr);
             BucketTests::EntryCounts lev0SnapCounts(lev0Snap);
             BucketTests::EntryCounts lev1CurrCounts(lev1Curr);
-            auto getVers = [](std::shared_ptr<Bucket> b) -> uint32_t {
-                return BucketInputIterator(b).getMetadata().ledgerVersion;
-            };
             switch (ledgerSeq)
             {
             default:
             case 8:
-                REQUIRE(getVers(lev1Curr) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev1Curr) == newProto);
                 REQUIRE(lev1CurrCounts.nInit != 0);
             case 7:
             case 6:
-                REQUIRE(getVers(lev0Snap) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev0Snap) == newProto);
                 REQUIRE(lev0SnapCounts.nInit != 0);
             case 5:
-                REQUIRE(getVers(lev0Curr) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev0Curr) == newProto);
                 REQUIRE(lev0CurrCounts.nInit != 0);
             }
         }
@@ -1583,14 +1580,11 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
             auto lev0Snap = lev0.getSnap();
             auto lev1Curr = lev1.getCurr();
             auto lev1Snap = lev1.getSnap();
-            auto getVers = [](std::shared_ptr<Bucket> b) -> uint32_t {
-                return BucketInputIterator(b).getMetadata().ledgerVersion;
-            };
             switch (ledgerSeq)
             {
             case 8:
-                REQUIRE(getVers(lev1Curr) == newProto);
-                REQUIRE(getVers(lev1Snap) == oldProto);
+                REQUIRE(Bucket::getBucketVersion(lev1Curr) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev1Snap) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 6);
                 // One more old-style merge despite the upgrade
                 // At ledger 8, level 2 spills, and starts an old-style merge,
@@ -1598,20 +1592,20 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
                 REQUIRE(mc.mPreShadowRemovalProtocolMerges == 6);
                 break;
             case 7:
-                REQUIRE(getVers(lev0Snap) == newProto);
-                REQUIRE(getVers(lev1Curr) == oldProto);
+                REQUIRE(Bucket::getBucketVersion(lev0Snap) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev1Curr) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 4);
                 REQUIRE(mc.mPreShadowRemovalProtocolMerges == 5);
                 break;
             case 6:
-                REQUIRE(getVers(lev0Snap) == newProto);
-                REQUIRE(getVers(lev1Curr) == oldProto);
+                REQUIRE(Bucket::getBucketVersion(lev0Snap) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev1Curr) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 3);
                 REQUIRE(mc.mPreShadowRemovalProtocolMerges == 5);
                 break;
             case 5:
-                REQUIRE(getVers(lev0Curr) == newProto);
-                REQUIRE(getVers(lev0Snap) == oldProto);
+                REQUIRE(Bucket::getBucketVersion(lev0Curr) == newProto);
+                REQUIRE(Bucket::getBucketVersion(lev0Snap) == oldProto);
                 REQUIRE(mc.mPostShadowRemovalProtocolMerges == 1);
                 REQUIRE(mc.mPreShadowRemovalProtocolMerges == 5);
                 break;

--- a/src/history/FileTransferInfo.h
+++ b/src/history/FileTransferInfo.h
@@ -28,10 +28,10 @@ class FileTransferInfo
     std::string getLocalDir(TmpDir const& localRoot) const;
 
   public:
-    FileTransferInfo(Bucket const& bucket)
+    FileTransferInfo(Bucket const& bucket, BucketSortOrder type)
         : mType(HISTORY_FILE_TYPE_BUCKET)
-        , mHexDigits(binToHex(bucket.getHash()))
-        , mLocalPath(bucket.getFilename())
+        , mHexDigits(binToHex(*bucket.getHash(type)))
+        , mLocalPath(*bucket.getFilename(type))
     {
     }
 

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -311,7 +311,7 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
             app.getBucketManager().getBucketByHash(hexToBin256(bucketHash));
         releaseAssert(bucket);
         int32_t version = 0;
-        if (bucket->getHash() != emptyHash)
+        if (!bucket->isEmpty())
         {
             version = Bucket::getBucketVersion(bucket);
             if (!nonEmptySeen)
@@ -441,9 +441,9 @@ HistoryArchiveState::HistoryArchiveState(uint32_t ledgerSeq,
     {
         HistoryStateBucket b;
         auto& level = buckets.getLevel(i);
-        b.curr = binToHex(level.getCurr()->getHash());
+        b.curr = binToHex(level.getCurr()->getPrimaryHash());
         b.next = level.getNext();
-        b.snap = binToHex(level.getSnap()->getHash());
+        b.snap = binToHex(level.getSnap()->getPrimaryHash());
         currentBuckets.push_back(b);
     }
 }

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -308,7 +308,7 @@ HistoryArchiveState::containsValidBuckets(Application& app) const
     // Process bucket, return version
     auto processBucket = [&](std::string const& bucketHash) {
         auto bucket =
-            app.getBucketManager().getBucketByHash(hexToBin256(bucketHash));
+            app.getBucketManager().getBucketByHashID(HashID(bucketHash));
         releaseAssert(bucket);
         int32_t version = 0;
         if (!bucket->isEmpty())
@@ -390,8 +390,7 @@ HistoryArchiveState::prepareForPublish(Application& app)
         auto& level = currentBuckets[i];
         auto& prev = currentBuckets[i - 1];
 
-        auto snap =
-            app.getBucketManager().getBucketByHash(hexToBin256(prev.snap));
+        auto snap = app.getBucketManager().getBucketByHashID(HashID(prev.snap));
         if (!level.next.isClear() &&
             protocolVersionStartsFrom(Bucket::getBucketVersion(snap),
                                       Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
@@ -432,7 +431,8 @@ HistoryArchiveState::HistoryArchiveState() : server(STELLAR_CORE_VERSION)
 
 HistoryArchiveState::HistoryArchiveState(uint32_t ledgerSeq,
                                          BucketList const& buckets,
-                                         std::string const& passphrase)
+                                         std::string const& passphrase,
+                                         uint32_t protocolVersion)
     : server(STELLAR_CORE_VERSION)
     , networkPassphrase(passphrase)
     , currentLedger(ledgerSeq)
@@ -441,9 +441,9 @@ HistoryArchiveState::HistoryArchiveState(uint32_t ledgerSeq,
     {
         HistoryStateBucket b;
         auto& level = buckets.getLevel(i);
-        b.curr = binToHex(level.getCurr()->getPrimaryHash());
+        b.curr = binToHex(level.getCurr()->getHashByProtocol(protocolVersion));
         b.next = level.getNext();
-        b.snap = binToHex(level.getSnap()->getPrimaryHash());
+        b.snap = binToHex(level.getSnap()->getHashByProtocol(protocolVersion));
         currentBuckets.push_back(b);
     }
 }

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -71,7 +71,8 @@ struct HistoryArchiveState
     HistoryArchiveState();
 
     HistoryArchiveState(uint32_t ledgerSeq, BucketList const& buckets,
-                        std::string const& networkPassphrase);
+                        std::string const& networkPassphrase,
+                        uint32_t protocolVersion);
 
     static std::string baseName();
     static std::string wellKnownRemoteDir();

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -219,8 +219,12 @@ HistoryManagerImpl::queueCurrentHistory()
 {
     ZoneScoped;
     auto ledger = mApp.getLedgerManager().getLastClosedLedgerNum();
+    auto protocolVersion = mApp.getLedgerManager()
+                               .getLastClosedLedgerHeader()
+                               .header.ledgerVersion;
     HistoryArchiveState has(ledger, mApp.getBucketManager().getBucketList(),
-                            mApp.getConfig().NETWORK_PASSPHRASE);
+                            mApp.getConfig().NETWORK_PASSPHRASE,
+                            protocolVersion);
 
     CLOG_DEBUG(History, "Queueing publish state for ledger {}", ledger);
     mEnqueueTimes.emplace(ledger, std::chrono::steady_clock::now());

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -149,7 +149,8 @@ StateSnapshot::differingHASFiles(HistoryArchiveState const& other)
     {
         auto b = mApp.getBucketManager().getBucketByHash(hexToBin256(hash));
         releaseAssert(b);
-        addIfExists(std::make_shared<FileTransferInfo>(*b));
+        addIfExists(std::make_shared<FileTransferInfo>(
+            *b, BucketSortOrder::SortByType));
     }
 
     return files;

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -147,10 +147,16 @@ StateSnapshot::differingHASFiles(HistoryArchiveState const& other)
 
     for (auto const& hash : mLocalState.differingBuckets(other))
     {
-        auto b = mApp.getBucketManager().getBucketByHash(hexToBin256(hash));
+        auto b = mApp.getBucketManager().getBucketByHashID(HashID(hash));
         releaseAssert(b);
-        addIfExists(std::make_shared<FileTransferInfo>(
-            *b, BucketSortOrder::SortByType));
+        auto sortOrder = BucketSortOrder::SortByType;
+        auto hashOp = b->getHash(sortOrder);
+        if (!hashOp || binToHex(*hashOp) != hash)
+        {
+            sortOrder = BucketSortOrder::SortByAccount;
+        }
+
+        addIfExists(std::make_shared<FileTransferInfo>(*b, sortOrder));
     }
 
     return files;

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -485,12 +485,12 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
                                  .getBucketList()
                                  .getLevel(0)
                                  .getCurr()
-                                 ->getHash());
+                                 ->getPrimaryHash());
     mBucket1Hashes.push_back(mApp.getBucketManager()
                                  .getBucketList()
                                  .getLevel(2)
                                  .getCurr()
-                                 ->getHash());
+                                 ->getPrimaryHash());
 
     rootBalances.push_back(root.getBalance());
     aliceBalances.push_back(alice.getBalance());
@@ -882,12 +882,12 @@ CatchupSimulation::validateCatchup(Application::pointer app)
                                .getBucketList()
                                .getLevel(0)
                                .getCurr()
-                               ->getHash();
+                               ->getPrimaryHash();
     auto haveBucket1Hash = app->getBucketManager()
                                .getBucketList()
                                .getLevel(2)
                                .getCurr()
-                               ->getHash();
+                               ->getPrimaryHash();
 
     CLOG_INFO(History, "Caught up: want Seq[{}] = {}", i, wantSeq);
     CLOG_INFO(History, "Caught up: have Seq[{}] = {}", i, haveSeq);

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -192,8 +192,8 @@ class CatchupSimulation
     std::vector<uint32_t> mLedgerSeqs;
     std::vector<uint256> mLedgerHashes;
     std::vector<uint256> mBucketListHashes;
-    std::vector<uint256> mBucket0Hashes;
-    std::vector<uint256> mBucket1Hashes;
+    std::vector<HashID> mBucket0IDs;
+    std::vector<HashID> mBucket1IDs;
 
     std::vector<int64_t> rootBalances;
     std::vector<int64_t> aliceBalances;

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -94,10 +94,22 @@ DownloadBucketsWork::yieldMoreWork()
         if (self)
         {
             auto bucketPath = ft.localPath_nogz();
-            auto b = app.getBucketManager().adoptFileAsBucket(bucketPath,
-                                                              hexToBin256(hash),
-                                                              /*objectsPut=*/0,
-                                                              /*bytesPut=*/0);
+            auto b = app.getBucketManager().adoptFileAsBucket(
+                bucketPath, hexToBin256(hash),
+                /*objectsPut=*/0,
+                /*bytesPut=*/0, BucketSortOrder::SortByType);
+            if (app.getConfig().EXPERIMENTAL_BUCKET_STORE)
+            {
+                auto resortedFilename = app.getBucketManager().resortFile(
+                    b, BucketSortOrder::SortByType,
+                    BucketSortOrder::SortByAccount);
+
+                // TODO: Calculate actual hash
+                auto Newhash = b->getHash(BucketSortOrder::SortByType);
+                app.getBucketManager().addFileToBucket(
+                    b, resortedFilename, Newhash,
+                    BucketSortOrder::SortByAccount);
+            }
             self->mBuckets[hash] = b;
         }
         return true;

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -100,12 +100,11 @@ DownloadBucketsWork::yieldMoreWork()
                 /*bytesPut=*/0, BucketSortOrder::SortByType);
             if (app.getConfig().EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT)
             {
+                Hash resortedHash;
                 auto resortedFilename = app.getBucketManager().resortFile(
                     b, BucketSortOrder::SortByType,
-                    BucketSortOrder::SortByAccount);
+                    BucketSortOrder::SortByAccount, resortedHash);
 
-                auto resortedHash =
-                    Bucket::extractFromFilename(resortedFilename);
                 app.getBucketManager().addFileToBucket(
                     b, resortedFilename, resortedHash,
                     BucketSortOrder::SortByAccount);

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -98,7 +98,7 @@ DownloadBucketsWork::yieldMoreWork()
                 bucketPath, hexToBin256(hash),
                 /*objectsPut=*/0,
                 /*bytesPut=*/0, BucketSortOrder::SortByType);
-            if (app.getConfig().EXPERIMENTAL_BUCKET_STORE)
+            if (app.getConfig().EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT)
             {
                 auto resortedFilename = app.getBucketManager().resortFile(
                     b, BucketSortOrder::SortByType,

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -104,10 +104,10 @@ DownloadBucketsWork::yieldMoreWork()
                     b, BucketSortOrder::SortByType,
                     BucketSortOrder::SortByAccount);
 
-                // TODO: Calculate actual hash
-                auto Newhash = b->getHash(BucketSortOrder::SortByType);
+                auto resortedHash =
+                    Bucket::extractFromFilename(resortedFilename);
                 app.getBucketManager().addFileToBucket(
-                    b, resortedFilename, Newhash,
+                    b, resortedFilename, resortedHash,
                     BucketSortOrder::SortByAccount);
             }
             self->mBuckets[hash] = b;

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -225,7 +225,9 @@ BucketListIsConsistentWithDatabase::checkOnBucketApply(
         for (BucketInputIterator iter(bucket); iter; ++iter)
         {
             auto const& e = *iter;
-            if (hasPreviousEntry && !BucketEntryIdCmp{}(previousEntry, e))
+            if (hasPreviousEntry &&
+                !BucketEntryIdCmp<BucketSortOrder::SortByType>(previousEntry,
+                                                               e))
             {
                 std::string s = "Bucket has out of order entries: ";
                 s += xdr_to_string(previousEntry, "previous");

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -93,7 +93,7 @@ InvariantManagerImpl::checkOnBucketApply(
             FMT_STRING(
                 R"(invariant "{}" does not hold on bucket {}[{}] = {}: {})"),
             invariant->getName(), isCurr ? "Curr" : "Snap", level,
-            binToHex(bucket->getPrimaryHash()), result);
+            bucket->getHashID().toHex(), result);
         onInvariantFailure(invariant, message, ledger);
     }
 }

--- a/src/invariant/InvariantManagerImpl.cpp
+++ b/src/invariant/InvariantManagerImpl.cpp
@@ -93,7 +93,7 @@ InvariantManagerImpl::checkOnBucketApply(
             FMT_STRING(
                 R"(invariant "{}" does not hold on bucket {}[{}] = {}: {})"),
             invariant->getName(), isCurr ? "Curr" : "Snap", level,
-            binToHex(bucket->getHash()), result);
+            binToHex(bucket->getPrimaryHash()), result);
         onInvariantFailure(invariant, message, ledger);
     }
 }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1226,7 +1226,8 @@ LedgerManagerImpl::storeCurrentLedger(LedgerHeader const& header,
     // Store the current HAS in the database; this is really just to checkpoint
     // the bucketlist so we can survive a restart and re-attach to the buckets.
     HistoryArchiveState has(header.ledgerSeq, bl,
-                            mApp.getConfig().NETWORK_PASSPHRASE);
+                            mApp.getConfig().NETWORK_PASSPHRASE,
+                            mApp.getConfig().LEDGER_PROTOCOL_VERSION);
 
     mApp.getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                        has.toString());

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -643,10 +643,12 @@ ApplicationImpl::validateAndLogConfig()
             "requires --in-memory");
     }
 
-    if (!mConfig.MODE_ENABLES_BUCKETLIST && mConfig.EXPERIMENTAL_BUCKET_STORE)
+    if (!mConfig.MODE_ENABLES_BUCKETLIST &&
+        mConfig.EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT)
     {
         throw std::invalid_argument(
-            "Bucket list disabled but EXPERIMENTAL_BUCKET_STORE set to true");
+            "Bucket list disabled but EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT "
+            "set to true");
     }
 
     if (isNetworkedValidator && mConfig.isInMemoryMode())

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -643,6 +643,12 @@ ApplicationImpl::validateAndLogConfig()
             "requires --in-memory");
     }
 
+    if (!mConfig.MODE_ENABLES_BUCKETLIST && mConfig.EXPERIMENTAL_BUCKET_STORE)
+    {
+        throw std::invalid_argument(
+            "Bucket list disabled but EXPERIMENTAL_BUCKET_STORE set to true");
+    }
+
     if (isNetworkedValidator && mConfig.isInMemoryMode())
     {
         throw std::invalid_argument(

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -421,7 +421,9 @@ mergeBucketList(Config cfg, std::string const& outputDir)
     auto bucket = bm.mergeBuckets(has);
 
     using std::filesystem::path;
-    path bpath(bucket->getFilename());
+    auto pathOp = bucket->getFilename(BucketSortOrder::SortByType);
+    releaseAssert(pathOp.has_value());
+    path bpath(*pathOp);
     path outpath(outputDir);
     outpath /= bpath.filename();
     if (fs::durableRename(bpath.string(), outpath.string(), outputDir))

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -176,7 +176,7 @@ setupApp(Config& cfg, VirtualClock& clock, uint32_t startAtLedger,
             for (auto const& b : has.allBuckets())
             {
                 auto bPtr =
-                    app->getBucketManager().getBucketByHash(hexToBin256(b));
+                    app->getBucketManager().getBucketByHashID(HashID(b));
                 releaseAssert(bPtr);
                 retained.insert(bPtr);
             }
@@ -421,7 +421,8 @@ mergeBucketList(Config cfg, std::string const& outputDir)
     auto bucket = bm.mergeBuckets(has);
 
     using std::filesystem::path;
-    auto pathOp = bucket->getFilename(BucketSortOrder::SortByType);
+    auto sortType = Bucket::protocolSortOrder(cfg.LEDGER_PROTOCOL_VERSION);
+    auto pathOp = bucket->getFilename(sortType);
     releaseAssert(pathOp.has_value());
     path bpath(*pathOp);
     path outpath(outputDir);
@@ -481,7 +482,7 @@ loadXdr(Config cfg, std::string const& bucketFile)
     Application::pointer app = Application::create(clock, cfg, false);
 
     uint256 zero;
-    Bucket bucket(bucketFile, zero);
+    Bucket bucket(bucketFile, zero, Bucket::getFileType(bucketFile));
     bucket.apply(*app);
 }
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -138,7 +138,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
     EXPERIMENTAL_PRECAUTION_DELAY_META = false;
-    EXPERIMENTAL_BUCKET_STORE = false;
+    EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT = false;
     // automatic maintenance settings:
     // short and prime with 1 hour which will cause automatic maintenance to
     // rarely conflict with any other scheduled tasks on a machine (that tend to
@@ -973,9 +973,9 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 EXPERIMENTAL_PRECAUTION_DELAY_META = readBool(item);
             }
-            else if (item.first == "EXPERIMENTAL_BUCKET_STORE")
+            else if (item.first == "EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT")
             {
-                EXPERIMENTAL_BUCKET_STORE = readBool(item);
+                EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT = readBool(item);
             }
             else if (item.first == "METADATA_DEBUG_LEDGERS")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -138,6 +138,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     CATCHUP_COMPLETE = false;
     CATCHUP_RECENT = 0;
     EXPERIMENTAL_PRECAUTION_DELAY_META = false;
+    EXPERIMENTAL_BUCKET_STORE = false;
     // automatic maintenance settings:
     // short and prime with 1 hour which will cause automatic maintenance to
     // rarely conflict with any other scheduled tasks on a machine (that tend to
@@ -971,6 +972,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "EXPERIMENTAL_PRECAUTION_DELAY_META")
             {
                 EXPERIMENTAL_PRECAUTION_DELAY_META = readBool(item);
+            }
+            else if (item.first == "EXPERIMENTAL_BUCKET_STORE")
+            {
+                EXPERIMENTAL_BUCKET_STORE = readBool(item);
             }
             else if (item.first == "METADATA_DEBUG_LEDGERS")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -265,6 +265,10 @@ class Config : public std::enable_shared_from_this<Config>
     // configuration) to delay emitting metadata by one ledger.
     bool EXPERIMENTAL_PRECAUTION_DELAY_META;
 
+    // A config parameter that when set enables building and managing (as-in:
+    // merges, garbage collects them, etc) buckets with an alternate sort order.
+    bool EXPERIMENTAL_BUCKET_STORE;
+
     // A config parameter that stores historical data, such as transactions,
     // fees, and scp history in the database
     bool MODE_STORES_HISTORY_MISC;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -267,7 +267,7 @@ class Config : public std::enable_shared_from_this<Config>
 
     // A config parameter that when set enables building and managing (as-in:
     // merges, garbage collects them, etc) buckets with an alternate sort order.
-    bool EXPERIMENTAL_BUCKET_STORE;
+    bool EXPERIMENTAL_BUCKETS_SORTED_BY_ACCOUNT;
 
     // A config parameter that stores historical data, such as transactions,
     // fees, and scp history in the database

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -19,7 +19,7 @@ using namespace std;
 std::string PersistentState::mapping[kLastEntry] = {
     "lastclosedledger", "historyarchivestate", "lastscpdata",
     "databaseschema",   "networkpassphrase",   "ledgerupgrades",
-    "rebuildledger"};
+    "rebuildledger",    "bucketfilemap"};
 
 std::string PersistentState::kSQLCreateStatement =
     "CREATE TABLE IF NOT EXISTS storestate ("

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -24,6 +24,7 @@ class PersistentState
         kNetworkPassphrase,
         kLedgerUpgrades,
         kRebuildLedger,
+        kBucketFileMap,
         kLastEntry,
     };
 

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -106,11 +106,9 @@ TEST_CASE("offline self-check works", "[applicationutils][selfcheck]")
             "client");
         catchupSimulation.catchupOffline(app, l1);
         chkConfig = app->getConfig();
-        auto filenameOp = app->getBucketManager()
-                              .getBucketList()
-                              .getLevel(0)
-                              .getCurr()
-                              ->getFilename(BucketSortOrder::SortByType);
+        auto bucket =
+            app->getBucketManager().getBucketList().getLevel(0).getCurr();
+        auto filenameOp = bucket->getFilename(bucket->getValidType());
         REQUIRE(filenameOp.has_value());
         victimBucketPath = *filenameOp;
     }

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -106,11 +106,13 @@ TEST_CASE("offline self-check works", "[applicationutils][selfcheck]")
             "client");
         catchupSimulation.catchupOffline(app, l1);
         chkConfig = app->getConfig();
-        victimBucketPath = app->getBucketManager()
-                               .getBucketList()
-                               .getLevel(0)
-                               .getCurr()
-                               ->getFilename();
+        auto filenameOp = app->getBucketManager()
+                              .getBucketList()
+                              .getLevel(0)
+                              .getCurr()
+                              ->getFilename(BucketSortOrder::SortByType);
+        REQUIRE(filenameOp.has_value());
+        victimBucketPath = *filenameOp;
     }
 
     // Step 3: run offline self-check on that application's state, see that it's

--- a/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
+++ b/src/transactions/simulation/TxSimGenerateBucketsWork.cpp
@@ -94,7 +94,7 @@ TxSimGenerateBucketsWork::processGeneratedBucket()
 
     auto newBucket = mIntermediateBuckets.front();
     mIntermediateBuckets.pop_front();
-    auto hash = newBucket->getHash();
+    auto hash = newBucket->getPrimaryHash();
     mBuckets[binToHex(hash)] = newBucket;
 
     // Forget any intermediate buckets produced

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -31,6 +31,8 @@ enum class ProtocolVersion : uint32_t
     V_16,
     V_17,
     V_18,
+    V_19,
+    V_20,
 };
 
 // Checks whether provided protocolVersion is before (i.e. strictly lower than)

--- a/src/util/test/XDRStreamTests.cpp
+++ b/src/util/test/XDRStreamTests.cpp
@@ -32,8 +32,9 @@ TEST_CASE("XDROutputFileStream fail modes", "[xdrstream]")
         SHA256 hasher;
         size_t bytes = 0;
         auto ledgerEntries = LedgerTestUtils::generateValidLedgerEntries(1);
+        // Just error testing, protocol version doesn't matter
         auto bucketEntries =
-            Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
+            Bucket::convertToBucketEntry(false, {}, ledgerEntries, {}, 0);
 
         REQUIRE_THROWS_AS(out.writeOne(bucketEntries[0], &hasher, &bytes),
                           std::runtime_error);
@@ -51,8 +52,8 @@ TEST_CASE("XDROutputFileStream fsync bench", "[!hide][xdrstream][bench]")
 
     SHA256 hasher;
     auto ledgerEntries = LedgerTestUtils::generateValidLedgerEntries(10000000);
-    auto bucketEntries =
-        Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
+    auto bucketEntries = Bucket::convertToBucketEntry(
+        false, {}, ledgerEntries, {}, cfg.LEDGER_PROTOCOL_VERSION);
 
     fs::mkpath(cfg.BUCKET_DIR_PATH);
 


### PR DESCRIPTION
# Description

Resolves #3359

This PR adds a new experimental flag `EXPERIMENTAL_BUCKET_STORE` that when set enables building and managing (as-in: merges, garbage collects them, etc) buckets with an alternate sort order. This alternative sort order groups account subentries together with their parent account entry so that they are spatially close together in the `Bucket` file. In the future, we plan to experiment with using the `BucketList` as the primary key-value store instead of an SQL database. This new sort order is required for this experiment to optimize some types of lookups, like when loading all trustlines associated with an account.

When `EXPERIMENTAL_BUCKET_STORE` is set to false, nothing changes. When `EXPERIMENTAL_BUCKET_STORE` is set to true, each `Bucket` will have two files associated with it, one sorted in the traditional order and one sorted in the new experimental sort order. These new files with the experimental sort order are still managed, garbage collected, and merged by the `BucketManager`. However, they are not yet used for anything else. In future updates, the experimental `Bucket` files may be used for key-value lookups with the `BucketList`. For now, since `BucketList` hashes are based off of the older sort order, every `Bucket` object must maintain 2 files each sorted differently. However, future updates could change history publication to use files sorted using the experimental sort order and `Bucket` objects would only need to maintain a single file again.

When `EXPERIMENTAL_BUCKET_STORE` is set, `Bucket` files are resorted in memory with `BucketManager::assumeState()` when downloading buckets from history. While some of the `Bucket` files can be large (currently over 500 mb for lower levels), this in memory sorting occurs only when catching up from history, so it should not be a large performance concern. After this initial in memory resorting, the new experimental files are managed and merged on the background thread along with the traditional, non-experimental `Bucket` files.

This is an on going experiment and it is strongly recommended that `EXPERIMENTAL_BUCKET_STORE` remains set to false (the default setting).

# Checklist
- [X] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [X] Rebased on top of master (no merge commits)
- [X] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [X] Compiles
- [X] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
