### PR TITLE
Flow control in bytes

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1428,6 +1428,18 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             throw std::runtime_error(msg);
         }
 
+        if (!(PEER_FLOOD_READING_CAPACITY_BYTES -
+                  FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES >=
+              FlowControlCapacity::MAX_FLOOD_MESSAGE_SIZE_BYTES))
+        {
+            std::string msg =
+                "Invalid configuration: the difference between "
+                "PEER_FLOOD_READING_CAPACITY_BYTES and "
+                "FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES must be at least "
+                "(MAX_FLOOD_MESSAGE_SIZE_BYTES)";
+            throw std::runtime_error(msg);
+        }
+
         verifyLoadGenOpCountForTestingConfigs();
 
         gIsProductionNetwork = NETWORK_PASSPHRASE ==

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -52,6 +52,8 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
     "LOADGEN_OP_COUNT_FOR_TESTING",
     "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING",
+    "LOADGEN_OP_SIZE_FOR_TESTING",
+    "LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING",
     "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING",
     "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING",
     "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING",
@@ -119,6 +121,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = std::vector<uint32>();
     LOADGEN_OP_COUNT_FOR_TESTING = {};
     LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {};
+    LOADGEN_OP_SIZE_FOR_TESTING = {};
+    LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING = {};
     CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = false;
     ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING =
         std::chrono::microseconds::zero();
@@ -824,6 +828,20 @@ Config::verifyLoadGenOpCountForTestingConfigs()
                                     "must have the exact same size.");
     }
 
+    if (LOADGEN_OP_SIZE_FOR_TESTING.size() !=
+        LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING.size())
+    {
+        throw std::invalid_argument("LOADGEN_OP_SIZE_FOR_TESTING and "
+                                    "LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING "
+                                    "must be defined together and "
+                                    "must have the exact same size.");
+    }
+
+    if (LOADGEN_OP_SIZE_FOR_TESTING.empty())
+    {
+        return;
+    }
+
     if (LOADGEN_OP_COUNT_FOR_TESTING.empty())
     {
         return;
@@ -1355,6 +1373,15 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING")
             {
                 LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
+            else if (item.first == "LOADGEN_OP_SIZE_FOR_TESTING")
+            {
+                LOADGEN_OP_SIZE_FOR_TESTING = readIntArray<uint32>(item);
+            }
+            else if (item.first == "LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING")
+            {
+                LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING =
                     readIntArray<uint32>(item);
             }
             else if (item.first == "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING")

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -221,6 +221,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     PEER_FLOOD_READING_CAPACITY_BYTES = 100000;
     FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 20000;
+    OUTBOUND_TX_QUEUE_BYTE_LIMIT = 1024 * 1024 * 3;
 
     // WORKER_THREADS: setting this too low risks a form of priority inversion
     // where a long-running background task occupies all worker threads and
@@ -975,6 +976,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES =
                     readInt<uint32_t>(item, 1);
+            }
+            else if (item.first == "OUTBOUND_TX_QUEUE_BYTE_LIMIT")
+            {
+                OUTBOUND_TX_QUEUE_BYTE_LIMIT = readInt<uint32_t>(item, 1);
             }
             else if (item.first == "PEER_PORT")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -248,6 +248,14 @@ class Config : public std::enable_shared_from_this<Config>
     // processes `FLOW_CONTROL_SEND_MORE_BATCH_SIZE` messages
     uint32_t FLOW_CONTROL_SEND_MORE_BATCH_SIZE;
 
+    // A config parameter that controls how many bytes worth of flood messages
+    // (tx or SCP) from a particular peer core can process simultaneously
+    uint32_t PEER_FLOOD_READING_CAPACITY_BYTES;
+
+    // When flow control is enabled, peer asks for more data every time it
+    // processes `FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES` bytes
+    uint32_t FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES;
+
     // A config parameter that allows a node to generate buckets. This should
     // be set to `false` only for testing purposes.
     bool MODE_ENABLES_BUCKETLIST;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -260,6 +260,9 @@ class Config : public std::enable_shared_from_this<Config>
     // processes `FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES` bytes
     uint32_t FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES;
 
+    // For testing only, remove later
+    uint32_t OUTBOUND_TX_QUEUE_BYTE_LIMIT;
+
     // A config parameter that allows a node to generate buckets. This should
     // be set to `false` only for testing purposes.
     bool MODE_ENABLES_BUCKETLIST;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -231,6 +231,10 @@ class Config : public std::enable_shared_from_this<Config>
     std::vector<unsigned short> LOADGEN_OP_COUNT_FOR_TESTING;
     std::vector<uint32> LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING;
 
+    // Additional number of bytes to add to every payment operation in loadgen
+    std::vector<uint32> LOADGEN_OP_SIZE_FOR_TESTING;
+    std::vector<uint32> LOADGEN_OP_SIZE_DISTRIBUTION_FOR_TESTING;
+
     // Waits for merges to complete before applying transactions during catchup
     bool CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING;
 

--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -1,0 +1,180 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/FlowControlCapacity.h"
+#include "main/Application.h"
+#include "overlay/OverlayManager.h"
+#include "util/Logging.h"
+
+namespace stellar
+{
+
+FlowControlCapacity::FlowControlCapacity(Application& app, NodeID nodeID)
+    : mApp(app), mNodeID(nodeID)
+{
+}
+
+void
+FlowControlCapacity::checkCapacityInvariants() const
+{
+    auto limits = getCapacityLimits();
+    releaseAssert(getCapacityLimits().mFloodCapacity >=
+                  mCapacity.mFloodCapacity);
+    if (limits.mTotalCapacity)
+    {
+        releaseAssert(mCapacity.mTotalCapacity);
+        releaseAssert(*limits.mTotalCapacity >= *mCapacity.mTotalCapacity);
+    }
+    else
+    {
+        releaseAssert(!mCapacity.mTotalCapacity);
+    }
+}
+
+void
+FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
+{
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        releaseAssert(hasOutboundCapacity(msg));
+        mOutboundCapacity -= getMsgResourceCount(msg);
+    }
+}
+
+bool
+FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
+{
+    checkCapacityInvariants();
+    auto msgResources = getMsgResourceCount(msg);
+    if (mCapacity.mTotalCapacity)
+    {
+        releaseAssert(mCapacity.mTotalCapacity >= msgResources);
+        *mCapacity.mTotalCapacity -= msgResources;
+    }
+
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        // No capacity to process flood message
+        if (mCapacity.mFloodCapacity < msgResources)
+        {
+            return false;
+        }
+
+        mCapacity.mFloodCapacity -= msgResources;
+        if (mCapacity.mFloodCapacity == 0)
+        {
+            CLOG_DEBUG(Overlay, "No flood capacity for peer {}",
+                       mApp.getConfig().toShortString(mNodeID));
+        }
+    }
+
+    return true;
+}
+
+uint64_t
+FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
+{
+    uint64_t releasedFloodCapacity = 0;
+    size_t resourcesFreed = getMsgResourceCount(msg);
+    if (mCapacity.mTotalCapacity)
+    {
+        *mCapacity.mTotalCapacity += resourcesFreed;
+    }
+
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        if (mCapacity.mFloodCapacity == 0)
+        {
+            CLOG_DEBUG(Overlay, "Got flood capacity for peer {} ({})",
+                       mApp.getConfig().toShortString(mNodeID),
+                       mCapacity.mFloodCapacity + resourcesFreed);
+        }
+        releasedFloodCapacity = resourcesFreed;
+        mCapacity.mFloodCapacity += resourcesFreed;
+    }
+    checkCapacityInvariants();
+    return releasedFloodCapacity;
+}
+
+FlowControlCapacityMessages::FlowControlCapacityMessages(Application& app,
+                                                         NodeID nodeID)
+    : FlowControlCapacity(app, nodeID)
+{
+    mCapacity = getCapacityLimits();
+}
+
+FlowControlCapacity::ReadingCapacity
+FlowControlCapacityMessages::getCapacityLimits() const
+{
+    return {
+        mApp.getConfig().PEER_FLOOD_READING_CAPACITY,
+        std::make_optional<uint64_t>(mApp.getConfig().PEER_READING_CAPACITY)};
+}
+
+uint64_t
+FlowControlCapacityMessages::getMsgResourceCount(StellarMessage const& msg)
+{
+    // Each message takes one unit of capacity
+    return 1;
+}
+
+void
+FlowControlCapacityMessages::releaseOutboundCapacity(StellarMessage const& msg)
+{
+    releaseAssert(msg.type() == SEND_MORE || msg.type() == SEND_MORE_EXTENDED);
+    auto numMessages = Peer::getNumMessages(msg);
+    if (!hasOutboundCapacity(msg) && numMessages != 0)
+    {
+        CLOG_DEBUG(Overlay, "Got outbound capacity for peer {}",
+                   mApp.getConfig().toShortString(mNodeID));
+    }
+    mOutboundCapacity += numMessages;
+}
+
+bool
+FlowControlCapacityMessages::hasOutboundCapacity(StellarMessage const& msg)
+{
+    return mOutboundCapacity > 0;
+}
+
+FlowControlCapacityBytes::FlowControlCapacityBytes(Application& app,
+                                                   NodeID nodeID)
+    : FlowControlCapacity(app, nodeID)
+{
+    mCapacity = getCapacityLimits();
+}
+
+FlowControlCapacity::ReadingCapacity
+FlowControlCapacityBytes::getCapacityLimits() const
+{
+    return {mApp.getConfig().PEER_FLOOD_READING_CAPACITY_BYTES, std::nullopt};
+}
+
+uint64_t
+FlowControlCapacityBytes::getMsgResourceCount(StellarMessage const& msg)
+{
+
+    return static_cast<uint64_t>(xdr::xdr_argpack_size(msg));
+}
+
+void
+FlowControlCapacityBytes::releaseOutboundCapacity(StellarMessage const& msg)
+{
+    releaseAssert(msg.type() == SEND_MORE_EXTENDED);
+    if (!hasOutboundCapacity(msg) &&
+        (msg.sendMoreExtendedMessage().numBytes != 0))
+    {
+        CLOG_DEBUG(Overlay, "Got outbound capacity for peer {}",
+                   mApp.getConfig().toShortString(mNodeID));
+    }
+    mOutboundCapacity += msg.sendMoreExtendedMessage().numBytes;
+};
+
+bool
+FlowControlCapacityBytes::hasOutboundCapacity(StellarMessage const& msg)
+{
+    return mOutboundCapacity >= getMsgResourceCount(msg);
+}
+
+}

--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -6,6 +6,7 @@
 #include "main/Application.h"
 #include "overlay/OverlayManager.h"
 #include "util/Logging.h"
+#include <Tracy.hpp>
 
 namespace stellar
 {
@@ -18,6 +19,7 @@ FlowControlCapacity::FlowControlCapacity(Application& app, NodeID nodeID)
 void
 FlowControlCapacity::checkCapacityInvariants() const
 {
+    ZoneScoped;
     auto limits = getCapacityLimits();
     releaseAssert(getCapacityLimits().mFloodCapacity >=
                   mCapacity.mFloodCapacity);
@@ -35,6 +37,7 @@ FlowControlCapacity::checkCapacityInvariants() const
 void
 FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
 {
+    ZoneScoped;
     if (mApp.getOverlayManager().isFloodMessage(msg))
     {
         releaseAssert(hasOutboundCapacity(msg));
@@ -45,6 +48,7 @@ FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
 bool
 FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
 {
+    ZoneScoped;
     checkCapacityInvariants();
     auto msgResources = getMsgResourceCount(msg);
     if (mCapacity.mTotalCapacity)
@@ -75,6 +79,7 @@ FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
 uint64_t
 FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
 {
+    ZoneScoped;
     uint64_t releasedFloodCapacity = 0;
     size_t resourcesFreed = getMsgResourceCount(msg);
     if (mCapacity.mTotalCapacity)
@@ -122,6 +127,7 @@ FlowControlCapacityMessages::getMsgResourceCount(StellarMessage const& msg)
 void
 FlowControlCapacityMessages::releaseOutboundCapacity(StellarMessage const& msg)
 {
+    ZoneScoped;
     releaseAssert(msg.type() == SEND_MORE || msg.type() == SEND_MORE_EXTENDED);
     auto numMessages = Peer::getNumMessages(msg);
     if (!hasOutboundCapacity(msg) && numMessages != 0)
@@ -161,6 +167,7 @@ FlowControlCapacityBytes::getMsgResourceCount(StellarMessage const& msg)
 void
 FlowControlCapacityBytes::releaseOutboundCapacity(StellarMessage const& msg)
 {
+    ZoneScoped;
     releaseAssert(msg.type() == SEND_MORE_EXTENDED);
     if (!hasOutboundCapacity(msg) &&
         (msg.sendMoreExtendedMessage().numBytes != 0))

--- a/src/overlay/FlowControlCapacity.h
+++ b/src/overlay/FlowControlCapacity.h
@@ -1,0 +1,109 @@
+#pragma once
+
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/StellarXDR.h"
+#include "util/GlobalChecks.h"
+#include <optional>
+
+namespace stellar
+{
+
+class Application;
+
+class FlowControlCapacity
+{
+  protected:
+    Application& mApp;
+    struct ReadingCapacity
+    {
+        uint64_t mFloodCapacity{0};
+        std::optional<uint64_t> mTotalCapacity;
+    };
+
+    // Capacity of local node configured by the operator
+    ReadingCapacity mCapacity;
+    // Capacity of a connected peer
+    uint64_t mOutboundCapacity{0};
+
+    NodeID const mNodeID;
+
+    // Implementers should provide a way to derive how much capacity this
+    // message will take
+    virtual uint64_t getMsgResourceCount(StellarMessage const& msg) = 0;
+    virtual ReadingCapacity getCapacityLimits() const = 0;
+
+    void checkCapacityInvariants() const;
+
+  public:
+    static constexpr uint32_t MAX_FLOOD_MESSAGE_SIZE_BYTES = 64000;
+
+    FlowControlCapacity(Application& app, NodeID peerID);
+    virtual ~FlowControlCapacity(){};
+    virtual void releaseOutboundCapacity(StellarMessage const& msg) = 0;
+    virtual bool hasOutboundCapacity(StellarMessage const& msg) = 0;
+    virtual bool hasReadingCapacity() = 0;
+    void lockOutboundCapacity(StellarMessage const& msg);
+    bool lockLocalCapacity(StellarMessage const& msg);
+    // Release capacity used by this message. Return a struct that indicates how
+    // much reading and flood capacity was freed
+    uint64_t releaseLocalCapacity(StellarMessage const& msg);
+
+    ReadingCapacity
+    getCapacity() const
+    {
+        return mCapacity;
+    }
+
+    uint64_t
+    getOutboundCapacity() const
+    {
+        return mOutboundCapacity;
+    }
+
+#ifdef BUILD_TESTS
+    void
+    setOutboundCapacity(uint64_t newCapacity)
+    {
+        mOutboundCapacity = newCapacity;
+    }
+#endif
+};
+
+class FlowControlCapacityBytes : public FlowControlCapacity
+{
+    virtual ReadingCapacity getCapacityLimits() const override;
+
+  public:
+    FlowControlCapacityBytes(Application& app, NodeID nodeID);
+    virtual ~FlowControlCapacityBytes(){};
+    virtual uint64_t getMsgResourceCount(StellarMessage const& msg) override;
+    virtual void releaseOutboundCapacity(StellarMessage const& msg) override;
+    virtual bool hasOutboundCapacity(StellarMessage const& msg) override;
+    virtual bool
+    hasReadingCapacity() override
+    {
+        return true;
+    }
+};
+
+class FlowControlCapacityMessages : public FlowControlCapacity
+{
+    virtual ReadingCapacity getCapacityLimits() const override;
+
+  public:
+    FlowControlCapacityMessages(Application& app, NodeID nodeID);
+    virtual ~FlowControlCapacityMessages(){};
+    virtual uint64_t getMsgResourceCount(StellarMessage const& msg) override;
+    virtual void releaseOutboundCapacity(StellarMessage const& msg) override;
+    virtual bool hasOutboundCapacity(StellarMessage const& msg) override;
+    virtual bool
+    hasReadingCapacity() override
+    {
+        checkCapacityInvariants();
+        return *mCapacity.mTotalCapacity > 0;
+    }
+};
+}

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -50,12 +50,11 @@ using namespace soci;
 
 static constexpr VirtualClock::time_point PING_NOT_SENT =
     VirtualClock::time_point::min();
-static constexpr size_t OUTBOUND_TX_QUEUE_BYTE_LIMIT = 1024 * 1024 * 3; // 3 MB
 
 size_t
 Peer::getOutboundQueueByteLimit() const
 {
-    return OUTBOUND_TX_QUEUE_BYTE_LIMIT;
+    return mApp.getConfig().OUTBOUND_TX_QUEUE_BYTE_LIMIT;
 }
 
 Peer::Peer(Application& app, PeerRole role)

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -321,6 +321,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     size_t mAdvertQueueTxHashCount{0};
     size_t mDemandQueueTxHashCount{0};
 
+    size_t mTxQueueByteCount{0};
+
     // As of MIN_OVERLAY_VERSION_FOR_FLOOD_ADVERT, peers accumulate an _advert_
     // of flood messages, then periodically flush the advert and await a
     // _demand_ message with a list of flood messages to send. Adverts are
@@ -366,6 +368,7 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
     void sendMessage(std::shared_ptr<StellarMessage const> msg,
                      bool log = true);
+    virtual size_t getOutboundQueueByteLimit() const;
 
     PeerRole
     getRole() const

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -80,7 +80,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
             // Wait until all nodes externalize
             simulation->crankUntil(
                 [&]() { return simulation->haveAllExternalized(2, 1); },
-                std::chrono::seconds(1), false);
+                std::chrono::seconds(10), false);
             for (auto const& n : nodes)
             {
                 REQUIRE(n->getLedgerManager().isSynced());
@@ -193,8 +193,8 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
         {
             SECTION("loopback")
             {
-                simulation = Topologies::core(
-                    4, .666f, Simulation::OVER_LOOPBACK, networkID, cfgGen2);
+                simulation = Topologies::core(4, 1, Simulation::OVER_LOOPBACK,
+                                              networkID, cfgGen2);
                 test(injectTransaction, ackedTransactions, true);
             }
             SECTION("tcp")

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -494,8 +494,34 @@ LoopbackPeerConnection::getAcceptor() const
 }
 
 bool
-LoopbackPeer::checkCapacity(uint64_t expectedOutboundCapacity) const
+LoopbackPeer::checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const
 {
-    return expectedOutboundCapacity == mOutboundCapacity;
+    // Outbound capacity is equal to the config on the other node
+    bool flowControlInBytes = mFlowControlBytes && otherPeer->mFlowControlBytes;
+    bool isValid =
+        otherPeer->getApp().getConfig().PEER_FLOOD_READING_CAPACITY ==
+        mFlowControlMessages->getOutboundCapacity();
+    if (flowControlInBytes)
+    {
+        isValid = isValid && (otherPeer->getApp()
+                                  .getConfig()
+                                  .PEER_FLOOD_READING_CAPACITY_BYTES ==
+                              mFlowControlBytes->getOutboundCapacity());
+    }
+
+    return isValid;
+}
+
+size_t
+LoopbackPeer::getOutboundQueueByteLimit() const
+{
+    if (mOutboundQueueLimit)
+    {
+        return *mOutboundQueueLimit;
+    }
+    else
+    {
+        return Peer::getOutboundQueueByteLimit();
+    }
 }
 }

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -74,6 +74,7 @@ class LoopbackPeer : public Peer
     size_t getMessagesQueued() const;
 
     virtual void scheduleRead() override;
+    virtual size_t getOutboundQueueByteLimit() const override;
 
     Stats const& getStats() const;
 
@@ -114,6 +115,20 @@ class LoopbackPeer : public Peer
 
     void clearInAndOutQueues();
 
+    void
+    setOutboundQueueLimit(size_t bytes)
+    {
+        mOutboundQueueLimit = std::make_optional<size_t>(bytes);
+    }
+
+    size_t
+    getTxQueueByteCount() const
+    {
+        return mTxQueueByteCount;
+    }
+
+    std::optional<size_t> mOutboundQueueLimit;
+
     std::string
     getDropReason() const
     {
@@ -126,17 +141,24 @@ class LoopbackPeer : public Peer
         return mOutboundQueues;
     }
 
-    uint64_t&
-    getOutboundCapacity()
+    std::unique_ptr<FlowControlCapacityMessages> const&
+    getFlowControlCapacityMessages() const
     {
-        return mOutboundCapacity;
+        return mFlowControlMessages;
     }
 
-    bool checkCapacity(uint64_t expectedOutboundCapacity) const;
+    std::unique_ptr<FlowControlCapacityBytes> const&
+    getFlowControlCapacityBytes() const
+    {
+        return mFlowControlBytes;
+    }
+
+    bool checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const;
 
     std::string getIP() const override;
 
     using Peer::addMsgAndMaybeTrimQueue;
+    using Peer::recvMessage;
     using Peer::sendAuth;
     using Peer::sendAuthenticatedMessage;
     using Peer::sendMessage;

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -38,7 +38,14 @@ class PeerStub : public Peer
         mPeerID = SecretKey::pseudoRandomForTesting().getPublicKey();
         mState = GOT_AUTH;
         mAddress = address;
-        mOutboundCapacity = std::numeric_limits<uint32>::max();
+        mFlowControlMessages =
+            std::make_unique<FlowControlCapacityMessages>(app, mPeerID);
+        mFlowControlBytes =
+            std::make_unique<FlowControlCapacityBytes>(app, mPeerID);
+        mFlowControlMessages->setOutboundCapacity(
+            std::numeric_limits<uint32>::max());
+        mFlowControlBytes->setOutboundCapacity(
+            std::numeric_limits<uint32>::max());
     }
     virtual std::string
     getIP() const override

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -155,12 +155,15 @@ TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
 
         SECTION("basic capacity accounting")
         {
+            conn.getInitiator()->setOutboundQueueLimit(txSize * 2);
+
             // Basic capacity math
             conn.getInitiator()->sendMessage(
                 std::make_shared<StellarMessage>(msg));
             REQUIRE(conn.getInitiator()
                         ->getFlowControlCapacityBytes()
                         ->getOutboundCapacity() == expectedCapacity);
+            REQUIRE(conn.getInitiator()->getTxQueueByteCount() == 0);
 
             conn.getAcceptor()->recvMessage(msg);
             REQUIRE(conn.getAcceptor()

--- a/src/protocol-curr/xdr/Stellar-overlay.x
+++ b/src/protocol-curr/xdr/Stellar-overlay.x
@@ -27,6 +27,12 @@ struct SendMore
     uint32 numMessages;
 };
 
+struct SendMoreExtended
+{
+    uint32 numMessages;
+    uint32 numBytes;
+};
+
 struct AuthCert
 {
     Curve25519Public pubkey;
@@ -83,7 +89,7 @@ struct PeerAddress
     uint32 numFailures;
 };
 
-// Next ID: 18
+// Next ID: 21
 enum MessageType
 {
     ERROR_MSG = 0,
@@ -112,6 +118,8 @@ enum MessageType
     SURVEY_RESPONSE = 15,
 
     SEND_MORE = 16,
+    SEND_MORE_EXTENDED = 20,
+
     FLOOD_ADVERT = 18,
     FLOOD_DEMAND = 19
 };
@@ -274,7 +282,8 @@ case GET_SCP_STATE:
     uint32 getSCPLedgerSeq; // ledger seq requested ; if 0, requests the latest
 case SEND_MORE:
     SendMore sendMoreMessage;
-
+case SEND_MORE_EXTENDED:
+    SendMoreExtended sendMoreExtendedMessage;
 // Pull mode
 case FLOOD_ADVERT:
      FloodAdvert floodAdvert;

--- a/src/protocol-curr/xdr/Stellar-transaction.x
+++ b/src/protocol-curr/xdr/Stellar-transaction.x
@@ -87,6 +87,7 @@ struct PaymentOp
     MuxedAccount destination; // recipient of the payment
     Asset asset;              // what they end up with
     int64 amount;             // amount they end up with
+    uint32 data<>;
 };
 
 /* PathPaymentStrictReceive

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -599,7 +599,8 @@ LoadGenerator::paymentTransaction(uint32_t numAccounts, uint32_t offset,
     paymentOps.reserve(opCount);
     for (uint32_t i = 0; i < opCount; ++i)
     {
-        paymentOps.emplace_back(txtest::payment(to->getPublicKey(), amount));
+        paymentOps.emplace_back(
+            txtest::payment(to->getPublicKey(), amount, mApp));
     }
 
     return std::make_pair(from, createTransactionFramePtr(from, paymentOps,
@@ -901,9 +902,8 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
     auto status = mApp.getHerder().recvTransaction(txf, true);
     if (status != TransactionQueue::AddResult::ADD_STATUS_PENDING)
     {
-        CLOG_INFO(LoadGen, "tx rejected '{}': {} ===> {}",
+        CLOG_INFO(LoadGen, "tx rejected '{}': ===> {}",
                   TX_STATUS_STRING[static_cast<int>(status)],
-                  xdr_to_string(txf->getEnvelope(), "TransactionEnvelope"),
                   xdr_to_string(txf->getResult(), "TransactionResult"));
         if (status == TransactionQueue::AddResult::ADD_STATUS_ERROR)
         {

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -165,8 +165,11 @@ Operation bumpSequence(SequenceNumber to);
 
 Operation createAccount(PublicKey const& dest, int64_t amount);
 
+Operation payment(PublicKey const& to, int64_t amount, Application& app);
 Operation payment(PublicKey const& to, int64_t amount);
 
+Operation payment(PublicKey const& to, Asset const& asset, int64_t amount,
+                  Application& app);
 Operation payment(PublicKey const& to, Asset const& asset, int64_t amount);
 
 Operation createClaimableBalance(Asset const& asset, int64_t amount,

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -243,6 +243,12 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.RUN_STANDALONE = true;
         thisConfig.FORCE_SCP = true;
 
+        thisConfig.PEER_READING_CAPACITY = 20;
+        thisConfig.PEER_FLOOD_READING_CAPACITY = 20;
+        thisConfig.FLOW_CONTROL_SEND_MORE_BATCH_SIZE = 10;
+        thisConfig.PEER_FLOOD_READING_CAPACITY_BYTES = 3000;
+        thisConfig.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 1000;
+
         thisConfig.MANUAL_CLOSE = true;
 
         thisConfig.TEST_CASES_ENABLED = true;


### PR DESCRIPTION
Updates to switch flow control capacity accounting to bytes instead of message counts. This allows us to support larger transactions (i.e. Soroban) better.