### PR TITLE
Bump soroban env to 0.0.10 release version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,8 +576,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80fc86c5eebeb729c4bf8dccc094b4954a183e931d37ca500f5204f9af296da8"
 dependencies = [
  "crate-git-revision",
  "soroban-env-macros",
@@ -588,8 +589,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62f740b0f8f45c4839dcd12a8986b450b878a1249a02654303c44cec98a50c4"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -611,8 +613,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1bdce38c634cf6408a609bd6a0eff32742016cdf72e8fb53b693edb3240ca5"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -623,8 +626,9 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f4c5c08eee325f470d359a842a672b64d972495f6622ea959776c582998787"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -634,13 +638,14 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "0.0.9"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eda2ab70#eda2ab70fbc2a9f78a12f54a211e308d1b6ac1b7"
+version = "0.0.10"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=c1480516#c14805161b54ba272108ba0503057683f2a688a2"
 
 [[package]]
 name = "soroban-wasmi"
 version = "0.16.0-soroban2"
-source = "git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc5dca8b60607a73948635d1b47f01986ca5b5a18c1a7ec22f6fda8a400dd360"
 dependencies = [
  "soroban-wasmi_core",
  "spin",
@@ -650,7 +655,8 @@ dependencies = [
 [[package]]
 name = "soroban-wasmi_core"
 version = "0.16.0-soroban2"
-source = "git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58caebfe0ad5e6d35c72f4894188d2ef9d6b01a6b67dadda2baf5700a322e453"
 dependencies = [
  "downcast-rs",
  "libm",
@@ -686,8 +692,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.7"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2775f4b6#2775f4b6f6ce2c9fcc22af42b0709d1047fabf8f"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be58701c2f78a534e26e202102c4f88480c55d069f8c891a3dc0fa8732620517"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [workspace]
 members = ["src/rust"]
 
-[patch.crates-io]
-stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "2775f4b6" }
-wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "862b32f5" }
-soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "eda2ab70" }
-soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "eda2ab70" }
+# [patch.crates-io]
+# stellar-xdr = { git = "https://github.com/stellar/rs-stellar-xdr", rev = "2775f4b6" }
+# wasmi = { package = "soroban-wasmi", git = "https://github.com/stellar/wasmi", rev = "862b32f5" }
+# soroban-env-common = { git = "https://github.com/stellar/rs-soroban-env", rev = "eda2ab70" }
+# soroban-native-sdk-macros = { git = "https://github.com/stellar/rs-soroban-env", rev = "eda2ab70" }
 
 [profile.release]
 codegen-units = 1

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,7 +14,5 @@ cxx = "1.0"
 im-rc = "15.0.0"
 base64 = "0.13.0"
 rustc-simple-version = "0.1.0"
-soroban-env-host = { git = "https://github.com/stellar/rs-soroban-env", rev = "eda2ab70", features = [
-    "vm",
-] }
-soroban-test-wasms = { git = "https://github.com/stellar/rs-soroban-env", rev = "eda2ab70" }
+soroban-env-host = { version = "0.0.10", features = [ "vm" ] }
+soroban-test-wasms = { git = "https://github.com/stellar/rs-soroban-env", rev = "c1480516" }


### PR DESCRIPTION
This just updates the soroban version we're using to the recent 0.0.10 release, which will be the target for this month's futurenet. It's XDR-compatible and environment-interface-compatible with the last futurenet version landed a couple days ago, just has a couple last minute bits of polish in intermediate packages.

(this change also comments-out the patch lines in Cargo.toml for now, we can uncomment them when/if we need to in the next development cycle)