### PR TITLE
Do not use the "define register" hack in VS.

### DIFF
--- a/src/util/xdrquery/XDRQueryScanner.ll
+++ b/src/util/xdrquery/XDRQueryScanner.ll
@@ -11,8 +11,8 @@
 #define fileno _fileno
 #else
 #include <unistd.h>
-#endif
 #define register
+#endif
 
 #include "util/xdrquery/XDRQueryParser.h"
 %}


### PR DESCRIPTION
Probably we should not be using this at all, but this at least fixes the VS build.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
