### PR TITLE
Add a wrapper for network configuration and load it when appropriate.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -518,6 +518,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnConfigSettingSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnContractDataSQL.cpp" />
+    <ClCompile Include="..\..\src\ledger\NetworkConfig.cpp" />
     <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp" />
     <ClCompile Include="..\..\src\main\Diagnostics.cpp" />
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp" />
@@ -948,6 +949,7 @@ exit /b 0
     <ClInclude Include="..\..\src\historywork\WriteVerifiedCheckpointHashesWork.h" />
     <ClInclude Include="..\..\src\ledger\InternalLedgerEntry.h" />
     <ClInclude Include="..\..\src\ledger\LedgerCloseMetaFrame.h" />
+    <ClInclude Include="..\..\src\ledger\NetworkConfig.h" />
     <ClInclude Include="..\..\src\ledger\NonSociRelatedException.h" />
     <ClInclude Include="..\..\src\main\Diagnostics.h" />
     <ClInclude Include="..\..\src\overlay\SurveyManager.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1324,6 +1324,9 @@
     <ClCompile Include="..\..\src\bucket\BucketIndexImpl.cpp">
       <Filter>bucket</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\ledger\NetworkConfig.cpp">
+      <Filter>ledger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2307,6 +2310,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\bucket\BucketIndexImpl.h">
       <Filter>bucket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ledger\NetworkConfig.h">
+      <Filter>ledger</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -32,9 +32,6 @@ class Upgrades
     // upgrades
     static std::chrono::hours const UPDGRADE_EXPIRATION_HOURS;
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    static uint32_t const CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES_V20;
-#endif
     struct UpgradeParameters
     {
         UpgradeParameters()

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -13,6 +13,7 @@
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
+#include "ledger/NetworkConfig.h"
 #include "ledger/TrustLineWrapper.h"
 #include "lib/catch.hpp"
 #include "simulation/Simulation.h"
@@ -804,13 +805,10 @@ TEST_CASE("config upgrades applied to ledger", "[upgrades]")
         executeUpgrade(*app, ledgerUpgrade);
 
         // upgrade was ignored
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto maxContractSizeEntry =
-            ltx.load(getMaxContractSizeKey()).current().data.configSetting();
-        REQUIRE(maxContractSizeEntry.configSettingID() ==
-                CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
-        REQUIRE(maxContractSizeEntry.contractMaxSizeBytes() ==
-                Upgrades::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES_V20);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .maxContractSizeBytes() ==
+                InitialNetworkConfig::MAX_CONTRACT_SIZE);
     }
 
     SECTION("known config upgrade set is applied")
@@ -828,7 +826,66 @@ TEST_CASE("config upgrades applied to ledger", "[upgrades]")
             ltx.load(getMaxContractSizeKey()).current().data.configSetting();
         REQUIRE(maxContractSizeEntry.configSettingID() ==
                 CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
-        REQUIRE(maxContractSizeEntry.contractMaxSizeBytes() == 32768);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .maxContractSizeBytes() == 32768);
+    }
+    SECTION("multi-item config upgrade set is applied")
+    {
+        // Verify values pre-upgrade
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .feeRatePerInstructionsIncrement() ==
+                InitialNetworkConfig::FEE_RATE_PER_INSTRUCTIONS_INCREMENT);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .ledgerMaxInstructions() ==
+                InitialNetworkConfig::LEDGER_MAX_INSTRUCTIONS);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .memoryLimit() == InitialNetworkConfig::MEMORY_LIMIT);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .txMaxInstructions() ==
+                InitialNetworkConfig::TX_MAX_INSTRUCTIONS);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .feeHistorical1KB() ==
+                InitialNetworkConfig::FEE_HISTORICAL_1KB);
+        ConfigUpgradeSetFrameConstPtr configUpgradeSet;
+        {
+            ConfigUpgradeSet configUpgradeSetXdr;
+            auto& configEntry = configUpgradeSetXdr.updatedEntry.emplace_back();
+            configEntry.configSettingID(CONFIG_SETTING_CONTRACT_COMPUTE_V0);
+            configEntry.contractCompute().feeRatePerInstructionsIncrement = 111;
+            configEntry.contractCompute().ledgerMaxInstructions = 222;
+            configEntry.contractCompute().memoryLimit = 333;
+            configEntry.contractCompute().txMaxInstructions = 444;
+            auto& configEntry2 =
+                configUpgradeSetXdr.updatedEntry.emplace_back();
+            configEntry2.configSettingID(
+                CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0);
+            configEntry2.contractHistoricalData().feeHistorical1KB = 555;
+            LedgerTxn ltx(app->getLedgerTxnRoot());
+            configUpgradeSet = makeConfigUpgradeSet(ltx, configUpgradeSetXdr);
+            ltx.commit();
+        }
+        executeUpgrade(*app, makeConfigUpgrade(*configUpgradeSet));
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .feeRatePerInstructionsIncrement() == 111);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .ledgerMaxInstructions() == 222);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .memoryLimit() == 333);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .txMaxInstructions() == 444);
+        REQUIRE(app->getLedgerManager()
+                    .getLastContractNetworkConfig()
+                    .feeHistorical1KB() == 555);
     }
 }
 
@@ -1973,8 +2030,7 @@ TEST_CASE("configuration initialized in version upgrade", "[upgrades]")
         ltx.load(getMaxContractSizeKey()).current().data.configSetting();
     REQUIRE(maxContractSizeEntry.configSettingID() ==
             CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
-    REQUIRE(maxContractSizeEntry.contractMaxSizeBytes() ==
-            Upgrades::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES_V20);
+    REQUIRE(maxContractSizeEntry.contractMaxSizeBytes() == 65536);
 }
 #endif
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -6,6 +6,7 @@
 
 #include "catchup/CatchupManager.h"
 #include "history/HistoryManager.h"
+#include "ledger/NetworkConfig.h"
 #include <memory>
 
 namespace stellar
@@ -118,6 +119,11 @@ class LedgerManager
     // return the maximum size of a transaction set to apply to the current
     // ledger expressed in number of operations
     virtual uint32_t getLastMaxTxSetSizeOps() const = 0;
+
+    // Return the contract-related network config corresponding to the
+    // last closed ledger.
+    virtual ContractNetworkConfig const&
+    getLastContractNetworkConfig() const = 0;
 
     // Return the (changing) number of seconds since the LCL closed.
     virtual uint64_t secondsSinceLastLedgerClose() const = 0;

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -8,6 +8,7 @@
 #include "history/HistoryManager.h"
 #include "ledger/LedgerCloseMetaFrame.h"
 #include "ledger/LedgerManager.h"
+#include "ledger/NetworkConfig.h"
 #include "ledger/TransactionResultSetFrame.h"
 #include "main/PersistentState.h"
 #include "transactions/TransactionFrame.h"
@@ -40,8 +41,6 @@ class BasicWork;
 
 class LedgerManagerImpl : public LedgerManager
 {
-    LedgerHeaderHistoryEntry mLastClosedLedger;
-
   protected:
     Application& mApp;
     std::unique_ptr<XDROutputFileStream> mMetaStream;
@@ -50,6 +49,9 @@ class LedgerManagerImpl : public LedgerManager
     std::filesystem::path mMetaDebugPath;
 
   private:
+    LedgerHeaderHistoryEntry mLastClosedLedger;
+    ContractNetworkConfig mLastContractNetworkConfig;
+
     medida::Timer& mTransactionApply;
     medida::Histogram& mTransactionCount;
     medida::Histogram& mOperationCount;
@@ -97,6 +99,11 @@ class LedgerManagerImpl : public LedgerManager
 
     void advanceLedgerPointers(LedgerHeader const& header,
                                bool debugLog = true);
+    // Reloads the network configuration from the ledger.
+    // This needs to be called after the protocol upgrades or once
+    // during the catchups/test setup etc.
+    // This call is read-only and hence `ltx` can be read-only.
+    void updateNetworkConfig(AbstractLedgerTxn& ltx);
     void logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
                            size_t numOps);
 
@@ -114,8 +121,9 @@ class LedgerManagerImpl : public LedgerManager
     int64_t getLastMinBalance(uint32_t ownerCount) const override;
     uint32_t getLastReserve() const override;
     uint32_t getLastTxFee() const override;
-
     uint32_t getLastClosedLedgerNum() const override;
+    ContractNetworkConfig const& getLastContractNetworkConfig() const override;
+
     uint64_t secondsSinceLastLedgerClose() const override;
     void syncMetrics() override;
 

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -1,0 +1,451 @@
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/NetworkConfig.h"
+#include "util/ProtocolVersion.h"
+
+namespace stellar
+{
+namespace
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+void
+createConfigSettingEntry(ConfigSettingEntry const& configSetting,
+                         AbstractLedgerTxn& ltxRoot)
+{
+    LedgerEntry e;
+    e.data.type(CONFIG_SETTING);
+    e.data.configSetting() = configSetting;
+    LedgerTxn ltx(ltxRoot);
+    ltx.create(e);
+    ltx.commit();
+}
+
+ConfigSettingEntry
+initialMaxContractSizeEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
+
+    entry.contractMaxSizeBytes() = InitialNetworkConfig::MAX_CONTRACT_SIZE;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractComputeSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_COMPUTE_V0);
+    auto& e = entry.contractCompute();
+
+    e.ledgerMaxInstructions = InitialNetworkConfig::LEDGER_MAX_INSTRUCTIONS;
+    e.txMaxInstructions = InitialNetworkConfig::TX_MAX_INSTRUCTIONS;
+    e.feeRatePerInstructionsIncrement =
+        InitialNetworkConfig::FEE_RATE_PER_INSTRUCTIONS_INCREMENT;
+    e.memoryLimit = InitialNetworkConfig::MEMORY_LIMIT;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractLedgerAccessSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_LEDGER_COST_V0);
+    auto& e = entry.contractLedgerCost();
+
+    e.ledgerMaxReadLedgerEntries =
+        InitialNetworkConfig::LEDGER_MAX_READ_LEDGER_ENTRIES;
+    e.ledgerMaxReadBytes = InitialNetworkConfig::LEDGER_MAX_READ_BYTES;
+    e.ledgerMaxWriteLedgerEntries =
+        InitialNetworkConfig::LEDGER_MAX_WRITE_LEDGER_ENTRIES;
+    e.ledgerMaxWriteBytes = InitialNetworkConfig::LEDGER_MAX_WRITE_BYTES;
+    e.txMaxReadLedgerEntries = InitialNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES;
+    e.txMaxReadBytes = InitialNetworkConfig::TX_MAX_READ_BYTES;
+    e.txMaxWriteLedgerEntries =
+        InitialNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES;
+    e.txMaxWriteBytes = InitialNetworkConfig::TX_MAX_WRITE_BYTES;
+    e.feeReadLedgerEntry = InitialNetworkConfig::FEE_READ_LEDGER_ENTRY;
+    e.feeWriteLedgerEntry = InitialNetworkConfig::FEE_WRITE_LEDGER_ENTRY;
+    e.feeRead1KB = InitialNetworkConfig::FEE_READ_1KB;
+    e.feeWrite1KB = InitialNetworkConfig::FEE_WRITE_1KB;
+    e.bucketListSizeBytes = InitialNetworkConfig::BUCKET_LIST_SIZE_BYTES;
+    e.bucketListFeeRateLow = InitialNetworkConfig::BUCKET_LIST_FEE_RATE_LOW;
+    e.bucketListFeeRateHigh = InitialNetworkConfig::BUCKET_LIST_FEE_RATE_HIGH;
+    e.bucketListGrowthFactor = InitialNetworkConfig::BUCKET_LIST_GROWTH_FACTOR;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractHistoricalDataSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0);
+    auto& e = entry.contractHistoricalData();
+
+    e.feeHistorical1KB = InitialNetworkConfig::FEE_HISTORICAL_1KB;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractMetaDataSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_META_DATA_V0);
+    auto& e = entry.contractMetaData();
+
+    e.txMaxExtendedMetaDataSizeBytes =
+        InitialNetworkConfig::TX_MAX_EXTENDED_META_DATA_SIZE_BYTES;
+    e.feeExtendedMetaData1KB = InitialNetworkConfig::FEE_EXTENDED_META_DATA_1KB;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractBandwidthSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_BANDWIDTH_V0);
+    auto& e = entry.contractBandwidth();
+
+    e.ledgerMaxPropagateSizeBytes =
+        InitialNetworkConfig::LEDGER_MAX_PROPAGATE_SIZE_BYTES;
+    e.txMaxSizeBytes = InitialNetworkConfig::TX_MAX_SIZE_BYTES;
+    e.feePropagateData1KB = InitialNetworkConfig::FEE_PROPAGATE_DATA_1KB;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialHostLogicVersionEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION);
+
+    entry.contractHostLogicVersion() = InitialNetworkConfig::HOST_LOGIC_VERSION;
+
+    return entry;
+}
+
+#endif
+}
+
+void
+ContractNetworkConfig::createLedgerEntriesForV20(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    createConfigSettingEntry(initialMaxContractSizeEntry(), ltx);
+    createConfigSettingEntry(initialContractComputeSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractLedgerAccessSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractHistoricalDataSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractMetaDataSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractBandwidthSettingsEntry(), ltx);
+    createConfigSettingEntry(initialHostLogicVersionEntry(), ltx);
+#endif
+}
+
+void
+ContractNetworkConfig::initializeGenesisLedgerForTesting(
+    uint32_t genesisLedgerProtocol, AbstractLedgerTxn& ltx)
+{
+    if (protocolVersionStartsFrom(genesisLedgerProtocol, ProtocolVersion::V_20))
+    {
+        ContractNetworkConfig::createLedgerEntriesForV20(ltx);
+    }
+}
+
+void
+ContractNetworkConfig::loadFromLedger(AbstractLedgerTxn& ltxRoot)
+{
+    LedgerTxn ltx(ltxRoot);
+    loadMaxContractSize(ltx);
+    loadComputeSettings(ltx);
+    loadLedgerAccessSettings(ltx);
+    loadHistoricalSettings(ltx);
+    loadMetaDataSettings(ltx);
+    loadBandwidthSettings(ltx);
+    loadHostLogicVersion(ltx);
+}
+
+uint32_t
+ContractNetworkConfig::maxContractSizeBytes() const
+{
+    return mMaxContractSizeBytes;
+}
+
+uint32_t
+ContractNetworkConfig::hostLogicVersion() const
+{
+    return mHostLogicVersion;
+}
+
+void
+ContractNetworkConfig::loadMaxContractSize(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES;
+    auto le = ltx.load(key).current();
+    mMaxContractSizeBytes = le.data.configSetting().contractMaxSizeBytes();
+#endif
+}
+
+void
+ContractNetworkConfig::loadComputeSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_COMPUTE_V0;
+    auto le = ltx.load(key).current();
+    auto const& configSetting = le.data.configSetting().contractCompute();
+    mLedgerMaxInstructions = configSetting.ledgerMaxInstructions;
+    mTxMaxInstructions = configSetting.txMaxInstructions;
+    mFeeRatePerInstructionsIncrement =
+        configSetting.feeRatePerInstructionsIncrement;
+    mMemoryLimit = configSetting.memoryLimit;
+#endif
+}
+
+void
+ContractNetworkConfig::loadLedgerAccessSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0;
+    auto le = ltx.load(key).current();
+    auto const& configSetting = le.data.configSetting().contractLedgerCost();
+    mLedgerMaxReadLedgerEntries = configSetting.ledgerMaxReadLedgerEntries;
+    mLedgerMaxReadBytes = configSetting.ledgerMaxReadBytes;
+    mLedgerMaxWriteLedgerEntries = configSetting.ledgerMaxWriteLedgerEntries;
+    mLedgerMaxWriteBytes = configSetting.ledgerMaxWriteBytes;
+    mTxMaxReadLedgerEntries = configSetting.txMaxReadLedgerEntries;
+    mTxMaxReadBytes = configSetting.txMaxReadBytes;
+    mTxMaxWriteLedgerEntries = configSetting.txMaxWriteLedgerEntries;
+    mTxMaxWriteBytes = configSetting.txMaxWriteBytes;
+    mFeeReadLedgerEntry = configSetting.feeReadLedgerEntry;
+    mFeeWriteLedgerEntry = configSetting.feeWriteLedgerEntry;
+    mFeeRead1KB = configSetting.feeRead1KB;
+    mFeeWrite1KB = configSetting.feeWrite1KB;
+    mBucketListSizeBytes = configSetting.bucketListSizeBytes;
+    mBucketListFeeRateLow = configSetting.bucketListFeeRateLow;
+    mBucketListFeeRateHigh = configSetting.bucketListFeeRateHigh;
+    mBucketListGrowthFactor = configSetting.bucketListGrowthFactor;
+#endif
+}
+
+void
+ContractNetworkConfig::loadHistoricalSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0;
+    auto le = ltx.load(key).current();
+    auto const& configSetting =
+        le.data.configSetting().contractHistoricalData();
+    mFeeHistorical1KB = configSetting.feeHistorical1KB;
+#endif
+}
+
+void
+ContractNetworkConfig::loadMetaDataSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION;
+    auto le = ltx.load(key).current();
+    mHostLogicVersion = le.data.configSetting().contractHostLogicVersion();
+#endif
+}
+
+void
+ContractNetworkConfig::loadBandwidthSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_BANDWIDTH_V0;
+    auto le = ltx.load(key).current();
+    auto const& configSetting = le.data.configSetting().contractBandwidth();
+    mLedgerMaxPropagateSizeBytes = configSetting.ledgerMaxPropagateSizeBytes;
+    mTxMaxSizeBytes = configSetting.txMaxSizeBytes;
+    mFeePropagateData1KB = configSetting.feePropagateData1KB;
+#endif
+}
+
+void
+ContractNetworkConfig::loadHostLogicVersion(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION;
+    auto le = ltx.load(key).current();
+    mHostLogicVersion = le.data.configSetting().contractHostLogicVersion();
+
+#endif
+}
+
+// Compute settings for contracts (instructions and memory).
+int64_t
+ContractNetworkConfig::ledgerMaxInstructions() const
+{
+    return mLedgerMaxInstructions;
+}
+
+int64_t
+ContractNetworkConfig::txMaxInstructions() const
+{
+    return mTxMaxInstructions;
+}
+
+int64_t
+ContractNetworkConfig::feeRatePerInstructionsIncrement() const
+{
+    return mFeeRatePerInstructionsIncrement;
+}
+
+uint32_t
+ContractNetworkConfig::memoryLimit() const
+{
+    return mMemoryLimit;
+}
+
+// Ledger access settings for contracts.
+uint32_t
+ContractNetworkConfig::ledgerMaxReadLedgerEntries() const
+{
+    return mLedgerMaxReadLedgerEntries;
+}
+
+uint32_t
+ContractNetworkConfig::ledgerMaxReadBytes() const
+{
+    return mLedgerMaxReadBytes;
+}
+
+uint32_t
+ContractNetworkConfig::ledgerMaxWriteLedgerEntries() const
+{
+    return mLedgerMaxWriteLedgerEntries;
+}
+
+uint32_t
+ContractNetworkConfig::ledgerMaxWriteBytes() const
+{
+    return mLedgerMaxWriteBytes;
+}
+
+uint32_t
+ContractNetworkConfig::txMaxReadLedgerEntries() const
+{
+    return mTxMaxReadLedgerEntries;
+}
+
+uint32_t
+ContractNetworkConfig::txMaxReadBytes() const
+{
+    return mTxMaxReadBytes;
+}
+
+uint32_t
+ContractNetworkConfig::txMaxWriteLedgerEntries() const
+{
+    return mTxMaxWriteLedgerEntries;
+}
+
+uint32_t
+ContractNetworkConfig::txMaxWriteBytes() const
+{
+    return mTxMaxWriteBytes;
+}
+
+int64_t
+ContractNetworkConfig::feeReadLedgerEntry() const
+{
+    return mFeeReadLedgerEntry;
+}
+
+int64_t
+ContractNetworkConfig::feeWriteLedgerEntry() const
+{
+    return mFeeWriteLedgerEntry;
+}
+
+int64_t
+ContractNetworkConfig::feeRead1KB() const
+{
+    return mFeeRead1KB;
+}
+
+int64_t
+ContractNetworkConfig::feeWrite1KB() const
+{
+    return mFeeWrite1KB;
+}
+
+int64_t
+ContractNetworkConfig::bucketListSizeBytes() const
+{
+    return mBucketListSizeBytes;
+}
+
+int64_t
+ContractNetworkConfig::bucketListFeeRateLow() const
+{
+    return mBucketListFeeRateLow;
+}
+
+int64_t
+ContractNetworkConfig::bucketListFeeRateHigh() const
+{
+    return mBucketListFeeRateHigh;
+}
+
+uint32_t
+ContractNetworkConfig::bucketListGrowthFactor() const
+{
+    return mBucketListGrowthFactor;
+}
+
+// Historical data (pushed to core archives) settings for contracts.
+int64_t
+ContractNetworkConfig::feeHistorical1KB() const
+{
+    return mFeeHistorical1KB;
+}
+
+// Meta data (pushed to downstream systems) settings for contracts.
+uint32_t
+ContractNetworkConfig::txMaxExtendedMetaDataSizeBytes() const
+{
+    return mTxMaxExtendedMetaDataSizeBytes;
+}
+
+int64_t
+ContractNetworkConfig::feeExtendedMetaData1KB() const
+{
+    return mFeeExtendedMetaData1KB;
+}
+
+// Bandwidth related data settings for contracts
+uint32_t
+ContractNetworkConfig::ledgerMaxPropagateSizeBytes() const
+{
+    return mLedgerMaxPropagateSizeBytes;
+}
+
+uint32_t
+ContractNetworkConfig::txMaxSizeBytes() const
+{
+    return mTxMaxSizeBytes;
+}
+
+int64_t
+ContractNetworkConfig::feePropagateData1KB() const
+{
+    return mFeePropagateData1KB;
+}
+
+}

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -1,0 +1,203 @@
+#pragma once
+
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstdint>
+#include <ledger/LedgerTxn.h>
+
+namespace stellar
+{
+
+// Defines the initial values of the network configuration
+// settings that are applied during the protocol version upgrade.
+// These values should never be changed after the protocol upgrade
+// happens - any further changes should be performed separately via
+// config upgrade mechanism.
+struct InitialNetworkConfig
+{
+    // Contract size settings
+    static constexpr uint32_t MAX_CONTRACT_SIZE = 65536;
+
+    // Compute settings
+    static constexpr int64_t LEDGER_MAX_INSTRUCTIONS = 1;
+    static constexpr int64_t TX_MAX_INSTRUCTIONS = 1;
+    static constexpr int64_t FEE_RATE_PER_INSTRUCTIONS_INCREMENT = 1;
+    static constexpr uint32_t MEMORY_LIMIT = 1;
+
+    // Ledger access settings
+    static constexpr uint32_t LEDGER_MAX_READ_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t LEDGER_MAX_READ_BYTES = 1;
+    static constexpr uint32_t LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t LEDGER_MAX_WRITE_BYTES = 1;
+    static constexpr uint32_t TX_MAX_READ_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t TX_MAX_READ_BYTES = 1;
+    static constexpr uint32_t TX_MAX_WRITE_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t TX_MAX_WRITE_BYTES = 1;
+    static constexpr int64_t FEE_READ_LEDGER_ENTRY = 1;
+    static constexpr int64_t FEE_WRITE_LEDGER_ENTRY = 1;
+    static constexpr int64_t FEE_READ_1KB = 1;
+    static constexpr int64_t FEE_WRITE_1KB = 1;
+    static constexpr int64_t BUCKET_LIST_SIZE_BYTES = 1;
+    static constexpr int64_t BUCKET_LIST_FEE_RATE_LOW = 1;
+    static constexpr int64_t BUCKET_LIST_FEE_RATE_HIGH = 1;
+    static constexpr uint32_t BUCKET_LIST_GROWTH_FACTOR = 1;
+
+    // Historical data settings
+    static constexpr int64_t FEE_HISTORICAL_1KB = 1;
+
+    // Bandwidth settings
+    static constexpr uint32_t LEDGER_MAX_PROPAGATE_SIZE_BYTES = 1;
+    static constexpr uint32_t TX_MAX_SIZE_BYTES = 1;
+    static constexpr int64_t FEE_PROPAGATE_DATA_1KB = 1;
+
+    // Meta data settings
+    static constexpr uint32_t TX_MAX_EXTENDED_META_DATA_SIZE_BYTES = 1;
+    static constexpr int64_t FEE_EXTENDED_META_DATA_1KB = 1;
+
+    // Host logic version
+    static constexpr uint32_t HOST_LOGIC_VERSION = 1;
+};
+
+// Wrapper for the contract-related network configuration.
+class ContractNetworkConfig
+{
+  public:
+    // Creates the initial contract configuration entries for protocol v20.
+    // This should happen once during the correspondent protocol version
+    // upgrade.
+    static void createLedgerEntriesForV20(AbstractLedgerTxn& ltx);
+    // Test-only function that initializes contract network configuration
+    // bypassing the normal upgrade process (i.e. when genesis ledger starts not
+    // at v1)
+    static void
+    initializeGenesisLedgerForTesting(uint32_t genesisLedgerProtocol,
+                                      AbstractLedgerTxn& ltx);
+
+    void loadFromLedger(AbstractLedgerTxn& ltx);
+    // Maximum allowed size of the contract Wasm that can be uploaded (in
+    // bytes).
+    uint32_t maxContractSizeBytes() const;
+
+    // Compute settings for contracts (instructions and memory).
+    // Maximum instructions per ledger
+    int64_t ledgerMaxInstructions() const;
+    // Maximum instructions per transaction
+    int64_t txMaxInstructions() const;
+    // Cost of 10000 instructions
+    int64_t feeRatePerInstructionsIncrement() const;
+    // Memory limit per contract/host function invocation. Unlike
+    // instructions, there is no fee for memory and it's not
+    // accumulated between operations - the same limit is applied
+    // to every operation.
+    uint32_t memoryLimit() const;
+
+    // Ledger access settings for contracts.
+    // Maximum number of ledger entry read operations per ledger
+    uint32_t ledgerMaxReadLedgerEntries() const;
+    // Maximum number of bytes that can be read per ledger
+    uint32_t ledgerMaxReadBytes() const;
+    // Maximum number of ledger entry write operations per ledger
+    uint32_t ledgerMaxWriteLedgerEntries() const;
+    // Maximum number of bytes that can be written per ledger
+    uint32_t ledgerMaxWriteBytes() const;
+    // Maximum number of ledger entry read operations per transaction
+    uint32_t txMaxReadLedgerEntries() const;
+    // Maximum number of bytes that can be read per transaction
+    uint32_t txMaxReadBytes() const;
+    // Maximum number of ledger entry write operations per transaction
+    uint32_t txMaxWriteLedgerEntries() const;
+    // Maximum number of bytes that can be written per transaction
+    uint32_t txMaxWriteBytes() const;
+    // Fee per ledger entry read
+    int64_t feeReadLedgerEntry() const;
+    // Fee per ledger entry write
+    int64_t feeWriteLedgerEntry() const;
+    // Fee for reading 1KB
+    int64_t feeRead1KB() const;
+    // Fee for writing 1KB
+    int64_t feeWrite1KB() const;
+    // Bucket list fees grow slowly up to that size
+    int64_t bucketListSizeBytes() const;
+    // Fee rate in stroops when the bucket list is empty
+    int64_t bucketListFeeRateLow() const;
+    // Fee rate in stroops when the bucket list reached bucketListSizeBytes
+    int64_t bucketListFeeRateHigh() const;
+    // Rate multiplier for any additional data past the first
+    // bucketListSizeBytes
+    uint32_t bucketListGrowthFactor() const;
+
+    // Historical data (pushed to core archives) settings for contracts.
+    // Fee for storing 1KB in archives
+    int64_t feeHistorical1KB() const;
+
+    // Meta data (pushed to downstream systems) settings for contracts.
+    // Maximum size of extended meta data produced by a transaction
+    uint32_t txMaxExtendedMetaDataSizeBytes() const;
+    // Fee for generating 1KB of extended meta data
+    int64_t feeExtendedMetaData1KB() const;
+
+    // Bandwidth related data settings for contracts
+    // Maximum size in bytes to propagate per ledger
+    uint32_t ledgerMaxPropagateSizeBytes() const;
+    // Maximum size in bytes for a transaction
+    uint32_t txMaxSizeBytes() const;
+    // Fee for propagating 1KB of data
+    int64_t feePropagateData1KB() const;
+
+    // Version of the Soroban host logic.
+    uint32_t hostLogicVersion() const;
+
+  private:
+    void loadMaxContractSize(AbstractLedgerTxn& ltx);
+    void loadComputeSettings(AbstractLedgerTxn& ltx);
+    void loadLedgerAccessSettings(AbstractLedgerTxn& ltx);
+    void loadHistoricalSettings(AbstractLedgerTxn& ltx);
+    void loadMetaDataSettings(AbstractLedgerTxn& ltx);
+    void loadBandwidthSettings(AbstractLedgerTxn& ltx);
+    void loadHostLogicVersion(AbstractLedgerTxn& ltx);
+
+    uint32_t mMaxContractSizeBytes{};
+
+    // Compute settings for contracts (instructions and memory).
+    int64_t mLedgerMaxInstructions{};
+    int64_t mTxMaxInstructions{};
+    int64_t mFeeRatePerInstructionsIncrement{};
+    uint32_t mMemoryLimit{};
+
+    // Ledger access settings for contracts.
+    uint32_t mLedgerMaxReadLedgerEntries{};
+    uint32_t mLedgerMaxReadBytes{};
+    uint32_t mLedgerMaxWriteLedgerEntries{};
+    uint32_t mLedgerMaxWriteBytes{};
+    uint32_t mTxMaxReadLedgerEntries{};
+    uint32_t mTxMaxReadBytes{};
+    uint32_t mTxMaxWriteLedgerEntries{};
+    uint32_t mTxMaxWriteBytes{};
+    int64_t mFeeReadLedgerEntry{};
+    int64_t mFeeWriteLedgerEntry{};
+    int64_t mFeeRead1KB{};
+    int64_t mFeeWrite1KB{};
+    int64_t mBucketListSizeBytes{};
+    int64_t mBucketListFeeRateLow{};
+    int64_t mBucketListFeeRateHigh{};
+    uint32_t mBucketListGrowthFactor{};
+
+    // Historical data (pushed to core archives) settings for contracts.
+    int64_t mFeeHistorical1KB{};
+
+    // Meta data (pushed to downstream systems) settings for contracts.
+    uint32_t mTxMaxExtendedMetaDataSizeBytes{};
+    int64_t mFeeExtendedMetaData1KB{};
+
+    // Bandwidth related data settings for contracts
+    uint32_t mLedgerMaxPropagateSizeBytes{};
+    uint32_t mTxMaxSizeBytes{};
+    int64_t mFeePropagateData1KB{};
+
+    // Host logic version
+    uint32_t mHostLogicVersion{};
+};
+
+}

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,9 +18,9 @@ rustc-simple-version = "0.1.0"
 [dependencies.soroban-env-host]
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "aa7424dc2ea8db1391365e229f550d726734ae55"
+rev = "c0cb12a98020286e705e5a3e6ac9bd02f49a3e88"
 features = ["vm"]
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "aa7424dc2ea8db1391365e229f550d726734ae55"
+rev = "c0cb12a98020286e705e5a3e6ac9bd02f49a3e88"

--- a/src/util/ProtocolVersion.h
+++ b/src/util/ProtocolVersion.h
@@ -50,7 +50,5 @@ bool protocolVersionEquals(uint32_t protocolVersion,
 constexpr ProtocolVersion GENERALIZED_TX_SET_PROTOCOL_VERSION =
     ProtocolVersion::V_20;
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 constexpr ProtocolVersion SOROBAN_PROTOCOL_VERSION = ProtocolVersion::V_20;
-#endif
 }


### PR DESCRIPTION
# Description

Add a wrapper for network configuration and load it when appropriate.

Getting the right configuration from the ledger using transactions would be quite cumbersome. Instead, provide access to all the relevant entries via getters (probably some of them will not be relevant for core; we can clean this up if needed).

Also generalized the initialization and upgrades process, as now we have a lot of various settings.

This is the Core-side implementaiton of https://github.com/stellar/stellar-core/issues/3691

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
