### PR TITLE
Introduce a capability to limit amount of DEX operations in tx sets

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -526,7 +526,6 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\test\SurveyManagerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\SurveyMessageLimiterTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TxAdvertQueueTests.cpp" />
-    <ClCompile Include="..\..\src\overlay\test\OverlayTestUtils.cpp" />
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\ClaimClaimableBalanceOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\EndSponsoringFutureReservesOpFrame.cpp" />

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -185,6 +185,22 @@ FLOOD_DEMAND_BACKOFF_DELAY_MS = 500
 # Will use lazy flooding only if both sides have pull mode enabled.
 ENABLE_PULL_MODE = true
 
+# Maximum allowed number of DEX-related operations in the transaction set.
+#
+# Transaction is considered to have DEX-related operations if it has path
+# payments or manage offer operations.
+#
+# Setting this to non-zero value results in the following:
+# - The node will limit the number of accepted DEX-related transactions
+#   proportional to `MAX_DEX_TX_OPERATIONS_IN_TX_SET / maxTxSetSize`
+#   (ledger header parameter).
+# - The node will broadcast less DEX-related transactions according to the
+#   proportion above.
+# - Starting from protocol 20 the node will nominate TX sets that respect
+#   this limit and potentially have DEX-related transactions surge-priced
+#   against each other.
+MAX_DEX_TX_OPERATIONS_IN_TX_SET = 0
+
 # EXPERIMENTAL_BUCKETLIST_DB (bool) default false
 # Determines whether BucketListDB is used as the primary key-value store
 # for Ledger Entry lookups. Currently experimental, should be set to false.

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -134,22 +134,26 @@ SurgePricingPriorityQueue::TxStackComparator::txLessThan(
     return lx < rx;
 }
 
-SurgePricingPriorityQueue::SurgePricingPriorityQueue(bool isHighestPriority,
-                                                     uint32_t opsLimit,
-                                                     size_t comparisonSeed)
+SurgePricingPriorityQueue::SurgePricingPriorityQueue(
+    bool isHighestPriority, std::shared_ptr<SurgePricingLaneConfig> settings,
+    size_t comparisonSeed)
     : mComparator(isHighestPriority, comparisonSeed)
-    , mOpsLimit(opsLimit)
-    , mOpsCount(0)
-    , mTxStackSet(mComparator)
+    , mLaneConfig(settings)
+    , mLaneOpsLimits(mLaneConfig->getLaneOpsLimits())
+    , mLaneOpsCount(mLaneOpsLimits.size())
+    , mTxStackSets(mLaneOpsLimits.size(), TxStackSet(mComparator))
 {
+    releaseAssert(!mLaneOpsLimits.empty());
 }
 
 std::vector<TransactionFrameBasePtr>
-SurgePricingPriorityQueue::getMostTopTxsWithinLimit(
-    std::vector<TxStackPtr> const& txStacks, uint32_t opsLimit)
+SurgePricingPriorityQueue::getMostTopTxsWithinLimits(
+    std::vector<TxStackPtr> const& txStacks,
+    std::shared_ptr<SurgePricingLaneConfig> laneConfig,
+    std::vector<bool>& hadTxNotFittingLane)
 {
     SurgePricingPriorityQueue queue(
-        /* isHighestPriority */ true, opsLimit,
+        /* isHighestPriority */ true, laneConfig,
         stellar::rand_uniform<size_t>(0, std::numeric_limits<size_t>::max()));
     for (auto txStack : txStacks)
     {
@@ -160,35 +164,39 @@ SurgePricingPriorityQueue::getMostTopTxsWithinLimit(
         txs.push_back(txStack.getTopTx());
         return VisitTxStackResult::TX_PROCESSED;
     };
-    uint32_t opsLeftUntilLimit;
-    queue.popTopTxs(/* allowGaps */ true, visitor, opsLeftUntilLimit);
+    std::vector<uint32_t> laneOpsLeftUntilLimit;
+    queue.popTopTxs(/* allowGaps */ true, visitor, laneOpsLeftUntilLimit,
+                    hadTxNotFittingLane);
     return txs;
 }
 
 void
 SurgePricingPriorityQueue::visitTopTxs(
-    std::vector<TxStackPtr> const& txStacks, uint32_t opsLimit,
-    size_t comparisonSeed,
+    std::vector<TxStackPtr> const& txStacks,
+    std::shared_ptr<SurgePricingLaneConfig> laneConfig, size_t comparisonSeed,
     std::function<VisitTxStackResult(TxStack const&)> const& visitor,
-    uint32_t& opsLeftUntilLimit)
+    std::vector<uint32_t>& laneOpsLeftUntilLimit)
 {
-    SurgePricingPriorityQueue queue(/* isHighestPriority */ true, opsLimit,
+    SurgePricingPriorityQueue queue(/* isHighestPriority */ true, laneConfig,
                                     comparisonSeed);
     for (auto txStack : txStacks)
     {
         queue.add(txStack);
     }
-    queue.popTopTxs(/* allowGaps */ false, visitor, opsLeftUntilLimit);
+    std::vector<bool> hadTxNotFittingLane;
+    queue.popTopTxs(/* allowGaps */ false, visitor, laneOpsLeftUntilLimit,
+                    hadTxNotFittingLane);
 }
 
 void
 SurgePricingPriorityQueue::add(TxStackPtr txStack)
 {
     releaseAssert(txStack != nullptr);
-    bool inserted = mTxStackSet.insert(txStack).second;
+    auto lane = mLaneConfig->getLane(*txStack->getTopTx());
+    bool inserted = mTxStackSets[lane].insert(txStack).second;
     if (inserted)
     {
-        mOpsCount += txStack->getNumOperations();
+        mLaneOpsCount[lane] += txStack->getNumOperations();
     }
 }
 
@@ -196,59 +204,121 @@ void
 SurgePricingPriorityQueue::erase(TxStackPtr txStack)
 {
     releaseAssert(txStack != nullptr);
-    auto it = mTxStackSet.find(txStack);
-    if (it != mTxStackSet.end())
+    auto lane = mLaneConfig->getLane(*txStack->getTopTx());
+    auto it = mTxStackSets[lane].find(txStack);
+    if (it != mTxStackSets[lane].end())
     {
-        erase(it);
+        erase(lane, it);
     }
 }
 
 void
+SurgePricingPriorityQueue::erase(Iterator const& it)
+{
+    auto innerIt = it.getInnerIter();
+    erase(innerIt.first, innerIt.second);
+}
+
+void
 SurgePricingPriorityQueue::erase(
-    SurgePricingPriorityQueue::TxStackSet::iterator iter)
+    size_t lane, SurgePricingPriorityQueue::TxStackSet::iterator iter)
 {
     auto ops = (*iter)->getNumOperations();
-    mOpsCount -= ops;
-    mTxStackSet.erase(iter);
+    mLaneOpsCount[lane] -= ops;
+    mTxStackSets[lane].erase(iter);
 }
 
 void
 SurgePricingPriorityQueue::popTopTxs(
     bool allowGaps,
     std::function<VisitTxStackResult(TxStack const&)> const& visitor,
-    uint32_t& opsLeftUntilLimit)
+    std::vector<uint32_t>& laneOpsLeftUntilLimit,
+    std::vector<bool>& hadTxNotFittingLane)
 {
-    opsLeftUntilLimit = mOpsLimit;
-
-    while (!mTxStackSet.empty())
+    laneOpsLeftUntilLimit = mLaneOpsLimits;
+    hadTxNotFittingLane.assign(mLaneOpsLimits.size(), false);
+    while (true)
     {
         auto currIt = getTop();
-        auto const& currTx = *(*currIt)->getTopTx();
-        auto currOps = currTx.getNumOperations();
-        if (currOps > opsLeftUntilLimit)
+        bool gapSkipped = false;
+        bool canPopSomeTx = true;
+
+        // Try to find a lane in the top iterator that hasn't reached limit yet.
+        while (!currIt.isEnd())
         {
-            if (allowGaps)
+            auto const& currTx = *(*currIt)->getTopTx();
+            auto currOps = currTx.getNumOperations();
+            auto lane = mLaneConfig->getLane(currTx);
+            if (currOps > laneOpsLeftUntilLimit[lane] ||
+                currOps > laneOpsLeftUntilLimit[GENERIC_LANE])
             {
-                erase(currIt);
-                continue;
+                if (allowGaps)
+                {
+                    // If gaps are allowed we just erase the iterator and
+                    // continue in the main loop.
+                    gapSkipped = true;
+                    erase(currIt);
+                    if (currOps > laneOpsLeftUntilLimit[lane])
+                    {
+                        hadTxNotFittingLane[lane] = true;
+                    }
+                    else
+                    {
+                        hadTxNotFittingLane[GENERIC_LANE] = true;
+                    }
+                    break;
+                }
+                else
+                {
+                    // If gaps are not allowed, but we only reach the limit for
+                    // the 'limited' lane, then we still can find some
+                    // transactions in the other lanes that would fit into
+                    // 'generic' and their own lanes.
+                    // We don't break the 'no gaps' invariant by doing so -
+                    // every lane stops being iterated over as soon as
+                    // non-fitting tx is found.
+                    if (lane != GENERIC_LANE &&
+                        currOps > laneOpsLeftUntilLimit[lane])
+                    {
+                        currIt.dropLane();
+                    }
+                    else
+                    {
+                        canPopSomeTx = false;
+                        break;
+                    }
+                }
             }
             else
             {
                 break;
             }
         }
-
+        if (gapSkipped)
+        {
+            continue;
+        }
+        if (!canPopSomeTx || currIt.isEnd())
+        {
+            break;
+        }
         // At this point, `currIt` points at the top transaction in the queue
-        // that is still within operation limits, so we can visit it and remove
-        // it from the queue.
+        // (within the allowed lanes) that is still within operation limits, so
+        // we can visit it and remove it from the queue.
         auto const& txStack = *currIt;
         auto visitRes = visitor(*txStack);
         auto ops = txStack->getTopTx()->getNumOperations();
+        auto lane = mLaneConfig->getLane(*txStack->getTopTx());
         // Only account for operation counts when transaction was actually
         // processed by the visitor.
         if (visitRes == VisitTxStackResult::TX_PROCESSED)
         {
-            opsLeftUntilLimit -= ops;
+            // 'Generic' lane's limit is shared between all the transactions.
+            laneOpsLeftUntilLimit[GENERIC_LANE] -= ops;
+            if (lane != GENERIC_LANE)
+            {
+                laneOpsLeftUntilLimit[lane] -= ops;
+            }
         }
         // Pop the tx from current iterator, unless the whole tx stack is
         // skipped.
@@ -266,49 +336,103 @@ SurgePricingPriorityQueue::popTopTxs(
 std::pair<bool, int64_t>
 SurgePricingPriorityQueue::canFitWithEviction(
     TransactionFrameBase const& tx, uint32_t txOpsDiscount,
-    std::vector<TxStackPtr>& txStacksToEvict) const
+    std::vector<std::pair<TxStackPtr, bool>>& txStacksToEvict) const
 {
     // This only makes sense when the lowest fee rate tx is on top.
     releaseAssert(!mComparator.isGreater());
 
+    auto lane = mLaneConfig->getLane(tx);
     if (tx.getNumOperations() < txOpsDiscount)
     {
         throw std::invalid_argument(
             "Discount shouldn't be larger than transaction operations count");
     }
     auto txNewOps = tx.getNumOperations() - txOpsDiscount;
-    if (txNewOps > mOpsLimit)
+    if (txNewOps > mLaneOpsLimits[GENERIC_LANE] ||
+        txNewOps > mLaneOpsLimits[lane])
     {
         CLOG_WARNING(
             Herder,
-            "Operation limit is lower size than transaction ops: {} < {}."
-            "Node won't be able to accept all transactions.",
-            mOpsLimit, txNewOps);
+            "Transaction fee lane has lower size than transaction ops: {} < "
+            "{}. Node won't be able to accept all transactions.",
+            txNewOps > mLaneOpsLimits[GENERIC_LANE]
+                ? mLaneOpsLimits[GENERIC_LANE]
+                : mLaneOpsLimits[lane],
+            txNewOps);
         return std::make_pair(false, 0ll);
     }
     uint32_t totalOps = sizeOps();
     uint32_t newTotalOps = totalOps + txNewOps;
-    bool fitWithoutEviction = newTotalOps <= mOpsLimit;
+    uint32_t newLaneOps = mLaneOpsCount[lane] + txNewOps;
+    // To fit the eviction, tx has to both fit into 'generic' lane's limit
+    // (shared among all the txs) and its own lane's limit.
+    bool fitWithoutEviction = newTotalOps <= mLaneOpsLimits[GENERIC_LANE] &&
+                              newLaneOps <= mLaneOpsLimits[lane];
     // If there is enough space, return.
     if (fitWithoutEviction)
     {
         return std::make_pair(true, 0ll);
     }
     auto iter = getTop();
-    int64_t neededTotalOps =
-        std::max<int64_t>(0, static_cast<int64_t>(newTotalOps) - mOpsLimit);
+    int64_t neededTotalOps = std::max<int64_t>(
+        0, static_cast<int64_t>(newTotalOps) - mLaneOpsLimits[GENERIC_LANE]);
+    int64_t neededLaneOps = std::max<int64_t>(
+        0LL, static_cast<int64_t>(newLaneOps) - mLaneOpsLimits[lane]);
     // The above checks should ensure there are some operations that need to be
     // evicted.
-    releaseAssert(neededTotalOps > 0);
-    while (neededTotalOps > 0)
+    releaseAssert(neededTotalOps > 0 || neededLaneOps > 0);
+    while (neededTotalOps > 0 || neededLaneOps > 0)
     {
+        bool evictedDueToLaneLimit = false;
+        while (!iter.isEnd())
+        {
+            auto const& evictTxStack = *iter;
+            auto const& evictTx = *evictTxStack->getTopTx();
+            auto evictLane = mLaneConfig->getLane(evictTx);
+            auto evictOps = evictTxStack->getNumOperations();
+            bool canEvict = false;
+            // Check if it makes sense to evict the current top tx stack.
+            //
+            // Simple cases: generic lane txs can evict anything; same lane txs
+            // can evict each other; any transaction can be evicted if per-lane
+            // limit hasn't been reached.
+            if (lane == GENERIC_LANE || lane == evictLane || neededLaneOps <= 0)
+            {
+                canEvict = true;
+            }
+            else if (neededTotalOps <= neededLaneOps)
+            {
+                // When we need to evict more ops from the tx's lane than from
+                // the generic lane, then we can only evict from tx's lane (any
+                // other evictions are pointless).
+                evictedDueToLaneLimit = true;
+            }
+            else
+            {
+                // In the final case `neededOps` is greater than `neededLaneOps`
+                // and the difference can be evicted from any lane.
+                int64_t nonLaneOpsToEvict = neededTotalOps - neededLaneOps;
+                canEvict = evictOps <= nonLaneOpsToEvict;
+            }
+            if (!canEvict)
+            {
+                // If we couldn't evict a cheaper transaction from a lane, then
+                // we shouldn't evict more expensive ones (even though some of
+                // them could be evicted following the `canEvict` logic above).
+                iter.dropLane();
+            }
+            else
+            {
+                break;
+            }
+        }
         // The preconditions are ensured above that we should be able to fit
-        // the transaction by evicting some transactions (given high enough
-        // fee).
-        releaseAssert(iter != mTxStackSet.end());
+        // the transaction by evicting some transactions.
+        releaseAssert(!iter.isEnd());
         auto const& evictTxStack = *iter;
         auto const& evictTx = *evictTxStack->getTopTx();
         auto evictOps = evictTxStack->getNumOperations();
+        auto evictLane = mLaneConfig->getLane(evictTx);
         // Only support this for single tx stacks (eventually we should only
         // have such stacks and share this invariant across all the queue
         // operations).
@@ -327,41 +451,58 @@ SurgePricingPriorityQueue::canFitWithEviction(
             return std::make_pair(false, 0ll);
         }
 
-        txStacksToEvict.emplace_back(evictTxStack);
+        txStacksToEvict.emplace_back(evictTxStack, evictedDueToLaneLimit);
         neededTotalOps -= evictOps;
-        if (neededTotalOps <= 0)
+        // Only reduce the needed lane ops when we evict from tx's lane or when
+        // we're trying to fit a 'generic' lane tx (as it can evict any other
+        // tx).
+        if (lane == GENERIC_LANE || lane == evictLane)
+        {
+            neededLaneOps -= evictOps;
+        }
+        if (neededTotalOps <= 0 && neededLaneOps <= 0)
         {
             return std::make_pair(true, 0ll);
         }
 
-        ++iter;
+        iter.advance();
     }
-    // The preconditions must guarantee that we find an evicted transaction set
-    // or report that the tx fee is too low.
+    // The preconditions must guarantee that we find an evicted transction set.
     releaseAssert(false);
 }
 
-SurgePricingPriorityQueue::TxStackSet::iterator
+SurgePricingPriorityQueue::Iterator
 SurgePricingPriorityQueue::getTop() const
 {
-    return mTxStackSet.begin();
+    std::vector<LaneIter> iters;
+    for (size_t lane = 0; lane < mTxStackSets.size(); ++lane)
+    {
+        auto const& txStackSet = mTxStackSets[lane];
+        if (txStackSet.empty())
+        {
+            continue;
+        }
+        iters.emplace_back(lane, txStackSet.begin());
+    }
+    return SurgePricingPriorityQueue::Iterator(*this, iters);
 }
 
 uint32_t
 SurgePricingPriorityQueue::sizeOps() const
 {
-    return mOpsCount;
+    return std::accumulate(mLaneOpsCount.begin(), mLaneOpsCount.end(),
+                           static_cast<uint32_t>(0));
 }
 
-void
-SurgePricingPriorityQueue::updateOpsLimit(uint32_t newLimit)
+uint32_t
+SurgePricingPriorityQueue::laneOps(size_t lane) const
 {
-    mOpsLimit = newLimit;
+    releaseAssert(lane < mLaneOpsCount.size());
+    return mLaneOpsCount[lane];
 }
 
 void
-SurgePricingPriorityQueue::popTopTx(
-    SurgePricingPriorityQueue::TxStackSet::iterator iter)
+SurgePricingPriorityQueue::popTopTx(SurgePricingPriorityQueue::Iterator iter)
 {
     auto txStack = *iter;
     erase(iter);
@@ -369,6 +510,100 @@ SurgePricingPriorityQueue::popTopTx(
     if (!txStack->empty())
     {
         add(txStack);
+    }
+}
+
+SurgePricingPriorityQueue::Iterator::Iterator(
+    SurgePricingPriorityQueue const& parent, std::vector<LaneIter> const& iters)
+    : mParent(parent), mIters(iters)
+{
+}
+
+std::vector<SurgePricingPriorityQueue::LaneIter>::iterator
+SurgePricingPriorityQueue::Iterator::getMutableInnerIter() const
+{
+    releaseAssert(!isEnd());
+    auto best = mIters.begin();
+    for (auto groupIt = std::next(mIters.begin()); groupIt != mIters.end();
+         ++groupIt)
+    {
+        auto& [group, it] = *groupIt;
+        if (mParent.mComparator(*it, *best->second))
+        {
+            best = groupIt;
+        }
+    }
+    return best;
+}
+
+TxStackPtr
+SurgePricingPriorityQueue::Iterator::operator*() const
+{
+    return *getMutableInnerIter()->second;
+}
+
+SurgePricingPriorityQueue::LaneIter
+SurgePricingPriorityQueue::Iterator::getInnerIter() const
+{
+    return *getMutableInnerIter();
+}
+
+bool
+SurgePricingPriorityQueue::Iterator::isEnd() const
+{
+    return mIters.empty();
+}
+
+void
+SurgePricingPriorityQueue::Iterator::advance()
+{
+    auto it = getMutableInnerIter();
+    ++it->second;
+    if (it->second == mParent.mTxStackSets[it->first].end())
+    {
+        mIters.erase(it);
+    }
+}
+
+void
+SurgePricingPriorityQueue::Iterator::dropLane()
+{
+    mIters.erase(getMutableInnerIter());
+}
+
+DexLimitingLaneConfig::DexLimitingLaneConfig(
+    uint32_t opsLimit, std::optional<uint32_t> dexOpsLimit)
+{
+    mLaneOpsLimits.push_back(opsLimit);
+    if (dexOpsLimit)
+    {
+        mLaneOpsLimits.push_back(*dexOpsLimit);
+    }
+}
+
+std::vector<uint32_t> const&
+DexLimitingLaneConfig::getLaneOpsLimits() const
+{
+    return mLaneOpsLimits;
+}
+
+void
+DexLimitingLaneConfig::updateGenericLaneLimit(uint32_t limit)
+{
+    mLaneOpsLimits[0] = limit;
+}
+
+size_t
+DexLimitingLaneConfig::getLane(TransactionFrameBase const& tx) const
+{
+    if (mLaneOpsLimits.size() > DexLimitingLaneConfig::DEX_LANE &&
+        tx.hasDexOperations())
+    {
+        return DexLimitingLaneConfig::DEX_LANE;
+    }
+    else
+    {
+        return SurgePricingPriorityQueue::GENERIC_LANE;
     }
 }
 } // namespace stellar

--- a/src/herder/SurgePricingUtils.h
+++ b/src/herder/SurgePricingUtils.h
@@ -45,8 +45,73 @@ class TxStack
 
 using TxStackPtr = std::shared_ptr<TxStack>;
 
+// Configuration for multi-lane transaction limiting and surge pricing.
+//
+// This configuration defines how many 'lanes' are there to compare and limit
+// transactions.
+//
+// The configuration has the following semantics:
+// - There exists at least one 'lane' for transactions.
+// - Each transaction belongs to exactly one lane.
+// - Every lane has an operation limit associated with it.
+// - The lane '0' is always considered to be 'generic' lane. It defines the
+//   maximum total number of operations allowed, i.e. transactions from *all*
+//   the lanes must fit into it. Transactions from this lane can take place of
+//   transactions from any other lane.
+// - Lanes '1' and following are considered to be 'limited'. Besides fitting
+//   into 'generic' lane, transactions from these lanes must also fit into
+//   their lane's limit. Also transactions from 'limited' lanes may have their
+//   own base fee that is not lower than the base fee for 'generic' lane.
+//
+// To summarize, this config defines the following invariants for some set of
+// transactions:
+// - `sum(tx.operations) <= laneOpsLimits[0]`
+// - `for each lane >= 1: sum(tx[lane].operations) <= laneOpsLimits[lane]`
+class SurgePricingLaneConfig
+{
+  public:
+    using TxLaneClassifier =
+        std::function<size_t(TransactionFrameBase const& tx)>;
+
+    // Returns a a lane the transaction belongs to.
+    virtual size_t getLane(TransactionFrameBase const& tx) const = 0;
+    // Returns per-lane operation limits.
+    virtual std::vector<uint32_t> const& getLaneOpsLimits() const = 0;
+    // Updates the limit of the generic lane. This is needed due to
+    // protocol upgrades (other lane limits are currently updated via
+    // configuration).
+    virtual void updateGenericLaneLimit(uint32_t limit) = 0;
+
+    virtual ~SurgePricingLaneConfig() = default;
+};
+
+// Lane configuration that optionally defines a limited lane for transactions
+// that have DEX operations (manager offer, path payments).
+class DexLimitingLaneConfig : public SurgePricingLaneConfig
+{
+  public:
+    // Index of the DEX limited lane.
+    static constexpr size_t DEX_LANE = 1;
+
+    // Creates the config. `opsLimit` is the total number of operations allowed
+    // (lane '0'). `dexOpsLimit` when non-`nullopt` defines a limited lane for
+    // transactions with DEX operations (otherwise only one lane is created).
+    DexLimitingLaneConfig(uint32_t opsLimit,
+                          std::optional<uint32_t> dexOpsLimit);
+
+    size_t getLane(TransactionFrameBase const& tx) const override;
+    std::vector<uint32_t> const& getLaneOpsLimits() const override;
+    virtual void updateGenericLaneLimit(uint32_t limit);
+
+  private:
+    size_t getTxLane(TransactionFrameBase const& tx) const;
+
+    std::vector<uint32_t> mLaneOpsLimits;
+};
+
 // Priority queue-like data structure that allows to store transactions ordered
-// by fee rate and perform operations that respect the operation count limits.
+// by fee rate and perform operations that respect the lane limits specified by
+// `SurgePricingLaneConfig`.
 //
 // The queue operates on transaction stacks and only the top transactions of the
 // stacks are compared. This allows to e.g. order transactions while preserving
@@ -54,16 +119,23 @@ using TxStackPtr = std::shared_ptr<TxStack>;
 class SurgePricingPriorityQueue
 {
   public:
+    // Index of the 'generic' lane. This has to be '0' and is used for clarity.
+    static constexpr size_t GENERIC_LANE = 0;
+
     // Helper that uses `SurgePricingPriorityQueue` to greedily select the
     // maximum subset of transactions from `txStacks` with maximum fee ratios
-    // such that the total operation count doesn't exceed `opsLimit`.
+    // within the limits specified by `laneConfig`.
     // The greedy ordering optimizes for the maximal fee ratio first, then for
     // the output operation count.
     // Transactions will be popped from the input `txStacks`, so after this call
     // `txStacks` will contain all the remaining transactions.
-    static std::vector<TransactionFrameBasePtr>
-    getMostTopTxsWithinLimit(std::vector<TxStackPtr> const& txStacks,
-                             uint32_t opsLimit);
+    // `hadTxNotFittingLane` is an output parameter that for every lane will
+    // identify whether there was a transaction that didn't fit into that lane's
+    // limit.
+    static std::vector<TransactionFrameBasePtr> getMostTopTxsWithinLimits(
+        std::vector<TxStackPtr> const& txStacks,
+        std::shared_ptr<SurgePricingLaneConfig> laneConfig,
+        std::vector<bool>& hadTxNotFittingLane);
 
     // Result of visiting the transaction stack in the `visitTopTxs`.
     // This serves as a callback output to let the queue know how to process the
@@ -71,37 +143,41 @@ class SurgePricingPriorityQueue
     enum class VisitTxStackResult
     {
         // Top transaction of the stack should be popped, but not counted
-        // towards the operation limit.
+        // towards the lane limits.
         TX_SKIPPED,
         // Top transaction of the stack should be popped and counted towards the
-        // operation limits.
+        // lane limits.
         TX_PROCESSED,
         // The whole stack should be skipped (no transactions are popped or
-        // counted towards the operation limit).
+        // counted towards the lane limits).
         TX_STACK_SKIPPED
     };
 
-    // Helper that uses `SurgePricingPriorityQueue` to visits the top (by fee
-    // rate) transactions in the `txStacks` until `opsLimit` is reached.
-    // The visiting process will end for a lane as soon as there is a
+    // Helper that uses `SurgePricingPriorityQueue` to visit the top (by fee
+    // rate) transactions in the `txStacks` until `laneConfig` limits are
+    // reached. The visiting process will end for a lane as soon as there is a
     // transaction that causes the limit to be exceeded.
     // `comparisonSeed` is used to break the comparison ties.
     // `visitor` should process the `TxStack` and provide an action to do with
     // that stack.
-    // `opsLeftUntilLimit` is an output parameter that will contain the number
-    // of operations left until the limit is reached.
+    // `laneOpsLeftUntilLimit` is an output parameter that for each lane will
+    // contain the number of operations left until lane's limit is reached.
     static void visitTopTxs(
-        std::vector<TxStackPtr> const& txStacks, uint32_t opsLimit,
+        std::vector<TxStackPtr> const& txStacks,
+        std::shared_ptr<SurgePricingLaneConfig> laneConfig,
         size_t comparisonSeed,
         std::function<VisitTxStackResult(TxStack const&)> const& visitor,
-        uint32_t& opsLeftUntilLimit);
+        std::vector<uint32_t>& laneOpsLeftUntilLimit);
 
-    // Creates a `SurgePricingPriorityQueue` with the provided `opsLimit`.
+    // Creates a `SurgePricingPriorityQueue` for the provided lane
+    // configuration.
     // `isHighestPriority` defines the comparison order: when it's `true` the
     // highest fee rate transactions are considered to be at the top, otherwise
     // the lowest fee rate transaction is at the top.
-    SurgePricingPriorityQueue(bool isHighestPriority, uint32_t opsLimit,
-                              size_t comparisonSeed);
+    SurgePricingPriorityQueue(
+        bool isHighestPriority,
+        std::shared_ptr<SurgePricingLaneConfig> laneConfig,
+        size_t comparisonSeed);
 
     // Adds a `TxStack` to this queue. The queue has ownership of the stack and
     // may pop transactions from it.
@@ -110,22 +186,25 @@ class SurgePricingPriorityQueue
     void erase(TxStackPtr txStack);
 
     // Checks whether a provided transaction could fit into this queue without
-    // violating the ops limit while evicting some lower fee rate `TxStacks`
-    // from the queue.
+    // violating the `laneConfig` limits while evicting some lower fee rate
+    // `TxStacks` from the queue.
     // Returns whether transaction can be fit and if not, returns the minimum
-    // required fee to possibly fit. `txOpsDiscount` is a number of operations
-    // to subtract from tx's operations when estimating the total operation
-    // counts. `txStacksToEvict` is an output parameter that will contain all
-    // the stacks that need to be evicted in order to fit `tx`.
-    std::pair<bool, int64_t>
-    canFitWithEviction(TransactionFrameBase const& tx, uint32_t txOpsDiscount,
-                       std::vector<TxStackPtr>& txStacksToEvict) const;
+    // required fee to possibly fit.
+    // `txOpsDiscount` is a number of operations to subtract from tx's
+    // operations when estimating the total operation counts.
+    // `txStacksToEvict` is an output parameter that will contain all the stacks
+    // that need to be evicted in order to fit `tx`. The `bool` argument
+    // indicates whether this `TxStack` has been evicted due to lane's limit (as
+    // opposed to 'generic' lane's limit).
+    std::pair<bool, int64_t> canFitWithEviction(
+        TransactionFrameBase const& tx, uint32_t txOpsDiscount,
+        std::vector<std::pair<TxStackPtr, bool>>& txStacksToEvict) const;
 
     // Returns total number of operations in all the stacks in this queue.
     uint32_t sizeOps() const;
 
-    // Sets the queue ops limit to `newLimit`.
-    void updateOpsLimit(uint32_t newLimit);
+    // Returns total number of operations in the provided lane of the queue.
+    uint32_t laneOps(size_t lane) const;
 
   private:
     class TxStackComparator
@@ -155,25 +234,58 @@ class SurgePricingPriorityQueue
     };
 
     using TxStackSet = std::set<TxStackPtr, TxStackComparator>;
+    using LaneIter = std::pair<size_t, TxStackSet::iterator>;
+
+    // Iterator for walking the queue from top to bottom, possibly restricted
+    // only to some lanes. The actual ordering is defined by
+    // `isHighestPriority`.
+    class Iterator
+    {
+      public:
+        Iterator(SurgePricingPriorityQueue const& parent,
+                 std::vector<LaneIter> const& iters);
+
+        TxStackPtr operator*() const;
+        // Gets the iterator of the `TxStackSet` corresponding to the current
+        // value.
+        LaneIter getInnerIter() const;
+        bool isEnd() const;
+        // Advances this iterator to the next value.
+        void advance();
+        // Removes a lane corresponding to the current value of the iterator.
+        void dropLane();
+
+      private:
+        std::vector<LaneIter>::iterator getMutableInnerIter() const;
+
+        SurgePricingPriorityQueue const& mParent;
+        std::vector<LaneIter> mutable mIters;
+    };
 
     // Generalized method for visiting and popping the top transactions in the
-    // queue until the ops limit is reached.
-    // This may leave the queue empty (when `allowGaps` is `true`) and hence is
+    // queue until the lane limits are reached.
+    // This leaves the queue empty (when `allowGaps` is `true`) and hence is
     // only used from the helper methods that don't expose the queue at all.
     void
     popTopTxs(bool allowGaps,
               std::function<VisitTxStackResult(TxStack const&)> const& visitor,
-              uint32_t& opsLeftUntilLimit);
+              std::vector<uint32_t>& laneOpsLeftUntilLimit,
+              std::vector<bool>& hadTxNotFittingLane);
 
-    void erase(SurgePricingPriorityQueue::TxStackSet::iterator iter);
-    void popTopTx(SurgePricingPriorityQueue::TxStackSet::iterator iter);
-    SurgePricingPriorityQueue::TxStackSet::iterator getTop() const;
+    void erase(Iterator const& it);
+    void erase(size_t lane,
+               SurgePricingPriorityQueue::TxStackSet::iterator iter);
+    void popTopTx(Iterator iter);
+
+    Iterator getTop() const;
 
     TxStackComparator const mComparator;
-    uint32_t mOpsLimit;
-    uint32_t mOpsCount;
+    std::shared_ptr<SurgePricingLaneConfig> mLaneConfig;
+    std::vector<uint32_t> const& mLaneOpsLimits;
 
-    TxStackSet mTxStackSet;
+    std::vector<uint32_t> mLaneOpsCount;
+
+    std::vector<TxStackSet> mTxStackSets;
 };
 
 } // namespace stellar

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -194,10 +194,11 @@ class TransactionQueue
 
     bool mShutdown{false};
     bool mWaiting{false};
-    uint32_t mBroadcastOpCarryover = 0;
+    std::vector<uint32_t> mBroadcastOpCarryover;
     VirtualTimer mBroadcastTimer;
 
-    uint32_t getMaxOpsToFloodThisPeriod() const;
+    std::pair<uint32_t, std::optional<uint32_t>>
+    getMaxOpsToFloodThisPeriod() const;
     bool broadcastSome();
     void broadcast(bool fromCallback);
     // broadcasts a single transaction
@@ -212,7 +213,7 @@ class TransactionQueue
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,
                      TimestampedTransactions::iterator& oldTxIter,
-                     std::vector<TxStackPtr>& txsToEvict);
+                     std::vector<std::pair<TxStackPtr, bool>>& txsToEvict);
 
     void releaseFeeMaybeEraseAccountState(TransactionFrameBasePtr tx);
 

--- a/src/herder/TxQueueLimiter.h
+++ b/src/herder/TxQueueLimiter.h
@@ -19,25 +19,28 @@ class TxQueueLimiter
     uint32 const mPoolLedgerMultiplier;
     LedgerManager& mLedgerManager;
 
-    // The bid of the last evicted transaction.
-    // This is also the maximum bid among evicted transactions.
-    std::pair<int64, uint32_t> mEvictedFeeBid;
+    UnorderedMap<TransactionFrameBasePtr, TxStackPtr> mStackForTx;
 
     // all known transactions
     std::unique_ptr<SurgePricingPriorityQueue> mTxs;
 
-    // Mapping from individual transactions to `TxStack`s containing them.
-    UnorderedMap<TransactionFrameBasePtr, TxStackPtr> mStackForTx;
+    // When non-nullopt, limit the number dex operations by this value
+    std::optional<uint32_t> mMaxDexOperations;
 
-    void resetTxs();
+    // Stores the maximum bid among the transactions evicted from every tx lane.
+    // Bids are stored as ratios (fee_bid / num_ops).
+    std::vector<std::pair<int64, uint32_t>> mLaneEvictedFeeBid;
+
+    // Configuration of SurgePricingPriorityQueue with the per-lane operation
+    // limits.
+    std::shared_ptr<SurgePricingLaneConfig> mSurgePricingLaneConfig;
 
   public:
-    TxQueueLimiter(uint32 multiplier, LedgerManager& lm);
+    TxQueueLimiter(uint32 multiplier, Application& app);
     ~TxQueueLimiter();
 
     void addTransaction(TransactionFrameBasePtr const& tx);
     void removeTransaction(TransactionFrameBasePtr const& tx);
-
 #ifdef BUILD_TESTS
     size_t size() const;
 #endif
@@ -47,7 +50,8 @@ class TxQueueLimiter
     // `txsToEvict` should be provided by the `canAddTx` call.
     // Note that evict must call `removeTransaction` as to make space.
     void evictTransactions(
-        std::vector<TxStackPtr> const& txsToEvict, uint32_t opsToFit,
+        std::vector<std::pair<TxStackPtr, bool>> const& txsToEvict,
+        TransactionFrameBase const& txToFit,
         std::function<void(TransactionFrameBasePtr const&)> evict);
 
     // oldTx is set when performing a replace by fee
@@ -60,9 +64,10 @@ class TxQueueLimiter
     // `txsToEvict` will contain transactions that need to be evicted in order
     // to fit the new transactions. It should be passed to `evictTransactions`
     // to perform the actual eviction.
-    std::pair<bool, int64> canAddTx(TransactionFrameBasePtr const& tx,
-                                    TransactionFrameBasePtr const& oldTx,
-                                    std::vector<TxStackPtr>& txsToEvict);
+    std::pair<bool, int64>
+    canAddTx(TransactionFrameBasePtr const& tx,
+             TransactionFrameBasePtr const& oldTx,
+             std::vector<std::pair<TxStackPtr, bool>>& txsToEvict);
 
     // Resets the state related to evictions (maximum evicted bid).
     void resetEvictionState();

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -138,7 +138,8 @@ class TxSetFrame : public NonMovableOrCopyable
     TxSetFrame(bool isGeneralized, Hash const& previousLedgerHash,
                Transactions const& txs);
 
-    // Computes the fees for transactions in this set.
+    // Computes the fees for transactions in this set based on information from
+    // the non-generalized tx set.
     // This has to be `const` in combination with `mutable` fee-related fields
     // in order to accommodate one specific case: legacy (non-generalized) tx
     // sets received from the peers don't include the fee information and we
@@ -146,7 +147,8 @@ class TxSetFrame : public NonMovableOrCopyable
     // Hence we lazily compute the fees in `getTxBaseFee` for such TxSetFrames.
     // This can be cleaned up after the protocol migration as non-generalized tx
     // sets won't exist in the network anymore.
-    void computeTxFees(LedgerHeader const& lclHeader) const;
+    void computeTxFeesForNonGeneralizedSet(LedgerHeader const& lclHeader) const;
+
     void computeContentsHash();
 
     std::optional<Hash> mHash;
@@ -158,8 +160,17 @@ class TxSetFrame : public NonMovableOrCopyable
                        bool useBaseFee, std::optional<int64_t> baseFee);
     void applySurgePricing(Application& app);
 
+    void computeTxFeesForNonGeneralizedSet(LedgerHeader const& lclHeader,
+                                           int64_t lowestBaseFee,
+                                           bool enableLogging) const;
+
     void computeTxFees(LedgerHeader const& lclHeader, int64_t lowestBaseFee,
                        bool enableLogging) const;
+
+    void computeTxFees(LedgerHeader const& ledgerHeader,
+                       SurgePricingLaneConfig const& surgePricingConfig,
+                       std::vector<int64_t> const& lowestLaneFee,
+                       std::vector<bool> const& hadTxNotFittingLane);
 
     bool const mIsGeneralized;
 

--- a/src/herder/simulation/TxSimTxSetFrame.cpp
+++ b/src/herder/simulation/TxSimTxSetFrame.cpp
@@ -16,7 +16,7 @@ SimApplyOrderTxSetFrame::SimApplyOrderTxSetFrame(
     Transactions const& txsInApplyOrder)
     : TxSetFrame(lclHeader, txsInApplyOrder), mTxsInApplyOrder(txsInApplyOrder)
 {
-    computeTxFees(lclHeader.header);
+    computeTxFeesForNonGeneralizedSet(lclHeader.header);
     computeContentsHash();
 }
 

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -20,6 +20,7 @@
 #include "util/Timer.h"
 #include "util/numeric128.h"
 #include "xdr/Stellar-transaction.h"
+#include "xdrpp/autocheck.h"
 
 #include <chrono>
 #include <fmt/chrono.h>
@@ -1316,7 +1317,7 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
     }
     SECTION("multi accounts limits")
     {
-        TxQueueLimiter limiter(3, app->getLedgerManager());
+        TxQueueLimiter limiter(3, *app);
 
         struct SetupElement
         {
@@ -1336,7 +1337,7 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
                 {
                     auto tx = transaction(*app, e.account, seq++, 1,
                                           opsFee.second, opsFee.first);
-                    std::vector<TxStackPtr> txsToEvict;
+                    std::vector<std::pair<TxStackPtr, bool>> txsToEvict;
                     bool can = limiter.canAddTx(tx, noTx, txsToEvict).first;
                     REQUIRE(can);
                     REQUIRE(txsToEvict.empty());
@@ -1362,14 +1363,14 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
                                  int fee, int64 expFeeOnFailed,
                                  int expEvictedOpsOnSuccess) {
             auto tx = transaction(*app, account, 1000, 1, fee, ops);
-            std::vector<TxStackPtr> txsToEvict;
+            std::vector<std::pair<TxStackPtr, bool>> txsToEvict;
             auto can = limiter.canAddTx(tx, noTx, txsToEvict);
             REQUIRE(expected == can.first);
             if (can.first)
             {
                 int evictedOps = 0;
                 limiter.evictTransactions(
-                    txsToEvict, ops, [&](TransactionFrameBasePtr const& evict) {
+                    txsToEvict, *tx, [&](TransactionFrameBasePtr const& evict) {
                         // can't evict cheaper transactions
                         auto cmp3 = feeRate3WayCompare(
                             evict->getFeeBid(), evict->getNumOperations(),
@@ -1406,7 +1407,7 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
         // that fee threshold is applied even when there is enough space in
         // the limiter, but some transactions were evicted before.
         auto checkMinFeeToFitWithNoEvict = [&](uint32_t minFee) {
-            std::vector<TxStackPtr> txsToEvict;
+            std::vector<std::pair<TxStackPtr, bool>> txsToEvict;
             // 0 fee is a special case as transaction shouldn't have 0 fee.
             // Hence we only check that fee of 1 allows transaction to be added.
             if (minFee == 0)
@@ -1475,6 +1476,240 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
             // now, reset the min fee requirement
             limiter.resetEvictionState();
             checkMinFeeToFitWithNoEvict(0);
+        }
+    }
+}
+
+TEST_CASE("TransactionQueue limiter with DEX separation",
+          "[herder][transactionqueue]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig();
+    cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 3;
+    cfg.FLOOD_TX_PERIOD_MS = 100;
+    cfg.MAX_DEX_TX_OPERATIONS_IN_TX_SET = 1;
+    auto app = createTestApplication(clock, cfg);
+    auto const minBalance2 = app->getLedgerManager().getLastMinBalance(2);
+
+    auto root = TestAccount::createRoot(*app);
+    auto account1 = root.create("a1", minBalance2);
+    auto account2 = root.create("a2", minBalance2);
+    auto account3 = root.create("a3", minBalance2);
+
+    // 3 * 3 = 9 operations limit, 3 * 1 = 3 DEX operations limit.
+    TxQueueLimiter limiter(3, *app);
+
+    std::vector<TransactionFrameBasePtr> txs;
+
+    TransactionFrameBasePtr noTx;
+
+    auto checkAndAddTx = [&](TestAccount& account, bool isDex, int ops, int fee,
+                             bool expected, int64 expFeeOnFailed,
+                             int expEvictedOpsOnSuccess) {
+        TransactionFrameBasePtr tx;
+        if (isDex)
+        {
+            tx = createSimpleDexTx(*app, account, ops, fee);
+        }
+        else
+        {
+            tx = transaction(*app, account, 1, 1, fee, ops);
+        }
+        std::vector<std::pair<TxStackPtr, bool>> txsToEvict;
+        auto can = limiter.canAddTx(tx, noTx, txsToEvict);
+        REQUIRE(can.first == expected);
+        if (can.first)
+        {
+            int evictedOps = 0;
+            limiter.evictTransactions(
+                txsToEvict, *tx, [&](TransactionFrameBasePtr const& evict) {
+                    // can't evict cheaper transactions (
+                    // evict.bid/evict.ops < tx->bid/tx->ops)
+                    REQUIRE(bigMultiply(evict->getFeeBid(),
+                                        tx->getNumOperations()) <
+                            bigMultiply(tx->getFeeBid(),
+                                        evict->getNumOperations()));
+                    // can't evict self
+                    bool same = evict->getSourceID() == tx->getSourceID();
+                    REQUIRE(!same);
+                    evictedOps += evict->getNumOperations();
+                    limiter.removeTransaction(evict);
+                });
+            REQUIRE(evictedOps == expEvictedOpsOnSuccess);
+            limiter.addTransaction(tx);
+        }
+        else
+        {
+            REQUIRE(can.second == expFeeOnFailed);
+        }
+    };
+
+    auto checkAndAddWithIncreasedBid = [&](TestAccount& account, bool isDex,
+                                           int ops, int opBid,
+                                           int expectedEvicted) {
+        checkAndAddTx(account, isDex, ops, ops * opBid, false, opBid * ops + 1,
+                      0);
+        checkAndAddTx(account, isDex, ops, ops * opBid + 1, true, 0,
+                      expectedEvicted);
+    };
+
+    SECTION("non-DEX transactions only")
+    {
+        // Fill capacity of 9 ops
+        checkAndAddTx(account2, false, 5, 300 * 5, true, 0, 0);
+        checkAndAddTx(account2, false, 1, 400, true, 0, 0);
+        checkAndAddTx(account1, false, 1, 100, true, 0, 0);
+        checkAndAddTx(account1, false, 2, 200 * 2, true, 0, 0);
+
+        // Cannot add transactions anymore without eviction.
+        checkAndAddTx(account2, false, 1, 100, false, 101, 0);
+        // Evict transactions with high enough bid.
+        checkAndAddTx(account2, false, 2, 2 * 200 + 1, true, 0, 3);
+    }
+    SECTION("DEX transactions only")
+    {
+        // Fill DEX capacity of 3 ops
+        checkAndAddTx(account1, true, 1, 100, true, 0, 0);
+        checkAndAddTx(account1, true, 2, 200, true, 0, 0);
+
+        // Cannot add DEX transactions anymore without eviction.
+        checkAndAddTx(account2, true, 1, 100, false, 101, 0);
+        // Evict DEX transactions with high enough bid.
+        checkAndAddTx(account2, true, 3, 3 * 200 + 1, true, 0, 3);
+    }
+    SECTION("DEX and non-DEX transactions")
+    {
+        // 3 DEX ops (bid 200)
+        checkAndAddTx(account1, true, 3, 200 * 3, true, 0, 0);
+
+        // 1 non-DEX op (bid 100) - fits
+        checkAndAddTx(account1, false, 1, 100, true, 0, 0);
+        // 1 DEX op (bid 100) - doesn't fit
+        checkAndAddTx(account1, true, 1, 100, false, 201, 0);
+
+        // 7 non-DEX ops (bid 200/op + 1) - evict all DEX and non-DEX txs.
+        checkAndAddTx(account2, false, 7, 200 * 7 + 1, true, 0, 4);
+
+        // 1 DEX op - while it fits, 200 bid is not enough (as we evicted tx
+        // with 200 DEX bid).
+        checkAndAddWithIncreasedBid(account1, true, 1, 200, 0);
+
+        // 1 non-DEX op - while it fits, 200 bid is not enough (as we evicted
+        // DEX tx with 200 bid before reaching the DEX ops limit).
+        checkAndAddWithIncreasedBid(account1, false, 1, 200, 0);
+    }
+
+    SECTION("DEX and non-DEX transactions with DEX limit reached")
+    {
+        // 2 DEX ops (bid 200/op)
+        checkAndAddTx(account1, true, 2, 200 * 2, true, 0, 0);
+
+        // 3 non-DEX ops (bid 100/op) - fits
+        checkAndAddTx(account1, false, 3, 100 * 3, true, 0, 0);
+        // 2 DEX ops (bid 300/op) - fits and evicts the previous DEX tx
+        checkAndAddTx(account2, true, 2, 300 * 2, true, 0, 2);
+
+        // 5 non-DEX ops (bid 250/op) - evict non-DEX tx.
+        checkAndAddTx(account2, false, 5, 250 * 5, true, 0, 3);
+
+        // 1 DEX op - while it fits, 200 bid is not enough (as we evicted tx
+        // with 200 DEX bid).
+        checkAndAddWithIncreasedBid(account1, true, 1, 200, 0);
+
+        // 1 non-DEX op - while it fits, 100 bid is not enough (as we evicted
+        // non-DEX tx with bid 100, but DEX tx was evicted due to DEX limit).
+        checkAndAddWithIncreasedBid(account1, false, 1, 100, 0);
+    }
+
+    SECTION("non-DEX transactions evict DEX transactions")
+    {
+        // Add 9 ops (2 + 1 DEX, 3 + 2 + 1 non-DEX)
+        checkAndAddTx(account1, true, 2, 100 * 2, true, 0, 0);
+        checkAndAddTx(account1, false, 3, 200 * 3, true, 0, 0);
+        checkAndAddTx(account1, true, 1, 300, true, 0, 0);
+        checkAndAddTx(account1, false, 2, 400 * 2, true, 0, 0);
+        checkAndAddTx(account1, false, 1, 500, true, 0, 0);
+
+        // Evict 2 DEX ops and 3 non-DEX ops.
+        checkAndAddWithIncreasedBid(account2, false, 5, 200, 5);
+    }
+
+    SECTION("DEX transactions evict non-DEX transactions in DEX slots")
+    {
+        SECTION("evict only due to global limit")
+        {
+            // 1 DEX op + 8 non-DEX ops (2 ops in DEX slots).
+            checkAndAddTx(account1, true, 1, 200, true, 0, 0);
+            checkAndAddTx(account1, false, 6, 400 * 6, true, 0, 0);
+            checkAndAddTx(account1, false, 1, 100, true, 0, 0);
+            checkAndAddTx(account1, false, 1, 300, true, 0, 0);
+
+            // Evict 1 DEX op and 100/300 non-DEX ops (bids strictly increase)
+            checkAndAddWithIncreasedBid(account2, true, 3, 300, 3);
+        }
+        SECTION("evict due to both global and DEX limits")
+        {
+            // 2 DEX ops + 7 non-DEX ops (1 op in DEX slots).
+            checkAndAddTx(account1, true, 2, 200 * 2, true, 0, 0);
+            checkAndAddTx(account1, false, 5, 400 * 6, true, 0, 0);
+            checkAndAddTx(account1, false, 1, 100, true, 0, 0);
+            checkAndAddTx(account1, false, 1, 150, true, 0, 0);
+
+            SECTION("fill all DEX slots")
+            {
+                // Evict 2 DEX ops and bid 100 non-DEX op (skip non-DEX 150 bid)
+                checkAndAddWithIncreasedBid(account2, true, 3, 200, 3);
+            }
+            SECTION("fill part of DEX slots")
+            {
+                // Evict 2 DEX ops and bid 100 non-DEX op (skip non-DEX 150 bid)
+                checkAndAddWithIncreasedBid(account2, true, 2, 200, 3);
+
+                SECTION("and add non-DEX tx")
+                {
+                    // Add a fitting non-DEX tx with at least 100 + 1 bid to
+                    // beat the evicted non-DEX tx.
+                    checkAndAddWithIncreasedBid(account2, false, 1, 100, 0);
+                }
+                SECTION("and add DEX tx")
+                {
+                    // Add a fitting non-DEX tx with at least 200 + 1 bid to
+                    // beat the evicted DEX tx.
+                    checkAndAddWithIncreasedBid(account2, true, 1, 200, 0);
+                }
+            }
+        }
+    }
+
+    SECTION("cannot evict transactions from the same account")
+    {
+        checkAndAddTx(account1, true, 3, 200 * 3, true, 0, 0);
+        checkAndAddTx(account2, false, 6, 100 * 6, true, 0, 0);
+
+        // Even though these transactions have high enough bid, they cannot
+        // evict transactions from the same account.
+        checkAndAddTx(account1, true, 3, 300 * 3, false, 0, 0);
+        checkAndAddTx(account2, false, 4, 300 * 4, false, 0, 0);
+
+        SECTION("but evict DEX transaction from a different account")
+        {
+            checkAndAddTx(account2, true, 3, 300 * 3, true, 0, 3);
+        }
+        SECTION("but evict non-DEX transaction from a different account")
+        {
+            checkAndAddTx(account1, false, 4, 300 * 4, true, 0, 6);
+        }
+    }
+
+    SECTION("cannot add transaction with more ops than limit")
+    {
+        SECTION("global limit")
+        {
+            checkAndAddTx(account1, false, 10, 200 * 10, false, 0, 0);
+        }
+        SECTION("DEX limit")
+        {
+            checkAndAddTx(account1, true, 4, 200 * 4, false, 0, 0);
         }
     }
 }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -236,6 +236,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     HALT_ON_INTERNAL_TRANSACTION_ERROR = false;
 
+    MAX_DEX_TX_OPERATIONS_IN_TX_SET = std::nullopt;
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
 #endif
@@ -1370,6 +1371,19 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "FLOW_CONTROL_SEND_MORE_BATCH_SIZE")
             {
                 FLOW_CONTROL_SEND_MORE_BATCH_SIZE = readInt<uint32_t>(item, 1);
+            }
+            else if (item.first == "MAX_DEX_TX_OPERATIONS_IN_TX_SET")
+            {
+                auto value = readInt<uint32_t>(item);
+                if (value > 0 && value < MAX_OPS_PER_TX + 2)
+                {
+                    throw std::invalid_argument(fmt::format(
+                        "MAX_DEX_TX_OPERATIONS_IN_TX_SET must be either 0 or "
+                        "at least {} in order to not drop any transactions.",
+                        MAX_OPS_PER_TX + 2));
+                }
+                MAX_DEX_TX_OPERATIONS_IN_TX_SET =
+                    value == 0 ? std::nullopt : std::make_optional(value);
             }
             else
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -374,6 +374,22 @@ class Config : public std::enable_shared_from_this<Config>
     // first time
     time_t MAXIMUM_LEDGER_CLOSETIME_DRIFT;
 
+    // Maximum allowed number of DEX-related operations in the transaction set.
+    //
+    // Transaction is considered to have DEX-related operations if it has path
+    // payments or manage offer operations.
+    //
+    // Setting this to non-nullopt value results in the following:
+    // - The node will limit the number of accepted DEX-related transactions
+    //   proportional to `MAX_DEX_TX_OPERATIONS_IN_TX_SET / maxTxSetSize`
+    //   (ledger header parameter).
+    // - The node will broadcast less DEX-related transactions according to the
+    //   proportion above.
+    // - Starting from protocol 20 the node will nominate TX sets that respect
+    //   this limit and potentially have DEX-related transactions surge-priced
+    //   against each other.
+    std::optional<uint32_t> MAX_DEX_TX_OPERATIONS_IN_TX_SET;
+
     // note: all versions in the range
     // [OVERLAY_PROTOCOL_MIN_VERSION, OVERLAY_PROTOCOL_VERSION] must be handled
     uint32_t OVERLAY_PROTOCOL_MIN_VERSION; // min overlay version understood

--- a/src/overlay/test/OverlayTestUtils.h
+++ b/src/overlay/test/OverlayTestUtils.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include <memory>
+#include <string>
 
 namespace stellar
 {

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -100,6 +100,8 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
               std::vector<TransactionFrameBasePtr> const& txs = {},
               bool strictOrder = false);
 
+TxSetResultMeta closeLedger(Application& app, TxSetFrameConstPtr txSet);
+
 TxSetResultMeta closeLedgerOn(Application& app, uint32 ledgerSeq,
                               time_t closeTime, TxSetFrameConstPtr txSet);
 
@@ -180,6 +182,9 @@ TransactionFramePtr createCreditPaymentTx(Application& app,
                                           SecretKey const& from,
                                           PublicKey const& to, Asset const& ci,
                                           SequenceNumber seq, int64_t amount);
+
+TransactionFramePtr createSimpleDexTx(Application& app, TestAccount& account,
+                                      int nbOps, uint32_t fee);
 
 Operation pathPayment(PublicKey const& to, Asset const& sendCur,
                       int64_t sendMax, Asset const& destCur, int64_t destAmount,


### PR DESCRIPTION
# Description

This PR introduces an optional configuration flag that when set limits the number of DEX-related operations in nominated transaction sets (starting with protocol-next) and limits the number of such operations accepted and broadcasted by the node (based only on flag).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
