### PR TITLE
Return contract result value

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -34,8 +34,9 @@ mod rust_bridge {
         file: String,
         hash: String,
     }
-    
+
     struct InvokeHostFunctionOutput {
+        result_value: RustBuf,
         contract_events: Vec<RustBuf>,
         modified_ledger_entries: Vec<RustBuf>,
     }

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -166,6 +166,7 @@ InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx, Config const& cfg)
     }
 
     innerResult().code(INVOKE_HOST_FUNCTION_SUCCESS);
+    xdr::xdr_from_opaque(out.result_value.data, innerResult().success());
     return true;
 }
 

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2,6 +2,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "xdr/Stellar-transaction.h"
 #include <iterator>
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 
@@ -239,6 +240,22 @@ TEST_CASE("invoke host function", "[tx][contract]")
                     REQUIRE(!tx->apply(*app, ltx, txm));
                 }
                 ltx.commit();
+                SCVal resultVal;
+                resultVal.type(stellar::SCV_STATUS);
+                resultVal.status().type(SCStatusType::SST_UNKNOWN_ERROR);
+                if (tx->getResult().result.code() == txSUCCESS &&
+                    !tx->getResult().result.results().empty())
+                {
+                    auto const& ores = tx->getResult().result.results().at(0);
+                    if (ores.tr().type() == INVOKE_HOST_FUNCTION &&
+                        ores.tr().invokeHostFunctionResult().code() ==
+                            INVOKE_HOST_FUNCTION_SUCCESS)
+                    {
+                        resultVal =
+                            ores.tr().invokeHostFunctionResult().success();
+                    }
+                }
+                return resultVal;
             };
 
             auto scContractID =


### PR DESCRIPTION
This continues on the end of https://github.com/stellar/stellar-core/pull/3516 with additional plumbing to pick up the result of a host-function call as described in https://github.com/stellar/stellar-protocol/issues/1307

The only change to look at separately here is the last, [0dca385](https://github.com/stellar/stellar-core/pull/3543/commits/0dca38599d3cb26f5986d3137d2a5b169b65b5da), which does that new plumbing. The rest should be covered by review of #3516