### PR TITLE
Nomination: do not vote for new values after confirming a candidate

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -134,4 +134,5 @@ scp.timing.first-to-self-externalize-lag | timer     | delay between first exter
 scp.timing.self-to-others-externalize-lag| timer     | delay between local node externalizing and later externalize messages from other nodes
 scp.value.invalid                        | meter     | SCP value is invalid
 scp.value.valid                          | meter     | SCP value is valid
+scp.slot.values-referenced               | histogram | number of values referenced per consensus round
 

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -538,6 +538,25 @@ HerderSCPDriver::setupTimer(uint64_t slotIndex, int timerID,
     }
 }
 
+void
+HerderSCPDriver::stopTimer(uint64 slotIndex, int timerID)
+{
+
+    auto timersIt = mSCPTimers.find(slotIndex);
+    if (timersIt == mSCPTimers.end())
+    {
+        return;
+    }
+
+    auto& slotTimers = timersIt->second;
+    auto it = slotTimers.find(timerID);
+    if (it != slotTimers.end())
+    {
+        auto& timer = *it->second;
+        timer.cancel();
+    }
+}
+
 // returns true if l < r
 // lh, rh are the hashes of l,h
 static bool

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -75,6 +75,8 @@ class HerderSCPDriver : public SCPDriver
                     std::chrono::milliseconds timeout,
                     std::function<void()> cb) override;
 
+    void stopTimer(uint64 slotIndex, int timerID) override;
+
     // hashing support
     Hash getHashOf(std::vector<xdr::opaque_vec<>> const& vals) const override;
 

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -162,6 +162,8 @@ class HerderSCPDriver : public SCPDriver
     medida::Histogram& mNominateTimeout;
     // Prepare timeouts per ledger
     medida::Histogram& mPrepareTimeout;
+    // Unique values referenced per ledger
+    medida::Histogram& mUniqueValues;
 
     // Externalize lag tracking for nodes in qset
     UnorderedMap<NodeID, medida::Timer> mQSetLag;
@@ -209,7 +211,7 @@ class HerderSCPDriver : public SCPDriver
                                                    StellarValue const& sv,
                                                    bool nomination) const;
 
-    void logQuorumInformation(uint64_t index);
+    void logQuorumInformationAndUpdateMetrics(uint64_t index);
 
     void clearSCPExecutionEvents();
 

--- a/src/scp/NominationProtocol.cpp
+++ b/src/scp/NominationProtocol.cpp
@@ -505,16 +505,19 @@ NominationProtocol::nominate(ValueWrapperPtr value, Value const& previousValue,
                              bool timedout)
 {
     ZoneScoped;
-    CLOG_DEBUG(SCP, "NominationProtocol::nominate ({}) {}", mRoundNumber,
-               mSlot.getSCP().getValueString(value->getValue()));
 
     // No need to continue nominating, as per the whitepaper:
     // "As soon as `v` has a candidate value, however, it must cease
     // voting to nominate `x` for any new values `x`"
     if (!mCandidates.empty())
     {
+        CLOG_DEBUG(SCP, "Skip nomination round {}, already have a candidate",
+                   mRoundNumber);
         return false;
     }
+
+    CLOG_DEBUG(SCP, "NominationProtocol::nominate ({}) {}", mRoundNumber,
+               mSlot.getSCP().getValueString(value->getValue()));
 
     bool updated = false;
 

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -172,6 +172,7 @@ class SCPDriver
     virtual void setupTimer(uint64 slotIndex, int timerID,
                             std::chrono::milliseconds timeout,
                             std::function<void()> cb) = 0;
+    virtual void stopTimer(uint64 slotIndex, int timerID) = 0;
 
     // `computeTimeout` computes a timeout given a round number
     // it should be sufficiently large such that nodes in a

--- a/src/scp/test/SCPUnitTests.cpp
+++ b/src/scp/test/SCPUnitTests.cpp
@@ -109,6 +109,11 @@ class TestNominationSCP : public SCPDriver
     {
     }
 
+    void
+    stopTimer(uint64 slotIndex, int timerID) override
+    {
+    }
+
     std::map<Hash, SCPQuorumSetPtr> mQuorumSets;
 
     Value const&


### PR DESCRIPTION
Resolves #3523 

- Cancel the nomination timer as soon as we have a candidate value. Turn `nominate` into a no-op when a node confirmed a candidate (just in case it ever gets called outside of the timer).
- add a metric to count how many values are referenced per consensus round. This is done at the slot purge time by counting referenced tx sets in the cache, so this way we know how many values we had to pull. Note that this metric includes value from self as well, even though sometimes the locally generated value might not actually be propagated to the network. If this is an issue, I can add an extra condition to count the local value only if the node actually nominated. Or we can move the cache population call (addTxSet) to when the node actually nominates its local value (but this might cause the node to pull the tx set it generated locally anyway) 