### PR TITLE
Calculate and expose more individual peer info through `peers` endpoint

### DIFF
--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -697,6 +697,7 @@ Some notable fields in `info` are:
 The `peers` command returns information on the peers the instance is connected to.
 
 This list is the result of both inbound connections from other peers and outbound connections from this node to other peers.
+If `compact=false`, then it also returns some extra metrics on each peer such as the number of dropped messages.
 
 `$ stellar-core http-command 'peers'`
 

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -179,9 +179,10 @@ format.
   Clear metrics for a specified domain. If no domain specified, clear all
   metrics (for testing purposes).
 
-* **peers?[&fullkeys=false]**
-  Returns the list of known peers in JSON format.
+* **peers?[&fullkeys=false&compact=true]**
+  Returns the list of known peers in JSON format with some metrics.
   If `fullkeys` is set, outputs unshortened public keys.
+  If `compact` is `false`, it will output extra metrics.
 
 * **quorum**
   `quorum?[node=NODE_ID][&compact=false][&fullkeys=false][&transitive=false]`<br>

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -258,6 +258,9 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
     http::server::server::parseParams(params, retMap);
 
     bool fullKeys = retMap["fullkeys"] == "true";
+    // compact should be true by default
+    // as the response can be quite verbose.
+    bool compact = retMap["compact"] != "false";
     Json::Value root;
 
     auto& pendingPeers = root["pending_peers"];
@@ -284,15 +287,9 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
             for (auto const& peer : peers)
             {
                 auto& peerNode = node[counter++];
-                peerNode["address"] = peer.second->toString();
-                peerNode["elapsed"] = (int)peer.second->getLifeTime().count();
-                peerNode["latency"] = (int)peer.second->getPing().count();
-                peerNode["ver"] = peer.second->getRemoteVersion();
-                peerNode["olver"] = (int)peer.second->getRemoteOverlayVersion();
+                peerNode = peer.second->getJsonInfo(compact);
                 peerNode["id"] =
                     mApp.getConfig().toStrKey(peer.first, fullKeys);
-                peerNode["flow_control"] =
-                    peer.second->getFlowControlJsonInfo();
             }
         };
     addAuthenticatedPeers(

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -294,6 +294,23 @@ Peer::getFlowControlJsonInfo() const
     return res;
 }
 
+Json::Value
+Peer::getJsonInfo(bool compact) const
+{
+    Json::Value res;
+    res["address"] = mAddress.toString();
+    res["elapsed"] = (int)getLifeTime().count();
+    res["latency"] = (int)getPing().count();
+    res["ver"] = getRemoteVersion();
+    res["olver"] = (int)getRemoteOverlayVersion();
+    res["flow_control"] = getFlowControlJsonInfo();
+    if (!compact)
+    {
+    }
+
+    return res;
+}
+
 void
 Peer::sendAuth()
 {

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -263,7 +263,7 @@ Peer::recurrentTimerExpired(asio::error_code const& error)
 }
 
 Json::Value
-Peer::getFlowControlJsonInfo() const
+Peer::getFlowControlJsonInfo(bool compact) const
 {
     Json::Value res;
     std::string stateStr;
@@ -291,6 +291,16 @@ Peer::getFlowControlJsonInfo() const
         res["peer_capacity"] = (Json::UInt64)mOutboundCapacity;
     }
 
+    if (!compact)
+    {
+        res["outbound_queue_delay_scp_p75"] = static_cast<Json::UInt64>(
+            mPeerMetrics.mOutboundQueueDelaySCP.GetSnapshot()
+                .get75thPercentile());
+        res["outbound_queue_delay_txs_p75"] = static_cast<Json::UInt64>(
+            mPeerMetrics.mOutboundQueueDelayTxs.GetSnapshot()
+                .get75thPercentile());
+    }
+
     return res;
 }
 
@@ -303,9 +313,38 @@ Peer::getJsonInfo(bool compact) const
     res["latency"] = (int)getPing().count();
     res["ver"] = getRemoteVersion();
     res["olver"] = (int)getRemoteOverlayVersion();
-    res["flow_control"] = getFlowControlJsonInfo();
+    res["flow_control"] = getFlowControlJsonInfo(compact);
     if (!compact)
     {
+        res["message_read"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mMessageRead);
+        res["message_write"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mMessageWrite);
+        res["byte_read"] = static_cast<Json::UInt64>(mPeerMetrics.mByteRead);
+        res["byte_write"] = static_cast<Json::UInt64>(mPeerMetrics.mByteWrite);
+
+        res["async_read"] = static_cast<Json::UInt64>(mPeerMetrics.mAsyncRead);
+        res["async_write"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mAsyncWrite);
+
+        res["message_drop"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mMessageDrop);
+
+        res["message_delay_in_write_queue_p75"] = static_cast<Json::UInt64>(
+            mPeerMetrics.mMessageDelayInWriteQueueTimer.GetSnapshot()
+                .get75thPercentile());
+        res["message_delay_in_async_write_p75"] = static_cast<Json::UInt64>(
+            mPeerMetrics.mMessageDelayInAsyncWriteTimer.GetSnapshot()
+                .get75thPercentile());
+
+        res["unique_flood_message_recv"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mUniqueFloodMessageRecv);
+        res["duplicate_flood_message_recv"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mDuplicateFloodMessageRecv);
+        res["unique_fetch_message_recv"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mUniqueFetchMessageRecv);
+        res["duplicate_fetch_message_recv"] =
+            static_cast<Json::UInt64>(mPeerMetrics.mDuplicateFetchMessageRecv);
     }
 
     return res;
@@ -548,6 +587,7 @@ Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
         sendQueueIsOverloaded())
     {
         getOverlayMetrics().mMessageDrop.Mark();
+        mPeerMetrics.mMessageDrop++;
         return;
     }
 
@@ -1021,10 +1061,15 @@ Peer::maybeSendNextBatch()
             auto& front = queue.front();
             sendAuthenticatedMessage(*(front.mMessage));
             auto& om = mApp.getOverlayManager().getOverlayMetrics();
-            auto& timer = front.mMessage->type() == SCP_MESSAGE
-                              ? om.mOutboundQueueDelaySCP
-                              : om.mOutboundQueueDelayTxs;
-            timer.Update(mApp.getClock().now() - front.mTimeEmplaced);
+            auto& aggregateTimer = front.mMessage->type() == SCP_MESSAGE
+                                       ? om.mOutboundQueueDelaySCP
+                                       : om.mOutboundQueueDelayTxs;
+            auto& peerTimer = front.mMessage->type() == SCP_MESSAGE
+                                  ? mPeerMetrics.mOutboundQueueDelaySCP
+                                  : mPeerMetrics.mOutboundQueueDelayTxs;
+            auto const& diff = mApp.getClock().now() - front.mTimeEmplaced;
+            aggregateTimer.Update(diff);
+            peerTimer.Update(diff);
             mOutboundCapacity--;
             if (mOutboundCapacity == 0)
             {
@@ -1763,6 +1808,21 @@ Peer::PeerMetrics::PeerMetrics(VirtualClock::time_point connectedTime)
     , mMessageWrite(0)
     , mByteRead(0)
     , mByteWrite(0)
+    , mAsyncRead(0)
+    , mAsyncWrite(0)
+    , mMessageDrop(0)
+    , mMessageDelayInWriteQueueTimer(medida::Timer(PEER_METRICS_DURATION_UNIT,
+                                                   PEER_METRICS_RATE_UNIT,
+                                                   PEER_METRICS_WINDOW_SIZE))
+    , mMessageDelayInAsyncWriteTimer(medida::Timer(PEER_METRICS_DURATION_UNIT,
+                                                   PEER_METRICS_RATE_UNIT,
+                                                   PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelaySCP(medida::Timer(PEER_METRICS_DURATION_UNIT,
+                                           PEER_METRICS_RATE_UNIT,
+                                           PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelayTxs(medida::Timer(PEER_METRICS_DURATION_UNIT,
+                                           PEER_METRICS_RATE_UNIT,
+                                           PEER_METRICS_WINDOW_SIZE))
     , mUniqueFloodBytesRecv(0)
     , mDuplicateFloodBytesRecv(0)
     , mUniqueFetchBytesRecv(0)

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -134,6 +134,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
     Peer::FlowControlState flowControlEnabled() const;
 
     Json::Value getFlowControlJsonInfo() const;
+    Json::Value getJsonInfo(bool compact) const;
 
   protected:
     Application& mApp;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -7,6 +7,7 @@
 #include "util/asio.h"
 #include "database/Database.h"
 #include "lib/json/json.h"
+#include "medida/timer.h"
 #include "overlay/PeerBareAddress.h"
 #include "overlay/StellarXDR.h"
 #include "util/NonCopyable.h"
@@ -57,6 +58,14 @@ class Peer : public std::enable_shared_from_this<Peer>,
     static constexpr uint32_t FIRST_VERSION_SUPPORTING_FLOW_CONTROL = 20;
     static constexpr std::chrono::seconds PEER_SEND_MODE_IDLE_TIMEOUT =
         std::chrono::seconds(60);
+    static constexpr std::chrono::nanoseconds PEER_METRICS_DURATION_UNIT =
+        std::chrono::milliseconds(1);
+    static constexpr std::chrono::nanoseconds PEER_METRICS_RATE_UNIT =
+        std::chrono::seconds(1);
+    // The reporting will be based on the previous
+    // PEER_METRICS_WINDOW_SIZE-second time window.
+    static constexpr std::chrono::seconds PEER_METRICS_WINDOW_SIZE =
+        std::chrono::seconds(300);
 
     typedef std::shared_ptr<Peer> pointer;
 
@@ -94,6 +103,14 @@ class Peer : public std::enable_shared_from_this<Peer>,
         uint64_t mMessageWrite;
         uint64_t mByteRead;
         uint64_t mByteWrite;
+        uint64_t mAsyncRead;
+        uint64_t mAsyncWrite;
+        uint64_t mMessageDrop;
+
+        medida::Timer mMessageDelayInWriteQueueTimer;
+        medida::Timer mMessageDelayInAsyncWriteTimer;
+        medida::Timer mOutboundQueueDelaySCP;
+        medida::Timer mOutboundQueueDelayTxs;
 
         uint64_t mUniqueFloodBytesRecv;
         uint64_t mDuplicateFloodBytesRecv;
@@ -113,7 +130,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
         VirtualClock::time_point mEnqueuedTime;
         VirtualClock::time_point mIssuedTime;
         VirtualClock::time_point mCompletedTime;
-        void recordWriteTiming(OverlayMetrics& metrics);
+        void recordWriteTiming(OverlayMetrics& metrics,
+                               PeerMetrics& peerMetrics);
         xdr::msg_ptr mMessage;
     };
 
@@ -133,7 +151,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     Peer::FlowControlState flowControlEnabled() const;
 
-    Json::Value getFlowControlJsonInfo() const;
+    Json::Value getFlowControlJsonInfo(bool compact) const;
     Json::Value getJsonInfo(bool compact) const;
 
   protected:


### PR DESCRIPTION
# Description

Resolves #3041

This PR calculates and exposes more metrics for each peer through the `peers` endpoint. The new output can be slightly verbose. If `compact=true`, the new output will be the same as the current output.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
