### PR TITLE
Changed param name 'fee' to 'basefee' in Stellar Documentation

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -284,7 +284,7 @@ format.
         It is the time the upgrade will be scheduled for. If it is in the past
         by less than 12 hours, the upgrade will occur immediately. If it's more
         than 12 hours, then the upgrade will be ignored<br>
-    * `fee` (uint32) This is what you would prefer the base fee to be. It is in
+    * `basefee` (uint32) This is what you would prefer the base fee to be. It is in
         stroops<br>
     * `basereserve` (uint32) This is what you would prefer the base reserve to
         be. It is in stroops.<br>


### PR DESCRIPTION
This PR edits `commands.md` file changing 'fee' with the proper 'basefee' param name