### PR TITLE
Use LF line endings for sh files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.sln    text -merge eol=crlf
 *.vcxproj text -merge eol=crlf
 *.vcxproj.filters text -merge eol=crlf
+*.sh text -merge eol=lf


### PR DESCRIPTION
# Description

sh scripts on Windows still need to have Unix line endings in order to be executable.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
