### PR TITLE
pull mode follow-up

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,7 +69,6 @@ overlay.byte.write                       | meter     | number of bytes sent
 overlay.async.read                       | meter     | number of async read requests issued
 overlay.async.write                      | meter     | number of async write requests issued
 overlay.connection.authenticated         | counter   | number of authenticated peers
-overlay.flow-control.percentage          | counter   | percentage of authenticated connections that enable flow control
 overlay.pull-mode.percentage             | counter   | percentage of authenticated connections that enable pull mode
 overlay.connection.latency               | timer     | estimated latency between peers
 overlay.connection.pending               | counter   | number of pending connections

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -713,8 +713,7 @@ If `compact=false`, then it also returns some extra metrics on each peer such as
                   "flood" : 500,
                   "reading" : 600
                },
-               "peer_capacity" : 100,
-               "state" : "enabled"
+               "peer_capacity" : 100
             },
            "id" : "sdf1",
            "olver" : 5,
@@ -731,8 +730,7 @@ If `compact=false`, then it also returns some extra metrics on each peer such as
                 "flood" : 500,
                 "reading" : 600
              },
-             "peer_capacity" : 100,
-             "state" : "enabled"
+             "peer_capacity" : 100
           },
           "id" : "sdf2",
           "olver" : 5,
@@ -747,8 +745,7 @@ If `compact=false`, then it also returns some extra metrics on each peer such as
                 "flood" : 500,
                 "reading" : 600
              },
-             "peer_capacity" : 100,
-             "state" : "enabled"
+             "peer_capacity" : 100
           },
           "id" : "sdf3",
           "olver" : 5,

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -655,6 +655,14 @@ TransactionQueue::removeApplied(Transactions const& appliedTxs)
             }
         }
     }
+
+    for (auto const& h : appliedHashes)
+    {
+        auto& bannedFront = mBannedTransactions.front();
+        bannedFront.emplace(h);
+        // do not mark metric for banning as this is the result of normal flow
+        // of operations
+    }
 }
 
 static void

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -159,9 +159,6 @@ class OverlayManager
     // Return number of authenticated peers
     virtual int getAuthenticatedPeersCount() const = 0;
 
-    // Return the number of flow-contolled peers
-    virtual int64_t getFlowControlPercentage() const = 0;
-
     // Return the percentage [0,100] of connections with pull-mode enabled
     virtual int64_t getPullModePercentage() const = 0;
 

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -686,7 +686,6 @@ OverlayManagerImpl::updateSizeCounters()
     mOverlayMetrics.mPendingPeersSize.set_count(getPendingPeersCount());
     mOverlayMetrics.mAuthenticatedPeersSize.set_count(
         getAuthenticatedPeersCount());
-    mOverlayMetrics.mFlowControlPercent.set_count(getFlowControlPercentage());
     mOverlayMetrics.mPullModePercent.set_count(getPullModePercentage());
 }
 
@@ -850,24 +849,6 @@ OverlayManagerImpl::getPendingPeersCount() const
 {
     return static_cast<int>(mInboundPeers.mPending.size() +
                             mOutboundPeers.mPending.size());
-}
-
-int64_t
-OverlayManagerImpl::getFlowControlPercentage() const
-{
-    auto allPeers = getAuthenticatedPeers();
-    if (allPeers.empty())
-    {
-        return 0;
-    }
-
-    auto fcCount =
-        std::count_if(allPeers.begin(), allPeers.end(), [&](auto const& item) {
-            return item.second->isFlowControlled();
-        });
-
-    auto pct = static_cast<double>(fcCount) / allPeers.size() * 100;
-    return std::llround(pct);
 }
 
 int64_t

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -156,7 +156,6 @@ class OverlayManagerImpl : public OverlayManager
     getOutboundAuthenticatedPeers() const override;
     std::map<NodeID, Peer::pointer> getAuthenticatedPeers() const override;
     int getAuthenticatedPeersCount() const override;
-    int64_t getFlowControlPercentage() const override;
     int64_t getPullModePercentage() const override;
 
     // returns nullptr if the passed peer isn't found

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -154,8 +154,6 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewCounter({"overlay", "connection", "pending"}))
     , mAuthenticatedPeersSize(app.getMetrics().NewCounter(
           {"overlay", "connection", "authenticated"}))
-    , mFlowControlPercent(app.getMetrics().NewCounter(
-          {"overlay", "flow-control", "percentage"}))
     , mPullModePercent(
           app.getMetrics().NewCounter({"overlay", "pull-mode", "percentage"}))
     , mUniqueFloodBytesRecv(app.getMetrics().NewMeter(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -105,7 +105,6 @@ struct OverlayMetrics
     medida::Meter& mMessagesBroadcast;
     medida::Counter& mPendingPeersSize;
     medida::Counter& mAuthenticatedPeersSize;
-    medida::Counter& mFlowControlPercent;
     medida::Counter& mPullModePercent;
 
     medida::Meter& mUniqueFloodBytesRecv;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -270,22 +270,8 @@ Peer::getFlowControlJsonInfo(bool compact) const
 {
     Json::Value res;
     std::string stateStr;
-    bool reportCapacity = false;
-    switch (flowControlEnabled())
-    {
-    case Peer::FlowControlState::ENABLED:
-        stateStr = "enabled";
-        reportCapacity = true;
-        break;
-    case Peer::FlowControlState::DISABLED:
-        stateStr = "disabled";
-        break;
-    case Peer::FlowControlState::DONT_KNOW:
-        stateStr = "don't know";
-        break;
-    };
-
-    res["state"] = stateStr;
+    bool reportCapacity =
+        flowControlEnabled() == Peer::FlowControlState::ENABLED;
     if (reportCapacity)
     {
         res["local_capacity"]["reading"] =
@@ -302,12 +288,15 @@ Peer::getFlowControlJsonInfo(bool compact) const
         res["outbound_queue_delay_txs_p75"] = static_cast<Json::UInt64>(
             mPeerMetrics.mOutboundQueueDelayTxs.GetSnapshot()
                 .get75thPercentile());
-        res["outbound_queue_delay_advert_p75"] = static_cast<Json::UInt64>(
-            mPeerMetrics.mOutboundQueueDelayAdvert.GetSnapshot()
-                .get75thPercentile());
-        res["outbound_queue_delay_demand_p75"] = static_cast<Json::UInt64>(
-            mPeerMetrics.mOutboundQueueDelayDemand.GetSnapshot()
-                .get75thPercentile());
+        if (mPullModeEnabled)
+        {
+            res["outbound_queue_delay_advert_p75"] = static_cast<Json::UInt64>(
+                mPeerMetrics.mOutboundQueueDelayAdvert.GetSnapshot()
+                    .get75thPercentile());
+            res["outbound_queue_delay_demand_p75"] = static_cast<Json::UInt64>(
+                mPeerMetrics.mOutboundQueueDelayDemand.GetSnapshot()
+                    .get75thPercentile());
+        }
     }
 
     return res;

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -1821,12 +1821,6 @@ auto numTxHashesAdvertised = [](std::shared_ptr<Application> app) {
         .count();
 };
 
-auto numAdvertSent = [](std::shared_ptr<Application> app) {
-    return app->getOverlayManager()
-        .getOverlayMetrics()
-        .mSendFloodAdvertMeter.count();
-};
-
 TEST_CASE("overlay pull mode", "[overlay][pullmode]")
 {
     VirtualClock clock;


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core/issues/3521 by banning applied transactions. Note that this broke one test which tries to re-add an applied transaction to the queue again (which now fails). I split the test into two sections that test two different sequences. 

Resolves https://github.com/stellar/stellar-core/issues/3520 by removing flow control percentage metrics plus minor changes to the peers endpoint. Note that we still report capacities as well as outbound queue stats, at these are useful to debugging. 