### PR TITLE
Extend load generator to produce high volume traffic

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -320,24 +320,33 @@ format.
   is started
 
 ### The following HTTP commands are exposed on test instances
-* **generateload**
-  `generateload[?mode=(create|pay|pretend)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L&spikesize=S&spikeinterval=I]`<br>
-  Artificially generate load for testing; must be used with
-  `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
-  * `create` mode creates new accounts.
-    Additionally, allows batching up to 100 account creations per transaction via 'batchsize'.
+* **generateload** `generateload[?mode=
+    (create|pay|pretend)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)]`
+
+    Artificially generate load for testing; must be used with
+    `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
+  * `create` mode creates new accounts. Additionally, allows batching up to 100
+    account creations per transaction via `batchsize`.
   * `pay` mode generates `PaymentOp` transactions on accounts specified
     (where the number of accounts can be offset).
-  * `pretend` mode generates transactions on accounts specified
-    (where the number of accounts can be offset). Operations in `pretend` mode are
-    designed to have a realistic size to help users "pretend" that they have real traffic.
+  * `pretend` mode generates transactions on accounts specified(where the number
+    of accounts can be offset). Operations in `pretend` mode are designed to
+    have a realistic size to help users "pretend" that they have real traffic.
     You can add optional configs `LOADGEN_OP_COUNT_FOR_TESTING` and
     `LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING` in the config file to specify
-    the # of ops / tx and how often they appear. More specifically, the probability
-    that a transaction contains `COUNT[i]` ops is
-    `DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...)`.
+    the # of ops / tx and how often they appear. More specifically, the
+    probability that a transaction contains `COUNT[i]` ops is `DISTRIBUTION
+    [i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...)`.
 
-  For `pay` and `pretend`, when a nonzero I is given, a spike will occur every I seconds injecting S transactions on top of `txrate`.
+  Non-`create` load generation makes use of the additional parameters:
+  * when a nonzero `spikeinterval` is given, a spike will occur every
+    `spikeinterval` seconds injecting `spikesize` transactions on top of
+    `txrate`
+  * `maxfeerate` defines the maximum per-operation fee for generated
+    transactions (when not specified only minimum base fee is used)
+  * when `skiplowfeetxs` is set to `true` the transactions that are not accepted by
+    the node due to having too low fee to pass the rate limiting are silently
+    skipped. Otherwise (by default), such transactions would cause load generation to fail.
 
 * **manualclose**
   If MANUAL_CLOSE is set to true in the .cfg file, this will cause the current

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -141,6 +141,8 @@ class Herder
                      std::optional<SecretKey> skToSignValue = std::nullopt) = 0;
 
     virtual VirtualTimer const& getTriggerTimer() const = 0;
+
+    virtual TransactionQueue& getTransactionQueue() = 0;
 #endif
     // a peer needs our SCP state
     virtual void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) = 0;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -168,7 +168,7 @@ class HerderImpl : public Herder
     // used for testing
     PendingEnvelopes& getPendingEnvelopes();
 
-    TransactionQueue& getTransactionQueue();
+    TransactionQueue& getTransactionQueue() override;
 #endif
 
     // helper function to verify envelopes are signed

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -1272,6 +1272,18 @@ TransactionQueue::getQueueSizeOps() const
 {
     return mTxQueueLimiter->size();
 }
+
+std::optional<int64_t>
+TransactionQueue::getInQueueSeqNum(AccountID const& account) const
+{
+    auto stateIter = mAccountStates.find(account);
+    if (stateIter == mAccountStates.end())
+    {
+        return std::nullopt;
+    }
+    auto& transactions = stateIter->second.mTransactions;
+    return transactions.back().mTx->getSeqNum();
+}
 #endif
 
 size_t

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -237,6 +237,7 @@ class TransactionQueue
 #ifdef BUILD_TESTS
   public:
     size_t getQueueSizeOps() const;
+    std::optional<int64_t> getInQueueSeqNum(AccountID const& account) const;
     std::function<void(TransactionFrameBasePtr&)> mTxBroadcastedEvent;
 #endif
 };

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2537,9 +2537,8 @@ TEST_CASE("upgrade to generalized tx set in network", "[upgrades][overlay]")
 
     auto& loadGen = nodes[0]->getLoadGenerator();
     // Generate 8 ledgers worth of txs (40 / 5).
-    loadGen.generateLoad(LoadGenMode::CREATE, /* nAccounts */ 40, 0, 0,
-                         /*txRate*/ 1,
-                         /*batchSize*/ 1, std::chrono::seconds(0), 0);
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ 40, /* txRate */ 1, /* batchSize */ 1));
     auto& loadGenDone =
         nodes[0]->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
     auto currLoadGenCount = loadGenDone.count();

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -45,6 +45,7 @@ class StatusManager;
 class AbstractLedgerTxnParent;
 class BasicWork;
 enum class LoadGenMode;
+struct GeneratedLoadConfig;
 
 #ifdef BUILD_TESTS
 class LoadGenerator;
@@ -260,11 +261,7 @@ class Application
 #ifdef BUILD_TESTS
     // If config.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING=true, generate some load
     // against the current application.
-    virtual void generateLoad(LoadGenMode mode, uint32_t nAccounts,
-                              uint32_t offset, uint32_t nTxs, uint32_t txRate,
-                              uint32_t batchSize,
-                              std::chrono::seconds spikeInterval,
-                              uint32_t spikeSize) = 0;
+    virtual void generateLoad(GeneratedLoadConfig cfg) = 0;
 
     // Access the load generator for manual operation.
     virtual LoadGenerator& getLoadGenerator() = 0;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -1004,15 +1004,10 @@ ApplicationImpl::advanceToLedgerBeforeManualCloseTarget(
 
 #ifdef BUILD_TESTS
 void
-ApplicationImpl::generateLoad(LoadGenMode mode, uint32_t nAccounts,
-                              uint32_t offset, uint32_t nTxs, uint32_t txRate,
-                              uint32_t batchSize,
-                              std::chrono::seconds spikeInterval,
-                              uint32_t spikeSize)
+ApplicationImpl::generateLoad(GeneratedLoadConfig cfg)
 {
     getMetrics().NewMeter({"loadgen", "run", "start"}, "run").Mark();
-    getLoadGenerator().generateLoad(mode, nAccounts, offset, nTxs, txRate,
-                                    batchSize, spikeInterval, spikeSize);
+    getLoadGenerator().generateLoad(cfg);
 }
 
 LoadGenerator&

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -103,11 +103,7 @@ class ApplicationImpl : public Application
                 std::optional<TimePoint> const& manualCloseTime) override;
 
 #ifdef BUILD_TESTS
-    virtual void generateLoad(LoadGenMode mode, uint32_t nAccounts,
-                              uint32_t offset, uint32_t nTxs, uint32_t txRate,
-                              uint32_t batchSize,
-                              std::chrono::seconds spikeInterval,
-                              uint32_t spikeSize) override;
+    virtual void generateLoad(GeneratedLoadConfig cfg) override;
 
     virtual LoadGenerator& getLoadGenerator() override;
 #endif

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -277,9 +277,10 @@ TEST_CASE("application setup", "[applicationutils]")
 
         // Generate a bit of load, and crank for some time
         auto& loadGen = validator->getLoadGenerator();
-        loadGen.generateLoad(LoadGenMode::CREATE, /* nAccounts */ 10, 0, 0,
-                             /*txRate*/ 1,
-                             /*batchSize*/ 1, std::chrono::seconds(0), 0);
+        loadGen.generateLoad(
+            GeneratedLoadConfig::createAccountsLoad(/* nAccounts */ 10,
+                                                    /* txRate */ 1,
+                                                    /* batchSize */ 1));
 
         auto& loadGenDone = validator->getMetrics().NewMeter(
             {"loadgen", "run", "complete"}, "run");
@@ -383,10 +384,10 @@ TEST_CASE("application setup", "[applicationutils]")
                                           .mCheckpointsDownloaded;
 
                     // Generate a bit of load, and crank for some time
-                    loadGen.generateLoad(
-                        LoadGenMode::PAY, /* nAccounts */ 10, 0, 10,
+                    loadGen.generateLoad(GeneratedLoadConfig::txLoad(
+                        LoadGenMode::PAY, /* nAccounts */ 10, /* nTxs */ 10,
                         /*txRate*/ 1,
-                        /*batchSize*/ 1, std::chrono::seconds(0), 0);
+                        /*batchSize*/ 1));
 
                     auto currLoadGenCount = loadGenDone.count();
 

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -1590,9 +1590,10 @@ TEST_CASE("overlay flow control", "[overlay][flowcontrol]")
         // Generate a bit of load to flood transactions, make sure nodes can
         // close ledgers properly
         auto& loadGen = node->getLoadGenerator();
-        loadGen.generateLoad(LoadGenMode::CREATE, /* nAccounts */ 10, 0, 0,
-                             /*txRate*/ 1,
-                             /*batchSize*/ 1, std::chrono::seconds(0), 0);
+        loadGen.generateLoad(
+            GeneratedLoadConfig::createAccountsLoad(/* nAccounts */ 10,
+                                                    /* txRate */ 1,
+                                                    /* batchSize */ 1));
 
         auto& loadGenDone =
             node->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
@@ -2204,9 +2205,10 @@ TEST_CASE("overlay pull mode loadgen", "[overlay][pullmode][acceptance]")
     // Create 5 txns each creating one new account.
     // Set a really high tx rate so we create the txns right away.
     auto const numAccounts = 5;
-    loadGen.generateLoad(LoadGenMode::CREATE, numAccounts, 0, 0,
-                         /*txRate*/ 1000,
-                         /*batchSize*/ 1, std::chrono::seconds(0), 0);
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ numAccounts,
+        /* txRate */ 1000,
+        /* batchSize */ 1));
 
     // Let the network close multiple ledgers.
     // If the logic to advertise or demand incorrectly sends more than

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -395,8 +395,10 @@ TEST_CASE(
     auto& app = *nodes[0]; // pick a node to generate load
 
     auto& loadGen = app.getLoadGenerator();
-    loadGen.generateLoad(LoadGenMode::CREATE, 3, 0, 0, 10, 100,
-                         std::chrono::seconds(0), 0);
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ 3,
+        /* txRate */ 10,
+        /* batchSize */ 100));
     try
     {
         simulation->crankUntil(
@@ -409,8 +411,8 @@ TEST_CASE(
             },
             3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
 
-        loadGen.generateLoad(LoadGenMode::PAY, 3, 0, 10, 10, 100,
-                             std::chrono::seconds(0), 0);
+        loadGen.generateLoad(
+            GeneratedLoadConfig::txLoad(LoadGenMode::PAY, 3, 10, 10, 100));
         simulation->crankUntil(
             [&]() {
                 return simulation->haveAllExternalized(8, 2) &&
@@ -523,8 +525,10 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
     uint32_t numItems = 500000;
 
     // Create accounts
-    loadGen.generateLoad(LoadGenMode::CREATE, numItems, 0, 0, 10, 100,
-                         std::chrono::seconds(0), 0);
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ 10,
+        /* txRate */ 10,
+        /* batchSize */ 100));
 
     auto& complete =
         appPtr->getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
@@ -539,8 +543,8 @@ TEST_CASE("Accounts vs latency", "[scalability][!hide]")
     txtime.Clear();
 
     // Generate payment txs
-    loadGen.generateLoad(LoadGenMode::PAY, numItems, 0, numItems / 10, 10, 100,
-                         std::chrono::seconds(0), 0);
+    loadGen.generateLoad(GeneratedLoadConfig::txLoad(LoadGenMode::PAY, numItems,
+                                                     numItems / 10, 10, 100));
     while (!io.stopped() && complete.count() == 1)
     {
         clock.crank();
@@ -574,8 +578,10 @@ netTopologyTest(std::string const& name,
         auto& app = *nodes[0];
 
         auto& loadGen = app.getLoadGenerator();
-        loadGen.generateLoad(LoadGenMode::CREATE, 50, 0, 0, 10, 100,
-                             std::chrono::seconds(0), 0);
+        loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+            /* nAccounts */ 50,
+            /* txRate */ 10,
+            /* batchSize */ 100));
         auto& complete =
             app.getMetrics().NewMeter({"loadgen", "run", "complete"}, "run");
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -49,6 +49,10 @@ const uint32_t LoadGenerator::TX_SUBMIT_MAX_TRIES = 10;
 // ledger.
 const uint32_t LoadGenerator::TIMEOUT_NUM_LEDGERS = 20;
 
+// After successfully submitting desired load, wait for this many ledgers
+// without checking for account consistency.
+const uint32_t LoadGenerator::COMPLETION_TIMEOUT_WITHOUT_CHECKS = 4;
+
 LoadGenerator::LoadGenerator(Application& app)
     : mMinBalance(0)
     , mLastSecond(0)
@@ -221,7 +225,17 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
     if ((isCreate && cfg.nAccounts == 0) || (!isCreate && cfg.nTxs == 0))
     {
         // Done submitting the load, now ensure it propagates to the DB.
-        waitTillComplete(isCreate);
+        if (!isCreate && cfg.skipLowFeeTxs)
+        {
+            // skipLowFeeTxs allows triggering tx queue limiter, which makes it
+            // hard to track the final seq nums. Hence just wait
+            // unconditionally.
+            waitTillCompleteWithoutChecks();
+        }
+        else
+        {
+            waitTillComplete(isCreate);
+        }
         return;
     }
 
@@ -251,15 +265,11 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
                                              cfg.batchSize, ledgerNum);
             break;
         case LoadGenMode::PAY:
-            cfg.nTxs = submitPaymentOrPretendTx(cfg.nAccounts, cfg.offset,
-                                                cfg.batchSize, ledgerNum,
-                                                cfg.nTxs, 1, cfg.mode);
+            cfg.nTxs = submitPaymentOrPretendTx(cfg, ledgerNum, 1);
             break;
         case LoadGenMode::PRETEND:
             auto opCount = chooseOpCount(mApp.getConfig());
-            cfg.nTxs = submitPaymentOrPretendTx(cfg.nAccounts, cfg.offset,
-                                                cfg.batchSize, ledgerNum,
-                                                cfg.nTxs, opCount, cfg.mode);
+            cfg.nTxs = submitPaymentOrPretendTx(cfg, ledgerNum, opCount);
             break;
         }
 
@@ -331,28 +341,43 @@ LoadGenerator::submitCreationTx(uint32_t nAccounts, uint32_t offset,
 }
 
 uint32_t
-LoadGenerator::submitPaymentOrPretendTx(uint32_t nAccounts, uint32_t offset,
-                                        uint32_t batchSize, uint32_t ledgerNum,
-                                        uint32_t nTxs, uint32_t opCount,
-                                        LoadGenMode mode)
+LoadGenerator::submitPaymentOrPretendTx(GeneratedLoadConfig const& cfg,
+                                        uint32_t ledgerNum, uint32_t opCount)
 {
-    auto sourceAccountId = rand_uniform<uint64_t>(0, nAccounts - 1) + offset;
+    auto sourceAccountId =
+        rand_uniform<uint64_t>(0, cfg.nAccounts - 1) + cfg.offset;
     TransactionFramePtr tx;
     TestAccountPtr from;
-    bool usePaymentOp = mode == LoadGenMode::PAY;
+    bool usePaymentOp = cfg.mode == LoadGenMode::PAY;
     std::tie(from, tx) =
         usePaymentOp
-            ? paymentTransaction(nAccounts, offset, ledgerNum, sourceAccountId)
-            : pretendTransaction(nAccounts, offset, ledgerNum, sourceAccountId,
-                                 opCount);
+            ? paymentTransaction(cfg.nAccounts, cfg.offset, ledgerNum,
+                                 sourceAccountId, cfg.maxGeneratedFeeRate)
+            : pretendTransaction(cfg.nAccounts, cfg.offset, ledgerNum,
+                                 sourceAccountId, opCount,
+                                 cfg.maxGeneratedFeeRate);
 
     TransactionResultCode code;
     TransactionQueue::AddResult status;
     uint32_t numTries = 0;
 
-    while ((status = execute(tx, mode, code, batchSize)) !=
+    while ((status = execute(tx, cfg.mode, code, cfg.batchSize)) !=
            TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
+
+        if (cfg.skipLowFeeTxs &&
+            (status ==
+                 TransactionQueue::AddResult::ADD_STATUS_TRY_AGAIN_LATER ||
+             status == TransactionQueue::AddResult::ADD_STATUS_ERROR &&
+                 code == txINSUFFICIENT_FEE))
+        {
+            // Rollback the seq num of the test account as we regenerate the
+            // transaction.
+            from->setSequenceNumber(from->getLastSequenceNumber() - 1);
+            CLOG_INFO(LoadGen, "skipped low fee tx with fee {}",
+                      tx->getFeeBid());
+            return cfg.nTxs;
+        }
         if (++numTries >= TX_SUBMIT_MAX_TRIES ||
             status != TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {
@@ -365,14 +390,15 @@ LoadGenerator::submitPaymentOrPretendTx(uint32_t nAccounts, uint32_t offset,
 
         // Regenerate a new payment tx
         std::tie(from, tx) =
-            usePaymentOp ? paymentTransaction(nAccounts, offset, ledgerNum,
-                                              sourceAccountId)
-                         : pretendTransaction(nAccounts, offset, ledgerNum,
-                                              sourceAccountId, opCount);
+            usePaymentOp
+                ? paymentTransaction(cfg.nAccounts, cfg.offset, ledgerNum,
+                                     sourceAccountId, cfg.maxGeneratedFeeRate)
+                : pretendTransaction(cfg.nAccounts, cfg.offset, ledgerNum,
+                                     sourceAccountId, opCount,
+                                     cfg.maxGeneratedFeeRate);
     }
 
-    nTxs -= 1;
-    return nTxs;
+    return cfg.nTxs - 1;
 }
 
 void
@@ -414,8 +440,9 @@ LoadGenerator::creationTransaction(uint64_t startAccount, uint64_t numItems,
 {
     vector<Operation> creationOps =
         createAccounts(startAccount, numItems, ledgerNum);
-    return std::make_pair(mRoot, createTransactionFramePtr(
-                                     mRoot, creationOps, LoadGenMode::CREATE));
+    return std::make_pair(mRoot, createTransactionFramePtr(mRoot, creationOps,
+                                                           LoadGenMode::CREATE,
+                                                           std::nullopt));
 }
 
 void
@@ -519,7 +546,8 @@ LoadGenerator::findAccount(uint64_t accountId, uint32_t ledgerNum)
 
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
 LoadGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
-                                  uint32_t ledgerNum, uint64_t sourceAccount)
+                                  uint32_t ledgerNum, uint64_t sourceAccount,
+                                  std::optional<uint32_t> maxGeneratedFeeRate)
 {
     TestAccountPtr to, from;
     uint64_t amount = 1;
@@ -527,14 +555,16 @@ LoadGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
         pickAccountPair(numAccounts, offset, ledgerNum, sourceAccount);
     vector<Operation> paymentOps = {
         txtest::payment(to->getPublicKey(), amount)};
-    return std::make_pair(
-        from, createTransactionFramePtr(from, paymentOps, LoadGenMode::PAY));
+    return std::make_pair(from, createTransactionFramePtr(from, paymentOps,
+                                                          LoadGenMode::PAY,
+                                                          maxGeneratedFeeRate));
 }
 
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
 LoadGenerator::pretendTransaction(uint32_t numAccounts, uint32_t offset,
                                   uint32_t ledgerNum, uint64_t sourceAccount,
-                                  uint32_t opCount)
+                                  uint32_t opCount,
+                                  std::optional<uint32_t> maxGeneratedFeeRate)
 {
     vector<Operation> ops;
     ops.reserve(opCount);
@@ -556,8 +586,9 @@ LoadGenerator::pretendTransaction(uint32_t numAccounts, uint32_t offset,
         }
         ops.push_back(txtest::setOptions(args));
     }
-    return std::make_pair(
-        acc, createTransactionFramePtr(acc, ops, LoadGenMode::PRETEND));
+    return std::make_pair(acc, createTransactionFramePtr(acc, ops,
+                                                         LoadGenMode::PRETEND,
+                                                         maxGeneratedFeeRate));
 }
 
 void
@@ -570,6 +601,14 @@ LoadGenerator::maybeHandleFailedTx(TestAccountPtr sourceAccount,
     if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR &&
         code == txBAD_SEQ)
     {
+        auto const& txQueue = mApp.getHerder().getTransactionQueue();
+        auto txQueueSeqNum =
+            txQueue.getInQueueSeqNum(sourceAccount->getPublicKey());
+        if (txQueueSeqNum)
+        {
+            sourceAccount->setSequenceNumber(*txQueueSeqNum);
+            return;
+        }
         if (!loadAccount(sourceAccount, mApp))
         {
             CLOG_ERROR(LoadGen, "Unable to reload account {}",
@@ -657,6 +696,34 @@ LoadGenerator::waitTillComplete(bool isCreate)
     }
 }
 
+void
+LoadGenerator::waitTillCompleteWithoutChecks()
+{
+    if (!mLoadTimer)
+    {
+        mLoadTimer = std::make_unique<VirtualTimer>(mApp.getClock());
+    }
+    if (++mWaitTillCompleteForLedgers == COMPLETION_TIMEOUT_WITHOUT_CHECKS)
+    {
+        auto inconsistencies = checkAccountSynced(mApp, /* isCreate */ false);
+        CLOG_INFO(LoadGen, "Load generation complete.");
+        if (!inconsistencies.empty())
+        {
+            CLOG_INFO(
+                LoadGen,
+                "{} account seq nums are not in sync with db; this is expected "
+                "for high traffic due to tx queue limiter evictions.",
+                inconsistencies.size());
+        }
+        mLoadgenComplete.Mark();
+        reset();
+        return;
+    }
+    mLoadTimer->expires_from_now(mApp.getConfig().getExpectedLedgerCloseTime());
+    mLoadTimer->async_wait([this]() { this->waitTillCompleteWithoutChecks(); },
+                           &VirtualTimer::onFailureNoop);
+}
+
 LoadGenerator::TxMetrics::TxMetrics(medida::MetricsRegistry& m)
     : mAccountCreated(m.NewMeter({"loadgen", "account", "created"}, "account"))
     , mNativePayment(m.NewMeter({"loadgen", "payment", "native"}, "payment"))
@@ -684,12 +751,31 @@ LoadGenerator::TxMetrics::report()
 }
 
 TransactionFramePtr
-LoadGenerator::createTransactionFramePtr(TestAccountPtr from,
-                                         std::vector<Operation> ops,
-                                         LoadGenMode mode)
+LoadGenerator::createTransactionFramePtr(
+    TestAccountPtr from, std::vector<Operation> ops, LoadGenMode mode,
+    std::optional<uint32_t> maxGeneratedFeeRate)
 {
-    auto txf = from->tx(ops);
+    int fee = 0;
 
+    if (maxGeneratedFeeRate)
+    {
+        auto baseFee = mApp.getLedgerManager().getLastTxFee();
+        auto feeRateDistr =
+            uniform_int_distribution<uint32_t>(baseFee, *maxGeneratedFeeRate);
+        // Add a bit more fee to get non-integer fee rates, such that
+        // `floor(fee / ops.size()) == feeRate`, but
+        // `fee / ops.size() >= feeRate`.
+        // This is to create a bit more realistic fee structure: in reality not
+        // every transaction would necessarily have the `fee == ops_count *
+        // some_int`. This also would exercise more code paths/logic during the
+        // transaction comparisons.
+        auto fractionalFeeDistr =
+            uniform_int_distribution<uint32_t>(0, ops.size() - 1);
+        fee = ops.size() * feeRateDistr(gRandomEngine) +
+              fractionalFeeDistr(gRandomEngine);
+    }
+    auto txf = transactionFromOperations(mApp, from->getSecretKey(),
+                                         from->nextSequenceNumber(), ops, fee);
     if (mode == LoadGenMode::PRETEND)
     {
         Memo memo(MEMO_TEXT);
@@ -722,6 +808,7 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
         break;
     case LoadGenMode::PRETEND:
         txm.mPretendOps.Mark(txf->getNumOperations());
+        break;
     }
 
     txm.mTxnAttempted.Mark();

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -37,8 +37,10 @@ TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
     auto& app = *nodes[0]; // pick a node to generate load
 
     auto& loadGen = app.getLoadGenerator();
-    loadGen.generateLoad(LoadGenMode::CREATE, 3, 0, 0, 10, 100,
-                         std::chrono::seconds(0), 0);
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ 3,
+        /* txRate */ 10,
+        /* batchSize */ 100));
     try
     {
         simulation->crankUntil(
@@ -49,8 +51,8 @@ TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
             },
             3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
 
-        loadGen.generateLoad(LoadGenMode::PRETEND, 3, 0, 5, 10, 100,
-                             std::chrono::seconds(0), 0);
+        loadGen.generateLoad(
+            GeneratedLoadConfig::txLoad(LoadGenMode::PRETEND, 3, 5, 10, 100));
 
         simulation->crankUntil(
             [&]() {


### PR DESCRIPTION
# Description

Extend load generator to produce high volume traffic that easily triggers limiting and surge pricing logic. Also added fee diversification and did some refactoring to easier introduce new parameters.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
