### PR TITLE
overlay: add new tests to help evaluate connectivity strategy

### DIFF
--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -153,16 +153,17 @@ LoopbackPeer::drop(std::string const& reason, DropDirection direction, DropMode)
 
     if (mState != GOT_AUTH)
     {
-        CLOG_DEBUG(Overlay, "TCPPeer::drop {} in state {} we called:{}",
+        CLOG_DEBUG(Overlay, "LoopbackPeer::drop {} in state {} we called:{}",
                    toString(), mState, mRole);
     }
     else if (direction == Peer::DropDirection::WE_DROPPED_REMOTE)
     {
-        CLOG_INFO(Overlay, "Dropping peer {}, reason {}", toString(), reason);
+        CLOG_DEBUG(Overlay, "Dropping peer {}, reason {}", toString(), reason);
     }
     else
     {
-        CLOG_INFO(Overlay, "peer {} dropped us, reason {}", toString(), reason);
+        CLOG_DEBUG(Overlay, "peer {} dropped us, reason {}", toString(),
+                   reason);
     }
 
     mDropReason = reason;

--- a/src/overlay/test/OverlayTestUtils.h
+++ b/src/overlay/test/OverlayTestUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "overlay/PeerManager.h"
 #include <memory>
 #include <string>
 
@@ -11,6 +12,7 @@ namespace stellar
 {
 
 class Application;
+class Simulation;
 
 namespace overlaytestutils
 {
@@ -23,7 +25,21 @@ uint64_t getUnfulfilledDemandCount(std::shared_ptr<Application> app);
 uint64_t getUnknownDemandCount(std::shared_ptr<Application> app);
 
 uint64_t getSentDemandCount(std::shared_ptr<Application> app);
+
 uint64_t getOverlayFloodMessageCount(std::shared_ptr<Application> app,
                                      std::string const& name);
+
+bool knowsAs(Application& knowingApp, Application& knownApp, PeerType peerType);
+
+bool doesNotKnow(Application& knowingApp, Application& knownApp);
+
+bool knowsAsInbound(Application& knowingApp, Application& knownApp);
+
+bool knowsAsOutbound(Application& knowingApp, Application& knownApp);
+
+int numberOfAppConnections(Application& app);
+
+int numberOfSimulationConnections(std::shared_ptr<Simulation> simulation);
+
 }
 }

--- a/src/overlay/test/OverlayTopologyTests.cpp
+++ b/src/overlay/test/OverlayTopologyTests.cpp
@@ -1,0 +1,348 @@
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "crypto/KeyUtils.h"
+#include "lib/catch.hpp"
+#include "main/Application.h"
+#include "overlay/OverlayManagerImpl.h"
+#include "overlay/test/LoopbackPeer.h"
+#include "overlay/test/OverlayTestUtils.h"
+#include "simulation/Simulation.h"
+#include "simulation/Topologies.h"
+#include "test/test.h"
+#include "util/Logging.h"
+
+#include <fmt/format.h>
+#include <numeric>
+
+using namespace stellar;
+using namespace stellar::overlaytestutils;
+
+namespace
+{
+
+using TraverseFunc =
+    std::function<void(Application& app, Application& otherApp)>;
+
+// A basic DFS algorithm to traverse the topology
+void
+dfs(Application& app, std::unordered_set<NodeID>& visited, TraverseFunc f)
+{
+    visited.emplace(app.getConfig().NODE_SEED.getPublicKey());
+    for (auto const& node : app.getOverlayManager().getAuthenticatedPeers())
+    {
+        if (visited.find(node.first) == visited.end())
+        {
+            auto& overlayApp = static_cast<ApplicationLoopbackOverlay&>(app);
+            auto port = node.second->getAddress().getPort();
+            auto otherApp = overlayApp.getSim().getAppFromPeerMap(port);
+            if (f)
+            {
+                f(app, *otherApp);
+            }
+            dfs(*otherApp, visited, f);
+        }
+    }
+}
+
+bool
+isConnected(int numNodes, int numWatchers, Simulation::pointer simulation)
+{
+    // Check if a graph is fully connected
+    std::unordered_set<NodeID> visited;
+    dfs(*simulation->getNodes()[0], visited, nullptr);
+    return visited.size() == (numNodes + numWatchers);
+}
+
+// Log basic information about each node in the topology
+void
+logTopologyInfo(Simulation::pointer simulation)
+{
+    for (auto const& node : simulation->getNodes())
+    {
+        CLOG_INFO(
+            Overlay,
+            "Connections for node ({}) {} --> outbound {}/inbound "
+            "{}, LCL={}",
+            (node->getConfig().NODE_IS_VALIDATOR ? "validator" : "watcher"),
+            node->getConfig().toShortString(
+                node->getConfig().NODE_SEED.getPublicKey()),
+            node->getOverlayManager().getOutboundAuthenticatedPeers().size(),
+            node->getOverlayManager().getInboundAuthenticatedPeers().size(),
+            node->getLedgerManager().getLastClosedLedgerNum());
+    }
+    CLOG_INFO(Overlay, "Total connections = {}",
+              numberOfSimulationConnections(simulation));
+}
+
+void
+populateGraphJson(Application& app, std::unordered_set<NodeID>& visited,
+                  Json::Value& res)
+{
+    auto func = [&](Application& app, Application& otherApp) {
+        auto id = KeyUtils::toStrKey(app.getConfig().NODE_SEED.getPublicKey());
+        auto otherId =
+            KeyUtils::toStrKey(otherApp.getConfig().NODE_SEED.getPublicKey());
+        Json::Value pp;
+        pp[otherId] = otherApp.getConfig().NODE_IS_VALIDATOR;
+        res[id]["peers"].append(pp);
+    };
+    dfs(app, visited, func);
+}
+
+void
+exportGraphJson(Json::Value graphJson, std::string prefix, int testID)
+{
+    std::string refJsonPath =
+        fmt::format("src/testdata/test-{}-topology-{}-{}.json", testID, prefix,
+                    std::to_string(rand_uniform(1, 100000)));
+
+    std::ofstream outJson;
+    outJson.exceptions(std::ios::failbit | std::ios::badbit);
+    outJson.open(refJsonPath);
+
+    outJson.write(graphJson.toStyledString().c_str(),
+                  graphJson.toStyledString().size());
+    outJson.close();
+}
+
+TEST_CASE("basic connectivity", "[overlay][connectivity][!hide]")
+{
+    auto test = [&](int maxOutbound, int maxInbound, int numNodes,
+                    int numWatchers) {
+        auto cfgs = std::vector<Config>{};
+        auto peers = std::vector<std::string>{};
+
+        for (int i = 1; i <= numNodes + numWatchers; ++i)
+        {
+            auto cfg = getTestConfig(i);
+            cfgs.push_back(cfg);
+            peers.push_back("127.0.0.1:" + std::to_string(cfg.PEER_PORT));
+        }
+        auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+
+        // Threshold 1 means everyone must agree, graph must be connected
+        auto simulation =
+            Topologies::separate(numNodes, 1, Simulation::OVER_LOOPBACK,
+                                 networkID, numWatchers, [&](int i) {
+                                     // Ignore idle app
+                                     if (i == 0)
+                                     {
+                                         auto cfg = getTestConfig();
+                                         cfg.TARGET_PEER_CONNECTIONS = 0;
+                                         return cfg;
+                                     }
+
+                                     auto cfg = cfgs[i - 1];
+
+                                     if (i > numNodes)
+                                     {
+                                         cfg.NODE_IS_VALIDATOR = false;
+                                         cfg.FORCE_SCP = false;
+                                     }
+                                     cfg.TARGET_PEER_CONNECTIONS = maxOutbound;
+                                     cfg.MAX_ADDITIONAL_PEER_CONNECTIONS =
+                                         maxInbound;
+                                     cfg.KNOWN_PEERS = peers;
+                                     cfg.RUN_STANDALONE = false;
+                                     return cfg;
+                                 });
+
+        simulation->startAllNodes();
+        simulation->crankForAtLeast(std::chrono::seconds(10), false);
+        logTopologyInfo(simulation);
+
+        simulation->crankUntil(
+            [&] { return simulation->haveAllExternalized(4, 1); },
+            5 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+        REQUIRE(isConnected(numNodes, numWatchers, simulation));
+        return simulation;
+    };
+
+    int topTierSize = 23;
+
+    SECTION("not enough capacity")
+    {
+        // Fail most of the time because topology is too sparse
+        REQUIRE_THROWS_AS(test(1, 20, topTierSize, 100), std::runtime_error);
+    }
+    SECTION("small fanout sufficient to stay connected")
+    {
+        // 2 outbound, 2 inbound, top tier only
+        test(2, 2, topTierSize, 0);
+    }
+    SECTION("large network is connected")
+    {
+        // 2 outbound, 4 inbound, 100 watchers
+        test(2, 4, topTierSize, 100);
+    }
+}
+
+TEST_CASE("peer churn", "[overlay][connectivity][!hide]")
+{
+    auto cfgs = std::vector<Config>{};
+    auto peers = std::vector<std::string>{};
+    int numNodes = 23;
+    int numWatchers = 77;
+
+    int maxOutbound = 2;
+    int maxInbound = 4;
+
+    std::vector<SecretKey> keys;
+    SCPQuorumSet qSet;
+    qSet.threshold = numNodes;
+    for (int i = 0; i < numNodes + numWatchers; i++)
+    {
+        auto key =
+            SecretKey::fromSeed(sha256("NODE_SEED_" + std::to_string(i)));
+        keys.push_back(key);
+        if (i < numNodes)
+        {
+            qSet.validators.push_back(key.getPublicKey());
+        }
+        auto cfg = getTestConfig(i + 1);
+
+        cfg.NODE_IS_VALIDATOR = i < numNodes;
+        cfg.FORCE_SCP = cfg.NODE_IS_VALIDATOR;
+        cfg.TARGET_PEER_CONNECTIONS = maxOutbound;
+        cfg.MAX_ADDITIONAL_PEER_CONNECTIONS = maxInbound;
+        cfg.KNOWN_PEERS = peers;
+        cfg.RUN_STANDALONE = false;
+        cfg.MODE_DOES_CATCHUP = false;
+
+        cfgs.push_back(cfg);
+        peers.push_back("127.0.0.1:" + std::to_string(cfg.PEER_PORT));
+    }
+
+    auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    auto simulation =
+        std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
+
+    // Gradually add (randomized) peers, and ensure everyone can connect
+    SECTION("add new peers")
+    {
+        std::vector<int> randomIndexes;
+        for (int i = 0; i < keys.size(); i++)
+        {
+            randomIndexes.push_back(i);
+        }
+        stellar::shuffle(std::begin(randomIndexes), std::end(randomIndexes),
+                         gRandomEngine);
+        // One-by-one add a node, ensure everyone can connect
+        for (int i = 0; i < randomIndexes.size(); i++)
+        {
+            CLOG_INFO(Overlay, "NODE {}", i);
+            auto index = randomIndexes[i];
+            auto newNode = simulation->addNode(keys[index], qSet, &cfgs[index]);
+            newNode->start();
+            simulation->crankForAtLeast(
+                std::chrono::seconds(rand_uniform(0, 3)), false);
+        }
+
+        simulation->crankForAtLeast(std::chrono::seconds(15), false);
+        logTopologyInfo(simulation);
+
+        // Verify graph is connected
+        REQUIRE(simulation->getNodes().size() == (numNodes + numWatchers));
+        REQUIRE(isConnected(numNodes, numWatchers, simulation));
+    }
+    SECTION("remove peers")
+    {
+        for (int i = 0; i < keys.size(); i++)
+        {
+            simulation->addNode(keys[i], qSet, &cfgs[i]);
+        }
+        simulation->startAllNodes();
+        simulation->crankUntil(
+            [&] { return simulation->haveAllExternalized(3, 1); },
+            5 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+        REQUIRE(isConnected(numNodes, numWatchers, simulation));
+
+        SECTION("basic churn - remove and add")
+        {
+            auto otherCfgs = std::vector<Config>{};
+
+            // Add a bit of churn by stopping and starting two random (possibly
+            // same) peers
+            for (int i = 0; i < 2; i++)
+            {
+                auto peerToChurn = rand_element(keys);
+                auto cfg = simulation->getNode(peerToChurn.getPublicKey())
+                               ->getConfig();
+                simulation->removeNode(peerToChurn.getPublicKey());
+                simulation->crankForAtLeast(std::chrono::seconds(30), false);
+                auto node = simulation->addNode(cfg.NODE_SEED, qSet, &cfg);
+                CLOG_INFO(Overlay, "Restart node {}",
+                          node->getConfig().toShortString(
+                              node->getConfig().NODE_SEED.getPublicKey()));
+                node->start();
+                simulation->crankForAtLeast(std::chrono::seconds(30), false);
+                REQUIRE(isConnected(numNodes, numWatchers, simulation));
+            }
+        }
+        SECTION("churn overtime")
+        {
+            // Note: increase iteration count to run the test for longer and
+            // increase confidence in topology convergence
+            int iterations = 10;
+            int numPeersToChurn = 3;
+            for (int i = 0; i < iterations; i++)
+            {
+                CLOG_INFO(Overlay, "Iteration: {}", i);
+
+                // Crank for random amount of time
+                simulation->crankForAtLeast(
+                    std::chrono::seconds(rand_uniform(0, 20)), false);
+
+                auto otherCfgs = std::vector<Config>{};
+                std::vector<SecretKey> peersToChurn;
+                while (peersToChurn.size() < numPeersToChurn)
+                {
+                    auto peerToChurn = rand_element(keys);
+                    if (std::find(peersToChurn.begin(), peersToChurn.end(),
+                                  peerToChurn) == peersToChurn.end())
+                    {
+                        peersToChurn.push_back(peerToChurn);
+                    }
+                }
+
+                // Delete 3 random unique peers
+                for (auto const& peerToChurn : peersToChurn)
+                {
+                    auto cfg = simulation->getNode(peerToChurn.getPublicKey())
+                                   ->getConfig();
+                    otherCfgs.push_back(cfg);
+                    simulation->removeNode(peerToChurn.getPublicKey());
+                }
+
+                // Wait 60 seconds to allow the network to re-configure, then
+                // restart removed nodes
+                simulation->crankForAtLeast(std::chrono::seconds(60), false);
+                for (int j = 0; j < peersToChurn.size(); j++)
+                {
+                    auto peerToChurn = peersToChurn[j];
+                    auto node = simulation->addNode(otherCfgs[j].NODE_SEED,
+                                                    qSet, &otherCfgs[j]);
+                    CLOG_INFO(Overlay, "Restart NODE {}",
+                              node->getConfig().toShortString(
+                                  node->getConfig().NODE_SEED.getPublicKey()));
+                    node->start();
+                }
+
+                // Allow nodes to reconnect
+                simulation->crankForAtLeast(std::chrono::seconds(60), false);
+                logTopologyInfo(simulation);
+                REQUIRE(isConnected(numNodes, numWatchers, simulation));
+            }
+
+            // Export resulting graph to JSON file
+            std::unordered_set<NodeID> visited;
+            Json::Value res;
+            populateGraphJson(*(simulation->getNodes()[0]), visited, res);
+            auto testID = rand_uniform(0, 100000);
+            exportGraphJson(res, "churn-overtime", testID);
+        }
+    }
+}
+}

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -755,7 +755,7 @@ bool
 LoopbackOverlayManager::connectToImpl(PeerBareAddress const& address,
                                       bool forceoutbound)
 {
-    CLOG_INFO(Overlay, "Connect to {}", address.toString());
+    CLOG_TRACE(Overlay, "Connect to {}", address.toString());
     auto currentConnection = getConnectedPeer(address);
     if (!currentConnection || (forceoutbound && currentConnection->getRole() ==
                                                     Peer::REMOTE_CALLED_US))
@@ -771,6 +771,10 @@ LoopbackOverlayManager::connectToImpl(PeerBareAddress const& address,
         getPeerManager().update(address, PeerManager::BackOffUpdate::INCREASE);
         auto& app = static_cast<ApplicationLoopbackOverlay&>(mApp);
         auto otherApp = app.getSim().getAppFromPeerMap(address.getPort());
+        if (!otherApp)
+        {
+            return false;
+        }
         auto res = LoopbackPeer::initiate(mApp, *otherApp);
         return res.first->getState() == Peer::CONNECTED;
     }

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -515,12 +515,17 @@ Simulation::crankAllNodes(int nbTicks)
 }
 
 bool
-Simulation::haveAllExternalized(uint32 num, uint32 maxSpread)
+Simulation::haveAllExternalized(uint32 num, uint32 maxSpread,
+                                bool validatorsOnly)
 {
     uint32_t min = UINT32_MAX, max = 0;
     for (auto it = mNodes.begin(); it != mNodes.end(); ++it)
     {
         auto app = it->second.mApp;
+        if (validatorsOnly && !app->getConfig().NODE_IS_VALIDATOR)
+        {
+            continue;
+        }
         auto n = app->getLedgerManager().getLastClosedLedgerNum();
         LOG_DEBUG(DEFAULT_LOG, "{} @ ledger#: {}", app->getConfig().PEER_PORT,
                   n);

--- a/src/simulation/Simulation.h
+++ b/src/simulation/Simulation.h
@@ -67,7 +67,8 @@ class Simulation
 
     // returns true if all nodes have externalized
     // triggers and exception if a node externalized higher than num+maxSpread
-    bool haveAllExternalized(uint32 num, uint32 maxSpread);
+    bool haveAllExternalized(uint32 num, uint32 maxSpread,
+                             bool validatorsOnly = false);
 
     size_t crankNode(NodeID const& id, VirtualClock::time_point timeout);
     size_t crankAllNodes(int nbTicks = 1);

--- a/src/simulation/Topologies.cpp
+++ b/src/simulation/Topologies.cpp
@@ -87,7 +87,7 @@ Topologies::cycle4(Hash const& networkID, Simulation::ConfigGen confGen,
 Simulation::pointer
 Topologies::separate(int nNodes, double quorumThresoldFraction,
                      Simulation::Mode mode, Hash const& networkID,
-                     Simulation::ConfigGen confGen,
+                     int numWatchers, Simulation::ConfigGen confGen,
                      Simulation::QuorumSetAdjuster qSetAdjust)
 {
     Simulation::pointer simulation =
@@ -113,6 +113,13 @@ Topologies::separate(int nNodes, double quorumThresoldFraction,
     {
         simulation->addNode(k, qSet);
     }
+
+    for (int i = 0; i < numWatchers; i++)
+    {
+        simulation->addNode(
+            SecretKey::fromSeed(sha256("NODE_SEED_WATCHER_" + to_string(i))),
+            qSet);
+    }
     return simulation;
 }
 
@@ -123,7 +130,7 @@ Topologies::core(int nNodes, double quorumThresoldFraction,
                  Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
-                                           networkID, confGen, qSetAdjust);
+                                           networkID, 0, confGen, qSetAdjust);
 
     auto nodes = simulation->getNodeIDs();
     assert(static_cast<int>(nodes.size()) == nNodes);
@@ -146,7 +153,7 @@ Topologies::cycle(int nNodes, double quorumThresoldFraction,
                   Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
-                                           networkID, confGen, qSetAdjust);
+                                           networkID, 0, confGen, qSetAdjust);
 
     auto nodes = simulation->getNodeIDs();
     assert(static_cast<int>(nodes.size()) == nNodes);
@@ -167,7 +174,7 @@ Topologies::branchedcycle(int nNodes, double quorumThresoldFraction,
                           Simulation::QuorumSetAdjuster qSetAdjust)
 {
     auto simulation = Topologies::separate(nNodes, quorumThresoldFraction, mode,
-                                           networkID, confGen, qSetAdjust);
+                                           networkID, 0, confGen, qSetAdjust);
 
     auto nodes = simulation->getNodeIDs();
     assert(static_cast<int>(nodes.size()) == nNodes);

--- a/src/simulation/Topologies.h
+++ b/src/simulation/Topologies.h
@@ -44,7 +44,8 @@ class Topologies
     // nNodes with same qSet - no connection created
     static Simulation::pointer
     separate(int nNodes, double quorumThresoldFraction, Simulation::Mode mode,
-             Hash const& networkID, Simulation::ConfigGen confGen = nullptr,
+             Hash const& networkID, int numWatchers = 0,
+             Simulation::ConfigGen confGen = nullptr,
              Simulation::QuorumSetAdjuster qSetAdjust = nullptr);
 
     // multi-tier quorum (core4 + mid-tier nodes that depend on 2 nodes of


### PR DESCRIPTION
A subset of tests used to help evaluate changes to connectivity strategy (the rest are still WIP as we hash out the new strategy). These help verify that the network topology remains connected with various connection targets. In addition, new tests were added to evaluate network churn: specifically, gradually adding new nodes, randomly removing and re-adding nodes on the network, and churning nodes for longer periods of time to evaluate potential long-term degradation in topology. 

Note that it should not be expected for these to always pass, given the random nature of our connection management. However, it is useful to run these tests in a loop to evaluate how new changes impact connectivity. 