### PR TITLE
Update XDR to include CAP-51 SC types

### DIFF
--- a/src/protocol-next/xdr/Stellar-contract.x
+++ b/src/protocol-next/xdr/Stellar-contract.x
@@ -171,7 +171,7 @@ case SCO_I64:
 case SCO_BINARY:
     opaque bin<SCVAL_LIMIT>;
 case SCO_BIG_INT:
-    SCBigInt bi;
+    SCBigInt bigInt;
 case SCO_HASH:
     SCHash hash;
 case SCO_PUBLIC_KEY:

--- a/src/protocol-next/xdr/Stellar-contract.x
+++ b/src/protocol-next/xdr/Stellar-contract.x
@@ -112,7 +112,10 @@ enum SCObjectType
     SCO_MAP = 1,
     SCO_U64 = 2,
     SCO_I64 = 3,
-    SCO_BINARY = 4
+    SCO_BINARY = 4,
+    SCO_BIG_INT = 5,
+    SCO_HASH = 6,
+    SCO_PUBLIC_KEY = 7
 
     // TODO: add more
 };
@@ -128,6 +131,33 @@ const SCVAL_LIMIT = 256000;
 typedef SCVal SCVec<SCVAL_LIMIT>;
 typedef SCMapEntry SCMap<SCVAL_LIMIT>;
 
+enum SCNumSign
+{
+    NEGATIVE = -1,
+    ZERO = 0,
+    POSITIVE = 1
+};
+
+union SCBigInt switch (SCNumSign sign)
+{
+case ZERO:
+    void;
+case POSITIVE:
+case NEGATIVE:
+    opaque magnitude<256000>;
+};
+
+enum SCHashType
+{
+    SCHASH_SHA256 = 0
+};
+
+union SCHash switch (SCHashType type)
+{
+case SCHASH_SHA256:
+    Hash sha256;
+};
+
 union SCObject switch (SCObjectType type)
 {
 case SCO_VEC:
@@ -140,5 +170,11 @@ case SCO_I64:
     int64 i64;
 case SCO_BINARY:
     opaque bin<SCVAL_LIMIT>;
+case SCO_BIG_INT:
+    SCBigInt bi;
+case SCO_HASH:
+    SCHash hash;
+case SCO_PUBLIC_KEY:
+    PublicKey publicKey;    
 };
 }


### PR DESCRIPTION
# Description

Linked to https://github.com/stellar/rs-stellar-xdr/pull/87
Updates protocol-next/xdr with types proposed in CAP-51
- bigint 
- hash
- publickey

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
