### PR TITLE
Add a new metric to track transaction latency

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -37,6 +37,7 @@ herder.pending-txs.age2                  | counter   | number of gen2 pending tr
 herder.pending-txs.age3                  | counter   | number of gen3 pending transactions
 herder.pending-txs.banned                | counter   | number of transactions that got banned
 herder.pending-txs.delay                 | timer     | time for transactions to be included in a ledger
+herder.pending-txs.self-delay            | timer     | time for transactions submitted from this node to be included in a ledger
 history.check.failure                    | meter     | history archive status checks failed
 history.check.success                    | meter     | history archive status checks succeeded
 history.publish.failure                  | meter     | published failed

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -117,7 +117,7 @@ class Herder
     virtual bool recvTxSet(Hash const& hash, TxSetFrame const& txset) = 0;
     // We are learning about a new transaction.
     virtual TransactionQueue::AddResult
-    recvTransaction(TransactionFrameBasePtr tx) = 0;
+    recvTransaction(TransactionFrameBasePtr tx, bool submittedFromSelf) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;
     virtual TxSetFrameConstPtr getTxSet(Hash const& hash) = 0;

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -442,10 +442,10 @@ HerderImpl::emitEnvelope(SCPEnvelope const& envelope)
 }
 
 TransactionQueue::AddResult
-HerderImpl::recvTransaction(TransactionFrameBasePtr tx)
+HerderImpl::recvTransaction(TransactionFrameBasePtr tx, bool submittedFromSelf)
 {
     ZoneScoped;
-    auto result = mTransactionQueue.tryAdd(tx);
+    auto result = mTransactionQueue.tryAdd(tx, submittedFromSelf);
     if (result == TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
         CLOG_TRACE(Herder, "recv transaction {} for {}",

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -94,7 +94,8 @@ class HerderImpl : public Herder
     void emitEnvelope(SCPEnvelope const& envelope);
 
     TransactionQueue::AddResult
-    recvTransaction(TransactionFrameBasePtr tx) override;
+    recvTransaction(TransactionFrameBasePtr tx,
+                    bool submittedFromSelf) override;
 
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope) override;
 #ifdef BUILD_TESTS

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -106,6 +106,7 @@ class TransactionQueue
         TransactionFrameBasePtr mTx;
         bool mBroadcasted;
         VirtualClock::time_point mInsertionTime;
+        bool mSubmittedFromSelf;
     };
     using TimestampedTransactions = std::vector<TimestampedTx>;
     using Transactions = std::vector<TransactionFrameBasePtr>;
@@ -125,7 +126,7 @@ class TransactionQueue
     static std::vector<AssetPair>
     findAllAssetPairsInvolvedInPaymentLoops(TransactionFrameBasePtr tx);
 
-    AddResult tryAdd(TransactionFrameBasePtr tx);
+    AddResult tryAdd(TransactionFrameBasePtr tx, bool submittedFromSelf);
     void removeApplied(Transactions const& txs);
     void ban(Transactions const& txs);
 
@@ -185,6 +186,7 @@ class TransactionQueue
     medida::Counter& mArbTxSeenCounter;
     medida::Counter& mArbTxDroppedCounter;
     medida::Timer& mTransactionsDelay;
+    medida::Timer& mTransactionsSelfDelay;
 
     UnorderedSet<OperationType> mFilteredTypes;
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -77,7 +77,7 @@ TEST_CASE_VERSIONS("standalone", "[herder][acceptance]")
             VirtualTimer setupTimer(*app);
 
             auto feedTx = [&](TransactionFramePtr& tx) {
-                REQUIRE(app->getHerder().recvTransaction(tx) ==
+                REQUIRE(app->getHerder().recvTransaction(tx, false) ==
                         TransactionQueue::AddResult::ADD_STATUS_PENDING);
             };
 
@@ -2950,9 +2950,9 @@ TEST_CASE("do not flood invalid transactions", "[herder]")
     // this will be invalid after tx1r gets applied
     auto tx2r = root.tx({payment(root, 1)});
 
-    herder.recvTransaction(tx1a);
-    herder.recvTransaction(tx1r);
-    herder.recvTransaction(tx2r);
+    herder.recvTransaction(tx1a, false);
+    herder.recvTransaction(tx1r, false);
+    herder.recvTransaction(tx2r, false);
 
     size_t numBroadcast = 0;
     tq.mTxBroadcastedEvent = [&](TransactionFrameBasePtr&) { ++numBroadcast; };
@@ -3056,7 +3056,7 @@ TEST_CASE("do not flood too many transactions", "[herder][transactionqueue]")
                 curFeeOffset--;
             }
 
-            REQUIRE(herder.recvTransaction(tx) ==
+            REQUIRE(herder.recvTransaction(tx, false) ==
                     TransactionQueue::AddResult::ADD_STATUS_PENDING);
             return tx;
         };
@@ -3318,7 +3318,7 @@ TEST_CASE("exclude transactions by operation type", "[herder]")
         auto acc = getAccount("acc");
         auto tx = root.tx({createAccount(acc.getPublicKey(), 1)});
 
-        REQUIRE(app->getHerder().recvTransaction(tx) ==
+        REQUIRE(app->getHerder().recvTransaction(tx, false) ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
     }
 
@@ -3333,7 +3333,7 @@ TEST_CASE("exclude transactions by operation type", "[herder]")
         auto acc = getAccount("acc");
         auto tx = root.tx({createAccount(acc.getPublicKey(), 1)});
 
-        REQUIRE(app->getHerder().recvTransaction(tx) ==
+        REQUIRE(app->getHerder().recvTransaction(tx, false) ==
                 TransactionQueue::AddResult::ADD_STATUS_FILTERED);
     }
 
@@ -3349,7 +3349,7 @@ TEST_CASE("exclude transactions by operation type", "[herder]")
         auto acc = getAccount("acc");
         auto tx = root.tx({createAccount(acc.getPublicKey(), 1)});
 
-        REQUIRE(app->getHerder().recvTransaction(tx) ==
+        REQUIRE(app->getHerder().recvTransaction(tx, false) ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
     }
 }

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -101,7 +101,7 @@ class TransactionQueueTest
     add(TransactionFrameBasePtr const& tx,
         TransactionQueue::AddResult AddResult)
     {
-        REQUIRE(mTransactionQueue.tryAdd(tx) == AddResult);
+        REQUIRE(mTransactionQueue.tryAdd(tx, false) == AddResult);
     }
 
     void
@@ -1147,7 +1147,7 @@ TEST_CASE_VERSIONS("TransactionQueue with PreconditionsV2",
             auto& herder = static_cast<HerderImpl&>(app->getHerder());
             auto& tq = herder.getTransactionQueue();
 
-            REQUIRE(herder.recvTransaction(tx) ==
+            REQUIRE(herder.recvTransaction(tx, false) ==
                     TransactionQueue::AddResult::ADD_STATUS_PENDING);
 
             REQUIRE(tq.toTxSet({})->sizeTx() == 1);
@@ -1407,7 +1407,7 @@ TEST_CASE("transaction queue starting sequence boundary",
         REQUIRE(acc1.loadSequenceNumber() == startingSeq - 1);
 
         TransactionQueue tq(*app, 4, 10, 4);
-        REQUIRE(tq.tryAdd(transaction(*app, acc1, 1, 1, 100)) ==
+        REQUIRE(tq.tryAdd(transaction(*app, acc1, 1, 1, 100), false) ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
 
         auto checkTxSet = [&](uint32_t ledgerSeq) {
@@ -1432,7 +1432,7 @@ TEST_CASE("transaction queue starting sequence boundary",
         TransactionQueue tq(*app, 4, 10, 4);
         for (size_t i = 1; i <= 4; ++i)
         {
-            REQUIRE(tq.tryAdd(transaction(*app, acc1, i, 1, 100)) ==
+            REQUIRE(tq.tryAdd(transaction(*app, acc1, i, 1, 100), false) ==
                     TransactionQueue::AddResult::ADD_STATUS_PENDING);
         }
 
@@ -1923,9 +1923,9 @@ TEST_CASE("remove applied", "[herder][transactionqueue]")
     auto tx3 = root.tx({payment(root, 4)});
     auto tx4 = root.tx({payment(root, 5)});
 
-    herder.recvTransaction(tx1a);
-    herder.recvTransaction(tx2);
-    herder.recvTransaction(tx3);
+    herder.recvTransaction(tx1a, false);
+    herder.recvTransaction(tx2, false);
+    herder.recvTransaction(tx3, false);
 
     {
         auto const& lcl = lm.getLastClosedLedgerHeader();
@@ -1946,7 +1946,7 @@ TEST_CASE("remove applied", "[herder][transactionqueue]")
     }
 
     REQUIRE(tq.toTxSet({})->sizeTx() == 1);
-    REQUIRE(herder.recvTransaction(tx4) ==
+    REQUIRE(herder.recvTransaction(tx4, false) ==
             TransactionQueue::AddResult::ADD_STATUS_PENDING);
     REQUIRE(tq.toTxSet({})->sizeTx() == 2);
 }

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1634,10 +1634,10 @@ TEST_CASE("upgrade to version 13", "[upgrades]")
     auto root = TestAccount::createRoot(*app);
     auto acc = root.create("A", lm.getLastMinBalance(2));
 
-    herder.recvTransaction(root.tx({payment(root, 1)}));
-    herder.recvTransaction(root.tx({payment(root, 2)}));
-    herder.recvTransaction(acc.tx({payment(acc, 1)}));
-    herder.recvTransaction(acc.tx({payment(acc, 2)}));
+    herder.recvTransaction(root.tx({payment(root, 1)}), false);
+    herder.recvTransaction(root.tx({payment(root, 2)}), false);
+    herder.recvTransaction(acc.tx({payment(acc, 1)}), false);
+    herder.recvTransaction(acc.tx({payment(acc, 2)}), false);
 
     auto txSet = herder.getTransactionQueue().toTxSet({});
     for (auto const& tx : txSet->getTxsInHashOrder())

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -683,7 +683,7 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
             // add it to our current set
             // and make sure it is valid
             TransactionQueue::AddResult status =
-                mApp.getHerder().recvTransaction(transaction);
+                mApp.getHerder().recvTransaction(transaction, true);
 
             output << "{"
                    << "\"status\": "
@@ -1008,7 +1008,7 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
             txFrame = fromAccount.tx({payment(toAccount, paymentAmount)});
         }
 
-        auto status = mApp.getHerder().recvTransaction(txFrame);
+        auto status = mApp.getHerder().recvTransaction(txFrame, true);
         root["status"] = TX_STATUS_STRING[static_cast<int>(status)];
         if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1321,7 +1321,7 @@ Peer::recvTransaction(StellarMessage const& msg)
 
         // add it to our current set
         // and make sure it is valid
-        auto recvRes = mApp.getHerder().recvTransaction(transaction);
+        auto recvRes = mApp.getHerder().recvTransaction(transaction, false);
 
         if (!(recvRes == TransactionQueue::AddResult::ADD_STATUS_PENDING ||
               recvRes == TransactionQueue::AddResult::ADD_STATUS_DUPLICATE))

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -152,7 +152,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
 
             // this is basically a modified version of Peer::recvTransaction
             auto msg = tx1->toStellarMessage();
-            auto res = inApp->getHerder().recvTransaction(tx1);
+            auto res = inApp->getHerder().recvTransaction(tx1, false);
             REQUIRE(res == TransactionQueue::AddResult::ADD_STATUS_PENDING);
             inApp->getOverlayManager().broadcastMessage(msg);
         };

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -745,7 +745,7 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
     StellarMessage msg(txf->toStellarMessage());
     txm.mTxnBytes.Mark(xdr::xdr_argpack_size(msg));
 
-    auto status = mApp.getHerder().recvTransaction(txf);
+    auto status = mApp.getHerder().recvTransaction(txf, true);
     if (status != TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
         CLOG_INFO(LoadGen, "tx rejected '{}': {} ===> {}",


### PR DESCRIPTION
Useful for node operators to see how long transactions submitted from their node take before they are accepted into the ledger.