### PR TITLE
Fix bug in BucketList invariant test

### DIFF
--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -368,7 +368,7 @@ class ApplyBucketsWorkDeleteEntry : public ApplyBucketsWork
                 mDeleted = true;
             }
         }
-        auto r = ApplyBucketsWork::onRun();
+        auto r = ApplyBucketsWork::doWork();
         if (r == State::WORK_SUCCESS)
         {
             REQUIRE(mDeleted);
@@ -532,7 +532,7 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
                 mModified = true;
             }
         }
-        auto r = ApplyBucketsWork::onRun();
+        auto r = ApplyBucketsWork::doWork();
         if (r == State::WORK_SUCCESS)
         {
             REQUIRE(mModified);


### PR DESCRIPTION
Fixes an invariant test bug introduced with BucketListDB update.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
