### PR TITLE
Fixup xdr hash script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
 #    && apt-get update
 
 # Install common compilation tools
-RUN apt-get -y install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev curl
+RUN apt-get -y install git build-essential pkg-config autoconf automake libtool bison flex sed perl libpq-dev parallel libunwind-dev curl
 
 # Update compiler tools
 RUN apt-get -y install libstdc++-10-dev clang-format-12 ccache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
             sudo apt-get -y install clang-12 llvm-12
           fi
       - name: install dependencies
-        run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev
+        run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev sed perl
       - name: Build
         run: |
           if test "${{ matrix.toolchain }}" = "gcc" ; then

--- a/INSTALL-Windows.md
+++ b/INSTALL-Windows.md
@@ -62,6 +62,7 @@ presumably depend on your operating system's setting might cause inconsistencies
       * `Bison`
       * `gcc`
       * `sed`
+      * `perl`
       * `curl`
     * Add `C:\MinGW\msys\1.0\bin;C:\MinGW\bin` to the end of `%PATH%`
 * Download and install cygwin 64 bit build from https://cygwin.com/install.html
@@ -71,6 +72,7 @@ presumably depend on your operating system's setting might cause inconsistencies
         * `curl` (command line)
         * `gcc-core`
         * `sed`
+        * `perl`
     * Add `c:\cygwin64\bin` to the end of `%PATH%` (at least for Visual Studio)
 
     > Note: if you're going to use 'cp'and 'mkdir' from cygwin (tests do),

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,7 +65,7 @@ To install Postgresql, follow instructions from the [Postgresql download page](h
 - `libpq-dev` unless you `./configure --disable-postgres` in the build step below.
 - 64-bit system
 - `clang-format-12` (for `make format` to work)
-- `perl`
+- `sed` and `perl`
 - `libunwind-dev`
 
 ### Ubuntu
@@ -93,7 +93,7 @@ After installing packages, head to [building with clang and libc++](#building-wi
 
 #### Installing packages
     # common packages
-    sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev libunwind-dev parallel
+    sudo apt-get install git build-essential pkg-config autoconf automake libtool bison flex libpq-dev libunwind-dev parallel sed perl
     # if using clang
     sudo apt-get install clang-12
     # clang with libstdc++
@@ -111,7 +111,7 @@ In order to install the llvm (clang) toolchain, you may have to follow instructi
 When building on OSX, here's some dependencies you'll need:
 - Install xcode
 - Install [homebrew](https://brew.sh)
-- `brew install libsodium libtool autoconf automake pkg-config libpq openssl parallel ccache bison`
+- `brew install libsodium libtool autoconf automake pkg-config libpq openssl parallel ccache bison sed perl`
 
 You'll also need to configure pkg-config by adding the following to your shell (`.zshenv` or `.zshrc`):
 ```zsh

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -y install iproute2 procps lsb-release \
                        git build-essential pkg-config autoconf automake libtool \
-                       bison flex libpq-dev parallel libunwind-dev \
+                       bison flex sed perl libpq-dev parallel libunwind-dev \
                        clang-12 libc++abi-12-dev libc++-12-dev \
                        postgresql curl
 

--- a/hash-xdrs.sh
+++ b/hash-xdrs.sh
@@ -22,7 +22,7 @@ namespace stellar {
 extern const std::vector<std::pair<std::filesystem::path, std::string>> XDR_FILES_SHA256 = {
 EOF
 
-sha256sum -b $1/xdr/*.x | grep -v Stellar-internal | sed -e 's/\([a-f0-9]\+\)[ \*]*\(.*\)/{"\2", "\1"},/'
+sha256sum -b $1/xdr/*.x | grep -v Stellar-internal | perl -pe 's/([a-f0-9]+)[ \*]+(.*)/{"$2", "$1"},/'
 
 echo '{"", ""}};'
 echo '}'


### PR DESCRIPTION
This fixes an issue where the script that we use to compute xdr hashes is not reliable on some platforms (MacOSX) because of a non standard interface.

This switches to using perl (that we already depend on) that is much more stable.
