### PR TITLE
Online catchup no longer waits for trigger ledger

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -513,7 +513,8 @@ DISABLE_XDR_FSYNC=false
 # Most people should leave this to 12
 # Number of most recent ledgers keep in memory. Storing more ledgers allows other
 # nodes to join the network without catching up. This is useful for simulation
-# testing purposes.
+# testing purposes. Note that the SCP checkpoint message is always kept and does
+# not count towards this limit.
 MAX_SLOTS_TO_REMEMBER=12
 
 # METADATA_OUTPUT_STREAM defaults to "", disabling it.

--- a/src/catchup/CatchupManagerImpl.h
+++ b/src/catchup/CatchupManagerImpl.h
@@ -90,5 +90,13 @@ class CatchupManagerImpl : public CatchupManager
     void bucketsApplied(uint32_t num) override;
     void txSetsApplied(uint32_t num) override;
     void fileDownloaded(std::string type, uint32_t num) override;
+
+#ifdef BUILD_TESTS
+    std::map<uint32_t, LedgerCloseData> const&
+    getBufferedLedgers() const
+    {
+        return mSyncingLedgers;
+    }
+#endif
 };
 }

--- a/src/herder/Herder.cpp
+++ b/src/herder/Herder.cpp
@@ -9,6 +9,8 @@ std::chrono::seconds const Herder::MAX_SCP_TIMEOUT_SECONDS(240);
 std::chrono::seconds const Herder::CONSENSUS_STUCK_TIMEOUT_SECONDS(35);
 std::chrono::seconds const Herder::OUT_OF_SYNC_RECOVERY_TIMER =
     std::chrono::seconds(10);
+std::chrono::seconds const Herder::SEND_LATEST_CHECKPOINT_DELAY =
+    std::chrono::seconds(2);
 std::chrono::seconds constexpr Herder::MAX_TIME_SLIP_SECONDS;
 std::chrono::seconds const Herder::NODE_EXPIRATION_SECONDS(240);
 // the value of LEDGER_VALIDITY_BRACKET should be in the order of

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -46,6 +46,10 @@ class Herder
     // timeout before triggering out of sync recovery
     static std::chrono::seconds const OUT_OF_SYNC_RECOVERY_TIMER;
 
+    // Timeout before sending latest checkpoint ledger after sending current SCP
+    // state
+    static std::chrono::seconds const SEND_LATEST_CHECKPOINT_DELAY;
+
     // Maximum time slip between nodes.
     static std::chrono::seconds constexpr MAX_TIME_SLIP_SECONDS =
         std::chrono::seconds{60};
@@ -161,6 +165,11 @@ class Herder
     // Return the maximum sequence number for any tx (or 0 if none) from a given
     // sender in the pending or recent tx sets.
     virtual SequenceNumber getMaxSeqInPendingTxs(AccountID const&) = 0;
+
+    // Returns sequence number for most recent completed checkpoint that the
+    // node knows about, as derived from
+    // trackingConsensusLedgerIndex
+    virtual uint32_t getMostRecentCheckpointSeq() = 0;
 
     virtual void triggerNextLedger(uint32_t ledgerSeqToTrigger,
                                    bool forceTrackingSCP) = 0;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -136,6 +136,8 @@ class HerderImpl : public Herder
 
     SequenceNumber getMaxSeqInPendingTxs(AccountID const&) override;
 
+    uint32_t getMostRecentCheckpointSeq() override;
+
     void triggerNextLedger(uint32_t ledgerSeqToTrigger,
                            bool checkTrackingSCP) override;
 
@@ -250,6 +252,8 @@ class HerderImpl : public Herder
 
     VirtualTimer mTxSetGarbageCollectTimer;
 
+    VirtualTimer mEarlyCatchupTimer;
+
     Application& mApp;
     LedgerManager& mLedgerManager;
 
@@ -277,7 +281,9 @@ class HerderImpl : public Herder
     // run a background job that re-analyzes the current quorum map.
     void checkAndMaybeReanalyzeQuorumMap();
 
-    // erase all data for ledgers strictly less than ledgerSeq
+    // erase all data for ledgers strictly less than ledgerSeq except for the
+    // first ledger on the current checkpoint. Hold onto this ledger so
+    // peers can catchup without waiting for the next checkpoint.
     void eraseBelow(uint32 ledgerSeq);
 
     struct QuorumMapIntersectionState

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -1115,16 +1115,23 @@ HerderSCPDriver::recordSCPExecutionMetrics(uint64_t slotIndex)
 }
 
 void
-HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex)
+HerderSCPDriver::purgeSlots(uint64_t maxSlotIndex, uint64 slotToKeep)
 {
     // Clean up timings map
     auto it = mSCPExecutionTimes.begin();
     while (it != mSCPExecutionTimes.end() && it->first < maxSlotIndex)
     {
-        it = mSCPExecutionTimes.erase(it);
+        if (it->first == slotToKeep)
+        {
+            ++it;
+        }
+        else
+        {
+            it = mSCPExecutionTimes.erase(it);
+        }
     }
 
-    getSCP().purgeSlots(maxSlotIndex);
+    getSCP().purgeSlots(maxSlotIndex, slotToKeep);
 }
 
 void

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -123,7 +123,7 @@ class HerderSCPDriver : public SCPDriver
     ValueWrapperPtr wrapValue(Value const& sv) override;
 
     // clean up older slots
-    void purgeSlots(uint64_t maxSlotIndex);
+    void purgeSlots(uint64_t maxSlotIndex, uint64 slotToKeep);
 
     double getExternalizeLag(NodeID const& id) const;
 

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -113,7 +113,7 @@ class PendingEnvelopes
 
     // stops all pending downloads for slots strictly below `slotIndex`
     // counts partially downloaded data towards the cost for that slot
-    void stopAllBelow(uint64 slotIndex);
+    void stopAllBelow(uint64 slotIndex, uint64 slotToKeep);
 
   public:
     PendingEnvelopes(Application& app, HerderImpl& herder);
@@ -178,8 +178,9 @@ class PendingEnvelopes
 
     SCPEnvelopeWrapperPtr pop(uint64 slotIndex);
 
-    // erases data for all slots strictly below `slotIndex`
-    void eraseBelow(uint64 slotIndex);
+    // erases data for all slots strictly below `slotIndex` except
+    // slotToKeep.
+    void eraseBelow(uint64 slotIndex, uint64 slotToKeep);
 
     void forceRebuildQuorum();
 

--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -316,12 +316,13 @@ FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
         // messages for the same slot and validator against the latest SCP
         // message and drop
         auto minSlotToRemember = mApp.getHerder().getMinLedgerSeqToRemember();
+        auto checkpointSeq = mApp.getHerder().getMostRecentCheckpointSeq();
         bool valueReplaced = false;
 
         for (auto it = queue.begin(); it != queue.end();)
         {
-            if (it->mMessage->envelope().statement.slotIndex <
-                minSlotToRemember)
+            if (auto index = it->mMessage->envelope().statement.slotIndex;
+                index < minSlotToRemember && index != checkpointSeq)
             {
                 it = queue.erase(it);
                 dropped++;

--- a/src/overlay/ItemFetcher.cpp
+++ b/src/overlay/ItemFetcher.cpp
@@ -100,22 +100,24 @@ ItemFetcher::fetchingFor(Hash const& itemHash) const
 }
 
 void
-ItemFetcher::stopFetchingBelow(uint64 slotIndex)
+ItemFetcher::stopFetchingBelow(uint64 slotIndex, uint64 slotToKeep)
 {
     // only perform this cleanup from the top of the stack as it causes
     // all sorts of evil side effects
     mApp.postOnMainThread(
-        [this, slotIndex]() { stopFetchingBelowInternal(slotIndex); },
+        [this, slotIndex, slotToKeep]() {
+            stopFetchingBelowInternal(slotIndex, slotToKeep);
+        },
         "ItemFetcher: stopFetchingBelow");
 }
 
 void
-ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex)
+ItemFetcher::stopFetchingBelowInternal(uint64 slotIndex, uint64 slotToKeep)
 {
     ZoneScoped;
     for (auto iter = mTrackers.begin(); iter != mTrackers.end();)
     {
-        if (!iter->second->clearEnvelopesBelow(slotIndex))
+        if (!iter->second->clearEnvelopesBelow(slotIndex, slotToKeep))
         {
             iter = mTrackers.erase(iter);
         }

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -76,7 +76,7 @@ class ItemFetcher : private NonMovableOrCopyable
      * below some @p slotIndex). Can also remove @see Tracker instances when
      * non needed anymore.
      */
-    void stopFetchingBelow(uint64 slotIndex);
+    void stopFetchingBelow(uint64 slotIndex, uint64 slotToKeep);
 
     /**
      * Called when given @p peer informs that it does not have data identified
@@ -96,7 +96,7 @@ class ItemFetcher : private NonMovableOrCopyable
 #endif
 
   protected:
-    void stopFetchingBelowInternal(uint64 slotIndex);
+    void stopFetchingBelowInternal(uint64 slotIndex, uint64 slotToKeep);
 
     Application& mApp;
     std::map<Hash, std::shared_ptr<Tracker>> mTrackers;

--- a/src/overlay/Tracker.cpp
+++ b/src/overlay/Tracker.cpp
@@ -52,13 +52,14 @@ Tracker::pop()
 
 // returns false if no one cares about this guy anymore
 bool
-Tracker::clearEnvelopesBelow(uint64 slotIndex)
+Tracker::clearEnvelopesBelow(uint64 slotIndex, uint64 slotToKeep)
 {
     ZoneScoped;
     for (auto iter = mWaitingEnvelopes.begin();
          iter != mWaitingEnvelopes.end();)
     {
-        if (iter->second.statement.slotIndex < slotIndex)
+        if (auto index = iter->second.statement.slotIndex;
+            index < slotIndex && index != slotToKeep)
         {
             iter = mWaitingEnvelopes.erase(iter);
         }

--- a/src/overlay/Tracker.h
+++ b/src/overlay/Tracker.h
@@ -103,11 +103,12 @@ class Tracker
 
     /**
      * Called periodically to remove old envelopes from list (with ledger id
-     * below some @p slotIndex).
+     * below some @p slotIndex). Envolope not removed if ledger id ==
+     * slotToKeep.
      *
      * Returns true if at least one envelope remained in list.
      */
-    bool clearEnvelopesBelow(uint64 slotIndex);
+    bool clearEnvelopesBelow(uint64 slotIndex, uint64 slotToKeep);
 
     /**
      * Add @p env to list of envelopes that will be resend to Herder when data

--- a/src/overlay/test/TrackerTests.cpp
+++ b/src/overlay/test/TrackerTests.cpp
@@ -107,7 +107,7 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
 
         SECTION("properly removes some old envelopes")
         {
-            REQUIRE(t.clearEnvelopesBelow(4));
+            REQUIRE(t.clearEnvelopesBelow(4, 4));
             REQUIRE(t.size() == 2);
             REQUIRE(env4 == t.pop());
             REQUIRE(env5 == t.pop());
@@ -115,8 +115,16 @@ TEST_CASE("Tracker works", "[overlay][Tracker]")
 
         SECTION("properly removes all old envelopes")
         {
-            REQUIRE(!t.clearEnvelopesBelow(6));
+            REQUIRE(!t.clearEnvelopesBelow(6, 6));
             REQUIRE(t.empty());
+        }
+
+        SECTION("keeps checkpoint envelope")
+        {
+            REQUIRE(t.clearEnvelopesBelow(5, 1));
+            REQUIRE(t.size() == 2);
+            REQUIRE(env1 == t.pop());
+            REQUIRE(env5 == t.pop());
         }
     }
 }

--- a/src/scp/SCP.cpp
+++ b/src/scp/SCP.cpp
@@ -70,12 +70,19 @@ SCP::getLocalNodeID()
 }
 
 void
-SCP::purgeSlots(uint64 maxSlotIndex)
+SCP::purgeSlots(uint64 maxSlotIndex, uint64 slotToKeep)
 {
     auto it = mKnownSlots.begin();
     while (it != mKnownSlots.end() && it->first < maxSlotIndex)
     {
-        it = mKnownSlots.erase(it);
+        if (it->first == slotToKeep)
+        {
+            it++;
+        }
+        else
+        {
+            it = mKnownSlots.erase(it);
+        }
     }
 }
 

--- a/src/scp/SCP.h
+++ b/src/scp/SCP.h
@@ -86,8 +86,8 @@ class SCP
                                   bool fullKeys = false, uint64 index = 0);
 
     // Purges all data relative to all the slots whose slotIndex is smaller
-    // than the specified `maxSlotIndex`.
-    void purgeSlots(uint64 maxSlotIndex);
+    // than the specified `maxSlotIndex` except for slotToKeep slot.
+    void purgeSlots(uint64 maxSlotIndex, uint64 slotToKeep);
 
     // Returns whether the local node is a validator.
     bool isValidator();
@@ -146,6 +146,12 @@ class SCP
     std::string envToStr(SCPEnvelope const& envelope,
                          bool fullKeys = false) const;
     std::string envToStr(SCPStatement const& st, bool fullKeys = false) const;
+
+    uint64
+    getHighestKnownSlotIndex()
+    {
+        return mKnownSlots.empty() ? 0 : mKnownSlots.rbegin()->first;
+    }
 
   private:
     // Calculate the state of the node for the given slot index.


### PR DESCRIPTION
# Description

Resolves #3622

This PR allows out-of-sync nodes to begin catchup immediately instead of waiting for a trigger ledger. This change reduces validator startup time by up to 5 minutes. To accomplish this, validators now save SCP messages for the first ledger on the current checkpoint. These messages contain the hash of the last ledger on the most recently completed checkpoint. When these messages are sent to out-of-sync nodes, this hash is used to immediately begin catchup up to the last completed checkpoint. After this "early catchup" finishes, we either apply the buffer ledgers, or run a 2nd smaller catchup if there is a gap between the first buffered ledger and the ledger that the "early catchup" reached.

While this change decreases validator startup time, it does slightly increase bandwidth requirements. SCP state now includes one additional ledger of information that validators must keep in memory and send to each other.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
