### PR TITLE
Flow control capacity accounting

### DIFF
--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -65,7 +65,6 @@ Peer::Peer(Application& app, PeerRole role)
           std::make_optional<VirtualClock::time_point>(app.getClock().now()))
     , mEnqueueTimeOfLastWrite(app.getClock().now())
     , mPeerMetrics(app.getClock().now())
-    , mFlowControlState(Peer::FlowControlState::DONT_KNOW)
     , mCapacity{app.getConfig().PEER_FLOOD_READING_CAPACITY,
                 app.getConfig().PEER_READING_CAPACITY}
     , mTxAdvertQueue(app)
@@ -97,28 +96,24 @@ Peer::beginMesssageProcessing(StellarMessage const& msg)
                   mCapacity.mFloodCapacity);
     releaseAssert(mApp.getConfig().PEER_READING_CAPACITY >=
                   mCapacity.mTotalCapacity);
-    // Check if flow control is enabled on the local node
-    if (flowControlEnabled() == Peer::FlowControlState::ENABLED)
+    releaseAssert(mCapacity.mTotalCapacity > 0);
+    mCapacity.mTotalCapacity--;
+
+    if (mApp.getOverlayManager().isFloodMessage(msg))
     {
-        releaseAssert(mCapacity.mTotalCapacity > 0);
-        mCapacity.mTotalCapacity--;
-
-        if (mApp.getOverlayManager().isFloodMessage(msg))
+        if (mCapacity.mFloodCapacity == 0)
         {
-            if (mCapacity.mFloodCapacity == 0)
-            {
-                drop("unexpected flood message, peer at capacity",
-                     Peer::DropDirection::WE_DROPPED_REMOTE,
-                     Peer::DropMode::IGNORE_WRITE_QUEUE);
-                return;
-            }
+            drop("unexpected flood message, peer at capacity",
+                 Peer::DropDirection::WE_DROPPED_REMOTE,
+                 Peer::DropMode::IGNORE_WRITE_QUEUE);
+            return;
+        }
 
-            mCapacity.mFloodCapacity--;
-            if (mCapacity.mFloodCapacity == 0)
-            {
-                CLOG_DEBUG(Overlay, "No flood capacity for peer {}",
-                           mApp.getConfig().toShortString(getPeerID()));
-            }
+        mCapacity.mFloodCapacity--;
+        if (mCapacity.mFloodCapacity == 0)
+        {
+            CLOG_DEBUG(Overlay, "No flood capacity for peer {}",
+                       mApp.getConfig().toShortString(getPeerID()));
         }
     }
 }
@@ -261,10 +256,8 @@ Peer::recurrentTimerExpired(asio::error_code const& error)
             drop("idle timeout", Peer::DropDirection::WE_DROPPED_REMOTE,
                  Peer::DropMode::IGNORE_WRITE_QUEUE);
         }
-        else if (flowControlEnabled() == Peer::FlowControlState::ENABLED &&
-                 mNoOutboundCapacity &&
-                 (now - *mNoOutboundCapacity) >=
-                     Peer::PEER_SEND_MODE_IDLE_TIMEOUT)
+        else if (mNoOutboundCapacity && (now - *mNoOutboundCapacity) >=
+                                            Peer::PEER_SEND_MODE_IDLE_TIMEOUT)
         {
             drop("idle timeout (no new flood requests)",
                  Peer::DropDirection::WE_DROPPED_REMOTE,
@@ -289,15 +282,9 @@ Peer::getFlowControlJsonInfo(bool compact) const
 {
     Json::Value res;
     std::string stateStr;
-    bool reportCapacity =
-        flowControlEnabled() == Peer::FlowControlState::ENABLED;
-    if (reportCapacity)
-    {
-        res["local_capacity"]["reading"] =
-            (Json::UInt64)mCapacity.mTotalCapacity;
-        res["local_capacity"]["flood"] = (Json::UInt64)mCapacity.mFloodCapacity;
-        res["peer_capacity"] = (Json::UInt64)mOutboundCapacity;
-    }
+    res["local_capacity"]["reading"] = (Json::UInt64)mCapacity.mTotalCapacity;
+    res["local_capacity"]["flood"] = (Json::UInt64)mCapacity.mFloodCapacity;
+    res["peer_capacity"] = (Json::UInt64)mOutboundCapacity;
 
     if (!compact)
     {
@@ -691,18 +678,9 @@ Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
 
     if (mApp.getOverlayManager().isFloodMessage(*msg))
     {
-        auto flowControl = flowControlEnabled();
-        if (flowControl == Peer::FlowControlState::DONT_KNOW)
-        {
-            // Drop any flood messages while flow control is being set
-            return;
-        }
-        else if (flowControl == Peer::FlowControlState::ENABLED)
-        {
-            addMsgAndMaybeTrimQueue(msg);
-            maybeSendNextBatch();
-            return;
-        }
+        addMsgAndMaybeTrimQueue(msg);
+        maybeSendNextBatch();
+        return;
     }
 
     sendAuthenticatedMessage(*msg);
@@ -846,28 +824,15 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
             return;
         }
 
-        if (mApp.getConfig().OVERLAY_PROTOCOL_VERSION <
-            Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
-        {
-            drop("does not support SEND_MORE",
-                 Peer::DropDirection::WE_DROPPED_REMOTE,
-                 Peer::DropMode::IGNORE_WRITE_QUEUE);
-            return;
-        }
-
         cat = "CTRL";
 
         if (stellarMsg.sendMoreMessage().numMessages == 0)
         {
-            auto msg = flowControlEnabled() == Peer::FlowControlState::ENABLED
-                           ? "unexpected SEND_MORE message"
-                           : "must enable flow control";
-            drop(msg, Peer::DropDirection::WE_DROPPED_REMOTE,
+            drop("unexpected SEND_MORE message",
+                 Peer::DropDirection::WE_DROPPED_REMOTE,
                  Peer::DropMode::IGNORE_WRITE_QUEUE);
             return;
         }
-
-        mFlowControlState = Peer::FlowControlState::ENABLED;
 
         if (stellarMsg.sendMoreMessage().numMessages >
             UINT64_MAX - mOutboundCapacity)
@@ -994,9 +959,6 @@ void
 Peer::recvSendMore(StellarMessage const& msg)
 {
     ZoneScoped;
-    // Flow control must be "on"
-    auto fc = flowControlEnabled();
-    releaseAssert(fc != Peer::FlowControlState::DONT_KNOW);
     releaseAssert(msg.sendMoreMessage().numMessages > 0);
 
     CLOG_TRACE(Overlay, "Peer {} sent SEND_MORE {}",
@@ -1005,32 +967,13 @@ Peer::recvSendMore(StellarMessage const& msg)
 
     // SEND_MORE means we can free some capacity, and dump the next batch of
     // messages onto the writing queue
-    if (fc == Peer::FlowControlState::ENABLED)
-    {
-        maybeSendNextBatch();
-    }
+    maybeSendNextBatch();
 }
 
 bool
 Peer::hasReadingCapacity() const
 {
-    return flowControlEnabled() != Peer::FlowControlState::ENABLED ||
-           mCapacity.mTotalCapacity > 0;
-}
-
-Peer::FlowControlState
-Peer::flowControlEnabled() const
-{
-    if (mFlowControlState == Peer::FlowControlState::DONT_KNOW)
-    {
-        return Peer::FlowControlState::DONT_KNOW;
-    }
-    if (mApp.getConfig().OVERLAY_PROTOCOL_VERSION <
-        Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
-    {
-        return Peer::FlowControlState::DISABLED;
-    }
-    return mFlowControlState;
+    return mCapacity.mTotalCapacity > 0;
 }
 
 void
@@ -1159,8 +1102,6 @@ Peer::maybeSendNextBatch()
 {
     ZoneScoped;
 
-    releaseAssert(flowControlEnabled() == Peer::FlowControlState::ENABLED);
-
     auto oldOutboundCapacity = mOutboundCapacity;
     for (int i = 0; i < mOutboundQueues.size(); i++)
     {
@@ -1228,8 +1169,7 @@ Peer::maybeSendNextBatch()
 void
 Peer::endMessageProcessing(StellarMessage const& msg)
 {
-    if (shouldAbort() ||
-        flowControlEnabled() != Peer::FlowControlState::ENABLED)
+    if (shouldAbort())
     {
         return;
     }
@@ -1823,8 +1763,7 @@ Peer::recvHello(Hello const& elo)
 
     if (mRemoteOverlayMinVersion > mRemoteOverlayVersion ||
         mRemoteOverlayVersion < mApp.getConfig().OVERLAY_PROTOCOL_MIN_VERSION ||
-        mRemoteOverlayMinVersion > mApp.getConfig().OVERLAY_PROTOCOL_VERSION ||
-        mRemoteOverlayVersion < Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
+        mRemoteOverlayMinVersion > mApp.getConfig().OVERLAY_PROTOCOL_VERSION)
     {
         CLOG_DEBUG(Overlay, "Protocol = [{},{}] expected: [{},{}]",
                    mRemoteOverlayMinVersion, mRemoteOverlayVersion,

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -93,6 +93,10 @@ Peer::rememberHash(Hash const& hash, uint32_t ledgerSeq)
 void
 Peer::beginMesssageProcessing(StellarMessage const& msg)
 {
+    releaseAssert(mApp.getConfig().PEER_FLOOD_READING_CAPACITY >=
+                  mCapacity.mFloodCapacity);
+    releaseAssert(mApp.getConfig().PEER_READING_CAPACITY >=
+                  mCapacity.mTotalCapacity);
     // Check if flow control is enabled on the local node
     if (flowControlEnabled() == Peer::FlowControlState::ENABLED)
     {
@@ -1257,6 +1261,10 @@ Peer::endMessageProcessing(StellarMessage const& msg)
         mIsPeerThrottled = false;
         scheduleRead();
     }
+    releaseAssert(mApp.getConfig().PEER_FLOOD_READING_CAPACITY >=
+                  mCapacity.mFloodCapacity);
+    releaseAssert(mApp.getConfig().PEER_READING_CAPACITY >=
+                  mCapacity.mTotalCapacity);
 }
 
 void

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -816,14 +816,6 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
         return;
     case SEND_MORE:
     {
-        if (mRemoteOverlayVersion < Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
-        {
-            drop("Peer sent SEND_MORE that it doesn't support",
-                 Peer::DropDirection::WE_DROPPED_REMOTE,
-                 Peer::DropMode::IGNORE_WRITE_QUEUE);
-            return;
-        }
-
         cat = "CTRL";
 
         if (stellarMsg.sendMoreMessage().numMessages == 0)
@@ -1875,13 +1867,8 @@ Peer::recvAuth(StellarMessage const& msg)
     }
 
     // Subtle: after successful auth, must send sendMore message first to tell
-    // the other peer if this node prefers to flow control the traffic or not
-    if (mRemoteOverlayVersion >= Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL &&
-        mApp.getConfig().OVERLAY_PROTOCOL_VERSION >=
-            Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL)
-    {
-        sendSendMore(mApp.getConfig().PEER_FLOOD_READING_CAPACITY);
-    }
+    // the other peer about the local node's reading capacity.
+    sendSendMore(mApp.getConfig().PEER_FLOOD_READING_CAPACITY);
 
     if (mRemoteOverlayVersion >= Peer::FIRST_VERSION_SUPPORTING_PULL_MODE &&
         mApp.getConfig().OVERLAY_PROTOCOL_VERSION >=

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -159,16 +159,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
         VirtualClock::time_point mTimeEmplaced;
     };
 
-    // Does this peer want flow control enabled
-    enum class FlowControlState
-    {
-        ENABLED,
-        DISABLED,
-        DONT_KNOW
-    };
-
-    Peer::FlowControlState flowControlEnabled() const;
-
     Json::Value getFlowControlJsonInfo(bool compact) const;
     Json::Value getJsonInfo(bool compact) const;
 
@@ -247,7 +237,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     std::chrono::milliseconds mLastPing;
 
     PeerMetrics mPeerMetrics;
-    FlowControlState mFlowControlState;
     ReadingCapacity mCapacity;
 
     OverlayMetrics& getOverlayMetrics();
@@ -426,12 +415,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     getPeerMetrics()
     {
         return mPeerMetrics;
-    }
-
-    bool
-    isFlowControlled() const
-    {
-        return mFlowControlState == Peer::FlowControlState::ENABLED;
     }
 
     std::string const& toString();

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -58,7 +58,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
 {
 
   public:
-    static constexpr uint32_t FIRST_VERSION_SUPPORTING_FLOW_CONTROL = 20;
     static constexpr uint32_t FIRST_VERSION_SUPPORTING_GENERALIZED_TX_SET = 23;
     static constexpr std::chrono::seconds PEER_SEND_MODE_IDLE_TIMEOUT =
         std::chrono::seconds(60);

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -702,22 +702,18 @@ TCPPeer::drop(std::string const& reason, DropDirection dropDirection,
         return;
     }
 
-    std::string connectionType =
-        isFlowControlled() ? "flow-controlled" : "not flow-controlled";
     if (mState != GOT_AUTH)
     {
-        CLOG_DEBUG(Overlay, "TCPPeer::drop {} {} in state {} we called:{}",
-                   connectionType, toString(), mState, mRole);
+        CLOG_DEBUG(Overlay, "TCPPeer::drop {} in state {} we called:{}",
+                   toString(), mState, mRole);
     }
     else if (dropDirection == Peer::DropDirection::WE_DROPPED_REMOTE)
     {
-        CLOG_INFO(Overlay, "Dropping {} peer {}, reason {}", connectionType,
-                  toString(), reason);
+        CLOG_INFO(Overlay, "Dropping peer {}, reason {}", toString(), reason);
     }
     else
     {
-        CLOG_INFO(Overlay, "{} peer {} dropped us, reason {}", connectionType,
-                  toString(), reason);
+        CLOG_INFO(Overlay, "peer {} dropped us, reason {}", toString(), reason);
     }
 
     mState = CLOSING;

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -129,7 +129,6 @@ class LoopbackPeer : public Peer
     std::string getIP() const override;
 
     using Peer::addMsgAndMaybeTrimQueue;
-    using Peer::flowControlEnabled;
     using Peer::sendAuth;
     using Peer::sendAuthenticatedMessage;
     using Peer::sendMessage;

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -39,7 +39,6 @@ class PeerStub : public Peer
         mState = GOT_AUTH;
         mAddress = address;
         mOutboundCapacity = std::numeric_limits<uint32>::max();
-        mFlowControlState = Peer::FlowControlState::ENABLED;
     }
     virtual std::string
     getIP() const override

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -1647,17 +1647,6 @@ TEST_CASE("overlay flow control", "[overlay][flowcontrol]")
                 3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false),
             std::runtime_error);
     }
-    SECTION("one peer doesn't support flow control")
-    {
-        configs[2].OVERLAY_PROTOCOL_VERSION =
-            Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL - 1;
-        setupSimulation();
-        REQUIRE_THROWS_AS(
-            simulation->crankUntil(
-                [&] { return simulation->haveAllExternalized(2, 1); },
-                3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false),
-            std::runtime_error);
-    }
 }
 
 PeerBareAddress


### PR DESCRIPTION
# Description

Resolves #3589 

As outlined in #3589, the race condition occurs when we start processing incoming messages before we turn on flow control and end processing them after we turn it on. This PR assumes that flow control is on always as all Overlay versions that meet the min overlay requirement enables pull mode on by default. 

- The first commit adds asserts to prevent this said behavior. 
- The second commit removes code for not turning on flow control, effectively fixing the bug.
- The third commit removes the constant specifying the minimum flow control version as it's already lower than the min overlay version. Furthermore, we remove a test that uses that as that test fails due to not meeting the min overlay version.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
