### PR TITLE
Disable BucketListDB when using in-memory mode

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1281,6 +1281,7 @@ run(CommandLineArgs const& args)
                     cfg.MODE_STORES_HISTORY_MISC = false;
                     cfg.MODE_USES_IN_MEMORY_LEDGER = false;
                     cfg.MODE_ENABLES_BUCKETLIST = false;
+                    cfg.EXPERIMENTAL_BUCKETLIST_DB = false;
                     cfg.PREFETCH_BATCH_SIZE = 0;
                 }
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1877,6 +1877,7 @@ Config::setInMemoryMode()
     MODE_STORES_HISTORY_MISC = false;
     MODE_STORES_HISTORY_LEDGERHEADERS = false;
     MODE_ENABLES_BUCKETLIST = true;
+    EXPERIMENTAL_BUCKETLIST_DB = false;
 }
 
 bool


### PR DESCRIPTION
# Description

Whenever In-memory mode is enabled, the BucketListDB flag is not overriden. This means that the BucketList might still index buckets even when in-memory mode is enabled even though the buckets will never be searched. This PR disables BucketListDB when in-memory mode is set.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
