### PR TITLE
Use less-rigorously-checked rustup in devcontainer due to bug in vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -67,7 +67,12 @@ RUN apt-get -y install cpp-10 gcc-10 g++-10
 # clang
 RUN apt-get -y install clang-12 llvm-12
 # rust
-RUN ./install-rust.sh
+# there is a bug in vscode's handling of devcontainer contexts that means
+# we can't access files outside this directory even with build.context,
+# but since we're building inside a container and only doing so for local
+# development, the security risks of running the normal rustup installer
+# are considerably less; for now we will tolerate them.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH "/root/.cargo/bin:$PATH"
 
 # clang by default


### PR DESCRIPTION
This is a "fix" for #3679 that I am not especially thrilled with but I spent half a day trying to fix it better and concluded that vscode's devcontainers don't really support anything better (build.context doesn't, for example, do what it's documented to do, and there appears to be no way to COPY or ADD things from outside the .devcontainer directory). Feel free to fix better sometime if this version distresses you, but .. I think the qualifiers in the comment here are accurate (it's really not much of a risk, this isn't building canonical packages or even CI) and .. I also think devcontainer use of stellar-core is probably not something that's ever going to work well. It's exceedingly slow and fragile.
