### PR TITLE
Build rust code with heavier optimization settings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,6 @@ wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", r
 soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "17ada13" }
 soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "17ada13" }
 
-
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
This just changes the release build parameters for the rust code so that, in particular, the wasmi VM inlines all of its opcode processing blocks. This wins a factor of 2-3 in performance, in microbenchmarks; it makes builds take longer but seemes worth doing.