### PR TITLE
Plumb errors status and event for failed contract host fn invocations.

### DIFF
--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -21,7 +21,8 @@ use soroban_env_host::{
     xdr::{
         AccountId, HostFunction, LedgerEntry, LedgerEntryData, LedgerFootprint, LedgerKey,
         LedgerKeyAccount, LedgerKeyContractData, LedgerKeyTrustLine, ReadXdr,
-        ScHostContextErrorCode, ScUnknownErrorCode, ScVec, WriteXdr, XDR_FILES_SHA256,
+        ScHostContextErrorCode, ScStatus, ScUnknownErrorCode, ScVal, ScVec, WriteXdr,
+        XDR_FILES_SHA256,
     },
     Host, HostError, LedgerInfo, MeteredOrdMap,
 };
@@ -283,22 +284,31 @@ fn invoke_host_function_or_maybe_panic(
         .try_finish()
         .map_err(|_h| CoreHostError::General("could not finalize host"))?;
     log_debug_events(&events);
+    let contract_events = extract_contract_events(&events)?;
     let result_value = match res {
         Ok(rv) => xdr_to_rust_buf(&rv)?,
         Err(err) => {
             debug!(target: TX, "invocation failed: {}", err);
-            return Err(err.into());
+            return Ok(InvokeHostFunctionOutput {
+                result_value: xdr_to_rust_buf(&ScVal::Status(ScStatus::try_from(&err)?))?,
+                contract_events,
+                modified_ledger_entries: Default::default(),
+                cpu_insns: budget.get_cpu_insns_count(),
+                mem_bytes: budget.get_mem_bytes_count(),
+                is_error: true,
+            });
         }
     };
     let modified_ledger_entries =
         build_xdr_ledger_entries_from_storage_map(&storage.footprint, &storage.map)?;
-    let contract_events = extract_contract_events(&events)?;
+
     Ok(InvokeHostFunctionOutput {
         result_value,
         contract_events,
         modified_ledger_entries,
         cpu_insns: budget.get_cpu_insns_count(),
         mem_bytes: budget.get_mem_bytes_count(),
+        is_error: false,
     })
 }
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -41,6 +41,9 @@ mod rust_bridge {
         modified_ledger_entries: Vec<RustBuf>,
         cpu_insns: u64,
         mem_bytes: u64,
+        // Flags whether result_value is an actual function output or an 
+        // error status.
+        is_error: bool,
     }
 
     struct PreflightHostFunctionOutput {

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -25,25 +25,28 @@ mod rust_bridge {
     // When we want to return owned data _from_ Rust, we typically want to do
     // the opposite: allocate on the Rust side as a Vec<u8> and then let the C++
     // side parse the data out of it and then drop it.
+    #[derive(Default)]
     struct RustBuf {
         data: Vec<u8>,
     }
 
     // We return these from get_xdr_hashes below.
+    #[derive(Default)]
     struct XDRFileHash {
         file: String,
         hash: String,
     }
 
+    #[derive(Default)]
     struct InvokeHostFunctionOutput {
         result_value: RustBuf,
         contract_events: Vec<RustBuf>,
         modified_ledger_entries: Vec<RustBuf>,
         cpu_insns: u64,
         mem_bytes: u64,
-        // Flags whether result_value is an actual function output or an 
-        // error status.
-        is_error: bool,
+        // Flags whether result_value is an SCVal from an Ok(...) return or an
+        // SCStatus carrying the Status from an Err(...) return.
+        result_is_status: bool,
     }
 
     struct PreflightHostFunctionOutput {
@@ -134,8 +137,8 @@ use b64::{from_base64, to_base64};
 
 mod contract;
 use contract::get_test_wasm_add_i32;
-use contract::get_test_wasm_contract_data;
 use contract::get_test_wasm_complex;
+use contract::get_test_wasm_contract_data;
 use contract::get_xdr_hashes;
 use contract::invoke_host_function;
 use contract::preflight_host_function;

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -283,6 +283,24 @@ InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx, Config const& cfg,
         innerResult().code(INVOKE_HOST_FUNCTION_TRAPPED);
         return false;
     }
+    
+    // Append events to the enclosing TransactionFrame, where
+    // they'll be picked up and transferred to the TxMeta.
+    for (auto const& buf : out.contract_events)
+    {
+        metrics.mEmitEvent++;
+        metrics.mEmitEventByte += buf.data.size();
+        ContractEvent evt;
+        xdr::xdr_from_opaque(buf.data, evt);
+        mParentTx.pushContractEvent(evt);
+    }
+
+    if (out.is_error)
+    {
+        innerResult().code(INVOKE_HOST_FUNCTION_ERROR);
+        xdr::xdr_from_opaque(out.result_value.data, innerResult().error());
+        return false;
+    }
 
     metrics.mCpuInsn = out.cpu_insns;
     metrics.mMemByte = out.mem_bytes;
@@ -319,17 +337,6 @@ InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx, Config const& cfg,
                 ltx.erase(lk);
             }
         }
-    }
-
-    // Append events to the enclosing TransactionFrame, where
-    // they'll be picked up and transferred to the TxMeta.
-    for (auto const& buf : out.contract_events)
-    {
-        metrics.mEmitEvent++;
-        metrics.mEmitEventByte += buf.data.size();
-        ContractEvent evt;
-        xdr::xdr_from_opaque(buf.data, evt);
-        mParentTx.pushContractEvent(evt);
     }
 
     innerResult().code(INVOKE_HOST_FUNCTION_SUCCESS);

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -283,19 +283,8 @@ InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx, Config const& cfg,
         innerResult().code(INVOKE_HOST_FUNCTION_TRAPPED);
         return false;
     }
-    
-    // Append events to the enclosing TransactionFrame, where
-    // they'll be picked up and transferred to the TxMeta.
-    for (auto const& buf : out.contract_events)
-    {
-        metrics.mEmitEvent++;
-        metrics.mEmitEventByte += buf.data.size();
-        ContractEvent evt;
-        xdr::xdr_from_opaque(buf.data, evt);
-        mParentTx.pushContractEvent(evt);
-    }
 
-    if (out.is_error)
+    if (out.result_is_status)
     {
         innerResult().code(INVOKE_HOST_FUNCTION_ERROR);
         xdr::xdr_from_opaque(out.result_value.data, innerResult().error());
@@ -337,6 +326,17 @@ InvokeHostFunctionOpFrame::doApply(AbstractLedgerTxn& ltx, Config const& cfg,
                 ltx.erase(lk);
             }
         }
+    }
+
+    // Append events to the enclosing TransactionFrame, where
+    // they'll be picked up and transferred to the TxMeta.
+    for (auto const& buf : out.contract_events)
+    {
+        metrics.mEmitEvent++;
+        metrics.mEmitEventByte += buf.data.size();
+        ContractEvent evt;
+        xdr::xdr_from_opaque(buf.data, evt);
+        mParentTx.pushContractEvent(evt);
     }
 
     innerResult().code(INVOKE_HOST_FUNCTION_SUCCESS);

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -215,7 +215,8 @@ TEST_CASE("invoke host function", "[tx][contract]")
                         ores.tr().invokeHostFunctionResult().code() ==
                             INVOKE_HOST_FUNCTION_ERROR)
                     {
-                        resultVal =
+                        resultVal.type(SCV_STATUS);
+                        resultVal.status() =
                             ores.tr().invokeHostFunctionResult().error();
                     }
                 }


### PR DESCRIPTION
# Description

This is a proof-of-concept PR, maybe it could be improved somehow.

I'm also not sure about plumbing the events; we can get rid of them if the proposed approach isn't feasible for some reason.

The XDR changes are in https://github.com/stellar/stellar-xdr-next/pull/48, so this won't build initially.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
