### PR TITLE
Bump Cargo.toml to current main head of rs-stellar-contract-env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "stellar-contract-env-common"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=52c55339c72ebe36863fbe249caa427f49d5513c#52c55339c72ebe36863fbe249caa427f49d5513c"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=9a783c26cbc022e0351538a3e9582a58510bc694#9a783c26cbc022e0351538a3e9582a58510bc694"
 dependencies = [
  "static_assertions",
  "stellar-xdr",
@@ -224,7 +224,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-env-host"
 version = "0.0.0"
-source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=52c55339c72ebe36863fbe249caa427f49d5513c#52c55339c72ebe36863fbe249caa427f49d5513c"
+source = "git+https://github.com/stellar/rs-stellar-contract-env?rev=9a783c26cbc022e0351538a3e9582a58510bc694#9a783c26cbc022e0351538a3e9582a58510bc694"
 dependencies = [
  "im-rc",
  "num-bigint",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.0"
-source = "git+https://github.com/graydon/rs-stellar-xdr?rev=3afd455d0f9831d773866b98f538df266474f1bf#3afd455d0f9831d773866b98f538df266474f1bf"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2a8b24c2978303612c49afcf005c1d35c592c97c#2a8b24c2978303612c49afcf005c1d35c592c97c"
 dependencies = [
  "base64",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -12,6 +12,6 @@ log = "0.4.17"
 cxx = "1.0"
 im-rc = "15.0.0"
 base64 = "0.13.0"
-stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "52c55339c72ebe36863fbe249caa427f49d5513c", features = [
+stellar-contract-env-host = { git = "https://github.com/stellar/rs-stellar-contract-env", rev = "9a783c26cbc022e0351538a3e9582a58510bc694", features = [
     "vm",
 ] }


### PR DESCRIPTION
Current master doesn't build because it landed with a reference to a contract-env branch that has subsequently been deleted.