### PR TITLE
Refactor TxSetFrame

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="DebugNoPostgres|x64">
@@ -319,6 +319,7 @@ exit /b 0
     <ClCompile Include="..\..\src\herder\test\UpgradesTests.cpp" />
     <ClCompile Include="..\..\src\herder\TxQueueLimiter.cpp" />
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp" />
+    <ClCompile Include="..\..\src\herder\TxSetUtils.cpp" />
     <ClCompile Include="..\..\src\herder\Upgrades.cpp" />
     <ClCompile Include="..\..\src\historywork\BatchDownloadWork.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumIntersectionCheckerImpl.cpp" />
@@ -707,6 +708,7 @@ exit /b 0
     <ClInclude Include="..\..\src\herder\QuorumTracker.h" />
     <ClInclude Include="..\..\src\herder\TxQueueLimiter.h" />
     <ClInclude Include="..\..\src\herder\TxSetFrame.h" />
+    <ClCompile Include="..\..\src\herder\TxSetUtils.h" />
     <ClInclude Include="..\..\src\herder\Upgrades.h" />
     <ClInclude Include="..\..\src\historywork\BatchDownloadWork.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionChecker.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="DebugNoPostgres|x64">
@@ -320,6 +320,7 @@ exit /b 0
     <ClCompile Include="..\..\src\herder\TxQueueLimiter.cpp" />
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp" />
     <ClCompile Include="..\..\src\herder\TxSetUtils.cpp" />
+    <ClCompile Include="..\..\src\herder\test\TestTxSetUtils.cpp" />
     <ClCompile Include="..\..\src\herder\Upgrades.cpp" />
     <ClCompile Include="..\..\src\historywork\BatchDownloadWork.cpp" />
     <ClCompile Include="..\..\src\herder\QuorumIntersectionCheckerImpl.cpp" />
@@ -709,6 +710,7 @@ exit /b 0
     <ClInclude Include="..\..\src\herder\TxQueueLimiter.h" />
     <ClInclude Include="..\..\src\herder\TxSetFrame.h" />
     <ClCompile Include="..\..\src\herder\TxSetUtils.h" />
+    <ClCompile Include="..\..\src\herder\test\TestTxSetUtils.h" />
     <ClInclude Include="..\..\src\herder\Upgrades.h" />
     <ClInclude Include="..\..\src\historywork\BatchDownloadWork.h" />
     <ClInclude Include="..\..\src\herder\QuorumIntersectionChecker.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="overlay">
@@ -535,6 +535,9 @@
       <Filter>herder</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\herder\TxSetFrame.cpp">
+      <Filter>herder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\herder\TxSetUtils.cpp">
       <Filter>herder</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\herder\Upgrades.cpp">
@@ -1653,6 +1656,9 @@
       <Filter>herder</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\TxSetFrame.h">
+      <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\herder\TxSetUtils.h">
       <Filter>herder</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\Upgrades.h">

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="overlay">
@@ -539,6 +539,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\herder\TxSetUtils.cpp">
       <Filter>herder</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\herder\test\TestTxSetUtils.cpp">
+      <Filter>herder\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\herder\Upgrades.cpp">
       <Filter>herder</Filter>
@@ -1660,6 +1663,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\herder\TxSetUtils.h">
       <Filter>herder</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\herder\test\TestTxSetUtils.h">
+      <Filter>herder\tests</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\Upgrades.h">
       <Filter>herder</Filter>

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -164,7 +164,7 @@ closeLedger(Application& app, std::optional<SecretKey> skToSignValue)
     CLOG_INFO(Bucket, "Artificially closing ledger {} with lcl={}, buckets={}",
               ledgerNum, hexAbbrev(lcl.hash),
               hexAbbrev(app.getBucketManager().getBucketList().getHash()));
-    auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
+    auto txSet = std::make_shared<TxSetFrame const>(lcl.hash);
     app.getHerder().externalizeValue(txSet, ledgerNum,
                                      lcl.header.scpValue.closeTime,
                                      emptyUpgradeSteps, skToSignValue);

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -98,7 +98,7 @@ ApplyCheckpointWork::openInputFiles()
     mFilesOpen = true;
 }
 
-TxSetFramePtr
+TxSetFrameConstPtr
 ApplyCheckpointWork::getCurrentTxSet()
 {
     ZoneScoped;
@@ -124,13 +124,14 @@ ApplyCheckpointWork::getCurrentTxSet()
         {
             releaseAssert(mTxHistoryEntry.ledgerSeq == seq);
             CLOG_DEBUG(History, "Loaded txset for ledger {}", seq);
-            return std::make_shared<TxSetFrame>(mApp.getNetworkID(),
-                                                mTxHistoryEntry.txSet);
+            return std::make_shared<TxSetFrame const>(mApp.getNetworkID(),
+                                                      mTxHistoryEntry.txSet);
         }
     } while (mTxIn && mTxIn.readOne(mTxHistoryEntry));
 
     CLOG_DEBUG(History, "Using empty txset for ledger {}", seq);
-    return std::make_shared<TxSetFrame>(lm.getLastClosedLedgerHeader().hash);
+    return std::make_shared<TxSetFrame const>(
+        lm.getLastClosedLedgerHeader().hash);
 }
 
 std::shared_ptr<LedgerCloseData>

--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -56,7 +56,7 @@ class ApplyCheckpointWork : public BasicWork
 
     std::shared_ptr<ConditionalWork> mConditionalWork;
 
-    TxSetFramePtr getCurrentTxSet();
+    TxSetFrameConstPtr getCurrentTxSet();
     void openInputFiles();
 
     std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -640,7 +640,7 @@ TxSimApplyTransactionsWork::onReset()
 
         TransactionSet txSetXDR;
         txSetXDR.previousLedgerHash = lclHeader.hash;
-        auto txSet = std::make_shared<TxSetFrame>(mNetworkID, txSetXDR);
+        auto txSet = std::make_shared<TxSetFrame const>(mNetworkID, txSetXDR);
 
         sv.txSetHash = txSet->getContentsHash();
         sv.closeTime = mHeaderHistory.header.scpValue.closeTime;

--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -707,8 +707,8 @@ TxSimApplyTransactionsWork::onRun()
     // generating transactions to handle offer creation (mapping created offer
     // id to a simulated one). When simulating pre-generated transactions, we
     // already have relevant offer ids in transaction results
-    auto txSet = std::make_shared<TxSimTxSetFrame>(
-        mNetworkID, lclHeader.hash, transactions, mResults, mMultiplier);
+    auto txSet = makeSimTxSetFrame(mNetworkID, lclHeader.hash, transactions,
+                                   mResults, mMultiplier);
 
     StellarValue sv;
     sv.txSetHash = txSet->getContentsHash();

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -120,7 +120,7 @@ class Herder
     recvTransaction(TransactionFrameBasePtr tx) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;
-    virtual TxSetFramePtr getTxSet(Hash const& hash) = 0;
+    virtual TxSetFrameConstPtr getTxSet(Hash const& hash) = 0;
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // We are learning about a new envelope.
@@ -133,7 +133,7 @@ class Herder
                                            TxSetFrame txset) = 0;
 
     virtual void
-    externalizeValue(std::shared_ptr<TxSetFrame> txSet, uint32_t ledgerSeq,
+    externalizeValue(TxSetFrameConstPtr txSet, uint32_t ledgerSeq,
                      uint64_t closeTime,
                      xdr::xvector<UpgradeType, 6> const& upgrades,
                      std::optional<SecretKey> skToSignValue = std::nullopt) = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -12,6 +12,7 @@
 #include "herder/LedgerCloseData.h"
 #include "herder/QuorumIntersectionChecker.h"
 #include "herder/TxSetFrame.h"
+#include "herder/TxSetUtils.h"
 #include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
@@ -1098,13 +1099,13 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger,
     upperBoundCloseTimeOffset = nextCloseTime - lcl.header.scpValue.closeTime;
     lowerBoundCloseTimeOffset = upperBoundCloseTimeOffset;
 
-    auto invalidTxs = TxSetFrame::getInvalidTxList(
+    auto removed = TxSetUtils::getInvalidTxList(
         mApp, *proposedSet, lowerBoundCloseTimeOffset,
         upperBoundCloseTimeOffset, false);
 
-    mTransactionQueue.ban(invalidTxs);
-    proposedSet = TxSetFrame::removeTxs(proposedSet, invalidTxs);
-    proposedSet = TxSetFrame::surgePricingFilter(proposedSet, mApp);
+    mTransactionQueue.ban(removed);
+    proposedSet = TxSetUtils::removeTxs(proposedSet, removed);
+    proposedSet = TxSetUtils::surgePricingFilter(proposedSet, mApp);
 
     // we not only check that the value is valid for consensus (offset=0) but
     // also that we performed the proper cleanup above
@@ -1794,7 +1795,7 @@ HerderImpl::updateTransactionQueue(
     lhhe.hash = HashUtils::random();
     auto txSet = mTransactionQueue.toTxSet(lhhe);
 
-    auto invalidTxs = TxSetFrame::getInvalidTxList(
+    auto removed = TxSetUtils::getInvalidTxList(
         mApp, *txSet, 0,
         getUpperBoundCloseTimeOffset(mApp, lhhe.header.scpValue.closeTime),
         false);

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -102,7 +102,7 @@ class HerderImpl : public Herder
                                    const SCPQuorumSet& qset,
                                    TxSetFrame txset) override;
 
-    void externalizeValue(std::shared_ptr<TxSetFrame> txSet, uint32_t ledgerSeq,
+    void externalizeValue(TxSetFrameConstPtr txSet, uint32_t ledgerSeq,
                           uint64_t closeTime,
                           xdr::xvector<UpgradeType, 6> const& upgrades,
                           std::optional<SecretKey> skToSignValue) override;
@@ -121,7 +121,7 @@ class HerderImpl : public Herder
     bool recvTxSet(Hash const& hash, const TxSetFrame& txset) override;
     void peerDoesntHave(MessageType type, uint256 const& itemID,
                         Peer::pointer peer) override;
-    TxSetFramePtr getTxSet(Hash const& hash) override;
+    TxSetFrameConstPtr getTxSet(Hash const& hash) override;
     SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;
 
     void processSCPQueue();

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -106,7 +106,7 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
     HerderImpl& mHerder;
 
     SCPQuorumSetPtr mQSet;
-    std::vector<TxSetFramePtr> mTxSets;
+    std::vector<TxSetFrameConstPtr> mTxSets;
 
   public:
     explicit SCPHerderEnvelopeWrapper(SCPEnvelope const& e, HerderImpl& herder)
@@ -301,7 +301,7 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
     }
 
     Hash const& txSetHash = b.txSetHash;
-    TxSetFramePtr txSet = mPendingEnvelopes.getTxSet(txSetHash);
+    TxSetFrameConstPtr txSet = mPendingEnvelopes.getTxSet(txSetHash);
 
     SCPDriver::ValidationLevel res;
 
@@ -790,7 +790,7 @@ HerderSCPDriver::logQuorumInformation(uint64_t index)
 
 void
 HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
-                          TxSetFramePtr proposedSet,
+                          TxSetFrameConstPtr proposedSet,
                           StellarValue const& previousValue)
 {
     ZoneScoped;
@@ -801,7 +801,7 @@ HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
     CLOG_DEBUG(Herder,
                "HerderSCPDriver::triggerNextLedger txSet.size: {} "
                "previousLedgerHash: {} value: {} slot: {}",
-               proposedSet->mTransactions.size(),
+               proposedSet->sizeTx(),
                hexAbbrev(proposedSet->previousLedgerHash()),
                hexAbbrev(valueHash), slotIndex);
 
@@ -1084,7 +1084,7 @@ class SCPHerderValueWrapper : public ValueWrapper
 {
     HerderImpl& mHerder;
 
-    TxSetFramePtr mTxSet;
+    TxSetFrameConstPtr mTxSet;
 
   public:
     explicit SCPHerderValueWrapper(StellarValue const& sv, Value const& value,

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -85,7 +85,8 @@ class HerderSCPDriver : public SCPDriver
     // Submit a value to consider for slotIndex
     // previousValue is the value from slotIndex-1
     void nominate(uint64_t slotIndex, StellarValue const& value,
-                  TxSetFramePtr proposedSet, StellarValue const& previousValue);
+                  TxSetFrameConstPtr proposedSet,
+                  StellarValue const& previousValue);
 
     SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;
 

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -6,8 +6,10 @@
 
 #include "herder/Herder.h"
 #include "herder/TxSetFrame.h"
+#include "herder/TxSetUtils.h"
 #include "medida/timer.h"
 #include "scp/SCPDriver.h"
+#include "util/RandomEvictionCache.h"
 #include "xdr/Stellar-ledger.h"
 #include <optional>
 
@@ -191,6 +193,11 @@ class HerderSCPDriver : public SCPDriver
     // indexed by slotIndex, timerID
     std::map<uint64_t, std::map<int, std::unique_ptr<VirtualTimer>>> mSCPTimers;
 
+    // validity of txSet
+    mutable RandomEvictionCache<TxSetUtils::TxSetValidityKey, bool,
+                                TxSetUtils::TxSetValidityKeyHash>
+        mTxSetValidCache;
+
     SCPDriver::ValidationLevel validateValueHelper(uint64_t slotIndex,
                                                    StellarValue const& sv,
                                                    bool nomination) const;
@@ -207,5 +214,8 @@ class HerderSCPDriver : public SCPDriver
                          std::string const& logStr,
                          std::chrono::nanoseconds threshold,
                          uint64_t slotIndex);
+
+    bool checkAndCacheTxSetValid(TxSetFrameConstPtr TxSet,
+                                 uint64_t closeTimeOffset) const;
 };
 }

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -14,9 +14,9 @@ using namespace std;
 namespace stellar
 {
 
-LedgerCloseData::LedgerCloseData(
-    uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-    StellarValue const& v, std::optional<Hash> const& expectedLedgerHash)
+LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFrameConstPtr txSet,
+                                 StellarValue const& v,
+                                 std::optional<Hash> const& expectedLedgerHash)
     : mLedgerSeq(ledgerSeq)
     , mTxSet(txSet)
     , mValue(v)

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -24,8 +24,7 @@ class LedgerCloseData
 {
   public:
     LedgerCloseData(
-        uint32_t ledgerSeq, std::shared_ptr<AbstractTxSetFrameForApply> txSet,
-        StellarValue const& v,
+        uint32_t ledgerSeq, TxSetFrameConstPtr txSet, StellarValue const& v,
         std::optional<Hash> const& expectedLedgerHash = std::nullopt);
 
     uint32_t
@@ -33,7 +32,7 @@ class LedgerCloseData
     {
         return mLedgerSeq;
     }
-    std::shared_ptr<AbstractTxSetFrameForApply>
+    TxSetFrameConstPtr
     getTxSet() const
     {
         return mTxSet;
@@ -51,7 +50,7 @@ class LedgerCloseData
 
   private:
     uint32_t mLedgerSeq;
-    std::shared_ptr<AbstractTxSetFrameForApply> mTxSet;
+    TxSetFrameConstPtr mTxSet;
     StellarValue mValue;
     std::optional<Hash> mExpectedLedgerHash;
 };

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -176,8 +176,9 @@ PendingEnvelopes::updateMetrics()
     mReadyCount.set_count(ready);
 }
 
-TxSetFramePtr
-PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot, TxSetFramePtr txset)
+TxSetFrameConstPtr
+PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot,
+                           TxSetFrameConstPtr txset)
 {
     auto res = getKnownTxSet(hash, slot, true);
     if (!res)
@@ -192,12 +193,12 @@ PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot, TxSetFramePtr txset)
 // tries to find a txset in memory, setting touch also touches the LRU,
 // extending the lifetime of the result *and* updating the slot number
 // to a greater value if needed
-TxSetFramePtr
+TxSetFrameConstPtr
 PendingEnvelopes::getKnownTxSet(Hash const& hash, uint64 slot, bool touch)
 {
     // slot is only used when `touch` is set
     releaseAssert(touch || (slot == 0));
-    TxSetFramePtr res;
+    TxSetFrameConstPtr res;
     auto it = mKnownTxSets.find(hash);
     if (it != mKnownTxSets.end())
     {
@@ -223,7 +224,7 @@ PendingEnvelopes::getKnownTxSet(Hash const& hash, uint64 slot, bool touch)
 
 void
 PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
-                           TxSetFramePtr txset)
+                           TxSetFrameConstPtr txset)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Add TxSet {}", hexAbbrev(hash));
@@ -233,7 +234,7 @@ PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
 }
 
 bool
-PendingEnvelopes::recvTxSet(Hash const& hash, TxSetFramePtr txset)
+PendingEnvelopes::recvTxSet(Hash const& hash, TxSetFrameConstPtr txset)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Got TxSet {}", hexAbbrev(hash));
@@ -707,7 +708,7 @@ PendingEnvelopes::forceRebuildQuorum()
     mRebuildQuorum = true;
 }
 
-TxSetFramePtr
+TxSetFrameConstPtr
 PendingEnvelopes::getTxSet(Hash const& hash)
 {
     return getKnownTxSet(hash, 0, false);

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -60,11 +60,11 @@ class PendingEnvelopes
     ItemFetcher mTxSetFetcher;
     ItemFetcher mQuorumSetFetcher;
 
-    using TxSetFramCacheItem = std::pair<uint64, TxSetFramePtr>;
+    using TxSetFramCacheItem = std::pair<uint64, TxSetFrameConstPtr>;
     // recent txsets
     RandomEvictionCache<Hash, TxSetFramCacheItem> mTxSetCache;
     // weak references to all known txsets
-    UnorderedMap<Hash, std::weak_ptr<TxSetFrame>> mKnownTxSets;
+    UnorderedMap<Hash, std::weak_ptr<TxSetFrame const>> mKnownTxSets;
 
     // keep track of txset/qset hash -> size pairs for quick access
     RandomEvictionCache<Hash, size_t> mValueSizeCache;
@@ -103,7 +103,7 @@ class PendingEnvelopes
 
     // tries to find a txset in memory, setting touch also touches the LRU,
     // extending the lifetime of the result
-    TxSetFramePtr getKnownTxSet(Hash const& hash, uint64 slot, bool touch);
+    TxSetFrameConstPtr getKnownTxSet(Hash const& hash, uint64 slot, bool touch);
 
     void cleanKnownData();
 
@@ -154,14 +154,15 @@ class PendingEnvelopes
      * in PendingEnvelopes.
      */
     void addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
-                  TxSetFramePtr txset);
+                  TxSetFrameConstPtr txset);
 
     /**
         Adds @p txset to the cache and returns the txset referenced by the cache
         NB: if caller wants to continue using txset after the call, it should
        use the returned value instead
     */
-    TxSetFramePtr putTxSet(Hash const& hash, uint64 slot, TxSetFramePtr txset);
+    TxSetFrameConstPtr putTxSet(Hash const& hash, uint64 slot,
+                                TxSetFrameConstPtr txset);
 
     /**
      * Check if @p txset identified by @p hash was requested before from peers.
@@ -170,7 +171,7 @@ class PendingEnvelopes
      *
      * Return true if TxSet useful (was asked for).
      */
-    bool recvTxSet(Hash const& hash, TxSetFramePtr txset);
+    bool recvTxSet(Hash const& hash, TxSetFrameConstPtr txset);
 
     void peerDoesntHave(MessageType type, Hash const& itemID,
                         Peer::pointer peer);
@@ -186,7 +187,7 @@ class PendingEnvelopes
 
     Json::Value getJsonInfo(size_t limit);
 
-    TxSetFramePtr getTxSet(Hash const& hash);
+    TxSetFrameConstPtr getTxSet(Hash const& hash);
     SCPQuorumSetPtr getQSet(Hash const& hash);
 
     // returns true if we think that the node is in the transitive quorum for

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -833,11 +833,11 @@ TransactionQueue::isBanned(Hash const& hash) const
         });
 }
 
-std::shared_ptr<TxSetFrame>
+TxSetFrameConstPtr
 TransactionQueue::toTxSet(LedgerHeaderHistoryEntry const& lcl) const
 {
     ZoneScoped;
-    auto result = std::make_shared<TxSetFrame>(lcl.hash);
+    std::vector<TransactionFrameBasePtr> txs;
 
     uint32_t const nextLedgerSeq = lcl.header.ledgerSeq + 1;
     int64_t const startingSeq = getStartingSequenceNumber(nextLedgerSeq);
@@ -856,11 +856,11 @@ TransactionQueue::toTxSet(LedgerHeaderHistoryEntry const& lcl) const
             {
                 break;
             }
-            result->add(tx.mTx);
+            txs.emplace_back(tx.mTx);
         }
     }
 
-    return result;
+    return std::make_shared<TxSetFrame const>(lcl.hash, txs);
 }
 
 void

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -142,8 +142,7 @@ class TransactionQueue
     size_t countBanned(int index) const;
     bool isBanned(Hash const& hash) const;
 
-    std::shared_ptr<TxSetFrame>
-    toTxSet(LedgerHeaderHistoryEntry const& lcl) const;
+    TxSetFrameConstPtr toTxSet(LedgerHeaderHistoryEntry const& lcl) const;
 
     struct ReplacedTransaction
     {

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -4,6 +4,7 @@
 
 #include "util/asio.h"
 #include "TxSetFrame.h"
+#include "TxSetUtils.h"
 #include "crypto/Hex.h"
 #include "crypto/Random.h"
 #include "crypto/SHA.h"
@@ -36,9 +37,9 @@ using namespace std;
 TxSetFrame::TxSetFrame(Hash const& previousLedgerHash,
                        Transactions const& transactions)
     : mPreviousLedgerHash(previousLedgerHash)
-    , mTxsInHashOrder(TxSetFrame::sortTxsInHashOrder(transactions))
+    , mTxsInHashOrder(TxSetUtils::sortTxsInHashOrder(transactions))
     , mHash(
-          TxSetFrame::computeContentsHash(previousLedgerHash, mTxsInHashOrder))
+          TxSetUtils::computeContentsHash(previousLedgerHash, mTxsInHashOrder))
 {
 }
 
@@ -49,45 +50,10 @@ TxSetFrame::TxSetFrame(Hash const& previousLedgerHash)
 
 TxSetFrame::TxSetFrame(Hash const& networkID, TransactionSet const& xdrSet)
     : mPreviousLedgerHash(xdrSet.previousLedgerHash)
-    , mTxsInHashOrder(TxSetFrame::sortTxsInHashOrder(networkID, xdrSet))
+    , mTxsInHashOrder(TxSetUtils::sortTxsInHashOrder(networkID, xdrSet))
     , mHash(
-          TxSetFrame::computeContentsHash(mPreviousLedgerHash, mTxsInHashOrder))
+          TxSetUtils::computeContentsHash(mPreviousLedgerHash, mTxsInHashOrder))
 {
-}
-
-static bool
-HashTxSorter(TransactionFrameBasePtr const& tx1,
-             TransactionFrameBasePtr const& tx2)
-{
-    // need to use the hash of whole tx here since multiple txs could have
-    // the same Contents
-    return tx1->getFullHash() < tx2->getFullHash();
-}
-
-// order the txset correctly
-// must take into account multiple tx from same account
-TxSetFrame::Transactions
-TxSetFrame::sortTxsInHashOrder(TxSetFrame::Transactions const& transactions)
-{
-    ZoneScoped;
-    TxSetFrame::Transactions sortedTxs(transactions);
-    std::sort(sortedTxs.begin(), sortedTxs.end(), HashTxSorter);
-    return sortedTxs;
-}
-
-TxSetFrame::Transactions
-sortTxsInHashOrder(Hash const& networkID, TransactionSet const& xdrSet)
-{
-    ZoneScoped;
-    TxSetFrame::Transactions txs;
-    txs.reserve(xdrSet.txs.size());
-    std::transform(xdrSet.txs.cbegin(), xdrSet.txs.cend(),
-                   std::back_inserter(txs),
-                   [&](TransactionEnvelope const& env) {
-                       return TransactionFrameBase::makeTransactionFromWire(
-                           networkID, env);
-                   });
-    return TxSetFrame::sortTxsInHashOrder(txs);
 }
 
 // We want to XOR the tx hash with the set hash.
@@ -121,7 +87,7 @@ TxSetFrame::Transactions
 TxSetFrame::getTxsInApplyOrder() const
 {
     ZoneScoped;
-    auto txQueues = TxSetFrame::buildAccountTxQueues(*this);
+    auto txQueues = TxSetUtils::buildAccountTxQueues(*this);
 
     // build txBatches
     // txBatches i-th element contains each i-th transaction for accounts with a
@@ -166,255 +132,6 @@ TxSetFrame::getTxsInApplyOrder() const
     return txsInApplyOrder;
 }
 
-struct SurgeCompare
-{
-    Hash mSeed;
-    SurgeCompare() : mSeed(HashUtils::random())
-    {
-    }
-
-    // return true if tx1 < tx2
-    bool
-    operator()(TxSetFrame::AccountTransactionQueue const* tx1,
-               TxSetFrame::AccountTransactionQueue const* tx2) const
-    {
-        if (tx1 == nullptr || tx1->empty())
-        {
-            return tx2 ? !tx2->empty() : false;
-        }
-        if (tx2 == nullptr || tx2->empty())
-        {
-            return false;
-        }
-
-        auto& top1 = tx1->front();
-        auto& top2 = tx2->front();
-
-        auto cmp3 = feeRate3WayCompare(top1, top2);
-
-        if (cmp3 != 0)
-        {
-            return cmp3 < 0;
-        }
-        // use hash of transaction as a tie breaker
-        return lessThanXored(top1->getFullHash(), top2->getFullHash(), mSeed);
-    }
-};
-
-UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
-TxSetFrame::buildAccountTxQueues(TxSetFrame const& txSet)
-{
-    ZoneScoped;
-    UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue> actTxQueueMap;
-    for (auto const& tx : txSet.getTxsInHashOrder())
-    {
-        auto id = tx->getSourceID();
-        auto it = actTxQueueMap.find(id);
-        if (it == actTxQueueMap.end())
-        {
-            auto d = std::make_pair(id, TxSetFrame::AccountTransactionQueue{});
-            auto r = actTxQueueMap.insert(d);
-            it = r.first;
-        }
-        it->second.emplace_back(tx);
-    }
-
-    for (auto& am : actTxQueueMap)
-    {
-        // sort each in sequence number order
-        std::sort(am.second.begin(), am.second.end(),
-                  [](TransactionFrameBasePtr const& tx1,
-                     TransactionFrameBasePtr const& tx2) {
-                      return tx1->getSeqNum() < tx2->getSeqNum();
-                  });
-    }
-    return actTxQueueMap;
-}
-
-TxSetFrameConstPtr
-TxSetFrame::surgePricingFilter(TxSetFrameConstPtr txSet, Application& app)
-{
-    ZoneScoped;
-    LedgerTxn ltx(app.getLedgerTxnRoot());
-    auto header = ltx.loadHeader();
-
-    bool maxIsOps = protocolVersionStartsFrom(header.current().ledgerVersion,
-                                              ProtocolVersion::V_11);
-
-    size_t opsLeft = app.getLedgerManager().getLastMaxTxSetSizeOps();
-
-    auto curSizeOps =
-        maxIsOps ? txSet->sizeOp() : (txSet->sizeTx() * MAX_OPS_PER_TX);
-    if (curSizeOps > opsLeft)
-    {
-        CLOG_WARNING(Herder, "surge pricing in effect! {} > {}", curSizeOps,
-                     opsLeft);
-
-        auto actTxQueueMap = buildAccountTxQueues(*txSet);
-
-        std::priority_queue<TxSetFrame::AccountTransactionQueue*,
-                            std::vector<TxSetFrame::AccountTransactionQueue*>,
-                            SurgeCompare>
-            surgeQueue;
-
-        for (auto& am : actTxQueueMap)
-        {
-            surgeQueue.push(&am.second);
-        }
-
-        TxSetFrame::Transactions updatedSet;
-        updatedSet.reserve(txSet->sizeTx());
-        while (opsLeft > 0 && !surgeQueue.empty())
-        {
-            auto cur = surgeQueue.top();
-            surgeQueue.pop();
-            // inspect the top candidate queue
-            auto& curTopTx = cur->front();
-            size_t opsCount =
-                maxIsOps ? curTopTx->getNumOperations() : MAX_OPS_PER_TX;
-            if (opsCount <= opsLeft)
-            {
-                // pop from this one
-                updatedSet.emplace_back(curTopTx);
-                cur->pop_front();
-                opsLeft -= opsCount;
-                // if there are more transactions, put it back
-                if (!cur->empty())
-                {
-                    surgeQueue.push(cur);
-                }
-            }
-            else
-            {
-                // drop this transaction -> we need to drop the others
-                cur->clear();
-            }
-        }
-
-        return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(),
-                                                  updatedSet);
-    }
-    return txSet;
-}
-
-TxSetFrame::Transactions
-TxSetFrame::getInvalidTxList(Application& app, TxSetFrame const& txSet,
-                             uint64_t lowerBoundCloseTimeOffset,
-                             uint64_t upperBoundCloseTimeOffset,
-                             bool returnEarlyOnFirstInvalidTx)
-{
-    ZoneScoped;
-    LedgerTxn ltx(app.getLedgerTxnRoot());
-
-    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
-                                  ProtocolVersion::V_19))
-    {
-        // This is done so minSeqLedgerGap is validated against the next
-        // ledgerSeq, which is what will be used at apply time
-        ltx.loadHeader().current().ledgerSeq =
-            app.getLedgerManager().getLastClosedLedgerNum() + 1;
-    }
-
-    UnorderedMap<AccountID, int64_t> accountFeeMap;
-    TxSetFrame::Transactions invalidTxs;
-
-    auto accountTxMap = buildAccountTxQueues(txSet);
-    for (auto& kv : accountTxMap)
-    {
-        int64_t lastSeq = 0;
-        auto iter = kv.second.begin();
-        while (iter != kv.second.end())
-        {
-            auto tx = *iter;
-            // In addition to checkValid, we also want to make sure that all but
-            // the transaction with the lowest seqNum on a given sourceAccount
-            // do not have minSeqAge and minSeqLedgerGap set
-            bool minSeqCheckIsInvalid =
-                iter != kv.second.begin() &&
-                (tx->getMinSeqAge() != 0 || tx->getMinSeqLedgerGap() != 0);
-            if (minSeqCheckIsInvalid ||
-                !tx->checkValid(ltx, lastSeq, lowerBoundCloseTimeOffset,
-                                upperBoundCloseTimeOffset))
-            {
-                invalidTxs.emplace_back(tx);
-                iter = kv.second.erase(iter);
-                if (returnEarlyOnFirstInvalidTx)
-                {
-                    if (minSeqCheckIsInvalid)
-                    {
-                        CLOG_DEBUG(Herder,
-                                   "minSeqAge or minSeqLedgerGap set on tx "
-                                   "without lowest seqNum. tx: {}",
-                                   xdr_to_string(tx->getEnvelope(),
-                                                 "TransactionEnvelope"));
-                    }
-                    else
-                    {
-                        CLOG_DEBUG(
-                            Herder,
-                            "Got bad txSet: {} tx invalid lastSeq:{} tx: {} "
-                            "result: {}",
-                            hexAbbrev(txSet.previousLedgerHash()), lastSeq,
-                            xdr_to_string(tx->getEnvelope(),
-                                          "TransactionEnvelope"),
-                            tx->getResultCode());
-                    }
-                    return invalidTxs;
-                }
-            }
-            else // update the account fee map
-            {
-                lastSeq = tx->getSeqNum();
-                int64_t& accFee = accountFeeMap[tx->getFeeSourceID()];
-                if (INT64_MAX - accFee < tx->getFeeBid())
-                {
-                    accFee = INT64_MAX;
-                }
-                else
-                {
-                    accFee += tx->getFeeBid();
-                }
-                ++iter;
-            }
-        }
-    }
-
-    auto header = ltx.loadHeader();
-    for (auto& kv : accountTxMap)
-    {
-        auto iter = kv.second.begin();
-        while (iter != kv.second.end())
-        {
-            auto tx = *iter;
-            auto feeSource = stellar::loadAccount(ltx, tx->getFeeSourceID());
-            auto totFee = accountFeeMap[tx->getFeeSourceID()];
-            if (getAvailableBalance(header, feeSource) < totFee)
-            {
-                while (iter != kv.second.end())
-                {
-                    invalidTxs.emplace_back(*iter);
-                    ++iter;
-                }
-                if (returnEarlyOnFirstInvalidTx)
-                {
-                    CLOG_DEBUG(Herder,
-                               "Got bad txSet: {} account can't pay fee tx: {}",
-                               hexAbbrev(txSet.previousLedgerHash()),
-                               xdr_to_string(tx->getEnvelope(),
-                                             "TransactionEnvelope"));
-                    return invalidTxs;
-                }
-            }
-            else
-            {
-                ++iter;
-            }
-        }
-    }
-
-    return invalidTxs;
-}
-
 // need to make sure every account that is submitting a tx has enough to pay
 // the fees of all the tx it has submitted in this set
 // check seq num
@@ -450,82 +167,9 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
         return false;
     }
 
-    return TxSetFrame::getInvalidTxList(app, *this, lowerBoundCloseTimeOffset,
+    return TxSetUtils::getInvalidTxList(app, *this, lowerBoundCloseTimeOffset,
                                         upperBoundCloseTimeOffset, true)
         .empty();
-}
-
-// Target use case is to remove a subset of invalid transactions from a TxSet.
-// I.e. txSet.size() >= txsToRemove.size()
-TxSetFrameConstPtr
-TxSetFrame::removeTxs(TxSetFrameConstPtr txSet,
-                      TxSetFrame::Transactions const& txsToRemove)
-{
-    // hashmap from the full txSet
-    std::unordered_map<Hash, TransactionFrameBasePtr> fullTxSetHashMap;
-    fullTxSetHashMap.reserve(txSet->sizeTx());
-    std::transform(txSet->getTxsInHashOrder().cbegin(),
-                   txSet->getTxsInHashOrder().cend(),
-                   std::inserter(fullTxSetHashMap, fullTxSetHashMap.end()),
-                   [](TransactionFrameBasePtr const& tx) {
-                       return std::pair<Hash, TransactionFrameBasePtr>{
-                           tx->getFullHash(), tx};
-                   });
-
-    // candidate tx hashes to be removed
-    std::unordered_set<Hash> removeTxHashSet;
-    removeTxHashSet.reserve(txsToRemove.size());
-    std::transform(
-        txsToRemove.cbegin(), txsToRemove.cend(),
-        std::inserter(removeTxHashSet, removeTxHashSet.end()),
-        [](TransactionFrameBasePtr const& tx) { return tx->getFullHash(); });
-
-    // remove txs
-    for (auto it = fullTxSetHashMap.begin(); it != fullTxSetHashMap.end();)
-    {
-        if (removeTxHashSet.find(it->first) != removeTxHashSet.end())
-        {
-            it = fullTxSetHashMap.erase(it);
-        }
-        else
-        {
-            ++it;
-        }
-    }
-
-    // get back remaining txs
-    TxSetFrame::Transactions txs;
-    txs.reserve(fullTxSetHashMap.size());
-    std::transform(fullTxSetHashMap.cbegin(), fullTxSetHashMap.cend(),
-                   std::back_inserter(txs),
-                   [](std::pair<Hash, TransactionFrameBasePtr> const& p) {
-                       return p.second;
-                   });
-
-    return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(), txs);
-}
-
-TxSetFrameConstPtr
-addTxs(TxSetFrameConstPtr txSet, TxSetFrame::Transactions const& newTxs)
-{
-    auto updated = txSet->getTxsInHashOrder();
-    updated.insert(updated.end(), newTxs.begin(), newTxs.end());
-    return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(),
-                                              updated);
-}
-
-Hash
-TxSetFrame::computeContentsHash(Hash const& previousLedgerHash,
-                                TxSetFrame::Transactions const& txsInHashOrder)
-{
-    ZoneScoped;
-    SHA256 hasher;
-    hasher.add(previousLedgerHash);
-    for (unsigned int n = 0; n < txsInHashOrder.size(); n++)
-    {
-        hasher.add(xdr::xdr_to_opaque(txsInHashOrder[n]->getEnvelope()));
-    }
-    return hasher.finish();
 }
 
 size_t
@@ -596,7 +240,7 @@ TxSetFrame::toXDR(TransactionSet& txSet) const
 {
     ZoneScoped;
     releaseAssert(std::is_sorted(mTxsInHashOrder.begin(), mTxsInHashOrder.end(),
-                                 HashTxSorter));
+                                 TxSetUtils::HashTxSorter));
     txSet.txs.resize(xdr::size32(mTxsInHashOrder.size()));
     for (unsigned int n = 0; n < mTxsInHashOrder.size(); n++)
     {

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -190,7 +190,7 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
         return false;
     }
 
-    return TxSetUtils::getInvalidTxList(app, *this, lowerBoundCloseTimeOffset,
+    return TxSetUtils::getInvalidTxList(*this, app, lowerBoundCloseTimeOffset,
                                         upperBoundCloseTimeOffset, true)
         .empty();
 }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -7,10 +7,8 @@
 #include "ledger/LedgerHashUtils.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrame.h"
-#include "util/UnorderedMap.h"
 #include <deque>
 #include <functional>
-#include <optional>
 
 namespace stellar
 {
@@ -45,10 +43,6 @@ class TxSetFrame
         return mHash;
     }
 
-    static Hash
-    computeContentsHash(Hash const& previousLedgerHash,
-                        TxSetFrame::Transactions const& txsInHashOrder);
-
     Hash const&
     previousLedgerHash() const
     {
@@ -63,30 +57,8 @@ class TxSetFrame
 
     virtual Transactions getTxsInApplyOrder() const;
 
-    static Transactions
-    sortTxsInHashOrder(TxSetFrame::Transactions const& transactions);
-
-    static Transactions sortTxsInHashOrder(Hash const& networkID,
-                                           TransactionSet const& xdrSet);
-
     bool checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) const;
-
-    static TxSetFrameConstPtr surgePricingFilter(TxSetFrameConstPtr txSet,
-                                                 Application& app);
-
-    static Transactions getInvalidTxList(Application& app,
-                                         TxSetFrame const& txSet,
-                                         uint64_t lowerBoundCloseTimeOffset,
-                                         uint64_t upperBoundCloseTimeOffset,
-                                         bool returnEarlyOnFirstInvalidTx);
-
-    static TxSetFrameConstPtr
-    removeTxs(TxSetFrameConstPtr txSet,
-              TxSetFrame::Transactions const& txsToRemove);
-
-    static TxSetFrameConstPtr addTxs(TxSetFrameConstPtr txSet,
-                                     TxSetFrame::Transactions const& newTxs);
 
     size_t size(LedgerHeader const& lh) const;
 
@@ -111,9 +83,6 @@ class TxSetFrame
     Transactions const mTxsInHashOrder;
 
     Hash const mHash;
-
-    static UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
-    buildAccountTxQueues(TxSetFrame const& txSet);
 
     friend struct SurgeCompare;
 };

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -14,10 +14,7 @@ namespace stellar
 {
 class Application;
 
-class TxSetFrame;
-using TxSetFrameConstPtr = std::shared_ptr<TxSetFrame const>;
-
-// A wrapper for a set of transactions that maintains the hash order
+// A wrapper for a set of transactions that if valid, maintains the hash order
 class TxSetFrame
 {
   public:
@@ -37,23 +34,11 @@ class TxSetFrame
     virtual ~TxSetFrame(){};
 
     // returns the hash of this tx set
-    Hash const&
-    getContentsHash() const
-    {
-        return mHash;
-    }
+    Hash const& getContentsHash() const;
 
-    Hash const&
-    previousLedgerHash() const
-    {
-        return mPreviousLedgerHash;
-    }
+    Hash const& previousLedgerHash() const;
 
-    Transactions const&
-    getTxsInHashOrder() const
-    {
-        return mTxsInHashOrder;
-    }
+    Transactions const& getTxsInHashOrder() const;
 
     virtual Transactions getTxsInApplyOrder() const;
 
@@ -65,7 +50,7 @@ class TxSetFrame
     size_t
     sizeTx() const
     {
-        return mTxsInHashOrder.size();
+        return mTxs.size();
     }
 
     size_t sizeOp() const;
@@ -80,11 +65,13 @@ class TxSetFrame
   protected:
     Hash const mPreviousLedgerHash;
 
-    Transactions const mTxsInHashOrder;
+    Transactions const mTxs;
 
     Hash const mHash;
 
     friend struct SurgeCompare;
 };
+
+using TxSetFrameConstPtr = std::shared_ptr<TxSetFrame const>;
 
 } // namespace stellar

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -19,44 +19,13 @@ class Application;
 class TxSetFrame;
 using TxSetFrameConstPtr = std::shared_ptr<TxSetFrame const>;
 
-class AbstractTxSetFrameForApply
-{
-  public:
-    virtual ~AbstractTxSetFrameForApply(){};
-
-    virtual int64_t getBaseFee(LedgerHeader const& lh) const = 0;
-
-    virtual Hash const& getContentsHash() const = 0;
-
-    virtual Hash const& previousLedgerHash() const = 0;
-
-    virtual size_t sizeTx() const = 0;
-
-    virtual size_t sizeOp() const = 0;
-
-    // virtual std::vector<TransactionFrameBasePtr> sortForApply() = 0;
-    virtual void toXDR(TransactionSet& set) const = 0;
-};
-
-class TxSetFrame : public AbstractTxSetFrameForApply
+// A wrapper for a set of transactions that maintains the hash order
+class TxSetFrame
 {
   public:
     using AccountTransactionQueue = std::deque<TransactionFrameBasePtr>;
     using Transactions = std::vector<TransactionFrameBasePtr>;
 
-  protected:
-    Hash const mPreviousLedgerHash;
-
-    Transactions const mTxsInHashOrder;
-
-    Hash const mHash;
-
-    static UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
-    buildAccountTxQueues(TxSetFrame const& txSet);
-
-    friend struct SurgeCompare;
-
-  public:
     TxSetFrame(Hash const& previousLedgerHash,
                Transactions const& transactions);
 
@@ -71,7 +40,7 @@ class TxSetFrame : public AbstractTxSetFrameForApply
 
     // returns the hash of this tx set
     Hash const&
-    getContentsHash() const override
+    getContentsHash() const
     {
         return mHash;
     }
@@ -81,7 +50,7 @@ class TxSetFrame : public AbstractTxSetFrameForApply
                         TxSetFrame::Transactions const& txsInHashOrder);
 
     Hash const&
-    previousLedgerHash() const override
+    previousLedgerHash() const
     {
         return mPreviousLedgerHash;
     }
@@ -122,18 +91,31 @@ class TxSetFrame : public AbstractTxSetFrameForApply
     size_t size(LedgerHeader const& lh) const;
 
     size_t
-    sizeTx() const override
+    sizeTx() const
     {
         return mTxsInHashOrder.size();
     }
 
-    size_t sizeOp() const override;
+    size_t sizeOp() const;
 
     // return the base fee associated with this transaction set
-    int64_t getBaseFee(LedgerHeader const& lh) const override;
+    int64_t getBaseFee(LedgerHeader const& lh) const;
 
     // return the sum of all fees that this transaction set would take
     int64_t getTotalFees(LedgerHeader const& lh) const;
-    void toXDR(TransactionSet& set) const override;
+    void toXDR(TransactionSet& set) const;
+
+  protected:
+    Hash const mPreviousLedgerHash;
+
+    Transactions const mTxsInHashOrder;
+
+    Hash const mHash;
+
+    static UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
+    buildAccountTxQueues(TxSetFrame const& txSet);
+
+    friend struct SurgeCompare;
 };
+
 } // namespace stellar

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -67,6 +67,8 @@ class TxSetFrame
 
     Transactions const mTxs;
 
+    bool const mTxsIsValidHashOrder;
+
     Hash const mHash;
 
     friend struct SurgeCompare;

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -1,0 +1,393 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/asio.h"
+#include "TxSetUtils.h"
+#include "crypto/Hex.h"
+#include "crypto/Random.h"
+#include "crypto/SHA.h"
+#include "database/Database.h"
+#include "herder/SurgePricingUtils.h"
+#include "ledger/LedgerManager.h"
+#include "ledger/LedgerTxn.h"
+#include "ledger/LedgerTxnEntry.h"
+#include "ledger/LedgerTxnHeader.h"
+#include "main/Application.h"
+#include "main/Config.h"
+#include "transactions/TransactionUtils.h"
+#include "util/GlobalChecks.h"
+#include "util/Logging.h"
+#include "util/ProtocolVersion.h"
+#include "util/XDRCereal.h"
+#include "util/XDROperators.h"
+#include "xdrpp/marshal.h"
+
+#include <Tracy.hpp>
+#include <algorithm>
+#include <list>
+#include <numeric>
+
+namespace stellar
+{
+namespace TxSetUtils
+{
+
+bool
+HashTxSorter(TransactionFrameBasePtr const& tx1,
+             TransactionFrameBasePtr const& tx2)
+{
+    // need to use the hash of whole tx here since multiple txs could have
+    // the same Contents
+    return tx1->getFullHash() < tx2->getFullHash();
+}
+
+// order the txset correctly
+// must take into account multiple tx from same account
+TxSetFrame::Transactions
+sortTxsInHashOrder(TxSetFrame::Transactions const& transactions)
+{
+    ZoneScoped;
+    TxSetFrame::Transactions sortedTxs(transactions);
+    std::sort(sortedTxs.begin(), sortedTxs.end(), HashTxSorter);
+    return sortedTxs;
+}
+
+TxSetFrame::Transactions
+sortTxsInHashOrder(Hash const& networkID, TransactionSet const& xdrSet)
+{
+    ZoneScoped;
+    TxSetFrame::Transactions txs;
+    txs.reserve(xdrSet.txs.size());
+    std::transform(xdrSet.txs.cbegin(), xdrSet.txs.cend(),
+                   std::back_inserter(txs),
+                   [&](TransactionEnvelope const& env) {
+                       return TransactionFrameBase::makeTransactionFromWire(
+                           networkID, env);
+                   });
+    return sortTxsInHashOrder(txs);
+}
+
+Hash
+computeContentsHash(Hash const& previousLedgerHash,
+                    TxSetFrame::Transactions const& txsInHashOrder)
+{
+    ZoneScoped;
+    SHA256 hasher;
+    hasher.add(previousLedgerHash);
+    for (unsigned int n = 0; n < txsInHashOrder.size(); n++)
+    {
+        hasher.add(xdr::xdr_to_opaque(txsInHashOrder[n]->getEnvelope()));
+    }
+    return hasher.finish();
+}
+
+UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
+buildAccountTxQueues(TxSetFrame const& txSet)
+{
+    ZoneScoped;
+    UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue> actTxQueueMap;
+    for (auto const& tx : txSet.getTxsInHashOrder())
+    {
+        auto id = tx->getSourceID();
+        auto it = actTxQueueMap.find(id);
+        if (it == actTxQueueMap.end())
+        {
+            auto d = std::make_pair(id, TxSetFrame::AccountTransactionQueue{});
+            auto r = actTxQueueMap.insert(d);
+            it = r.first;
+        }
+        it->second.emplace_back(tx);
+    }
+
+    for (auto& am : actTxQueueMap)
+    {
+        // sort each in sequence number order
+        std::sort(am.second.begin(), am.second.end(),
+                  [](TransactionFrameBasePtr const& tx1,
+                     TransactionFrameBasePtr const& tx2) {
+                      return tx1->getSeqNum() < tx2->getSeqNum();
+                  });
+    }
+    return actTxQueueMap;
+}
+
+struct SurgeCompare
+{
+    Hash mSeed;
+    SurgeCompare() : mSeed(HashUtils::random())
+    {
+    }
+
+    // return true if tx1 < tx2
+    bool
+    operator()(TxSetFrame::AccountTransactionQueue const* tx1,
+               TxSetFrame::AccountTransactionQueue const* tx2) const
+    {
+        if (tx1 == nullptr || tx1->empty())
+        {
+            return tx2 ? !tx2->empty() : false;
+        }
+        if (tx2 == nullptr || tx2->empty())
+        {
+            return false;
+        }
+
+        auto& top1 = tx1->front();
+        auto& top2 = tx2->front();
+
+        auto cmp3 = feeRate3WayCompare(top1, top2);
+
+        if (cmp3 != 0)
+        {
+            return cmp3 < 0;
+        }
+        // use hash of transaction as a tie breaker
+        return lessThanXored(top1->getFullHash(), top2->getFullHash(), mSeed);
+    }
+};
+
+TxSetFrameConstPtr
+surgePricingFilter(TxSetFrameConstPtr txSet, Application& app)
+{
+    ZoneScoped;
+    LedgerTxn ltx(app.getLedgerTxnRoot());
+    auto header = ltx.loadHeader();
+
+    bool maxIsOps = protocolVersionStartsFrom(header.current().ledgerVersion,
+                                              ProtocolVersion::V_11);
+
+    size_t opsLeft = app.getLedgerManager().getLastMaxTxSetSizeOps();
+
+    auto curSizeOps =
+        maxIsOps ? txSet->sizeOp() : (txSet->sizeTx() * MAX_OPS_PER_TX);
+    if (curSizeOps > opsLeft)
+    {
+        CLOG_WARNING(Herder, "surge pricing in effect! {} > {}", curSizeOps,
+                     opsLeft);
+
+        auto actTxQueueMap = buildAccountTxQueues(*txSet);
+
+        std::priority_queue<TxSetFrame::AccountTransactionQueue*,
+                            std::vector<TxSetFrame::AccountTransactionQueue*>,
+                            SurgeCompare>
+            surgeQueue;
+
+        for (auto& am : actTxQueueMap)
+        {
+            surgeQueue.push(&am.second);
+        }
+
+        TxSetFrame::Transactions updatedSet;
+        updatedSet.reserve(txSet->sizeTx());
+        while (opsLeft > 0 && !surgeQueue.empty())
+        {
+            auto cur = surgeQueue.top();
+            surgeQueue.pop();
+            // inspect the top candidate queue
+            auto& curTopTx = cur->front();
+            size_t opsCount =
+                maxIsOps ? curTopTx->getNumOperations() : MAX_OPS_PER_TX;
+            if (opsCount <= opsLeft)
+            {
+                // pop from this one
+                updatedSet.emplace_back(curTopTx);
+                cur->pop_front();
+                opsLeft -= opsCount;
+                // if there are more transactions, put it back
+                if (!cur->empty())
+                {
+                    surgeQueue.push(cur);
+                }
+            }
+            else
+            {
+                // drop this transaction -> we need to drop the others
+                cur->clear();
+            }
+        }
+
+        return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(),
+                                                  updatedSet);
+    }
+    return txSet;
+}
+
+TxSetFrame::Transactions
+getInvalidTxList(Application& app, TxSetFrame const& txSet,
+                 uint64_t lowerBoundCloseTimeOffset,
+                 uint64_t upperBoundCloseTimeOffset,
+                 bool returnEarlyOnFirstInvalidTx)
+{
+    ZoneScoped;
+    LedgerTxn ltx(app.getLedgerTxnRoot());
+
+    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                  ProtocolVersion::V_19))
+    {
+        // This is done so minSeqLedgerGap is validated against the next
+        // ledgerSeq, which is what will be used at apply time
+        ltx.loadHeader().current().ledgerSeq =
+            app.getLedgerManager().getLastClosedLedgerNum() + 1;
+    }
+
+    UnorderedMap<AccountID, int64_t> accountFeeMap;
+    TxSetFrame::Transactions invalidTxs;
+
+    auto accountTxMap = buildAccountTxQueues(txSet);
+    for (auto& kv : accountTxMap)
+    {
+        int64_t lastSeq = 0;
+        auto iter = kv.second.begin();
+        while (iter != kv.second.end())
+        {
+            auto tx = *iter;
+            // In addition to checkValid, we also want to make sure that all but
+            // the transaction with the lowest seqNum on a given sourceAccount
+            // do not have minSeqAge and minSeqLedgerGap set
+            bool minSeqCheckIsInvalid =
+                iter != kv.second.begin() &&
+                (tx->getMinSeqAge() != 0 || tx->getMinSeqLedgerGap() != 0);
+            if (minSeqCheckIsInvalid ||
+                !tx->checkValid(ltx, lastSeq, lowerBoundCloseTimeOffset,
+                                upperBoundCloseTimeOffset))
+            {
+                invalidTxs.emplace_back(tx);
+                iter = kv.second.erase(iter);
+                if (returnEarlyOnFirstInvalidTx)
+                {
+                    if (minSeqCheckIsInvalid)
+                    {
+                        CLOG_DEBUG(Herder,
+                                   "minSeqAge or minSeqLedgerGap set on tx "
+                                   "without lowest seqNum. tx: {}",
+                                   xdr_to_string(tx->getEnvelope(),
+                                                 "TransactionEnvelope"));
+                    }
+                    else
+                    {
+                        CLOG_DEBUG(
+                            Herder,
+                            "Got bad txSet: {} tx invalid lastSeq:{} tx: {} "
+                            "result: {}",
+                            hexAbbrev(txSet.previousLedgerHash()), lastSeq,
+                            xdr_to_string(tx->getEnvelope(),
+                                          "TransactionEnvelope"),
+                            tx->getResultCode());
+                    }
+                    return invalidTxs;
+                }
+            }
+            else // update the account fee map
+            {
+                lastSeq = tx->getSeqNum();
+                int64_t& accFee = accountFeeMap[tx->getFeeSourceID()];
+                if (INT64_MAX - accFee < tx->getFeeBid())
+                {
+                    accFee = INT64_MAX;
+                }
+                else
+                {
+                    accFee += tx->getFeeBid();
+                }
+                ++iter;
+            }
+        }
+    }
+
+    auto header = ltx.loadHeader();
+    for (auto& kv : accountTxMap)
+    {
+        auto iter = kv.second.begin();
+        while (iter != kv.second.end())
+        {
+            auto tx = *iter;
+            auto feeSource = stellar::loadAccount(ltx, tx->getFeeSourceID());
+            auto totFee = accountFeeMap[tx->getFeeSourceID()];
+            if (getAvailableBalance(header, feeSource) < totFee)
+            {
+                while (iter != kv.second.end())
+                {
+                    invalidTxs.emplace_back(*iter);
+                    ++iter;
+                }
+                if (returnEarlyOnFirstInvalidTx)
+                {
+                    CLOG_DEBUG(Herder,
+                               "Got bad txSet: {} account can't pay fee tx: {}",
+                               hexAbbrev(txSet.previousLedgerHash()),
+                               xdr_to_string(tx->getEnvelope(),
+                                             "TransactionEnvelope"));
+                    return invalidTxs;
+                }
+            }
+            else
+            {
+                ++iter;
+            }
+        }
+    }
+
+    return invalidTxs;
+}
+
+// Target use case is to remove a subset of invalid transactions from a TxSet.
+// I.e. txSet.size() >= txsToRemove.size()
+TxSetFrameConstPtr
+removeTxs(TxSetFrameConstPtr txSet, TxSetFrame::Transactions const& txsToRemove)
+{
+    // hashmap from the full txSet
+    std::unordered_map<Hash, TransactionFrameBasePtr> fullTxSetHashMap;
+    fullTxSetHashMap.reserve(txSet->sizeTx());
+    std::transform(txSet->getTxsInHashOrder().cbegin(),
+                   txSet->getTxsInHashOrder().cend(),
+                   std::inserter(fullTxSetHashMap, fullTxSetHashMap.end()),
+                   [](TransactionFrameBasePtr const& tx) {
+                       return std::pair<Hash, TransactionFrameBasePtr>{
+                           tx->getFullHash(), tx};
+                   });
+
+    // candidate tx hashes to be removed
+    std::unordered_set<Hash> removeTxHashSet;
+    removeTxHashSet.reserve(txsToRemove.size());
+    std::transform(
+        txsToRemove.cbegin(), txsToRemove.cend(),
+        std::inserter(removeTxHashSet, removeTxHashSet.end()),
+        [](TransactionFrameBasePtr const& tx) { return tx->getFullHash(); });
+
+    // remove txs
+    for (auto it = fullTxSetHashMap.begin(); it != fullTxSetHashMap.end();)
+    {
+        if (removeTxHashSet.find(it->first) != removeTxHashSet.end())
+        {
+            it = fullTxSetHashMap.erase(it);
+        }
+        else
+        {
+            ++it;
+        }
+    }
+
+    // get back remaining txs
+    TxSetFrame::Transactions txs;
+    txs.reserve(fullTxSetHashMap.size());
+    std::transform(fullTxSetHashMap.cbegin(), fullTxSetHashMap.cend(),
+                   std::back_inserter(txs),
+                   [](std::pair<Hash, TransactionFrameBasePtr> const& p) {
+                       return p.second;
+                   });
+
+    return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(), txs);
+}
+
+TxSetFrameConstPtr
+addTxs(TxSetFrameConstPtr txSet, TxSetFrame::Transactions const& newTxs)
+{
+    auto updated = txSet->getTxsInHashOrder();
+    updated.insert(updated.end(), newTxs.begin(), newTxs.end());
+    return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(),
+                                              updated);
+}
+
+} // namespace TxSetUtils
+} // namespace stellar

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -30,16 +30,16 @@
 
 namespace stellar
 {
-namespace TxSetUtils
+namespace
 {
-
 bool
-TxSetUtils::HashTxSorter(TransactionFrameBasePtr const& tx1,
+hashTxSorter(TransactionFrameBasePtr const& tx1,
                          TransactionFrameBasePtr const& tx2)
 {
     // need to use the hash of whole tx here since multiple txs could have
     // the same Contents
     return tx1->getFullHash() < tx2->getFullHash();
+}
 }
 
 bool

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -1,0 +1,52 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "util/UnorderedMap.h"
+#include "xdr/Stellar-types.h"
+#include <deque>
+#include <herder/TxSetFrame.h>
+
+namespace stellar
+{
+namespace TxSetUtils
+{
+
+bool HashTxSorter(TransactionFrameBasePtr const& tx1,
+                  TransactionFrameBasePtr const& tx2);
+
+TxSetFrame::Transactions
+sortTxsInHashOrder(TxSetFrame::Transactions const& transactions);
+
+TxSetFrame::Transactions sortTxsInHashOrder(Hash const& networkID,
+                                            TransactionSet const& xdrSet);
+
+Hash computeContentsHash(Hash const& previousLedgerHash,
+                         TxSetFrame::Transactions const& txsInHashOrder);
+
+UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
+buildAccountTxQueues(TxSetFrame const& txSet);
+
+TxSetFrameConstPtr surgePricingFilter(TxSetFrameConstPtr txSet,
+                                      Application& app);
+
+// Returns transactions from a TxSet that are invalid. If
+// returnEarlyOnFirstInvalidTx is true, return immediately if an invalid
+// transaction is found (instead of finding all of them), this is useful for
+// checking if a TxSet is valid.
+TxSetFrame::Transactions getInvalidTxList(Application& app,
+                                          TxSetFrame const& txSet,
+                                          uint64_t lowerBoundCloseTimeOffset,
+                                          uint64_t upperBoundCloseTimeOffset,
+                                          bool returnEarlyOnFirstInvalidTx);
+
+TxSetFrameConstPtr removeTxs(TxSetFrameConstPtr txSet,
+                             TxSetFrame::Transactions const& txsToRemove);
+
+TxSetFrameConstPtr addTxs(TxSetFrameConstPtr txSet,
+                          TxSetFrame::Transactions const& newTxs);
+
+} // namespace TxSetUtils
+} // namespace stellar

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -4,69 +4,71 @@
 
 #pragma once
 
+#include "herder/TxSetFrame.h"
 #include "util/UnorderedMap.h"
 #include "xdr/Stellar-types.h"
-#include <deque>
-#include <herder/TxSetFrame.h>
 #include <ledger/LedgerHashUtils.h>
 #include <tuple>
 
 namespace stellar
 {
-namespace TxSetUtils
-{
-
-bool HashTxSorter(TransactionFrameBasePtr const& tx1,
-                  TransactionFrameBasePtr const& tx2);
-
-TxSetFrame::Transactions
-sortTxsInHashOrder(TxSetFrame::Transactions const& transactions);
-
-TxSetFrame::Transactions sortTxsInHashOrder(Hash const& networkID,
-                                            TransactionSet const& xdrSet);
-
-Hash computeContentsHash(Hash const& previousLedgerHash,
-                         TxSetFrame::Transactions const& txsInHashOrder);
-
-UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
-buildAccountTxQueues(TxSetFrame const& txSet);
-
-TxSetFrameConstPtr surgePricingFilter(TxSetFrameConstPtr txSet,
-                                      Application& app);
-
-// Returns transactions from a TxSet that are invalid. If
-// returnEarlyOnFirstInvalidTx is true, return immediately if an invalid
-// transaction is found (instead of finding all of them), this is useful for
-// checking if a TxSet is valid.
-TxSetFrame::Transactions getInvalidTxList(Application& app,
-                                          TxSetFrame const& txSet,
-                                          uint64_t lowerBoundCloseTimeOffset,
-                                          uint64_t upperBoundCloseTimeOffset,
-                                          bool returnEarlyOnFirstInvalidTx);
-
-TxSetFrameConstPtr removeTxs(TxSetFrameConstPtr txSet,
-                             TxSetFrame::Transactions const& txsToRemove);
-
-TxSetFrameConstPtr addTxs(TxSetFrameConstPtr txSet,
-                          TxSetFrame::Transactions const& newTxs);
-
-// For caching TxSet validity. Consist of {lcl.hash, txSetHash,
-// lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset}
-using TxSetValidityKey = std::tuple<Hash, Hash, uint64_t, uint64_t>;
-
-class TxSetValidityKeyHash
+class TxSetUtils
 {
   public:
-    size_t
-    operator()(TxSetValidityKey const& key) const
-    {
-        size_t res = std::hash<Hash>()(std::get<0>(key));
-        hashMix(res, std::hash<Hash>()(std::get<1>(key)));
-        hashMix(res, std::get<2>(key));
-        hashMix(res, std::get<3>(key));
-        return res;
-    }
-};
+    static bool HashTxSorter(TransactionFrameBasePtr const& tx1,
+                             TransactionFrameBasePtr const& tx2);
 
-} // namespace TxSetUtils
+    static bool isValidHashOrder(TxSetFrame::Transactions const& txs);
+
+    static TxSetFrame::Transactions
+    extractTxsFromXdrSet(Hash const& networkID, TransactionSet const& xdrSet);
+
+    static TxSetFrame::Transactions
+    sortTxsInHashOrder(TxSetFrame::Transactions const& transactions);
+
+    static Hash
+    computeContentsHash(Hash const& previousLedgerHash,
+                        TxSetFrame::Transactions const& txsInHashOrder);
+
+    static UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
+    buildAccountTxQueues(TxSetFrame const& txSet);
+
+    static TxSetFrameConstPtr surgePricingFilter(TxSetFrameConstPtr txSet,
+                                                 Application& app);
+
+    // Returns transactions from a TxSet that are invalid. If
+    // returnEarlyOnFirstInvalidTx is true, return immediately if an invalid
+    // transaction is found (instead of finding all of them), this is useful for
+    // checking if a TxSet is valid.
+    static TxSetFrame::Transactions
+    getInvalidTxList(Application& app, TxSetFrame const& txSet,
+                     uint64_t lowerBoundCloseTimeOffset,
+                     uint64_t upperBoundCloseTimeOffset,
+                     bool returnEarlyOnFirstInvalidTx);
+
+    // For caching TxSet validity. Consist of {lcl.hash, txSetHash,
+    // lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset}
+    using TxSetValidityKey = std::tuple<Hash, Hash, uint64_t, uint64_t>;
+
+    class TxSetValidityKeyHash
+    {
+      public:
+        size_t
+        operator()(TxSetValidityKey const& key) const
+        {
+            size_t res = std::hash<Hash>()(std::get<0>(key));
+            hashMix(res, std::hash<Hash>()(std::get<1>(key)));
+            hashMix(res, std::get<2>(key));
+            hashMix(res, std::get<3>(key));
+            return res;
+        }
+    };
+
+  private:
+    static TxSetFrameConstPtr
+    removeTxs(TxSetFrameConstPtr txSet,
+              TxSetFrame::Transactions const& txsToRemove);
+
+    friend class TestTxSetUtils;
+}; // class TxSetUtils
 } // namespace stellar

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -38,10 +38,16 @@ class TxSetUtils
     // transaction is found (instead of finding all of them), this is useful for
     // checking if a TxSet is valid.
     static TxSetFrame::Transactions
-    getInvalidTxList(Application& app, TxSetFrame const& txSet,
+    getInvalidTxList(TxSetFrame const& txSet, Application& app,
                      uint64_t lowerBoundCloseTimeOffset,
                      uint64_t upperBoundCloseTimeOffset,
                      bool returnEarlyOnFirstInvalidTx);
+
+    static TxSetFrameConstPtr trimInvalid(TxSetFrameConstPtr txSet,
+                                          Application& app,
+                                          uint64_t lowerBoundCloseTimeOffset,
+                                          uint64_t upperBoundCloseTimeOffset,
+                                          TxSetFrame::Transactions& invalidTxs);
 
     // For caching TxSet validity. Consist of {lcl.hash, txSetHash,
     // lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset}

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -8,6 +8,8 @@
 #include "xdr/Stellar-types.h"
 #include <deque>
 #include <herder/TxSetFrame.h>
+#include <ledger/LedgerHashUtils.h>
+#include <tuple>
 
 namespace stellar
 {
@@ -47,6 +49,24 @@ TxSetFrameConstPtr removeTxs(TxSetFrameConstPtr txSet,
 
 TxSetFrameConstPtr addTxs(TxSetFrameConstPtr txSet,
                           TxSetFrame::Transactions const& newTxs);
+
+// For caching TxSet validity. Consist of {lcl.hash, txSetHash,
+// lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset}
+using TxSetValidityKey = std::tuple<Hash, Hash, uint64_t, uint64_t>;
+
+class TxSetValidityKeyHash
+{
+  public:
+    size_t
+    operator()(TxSetValidityKey const& key) const
+    {
+        size_t res = std::hash<Hash>()(std::get<0>(key));
+        hashMix(res, std::hash<Hash>()(std::get<1>(key)));
+        hashMix(res, std::get<2>(key));
+        hashMix(res, std::get<3>(key));
+        return res;
+    }
+};
 
 } // namespace TxSetUtils
 } // namespace stellar

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -15,9 +15,6 @@ namespace stellar
 class TxSetUtils
 {
   public:
-    static bool HashTxSorter(TransactionFrameBasePtr const& tx1,
-                             TransactionFrameBasePtr const& tx2);
-
     static bool isValidHashOrder(TxSetFrame::Transactions const& txs);
 
     static TxSetFrame::Transactions

--- a/src/herder/simulation/TxSimTxSetFrame.cpp
+++ b/src/herder/simulation/TxSimTxSetFrame.cpp
@@ -3,89 +3,26 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "herder/simulation/TxSimTxSetFrame.h"
-#include "crypto/SHA.h"
-#include "transactions/TransactionBridge.h"
 #include "transactions/simulation/TxSimFeeBumpTransactionFrame.h"
 #include "transactions/simulation/TxSimTransactionFrame.h"
-#include "xdrpp/marshal.h"
-#include <numeric>
 
 namespace stellar
 {
 namespace txsimulation
 {
 
-static Hash
-computeContentsHash(Hash const& networkID, Hash const& previousLedgerHash,
-                    std::vector<TransactionEnvelope> transactions)
+TxSetFrameConstPtr
+makeSimTxSetFrame(Hash const& networkID, Hash const& previousLedgerHash,
+                  std::vector<TransactionEnvelope> const& transactions,
+                  std::vector<TransactionResultPair> const& results,
+                  uint32_t multiplier)
 {
-    TransactionSet txSet;
-    txSet.previousLedgerHash = previousLedgerHash;
-    txSet.txs.insert(txSet.txs.end(), transactions.begin(), transactions.end());
-    return TxSetFrame(networkID, txSet).getContentsHash();
-}
+    std::vector<TransactionFrameBasePtr> txs;
+    txs.reserve(transactions.size());
 
-TxSimTxSetFrame::TxSimTxSetFrame(
-    Hash const& networkID, Hash const& previousLedgerHash,
-    std::vector<TransactionEnvelope> const& transactions,
-    std::vector<TransactionResultPair> const& results, uint32_t multiplier)
-    : mNetworkID(networkID)
-    , mPreviousLedgerHash(previousLedgerHash)
-    , mTransactions(transactions)
-    , mResults(results)
-    , mContentsHash(
-          computeContentsHash(mNetworkID, mPreviousLedgerHash, mTransactions))
-    , mMultiplier(multiplier)
-{
-}
-
-int64_t
-TxSimTxSetFrame::getBaseFee(LedgerHeader const& lh) const
-{
-    return 0;
-}
-
-Hash const&
-TxSimTxSetFrame::getContentsHash()
-{
-    return mContentsHash;
-}
-
-Hash const&
-TxSimTxSetFrame::previousLedgerHash() const
-{
-    return mPreviousLedgerHash;
-}
-
-size_t
-TxSimTxSetFrame::sizeTx() const
-{
-    return mTransactions.size();
-}
-
-size_t
-TxSimTxSetFrame::sizeOp() const
-{
-    return std::accumulate(mTransactions.begin(), mTransactions.end(),
-                           size_t(0), [](size_t a, TransactionEnvelope txEnv) {
-                               auto ops = txbridge::getOperations(txEnv).size();
-                               if (txEnv.type() == ENVELOPE_TYPE_TX_FEE_BUMP)
-                               {
-                                   ++ops;
-                               }
-                               return a + ops;
-                           });
-}
-
-std::vector<TransactionFrameBasePtr>
-TxSimTxSetFrame::sortForApply()
-{
-    std::vector<TransactionFrameBasePtr> res;
-    res.reserve(mTransactions.size());
-
-    auto resultIter = mResults.cbegin();
+    auto resultIter = results.cbegin();
     uint32_t partition = 0;
-    for (auto const& txEnv : mTransactions)
+    for (auto const& txEnv : transactions)
     {
         TransactionFrameBasePtr txFrame;
         switch (txEnv.type())
@@ -93,40 +30,28 @@ TxSimTxSetFrame::sortForApply()
         case ENVELOPE_TYPE_TX_V0:
         case ENVELOPE_TYPE_TX:
             txFrame = std::make_shared<TxSimTransactionFrame>(
-                mNetworkID, txEnv, resultIter->result, partition);
+                networkID, txEnv, resultIter->result, partition);
             break;
         case ENVELOPE_TYPE_TX_FEE_BUMP:
             txFrame = std::make_shared<TxSimFeeBumpTransactionFrame>(
-                mNetworkID, txEnv, resultIter->result, partition);
+                networkID, txEnv, resultIter->result, partition);
             break;
         default:
             abort();
         }
 
-        res.emplace_back(txFrame);
+        txs.emplace_back(txFrame);
         ++resultIter;
-        if (++partition == mMultiplier)
+        if (++partition == multiplier)
         {
             partition = 0;
         }
     }
 
-    assert(resultIter == mResults.end());
-    return res;
+    assert(resultIter == results.end());
+    return std::make_shared<SimApplyOrderTxSetFrame const>(previousLedgerHash,
+                                                           txs);
 }
 
-void
-TxSimTxSetFrame::toXDR(TransactionSet& set)
-{
-    // Delegate to TxSetFrame and explicitly call sortForHash on it for now;
-    // likely this whole class will go away at some point.
-    TransactionSet txSet;
-    txSet.previousLedgerHash = mPreviousLedgerHash;
-    txSet.txs.insert(txSet.txs.end(), mTransactions.begin(),
-                     mTransactions.end());
-    TxSetFrame tf(mNetworkID, txSet);
-    tf.sortForHash();
-    tf.toXDR(set);
-}
 }
 }

--- a/src/herder/simulation/TxSimTxSetFrame.h
+++ b/src/herder/simulation/TxSimTxSetFrame.h
@@ -11,33 +11,32 @@ namespace stellar
 namespace txsimulation
 {
 
-class TxSimTxSetFrame : public AbstractTxSetFrameForApply
+// TxSetFrame preserving arbitrary passed-in apply order for simulation
+class SimApplyOrderTxSetFrame : public TxSetFrame
 {
-    Hash const mNetworkID;
-    Hash const mPreviousLedgerHash;
-    std::vector<TransactionEnvelope> const mTransactions;
-    std::vector<TransactionResultPair> const mResults;
-    Hash const mContentsHash;
-    uint32_t const mMultiplier;
-
   public:
-    TxSimTxSetFrame(Hash const& networkID, Hash const& previousLedgerHash,
-                    std::vector<TransactionEnvelope> const& transactions,
-                    std::vector<TransactionResultPair> const& results,
-                    uint32_t multiplier);
+    SimApplyOrderTxSetFrame(Hash const& previousLedgerHash,
+                            Transactions const& transactions)
+        : TxSetFrame(previousLedgerHash, transactions)
+        , mTxsInApplyOrder(transactions)
+    {
+    }
 
-    int64_t getBaseFee(LedgerHeader const& lh) const override;
+    Transactions
+    getTxsInApplyOrder() const override
+    {
+        return mTxsInApplyOrder;
+    }
 
-    Hash const& getContentsHash() override;
-
-    Hash const& previousLedgerHash() const override;
-
-    size_t sizeTx() const override;
-
-    size_t sizeOp() const override;
-
-    std::vector<TransactionFrameBasePtr> sortForApply() override;
-    void toXDR(TransactionSet& set) override;
+  private:
+    Transactions mTxsInApplyOrder;
 };
+
+TxSetFrameConstPtr
+makeSimTxSetFrame(Hash const& networkID, Hash const& previousLedgerHash,
+                  std::vector<TransactionEnvelope> const& transactions,
+                  std::vector<TransactionResultPair> const& results,
+                  uint32_t multiplier);
+
 }
 }

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -56,7 +56,7 @@ testQuorumTracker()
     struct ValuesTxSet
     {
         Value mSignedV;
-        TxSetFramePtr mTxSet;
+        TxSetFrameConstPtr mTxSet;
     };
 
     auto recvEnvelope = [&](SCPEnvelope envelope, uint64 slotID,
@@ -109,7 +109,7 @@ testQuorumTracker()
     };
     auto makeValue = [&](int i) {
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-        auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
+        auto txSet = std::make_shared<TxSetFrame const>(lcl.hash);
         StellarValue sv = herder->makeStellarValue(
             txSet->getContentsHash(), lcl.header.scpValue.closeTime + i,
             emptyUpgradeSteps, valSigner);

--- a/src/herder/test/TestTxSetUtils.cpp
+++ b/src/herder/test/TestTxSetUtils.cpp
@@ -1,0 +1,39 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "TestTxSetUtils.h"
+
+namespace stellar
+{
+
+TxSetFrameConstPtr
+TestTxSetUtils::addTxs(TxSetFrameConstPtr txSet,
+                       TxSetFrame::Transactions const& newTxs)
+{
+    auto updated = txSet->getTxsInHashOrder();
+    updated.insert(updated.end(), newTxs.begin(), newTxs.end());
+    return std::make_shared<TxSetFrame const>(txSet->previousLedgerHash(),
+                                              updated);
+}
+
+TxSetFrameConstPtr
+TestTxSetUtils::removeTxs(TxSetFrameConstPtr txSet,
+                          TxSetFrame::Transactions const& txsToRemove)
+{
+    return TxSetUtils::removeTxs(txSet, txsToRemove);
+}
+
+TxSetFrameConstPtr
+TestTxSetUtils::makeIllSortedTxSet(Hash const& networkID,
+                                   TxSetFrameConstPtr goodTxSet)
+{
+    TransactionSet xdrSet;
+    goodTxSet->toXDR(xdrSet);
+    // rearrange it out of order
+    releaseAssert(xdrSet.txs.size() >= 2);
+    std::swap(xdrSet.txs[0], xdrSet.txs[1]);
+    return std::make_shared<TxSetFrame const>(networkID, xdrSet);
+}
+
+} // namespace stellar

--- a/src/herder/test/TestTxSetUtils.h
+++ b/src/herder/test/TestTxSetUtils.h
@@ -1,0 +1,25 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#pragma once
+
+#include "herder/TxSetUtils.h"
+
+namespace stellar
+{
+class TestTxSetUtils
+{
+  public:
+    static TxSetFrameConstPtr addTxs(TxSetFrameConstPtr txSet,
+                                     TxSetFrame::Transactions const& newTxs);
+
+    static TxSetFrameConstPtr
+    removeTxs(TxSetFrameConstPtr txSet,
+              TxSetFrame::Transactions const& txsToRemove);
+
+    static TxSetFrameConstPtr makeIllSortedTxSet(Hash const& networkID,
+                                                 TxSetFrameConstPtr goodTxSet);
+
+}; // class TestTxSetUtils
+} // namespace stellar

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -503,8 +503,6 @@ TEST_CASE("Ledger Manager applies upgrades properly", "[upgrades]")
     auto app = createTestApplication(clock, cfg);
 
     auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-    auto const& lastHash = lcl.hash;
-    auto txSet = std::make_shared<TxSetFrame>(lastHash);
 
     REQUIRE(lcl.header.ledgerVersion == LedgerManager::GENESIS_LEDGER_VERSION);
     REQUIRE(lcl.header.baseFee == LedgerManager::GENESIS_LEDGER_BASE_FEE);
@@ -567,7 +565,7 @@ TEST_CASE("upgrade to version 10", "[upgrades]")
     auto txFee = lm.getLastTxFee();
 
     auto const& lcl = lm.getLastClosedLedgerHeader();
-    auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
+    auto txSet = std::make_shared<TxSetFrame const>(lcl.hash);
 
     auto root = TestAccount::createRoot(*app);
     auto issuer = root.create("issuer", lm.getLastMinBalance(0) + 100 * txFee);
@@ -1411,15 +1409,14 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
     {
         auto stranger =
             TestAccount{*app, txtest::getAccount(fmt::format("stranger{}", i))};
-        TxSetFramePtr txSet =
-            std::make_shared<TxSetFrame>(lm.getLastClosedLedgerHeader().hash);
         uint32_t ledgerSeq = lm.getLastClosedLedgerNum() + 1;
         uint64_t minBalance = lm.getLastMinBalance(5);
         uint64_t big = minBalance + ledgerSeq;
         uint64_t closeTime = 60 * 5 * ledgerSeq;
-        txSet->add(root.tx({txtest::createAccount(stranger, big)}));
-        // Provoke sortForHash and hash-caching:
-        txSet->getContentsHash();
+        TxSetFrameConstPtr txSet = std::make_shared<TxSetFrame const>(
+            lm.getLastClosedLedgerHeader().hash,
+            TxSetFrame::Transactions{
+                root.tx({txtest::createAccount(stranger, big)})});
 
         // On 4th iteration of advance (a.k.a. ledgerSeq 5), perform a
         // ledger-protocol version upgrade to the new protocol, to activate
@@ -1535,15 +1532,14 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
     {
         auto stranger =
             TestAccount{*app, txtest::getAccount(fmt::format("stranger{}", i))};
-        TxSetFramePtr txSet =
-            std::make_shared<TxSetFrame>(lm.getLastClosedLedgerHeader().hash);
         uint32_t ledgerSeq = lm.getLastClosedLedgerNum() + 1;
         uint64_t minBalance = lm.getLastMinBalance(5);
         uint64_t big = minBalance + ledgerSeq;
         uint64_t closeTime = 60 * 5 * ledgerSeq;
-        txSet->add(root.tx({txtest::createAccount(stranger, big)}));
-        // Provoke sortForHash and hash-caching:
-        txSet->getContentsHash();
+        TxSetFrameConstPtr txSet = std::make_shared<TxSetFrame const>(
+            lm.getLastClosedLedgerHeader().hash,
+            TxSetFrame::Transactions{
+                root.tx({txtest::createAccount(stranger, big)})});
 
         // On 4th iteration of advance (a.k.a. ledgerSeq 5), perform a
         // ledger-protocol version upgrade to the new protocol, to
@@ -1644,7 +1640,7 @@ TEST_CASE("upgrade to version 13", "[upgrades]")
     herder.recvTransaction(acc.tx({payment(acc, 2)}));
 
     auto txSet = herder.getTransactionQueue().toTxSet({});
-    for (auto const& tx : txSet->mTransactions)
+    for (auto const& tx : txSet->getTxsInHashOrder())
     {
         REQUIRE(tx->getEnvelope().type() == ENVELOPE_TYPE_TX_V0);
     }
@@ -1653,7 +1649,7 @@ TEST_CASE("upgrade to version 13", "[upgrades]")
         auto const& lcl = lm.getLastClosedLedgerHeader();
         auto ledgerSeq = lcl.header.ledgerSeq + 1;
 
-        auto emptyTxSet = std::make_shared<TxSetFrame>(lcl.hash);
+        auto emptyTxSet = std::make_shared<TxSetFrame const>(lcl.hash);
         herder.getPendingEnvelopes().putTxSet(emptyTxSet->getContentsHash(),
                                               ledgerSeq, emptyTxSet);
 
@@ -1667,7 +1663,7 @@ TEST_CASE("upgrade to version 13", "[upgrades]")
     }
 
     txSet = herder.getTransactionQueue().toTxSet({});
-    for (auto const& tx : txSet->mTransactions)
+    for (auto const& tx : txSet->getTxsInHashOrder())
     {
         REQUIRE(tx->getEnvelope().type() == ENVELOPE_TYPE_TX);
     }
@@ -1682,9 +1678,6 @@ TEST_CASE_VERSIONS("upgrade base reserve", "[upgrades]")
 
     auto& lm = app->getLedgerManager();
     auto txFee = lm.getLastTxFee();
-
-    auto const& lcl = lm.getLastClosedLedgerHeader();
-    auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
 
     auto root = TestAccount::createRoot(*app);
     auto issuer = root.create("issuer", lm.getLastMinBalance(0) + 100 * txFee);

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1000,15 +1000,15 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
             auto stranger = TestAccount{
                 *a, txtest::getAccount(fmt::format("stranger{}", i))};
             auto& lm = a->getLedgerManager();
-            TxSetFramePtr txSet = std::make_shared<TxSetFrame>(
-                lm.getLastClosedLedgerHeader().hash);
             uint32_t ledgerSeq = lm.getLastClosedLedgerNum() + 1;
             uint64_t minBalance = lm.getLastMinBalance(5);
             uint64_t big = minBalance + ledgerSeq;
             uint64_t closeTime = 60 * 5 * ledgerSeq;
-            txSet->add(root.tx({txtest::createAccount(stranger, big)}));
-            // Provoke sortForHash and hash-caching:
-            txSet->getContentsHash();
+
+            TxSetFrameConstPtr txSet = std::make_shared<TxSetFrame const>(
+                lm.getLastClosedLedgerHeader().hash,
+                TxSetFrame::Transactions{
+                    root.tx({txtest::createAccount(stranger, big)})});
 
             // On first iteration of advance, perform a ledger-protocol version
             // upgrade to the new protocol, to activate INITENTRY behaviour.

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -616,7 +616,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     mLastClose = now;
     mLedgerAge.set_count(0);
 
-    std::shared_ptr<AbstractTxSetFrameForApply> txSet = ledgerData.getTxSet();
+    TxSetFrameConstPtr txSet = ledgerData.getTxSet();
 
     // If we do not support ledger version, we can't apply that ledger, fail!
     if (header.current().ledgerVersion >
@@ -685,7 +685,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     // the transaction set that was agreed upon by consensus
     // was sorted by hash; we reorder it so that transactions are
     // sorted such that sequence numbers are respected
-    vector<TransactionFrameBasePtr> txs = ledgerData.getTxSet()->sortForApply();
+    std::vector<TransactionFrameBasePtr> txs = txSet->getTxsInApplyOrder();
 
     // first, prefetch source accounts for txset, then charge fees
     prefetchTxSourceIds(txs);

--- a/src/ledger/readme.md
+++ b/src/ledger/readme.md
@@ -150,7 +150,7 @@ but when it comes to actually applying them, they need to be sorted such that
 transactions for a given account are applied in sequence number order and also
 randomized enough so that it becomes unfeasible to submit a transaction and
 guarantee that it will be executed before or after another transaction in the set.
-_See `TxSetFrame::sortForApply` for more detail._
+_See `TxSetFrame::getTxsInApplyOrder` for more detail._
 
 2. Once the list of transactions to apply is computed, each transaction is
 applied to the ledger.

--- a/src/ledger/test/LedgerHeaderTests.cpp
+++ b/src/ledger/test/LedgerHeaderTests.cpp
@@ -70,7 +70,7 @@ TEST_CASE("ledgerheader", "[ledger]")
 
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
         auto const& lastHash = lcl.hash;
-        TxSetFramePtr txSet = make_shared<TxSetFrame>(lastHash);
+        TxSetFrameConstPtr txSet = make_shared<TxSetFrame const>(lastHash);
 
         // close this ledger
         StellarValue sv = app->getHerder().makeStellarValue(

--- a/src/ledger/test/LedgerTests.cpp
+++ b/src/ledger/test/LedgerTests.cpp
@@ -20,7 +20,7 @@ TEST_CASE("cannot close ledger with unsupported ledger version", "[ledger]")
 
     auto applyEmptyLedger = [&]() {
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-        auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
+        auto txSet = std::make_shared<TxSetFrame const>(lcl.hash);
 
         StellarValue sv = app->getHerder().makeStellarValue(
             txSet->getContentsHash(), 1, emptyUpgradeSteps,

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -25,7 +25,6 @@ namespace stellar
 class Tracker;
 class TxSetFrame;
 struct SCPQuorumSet;
-using TxSetFramePtr = std::shared_ptr<TxSetFrame>;
 using SCPQuorumSetPtr = std::shared_ptr<SCPQuorumSet>;
 using AskPeer = std::function<void(Peer::pointer, Hash)>;
 

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -252,9 +252,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             // create the transaction set containing this transaction
             auto const& lcl =
                 inApp->getLedgerManager().getLastClosedLedgerHeader();
-            TxSetFrame txSet(lcl.hash);
-            txSet.add(tx1);
-            txSet.sortForHash();
+            TxSetFrame txSet(lcl.hash, {tx1});
             auto& herder = static_cast<HerderImpl&>(inApp->getHerder());
 
             // build the quorum set used by this message

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -465,21 +465,6 @@ closeLedgerOn(Application& app, int day, int month, int year,
                          strictOrder);
 }
 
-class TxSetFrameStrictOrderForTesting : public TxSetFrame
-{
-  public:
-    TxSetFrameStrictOrderForTesting(Hash const& previousLedgerHash)
-        : TxSetFrame(previousLedgerHash){};
-
-    std::vector<TransactionFrameBasePtr>
-    sortForApply() override
-    {
-        return mTransactions;
-    };
-
-    void sortForHash() override{};
-};
-
 TxSetResultMeta
 closeLedger(Application& app, std::vector<TransactionFrameBasePtr> const& txs,
             bool strictOrder)
@@ -505,8 +490,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
         closeTime = lastCloseTime;
     }
 
-    std::shared_ptr<TxSetFrame> txSet;
-    auto lclHash = app.getLedgerManager().getLastClosedLedgerHeader().hash;
+    TxSetFrameConstPtr txSet;
     if (strictOrder)
     {
         txSet = std::make_shared<txsimulation::SimApplyOrderTxSetFrame const>(
@@ -514,17 +498,14 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
     }
     else
     {
-        txSet = std::make_shared<TxSetFrame>(lclHash);
+        txSet = std::make_shared<TxSetFrame const>(
+            app.getLedgerManager().getLastClosedLedgerHeader().hash, txs);
     }
-
-    for (auto const& tx : txs)
-    {
-        txSet->add(tx);
-    }
-
-    txSet->sortForHash();
     if (!strictOrder)
     {
+        // `strictOrder` means the txs in the txSet will be applied in the exact
+        // same order as they were constructed. It could also imply the txs
+        // themselves maybe intentionally invalid for testing purpose.
         REQUIRE(txSet->checkValid(app, 0, 0));
     }
 
@@ -1542,7 +1523,7 @@ executeUpgrades(Application& app, xdr::xvector<UpgradeType, 6> const& upgrades)
 {
     auto& lm = app.getLedgerManager();
     auto const& lcl = lm.getLastClosedLedgerHeader();
-    auto txSet = std::make_shared<TxSetFrame>(lcl.hash);
+    auto txSet = std::make_shared<TxSetFrame const>(lcl.hash);
 
     auto lastCloseTime = lcl.header.scpValue.closeTime;
     app.getHerder().externalizeValue(txSet, lcl.header.ledgerSeq + 1,

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -7,6 +7,7 @@
 #include "crypto/SignerKey.h"
 #include "database/Database.h"
 #include "herder/Herder.h"
+#include "herder/simulation/TxSimTxSetFrame.h"
 #include "invariant/InvariantManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
@@ -508,7 +509,8 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
     auto lclHash = app.getLedgerManager().getLastClosedLedgerHeader().hash;
     if (strictOrder)
     {
-        txSet = std::make_shared<TxSetFrameStrictOrderForTesting>(lclHash);
+        txSet = std::make_shared<txsimulation::SimApplyOrderTxSetFrame const>(
+            app.getLedgerManager().getLastClosedLedgerHeader().hash, txs);
     }
     else
     {

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -64,12 +64,11 @@ TEST_CASE("txset - correct apply order", "[tx][envelope]")
 
     Hash h;
     h[0] = 2;
-    auto txSet = std::make_shared<TxSetFrame>(h);
-    txSet->add(tx1);
-    txSet->add(tx2);
+    auto txSet = std::make_shared<TxSetFrame const>(
+        h, TxSetFrame::Transactions{tx1, tx2});
 
     // Sort for apply re-orders transaction set
-    auto txs = txSet->sortForApply();
+    auto txs = txSet->getTxsInApplyOrder();
     REQUIRE(txs.size() == 2);
     REQUIRE(txs[1]->getFullHash() == tx1->getFullHash());
     REQUIRE(txs[0]->getFullHash() == tx2->getFullHash());
@@ -1864,11 +1863,10 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
         TransactionFramePtr txFrame;
         auto setup = [&]() {
-            auto txSet = std::make_shared<TxSetFrame>(
-                app->getLedgerManager().getLastClosedLedgerHeader().hash);
-
             txFrame = root.tx({createAccount(a1, paymentAmount)});
-            txSet->add(txFrame);
+            auto txSet = std::make_shared<TxSetFrame const>(
+                app->getLedgerManager().getLastClosedLedgerHeader().hash,
+                TxSetFrame::Transactions{txFrame});
 
             // Close this ledger
             auto lastCloseTime = app->getLedgerManager()


### PR DESCRIPTION
# Description

Resolves `TxSetFrame` part of #2163 as well as #2363
- Make `TxSetFrame` immutable
- Transactions in `TxSetFrame` are guaranteed to be in hash order, and hash computed on construction.
- Move out utility functions and methods that used to mutate `TxSetFrame` into `TxSetUtils.cpp`
- Remove abstract base class. Repurpose the "TxSim" class into and a child class of `TxSetFrame` that preserves the apply order. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
