### PR TITLE
overlay tech debt: flow control

### DIFF
--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -1,0 +1,425 @@
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/FlowControl.h"
+#include "herder/Herder.h"
+#include "main/Application.h"
+#include "medida/meter.h"
+#include "medida/metrics_registry.h"
+#include "medida/timer.h"
+#include "overlay/OverlayManager.h"
+#include "overlay/OverlayMetrics.h"
+#include "util/Logging.h"
+#include <Tracy.hpp>
+
+namespace stellar
+{
+
+constexpr std::chrono::seconds const OUTBOUND_QUEUE_TIMEOUT =
+    std::chrono::seconds(30);
+
+FlowControl::FlowControl(Application& app)
+    : mApp(app)
+    , mNoOutboundCapacity(
+          std::make_optional<VirtualClock::time_point>(app.getClock().now()))
+{
+    mFlowControlCapacity =
+        std::make_shared<FlowControlMessageCapacity>(mApp, mNodeID);
+}
+
+void
+FlowControl::sendSendMore(uint32_t numMessages, std::shared_ptr<Peer> peer)
+{
+    ZoneScoped;
+    StellarMessage m;
+    m.type(SEND_MORE);
+    m.sendMoreMessage().numMessages = numMessages;
+    auto msgPtr = std::make_shared<StellarMessage const>(m);
+    peer->sendMessage(msgPtr);
+}
+
+// Start flow control: send SEND_MORE to a peer to indicate available capacity
+void
+FlowControl::start(std::weak_ptr<Peer> peer,
+                   std::function<void(StellarMessage const&)> sendCb)
+{
+    auto peerPtr = peer.lock();
+    if (!peerPtr)
+    {
+        return;
+    }
+
+    mNodeID = peerPtr->getPeerID();
+    mSendCallback = sendCb;
+    sendSendMore(mApp.getConfig().PEER_FLOOD_READING_CAPACITY, peerPtr);
+}
+
+void
+FlowControl::maybeReleaseCapacityAndTriggerSend(StellarMessage const& msg)
+{
+    ZoneScoped;
+    if (msg.type() == SEND_MORE)
+    {
+        releaseAssert(getNumMessages(msg) > 0);
+        mNoOutboundCapacity.reset();
+        mFlowControlCapacity->releaseOutboundCapacity(msg);
+
+        CLOG_TRACE(Overlay, "{}: Peer {} sent SEND_MORE {}",
+                   mApp.getConfig().toShortString(
+                       mApp.getConfig().NODE_SEED.getPublicKey()),
+                   mApp.getConfig().toShortString(mNodeID),
+                   getNumMessages(msg));
+
+        // SEND_MORE means we can free some capacity, and dump the next batch of
+        // messages onto the writing queue
+        maybeSendNextBatch();
+    }
+}
+
+void
+FlowControl::maybeSendNextBatch()
+{
+    ZoneScoped;
+
+    if (!mSendCallback)
+    {
+        throw std::runtime_error(
+            "MaybeSendNextBatch: FLowControl was not started properly");
+    }
+
+    int sent = 0;
+    for (int i = 0; i < mOutboundQueues.size(); i++)
+    {
+        auto& queue = mOutboundQueues[i];
+        while (!queue.empty())
+        {
+            auto& front = queue.front();
+            auto const& msg = *(front.mMessage);
+            if (!mFlowControlCapacity->hasOutboundCapacity(msg))
+            {
+                break;
+            }
+
+            mSendCallback(msg);
+            ++sent;
+            auto& om = mApp.getOverlayManager().getOverlayMetrics();
+
+            auto const& diff = mApp.getClock().now() - front.mTimeEmplaced;
+            mFlowControlCapacity->lockOutboundCapacity(msg);
+            switch (front.mMessage->type())
+            {
+            case TRANSACTION:
+            {
+                om.mOutboundQueueDelayTxs.Update(diff);
+                mMetrics.mOutboundQueueDelayTxs.Update(diff);
+            }
+            break;
+            case SCP_MESSAGE:
+            {
+                om.mOutboundQueueDelaySCP.Update(diff);
+                mMetrics.mOutboundQueueDelaySCP.Update(diff);
+            }
+            break;
+            case FLOOD_DEMAND:
+            {
+                om.mOutboundQueueDelayDemand.Update(diff);
+                mMetrics.mOutboundQueueDelayDemand.Update(diff);
+                size_t s = front.mMessage->floodDemand().txHashes.size();
+                releaseAssert(mDemandQueueTxHashCount >= s);
+                mDemandQueueTxHashCount -= s;
+            }
+            break;
+            case FLOOD_ADVERT:
+            {
+                om.mOutboundQueueDelayAdvert.Update(diff);
+                mMetrics.mOutboundQueueDelayAdvert.Update(diff);
+                size_t s = front.mMessage->floodAdvert().txHashes.size();
+                releaseAssert(mAdvertQueueTxHashCount >= s);
+                mAdvertQueueTxHashCount -= s;
+            }
+            break;
+            default:
+                abort();
+            }
+            if (!mFlowControlCapacity->hasOutboundCapacity(msg))
+            {
+                CLOG_DEBUG(Overlay, "{}: No outbound capacity for peer {}",
+                           mApp.getConfig().toShortString(
+                               mApp.getConfig().NODE_SEED.getPublicKey()),
+                           mApp.getConfig().toShortString(mNodeID));
+                mNoOutboundCapacity =
+                    std::make_optional<VirtualClock::time_point>(
+                        mApp.getClock().now());
+            }
+            queue.pop_front();
+        }
+    }
+
+    CLOG_TRACE(Overlay, "{} Peer {}: send next flood batch of {}",
+               mApp.getConfig().toShortString(
+                   mApp.getConfig().NODE_SEED.getPublicKey()),
+               mApp.getConfig().toShortString(mNodeID), sent);
+}
+
+bool
+FlowControl::maybeSendMessage(std::shared_ptr<StellarMessage const> msg)
+{
+    ZoneScoped;
+    if (mApp.getOverlayManager().isFloodMessage(*msg))
+    {
+        addMsgAndMaybeTrimQueue(msg);
+        maybeSendNextBatch();
+        return true;
+    }
+    return false;
+}
+
+bool
+FlowControl::beginMessageProcessing(StellarMessage const& msg)
+{
+    return mFlowControlCapacity->lockLocalCapacity(msg);
+}
+
+void
+FlowControl::endMessageProcessing(StellarMessage const& msg,
+                                  std::weak_ptr<Peer> peer)
+{
+    ZoneScoped;
+
+    mFloodDataProcessed += mFlowControlCapacity->releaseLocalCapacity(msg);
+
+    releaseAssert(mFloodDataProcessed <=
+                  mApp.getConfig().FLOW_CONTROL_SEND_MORE_BATCH_SIZE);
+    bool shouldSendMore = mFloodDataProcessed ==
+                          mApp.getConfig().FLOW_CONTROL_SEND_MORE_BATCH_SIZE;
+    auto peerPtr = peer.lock();
+
+    if (shouldSendMore && peerPtr)
+    {
+        sendSendMore(mFloodDataProcessed, peerPtr);
+        mFloodDataProcessed = 0;
+    }
+}
+
+bool
+FlowControl::canRead() const
+{
+    return mFlowControlCapacity->getCapacity().mTotalCapacity > 0;
+}
+
+uint32_t
+FlowControl::getNumMessages(StellarMessage const& msg)
+{
+    releaseAssert(msg.type() == SEND_MORE);
+    return msg.sendMoreMessage().numMessages;
+}
+
+bool
+FlowControl::isSendMoreValid(StellarMessage const& msg,
+                             std::string& errorMsg) const
+{
+    releaseAssert(msg.type() == SEND_MORE);
+    if (getNumMessages(msg) == 0)
+    {
+        errorMsg =
+            fmt::format("unexpected {} message",
+                        xdr::xdr_traits<MessageType>::enum_name(msg.type()));
+        return false;
+    }
+
+    auto overflow = getNumMessages(msg) >
+                    (UINT64_MAX - mFlowControlCapacity->getOutboundCapacity());
+    if (overflow)
+    {
+        errorMsg = "Peer capacity overflow";
+        return false;
+    }
+    return true;
+}
+
+bool
+dropMessageAfterTimeout(FlowControl::QueuedOutboundMessage const& queuedMsg,
+                        VirtualClock::time_point now)
+{
+    auto const& msg = *(queuedMsg.mMessage);
+    bool dropType = msg.type() == TRANSACTION || msg.type() == FLOOD_ADVERT ||
+                    msg.type() == FLOOD_DEMAND;
+    return dropType && (now - queuedMsg.mTimeEmplaced > OUTBOUND_QUEUE_TIMEOUT);
+}
+
+void
+FlowControl::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
+{
+    ZoneScoped;
+
+    releaseAssert(msg);
+    auto type = msg->type();
+    size_t msgQInd = 0;
+    auto now = mApp.getClock().now();
+
+    switch (type)
+    {
+    case SCP_MESSAGE:
+    {
+        msgQInd = 0;
+    }
+    break;
+    case TRANSACTION:
+    {
+        msgQInd = 1;
+    }
+    break;
+    case FLOOD_DEMAND:
+    {
+        msgQInd = 2;
+        size_t s = msg->floodDemand().txHashes.size();
+        mDemandQueueTxHashCount += s;
+    }
+    break;
+    case FLOOD_ADVERT:
+    {
+        msgQInd = 3;
+        size_t s = msg->floodAdvert().txHashes.size();
+        mAdvertQueueTxHashCount += s;
+    }
+    break;
+    default:
+        abort();
+    }
+    auto& queue = mOutboundQueues[msgQInd];
+
+    queue.emplace_back(QueuedOutboundMessage{msg, mApp.getClock().now()});
+
+    size_t dropped = 0;
+
+    uint32_t const limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
+    auto& om = mApp.getOverlayManager().getOverlayMetrics();
+    if (type == TRANSACTION)
+    {
+        if (queue.size() > limit)
+        {
+            dropped = queue.size() - limit;
+            queue.erase(queue.begin(), queue.begin() + dropped);
+        }
+        while (!queue.empty() && dropMessageAfterTimeout(queue.front(), now))
+        {
+            ++dropped;
+            queue.pop_front();
+        }
+        om.mOutboundQueueDropTxs.Mark(dropped);
+    }
+    else if (type == SCP_MESSAGE)
+    {
+        // Iterate over the message queue. If we found any messages for slots we
+        // don't keep in-memory anymore, delete those. Otherwise, compare
+        // messages for the same slot and validator against the latest SCP
+        // message and drop
+        auto minSlotToRemember = mApp.getHerder().getMinLedgerSeqToRemember();
+        bool valueReplaced = false;
+
+        for (auto it = queue.begin(); it != queue.end();)
+        {
+            if (it->mMessage->envelope().statement.slotIndex <
+                minSlotToRemember)
+            {
+                it = queue.erase(it);
+                dropped++;
+            }
+            else if (!valueReplaced && it != queue.end() - 1 &&
+                     mApp.getHerder().isNewerNominationOrBallotSt(
+                         it->mMessage->envelope().statement,
+                         queue.back().mMessage->envelope().statement))
+            {
+                valueReplaced = true;
+                *it = std::move(queue.back());
+                queue.pop_back();
+                dropped++;
+                ++it;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+        om.mOutboundQueueDropSCP.Mark(dropped);
+    }
+    else if (type == FLOOD_ADVERT)
+    {
+        while (mAdvertQueueTxHashCount > limit ||
+               (!queue.empty() && dropMessageAfterTimeout(queue.front(), now)))
+        {
+            dropped++;
+            size_t s = queue.front().mMessage->floodAdvert().txHashes.size();
+            releaseAssert(mAdvertQueueTxHashCount >= s);
+            mAdvertQueueTxHashCount -= s;
+            queue.pop_front();
+        }
+        om.mOutboundQueueDropAdvert.Mark(dropped);
+    }
+    else if (type == FLOOD_DEMAND)
+    {
+        while (mDemandQueueTxHashCount > limit ||
+               (!queue.empty() && dropMessageAfterTimeout(queue.front(), now)))
+        {
+            dropped++;
+            size_t s = queue.front().mMessage->floodDemand().txHashes.size();
+            releaseAssert(mDemandQueueTxHashCount >= s);
+            mDemandQueueTxHashCount -= s;
+            queue.pop_front();
+        }
+        om.mOutboundQueueDropDemand.Mark(dropped);
+    }
+
+    if (dropped && Logging::logTrace("Overlay"))
+    {
+        CLOG_TRACE(Overlay, "Dropped {} {} messages to peer {}", dropped,
+                   xdr::xdr_traits<MessageType>::enum_name(type),
+                   mApp.getConfig().toShortString(mNodeID));
+    }
+}
+
+Json::Value
+FlowControl::getFlowControlJsonInfo(bool compact) const
+{
+    Json::Value res;
+    res["local_capacity"]["reading"] = static_cast<Json::UInt64>(
+        mFlowControlCapacity->getCapacity().mTotalCapacity);
+    res["local_capacity"]["flood"] = static_cast<Json::UInt64>(
+        mFlowControlCapacity->getCapacity().mFloodCapacity);
+    res["peer_capacity"] =
+        static_cast<Json::UInt64>(mFlowControlCapacity->getOutboundCapacity());
+
+    if (!compact)
+    {
+        res["outbound_queue_delay_scp_p75"] = static_cast<Json::UInt64>(
+            mMetrics.mOutboundQueueDelaySCP.GetSnapshot().get75thPercentile());
+        res["outbound_queue_delay_txs_p75"] = static_cast<Json::UInt64>(
+            mMetrics.mOutboundQueueDelayTxs.GetSnapshot().get75thPercentile());
+        res["outbound_queue_delay_advert_p75"] = static_cast<Json::UInt64>(
+            mMetrics.mOutboundQueueDelayAdvert.GetSnapshot()
+                .get75thPercentile());
+        res["outbound_queue_delay_demand_p75"] = static_cast<Json::UInt64>(
+            mMetrics.mOutboundQueueDelayDemand.GetSnapshot()
+                .get75thPercentile());
+    }
+
+    return res;
+}
+
+FlowControl::FlowControlMetrics::FlowControlMetrics()
+    : mOutboundQueueDelaySCP(medida::Timer(Peer::PEER_METRICS_DURATION_UNIT,
+                                           Peer::PEER_METRICS_RATE_UNIT,
+                                           Peer::PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelayTxs(medida::Timer(Peer::PEER_METRICS_DURATION_UNIT,
+                                           Peer::PEER_METRICS_RATE_UNIT,
+                                           Peer::PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelayAdvert(medida::Timer(Peer::PEER_METRICS_DURATION_UNIT,
+                                              Peer::PEER_METRICS_RATE_UNIT,
+                                              Peer::PEER_METRICS_WINDOW_SIZE))
+    , mOutboundQueueDelayDemand(medida::Timer(Peer::PEER_METRICS_DURATION_UNIT,
+                                              Peer::PEER_METRICS_RATE_UNIT,
+                                              Peer::PEER_METRICS_WINDOW_SIZE))
+{
+}
+}

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -1,0 +1,139 @@
+#pragma once
+
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "lib/json/json.h"
+#include "medida/timer.h"
+#include "overlay/FlowControlCapacity.h"
+#include "util/Timer.h"
+#include <optional>
+
+namespace stellar
+{
+
+class Peer;
+
+// The FlowControl class allows core to throttle flood traffic among its
+// connections. If a connections wants to use flow control, it should maintain
+// an instance of this class, and use the following methods:
+// * Inbound processing. Whenever a new message is received,
+// begin/endMessageProcessing methods should be called to appropriately keep
+// track of allowed capacity and potentially request more data from the
+// connection.
+// * Outbound processing. `sendMessage` will queue appropriate flood messages,
+// and ensure that those are only sent when the receiver is ready to accept.
+// This module also performs load shedding.
+class FlowControl
+{
+  public:
+    struct QueuedOutboundMessage
+    {
+        std::shared_ptr<StellarMessage const> mMessage;
+        VirtualClock::time_point mTimeEmplaced;
+    };
+
+  private:
+    struct FlowControlMetrics
+    {
+        FlowControlMetrics();
+        medida::Timer mOutboundQueueDelaySCP;
+        medida::Timer mOutboundQueueDelayTxs;
+        medida::Timer mOutboundQueueDelayAdvert;
+        medida::Timer mOutboundQueueDelayDemand;
+    };
+
+    // How many _hashes_ in total are queued?
+    // NB: Each advert & demand contains a _vector_ of tx hashes.
+    size_t mAdvertQueueTxHashCount{0};
+    size_t mDemandQueueTxHashCount{0};
+    NodeID mNodeID;
+    std::shared_ptr<FlowControlCapacity> mFlowControlCapacity;
+    Application& mApp;
+
+    // Outbound queues indexes by priority
+    // Priority 0 - SCP messages
+    // Priority 1 - transactions
+    // Priority 2 - flood demands
+    // Priority 3 - flood adverts
+    std::array<std::deque<QueuedOutboundMessage>, 4> mOutboundQueues;
+
+    // How many flood messages have we received and processed since sending
+    // SEND_MORE to this peer
+    uint64_t mFloodDataProcessed{0};
+    std::optional<VirtualClock::time_point> mNoOutboundCapacity;
+    FlowControlMetrics mMetrics;
+    std::function<void(StellarMessage const&)> mSendCallback;
+
+    // Release capacity used by this message. Return a struct that indicates how
+    // much reading and flood capacity was freed
+    void maybeSendNextBatch();
+    // This methods drops obsolete load from the outbound queue
+    void addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg);
+    void sendSendMore(uint32_t numMessages, std::shared_ptr<Peer> peer);
+
+  public:
+    FlowControl(Application& app);
+    virtual ~FlowControl() = default;
+
+    virtual bool maybeSendMessage(std::shared_ptr<StellarMessage const> msg);
+    void maybeReleaseCapacityAndTriggerSend(StellarMessage const& msg);
+
+#ifdef BUILD_TESTS
+    std::shared_ptr<FlowControlCapacity>
+    getFlowControlCapacity() const
+    {
+        return mFlowControlCapacity;
+    }
+
+    void
+    addToQueueAndMaybeTrimForTesting(std::shared_ptr<StellarMessage const> msg)
+    {
+        addMsgAndMaybeTrimQueue(msg);
+    }
+
+    std::array<std::deque<QueuedOutboundMessage>, 4>&
+    getQueuesForTesting()
+    {
+        return mOutboundQueues;
+    }
+
+    void
+    sendSendMoreForTesting(uint32_t numMessages, std::shared_ptr<Peer> peer)
+    {
+        sendSendMore(numMessages, peer);
+    }
+#endif
+
+    static uint32_t getNumMessages(StellarMessage const& msg);
+    bool isSendMoreValid(StellarMessage const& msg,
+                         std::string& errorMsg) const;
+
+    // This method ensures local capacity is locked now that we've received a
+    // new message
+    bool beginMessageProcessing(StellarMessage const& msg);
+
+    // This method ensures local capacity is released now that we've finished
+    // processing the message. It returns available capacity that can now be
+    // requested from the peer.
+    void endMessageProcessing(StellarMessage const& msg,
+                              std::weak_ptr<Peer> peer);
+    bool canRead() const;
+
+    // This method return last timestamp (if any) when peer had no available
+    // outbound capacity (useful to diagnose if the connection is stuck for any
+    // reason)
+    std::optional<VirtualClock::time_point>
+    getOutboundCapacityTimestamp() const
+    {
+        return mNoOutboundCapacity;
+    }
+
+    Json::Value getFlowControlJsonInfo(bool compact) const;
+
+    void start(std::weak_ptr<Peer> peer,
+               std::function<void(StellarMessage const&)> sendCb);
+};
+
+}

--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -1,0 +1,136 @@
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/FlowControlCapacity.h"
+#include "main/Application.h"
+#include "overlay/FlowControl.h"
+#include "overlay/OverlayManager.h"
+#include "util/Logging.h"
+#include <Tracy.hpp>
+
+namespace stellar
+{
+
+FlowControlMessageCapacity::FlowControlMessageCapacity(Application& app,
+                                                       NodeID const& nodeID)
+    : FlowControlCapacity(app, nodeID)
+{
+    mCapacity = getCapacityLimits();
+}
+
+uint64_t
+FlowControlMessageCapacity::getMsgResourceCount(StellarMessage const& msg) const
+{
+    // Each message takes one unit of capacity
+    return 1;
+}
+
+FlowControlCapacity::ReadingCapacity
+FlowControlMessageCapacity::getCapacityLimits() const
+{
+    return {mApp.getConfig().PEER_FLOOD_READING_CAPACITY,
+            mApp.getConfig().PEER_READING_CAPACITY};
+}
+
+void
+FlowControlMessageCapacity::releaseOutboundCapacity(StellarMessage const& msg)
+{
+    ZoneScoped;
+    releaseAssert(msg.type() == SEND_MORE);
+    auto numMessages = FlowControl::getNumMessages(msg);
+    if (!hasOutboundCapacity(msg) && numMessages != 0)
+    {
+        CLOG_DEBUG(Overlay, "Got outbound capacity for peer {}",
+                   mApp.getConfig().toShortString(mNodeID));
+    }
+    mOutboundCapacity += numMessages;
+}
+
+FlowControlCapacity::FlowControlCapacity(Application& app, NodeID const& nodeID)
+    : mApp(app), mNodeID(nodeID)
+{
+}
+
+void
+FlowControlCapacity::checkCapacityInvariants() const
+{
+    ZoneScoped;
+    releaseAssert(getCapacityLimits().mFloodCapacity >=
+                  mCapacity.mFloodCapacity);
+    releaseAssert(getCapacityLimits().mTotalCapacity >=
+                  mCapacity.mTotalCapacity);
+}
+
+void
+FlowControlCapacity::lockOutboundCapacity(StellarMessage const& msg)
+{
+    ZoneScoped;
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        releaseAssert(hasOutboundCapacity(msg));
+        mOutboundCapacity -= getMsgResourceCount(msg);
+    }
+}
+
+bool
+FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
+{
+    ZoneScoped;
+    checkCapacityInvariants();
+    auto msgResources = getMsgResourceCount(msg);
+    if (mCapacity.mTotalCapacity)
+    {
+        releaseAssert(mCapacity.mTotalCapacity >= msgResources);
+        mCapacity.mTotalCapacity -= msgResources;
+    }
+
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        // No capacity to process flood message
+        if (mCapacity.mFloodCapacity < msgResources)
+        {
+            return false;
+        }
+
+        mCapacity.mFloodCapacity -= msgResources;
+        if (mCapacity.mFloodCapacity == 0)
+        {
+            CLOG_DEBUG(Overlay, "No flood capacity for peer {}",
+                       mApp.getConfig().toShortString(mNodeID));
+        }
+    }
+
+    return true;
+}
+
+uint64_t
+FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
+{
+    ZoneScoped;
+    uint64_t releasedFloodCapacity = 0;
+    size_t resourcesFreed = getMsgResourceCount(msg);
+    mCapacity.mTotalCapacity += resourcesFreed;
+
+    if (mApp.getOverlayManager().isFloodMessage(msg))
+    {
+        if (mCapacity.mFloodCapacity == 0)
+        {
+            CLOG_DEBUG(Overlay, "Got flood capacity for peer {} ({})",
+                       mApp.getConfig().toShortString(mNodeID),
+                       mCapacity.mFloodCapacity + resourcesFreed);
+        }
+        releasedFloodCapacity = resourcesFreed;
+        mCapacity.mFloodCapacity += resourcesFreed;
+    }
+    checkCapacityInvariants();
+    return releasedFloodCapacity;
+}
+
+bool
+FlowControlCapacity::hasOutboundCapacity(StellarMessage const& msg) const
+{
+    ZoneScoped;
+    return mOutboundCapacity >= getMsgResourceCount(msg);
+}
+}

--- a/src/overlay/FlowControlCapacity.h
+++ b/src/overlay/FlowControlCapacity.h
@@ -1,0 +1,76 @@
+#pragma once
+
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/StellarXDR.h"
+
+namespace stellar
+{
+
+class Application;
+
+class FlowControlCapacity
+{
+  protected:
+    Application& mApp;
+
+    struct ReadingCapacity
+    {
+        uint64_t mFloodCapacity;
+        uint64_t mTotalCapacity;
+    };
+
+    // Capacity of local node configured by the operator
+    ReadingCapacity mCapacity;
+
+    // Capacity of a connected peer
+    uint64_t mOutboundCapacity{0};
+    NodeID const& mNodeID;
+
+  public:
+    virtual uint64_t getMsgResourceCount(StellarMessage const& msg) const = 0;
+    virtual ReadingCapacity getCapacityLimits() const = 0;
+    virtual void releaseOutboundCapacity(StellarMessage const& msg) = 0;
+
+    void lockOutboundCapacity(StellarMessage const& msg);
+    bool lockLocalCapacity(StellarMessage const& msg);
+    uint64_t releaseLocalCapacity(StellarMessage const& msg);
+
+    bool hasOutboundCapacity(StellarMessage const& msg) const;
+    void checkCapacityInvariants() const;
+    ReadingCapacity
+    getCapacity() const
+    {
+        return mCapacity;
+    }
+
+    uint64_t
+    getOutboundCapacity() const
+    {
+        return mOutboundCapacity;
+    }
+
+#ifdef BUILD_TESTS
+    void
+    setOutboundCapacity(uint64_t newCapacity)
+    {
+        mOutboundCapacity = newCapacity;
+    }
+#endif
+
+    FlowControlCapacity(Application& app, NodeID const& nodeID);
+};
+
+class FlowControlMessageCapacity : public FlowControlCapacity
+{
+  public:
+    FlowControlMessageCapacity(Application& app, NodeID const& nodeID);
+    virtual ~FlowControlMessageCapacity() = default;
+    virtual uint64_t
+    getMsgResourceCount(StellarMessage const& msg) const override;
+    virtual ReadingCapacity getCapacityLimits() const override;
+    void releaseOutboundCapacity(StellarMessage const& msg) override;
+};
+}

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -15,6 +15,7 @@
 #include "ledger/LedgerManager.h"
 #include "main/Application.h"
 #include "main/Config.h"
+#include "overlay/FlowControl.h"
 #include "overlay/OverlayManager.h"
 #include "overlay/OverlayMetrics.h"
 #include "overlay/PeerAuth.h"
@@ -44,8 +45,6 @@ namespace stellar
 {
 
 constexpr uint32 const ADVERT_CACHE_SIZE = 50000;
-constexpr std::chrono::seconds const OUTBOUND_QUEUE_TIMEOUT =
-    std::chrono::seconds(30);
 
 using namespace std;
 using namespace soci;
@@ -57,18 +56,15 @@ Peer::Peer(Application& app, PeerRole role)
     : mApp(app)
     , mRole(role)
     , mState(role == WE_CALLED_REMOTE ? CONNECTING : CONNECTED)
+    , mFlowControl(std::make_shared<FlowControl>(mApp))
     , mRemoteOverlayMinVersion(0)
     , mRemoteOverlayVersion(0)
     , mCreationTime(app.getClock().now())
     , mRecurringTimer(app)
     , mLastRead(app.getClock().now())
     , mLastWrite(app.getClock().now())
-    , mNoOutboundCapacity(
-          std::make_optional<VirtualClock::time_point>(app.getClock().now()))
     , mEnqueueTimeOfLastWrite(app.getClock().now())
     , mPeerMetrics(app.getClock().now())
-    , mCapacity{app.getConfig().PEER_FLOOD_READING_CAPACITY,
-                app.getConfig().PEER_READING_CAPACITY}
     , mTxAdvertQueue(app)
     , mAdvertTimer(app)
     , mAdvertHistory(ADVERT_CACHE_SIZE)
@@ -91,35 +87,6 @@ Peer::rememberHash(Hash const& hash, uint32_t ledgerSeq)
     mAdvertHistory.put(hash, ledgerSeq);
 }
 
-void
-Peer::beginMesssageProcessing(StellarMessage const& msg)
-{
-    releaseAssert(mApp.getConfig().PEER_FLOOD_READING_CAPACITY >=
-                  mCapacity.mFloodCapacity);
-    releaseAssert(mApp.getConfig().PEER_READING_CAPACITY >=
-                  mCapacity.mTotalCapacity);
-    releaseAssert(mCapacity.mTotalCapacity > 0);
-    mCapacity.mTotalCapacity--;
-
-    if (mApp.getOverlayManager().isFloodMessage(msg))
-    {
-        if (mCapacity.mFloodCapacity == 0)
-        {
-            drop("unexpected flood message, peer at capacity",
-                 Peer::DropDirection::WE_DROPPED_REMOTE,
-                 Peer::DropMode::IGNORE_WRITE_QUEUE);
-            return;
-        }
-
-        mCapacity.mFloodCapacity--;
-        if (mCapacity.mFloodCapacity == 0)
-        {
-            CLOG_DEBUG(Overlay, "No flood capacity for peer {}",
-                       mApp.getConfig().toShortString(getPeerID()));
-        }
-    }
-}
-
 Peer::MsgCapacityTracker::MsgCapacityTracker(std::weak_ptr<Peer> peer,
                                              StellarMessage const& msg)
     : mWeakPeer(peer), mMsg(msg)
@@ -129,7 +96,7 @@ Peer::MsgCapacityTracker::MsgCapacityTracker(std::weak_ptr<Peer> peer,
     {
         throw std::runtime_error("Invalid peer");
     }
-    self->beginMesssageProcessing(mMsg);
+    self->beginMessageProcessing(mMsg);
 }
 
 Peer::MsgCapacityTracker::~MsgCapacityTracker()
@@ -174,6 +141,41 @@ Peer::sendHello()
 
     auto msgPtr = std::make_shared<StellarMessage const>(msg);
     sendMessage(msgPtr);
+}
+
+void
+Peer::beginMessageProcessing(StellarMessage const& msg)
+{
+    releaseAssert(mFlowControl);
+    auto success = mFlowControl->beginMessageProcessing(msg);
+    if (!success)
+    {
+        drop("unexpected flood message, peer at capacity",
+             Peer::DropDirection::WE_DROPPED_REMOTE,
+             Peer::DropMode::IGNORE_WRITE_QUEUE);
+    }
+}
+
+void
+Peer::endMessageProcessing(StellarMessage const& msg)
+{
+    if (shouldAbort())
+    {
+        return;
+    }
+
+    releaseAssert(mFlowControl);
+    std::weak_ptr<Peer> self = shared_from_this();
+    mFlowControl->endMessageProcessing(msg, self);
+
+    releaseAssert(canRead());
+    if (mIsPeerThrottled)
+    {
+        CLOG_DEBUG(Overlay, "Stop throttling reading from peer {}",
+                   mApp.getConfig().toShortString(getPeerID()));
+        mIsPeerThrottled = false;
+        scheduleRead();
+    }
 }
 
 AuthCert
@@ -258,8 +260,9 @@ Peer::recurrentTimerExpired(asio::error_code const& error)
             drop("idle timeout", Peer::DropDirection::WE_DROPPED_REMOTE,
                  Peer::DropMode::IGNORE_WRITE_QUEUE);
         }
-        else if (mNoOutboundCapacity && (now - *mNoOutboundCapacity) >=
-                                            Peer::PEER_SEND_MODE_IDLE_TIMEOUT)
+        else if (mFlowControl && mFlowControl->getOutboundCapacityTimestamp() &&
+                 (now - *(mFlowControl->getOutboundCapacityTimestamp())) >=
+                     Peer::PEER_SEND_MODE_IDLE_TIMEOUT)
         {
             drop("idle timeout (no new flood requests)",
                  Peer::DropDirection::WE_DROPPED_REMOTE,
@@ -280,34 +283,6 @@ Peer::recurrentTimerExpired(asio::error_code const& error)
 }
 
 Json::Value
-Peer::getFlowControlJsonInfo(bool compact) const
-{
-    Json::Value res;
-    std::string stateStr;
-    res["local_capacity"]["reading"] = (Json::UInt64)mCapacity.mTotalCapacity;
-    res["local_capacity"]["flood"] = (Json::UInt64)mCapacity.mFloodCapacity;
-    res["peer_capacity"] = (Json::UInt64)mOutboundCapacity;
-
-    if (!compact)
-    {
-        res["outbound_queue_delay_scp_p75"] = static_cast<Json::UInt64>(
-            mPeerMetrics.mOutboundQueueDelaySCP.GetSnapshot()
-                .get75thPercentile());
-        res["outbound_queue_delay_txs_p75"] = static_cast<Json::UInt64>(
-            mPeerMetrics.mOutboundQueueDelayTxs.GetSnapshot()
-                .get75thPercentile());
-        res["outbound_queue_delay_advert_p75"] = static_cast<Json::UInt64>(
-            mPeerMetrics.mOutboundQueueDelayAdvert.GetSnapshot()
-                .get75thPercentile());
-        res["outbound_queue_delay_demand_p75"] = static_cast<Json::UInt64>(
-            mPeerMetrics.mOutboundQueueDelayDemand.GetSnapshot()
-                .get75thPercentile());
-    }
-
-    return res;
-}
-
-Json::Value
 Peer::getJsonInfo(bool compact) const
 {
     Json::Value res;
@@ -316,7 +291,10 @@ Peer::getJsonInfo(bool compact) const
     res["latency"] = (int)getPing().count();
     res["ver"] = getRemoteVersion();
     res["olver"] = (int)getRemoteOverlayVersion();
-    res["flow_control"] = getFlowControlJsonInfo(compact);
+    if (mFlowControl)
+    {
+        res["flow_control"] = mFlowControl->getFlowControlJsonInfo(compact);
+    }
     if (!compact)
     {
         res["pull_mode"]["advert_delay"] = static_cast<Json::UInt64>(
@@ -695,14 +673,12 @@ Peer::sendMessage(std::shared_ptr<StellarMessage const> msg, bool log)
         break;
     };
 
-    if (mApp.getOverlayManager().isFloodMessage(*msg))
+    releaseAssert(mFlowControl);
+    if (!mFlowControl->maybeSendMessage(msg))
     {
-        addMsgAndMaybeTrimQueue(msg);
-        maybeSendNextBatch();
-        return;
+        // Outgoing message is not flow-controlled, send it directly
+        sendAuthenticatedMessage(*msg);
     }
-
-    sendAuthenticatedMessage(*msg);
 }
 
 void
@@ -833,45 +809,13 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
     case AUTH:
         Peer::recvRawMessage(stellarMsg);
         return;
-    case SEND_MORE:
-    {
-        cat = "CTRL";
-
-        if (stellarMsg.sendMoreMessage().numMessages == 0)
-        {
-            drop("unexpected SEND_MORE message",
-                 Peer::DropDirection::WE_DROPPED_REMOTE,
-                 Peer::DropMode::IGNORE_WRITE_QUEUE);
-            return;
-        }
-
-        if (stellarMsg.sendMoreMessage().numMessages >
-            UINT64_MAX - mOutboundCapacity)
-        {
-            drop("Peer capacity overflow",
-                 Peer::DropDirection::WE_DROPPED_REMOTE,
-                 Peer::DropMode::IGNORE_WRITE_QUEUE);
-            return;
-        }
-
-        mNoOutboundCapacity.reset();
-        if (mOutboundCapacity == 0 &&
-            stellarMsg.sendMoreMessage().numMessages != 0)
-        {
-            CLOG_DEBUG(Overlay, "Got outbound capacity for peer {}",
-                       mApp.getConfig().toShortString(getPeerID()));
-        }
-        mOutboundCapacity += stellarMsg.sendMoreMessage().numMessages;
-        break;
-    }
-
     // control messages
     case GET_PEERS:
     case PEERS:
     case ERROR_MSG:
+    case SEND_MORE:
         cat = "CTRL";
         break;
-
     // high volume flooding
     case TRANSACTION:
     case FLOOD_ADVERT:
@@ -946,285 +890,10 @@ Peer::recvMessage(StellarMessage const& stellarMsg)
 }
 
 void
-Peer::sendSendMore(uint32_t numMessages)
-{
-    ZoneScoped;
-    StellarMessage m;
-    m.type(SEND_MORE);
-    m.sendMoreMessage().numMessages = numMessages;
-    auto msgPtr = std::make_shared<StellarMessage const>(m);
-    sendMessage(msgPtr);
-}
-
-void
 Peer::recvSendMore(StellarMessage const& msg)
 {
-    ZoneScoped;
-    releaseAssert(msg.sendMoreMessage().numMessages > 0);
-
-    CLOG_TRACE(Overlay, "Peer {} sent SEND_MORE {}",
-               mApp.getConfig().toShortString(getPeerID()),
-               msg.sendMoreMessage().numMessages);
-
-    // SEND_MORE means we can free some capacity, and dump the next batch of
-    // messages onto the writing queue
-    maybeSendNextBatch();
-}
-
-bool
-Peer::hasReadingCapacity() const
-{
-    return mCapacity.mTotalCapacity > 0;
-}
-
-bool
-dropMessageAfterTimeout(Peer::QueuedOutboundMessage const& queuedMsg,
-                        VirtualClock::time_point now)
-{
-    auto const& msg = *(queuedMsg.mMessage);
-    bool dropType = msg.type() == TRANSACTION || msg.type() == FLOOD_ADVERT ||
-                    msg.type() == FLOOD_DEMAND;
-    return dropType && (now - queuedMsg.mTimeEmplaced > OUTBOUND_QUEUE_TIMEOUT);
-}
-
-void
-Peer::addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg)
-{
-    ZoneScoped;
-
-    releaseAssert(msg);
-    auto type = msg->type();
-    size_t msgQInd = 0;
-    auto now = mApp.getClock().now();
-
-    switch (type)
-    {
-    case SCP_MESSAGE:
-    {
-        msgQInd = 0;
-    }
-    break;
-    case TRANSACTION:
-    {
-        msgQInd = 1;
-    }
-    break;
-    case FLOOD_DEMAND:
-    {
-        msgQInd = 2;
-        size_t s = msg->floodDemand().txHashes.size();
-        mDemandQueueTxHashCount += s;
-    }
-    break;
-    case FLOOD_ADVERT:
-    {
-        msgQInd = 3;
-        size_t s = msg->floodAdvert().txHashes.size();
-        mAdvertQueueTxHashCount += s;
-    }
-    break;
-    default:
-        abort();
-    }
-    auto& queue = mOutboundQueues[msgQInd];
-
-    queue.emplace_back(QueuedOutboundMessage{msg, mApp.getClock().now()});
-
-    size_t dropped = 0;
-
-    uint32_t const limit = mApp.getLedgerManager().getLastMaxTxSetSizeOps();
-    if (type == TRANSACTION)
-    {
-        if (queue.size() > limit)
-        {
-            dropped = queue.size() - limit;
-            queue.erase(queue.begin(), queue.begin() + dropped);
-        }
-        while (!queue.empty() && dropMessageAfterTimeout(queue.front(), now))
-        {
-            ++dropped;
-            queue.pop_front();
-        }
-        getOverlayMetrics().mOutboundQueueDropTxs.Mark(dropped);
-    }
-    else if (type == SCP_MESSAGE)
-    {
-        // Iterate over the message queue. If we found any messages for slots we
-        // don't keep in-memory anymore, delete those. Otherwise, compare
-        // messages for the same slot and validator against the latest SCP
-        // message and drop
-        auto minSlotToRemember = mApp.getHerder().getMinLedgerSeqToRemember();
-        bool valueReplaced = false;
-
-        for (auto it = queue.begin(); it != queue.end();)
-        {
-            if (it->mMessage->envelope().statement.slotIndex <
-                minSlotToRemember)
-            {
-                it = queue.erase(it);
-                dropped++;
-            }
-            else if (!valueReplaced && it != queue.end() - 1 &&
-                     mApp.getHerder().isNewerNominationOrBallotSt(
-                         it->mMessage->envelope().statement,
-                         queue.back().mMessage->envelope().statement))
-            {
-                valueReplaced = true;
-                *it = std::move(queue.back());
-                queue.pop_back();
-                dropped++;
-                ++it;
-            }
-            else
-            {
-                ++it;
-            }
-        }
-        getOverlayMetrics().mOutboundQueueDropSCP.Mark(dropped);
-    }
-    else if (type == FLOOD_ADVERT)
-    {
-        while (mAdvertQueueTxHashCount > limit ||
-               (!queue.empty() && dropMessageAfterTimeout(queue.front(), now)))
-        {
-            dropped++;
-            size_t s = queue.front().mMessage->floodAdvert().txHashes.size();
-            releaseAssert(mAdvertQueueTxHashCount >= s);
-            mAdvertQueueTxHashCount -= s;
-            queue.pop_front();
-        }
-        getOverlayMetrics().mOutboundQueueDropAdvert.Mark(dropped);
-    }
-    else if (type == FLOOD_DEMAND)
-    {
-        while (mDemandQueueTxHashCount > limit ||
-               (!queue.empty() && dropMessageAfterTimeout(queue.front(), now)))
-        {
-            dropped++;
-            size_t s = queue.front().mMessage->floodDemand().txHashes.size();
-            releaseAssert(mDemandQueueTxHashCount >= s);
-            mDemandQueueTxHashCount -= s;
-            queue.pop_front();
-        }
-        getOverlayMetrics().mOutboundQueueDropDemand.Mark(dropped);
-    }
-
-    if (dropped && Logging::logTrace("Overlay"))
-    {
-        CLOG_TRACE(Overlay, "Dropped {} {} messages to peer {}", dropped,
-                   xdr::xdr_traits<MessageType>::enum_name(type),
-                   mApp.getConfig().toShortString(getPeerID()));
-    }
-}
-
-void
-Peer::maybeSendNextBatch()
-{
-    ZoneScoped;
-
-    auto oldOutboundCapacity = mOutboundCapacity;
-    for (int i = 0; i < mOutboundQueues.size(); i++)
-    {
-        auto& queue = mOutboundQueues[i];
-        while (!queue.empty() && mOutboundCapacity > 0)
-        {
-            auto& front = queue.front();
-            sendAuthenticatedMessage(*(front.mMessage));
-            auto& om = mApp.getOverlayManager().getOverlayMetrics();
-
-            auto const& diff = mApp.getClock().now() - front.mTimeEmplaced;
-            mOutboundCapacity--;
-            switch (front.mMessage->type())
-            {
-            case TRANSACTION:
-            {
-                om.mOutboundQueueDelayTxs.Update(diff);
-                mPeerMetrics.mOutboundQueueDelayTxs.Update(diff);
-            }
-            break;
-            case SCP_MESSAGE:
-            {
-                om.mOutboundQueueDelaySCP.Update(diff);
-                mPeerMetrics.mOutboundQueueDelaySCP.Update(diff);
-            }
-            break;
-            case FLOOD_DEMAND:
-            {
-                om.mOutboundQueueDelayDemand.Update(diff);
-                mPeerMetrics.mOutboundQueueDelayDemand.Update(diff);
-                size_t s = front.mMessage->floodDemand().txHashes.size();
-                releaseAssert(mDemandQueueTxHashCount >= s);
-                mDemandQueueTxHashCount -= s;
-            }
-            break;
-            case FLOOD_ADVERT:
-            {
-                om.mOutboundQueueDelayAdvert.Update(diff);
-                mPeerMetrics.mOutboundQueueDelayAdvert.Update(diff);
-                size_t s = front.mMessage->floodAdvert().txHashes.size();
-                releaseAssert(mAdvertQueueTxHashCount >= s);
-                mAdvertQueueTxHashCount -= s;
-            }
-            break;
-            default:
-                abort();
-            }
-            if (mOutboundCapacity == 0)
-            {
-                CLOG_DEBUG(Overlay, "No outbound capacity for peer {}",
-                           mApp.getConfig().toShortString(getPeerID()));
-                mNoOutboundCapacity =
-                    std::make_optional<VirtualClock::time_point>(
-                        mApp.getClock().now());
-            }
-            queue.pop_front();
-        }
-    }
-
-    CLOG_TRACE(Overlay, "Peer {}: send next flood batch of {}",
-               mApp.getConfig().toShortString(getPeerID()),
-               (oldOutboundCapacity - mOutboundCapacity));
-}
-
-void
-Peer::endMessageProcessing(StellarMessage const& msg)
-{
-    if (shouldAbort())
-    {
-        return;
-    }
-
-    mCapacity.mTotalCapacity++;
-    if (mApp.getOverlayManager().isFloodMessage(msg))
-    {
-        if (mCapacity.mFloodCapacity == 0)
-        {
-            CLOG_DEBUG(Overlay, "Got flood capacity for peer {}",
-                       mApp.getConfig().toShortString(getPeerID()));
-        }
-        mCapacity.mFloodCapacity++;
-        mFloodMsgsProcessed++;
-
-        if (mFloodMsgsProcessed ==
-            mApp.getConfig().FLOW_CONTROL_SEND_MORE_BATCH_SIZE)
-        {
-            sendSendMore(mApp.getConfig().FLOW_CONTROL_SEND_MORE_BATCH_SIZE);
-            mFloodMsgsProcessed = 0;
-        }
-    }
-
-    // Got some capacity back, can schedule more reads now
-    if (mIsPeerThrottled)
-    {
-        CLOG_DEBUG(Overlay, "Stop throttling reading from peer {}",
-                   mApp.getConfig().toShortString(getPeerID()));
-        mIsPeerThrottled = false;
-        scheduleRead();
-    }
-    releaseAssert(mApp.getConfig().PEER_FLOOD_READING_CAPACITY >=
-                  mCapacity.mFloodCapacity);
-    releaseAssert(mApp.getConfig().PEER_READING_CAPACITY >=
-                  mCapacity.mTotalCapacity);
+    releaseAssert(mFlowControl);
+    mFlowControl->maybeReleaseCapacityAndTriggerSend(msg);
 }
 
 void
@@ -1369,6 +1038,14 @@ Peer::recvRawMessage(StellarMessage const& stellarMsg)
     break;
     case SEND_MORE:
     {
+        std::string errorMsg;
+        releaseAssert(mFlowControl);
+        if (!mFlowControl->isSendMoreValid(stellarMsg, errorMsg))
+        {
+            drop(errorMsg, Peer::DropDirection::WE_DROPPED_REMOTE,
+                 Peer::DropMode::IGNORE_WRITE_QUEUE);
+            return;
+        }
         auto t = getOverlayMetrics().mRecvSendMoreTimer.TimeScope();
         recvSendMore(stellarMsg);
     }
@@ -1569,6 +1246,13 @@ std::chrono::milliseconds
 Peer::getPing() const
 {
     return mLastPing;
+}
+
+bool
+Peer::canRead() const
+{
+    releaseAssert(mFlowControl);
+    return mFlowControl->canRead();
 }
 
 void
@@ -1912,7 +1596,15 @@ Peer::recvAuth(StellarMessage const& msg)
 
     // Subtle: after successful auth, must send sendMore message first to tell
     // the other peer about the local node's reading capacity.
-    sendSendMore(mApp.getConfig().PEER_FLOOD_READING_CAPACITY);
+    auto weakSelf = std::weak_ptr<Peer>(self);
+    auto sendCb = [weakSelf](StellarMessage const& msg) {
+        auto self = weakSelf.lock();
+        if (self)
+        {
+            self->sendAuthenticatedMessage(msg);
+        }
+    };
+    mFlowControl->start(weakSelf, sendCb);
 
     if (mRemoteOverlayVersion < Peer::FIRST_VERSION_REQUIRING_PULL_MODE &&
         msg.auth().flags != AUTH_MSG_FLAG_PULL_MODE_REQUESTED)
@@ -2037,18 +1729,6 @@ Peer::PeerMetrics::PeerMetrics(VirtualClock::time_point connectedTime)
     , mMessageDelayInAsyncWriteTimer(medida::Timer(PEER_METRICS_DURATION_UNIT,
                                                    PEER_METRICS_RATE_UNIT,
                                                    PEER_METRICS_WINDOW_SIZE))
-    , mOutboundQueueDelaySCP(medida::Timer(PEER_METRICS_DURATION_UNIT,
-                                           PEER_METRICS_RATE_UNIT,
-                                           PEER_METRICS_WINDOW_SIZE))
-    , mOutboundQueueDelayTxs(medida::Timer(PEER_METRICS_DURATION_UNIT,
-                                           PEER_METRICS_RATE_UNIT,
-                                           PEER_METRICS_WINDOW_SIZE))
-    , mOutboundQueueDelayAdvert(medida::Timer(PEER_METRICS_DURATION_UNIT,
-                                              PEER_METRICS_RATE_UNIT,
-                                              PEER_METRICS_WINDOW_SIZE))
-    , mOutboundQueueDelayDemand(medida::Timer(PEER_METRICS_DURATION_UNIT,
-                                              PEER_METRICS_RATE_UNIT,
-                                              PEER_METRICS_WINDOW_SIZE))
     , mAdvertQueueDelay(medida::Timer(PEER_METRICS_DURATION_UNIT,
                                       PEER_METRICS_RATE_UNIT,
                                       PEER_METRICS_WINDOW_SIZE))

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -25,6 +25,7 @@ typedef std::shared_ptr<SCPQuorumSet> SCPQuorumSetPtr;
 class Application;
 class LoopbackPeer;
 struct OverlayMetrics;
+class FlowControl;
 
 // Peer class represents a connected peer (either inbound or outbound)
 //
@@ -67,8 +68,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
         std::chrono::seconds(300);
 
     bool peerKnowsHash(Hash const& hash);
-    void rememberHash(Hash const& hash, uint32_t ledgerSeq);
-
     typedef std::shared_ptr<Peer> pointer;
 
     enum PeerState
@@ -111,10 +110,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
 
         medida::Timer mMessageDelayInWriteQueueTimer;
         medida::Timer mMessageDelayInAsyncWriteTimer;
-        medida::Timer mOutboundQueueDelaySCP;
-        medida::Timer mOutboundQueueDelayTxs;
-        medida::Timer mOutboundQueueDelayAdvert;
-        medida::Timer mOutboundQueueDelayDemand;
         medida::Timer mAdvertQueueDelay;
         medida::Timer mPullLatency;
 
@@ -149,13 +144,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
         xdr::msg_ptr mMessage;
     };
 
-    struct QueuedOutboundMessage
-    {
-        std::shared_ptr<StellarMessage const> mMessage;
-        VirtualClock::time_point mTimeEmplaced;
-    };
-
-    Json::Value getFlowControlJsonInfo(bool compact) const;
     Json::Value getJsonInfo(bool compact) const;
 
   protected:
@@ -166,6 +154,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     NodeID mPeerID;
     uint256 mSendNonce;
     uint256 mRecvNonce;
+
+    std::shared_ptr<FlowControl> mFlowControl;
 
     class MsgCapacityTracker : private NonMovableOrCopyable
     {
@@ -179,34 +169,11 @@ class Peer : public std::enable_shared_from_this<Peer>,
         std::weak_ptr<Peer> getPeer();
     };
 
-    struct ReadingCapacity
-    {
-        uint64_t mFloodCapacity;
-        uint64_t mTotalCapacity;
-    };
-
-    // Outbound queues indexes by priority
-    // Priority 0 - SCP messages
-    // Priority 1 - transactions
-    // Priority 2 - flood demands
-    // Priority 3 - flood adverts
-    std::array<std::deque<QueuedOutboundMessage>, 4> mOutboundQueues;
-
-    // This methods drops obsolete load from the outbound queue
-    void addMsgAndMaybeTrimQueue(std::shared_ptr<StellarMessage const> msg);
-
-    // How many flood messages have we received and processed since sending
-    // SEND_MORE to this peer
-    uint64_t mFloodMsgsProcessed{0};
-
-    // How many flood messages can we send to this peer
-    uint64_t mOutboundCapacity{0};
-
     // Is this peer currently throttled due to lack of capacity
     bool mIsPeerThrottled{false};
 
     // Does local node have capacity to read from this peer
-    bool hasReadingCapacity() const;
+    bool canRead() const;
 
     HmacSha256Key mSendMacKey;
     HmacSha256Key mRecvMacKey;
@@ -223,7 +190,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     VirtualTimer mRecurringTimer;
     VirtualClock::time_point mLastRead;
     VirtualClock::time_point mLastWrite;
-    std::optional<VirtualClock::time_point> mNoOutboundCapacity;
     VirtualClock::time_point mEnqueueTimeOfLastWrite;
 
     static Hash pingIDfromTimePoint(VirtualClock::time_point const& tp);
@@ -233,7 +199,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     std::chrono::milliseconds mLastPing;
 
     PeerMetrics mPeerMetrics;
-    ReadingCapacity mCapacity;
 
     OverlayMetrics& getOverlayMetrics();
 
@@ -272,7 +237,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void sendDontHave(MessageType type, uint256 const& itemID);
     void sendPeers();
     void sendError(ErrorCode error, std::string const& message);
-    void sendSendMore(uint32_t numMessages);
 
     // NB: This is a move-argument because the write-buffer has to travel
     // with the write-request through the async IO system, and we might have
@@ -298,23 +262,15 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void startRecurrentTimer();
     void recurrentTimerExpired(asio::error_code const& error);
     std::chrono::seconds getIOTimeout() const;
+    void rememberHash(Hash const& hash, uint32_t ledgerSeq);
 
     // helper method to acknownledge that some bytes were received
     void receivedBytes(size_t byteCount, bool gotFullMessage);
 
     void sendAuthenticatedMessage(StellarMessage const& msg);
-
-    void beginMesssageProcessing(StellarMessage const& msg);
+    void beginMessageProcessing(StellarMessage const& msg);
     void endMessageProcessing(StellarMessage const& msg);
-
-    void maybeSendNextBatch();
-
     TxAdvertQueue mTxAdvertQueue;
-
-    // How many _hashes_ in total are queued?
-    // NB: Each advert & demand contains a _vector_ of tx hashes.
-    size_t mAdvertQueueTxHashCount{0};
-    size_t mDemandQueueTxHashCount{0};
 
     // As of MIN_OVERLAY_VERSION_FOR_FLOOD_ADVERT, peers accumulate an _advert_
     // of flood messages, then periodically flush the advert and await a
@@ -445,5 +401,13 @@ class Peer : public std::enable_shared_from_this<Peer>,
     };
 
     friend class LoopbackPeer;
+
+#ifdef BUILD_TESTS
+    std::shared_ptr<FlowControl>
+    getFlowControl() const
+    {
+        return mFlowControl;
+    }
+#endif
 };
 }

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -17,12 +17,6 @@
 #include "util/Timer.h"
 #include "xdrpp/message.h"
 
-namespace medida
-{
-class Timer;
-class Meter;
-}
-
 namespace stellar
 {
 
@@ -433,23 +427,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // These exist mostly to be overridden in TCPPeer and callable via
     // shared_ptr<Peer> as a captured shared_from_this().
     virtual void connectHandler(asio::error_code const& ec);
-
-    virtual void
-    writeHandler(asio::error_code const& error, size_t bytes_transferred,
-                 size_t messages_transferred)
-    {
-    }
-
-    virtual void
-    readHeaderHandler(asio::error_code const& error, size_t bytes_transferred)
-    {
-    }
-
-    virtual void
-    readBodyHandler(asio::error_code const& error, size_t bytes_transferred,
-                    size_t expected_length)
-    {
-    }
 
     virtual void drop(std::string const& reason, DropDirection dropDirection,
                       DropMode dropMode) = 0;

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -431,7 +431,7 @@ TCPPeer::scheduleRead()
         return;
     }
 
-    releaseAssert(hasReadingCapacity());
+    releaseAssert(canRead());
 
     assertThreadIsMain();
     if (shouldAbort())
@@ -449,7 +449,7 @@ TCPPeer::startRead()
 {
     ZoneScoped;
     assertThreadIsMain();
-    releaseAssert(hasReadingCapacity());
+    releaseAssert(canRead());
     if (shouldAbort())
     {
         return;
@@ -503,7 +503,7 @@ TCPPeer::startRead()
                 }
                 noteFullyReadBody(length);
                 recvMessage();
-                if (!hasReadingCapacity())
+                if (!canRead())
                 {
                     // Break and wait until more capacity frees up
                     CLOG_DEBUG(Overlay, "Throttle reading from peer {}!",
@@ -520,7 +520,7 @@ TCPPeer::startRead()
         else
         {
             // No throttling - we just read a header, so we must have capacity
-            releaseAssert(hasReadingCapacity());
+            releaseAssert(canRead());
 
             // We read a header synchronously, but don't have enough data in the
             // buffered_stream to read the body synchronously. Pretend we just
@@ -648,7 +648,7 @@ TCPPeer::readBodyHandler(asio::error_code const& error,
         // sequence happens after the first read of a single large input-buffer
         // worth of input. Even when we weren't preempted, we still bounce off
         // the per-peer scheduler queue here, to balance input across peers.
-        if (!hasReadingCapacity())
+        if (!canRead())
         {
             // No more capacity after processing this message
             CLOG_DEBUG(Overlay,
@@ -667,7 +667,7 @@ TCPPeer::recvMessage()
 {
     ZoneScoped;
     assertThreadIsMain();
-    releaseAssert(hasReadingCapacity());
+    releaseAssert(canRead());
 
     try
     {

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -58,12 +58,12 @@ class TCPPeer : public Peer
 
     void writeHandler(asio::error_code const& error,
                       std::size_t bytes_transferred,
-                      std::size_t messages_transferred) override;
+                      std::size_t messages_transferred);
     void readHeaderHandler(asio::error_code const& error,
-                           std::size_t bytes_transferred) override;
+                           std::size_t bytes_transferred);
     void readBodyHandler(asio::error_code const& error,
                          std::size_t bytes_transferred,
-                         std::size_t expected_length) override;
+                         std::size_t expected_length);
     void shutdown();
 
   public:

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -228,7 +228,7 @@ duplicateMessage(Peer::TimestampedMessage const& msg)
 void
 LoopbackPeer::processInQueue()
 {
-    if (!hasReadingCapacity())
+    if (!canRead())
     {
         mIsPeerThrottled = true;
         return;
@@ -525,6 +525,7 @@ LoopbackPeerConnection::getAcceptor() const
 bool
 LoopbackPeer::checkCapacity(uint64_t expectedOutboundCapacity) const
 {
-    return expectedOutboundCapacity == mOutboundCapacity;
+    return expectedOutboundCapacity ==
+           getFlowControl()->getFlowControlCapacity()->getOutboundCapacity();
 }
 }

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "overlay/FlowControl.h"
 #include "overlay/Peer.h"
 #include <deque>
 #include <random>
@@ -125,27 +126,27 @@ class LoopbackPeer : public Peer
         return mDropReason;
     }
 
-    std::array<std::deque<QueuedOutboundMessage>, 4>&
+    std::array<std::deque<FlowControl::QueuedOutboundMessage>, 4>&
     getQueues()
     {
-        return mOutboundQueues;
+        return getFlowControl()->getQueuesForTesting();
     }
 
-    uint64_t&
+    uint64_t
     getOutboundCapacity()
     {
-        return mOutboundCapacity;
+        return getFlowControl()
+            ->getFlowControlCapacity()
+            ->getOutboundCapacity();
     }
 
     bool checkCapacity(uint64_t expectedOutboundCapacity) const;
 
     std::string getIP() const override;
 
-    using Peer::addMsgAndMaybeTrimQueue;
     using Peer::sendAuth;
     using Peer::sendAuthenticatedMessage;
     using Peer::sendMessage;
-    using Peer::sendSendMore;
 
     friend class LoopbackPeerConnection;
 };

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -304,6 +304,10 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         thisConfig.WORKER_THREADS = 2;
         thisConfig.QUORUM_INTERSECTION_CHECKER = false;
         thisConfig.METADATA_DEBUG_LEDGERS = 0;
+
+        thisConfig.PEER_READING_CAPACITY = 20;
+        thisConfig.PEER_FLOOD_READING_CAPACITY = 20;
+        thisConfig.FLOW_CONTROL_SEND_MORE_BATCH_SIZE = 10;
 #ifdef BEST_OFFER_DEBUGGING
         thisConfig.BEST_OFFER_DEBUGGING_ENABLED = true;
 #endif


### PR DESCRIPTION
Resolves #3676 

First pass at decoupling Peer class into separate modules to ease code reviewing and testing. For now, I kept the tests as-is, but in the next iteration it'd be nice to audit and cleanup tests as well (maybe when we add bytes accounting). Specifically, it should now be easier to test flow-control-specific functionality (capacity accounting, outbound queuing, outbound purging etc) in an isolated way without depending on the internals of Peer/Application. 