### PR TITLE
Update ops limit in `TxQueueLimiter` every time we try adding tx.

### DIFF
--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -354,6 +354,12 @@ SurgePricingPriorityQueue::sizeOps() const
 }
 
 void
+SurgePricingPriorityQueue::updateOpsLimit(uint32_t newLimit)
+{
+    mOpsLimit = newLimit;
+}
+
+void
 SurgePricingPriorityQueue::popTopTx(
     SurgePricingPriorityQueue::TxStackSet::iterator iter)
 {

--- a/src/herder/SurgePricingUtils.h
+++ b/src/herder/SurgePricingUtils.h
@@ -124,6 +124,9 @@ class SurgePricingPriorityQueue
     // Returns total number of operations in all the stacks in this queue.
     uint32_t sizeOps() const;
 
+    // Sets the queue ops limit to `newLimit`.
+    void updateOpsLimit(uint32_t newLimit);
+
   private:
     class TxStackComparator
     {

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -140,6 +140,9 @@ TxQueueLimiter::canAddTx(TransactionFrameBasePtr const& newTx,
         releaseAssert(oldTxOps <= newTxOps);
         txOpsDiscount = newTxOps - oldTxOps;
     }
+    // Update the operation limits in case upgrade happened. This is cheap
+    // enough to happen unconditionally without relying on upgrade triggers.
+    mTxs->updateOpsLimit(maxQueueSizeOps());
     return mTxs->canFitWithEviction(*newTx, txOpsDiscount, txsToEvict);
 }
 


### PR DESCRIPTION
# Description

This is how the limiter has worked before the refactoring.

I somehow convinced myself that we reset limiter on upgrades, but that's not true. So for simplicity I just update the limit to make sure we always have up-to-date ops limit.


# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
