### PR TITLE
re-enable ccache per protocol version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,9 @@ jobs:
         with:
           path: |
             /home/runner/.ccache
-          # we do not include ${{ matrix.protocol }} in this cache key. That flag ultimately causes
-          # an altered -D define, which _does_ cause a ccache direct-mode miss, but only one file
-          # has any difference when preprocessed, so ccache still gets a fallback cpp-mode hit. The
-          # one file that does vary (that compiles-in the protocol version number) is small enough
-          # that we can tolerate a miss and/or hold both versions of it in cache.
-          key: ${{ runner.os }}-${{ matrix.toolchain }}-cacheID-${{ steps.cache_extra_id.outputs.id }}
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-${{ steps.cache_extra_id.outputs.id }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.toolchain }}-cacheID-
+            ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-
       - uses: actions/checkout@v2
         with:
            fetch-depth: 200


### PR DESCRIPTION
I think this was broken when we split curr vs next protocol.

Looking at https://github.com/stellar/stellar-core/actions/runs/2436952384

"current" builds take 14 minutes
"next" builds take 1h+

