### PR TITLE
Updated handling of configuration ledger entries

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,4 +25,4 @@
 	ignore = dirty
 [submodule "src/protocol-next/xdr"]
 	path = src/protocol-next/xdr
-	url = https://github.com/stellar/stellar-xdr-next.git
+	url = https://github.com/dmkozh/stellar-xdr-next.git

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -206,7 +206,6 @@ BucketApplicator::Counters::reset(VirtualClock::time_point now)
     mContractDataUpsert = 0;
     mContractDataDelete = 0;
     mConfigSettingUpsert = 0;
-    mConfigSettingDelete = 0;
 }
 
 void
@@ -215,8 +214,7 @@ BucketApplicator::Counters::getRates(
     uint64_t& tu_sec, uint64_t& td_sec, uint64_t& ou_sec, uint64_t& od_sec,
     uint64_t& du_sec, uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
     uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec, uint64_t& cdd_sec,
-    uint64_t& ccu_sec, uint64_t& ccd_sec, uint64_t& csu_sec, uint64_t& csd_sec,
-    uint64_t& T_sec, uint64_t& total)
+    uint64_t& ccu_sec, uint64_t& ccd_sec, uint64_t& csu_sec,     uint64_t& T_sec, uint64_t& total)
 {
     VirtualClock::duration dur = now - mStarted;
     auto usec = std::chrono::duration_cast<std::chrono::microseconds>(dur);
@@ -225,7 +223,7 @@ BucketApplicator::Counters::getRates(
             mTrustLineDelete + mOfferUpsert + mOfferDelete + mDataUpsert +
             mDataDelete + mClaimableBalanceUpsert + mClaimableBalanceDelete +
             mLiquidityPoolUpsert + mLiquidityPoolDelete + mContractDataUpsert +
-            mContractDataDelete + mConfigSettingUpsert + mConfigSettingDelete;
+            mContractDataDelete + mConfigSettingUpsert;
     au_sec = (mAccountUpsert * 1000000) / usecs;
     ad_sec = (mAccountDelete * 1000000) / usecs;
     tu_sec = (mTrustLineUpsert * 1000000) / usecs;
@@ -243,7 +241,6 @@ BucketApplicator::Counters::getRates(
     ccu_sec = (mContractCodeUpsert * 1000000) / usecs;
     ccd_sec = (mContractCodeDelete * 1000000) / usecs;
     csu_sec = (mConfigSettingUpsert * 1000000) / usecs;
-    csd_sec = (mConfigSettingDelete * 1000000) / usecs;
     T_sec = (total * 1000000) / usecs;
 }
 
@@ -254,28 +251,27 @@ BucketApplicator::Counters::logInfo(std::string const& bucketName,
 {
     uint64_t au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec, dd_sec,
         cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec, ccd_sec,
-        csu_sec, csd_sec, T_sec, total;
+        csu_sec, T_sec, total;
     getRates(now, au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec,
              dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec,
-             ccd_sec, csu_sec, csd_sec, T_sec, total);
+             ccd_sec, csu_sec, T_sec, total);
     CLOG_INFO(Bucket,
               "Apply-rates for {}-entry bucket {}.{} au:{} ad:{} tu:{} td:{} "
               "ou:{} od:{} du:{} dd:{} cu:{} cd:{} lu:{} ld:{} "
-              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} csd{} T:{}",
+              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} T:{}",
               total, level, bucketName, au_sec, ad_sec, tu_sec, td_sec, ou_sec,
               od_sec, du_sec, dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec,
-              cdd_sec, ccu_sec, ccd_sec, csu_sec, csd_sec, T_sec);
+              cdd_sec, ccu_sec, ccd_sec, csu_sec, T_sec);
     CLOG_INFO(Bucket,
               "Entry-counts for {}-entry bucket {}.{} au:{} ad:{} tu:{} td:{} "
               "ou:{} od:{} du:{} dd:{} cu:{} cd:{} lu:{} ld:{} "
-              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} csd:{}",
+              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{}",
               total, level, bucketName, mAccountUpsert, mAccountDelete,
               mTrustLineUpsert, mTrustLineDelete, mOfferUpsert, mOfferDelete,
               mDataUpsert, mDataDelete, mClaimableBalanceUpsert,
               mClaimableBalanceDelete, mLiquidityPoolUpsert,
               mLiquidityPoolDelete, mContractDataUpsert, mContractDataDelete,
-              mContractCodeUpsert, mContractCodeDelete, mConfigSettingUpsert,
-              mConfigSettingDelete);
+              mContractCodeUpsert, mContractCodeDelete, mConfigSettingUpsert);
 }
 
 void
@@ -285,17 +281,17 @@ BucketApplicator::Counters::logDebug(std::string const& bucketName,
 {
     uint64_t au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec, dd_sec,
         cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec, ccd_sec,
-        csu_sec, csd_sec, T_sec, total;
+        csu_sec, T_sec, total;
     getRates(now, au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec,
              dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec,
-             ccd_sec, csu_sec, csd_sec, T_sec, total);
+             ccd_sec, csu_sec, T_sec, total);
     CLOG_DEBUG(Bucket,
                "Apply-rates for {}-entry bucket {}.{} au:{} ad:{} tu:{} td:{} "
                "ou:{} od:{} du:{} dd:{} cu:{} cd:{} lu:{} ld:{} "
-               "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} csd{} T:{}",
+               "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} T:{}",
                total, level, bucketName, au_sec, ad_sec, tu_sec, td_sec, ou_sec,
                od_sec, du_sec, dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec,
-               cdd_sec, ccu_sec, ccd_sec, csu_sec, csd_sec, T_sec);
+               cdd_sec, ccu_sec, ccd_sec, csu_sec, T_sec);
 }
 
 void
@@ -366,7 +362,6 @@ BucketApplicator::Counters::mark(BucketEntry const& e)
             ++mContractCodeDelete;
             break;
         case CONFIG_SETTING:
-            ++mConfigSettingDelete;
             break;
 #endif
         }

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -54,14 +54,13 @@ class BucketApplicator
         uint64_t mContractCodeUpsert;
         uint64_t mContractCodeDelete;
         uint64_t mConfigSettingUpsert;
-        uint64_t mConfigSettingDelete;
         void getRates(VirtualClock::time_point now, uint64_t& au_sec,
                       uint64_t& ad_sec, uint64_t& tu_sec, uint64_t& td_sec,
                       uint64_t& ou_sec, uint64_t& od_sec, uint64_t& du_sec,
                       uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
                       uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec,
                       uint64_t& cdd_sec, uint64_t& ccu_sec, uint64_t& ccd_sec,
-                      uint64_t& cfgu_sec, uint64_t& cfgd_sec, uint64_t& T_sec,
+                      uint64_t& cfgu_sec, uint64_t& T_sec,
                       uint64_t& total);
 
       public:

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -4,6 +4,8 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include <type_traits>
+
 #include "overlay/StellarXDR.h"
 #include "util/XDROperators.h"
 
@@ -90,8 +92,22 @@ struct LedgerEntryIdCmp
         case CONTRACT_CODE:
             return a.contractCode().hash < b.contractCode().hash;
         case CONFIG_SETTING:
-            return a.configSetting().configSettingID <
-                   b.configSetting().configSettingID;
+        {
+            auto getConfigSettingId = [](auto const& v) -> ConfigSettingID {
+                using ConfigT = decltype(v);
+                if constexpr (std::is_same_v<ConfigT, LedgerKey const&>)
+                {
+                    return v.configSetting().configSettingID;
+                }
+                else if constexpr (std::is_same_v<ConfigT,
+                                                  LedgerEntry::_data_t const&>)
+                {
+                    return v.configSetting().configSettingID();
+                }
+                throw std::runtime_error("Unexpected entry type");
+            };
+            return getConfigSettingId(a) < getConfigSettingId(b);
+        }
 #endif
         }
         return false;

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -56,7 +56,14 @@ class BucketIndexTest
         do
         {
             ++ledger;
-            auto entries = LedgerTestUtils::generateValidLedgerEntries(10);
+            auto entries =
+                LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                    {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                        CONFIG_SETTING
+#endif
+                    },
+                    10);
             f(entries);
             closeLedger(*mApp);
         } while (!BucketList::levelShouldSpill(ledger, mLevelsToBuild - 1));
@@ -190,10 +197,16 @@ class BucketIndexTest
             if (rand_flip())
             {
                 // Add keys not in bucket list as well
-                for (size_t j = 0; j < 10; ++j)
-                {
-                    searchSubset.emplace(LedgerTestUtils::generateLedgerKey(3));
-                }
+                auto addKeys =
+                    LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                        {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                            CONFIG_SETTING
+#endif
+                        },
+                        10);
+
+                searchSubset.insert(addKeys.begin(), addKeys.end());
             }
 
             auto blLoad = mBM.loadKeys(searchSubset);
@@ -205,7 +218,14 @@ class BucketIndexTest
     testInvalidKeys()
     {
         // Load should return empty vector for keys not in bucket list
-        auto keysNotInBL = LedgerTestUtils::generateLedgerKeys(10);
+        auto keysNotInBL =
+            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                },
+                10);
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -190,7 +190,7 @@ TEST_CASE_VERSIONS("bucketmanager ownership", "[bucket][bucketmanager]")
         Application::pointer app = createTestApplication(clock, cfg);
 
         std::vector<LedgerEntry> live(
-            LedgerTestUtils::generateValidLedgerEntries(10));
+            LedgerTestUtils::generateValidUniqueLedgerEntries(10));
         std::vector<LedgerKey> dead{};
 
         std::shared_ptr<Bucket> b1;
@@ -243,7 +243,11 @@ TEST_CASE_VERSIONS("bucketmanager ownership", "[bucket][bucketmanager]")
         CHECK(b1.use_count() == 3);
 
         // But if we mutate the curr bucket of the bucketlist, it should.
-        live[0] = LedgerTestUtils::generateValidLedgerEntry(10);
+        live[0] = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            CONFIG_SETTING
+#endif
+        });
         bl.addBatch(*app, 1, getAppLedgerVersion(app), {}, live, dead);
         clearFutures(app, bl);
         CHECK(b1.use_count() == 2);
@@ -274,7 +278,7 @@ TEST_CASE("bucketmanager missing buckets fail", "[bucket][bucketmanager]")
         {
             ++ledger;
             lm.setNextLedgerEntryBatchForBucketTesting(
-                {}, LedgerTestUtils::generateValidLedgerEntries(10), {});
+                {}, LedgerTestUtils::generateValidUniqueLedgerEntries(10), {});
             closeLedger(*app);
         } while (!BucketList::levelShouldSpill(ledger, level - 1));
         auto someBucket = bl.getLevel(1).getCurr();
@@ -315,7 +319,8 @@ TEST_CASE_VERSIONS("bucketmanager reattach to finished merge",
         {
             ++ledger;
             bl.addBatch(*app, ledger, vers, {},
-                        LedgerTestUtils::generateValidLedgerEntries(10), {});
+                        LedgerTestUtils::generateValidUniqueLedgerEntries(10),
+                        {});
             bm.forgetUnreferencedBuckets();
         } while (!BucketList::levelShouldSpill(ledger, level - 1));
 
@@ -398,7 +403,8 @@ TEST_CASE_VERSIONS("bucketmanager reattach to running merge",
             // between the main thread here and the background workers doing
             // the merges.
             bl.addBatch(*app, ledger, vers, {},
-                        LedgerTestUtils::generateValidLedgerEntries(100), {});
+                        LedgerTestUtils::generateValidUniqueLedgerEntries(100),
+                        {});
 
             bm.forgetUnreferencedBuckets();
 
@@ -456,7 +462,14 @@ TEST_CASE("bucketmanager do not leak empty-merge futures",
     // subsequent merges touch them, producing empty buckets.
     for (size_t i = 0; i < 128; ++i)
     {
-        auto entries = LedgerTestUtils::generateValidLedgerEntries(8);
+        auto entries =
+            LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                },
+                8);
         REQUIRE(entries.size() == 8);
         for (auto const& e : entries)
         {
@@ -530,7 +543,8 @@ TEST_CASE_VERSIONS(
             CLOG_INFO(Bucket, "finished-merge reattachments while queueing: {}",
                       ra);
             bl.addBatch(*app, lm.getLastClosedLedgerNum() + 1, vers, {},
-                        LedgerTestUtils::generateValidLedgerEntries(100), {});
+                        LedgerTestUtils::generateValidUniqueLedgerEntries(100),
+                        {});
             clock.crank(false);
             bm.forgetUnreferencedBuckets();
         }
@@ -1317,10 +1331,12 @@ TEST_CASE_VERSIONS("bucket persistence over app restart",
             cfg0.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION;
         cfg1.ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = true;
 
+        auto batch_entries =
+            LedgerTestUtils::generateValidUniqueLedgerEntries(110);
         std::vector<std::vector<LedgerEntry>> batches;
-        for (uint32_t i = 0; i < 110; ++i)
+        for (auto const& batch_entry : batch_entries)
         {
-            batches.push_back(LedgerTestUtils::generateValidLedgerEntries(1));
+            batches.emplace_back().push_back(batch_entry);
         }
 
         // Inject a common object at the first batch we're going to run

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -19,11 +19,8 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     Application::pointer app = createTestApplication(clock, cfg);
 
     auto getValidBucket = [&](int numEntries = 10) {
-        std::vector<LedgerEntry> live(numEntries);
-        for (auto& e : live)
-        {
-            e = LedgerTestUtils::generateValidLedgerEntry(3);
-        }
+        std::vector<LedgerEntry> live =
+            LedgerTestUtils::generateValidUniqueLedgerEntries(numEntries);
         std::shared_ptr<Bucket> b1 = Bucket::fresh(
             app->getBucketManager(), BucketTestUtils::getAppLedgerVersion(app),
             {}, live, {},

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1143,8 +1143,9 @@ TEST_CASE_VERSIONS(
             while (hm.getPublishQueueCount() != 1)
             {
                 uint32_t ledger = lm.getLastClosedLedgerNum() + 1;
-                bl.addBatch(*app, ledger, cfg.LEDGER_PROTOCOL_VERSION, {},
-                            LedgerTestUtils::generateValidLedgerEntries(8), {});
+                bl.addBatch(
+                    *app, ledger, cfg.LEDGER_PROTOCOL_VERSION, {},
+                    LedgerTestUtils::generateValidUniqueLedgerEntries(8), {});
                 clock.crank(true);
             }
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -136,7 +136,7 @@ std::pair<std::string, uint256>
 BucketOutputIteratorForTesting::writeTmpTestBucket()
 {
     auto ledgerEntries =
-        LedgerTestUtils::generateValidLedgerEntries(NUM_ITEMS_PER_BUCKET);
+        LedgerTestUtils::generateValidUniqueLedgerEntries(NUM_ITEMS_PER_BUCKET);
     auto bucketEntries =
         Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
     for (auto const& bucketEntry : bucketEntries)

--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -96,19 +96,14 @@ updateChangedSubEntriesCount(
     }
     case CLAIMABLE_BALANCE:
     case LIQUIDITY_POOL:
-    {
-        // claimable balance and liquidity pools are not subentries
-        break;
-    }
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     case CONTRACT_DATA:
     case CONTRACT_CODE:
     case CONFIG_SETTING:
-    {
-        // contract entries are not subentries
-        break;
-    }
 #endif
+        // Claimable balances, liquidity pools, contract data and configuration
+        // settings are not subentries
+        break;
     default:
         abort();
     }

--- a/src/invariant/test/SponsorshipCountIsValidTests.cpp
+++ b/src/invariant/test/SponsorshipCountIsValidTests.cpp
@@ -72,6 +72,11 @@ TEST_CASE("sponsorship invariant", "[invariant][sponsorshipcountisvalid]")
             le.data.claimableBalance() =
                 LedgerTestUtils::generateValidClaimableBalanceEntry();
             break;
+        case LIQUIDITY_POOL:
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        case CONTRACT_DATA:
+        case CONFIG_SETTING:
+#endif
         default:
             abort();
         }

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -76,7 +76,6 @@ class BulkLedgerEntryChangeAccumulator
     std::vector<EntryIterator> mContractCodeToUpsert;
     std::vector<EntryIterator> mContractCodeToDelete;
     std::vector<EntryIterator> mConfigSettingsToUpsert;
-    std::vector<EntryIterator> mConfigSettingsToDelete;
 #endif
 
   public:
@@ -157,12 +156,6 @@ class BulkLedgerEntryChangeAccumulator
     getConfigSettingsToUpsert()
     {
         return mConfigSettingsToUpsert;
-    }
-
-    std::vector<EntryIterator>&
-    getConfigSettingsToDelete()
-    {
-        return mConfigSettingsToDelete;
     }
 
     std::vector<EntryIterator>&
@@ -392,6 +385,7 @@ class LedgerTxn::Impl
     void throwIfChild() const;
     void throwIfSealed() const;
     void throwIfNotExactConsistency() const;
+    void throwIfErasingConfig(InternalLedgerKey const& key) const;
 
     // getDeltaVotes has the basic exception safety guarantee. If it throws an
     // exception, then
@@ -808,8 +802,6 @@ class LedgerTxnRoot::Impl
     void bulkDeleteContractCode(std::vector<EntryIterator> const& entries,
                                 LedgerTxnConsistency cons);
     void bulkUpsertConfigSettings(std::vector<EntryIterator> const& entries);
-    void bulkDeleteConfigSettings(std::vector<EntryIterator> const& entries,
-                                  LedgerTxnConsistency cons);
 #endif
 
     static std::string tableFromLedgerEntryType(LedgerEntryType let);

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -5,9 +5,11 @@
 #include "LedgerTestUtils.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
+#include "ledger/LedgerHashUtils.h"
 #include "main/Config.h"
 #include "util/Logging.h"
 #include "util/Math.h"
+#include "util/UnorderedSet.h"
 #include "util/types.h"
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 #include "xdr/Stellar-contract.h"
@@ -123,8 +125,9 @@ randomlyModifyEntry(LedgerEntry& e)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     case CONFIG_SETTING:
     {
-        e.data.configSetting().setting.type(CONFIG_SETTING_TYPE_UINT32);
-        e.data.configSetting().setting.uint32Val() =
+        e.data.configSetting().configSettingID(
+            CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
+        e.data.configSetting().contractMaxSizeBytes() =
             autocheck::generator<uint32_t>{}();
         makeValid(e.data.configSetting());
         break;
@@ -326,8 +329,8 @@ void
 makeValid(ConfigSettingEntry& ce)
 {
     auto ids = xdr::xdr_traits<ConfigSettingID>::enum_values();
-    ce.configSettingID =
-        static_cast<ConfigSettingID>(ids.at(ce.configSettingID % ids.size()));
+    ce.configSettingID(static_cast<ConfigSettingID>(
+        ids.at(ce.configSettingID() % ids.size())));
 }
 
 void
@@ -401,7 +404,7 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
     }
 }
 
-static auto validLedgerEntryGeneratorMaybeIncludingConfig = autocheck::map(
+static auto validLedgerEntryGenerator = autocheck::map(
     [](LedgerEntry&& le, size_t s) {
         auto& led = le.data;
         le.lastModifiedLedgerSeq = le.lastModifiedLedgerSeq & INT32_MAX;
@@ -441,20 +444,6 @@ static auto validLedgerEntryGeneratorMaybeIncludingConfig = autocheck::map(
         return std::move(le);
     },
     autocheck::generator<LedgerEntry>());
-
-// When compiling the next protocol version we might be able to generate
-// CONFIG_SETTING entries, but we explicitly exclude them from the default
-// generator here because they violate an assumption that the rest of the
-// machinery here makes: that randomly generated keys are (statistically)
-// guaranteed to be disjoint.
-static auto validLedgerEntryGenerator =
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    autocheck::such_that(
-        [](LedgerEntry const& le) { return le.data.type() != CONFIG_SETTING; },
-        validLedgerEntryGeneratorMaybeIncludingConfig);
-#else
-    validLedgerEntryGeneratorMaybeIncludingConfig;
-#endif
 
 static auto ledgerKeyGenerator =
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
@@ -536,6 +525,17 @@ generateValidLedgerEntry(size_t b)
     return validLedgerEntryGenerator(b);
 }
 
+LedgerEntry
+generateValidLedgerEntryOfType(LedgerEntryType type)
+{
+    auto entry = generateValidLedgerEntry();
+    while (entry.data.type() != type)
+    {
+        entry = generateValidLedgerEntry();
+    }
+    return entry;
+}
+
 std::vector<LedgerEntry>
 generateValidLedgerEntries(size_t n)
 {
@@ -543,17 +543,65 @@ generateValidLedgerEntries(size_t n)
     return vecgen(n);
 }
 
-LedgerKey
-generateLedgerKey(size_t n)
+std::vector<LedgerEntry>
+generateValidUniqueLedgerEntries(size_t n)
 {
-    return ledgerKeyGenerator(n);
+    UnorderedSet<LedgerKey> keys;
+    std::vector<LedgerEntry> entries;
+    while (entries.size() < n)
+    {
+        auto entry = generateValidLedgerEntry();
+        auto key = LedgerEntryKey(entry);
+        if (keys.find(key) != keys.end())
+        {
+            continue;
+        }
+        keys.insert(key);
+        entries.push_back(entry);
+    }
+    return entries;
+}
+
+LedgerEntry
+generateValidLedgerEntryWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b)
+{
+    while (true)
+    {
+        auto entry = generateValidLedgerEntry(b);
+        if (excludedTypes.find(entry.data.type()) == excludedTypes.end())
+        {
+            return entry;
+        }
+    }
+}
+
+std::vector<LedgerEntry>
+generateValidLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
+{
+    std::vector<LedgerEntry> res;
+    res.reserve(n);
+    for (int i = 0; i < n; ++i)
+    {
+        res.push_back(generateValidLedgerEntryWithExclusions(excludedTypes));
+    }
+    return res;
 }
 
 std::vector<LedgerKey>
-generateLedgerKeys(size_t n)
+generateValidLedgerEntryKeysWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
-    static auto vecgen = autocheck::list_of(ledgerKeyGenerator);
-    return vecgen(n);
+    auto entries = LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+        excludedTypes, n);
+    std::vector<LedgerKey> keys;
+    keys.reserve(entries.size());
+    for (auto const& entry : entries)
+    {
+        keys.push_back(LedgerEntryKey(entry));
+    }
+    return keys;
 }
 
 AccountEntry

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -38,11 +38,18 @@ void makeValid(LedgerHeaderHistoryEntry& lh,
                HistoryManager::LedgerVerificationStatus state);
 
 LedgerEntry generateValidLedgerEntry(size_t b = 3);
-std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
+LedgerEntry generateValidLedgerEntryOfType(LedgerEntryType type);
 
-// Use this instead of generator<LedgerKey> to avoid CONFIG_SETTING
-LedgerKey generateLedgerKey(size_t n);
-std::vector<LedgerKey> generateLedgerKeys(size_t n);
+std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
+std::vector<LedgerEntry> generateValidUniqueLedgerEntries(size_t n);
+
+std::vector<LedgerKey> generateValidLedgerEntryKeysWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
+
+LedgerEntry generateValidLedgerEntryWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b = 3);
+std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
 
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -104,8 +104,8 @@ generateLedgerEntryWithSameKey(LedgerEntry const& leBase)
         case CONFIG_SETTING:
             le.data.configSetting() =
                 LedgerTestUtils::generateValidConfigSettingEntry();
-            le.data.configSetting().configSettingID =
-                leBase.data.configSetting().configSettingID;
+            le.data.configSetting().configSettingID(
+                leBase.data.configSetting().configSettingID());
             break;
         case CONTRACT_DATA:
             le.data.contractData() =
@@ -216,6 +216,13 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
 
         SECTION("erased in child")
         {
+            le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            key = LedgerEntryKey(le1);
+            le2 = generateLedgerEntryWithSameKey(le1);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le1));
 
@@ -287,6 +294,14 @@ TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgertxn]")
 
             SECTION("erased in child")
             {
+                le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                });
+                le1.lastModifiedLedgerSeq = 1;
+                key = LedgerEntryKey(le1);
+                le2 = generateLedgerEntryWithSameKey(le1);
                 LedgerTxn ltx1(app->getLedgerTxnRoot());
                 REQUIRE(ltx1.create(le1));
 
@@ -373,6 +388,12 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
         {
             auto iter = entries.begin();
             std::advance(iter, dist(gRandomEngine));
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            if (iter->first.type() == CONFIG_SETTING)
+            {
+                continue;
+            }
+#endif
             eraseBatch.insert(iter->first);
         }
 
@@ -570,6 +591,13 @@ TEST_CASE("LedgerTxn create", "[ledgertxn]")
 
     SECTION("when key exists in grandparent, erased in parent")
     {
+        le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            CONFIG_SETTING
+#endif
+        });
+        le.lastModifiedLedgerSeq = 1;
+        key = LedgerEntryKey(le);
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         REQUIRE(ltx1.create(le));
 
@@ -651,6 +679,13 @@ TEST_CASE("LedgerTxn createWithoutLoading and updateWithoutLoading",
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -684,7 +719,12 @@ TEST_CASE("LedgerTxn erase", "[ledgertxn]")
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
+        LedgerEntry le =
+            LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
         le.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le);
 
@@ -704,6 +744,19 @@ TEST_CASE("LedgerTxn erase", "[ledgertxn]")
             ltx1.getDelta();
             REQUIRE_THROWS_AS(ltx1.erase(key), std::runtime_error);
         }
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        SECTION("fails for configuration")
+        {
+            auto configLe =
+                LedgerTestUtils::generateValidLedgerEntryOfType(CONFIG_SETTING);
+            configLe.lastModifiedLedgerSeq = 1;
+            LedgerTxn ltx1(app->getLedgerTxnRoot());
+            REQUIRE(ltx1.create(configLe));
+            REQUIRE_THROWS_AS(ltx1.erase(LedgerEntryKey(configLe)),
+                              std::runtime_error);
+        }
+#endif
 
         SECTION("when key does not exist")
         {
@@ -727,6 +780,13 @@ TEST_CASE("LedgerTxn erase", "[ledgertxn]")
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -757,7 +817,12 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
+        LedgerEntry le =
+            LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
         le.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le);
 
@@ -781,7 +846,18 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
             REQUIRE_THROWS_AS(ltx1.eraseWithoutLoading(key),
                               std::runtime_error);
         }
-
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        SECTION("fails for configuration")
+        {
+            auto configLe =
+                LedgerTestUtils::generateValidLedgerEntryOfType(CONFIG_SETTING);
+            configLe.lastModifiedLedgerSeq = 1;
+            LedgerTxn ltx1(app->getLedgerTxnRoot());
+            REQUIRE(ltx1.create(configLe));
+            REQUIRE_THROWS_AS(ltx1.erase(LedgerEntryKey(configLe)),
+                              std::runtime_error);
+        }
+#endif
         SECTION("when key does not exist")
         {
             LedgerTxn ltx1(app->getLedgerTxnRoot());
@@ -803,6 +879,13 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -1333,6 +1416,15 @@ TEST_CASE_VERSIONS("LedgerTxn load", "[ledgertxn]")
 
                 SECTION("when key exists in grandparent, erased in parent")
                 {
+                    le =
+                        LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                            {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                                CONFIG_SETTING
+#endif
+                            });
+                    le.lastModifiedLedgerSeq = 1;
+                    key = LedgerEntryKey(le);
                     LedgerTxn ltx1(app->getLedgerTxnRoot());
                     REQUIRE(ltx1.create(le));
 
@@ -1410,8 +1502,7 @@ TEST_CASE_VERSIONS("LedgerTxn load", "[ledgertxn]")
                     {
                         for (int i = 0; i < 1000; ++i)
                         {
-                            LedgerKey lk =
-                                LedgerTestUtils::generateLedgerKey(5);
+                            LedgerKey lk = autocheck::generator<LedgerKey>()(5);
 
                             try
                             {
@@ -1487,6 +1578,13 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
 
     SECTION("when key exists in grandparent, erased in parent")
     {
+        le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            CONFIG_SETTING
+#endif
+        });
+        le.lastModifiedLedgerSeq = 1;
+        key = LedgerEntryKey(le);
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         REQUIRE(ltx1.create(le));
 

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -689,7 +689,13 @@ TEST_CASE("Bucket list entries vs write throughput", "[scalability][!hide]")
             *app, i, Config::CURRENT_LEDGER_PROTOCOL_VERSION,
             LedgerTestUtils::generateValidLedgerEntries(100),
             LedgerTestUtils::generateValidLedgerEntries(20),
-            LedgerTestUtils::generateLedgerKeys(5));
+            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                },
+                5));
 
         if ((i & 0xff) == 0xff)
         {

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -243,7 +243,7 @@ generateStoredLedgerKeys(StoredLedgerKeys::iterator begin,
     // Generate unvalidated ledger entry keys.
     std::generate(firstUnvalidatedLedgerKey, end, []() {
         size_t const entrySize = 3;
-        return LedgerTestUtils::generateLedgerKey(entrySize);
+        return autocheck::generator<LedgerKey>()(entrySize);
     });
 }
 

--- a/src/transactions/simulation/TxSimUtils.cpp
+++ b/src/transactions/simulation/TxSimUtils.cpp
@@ -391,6 +391,8 @@ generateScaledLiveEntries(
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
         case CONFIG_SETTING:
         case CONTRACT_DATA:
+            // Don't do anything for now.
+            break;
 #endif
         default:
             abort();

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -60,7 +60,7 @@ LedgerEntryKey(LedgerEntry const& e)
         k.contractCode().hash = d.contractCode().hash;
         break;
     case CONFIG_SETTING:
-        k.configSetting().configSettingID = d.configSetting().configSettingID;
+        k.configSetting().configSettingID = d.configSetting().configSettingID();
         break;
 #endif
 


### PR DESCRIPTION
# Description

These updates are based on my previous work on SPEEDEX configuration PR.

- Update the code to handle proposed XDR changes (https://github.com/stellar/stellar-xdr-next/pull/27)
- Make configuration not removable (this seems like a feature that has potential to end up as a footgun)
- Increase test coverage by generating configuration entries by default, but either ensuring the uniqueness of generated ledger entries or by explicitly excluding them where relevant.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
