### PR TITLE
Config Setting upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,8 +585,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-common"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=aa7424dc2ea8db1391365e229f550d726734ae55#aa7424dc2ea8db1391365e229f550d726734ae55"
 dependencies = [
  "crate-git-revision",
  "ethnum",
@@ -598,8 +598,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-host"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=aa7424dc2ea8db1391365e229f550d726734ae55#aa7424dc2ea8db1391365e229f550d726734ae55"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -620,8 +620,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-env-macros"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=aa7424dc2ea8db1391365e229f550d726734ae55#aa7424dc2ea8db1391365e229f550d726734ae55"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -635,8 +635,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-native-sdk-macros"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=aa7424dc2ea8db1391365e229f550d726734ae55#aa7424dc2ea8db1391365e229f550d726734ae55"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -646,8 +646,8 @@ dependencies = [
 
 [[package]]
 name = "soroban-test-wasms"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=75b21696b0636bd145b7acb47a6fed4621b05978#75b21696b0636bd145b7acb47a6fed4621b05978"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=aa7424dc2ea8db1391365e229f550d726734ae55#aa7424dc2ea8db1391365e229f550d726734ae55"
 
 [[package]]
 name = "soroban-wasmi"
@@ -698,8 +698,8 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "0.0.14"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=07aff1190dc3f97b889d31b2bfb77098e7db55ce#07aff1190dc3f97b889d31b2bfb77098e7db55ce"
+version = "0.0.15"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=bcf6f4c3a9dd32822a20af89880650a421d10e7f#bcf6f4c3a9dd32822a20af89880650a421d10e7f"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/docs/software/admin.md
+++ b/docs/software/admin.md
@@ -1061,6 +1061,7 @@ The network settings are:
   * the maximum number of operations that can be included in a given ledger close
   * the cost (fee) associated with processing operations
   * the base reserve used to calculate the lumen balance needed to store things in the ledger
+  * generalized network settings stored in ConfigSettingEntries.
 
 When the network time is later than the `upgradetime` specified in
 the upgrade settings, the validator will vote to update the network

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -296,6 +296,12 @@ format.
         When specified it must match one of the protocol versions supported
         by the node and should be greater than ledgerVersion from the current
         ledger<br>
+    * `configupgradesetkey` (base64 encoded XDR serialized `ConfigUpgradeSetKey`)
+        this key will be converted to a ContractData LedgerKey, and the
+        ContractData LedgerEntry retrieved with that will have a val of SCV_BYTES
+        containing a serialized ConfigUpgradeSet. Each ConfigSettingEntry in the
+        ConfigUpgradeSet will be used to update the existing network ConfigSettingEntry
+        that exists at the corresponding CONFIG_SETTING LedgerKey.
 
 * **surveytopology**
   `surveytopology?duration=DURATION&node=NODE_ID`<br>

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -50,6 +50,11 @@ Upgrades are specified with:
 * protocolversion - upgrades value of ledgerVersion in ledger header, uses
   upgrade type LEDGER_UPGRADE_VERSION (when specified it has to match the
   supported version number)
+* configupgradesetkey - this key will be converted to a ContractData LedgerKey, and the
+  ContractData LedgerEntry retrieved with that will have a val of SCV_BYTES
+  containing a serialized ConfigUpgradeSet. Each ConfigSettingEntry in the
+  ConfigUpgradeSet will be used to update the existing network ConfigSettingEntry
+  that exists at the corresponding CONFIG_SETTING LedgerKey.
 
 #### Limitations of the current implementation
 There is an assumption that validator operators are either paying attention to network wide proposals

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -206,7 +206,6 @@ BucketApplicator::Counters::reset(VirtualClock::time_point now)
     mContractDataUpsert = 0;
     mContractDataDelete = 0;
     mConfigSettingUpsert = 0;
-    mConfigSettingDelete = 0;
 }
 
 void
@@ -215,8 +214,7 @@ BucketApplicator::Counters::getRates(
     uint64_t& tu_sec, uint64_t& td_sec, uint64_t& ou_sec, uint64_t& od_sec,
     uint64_t& du_sec, uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
     uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec, uint64_t& cdd_sec,
-    uint64_t& ccu_sec, uint64_t& ccd_sec, uint64_t& csu_sec, uint64_t& csd_sec,
-    uint64_t& T_sec, uint64_t& total)
+    uint64_t& ccu_sec, uint64_t& ccd_sec, uint64_t& csu_sec,     uint64_t& T_sec, uint64_t& total)
 {
     VirtualClock::duration dur = now - mStarted;
     auto usec = std::chrono::duration_cast<std::chrono::microseconds>(dur);
@@ -225,7 +223,7 @@ BucketApplicator::Counters::getRates(
             mTrustLineDelete + mOfferUpsert + mOfferDelete + mDataUpsert +
             mDataDelete + mClaimableBalanceUpsert + mClaimableBalanceDelete +
             mLiquidityPoolUpsert + mLiquidityPoolDelete + mContractDataUpsert +
-            mContractDataDelete + mConfigSettingUpsert + mConfigSettingDelete;
+            mContractDataDelete + mConfigSettingUpsert;
     au_sec = (mAccountUpsert * 1000000) / usecs;
     ad_sec = (mAccountDelete * 1000000) / usecs;
     tu_sec = (mTrustLineUpsert * 1000000) / usecs;
@@ -243,7 +241,6 @@ BucketApplicator::Counters::getRates(
     ccu_sec = (mContractCodeUpsert * 1000000) / usecs;
     ccd_sec = (mContractCodeDelete * 1000000) / usecs;
     csu_sec = (mConfigSettingUpsert * 1000000) / usecs;
-    csd_sec = (mConfigSettingDelete * 1000000) / usecs;
     T_sec = (total * 1000000) / usecs;
 }
 
@@ -254,28 +251,27 @@ BucketApplicator::Counters::logInfo(std::string const& bucketName,
 {
     uint64_t au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec, dd_sec,
         cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec, ccd_sec,
-        csu_sec, csd_sec, T_sec, total;
+        csu_sec, T_sec, total;
     getRates(now, au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec,
              dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec,
-             ccd_sec, csu_sec, csd_sec, T_sec, total);
+             ccd_sec, csu_sec, T_sec, total);
     CLOG_INFO(Bucket,
               "Apply-rates for {}-entry bucket {}.{} au:{} ad:{} tu:{} td:{} "
               "ou:{} od:{} du:{} dd:{} cu:{} cd:{} lu:{} ld:{} "
-              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} csd{} T:{}",
+              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} T:{}",
               total, level, bucketName, au_sec, ad_sec, tu_sec, td_sec, ou_sec,
               od_sec, du_sec, dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec,
-              cdd_sec, ccu_sec, ccd_sec, csu_sec, csd_sec, T_sec);
+              cdd_sec, ccu_sec, ccd_sec, csu_sec, T_sec);
     CLOG_INFO(Bucket,
               "Entry-counts for {}-entry bucket {}.{} au:{} ad:{} tu:{} td:{} "
               "ou:{} od:{} du:{} dd:{} cu:{} cd:{} lu:{} ld:{} "
-              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} csd:{}",
+              "cdu:{} cdd:{} ccu:{} ccd:{} csu:{}",
               total, level, bucketName, mAccountUpsert, mAccountDelete,
               mTrustLineUpsert, mTrustLineDelete, mOfferUpsert, mOfferDelete,
               mDataUpsert, mDataDelete, mClaimableBalanceUpsert,
               mClaimableBalanceDelete, mLiquidityPoolUpsert,
               mLiquidityPoolDelete, mContractDataUpsert, mContractDataDelete,
-              mContractCodeUpsert, mContractCodeDelete, mConfigSettingUpsert,
-              mConfigSettingDelete);
+              mContractCodeUpsert, mContractCodeDelete, mConfigSettingUpsert);
 }
 
 void
@@ -285,17 +281,17 @@ BucketApplicator::Counters::logDebug(std::string const& bucketName,
 {
     uint64_t au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec, dd_sec,
         cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec, ccd_sec,
-        csu_sec, csd_sec, T_sec, total;
+        csu_sec, T_sec, total;
     getRates(now, au_sec, ad_sec, tu_sec, td_sec, ou_sec, od_sec, du_sec,
              dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec, cdd_sec, ccu_sec,
-             ccd_sec, csu_sec, csd_sec, T_sec, total);
+             ccd_sec, csu_sec, T_sec, total);
     CLOG_DEBUG(Bucket,
                "Apply-rates for {}-entry bucket {}.{} au:{} ad:{} tu:{} td:{} "
                "ou:{} od:{} du:{} dd:{} cu:{} cd:{} lu:{} ld:{} "
-               "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} csd{} T:{}",
+               "cdu:{} cdd:{} ccu:{} ccd:{} csu:{} T:{}",
                total, level, bucketName, au_sec, ad_sec, tu_sec, td_sec, ou_sec,
                od_sec, du_sec, dd_sec, cu_sec, cd_sec, lu_sec, ld_sec, cdu_sec,
-               cdd_sec, ccu_sec, ccd_sec, csu_sec, csd_sec, T_sec);
+               cdd_sec, ccu_sec, ccd_sec, csu_sec, T_sec);
 }
 
 void
@@ -366,7 +362,6 @@ BucketApplicator::Counters::mark(BucketEntry const& e)
             ++mContractCodeDelete;
             break;
         case CONFIG_SETTING:
-            ++mConfigSettingDelete;
             break;
 #endif
         }

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -214,7 +214,8 @@ BucketApplicator::Counters::getRates(
     uint64_t& tu_sec, uint64_t& td_sec, uint64_t& ou_sec, uint64_t& od_sec,
     uint64_t& du_sec, uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
     uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec, uint64_t& cdd_sec,
-    uint64_t& ccu_sec, uint64_t& ccd_sec, uint64_t& csu_sec,     uint64_t& T_sec, uint64_t& total)
+    uint64_t& ccu_sec, uint64_t& ccd_sec, uint64_t& csu_sec, uint64_t& T_sec,
+    uint64_t& total)
 {
     VirtualClock::duration dur = now - mStarted;
     auto usec = std::chrono::duration_cast<std::chrono::microseconds>(dur);

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -60,8 +60,7 @@ class BucketApplicator
                       uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
                       uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec,
                       uint64_t& cdd_sec, uint64_t& ccu_sec, uint64_t& ccd_sec,
-                      uint64_t& cfgu_sec, uint64_t& T_sec,
-                      uint64_t& total);
+                      uint64_t& cfgu_sec, uint64_t& T_sec, uint64_t& total);
 
       public:
         Counters(VirtualClock::time_point now);

--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -54,14 +54,13 @@ class BucketApplicator
         uint64_t mContractCodeUpsert;
         uint64_t mContractCodeDelete;
         uint64_t mConfigSettingUpsert;
-        uint64_t mConfigSettingDelete;
         void getRates(VirtualClock::time_point now, uint64_t& au_sec,
                       uint64_t& ad_sec, uint64_t& tu_sec, uint64_t& td_sec,
                       uint64_t& ou_sec, uint64_t& od_sec, uint64_t& du_sec,
                       uint64_t& dd_sec, uint64_t& cu_sec, uint64_t& cd_sec,
                       uint64_t& lu_sec, uint64_t& ld_sec, uint64_t& cdu_sec,
                       uint64_t& cdd_sec, uint64_t& ccu_sec, uint64_t& ccd_sec,
-                      uint64_t& cfgu_sec, uint64_t& cfgd_sec, uint64_t& T_sec,
+                      uint64_t& cfgu_sec, uint64_t& T_sec,
                       uint64_t& total);
 
       public:

--- a/src/bucket/LedgerCmp.h
+++ b/src/bucket/LedgerCmp.h
@@ -4,6 +4,8 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include <type_traits>
+
 #include "overlay/StellarXDR.h"
 #include "util/XDROperators.h"
 
@@ -90,8 +92,22 @@ struct LedgerEntryIdCmp
         case CONTRACT_CODE:
             return a.contractCode().hash < b.contractCode().hash;
         case CONFIG_SETTING:
-            return a.configSetting().configSettingID <
-                   b.configSetting().configSettingID;
+        {
+            auto getConfigSettingId = [](auto const& v) -> ConfigSettingID {
+                using ConfigT = decltype(v);
+                if constexpr (std::is_same_v<ConfigT, LedgerKey const&>)
+                {
+                    return v.configSetting().configSettingID;
+                }
+                else if constexpr (std::is_same_v<ConfigT,
+                                                  LedgerEntry::_data_t const&>)
+                {
+                    return v.configSetting().configSettingID();
+                }
+                throw std::runtime_error("Unexpected entry type");
+            };
+            return getConfigSettingId(a) < getConfigSettingId(b);
+        }
 #endif
         }
         return false;

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -57,7 +57,14 @@ class BucketIndexTest
         do
         {
             ++ledger;
-            auto entries = LedgerTestUtils::generateValidLedgerEntries(10);
+            auto entries =
+                LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                    {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                        CONFIG_SETTING
+#endif
+                    },
+                    10);
             f(entries);
             closeLedger(*mApp);
         } while (!BucketList::levelShouldSpill(ledger, mLevelsToBuild - 1));
@@ -198,10 +205,16 @@ class BucketIndexTest
             if (rand_flip())
             {
                 // Add keys not in bucket list as well
-                for (size_t j = 0; j < 10; ++j)
-                {
-                    searchSubset.emplace(LedgerTestUtils::generateLedgerKey(3));
-                }
+                auto addKeys =
+                    LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                        {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                            CONFIG_SETTING
+#endif
+                        },
+                        10);
+
+                searchSubset.insert(addKeys.begin(), addKeys.end());
             }
 
             auto blLoad = getBM().loadKeys(searchSubset);
@@ -213,7 +226,14 @@ class BucketIndexTest
     testInvalidKeys()
     {
         // Load should return empty vector for keys not in bucket list
-        auto keysNotInBL = LedgerTestUtils::generateLedgerKeys(10);
+        auto keysNotInBL =
+            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                },
+                10);
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -140,9 +140,16 @@ TEST_CASE_VERSIONS("bucket list", "[bucket][bucketlist]")
                  !app->getClock().getIOContext().stopped() && i < 130; ++i)
             {
                 app->getClock().crank(false);
-                bl.addBatch(*app, i, getAppLedgerVersion(app), {},
-                            LedgerTestUtils::generateValidLedgerEntries(8),
-                            LedgerTestUtils::generateLedgerKeys(5));
+                bl.addBatch(
+                    *app, i, getAppLedgerVersion(app), {},
+                    LedgerTestUtils::generateValidUniqueLedgerEntries(8),
+                    LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                        {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                            CONFIG_SETTING
+#endif
+                        },
+                        5));
                 if (i % 10 == 0)
                     CLOG_DEBUG(Bucket, "Added batch {}, hash={}", i,
                                binToHex(bl.getHash()));
@@ -186,7 +193,8 @@ TEST_CASE_VERSIONS("bucket list shadowing pre/post proto 12",
              ++i)
         {
             app->getClock().crank(false);
-            auto liveBatch = LedgerTestUtils::generateValidLedgerEntries(5);
+            auto liveBatch =
+                LedgerTestUtils::generateValidUniqueLedgerEntries(5);
 
             BucketEntry BucketEntryAlice, BucketEntryBob;
             alice.balance++;
@@ -201,14 +209,21 @@ TEST_CASE_VERSIONS("bucket list shadowing pre/post proto 12",
             BucketEntryBob.liveEntry().data.account() = bob;
             liveBatch.push_back(BucketEntryBob.liveEntry());
 
-            bl.addBatch(*app, i, getAppLedgerVersion(app), {}, liveBatch,
-                        LedgerTestUtils::generateLedgerKeys(5));
+            bl.addBatch(
+                *app, i, getAppLedgerVersion(app), {}, liveBatch,
+                LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                    {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                        CONFIG_SETTING
+#endif
+                    },
+                    5));
             if (i % 100 == 0)
             {
                 CLOG_DEBUG(Bucket, "Added batch {}, hash={}", i,
                            binToHex(bl.getHash()));
-                // Alice and bob should be in either curr or snap of level 0 and
-                // 1
+                // Alice and bob should be in either curr or snap of level 0
+                // and 1
                 for (uint32_t j = 0; j < 2; ++j)
                 {
                     auto const& lev = bl.getLevel(j);
@@ -274,18 +289,30 @@ TEST_CASE_VERSIONS("bucket tombstones expire at bottom level",
         for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
         {
             auto& level = bl.getLevel(i);
-            level.setCurr(
-                Bucket::fresh(bm, getAppLedgerVersion(app), {},
-                              LedgerTestUtils::generateValidLedgerEntries(8),
-                              LedgerTestUtils::generateLedgerKeys(8),
-                              /*countMergeEvents=*/true, clock.getIOContext(),
-                              /*doFsync=*/true));
-            level.setSnap(
-                Bucket::fresh(bm, getAppLedgerVersion(app), {},
-                              LedgerTestUtils::generateValidLedgerEntries(8),
-                              LedgerTestUtils::generateLedgerKeys(8),
-                              /*countMergeEvents=*/true, clock.getIOContext(),
-                              /*doFsync=*/true));
+            level.setCurr(Bucket::fresh(
+                bm, getAppLedgerVersion(app), {},
+                LedgerTestUtils::generateValidUniqueLedgerEntries(8),
+                LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                    {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                        CONFIG_SETTING
+#endif
+                    },
+                    5),
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true));
+            level.setSnap(Bucket::fresh(
+                bm, getAppLedgerVersion(app), {},
+                LedgerTestUtils::generateValidUniqueLedgerEntries(8),
+                LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                    {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                        CONFIG_SETTING
+#endif
+                    },
+                    5),
+                /*countMergeEvents=*/true, clock.getIOContext(),
+                /*doFsync=*/true));
         }
 
         for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
@@ -295,9 +322,16 @@ TEST_CASE_VERSIONS("bucket tombstones expire at bottom level",
             for (auto j : ledgers)
             {
                 auto n = mergeTimer.count();
-                bl.addBatch(*app, j, getAppLedgerVersion(app), {},
-                            LedgerTestUtils::generateValidLedgerEntries(8),
-                            LedgerTestUtils::generateLedgerKeys(8));
+                bl.addBatch(
+                    *app, j, getAppLedgerVersion(app), {},
+                    LedgerTestUtils::generateValidUniqueLedgerEntries(8),
+                    LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                        {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                            CONFIG_SETTING
+#endif
+                        },
+                        5));
                 app->getClock().crank(false);
                 for (uint32_t k = 0u; k < BucketList::kNumLevels; ++k)
                 {
@@ -332,15 +366,21 @@ TEST_CASE_VERSIONS("bucket tombstones mutually-annihilate init entries",
     Config const& cfg = getTestConfig();
 
     for_versions_with_differing_bucket_logic(cfg, [&](Config const& cfg) {
+        int const BatchCount = 512;
+        int const BatchSize = 8;
         Application::pointer app = createTestApplication(clock, cfg);
         BucketList bl;
         auto vers = getAppLedgerVersion(app);
         autocheck::generator<bool> flip;
         std::deque<LedgerEntry> entriesToModify;
-        for (uint32_t i = 1; i < 512; ++i)
+        std::vector<LedgerEntry> allEntries =
+            LedgerTestUtils::generateValidUniqueLedgerEntries(BatchCount *
+                                                              BatchSize);
+        for (uint32_t i = 1; i <= BatchCount; ++i)
         {
-            std::vector<LedgerEntry> initEntries =
-                LedgerTestUtils::generateValidLedgerEntries(8);
+            std::vector<LedgerEntry> initEntries(
+                allEntries.begin() + (i - 1) * BatchSize,
+                allEntries.begin() + i * BatchSize);
             std::vector<LedgerEntry> liveEntries;
             std::vector<LedgerKey> deadEntries;
             for (auto const& e : initEntries)
@@ -351,7 +391,11 @@ TEST_CASE_VERSIONS("bucket tombstones mutually-annihilate init entries",
             {
                 LedgerEntry e = entriesToModify.front();
                 entriesToModify.pop_front();
-                if (flip())
+                if (flip()
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    || e.data.type() == CONFIG_SETTING
+#endif
+                )
                 {
                     // Entry will survive another round of the
                     // queue.
@@ -574,16 +618,15 @@ TEST_CASE("BucketList check bucket sizes", "[bucket][bucketlist][count]")
     Application::pointer app = createTestApplication(clock, cfg);
     BucketList& bl = app->getBucketManager().getBucketList();
     std::vector<LedgerKey> emptySet;
-
+    auto ledgers = LedgerTestUtils::generateValidUniqueLedgerEntries(256);
     for (uint32_t ledgerSeq = 1; ledgerSeq <= 256; ++ledgerSeq)
     {
         if (ledgerSeq >= 2)
         {
             app->getClock().crank(false);
-            auto ledgers = LedgerTestUtils::generateValidLedgerEntries(1);
-            ledgers[0].lastModifiedLedgerSeq = ledgerSeq;
-            bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {}, ledgers,
-                        emptySet);
+            ledgers[ledgerSeq - 1].lastModifiedLedgerSeq = ledgerSeq;
+            bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {},
+                        {ledgers[ledgerSeq - 1]}, emptySet);
         }
         for (uint32_t level = 0; level < BucketList::kNumLevels; ++level)
         {

--- a/src/bucket/test/BucketMergeMapTests.cpp
+++ b/src/bucket/test/BucketMergeMapTests.cpp
@@ -19,11 +19,8 @@ TEST_CASE("bucket merge map", "[bucket][bucketmergemap]")
     Application::pointer app = createTestApplication(clock, cfg);
 
     auto getValidBucket = [&](int numEntries = 10) {
-        std::vector<LedgerEntry> live(numEntries);
-        for (auto& e : live)
-        {
-            e = LedgerTestUtils::generateValidLedgerEntry(3);
-        }
+        std::vector<LedgerEntry> live =
+            LedgerTestUtils::generateValidUniqueLedgerEntries(numEntries);
         std::shared_ptr<Bucket> b1 = Bucket::fresh(
             app->getBucketManager(), BucketTestUtils::getAppLedgerVersion(app),
             {}, live, {},

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1197,7 +1197,8 @@ HerderImpl::setUpgrades(Upgrades::UpgradeParameters const& upgrades)
 std::string
 HerderImpl::getUpgradesJson()
 {
-    return mUpgrades.getParameters().toJson();
+    LedgerTxn ltx(mApp.getLedgerTxnRoot());
+    return mUpgrades.getParameters().toDebugJson(ltx);
 }
 
 void

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1127,7 +1127,11 @@ HerderImpl::triggerNextLedger(uint32_t ledgerSeqToTrigger,
     auto newUpgrades = emptyUpgradeSteps;
 
     // see if we need to include some upgrades
-    auto upgrades = mUpgrades.createUpgradesFor(lcl.header);
+    std::vector<LedgerUpgrade> upgrades;
+    {
+        LedgerTxn ltx(mApp.getLedgerTxnRoot());
+        upgrades = mUpgrades.createUpgradesFor(lcl.header, ltx);
+    }
     for (auto const& upgrade : upgrades)
     {
         Value v(xdr::xdr_to_opaque(upgrade));
@@ -1744,7 +1748,9 @@ HerderImpl::restoreUpgrades()
     if (!s.empty())
     {
         Upgrades::UpgradeParameters p;
-        p.fromJson(s);
+
+        LedgerTxn ltx(mApp.getLedgerTxnRoot());
+        p.fromJson(s, ltx);
         try
         {
             // use common code to set status

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -360,18 +360,19 @@ HerderSCPDriver::validateValue(uint64_t slotIndex, Value const& value,
         auto const& lcl = mLedgerManager.getLastClosedLedgerHeader();
 
         LedgerUpgradeType lastUpgradeType = LEDGER_UPGRADE_VERSION;
+
         // check upgrades
         for (size_t i = 0;
              i < b.upgrades.size() && res != SCPDriver::kInvalidValue; i++)
         {
             LedgerUpgradeType thisUpgradeType;
             if (!mUpgrades.isValid(b.upgrades[i], thisUpgradeType, nomination,
-                                   mApp.getConfig(), lcl.header))
+                                   mApp, lcl.header))
             {
-                CLOG_TRACE(
-                    Herder,
-                    "HerderSCPDriver::validateValue invalid step at index {}",
-                    i);
+                CLOG_TRACE(Herder,
+                           "HerderSCPDriver::validateValue invalid step at "
+                           "index {}",
+                           i);
                 res = SCPDriver::kInvalidValue;
             }
             else if (i != 0 && (lastUpgradeType >= thisUpgradeType))
@@ -421,7 +422,7 @@ HerderSCPDriver::extractValidValue(uint64_t slotIndex, Value const& value)
         LedgerUpgradeType thisUpgradeType;
         for (auto it = b.upgrades.begin(); it != b.upgrades.end();)
         {
-            if (!mUpgrades.isValid(*it, thisUpgradeType, true, mApp.getConfig(),
+            if (!mUpgrades.isValid(*it, thisUpgradeType, true, mApp,
                                    lcl.header))
             {
                 it = b.upgrades.erase(it);

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -205,40 +205,41 @@ Upgrades::getParameters() const
 }
 
 std::vector<LedgerUpgrade>
-Upgrades::createUpgradesFor(LedgerHeader const& header,
+Upgrades::createUpgradesFor(LedgerHeader const& lclHeader,
                             AbstractLedgerTxn& ltx) const
 {
     auto result = std::vector<LedgerUpgrade>{};
-    if (!timeForUpgrade(header.scpValue.closeTime))
+    if (!timeForUpgrade(lclHeader.scpValue.closeTime))
     {
         return result;
     }
 
     if (mParams.mProtocolVersion &&
-        (header.ledgerVersion != *mParams.mProtocolVersion))
+        (lclHeader.ledgerVersion != *mParams.mProtocolVersion))
     {
         result.emplace_back(LEDGER_UPGRADE_VERSION);
         result.back().newLedgerVersion() = *mParams.mProtocolVersion;
     }
-    if (mParams.mBaseFee && (header.baseFee != *mParams.mBaseFee))
+    if (mParams.mBaseFee && (lclHeader.baseFee != *mParams.mBaseFee))
     {
         result.emplace_back(LEDGER_UPGRADE_BASE_FEE);
         result.back().newBaseFee() = *mParams.mBaseFee;
     }
     if (mParams.mMaxTxSetSize &&
-        (header.maxTxSetSize != *mParams.mMaxTxSetSize))
+        (lclHeader.maxTxSetSize != *mParams.mMaxTxSetSize))
     {
         result.emplace_back(LEDGER_UPGRADE_MAX_TX_SET_SIZE);
         result.back().newMaxTxSetSize() = *mParams.mMaxTxSetSize;
     }
-    if (mParams.mBaseReserve && (header.baseReserve != *mParams.mBaseReserve))
+    if (mParams.mBaseReserve &&
+        (lclHeader.baseReserve != *mParams.mBaseReserve))
     {
         result.emplace_back(LEDGER_UPGRADE_BASE_RESERVE);
         result.back().newBaseReserve() = *mParams.mBaseReserve;
     }
     if (mParams.mFlags)
     {
-        if (LedgerHeaderUtils::getFlags(header) != *mParams.mFlags)
+        if (LedgerHeaderUtils::getFlags(lclHeader) != *mParams.mFlags)
         {
             result.emplace_back(LEDGER_UPGRADE_FLAGS);
             result.back().newFlags() = *mParams.mFlags;

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -62,6 +62,7 @@ class Upgrades
 
         std::string toJson() const;
         void fromJson(std::string const& s, stellar::AbstractLedgerTxn& ltx);
+        std::string toDebugJson(stellar::AbstractLedgerTxn& ltx) const;
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
         std::optional<ConfigUpgradeSetKey> mConfigUpgradeSetKey;

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -78,7 +78,7 @@ class Upgrades
     UpgradeParameters const& getParameters() const;
 
     // create upgrades for given ledger
-    std::vector<LedgerUpgrade> createUpgradesFor(LedgerHeader const& header,
+    std::vector<LedgerUpgrade> createUpgradesFor(LedgerHeader const& lclHeader,
                                                  AbstractLedgerTxn& ltx) const;
 
     // apply upgrade to ledger header

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2852,7 +2852,7 @@ TEST_CASE("upgrade to generalized tx set in network", "[upgrades][overlay]")
     auto simulation = Topologies::core(
         4, 0.75, Simulation::OVER_LOOPBACK, networkID, [](int i) {
             auto cfg = getTestConfig(i, Config::TESTDB_ON_DISK_SQLITE);
-            cfg.MAX_SLOTS_TO_REMEMBER = 10;
+            cfg.MAX_SLOTS_TO_REMEMBER = 12;
             cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
                 static_cast<uint32_t>(GENERALIZED_TX_SET_PROTOCOL_VERSION) - 1;
             return cfg;
@@ -2921,7 +2921,7 @@ TEST_CASE("upgrade to generalized tx set in network", "[upgrades][overlay]")
     }
     // Let the network to externalize 1 more ledger.
     simulation->crankUntil(
-        [&]() { return simulation->haveAllExternalized(12, 10); },
+        [&]() { return simulation->haveAllExternalized(12, 12); },
         Herder::EXP_LEDGER_TIMESPAN_SECONDS * 2, false);
 
     auto getLedgerTxSet = [](Application& node, uint32_t ledger) {

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1143,8 +1143,9 @@ TEST_CASE_VERSIONS(
             while (hm.getPublishQueueCount() != 1)
             {
                 uint32_t ledger = lm.getLastClosedLedgerNum() + 1;
-                bl.addBatch(*app, ledger, cfg.LEDGER_PROTOCOL_VERSION, {},
-                            LedgerTestUtils::generateValidLedgerEntries(8), {});
+                bl.addBatch(
+                    *app, ledger, cfg.LEDGER_PROTOCOL_VERSION, {},
+                    LedgerTestUtils::generateValidUniqueLedgerEntries(8), {});
                 clock.crank(true);
             }
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -136,7 +136,7 @@ std::pair<std::string, uint256>
 BucketOutputIteratorForTesting::writeTmpTestBucket()
 {
     auto ledgerEntries =
-        LedgerTestUtils::generateValidLedgerEntries(NUM_ITEMS_PER_BUCKET);
+        LedgerTestUtils::generateValidUniqueLedgerEntries(NUM_ITEMS_PER_BUCKET);
     auto bucketEntries =
         Bucket::convertToBucketEntry(false, {}, ledgerEntries, {});
     for (auto const& bucketEntry : bucketEntries)

--- a/src/invariant/AccountSubEntriesCountIsValid.cpp
+++ b/src/invariant/AccountSubEntriesCountIsValid.cpp
@@ -96,19 +96,14 @@ updateChangedSubEntriesCount(
     }
     case CLAIMABLE_BALANCE:
     case LIQUIDITY_POOL:
-    {
-        // claimable balance and liquidity pools are not subentries
-        break;
-    }
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     case CONTRACT_DATA:
     case CONTRACT_CODE:
     case CONFIG_SETTING:
-    {
-        // contract entries are not subentries
-        break;
-    }
 #endif
+        // Claimable balances, liquidity pools, contract data and configuration
+        // settings are not subentries
+        break;
     default:
         abort();
     }

--- a/src/invariant/test/SponsorshipCountIsValidTests.cpp
+++ b/src/invariant/test/SponsorshipCountIsValidTests.cpp
@@ -72,6 +72,11 @@ TEST_CASE("sponsorship invariant", "[invariant][sponsorshipcountisvalid]")
             le.data.claimableBalance() =
                 LedgerTestUtils::generateValidClaimableBalanceEntry();
             break;
+        case LIQUIDITY_POOL:
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        case CONTRACT_DATA:
+        case CONFIG_SETTING:
+#endif
         default:
             abort();
         }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -740,12 +740,16 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         case Upgrades::UpgradeValidity::VALID:
             break;
         case Upgrades::UpgradeValidity::XDR_INVALID:
-            throw std::runtime_error(
-                fmt::format(FMT_STRING("Unknown upgrade at index {:d}"), i));
+        {
+            CLOG_ERROR(Ledger, "Unknown upgrade at index {}", i);
+            continue;
+        }
         case Upgrades::UpgradeValidity::INVALID:
-            throw std::runtime_error(
-                fmt::format(FMT_STRING("Invalid upgrade at index {:d}: {}"), i,
-                            xdr_to_string(lupgrade, "LedgerUpgrade")));
+        {
+            CLOG_ERROR(Ledger, "Invalid upgrade at index {}: {}", i,
+                       xdr_to_string(lupgrade, "LedgerUpgrade"));
+            continue;
+        }
         }
 
         try

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -733,9 +733,8 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     for (size_t i = 0; i < sv.upgrades.size(); i++)
     {
         LedgerUpgrade lupgrade;
-        auto valid = Upgrades::isValidForApply(
-            sv.upgrades[i], lupgrade, ltx.loadHeader().current(),
-            mApp.getConfig().LEDGER_PROTOCOL_VERSION);
+        auto valid = Upgrades::isValidForApply(sv.upgrades[i], lupgrade, mApp,
+                                               ltx, ltx.loadHeader().current());
         switch (valid)
         {
         case Upgrades::UpgradeValidity::VALID:
@@ -752,7 +751,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         try
         {
             LedgerTxn ltxUpgrade(ltx);
-            Upgrades::applyTo(lupgrade, ltxUpgrade);
+            Upgrades::applyTo(lupgrade, mApp, ltxUpgrade);
 
             auto ledgerSeq = ltxUpgrade.loadHeader().current().ledgerSeq;
             LedgerEntryChanges changes = ltxUpgrade.getChanges();

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -76,7 +76,6 @@ class BulkLedgerEntryChangeAccumulator
     std::vector<EntryIterator> mContractCodeToUpsert;
     std::vector<EntryIterator> mContractCodeToDelete;
     std::vector<EntryIterator> mConfigSettingsToUpsert;
-    std::vector<EntryIterator> mConfigSettingsToDelete;
 #endif
 
   public:
@@ -157,12 +156,6 @@ class BulkLedgerEntryChangeAccumulator
     getConfigSettingsToUpsert()
     {
         return mConfigSettingsToUpsert;
-    }
-
-    std::vector<EntryIterator>&
-    getConfigSettingsToDelete()
-    {
-        return mConfigSettingsToDelete;
     }
 
     std::vector<EntryIterator>&
@@ -392,6 +385,7 @@ class LedgerTxn::Impl
     void throwIfChild() const;
     void throwIfSealed() const;
     void throwIfNotExactConsistency() const;
+    void throwIfErasingConfig(InternalLedgerKey const& key) const;
 
     // getDeltaVotes has the basic exception safety guarantee. If it throws an
     // exception, then
@@ -808,8 +802,6 @@ class LedgerTxnRoot::Impl
     void bulkDeleteContractCode(std::vector<EntryIterator> const& entries,
                                 LedgerTxnConsistency cons);
     void bulkUpsertConfigSettings(std::vector<EntryIterator> const& entries);
-    void bulkDeleteConfigSettings(std::vector<EntryIterator> const& entries,
-                                  LedgerTxnConsistency cons);
 #endif
 
     static std::string tableFromLedgerEntryType(LedgerEntryType let);

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -5,9 +5,11 @@
 #include "LedgerTestUtils.h"
 #include "crypto/SHA.h"
 #include "crypto/SecretKey.h"
+#include "ledger/LedgerHashUtils.h"
 #include "main/Config.h"
 #include "util/Logging.h"
 #include "util/Math.h"
+#include "util/UnorderedSet.h"
 #include "util/types.h"
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 #include "xdr/Stellar-contract.h"
@@ -123,8 +125,9 @@ randomlyModifyEntry(LedgerEntry& e)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     case CONFIG_SETTING:
     {
-        e.data.configSetting().setting.type(CONFIG_SETTING_TYPE_UINT32);
-        e.data.configSetting().setting.uint32Val() =
+        e.data.configSetting().configSettingID(
+            CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
+        e.data.configSetting().contractMaxSizeBytes() =
             autocheck::generator<uint32_t>{}();
         makeValid(e.data.configSetting());
         break;
@@ -326,8 +329,8 @@ void
 makeValid(ConfigSettingEntry& ce)
 {
     auto ids = xdr::xdr_traits<ConfigSettingID>::enum_values();
-    ce.configSettingID =
-        static_cast<ConfigSettingID>(ids.at(ce.configSettingID % ids.size()));
+    ce.configSettingID(static_cast<ConfigSettingID>(
+        ids.at(ce.configSettingID() % ids.size())));
 }
 
 void
@@ -401,7 +404,7 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
     }
 }
 
-static auto validLedgerEntryGeneratorMaybeIncludingConfig = autocheck::map(
+static auto validLedgerEntryGenerator = autocheck::map(
     [](LedgerEntry&& le, size_t s) {
         auto& led = le.data;
         le.lastModifiedLedgerSeq = le.lastModifiedLedgerSeq & INT32_MAX;
@@ -441,20 +444,6 @@ static auto validLedgerEntryGeneratorMaybeIncludingConfig = autocheck::map(
         return std::move(le);
     },
     autocheck::generator<LedgerEntry>());
-
-// When compiling the next protocol version we might be able to generate
-// CONFIG_SETTING entries, but we explicitly exclude them from the default
-// generator here because they violate an assumption that the rest of the
-// machinery here makes: that randomly generated keys are (statistically)
-// guaranteed to be disjoint.
-static auto validLedgerEntryGenerator =
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    autocheck::such_that(
-        [](LedgerEntry const& le) { return le.data.type() != CONFIG_SETTING; },
-        validLedgerEntryGeneratorMaybeIncludingConfig);
-#else
-    validLedgerEntryGeneratorMaybeIncludingConfig;
-#endif
 
 static auto ledgerKeyGenerator =
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
@@ -536,6 +525,17 @@ generateValidLedgerEntry(size_t b)
     return validLedgerEntryGenerator(b);
 }
 
+LedgerEntry
+generateValidLedgerEntryOfType(LedgerEntryType type)
+{
+    auto entry = generateValidLedgerEntry();
+    while (entry.data.type() != type)
+    {
+        entry = generateValidLedgerEntry();
+    }
+    return entry;
+}
+
 std::vector<LedgerEntry>
 generateValidLedgerEntries(size_t n)
 {
@@ -543,17 +543,65 @@ generateValidLedgerEntries(size_t n)
     return vecgen(n);
 }
 
-LedgerKey
-generateLedgerKey(size_t n)
+std::vector<LedgerEntry>
+generateValidUniqueLedgerEntries(size_t n)
 {
-    return ledgerKeyGenerator(n);
+    UnorderedSet<LedgerKey> keys;
+    std::vector<LedgerEntry> entries;
+    while (entries.size() < n)
+    {
+        auto entry = generateValidLedgerEntry();
+        auto key = LedgerEntryKey(entry);
+        if (keys.find(key) != keys.end())
+        {
+            continue;
+        }
+        keys.insert(key);
+        entries.push_back(entry);
+    }
+    return entries;
+}
+
+LedgerEntry
+generateValidLedgerEntryWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b)
+{
+    while (true)
+    {
+        auto entry = generateValidLedgerEntry(b);
+        if (excludedTypes.find(entry.data.type()) == excludedTypes.end())
+        {
+            return entry;
+        }
+    }
+}
+
+std::vector<LedgerEntry>
+generateValidLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
+{
+    std::vector<LedgerEntry> res;
+    res.reserve(n);
+    for (int i = 0; i < n; ++i)
+    {
+        res.push_back(generateValidLedgerEntryWithExclusions(excludedTypes));
+    }
+    return res;
 }
 
 std::vector<LedgerKey>
-generateLedgerKeys(size_t n)
+generateValidLedgerEntryKeysWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
 {
-    static auto vecgen = autocheck::list_of(ledgerKeyGenerator);
-    return vecgen(n);
+    auto entries = LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+        excludedTypes, n);
+    std::vector<LedgerKey> keys;
+    keys.reserve(entries.size());
+    for (auto const& entry : entries)
+    {
+        keys.push_back(LedgerEntryKey(entry));
+    }
+    return keys;
 }
 
 AccountEntry

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -38,11 +38,18 @@ void makeValid(LedgerHeaderHistoryEntry& lh,
                HistoryManager::LedgerVerificationStatus state);
 
 LedgerEntry generateValidLedgerEntry(size_t b = 3);
-std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
+LedgerEntry generateValidLedgerEntryOfType(LedgerEntryType type);
 
-// Use this instead of generator<LedgerKey> to avoid CONFIG_SETTING
-LedgerKey generateLedgerKey(size_t n);
-std::vector<LedgerKey> generateLedgerKeys(size_t n);
+std::vector<LedgerEntry> generateValidLedgerEntries(size_t n);
+std::vector<LedgerEntry> generateValidUniqueLedgerEntries(size_t n);
+
+std::vector<LedgerKey> generateValidLedgerEntryKeysWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
+
+LedgerEntry generateValidLedgerEntryWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b = 3);
+std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
 
 AccountEntry generateValidAccountEntry(size_t b = 3);
 std::vector<AccountEntry> generateValidAccountEntries(size_t n);

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -104,8 +104,8 @@ generateLedgerEntryWithSameKey(LedgerEntry const& leBase)
         case CONFIG_SETTING:
             le.data.configSetting() =
                 LedgerTestUtils::generateValidConfigSettingEntry();
-            le.data.configSetting().configSettingID =
-                leBase.data.configSetting().configSettingID;
+            le.data.configSetting().configSettingID(
+                leBase.data.configSetting().configSettingID());
             break;
         case CONTRACT_DATA:
             le.data.contractData() =
@@ -216,6 +216,13 @@ TEST_CASE("LedgerTxn commit into LedgerTxn", "[ledgertxn]")
 
         SECTION("erased in child")
         {
+            le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            key = LedgerEntryKey(le1);
+            le2 = generateLedgerEntryWithSameKey(le1);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le1));
 
@@ -287,6 +294,14 @@ TEST_CASE("LedgerTxn rollback into LedgerTxn", "[ledgertxn]")
 
             SECTION("erased in child")
             {
+                le1 = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                });
+                le1.lastModifiedLedgerSeq = 1;
+                key = LedgerEntryKey(le1);
+                le2 = generateLedgerEntryWithSameKey(le1);
                 LedgerTxn ltx1(app->getLedgerTxnRoot());
                 REQUIRE(ltx1.create(le1));
 
@@ -373,6 +388,12 @@ TEST_CASE("LedgerTxn round trip", "[ledgertxn]")
         {
             auto iter = entries.begin();
             std::advance(iter, dist(gRandomEngine));
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            if (iter->first.type() == CONFIG_SETTING)
+            {
+                continue;
+            }
+#endif
             eraseBatch.insert(iter->first);
         }
 
@@ -570,6 +591,13 @@ TEST_CASE("LedgerTxn create", "[ledgertxn]")
 
     SECTION("when key exists in grandparent, erased in parent")
     {
+        le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            CONFIG_SETTING
+#endif
+        });
+        le.lastModifiedLedgerSeq = 1;
+        key = LedgerEntryKey(le);
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         REQUIRE(ltx1.create(le));
 
@@ -651,6 +679,13 @@ TEST_CASE("LedgerTxn createWithoutLoading and updateWithoutLoading",
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -684,7 +719,12 @@ TEST_CASE("LedgerTxn erase", "[ledgertxn]")
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
+        LedgerEntry le =
+            LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
         le.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le);
 
@@ -704,6 +744,19 @@ TEST_CASE("LedgerTxn erase", "[ledgertxn]")
             ltx1.getDelta();
             REQUIRE_THROWS_AS(ltx1.erase(key), std::runtime_error);
         }
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        SECTION("fails for configuration")
+        {
+            auto configLe =
+                LedgerTestUtils::generateValidLedgerEntryOfType(CONFIG_SETTING);
+            configLe.lastModifiedLedgerSeq = 1;
+            LedgerTxn ltx1(app->getLedgerTxnRoot());
+            REQUIRE(ltx1.create(configLe));
+            REQUIRE_THROWS_AS(ltx1.erase(LedgerEntryKey(configLe)),
+                              std::runtime_error);
+        }
+#endif
 
         SECTION("when key does not exist")
         {
@@ -727,6 +780,13 @@ TEST_CASE("LedgerTxn erase", "[ledgertxn]")
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -757,7 +817,12 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
         VirtualClock clock;
         auto app = createTestApplication(clock, getTestConfig(0, mode));
 
-        LedgerEntry le = LedgerTestUtils::generateValidLedgerEntry();
+        LedgerEntry le =
+            LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
         le.lastModifiedLedgerSeq = 1;
         LedgerKey key = LedgerEntryKey(le);
 
@@ -781,7 +846,18 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
             REQUIRE_THROWS_AS(ltx1.eraseWithoutLoading(key),
                               std::runtime_error);
         }
-
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        SECTION("fails for configuration")
+        {
+            auto configLe =
+                LedgerTestUtils::generateValidLedgerEntryOfType(CONFIG_SETTING);
+            configLe.lastModifiedLedgerSeq = 1;
+            LedgerTxn ltx1(app->getLedgerTxnRoot());
+            REQUIRE(ltx1.create(configLe));
+            REQUIRE_THROWS_AS(ltx1.erase(LedgerEntryKey(configLe)),
+                              std::runtime_error);
+        }
+#endif
         SECTION("when key does not exist")
         {
             LedgerTxn ltx1(app->getLedgerTxnRoot());
@@ -803,6 +879,13 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
 
         SECTION("when key exists in grandparent, erased in parent")
         {
+            le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                CONFIG_SETTING
+#endif
+            });
+            le.lastModifiedLedgerSeq = 1;
+            key = LedgerEntryKey(le);
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE(ltx1.create(le));
 
@@ -1333,6 +1416,15 @@ TEST_CASE_VERSIONS("LedgerTxn load", "[ledgertxn]")
 
                 SECTION("when key exists in grandparent, erased in parent")
                 {
+                    le =
+                        LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                            {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                                CONFIG_SETTING
+#endif
+                            });
+                    le.lastModifiedLedgerSeq = 1;
+                    key = LedgerEntryKey(le);
                     LedgerTxn ltx1(app->getLedgerTxnRoot());
                     REQUIRE(ltx1.create(le));
 
@@ -1410,8 +1502,7 @@ TEST_CASE_VERSIONS("LedgerTxn load", "[ledgertxn]")
                     {
                         for (int i = 0; i < 1000; ++i)
                         {
-                            LedgerKey lk =
-                                LedgerTestUtils::generateLedgerKey(5);
+                            LedgerKey lk = autocheck::generator<LedgerKey>()(5);
 
                             try
                             {
@@ -1487,6 +1578,13 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
 
     SECTION("when key exists in grandparent, erased in parent")
     {
+        le = LedgerTestUtils::generateValidLedgerEntryWithExclusions({
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            CONFIG_SETTING
+#endif
+        });
+        le.lastModifiedLedgerSeq = 1;
+        key = LedgerEntryKey(le);
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         REQUIRE(ltx1.create(le));
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -199,6 +199,14 @@ checkXDRFileIdentity()
                             cpp.first, cpp.second));
         }
     }
+
+    if (stellar::XDR_FILES_SHA256.size() != rustHashes.size())
+    {
+        throw std::runtime_error(
+            fmt::format("Number of xdr hashes don't match between C++ and "
+                        "Rust. C++ size = {} and Rust size = {}.",
+                        stellar::XDR_FILES_SHA256.size(), rustHashes.size()));
+    }
 }
 #endif
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -16,11 +16,11 @@ base64 = "0.13.0"
 rustc-simple-version = "0.1.0"
 
 [dependencies.soroban-env-host]
-version = "0.0.14"
+version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "75b21696b0636bd145b7acb47a6fed4621b05978"
+rev = "aa7424dc2ea8db1391365e229f550d726734ae55"
 features = ["vm"]
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "75b21696b0636bd145b7acb47a6fed4621b05978"
+rev = "aa7424dc2ea8db1391365e229f550d726734ae55"

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -560,7 +560,10 @@ pub(crate) fn get_test_wasm_add_i32() -> Result<RustBuf, Box<dyn Error>> {
 }
 pub(crate) fn get_test_wasm_contract_data() -> Result<RustBuf, Box<dyn Error>> {
     Ok(RustBuf {
-        data: soroban_test_wasms::CONTRACT_DATA.iter().cloned().collect(),
+        data: soroban_test_wasms::CONTRACT_STORAGE
+            .iter()
+            .cloned()
+            .collect(),
     })
 }
 

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -191,6 +191,6 @@ fn get_soroban_xdr_bindings_base_xdr_git_version() -> String {
     match soroban_env_host::VERSION.xdr.xdr {
         "next" => soroban_env_host::VERSION.xdr.xdr_next.to_string(),
         "curr" => soroban_env_host::VERSION.xdr.xdr_curr.to_string(),
-        _ => "unknown configuration".to_string()
+        _ => "unknown configuration".to_string(),
     }
 }

--- a/src/simulation/CoreTests.cpp
+++ b/src/simulation/CoreTests.cpp
@@ -689,7 +689,13 @@ TEST_CASE("Bucket list entries vs write throughput", "[scalability][!hide]")
             *app, i, Config::CURRENT_LEDGER_PROTOCOL_VERSION,
             LedgerTestUtils::generateValidLedgerEntries(100),
             LedgerTestUtils::generateValidLedgerEntries(20),
-            LedgerTestUtils::generateLedgerKeys(5));
+            LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
+                {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                },
+                5));
 
         if ((i & 0xff) == 0xff)
         {

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -243,7 +243,7 @@ generateStoredLedgerKeys(StoredLedgerKeys::iterator begin,
     // Generate unvalidated ledger entry keys.
     std::generate(firstUnvalidatedLedgerKey, end, []() {
         size_t const entrySize = 3;
-        return LedgerTestUtils::generateLedgerKey(entrySize);
+        return autocheck::generator<LedgerKey>()(entrySize);
     });
 }
 

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -282,9 +282,11 @@ transactionFrameFromOps(Hash const& networkID, TestAccount& source,
 LedgerUpgrade makeBaseReserveUpgrade(int baseReserve);
 
 LedgerHeader executeUpgrades(Application& app,
-                             xdr::xvector<UpgradeType, 6> const& upgrades);
+                             xdr::xvector<UpgradeType, 6> const& upgrades,
+                             bool upgradesIgnored = false);
 
-LedgerHeader executeUpgrade(Application& app, LedgerUpgrade const& lupgrade);
+LedgerHeader executeUpgrade(Application& app, LedgerUpgrade const& lupgrade,
+                            bool upgradeIgnored = false);
 
 void
 depositTradeWithdrawTest(Application& app, TestAccount& root, int depositSize,

--- a/src/transactions/simulation/TxSimUtils.cpp
+++ b/src/transactions/simulation/TxSimUtils.cpp
@@ -391,6 +391,8 @@ generateScaledLiveEntries(
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
         case CONFIG_SETTING:
         case CONTRACT_DATA:
+            // Don't do anything for now.
+            break;
 #endif
         default:
             abort();

--- a/src/util/types.cpp
+++ b/src/util/types.cpp
@@ -60,7 +60,7 @@ LedgerEntryKey(LedgerEntry const& e)
         k.contractCode().hash = d.contractCode().hash;
         break;
     case CONFIG_SETTING:
-        k.configSetting().configSettingID = d.configSetting().configSettingID;
+        k.configSetting().configSettingID = d.configSetting().configSettingID();
         break;
 #endif
 


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/rs-soroban-env/issues/664.

Add a mechanism to propose upgrades that are stored in ContractData ledger entries. This PR is built on top of https://github.com/stellar/stellar-core/pull/3522, and starts with the "ConfigSettingEntry upgrades" commit.

Related xdr change - https://github.com/stellar/stellar-xdr/pull/75.

xdr has not been merged in yet so this PR will fail until that happens.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
