### PR TITLE
Add methods for identifying DEX-related operations and transactions.

### DIFF
--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -33,6 +33,12 @@ FeeBumpTransactionFrame::convertInnerTxToV1(TransactionEnvelope const& envelope)
     return e;
 }
 
+bool
+FeeBumpTransactionFrame::hasDexOperations() const
+{
+    return mInnerTx->hasDexOperations();
+}
+
 FeeBumpTransactionFrame::FeeBumpTransactionFrame(
     Hash const& networkID, TransactionEnvelope const& envelope)
     : mEnvelope(envelope)

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -97,5 +97,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     static TransactionEnvelope
     convertInnerTxToV1(TransactionEnvelope const& envelope);
+
+    bool hasDexOperations() const override;
 };
 }

--- a/src/transactions/ManageOfferOpFrameBase.cpp
+++ b/src/transactions/ManageOfferOpFrameBase.cpp
@@ -538,6 +538,12 @@ ManageOfferOpFrameBase::doApply(AbstractLedgerTxn& ltxOuter)
     return true;
 }
 
+bool
+ManageOfferOpFrameBase::isDexOperation() const
+{
+    return !isDeleteOffer();
+}
+
 int64_t
 ManageOfferOpFrameBase::generateNewOfferID(LedgerTxnHeader& header)
 {

--- a/src/transactions/ManageOfferOpFrameBase.h
+++ b/src/transactions/ManageOfferOpFrameBase.h
@@ -41,6 +41,9 @@ class ManageOfferOpFrameBase : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     bool doApply(AbstractLedgerTxn& lsOuter) override;
+
+    bool isDexOperation() const override;
+
     void
     insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -268,6 +268,12 @@ OperationFrame::resetResultSuccess()
     mResult.tr().type(mOperation.body.type());
 }
 
+bool
+OperationFrame::isDexOperation() const
+{
+    return false;
+}
+
 void
 OperationFrame::insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const
 {

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -91,5 +91,7 @@ class OperationFrame
 
     virtual void
     insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const;
+
+    virtual bool isDexOperation() const;
 };
 }

--- a/src/transactions/PathPaymentOpFrameBase.cpp
+++ b/src/transactions/PathPaymentOpFrameBase.cpp
@@ -46,6 +46,14 @@ PathPaymentOpFrameBase::insertLedgerKeysToPrefetch(
 }
 
 bool
+PathPaymentOpFrameBase::isDexOperation() const
+{
+    auto const& src = getSourceAsset();
+    auto const& dest = getDestAsset();
+    return !getPath().empty() || !(src == dest);
+}
+
+bool
 PathPaymentOpFrameBase::checkIssuer(AbstractLedgerTxn& ltx, Asset const& asset)
 {
     if (asset.type() != ASSET_TYPE_NATIVE)

--- a/src/transactions/PathPaymentOpFrameBase.h
+++ b/src/transactions/PathPaymentOpFrameBase.h
@@ -37,6 +37,8 @@ class PathPaymentOpFrameBase : public OperationFrame
     void
     insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;
 
+    bool isDexOperation() const override;
+
     virtual bool checkTransfer(int64_t maxSend, int64_t amountSend,
                                int64_t maxRecv, int64_t amountRecv) const = 0;
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -51,6 +51,21 @@ TransactionFrame::TransactionFrame(Hash const& networkID,
                                    TransactionEnvelope const& envelope)
     : mEnvelope(envelope), mNetworkID(networkID)
 {
+    // Create operation frames with dummy results. Currently the proper results
+    // are initialized in `TransactionFrame::resetResults` and eventually the
+    // operation frames should be decoupled from the results completely and
+    // created just once.
+    auto& ops = mEnvelope.type() == ENVELOPE_TYPE_TX_V0
+                    ? mEnvelope.v0().tx.operations
+                    : mEnvelope.v1().tx.operations;
+    getResult().result.code(txFAILED);
+    getResult().result.results().resize(static_cast<uint32_t>(ops.size()));
+
+    for (size_t i = 0; i < ops.size(); i++)
+    {
+        mOperations.push_back(
+            makeOperation(ops[i], getResult().result.results()[i], i));
+    }
 }
 
 Hash const&
@@ -311,6 +326,19 @@ TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
     {
         return stellar::loadAccount(ltx, accountID);
     }
+}
+
+bool
+TransactionFrame::hasDexOperations() const
+{
+    for (auto const& op : mOperations)
+    {
+        if (op->isDexOperation())
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 std::shared_ptr<OperationFrame>

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -221,5 +221,7 @@ class TransactionFrame : public TransactionFrameBase
     std::optional<SequenceNumber const> const getMinSeqNum() const override;
     Duration getMinSeqAge() const override;
     uint32 getMinSeqLedgerGap() const override;
+
+    bool hasDexOperations() const override;
 };
 }

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -68,5 +68,7 @@ class TransactionFrameBase
                                   std::optional<int64_t> baseFee) = 0;
 
     virtual StellarMessage toStellarMessage() const = 0;
+
+    virtual bool hasDexOperations() const = 0;
 };
 }


### PR DESCRIPTION
# Description

Add methods for identifying DEX-related operations and transactions. This is in preparation to introducing separate fee lane for DEX operations.

I had to initialize `OperationFrame`s in `TransactionFrame` constructor because we may need to execute the check before `resetResults` is called.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
