### PR TITLE
Update the CKMS test to make it less flaky

### DIFF
--- a/src/util/test/MetricTests.cpp
+++ b/src/util/test/MetricTests.cpp
@@ -28,6 +28,45 @@ using uniform_u64 = stellar::uniform_int_distribution<uint64_t>;
 // how much data to keep in memory when comparing datasets
 static std::chrono::seconds const sampleCutoff(60 * 5);
 
+void
+sleepTillNextBucketIfNecessary(std::chrono::seconds const& windowSize)
+{
+    // Medida doesn't support any virtual clock.
+    // Therefore, the following tests use the real time.
+    // This makes tests flaky as they will fail when it's too close to the end
+    // of a bucket. For instance, if a test starts at 11:59:59.998, then the
+    // first event it records might go into [11:59:30, 12:00:00] but the next
+    // event might go into [12:00:00, 12:00:30] even if they occur within 0.003
+    // seconds. This function makes sure that we'll be in the first `threshold`
+    // milliseconds of the window.
+
+    auto const threshold = std::chrono::milliseconds(100);
+    for (;;)
+    {
+        auto offset =
+            std::chrono::system_clock::now().time_since_epoch() % windowSize;
+        if (offset < threshold)
+        {
+            break;
+        }
+        // Sleep half of `threshold` until we get to the first `threshold`
+        // milliseconds of the time window.
+        std::this_thread::sleep_for(threshold / 2);
+    }
+}
+void
+sleepAtLeast(std::chrono::seconds const& duration)
+{
+    // By sleeping a shorter amount repeatedly,
+    // we reduce the risk of sleeping too much.
+    auto const threshold = std::chrono::milliseconds(10);
+    auto end = std::chrono::system_clock::now() + duration;
+    while (std::chrono::system_clock::now() < end)
+    {
+        std::this_thread::sleep_for(threshold);
+    }
+}
+
 // Helper for diagnostics.
 void
 printDistribution(std::vector<double> const& dist, size_t nbuckets = 10)
@@ -535,12 +574,13 @@ template <typename Dist, typename... Args>
 void
 testCKMSSample(int const count, Args... args)
 {
-    auto const windowSize = std::chrono::seconds(1);
+    auto const windowSize = std::chrono::seconds(5);
     medida::Histogram hist{medida::SamplingInterface::kCKMS, windowSize};
 
     double const error = 0.001;
     auto const percentiles = {0.5, 0.75, 0.9, 0.99};
 
+    sleepTillNextBucketIfNecessary(windowSize);
     std::vector<int64_t> values;
     values.reserve(count);
     Dist dist(std::forward<Args>(args)...);
@@ -563,9 +603,10 @@ testCKMSSample(int const count, Args... args)
     }
 
     // There is no easy way to fast-forward time in Medida.
-    // We need to wait for 1 second so that the window with `count`
+    // We need to wait for windowSize seconds so that the window with `count`
     // samples are in the previous window, not in the current window.
-    std::this_thread::sleep_for(windowSize);
+    sleepAtLeast(windowSize);
+
     {
         // Now all the samples we added are in the previous window
         // which CKMSSample reports.
@@ -581,7 +622,7 @@ testCKMSSample(int const count, Args... args)
         }
     }
 
-    std::this_thread::sleep_for(windowSize);
+    sleepAtLeast(windowSize);
 
     {
         // Now all the samples are two windows ago.

--- a/src/util/test/MetricTests.cpp
+++ b/src/util/test/MetricTests.cpp
@@ -44,7 +44,9 @@ sleepTillNextBucketIfNecessary(std::chrono::seconds const& windowSize)
     for (;;)
     {
         auto offset =
-            std::chrono::system_clock::now().time_since_epoch() % windowSize;
+            std::chrono::system_clock::now().time_since_epoch() %
+            std::chrono::duration_cast<
+                medida::SystemClock::time_point::duration>(windowSize);
         if (offset < threshold)
         {
             break;


### PR DESCRIPTION
# Description

[7/6: I updated the PR description majorly as the PR itself changed.]

This test has failed at least three times in the past week including [this](https://github.com/stellar/stellar-core/runs/7202154985?check_suite_focus=true) and [this](https://github.com/stellar/stellar-core/runs/7138490703?check_suite_focus=true). After some analysis, there are four issues:

1. The original CKMS implementation doesn't round down a fraction of a second. For instance, if the test starts at 12:00:00.123, then the first time window will be [12:00:00.123, 12:00:30.123] instead of [12:00:00, 12:00:30]. This was fixed by https://github.com/stellar/medida/pull/33.
2. These CKMS tests expect `std::this_thread::sleep_for` to sleep for the exact amount. However, it's possible that we'll sleep longer than that.
3. These CKMS tests use 1 second as a time window, and the test will go wrong if slow executions get us to the next time window unintentionally. 1 second is enough for a fast computer to process `O(10^5)` numbers in the CKMS data structure. However, the CI machine isn't necessarily super fast, and various factors including parallel execution, asan and extra checks may further slow it down. 
4. If the tests start near the end of a time window, we'll unintentionally go to the next bucket.
  Suppose the test starts near the end of a time bucket.
    - 11:59:59.998: The test starts
    - 11:59:59.999: Generate a random number 3, record it.
    - 12:00:00.001: Generate a random number 4, record it.
    - 12:00:00.002: Check the metrics.
    - In a test case like this, the vast majority of the time, {3, 4} would go into the same bucket. However, if the test starts at a weird time like this, 3 and 4 would go into [11:59:30, 12:00:00] and [12:00:00, 12:00:30], respectively.

Issue 2 => I was able to reproduce this by intentionally increasing the sleep duration. This PR addresses this issue by repeatedly sleeping a short amount of time until we have slept the desired amount.
Issue 3 => @graydon was able to reproduce this locally by running this in a loop. This PR increases the time window to 5 seconds. 
Issue 4 => I was able to reproduce this reliably by intentionally waiting until the end of a time window, like 11:59:59.998. (Note that Issue 4 _becomes_ an issue after fixing Issue 1!)

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
