### PR TITLE
Include ledger sequence in preflight response

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -696,7 +696,6 @@ CommandHandler::preflight(std::string const& params, std::string& retStr)
             acct = KeyUtils::fromStrKey<PublicKey>(sourceAcct);
         }
         InvokeHostFunctionOp op;
-        std::vector<uint8_t> binBlob;
         fromOpaqueBase64(op, blob);
         root = InvokeHostFunctionOpFrame::preflight(mApp, op, acct);
     }

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -220,9 +220,11 @@ InvokeHostFunctionOpFrame::preflight(Application& app,
 {
     auto cb = std::make_unique<PreflightCallbacks>(app);
     Json::Value root;
+    LedgerTxn ltx(app.getLedgerTxnRoot());
+    root["ledger"] = ltx.loadHeader().current().ledgerSeq;
+
     try
     {
-        LedgerTxn ltx(app.getLedgerTxnRoot());
         PreflightHostFunctionOutput out = rust_bridge::preflight_host_function(
             toVec(op.function), toVec(op.parameters), toVec(sourceAccount),
             getLedgerInfo(ltx, app.getConfig()), std::move(cb));


### PR DESCRIPTION
# Description

This commit adds a ledger sequence to the preflight response which is useful because execution of a smart contract will depend on the state of the ledger when the operation is applied.
<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
