### PR TITLE
Replicate hack for avoiding flex's use of keyword

### DIFF
--- a/src/util/xdrquery/XDRQueryScanner.ll
+++ b/src/util/xdrquery/XDRQueryScanner.ll
@@ -12,6 +12,7 @@
 #else
 #include <unistd.h>
 #endif
+#define register
 
 #include "util/xdrquery/XDRQueryParser.h"
 %}


### PR DESCRIPTION
This just replicates the same hack xdrc uses to work around flex emitting code that uses the ancient `register` keyword, which is now a hard error in C++17: redefine the keyword to nothing.