### PR TITLE
Improve logging & documentation on connection count adjustment

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -100,11 +100,13 @@ PEER_PORT=11625
 # This controls how aggressively the server will connect to other peers.
 # It will send outbound connection attempts until it is at this
 # number of outbound peer connections.
+# This value may be additionally capped by OS limits of open connections.
 TARGET_PEER_CONNECTIONS=8
 
 # MAX_ADDITIONAL_PEER_CONNECTIONS (Integer) default -1
 # Numbers of peers allowed to make inbound connection to this instance
 # Setting this too low will result in peers stranded out of the network
+# This value may be additionally capped by OS limits of open connections.
 # -1: use TARGET_PEER_CONNECTIONS*8 as value for this field
 MAX_ADDITIONAL_PEER_CONNECTIONS=-1
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1479,6 +1479,11 @@ Config::adjust()
         }
     }
 
+    auto const originalMaxAdditionalPeerConnections =
+        MAX_ADDITIONAL_PEER_CONNECTIONS;
+    auto const originalTargetPeerConnections = TARGET_PEER_CONNECTIONS;
+    auto const originalMaxPendingConnections = MAX_PENDING_CONNECTIONS;
+
     int maxFsConnections = std::min<int>(
         std::numeric_limits<unsigned short>::max(), fs::getMaxConnections());
 
@@ -1560,6 +1565,23 @@ Config::adjust()
         MAX_OUTBOUND_PENDING_CONNECTIONS = 0;
         MAX_INBOUND_PENDING_CONNECTIONS = 0;
     }
+    auto warnIfChanged = [&](std::string const name, auto const originalValue,
+                             auto const newValue) {
+        if (originalValue != newValue)
+        {
+            LOG_WARNING(DEFAULT_LOG,
+                        "Adjusted {} from {} to {} due to OS limits (the "
+                        "maximum number of file descriptors)",
+                        name, originalValue, newValue);
+        }
+    };
+    warnIfChanged("MAX_ADDITIONAL_PEER_CONNECTIONS",
+                  originalMaxAdditionalPeerConnections,
+                  MAX_ADDITIONAL_PEER_CONNECTIONS);
+    warnIfChanged("TARGET_PEER_CONNECTIONS", originalTargetPeerConnections,
+                  TARGET_PEER_CONNECTIONS);
+    warnIfChanged("MAX_PENDING_CONNECTIONS", originalMaxPendingConnections,
+                  MAX_PENDING_CONNECTIONS);
 }
 
 void


### PR DESCRIPTION
# Description

Resolves #3596 

Core adjusts some config values for connection counts due to OS limits. This PR improves logging and documentation of that feature.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
