### PR TITLE
Fix reporting of base XDR git version (was reporting "next")

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -188,5 +188,9 @@ fn get_soroban_xdr_bindings_git_version() -> String {
 }
 
 fn get_soroban_xdr_bindings_base_xdr_git_version() -> String {
-    soroban_env_host::VERSION.xdr.xdr.to_string()
+    match soroban_env_host::VERSION.xdr.xdr {
+        "next" => soroban_env_host::VERSION.xdr.xdr_next.to_string(),
+        "curr" => soroban_env_host::VERSION.xdr.xdr_curr.to_string(),
+        _ => "unknown configuration".to_string()
+    }
 }


### PR DESCRIPTION
In [this change](https://github.com/stellar/rs-stellar-xdr/commit/32830380260b1e049338bfc9a368d7d1ddae7c10#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R91-R115) @leighmcculloch changed the meaning of one of the version fields from rs-stellar-xdr. As a result, lately we've just been reporting the string `"next"` for the base XDR git version, rather than a proper hash.

This PR adapts to the change and thus fixes the externally observable behaviour back to what it was before.
 
Before this change:

```
$ ./src/stellar-core version
v19.8.0-33-g53ea43ace
rust version: rustc 1.68.0 (2c8cc3432 2023-03-06)
soroban-env-host: 
    package version: 0.0.14
    git version: 7dde7cb0b35957856a1e0c11432e00532ae20cf8
    interface version: 32
    rs-stellar-xdr:
        package version: 0.0.14
        git version: 07aff1190dc3f97b889d31b2bfb77098e7db55ce
        base XDR git version: next
```

With this change:

```
$ ./src/stellar-core version
v19.8.0-33-g53ea43ace-dirty
rust version: rustc 1.68.0 (2c8cc3432 2023-03-06)
soroban-env-host: 
    package version: 0.0.14
    git version: 7dde7cb0b35957856a1e0c11432e00532ae20cf8
    interface version: 32
    rs-stellar-xdr:
        package version: 0.0.14
        git version: 07aff1190dc3f97b889d31b2bfb77098e7db55ce
        base XDR git version: 7356dc237ee0db5626561c129fb3fa4beaabbac6
```