### PR TITLE
Discard envelopes with unsigned txsets and do not fetch them 

### DIFF
--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -286,6 +286,16 @@ PendingEnvelopes::recvSCPEnvelope(SCPEnvelope const& envelope)
         return Herder::ENVELOPE_STATUS_DISCARDED;
     }
 
+    auto const& values = getStellarValues(envelope.statement);
+    if (std::any_of(values.begin(), values.end(), [](auto const& value) {
+            return value.ext.v() != STELLAR_VALUE_SIGNED;
+        }))
+    {
+        CLOG_TRACE(Herder, "Dropping envelope from {} (value not signed)",
+                   mApp.getConfig().toShortString(nodeID));
+        return Herder::ENVELOPE_STATUS_DISCARDED;
+    }
+
     // did we discard this envelope?
     // do we already have this envelope?
     // do we have the qset


### PR DESCRIPTION
# Description

Resolves #2562 

We check if transaction sets are signed in `validateValueHelper` in `HerderSCPDrive`, and if so, we ignore the envelope. Since we can check whether txsets are unsigned before fetching them, we should check them to avoid unnecessary fetching. 


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
