### PR TITLE
More versioning tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,24 +625,24 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618#541a410bb9a73842b33a8908c5afab08a37fa618"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618)",
+ "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=5e7cd5792894a3f067067a868f30a62697c1dd7b)",
+ "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=48052d83db7f577164264d916b8590d792a67b02)",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442#dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802#b79db4cee33016b11a9329abdf56da873dbaf802"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442)",
+ "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=5b807e5652c1efe6c21d88ba8bca1b76254c4897)",
@@ -651,7 +651,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618#541a410bb9a73842b33a8908c5afab08a37fa618"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -663,8 +663,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618)",
- "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618)",
+ "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
+ "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442#dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802#b79db4cee33016b11a9329abdf56da873dbaf802"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -685,8 +685,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442)",
- "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442)",
+ "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802)",
+ "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -695,14 +695,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618#541a410bb9a73842b33a8908c5afab08a37fa618"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=5e7cd5792894a3f067067a868f30a62697c1dd7b)",
+ "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=48052d83db7f577164264d916b8590d792a67b02)",
  "syn 1.0.109",
  "thiserror",
 ]
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442#dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802#b79db4cee33016b11a9329abdf56da873dbaf802"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618#541a410bb9a73842b33a8908c5afab08a37fa618"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442#dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802#b79db4cee33016b11a9329abdf56da873dbaf802"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442#dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
 
 [[package]]
 name = "soroban-wasmi"
@@ -792,15 +792,15 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=541a410bb9a73842b33a8908c5afab08a37fa618)",
- "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442)",
+ "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
+ "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802)",
  "soroban-test-wasms",
 ]
 
 [[package]]
 name = "stellar-xdr"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5b807e5652c1efe6c21d88ba8bca1b76254c4897#5b807e5652c1efe6c21d88ba8bca1b76254c4897"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=48052d83db7f577164264d916b8590d792a67b02#48052d83db7f577164264d916b8590d792a67b02"
 dependencies = [
  "base64",
  "crate-git-revision",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5e7cd5792894a3f067067a868f30a62697c1dd7b#5e7cd5792894a3f067067a868f30a62697c1dd7b"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=5b807e5652c1efe6c21d88ba8bca1b76254c4897#5b807e5652c1efe6c21d88ba8bca1b76254c4897"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/docs/versioning-soroban.md
+++ b/docs/versioning-soroban.md
@@ -139,10 +139,14 @@ There are three caveats to the above:
      relax the second criterion, only warning.
 
   3. When soroban is in a pre-1.0 state we also _tighten_ the third criterion,
-     treating _minor_ versions as incompatible and even incorporating a
-     manually-specified "interface number" in the build that allows us to force
-     recompiling contracts when the interface-number changes. This is done by
-     storing a 64 bit value in the WASM where only the low 32 bits are the
-     protocol number, and the high 32 bits will eventually be 0 but are given
-     the "interface number" during pre-1.0 development.
+     specifying both a 32-bit protocol version and a secondary 32-bit
+     "pre-release version" into a composite 64-bit "interface version number"
+     stored in the WASM (the low 32 bits are the pre-release number, the high 32
+     bits are the protocol number). While the protocol version comparison allows
+     contracts compiled with old protocols to run on new hosts, the pre-release
+     number has to match _exactly_ for a contract to run. This allows forcing
+     recompilation of pre-release contracts by bumping the pre-release version.
+     After soroban 1.0 is released, in any release with a nonzero major version
+     number, the pre-release version component of the interface version must
+     always be zero.
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -15,10 +15,10 @@ stellar_core_SOURCES = main/StellarCoreVersion.cpp main/XDRFilesSha256.cpp $(SRC
 endif # !BUILD_TESTS
 
 if ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-main/XDRFilesSha256.cpp: $(SRC_X_FILES) Makefile.am $(top_srcdir)/hash-xdrs.sh
+main/XDRFilesSha256.cpp: $(SRC_X_FILES) Makefile $(top_srcdir)/hash-xdrs.sh
 	$(top_srcdir)/hash-xdrs.sh protocol-next >$@
 else
-main/XDRFilesSha256.cpp: $(SRC_X_FILES) Makefile.am $(top_srcdir)/hash-xdrs.sh
+main/XDRFilesSha256.cpp: $(SRC_X_FILES) Makefile $(top_srcdir)/hash-xdrs.sh
 	$(top_srcdir)/hash-xdrs.sh protocol-curr >$@
 endif
 
@@ -85,15 +85,15 @@ $(RUST_CXXBRIDGE):
 	mkdir -p $(RUST_BIN_DIR)
 	$(CARGO) install --root $(RUST_BUILD_DIR) cxxbridge-cmd --version 1.0.68
 
-rust/RustBridge.h: rust/src/lib.rs $(SRC_RUST_FILES) Makefile.am $(RUST_CXXBRIDGE)
+rust/RustBridge.h: rust/src/lib.rs $(SRC_RUST_FILES) Makefile $(RUST_CXXBRIDGE)
 	$(RUST_CXXBRIDGE) $< --header --output $@.tmp
 	if cmp -s $@.tmp $@; then rm -v $@.tmp; else mv -v $@.tmp $@; fi
 
-rust/RustBridge.cpp: rust/src/lib.rs $(SRC_RUST_FILES) Makefile.am $(RUST_CXXBRIDGE)
+rust/RustBridge.cpp: rust/src/lib.rs $(SRC_RUST_FILES) Makefile $(RUST_CXXBRIDGE)
 	$(RUST_CXXBRIDGE) $< --output $@.tmp
 	if cmp -s $@.tmp $@; then rm -v $@.tmp; else mv -v $@.tmp $@; fi
 
-$(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile.am
+$(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile
 	cd $(RUST_BUILD_DIR) && cargo build --$(RUST_PROFILE) --target-dir $(abspath $(RUST_TARGET_DIR)) $(CARGO_FEATURES)
 	ranlib $@
 else

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1413,6 +1413,9 @@ ConfigUpgradeSetFrame::isValidForApply() const
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_META_DATA_V0:
+        case ConfigSettingID::
+            CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS:
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES:
             // For now none of these settings have any semantical value.
             // Validation should be implemented when implementing/tuning
             // the respective settings.

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1400,8 +1400,12 @@ runVersion(CommandLineArgs const&)
               << rust_bridge::get_soroban_env_git_versions().curr.c_str()
               << std::endl;
 
-    std::cout << "        interface version: "
-              << rust_bridge::get_soroban_env_interface_versions().curr
+    std::cout << "        ledger protocol version: "
+              << rust_bridge::get_soroban_env_ledger_protocol_versions().curr
+              << std::endl;
+
+    std::cout << "        pre-release version: "
+              << rust_bridge::get_soroban_env_pre_release_versions().curr
               << std::endl;
 
     std::cout << "        rs-stellar-xdr:" << std::endl;
@@ -1430,8 +1434,13 @@ runVersion(CommandLineArgs const&)
                   << rust_bridge::get_soroban_env_git_versions().prev.c_str()
                   << std::endl;
 
-        std::cout << "        interface version: "
-                  << rust_bridge::get_soroban_env_interface_versions().prev
+        std::cout
+            << "        ledger protocol version: "
+            << rust_bridge::get_soroban_env_ledger_protocol_versions().prev
+            << std::endl;
+
+        std::cout << "        pre-release version: "
+                  << rust_bridge::get_soroban_env_pre_release_versions().prev
                   << std::endl;
 
         std::cout << "        rs-stellar-xdr:" << std::endl;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -233,7 +233,7 @@ checkStellarCoreMajorVersionProtocolIdentity()
     else
     {
         std::cerr << "Warning: running non-release version "
-                  << STELLAR_CORE_VERSION << " of stellar-core";
+                  << STELLAR_CORE_VERSION << " of stellar-core" << std::endl;
     }
 }
 #endif

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -27,7 +27,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+rev = "1599a5a57edfd23ce5d7feee49faac7988ee5249"
 features = ["vm"]
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
@@ -52,12 +52,12 @@ optional = true
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "541a410bb9a73842b33a8908c5afab08a37fa618"
+rev = "b79db4cee33016b11a9329abdf56da873dbaf802"
 features = ["vm"]
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "dab3fd1a813e2bf5c6b23cd828d46de11f40b442"
+rev = "1599a5a57edfd23ce5d7feee49faac7988ee5249"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=dab3fd1a813e2bf5c6b23cd828d46de11f40b442#dab3fd1a813e2bf5c6b23cd828d46de11f40b442
+soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249
 ├── tinyvec 1.6.0 checksum:87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50
 │   └── tinyvec_macros 0.1.1 checksum:1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f

--- a/src/rust/src/host-dep-tree-prev.txt
+++ b/src/rust/src/host-dep-tree-prev.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=83ab1b0e2ce7e08d33d686ed4b4ea0564b454160#83ab1b0e2ce7e08d33d686ed4b4ea0564b454160
+soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802#b79db4cee33016b11a9329abdf56da873dbaf802
 ├── tinyvec 1.6.0 checksum:87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50
 │   └── tinyvec_macros 0.1.1 checksum:1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -497,7 +497,7 @@ pub(crate) fn invoke_host_functions(
         if ledger_info.protocol_version == config_max_protocol - 1 {
             return soroban_prev::contract::invoke_host_functions(
                 enable_diagnostics,
-                hf_buf,
+                hf_bufs,
                 resources_buf,
                 source_account_buf,
                 ledger_info,

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -79,8 +79,8 @@ mod rust_bridge {
     }
 
     struct VersionNumPair {
-        curr: u64,
-        prev: u64,
+        curr: u32,
+        prev: u32,
     }
 
     struct XDRHashesPair {
@@ -120,8 +120,11 @@ mod rust_bridge {
         // Return the env git versions used to build this binary.
         fn get_soroban_env_git_versions() -> VersionStringPair;
 
-        // Return the env interface versions used to build this binary.
-        fn get_soroban_env_interface_versions() -> VersionNumPair;
+        // Return the env protocol versions used to build this binary.
+        fn get_soroban_env_ledger_protocol_versions() -> VersionNumPair;
+
+        // Return the env pre-release versions used to build this binary.
+        fn get_soroban_env_pre_release_versions() -> VersionNumPair;
 
         // Return the rust XDR bindings cargo package versions used to build this binary.
         fn get_soroban_xdr_bindings_pkg_versions() -> VersionStringPair;
@@ -237,27 +240,49 @@ fn package_matches_hash(pkg: &cargo_lock::Package, hash: &str) -> bool {
     false
 }
 fn check_lockfile_has_expected_dep_tree(
-    protocol_version: u32,
+    stellar_core_proto_version: u32,
+    soroban_host_interface_version: u64,
     lockfile: &Lockfile,
     curr_or_prev: &str,
     package_hash: &str,
     expected: &str,
 ) {
+    use soroban_curr::soroban_env_host::meta::{
+        get_ledger_protocol_version, get_pre_release_version,
+    };
+    let soroban_host_proto_version = get_ledger_protocol_version(soroban_host_interface_version);
+    let soroban_host_pre_release_version = get_pre_release_version(soroban_host_interface_version);
+
+    // FIXME: this is fairly harmless, but old versions of soroban didn't encode a
+    // protocol version in their interface version at all, so will report zero here.
+    // For now we ignore this, but should tighten the test up before final.
+    if soroban_host_proto_version != 0 && stellar_core_proto_version != soroban_host_proto_version {
+        panic!(
+            "stellar-core supports protocol {} but soroban host supports {}",
+            stellar_core_proto_version, soroban_host_proto_version
+        );
+    }
+
     let pkg = lockfile
         .packages
         .iter()
         .find(|p| p.name.as_str() == "soroban-env-host" && package_matches_hash(p, package_hash))
         .expect("locating host package in Cargo.lock");
 
+    if soroban_host_pre_release_version != 0 && pkg.version.major != 0 {
+        panic!("soroban interface version indicates pre-release {} but package version is {}, with nonzero major version",
+                soroban_host_pre_release_version, pkg.version)
+    }
+
     if pkg.version.major == 0 {
         eprintln!(
             "Warning: soroban-env-host-{} is running a pre-release version {}",
             curr_or_prev, pkg.version
         );
-    } else if pkg.version.major != protocol_version as u64 {
+    } else if pkg.version.major != stellar_core_proto_version as u64 {
         panic!(
             "soroban-env-host-{} version {} major version {} does not match expected protocol version {}",
-            curr_or_prev, pkg.version, pkg.version.major, protocol_version
+            curr_or_prev, pkg.version, pkg.version.major, stellar_core_proto_version
         )
     }
 
@@ -300,6 +325,10 @@ fn check_lockfile_has_expected_dep_tree(
 // accidentally bumps dependencies (which cargo does fairly easily), and also to
 // make crystal clear when doing a commit that intentionally bumps dependencies
 // which of the _dependency tree(s)_ is being affected, and how.
+//
+// The check additionally checks that the major version number of soroban that
+// is compiled-in matches its max supported protocol number and that that
+// is the same as stellar-core's max supported protocol number.
 pub fn check_lockfile_has_expected_dep_trees(curr_max_protocol_version: u32) {
     static CARGO_LOCK_FILE_CONTENT: &'static str = include_str!("../../../Cargo.lock");
 
@@ -312,6 +341,7 @@ pub fn check_lockfile_has_expected_dep_trees(curr_max_protocol_version: u32) {
 
     check_lockfile_has_expected_dep_tree(
         curr_max_protocol_version,
+        soroban_env_host_curr::meta::INTERFACE_VERSION,
         &lockfile,
         "curr",
         soroban_env_host_curr::VERSION.rev,
@@ -320,6 +350,7 @@ pub fn check_lockfile_has_expected_dep_trees(curr_max_protocol_version: u32) {
     #[cfg(feature = "soroban-env-host-prev")]
     check_lockfile_has_expected_dep_tree(
         curr_max_protocol_version - 1,
+        soroban_env_host_prev::meta::INTERFACE_VERSION,
         &lockfile,
         "prev",
         soroban_env_host_prev::VERSION.rev,
@@ -354,11 +385,29 @@ fn get_soroban_env_git_versions() -> VersionStringPair {
     }
 }
 
-fn get_soroban_env_interface_versions() -> VersionNumPair {
+fn get_soroban_env_ledger_protocol_versions() -> VersionNumPair {
+    use curr_host::meta::get_ledger_protocol_version;
+    use soroban_curr::soroban_env_host as curr_host;
+    #[cfg(feature = "soroban-env-host-prev")]
+    use soroban_prev::soroban_env_host as prev_host;
     VersionNumPair {
-        curr: soroban_curr::soroban_env_host::VERSION.interface,
+        curr: get_ledger_protocol_version(curr_host::VERSION.interface),
         #[cfg(feature = "soroban-env-host-prev")]
-        prev: soroban_prev::soroban_env_host::VERSION.interface,
+        prev: get_ledger_protocol_version(prev_host::VERSION.interface),
+        #[cfg(not(feature = "soroban-env-host-prev"))]
+        prev: 0,
+    }
+}
+
+fn get_soroban_env_pre_release_versions() -> VersionNumPair {
+    use curr_host::meta::get_pre_release_version;
+    use soroban_curr::soroban_env_host as curr_host;
+    #[cfg(feature = "soroban-env-host-prev")]
+    use soroban_prev::soroban_env_host as prev_host;
+    VersionNumPair {
+        curr: get_pre_release_version(curr_host::VERSION.interface),
+        #[cfg(feature = "soroban-env-host-prev")]
+        prev: get_pre_release_version(prev_host::VERSION.interface),
         #[cfg(not(feature = "soroban-env-host-prev"))]
         prev: 0,
     }


### PR DESCRIPTION
Nothing surprising here, just more tightening of the logic around version comparisons -- now soroban's interface version information, core's protocol version, and both core and soroban's major versions are all checked for identity.

Also fixed a few minor omissions along the way from previous recent commits.