### PR TITLE
Add a wrapper for network configuration and load it when appropriate.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -518,9 +518,12 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnConfigSettingSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnContractDataSQL.cpp" />
+    <ClCompile Include="..\..\src\ledger\NetworkConfig.cpp" />
     <ClCompile Include="..\..\src\ledger\test\LedgerCloseMetaStreamTests.cpp" />
     <ClCompile Include="..\..\src\main\Diagnostics.cpp" />
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp" />
+    <ClCompile Include="..\..\src\overlay\FlowControl.cpp" />
+    <ClCompile Include="..\..\src\overlay\FlowControlCapacity.cpp" />
     <ClCompile Include="..\..\src\overlay\SurveyManager.cpp" />
     <ClCompile Include="..\..\src\overlay\SurveyMessageLimiter.cpp" />
     <ClCompile Include="..\..\src\overlay\test\SurveyManagerTests.cpp" />
@@ -740,8 +743,6 @@ exit /b 0
     <ClCompile Include="..\..\src\main\test\SelfCheckTests.cpp" />
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp" />
     <ClCompile Include="..\..\src\overlay\Floodgate.cpp" />
-    <ClCompile Include="..\..\src\overlay\FlowControl.cpp" />
-    <ClCompile Include="..\..\src\overlay\FlowControlCapacity.cpp" />
     <ClCompile Include="..\..\src\overlay\ItemFetcher.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayManagerImpl.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayMetrics.cpp" />
@@ -950,8 +951,11 @@ exit /b 0
     <ClInclude Include="..\..\src\historywork\WriteVerifiedCheckpointHashesWork.h" />
     <ClInclude Include="..\..\src\ledger\InternalLedgerEntry.h" />
     <ClInclude Include="..\..\src\ledger\LedgerCloseMetaFrame.h" />
+    <ClInclude Include="..\..\src\ledger\NetworkConfig.h" />
     <ClInclude Include="..\..\src\ledger\NonSociRelatedException.h" />
     <ClInclude Include="..\..\src\main\Diagnostics.h" />
+    <ClInclude Include="..\..\src\overlay\FlowControl.h" />
+    <ClInclude Include="..\..\src\overlay\FlowControlCapacity.h" />
     <ClInclude Include="..\..\src\overlay\SurveyManager.h" />
     <ClInclude Include="..\..\src\overlay\SurveyMessageLimiter.h" />
     <ClInclude Include="..\..\src\test\Fuzzer.h" />
@@ -1095,8 +1099,6 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\BanManager.h" />
     <ClInclude Include="..\..\src\overlay\BanManagerImpl.h" />
     <ClInclude Include="..\..\src\overlay\Floodgate.h" />
-    <ClCompile Include="..\..\src\overlay\FlowControl.h" />
-    <ClCompile Include="..\..\src\overlay\FlowControlCapacity.h" />
     <ClInclude Include="..\..\src\overlay\ItemFetcher.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManager.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManagerImpl.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -954,12 +954,6 @@
     <ClCompile Include="..\..\src\overlay\Floodgate.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\overlay\FlowControl.cpp">
-      <Filter>overlay</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\overlay\FlowControlCapacity.cpp">
-      <Filter>overlay</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\overlay\ItemFetcher.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
@@ -1329,6 +1323,15 @@
     </ClCompile>
     <ClCompile Include="..\..\src\bucket\BucketIndexImpl.cpp">
       <Filter>bucket</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ledger\NetworkConfig.cpp">
+      <Filter>ledger</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\FlowControl.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\FlowControlCapacity.cpp">
+      <Filter>overlay</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1953,12 +1956,6 @@
     <ClInclude Include="..\..\src\overlay\Floodgate.h">
       <Filter>overlay</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\overlay\FlowControl.h">
-      <Filter>overlay</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\overlay\FlowControlCapacity.h">
-      <Filter>overlay</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\overlay\ItemFetcher.h">
       <Filter>overlay</Filter>
     </ClInclude>
@@ -2319,6 +2316,15 @@
     </ClInclude>
     <ClInclude Include="..\..\src\bucket\BucketIndexImpl.h">
       <Filter>bucket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\ledger\NetworkConfig.h">
+      <Filter>ledger</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\FlowControl.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\FlowControlCapacity.h">
+      <Filter>overlay</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -117,10 +117,6 @@ namespace stellar
 
 std::chrono::hours const Upgrades::UPDGRADE_EXPIRATION_HOURS(12);
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-uint32_t const Upgrades::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES_V20(65536);
-#endif
-
 std::string
 Upgrades::UpgradeParameters::toJson() const
 {
@@ -1191,30 +1187,6 @@ upgradeFromProtocol15To16(AbstractLedgerTxn& ltx)
     }
 }
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-static void
-createConfigSettingEntry(ConfigSettingEntry const& configSetting,
-                         AbstractLedgerTxn& ltxRoot)
-{
-    LedgerEntry e;
-    e.data.type(CONFIG_SETTING);
-    e.data.configSetting() = configSetting;
-    LedgerTxn ltx(ltxRoot);
-    ltx.create(e);
-    ltx.commit();
-}
-
-static void
-initializeConfigs(AbstractLedgerTxn& ltx)
-{
-    ConfigSettingEntry contractMaxSize(CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
-    contractMaxSize.contractMaxSizeBytes() =
-        Upgrades::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES_V20;
-    createConfigSettingEntry(contractMaxSize, ltx);
-}
-
-#endif
-
 static bool
 needUpgradeToVersion(ProtocolVersion targetVersion, uint32_t prevVersion,
                      uint32_t newVersion)
@@ -1243,7 +1215,7 @@ Upgrades::applyVersionUpgrade(AbstractLedgerTxn& ltx, uint32_t newVersion)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     if (needUpgradeToVersion(SOROBAN_PROTOCOL_VERSION, prevVersion, newVersion))
     {
-        initializeConfigs(ltx);
+        SorobanNetworkConfig::createLedgerEntriesForV20(ltx);
     }
 #endif
 }
@@ -1435,6 +1407,17 @@ ConfigUpgradeSetFrame::isValidForApply() const
         {
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
             valid = configEntry.contractMaxSizeBytes() > 0;
+            break;
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_COMPUTE_V0:
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_META_DATA_V0:
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_HOST_LOGIC_VERSION:
+            // For now none of these settings have any semantical value.
+            // Validation should be implemented when implementing/tuning
+            // the respective settings.
+            valid = true;
             break;
         }
         if (!valid)

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -32,9 +32,6 @@ class Upgrades
     // upgrades
     static std::chrono::hours const UPDGRADE_EXPIRATION_HOURS;
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    static uint32_t const CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES_V20;
-#endif
     struct UpgradeParameters
     {
         UpgradeParameters()

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -130,7 +130,14 @@ struct BucketListGenerator
     virtual std::vector<LedgerEntry>
     generateLiveEntries(AbstractLedgerTxn& ltx)
     {
-        auto entries = LedgerTestUtils::generateValidLedgerEntries(5);
+        auto entries =
+            LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                {
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+                    CONFIG_SETTING
+#endif
+                },
+                5);
         for (auto& le : entries)
         {
             le.lastModifiedLedgerSeq = mLedgerSeq;

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -6,6 +6,7 @@
 
 #include "catchup/CatchupManager.h"
 #include "history/HistoryManager.h"
+#include "ledger/NetworkConfig.h"
 #include <memory>
 
 namespace stellar
@@ -118,6 +119,13 @@ class LedgerManager
     // return the maximum size of a transaction set to apply to the current
     // ledger expressed in number of operations
     virtual uint32_t getLastMaxTxSetSizeOps() const = 0;
+
+    // Return the network config for Soroban.
+    // The config is automatically refreshed on protocol upgrades.
+    // Ledger txn here is needed for the sake of lazy load; it won't be
+    // used most of the time.
+    virtual SorobanNetworkConfig const&
+    getSorobanNetworkConfig(AbstractLedgerTxn& ltx) = 0;
 
     // Return the (changing) number of seconds since the LCL closed.
     virtual uint64_t secondsSinceLastLedgerClose() const = 0;

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -1,0 +1,430 @@
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "ledger/NetworkConfig.h"
+#include "util/ProtocolVersion.h"
+
+namespace stellar
+{
+namespace
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+void
+createConfigSettingEntry(ConfigSettingEntry const& configSetting,
+                         AbstractLedgerTxn& ltxRoot)
+{
+    LedgerEntry e;
+    e.data.type(CONFIG_SETTING);
+    e.data.configSetting() = configSetting;
+    LedgerTxn ltx(ltxRoot);
+    ltx.create(e);
+    ltx.commit();
+}
+
+ConfigSettingEntry
+initialMaxContractSizeEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES);
+
+    entry.contractMaxSizeBytes() =
+        InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractComputeSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_COMPUTE_V0);
+    auto& e = entry.contractCompute();
+
+    e.ledgerMaxInstructions =
+        InitialSorobanNetworkConfig::LEDGER_MAX_INSTRUCTIONS;
+    e.txMaxInstructions = InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
+    e.feeRatePerInstructionsIncrement =
+        InitialSorobanNetworkConfig::FEE_RATE_PER_INSTRUCTIONS_INCREMENT;
+    e.memoryLimit = InitialSorobanNetworkConfig::MEMORY_LIMIT;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractLedgerAccessSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_LEDGER_COST_V0);
+    auto& e = entry.contractLedgerCost();
+
+    e.ledgerMaxReadLedgerEntries =
+        InitialSorobanNetworkConfig::LEDGER_MAX_READ_LEDGER_ENTRIES;
+    e.ledgerMaxReadBytes = InitialSorobanNetworkConfig::LEDGER_MAX_READ_BYTES;
+    e.ledgerMaxWriteLedgerEntries =
+        InitialSorobanNetworkConfig::LEDGER_MAX_WRITE_LEDGER_ENTRIES;
+    e.ledgerMaxWriteBytes = InitialSorobanNetworkConfig::LEDGER_MAX_WRITE_BYTES;
+    e.txMaxReadLedgerEntries =
+        InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES;
+    e.txMaxReadBytes = InitialSorobanNetworkConfig::TX_MAX_READ_BYTES;
+    e.txMaxWriteLedgerEntries =
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES;
+    e.txMaxWriteBytes = InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
+    e.feeReadLedgerEntry = InitialSorobanNetworkConfig::FEE_READ_LEDGER_ENTRY;
+    e.feeWriteLedgerEntry = InitialSorobanNetworkConfig::FEE_WRITE_LEDGER_ENTRY;
+    e.feeRead1KB = InitialSorobanNetworkConfig::FEE_READ_1KB;
+    e.feeWrite1KB = InitialSorobanNetworkConfig::FEE_WRITE_1KB;
+    e.bucketListSizeBytes = InitialSorobanNetworkConfig::BUCKET_LIST_SIZE_BYTES;
+    e.bucketListFeeRateLow =
+        InitialSorobanNetworkConfig::BUCKET_LIST_FEE_RATE_LOW;
+    e.bucketListFeeRateHigh =
+        InitialSorobanNetworkConfig::BUCKET_LIST_FEE_RATE_HIGH;
+    e.bucketListGrowthFactor =
+        InitialSorobanNetworkConfig::BUCKET_LIST_GROWTH_FACTOR;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractHistoricalDataSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0);
+    auto& e = entry.contractHistoricalData();
+
+    e.feeHistorical1KB = InitialSorobanNetworkConfig::FEE_HISTORICAL_1KB;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractMetaDataSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_META_DATA_V0);
+    auto& e = entry.contractMetaData();
+
+    e.txMaxExtendedMetaDataSizeBytes =
+        InitialSorobanNetworkConfig::TX_MAX_EXTENDED_META_DATA_SIZE_BYTES;
+    e.feeExtendedMetaData1KB =
+        InitialSorobanNetworkConfig::FEE_EXTENDED_META_DATA_1KB;
+
+    return entry;
+}
+
+ConfigSettingEntry
+initialContractBandwidthSettingsEntry()
+{
+    ConfigSettingEntry entry(CONFIG_SETTING_CONTRACT_BANDWIDTH_V0);
+    auto& e = entry.contractBandwidth();
+
+    e.ledgerMaxPropagateSizeBytes =
+        InitialSorobanNetworkConfig::LEDGER_MAX_PROPAGATE_SIZE_BYTES;
+    e.txMaxSizeBytes = InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES;
+    e.feePropagateData1KB = InitialSorobanNetworkConfig::FEE_PROPAGATE_DATA_1KB;
+
+    return entry;
+}
+
+#endif
+}
+
+void
+SorobanNetworkConfig::createLedgerEntriesForV20(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    createConfigSettingEntry(initialMaxContractSizeEntry(), ltx);
+    createConfigSettingEntry(initialContractComputeSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractLedgerAccessSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractHistoricalDataSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractMetaDataSettingsEntry(), ltx);
+    createConfigSettingEntry(initialContractBandwidthSettingsEntry(), ltx);
+#endif
+}
+
+void
+SorobanNetworkConfig::initializeGenesisLedgerForTesting(
+    uint32_t genesisLedgerProtocol, AbstractLedgerTxn& ltx)
+{
+    if (protocolVersionStartsFrom(genesisLedgerProtocol, ProtocolVersion::V_20))
+    {
+        SorobanNetworkConfig::createLedgerEntriesForV20(ltx);
+    }
+}
+
+void
+SorobanNetworkConfig::loadFromLedger(AbstractLedgerTxn& ltxRoot)
+{
+    LedgerTxn ltx(ltxRoot);
+    loadMaxContractSize(ltx);
+    loadComputeSettings(ltx);
+    loadLedgerAccessSettings(ltx);
+    loadHistoricalSettings(ltx);
+    loadMetaDataSettings(ltx);
+    loadBandwidthSettings(ltx);
+}
+
+uint32_t
+SorobanNetworkConfig::maxContractSizeBytes() const
+{
+    return mMaxContractSizeBytes;
+}
+
+void
+SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES;
+    auto le = ltx.loadWithoutRecord(key).current();
+    mMaxContractSizeBytes = le.data.configSetting().contractMaxSizeBytes();
+#endif
+}
+
+void
+SorobanNetworkConfig::loadComputeSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_COMPUTE_V0;
+    auto le = ltx.loadWithoutRecord(key).current();
+    auto const& configSetting = le.data.configSetting().contractCompute();
+    mLedgerMaxInstructions = configSetting.ledgerMaxInstructions;
+    mTxMaxInstructions = configSetting.txMaxInstructions;
+    mFeeRatePerInstructionsIncrement =
+        configSetting.feeRatePerInstructionsIncrement;
+    mMemoryLimit = configSetting.memoryLimit;
+#endif
+}
+
+void
+SorobanNetworkConfig::loadLedgerAccessSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0;
+    auto le = ltx.loadWithoutRecord(key).current();
+    auto const& configSetting = le.data.configSetting().contractLedgerCost();
+    mLedgerMaxReadLedgerEntries = configSetting.ledgerMaxReadLedgerEntries;
+    mLedgerMaxReadBytes = configSetting.ledgerMaxReadBytes;
+    mLedgerMaxWriteLedgerEntries = configSetting.ledgerMaxWriteLedgerEntries;
+    mLedgerMaxWriteBytes = configSetting.ledgerMaxWriteBytes;
+    mTxMaxReadLedgerEntries = configSetting.txMaxReadLedgerEntries;
+    mTxMaxReadBytes = configSetting.txMaxReadBytes;
+    mTxMaxWriteLedgerEntries = configSetting.txMaxWriteLedgerEntries;
+    mTxMaxWriteBytes = configSetting.txMaxWriteBytes;
+    mFeeReadLedgerEntry = configSetting.feeReadLedgerEntry;
+    mFeeWriteLedgerEntry = configSetting.feeWriteLedgerEntry;
+    mFeeRead1KB = configSetting.feeRead1KB;
+    mFeeWrite1KB = configSetting.feeWrite1KB;
+    mBucketListSizeBytes = configSetting.bucketListSizeBytes;
+    mBucketListFeeRateLow = configSetting.bucketListFeeRateLow;
+    mBucketListFeeRateHigh = configSetting.bucketListFeeRateHigh;
+    mBucketListGrowthFactor = configSetting.bucketListGrowthFactor;
+#endif
+}
+
+void
+SorobanNetworkConfig::loadHistoricalSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0;
+    auto le = ltx.loadWithoutRecord(key).current();
+    auto const& configSetting =
+        le.data.configSetting().contractHistoricalData();
+    mFeeHistorical1KB = configSetting.feeHistorical1KB;
+#endif
+}
+
+void
+SorobanNetworkConfig::loadMetaDataSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_META_DATA_V0;
+    auto le = ltx.loadWithoutRecord(key).current();
+    auto const& configSetting = le.data.configSetting().contractMetaData();
+    mFeeExtendedMetaData1KB = configSetting.feeExtendedMetaData1KB;
+    mTxMaxExtendedMetaDataSizeBytes =
+        configSetting.txMaxExtendedMetaDataSizeBytes;
+#endif
+}
+
+void
+SorobanNetworkConfig::loadBandwidthSettings(AbstractLedgerTxn& ltx)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerKey key(CONFIG_SETTING);
+    key.configSetting().configSettingID =
+        ConfigSettingID::CONFIG_SETTING_CONTRACT_BANDWIDTH_V0;
+    auto le = ltx.loadWithoutRecord(key).current();
+    auto const& configSetting = le.data.configSetting().contractBandwidth();
+    mLedgerMaxPropagateSizeBytes = configSetting.ledgerMaxPropagateSizeBytes;
+    mTxMaxSizeBytes = configSetting.txMaxSizeBytes;
+    mFeePropagateData1KB = configSetting.feePropagateData1KB;
+#endif
+}
+
+// Compute settings for contracts (instructions and memory).
+int64_t
+SorobanNetworkConfig::ledgerMaxInstructions() const
+{
+    return mLedgerMaxInstructions;
+}
+
+int64_t
+SorobanNetworkConfig::txMaxInstructions() const
+{
+    return mTxMaxInstructions;
+}
+
+int64_t
+SorobanNetworkConfig::feeRatePerInstructionsIncrement() const
+{
+    return mFeeRatePerInstructionsIncrement;
+}
+
+uint32_t
+SorobanNetworkConfig::memoryLimit() const
+{
+    return mMemoryLimit;
+}
+
+// Ledger access settings for contracts.
+uint32_t
+SorobanNetworkConfig::ledgerMaxReadLedgerEntries() const
+{
+    return mLedgerMaxReadLedgerEntries;
+}
+
+uint32_t
+SorobanNetworkConfig::ledgerMaxReadBytes() const
+{
+    return mLedgerMaxReadBytes;
+}
+
+uint32_t
+SorobanNetworkConfig::ledgerMaxWriteLedgerEntries() const
+{
+    return mLedgerMaxWriteLedgerEntries;
+}
+
+uint32_t
+SorobanNetworkConfig::ledgerMaxWriteBytes() const
+{
+    return mLedgerMaxWriteBytes;
+}
+
+uint32_t
+SorobanNetworkConfig::txMaxReadLedgerEntries() const
+{
+    return mTxMaxReadLedgerEntries;
+}
+
+uint32_t
+SorobanNetworkConfig::txMaxReadBytes() const
+{
+    return mTxMaxReadBytes;
+}
+
+uint32_t
+SorobanNetworkConfig::txMaxWriteLedgerEntries() const
+{
+    return mTxMaxWriteLedgerEntries;
+}
+
+uint32_t
+SorobanNetworkConfig::txMaxWriteBytes() const
+{
+    return mTxMaxWriteBytes;
+}
+
+int64_t
+SorobanNetworkConfig::feeReadLedgerEntry() const
+{
+    return mFeeReadLedgerEntry;
+}
+
+int64_t
+SorobanNetworkConfig::feeWriteLedgerEntry() const
+{
+    return mFeeWriteLedgerEntry;
+}
+
+int64_t
+SorobanNetworkConfig::feeRead1KB() const
+{
+    return mFeeRead1KB;
+}
+
+int64_t
+SorobanNetworkConfig::feeWrite1KB() const
+{
+    return mFeeWrite1KB;
+}
+
+int64_t
+SorobanNetworkConfig::bucketListSizeBytes() const
+{
+    return mBucketListSizeBytes;
+}
+
+int64_t
+SorobanNetworkConfig::bucketListFeeRateLow() const
+{
+    return mBucketListFeeRateLow;
+}
+
+int64_t
+SorobanNetworkConfig::bucketListFeeRateHigh() const
+{
+    return mBucketListFeeRateHigh;
+}
+
+uint32_t
+SorobanNetworkConfig::bucketListGrowthFactor() const
+{
+    return mBucketListGrowthFactor;
+}
+
+// Historical data (pushed to core archives) settings for contracts.
+int64_t
+SorobanNetworkConfig::feeHistorical1KB() const
+{
+    return mFeeHistorical1KB;
+}
+
+// Meta data (pushed to downstream systems) settings for contracts.
+uint32_t
+SorobanNetworkConfig::txMaxExtendedMetaDataSizeBytes() const
+{
+    return mTxMaxExtendedMetaDataSizeBytes;
+}
+
+int64_t
+SorobanNetworkConfig::feeExtendedMetaData1KB() const
+{
+    return mFeeExtendedMetaData1KB;
+}
+
+// Bandwidth related data settings for contracts
+uint32_t
+SorobanNetworkConfig::ledgerMaxPropagateSizeBytes() const
+{
+    return mLedgerMaxPropagateSizeBytes;
+}
+
+uint32_t
+SorobanNetworkConfig::txMaxSizeBytes() const
+{
+    return mTxMaxSizeBytes;
+}
+
+int64_t
+SorobanNetworkConfig::feePropagateData1KB() const
+{
+    return mFeePropagateData1KB;
+}
+
+}

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -1,0 +1,193 @@
+#pragma once
+
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include <cstdint>
+#include <ledger/LedgerTxn.h>
+
+namespace stellar
+{
+
+// Defines the initial values of the network configuration
+// settings that are applied during the protocol version upgrade.
+// These values should never be changed after the protocol upgrade
+// happens - any further changes should be performed separately via
+// config upgrade mechanism.
+struct InitialSorobanNetworkConfig
+{
+    // Contract size settings
+    static constexpr uint32_t MAX_CONTRACT_SIZE = 65536;
+
+    // Compute settings
+    static constexpr int64_t LEDGER_MAX_INSTRUCTIONS = 1;
+    static constexpr int64_t TX_MAX_INSTRUCTIONS = 1;
+    static constexpr int64_t FEE_RATE_PER_INSTRUCTIONS_INCREMENT = 1;
+    static constexpr uint32_t MEMORY_LIMIT = 1;
+
+    // Ledger access settings
+    static constexpr uint32_t LEDGER_MAX_READ_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t LEDGER_MAX_READ_BYTES = 1;
+    static constexpr uint32_t LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t LEDGER_MAX_WRITE_BYTES = 1;
+    static constexpr uint32_t TX_MAX_READ_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t TX_MAX_READ_BYTES = 1;
+    static constexpr uint32_t TX_MAX_WRITE_LEDGER_ENTRIES = 1;
+    static constexpr uint32_t TX_MAX_WRITE_BYTES = 1;
+    static constexpr int64_t FEE_READ_LEDGER_ENTRY = 1;
+    static constexpr int64_t FEE_WRITE_LEDGER_ENTRY = 1;
+    static constexpr int64_t FEE_READ_1KB = 1;
+    static constexpr int64_t FEE_WRITE_1KB = 1;
+    static constexpr int64_t BUCKET_LIST_SIZE_BYTES = 1;
+    static constexpr int64_t BUCKET_LIST_FEE_RATE_LOW = 1;
+    static constexpr int64_t BUCKET_LIST_FEE_RATE_HIGH = 1;
+    static constexpr uint32_t BUCKET_LIST_GROWTH_FACTOR = 1;
+
+    // Historical data settings
+    static constexpr int64_t FEE_HISTORICAL_1KB = 1;
+
+    // Bandwidth settings
+    static constexpr uint32_t LEDGER_MAX_PROPAGATE_SIZE_BYTES = 1;
+    static constexpr uint32_t TX_MAX_SIZE_BYTES = 1;
+    static constexpr int64_t FEE_PROPAGATE_DATA_1KB = 1;
+
+    // Meta data settings
+    static constexpr uint32_t TX_MAX_EXTENDED_META_DATA_SIZE_BYTES = 1;
+    static constexpr int64_t FEE_EXTENDED_META_DATA_1KB = 1;
+};
+
+// Wrapper for the contract-related network configuration.
+class SorobanNetworkConfig
+{
+  public:
+    // Creates the initial contract configuration entries for protocol v20.
+    // This should happen once during the correspondent protocol version
+    // upgrade.
+    static void createLedgerEntriesForV20(AbstractLedgerTxn& ltx);
+    // Test-only function that initializes contract network configuration
+    // bypassing the normal upgrade process (i.e. when genesis ledger starts not
+    // at v1)
+    static void
+    initializeGenesisLedgerForTesting(uint32_t genesisLedgerProtocol,
+                                      AbstractLedgerTxn& ltx);
+
+    void loadFromLedger(AbstractLedgerTxn& ltx);
+    // Maximum allowed size of the contract Wasm that can be uploaded (in
+    // bytes).
+    uint32_t maxContractSizeBytes() const;
+
+    // Compute settings for contracts (instructions and memory).
+    // Maximum instructions per ledger
+    int64_t ledgerMaxInstructions() const;
+    // Maximum instructions per transaction
+    int64_t txMaxInstructions() const;
+    // Cost of 10000 instructions
+    int64_t feeRatePerInstructionsIncrement() const;
+    // Memory limit per contract/host function invocation. Unlike
+    // instructions, there is no fee for memory and it's not
+    // accumulated between operations - the same limit is applied
+    // to every operation.
+    uint32_t memoryLimit() const;
+
+    // Ledger access settings for contracts.
+    // Maximum number of ledger entry read operations per ledger
+    uint32_t ledgerMaxReadLedgerEntries() const;
+    // Maximum number of bytes that can be read per ledger
+    uint32_t ledgerMaxReadBytes() const;
+    // Maximum number of ledger entry write operations per ledger
+    uint32_t ledgerMaxWriteLedgerEntries() const;
+    // Maximum number of bytes that can be written per ledger
+    uint32_t ledgerMaxWriteBytes() const;
+    // Maximum number of ledger entry read operations per transaction
+    uint32_t txMaxReadLedgerEntries() const;
+    // Maximum number of bytes that can be read per transaction
+    uint32_t txMaxReadBytes() const;
+    // Maximum number of ledger entry write operations per transaction
+    uint32_t txMaxWriteLedgerEntries() const;
+    // Maximum number of bytes that can be written per transaction
+    uint32_t txMaxWriteBytes() const;
+    // Fee per ledger entry read
+    int64_t feeReadLedgerEntry() const;
+    // Fee per ledger entry write
+    int64_t feeWriteLedgerEntry() const;
+    // Fee for reading 1KB
+    int64_t feeRead1KB() const;
+    // Fee for writing 1KB
+    int64_t feeWrite1KB() const;
+    // Bucket list fees grow slowly up to that size
+    int64_t bucketListSizeBytes() const;
+    // Fee rate in stroops when the bucket list is empty
+    int64_t bucketListFeeRateLow() const;
+    // Fee rate in stroops when the bucket list reached bucketListSizeBytes
+    int64_t bucketListFeeRateHigh() const;
+    // Rate multiplier for any additional data past the first
+    // bucketListSizeBytes
+    uint32_t bucketListGrowthFactor() const;
+
+    // Historical data (pushed to core archives) settings for contracts.
+    // Fee for storing 1KB in archives
+    int64_t feeHistorical1KB() const;
+
+    // Meta data (pushed to downstream systems) settings for contracts.
+    // Maximum size of extended meta data produced by a transaction
+    uint32_t txMaxExtendedMetaDataSizeBytes() const;
+    // Fee for generating 1KB of extended meta data
+    int64_t feeExtendedMetaData1KB() const;
+
+    // Bandwidth related data settings for contracts
+    // Maximum size in bytes to propagate per ledger
+    uint32_t ledgerMaxPropagateSizeBytes() const;
+    // Maximum size in bytes for a transaction
+    uint32_t txMaxSizeBytes() const;
+    // Fee for propagating 1KB of data
+    int64_t feePropagateData1KB() const;
+
+  private:
+    void loadMaxContractSize(AbstractLedgerTxn& ltx);
+    void loadComputeSettings(AbstractLedgerTxn& ltx);
+    void loadLedgerAccessSettings(AbstractLedgerTxn& ltx);
+    void loadHistoricalSettings(AbstractLedgerTxn& ltx);
+    void loadMetaDataSettings(AbstractLedgerTxn& ltx);
+    void loadBandwidthSettings(AbstractLedgerTxn& ltx);
+
+    uint32_t mMaxContractSizeBytes{};
+
+    // Compute settings for contracts (instructions and memory).
+    int64_t mLedgerMaxInstructions{};
+    int64_t mTxMaxInstructions{};
+    int64_t mFeeRatePerInstructionsIncrement{};
+    uint32_t mMemoryLimit{};
+
+    // Ledger access settings for contracts.
+    uint32_t mLedgerMaxReadLedgerEntries{};
+    uint32_t mLedgerMaxReadBytes{};
+    uint32_t mLedgerMaxWriteLedgerEntries{};
+    uint32_t mLedgerMaxWriteBytes{};
+    uint32_t mTxMaxReadLedgerEntries{};
+    uint32_t mTxMaxReadBytes{};
+    uint32_t mTxMaxWriteLedgerEntries{};
+    uint32_t mTxMaxWriteBytes{};
+    int64_t mFeeReadLedgerEntry{};
+    int64_t mFeeWriteLedgerEntry{};
+    int64_t mFeeRead1KB{};
+    int64_t mFeeWrite1KB{};
+    int64_t mBucketListSizeBytes{};
+    int64_t mBucketListFeeRateLow{};
+    int64_t mBucketListFeeRateHigh{};
+    uint32_t mBucketListGrowthFactor{};
+
+    // Historical data (pushed to core archives) settings for contracts.
+    int64_t mFeeHistorical1KB{};
+
+    // Meta data (pushed to downstream systems) settings for contracts.
+    uint32_t mTxMaxExtendedMetaDataSizeBytes{};
+    int64_t mFeeExtendedMetaData1KB{};
+
+    // Bandwidth related data settings for contracts
+    uint32_t mLedgerMaxPropagateSizeBytes{};
+    uint32_t mTxMaxSizeBytes{};
+    int64_t mFeePropagateData1KB{};
+};
+
+}

--- a/src/overlay/test/OverlayTestUtils.cpp
+++ b/src/overlay/test/OverlayTestUtils.cpp
@@ -2,11 +2,13 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "overlay/test/OverlayTestUtils.h"
+#include <numeric>
+
 #include "main/Application.h"
 #include "medida/metrics_registry.h"
 #include "overlay/OverlayManager.h"
 #include "overlay/OverlayMetrics.h"
+#include "overlay/test/OverlayTestUtils.h"
 #include "simulation/Simulation.h"
 #include "util/Logging.h"
 

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -1593,21 +1593,6 @@ LedgerHeader
 executeUpgrades(Application& app, xdr::xvector<UpgradeType, 6> const& upgrades,
                 bool upgradesIgnored)
 {
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    LedgerKey key(LedgerEntryType::CONFIG_SETTING);
-    key.configSetting().configSettingID =
-        ConfigSettingID::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES;
-    std::optional<LedgerEntry> currConfigSetting;
-    {
-        LedgerTxn ltx(app.getLedgerTxnRoot());
-        auto ltxe = ltx.load(key);
-        if (ltxe)
-        {
-            currConfigSetting = ltxe.current();
-        }
-    }
-#endif
-
     auto& lm = app.getLedgerManager();
     auto currLh = app.getLedgerManager().getLastClosedLedgerHeader().header;
 
@@ -1628,21 +1613,6 @@ executeUpgrades(Application& app, xdr::xvector<UpgradeType, 6> const& upgrades,
         {
             REQUIRE(currLh.ext.v1().flags == newHeader.ext.v1().flags);
         }
-
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-        {
-            LedgerTxn ltx(app.getLedgerTxnRoot());
-            auto ltxe = ltx.load(key);
-            if (currConfigSetting)
-            {
-                REQUIRE((ltxe && *currConfigSetting == ltxe.current()));
-            }
-            else
-            {
-                REQUIRE(!ltxe);
-            }
-        }
-#endif
     }
     return lm.getLastClosedLedgerHeader().header;
 };

--- a/src/testdata/ledger-close-meta-v2-protocol-20.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-20.json
@@ -3,24 +3,24 @@
         "v": 2,
         "v2": {
             "ledgerHeader": {
-                "hash": "d0b37ed561e1b90f5e1497fef6cfe7833aaf0998950e48e7b27f6be846e9461b",
+                "hash": "1410f70525bc7816b410a76b1d580c00f0931f53c5d69c74e776dc4061fb1ce7",
                 "header": {
                     "ledgerVersion": 20,
-                    "previousLedgerHash": "dd561a327b014b0f511959d018de7bb71642ae1a1cccb50f3a54a0f4a87ad45a",
+                    "previousLedgerHash": "5472c67a3e045697b055b00a1c3faf1496eac068495b48b590d946b76b95acf6",
                     "scpValue": {
-                        "txSetHash": "4f341d680ef63cae2a8d8d3a866645fa69157c3ff2a67591cccc290f85d6d886",
+                        "txSetHash": "a7f687217f88a7804c13336e4068a44642276368bfebb023fd6811fd22a57619",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "a07c453be53007af033ca955f90a13c46bab315601927eabf9d1288057ed4ff586176a55c4e8ec7f0e17eff056ff60ab8f69b18b7642feb48372ce32f3ea190d"
+                                "signature": "202a781ca98239dd8beab7bda688f7f11f6cf8e511e360ac35ecc78f4cf6076b5d497cf93671059dfb34fe84e11571d6b35f625ea5734fc20bbd3170025f2106"
                             }
                         }
                     },
-                    "txSetResultHash": "cf65fee29665ff0c2a6910b24c420a487a7416ccd79c683b48aac1d45ad21faa",
-                    "bucketListHash": "67491b450fff11a412253e08811318abd30b17e429e1c824be57e496ba80d745",
+                    "txSetResultHash": "cd1398cda325d4eada631301e6501421cda30fd0b43da3e5d0ffb26caf073b0a",
+                    "bucketListHash": "b93f478412fb33f5dc20bdfa0a33e0a0a93cfe65aef4f1234b28f24ff3aca397",
                     "ledgerSeq": 6,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -46,7 +46,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "dd561a327b014b0f511959d018de7bb71642ae1a1cccb50f3a54a0f4a87ad45a",
+                    "previousLedgerHash": "5472c67a3e045697b055b00a1c3faf1496eac068495b48b590d946b76b95acf6",
                     "phases": [
                         {
                             "v": 0,
@@ -176,6 +176,360 @@
                 }
             },
             "txProcessing": [
+                {
+                    "result": {
+                        "transactionHash": "66efe325ead9f52082c8908b7813bd96793fd5ff0f1e50fdc50b23f68938dd4d",
+                        "hashOfMetaHashes": "847cc25b01018aec5d3e1e22b2d8a1c3804675ee6ea9811d75828437558686a5"
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 3,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 400000000,
+                                        "seqNum": 12884901888,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 6,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 399999700,
+                                        "seqNum": 12884901888,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 6,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399999700,
+                                                "seqNum": 12884901888,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 6,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399999700,
+                                                "seqNum": 12884901888,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 4,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
+                                                "balance": 200010000,
+                                                "seqNum": 17179869184,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 6,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
+                                                "balance": 200010000,
+                                                "seqNum": 17179869185,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 6,
+                                                                        "seqTime": 0
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 5,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 0,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 50,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 50,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 100,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "txChangesAfter": [],
+                            "events": [],
+                            "txResult": {
+                                "feeCharged": 300,
+                                "result": {
+                                    "code": "txFEE_BUMP_INNER_SUCCESS",
+                                    "innerResultPair": {
+                                        "transactionHash": "5ab197acffd4b32d320df39b2b1f76246e2279fa8070c6c690cca1343e5e7e0b",
+                                        "result": {
+                                            "feeCharged": 200,
+                                            "result": {
+                                                "code": "txSUCCESS",
+                                                "results": [
+                                                    {
+                                                        "code": "opINNER",
+                                                        "tr": {
+                                                            "type": "PAYMENT",
+                                                            "paymentResult": {
+                                                                "code": "PAYMENT_SUCCESS"
+                                                            }
+                                                        }
+                                                    },
+                                                    {
+                                                        "code": "opINNER",
+                                                        "tr": {
+                                                            "type": "PAYMENT",
+                                                            "paymentResult": {
+                                                                "code": "PAYMENT_SUCCESS"
+                                                            }
+                                                        }
+                                                    }
+                                                ]
+                                            },
+                                            "ext": {
+                                                "v": 0
+                                            }
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            },
+                            "hashes": [
+                                "5e76866b312f53a1b1aa40b9c6bf0bde5c5d8735857c5c18e64f9a59f6528433",
+                                "df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119",
+                                "378b89ef6afaa954ea5f891347e31aae15a5504756a384feeabc47e0f60e7217"
+                            ],
+                            "diagnosticEvents": []
+                        }
+                    }
+                },
                 {
                     "result": {
                         "transactionHash": "0db2322d85e9d8ea2421559922bb6107429650ebdad304c907480853d465c10d",
@@ -620,360 +974,6 @@
                                 "0737d31b38576c80823e6aa85b45a09ff78745fa3abd6ef8d405ba2533d66172",
                                 "df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119",
                                 "af84e88b1979ab15bfcdbfde2fcd6c9d3a070d86f80cf0ee7fbe11107f998e06"
-                            ],
-                            "diagnosticEvents": []
-                        }
-                    }
-                },
-                {
-                    "result": {
-                        "transactionHash": "66efe325ead9f52082c8908b7813bd96793fd5ff0f1e50fdc50b23f68938dd4d",
-                        "hashOfMetaHashes": "847cc25b01018aec5d3e1e22b2d8a1c3804675ee6ea9811d75828437558686a5"
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 3,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 400000000,
-                                        "seqNum": 12884901888,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 6,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 399999700,
-                                        "seqNum": 12884901888,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 6,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399999700,
-                                                "seqNum": 12884901888,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 6,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399999700,
-                                                "seqNum": 12884901888,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 4,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
-                                                "balance": 200010000,
-                                                "seqNum": 17179869184,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 6,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
-                                                "balance": 200010000,
-                                                "seqNum": 17179869185,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 6,
-                                                                        "seqTime": 0
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 5,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 0,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 50,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 50,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 100,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "txChangesAfter": [],
-                            "events": [],
-                            "txResult": {
-                                "feeCharged": 300,
-                                "result": {
-                                    "code": "txFEE_BUMP_INNER_SUCCESS",
-                                    "innerResultPair": {
-                                        "transactionHash": "5ab197acffd4b32d320df39b2b1f76246e2279fa8070c6c690cca1343e5e7e0b",
-                                        "result": {
-                                            "feeCharged": 200,
-                                            "result": {
-                                                "code": "txSUCCESS",
-                                                "results": [
-                                                    {
-                                                        "code": "opINNER",
-                                                        "tr": {
-                                                            "type": "PAYMENT",
-                                                            "paymentResult": {
-                                                                "code": "PAYMENT_SUCCESS"
-                                                            }
-                                                        }
-                                                    },
-                                                    {
-                                                        "code": "opINNER",
-                                                        "tr": {
-                                                            "type": "PAYMENT",
-                                                            "paymentResult": {
-                                                                "code": "PAYMENT_SUCCESS"
-                                                            }
-                                                        }
-                                                    }
-                                                ]
-                                            },
-                                            "ext": {
-                                                "v": 0
-                                            }
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            },
-                            "hashes": [
-                                "5e76866b312f53a1b1aa40b9c6bf0bde5c5d8735857c5c18e64f9a59f6528433",
-                                "df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119",
-                                "378b89ef6afaa954ea5f891347e31aae15a5504756a384feeabc47e0f60e7217"
                             ],
                             "diagnosticEvents": []
                         }

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -65,11 +65,20 @@ TEST_CASE("txset - correct apply order", "[tx][envelope]")
     auto txSet = TxSetFrame::makeFromTransactions(
         TxSetFrame::Transactions{tx1, tx2}, *app, 0, 0);
 
-    // Sort for apply re-orders transaction set
     auto txs = txSet->getTxsInApplyOrder();
     REQUIRE(txs.size() == 2);
-    REQUIRE(txs[1]->getFullHash() == tx1->getFullHash());
-    REQUIRE(txs[0]->getFullHash() == tx2->getFullHash());
+    // Sort for apply re-orders transaction set based on the contents hash
+    if (lessThanXored(tx1->getFullHash(), tx2->getFullHash(),
+                      txSet->getContentsHash()))
+    {
+        REQUIRE(txs[0]->getFullHash() == tx1->getFullHash());
+        REQUIRE(txs[1]->getFullHash() == tx2->getFullHash());
+    }
+    else
+    {
+        REQUIRE(txs[1]->getFullHash() == tx1->getFullHash());
+        REQUIRE(txs[0]->getFullHash() == tx2->getFullHash());
+    }
 }
 
 TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")


### PR DESCRIPTION
# Description

Add a wrapper for network configuration and load it when appropriate.

Getting the right configuration from the ledger using transactions would be quite cumbersome. Instead, provide access to all the relevant entries via getters (probably some of them will not be relevant for core; we can clean this up if needed).

Also generalized the initialization and upgrades process, as now we have a lot of various settings.

This is the Core-side implementation of https://github.com/stellar/stellar-core/issues/3691

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)