### PR TITLE
minor fix: properly handle output file in WriteVerifiedCheckpointHashesWork

### DIFF
--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -199,4 +199,10 @@ WriteVerifiedCheckpointHashesWork::resetIter()
     endOutputFile();
     startOutputFile();
 }
+
+void
+WriteVerifiedCheckpointHashesWork::onSuccess()
+{
+    endOutputFile();
+}
 }

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.h
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.h
@@ -36,6 +36,8 @@ class WriteVerifiedCheckpointHashesWork : public BatchWork
     static Hash loadHashFromJsonOutput(uint32_t seq,
                                        std::string const& filename);
 
+    void onSuccess() override;
+
   private:
     // This class is a batch work, but it also creates a conditional dependency
     // chain among its batch elements (for trusted ledger propagation): this

--- a/src/historywork/test/HistoryWorkTests.cpp
+++ b/src/historywork/test/HistoryWorkTests.cpp
@@ -38,12 +38,6 @@ TEST_CASE("write verified checkpoint hashes", "[historywork]")
             pair, file, nestedBatchSize);
         REQUIRE(w->getState() == BasicWork::State::WORK_SUCCESS);
     }
-    // Make sure w is destroyed.
-    wm.shutdown();
-    while (wm.getState() != BasicWork::State::WORK_ABORTED)
-    {
-        catchupSimulation.getClock().crank();
-    }
 
     for (auto const& p : pairs)
     {


### PR DESCRIPTION
Discovered while investigating https://github.com/stellar/stellar-core/issues/3400, the work should handle the output file on success