### PR TITLE
Work around bugs in automake 1.15 on ubuntu 18.04 LTS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,39 +32,48 @@ SUFFIXES = .x .h .rs
 .x.h:
 	$(XDRC) -hh -pedantic -o $@ $<
 
+# Old automakes have buggy dependency tracking for conditional generated
+# sources. We work around this here by making rust/bridge.{cpp,h} generated in
+# all cases, and just empty in the non-rust case. Also because of the way old
+# automake relies on horrible path-munging code in config.status to extract the
+# names of depfiles from the Makefile itself, we can't use any variables in the
+# SOURCES addition we're doing here, have to list unadorned paths.
 
-# This needs to be outside the next-protocol block
-# because, weirdly, RUST_BUILD_DIR winds up embedded
-# in generated Makefile for tracking bridge.Po even
-# when we are not building the bridge. Automake is odd.
-RUST_BUILD_DIR=$(top_builddir)/src/rust
+BUILT_SOURCES += rust/bridge.h rust/bridge.cpp
+stellar_core_SOURCES += rust/bridge.h rust/bridge.cpp
 
 if ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-RUST_SRC_DIR=$(top_srcdir)/src/rust/src
+RUST_BUILD_DIR=$(top_builddir)/src/rust
 RUST_BIN_DIR=$(RUST_BUILD_DIR)/bin
 RUST_TARGET_DIR=$(RUST_BUILD_DIR)/target
 RUST_CXXBRIDGE=$(RUST_BIN_DIR)/cxxbridge
 RUST_PROFILE=release
 LIBRUST_STELLAR_CORE=$(RUST_TARGET_DIR)/$(RUST_PROFILE)/librust_stellar_core.a
-BUILT_SOURCES += $(RUST_BUILD_DIR)/bridge.h $(RUST_BUILD_DIR)/bridge.cpp
-stellar_core_SOURCES += $(RUST_BUILD_DIR)/bridge.h $(RUST_BUILD_DIR)/bridge.cpp
 stellar_core_LDADD += $(LIBRUST_STELLAR_CORE) -ldl
 
 $(RUST_CXXBRIDGE):
 	mkdir -p $(RUST_BIN_DIR)
 	$(CARGO) install --root $(RUST_BUILD_DIR) cxxbridge-cmd
 
-$(RUST_BUILD_DIR)/bridge.h: $(RUST_SRC_DIR)/lib.rs $(SRC_RUST_FILES) $(top_srcdir)/src/Makefile.am $(RUST_CXXBRIDGE)
+rust/bridge.h: $(SRC_RUST_FILES) Makefile.am $(RUST_CXXBRIDGE)
 	$(RUST_CXXBRIDGE) $< --header --output $@.tmp
 	if cmp -s $@.tmp $@; then rm -v $@.tmp; else mv -v $@.tmp $@; fi
 
-$(RUST_BUILD_DIR)/bridge.cpp: $(RUST_SRC_DIR)/lib.rs $(SRC_RUST_FILES) $(top_srcdir)/src/Makefile.am $(RUST_CXXBRIDGE)
+rust/bridge.cpp: $(SRC_RUST_FILES) Makefile.am $(RUST_CXXBRIDGE)
 	$(RUST_CXXBRIDGE) $< --output $@.tmp
 	if cmp -s $@.tmp $@; then rm -v $@.tmp; else mv -v $@.tmp $@; fi
 
-$(LIBRUST_STELLAR_CORE): $(SRC_RUST_FILES) $(top_srcdir)/src/Makefile.am
+$(LIBRUST_STELLAR_CORE): $(SRC_RUST_FILES) Makefile.am
 	cd $(RUST_BUILD_DIR) && cargo build --$(RUST_PROFILE) --target-dir $(abspath $(RUST_TARGET_DIR))
 	ranlib $@
+else
+
+rust/bridge.cpp:
+	touch $@
+
+rust/bridge.h:
+	touch $@
+
 endif # ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 
 


### PR DESCRIPTION
Unfortunately my first go at merging Rust support included some automake code that old versions of automake (specifically v1.15.1 on ubuntu 18.04 LTS) does not like. @satyamz noticed this is causing the package to fail to build in CI -- this PR fixes the breakage.

(In particular, [this somewhat astounding code](https://github.com/autotools-mirror/automake/commit/6a675ef17edf7109da189f5ae70e2dc6b7665896#diff-fe23e03836525d5af57c48fff22a40fc65a6478a501bf68fca8e54d2fe7a2f2aL45-L58) in automake that was removed in 2015 is the culprit, but apparently it didn't make it into an ubuntu release until 20.04 LTS)