### PR TITLE
Fix CI Github action workflow warning (deprecated features)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,16 +27,16 @@ jobs:
         #  3. fallback (restore-keys) to the most recent cache
         id: cache_extra_id
         run: |
-          echo "::set-output name=id::$(( $(date +'%s') / 60 / 60 ))"
+          echo "id=$(( $(date +'%s') / 60 / 60 ))" >> $GITHUB_OUTPUT
       - name: Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.0.11
         with:
           path: |
             /home/runner/.ccache
           key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-${{ steps.cache_extra_id.outputs.id }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.2.0
         with:
            fetch-depth: 200
            submodules: true


### PR DESCRIPTION
We're getting a bunch of warnings that certain features are being deprecated - this adjusts the workflow to the new patterns:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/cache@v2.1.4, actions/checkout@v2

The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
