### PR TITLE
Fix the ordering issue and add the respective check.

### DIFF
--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -521,6 +521,13 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
         return false;
     }
 
+    if (!std::is_sorted(mTxs.begin(), mTxs.end(), &TxSetUtils::hashTxSorter))
+    {
+        CLOG_DEBUG(Herder, "Got bad txSet: {} is not in hash order",
+                   hexAbbrev(mPreviousLedgerHash));
+        return false;
+    }
+
     if (std::adjacent_find(mTxs.begin(), mTxs.end(),
                            [](auto const& lhs, auto const& rhs) {
                                return lhs->getFullHash() == rhs->getFullHash();
@@ -840,7 +847,7 @@ TxSetFrame::surgePricingFilter(uint32_t opsLeft)
             cur->clear();
         }
     }
-    mTxs = filteredTxs;
+    mTxs = TxSetUtils::sortTxsInHashOrder(filteredTxs);
 }
 
 void


### PR DESCRIPTION
# Description

Fix the `TxSetFrame` ordering issue and add the respective check.

Simply adding the check causes crash in tests (e.g. surge pricing), hence I'm not adding any new tests to specifically handle this issue.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
