### PR TITLE
Don't return error for `test --list-tests` and similar commands.

### DIFF
--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -428,6 +428,14 @@ runTest(CommandLineArgs const& args)
     LOG_INFO(DEFAULT_LOG, "Logging to {}", logFile);
 
     auto r = session.run();
+    // In the 'list' modes Catch returns the number of tests listed. We don't
+    // want to treat this value as and error code.
+    if (session.configData().listTests ||
+        session.configData().listTestNamesOnly ||
+        session.configData().listTags || session.configData().listReporters)
+    {
+        r = 0;
+    }
     gTestRoots.clear();
     clearConfigs();
 


### PR DESCRIPTION
# Description

Catch returns the number of listed tests and we propagate it as an error code. Besides looking confusing, this breaks some plugins that expect `--list-tests` to succeed.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
