### PR TITLE
update build instructions for macOS

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,11 +106,13 @@ When building on OSX, here's some dependencies you'll need:
 - `brew install openssl` (required for postgres)
 - `brew install parallel` (required for running tests)
 - `brew install ccache` (required for enabling ccache)
+- `brew install bison` (the version that comes with the OS is too old)
 
 You'll also need to configure pkg-config by adding the following to your shell (`.zshenv` or `.zshrc`):
 ```zsh
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/libpq/lib/pkgconfig"
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:$(brew --prefix)/opt/openssl@3/lib/pkgconfig"
+export PATH="$(brew --prefix bison)/bin:$PATH"
 ```
 
 ### Windows


### PR DESCRIPTION
# Description

This PR updates the installation instruction for macOS, by updating the `bison` utility to the latest version.
The version that comes with macOS 12.6 is 2.3, and we need version 3.2 or newer. The current version provided
with the current change is 3..8.2.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

# Note
While it's great that we listing this so nicely in the installation instructions, I would be happy to see this embedded into a script that would configure my system automatically for compilation.