### PR TITLE
Fix rust install script

### DIFF
--- a/install-rust.sh
+++ b/install-rust.sh
@@ -19,6 +19,14 @@ set -x
 # rust-toolchain.toml. This file will pick it up automatically.
 RUST_VERSION=$(perl -ne 'if (/channel\s+=\s+"(\d+\.\d+)"/) { print $1 }' rust-toolchain.toml)
 
+# A specific version of rustup is selected for checksum stability. This install
+# script is intended to continue to work even after new versions of rustup are
+# released and it will continue to do so if we pin to a specific version. If we
+# do not pin to a specific version the checksums will fail for previously tagged
+# versions of core if the repository is cloned and this script is triggered
+# either manually or via one of the Docker image build processes.
+RUSTUP_VERSION=1.25.1
+
 # This is the SHA256 if the rustup-init binary (which is the same as rustup --
 # it renames itself) and should be retrieved from a trusted source (eg. the rust
 # website and/or by running sha256sum on a local copy of rustup you believe to
@@ -50,7 +58,7 @@ esac
 # check their PGP signatures match the Rust project's signing key (the signing
 # key is embedded in rustup).
 rm -f rustup-init
-curl --fail --output rustup-init "https://static.rust-lang.org/rustup/dist/${HOST_TRIPLE}/rustup-init"
+curl --fail --output rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${HOST_TRIPLE}/rustup-init"
 echo "${RUSTUP_SHA256} rustup-init" | sha256sum --check
 chmod 0755 rustup-init
 ./rustup-init -y --verbose --profile default --default-host "${HOST_TRIPLE}" --default-toolchain "${RUST_VERSION}"


### PR DESCRIPTION
# Description

Resolves #3653

Pins the rustup version in the install rust script.

The install rust script expects a stable rustup-init binary as it requires that the binary's checksum is consistent and matches the values hardcoded in the install script.

When a new version of rustup is release, as happened in the last few days, the install script breaks and must be updated. This has several impacts:

It is inconvenient for developers using the script who cannot use the script until it is fixed. These developers probably do not care about whether they are using the latest rustup or not.

it breaks builds of previous tags of stellar-core. Previous tags of stellar-core are used in docker images. e.g. The quickstart image.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
