### PR TITLE
Pull-mode flooding

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -498,6 +498,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\SurveyMessageLimiter.cpp" />
     <ClCompile Include="..\..\src\overlay\test\SurveyManagerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\SurveyMessageLimiterTests.cpp" />
+    <ClCompile Include="..\..\src\overlay\test\TxAdvertQueueTests.cpp" />
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\ClaimClaimableBalanceOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\EndSponsoringFutureReservesOpFrame.cpp" />
@@ -729,6 +730,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\test\TCPPeerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TrackerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\Tracker.cpp" />
+    <ClCompile Include="..\..\src\overlay\TxAdvertQueue.cpp" />
     <ClCompile Include="..\..\src\transactions\AllowTrustOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\BumpSequenceOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\ChangeTrustOpFrame.cpp" />
@@ -1062,6 +1064,7 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\TCPPeer.h" />
     <ClInclude Include="..\..\src\overlay\test\LoopbackPeer.h" />
     <ClInclude Include="..\..\src\overlay\Tracker.h" />
+    <ClInclude Include="..\..\src\overlay\TxAdvertQueue.h" />
     <ClInclude Include="..\..\src\process\ProcessManager.h" />
     <ClInclude Include="..\..\src\process\ProcessManagerImpl.h" />
     <ClInclude Include="..\..\src\rust\CppShims.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -981,6 +981,9 @@
     <ClCompile Include="..\..\src\overlay\Tracker.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\overlay\TxAdvertQueue.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\herder\test\QuorumTrackerTests.cpp">
       <Filter>herder\test</Filter>
     </ClCompile>
@@ -1280,6 +1283,9 @@
     </ClCompile>
     <ClCompile Include="..\..\src\transactions\InvokeHostFunctionOpFrame.cpp">
       <Filter>transactions</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\test\TxAdvertQueueTests.cpp">
+      <Filter>overlay\tests</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1938,6 +1944,9 @@
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\Tracker.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\TxAdvertQueue.h">
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\herder\QuorumTracker.h">

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -17,7 +17,7 @@ ARG CC=clang-10
 ARG CXX=clang++-10
 ARG CFLAGS='-O3 -g1 -fno-omit-frame-pointer'
 ARG CXXFLAGS='-O3 -g1 -fno-omit-frame-pointer -stdlib=libc++'
-ARG CONFIGURE_FLAGS
+ARG CONFIGURE_FLAGS='--enable-tracy'
 
 RUN ./autogen.sh
 RUN ./configure CC="${CC}" CXX="${CXX}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" ${CONFIGURE_FLAGS}

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -70,6 +70,7 @@ overlay.async.read                       | meter     | number of async read requ
 overlay.async.write                      | meter     | number of async write requests issued
 overlay.connection.authenticated         | counter   | number of authenticated peers
 overlay.flow-control.percentage          | counter   | percentage of authenticated connections that enable flow control
+overlay.pull-mode.percentage             | counter   | percentage of authenticated connections that enable pull mode
 overlay.connection.latency               | timer     | estimated latency between peers
 overlay.connection.pending               | counter   | number of pending connections
 overlay.delay.async-write                | timer     | time between each message's async write issue and completion
@@ -78,6 +79,13 @@ overlay.error.read                       | meter     | error while receiving a m
 overlay.error.write                      | meter     | error while sending a message
 overlay.fetch.txset                      | timer     | time to complete fetching of a txset
 overlay.fetch.qset                       | timer     | time to complete fetching of a qset
+overlay.flood.advertised                 | meter     | transactions advertised through pull mode
+overlay.flood.demanded                   | meter     | transactions demanded through pull mode
+overlay.flood.fulfilled                  | meter     | demanded transactions fulfilled through pull mode
+overlay.flood.unfulfilled-banned         | meter     | transactions we failed to fulfilled since they are banned
+overlay.flood.unfulfilled-unknown        | meter     | transactions we failed to fulfilled since they are unknown
+overlay.flood.tx-pull-latency            | timer     | time between the first demand and the first time we receive the txn
+overlay.flood.abandoned-demands          | meter     | tx hash pull demands that no peers responded
 overlay.flood.broadcast                  | meter     | message sent as broadcast per peer
 overlay.flood.duplicate_recv             | meter     | number of bytes of flooded messages that have already been received
 overlay.flood.unique_recv                | meter     | number of bytes of flooded messages that have not yet been received
@@ -85,8 +93,8 @@ overlay.inbound.attempt                  | meter     | inbound connection attemp
 overlay.inbound.drop                     | meter     | inbound connection dropped
 overlay.inbound.establish                | meter     | inbound connection established (added to pending)
 overlay.inbound.reject                   | meter     | inbound connection rejected
-overlay.outbound-queue.scp               | timer     | time SCP traffic sits in flow-controlled queues
-overlay.outbound-queue.tx                | timer     | time tx traffic sits in flow-controlled queues
+overlay.outbound-queue.<X>               | timer     | time <X> traffic sits in flow-controlled queues
+overlay.outbound-queue.drop-<X>          | meter     | number of <X> messages dropped from flow-controlled queues
 overlay.item-fetcher.next-peer           | meter     | ask for item past the first one
 overlay.memory.flood-known               | counter   | number of known flooded entries
 overlay.message.broadcast                | meter     | message broadcasted

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -718,6 +718,7 @@ If `compact=false`, then it also returns some extra metrics on each peer such as
             },
            "id" : "sdf1",
            "olver" : 5,
+           "pull_mode": false,
            "ver" : "v9.1.0"
         }
      ],
@@ -735,6 +736,7 @@ If `compact=false`, then it also returns some extra metrics on each peer such as
           },
           "id" : "sdf2",
           "olver" : 5,
+          "pull_mode": true,
           "ver" : "v9.1.0"
        },
        {
@@ -750,6 +752,7 @@ If `compact=false`, then it also returns some extra metrics on each peer such as
           },
           "id" : "sdf3",
           "olver" : 5,
+          "pull_mode": true,
           "ver" : "v9.1.0"
         }
      ]

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -164,6 +164,25 @@ FLOOD_ARB_TX_BASE_ALLOWANCE = 5
 # numbers make for more forceful damping.
 FLOOD_ARB_TX_DAMPING_FACTOR = 0.8
 
+# FLOOD_DEMAND_PERIOD_MS (Integer) default 200
+# Time in milliseconds between pull-mode demands
+FLOOD_DEMAND_PERIOD_MS = 200
+
+# FLOOD_ADVERT_PERIOD_MS (Integer) default 100
+# Time in milliseconds between pull-mode adverts
+FLOOD_ADVERT_PERIOD_MS = 100
+
+# FLOOD_DEMAND_BACKOFF_DELAY_MS (Integer) default 500
+# Time in milliseconds used for the linear-backoff strategy
+# in pull mode. The n-th demand will be made n * FLOOD_DEMAND_BACKOFF_DELAY_MS
+# ms after the (n-1)th demand.
+FLOOD_DEMAND_BACKOFF_DELAY_MS = 500
+
+# ENABLE_PULL_MODE (bool) default false
+# Determines whether to flood txns lazily by first flooding their hashes.
+# Will use lazy flooding only if both sides have pull mode enabled.
+ENABLE_PULL_MODE = false
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -190,5 +190,9 @@ class Herder
                                                     bool fullKeys) = 0;
     virtual QuorumTracker::QuorumMap const&
     getCurrentlyTrackedQuorum() const = 0;
+
+    virtual size_t getMaxQueueSizeOps() const = 0;
+    virtual bool isBannedTx(Hash const& hash) const = 0;
+    virtual TransactionFrameBaseConstPtr getTx(Hash const& hash) const = 0;
 };
 }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1982,4 +1982,22 @@ HerderImpl::isNewerNominationOrBallotSt(SCPStatement const& oldSt,
     return getSCP().isNewerNominationOrBallotSt(oldSt, newSt);
 }
 
+size_t
+HerderImpl::getMaxQueueSizeOps() const
+{
+    return mTransactionQueue.getMaxQueueSizeOps();
+}
+
+bool
+HerderImpl::isBannedTx(Hash const& hash) const
+{
+    return mTransactionQueue.isBanned(hash);
+}
+
+TransactionFrameBaseConstPtr
+HerderImpl::getTx(Hash const& hash) const
+{
+    return mTransactionQueue.getTx(hash);
+}
+
 }

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -179,6 +179,10 @@ class HerderImpl : public Herder
     // helper function to verify SCPValues are signed
     bool verifyStellarValueSignature(StellarValue const& sv);
 
+    size_t getMaxQueueSizeOps() const override;
+    bool isBannedTx(Hash const& hash) const override;
+    TransactionFrameBaseConstPtr getTx(Hash const& hash) const override;
+
   private:
     // return true if values referenced by envelope have a valid close time:
     // * it's within the allowed range (using lcl if possible)

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -142,6 +142,7 @@ class TransactionQueue
 
     size_t countBanned(int index) const;
     bool isBanned(Hash const& hash) const;
+    TransactionFrameBaseConstPtr getTx(Hash const& hash) const;
 
     TxSetFrame::Transactions getTransactions(LedgerHeader const& lcl) const;
 
@@ -156,6 +157,7 @@ class TransactionQueue
     void rebroadcast();
 
     void shutdown();
+    size_t getMaxQueueSizeOps() const;
 
   private:
     /**
@@ -224,6 +226,8 @@ class TransactionQueue
 
     std::unique_ptr<TxQueueLimiter> mTxQueueLimiter;
     UnorderedMap<AssetPair, uint32_t, AssetPairHash> mArbitrageFloodDamping;
+
+    UnorderedMap<Hash, TransactionFrameBasePtr> mKnownTxHashes;
 
     size_t mBroadcastSeed;
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -128,7 +128,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     MAXIMUM_LEDGER_CLOSETIME_DRIFT = 50;
 
     OVERLAY_PROTOCOL_MIN_VERSION = 21;
-    OVERLAY_PROTOCOL_VERSION = 23;
+    OVERLAY_PROTOCOL_VERSION = 24;
 
     VERSION_STR = STELLAR_CORE_VERSION;
 
@@ -196,6 +196,11 @@ Config::Config() : NODE_SEED(SecretKey::random())
     FLOOD_TX_PERIOD_MS = 200;
     FLOOD_ARB_TX_BASE_ALLOWANCE = 5;
     FLOOD_ARB_TX_DAMPING_FACTOR = 0.8;
+
+    FLOOD_DEMAND_PERIOD_MS = std::chrono::milliseconds(200);
+    FLOOD_ADVERT_PERIOD_MS = std::chrono::milliseconds(100);
+    FLOOD_DEMAND_BACKOFF_DELAY_MS = std::chrono::milliseconds(500);
+    ENABLE_PULL_MODE = false;
 
     MAX_BATCH_WRITE_COUNT = 1024;
     MAX_BATCH_WRITE_BYTES = 1 * 1024 * 1024;
@@ -1129,6 +1134,25 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "FLOOD_TX_PERIOD_MS")
             {
                 FLOOD_TX_PERIOD_MS = readInt<int>(item, 1);
+            }
+            else if (item.first == "FLOOD_DEMAND_PERIOD_MS")
+            {
+                FLOOD_DEMAND_PERIOD_MS =
+                    std::chrono::milliseconds(readInt<int>(item, 1));
+            }
+            else if (item.first == "FLOOD_ADVERT_PERIOD_MS")
+            {
+                FLOOD_ADVERT_PERIOD_MS =
+                    std::chrono::milliseconds(readInt<int>(item, 1));
+            }
+            else if (item.first == "FLOOD_DEMAND_BACKOFF_DELAY_MS")
+            {
+                FLOOD_DEMAND_BACKOFF_DELAY_MS =
+                    std::chrono::milliseconds(readInt<int>(item, 1));
+            }
+            else if (item.first == "ENABLE_PULL_MODE")
+            {
+                ENABLE_PULL_MODE = readBool(item);
             }
             else if (item.first == "FLOOD_ARB_TX_BASE_ALLOWANCE")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -244,6 +244,9 @@ class Config : public std::enable_shared_from_this<Config>
     // processes `FLOW_CONTROL_SEND_MORE_BATCH_SIZE` messages
     uint32_t FLOW_CONTROL_SEND_MORE_BATCH_SIZE;
 
+    // Used to flood transactions lazily by first flooding their hashes.
+    bool ENABLE_PULL_MODE;
+
     // A config parameter that allows a node to generate buckets. This should
     // be set to `false` only for testing purposes.
     bool MODE_ENABLES_BUCKETLIST;
@@ -393,6 +396,10 @@ class Config : public std::enable_shared_from_this<Config>
     int FLOOD_TX_PERIOD_MS;
     int32_t FLOOD_ARB_TX_BASE_ALLOWANCE;
     double FLOOD_ARB_TX_DAMPING_FACTOR;
+
+    std::chrono::milliseconds FLOOD_DEMAND_PERIOD_MS;
+    std::chrono::milliseconds FLOOD_ADVERT_PERIOD_MS;
+    std::chrono::milliseconds FLOOD_DEMAND_BACKOFF_DELAY_MS;
     static constexpr size_t const POSSIBLY_PREFERRED_EXTRA = 2;
     static constexpr size_t const REALLY_DEAD_NUM_FAILURES_CUTOFF = 120;
 

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -48,6 +48,7 @@ class Floodgate
     Application& mApp;
     medida::Counter& mFloodMapSize;
     medida::Meter& mSendFromBroadcast;
+    medida::Meter& mMessagesAdvertised;
     bool mShuttingDown;
 
   public:
@@ -60,7 +61,9 @@ class Floodgate
                    Hash& msgID);
 
     // returns true if msg was sent to at least one peer
-    bool broadcast(StellarMessage const& msg, bool force);
+    // The hash required for transactions
+    bool broadcast(StellarMessage const& msg, bool force,
+                   std::optional<Hash> const& hash = std::nullopt);
 
     // returns the list of peers that sent us the item with hash `msgID`
     // NB: `msgID` is the hash of a `StellarMessage`

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -66,8 +66,11 @@ class OverlayManager
 
     // Send a given message to all peers, via the FloodGate.
     // returns true if message was sent to at least one peer
-    virtual bool broadcastMessage(StellarMessage const& msg,
-                                  bool force = false) = 0;
+    // When passing a transaction message,
+    // the hash of TransactionEnvelope must be passed also for pull mode.
+    virtual bool
+    broadcastMessage(StellarMessage const& msg, bool force = false,
+                     std::optional<Hash> const hash = std::nullopt) = 0;
 
     // Make a note in the FloodGate that a given peer has provided us with a
     // given broadcast message, so that it is inhibited from being resent to
@@ -159,6 +162,9 @@ class OverlayManager
     // Return the number of flow-contolled peers
     virtual int64_t getFlowControlPercentage() const = 0;
 
+    // Return the percentage [0,100] of connections with pull-mode enabled
+    virtual int64_t getPullModePercentage() const = 0;
+
     // Attempt to connect to a peer identified by peer address.
     virtual void connectTo(PeerBareAddress const& address) = 0;
 
@@ -188,6 +194,10 @@ class OverlayManager
 
     virtual void updateFloodRecord(StellarMessage const& oldMsg,
                                    StellarMessage const& newMsg) = 0;
+
+    virtual void recordTxPullLatency(Hash const& hash) = 0;
+
+    virtual size_t getMaxAdvertSize() const = 0;
 
     virtual ~OverlayManager()
     {

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1154,7 +1154,7 @@ size_t
 OverlayManagerImpl::getMaxAdvertSize() const
 {
     auto const& cfg = mApp.getConfig();
-    long ledgerCloseTime =
+    auto ledgerCloseTime =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             cfg.getExpectedLedgerCloseTime())
             .count();
@@ -1178,7 +1178,7 @@ size_t
 OverlayManagerImpl::getMaxDemandSize() const
 {
     auto const& cfg = mApp.getConfig();
-    long ledgerCloseTime =
+    auto ledgerCloseTime =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             cfg.getExpectedLedgerCloseTime())
             .count();

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -7,6 +7,8 @@
 #include "crypto/SecretKey.h"
 #include "crypto/ShortHash.h"
 #include "database/Database.h"
+#include "herder/Herder.h"
+#include "ledger/LedgerManager.h"
 #include "lib/util/stdrandom.h"
 #include "main/Application.h"
 #include "main/Config.h"
@@ -40,6 +42,10 @@ using namespace std;
 
 constexpr std::chrono::seconds PEER_IP_RESOLVE_DELAY(600);
 constexpr std::chrono::seconds PEER_IP_RESOLVE_RETRY_DELAY(10);
+// Regardless of the number of failed attempts &
+// FLOOD_DEMAND_BACKOFF_DELAY_MS it doesn't make much sense to wait much
+// longer than 2 seconds between re-issuing demands.
+constexpr std::chrono::seconds MAX_DELAY_DEMAND{2};
 
 OverlayManagerImpl::PeersList::PeersList(
     OverlayManagerImpl& overlayManager,
@@ -268,6 +274,7 @@ OverlayManagerImpl::OverlayManagerImpl(Application& app)
     , mPeerIPTimer(app)
     , mFloodGate(app)
     , mSurveyManager(make_shared<SurveyManager>(app))
+    , mDemandTimer(app)
     , mResolvingPeersWithBackoff(true)
     , mResolvingPeersRetryCount(0)
 
@@ -300,6 +307,11 @@ OverlayManagerImpl::start()
                 tick();
             },
             VirtualTimer::onFailureNoop);
+    }
+    if (mApp.getConfig().ENABLE_PULL_MODE)
+    {
+        // Start demanding.
+        demand();
     }
 }
 
@@ -675,6 +687,7 @@ OverlayManagerImpl::updateSizeCounters()
     mOverlayMetrics.mAuthenticatedPeersSize.set_count(
         getAuthenticatedPeersCount());
     mOverlayMetrics.mFlowControlPercent.set_count(getFlowControlPercentage());
+    mOverlayMetrics.mPullModePercent.set_count(getPullModePercentage());
 }
 
 void
@@ -857,6 +870,24 @@ OverlayManagerImpl::getFlowControlPercentage() const
     return std::llround(pct);
 }
 
+int64_t
+OverlayManagerImpl::getPullModePercentage() const
+{
+    auto allPeers = getAuthenticatedPeers();
+    if (allPeers.empty())
+    {
+        return 0;
+    }
+
+    auto pullModeCount =
+        std::count_if(allPeers.begin(), allPeers.end(), [&](auto const& item) {
+            return item.second->isPullModeEnabled();
+        });
+
+    auto pct = static_cast<double>(pullModeCount) / allPeers.size() * 100;
+    return std::llround(pct);
+}
+
 int
 OverlayManagerImpl::getAuthenticatedPeersCount() const
 {
@@ -893,9 +924,9 @@ OverlayManagerImpl::isPreferred(Peer* peer) const
 bool
 OverlayManagerImpl::isFloodMessage(StellarMessage const& msg)
 {
-    return msg.type() == SCP_MESSAGE || msg.type() == TRANSACTION;
+    return msg.type() == SCP_MESSAGE || msg.type() == TRANSACTION ||
+           msg.type() == FLOOD_DEMAND || msg.type() == FLOOD_ADVERT;
 }
-
 std::vector<Peer::pointer>
 OverlayManagerImpl::getRandomAuthenticatedPeers()
 {
@@ -962,10 +993,11 @@ OverlayManagerImpl::forgetFloodedMsg(Hash const& msgID)
 }
 
 bool
-OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force)
+OverlayManagerImpl::broadcastMessage(StellarMessage const& msg, bool force,
+                                     std::optional<Hash> const hash)
 {
     ZoneScoped;
-    auto res = mFloodGate.broadcast(msg, force);
+    auto res = mFloodGate.broadcast(msg, force, hash);
     if (res)
     {
         mOverlayMetrics.mMessagesBroadcast.Mark();
@@ -1021,6 +1053,8 @@ OverlayManagerImpl::shutdown()
     mFloodGate.shutdown();
     mInboundPeers.shutdown();
     mOutboundPeers.shutdown();
+
+    mDemandTimer.cancel();
 
     // Stop ticking and resolving peers
     mTimer.cancel();
@@ -1115,4 +1149,222 @@ OverlayManagerImpl::updateFloodRecord(StellarMessage const& oldMsg,
     ZoneScoped;
     mFloodGate.updateRecord(oldMsg, newMsg);
 }
+
+size_t
+OverlayManagerImpl::getMaxAdvertSize() const
+{
+    auto const& cfg = mApp.getConfig();
+    long ledgerCloseTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            cfg.getExpectedLedgerCloseTime())
+            .count();
+    double opRatePerLedger = cfg.FLOOD_OP_RATE_PER_LEDGER;
+    size_t maxOps = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+    double opsToFloodPerLedgerDbl =
+        opRatePerLedger * static_cast<double>(maxOps);
+    releaseAssertOrThrow(opsToFloodPerLedgerDbl >= 0.0);
+    int64_t opsToFloodPerLedger = static_cast<int64_t>(opsToFloodPerLedgerDbl);
+
+    size_t res = static_cast<size_t>(bigDivideOrThrow(
+        opsToFloodPerLedger, cfg.FLOOD_ADVERT_PERIOD_MS.count(),
+        ledgerCloseTime, Rounding::ROUND_UP));
+
+    res = std::max<size_t>(1, res);
+    res = std::min<size_t>(TX_ADVERT_VECTOR_MAX_SIZE, res);
+    return res;
+}
+
+size_t
+OverlayManagerImpl::getMaxDemandSize() const
+{
+    auto const& cfg = mApp.getConfig();
+    long ledgerCloseTime =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            cfg.getExpectedLedgerCloseTime())
+            .count();
+    double opRatePerLedger = cfg.FLOOD_OP_RATE_PER_LEDGER;
+    double queueSizeInOpsDbl =
+        static_cast<double>(mApp.getHerder().getMaxQueueSizeOps()) *
+        opRatePerLedger;
+    releaseAssertOrThrow(queueSizeInOpsDbl >= 0.0);
+    int64_t queueSizeInOps = static_cast<int64_t>(queueSizeInOpsDbl);
+
+    size_t res = static_cast<size_t>(
+        bigDivideOrThrow(queueSizeInOps, cfg.FLOOD_DEMAND_PERIOD_MS.count(),
+                         ledgerCloseTime, Rounding::ROUND_UP));
+    res = std::max<size_t>(1, res);
+    res = std::min<size_t>(TX_DEMAND_VECTOR_MAX_SIZE, res);
+    return res;
+}
+
+void
+OverlayManagerImpl::recordTxPullLatency(Hash const& hash)
+{
+    auto it = mDemandHistoryMap.find(hash);
+    if (it != mDemandHistoryMap.end() && !it->second.latencyRecorded)
+    {
+        auto delta = mApp.getClock().now() - it->second.firstDemanded;
+        mOverlayMetrics.mTxPullLatency.Update(delta);
+        it->second.latencyRecorded = true;
+    }
+}
+
+std::chrono::milliseconds
+OverlayManagerImpl::retryDelayDemand(int numAttemptsMade) const
+{
+    auto res = numAttemptsMade * mApp.getConfig().FLOOD_DEMAND_BACKOFF_DELAY_MS;
+    return std::min(res, std::chrono::milliseconds(MAX_DELAY_DEMAND));
+}
+
+OverlayManagerImpl::DemandStatus
+OverlayManagerImpl::demandStatus(Hash const& txHash, Peer::pointer peer) const
+{
+    if (mApp.getHerder().isBannedTx(txHash) ||
+        mApp.getHerder().getTx(txHash) != nullptr)
+    {
+        return DemandStatus::DISCARD;
+    }
+    auto it = mDemandHistoryMap.find(txHash);
+    if (it == mDemandHistoryMap.end())
+    {
+        // never demanded
+        return DemandStatus::DEMAND;
+    }
+    auto& demandedPeers = it->second.peers;
+    if (demandedPeers.find(peer->getPeerID()) != demandedPeers.end())
+    {
+        // We've already demanded.
+        return DemandStatus::DISCARD;
+    }
+    int const numDemanded = static_cast<int>(demandedPeers.size());
+    auto const lastDemanded = it->second.lastDemanded;
+
+    if (numDemanded < MAX_RETRY_COUNT)
+    {
+        // Check if it's been a while since our last demand
+        if ((mApp.getClock().now() - lastDemanded) >=
+            retryDelayDemand(numDemanded))
+        {
+            return DemandStatus::DEMAND;
+        }
+        else
+        {
+            return DemandStatus::RETRY_LATER;
+        }
+    }
+    return DemandStatus::DISCARD;
+}
+
+void
+OverlayManagerImpl::demand()
+{
+    ZoneScoped;
+    if (mShuttingDown)
+    {
+        return;
+    }
+    auto const now = mApp.getClock().now();
+
+    // We determine that demands are obsolete after maxRetention.
+    auto maxRetention = MAX_DELAY_DEMAND * MAX_RETRY_COUNT * 2;
+    while (!mPendingDemands.empty())
+    {
+        auto const& it = mDemandHistoryMap.find(mPendingDemands.front());
+        if ((now - it->second.firstDemanded) >= maxRetention)
+        {
+            if (!it->second.latencyRecorded)
+            {
+                // We never received the txn.
+                mOverlayMetrics.mAbandonedDemandMeter.Mark();
+            }
+            mPendingDemands.pop();
+            mDemandHistoryMap.erase(it);
+        }
+        else
+        {
+            // The oldest demand in mPendingDemands isn't old enough
+            // to be deleted from our record.
+            break;
+        }
+    }
+
+    auto authenticatedPeers = getAuthenticatedPeers();
+    std::vector<Peer::pointer> pullModePeers;
+    for (auto const& peer : authenticatedPeers)
+    {
+        if (peer.second->isPullModeEnabled())
+        {
+            pullModePeers.push_back(peer.second);
+        }
+    }
+    stellar::shuffle(pullModePeers.begin(), pullModePeers.end(), gRandomEngine);
+
+    auto const& cfg = mApp.getConfig();
+
+    UnorderedMap<Peer::pointer, std::pair<TxDemandVector, std::list<Hash>>>
+        demandMap;
+    bool anyNewDemand = false;
+    do
+    {
+        anyNewDemand = false;
+        for (auto const& peer : pullModePeers)
+        {
+            auto& demPair = demandMap[peer];
+            auto& demand = demPair.first;
+            auto& retry = demPair.second;
+            bool addedNewDemand = false;
+            while (demand.size() < getMaxDemandSize() &&
+                   peer->getTxAdvertQueue().size() > 0 && !addedNewDemand)
+            {
+                auto txHash = peer->getTxAdvertQueue().pop();
+
+                switch (demandStatus(txHash, peer))
+                {
+                case DemandStatus::DEMAND:
+                    demand.push_back(txHash);
+                    if (mDemandHistoryMap.find(txHash) ==
+                        mDemandHistoryMap.end())
+                    {
+                        // We don't have any pending demand record of this tx
+                        // hash.
+                        mPendingDemands.push(txHash);
+                        mDemandHistoryMap[txHash].firstDemanded = now;
+                    }
+                    mDemandHistoryMap[txHash].peers.insert(peer->getPeerID());
+                    mDemandHistoryMap[txHash].lastDemanded = now;
+                    addedNewDemand = true;
+                    break;
+                case DemandStatus::RETRY_LATER:
+                    retry.push_back(txHash);
+                    break;
+                case DemandStatus::DISCARD:
+                    break;
+                }
+            }
+            anyNewDemand |= addedNewDemand;
+        }
+    } while (anyNewDemand);
+
+    for (auto const& peer : pullModePeers)
+    {
+        // We move `demand` here and also pass `retry` as a reference
+        // which gets appended. Don't touch `demand` or `retry` after here.
+        peer->sendTxDemand(std::move(demandMap[peer].first));
+        peer->getTxAdvertQueue().appendHashesToRetryAndMaybeTrim(
+            demandMap[peer].second);
+    }
+
+    // mPendingDemands and mDemandHistoryMap must always contain exactly the
+    // same tx hashes.
+    releaseAssert(mPendingDemands.size() == mDemandHistoryMap.size());
+
+    mDemandTimer.expires_from_now(cfg.FLOOD_DEMAND_PERIOD_MS);
+    mDemandTimer.async_wait([this](asio::error_code const& error) {
+        if (!error)
+        {
+            this->demand();
+        }
+    });
+}
+
 }

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -95,6 +95,35 @@ class OverlayManagerImpl : public OverlayManager
 
     std::shared_ptr<SurveyManager> mSurveyManager;
 
+    // This gets called once when starting
+    // and it continues to call itself every FLOOD_DEMAND_PERIOD_MS.
+    void demand();
+    VirtualTimer mDemandTimer;
+    struct DemandHistory
+    {
+        VirtualClock::time_point firstDemanded;
+        VirtualClock::time_point lastDemanded;
+        UnorderedSet<NodeID> peers;
+        bool latencyRecorded{false};
+    };
+    UnorderedMap<Hash, DemandHistory> mDemandHistoryMap;
+
+    std::queue<Hash> mPendingDemands;
+    enum class DemandStatus
+    {
+        DEMAND,      // Demand
+        RETRY_LATER, // The timer hasn't expired, and we need to come back to
+                     // this.
+        DISCARD      // We should never demand this txn from this peer.
+    };
+    DemandStatus demandStatus(Hash const& txHash, Peer::pointer) const;
+
+    // After `MAX_RETRY_COUNT` attempts with linear back-off, we assume that
+    // no one has the transaction.
+    int const MAX_RETRY_COUNT = 15;
+    std::chrono::milliseconds retryDelayDemand(int numAttemptsMade) const;
+    size_t getMaxDemandSize() const;
+
   public:
     OverlayManagerImpl(Application& app);
     ~OverlayManagerImpl();
@@ -103,8 +132,9 @@ class OverlayManagerImpl : public OverlayManager
     bool recvFloodedMsgID(StellarMessage const& msg, Peer::pointer peer,
                           Hash& msgID) override;
     void forgetFloodedMsg(Hash const& msgID) override;
-    bool broadcastMessage(StellarMessage const& msg,
-                          bool force = false) override;
+    bool
+    broadcastMessage(StellarMessage const& msg, bool force = false,
+                     std::optional<Hash> const hash = std::nullopt) override;
     void connectTo(PeerBareAddress const& address) override;
 
     void addInboundConnection(Peer::pointer peer) override;
@@ -127,6 +157,7 @@ class OverlayManagerImpl : public OverlayManager
     std::map<NodeID, Peer::pointer> getAuthenticatedPeers() const override;
     int getAuthenticatedPeersCount() const override;
     int64_t getFlowControlPercentage() const override;
+    int64_t getPullModePercentage() const override;
 
     // returns nullptr if the passed peer isn't found
     Peer::pointer getConnectedPeer(PeerBareAddress const& address) override;
@@ -154,6 +185,9 @@ class OverlayManagerImpl : public OverlayManager
 
     void updateFloodRecord(StellarMessage const& oldMsg,
                            StellarMessage const& newMsg) override;
+
+    void recordTxPullLatency(Hash const& hash) override;
+    size_t getMaxAdvertSize() const override;
 
   private:
     struct ResolvedPeers

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -73,6 +73,12 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "recv", "survey-request"}))
     , mRecvSurveyResponseTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "survey-response"}))
+
+    , mRecvFloodAdvertTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "flood-advert"}))
+    , mRecvFloodDemandTimer(
+          app.getMetrics().NewTimer({"overlay", "recv", "flood-demand"}))
+
     , mMessageDelayInWriteQueueTimer(
           app.getMetrics().NewTimer({"overlay", "delay", "write-queue"}))
     , mMessageDelayInAsyncWriteTimer(
@@ -81,7 +87,19 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "outbound-queue", "scp"}))
     , mOutboundQueueDelayTxs(
           app.getMetrics().NewTimer({"overlay", "outbound-queue", "tx"}))
+    , mOutboundQueueDelayAdvert(
+          app.getMetrics().NewTimer({"overlay", "outbound-queue", "advert"}))
+    , mOutboundQueueDelayDemand(
+          app.getMetrics().NewTimer({"overlay", "outbound-queue", "demand"}))
 
+    , mOutboundQueueDropSCP(app.getMetrics().NewMeter(
+          {"overlay", "outbound-queue", "drop-scp"}, "message"))
+    , mOutboundQueueDropTxs(app.getMetrics().NewMeter(
+          {"overlay", "outbound-queue", "drop-tx"}, "message"))
+    , mOutboundQueueDropAdvert(app.getMetrics().NewMeter(
+          {"overlay", "outbound-queue", "drop-advert"}, "message"))
+    , mOutboundQueueDropDemand(app.getMetrics().NewMeter(
+          {"overlay", "outbound-queue", "drop-demand"}, "message"))
     , mSendErrorMeter(
           app.getMetrics().NewMeter({"overlay", "send", "error"}, "message"))
     , mSendHelloMeter(
@@ -114,6 +132,22 @@ OverlayMetrics::OverlayMetrics(Application& app)
           {"overlay", "send", "survey-request"}, "message"))
     , mSendSurveyResponseMeter(app.getMetrics().NewMeter(
           {"overlay", "send", "survey-response"}, "message"))
+    , mSendFloodAdvertMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "flood-advert"}, "message"))
+    , mSendFloodDemandMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "flood-demand"}, "message"))
+    , mMessagesDemanded(app.getMetrics().NewMeter(
+          {"overlay", "flood", "demanded"}, "message"))
+    , mMessagesFulfilledMeter(app.getMetrics().NewMeter(
+          {"overlay", "flood", "fulfilled"}, "message"))
+    , mBannedMessageUnfulfilledMeter(app.getMetrics().NewMeter(
+          {"overlay", "flood", "unfulfilled-banned"}, "message"))
+    , mUnknownMessageUnfulfilledMeter(app.getMetrics().NewMeter(
+          {"overlay", "flood", "unfulfilled-unknown"}, "message"))
+    , mTxPullLatency(
+          app.getMetrics().NewTimer({"overlay", "flood", "tx-pull-latency"}))
+    , mAbandonedDemandMeter(app.getMetrics().NewMeter(
+          {"overlay", "flood", "abandoned-demands"}, "message"))
     , mMessagesBroadcast(app.getMetrics().NewMeter(
           {"overlay", "message", "broadcast"}, "message"))
     , mPendingPeersSize(
@@ -122,6 +156,8 @@ OverlayMetrics::OverlayMetrics(Application& app)
           {"overlay", "connection", "authenticated"}))
     , mFlowControlPercent(app.getMetrics().NewCounter(
           {"overlay", "flow-control", "percentage"}))
+    , mPullModePercent(
+          app.getMetrics().NewCounter({"overlay", "pull-mode", "percentage"}))
     , mUniqueFloodBytesRecv(app.getMetrics().NewMeter(
           {"overlay", "flood", "unique-recv"}, "byte"))
     , mDuplicateFloodBytesRecv(app.getMetrics().NewMeter(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -60,11 +60,20 @@ struct OverlayMetrics
     medida::Timer& mRecvSurveyRequestTimer;
     medida::Timer& mRecvSurveyResponseTimer;
 
+    medida::Timer& mRecvFloodAdvertTimer;
+    medida::Timer& mRecvFloodDemandTimer;
+
     medida::Timer& mMessageDelayInWriteQueueTimer;
     medida::Timer& mMessageDelayInAsyncWriteTimer;
 
     medida::Timer& mOutboundQueueDelaySCP;
     medida::Timer& mOutboundQueueDelayTxs;
+    medida::Timer& mOutboundQueueDelayAdvert;
+    medida::Timer& mOutboundQueueDelayDemand;
+    medida::Meter& mOutboundQueueDropSCP;
+    medida::Meter& mOutboundQueueDropTxs;
+    medida::Meter& mOutboundQueueDropAdvert;
+    medida::Meter& mOutboundQueueDropDemand;
 
     medida::Meter& mSendErrorMeter;
     medida::Meter& mSendHelloMeter;
@@ -84,10 +93,20 @@ struct OverlayMetrics
     medida::Meter& mSendSurveyRequestMeter;
     medida::Meter& mSendSurveyResponseMeter;
 
+    medida::Meter& mSendFloodAdvertMeter;
+    medida::Meter& mSendFloodDemandMeter;
+    medida::Meter& mMessagesDemanded;
+    medida::Meter& mMessagesFulfilledMeter;
+    medida::Meter& mBannedMessageUnfulfilledMeter;
+    medida::Meter& mUnknownMessageUnfulfilledMeter;
+    medida::Timer& mTxPullLatency;
+    medida::Meter& mAbandonedDemandMeter;
+
     medida::Meter& mMessagesBroadcast;
     medida::Counter& mPendingPeersSize;
     medida::Counter& mAuthenticatedPeersSize;
     medida::Counter& mFlowControlPercent;
+    medida::Counter& mPullModePercent;
 
     medida::Meter& mUniqueFloodBytesRecv;
     medida::Meter& mDuplicateFloodBytesRecv;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1033,7 +1033,6 @@ Peer::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
     {
         msgQInd = 2;
         size_t s = msg->floodDemand().txHashes.size();
-        releaseAssert(s <= INT32_MAX - mDemandQueueTxHashCount);
         mDemandQueueTxHashCount += s;
     }
     break;
@@ -1041,7 +1040,6 @@ Peer::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
     {
         msgQInd = 3;
         size_t s = msg->floodAdvert().txHashes.size();
-        releaseAssert(s <= INT32_MAX - mAdvertQueueTxHashCount);
         mAdvertQueueTxHashCount += s;
     }
     break;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -2106,6 +2106,8 @@ Peer::sendTxDemand(TxDemandVector&& demands)
         CLOG_TRACE(Overlay, "Peer::sendTxDemand -- demanding {} txns from {}",
                    msg->floodDemand().txHashes.size(),
                    mApp.getConfig().toShortString(getPeerID()));
+        getOverlayMetrics().mMessagesDemanded.Mark(
+            msg->floodDemand().txHashes.size());
         mApp.postOnMainThread(
             [weak, msg = std::move(msg)]() {
                 auto strong = weak.lock();
@@ -2115,7 +2117,6 @@ Peer::sendTxDemand(TxDemandVector&& demands)
                 }
             },
             "sendTxDemand");
-        getOverlayMetrics().mMessagesDemanded.Mark(demands.size());
         ++mPeerMetrics.mTxDemandSent;
     }
 }

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -66,6 +66,8 @@ Peer::Peer(Application& app, PeerRole role)
     , mFlowControlState(Peer::FlowControlState::DONT_KNOW)
     , mCapacity{app.getConfig().PEER_FLOOD_READING_CAPACITY,
                 app.getConfig().PEER_READING_CAPACITY}
+    , mTxAdvertQueue(app)
+    , mAdvertTimer(app)
 {
     mPingSentTime = PING_NOT_SENT;
     mLastPing = std::chrono::hours(24); // some default very high value
@@ -300,6 +302,12 @@ Peer::getFlowControlJsonInfo(bool compact) const
         res["outbound_queue_delay_txs_p75"] = static_cast<Json::UInt64>(
             mPeerMetrics.mOutboundQueueDelayTxs.GetSnapshot()
                 .get75thPercentile());
+        res["outbound_queue_delay_advert_p75"] = static_cast<Json::UInt64>(
+            mPeerMetrics.mOutboundQueueDelayAdvert.GetSnapshot()
+                .get75thPercentile());
+        res["outbound_queue_delay_demand_p75"] = static_cast<Json::UInt64>(
+            mPeerMetrics.mOutboundQueueDelayDemand.GetSnapshot()
+                .get75thPercentile());
     }
 
     return res;
@@ -315,6 +323,7 @@ Peer::getJsonInfo(bool compact) const
     res["ver"] = getRemoteVersion();
     res["olver"] = (int)getRemoteOverlayVersion();
     res["flow_control"] = getFlowControlJsonInfo(compact);
+    res["pull_mode"] = isPullModeEnabled();
     if (!compact)
     {
         res["message_read"] =
@@ -357,6 +366,10 @@ Peer::sendAuth()
     ZoneScoped;
     StellarMessage msg;
     msg.type(AUTH);
+    if (mApp.getConfig().ENABLE_PULL_MODE)
+    {
+        msg.auth().flags = AUTH_MSG_FLAG_PULL_MODE_REQUESTED;
+    }
     auto msgPtr = std::make_shared<StellarMessage const>(msg);
     sendMessage(msgPtr);
 }
@@ -365,6 +378,18 @@ std::string const&
 Peer::toString()
 {
     return mAddress.toString();
+}
+
+void
+Peer::shutdown()
+{
+    if (mShuttingDown)
+    {
+        return;
+    }
+    mShuttingDown = true;
+    mRecurringTimer.cancel();
+    mAdvertTimer.cancel();
 }
 
 void
@@ -566,6 +591,10 @@ Peer::msgSummary(StellarMessage const& msg)
         return SurveyManager::getMsgSummary(msg);
     case SEND_MORE:
         return "SENDMORE";
+    case FLOOD_ADVERT:
+        return "FLODADVERT";
+    case FLOOD_DEMAND:
+        return "FLOODDEMAND";
     }
     return "UNKNOWN";
 }
@@ -643,6 +672,12 @@ Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
         break;
     case SEND_MORE:
         getOverlayMetrics().mSendSendMoreMeter.Mark();
+        break;
+    case FLOOD_ADVERT:
+        getOverlayMetrics().mSendFloodAdvertMeter.Mark();
+        break;
+    case FLOOD_DEMAND:
+        getOverlayMetrics().mSendFloodDemandMeter.Mark();
         break;
     };
 
@@ -981,18 +1016,52 @@ Peer::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
 
     releaseAssert(msg);
     auto type = msg->type();
-    auto& queue = type == SCP_MESSAGE ? mOutboundQueues[0] : mOutboundQueues[1];
+    size_t msgQInd = 0;
+    switch (type)
+    {
+    case SCP_MESSAGE:
+    {
+        msgQInd = 0;
+    }
+    break;
+    case TRANSACTION:
+    {
+        msgQInd = 1;
+    }
+    break;
+    case FLOOD_DEMAND:
+    {
+        msgQInd = 2;
+        size_t s = msg->floodDemand().txHashes.size();
+        releaseAssert(s <= INT32_MAX - mDemandQueueTxHashCount);
+        mDemandQueueTxHashCount += s;
+    }
+    break;
+    case FLOOD_ADVERT:
+    {
+        msgQInd = 3;
+        size_t s = msg->floodAdvert().txHashes.size();
+        releaseAssert(s <= INT32_MAX - mAdvertQueueTxHashCount);
+        mAdvertQueueTxHashCount += s;
+    }
+    break;
+    default:
+        abort();
+    }
+    auto& queue = mOutboundQueues[msgQInd];
+
     queue.emplace_back(QueuedOutboundMessage{msg, mApp.getClock().now()});
 
     size_t dropped = 0;
 
+    uint32_t const limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
     if (type == TRANSACTION)
     {
-        uint32_t limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
         if (queue.size() > limit)
         {
             dropped = queue.size() - limit;
             queue.erase(queue.begin(), queue.begin() + dropped);
+            getOverlayMetrics().mOutboundQueueDropTxs.Mark(dropped);
         }
     }
     else if (type == SCP_MESSAGE)
@@ -1028,12 +1097,37 @@ Peer::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
                 ++it;
             }
         }
+        getOverlayMetrics().mOutboundQueueDropSCP.Mark(dropped);
+    }
+    else if (type == FLOOD_ADVERT)
+    {
+        while (mAdvertQueueTxHashCount > limit)
+        {
+            dropped++;
+            size_t s = queue.front().mMessage->floodAdvert().txHashes.size();
+            releaseAssert(mAdvertQueueTxHashCount >= s);
+            mAdvertQueueTxHashCount -= s;
+            queue.pop_front();
+        }
+        getOverlayMetrics().mOutboundQueueDropAdvert.Mark(dropped);
+    }
+    else if (type == FLOOD_DEMAND)
+    {
+        while (mDemandQueueTxHashCount > limit)
+        {
+            dropped++;
+            size_t s = queue.front().mMessage->floodDemand().txHashes.size();
+            releaseAssert(mDemandQueueTxHashCount >= s);
+            mDemandQueueTxHashCount -= s;
+            queue.pop_front();
+        }
+        getOverlayMetrics().mOutboundQueueDropDemand.Mark(dropped);
     }
 
     if (dropped && Logging::logTrace("Overlay"))
     {
         CLOG_TRACE(Overlay, "Dropped {} {} messages to peer {}", dropped,
-                   (type == TRANSACTION ? "tx" : "SCP"),
+                   xdr::xdr_traits<MessageType>::enum_name(type),
                    mApp.getConfig().toShortString(getPeerID()));
     }
 }
@@ -1054,16 +1148,44 @@ Peer::maybeSendNextBatch()
             auto& front = queue.front();
             sendAuthenticatedMessage(*(front.mMessage));
             auto& om = mApp.getOverlayManager().getOverlayMetrics();
-            auto& aggregateTimer = front.mMessage->type() == SCP_MESSAGE
-                                       ? om.mOutboundQueueDelaySCP
-                                       : om.mOutboundQueueDelayTxs;
-            auto& peerTimer = front.mMessage->type() == SCP_MESSAGE
-                                  ? mPeerMetrics.mOutboundQueueDelaySCP
-                                  : mPeerMetrics.mOutboundQueueDelayTxs;
+
             auto const& diff = mApp.getClock().now() - front.mTimeEmplaced;
-            aggregateTimer.Update(diff);
-            peerTimer.Update(diff);
             mOutboundCapacity--;
+            switch (front.mMessage->type())
+            {
+            case TRANSACTION:
+            {
+                om.mOutboundQueueDelayTxs.Update(diff);
+                mPeerMetrics.mOutboundQueueDelayTxs.Update(diff);
+            }
+            break;
+            case SCP_MESSAGE:
+            {
+                om.mOutboundQueueDelaySCP.Update(diff);
+                mPeerMetrics.mOutboundQueueDelaySCP.Update(diff);
+            }
+            break;
+            case FLOOD_DEMAND:
+            {
+                om.mOutboundQueueDelayDemand.Update(diff);
+                mPeerMetrics.mOutboundQueueDelayDemand.Update(diff);
+                size_t s = front.mMessage->floodDemand().txHashes.size();
+                releaseAssert(mDemandQueueTxHashCount >= s);
+                mDemandQueueTxHashCount -= s;
+            }
+            break;
+            case FLOOD_ADVERT:
+            {
+                om.mOutboundQueueDelayAdvert.Update(diff);
+                mPeerMetrics.mOutboundQueueDelayAdvert.Update(diff);
+                size_t s = front.mMessage->floodAdvert().txHashes.size();
+                releaseAssert(mAdvertQueueTxHashCount >= s);
+                mAdvertQueueTxHashCount -= s;
+            }
+            break;
+            default:
+                abort();
+            }
             if (mOutboundCapacity == 0)
             {
                 CLOG_DEBUG(Overlay, "No outbound capacity for peer {}",
@@ -1265,6 +1387,19 @@ Peer::recvRawMessage(StellarMessage const& stellarMsg)
         recvSendMore(stellarMsg);
     }
     break;
+
+    case FLOOD_ADVERT:
+    {
+        auto t = getOverlayMetrics().mRecvFloodAdvertTimer.TimeScope();
+        recvFloodAdvert(stellarMsg);
+    }
+    break;
+
+    case FLOOD_DEMAND:
+    {
+        auto t = getOverlayMetrics().mRecvFloodDemandTimer.TimeScope();
+        recvFloodDemand(stellarMsg);
+    }
     }
 }
 
@@ -1366,6 +1501,15 @@ Peer::recvTransaction(StellarMessage const& msg)
         Hash msgID;
         mApp.getOverlayManager().recvFloodedMsgID(msg, shared_from_this(),
                                                   msgID);
+
+        if (isPullModeEnabled())
+        {
+            // It does not make sense to record the latency if the transaction
+            // is coming from a node that we didn't demand it from.
+            // Peers with pull mode enabled should send txns only if demanded.
+            mApp.getOverlayManager().recordTxPullLatency(
+                transaction->getFullHash());
+        }
 
         // add it to our current set
         // and make sure it is valid
@@ -1765,6 +1909,15 @@ Peer::recvAuth(StellarMessage const& msg)
         sendSendMore(mApp.getConfig().PEER_FLOOD_READING_CAPACITY);
     }
 
+    if (mRemoteOverlayVersion >= Peer::FIRST_VERSION_SUPPORTING_PULL_MODE &&
+        mApp.getConfig().OVERLAY_PROTOCOL_VERSION >=
+            Peer::FIRST_VERSION_SUPPORTING_PULL_MODE &&
+        msg.auth().flags == AUTH_MSG_FLAG_PULL_MODE_REQUESTED &&
+        mApp.getConfig().ENABLE_PULL_MODE)
+    {
+        mPullModeEnabled = true;
+    }
+
     // Ask for SCP data _after_ the flow control message
     auto low = mApp.getHerder().getMinLedgerSeqToAskPeers();
     sendGetScpState(low);
@@ -1840,6 +1993,18 @@ Peer::recvSurveyResponseMessage(StellarMessage const& msg)
         msg, shared_from_this());
 }
 
+void
+Peer::recvFloodAdvert(StellarMessage const& msg)
+{
+    mTxAdvertQueue.queueAndMaybeTrim(msg.floodAdvert().txHashes);
+}
+
+void
+Peer::recvFloodDemand(StellarMessage const& msg)
+{
+    fulfillDemand(msg.floodDemand());
+}
+
 Peer::PeerMetrics::PeerMetrics(VirtualClock::time_point connectedTime)
     : mMessageRead(0)
     , mMessageWrite(0)
@@ -1860,6 +2025,12 @@ Peer::PeerMetrics::PeerMetrics(VirtualClock::time_point connectedTime)
     , mOutboundQueueDelayTxs(medida::Timer(PEER_METRICS_DURATION_UNIT,
                                            PEER_METRICS_RATE_UNIT,
                                            PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelayAdvert(medida::Timer(PEER_METRICS_DURATION_UNIT,
+                                              PEER_METRICS_RATE_UNIT,
+                                              PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelayDemand(medida::Timer(PEER_METRICS_DURATION_UNIT,
+                                              PEER_METRICS_RATE_UNIT,
+                                              PEER_METRICS_WINDOW_SIZE))
     , mUniqueFloodBytesRecv(0)
     , mDuplicateFloodBytesRecv(0)
     , mUniqueFetchBytesRecv(0)
@@ -1868,7 +2039,155 @@ Peer::PeerMetrics::PeerMetrics(VirtualClock::time_point connectedTime)
     , mDuplicateFloodMessageRecv(0)
     , mUniqueFetchMessageRecv(0)
     , mDuplicateFetchMessageRecv(0)
+    , mTxHashReceived(0)
     , mConnectedTime(connectedTime)
+    , mMessagesFulfilled(0)
+    , mBannedMessageUnfulfilled(0)
+    , mUnknownMessageUnfulfilled(0)
 {
 }
+
+bool
+Peer::isPullModeEnabled() const
+{
+    return mPullModeEnabled;
+}
+
+void
+Peer::queueTxHashToAdvertise(Hash const& txHash)
+{
+    if (mTxHashesToAdvertise.empty())
+    {
+        startAdvertTimer();
+    }
+
+    if (mTxHashesToAdvertise.size() == TX_ADVERT_VECTOR_MAX_SIZE)
+    {
+        CLOG_TRACE(Overlay,
+                   "mTxHashesToAdvertise is full, dropping the txn hash");
+        return;
+    }
+
+    mTxHashesToAdvertise.emplace_back(txHash);
+
+    // Flush adverts at the earliest of the following two conditions:
+    // 1. The number of hashes reaches the threshold.
+    // 2. The oldest tx hash hash been in the queue for FLOOD_TX_PERIOD_MS.
+    if (mTxHashesToAdvertise.size() ==
+        mApp.getOverlayManager().getMaxAdvertSize())
+    {
+        flushAdvert();
+    }
+}
+
+void
+Peer::startAdvertTimer()
+{
+    if (shouldAbort())
+    {
+        return;
+    }
+    mAdvertTimer.expires_from_now(mApp.getConfig().FLOOD_ADVERT_PERIOD_MS);
+    mAdvertTimer.async_wait([this](asio::error_code const& error) {
+        if (!error)
+        {
+            flushAdvert();
+        }
+    });
+}
+
+void
+Peer::sendTxDemand(TxDemandVector&& demands)
+{
+    if (demands.size() > 0)
+    {
+        auto msg = std::make_shared<StellarMessage>();
+        msg->type(FLOOD_DEMAND);
+        msg->floodDemand().txHashes = std::move(demands);
+        std::weak_ptr<Peer> weak(static_pointer_cast<Peer>(shared_from_this()));
+        CLOG_TRACE(Overlay, "Peer::sendTxDemand -- demanding {} txns from {}",
+                   msg->floodDemand().txHashes.size(),
+                   mApp.getConfig().toShortString(getPeerID()));
+        mApp.postOnMainThread(
+            [weak, msg = std::move(msg)]() {
+                auto strong = weak.lock();
+                if (strong)
+                {
+                    strong->sendMessage(msg);
+                }
+            },
+            "sendTxDemand");
+        getOverlayMetrics().mMessagesDemanded.Mark(demands.size());
+        ++mPeerMetrics.mTxDemandSent;
+    }
+}
+
+void
+Peer::flushAdvert()
+{
+    if (mTxHashesToAdvertise.size() > 0)
+    {
+        StellarMessage adv;
+        adv.type(FLOOD_ADVERT);
+
+        adv.floodAdvert().txHashes = std::move(mTxHashesToAdvertise);
+        mTxHashesToAdvertise.clear();
+        auto msg = std::make_shared<StellarMessage>(adv);
+        std::weak_ptr<Peer> weak(static_pointer_cast<Peer>(shared_from_this()));
+        CLOG_TRACE(Overlay, "Peer::flushAdvert -- flushing {} tx hashes to {}",
+                   msg->floodAdvert().txHashes.size(),
+                   mApp.getConfig().toShortString(getPeerID()));
+        mApp.postOnMainThread(
+            [weak, msg = std::move(msg)]() {
+                auto strong = weak.lock();
+                if (strong)
+                {
+                    strong->sendMessage(msg);
+                }
+            },
+            "flushAdvert");
+    }
+}
+
+void
+Peer::fulfillDemand(FloodDemand const& dmd)
+{
+    ZoneScoped;
+    auto& herder = mApp.getHerder();
+
+    for (auto const& h : dmd.txHashes)
+    {
+        auto tx = herder.getTx(h);
+        if (tx)
+        {
+            // The tx exists
+            CLOG_TRACE(Overlay, "fulfilled demand for {} demanded by {}",
+                       hexAbbrev(h), KeyUtils::toShortString(getPeerID()));
+            mPeerMetrics.mMessagesFulfilled++;
+            getOverlayMetrics().mMessagesFulfilledMeter.Mark();
+            auto smsg =
+                std::make_shared<StellarMessage>(tx->toStellarMessage());
+            sendMessage(smsg);
+        }
+        else
+        {
+            auto banned = herder.isBannedTx(h);
+            CLOG_TRACE(Overlay,
+                       "can't fulfill demand for {} hash {} demanded by {}",
+                       banned ? "banned" : "unknown", hexAbbrev(h),
+                       KeyUtils::toShortString(getPeerID()));
+            if (banned)
+            {
+                getOverlayMetrics().mBannedMessageUnfulfilledMeter.Mark();
+                mPeerMetrics.mBannedMessageUnfulfilled++;
+            }
+            else
+            {
+                getOverlayMetrics().mUnknownMessageUnfulfilledMeter.Mark();
+                mPeerMetrics.mUnknownMessageUnfulfilled++;
+            }
+        }
+    }
+}
+
 }

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -324,8 +324,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     // How many _hashes_ in total are queued?
     // NB: Each advert & demand contains a _vector_ of tx hashes.
-    uint32_t mAdvertQueueTxHashCount{0};
-    uint32_t mDemandQueueTxHashCount{0};
+    size_t mAdvertQueueTxHashCount{0};
+    size_t mDemandQueueTxHashCount{0};
 
     // As of MIN_OVERLAY_VERSION_FOR_FLOOD_ADVERT, peers accumulate an _advert_
     // of flood messages, then periodically flush the advert and await a

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -10,6 +10,7 @@
 #include "medida/timer.h"
 #include "overlay/PeerBareAddress.h"
 #include "overlay/StellarXDR.h"
+#include "overlay/TxAdvertQueue.h"
 #include "util/NonCopyable.h"
 #include "util/Timer.h"
 #include "xdrpp/message.h"
@@ -63,6 +64,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
         std::chrono::milliseconds(1);
     static constexpr std::chrono::nanoseconds PEER_METRICS_RATE_UNIT =
         std::chrono::seconds(1);
+    static constexpr uint32_t FIRST_VERSION_SUPPORTING_PULL_MODE = 24;
+
     // The reporting will be based on the previous
     // PEER_METRICS_WINDOW_SIZE-second time window.
     static constexpr std::chrono::seconds PEER_METRICS_WINDOW_SIZE =
@@ -112,6 +115,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
         medida::Timer mMessageDelayInAsyncWriteTimer;
         medida::Timer mOutboundQueueDelaySCP;
         medida::Timer mOutboundQueueDelayTxs;
+        medida::Timer mOutboundQueueDelayAdvert;
+        medida::Timer mOutboundQueueDelayDemand;
 
         uint64_t mUniqueFloodBytesRecv;
         uint64_t mDuplicateFloodBytesRecv;
@@ -123,7 +128,14 @@ class Peer : public std::enable_shared_from_this<Peer>,
         uint64_t mUniqueFetchMessageRecv;
         uint64_t mDuplicateFetchMessageRecv;
 
+        uint64_t mTxHashReceived;
+        uint64_t mTxDemandSent;
+
         VirtualClock::time_point mConnectedTime;
+
+        uint64_t mMessagesFulfilled;
+        uint64_t mBannedMessageUnfulfilled;
+        uint64_t mUnknownMessageUnfulfilled;
     };
 
     struct TimestampedMessage
@@ -185,7 +197,9 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // Outbound queues indexes by priority
     // Priority 0 - SCP messages
     // Priority 1 - transactions
-    std::array<std::deque<QueuedOutboundMessage>, 2> mOutboundQueues;
+    // Priority 2 - flood demands
+    // Priority 3 - flood adverts
+    std::array<std::deque<QueuedOutboundMessage>, 4> mOutboundQueues;
 
     // This methods drops obsolete load from the outbound queue
     void addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg);
@@ -259,6 +273,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void recvSCPQuorumSet(StellarMessage const& msg);
     void recvSCPMessage(StellarMessage const& msg);
     void recvGetSCPState(StellarMessage const& msg);
+    void recvFloodAdvert(StellarMessage const& msg);
+    void recvFloodDemand(StellarMessage const& msg);
 
     void sendHello();
     void sendAuth();
@@ -303,6 +319,26 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     void maybeSendNextBatch();
 
+    bool mPullModeEnabled{false};
+    TxAdvertQueue mTxAdvertQueue;
+
+    // How many _hashes_ in total are queued?
+    // NB: Each advert & demand contains a _vector_ of tx hashes.
+    uint32_t mAdvertQueueTxHashCount{0};
+    uint32_t mDemandQueueTxHashCount{0};
+
+    // As of MIN_OVERLAY_VERSION_FOR_FLOOD_ADVERT, peers accumulate an _advert_
+    // of flood messages, then periodically flush the advert and await a
+    // _demand_ message with a list of flood messages to send. Adverts are
+    // typically smaller than full messages and batching them means we also
+    // amortize the authentication framing.
+    TxAdvertVector mTxHashesToAdvertise;
+    void flushAdvert();
+    VirtualTimer mAdvertTimer;
+    void startAdvertTimer();
+
+    bool mShuttingDown;
+
   public:
     Peer(Application& app, PeerRole role);
 
@@ -311,6 +347,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     {
         return mApp;
     }
+
+    void shutdown();
 
     std::string msgSummary(StellarMessage const& stellarMsg);
     void sendGetTxSet(uint256 const& setID);
@@ -417,6 +455,17 @@ class Peer : public std::enable_shared_from_this<Peer>,
     virtual ~Peer()
     {
     }
+
+    bool isPullModeEnabled() const;
+    void sendTxDemand(TxDemandVector&& demands);
+    void fulfillDemand(FloodDemand const& dmd);
+    void queueTxHashToAdvertise(Hash const& hash);
+    void queueTxHashAndMaybeTrim(Hash const& hash);
+    TxAdvertQueue&
+    getTxAdvertQueue()
+    {
+        return mTxAdvertQueue;
+    };
 
     friend class LoopbackPeer;
 };

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -97,7 +97,7 @@ TCPPeer::accept(Application& app, shared_ptr<TCPPeer::SocketType> socket)
 TCPPeer::~TCPPeer()
 {
     assertThreadIsMain();
-    mRecurringTimer.cancel();
+    Peer::shutdown();
     if (mSocket)
     {
         // Ignore: this indicates an attempt to cancel events

--- a/src/overlay/TxAdvertQueue.cpp
+++ b/src/overlay/TxAdvertQueue.cpp
@@ -1,0 +1,76 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/TxAdvertQueue.h"
+#include "ledger/LedgerManager.h"
+
+namespace stellar
+{
+
+TxAdvertQueue::TxAdvertQueue(Application& app) : mApp(app)
+{
+}
+
+size_t
+TxAdvertQueue::size() const
+{
+    return mIncomingTxHashes.size() + mTxHashesToRetry.size();
+}
+
+void
+TxAdvertQueue::appendHashesToRetryAndMaybeTrim(std::list<Hash>& list)
+{
+    mTxHashesToRetry.splice(mTxHashesToRetry.end(), list);
+    while (size() > mApp.getLedgerManager().getLastMaxTxSetSizeOps())
+    {
+        pop();
+    }
+}
+
+void
+TxAdvertQueue::queueAndMaybeTrim(TxAdvertVector const& txHashes)
+{
+    auto it = txHashes.begin();
+    size_t const limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+    if (txHashes.size() > limit)
+    {
+        // If txHashes has more than getLastMaxTxSetSizeOps txns, then
+        // the first (txHashes.size() - getLastMaxTxSetSizeOps) txns will be
+        // popped in the while loop below. Therefore, we won't even bother
+        // pushing them.
+        it += txHashes.size() - limit;
+    }
+
+    while (it != txHashes.end())
+    {
+        mIncomingTxHashes.emplace_back(*it);
+        it++;
+    }
+
+    while (size() > limit)
+    {
+        pop();
+    }
+}
+
+Hash
+TxAdvertQueue::pop()
+{
+    releaseAssert(size() > 0);
+
+    if (mTxHashesToRetry.size() > 0)
+    {
+        auto const h = mTxHashesToRetry.front();
+        mTxHashesToRetry.pop_front();
+        return h;
+    }
+    else
+    {
+        auto const h = mIncomingTxHashes.front();
+        mIncomingTxHashes.pop_front();
+        return h;
+    }
+}
+
+}

--- a/src/overlay/TxAdvertQueue.h
+++ b/src/overlay/TxAdvertQueue.h
@@ -1,0 +1,39 @@
+#pragma once
+
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+
+namespace stellar
+{
+
+// TxAdvertQueue class stores and properly trims incoming tx hashes
+// and also maintains retries.
+//
+//
+// When looking for the next tx hash to try,
+// we first check the first element in the retry queue. If the retry
+// queue is empty, then we look at mIncomingTxHashes and pop the first element.
+// Both mIncomingTxHashes and mTxHashesToRetry are FIFO.
+
+class TxAdvertQueue
+{
+  private:
+    Application& mApp;
+
+    std::deque<Hash> mIncomingTxHashes;
+    std::list<Hash> mTxHashesToRetry;
+
+  public:
+    TxAdvertQueue(Application& app);
+
+    size_t size() const;
+
+    Hash pop();
+
+    void queueAndMaybeTrim(TxAdvertVector const& hash);
+    void appendHashesToRetryAndMaybeTrim(std::list<Hash>& list);
+};
+}

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -110,7 +110,7 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction, DropMode)
 
     mDropReason = reason;
     mState = CLOSING;
-    mRecurringTimer.cancel();
+    Peer::shutdown();
     getApp().getOverlayManager().removePeer(this);
 
     auto remote = mRemote.lock();

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -112,7 +112,7 @@ class LoopbackPeer : public Peer
         return mDropReason;
     }
 
-    std::array<std::deque<QueuedOutboundMessage>, 2>&
+    std::array<std::deque<QueuedOutboundMessage>, 4>&
     getQueues()
     {
         return mOutboundQueues;

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -270,15 +270,18 @@ class OverlayManagerTests
                 pm.recvFloodedMsg(AtoB, p.second);
             }
         }
-        pm.broadcastMessage(AtoB);
+        auto broadcastTxnMsg = [&](auto msg) {
+            pm.broadcastMessage(msg, false, xdrSha256(msg.transaction()));
+        };
+        broadcastTxnMsg(AtoB);
         crank(10);
         std::vector<int> expected{1, 1, 0, 1, 1};
         REQUIRE(sentCounts(pm) == expected);
-        pm.broadcastMessage(AtoB);
+        broadcastTxnMsg(AtoB);
         crank(10);
         REQUIRE(sentCounts(pm) == expected);
         StellarMessage CtoD = c.tx({payment(d, 10)})->toStellarMessage();
-        pm.broadcastMessage(CtoD);
+        broadcastTxnMsg(CtoD);
         crank(10);
         std::vector<int> expectedFinal{2, 2, 1, 2, 2};
         REQUIRE(sentCounts(pm) == expectedFinal);
@@ -286,7 +289,7 @@ class OverlayManagerTests
         // Test that we updating a flood record actually prevents re-broadcast
         StellarMessage AtoC = a.tx({payment(c, 10)})->toStellarMessage();
         pm.updateFloodRecord(AtoB, AtoC);
-        pm.broadcastMessage(AtoC);
+        broadcastTxnMsg(AtoC);
         crank(10);
         REQUIRE(sentCounts(pm) == expectedFinal);
     }

--- a/src/overlay/test/TxAdvertQueueTests.cpp
+++ b/src/overlay/test/TxAdvertQueueTests.cpp
@@ -1,0 +1,71 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/LedgerManager.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "overlay/TxAdvertQueue.h"
+#include "test/TestUtils.h"
+#include "test/test.h"
+
+namespace stellar
+{
+TEST_CASE("TxAdvertQueueTests", "[flood][pullmode][acceptance]")
+{
+    VirtualClock clock;
+    Config const& cfg = getTestConfig(0);
+    auto app = createTestApplication(clock, cfg);
+    TxAdvertQueue advertQueue(*app);
+    auto limit = app->getLedgerManager().getLastMaxTxSetSizeOps();
+    auto getHash = [](auto i) { return sha256(std::to_string(i)); };
+
+    std::list<Hash> retry;
+
+    // Check the trimming logic for incoming adverts.
+    TxAdvertVector hashes;
+    for (uint32_t i = 0; i < limit; i++)
+    {
+        hashes.push_back(getHash(i));
+        retry.push_back(getHash(limit + i));
+    }
+    advertQueue.queueAndMaybeTrim(hashes);
+    REQUIRE(advertQueue.size() == limit);
+
+    advertQueue.appendHashesToRetryAndMaybeTrim(retry);
+    REQUIRE(advertQueue.size() == limit);
+
+    for (uint32_t i = 0; i < limit; i++)
+    {
+        // Since the TxAdvertQueue is "FIFO",
+        // the retry hashes gets popped first.
+        // Therefore, we should only have the new hashes.
+        auto h = advertQueue.pop();
+        REQUIRE(h == getHash(i));
+    }
+    REQUIRE(advertQueue.size() == 0);
+    hashes.clear();
+    retry.clear();
+    for (uint32_t i = 0; i < (limit / 2); i++)
+    {
+        hashes.push_back(getHash(i));
+        retry.push_back(getHash(limit + i));
+    }
+    advertQueue.queueAndMaybeTrim(hashes);
+    advertQueue.appendHashesToRetryAndMaybeTrim(retry);
+    REQUIRE(advertQueue.size() == ((limit / 2) * 2));
+    for (uint32_t i = 0; i < limit / 2; i++)
+    {
+        // We pop retry hashes first.
+        auto h = advertQueue.pop();
+        REQUIRE(h == getHash(limit + i));
+    }
+    for (uint32_t i = 0; i < limit / 2; i++)
+    {
+        // We pop new hashes next.
+        auto h = advertQueue.pop();
+        REQUIRE(h == getHash(i));
+    }
+    REQUIRE(advertQueue.size() == 0);
+}
+}

--- a/src/protocol-curr/xdr/Stellar-overlay.x
+++ b/src/protocol-curr/xdr/Stellar-overlay.x
@@ -47,11 +47,20 @@ struct Hello
     uint256 nonce;
 };
 
+
+// During the roll-out phrase, pull mode will be optional.
+// Therefore, we need a way to communicate with other nodes
+// that we want/don't want pull mode.
+// However, the goal is for everyone to enable it by default,
+// so we don't want to introduce a new member variable.
+// For now, we'll use the `flags` field (originally named
+// `unused`) in `Auth`.
+// 100 is just a number that is not 0.
+const AUTH_MSG_FLAG_PULL_MODE_REQUESTED = 100;
+
 struct Auth
 {
-    // Empty message, just to confirm
-    // establishment of MAC keys.
-    int unused;
+    int flags;
 };
 
 enum IPAddrType
@@ -102,7 +111,9 @@ enum MessageType
     SURVEY_REQUEST = 14,
     SURVEY_RESPONSE = 15,
 
-    SEND_MORE = 16
+    SEND_MORE = 16,
+    FLOOD_ADVERT = 18,
+    FLOOD_DEMAND = 19
 };
 
 struct DontHave
@@ -185,6 +196,22 @@ case SURVEY_TOPOLOGY:
     TopologyResponseBody topologyResponseBody;
 };
 
+const TX_ADVERT_VECTOR_MAX_SIZE = 1000;
+typedef Hash TxAdvertVector<TX_ADVERT_VECTOR_MAX_SIZE>;
+
+struct FloodAdvert
+{
+    TxAdvertVector txHashes;
+};
+
+const TX_DEMAND_VECTOR_MAX_SIZE = 1000;
+typedef Hash TxDemandVector<TX_DEMAND_VECTOR_MAX_SIZE>;
+
+struct FloodDemand
+{
+    TxDemandVector txHashes;
+};
+
 union StellarMessage switch (MessageType type)
 {
 case ERROR_MSG:
@@ -227,6 +254,12 @@ case GET_SCP_STATE:
     uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 case SEND_MORE:
     SendMore sendMoreMessage;
+
+// Pull mode
+case FLOOD_ADVERT:
+     FloodAdvert floodAdvert;
+case FLOOD_DEMAND:
+     FloodDemand floodDemand;
 };
 
 union AuthenticatedMessage switch (uint32 v)

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -760,7 +760,8 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
     }
     else
     {
-        mApp.getOverlayManager().broadcastMessage(msg);
+        mApp.getOverlayManager().broadcastMessage(msg, false,
+                                                  txf->getFullHash());
     }
 
     return status;


### PR DESCRIPTION
# Description

Resolves #3384.

Based on https://github.com/stellar/stellar-core/pull/2432. Some differences in the design are:

- Implementation of flow control for adverts and demands
- Use of SHA-256 to hash txns.
- Round-robin when creating demands 


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
