### PR TITLE
Pin `cxxbridge` tool at v 1.0.68 to match `Cargo.lock`.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -1526,8 +1526,8 @@ $(OutDir)\bin\cxxbridge.exe ..\..\src\rust\src\lib.rs --output src\$(Configurati
     </CustomBuild>
     <CustomBuild Include="..\..\src\rust\install-cxxbridge-cmd">
       <FileType>Document</FileType>
-      <Command>cargo install --root $(OutDir) cxxbridge-cmd</Command>
-      <Message>cargo install --root $(OutDir) cxxbridge-cmd</Message>
+      <Command>cargo install --root $(OutDir) cxxbridge-cmd --version 1.0.68</Command>
+      <Message>cargo install --root $(OutDir) cxxbridge-cmd --version 1.0.68</Message>
       <Outputs>$(OutDir)/bin/cxxbridge.exe</Outputs>
     </CustomBuild>
     <None Include="..\..\src\rust\src\b64.rs" />

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,7 +76,7 @@ stellar_core_LDADD += $(LIBRUST_STELLAR_CORE) -ldl
 
 $(RUST_CXXBRIDGE):
 	mkdir -p $(RUST_BIN_DIR)
-	$(CARGO) install --root $(RUST_BUILD_DIR) cxxbridge-cmd
+	$(CARGO) install --root $(RUST_BUILD_DIR) cxxbridge-cmd --version 1.0.68
 
 rust/RustBridge.h: rust/src/lib.rs $(SRC_RUST_FILES) Makefile.am $(RUST_CXXBRIDGE)
 	$(RUST_CXXBRIDGE) $< --header --output $@.tmp


### PR DESCRIPTION
# Description

Pin `cxxbridge` tool at v 1.0.68 to match `cxx` crates in `Cargo.lock`.

Ideally we would do that automatically, but that addresses the issue of version mismatch for the time being.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
