### PR TITLE
First sketch of InvokeHostFunctionOp preflight endpoint.

### DIFF
--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -54,6 +54,10 @@ class CommandHandler
     void getcursor(std::string const& params, std::string& retStr);
     void scpInfo(std::string const& params, std::string& retStr);
     void tx(std::string const& params, std::string& retStr);
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    void preflight(std::string const& params, std::string& retStr);
+    void getLedgerEntry(std::string const& params, std::string& retStr);
+#endif
     void unban(std::string const& params, std::string& retStr);
     void upgrades(std::string const& params, std::string& retStr);
     void surveyTopology(std::string const&, std::string& retStr);

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -34,13 +34,15 @@ TEST_CASE_VERSIONS("transaction envelope bridge", "[commandhandler]")
     auto& ch = app->getCommandHandler();
     auto baseFee = app->getLedgerManager().getLastTxFee();
 
-    std::string const PENDING_RESULT = "{\"status\": \"PENDING\"}";
+    std::string const PENDING_RESULT = "{\"status\":\"PENDING\"}\n";
     auto errorResult = [](TransactionResultCode resultCode, int64_t fee) {
         TransactionResult txRes;
         txRes.feeCharged = fee;
         txRes.result.code(resultCode);
         auto inner = decoder::encode_b64(xdr::xdr_to_opaque(txRes));
-        return "{\"status\": \"ERROR\" , \"error\": \"" + inner + "\"}";
+        return
+
+            std::string("{\"error\":\"") + inner + "\",\"status\":\"ERROR\"}\n";
     };
 
     auto sign = [&](auto& signatures, SecretKey const& key, auto... input) {

--- a/src/rust/CppShims.h
+++ b/src/rust/CppShims.h
@@ -12,8 +12,32 @@
 // constructors, etc). We isolate them in this file to avoid polluting normal
 // C++ code with too much interop glue.
 
+namespace rust
+{
+inline namespace cxxbridge1
+{
+template <typename T> class Vec;
+}
+}
+struct XDRBuf;
 namespace stellar
 {
+class Application;
+struct PreflightResults;
+struct PreflightCallbacks
+{
+    Application& mApp;
+    PreflightResults& mRes;
+    PreflightCallbacks(Application& app, PreflightResults& res)
+        : mApp(app), mRes(res){};
+    XDRBuf get_ledger_entry(rust::Vec<uint8_t> const& key);
+    bool has_ledger_entry(rust::Vec<uint8_t> const& key);
+    void set_result_value(rust::Vec<uint8_t> const& val);
+    void set_result_footprint(rust::Vec<uint8_t> const& footprint);
+    void set_result_cpu_insns(uint64_t cpu);
+    void set_result_mem_bytes(uint64_t mem);
+};
+
 inline bool
 shim_isLogLevelAtLeast(std::string const& partition, LogLevel level)
 {

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "xdr/Stellar-transaction.h"
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 #include "transactions/OperationFrame.h"
 
@@ -31,6 +32,9 @@ class InvokeHostFunctionOpFrame : public OperationFrame
 
     bool doApply(AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
+
+    static Json::Value preflight(Application& app,
+                                 InvokeHostFunctionOp const& op);
 
     void
     insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;


### PR DESCRIPTION
This implements a new `preflight?blob=<InvokeHostFunctionOp>` HTTP endpoint which then runs the requested op _synchronously_ against the current ledger in preflight / footprint-recording mode, and reports back

- the host-function call result
- the storage footprint that was recorded
- the cpu instruction and memory byte counts (since we don't currently have a way to translate these into "gas costs")

It also adds a new `getledgerentry?key=<LedgerKey>` HTTP endpoint, which returns a status, encoded ledger entry, and ledger number (for consistency validation on the caller), because there's some ongoing discussion about doing preflight in the CLI client / in an RPC host / closer to the operator and it's harmless to include at this point (it's short and not part of release builds or anything, easy to remove later).

I also very slightly cleaned up the `tx?blob=` endpoint because it kinda looks like nobody has touched it in 7 years and it's a little messy. And I slightly cleaned up the existing call path for `invoke_host_function`.

Addresses #3484 and https://github.com/stellar/soroban-cli/issues/63