### PR TITLE
Add a new load generation mode that produces DEX transactions.

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -321,7 +321,7 @@ format.
 
 ### The following HTTP commands are exposed on test instances
 * **generateload** `generateload[?mode=
-    (create|pay|pretend)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)]`
+    (create|pay|pretend|mixed_txs)&accounts=N&offset=K&txs=M&txrate=R&batchsize=L&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D]`
 
     Artificially generate load for testing; must be used with
     `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
@@ -337,6 +337,10 @@ format.
     the # of ops / tx and how often they appear. More specifically, the
     probability that a transaction contains `COUNT[i]` ops is `DISTRIBUTION
     [i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...)`.
+  * `mixed_txs` mode generates a mix of DEX and non-DEX transactions
+    (containing `PaymentOp` and `ManageBuyOfferOp` operations respectively).
+    The fraction of DEX transactions generated is defined by the `dextxpercent`
+    parameter (accepts integer value from 0 to 100).
 
   Non-`create` load generation makes use of the additional parameters:
   * when a nonzero `spikeinterval` is given, a spike will occur every

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -989,7 +989,9 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             parseOptionalParam<uint32_t>(map, "maxfeerate");
         cfg.skipLowFeeTxs =
             parseOptionalParamOrDefault<bool>(map, "skiplowfeetxs", false);
-
+        // Only for MIXED_TX mode; fraction of DEX transactions.
+        cfg.dexTxPercent =
+            parseOptionalParamOrDefault<uint32_t>(map, "dextxpercent", 0);
         if (cfg.batchSize > 100)
         {
             cfg.batchSize = 100;

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -17,16 +17,16 @@ using namespace stellar;
 
 TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
 {
-    auto cfg = getTestConfig();
-
-    // 50% of transactions contain 2 ops,
-    // and 50% of transactions contain 3 ops.
-    cfg.LOADGEN_OP_COUNT_FOR_TESTING = {2, 3};
-    cfg.LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {1, 1};
-
-    Hash networkID = sha256(cfg.NETWORK_PASSPHRASE);
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     Simulation::pointer simulation =
-        Topologies::pair(Simulation::OVER_LOOPBACK, networkID);
+        Topologies::pair(Simulation::OVER_LOOPBACK, networkID, [](int i) {
+            auto cfg = getTestConfig(i);
+            // 50% of transactions contain 2 ops,
+            // and 50% of transactions contain 3 ops.
+            cfg.LOADGEN_OP_COUNT_FOR_TESTING = {2, 3};
+            cfg.LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {1, 1};
+            return cfg;
+        });
 
     simulation->startAllNodes();
     simulation->crankUntil(
@@ -75,9 +75,82 @@ TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
                 .NewMeter({"loadgen", "account", "created"}, "account")
                 .count() == 100);
     REQUIRE(app.getMetrics()
-                .NewMeter({"loadgen", "payment", "native"}, "txn")
+                .NewMeter({"loadgen", "payment", "submitted"}, "op")
                 .count() == 0);
     REQUIRE(app.getMetrics()
                 .NewMeter({"loadgen", "pretend", "submitted"}, "op")
-                .count() == 5);
+                .count() >= 2 * 5);
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "pretend", "submitted"}, "op")
+                .count() <= 3 * 5);
+}
+
+TEST_CASE("Multi-op mixed transactions are valid", "[loadgen]")
+{
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    Simulation::pointer simulation =
+        Topologies::pair(Simulation::OVER_LOOPBACK, networkID, [](int i) {
+            auto cfg = getTestConfig(i);
+
+            cfg.LOADGEN_OP_COUNT_FOR_TESTING = {3};
+            cfg.LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {1};
+            cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
+            return cfg;
+        });
+
+    simulation->startAllNodes();
+    simulation->crankUntil(
+        [&]() { return simulation->haveAllExternalized(3, 1); },
+        2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    auto nodes = simulation->getNodes();
+    auto& app = *nodes[0]; // pick a node to generate load
+
+    auto& loadGen = app.getLoadGenerator();
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ 10,
+        /* txRate */ 10,
+        /* batchSize */ 100));
+    try
+    {
+        simulation->crankUntil(
+            [&]() {
+                return app.getMetrics()
+                           .NewMeter({"loadgen", "run", "complete"}, "run")
+                           .count() == 1;
+            },
+            3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+        auto config = GeneratedLoadConfig::txLoad(LoadGenMode::MIXED_TXS, 10,
+                                                  100, 10, 100);
+        config.dexTxPercent = 50;
+        loadGen.generateLoad(config);
+        simulation->crankUntil(
+            [&]() {
+                return app.getMetrics()
+                           .NewMeter({"loadgen", "run", "complete"}, "run")
+                           .count() == 2;
+            },
+            15 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+    }
+    catch (...)
+    {
+        auto problems = loadGen.checkAccountSynced(app, false);
+        REQUIRE(problems.empty());
+    }
+
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "txn", "rejected"}, "txn")
+                .count() == 0);
+    REQUIRE(app.getMetrics()
+                .NewMeter({"loadgen", "account", "created"}, "account")
+                .count() == 100);
+    auto nonDexOps = app.getMetrics()
+                         .NewMeter({"loadgen", "payment", "submitted"}, "op")
+                         .count();
+    auto dexOps = app.getMetrics()
+                      .NewMeter({"loadgen", "manageoffer", "submitted"}, "op")
+                      .count();
+    REQUIRE(nonDexOps > 0);
+    REQUIRE(dexOps > 0);
+    REQUIRE(dexOps + nonDexOps == 3 * 100);
 }


### PR DESCRIPTION
# Description

This allows to test setups that involve the mix of non-DEX and DEX traffic and its interaction with the DEX-limiting config setting.

Also refactored the loadgen code a bit and fixed the existing test.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
