### PR TITLE
Better bloom filter metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -31,6 +31,7 @@ bucket.batch.objectsadded                | meter     | number of objects added p
 bucket.memory.shared                     | counter   | number of buckets referenced (excluding publish queue)
 bucket.merge-time.level-<X>              | timer     | time to merge two buckets on level <X>
 bucket.snap.merge                        | timer     | time to merge two buckets
+bucketlistDB.bloom.lookups               | meter     | number of bloom filter lookups
 bucketlistDB.bloom.misses                | meter     | number of bloom filter false positives
 bucketlistDB.query.loads                 | meter     | number of BucketListDB load queries
 bucketlistDB.bulk.inflationWinners       | timer     | time to load inflation winners

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -94,5 +94,6 @@ class BucketIndex : public NonMovableOrCopyable
     virtual Iterator end() const = 0;
 
     virtual void markBloomMiss() const = 0;
+    virtual void markBloomLookup() const = 0;
 };
 }

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -219,6 +219,7 @@ class BucketManager : NonMovableOrCopyable
     loadInflationWinners(size_t maxWinners, int64_t minBalance) const = 0;
 
     virtual medida::Meter& getBloomMissMeter() const = 0;
+    virtual medida::Meter& getBloomLookupMeter() const = 0;
 
 #ifdef BUILD_TESTS
     // Install a fake/assumed ledger version and bucket list hash to use in next

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -120,6 +120,8 @@ BucketManagerImpl::BucketManagerImpl(Application& app)
           {"bucketlistDB", "query", "loads"}, "query"))
     , mBucketListDBBloomMisses(app.getMetrics().NewMeter(
           {"bucketlistDB", "bloom", "misses"}, "bloom"))
+    , mBucketListDBBloomLookups(app.getMetrics().NewMeter(
+          {"bucketlistDB", "bloom", "lookups"}, "bloom"))
     // Minimal DB is stored in the buckets dir, so delete it only when
     // mode does not use minimal DB
     , mDeleteEntireBucketDirInDtor(
@@ -939,6 +941,12 @@ medida::Meter&
 BucketManagerImpl::getBloomMissMeter() const
 {
     return mBucketListDBBloomMisses;
+}
+
+medida::Meter&
+BucketManagerImpl::getBloomLookupMeter() const
+{
+    return mBucketListDBBloomLookups;
 }
 
 void

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -48,6 +48,7 @@ class BucketManagerImpl : public BucketManager
     medida::Counter& mSharedBucketsSize;
     medida::Meter& mBucketListDBQueryMeter;
     medida::Meter& mBucketListDBBloomMisses;
+    medida::Meter& mBucketListDBBloomLookups;
     mutable UnorderedMap<LedgerEntryType, medida::Timer&>
         mBucketListDBPointTimers{};
     mutable UnorderedMap<std::string, medida::Timer&> mBucketListDBBulkTimers{};
@@ -139,6 +140,7 @@ class BucketManagerImpl : public BucketManager
     std::vector<InflationWinner>
     loadInflationWinners(size_t maxWinners, int64_t minBalance) const override;
     medida::Meter& getBloomMissMeter() const override;
+    medida::Meter& getBloomLookupMeter() const override;
 
 #ifdef BUILD_TESTS
     // Install a fake/assumed ledger version and bucket list hash to use in next


### PR DESCRIPTION
# Description

Resolves #3604 

This PR provides better metrics and log messages for BucketListDB bloom filters. Previously, it appeared that the bloom filter false positive rate was too high due to element count underestimation. However, this was due to faulty metrics. In practice, the false positive rate is significantly better than our target and underestimation is not an issue. 

To calculate false positive rates previously, we used the number of ledger entries queried. However, one ledger entry query may lead to several bloom filter queries since we have to check multiple levels of the BucketList for an entry. This PR adds an explicit bloom filter query metric to provide more accurate false positive rates and also logs bloom filter setup parameters. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
