### PR TITLE
Properly cleanup the container in `TxQueueLimiter`.

### DIFF
--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -110,6 +110,7 @@ TxQueueLimiter::removeTransaction(TransactionFrameBasePtr const& tx)
             "invalid state (missing tx) while removing tx in TxQueueLimiter");
     }
     mTxs->erase(txStackIt->second);
+    mStackForTx.erase(txStackIt);
 }
 
 std::pair<bool, int64>
@@ -189,5 +190,6 @@ TxQueueLimiter::resetTxs()
     mTxs = std::make_unique<SurgePricingPriorityQueue>(
         /* isHighestPriority */ false, maxQueueSizeOps(),
         stellar::rand_uniform<size_t>(0, std::numeric_limits<size_t>::max()));
+    mStackForTx.clear();
 }
 }


### PR DESCRIPTION
# Description

Not cleaning it up resulted in tx frames to be stuck in memory forever.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
