### PR TITLE
Cleaned up BucketApplicator::Counters

### DIFF
--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -32,26 +32,26 @@ class BucketApplicator
   public:
     class Counters
     {
-        // indexed by LedgerEntryType, i.e. offer counter == CounterArray[OFFER]
-        // array size == num enums in LedgerEntryType
-        typedef std::array<uint64_t, 8> CounterArray;
+        struct CounterEntry
+        {
+            uint64_t numUpserted;
+            uint64_t numDeleted;
+        };
 
         // We avoid using medida metrics here here because BucketApplicator
         // activity is typically a rare thing that happens only during catchup
         // and we don't want to pollute the regular operational metrics
         // interface with these counts.
         VirtualClock::time_point mStarted;
-        CounterArray mUpserted{0};
-        CounterArray mDeleted{0};
+        std::map<LedgerEntryType, CounterEntry> mCounters;
 
-        void getRates(VirtualClock::time_point now, CounterArray& upserted_sec,
-                      CounterArray& deleted_sec, uint64_t& T_sec,
-                      uint64_t& total);
+        void getRates(VirtualClock::time_point now,
+                      std::map<LedgerEntryType, CounterEntry>& sec_count,
+                      uint64_t& T_sec, uint64_t& total);
 
-        std::string logStr(uint64_t total, uint64_t level,
-                           std::string const& bucketName,
-                           CounterArray const& upserted,
-                           CounterArray const& deleted);
+        std::string
+        logStr(uint64_t total, uint64_t level, std::string const& bucketName,
+               std::map<LedgerEntryType, CounterEntry> const& counters);
 
       public:
         Counters(VirtualClock::time_point now);

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -32,38 +32,26 @@ class BucketApplicator
   public:
     class Counters
     {
+        // indexed by LedgerEntryType, i.e. offer counter == CounterArray[OFFER]
+        // array size == num enums in LedgerEntryType
+        typedef std::array<uint64_t, 8> CounterArray;
+
         // We avoid using medida metrics here here because BucketApplicator
         // activity is typically a rare thing that happens only during catchup
         // and we don't want to pollute the regular operational metrics
         // interface with these counts.
         VirtualClock::time_point mStarted;
-        uint64_t mAccountUpsert;
-        uint64_t mAccountDelete;
-        uint64_t mTrustLineUpsert;
-        uint64_t mTrustLineDelete;
-        uint64_t mOfferUpsert;
-        uint64_t mOfferDelete;
-        uint64_t mDataUpsert;
-        uint64_t mDataDelete;
-        uint64_t mClaimableBalanceUpsert;
-        uint64_t mClaimableBalanceDelete;
-        uint64_t mLiquidityPoolUpsert;
-        uint64_t mLiquidityPoolDelete;
-        uint64_t mContractDataUpsert;
-        uint64_t mContractDataDelete;
-        uint64_t mContractCodeUpsert;
-        uint64_t mContractCodeDelete;
-        uint64_t mConfigSettingUpsert;
-        uint64_t mTTLUpsert;
-        uint64_t mTTLDelete;
-        void getRates(VirtualClock::time_point now, uint64_t& au_sec,
-                      uint64_t& ad_sec, uint64_t& tu_sec, uint64_t& td_sec,
-                      uint64_t& ou_sec, uint64_t& od_sec, uint64_t& du_sec,
-                      uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
-                      uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec,
-                      uint64_t& cdd_sec, uint64_t& ccu_sec, uint64_t& ccd_sec,
-                      uint64_t& csu_sec, uint64_t& eeu_sec, uint64_t& eed_sec,
-                      uint64_t& T_sec, uint64_t& total);
+        CounterArray mUpserted{0};
+        CounterArray mDeleted{0};
+
+        void getRates(VirtualClock::time_point now, CounterArray& upserted_sec,
+                      CounterArray& deleted_sec, uint64_t& T_sec,
+                      uint64_t& total);
+
+        std::string logStr(uint64_t total, uint64_t level,
+                           std::string const& bucketName,
+                           CounterArray const& upserted,
+                           CounterArray const& deleted);
 
       public:
         Counters(VirtualClock::time_point now);


### PR DESCRIPTION
# Description

Resolves #3114. Cleans up `BucketApplicator::Counters`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
