### PR TITLE
Add some soroban metrics.

### DIFF
--- a/src/rust/CppShims.h
+++ b/src/rust/CppShims.h
@@ -23,10 +23,13 @@ struct CxxBuf;
 namespace stellar
 {
 class Application;
+struct HostFunctionMetrics;
 struct PreflightCallbacks
 {
     Application& mApp;
-    PreflightCallbacks(Application& app) : mApp(app){};
+    HostFunctionMetrics& mMetrics;
+    PreflightCallbacks(Application& app, HostFunctionMetrics& metrics)
+        : mApp(app), mMetrics(metrics){};
     CxxBuf get_ledger_entry(rust::Vec<uint8_t> const& key);
     bool has_ledger_entry(rust::Vec<uint8_t> const& key);
 };

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -279,7 +279,7 @@ fn invoke_host_function_or_maybe_panic(
         HostFunction::name(&hf)
     );
     let res = host.invoke_function(hf, args);
-    let (storage, _budget, events) = host
+    let (storage, budget, events) = host
         .try_finish()
         .map_err(|_h| CoreHostError::General("could not finalize host"))?;
     log_debug_events(&events);
@@ -297,6 +297,8 @@ fn invoke_host_function_or_maybe_panic(
         result_value,
         contract_events,
         modified_ledger_entries,
+        cpu_insns: budget.get_cpu_insns_count(),
+        mem_bytes: budget.get_mem_bytes_count(),
     })
 }
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -39,6 +39,8 @@ mod rust_bridge {
         result_value: RustBuf,
         contract_events: Vec<RustBuf>,
         modified_ledger_entries: Vec<RustBuf>,
+        cpu_insns: u64,
+        mem_bytes: u64,
     }
 
     struct PreflightHostFunctionOutput {

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "xdr/Stellar-transaction.h"
+#include <medida/metrics_registry.h>
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 #include "transactions/OperationFrame.h"
 
@@ -31,7 +32,8 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     bool isOpSupported(LedgerHeader const& header) const override;
 
     bool doApply(AbstractLedgerTxn& ltx) override;
-    bool doApply(AbstractLedgerTxn& ltx, Config const& cfg) override;
+    bool doApply(AbstractLedgerTxn& ltx, Config const& cfg,
+                 medida::MetricsRegistry& metrics) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     static Json::Value preflight(Application& app,

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -34,6 +34,7 @@
 #include "util/ProtocolVersion.h"
 #include "util/XDRCereal.h"
 #include <Tracy.hpp>
+#include <medida/metrics_registry.h>
 
 namespace stellar
 {
@@ -134,7 +135,8 @@ OperationFrame::OperationFrame(Operation const& op, OperationResult& res,
 
 bool
 OperationFrame::apply(SignatureChecker& signatureChecker,
-                      AbstractLedgerTxn& ltx, Config const& cfg)
+                      AbstractLedgerTxn& ltx, Config const& cfg,
+                      medida::MetricsRegistry& metrics)
 {
     ZoneScoped;
     bool res;
@@ -142,7 +144,7 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
     res = checkValid(signatureChecker, ltx, true);
     if (res)
     {
-        res = doApply(ltx, cfg);
+        res = doApply(ltx, cfg, metrics);
         CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
     }
 
@@ -150,10 +152,11 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
 }
 
 bool
-OperationFrame::doApply(AbstractLedgerTxn& ltx, Config const& _cfg)
+OperationFrame::doApply(AbstractLedgerTxn& ltx, Config const& _cfg,
+                        medida::MetricsRegistry& _metrics)
 {
-    // By default we ignore the cfg, but subclasses can override
-    // to intercept and use it.
+    // By default we ignore the cfg and metrics, but subclasses can override to
+    // intercept and use them.
     return doApply(ltx);
 }
 

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -8,6 +8,7 @@
 #include "ledger/LedgerManager.h"
 #include "overlay/StellarXDR.h"
 #include "util/types.h"
+#include <medida/metrics_registry.h>
 #include <memory>
 
 namespace medida
@@ -40,7 +41,8 @@ class OperationFrame
     OperationResult& mResult;
 
     virtual bool doCheckValid(uint32_t ledgerVersion) = 0;
-    virtual bool doApply(AbstractLedgerTxn& ltx, Config const& cfg);
+    virtual bool doApply(AbstractLedgerTxn& ltx, Config const& cfg,
+                         medida::MetricsRegistry& metrics);
     virtual bool doApply(AbstractLedgerTxn& ltx) = 0;
 
     // returns the threshold this operation requires
@@ -83,7 +85,7 @@ class OperationFrame
                     AbstractLedgerTxn& ltxOuter, bool forApply);
 
     bool apply(SignatureChecker& signatureChecker, AbstractLedgerTxn& ltx,
-               Config const& cfg);
+               Config const& cfg, medida::MetricsRegistry& metrics);
 
     Operation const&
     getOperation() const

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1068,11 +1068,12 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
         auto& opTimer =
             app.getMetrics().NewTimer({"ledger", "operation", "apply"});
         Config const& cfg = app.getConfig();
+        medida::MetricsRegistry& metrics = app.getMetrics();
         for (auto& op : mOperations)
         {
             auto time = opTimer.TimeScope();
             LedgerTxn ltxOp(ltxTx);
-            bool txRes = op->apply(signatureChecker, ltxOp, cfg);
+            bool txRes = op->apply(signatureChecker, ltxOp, cfg, metrics);
 
             if (!txRes)
             {

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -274,6 +274,13 @@ TEST_CASE("invoke host function", "[tx][contract]")
 
             // Correct function call
             call({scContractID, scFunc, sc7, sc16}, true);
+            REQUIRE(app->getMetrics()
+                        .NewTimer({"host-fn", "invoke-contract", "exec"})
+                        .count() != 0);
+            REQUIRE(
+                app->getMetrics()
+                    .NewMeter({"host-fn", "invoke-contract", "success"}, "call")
+                    .count() != 0);
 
             // Too many parameters for "add"
             call({scContractID, scFunc, sc7, sc16, makeI32(0)}, false);


### PR DESCRIPTION
This adds an initial rough set of new metrics related to soroban. They're all grouped under `host-fn` and track basic parameters of invocations and preflights: ledger entries and their sizes read and written, events emitted, CPU and memory budget consumption and overall execution time.

I did not document them in metrics.md because they're entirely ifdef'ed out at this point, and likely to change before we finalize them.