### PR TITLE
Unify fee-based transaction comparisions

### DIFF
--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -3,20 +3,30 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "herder/SurgePricingUtils.h"
+#include "crypto/SecretKey.h"
+#include "util/Logging.h"
 #include "util/numeric128.h"
+#include "util/types.h"
+#include <numeric>
 
 namespace stellar
 {
-
-using namespace std;
+namespace
+{
 
 int
-feeRate3WayCompare(int64 lFeeBid, uint32 lNbOps, int64 rFeeBid, uint32 rNbOps)
+feeRate3WayCompare(TransactionFrameBase const& l, TransactionFrameBase const& r)
 {
-    // compare fee/numOps between l and r
-    // getNumOperations >= 1 because SurgeCompare can only be used on
-    // valid transactions
-    //
+    return stellar::feeRate3WayCompare(l.getFeeBid(), l.getNumOperations(),
+                                       r.getFeeBid(), r.getNumOperations());
+}
+
+} // namespace
+
+int
+feeRate3WayCompare(int64_t lFeeBid, uint32_t lNbOps, int64_t rFeeBid,
+                   uint32_t rNbOps)
+{
     // Let f1, f2 be the two fee bids, and let n1, n2 be the two
     // operation counts. We want to calculate the boolean comparison
     // "f1 / n1 < f2 / n2" but, since these are uint128s, we want to
@@ -27,7 +37,6 @@ feeRate3WayCompare(int64 lFeeBid, uint32 lNbOps, int64 rFeeBid, uint32 rNbOps)
     //               f1 / n1 < f2 / n2
     //  == f1 * n1 * n2 / n1 < f2 * n1 * n2 / n2
     //  == f1 *      n2      < f2 * n1
-
     auto v1 = bigMultiply(lFeeBid, rNbOps);
     auto v2 = bigMultiply(rFeeBid, lNbOps);
     if (v1 < v2)
@@ -41,10 +50,319 @@ feeRate3WayCompare(int64 lFeeBid, uint32 lNbOps, int64 rFeeBid, uint32 rNbOps)
     return 0;
 }
 
-int
-feeRate3WayCompare(TransactionFrameBase const& l, TransactionFrameBase const& r)
+int64_t
+computeBetterFee(TransactionFrameBase const& tx, int64_t refFeeBid,
+                 uint32_t refNbOps)
 {
-    return feeRate3WayCompare(l.getFeeBid(), l.getNumOperations(),
-                              r.getFeeBid(), r.getNumOperations());
+    constexpr auto m = std::numeric_limits<int64_t>::max();
+
+    int64 minFee = m;
+    int64 v;
+    if (bigDivide(v, refFeeBid, tx.getNumOperations(), refNbOps,
+                  Rounding::ROUND_DOWN) &&
+        v < m)
+    {
+        minFee = v + 1;
+    }
+    return minFee;
+}
+
+SurgePricingPriorityQueue::TxStackComparator::TxStackComparator(bool isGreater,
+                                                                size_t seed)
+    : mIsGreater(isGreater), mSeed(seed)
+{
+}
+
+bool
+SurgePricingPriorityQueue::TxStackComparator::operator()(
+    TxStackPtr const& txStack1, TxStackPtr const& txStack2) const
+{
+    return txStackLessThan(*txStack1, *txStack2) ^ mIsGreater;
+}
+
+bool
+SurgePricingPriorityQueue::TxStackComparator::compareFeeOnly(
+    TransactionFrameBase const& tx1, TransactionFrameBase const& tx2) const
+{
+    return compareFeeOnly(tx1.getFeeBid(), tx1.getNumOperations(),
+                          tx2.getFeeBid(), tx2.getNumOperations());
+}
+
+bool
+SurgePricingPriorityQueue::TxStackComparator::compareFeeOnly(
+    int64_t tx1Bid, uint32_t tx1Ops, int64_t tx2Bid, uint32_t tx2Ops) const
+{
+    bool isLess = feeRate3WayCompare(tx1Bid, tx1Ops, tx2Bid, tx2Ops) < 0;
+    return isLess ^ mIsGreater;
+}
+
+bool
+SurgePricingPriorityQueue::TxStackComparator::isGreater() const
+{
+    return mIsGreater;
+}
+
+bool
+SurgePricingPriorityQueue::TxStackComparator::txStackLessThan(
+    TxStack const& txStack1, TxStack const& txStack2) const
+{
+    if (txStack1.empty())
+    {
+        return !txStack2.empty();
+    }
+    if (txStack2.empty())
+    {
+        return false;
+    }
+    return txLessThan(txStack1.getTopTx(), txStack2.getTopTx(), true);
+}
+
+bool
+SurgePricingPriorityQueue::TxStackComparator::txLessThan(
+    TransactionFrameBaseConstPtr const& tx1,
+    TransactionFrameBaseConstPtr const& tx2, bool breakTiesWithHash) const
+{
+    auto cmp3 = feeRate3WayCompare(*tx1, *tx2);
+
+    if (cmp3 != 0 || !breakTiesWithHash)
+    {
+        return cmp3 < 0;
+    }
+    // break tie with pointer arithmetic
+    auto lx = reinterpret_cast<size_t>(tx1.get()) ^ mSeed;
+    auto rx = reinterpret_cast<size_t>(tx2.get()) ^ mSeed;
+    return lx < rx;
+}
+
+SurgePricingPriorityQueue::SurgePricingPriorityQueue(bool isHighestPriority,
+                                                     uint32_t opsLimit,
+                                                     size_t comparisonSeed)
+    : mComparator(isHighestPriority, comparisonSeed)
+    , mOpsLimit(opsLimit)
+    , mOpsCount(0)
+    , mTxStackSet(mComparator)
+{
+}
+
+std::vector<TransactionFrameBasePtr>
+SurgePricingPriorityQueue::getMostTopTxsWithinLimit(
+    std::vector<TxStackPtr> const& txStacks, uint32_t opsLimit)
+{
+    SurgePricingPriorityQueue queue(
+        /* isHighestPriority */ true, opsLimit,
+        stellar::rand_uniform<size_t>(0, std::numeric_limits<size_t>::max()));
+    for (auto txStack : txStacks)
+    {
+        queue.add(txStack);
+    }
+    std::vector<TransactionFrameBasePtr> txs;
+    auto visitor = [&txs](TxStack const& txStack) {
+        txs.push_back(txStack.getTopTx());
+        return VisitTxStackResult::TX_PROCESSED;
+    };
+    uint32_t opsLeftUntilLimit;
+    queue.popTopTxs(/* allowGaps */ true, visitor, opsLeftUntilLimit);
+    return txs;
+}
+
+void
+SurgePricingPriorityQueue::visitTopTxs(
+    std::vector<TxStackPtr> const& txStacks, uint32_t opsLimit,
+    size_t comparisonSeed,
+    std::function<VisitTxStackResult(TxStack const&)> const& visitor,
+    uint32_t& opsLeftUntilLimit)
+{
+    SurgePricingPriorityQueue queue(/* isHighestPriority */ true, opsLimit,
+                                    comparisonSeed);
+    for (auto txStack : txStacks)
+    {
+        queue.add(txStack);
+    }
+    queue.popTopTxs(/* allowGaps */ false, visitor, opsLeftUntilLimit);
+}
+
+void
+SurgePricingPriorityQueue::add(TxStackPtr txStack)
+{
+    releaseAssert(txStack != nullptr);
+    bool inserted = mTxStackSet.insert(txStack).second;
+    if (inserted)
+    {
+        mOpsCount += txStack->getNumOperations();
+    }
+}
+
+void
+SurgePricingPriorityQueue::erase(TxStackPtr txStack)
+{
+    releaseAssert(txStack != nullptr);
+    auto it = mTxStackSet.find(txStack);
+    if (it != mTxStackSet.end())
+    {
+        erase(it);
+    }
+}
+
+void
+SurgePricingPriorityQueue::erase(
+    SurgePricingPriorityQueue::TxStackSet::iterator iter)
+{
+    auto ops = (*iter)->getNumOperations();
+    mOpsCount -= ops;
+    mTxStackSet.erase(iter);
+}
+
+void
+SurgePricingPriorityQueue::popTopTxs(
+    bool allowGaps,
+    std::function<VisitTxStackResult(TxStack const&)> const& visitor,
+    uint32_t& opsLeftUntilLimit)
+{
+    opsLeftUntilLimit = mOpsLimit;
+
+    while (!mTxStackSet.empty())
+    {
+        auto currIt = getTop();
+        auto const& currTx = *(*currIt)->getTopTx();
+        auto currOps = currTx.getNumOperations();
+        if (currOps > opsLeftUntilLimit)
+        {
+            if (allowGaps)
+            {
+                erase(currIt);
+                continue;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        // At this point, `currIt` points at the top transaction in the queue
+        // that is still within operation limits, so we can visit it and remove
+        // it from the queue.
+        auto const& txStack = *currIt;
+        auto visitRes = visitor(*txStack);
+        auto ops = txStack->getTopTx()->getNumOperations();
+        // Only account for operation counts when transaction was actually
+        // processed by the visitor.
+        if (visitRes == VisitTxStackResult::TX_PROCESSED)
+        {
+            opsLeftUntilLimit -= ops;
+        }
+        // Pop the tx from current iterator, unless the whole tx stack is
+        // skipped.
+        if (visitRes == VisitTxStackResult::TX_STACK_SKIPPED)
+        {
+            erase(currIt);
+        }
+        else
+        {
+            popTopTx(currIt);
+        }
+    }
+}
+
+std::pair<bool, int64_t>
+SurgePricingPriorityQueue::canFitWithEviction(
+    TransactionFrameBase const& tx, uint32_t txOpsDiscount,
+    std::vector<TxStackPtr>& txStacksToEvict) const
+{
+    // This only makes sense when the lowest fee rate tx is on top.
+    releaseAssert(!mComparator.isGreater());
+
+    if (tx.getNumOperations() < txOpsDiscount)
+    {
+        throw std::invalid_argument(
+            "Discount shouldn't be larger than transaction operations count");
+    }
+    auto txNewOps = tx.getNumOperations() - txOpsDiscount;
+    if (txNewOps > mOpsLimit)
+    {
+        CLOG_WARNING(
+            Herder,
+            "Operation limit is lower size than transaction ops: {} < {}."
+            "Node won't be able to accept all transactions.",
+            mOpsLimit, txNewOps);
+        return std::make_pair(false, 0ll);
+    }
+    uint32_t totalOps = sizeOps();
+    uint32_t newTotalOps = totalOps + txNewOps;
+    bool fitWithoutEviction = newTotalOps <= mOpsLimit;
+    // If there is enough space, return.
+    if (fitWithoutEviction)
+    {
+        return std::make_pair(true, 0ll);
+    }
+    auto iter = getTop();
+    int64_t neededTotalOps =
+        std::max<int64_t>(0, static_cast<int64_t>(newTotalOps) - mOpsLimit);
+    // The above checks should ensure there are some operations that need to be
+    // evicted.
+    releaseAssert(neededTotalOps > 0);
+    while (neededTotalOps > 0)
+    {
+        // The preconditions are ensured above that we should be able to fit
+        // the transaction by evicting some transactions (given high enough
+        // fee).
+        releaseAssert(iter != mTxStackSet.end());
+        auto const& evictTxStack = *iter;
+        auto const& evictTx = *evictTxStack->getTopTx();
+        auto evictOps = evictTxStack->getNumOperations();
+        // Only support this for single tx stacks (eventually we should only
+        // have such stacks and share this invariant across all the queue
+        // operations).
+        releaseAssert(evictOps == evictTx.getNumOperations());
+
+        // Evicted tx must have a strictly lower fee than the new tx.
+        if (!mComparator.compareFeeOnly(evictTx, tx))
+        {
+            auto minFee = computeBetterFee(tx, evictTx.getFeeBid(),
+                                           evictTx.getNumOperations());
+            return std::make_pair(false, minFee);
+        }
+        // Ensure that this transaction is not from the same account.
+        if (tx.getSourceID() == evictTx.getSourceID())
+        {
+            return std::make_pair(false, 0ll);
+        }
+
+        txStacksToEvict.emplace_back(evictTxStack);
+        neededTotalOps -= evictOps;
+        if (neededTotalOps <= 0)
+        {
+            return std::make_pair(true, 0ll);
+        }
+
+        ++iter;
+    }
+    // The preconditions must guarantee that we find an evicted transaction set
+    // or report that the tx fee is too low.
+    releaseAssert(false);
+}
+
+SurgePricingPriorityQueue::TxStackSet::iterator
+SurgePricingPriorityQueue::getTop() const
+{
+    return mTxStackSet.begin();
+}
+
+uint32_t
+SurgePricingPriorityQueue::sizeOps() const
+{
+    return mOpsCount;
+}
+
+void
+SurgePricingPriorityQueue::popTopTx(
+    SurgePricingPriorityQueue::TxStackSet::iterator iter)
+{
+    auto txStack = *iter;
+    erase(iter);
+    txStack->popTopTx();
+    if (!txStack->empty())
+    {
+        add(txStack);
+    }
 }
 } // namespace stellar

--- a/src/herder/SurgePricingUtils.h
+++ b/src/herder/SurgePricingUtils.h
@@ -4,15 +4,173 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include <set>
+
 #include "transactions/TransactionFrameBase.h"
 
 namespace stellar
 {
-// 3-way fee rate compare variants
-int feeRate3WayCompare(int64 lFeeBid, uint32 lNbOps, int64 rFeeBid,
-                       uint32 rNbOps);
+// Compare fee/numOps between `l` and `r`.
+// Returns -1 if `l` is strictly less than `r`, `1` if it's strictly greater and
+// 0 when both are equal.
+int feeRate3WayCompare(int64_t lFeeBid, uint32_t lNbOps, int64_t rFeeBid,
+                       uint32_t rNbOps);
 
-int feeRate3WayCompare(TransactionFrameBase const& l,
-                       TransactionFrameBase const& r);
+// Compute the fee bid that `tx` should have in order to beat
+// a transaction `ref` with fee bid `refFeeBid` and `refNbOps` operations.
+int64_t computeBetterFee(TransactionFrameBase const& tx, int64_t refFeeBid,
+                         uint32_t refNbOps);
+
+// Interface for a stack-like container holding transactions.
+// This needs to be implemented by any user of `SurgePricingPriorityQueue`, as
+// it operates on stacks and not bare transactions.
+//
+// This interface is not strictly a stack as it just defines the 'pop' operation
+// and leaves the element additions up to the implementer. So the naming here is
+// mostly to be in contrast with `SurgePricingPriorityQueue`.
+class TxStack
+{
+  public:
+    // Gets the transaction on top of the stack.
+    virtual TransactionFrameBasePtr getTopTx() const = 0;
+    // Pops the transaction from top of the stack.
+    virtual void popTopTx() = 0;
+    // Returns the total number of operations in the stack.
+    virtual uint32_t getNumOperations() const = 0;
+    // Returns whether this stack is empty.
+    virtual bool empty() const = 0;
+
+    virtual ~TxStack() = default;
+};
+
+using TxStackPtr = std::shared_ptr<TxStack>;
+
+// Priority queue-like data structure that allows to store transactions ordered
+// by fee rate and perform operations that respect the operation count limits.
+//
+// The queue operates on transaction stacks and only the top transactions of the
+// stacks are compared. This allows to e.g. order transactions while preserving
+// the seq num order.
+class SurgePricingPriorityQueue
+{
+  public:
+    // Helper that uses `SurgePricingPriorityQueue` to greedily select the
+    // maximum subset of transactions from `txStacks` with maximum fee ratios
+    // such that the total operation count doesn't exceed `opsLimit`.
+    // The greedy ordering optimizes for the maximal fee ratio first, then for
+    // the output operation count.
+    // Transactions will be popped from the input `txStacks`, so after this call
+    // `txStacks` will contain all the remaining transactions.
+    static std::vector<TransactionFrameBasePtr>
+    getMostTopTxsWithinLimit(std::vector<TxStackPtr> const& txStacks,
+                             uint32_t opsLimit);
+
+    // Result of visiting the transaction stack in the `visitTopTxs`.
+    // This serves as a callback output to let the queue know how to process the
+    // visited stack.
+    enum class VisitTxStackResult
+    {
+        // Top transaction of the stack should be popped, but not counted
+        // towards the operation limit.
+        TX_SKIPPED,
+        // Top transaction of the stack should be popped and counted towards the
+        // operation limits.
+        TX_PROCESSED,
+        // The whole stack should be skipped (no transactions are popped or
+        // counted towards the operation limit).
+        TX_STACK_SKIPPED
+    };
+
+    // Helper that uses `SurgePricingPriorityQueue` to visits the top (by fee
+    // rate) transactions in the `txStacks` until `opsLimit` is reached.
+    // The visiting process will end for a lane as soon as there is a
+    // transaction that causes the limit to be exceeded.
+    // `comparisonSeed` is used to break the comparison ties.
+    // `visitor` should process the `TxStack` and provide an action to do with
+    // that stack.
+    // `opsLeftUntilLimit` is an output parameter that will contain the number
+    // of operations left until the limit is reached.
+    static void visitTopTxs(
+        std::vector<TxStackPtr> const& txStacks, uint32_t opsLimit,
+        size_t comparisonSeed,
+        std::function<VisitTxStackResult(TxStack const&)> const& visitor,
+        uint32_t& opsLeftUntilLimit);
+
+    // Creates a `SurgePricingPriorityQueue` with the provided `opsLimit`.
+    // `isHighestPriority` defines the comparison order: when it's `true` the
+    // highest fee rate transactions are considered to be at the top, otherwise
+    // the lowest fee rate transaction is at the top.
+    SurgePricingPriorityQueue(bool isHighestPriority, uint32_t opsLimit,
+                              size_t comparisonSeed);
+
+    // Adds a `TxStack` to this queue. The queue has ownership of the stack and
+    // may pop transactions from it.
+    void add(TxStackPtr txStack);
+    // Erases a `TxStack` from this queue.
+    void erase(TxStackPtr txStack);
+
+    // Checks whether a provided transaction could fit into this queue without
+    // violating the ops limit while evicting some lower fee rate `TxStacks`
+    // from the queue.
+    // Returns whether transaction can be fit and if not, returns the minimum
+    // required fee to possibly fit. `txOpsDiscount` is a number of operations
+    // to subtract from tx's operations when estimating the total operation
+    // counts. `txStacksToEvict` is an output parameter that will contain all
+    // the stacks that need to be evicted in order to fit `tx`.
+    std::pair<bool, int64_t>
+    canFitWithEviction(TransactionFrameBase const& tx, uint32_t txOpsDiscount,
+                       std::vector<TxStackPtr>& txStacksToEvict) const;
+
+    // Returns total number of operations in all the stacks in this queue.
+    uint32_t sizeOps() const;
+
+  private:
+    class TxStackComparator
+    {
+      public:
+        TxStackComparator(bool isGreater, size_t seed);
+
+        bool operator()(TxStackPtr const& txStack1,
+                        TxStackPtr const& txStack2) const;
+
+        bool compareFeeOnly(TransactionFrameBase const& tx1,
+                            TransactionFrameBase const& tx2) const;
+        bool compareFeeOnly(int64_t tx1Bid, uint32_t tx1Ops, int64_t tx2Bid,
+                            uint32_t tx2Ops) const;
+        bool isGreater() const;
+
+      private:
+        bool txStackLessThan(TxStack const& txStack1,
+                             TxStack const& txStack2) const;
+
+        bool txLessThan(TransactionFrameBaseConstPtr const& tx1,
+                        TransactionFrameBaseConstPtr const& tx2,
+                        bool breakTiesWithHash) const;
+
+        bool const mIsGreater;
+        size_t mSeed;
+    };
+
+    using TxStackSet = std::set<TxStackPtr, TxStackComparator>;
+
+    // Generalized method for visiting and popping the top transactions in the
+    // queue until the ops limit is reached.
+    // This may leave the queue empty (when `allowGaps` is `true`) and hence is
+    // only used from the helper methods that don't expose the queue at all.
+    void
+    popTopTxs(bool allowGaps,
+              std::function<VisitTxStackResult(TxStack const&)> const& visitor,
+              uint32_t& opsLeftUntilLimit);
+
+    void erase(SurgePricingPriorityQueue::TxStackSet::iterator iter);
+    void popTopTx(SurgePricingPriorityQueue::TxStackSet::iterator iter);
+    SurgePricingPriorityQueue::TxStackSet::iterator getTop() const;
+
+    TxStackComparator const mComparator;
+    uint32_t mOpsLimit;
+    uint32_t mOpsCount;
+
+    TxStackSet mTxStackSet;
+};
 
 } // namespace stellar

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -4,6 +4,7 @@
 
 #include "herder/TransactionQueue.h"
 #include "crypto/SecretKey.h"
+#include "herder/SurgePricingUtils.h"
 #include "herder/TxQueueLimiter.h"
 #include "ledger/LedgerHashUtils.h"
 #include "ledger/LedgerManager.h"
@@ -190,7 +191,8 @@ isDuplicateTx(TransactionFrameBasePtr oldTx, TransactionFrameBasePtr newTx)
 TransactionQueue::AddResult
 TransactionQueue::canAdd(TransactionFrameBasePtr tx,
                          AccountStates::iterator& stateIter,
-                         TimestampedTransactions::iterator& oldTxIter)
+                         TimestampedTransactions::iterator& oldTxIter,
+                         std::vector<TxStackPtr>& txsToEvict)
 {
     ZoneScoped;
     if (isBanned(tx->getFullHash()))
@@ -291,7 +293,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
         }
     }
 
-    auto canAddRes = mTxQueueLimiter->canAddTx(tx, oldTx);
+    auto canAddRes = mTxQueueLimiter->canAddTx(tx, oldTx, txsToEvict);
     if (!canAddRes.first)
     {
         ban({tx});
@@ -489,7 +491,8 @@ TransactionQueue::tryAdd(TransactionFrameBasePtr tx, bool submittedFromSelf)
     ZoneScoped;
     AccountStates::iterator stateIter;
     TimestampedTransactions::iterator oldTxIter;
-    auto const res = canAdd(tx, stateIter, oldTxIter);
+    std::vector<TxStackPtr> txsToEvict;
+    auto const res = canAdd(tx, stateIter, oldTxIter, txsToEvict);
     if (res != TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
         return res;
@@ -522,14 +525,9 @@ TransactionQueue::tryAdd(TransactionFrameBasePtr tx, bool submittedFromSelf)
 
     // make space so that we can add this transaction
     // this will succeed as `canAdd` ensures that this is the case
-    if (!mTxQueueLimiter->evictTransactions(
-            ops, [&](TransactionFrameBasePtr const& txToEvict) {
-                ban({txToEvict});
-            }))
-    {
-        throw std::logic_error(
-            "Invalid queue state, could not evict transactions");
-    }
+    mTxQueueLimiter->evictTransactions(
+        txsToEvict, ops,
+        [&](TransactionFrameBasePtr const& txToEvict) { ban({txToEvict}); });
     mTxQueueLimiter->addTransaction(tx);
     mKnownTxHashes[tx->getFullHash()] = tx;
 
@@ -819,7 +817,7 @@ TransactionQueue::shift()
     {
         mSizeByAge[i]->set_count(sizes[i]);
     }
-    mTxQueueLimiter->resetMinFeeNeeded();
+    mTxQueueLimiter->resetEvictionState();
     // pick a new randomizing seed for tie breaking
     mBroadcastSeed =
         rand_uniform<uint64>(0, std::numeric_limits<uint64>::max());
@@ -911,26 +909,26 @@ TransactionQueue::maybeVersionUpgraded()
     mLedgerVersion = lcl.header.ledgerVersion;
 }
 
-size_t
+uint32_t
 TransactionQueue::getMaxOpsToFloodThisPeriod() const
 {
     auto& cfg = mApp.getConfig();
     double opRatePerLedger = cfg.FLOOD_OP_RATE_PER_LEDGER;
 
-    size_t maxOps = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+    auto maxOps = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
     double opsToFloodLedgerDbl = opRatePerLedger * maxOps;
     releaseAssertOrThrow(opsToFloodLedgerDbl >= 0.0);
     releaseAssertOrThrow(isRepresentableAsInt64(opsToFloodLedgerDbl));
     int64_t opsToFloodLedger = static_cast<int64_t>(opsToFloodLedgerDbl);
 
-    int64_t opsToFlood;
-    opsToFlood =
+    int64_t opsToFlood =
         mBroadcastOpCarryover +
         bigDivideOrThrow(opsToFloodLedger, cfg.FLOOD_TX_PERIOD_MS,
                          cfg.getExpectedLedgerCloseTime().count() * 1000,
                          Rounding::ROUND_UP);
-    releaseAssertOrThrow(opsToFlood >= 0);
-    return static_cast<size_t>(opsToFlood);
+    releaseAssertOrThrow(opsToFlood >= 0 &&
+                         opsToFlood <= std::numeric_limits<uint32_t>::max());
+    return opsToFlood;
 }
 
 TransactionQueue::BroadcastStatus
@@ -1031,46 +1029,70 @@ TransactionQueue::broadcastTx(AccountState& state, TimestampedTx& tx)
                : BroadcastStatus::BROADCAST_STATUS_ALREADY;
 }
 
-struct TxQueueTracker
+class TxQueueTracker : public TxStack
 {
-    TransactionQueue::TimestampedTransactions::iterator mCur;
-    TransactionQueue::AccountState* mAccountState;
+  public:
+    TxQueueTracker(TransactionQueue::AccountState* accountState)
+        : mAccountState(accountState)
+    {
+        mCur = mAccountState->mTransactions.begin();
+        skipToFirstNotBroadcasted();
+        // there should be at least one tx to broadcast in this queue
+        releaseAssert(!empty());
+    }
 
-    // skips to first transaction not broadcasted yet
+    TransactionFrameBasePtr
+    getTopTx() const override
+    {
+        releaseAssert(!empty());
+        return mCur->mTx;
+    }
+
+    TransactionQueue::TimestampedTx&
+    getCurrentTimestampedTx() const
+    {
+        return *mCur;
+    }
+
     bool
+    empty() const override
+    {
+        return mCur == mAccountState->mTransactions.end();
+    }
+
+    void
+    popTopTx() override
+    {
+        ++mCur;
+        skipToFirstNotBroadcasted();
+    }
+
+    uint32_t
+    getNumOperations() const override
+    {
+        // Operation count tracking is not relevant for this TxStack.
+        return 0;
+    }
+
+    TransactionQueue::AccountState&
+    getAccountState() const
+    {
+        return *mAccountState;
+    }
+
+  private:
+    // skips to first transaction not broadcasted yet
+    void
     skipToFirstNotBroadcasted()
     {
         while (mCur != mAccountState->mTransactions.end() && mCur->mBroadcasted)
         {
             ++mCur;
         }
-        return mCur != mAccountState->mTransactions.end();
     }
 
-    struct Comparator
-    {
-        size_t mSeed;
-        Comparator(size_t seed) : mSeed(seed)
-        {
-        }
-
-        // return true if l < r
-        // compares tx `cur` for each TxTracker as to implement surge
-        // pricing comparison
-        bool
-        operator()(TxQueueTracker const& l, TxQueueTracker const& r) const
-        {
-            if (l.mCur == l.mAccountState->mTransactions.end())
-            {
-                return r.mCur != r.mAccountState->mTransactions.end();
-            }
-            if (r.mCur == r.mAccountState->mTransactions.end())
-            {
-                return false;
-            }
-            return lessThanXored(l.mCur->mTx, r.mCur->mTx, mSeed);
-        }
-    };
+    TransactionQueue::TimestampedTransactions::iterator mCur;
+    TransactionQueue::AccountState* mAccountState;
 };
 
 bool
@@ -1081,73 +1103,59 @@ TransactionQueue::broadcastSome()
     // highest base fee not broadcasted so far.
     // This broadcasts from account queues in order as to maximize chances of
     // propagation.
-    size_t opsToFlood = getMaxOpsToFloodThisPeriod();
+    auto opsToFlood = getMaxOpsToFloodThisPeriod();
 
-    // uses a priority queue of trackers, using a custom comparator as to
-    // prioritize higher fee queues
-    TxQueueTracker::Comparator comp(mBroadcastSeed);
-    std::priority_queue<TxQueueTracker, std::vector<TxQueueTracker>,
-                        TxQueueTracker::Comparator>
-        iters(comp);
     size_t totalOpsToFlood = 0;
-    for (auto& m : mAccountStates)
+    std::vector<TxStackPtr> trackersToBroadcast;
+    for (auto& [_, accountState] : mAccountStates)
     {
-        auto asOps = m.second.mBroadcastQueueOps;
+        auto asOps = accountState.mBroadcastQueueOps;
         if (asOps != 0)
         {
-            TxQueueTracker tracker{m.second.mTransactions.begin(), &m.second};
-            auto r = tracker.skipToFirstNotBroadcasted();
-            // there should be at least one tx to broadcast in this queue
-            releaseAssert(r);
-            iters.emplace(tracker);
+            trackersToBroadcast.emplace_back(
+                std::make_shared<TxQueueTracker>(&accountState));
             totalOpsToFlood += asOps;
         }
     }
 
     std::vector<TransactionFrameBasePtr> banningTxs;
-    while (opsToFlood != 0 && !iters.empty())
-    {
-        auto curTracker = iters.top();
-        iters.pop();
+    auto visitor = [this, &totalOpsToFlood,
+                    &banningTxs](TxStack const& txStack) {
+        auto const& curTracker = static_cast<TxQueueTracker const&>(txStack);
         // look at the next candidate transaction for that account
-        auto& cur = curTracker.mCur;
-        auto& tx = cur->mTx;
+        auto& cur = curTracker.getCurrentTimestampedTx();
+        auto tx = curTracker.getTopTx();
         // by construction, cur points to non broadcasted transactions
-        releaseAssert(!cur->mBroadcasted);
-        if (opsToFlood < tx->getNumOperations())
-        {
-            // as we can't flood this transaction we have to wait to
-            // accumulate more flooding credit
-            break;
-        }
-        auto bStatus = broadcastTx(*curTracker.mAccountState, *cur);
+        releaseAssert(!cur.mBroadcasted);
+        auto bStatus = broadcastTx(curTracker.getAccountState(), cur);
         if (bStatus == BroadcastStatus::BROADCAST_STATUS_SUCCESS)
         {
-            auto ops = tx->getNumOperations();
-            opsToFlood -= ops;
-            totalOpsToFlood -= ops;
+            totalOpsToFlood -= tx->getNumOperations();
+            return SurgePricingPriorityQueue::VisitTxStackResult::TX_PROCESSED;
         }
-        // when skipping, we ban the transaction and skip the remainder of the
-        // queue
-        if (bStatus == BroadcastStatus::BROADCAST_STATUS_SKIPPED)
+        else if (bStatus == BroadcastStatus::BROADCAST_STATUS_SKIPPED)
         {
+            // When skipping, we ban the transaction and skip the remainder of
+            // the stack.
             banningTxs.emplace_back(tx);
+            return SurgePricingPriorityQueue::VisitTxStackResult::
+                TX_STACK_SKIPPED;
         }
         else
         {
-            cur++;
-            // if we're not done with this account, add the tracker back
-            if (curTracker.skipToFirstNotBroadcasted())
-            {
-                iters.push(curTracker);
-            }
+            // Already broadcasted; don't invalidate the stack but also don't
+            // count transaction as processed.
+            return SurgePricingPriorityQueue::VisitTxStackResult::TX_SKIPPED;
         }
-    }
+    };
+    SurgePricingPriorityQueue::visitTopTxs(trackersToBroadcast, opsToFlood,
+                                           mBroadcastSeed, visitor,
+                                           mBroadcastOpCarryover);
     ban(banningTxs);
     // carry over remainder, up to MAX_OPS_PER_TX ops
     // reason is that if we add 1 next round, we can flood a "worst case fee
     // bump" tx
-    mBroadcastOpCarryover = std::min<size_t>(opsToFlood, MAX_OPS_PER_TX + 1);
+    mBroadcastOpCarryover = std::min(mBroadcastOpCarryover, MAX_OPS_PER_TX + 1);
     return totalOpsToFlood != 0;
 }
 

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "crypto/SecretKey.h"
+#include "herder/TxQueueLimiter.h"
 #include "herder/TxSetFrame.h"
 #include "ledger/LedgerTxn.h"
 #include "transactions/TransactionFrame.h"
@@ -30,7 +31,6 @@ namespace stellar
 {
 
 class Application;
-class TxQueueLimiter;
 
 /**
  * TransactionQueue keeps received transactions that are valid and have not yet
@@ -194,10 +194,10 @@ class TransactionQueue
 
     bool mShutdown{false};
     bool mWaiting{false};
-    size_t mBroadcastOpCarryover{0};
+    uint32_t mBroadcastOpCarryover = 0;
     VirtualTimer mBroadcastTimer;
 
-    size_t getMaxOpsToFloodThisPeriod() const;
+    uint32_t getMaxOpsToFloodThisPeriod() const;
     bool broadcastSome();
     void broadcast(bool fromCallback);
     // broadcasts a single transaction
@@ -211,7 +211,8 @@ class TransactionQueue
 
     AddResult canAdd(TransactionFrameBasePtr tx,
                      AccountStates::iterator& stateIter,
-                     TimestampedTransactions::iterator& oldTxIter);
+                     TimestampedTransactions::iterator& oldTxIter,
+                     std::vector<TxStackPtr>& txsToEvict);
 
     void releaseFeeMaybeEraseAccountState(TransactionFrameBasePtr tx);
 
@@ -231,7 +232,7 @@ class TransactionQueue
 
     size_t mBroadcastSeed;
 
-    friend struct TxQueueTracker;
+    friend class TxQueueTracker;
 
 #ifdef BUILD_TESTS
   public:

--- a/src/herder/TxQueueLimiter.h
+++ b/src/herder/TxQueueLimiter.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "herder/SurgePricingUtils.h"
 #include "ledger/LedgerManager.h"
 #include "transactions/TransactionFrame.h"
 #include "util/UnorderedMap.h"
@@ -11,44 +12,43 @@
 
 namespace stellar
 {
-class QueueLimiterTxMap;
+
 class TxQueueLimiter
 {
-    // size of the transaction queue, in operations
-    size_t mQueueSizeOps{0};
     // number of ledgers we can pool in memory
     uint32 const mPoolLedgerMultiplier;
     LedgerManager& mLedgerManager;
-    // minimum fee needed for a transaction
-    // stored as a pair (fee bid, nb operations)
-    std::pair<int64, uint32> mMinFeeNeeded;
+
+    // The bid of the last evicted transaction.
+    // This is also the maximum bid among evicted transactions.
+    std::pair<int64, uint32_t> mEvictedFeeBid;
 
     // all known transactions
-    std::unique_ptr<QueueLimiterTxMap> mTxs;
-    TransactionFrameBasePtr getWorstTransaction();
+    std::unique_ptr<SurgePricingPriorityQueue> mTxs;
+
+    // Mapping from individual transactions to `TxStack`s containing them.
+    UnorderedMap<TransactionFrameBasePtr, TxStackPtr> mStackForTx;
+
+    void resetTxs();
 
   public:
     TxQueueLimiter(uint32 multiplier, LedgerManager& lm);
     ~TxQueueLimiter();
 
-    size_t
-    size() const
-    {
-        return mQueueSizeOps;
-    }
-    size_t maxQueueSizeOps() const;
-
     void addTransaction(TransactionFrameBasePtr const& tx);
     void removeTransaction(TransactionFrameBasePtr const& tx);
 
-    // evict the worst transactions until there
-    // is enough capacity to insert ops operations
-    // by calling `evict` - note that evict must call `removeTransaction`
-    // as to make space
-    // returns false if it ran out of transactions before
-    // reaching its goal
-    bool evictTransactions(
-        size_t ops, std::function<void(TransactionFrameBasePtr const&)> evict);
+#ifdef BUILD_TESTS
+    size_t size() const;
+#endif
+    uint32_t maxQueueSizeOps() const;
+
+    // Evict `txsToEvict` from the limiter by calling `evict`.
+    // `txsToEvict` should be provided by the `canAddTx` call.
+    // Note that evict must call `removeTransaction` as to make space.
+    void evictTransactions(
+        std::vector<TxStackPtr> const& txsToEvict, uint32_t opsToFit,
+        std::function<void(TransactionFrameBasePtr const&)> evict);
 
     // oldTx is set when performing a replace by fee
     // return
@@ -57,17 +57,17 @@ class TxQueueLimiter
     //    second=0 if caller needs to wait
     //    second=minimum fee needed for tx to pass the next round of
     //    validation
+    // `txsToEvict` will contain transactions that need to be evicted in order
+    // to fit the new transactions. It should be passed to `evictTransactions`
+    // to perform the actual eviction.
     std::pair<bool, int64> canAddTx(TransactionFrameBasePtr const& tx,
-                                    TransactionFrameBasePtr const& oldTx) const;
+                                    TransactionFrameBasePtr const& oldTx,
+                                    std::vector<TxStackPtr>& txsToEvict);
 
+    // Resets the state related to evictions (maximum evicted bid).
+    void resetEvictionState();
+
+    // Resets the internal transaction container and the eviction state.
     void reset();
-
-    // txs must have strictly more base fee bid than this
-    std::pair<int64, uint32> getMinFeeNeeded() const;
-
-    void resetMinFeeNeeded();
 };
-
-bool lessThanXored(TransactionFrameBasePtr const& l,
-                   TransactionFrameBasePtr const& r, size_t seed);
 }

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "herder/SurgePricingUtils.h"
 #include "ledger/LedgerHashUtils.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrame.h"
@@ -12,6 +13,7 @@
 
 #include <deque>
 #include <functional>
+#include <optional>
 #include <unordered_map>
 
 namespace stellar
@@ -23,7 +25,6 @@ using TxSetFrameConstPtr = std::shared_ptr<TxSetFrame const>;
 class TxSetFrame : public NonMovableOrCopyable
 {
   public:
-    using AccountTransactionQueue = std::deque<TransactionFrameBasePtr>;
     using Transactions = std::vector<TransactionFrameBasePtr>;
 
     // Creates a valid TxSetFrame from the provided transactions.
@@ -155,7 +156,10 @@ class TxSetFrame : public NonMovableOrCopyable
     bool addTxsFromXdr(Hash const& networkID,
                        xdr::xvector<TransactionEnvelope> const& txs,
                        bool useBaseFee, std::optional<int64_t> baseFee);
-    void surgePricingFilter(uint32_t opsLeft);
+    void applySurgePricing(Application& app);
+
+    void computeTxFees(LedgerHeader const& lclHeader, int64_t lowestBaseFee,
+                       bool enableLogging) const;
 
     bool const mIsGeneralized;
 

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -13,6 +13,23 @@
 namespace stellar
 {
 
+class AccountTransactionQueue : public TxStack
+{
+  public:
+    AccountTransactionQueue(
+        std::vector<TransactionFrameBasePtr> const& accountTxs);
+
+    TransactionFrameBasePtr getTopTx() const override;
+    bool empty() const override;
+    void popTopTx() override;
+    uint32_t getNumOperations() const override;
+
+    std::deque<TransactionFrameBasePtr> mTxs;
+
+  private:
+    uint32_t mNumOperations = 0;
+};
+
 class TxSetUtils
 {
   public:
@@ -22,7 +39,7 @@ class TxSetUtils
     static TxSetFrame::Transactions
     sortTxsInHashOrder(TxSetFrame::Transactions const& transactions);
 
-    static UnorderedMap<AccountID, TxSetFrame::AccountTransactionQueue>
+    static std::vector<std::shared_ptr<AccountTransactionQueue>>
     buildAccountTxQueues(TxSetFrame::Transactions const& txs);
 
     // Returns transactions from a TxSet that are invalid. If

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3277,7 +3277,7 @@ TEST_CASE("do not flood too many transactions", "[herder][transactionqueue]")
         }
 
         std::map<AccountID, SequenceNumber> bcastTracker;
-        TransactionFrameBasePtr lastTx;
+        size_t numBroadcast = 0;
         tq.mTxBroadcastedEvent = [&](TransactionFrameBasePtr& tx) {
             // ensure that sequence numbers are correct per account
             auto expected = tx->getSeqNum();
@@ -3290,6 +3290,7 @@ TEST_CASE("do not flood too many transactions", "[herder][transactionqueue]")
             // check if we have the expected fee
             REQUIRE(tx->getFeeBid() == fees.front());
             fees.pop_front();
+            ++numBroadcast;
         };
 
         REQUIRE(tq.getTransactions({}).size() == numTx);
@@ -3298,11 +3299,6 @@ TEST_CASE("do not flood too many transactions", "[herder][transactionqueue]")
         // re-broadcasted during externalize
         fees.pop_front();
         fees.pop_front();
-
-        size_t numBroadcast = 0;
-        tq.mTxBroadcastedEvent = [&](TransactionFrameBasePtr&) {
-            ++numBroadcast;
-        };
 
         externalize(cfg.NODE_SEED, lm, herder, {tx1a, tx1r}, *app);
 


### PR DESCRIPTION
# Description

This introduces a common data structure (`SurgePricingPriorityQueue`) that orders the transactions by the fee rate and is aware of operation limits. This data structure is then used in the 3 places that do fee-based transaction comparisons: `TransactionQueue`, `TxQueueLimiter` and `TxSetFrame`.

The refactoring is functionally a no-op and serves as a preparation for introducing more complex transaction comparison logic.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
