### PR TITLE
Bug 3548 set ledgerinfo on host

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -673,18 +673,24 @@ CommandHandler::preflight(std::string const& params, std::string& retStr)
     std::map<std::string, std::string> paramMap;
     http::server::server::parseParams(params, paramMap);
     std::string blob = paramMap["blob"];
+    std::string sourceAcct = paramMap["source_account"];
     if (!blob.empty())
     {
+        AccountID acct;
+        if (!sourceAcct.empty())
+        {
+            acct = KeyUtils::fromStrKey<PublicKey>(sourceAcct);
+        }
         InvokeHostFunctionOp op;
         std::vector<uint8_t> binBlob;
         fromOpaqueBase64(op, blob);
-        root = InvokeHostFunctionOpFrame::preflight(mApp, op);
+        root = InvokeHostFunctionOpFrame::preflight(mApp, op, acct);
     }
     else
     {
         throw std::invalid_argument(
             "Must specify an InvokeHostFunctionOp blob: preflight?blob=<op in "
-            "base64 XDR format>");
+            "base64 XDR format>[&source_account=<strkey>]");
     }
     retStr = Json::FastWriter().write(root);
 }

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     log::partition::TX,
-    rust_bridge::{Bytes, PreflightCallbacks, XDRBuf, XDRFileHash},
+    rust_bridge::{Bytes, CxxLedgerInfo, PreflightCallbacks, XDRBuf, XDRFileHash},
 };
 use cxx::{CxxVector, UniquePtr};
 use log::info;
@@ -19,9 +19,21 @@ use soroban_env_host::{
         LedgerKeyAccount, LedgerKeyContractData, LedgerKeyTrustLine, ReadXdr,
         ScHostContextErrorCode, ScUnknownErrorCode, ScVec, WriteXdr, XDR_FILES_SHA256,
     },
-    Host, HostError, MeteredOrdMap,
+    Host, HostError, LedgerInfo, MeteredOrdMap,
 };
 use std::error::Error;
+
+impl From<CxxLedgerInfo> for LedgerInfo {
+    fn from(c: CxxLedgerInfo) -> Self {
+        Self {
+            protocol_version: c.protocol_version,
+            sequence_number: c.sequence_number,
+            timestamp: c.timestamp,
+            network_passphrase: c.network_passphrase,
+            base_reserve: c.base_reserve,
+        }
+    }
+}
 
 #[derive(Debug)]
 enum CoreHostError {
@@ -196,6 +208,7 @@ pub(crate) fn invoke_host_function(
     args_buf: &XDRBuf,
     footprint_buf: &XDRBuf,
     source_account_buf: &XDRBuf,
+    ledger_info: CxxLedgerInfo,
     ledger_entries: &Vec<XDRBuf>,
 ) -> Result<Vec<Bytes>, Box<dyn Error>> {
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
@@ -204,6 +217,7 @@ pub(crate) fn invoke_host_function(
             args_buf,
             footprint_buf,
             source_account_buf,
+            ledger_info,
             ledger_entries,
         )
     }));
@@ -218,6 +232,7 @@ fn invoke_host_function_or_maybe_panic(
     args_buf: &XDRBuf,
     footprint_buf: &XDRBuf,
     source_account_buf: &XDRBuf,
+    ledger_info: CxxLedgerInfo,
     ledger_entries: &Vec<XDRBuf>,
 ) -> Result<Vec<Bytes>, Box<dyn Error>> {
     let budget = Budget::default();
@@ -232,6 +247,7 @@ fn invoke_host_function_or_maybe_panic(
     let storage = Storage::with_enforcing_footprint_and_map(footprint, map);
     let host = Host::with_storage_and_budget(storage, budget);
     host.set_source_account(source_account);
+    host.set_ledger_info(ledger_info.into());
 
     info!(target: TX, "Invoking host function {}", hf.to_string());
     host.invoke_function(hf, args)?;
@@ -303,10 +319,11 @@ fn storage_footprint_to_ledger_footprint(
 pub(crate) fn preflight_host_function(
     hf_buf: &CxxVector<u8>,
     args_buf: &CxxVector<u8>,
+    ledger_info: CxxLedgerInfo,
     cb: UniquePtr<PreflightCallbacks>,
 ) -> Result<(), Box<dyn Error>> {
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        preflight_host_function_or_maybe_panic(hf_buf, args_buf, cb)
+        preflight_host_function_or_maybe_panic(hf_buf, args_buf, ledger_info, cb)
     }));
     match res {
         Err(_) => Err(CoreHostError::General("contract host panicked").into()),
@@ -317,6 +334,7 @@ pub(crate) fn preflight_host_function(
 fn preflight_host_function_or_maybe_panic(
     hf_buf: &CxxVector<u8>,
     args_buf: &CxxVector<u8>,
+    ledger_info: CxxLedgerInfo,
     cb: UniquePtr<PreflightCallbacks>,
 ) -> Result<(), Box<dyn Error>> {
     let hf = xdr_from_slice::<HostFunction>(hf_buf.as_slice())?;
@@ -326,6 +344,7 @@ fn preflight_host_function_or_maybe_panic(
     let storage = Storage::with_recording_footprint(src);
     let budget = Budget::default();
     let host = Host::with_storage_and_budget(storage, budget);
+    host.set_ledger_info(ledger_info.into());
     let val = host.invoke_function(hf, args)?;
 
     // Recover, convert and return the storage footprint and other values to C++.

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -65,6 +65,7 @@ mod rust_bridge {
         fn preflight_host_function(
             hf_buf: &CxxVector<u8>,
             args: &CxxVector<u8>,
+            source_account: &CxxVector<u8>,
             ledger_info: CxxLedgerInfo,
             cb: UniquePtr<PreflightCallbacks>,
         ) -> Result<()>;

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -40,6 +40,14 @@ mod rust_bridge {
         LVL_TRACE = 5,
     }
 
+    struct CxxLedgerInfo {
+        pub protocol_version: u32,
+        pub sequence_number: u32,
+        pub timestamp: u64,
+        pub network_passphrase: Vec<u8>,
+        pub base_reserve: u32,
+    }
+
     // The extern "Rust" block declares rust stuff we're going to export to C++.
     #[namespace = "stellar::rust_bridge"]
     extern "Rust" {
@@ -51,11 +59,13 @@ mod rust_bridge {
             args: &XDRBuf,
             footprint: &XDRBuf,
             source_account: &XDRBuf,
+            ledger_info: CxxLedgerInfo,
             ledger_entries: &Vec<XDRBuf>,
         ) -> Result<Vec<Bytes>>;
         fn preflight_host_function(
             hf_buf: &CxxVector<u8>,
             args: &CxxVector<u8>,
+            ledger_info: CxxLedgerInfo,
             cb: UniquePtr<PreflightCallbacks>,
         ) -> Result<()>;
         fn init_logging(maxLevel: LogLevel) -> Result<()>;

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -233,7 +233,8 @@ PreflightCallbacks::set_result_mem_bytes(uint64_t mem)
 
 Json::Value
 InvokeHostFunctionOpFrame::preflight(Application& app,
-                                     InvokeHostFunctionOp const& op)
+                                     InvokeHostFunctionOp const& op,
+                                     AccountID const& sourceAccount)
 {
     PreflightResults res;
     auto cb = std::make_unique<PreflightCallbacks>(app, res);
@@ -243,7 +244,8 @@ InvokeHostFunctionOpFrame::preflight(Application& app,
         LedgerTxn ltx(app.getLedgerTxnRoot());
         rust_bridge::preflight_host_function(
             toXDRVec(op.function), toXDRVec(op.parameters),
-            getLedgerInfo(ltx, app.getConfig()), std::move(cb));
+            toXDRVec(sourceAccount), getLedgerInfo(ltx, app.getConfig()),
+            std::move(cb));
         root["status"] = "OK";
         root["result"] = toOpaqueBase64(res.mResult);
         root["footprint"] = toOpaqueBase64(res.mFootprint);

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -4,6 +4,7 @@
 
 // clang-format off
 // This needs to be included first
+#include "util/GlobalChecks.h"
 #include <json/json.h>
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 #include "rust/RustVecXdrMarshal.h"
@@ -24,6 +25,22 @@
 
 namespace stellar
 {
+
+CxxLedgerInfo
+getLedgerInfo(AbstractLedgerTxn& ltx, Config const& cfg)
+{
+    CxxLedgerInfo info;
+    auto const& hdr = ltx.loadHeader().current();
+    info.base_reserve = hdr.baseReserve;
+    info.protocol_version = hdr.ledgerVersion;
+    info.sequence_number = hdr.ledgerSeq;
+    info.timestamp = hdr.scpValue.closeTime;
+    for (auto c : cfg.NETWORK_PASSPHRASE)
+    {
+        info.network_passphrase.push_back(static_cast<unsigned char>(c));
+    }
+    return info;
+}
 
 template <typename T>
 std::vector<uint8_t>
@@ -62,6 +79,12 @@ InvokeHostFunctionOpFrame::isOpSupported(LedgerHeader const& header) const
 bool
 InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx)
 {
+    throw std::runtime_error("InvokeHostFunctionOpFrame::doApply needs Config");
+}
+
+bool
+InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx, Config const& cfg)
+{
     // Get the entries for the footprint
     rust::Vec<XDRBuf> ledgerEntryXdrBufs;
     ledgerEntryXdrBufs.reserve(mInvokeHostFunction.footprint.readOnly.size() +
@@ -91,7 +114,7 @@ InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx)
             toXDRBuf(mInvokeHostFunction.function),
             toXDRBuf(mInvokeHostFunction.parameters),
             toXDRBuf(mInvokeHostFunction.footprint), toXDRBuf(getSourceID()),
-            ledgerEntryXdrBufs);
+            getLedgerInfo(ltx, cfg), ledgerEntryXdrBufs);
     }
     catch (std::exception&)
     {
@@ -217,8 +240,10 @@ InvokeHostFunctionOpFrame::preflight(Application& app,
     Json::Value root;
     try
     {
+        LedgerTxn ltx(app.getLedgerTxnRoot());
         rust_bridge::preflight_host_function(
-            toXDRVec(op.function), toXDRVec(op.parameters), std::move(cb));
+            toXDRVec(op.function), toXDRVec(op.parameters),
+            getLedgerInfo(ltx, app.getConfig()), std::move(cb));
         root["status"] = "OK";
         root["result"] = toOpaqueBase64(res.mResult);
         root["footprint"] = toOpaqueBase64(res.mFootprint);

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -35,7 +35,8 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     static Json::Value preflight(Application& app,
-                                 InvokeHostFunctionOp const& op);
+                                 InvokeHostFunctionOp const& op,
+                                 AccountID const& sourceAccount);
 
     void
     insertLedgerKeysToPrefetch(UnorderedSet<LedgerKey>& keys) const override;

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -31,6 +31,7 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     bool isOpSupported(LedgerHeader const& header) const override;
 
     bool doApply(AbstractLedgerTxn& ltx) override;
+    bool doApply(AbstractLedgerTxn& ltx, Config const& cfg) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     static Json::Value preflight(Application& app,

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -134,7 +134,7 @@ OperationFrame::OperationFrame(Operation const& op, OperationResult& res,
 
 bool
 OperationFrame::apply(SignatureChecker& signatureChecker,
-                      AbstractLedgerTxn& ltx)
+                      AbstractLedgerTxn& ltx, Config const& cfg)
 {
     ZoneScoped;
     bool res;
@@ -142,11 +142,19 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
     res = checkValid(signatureChecker, ltx, true);
     if (res)
     {
-        res = doApply(ltx);
+        res = doApply(ltx, cfg);
         CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
     }
 
     return res;
+}
+
+bool
+OperationFrame::doApply(AbstractLedgerTxn& ltx, Config const& _cfg)
+{
+    // By default we ignore the cfg, but subclasses can override
+    // to intercept and use it.
+    return doApply(ltx);
 }
 
 ThresholdLevel

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -40,6 +40,7 @@ class OperationFrame
     OperationResult& mResult;
 
     virtual bool doCheckValid(uint32_t ledgerVersion) = 0;
+    virtual bool doApply(AbstractLedgerTxn& ltx, Config const& cfg);
     virtual bool doApply(AbstractLedgerTxn& ltx) = 0;
 
     // returns the threshold this operation requires
@@ -81,7 +82,8 @@ class OperationFrame
     bool checkValid(SignatureChecker& signatureChecker,
                     AbstractLedgerTxn& ltxOuter, bool forApply);
 
-    bool apply(SignatureChecker& signatureChecker, AbstractLedgerTxn& ltx);
+    bool apply(SignatureChecker& signatureChecker, AbstractLedgerTxn& ltx,
+               Config const& cfg);
 
     Operation const&
     getOperation() const

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1029,11 +1029,12 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             app.getConfig().LEDGER_PROTOCOL_MIN_VERSION_INTERNAL_ERROR_REPORT;
         auto& opTimer =
             app.getMetrics().NewTimer({"ledger", "operation", "apply"});
+        Config const& cfg = app.getConfig();
         for (auto& op : mOperations)
         {
             auto time = opTimer.TimeScope();
             LedgerTxn ltxOp(ltxTx);
-            bool txRes = op->apply(signatureChecker, ltxOp);
+            bool txRes = op->apply(signatureChecker, ltxOp, cfg);
 
             if (!txRes)
             {


### PR DESCRIPTION
This continues on the end of #3541 (which is ready to land and does a small amount of reorg in contract.rs) adding in two small but critical bits for the current development iteration:

  - Populate the LedgerInfo fields on the host in both real and preflight modes (this is bug #3548)
  - Accept a `source_account=<strkey>` argument on the preflight endpoint and populate the source account on the preflight host with it (this is a followup to #3553 which missed it)

This change does not include any testing. Unfortunately to test both of these well we need to write a wasm blob and I figured it'd be better to try unblocking folks with this code now and provide the testing later. I will write a wasm blob tomorrow as a followup.