### PR TITLE
Filter out non LEDGER_ENTRYs in captive core

### DIFF
--- a/src/ledger/InMemoryLedgerTxn.h
+++ b/src/ledger/InMemoryLedgerTxn.h
@@ -50,6 +50,30 @@ class InMemoryLedgerTxn : public LedgerTxn
     void updateLedgerKeyMap(InternalLedgerKey const& genKey, bool add) noexcept;
     void updateLedgerKeyMap(EntryIterator iter);
 
+    class FilteredEntryIteratorImpl : public EntryIterator::AbstractImpl
+    {
+        EntryIterator mIter;
+
+      public:
+        explicit FilteredEntryIteratorImpl(EntryIterator const& begin);
+
+        void advance() override;
+
+        bool atEnd() const override;
+
+        InternalLedgerEntry const& entry() const override;
+
+        LedgerEntryPtr const& entryPtr() const override;
+
+        bool entryExists() const override;
+
+        InternalLedgerKey const& key() const override;
+
+        std::unique_ptr<EntryIterator::AbstractImpl> clone() const override;
+    };
+
+    EntryIterator getFilteredEntryIterator(EntryIterator const& iter);
+
   public:
     InMemoryLedgerTxn(InMemoryLedgerTxnRoot& parent, Database& db);
     virtual ~InMemoryLedgerTxn();


### PR DESCRIPTION
# Description


# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
