### PR TITLE
Bucket list info

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -861,7 +861,10 @@ exit /b 0
     <ClCompile Include="..\..\src\work\WorkScheduler.cpp" />
     <ClCompile Include="..\..\src\work\WorkSequence.cpp" />
     <ClCompile Include="..\..\src\work\WorkWithCallback.cpp" />
-    <ClCompile Include="src\$(Configuration)\generated\rust\RustBridge.cpp" />
+    <ClCompile Include="src\$(Configuration)\generated\rust\RustBridge.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='DebugCurrV|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='ReleaseCurrV|x64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="src\$(Configuration)\generated\xdr\XDRFilesSha256.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -184,9 +184,9 @@ format.
   `droppeer?node=NODE_ID[&ban=D]`<br>
   Drops peer identified by NODE_ID, when D is 1 the peer is also banned.
 
-* **info**
+* **info[?compact=true]**
   Returns information about the server in JSON format (sync state, connected
-  peers, etc).
+  peers, etc). When `compact` is set to `false`, adds additional information
 
 * **ll**  
   `ll?level=L[&partition=P]`<br>

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -277,10 +277,10 @@ class Application
     virtual void reportCfgMetrics() = 0;
 
     // Get information about the instance as JSON object
-    virtual Json::Value getJsonInfo() = 0;
+    virtual Json::Value getJsonInfo(bool verbose) = 0;
 
     // Report information about the instance to standard logging
-    virtual void reportInfo() = 0;
+    virtual void reportInfo(bool verbose) = 0;
 
     // Schedule background work to do some (basic, online) self-checks.
     // Returns a WorkSequence that can be monitored for completion.

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -448,7 +448,7 @@ ApplicationImpl::reportCfgMetrics()
 }
 
 Json::Value
-ApplicationImpl::getJsonInfo()
+ApplicationImpl::getJsonInfo(bool verbose)
 {
     auto root = Json::Value{};
 
@@ -476,6 +476,20 @@ ApplicationImpl::getJsonInfo()
     }
 
     info["ledger"]["age"] = (int)lm.secondsSinceLastLedgerClose();
+
+    if (verbose)
+    {
+        auto has = lm.getLastClosedLedgerHAS();
+        auto& levels = info["ledger"]["bucketlist"];
+        for (auto const& l : has.currentBuckets)
+        {
+            Json::Value levelInfo;
+            levelInfo["curr"] = l.curr;
+            levelInfo["snap"] = l.snap;
+            levels.append(levelInfo);
+        }
+    }
+
     info["peers"]["pending_count"] = getOverlayManager().getPendingPeersCount();
     info["peers"]["authenticated_count"] =
         getOverlayManager().getAuthenticatedPeersCount();
@@ -525,11 +539,11 @@ ApplicationImpl::getJsonInfo()
 }
 
 void
-ApplicationImpl::reportInfo()
+ApplicationImpl::reportInfo(bool verbose)
 {
     mLedgerManager->loadLastKnownLedger(nullptr);
     LOG_INFO(DEFAULT_LOG, "Reporting application info");
-    std::cout << getJsonInfo().toStyledString() << std::endl;
+    std::cout << getJsonInfo(verbose).toStyledString() << std::endl;
 }
 
 std::shared_ptr<BasicWork>

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -112,9 +112,9 @@ class ApplicationImpl : public Application
 
     virtual void reportCfgMetrics() override;
 
-    virtual Json::Value getJsonInfo() override;
+    virtual Json::Value getJsonInfo(bool verbose) override;
 
-    virtual void reportInfo() override;
+    virtual void reportInfo(bool verbose) override;
 
     virtual std::shared_ptr<BasicWork>
     scheduleSelfCheck(bool waitUntilNextCheckpoint) override;

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -666,13 +666,13 @@ initializeDatabase(Config cfg)
 }
 
 void
-showOfflineInfo(Config cfg)
+showOfflineInfo(Config cfg, bool verbose)
 {
     // needs real time to display proper stats
     VirtualClock clock(VirtualClock::REAL_TIME);
     cfg.setNoListen();
     Application::pointer app = Application::create(clock, cfg, false);
-    app->reportInfo();
+    app->reportInfo(verbose);
 }
 
 #ifdef BUILD_TESTS
@@ -868,7 +868,7 @@ catchup(Application::pointer app, CatchupConfiguration cc,
     }
     LOG_INFO(DEFAULT_LOG, "*");
 
-    catchupInfo = app->getJsonInfo();
+    catchupInfo = app->getJsonInfo(true);
     return synced ? 0 : 3;
 }
 

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -30,7 +30,7 @@ int dumpLedger(Config cfg, std::string const& outputFile,
                std::optional<uint64_t> limit,
                std::optional<std::string> groupBy,
                std::optional<std::string> aggregate);
-void showOfflineInfo(Config cfg);
+void showOfflineInfo(Config cfg, bool verbose);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);
 #ifdef BUILD_TESTS
 void loadXdr(Config cfg, std::string const& bucketFile);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -326,10 +326,13 @@ CommandHandler::peers(std::string const& params, std::string& retStr)
 }
 
 void
-CommandHandler::info(std::string const&, std::string& retStr)
+CommandHandler::info(std::string const& params, std::string& retStr)
 {
     ZoneScoped;
-    retStr = mApp.getJsonInfo().toStyledString();
+    std::map<std::string, std::string> retMap;
+    http::server::server::parseParams(params, retMap);
+
+    retStr = mApp.getJsonInfo(retMap["compact"] == "false").toStyledString();
 }
 
 static bool

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1201,7 +1201,7 @@ runOfflineInfo(CommandLineArgs const& args)
     CommandLine::ConfigOption configOption;
 
     return runWithHelp(args, {configurationParser(configOption)}, [&] {
-        showOfflineInfo(configOption.getConfig());
+        showOfflineInfo(configOption.getConfig(), true);
         return 0;
     });
 }


### PR DESCRIPTION
Resolves #3616 

Adds level and bucket information to the `ledger` section emitted when performing `catchup`.

As the code is shared with the `info` endpoint, I added a new option to `info` as to avoid the verbose output by default.

```
"ledger" : {
         "age" : 526,
         "baseFee" : 100,
         "baseReserve" : 5000000,
         "bucketlist" : [
            [
               "dcba7486da350ee5556e9a41eaef54ae308cc0ebedcc32b35176e430397b3d2d",
               "d0f806f6c944f5bf5d08eb0dd1e44784dd2bb382578b8754361225e9921d1034"
            ],
            [
               "b074145a2978ea067ab9f5f21cb1bceca9c94300b7f8ce86b659ac871b4f99a0",
               "df72dbaab31adf770b8e6bb92aa4740179266ff56d5aa4b997f0c5a2bb75a857"
            ],
            [
               "35a16f226662798080b3ec6fcfdbd87df6b3d73a91626fb9ec6228185317c088",
               "de33acdfb5d22a91e43652efe8236239ccb671fc3e5e9fa4aa2097878ad9a962"
            ],
            [
               "cf96fec89e30eb258075870d0429e4578d5ada1042975211aa16ecc6a2311998",
               "6421c310690dbf68a6cf60243ffae10aa00ccccf6e7a4b8d0d3501f102e83142"
            ],
            [
               "109caf2691cff052d2ba31953e38a559571883fcd07ecceba146042462c62967",
               "3fa689949132b977ff3b298daf8dea6fa379761c661693a2eea4492e489b028b"
            ],
            [
               "c345ad4bb7cce9033d31c8747054b5ab7e7be5da2ffa59f7af700e64ea51da72",
               "c518f1ac76a5948267051cdbedda505b67cdb44be0d17086fddb7b6c2f8abc02"
            ],
            [
               "7a6b15180bc8a20699e38f53294b1c7912a1f9d9c27ae35f974907a74470c8da",
               "984a61244d78a66d22961d68b92c4545d767cdf723a3c8d44c6e4d7e65ffbf3c"
            ],
            [
               "40bcb7d206f648617ebbd499e9ff51761c2f5efe5bf1c244fb21538451dbfc0a",
               "5c932fbc7d7b8fa0681136537a1610230ebeb1eb9b4ecb9629dfe60c1fba9644"
            ],
            [
               "1cad3dcb260d8bceb1fb909fae7d1edc923369056aab0a8b8369b9ca97aa0c21",
               "6756f7a09ebeed43ab5d080774d6d040ac42e074e19f147d1b5b1eae73a35e2f"
            ],
            [
               "d1da9e09b0ce455c06495daf9033a16ae467d6e543c3a3f2a41fd02eb623defd",
               "805c8eacc9ede6cdb9e7882fc484a6608a4a74a160ce5ae05e1f79a5623f421f"
            ],
            [
               "05b98a7ec9dfb14aa2a2aca5495a0e8a6eaf539ea57471b05ffb05780b109403",
               "0000000000000000000000000000000000000000000000000000000000000000"
            ]
         ],
         "closeTime" : 1670032508,
         "hash" : "c8f995d4de473c0d74209797e7bad8eebd8d8fc0c172565bec8f53e9a95c5638",
         "maxTxSetSize" : 105,
         "num" : 1310463,
         "version" : 19
      }
```