### PR TITLE
Make tx set frame order matter only during encoding/decoding.

### DIFF
--- a/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
+++ b/src/catchup/simulation/TxSimApplyTransactionsWork.cpp
@@ -527,7 +527,7 @@ TxSimApplyTransactionsWork::getNextLedgerFromHistoryArchive()
             txSetFrame =
                 TxSetFrame::makeFromWire(mNetworkID, txHistoryEntry.txSet);
         }
-        for (auto const& txFrame : txSetFrame->getTxsInHashOrder())
+        for (auto const& txFrame : txSetFrame->getTxs())
         {
             transactions[txFrame->getContentsHash()] = &txFrame->getEnvelope();
         }

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -219,7 +219,7 @@ HerderImpl::newSlotExternalized(bool synchronous, StellarValue const& value)
     auto externalizedSet = mPendingEnvelopes.getTxSet(value.txSetHash);
     if (externalizedSet)
     {
-        updateTransactionQueue(externalizedSet->getTxsInHashOrder());
+        updateTransactionQueue(externalizedSet->getTxs());
     }
 
     // Evict slots that are outside of our ledger validity bracket

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -32,6 +32,9 @@ class TxSetFrame : public NonMovableOrCopyable
     // there are too many remaining transactions surge pricing is applied.
     // The result is guaranteed to pass `checkValid` check with the same
     // arguments as in this method, so additional validation is not needed.
+    //
+    // **Note**: the output `TxSetFrame` will *not* contain the input
+    // transaction pointers.
     static TxSetFrameConstPtr
     makeFromTransactions(Transactions const& txs, Application& app,
                          uint64_t lowerBoundCloseTimeOffset,
@@ -76,9 +79,8 @@ class TxSetFrame : public NonMovableOrCopyable
 
     Hash const& previousLedgerHash() const;
 
-    // Gets all the transactions belonging to this frame sorted by their full
-    // hashes.
-    Transactions const& getTxsInHashOrder() const;
+    // Gets all the transactions belonging to this frame in arbitrary order.
+    Transactions const& getTxs() const;
 
     /*
     Build a list of transaction ready to be applied to the last closed ledger,

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1133,7 +1133,7 @@ TEST_CASE("txset base fee", "[herder][txset]")
         auto balancesBefore = getBalances();
 
         // apply this
-        closeLedger(*app, txSet->getTxsInHashOrder());
+        closeLedger(*app, txSet->getTxs());
 
         auto balancesAfter = getBalances();
         int64_t lowFee = INT64_MAX, highFee = 0;
@@ -1341,7 +1341,7 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
         auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
         REQUIRE(txSet->size(lhCopy) == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
         // check that the expected tx are there
-        for (auto const& tx : txSet->getTxsInHashOrder())
+        for (auto const& tx : txSet->getTxs())
         {
             REQUIRE(tx->getSourceID() == root.getPublicKey());
         }
@@ -1365,7 +1365,7 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
         auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
         REQUIRE(txSet->size(lhCopy) == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
         // check that the expected tx are there
-        for (auto const& tx : txSet->getTxsInHashOrder())
+        for (auto const& tx : txSet->getTxs())
         {
             REQUIRE(tx->getSourceID() == root.getPublicKey());
         }
@@ -1870,8 +1870,8 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
             // only if we expect it to be invalid.
             auto closeTimeOffset = nextCloseTime - lclCloseTime;
             TxSetFrame::Transactions removed;
-            TxSetUtils::trimInvalid(txSet->getTxsInHashOrder(), *app,
-                                    closeTimeOffset, closeTimeOffset, removed);
+            TxSetUtils::trimInvalid(txSet->getTxs(), *app, closeTimeOffset,
+                                    closeTimeOffset, removed);
             REQUIRE(removed.size() == (expectValid ? 0 : 1));
         };
 
@@ -3169,7 +3169,7 @@ TEST_CASE("do not flood invalid transactions", "[herder]")
     auto txs = tq.getTransactions(lhhe.header);
     auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
     REQUIRE(txSet->sizeTx() == 1);
-    REQUIRE(txSet->getTxsInHashOrder().front()->getContentsHash() ==
+    REQUIRE(txSet->getTxs().front()->getContentsHash() ==
             tx1a->getContentsHash());
     REQUIRE(txSet->checkValid(*app, 0, 0));
 }

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -416,9 +416,6 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     auto checkXdrRoundtrip = [&](GeneralizedTransactionSet const& txSetXdr) {
         auto frame = TxSetFrame::makeFromWire(app->getNetworkID(), txSetXdr);
         REQUIRE(frame->checkValid(*app, 0, 0));
-        REQUIRE(std::is_sorted(frame->getTxsInHashOrder().begin(),
-                               frame->getTxsInHashOrder().end(),
-                               &TxSetUtils::hashTxSorter));
         GeneralizedTransactionSet newXdr;
         frame->toXDR(newXdr);
         REQUIRE(newXdr == txSetXdr);
@@ -572,7 +569,7 @@ TEST_CASE("generalized tx set fees", "[txset]")
 
         REQUIRE(txSet->checkValid(*app, 0, 0));
         std::vector<std::optional<int64_t>> fees;
-        for (auto const& tx : txSet->getTxsInHashOrder())
+        for (auto const& tx : txSet->getTxs())
         {
             fees.push_back(txSet->getTxBaseFee(
                 tx,

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -643,8 +643,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
 
                 auto r = closeLedger(*app, {tx1, txMinSeqNumSrc}, true);
 
-                REQUIRE(tx1->getResult()
-                            .result.results()[0]
+                REQUIRE(r[0].first.result.result.results()[0]
                             .tr()
                             .accountMergeResult()
                             .code() == ACCOUNT_MERGE_SEQNUM_TOO_FAR);
@@ -665,8 +664,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
 
                 auto r = closeLedger(*app, {tx1, tx2, tx3, txMinSeqNumSrc});
 
-                REQUIRE(tx1->getResult()
-                            .result.results()[0]
+                REQUIRE(r[0].first.result.result.results()[0]
                             .tr()
                             .accountMergeResult()
                             .code() == ACCOUNT_MERGE_SEQNUM_TOO_FAR);
@@ -684,8 +682,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                 auto r = closeLedger(*app, {tx1, tx2}, true);
 
                 checkTx(0, r, txSUCCESS);
-                REQUIRE(tx2->getResult()
-                            .result.results()[0]
+                REQUIRE(r[1].first.result.result.results()[0]
                             .tr()
                             .accountMergeResult()
                             .code() == ACCOUNT_MERGE_SEQNUM_TOO_FAR);

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -2377,12 +2377,12 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                     auto r = closeLedgerOn(*app, 1, 2, 2016, {tx1, tx2});
 
-                    REQUIRE(tx1->getResultCode() == txSUCCESS);
-                    REQUIRE(tx2->getResultCode() == txFAILED);
+                    checkTx(0, r, txSUCCESS);
+                    checkTx(1, r, txFAILED);
                     REQUIRE(PaymentOpFrame::getInnerCode(
-                                getFirstResult(*tx2)) == PAYMENT_SUCCESS);
-                    REQUIRE(tx2->getOperations()[1]->getResultCode() ==
-                            opBAD_AUTH);
+                                r[1].first.result.result.results()[0]) ==
+                            PAYMENT_SUCCESS);
+                    REQUIRE(r[1].first.result.result.code() == opBAD_AUTH);
                 });
             }
         }


### PR DESCRIPTION
# Description

Resolves #3495

Make tx set frame order matter only during encoding/decoding.

There is no reason to maintain the order in memory and then implicitly assume it's preserved during encoding. Instead, we store transactions in arbitrary order in memory and sort only during encoding to XDR. This hopefully should reduce the risk of outputting a malformed tx set.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
