### PR TITLE
Make it possible to print SCVal using print-xdr

### DIFF
--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -277,7 +277,13 @@ printXdr(std::string const& filename, std::string const& filetype, bool base64,
         {"result", PRINTONEXDR(TransactionResult)},
         {"resultpair", PRINTONEXDR(TransactionResultPair)},
         {"tx", PRINTONEXDR(TransactionEnvelope)},
-        {"txfee", PRINTONEXDR(LedgerEntryChanges)}};
+        {"txfee", PRINTONEXDR(LedgerEntryChanges)}
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        ,
+        {"scval", PRINTONEXDR(SCVal)}
+#endif
+    };
+
 #undef PRINTONEXDR
 
     try


### PR DESCRIPTION
# Description

This is just a useful debugging facility when working on Soroban.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
