### PR TITLE
switch to llvm-12 (from llvm-10) and to gcc-10 (from gcc-8)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,22 +20,26 @@ AlwaysBreakTemplateDeclarations: false
 BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
-  AfterClass:      false
-  AfterControlStatement: false
-  AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterCaseLabel:  true
+  AfterClass:      true
+  AfterControlStatement: Always
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     true
+  BeforeElse:      true
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Allman
+BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,19 +60,19 @@ RUN apt-get update \
 RUN apt-get -y install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev curl
 
 # Update compiler tools
-RUN apt-get -y install libstdc++-8-dev clang-format-10 ccache
+RUN apt-get -y install libstdc++-10-dev clang-format-12 ccache
 
 # gcc
-RUN apt-get -y install cpp-8 gcc-8 g++-8
+RUN apt-get -y install cpp-10 gcc-10 g++-10
 # clang
-RUN apt-get -y install clang-10 llvm-10
+RUN apt-get -y install clang-12 llvm-12
 # rust
 RUN ./install-rust.sh
 ENV PATH "/root/.cargo/bin:$PATH"
 
 # clang by default
-ENV CC=clang-10
-ENV CXX=clang++-10
+ENV CC=clang-12
+ENV CXX=clang++-12
 
 # Install postgresql to enable tests under make check
 RUN apt-get -y install postgresql

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,11 @@ jobs:
           sudo apt-get -y install --no-install-recommends apt-utils dialog git iproute2 procps lsb-release
       - name: install tool chain
         run: |
-          sudo apt-get -y install libstdc++-8-dev clang-format-10 ccache
+          sudo apt-get -y install libstdc++-10-dev clang-format-12 ccache
           if test "${{ matrix.toolchain }}" = "gcc" ; then
-            sudo apt-get -y install cpp-8 gcc-8 g++-8
+            sudo apt-get -y install cpp-10 gcc-10 g++-10
           else
-            sudo apt-get -y install clang-10 llvm-10
+            sudo apt-get -y install clang-12 llvm-12
           fi
       - name: install dependencies
         run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev

--- a/INSTALL-Windows.md
+++ b/INSTALL-Windows.md
@@ -94,8 +94,8 @@ If you do not have cURL installed
 ## clang-format
 
 For making changes to the code, you should install the clang-format tool and Visual Studio extension, you can find both at http://llvm.org/builds/
-* note that the version of clang-format used currently is 10.0 (other versions may not format the same way).
-* we recommend downloading 10.0 from http://releases.llvm.org/download.html
+* note that the version of clang-format used currently is 12.0 (other versions may not format the same way).
+* we recommend downloading 12.0 from http://releases.llvm.org/download.html
 
 # Build on Windows using the Windows Subsystem for Linux
 To setup the subsystem, go to https://msdn.microsoft.com/en-us/commandline/wsl/install_guide

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,27 +58,27 @@ To install Postgresql, follow instructions from the [Postgresql download page](h
 ## Build Dependencies
 
 - c++ toolchain and headers that supports c++17
-    - `clang` >= 10.0
-    - `g++` >= 8.0
+    - `clang` >= 12.0
+    - `g++` >= 10.0
 - `pkg-config`
 - `bison` and `flex`
 - `libpq-dev` unless you `./configure --disable-postgres` in the build step below.
 - 64-bit system
-- `clang-format-10` (for `make format` to work)
+- `clang-format-12` (for `make format` to work)
 - `perl`
 - `libunwind-dev`
 
 ### Ubuntu
 
-#### Ubuntu 18.04
+#### Ubuntu 20.04
 You can install the [test toolchain](#adding-the-test-toolchain) to build and run stellar-core with the latest version of the llvm toolchain.
 
 Alternatively, if you want to just depend on stock Ubuntu, you will have to build with clang *and* have use `libc++` instead of `libstdc++` when compiling.
 
-Ubuntu 18.04 has clang-10 available, that you can install with
+Ubuntu 20.04 has clang-12 available, that you can install with
 
-    # install clang-10 toolchain
-    sudo apt-get install clang-10
+    # install clang-12 toolchain
+    sudo apt-get install clang-12
 
 After installing packages, head to [building with clang and libc++](#building-with-clang-and-libc).
 
@@ -95,17 +95,17 @@ After installing packages, head to [building with clang and libc++](#building-wi
     # common packages
     sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev libunwind-dev parallel
     # if using clang
-    sudo apt-get install clang-10
+    sudo apt-get install clang-12
     # clang with libstdc++
-    sudo apt-get install gcc-8
+    sudo apt-get install gcc-10
     # if using g++ or building with libstdc++
-    # sudo apt-get install gcc-8 g++-8 cpp-8
+    # sudo apt-get install gcc-10 g++-10 cpp-10
 
 In order to make changes, you'll need to install the proper version of clang-format.
 
 In order to install the llvm (clang) toolchain, you may have to follow instructions on https://apt.llvm.org/
 
-    sudo apt-get install clang-format-10
+    sudo apt-get install clang-format-12
 
 ### OS X
 When building on OSX, here's some dependencies you'll need:
@@ -130,7 +130,7 @@ See [INSTALL-Windows.md](INSTALL-Windows.md)
 - `git submodule init`
 - `git submodule update`
 - Type `./autogen.sh`.
-- Type `./configure`   *(If configure complains about compiler versions, try `CXX=clang-10 ./configure` or `CXX=g++-8 ./configure` or similar, depending on your compiler.)*
+- Type `./configure`   *(If configure complains about compiler versions, try `CXX=clang-12 ./configure` or `CXX=g++-10 ./configure` or similar, depending on your compiler.)*
 - Type `make` or `make -j<N>` (where `<N>` is the number of parallel builds, a number less than the number of CPU cores available, e.g. `make -j3`)
 - Type `make check` to run tests.
 - Type `make install` to install.
@@ -141,15 +141,15 @@ On some systems, building with `libc++`, [LLVM's version of the standard library
 
 NB: there are newer versions available of both clang and libc++, you will have to use the versions suited for your system.
 
-You may need to install additional packages for this, for example, on Linux Ubuntu 18.04 LTS with clang-10:
+You may need to install additional packages for this, for example, on Linux Ubuntu 20.04 LTS with clang-12:
 
     # install libc++ headers
-    sudo apt-get install libc++-10-dev libc++abi-10-dev
+    sudo apt-get install libc++-12-dev libc++abi-12-dev
 
 Here are sample steps to achieve this:
 
-    export CC=clang-10
-    export CXX=clang++-10
+    export CC=clang-12
+    export CXX=clang++-12
     export CFLAGS="-O3 -g1 -fno-omit-frame-pointer"
     export CXXFLAGS="$CFLAGS -stdlib=libc++"
     git clone https://github.com/stellar/stellar-core.git

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -89,20 +89,20 @@ hash -r
 
 if test $CXX = 'clang++'; then
     RUN_PARTITIONS=$(seq 0 $((NPROCS-1)))
-    which clang-10
-    ln -s `which clang-10` bin/clang
-    which clang++-10
-    ln -s `which clang++-10` bin/clang++
-    which llvm-symbolizer-10
-    ln -s `which llvm-symbolizer-10` bin/llvm-symbolizer
+    which clang-12
+    ln -s `which clang-12` bin/clang
+    which clang++-12
+    ln -s `which clang++-12` bin/clang++
+    which llvm-symbolizer-12
+    ln -s `which llvm-symbolizer-12` bin/llvm-symbolizer
     clang -v
     llvm-symbolizer --version || true
 elif test $CXX = 'g++'; then
     RUN_PARTITIONS=$(seq $NPROCS $((2*NPROCS-1)))
-    which gcc-8
-    ln -s `which gcc-8` bin/gcc
-    which g++-8
-    ln -s `which g++-8` bin/g++
+    which gcc-10
+    ln -s `which gcc-10` bin/gcc
+    which g++-10
+    ln -s `which g++-10` bin/g++
     which g++
     g++ -v
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -250,7 +250,7 @@ if test "$FS_WORKS" = "no"; then
 fi
 
 # prefer 10 as it's the one we use
-AC_CHECK_PROGS(CLANG_FORMAT, [clang-format-10 clang-format])
+AC_CHECK_PROGS(CLANG_FORMAT, [clang-format-12 clang-format])
 AM_CONDITIONAL([USE_CLANG_FORMAT], [test "x$CLANG_FORMAT" != "x"])
 
 AX_VALGRIND_CHECK

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get -y install iproute2 procps lsb-release \
                        git build-essential pkg-config autoconf automake libtool \
                        bison flex libpq-dev parallel libunwind-dev \
-                       clang-10 libc++abi-10-dev libc++-10-dev \
+                       clang-12 libc++abi-12-dev libc++-12-dev \
                        postgresql curl
 
 COPY . stellar-core/
@@ -13,8 +13,8 @@ WORKDIR stellar-core
 RUN git clean -dXf
 RUN git submodule foreach --recursive git clean -dXf
 
-ARG CC=clang-10
-ARG CXX=clang++-10
+ARG CC=clang-12
+ARG CXX=clang++-12
 ARG CFLAGS='-O3 -g1 -fno-omit-frame-pointer'
 ARG CXXFLAGS='-O3 -g1 -fno-omit-frame-pointer -stdlib=libc++'
 ARG CONFIGURE_FLAGS='--enable-tracy --enable-sdfprefs --enable-next-protocol-version-unsafe-for-production'
@@ -30,7 +30,7 @@ RUN make install
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-    apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-10 libc++1-10
+    apt-get -y install libunwind8 postgresql curl sqlite iproute2 libc++abi1-12 libc++1-12
 
 COPY --from=buildstage /usr/local/bin/stellar-core /usr/local/bin/stellar-core
 EXPOSE 11625

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -63,10 +63,10 @@ improvements described above).
 
 note: you may have to provide a default clang/clang++, this can be done in many ways.
 
-For example, this makes clang-10 the default:
+For example, this makes clang-12 the default:
 
 ```
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10   81 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-10    --slave /usr/share/man/man1/clang.1.gz clang.1.gz /usr/share/man/man1/clang-10.1.gz --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-10  --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-10 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-10
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12   81 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-12    --slave /usr/share/man/man1/clang.1.gz clang.1.gz /usr/share/man/man1/clang-12.1.gz --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-12  --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-12 --slave /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-12
 ```
 
 ## Building an instrumented stellar-core


### PR DESCRIPTION
this allows to build with stock toolchains on Ubuntu 22.04 and 20.04
