### PR TITLE
Remove mutable result from TransactionFrame into test-only classes

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -117,7 +117,7 @@ class Herder
     virtual bool recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
     virtual TransactionQueue::AddResult
-    recvTransaction(TransactionFrameBasePtr tx) = 0;
+    recvTransaction(TransactionFrameBasePtr tx, TransactionResult& txRes) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;
     virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -440,10 +440,11 @@ HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
 }
 
 TransactionQueue::AddResult
-HerderImpl::recvTransaction(TransactionFrameBasePtr tx)
+HerderImpl::recvTransaction(TransactionFrameBasePtr tx,
+                            TransactionResult& txRes)
 {
     ZoneScoped;
-    auto result = mTransactionQueue.tryAdd(tx);
+    auto result = mTransactionQueue.tryAdd(tx, txRes);
     if (result == TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
         CLOG_TRACE(Herder, "recv transaction {} for {}",

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -94,7 +94,8 @@ class HerderImpl : public Herder
     void emitEnvelope(SCPEnvelope const& envelope);
 
     TransactionQueue::AddResult
-    recvTransaction(TransactionFrameBasePtr tx) override;
+    recvTransaction(TransactionFrameBasePtr tx,
+                    TransactionResult& txRes) override;
 
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
 #ifdef BUILD_TESTS

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -125,7 +125,7 @@ class TransactionQueue
     static std::vector<AssetPair>
     findAllAssetPairsInvolvedInPaymentLoops(TransactionFrameBasePtr tx);
 
-    AddResult tryAdd(TransactionFrameBasePtr tx);
+    AddResult tryAdd(TransactionFrameBasePtr tx, TransactionResult& txRes);
     void removeApplied(Transactions const& txs);
     void ban(Transactions const& txs);
 
@@ -206,7 +206,7 @@ class TransactionQueue
     };
     BroadcastStatus broadcastTx(AccountState& state, TimestampedTx& tx);
 
-    AddResult canAdd(TransactionFrameBasePtr tx,
+    AddResult canAdd(TransactionFrameBasePtr tx, TransactionResult& txRes,
                      AccountStates::iterator& stateIter,
                      TimestampedTransactions::iterator& oldTxIter);
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -313,9 +313,10 @@ TxSetFrame::checkOrTrim(Application& app,
             bool minSeqCheckIsInvalid =
                 iter != kv.second.begin() &&
                 (tx->getMinSeqAge() != 0 || tx->getMinSeqLedgerGap() != 0);
+            TransactionResult txRes;
             if (minSeqCheckIsInvalid ||
                 !tx->checkValid(ltx, lastSeq, lowerBoundCloseTimeOffset,
-                                upperBoundCloseTimeOffset))
+                                upperBoundCloseTimeOffset, txRes))
             {
                 if (justCheck)
                 {
@@ -336,7 +337,7 @@ TxSetFrame::checkOrTrim(Application& app,
                             hexAbbrev(mPreviousLedgerHash), lastSeq,
                             xdr_to_string(tx->getEnvelope(),
                                           "TransactionEnvelope"),
-                            tx->getResultCode());
+                            txRes.result.code());
                     }
                     return false;
                 }

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1638,10 +1638,14 @@ TEST_CASE("upgrade to version 13", "[upgrades]")
     auto root = TestAccount::createRoot(*app);
     auto acc = root.create("A", lm.getLastMinBalance(2));
 
-    herder.recvTransaction(root.tx({payment(root, 1)}));
-    herder.recvTransaction(root.tx({payment(root, 2)}));
-    herder.recvTransaction(acc.tx({payment(acc, 1)}));
-    herder.recvTransaction(acc.tx({payment(acc, 2)}));
+    auto tx1r = root.tx({payment(root, 1)});
+    auto tx2r = root.tx({payment(root, 2)});
+    auto tx1a = acc.tx({payment(acc, 1)});
+    auto tx2a = acc.tx({payment(acc, 2)});
+    herder.recvTransaction(tx1r, tx1r->getResult());
+    herder.recvTransaction(tx2r, tx2r->getResult());
+    herder.recvTransaction(tx1a, tx1a->getResult());
+    herder.recvTransaction(tx2a, tx2a->getResult());
 
     auto txSet = herder.getTransactionQueue().toTxSet({});
     for (auto const& tx : txSet->mTransactions)

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -66,11 +66,13 @@ class LedgerManagerImpl : public LedgerManager
 
     void
     processFeesSeqNums(std::vector<TransactionFrameBasePtr>& txs,
+                       std::vector<TransactionResult>& txResults,
                        AbstractLedgerTxn& ltxOuter, int64_t baseFee,
                        std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta);
 
     void
     applyTransactions(std::vector<TransactionFrameBasePtr>& txs,
+                      std::vector<TransactionResult>& txResults,
                       AbstractLedgerTxn& ltx, TransactionResultSet& txResultSet,
                       std::unique_ptr<LedgerCloseMeta> const& ledgerCloseMeta,
                       int64 curBaseFee);

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1321,7 +1321,8 @@ Peer::recvTransaction(StellarMessage const& msg)
 
         // add it to our current set
         // and make sure it is valid
-        auto recvRes = mApp.getHerder().recvTransaction(transaction);
+        TransactionResult txRes;
+        auto recvRes = mApp.getHerder().recvTransaction(transaction, txRes);
 
         if (!(recvRes == TransactionQueue::AddResult::ADD_STATUS_PENDING ||
               recvRes == TransactionQueue::AddResult::ADD_STATUS_DUPLICATE))

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -152,7 +152,8 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
 
             // this is basically a modified version of Peer::recvTransaction
             auto msg = tx1->toStellarMessage();
-            auto res = inApp->getHerder().recvTransaction(tx1);
+            auto res =
+                inApp->getHerder().recvTransaction(tx1, tx1->getResult());
             REQUIRE(res == TransactionQueue::AddResult::ADD_STATUS_PENDING);
             inApp->getOverlayManager().broadcastMessage(msg);
         };

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -745,16 +745,17 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
     StellarMessage msg(txf->toStellarMessage());
     txm.mTxnBytes.Mark(xdr::xdr_argpack_size(msg));
 
-    auto status = mApp.getHerder().recvTransaction(txf);
+    TransactionResult txRes;
+    auto status = mApp.getHerder().recvTransaction(txf, txRes);
     if (status != TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
         CLOG_INFO(LoadGen, "tx rejected '{}': {} ===> {}",
                   TX_STATUS_STRING[static_cast<int>(status)],
                   xdr_to_string(txf->getEnvelope(), "TransactionEnvelope"),
-                  xdr_to_string(txf->getResult(), "TransactionResult"));
+                  xdr_to_string(txRes, "TransactionResult"));
         if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {
-            code = txf->getResultCode();
+            code = txRes.result.code();
         }
         txm.mTxnRejected.Mark();
     }

--- a/src/test/TestTransactionFrame.cpp
+++ b/src/test/TestTransactionFrame.cpp
@@ -1,0 +1,181 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "TestTransactionFrame.h"
+#include "transactions/TransactionFrameBase.h"
+
+namespace stellar
+{
+
+void
+TestTransactionFrame::resetResults(LedgerHeader const& header, int64_t baseFee,
+                                   bool applying, TransactionResult& txResult)
+{
+    TransactionFrame::resetResults(header, baseFee, applying, mResult);
+    syncResult(txResult);
+}
+
+bool
+TestTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+                                 SequenceNumber current, bool chargeFee,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset,
+                                 TransactionResult& txResult)
+{
+    bool res = TransactionFrame::checkValid(ltxOuter, current, chargeFee,
+                                            lowerBoundCloseTimeOffset,
+                                            upperBoundCloseTimeOffset, mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+                                 SequenceNumber current,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset,
+                                 TransactionResult& txResult)
+{
+    bool res = TransactionFrame::checkValid(ltxOuter, current,
+                                            lowerBoundCloseTimeOffset,
+                                            upperBoundCloseTimeOffset, mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+                                 SequenceNumber current,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset)
+{
+    return checkValid(ltxOuter, current, lowerBoundCloseTimeOffset,
+                      upperBoundCloseTimeOffset, mResult);
+}
+
+void
+TestTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                                       TransactionResult& txResult)
+{
+    TransactionFrame::processFeeSeqNum(ltx, baseFee, mResult);
+    syncResult(txResult);
+}
+
+void
+TestTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
+{
+    processFeeSeqNum(ltx, baseFee, mResult);
+}
+
+bool
+TestTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                            TransactionMeta& meta, bool chargeFee,
+                            TransactionResult& txResult)
+{
+    bool res = TransactionFrame::apply(app, ltx, meta, chargeFee, mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                            TransactionMeta& meta, TransactionResult& txResult)
+{
+    bool res = TransactionFrame::apply(app, ltx, meta, mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                            TransactionMeta& meta)
+{
+    return apply(app, ltx, meta, mResult);
+}
+
+bool
+TestTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                            TransactionResult& txResult)
+{
+    bool res = TransactionFrame::apply(app, ltx, mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestFeeBumpTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                                   TransactionMeta& meta,
+                                   TransactionResult& txResult)
+{
+    bool res = FeeBumpTransactionFrame::apply(app, ltx, meta, mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestFeeBumpTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                                   TransactionMeta& meta)
+{
+    return apply(app, ltx, meta, mResult);
+}
+
+bool
+TestFeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+                                        SequenceNumber current,
+                                        uint64_t lowerBoundCloseTimeOffset,
+                                        uint64_t upperBoundCloseTimeOffset,
+                                        TransactionResult& txResult)
+{
+    bool res = FeeBumpTransactionFrame::checkValid(
+        ltxOuter, current, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
+        mResult);
+    syncResult(txResult);
+    return res;
+}
+
+bool
+TestFeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+                                        SequenceNumber current,
+                                        uint64_t lowerBoundCloseTimeOffset,
+                                        uint64_t upperBoundCloseTimeOffset)
+{
+    return checkValid(ltxOuter, current, lowerBoundCloseTimeOffset,
+                      upperBoundCloseTimeOffset, mResult);
+}
+
+void
+TestFeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
+                                              int64_t baseFee,
+                                              TransactionResult& txResult)
+{
+    FeeBumpTransactionFrame::processFeeSeqNum(ltx, baseFee, mResult);
+    syncResult(txResult);
+}
+
+void
+TestFeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
+                                              int64_t baseFee)
+{
+    processFeeSeqNum(ltx, baseFee, mResult);
+}
+
+TransactionFrameBasePtr
+TransactionFrameBase::makeTestTransactionFromWire(
+    Hash const& networkID, TransactionEnvelope const& env)
+{
+    switch (env.type())
+    {
+    case ENVELOPE_TYPE_TX_V0:
+    case ENVELOPE_TYPE_TX:
+        return std::make_shared<TestTransactionFrame>(networkID, env);
+    case ENVELOPE_TYPE_TX_FEE_BUMP:
+        return std::make_shared<TestFeeBumpTransactionFrame>(
+            networkID, env,
+            std::make_shared<TestTransactionFrame>(
+                networkID, FeeBumpTransactionFrame::convertInnerTxToV1(env)));
+    default:
+        abort();
+    }
+}
+}

--- a/src/test/TestTransactionFrame.h
+++ b/src/test/TestTransactionFrame.h
@@ -1,0 +1,137 @@
+#pragma once
+
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "transactions/FeeBumpTransactionFrame.h"
+#include "transactions/TransactionFrame.h"
+
+namespace stellar
+{
+
+class TestTransactionFrame : public TransactionFrame
+{
+  private:
+    TransactionResult mResult;
+    void
+    syncResult(TransactionResult& txResult)
+    {
+        if (&txResult != &mResult)
+        {
+            txResult = mResult;
+        }
+    }
+
+  public:
+    TestTransactionFrame(Hash const& networkID,
+                         TransactionEnvelope const& envelope)
+        : TransactionFrame(networkID, envelope)
+    {
+    }
+
+    virtual ~TestTransactionFrame() = default;
+
+    TransactionResult&
+    getResult() override
+    {
+        return mResult;
+    }
+
+    TransactionResultCode
+    getResultCode() const override
+    {
+        return mResult.result.code();
+    }
+
+    void resetResults(LedgerHeader const& header, int64_t baseFee,
+                      bool applying, TransactionResult& txResult) override;
+
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset,
+                    TransactionResult& txResult) override;
+
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset,
+                    TransactionResult& txResult) override;
+
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset) override;
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                          TransactionResult& txResult) override;
+
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
+
+    bool apply(Application& app, AbstractLedgerTxn& ltx, TransactionMeta& meta,
+               bool chargeFee, TransactionResult& txResult) override;
+
+    bool apply(Application& app, AbstractLedgerTxn& ltx, TransactionMeta& meta,
+               TransactionResult& txResult) override;
+
+    bool apply(Application& app, AbstractLedgerTxn& ltx,
+               TransactionMeta& meta) override;
+
+    bool apply(Application& app, AbstractLedgerTxn& ltx,
+               TransactionResult& txResult) override;
+};
+
+class TestFeeBumpTransactionFrame : public FeeBumpTransactionFrame
+{
+  private:
+    TransactionResult mResult;
+
+    void
+    syncResult(TransactionResult& txResult)
+    {
+        if (&txResult != &mResult)
+        {
+            txResult = mResult;
+        }
+    }
+
+  public:
+    TestFeeBumpTransactionFrame(Hash const& networkID,
+                                TransactionEnvelope const& envelope,
+                                TransactionFramePtr innerTx)
+        : FeeBumpTransactionFrame(networkID, envelope, innerTx)
+    {
+    }
+
+    virtual ~TestFeeBumpTransactionFrame() = default;
+
+    TransactionResult&
+    getResult() override
+    {
+        return mResult;
+    }
+
+    TransactionResultCode
+    getResultCode() const override
+    {
+        return mResult.result.code();
+    }
+
+    bool apply(Application& app, AbstractLedgerTxn& ltx, TransactionMeta& meta,
+               TransactionResult& txResult) override;
+
+    bool apply(Application& app, AbstractLedgerTxn& ltx,
+               TransactionMeta& meta) override;
+
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset,
+                    TransactionResult& txResult) override;
+
+    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                    uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset) override;
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                          TransactionResult& txResult) override;
+
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
+};
+
+}

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -126,7 +126,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
     TransactionResultCode code;
     AccountEntry srcAccountBefore;
 
-    auto checkedTx = TransactionFrameBase::makeTransactionFromWire(
+    auto checkedTx = TransactionFrameBase::makeTestTransactionFromWire(
         app.getNetworkID(), tx->getEnvelope());
     bool checkedTxApplyRes = false;
     {
@@ -401,7 +401,7 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
 {
     auto shouldValidateOk = validationResult.code == txSUCCESS;
 
-    auto checkedTx = TransactionFrameBase::makeTransactionFromWire(
+    auto checkedTx = TransactionFrameBase::makeTestTransactionFromWire(
         app.getNetworkID(), tx->getEnvelope());
     {
         LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -610,7 +610,8 @@ transactionFromOperationsV0(Application& app, SecretKey const& from,
               std::back_inserter(e.v0().tx.operations));
 
     auto res = std::static_pointer_cast<TransactionFrame>(
-        TransactionFrameBase::makeTransactionFromWire(app.getNetworkID(), e));
+        TransactionFrameBase::makeTestTransactionFromWire(app.getNetworkID(),
+                                                          e));
     res->addSignature(from);
     return res;
 }
@@ -639,7 +640,8 @@ transactionFromOperationsV1(Application& app, SecretKey const& from,
     }
 
     auto res = std::static_pointer_cast<TransactionFrame>(
-        TransactionFrameBase::makeTransactionFromWire(app.getNetworkID(), e));
+        TransactionFrameBase::makeTestTransactionFromWire(app.getNetworkID(),
+                                                          e));
     res->addSignature(from);
     return res;
 }
@@ -1515,7 +1517,7 @@ transactionFrameFromOps(Hash const& networkID, TestAccount& source,
                         std::vector<SecretKey> const& opKeys,
                         std::optional<PreconditionsV2> cond)
 {
-    return TransactionFrameBase::makeTransactionFromWire(
+    return TransactionFrameBase::makeTestTransactionFromWire(
         networkID, envelopeFromOps(networkID, source, ops, opKeys, cond));
 }
 

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -14,9 +14,8 @@ class SignatureChecker;
 
 class FeeBumpTransactionFrame : public TransactionFrameBase
 {
+  protected:
     TransactionEnvelope mEnvelope;
-    TransactionResult mResult;
-
     TransactionFramePtr mInnerTx;
 
     Hash const& mNetworkID;
@@ -26,7 +25,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     bool checkSignature(SignatureChecker& signatureChecker,
                         LedgerTxnEntry const& account, int32_t neededWeight);
 
-    bool commonValidPreSeqNum(AbstractLedgerTxn& ltx);
+    bool commonValidPreSeqNum(AbstractLedgerTxn& ltx,
+                              TransactionResult& txResult);
 
     enum ValidationType
     {
@@ -37,31 +37,28 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     };
 
     ValidationType commonValid(SignatureChecker& signatureChecker,
-                               AbstractLedgerTxn& ltxOuter, bool applying);
+                               AbstractLedgerTxn& ltxOuter, bool applying,
+                               TransactionResult& txResult);
 
     void removeOneTimeSignerKeyFromFeeSource(AbstractLedgerTxn& ltx) const;
 
-  protected:
     void resetResults(LedgerHeader const& header, int64_t baseFee,
-                      bool applying);
+                      bool applying, TransactionResult& innerRes,
+                      TransactionResult& outerRes);
 
   public:
     FeeBumpTransactionFrame(Hash const& networkID,
                             TransactionEnvelope const& envelope);
-#ifdef BUILD_TESTS
-    FeeBumpTransactionFrame(Hash const& networkID,
-                            TransactionEnvelope const& envelope,
-                            TransactionFramePtr innerTx);
-#endif
 
     virtual ~FeeBumpTransactionFrame(){};
 
-    bool apply(Application& app, AbstractLedgerTxn& ltx,
-               TransactionMeta& meta) override;
+    bool apply(Application& app, AbstractLedgerTxn& ltx, TransactionMeta& meta,
+               TransactionResult& txResult) override;
 
     bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
                     uint64_t lowerBoundCloseTimeOffset,
-                    uint64_t upperBoundCloseTimeOffset) override;
+                    uint64_t upperBoundCloseTimeOffset,
+                    TransactionResult& txResult) override;
 
     TransactionEnvelope const& getEnvelope() const override;
 
@@ -76,10 +73,6 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     uint32_t getNumOperations() const override;
     std::vector<Operation> const& getRawOperations() const override;
-
-    TransactionResult& getResult() override;
-    TransactionResultCode getResultCode() const override;
-
     SequenceNumber getSeqNum() const override;
     AccountID getFeeSourceID() const override;
     AccountID getSourceID() const override;
@@ -91,11 +84,50 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
     void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
 
-    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
-
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                          TransactionResult& txResult) override;
     StellarMessage toStellarMessage() const override;
 
     static TransactionEnvelope
     convertInnerTxToV1(TransactionEnvelope const& envelope);
+
+#ifdef BUILD_TESTS
+    FeeBumpTransactionFrame(Hash const& networkID,
+                            TransactionEnvelope const& envelope,
+                            TransactionFramePtr innerTx);
+
+    bool
+    apply(Application& app, AbstractLedgerTxn& ltx,
+          TransactionMeta& meta) override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    bool
+    checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+               uint64_t lowerBoundCloseTimeOffset,
+               uint64_t upperBoundCloseTimeOffset) override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    TransactionResult&
+    getResult() override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    TransactionResultCode
+    getResultCode() const override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+
+    void
+    processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override
+    {
+        throw std::runtime_error("Not implemented");
+    }
+#endif
 };
 }

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -27,11 +27,12 @@ class TransactionFrameBase
                             TransactionEnvelope const& env);
 
     virtual bool apply(Application& app, AbstractLedgerTxn& ltx,
-                       TransactionMeta& meta) = 0;
+                       TransactionMeta& meta, TransactionResult& txResult) = 0;
 
     virtual bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
                             uint64_t lowerBoundCloseTimeOffset,
-                            uint64_t upperBoundCloseTimeOffset) = 0;
+                            uint64_t upperBoundCloseTimeOffset,
+                            TransactionResult& txResult) = 0;
 
     virtual TransactionEnvelope const& getEnvelope() const = 0;
 
@@ -46,9 +47,6 @@ class TransactionFrameBase
     virtual uint32_t getNumOperations() const = 0;
     virtual std::vector<Operation> const& getRawOperations() const = 0;
 
-    virtual TransactionResult& getResult() = 0;
-    virtual TransactionResultCode getResultCode() const = 0;
-
     virtual SequenceNumber getSeqNum() const = 0;
     virtual AccountID getFeeSourceID() const = 0;
     virtual AccountID getSourceID() const = 0;
@@ -60,8 +58,23 @@ class TransactionFrameBase
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const = 0;
     virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const = 0;
 
-    virtual void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) = 0;
+    virtual void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                                  TransactionResult& txResult) = 0;
 
     virtual StellarMessage toStellarMessage() const = 0;
+
+#ifdef BUILD_TESTS
+    static TransactionFrameBasePtr
+    makeTestTransactionFromWire(Hash const& networkID,
+                                TransactionEnvelope const& env);
+    virtual bool apply(Application& app, AbstractLedgerTxn& ltx,
+                       TransactionMeta& meta) = 0;
+    virtual bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+                            uint64_t lowerBoundCloseTimeOffset,
+                            uint64_t upperBoundCloseTimeOffset) = 0;
+    virtual TransactionResult& getResult() = 0;
+    virtual TransactionResultCode getResultCode() const = 0;
+    virtual void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) = 0;
+#endif
 };
 }

--- a/src/transactions/simulation/TxSimFeeBumpTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimFeeBumpTransactionFrame.cpp
@@ -33,9 +33,11 @@ TxSimFeeBumpTransactionFrame::getFee(const stellar::LedgerHeader& header,
 
 void
 TxSimFeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
-                                               int64_t baseFee)
+                                               int64_t baseFee,
+                                               TransactionResult& txResult)
 {
-    resetResults(ltx.loadHeader().current(), baseFee, true);
+    TransactionResult innerRes;
+    resetResults(ltx.loadHeader().current(), baseFee, true, innerRes, txResult);
 
     auto feeSource = stellar::loadAccount(ltx, getFeeSourceID());
     if (!feeSource)
@@ -45,7 +47,7 @@ TxSimFeeBumpTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx,
     auto& acc = feeSource.current().data.account();
 
     auto header = ltx.loadHeader();
-    int64_t& fee = getResult().feeCharged;
+    int64_t& fee = txResult.feeCharged;
     if (fee > 0)
     {
         fee = std::min(acc.balance, fee);

--- a/src/transactions/simulation/TxSimFeeBumpTransactionFrame.h
+++ b/src/transactions/simulation/TxSimFeeBumpTransactionFrame.h
@@ -27,7 +27,8 @@ class TxSimFeeBumpTransactionFrame : public FeeBumpTransactionFrame
 
     int64_t getFee(LedgerHeader const& header, int64_t baseFee,
                    bool applying) const override;
-    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                          TransactionResult& txResult) override;
 };
 }
 }

--- a/src/transactions/simulation/TxSimTransactionFrame.cpp
+++ b/src/transactions/simulation/TxSimTransactionFrame.cpp
@@ -100,12 +100,13 @@ TxSimTransactionFrame::getFee(LedgerHeader const& header, int64_t baseFee,
 }
 
 void
-TxSimTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
+TxSimTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                                        TransactionResult& txResult)
 {
     mCachedAccount.reset();
 
     auto header = ltx.loadHeader();
-    resetResults(header.current(), baseFee, true);
+    resetResults(header.current(), baseFee, true, txResult);
 
     auto sourceAccount = loadSourceAccount(ltx, header);
     if (!sourceAccount)
@@ -114,7 +115,7 @@ TxSimTransactionFrame::processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee)
     }
     auto& acc = sourceAccount.current().data.account();
 
-    int64_t& fee = getResult().feeCharged;
+    int64_t& fee = txResult.feeCharged;
     if (fee > 0)
     {
         fee = std::min(acc.balance, fee);

--- a/src/transactions/simulation/TxSimTransactionFrame.h
+++ b/src/transactions/simulation/TxSimTransactionFrame.h
@@ -31,7 +31,8 @@ class TxSimTransactionFrame : public TransactionFrame
     int64_t getFee(LedgerHeader const& header, int64_t baseFee,
                    bool applying) const override;
 
-    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee) override;
+    void processFeeSeqNum(AbstractLedgerTxn& ltx, int64_t baseFee,
+                          TransactionResult& txResult) override;
     void processSeqNum(AbstractLedgerTxn& ltx) override;
 
   public:

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -58,7 +58,7 @@ feeBump(Hash const& networkID, TestAccount& feeSource, TestAccount& source,
     auto& env = fb.feeBump().tx.innerTx;
     sign(networkID, source, env.v1());
     sign(networkID, feeSource, fb.feeBump());
-    return TransactionFrameBase::makeTransactionFromWire(networkID, fb);
+    return TransactionFrameBase::makeTestTransactionFromWire(networkID, fb);
 }
 
 TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
@@ -128,7 +128,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fbXDR = feeBumpUnsigned(acc, root, root, 2 * fee, fee, 1);
                 sign(app->getNetworkID(), root,
                      fbXDR.feeBump().tx.innerTx.v1());
-                auto fb = TransactionFrameBase::makeTransactionFromWire(
+                auto fb = TransactionFrameBase::makeTestTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
@@ -146,7 +146,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 sign(app->getNetworkID(), acc, fbXDR.feeBump());
                 sign(app->getNetworkID(), root,
                      fbXDR.feeBump().tx.innerTx.v1());
-                auto fb = TransactionFrameBase::makeTransactionFromWire(
+                auto fb = TransactionFrameBase::makeTestTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
@@ -175,7 +175,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                      fbXDR.feeBump().tx.innerTx.v1());
                 sign(app->getNetworkID(), acc, fbXDR.feeBump());
                 sign(app->getNetworkID(), root, fbXDR.feeBump());
-                auto fb = TransactionFrameBase::makeTransactionFromWire(
+                auto fb = TransactionFrameBase::makeTestTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
@@ -189,7 +189,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
             for_versions_from(13, *app, [&] {
                 auto fbXDR = feeBumpUnsigned(acc, root, root, 2 * fee, fee, 1);
                 sign(app->getNetworkID(), acc, fbXDR.feeBump());
-                auto fb = TransactionFrameBase::makeTransactionFromWire(
+                auto fb = TransactionFrameBase::makeTestTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
@@ -335,7 +335,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                      fbXDR.feeBump().tx.innerTx.v1());
                 sign(app->getNetworkID(), acc, fbXDR.feeBump());
                 sign(app->getNetworkID(), root, fbXDR.feeBump());
-                auto fb = TransactionFrameBase::makeTransactionFromWire(
+                auto fb = TransactionFrameBase::makeTestTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -421,7 +421,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fbXDR = feeBumpUnsigned(acc, root, root, 2 * fee, fee, 1);
                 ++fbXDR.feeBump().tx.innerTx.v1().tx.seqNum;
 
-                auto fb = TransactionFrameBase::makeTransactionFromWire(
+                auto fb = TransactionFrameBase::makeTestTransactionFromWire(
                     app->getNetworkID(), fbXDR);
 
                 SignerKey txSigner(SIGNER_KEY_TYPE_PRE_AUTH_TX);


### PR DESCRIPTION
# Description

Resolves "TransactionFrame" part of #2163
Refactor for `TransactionFrame` class-family (including `TransactionFrame`, `TransactionFrameBase`, `FeeBumpTransactionFrame`, `Fuzzer*TransactionFrame`, `TxSim*TransactionFrame`). 
Make the class immutable by removing the member `TransactionResult`, instead pass them externally. 
Separate test code from production code by creating `TestTransactionFrame` and `TestFeeBumpTransactionFrame` that contains the old (mutable) behavior. This is to save from changing boilerplate code in tests everywhere that interacts with `TransactionFrameBase` (and its derived classes). 


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
