### PR TITLE
[Cleanup] Refactor some utility functions in Overlay tests

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -526,6 +526,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\test\SurveyManagerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\SurveyMessageLimiterTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TxAdvertQueueTests.cpp" />
+    <ClCompile Include="..\..\src\overlay\test\OverlayTestUtils.cpp" />
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\ClaimClaimableBalanceOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\EndSponsoringFutureReservesOpFrame.cpp" />
@@ -756,6 +757,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\test\LoopbackPeer.cpp" />
     <ClCompile Include="..\..\src\overlay\test\OverlayManagerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\OverlayTests.cpp" />
+    <ClCompile Include="..\..\src\overlay\test\OverlayTestUtils.cpp" />
     <ClCompile Include="..\..\src\overlay\test\PeerManagerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TCPPeerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TrackerTests.cpp" />
@@ -1104,6 +1106,7 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\test\LoopbackPeer.h" />
     <ClInclude Include="..\..\src\overlay\Tracker.h" />
     <ClInclude Include="..\..\src\overlay\TxAdvertQueue.h" />
+    <ClInclude Include="..\..\src\overlay\test\TxAdvertQueue.h" />
     <ClInclude Include="..\..\src\process\ProcessManager.h" />
     <ClInclude Include="..\..\src\process\ProcessManagerImpl.h" />
     <ClInclude Include="..\..\src\rust\CppShims.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -936,6 +936,9 @@
     <ClCompile Include="..\..\src\overlay\test\OverlayTests.cpp">
       <Filter>overlay\tests</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\overlay\test\OverlayTestUtils.cpp">
+      <Filter>overlay\tests</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\overlay\test\PeerManagerTests.cpp">
       <Filter>overlay\tests</Filter>
     </ClCompile>
@@ -1931,6 +1934,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\transactions\TransactionUtils.h">
       <Filter>transactions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\test\OverlayTestUtils.h">
+      <Filter>overlay\tests</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\test\LoopbackPeer.h">
       <Filter>overlay\tests</Filter>

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -14,6 +14,7 @@
 #include "overlay/OverlayMetrics.h"
 #include "overlay/PeerDoor.h"
 #include "overlay/TCPPeer.h"
+#include "overlay/test/OverlayTestUtils.h"
 #include "simulation/Simulation.h"
 #include "simulation/Topologies.h"
 #include "test/TestAccount.h"
@@ -236,26 +237,11 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
                     auto advertsRecvd = om.mRecvFloodAdvertTimer.count();
                     auto demandsSent = om.mSendFloodDemandMeter.count();
                     auto hashesQueued =
-                        app->getMetrics()
-                            .NewMeter({"overlay", "flood", "advertised"},
-                                      "message")
-                            .count();
+                        overlaytestutils::getAdvertisedHashCount(app);
                     auto demandFulfilled =
-                        app->getMetrics()
-                            .NewMeter({"overlay", "flood", "fulfilled"},
-                                      "message")
-                            .count();
+                        overlaytestutils::getFulfilledDemandCount(app);
                     auto messagesUnfulfilled =
-                        app->getMetrics()
-                            .NewMeter(
-                                {"overlay", "flood", "unfulfilled-unknown"},
-                                "message")
-                            .count() +
-                        app->getMetrics()
-                            .NewMeter(
-                                {"overlay", "flood", "unfulfilled-banned"},
-                                "message")
-                            .count();
+                        overlaytestutils::getUnfulfilledDemandCount(app);
 
                     LOG_DEBUG(
                         DEFAULT_LOG,
@@ -284,20 +270,15 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
 
                 SECTION("advertise same transaction after some time")
                 {
-                    auto hashesAdvertised = [&](Application::pointer app) {
-                        return app->getMetrics()
-                            .NewMeter({"overlay", "flood", "advertised"},
-                                      "message")
-                            .count();
-                    };
-
                     for (auto const& node : nodes)
                     {
-                        auto before = hashesAdvertised(node);
+                        auto before =
+                            overlaytestutils::getAdvertisedHashCount(node);
                         node->getOverlayManager().broadcastMessage(
                             testTransaction->toStellarMessage(), false,
                             testTransaction->getFullHash());
-                        REQUIRE(before == hashesAdvertised(node));
+                        REQUIRE(before ==
+                                overlaytestutils::getAdvertisedHashCount(node));
                     }
 
                     // Now crank for some time and trigger cleanups
@@ -315,12 +296,14 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
                     // Ensure old transaction gets re-broadcasted
                     for (auto const& node : nodes)
                     {
-                        auto before = hashesAdvertised(node);
+                        auto before =
+                            overlaytestutils::getAdvertisedHashCount(node);
                         node->getOverlayManager().broadcastMessage(
                             testTransaction->toStellarMessage(), false,
                             testTransaction->getFullHash());
 
-                        REQUIRE(before + 1 == hashesAdvertised(node));
+                        REQUIRE(before + 1 ==
+                                overlaytestutils::getAdvertisedHashCount(node));
                     }
                 }
             }
@@ -343,26 +326,11 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
                     auto advertsRecvd = om.mRecvFloodAdvertTimer.count();
                     auto demandsSent = om.mSendFloodDemandMeter.count();
                     auto hashesQueued =
-                        app->getMetrics()
-                            .NewMeter({"overlay", "flood", "advertised"},
-                                      "message")
-                            .count();
+                        overlaytestutils::getAdvertisedHashCount(app);
                     auto demandFulfilled =
-                        app->getMetrics()
-                            .NewMeter({"overlay", "flood", "fulfilled"},
-                                      "message")
-                            .count();
+                        overlaytestutils::getFulfilledDemandCount(app);
                     auto messagesUnfulfilled =
-                        app->getMetrics()
-                            .NewMeter(
-                                {"overlay", "flood", "unfulfilled-unknown"},
-                                "message")
-                            .count() +
-                        app->getMetrics()
-                            .NewMeter(
-                                {"overlay", "flood", "unfulfilled-banned"},
-                                "message")
-                            .count();
+                        overlaytestutils::getUnfulfilledDemandCount(app);
 
                     LOG_DEBUG(
                         DEFAULT_LOG,

--- a/src/overlay/test/OverlayTestUtils.cpp
+++ b/src/overlay/test/OverlayTestUtils.cpp
@@ -1,0 +1,61 @@
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/test/OverlayTestUtils.h"
+#include "main/Application.h"
+#include "medida/metrics_registry.h"
+#include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
+
+namespace stellar
+{
+
+namespace overlaytestutils
+{
+
+uint64_t
+getOverlayFloodMessageCount(std::shared_ptr<Application> app,
+                            std::string const& name)
+{
+    return app->getMetrics()
+        .NewMeter({"overlay", "flood", name}, "message")
+        .count();
+}
+
+uint64_t
+getAdvertisedHashCount(std::shared_ptr<Application> app)
+{
+    return getOverlayFloodMessageCount(app, "advertised");
+}
+
+uint64_t
+getFulfilledDemandCount(std::shared_ptr<Application> app)
+{
+    return getOverlayFloodMessageCount(app, "fulfilled");
+}
+
+uint64_t
+getUnfulfilledDemandCount(std::shared_ptr<Application> app)
+{
+    return getOverlayFloodMessageCount(app, "unfulfilled-unknown") +
+           getOverlayFloodMessageCount(app, "unfulfilled-banned");
+}
+
+uint64_t
+getUnknownDemandCount(std::shared_ptr<Application> app)
+{
+    return getOverlayFloodMessageCount(app, "unfulfilled-unknown");
+}
+
+uint64_t
+getSentDemandCount(std::shared_ptr<Application> app)
+{
+    return app->getOverlayManager()
+        .getOverlayMetrics()
+        .mSendFloodDemandMeter.count();
+}
+
+}
+
+}

--- a/src/overlay/test/OverlayTestUtils.h
+++ b/src/overlay/test/OverlayTestUtils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Copyright 2022 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <memory>
+
+namespace stellar
+{
+
+class Application;
+
+namespace overlaytestutils
+{
+uint64_t getAdvertisedHashCount(std::shared_ptr<Application> app);
+
+uint64_t getFulfilledDemandCount(std::shared_ptr<Application> app);
+
+uint64_t getUnfulfilledDemandCount(std::shared_ptr<Application> app);
+
+uint64_t getUnknownDemandCount(std::shared_ptr<Application> app);
+
+uint64_t getSentDemandCount(std::shared_ptr<Application> app);
+uint64_t getOverlayFloodMessageCount(std::shared_ptr<Application> app,
+                                     std::string const& name);
+}
+}


### PR DESCRIPTION
# Description

Resolves #3600 

The same utility functions in Overlay tests were defined in multiple locations. This PR puts them all in the same file so we don't have to continue to re-define them.



# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
