### PR TITLE
ifdef-BUILD_TESTS-guard a definition to match its declaration.

### DIFF
--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -235,11 +235,13 @@ TxSetFrame::TxSetFrame(bool isGeneralized, Hash const& previousLedgerHash,
 {
 }
 
+#ifdef BUILD_TESTS
 bool
 TxSetFrame::checkValidStructure() const
 {
     return true;
 }
+#endif
 
 TxSetFrame::TxSetFrame(LedgerHeaderHistoryEntry const& lclHeader,
                        Transactions const& txs)


### PR DESCRIPTION
This just fixes a build failure that slipped through -- only triggers when building with `--disable-tests` for a package / release.