### PR TITLE
Added BucketListDB init tests and invariant checks

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -377,7 +377,7 @@ Bucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
     }
 
     return out.getBucket(bucketManager,
-                         bucketManager.getConfig().EXPERIMENTAL_BUCKETLIST_DB);
+                         bucketManager.getConfig().isUsingBucketListDB());
 }
 
 static void
@@ -872,8 +872,7 @@ Bucket::merge(BucketManager& bucketManager, uint32_t maxProtocolVersion,
     }
     MergeKey mk{keepDeadEntries, oldBucket, newBucket, shadows};
     return out.getBucket(bucketManager,
-                         bucketManager.getConfig().EXPERIMENTAL_BUCKETLIST_DB,
-                         &mk);
+                         bucketManager.getConfig().isUsingBucketListDB(), &mk);
 }
 
 uint32_t

--- a/src/bucket/BucketIndex.cpp
+++ b/src/bucket/BucketIndex.cpp
@@ -34,6 +34,12 @@ getDummyPoolShareTrustlineKey(AccountID const& accountID, uint8_t fill)
     return key;
 }
 
+bool
+BucketIndex::typeNotSupported(LedgerEntryType t)
+{
+    return t == OFFER;
+}
+
 // Index maps a range of BucketEntry's to the associated offset
 // within the bucket file. Index stored as vector of pairs:
 // First: LedgerKey/Key ranges sorted in the same scheme as LedgerEntryCmp
@@ -248,7 +254,7 @@ BucketIndex::createIndex(BucketManager const& bm,
 {
     ZoneScoped;
     auto const& cfg = bm.getConfig();
-    releaseAssertOrThrow(cfg.EXPERIMENTAL_BUCKETLIST_DB);
+    releaseAssertOrThrow(cfg.isUsingBucketListDB());
     releaseAssertOrThrow(!filename.empty());
 
     auto pageSizeExp = cfg.EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT;

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -59,6 +59,9 @@ class BucketIndex : public NonMovableOrCopyable
 
     inline static const std::string DBBackendState = "bl";
 
+    // Returns true if LedgerEntryType not supported by BucketListDB
+    static bool typeNotSupported(LedgerEntryType t);
+
     // Builds index for given bucketfile. This is expensive (> 20 seconds for
     // the largest buckets) and should only be called once. If pageSize == 0 or
     // if file size is less than the cutoff, individual key index is used.

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -898,8 +898,7 @@ BucketManagerImpl::getPointLoadTimer(LedgerEntryType t) const
 std::shared_ptr<LedgerEntry>
 BucketManagerImpl::getLedgerEntry(LedgerKey const& k) const
 {
-    releaseAssertOrThrow(getConfig().MODE_ENABLES_BUCKETLIST &&
-                         getConfig().EXPERIMENTAL_BUCKETLIST_DB);
+    releaseAssertOrThrow(getConfig().isUsingBucketListDB());
     auto timer = getPointLoadTimer(k.type()).TimeScope();
     return mBucketList->getLedgerEntry(k);
 }
@@ -908,8 +907,7 @@ std::vector<LedgerEntry>
 BucketManagerImpl::loadKeys(
     std::set<LedgerKey, LedgerEntryIdCmp> const& keys) const
 {
-    releaseAssertOrThrow(getConfig().MODE_ENABLES_BUCKETLIST &&
-                         getConfig().EXPERIMENTAL_BUCKETLIST_DB);
+    releaseAssertOrThrow(getConfig().isUsingBucketListDB());
     auto timer = getBulkLoadTimer("prefetch").TimeScope();
     return mBucketList->loadKeys(keys);
 }
@@ -918,8 +916,7 @@ std::vector<LedgerEntry>
 BucketManagerImpl::loadPoolShareTrustLinesByAccountAndAsset(
     AccountID const& accountID, Asset const& asset) const
 {
-    releaseAssertOrThrow(getConfig().MODE_ENABLES_BUCKETLIST &&
-                         getConfig().EXPERIMENTAL_BUCKETLIST_DB);
+    releaseAssertOrThrow(getConfig().isUsingBucketListDB());
     auto timer = getBulkLoadTimer("poolshareTrustlines").TimeScope();
     return mBucketList->loadPoolShareTrustLinesByAccountAndAsset(
         accountID, asset, getConfig());
@@ -929,8 +926,7 @@ std::vector<InflationWinner>
 BucketManagerImpl::loadInflationWinners(size_t maxWinners,
                                         int64_t minBalance) const
 {
-    releaseAssertOrThrow(getConfig().MODE_ENABLES_BUCKETLIST &&
-                         getConfig().EXPERIMENTAL_BUCKETLIST_DB);
+    releaseAssertOrThrow(getConfig().isUsingBucketListDB());
     auto timer = getBulkLoadTimer("inflationWinners").TimeScope();
     return mBucketList->loadInflationWinners(maxWinners, minBalance);
 }

--- a/src/catchup/AssumeStateWork.cpp
+++ b/src/catchup/AssumeStateWork.cpp
@@ -27,7 +27,7 @@ AssumeStateWork::doWork()
         std::vector<std::shared_ptr<BasicWork>> seq;
 
         mApp.getBucketManager().assumeState(mHas);
-        if (mApp.getConfig().EXPERIMENTAL_BUCKETLIST_DB)
+        if (mApp.getConfig().isUsingBucketListDB())
         {
             seq.push_back(std::make_shared<IndexBucketsWork>(mApp));
         }

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -239,12 +239,13 @@ CatchupWork::downloadApplyBuckets()
     }
 
     std::shared_ptr<ApplyBucketsWork> applyBuckets;
-    if (mApp.getConfig().EXPERIMENTAL_BUCKETLIST_DB)
+    if (mApp.getConfig().isUsingBucketListDB())
     {
-        // Only apply offers to SQL DB when BucketList lookup is enabled
-        auto filter = [](LedgerEntryType t) { return t == OFFER; };
+        // Only apply unsupported BucketListDB types to SQL DB when BucketList
+        // lookup is enabled
         applyBuckets = std::make_shared<ApplyBucketsWork>(
-            mApp, mBuckets, *mBucketHAS, version, filter);
+            mApp, mBuckets, *mBucketHAS, version,
+            BucketIndex::typeNotSupported);
     }
     else
     {

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -150,7 +150,7 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
     std::set<LedgerEntryType> toDrop;
     std::set<LedgerEntryType> toRebuild;
     auto& ps = app.getPersistentState();
-    auto blEnabled = app.getConfig().EXPERIMENTAL_BUCKETLIST_DB;
+    auto bucketListDBEnabled = app.getConfig().isUsingBucketListDB();
     for (auto let : xdr::xdr_traits<LedgerEntryType>::enum_values())
     {
         LedgerEntryType t = static_cast<LedgerEntryType>(let);
@@ -161,7 +161,7 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
         }
 
         // If bucketlist is enabled, drop all tables except for offers
-        if (let != OFFER && blEnabled)
+        if (let != OFFER && bucketListDBEnabled)
         {
             toDrop.emplace(t);
         }
@@ -676,36 +676,48 @@ ApplicationImpl::validateAndLogConfig()
 
     if (mConfig.EXPERIMENTAL_BUCKETLIST_DB)
     {
-        mPersistentState->setState(PersistentState::kDBBackend,
-                                   BucketIndex::DBBackendState);
-        auto pageSizeExp =
-            mConfig.EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT;
-        if (pageSizeExp != 0)
+        if (mConfig.isUsingBucketListDB())
         {
-            // If the page size is less than 256 bytes, it is essentially
-            // indexing individual keys, so page size should be set to 0
-            // instead.
-            if (pageSizeExp < 8)
+            mPersistentState->setState(PersistentState::kDBBackend,
+                                       BucketIndex::DBBackendState);
+            auto pageSizeExp =
+                mConfig.EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT;
+            if (pageSizeExp != 0)
             {
-                throw std::invalid_argument(
-                    "EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT "
-                    "must be at least 8 or set to 0 for individual entry "
-                    "indexing");
+                // If the page size is less than 256 bytes, it is essentially
+                // indexing individual keys, so page size should be set to 0
+                // instead.
+                if (pageSizeExp < 8)
+                {
+                    throw std::invalid_argument(
+                        "EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT "
+                        "must be at least 8 or set to 0 for individual entry "
+                        "indexing");
+                }
+
+                // Check if pageSize will cause overflow
+                if (pageSizeExp > 31)
+                {
+                    throw std::invalid_argument(
+                        "EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT "
+                        "must be less than 32");
+                }
             }
 
-            // Check if pageSize will cause overflow
-            if (pageSizeExp > 31)
-            {
-                throw std::invalid_argument(
-                    "EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT "
-                    "must be less than 32");
-            }
+            CLOG_INFO(
+                Bucket,
+                "BucketListDB enabled: pageSizeExponent: {} indexCutOff: {}MB",
+                pageSizeExp, mConfig.EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF);
         }
-
-        CLOG_INFO(
-            Bucket,
-            "BucketListDB enabled: pageSizeExponent: {} indexCutOff: {}MB",
-            pageSizeExp, mConfig.EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF);
+        else
+        {
+            CLOG_WARNING(
+                Bucket,
+                "EXPERIMENTAL_BUCKETLIST_DB flag set but "
+                "BucketListDB not enabled. To enable BucketListDB, "
+                "MODE_ENABLES_BUCKETLIST must be set and --in-memory flag "
+                "must not be used.");
+        }
     }
     else if (mPersistentState->getState(PersistentState::kDBBackend) ==
              BucketIndex::DBBackendState)

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1908,6 +1908,13 @@ Config::isInMemoryMode() const
 }
 
 bool
+Config::isUsingBucketListDB() const
+{
+    return EXPERIMENTAL_BUCKETLIST_DB && !MODE_USES_IN_MEMORY_LEDGER &&
+           MODE_ENABLES_BUCKETLIST;
+}
+
+bool
 Config::isInMemoryModeWithoutMinimalDB() const
 {
     return MODE_USES_IN_MEMORY_LEDGER && !MODE_STORES_HISTORY_LEDGERHEADERS;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -518,6 +518,7 @@ class Config : public std::enable_shared_from_this<Config>
     void setInMemoryMode();
     bool isInMemoryMode() const;
     bool isInMemoryModeWithoutMinimalDB() const;
+    bool isUsingBucketListDB() const;
     bool modeStoresAllHistory() const;
     bool modeStoresAnyHistory() const;
     void logBasicInfo();

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -175,7 +175,7 @@ PersistentState::setRebuildForType(LedgerEntryType let)
 
     // Only allow rebuilds for offer table if BucketListDB enabled, other tables
     // don't exist
-    if (mApp.getConfig().EXPERIMENTAL_BUCKETLIST_DB && let != OFFER)
+    if (mApp.getConfig().isUsingBucketListDB() && let != OFFER)
     {
         return;
     }


### PR DESCRIPTION
# Description

Resolves #3623.

This PR adds several captive-core and BucketListDB related unit tests. In particular, it tests the BucketListDB startup path and several edge cases for in-memory mode in captive-core. There are also several bug fixes, including fixing BucketList related invariants that were broken when BucketListDB was enabled and some captive-core performance bugs introduced by BucketListDB.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
