### PR TITLE
Bump env and add complex-wasm testcase.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=96d7a04#96d7a04761916f2d7ba312bea3a2d565b5e85416"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=17ada13#17ada1354bb7f709d2198d1946787c14946e773f"
 dependencies = [
  "soroban-env-macros",
  "soroban-wasmi",
@@ -538,7 +538,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=96d7a04#96d7a04761916f2d7ba312bea3a2d565b5e85416"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=17ada13#17ada1354bb7f709d2198d1946787c14946e773f"
 dependencies = [
  "backtrace",
  "dyn-fmt",
@@ -574,7 +574,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=96d7a04#96d7a04761916f2d7ba312bea3a2d565b5e85416"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=17ada13#17ada1354bb7f709d2198d1946787c14946e773f"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.5"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=96d7a04#96d7a04761916f2d7ba312bea3a2d565b5e85416"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=17ada13#17ada1354bb7f709d2198d1946787c14946e773f"
 
 [[package]]
 name = "soroban-wasmi"
@@ -637,7 +637,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.2"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f87409c#f87409c3baf87d7858f7f7b6c283ed0a9ca13387"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=88ded341#88ded341ffbf54372ce851f766610ef978784d2a"
 dependencies = [
  "base64",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,9 @@
 members = ["src/rust"]
 
 [patch.crates-io]
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "f87409c" }
+stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "88ded341" }
 wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "a61b6df" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "96d7a04" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "96d7a04" }
+soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "17ada13" }
+soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "17ada13" }
 
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,7 +14,7 @@ cxx = "1.0"
 im-rc = "15.0.0"
 base64 = "0.13.0"
 rustc-simple-version = "0.1.0"
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "96d7a04", features = [
+soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "17ada13", features = [
     "vm",
 ] }
-soroban-test-wasms = { git = "https://github.com/stellar/rs-soroban-env", rev = "96d7a04" }
+soroban-test-wasms = { git = "https://github.com/stellar/rs-soroban-env", rev = "17ada13" }

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -480,3 +480,9 @@ pub(crate) fn get_test_wasm_contract_data() -> Result<RustBuf, Box<dyn Error>> {
         data: soroban_test_wasms::CONTRACT_DATA.iter().cloned().collect(),
     })
 }
+
+pub(crate) fn get_test_wasm_complex() -> Result<RustBuf, Box<dyn Error>> {
+    Ok(RustBuf {
+        data: soroban_test_wasms::COMPLEX.iter().cloned().collect(),
+    })
+}

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -98,6 +98,7 @@ mod rust_bridge {
         // Accessors for test wasms, compiled into soroban-test-wasms crate.
         fn get_test_wasm_add_i32() -> Result<RustBuf>;
         fn get_test_wasm_contract_data() -> Result<RustBuf>;
+        fn get_test_wasm_complex() -> Result<RustBuf>;
 
         // Return the rustc version used to build this binary.
         fn get_rustc_version() -> String;
@@ -131,6 +132,7 @@ use b64::{from_base64, to_base64};
 mod contract;
 use contract::get_test_wasm_add_i32;
 use contract::get_test_wasm_contract_data;
+use contract::get_test_wasm_complex;
 use contract::get_xdr_hashes;
 use contract::invoke_host_function;
 use contract::preflight_host_function;


### PR DESCRIPTION
This bumps the env by a few days (to 17ada13), absorbing recent changes over the past week, including those that disable ed25519 contract creation, and a recent new wasm testcase I added today that exercises a bit more of the recently-enabled host embedding interface (preflight, events, etc) from the guest side.

It should probably only land if @paulbellamy and @leighmcculloch want it currently -- I don't want to get in anyone's way / break e2e tests just about to start working, but .. if it's desirable to shift to a slightly newer env, this does so.

(It also removes the ed25519 tests @sisuresh added a while back -- they can be fished out of git and re-enabled when that redesign is completed)