### PR TITLE
Enforce resource limits for Soroban

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,33 +625,33 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
+ "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=48052d83db7f577164264d916b8590d792a67b02)",
+ "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=76a4fa1ada4d3e175c627b7d023ceca06f757289)",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97#409474c96c8f1b38cd52753446b5324604227e97"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97)",
+ "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=2302358949c88e6e7529ee46947e41212e6de3b1)",
+ "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=df3a145bfaf75504bc85f20eceb49b4536836e18)",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -663,8 +663,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
- "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
+ "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
+ "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97#409474c96c8f1b38cd52753446b5324604227e97"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -685,8 +685,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2 0.10.6",
- "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97)",
- "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97)",
+ "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
+ "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -695,14 +695,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=48052d83db7f577164264d916b8590d792a67b02)",
+ "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=76a4fa1ada4d3e175c627b7d023ceca06f757289)",
  "syn 1.0.109",
  "thiserror",
 ]
@@ -710,14 +710,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97#409474c96c8f1b38cd52753446b5324604227e97"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=2302358949c88e6e7529ee46947e41212e6de3b1)",
+ "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=df3a145bfaf75504bc85f20eceb49b4536836e18)",
  "syn 1.0.109",
  "thiserror",
 ]
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249#1599a5a57edfd23ce5d7feee49faac7988ee5249"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97#409474c96c8f1b38cd52753446b5324604227e97"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -747,7 +747,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97#409474c96c8f1b38cd52753446b5324604227e97"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
 
 [[package]]
 name = "soroban-wasmi"
@@ -792,15 +792,15 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=1599a5a57edfd23ce5d7feee49faac7988ee5249)",
- "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97)",
+ "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
+ "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
  "soroban-test-wasms",
 ]
 
 [[package]]
 name = "stellar-xdr"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2302358949c88e6e7529ee46947e41212e6de3b1#2302358949c88e6e7529ee46947e41212e6de3b1"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=76a4fa1ada4d3e175c627b7d023ceca06f757289#76a4fa1ada4d3e175c627b7d023ceca06f757289"
 dependencies = [
  "base64",
  "crate-git-revision",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=48052d83db7f577164264d916b8590d792a67b02#48052d83db7f577164264d916b8590d792a67b02"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=df3a145bfaf75504bc85f20eceb49b4536836e18#df3a145bfaf75504bc85f20eceb49b4536836e18"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -325,7 +325,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
         ltx.loadHeader().current().ledgerSeq =
             mApp.getLedgerManager().getLastClosedLedgerNum() + 1;
     }
-    if (!tx->checkValid(ltx, seqNum, 0,
+    if (!tx->checkValid(mApp, ltx, seqNum, 0,
                         getUpperBoundCloseTimeOffset(mApp, closeTime)))
     {
         return TransactionQueue::AddResult::ADD_STATUS_ERROR;

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -178,7 +178,7 @@ TxSetUtils::getInvalidTxList(TxSetFrame::Transactions const& txs,
                 iter != accountQueue->mTxs.begin() &&
                 (tx->getMinSeqAge() != 0 || tx->getMinSeqLedgerGap() != 0);
             if (minSeqCheckIsInvalid ||
-                !tx->checkValid(ltx, lastSeq, lowerBoundCloseTimeOffset,
+                !tx->checkValid(app, ltx, lastSeq, lowerBoundCloseTimeOffset,
                                 upperBoundCloseTimeOffset))
             {
                 invalidTxs.emplace_back(tx);

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2178,7 +2178,7 @@ TEST_CASE_VERSIONS("upgrade base reserve", "[upgrades]")
         auto submitTx = [&](TransactionFrameBasePtr tx) {
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
             ltx.commit();
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -50,7 +50,7 @@ class LedgerManagerImpl : public LedgerManager
 
   private:
     LedgerHeaderHistoryEntry mLastClosedLedger;
-    std::optional<SorobanNetworkConfig> mLastSorobanNetworkConfig;
+    std::optional<SorobanNetworkConfig> mSorobanNetworkConfig;
 
     medida::Timer& mTransactionApply;
     medida::Histogram& mTransactionCount;

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -136,47 +136,68 @@ initialCpuCostParamsEntry()
         {
         case WasmInsnExec:
             params[val] = ContractCostParamEntry{22, 0, ExtensionPoint{0}};
+            break;
         case WasmMemAlloc:
             params[val] = ContractCostParamEntry{521, 0, ExtensionPoint{0}};
+            break;
         case HostMemAlloc:
             params[val] = ContractCostParamEntry{883, 0, ExtensionPoint{0}};
+            break;
         case HostMemCpy:
             params[val] = ContractCostParamEntry{24, 0, ExtensionPoint{0}};
+            break;
         case HostMemCmp:
             params[val] = ContractCostParamEntry{42, 1, ExtensionPoint{0}};
+            break;
         case InvokeHostFunction:
             params[val] = ContractCostParamEntry{759, 0, ExtensionPoint{0}};
+            break;
         case VisitObject:
             params[val] = ContractCostParamEntry{29, 0, ExtensionPoint{0}};
+            break;
         case ValXdrConv:
             params[val] = ContractCostParamEntry{177, 0, ExtensionPoint{0}};
+            break;
         case ValSer:
             params[val] = ContractCostParamEntry{741, 0, ExtensionPoint{0}};
+            break;
         case ValDeser:
             params[val] = ContractCostParamEntry{846, 0, ExtensionPoint{0}};
+            break;
         case ComputeSha256Hash:
             params[val] = ContractCostParamEntry{1912, 32, ExtensionPoint{0}};
+            break;
         case ComputeEd25519PubKey:
             params[val] = ContractCostParamEntry{25766, 0, ExtensionPoint{0}};
+            break;
         case MapEntry:
             params[val] = ContractCostParamEntry{59, 0, ExtensionPoint{0}};
+            break;
         case VecEntry:
             params[val] = ContractCostParamEntry{14, 0, ExtensionPoint{0}};
+            break;
         case GuardFrame:
             params[val] = ContractCostParamEntry{4512, 0, ExtensionPoint{0}};
+            break;
         case VerifyEd25519Sig:
             params[val] = ContractCostParamEntry{368361, 20, ExtensionPoint{0}};
+            break;
         case VmMemRead:
             params[val] = ContractCostParamEntry{95, 0, ExtensionPoint{0}};
+            break;
         case VmMemWrite:
             params[val] = ContractCostParamEntry{97, 0, ExtensionPoint{0}};
+            break;
         case VmInstantiation:
             params[val] =
                 ContractCostParamEntry{805445, 307, ExtensionPoint{0}};
+            break;
         case InvokeVmFunction:
             params[val] = ContractCostParamEntry{6212, 0, ExtensionPoint{0}};
+            break;
         case ChargeBudget:
             params[val] = ContractCostParamEntry{198, 0, ExtensionPoint{0}};
+            break;
         }
     }
 
@@ -197,47 +218,68 @@ initialMemCostParamsEntry()
         {
         case WasmInsnExec:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case WasmMemAlloc:
             params[val] = ContractCostParamEntry{66136, 1, ExtensionPoint{0}};
+            break;
         case HostMemAlloc:
             params[val] = ContractCostParamEntry{8, 1, ExtensionPoint{0}};
+            break;
         case HostMemCpy:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case HostMemCmp:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case InvokeHostFunction:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case VisitObject:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case ValXdrConv:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case ValSer:
             params[val] = ContractCostParamEntry{9, 3, ExtensionPoint{0}};
+            break;
         case ValDeser:
             params[val] = ContractCostParamEntry{4, 1, ExtensionPoint{0}};
+            break;
         case ComputeSha256Hash:
             params[val] = ContractCostParamEntry{40, 0, ExtensionPoint{0}};
+            break;
         case ComputeEd25519PubKey:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case MapEntry:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case VecEntry:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case GuardFrame:
             params[val] = ContractCostParamEntry{267, 0, ExtensionPoint{0}};
+            break;
         case VerifyEd25519Sig:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case VmMemRead:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case VmMemWrite:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         case VmInstantiation:
             params[val] =
                 ContractCostParamEntry{1100352, 53, ExtensionPoint{0}};
+            break;
         case InvokeVmFunction:
             params[val] = ContractCostParamEntry{267, 0, ExtensionPoint{0}};
+            break;
         case ChargeBudget:
             params[val] = ContractCostParamEntry{0, 0, ExtensionPoint{0}};
+            break;
         }
     }
 
@@ -275,13 +317,15 @@ SorobanNetworkConfig::initializeGenesisLedgerForTesting(
 void
 SorobanNetworkConfig::loadFromLedger(AbstractLedgerTxn& ltxRoot)
 {
-    LedgerTxn ltx(ltxRoot);
+    LedgerTxn ltx(ltxRoot, false, TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
     loadMaxContractSize(ltx);
     loadComputeSettings(ltx);
     loadLedgerAccessSettings(ltx);
     loadHistoricalSettings(ltx);
     loadMetaDataSettings(ltx);
     loadBandwidthSettings(ltx);
+    loadCpuCostParams(ltx);
+    loadMemCostParams(ltx);
 }
 
 uint32_t

--- a/src/main/test/CommandHandlerTests.cpp
+++ b/src/main/test/CommandHandlerTests.cpp
@@ -509,7 +509,7 @@ TEST_CASE("manualclose", "[commandhandler]")
 
             {
                 LedgerTxn checkLtx(app->getLedgerTxnRoot());
-                auto valid = txFrame->checkValid(checkLtx, 0, 0, 0);
+                auto valid = txFrame->checkValid(*app, checkLtx, 0, 0, 0);
                 REQUIRE(valid);
             }
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -27,7 +27,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "409474c96c8f1b38cd52753446b5324604227e97"
+rev = "efffbbb9b5be442e58aecead3362bae2c9613c75"
 features = ["vm"]
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
@@ -52,12 +52,12 @@ optional = true
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "1599a5a57edfd23ce5d7feee49faac7988ee5249"
+rev = "e5cdfd871093e002428f924162152df248a0e22b"
 features = ["vm"]
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "409474c96c8f1b38cd52753446b5324604227e97"
+rev = "efffbbb9b5be442e58aecead3362bae2c9613c75"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=409474c96c8f1b38cd52753446b5324604227e97#409474c96c8f1b38cd52753446b5324604227e97
+soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75
 ├── tinyvec 1.6.0 checksum:87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50
 │   └── tinyvec_macros 0.1.1 checksum:1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -66,6 +66,9 @@ mod rust_bridge {
         pub timestamp: u64,
         pub network_id: Vec<u8>,
         pub base_reserve: u32,
+        pub memory_limit: u32,
+        pub cpu_cost_params: CxxBuf,
+        pub mem_cost_params: CxxBuf,
     }
 
     #[derive(Debug)]
@@ -297,7 +300,8 @@ fn check_lockfile_has_expected_dep_tree(
         .expect("rendering dep tree");
 
     let tree_str = String::from_utf8_lossy(&tree_buf);
-    if tree_str != expected {
+    // Normalize line endings to support Windows builds.
+    if tree_str.replace("\r\n", "\n") != expected.replace("\r\n", "\n") {
         eprintln!(
             "Expected '{}' host dependency tree (in host-dep-tree-{}.txt):",
             curr_or_prev, curr_or_prev

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -136,7 +136,7 @@ applyCheck(TransactionFramePtr tx, Application& app, bool checkSeqNum)
     {
         LedgerTxn ltxFeeProc(ltx);
         // use checkedTx here for validity check as to keep tx untouched
-        check = checkedTx->checkValid(ltxFeeProc, 0, 0, 0);
+        check = checkedTx->checkValid(app, ltxFeeProc, 0, 0, 0);
         checkResult = checkedTx->getResult();
         REQUIRE((!check || checkResult.result.code() == txSUCCESS));
 
@@ -412,7 +412,7 @@ validateTxResults(TransactionFramePtr const& tx, Application& app,
         app.getNetworkID(), tx->getEnvelope());
     {
         LedgerTxn ltx(app.getLedgerTxnRoot());
-        REQUIRE(checkedTx->checkValid(ltx, 0, 0, 0) == shouldValidateOk);
+        REQUIRE(checkedTx->checkValid(app, ltx, 0, 0, 0) == shouldValidateOk);
     }
     REQUIRE(checkedTx->getResult().result.code() == validationResult.code);
     REQUIRE(checkedTx->getResult().feeCharged == validationResult.fee);

--- a/src/testdata/ledger-close-meta-v2-protocol-20.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-20.json
@@ -3,24 +3,24 @@
         "v": 2,
         "v2": {
             "ledgerHeader": {
-                "hash": "a3703cc9b9815fe1f4116862aa314d222f1a6f2756b8a2c071cd96ddfbcb129e",
+                "hash": "1e4a1b7bf54f269d57611b1bbc0f6927e4f1ae114170a4c3a8bb67313dbb1c8c",
                 "header": {
                     "ledgerVersion": 20,
-                    "previousLedgerHash": "72877840ba8818bcaa67f4135c9de2f7277b4bf18b317282952a86039dc14458",
+                    "previousLedgerHash": "7718e2747a4acefbf98b797576559d280390cc432494d40cec33759c7118b541",
                     "scpValue": {
-                        "txSetHash": "59b1ab7896572577f19fd1cbbd138a2cfc870fc15e5fd05da927646325a8da2d",
+                        "txSetHash": "5451be3e696676c83debf50276e884ed457a4f9dfd55e6c02b4f66850187e44b",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "76507caa114ff92e30ac982eebac8c0560217921abba9903d66f7974a3aa2d13ba940fbf8478ca075f14d089768134f2ec7a46d2aa9af53d2f8039f010bf4501"
+                                "signature": "63971eba040ec8c4a1ff7a695dd915581fa66cbb004ab121f05a1c2360c36f6938413d1398c906e062be067fe3bc7af351aaee14bd07fe759ff22ffd1347bb0a"
                             }
                         }
                     },
                     "txSetResultHash": "cf65fee29665ff0c2a6910b24c420a487a7416ccd79c683b48aac1d45ad21faa",
-                    "bucketListHash": "6eefdddd9bf1358f6c413d72defeb39a13f30e7367218a26c0e3811dfa5515a6",
+                    "bucketListHash": "77d8199347aafeba7e58252be3d927b2c9c9f02a32f01036f46d11727ee1526e",
                     "ledgerSeq": 6,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -46,7 +46,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "72877840ba8818bcaa67f4135c9de2f7277b4bf18b317282952a86039dc14458",
+                    "previousLedgerHash": "7718e2747a4acefbf98b797576559d280390cc432494d40cec33759c7118b541",
                     "phases": [
                         {
                             "v": 0,

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -47,7 +47,7 @@ FeeBumpTransactionFrame::isSoroban() const
 }
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-SorobanResources
+SorobanResources const&
 FeeBumpTransactionFrame::sorobanResources() const
 {
     return mInnerTx->sorobanResources();
@@ -163,7 +163,8 @@ FeeBumpTransactionFrame::checkSignature(SignatureChecker& signatureChecker,
 }
 
 bool
-FeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+FeeBumpTransactionFrame::checkValid(Application& app,
+                                    AbstractLedgerTxn& ltxOuter,
                                     SequenceNumber current,
                                     uint64_t lowerBoundCloseTimeOffset,
                                     uint64_t upperBoundCloseTimeOffset)
@@ -187,7 +188,7 @@ FeeBumpTransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
     }
 
     bool res = mInnerTx->checkValidWithOptionallyChargedFee(
-        ltx, current, false, lowerBoundCloseTimeOffset,
+        app, ltx, current, false, lowerBoundCloseTimeOffset,
         upperBoundCloseTimeOffset);
     updateResult(getResult(), mInnerTx);
     return res;

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -60,8 +60,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     bool apply(Application& app, AbstractLedgerTxn& ltx,
                TransactionMetaFrame& meta) override;
 
-    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
-                    uint64_t lowerBoundCloseTimeOffset,
+    bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
+                    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
 
     TransactionEnvelope const& getEnvelope() const override;
@@ -103,7 +103,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     bool isSoroban() const override;
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    SorobanResources sorobanResources() const override;
+    SorobanResources const& sorobanResources() const override;
 #endif
 };
 }

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -352,6 +352,11 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx)
         keys.emplace(std::move(lk));
     }
     metadataSizeBytes += metrics.mLedgerWriteByte;
+    if (resources.extendedMetaDataSizeBytes < metadataSizeBytes)
+    {
+        innerResult().code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        return false;
+    }
 
     // Erase every entry not returned
     for (auto const& lk : footprint.readWrite)

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -36,8 +36,7 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     bool isOpSupported(LedgerHeader const& header) const override;
 
     bool doApply(AbstractLedgerTxn& ltx) override;
-    bool doApply(AbstractLedgerTxn& ltx, Config const& cfg,
-                 medida::MetricsRegistry& metrics) override;
+    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     void

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -134,9 +134,8 @@ OperationFrame::OperationFrame(Operation const& op, OperationResult& res,
 }
 
 bool
-OperationFrame::apply(SignatureChecker& signatureChecker,
-                      AbstractLedgerTxn& ltx, Config const& cfg,
-                      medida::MetricsRegistry& metrics)
+OperationFrame::apply(Application& app, SignatureChecker& signatureChecker,
+                      AbstractLedgerTxn& ltx)
 {
     ZoneScoped;
     bool res;
@@ -144,7 +143,7 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
     res = checkValid(signatureChecker, ltx, true);
     if (res)
     {
-        res = doApply(ltx, cfg, metrics);
+        res = doApply(app, ltx);
         CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
     }
 
@@ -152,11 +151,10 @@ OperationFrame::apply(SignatureChecker& signatureChecker,
 }
 
 bool
-OperationFrame::doApply(AbstractLedgerTxn& ltx, Config const& _cfg,
-                        medida::MetricsRegistry& _metrics)
+OperationFrame::doApply(Application& _app, AbstractLedgerTxn& ltx)
 {
-    // By default we ignore the cfg and metrics, but subclasses can override to
-    // intercept and use them.
+    // By default we ignore the app, but subclasses can override to
+    // intercept and use it.
     return doApply(ltx);
 }
 

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -41,8 +41,7 @@ class OperationFrame
     OperationResult& mResult;
 
     virtual bool doCheckValid(uint32_t ledgerVersion) = 0;
-    virtual bool doApply(AbstractLedgerTxn& ltx, Config const& cfg,
-                         medida::MetricsRegistry& metrics);
+    virtual bool doApply(Application& app, AbstractLedgerTxn& ltx);
     virtual bool doApply(AbstractLedgerTxn& ltx) = 0;
 
     // returns the threshold this operation requires
@@ -84,8 +83,8 @@ class OperationFrame
     bool checkValid(SignatureChecker& signatureChecker,
                     AbstractLedgerTxn& ltxOuter, bool forApply);
 
-    bool apply(SignatureChecker& signatureChecker, AbstractLedgerTxn& ltx,
-               Config const& cfg, medida::MetricsRegistry& metrics);
+    bool apply(Application& app, SignatureChecker& signatureChecker,
+               AbstractLedgerTxn& ltx);
 
     Operation const&
     getOperation() const

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -553,6 +553,11 @@ TransactionFrame::validateSorobanResources(
     {
         return false;
     }
+    auto txSize = xdr::xdr_size(mEnvelope.v1().tx);
+    if (txSize > config.txMaxSizeBytes())
+    {
+        return false;
+    }
     return true;
 }
 #endif

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -364,7 +364,7 @@ TransactionFrame::isSoroban() const
 }
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-SorobanResources
+SorobanResources const&
 TransactionFrame::sorobanResources() const
 {
     releaseAssertOrThrow(isSoroban());
@@ -523,6 +523,38 @@ TransactionFrame::validateSorobanOpsConsistency() const
     }
     return true;
 }
+
+bool
+TransactionFrame::validateSorobanResources(
+    SorobanNetworkConfig const& config) const
+{
+    auto const& resources = sorobanResources();
+    size_t readEntries = resources.footprint.readOnly.size();
+    size_t writeEntries = resources.footprint.readWrite.size();
+    if (resources.instructions > config.txMaxInstructions())
+    {
+        return false;
+    }
+    if (resources.readBytes > config.txMaxReadBytes())
+    {
+        return false;
+    }
+    if (resources.writeBytes > config.txMaxWriteBytes())
+    {
+        return false;
+    }
+    if (resources.extendedMetaDataSizeBytes >
+        config.txMaxExtendedMetaDataSizeBytes())
+    {
+        return false;
+    }
+    if (readEntries + writeEntries > config.txMaxReadLedgerEntries() ||
+        writeEntries > config.txMaxWriteLedgerEntries())
+    {
+        return false;
+    }
+    return true;
+}
 #endif
 
 bool
@@ -623,15 +655,16 @@ TransactionFrame::isTooEarlyForAccount(LedgerTxnHeader const& header,
 }
 
 bool
-TransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee,
+TransactionFrame::commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
+                                       bool chargeFee,
                                        uint64_t lowerBoundCloseTimeOffset,
                                        uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     // this function does validations that are independent of the account state
     //    (stay true regardless of other side effects)
-    auto header = ltx.loadHeader();
-    uint32_t ledgerVersion = header.current().ledgerVersion;
+
+    uint32_t ledgerVersion = ltx.loadHeader().current().ledgerVersion;
     if ((protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_13) &&
          (mEnvelope.type() == ENVELOPE_TYPE_TX ||
           hasMuxedAccount(mEnvelope))) ||
@@ -684,8 +717,29 @@ TransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee,
         getResult().result.code(txMALFORMED);
         return false;
     }
+    if (isSoroban())
+    {
+        if (protocolVersionIsBefore(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
+        {
+            getResult().result.code(txMALFORMED);
+            return false;
+        }
+        if (mEnvelope.type() != ENVELOPE_TYPE_TX ||
+            mEnvelope.v1().tx.ext.v() != 1)
+        {
+            getResult().result.code(txMALFORMED);
+            return false;
+        }
+        auto const& sorobanConfig =
+            app.getLedgerManager().getSorobanNetworkConfig(ltx);
+        if (!validateSorobanResources(sorobanConfig))
+        {
+            getResult().result.code(txSOROBAN_RESOURCE_LIMIT_EXCEEDED);
+            return false;
+        }
+    }
 #endif
-
+    auto header = ltx.loadHeader();
     if (isTooEarly(header, lowerBoundCloseTimeOffset))
     {
         getResult().result.code(txTOO_EARLY);
@@ -820,7 +874,8 @@ TransactionFrame::isBadSeq(LedgerTxnHeader const& header, int64_t seqNum) const
 }
 
 TransactionFrame::ValidationType
-TransactionFrame::commonValid(SignatureChecker& signatureChecker,
+TransactionFrame::commonValid(Application& app,
+                              SignatureChecker& signatureChecker,
                               AbstractLedgerTxn& ltxOuter,
                               SequenceNumber current, bool applying,
                               bool chargeFee,
@@ -838,7 +893,7 @@ TransactionFrame::commonValid(SignatureChecker& signatureChecker,
             "Applying transaction with non-current closeTime");
     }
 
-    if (!commonValidPreSeqNum(ltx, chargeFee, lowerBoundCloseTimeOffset,
+    if (!commonValidPreSeqNum(app, ltx, chargeFee, lowerBoundCloseTimeOffset,
                               upperBoundCloseTimeOffset))
     {
         return res;
@@ -1001,8 +1056,9 @@ TransactionFrame::removeAccountSigner(AbstractLedgerTxn& ltxOuter,
 
 bool
 TransactionFrame::checkValidWithOptionallyChargedFee(
-    AbstractLedgerTxn& ltxOuter, SequenceNumber current, bool chargeFee,
-    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset)
+    Application& app, AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+    bool chargeFee, uint64_t lowerBoundCloseTimeOffset,
+    uint64_t upperBoundCloseTimeOffset)
 {
     ZoneScoped;
     mCachedAccount.reset();
@@ -1019,7 +1075,7 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
                                       getContentsHash(),
                                       getSignatures(mEnvelope)};
     bool res =
-        commonValid(signatureChecker, ltx, current, false, chargeFee,
+        commonValid(app, signatureChecker, ltx, current, false, chargeFee,
                     lowerBoundCloseTimeOffset,
                     upperBoundCloseTimeOffset) == ValidationType::kMaybeValid;
     if (res)
@@ -1046,12 +1102,12 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
 }
 
 bool
-TransactionFrame::checkValid(AbstractLedgerTxn& ltxOuter,
+TransactionFrame::checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
                              SequenceNumber current,
                              uint64_t lowerBoundCloseTimeOffset,
                              uint64_t upperBoundCloseTimeOffset)
 {
-    return checkValidWithOptionallyChargedFee(ltxOuter, current, true,
+    return checkValidWithOptionallyChargedFee(app, ltxOuter, current, true,
                                               lowerBoundCloseTimeOffset,
                                               upperBoundCloseTimeOffset);
 }
@@ -1119,13 +1175,12 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             app.getConfig().LEDGER_PROTOCOL_MIN_VERSION_INTERNAL_ERROR_REPORT;
         auto& opTimer =
             app.getMetrics().NewTimer({"ledger", "operation", "apply"});
-        Config const& cfg = app.getConfig();
-        medida::MetricsRegistry& metrics = app.getMetrics();
+
         for (auto& op : mOperations)
         {
             auto time = opTimer.TimeScope();
             LedgerTxn ltxOp(ltxTx);
-            bool txRes = op->apply(signatureChecker, ltxOp, cfg, metrics);
+            bool txRes = op->apply(app, signatureChecker, ltxOp);
 
             if (!txRes)
             {
@@ -1286,7 +1341,7 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
         // we'll skip trying to apply operations but we'll still
         // process the sequence number if needed
         auto cv =
-            commonValid(signatureChecker, ltxTx, 0, true, chargeFee, 0, 0);
+            commonValid(app, signatureChecker, ltxTx, 0, true, chargeFee, 0, 0);
         if (cv >= ValidationType::kInvalidUpdateSeqNum)
         {
             processSeqNum(ltxTx);

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "ledger/InternalLedgerEntry.h"
+#include "ledger/NetworkConfig.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrameBase.h"
 #include "transactions/TransactionMetaFrame.h"
@@ -82,13 +83,15 @@ class TransactionFrame : public TransactionFrameBase
                               LedgerTxnEntry const& sourceAccount,
                               uint64_t lowerBoundCloseTimeOffset) const;
 
-    bool commonValidPreSeqNum(AbstractLedgerTxn& ltx, bool chargeFee,
+    bool commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
+                              bool chargeFee,
                               uint64_t lowerBoundCloseTimeOffset,
                               uint64_t upperBoundCloseTimeOffset);
 
     virtual bool isBadSeq(LedgerTxnHeader const& header, int64_t seqNum) const;
 
-    ValidationType commonValid(SignatureChecker& signatureChecker,
+    ValidationType commonValid(Application& app,
+                               SignatureChecker& signatureChecker,
                                AbstractLedgerTxn& ltxOuter,
                                SequenceNumber current, bool applying,
                                bool chargeFee,
@@ -121,6 +124,7 @@ class TransactionFrame : public TransactionFrameBase
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     bool validateSorobanOpsConsistency() const;
+    bool validateSorobanResources(SorobanNetworkConfig const& config) const;
 #endif
 
   public:
@@ -200,13 +204,14 @@ class TransactionFrame : public TransactionFrameBase
                                  AccountID const& accountID);
     bool checkExtraSigners(SignatureChecker& signatureChecker);
 
-    bool checkValidWithOptionallyChargedFee(AbstractLedgerTxn& ltxOuter,
+    bool checkValidWithOptionallyChargedFee(Application& app,
+                                            AbstractLedgerTxn& ltxOuter,
                                             SequenceNumber current,
                                             bool chargeFee,
                                             uint64_t lowerBoundCloseTimeOffset,
                                             uint64_t upperBoundCloseTimeOffset);
-    bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
-                    uint64_t lowerBoundCloseTimeOffset,
+    bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
+                    SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
 
     void
@@ -241,7 +246,7 @@ class TransactionFrame : public TransactionFrameBase
 
     bool isSoroban() const override;
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    SorobanResources sorobanResources() const override;
+    SorobanResources const& sorobanResources() const override;
 #endif
 };
 }

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -35,7 +35,8 @@ class TransactionFrameBase
     virtual bool apply(Application& app, AbstractLedgerTxn& ltx,
                        TransactionMetaFrame& meta) = 0;
 
-    virtual bool checkValid(AbstractLedgerTxn& ltxOuter, SequenceNumber current,
+    virtual bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
+                            SequenceNumber current,
                             uint64_t lowerBoundCloseTimeOffset,
                             uint64_t upperBoundCloseTimeOffset) = 0;
 
@@ -75,7 +76,7 @@ class TransactionFrameBase
 
     virtual bool isSoroban() const = 0;
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    virtual SorobanResources sorobanResources() const = 0;
+    virtual SorobanResources const& sorobanResources() const = 0;
 #endif
 };
 }

--- a/src/transactions/test/BeginSponsoringFutureReservesTests.cpp
+++ b/src/transactions/test/BeginSponsoringFutureReservesTests.cpp
@@ -50,7 +50,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
                 {root.op(beginSponsoringFutureReserves(a1))}, {});
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             ltx.commit();
 
             REQUIRE(getOperationResultCode(tx, 0) == opNOT_SUPPORTED);
@@ -65,7 +65,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
                 {root.op(beginSponsoringFutureReserves(root))}, {});
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             ltx.commit();
 
             REQUIRE(getBeginSponsoringFutureReservesResultCode(tx, 0) ==
@@ -85,7 +85,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(!tx->apply(*app, ltx, txm));
             ltx.commit();
 
@@ -107,7 +107,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(!tx->apply(*app, ltx, txm));
             ltx.commit();
 
@@ -130,7 +130,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(!tx->apply(*app, ltx, txm));
             ltx.commit();
 
@@ -157,7 +157,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(!tx->apply(*app, ltx, txm));
             ltx.commit();
 
@@ -181,7 +181,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
             ltx.commit();
 
@@ -209,7 +209,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm1(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx1->apply(*app, ltx, txm1));
 
             checkSponsorship(ltx, trustlineKey(a1, cur1), 1,
@@ -223,7 +223,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
                 {a1});
 
             TransactionMetaFrame txm2(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx2->apply(*app, ltx, txm2));
 
             checkSponsorship(ltx, a1.getPublicKey(), signer.key, 2,
@@ -265,7 +265,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->getResultCode() == txBAD_MIN_SEQ_AGE_OR_GAP);
                 }
 
@@ -273,7 +273,7 @@ TEST_CASE_VERSIONS("sponsor future reserves", "[tx][sponsorship]")
                     // this increments ledgerSeq
                     closeLedger(*app);
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
                 }
             }

--- a/src/transactions/test/ChangeTrustTests.cpp
+++ b/src/transactions/test/ChangeTrustTests.cpp
@@ -294,7 +294,7 @@ TEST_CASE_VERSIONS("change trust", "[tx][changetrust]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
         });
     }
@@ -701,7 +701,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
                     ltx.commit();
@@ -731,7 +731,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txFAILED);
 
@@ -756,7 +756,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txFAILED);
 
@@ -780,7 +780,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
                 }
@@ -802,7 +802,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
                 }
@@ -830,7 +830,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     ltx.commit();
                 };
@@ -879,7 +879,7 @@ TEST_CASE_VERSIONS("change trust pool share trustline",
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx->apply(*app, ltx, txm));
                         ltx.commit();
                     }

--- a/src/transactions/test/ClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClaimableBalanceTests.cpp
@@ -177,7 +177,7 @@ validateBalancesOnCreateAndClaim(TestAccount& createAcc, TestAccount& claimAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(tx->apply(app, ltx, txm));
         REQUIRE(tx->getResultCode() == txSUCCESS);
 
@@ -236,7 +236,7 @@ validateBalancesOnCreateAndClaim(TestAccount& createAcc, TestAccount& claimAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(tx->apply(app, ltx, txm));
         ltx.commit();
 
@@ -257,7 +257,7 @@ validateBalancesOnCreateAndClaim(TestAccount& createAcc, TestAccount& claimAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(tx->apply(app, ltx, txm));
         ltx.commit();
 
@@ -1164,7 +1164,7 @@ TEST_CASE_VERSIONS("claimableBalance", "[tx][claimablebalance]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
             REQUIRE(tx->getResultCode() == txSUCCESS);
 
@@ -1177,7 +1177,7 @@ TEST_CASE_VERSIONS("claimableBalance", "[tx][claimablebalance]")
                 {});
 
             TransactionMetaFrame txm2(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(!tx2->apply(*app, ltx, txm2));
             REQUIRE(tx2->getResultCode() == txFAILED);
 
@@ -1242,7 +1242,7 @@ TEST_CASE_VERSIONS("claimableBalance", "[tx][claimablebalance]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
                     ltx.commit();
@@ -1272,7 +1272,7 @@ TEST_CASE_VERSIONS("claimableBalance", "[tx][claimablebalance]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
                     REQUIRE(tx2->getResultCode() == txSUCCESS);
 

--- a/src/transactions/test/ClawbackClaimableBalanceTests.cpp
+++ b/src/transactions/test/ClawbackClaimableBalanceTests.cpp
@@ -113,7 +113,7 @@ TEST_CASE_VERSIONS("clawbackClaimableBalance",
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
 

--- a/src/transactions/test/CreateAccountTests.cpp
+++ b/src/transactions/test/CreateAccountTests.cpp
@@ -52,11 +52,11 @@ TEST_CASE_VERSIONS("create account", "[tx][createaccount]")
                 {root.op(createAccount(key.getPublicKey(), 1))}, {});
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx1->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx1->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(getCreateAccountResultCode(tx1, 0) ==
                     CREATE_ACCOUNT_MALFORMED);
 
-            REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
         });
 
         for_versions_from(14, *app, [&] {
@@ -70,11 +70,11 @@ TEST_CASE_VERSIONS("create account", "[tx][createaccount]")
                 {root.op(createAccount(key.getPublicKey(), 0))}, {});
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx1->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx1->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(getCreateAccountResultCode(tx1, 0) ==
                     CREATE_ACCOUNT_MALFORMED);
 
-            REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
         });
     }
 
@@ -86,7 +86,7 @@ TEST_CASE_VERSIONS("create account", "[tx][createaccount]")
                                         {root.op(createAccount(root, -1))}, {});
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(getCreateAccountResultCode(tx, 0) ==
                     CREATE_ACCOUNT_MALFORMED);
         });
@@ -184,7 +184,7 @@ TEST_CASE_VERSIONS("create account", "[tx][createaccount]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 TransactionMetaFrame txm(
                     ltx.loadHeader().current().ledgerVersion);
-                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(tx->apply(*app, ltx, txm));
                 ltx.commit();
             }

--- a/src/transactions/test/EndSponsoringFutureReservesTests.cpp
+++ b/src/transactions/test/EndSponsoringFutureReservesTests.cpp
@@ -47,7 +47,7 @@ TEST_CASE_VERSIONS("confirm and clear sponsor", "[tx][sponsorship]")
                 {root.op(endSponsoringFutureReserves())}, {});
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
 
             REQUIRE(getOperationResultCode(tx, 0) == opNOT_SUPPORTED);
         });
@@ -63,7 +63,7 @@ TEST_CASE_VERSIONS("confirm and clear sponsor", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(!tx->apply(*app, ltx, txm));
 
             REQUIRE(tx->getResult().result.code() == txFAILED);

--- a/src/transactions/test/FeeBumpTransactionTests.cpp
+++ b/src/transactions/test/FeeBumpTransactionTests.cpp
@@ -80,7 +80,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee, fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txNOT_SUPPORTED);
             });
         }
@@ -91,7 +91,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee - 1, 1, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
                 REQUIRE(fb->getResult().feeCharged == 2 * fee);
             });
@@ -103,7 +103,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), root, root, root,
                                   2 * fee + 1, 101, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_FEE);
                 REQUIRE(fb->getResult().feeCharged == 2 * 101);
             });
@@ -116,7 +116,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txNO_ACCOUNT);
             });
         }
@@ -131,7 +131,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH);
             });
         }
@@ -149,7 +149,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH);
             });
         }
@@ -161,7 +161,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txINSUFFICIENT_BALANCE);
             });
         }
@@ -178,7 +178,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txBAD_AUTH_EXTRA);
             });
         }
@@ -192,7 +192,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = TransactionFrameBase::makeTransactionFromWire(
                     app->getNetworkID(), fbXDR);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_FAILED);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -209,7 +209,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, -1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(!fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(!fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_FAILED);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -229,7 +229,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                 auto fb = feeBump(app->getNetworkID(), acc, root, root, 2 * fee,
                                   fee, 1);
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_SUCCESS);
                 auto const& fbRes = fb->getResult();
                 REQUIRE(fbRes.feeCharged == 2 * fee);
@@ -273,7 +273,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 }
                 acc.merge(root);
                 {
@@ -294,7 +294,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 }
                 acc.setOptions(setMasterWeight(0));
                 {
@@ -315,7 +315,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 }
                 acc.pay(root, 2 * fee);
                 {
@@ -342,7 +342,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                     app->getNetworkID(), fbXDR);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 }
 
                 auto setOptionsTx = acc.tx({setOptions(setLowThreshold(1))});
@@ -367,7 +367,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                                   fee, 1);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 }
 
                 auto setOptionsOp = setOptions(setMasterWeight(0));
@@ -398,7 +398,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                                   fee, INT64_MAX);
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                 }
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -454,7 +454,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResultCode() == txSUCCESS);
 
@@ -469,7 +469,7 @@ TEST_CASE_VERSIONS("fee bump transactions", "[tx][feebump]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(fb->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(fb->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(fb->getResultCode() == txFEE_BUMP_INNER_SUCCESS);
                 }
                 {

--- a/src/transactions/test/ManageBuyOfferTests.cpp
+++ b/src/transactions/test/ManageBuyOfferTests.cpp
@@ -376,7 +376,7 @@ TEST_CASE_VERSIONS("manage buy offer liabilities", "[tx][offers]")
 
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                tx->checkValid(ltx, 0, 0, 0);
+                tx->checkValid(*app, ltx, 0, 0, 0);
             }
 
             auto buyOp = std::static_pointer_cast<ManageBuyOfferOpFrame>(

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -752,7 +752,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, dest, signer.key, 2,
@@ -818,7 +818,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, key.getPublicKey(), 1,
@@ -890,7 +890,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
                     REQUIRE(tx->getResult()
                                 .result.results()[1]
@@ -913,7 +913,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx->apply(*app, ltx, txm));
 
                         checkSponsorship(ltx, sponsoringAcc, 0, nullptr, 0, 2,

--- a/src/transactions/test/OfferTests.cpp
+++ b/src/transactions/test/OfferTests.cpp
@@ -3012,7 +3012,7 @@ TEST_CASE_VERSIONS("create offer", "[tx][offers]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
             ltx.commit();
         };
@@ -3039,7 +3039,7 @@ TEST_CASE_VERSIONS("create offer", "[tx][offers]")
             auto expOfferID = ltx.loadHeader().current().idPool + 1;
 
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
 
             auto const& results = tx->getResult().result.results();
@@ -3750,7 +3750,7 @@ TEST_CASE_VERSIONS("create offer", "[tx][offers]")
 
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     REQUIRE(!loadOffer(ltx, a2.getPublicKey(), expOfferID));
@@ -3793,7 +3793,7 @@ TEST_CASE_VERSIONS("create offer", "[tx][offers]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 TransactionMetaFrame txm(
                     ltx.loadHeader().current().ledgerVersion);
-                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(tx->apply(*app, ltx, txm));
                 ltx.commit();
             }
@@ -3855,7 +3855,7 @@ TEST_CASE_VERSIONS("create offer", "[tx][offers]")
 
                 TransactionMetaFrame txm(
                     ltx.loadHeader().current().ledgerVersion);
-                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(tx->apply(*app, ltx, txm));
 
                 REQUIRE(loadOffer(ltx, acc1.getPublicKey(), offerIdUsdXlm));

--- a/src/transactions/test/PathPaymentTests.cpp
+++ b/src/transactions/test/PathPaymentTests.cpp
@@ -4443,7 +4443,7 @@ TEST_CASE_VERSIONS("pathpayment", "[tx][pathpayment]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->apply(*app, ltx, txm));
             ltx.commit();
         };
@@ -4836,7 +4836,7 @@ TEST_CASE_VERSIONS("pathpayment", "[tx][pathpayment]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 TransactionMetaFrame txm(
                     ltx.loadHeader().current().ledgerVersion);
-                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(tx->apply(*app, ltx, txm));
                 ltx.commit();
             }

--- a/src/transactions/test/RevokeSponsorshipTests.cpp
+++ b/src/transactions/test/RevokeSponsorshipTests.cpp
@@ -65,7 +65,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, accountKey(a1), 0, nullptr);
@@ -85,7 +85,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, trustlineKey(a1, cur1), 0, nullptr);
@@ -106,7 +106,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, a1, signer.key, 0, nullptr);
@@ -130,7 +130,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
@@ -160,7 +160,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, accountKey(a1), 1,
@@ -184,7 +184,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, trustlineKey(a1, cur1), 1,
@@ -216,7 +216,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                             LedgerTxn ltx(app->getLedgerTxnRoot());
                             TransactionMetaFrame txm(
                                 ltx.loadHeader().current().ledgerVersion);
-                            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                             REQUIRE(tx->apply(*app, ltx, txm));
                             ltx.commit();
                         }
@@ -231,7 +231,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx->apply(*app, ltx, txm));
 
                         checkSponsorship(ltx, a1, signer.key, 2,
@@ -277,7 +277,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, claimableBalanceKey(balanceID), 1,
@@ -307,7 +307,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -318,7 +318,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, accountKey(a1.getPublicKey()), 1,
@@ -343,7 +343,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -353,7 +353,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, trustlineKey(a1, cur1), 1, nullptr);
@@ -377,7 +377,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -386,7 +386,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, a1, signer.key, 2, nullptr);
@@ -410,7 +410,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto balanceID = tx1->getResult()
@@ -427,7 +427,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx2->apply(*app, ltx, txm2));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx2, 0) ==
@@ -459,7 +459,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -472,7 +472,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, a1, 1, &a2.getPublicKey(), 0, 2, 0,
@@ -497,7 +497,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -509,7 +509,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, trustlineKey(a1, cur1), 1,
@@ -536,7 +536,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
                     auto tx2 = transactionFrameFromOps(
                         app->getNetworkID(), root,
@@ -547,7 +547,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, a1, signer.key, 2,
@@ -574,7 +574,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto balanceID = tx1->getResult()
@@ -593,7 +593,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, claimableBalanceKey(balanceID), 1,
@@ -620,7 +620,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -632,7 +632,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, dataKey(a1, dataName), 1,
@@ -661,7 +661,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto offerID = ltx.loadHeader().current().idPool;
@@ -674,7 +674,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, offerKey(a1, offerID), 1,
@@ -702,7 +702,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -715,7 +715,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, accountKey(a1.getPublicKey()), 1,
@@ -740,7 +740,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -752,7 +752,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, trustlineKey(a1, cur1), 1, nullptr);
@@ -776,7 +776,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -788,7 +788,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, a1, signer.key, 2, nullptr);
@@ -813,7 +813,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto tx2 = transactionFrameFromOps(
@@ -825,7 +825,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, dataKey(a1, dataName), 1, nullptr);
@@ -851,7 +851,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx1->apply(*app, ltx, txm1));
 
                     auto offerID = ltx.loadHeader().current().idPool;
@@ -864,7 +864,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx2->apply(*app, ltx, txm2));
 
                     checkSponsorship(ltx, offerKey(a1, offerID), 1, nullptr);
@@ -891,7 +891,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
@@ -919,7 +919,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
@@ -945,7 +945,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
@@ -958,7 +958,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                     TransactionMetaFrame txm2(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx2->apply(*app, ltx, txm2));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx2, 0) ==
@@ -993,7 +993,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm1(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx->apply(*app, ltx, txm1));
                         checkSponsorship(ltx, a1, 0, &root.getPublicKey(), 1, 2,
                                          0, 1);
@@ -1022,7 +1022,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm1(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(!tx->apply(*app, ltx, txm1));
 
                     REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
@@ -1044,7 +1044,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                         TransactionMetaFrame txm2(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx2->apply(*app, ltx, txm2));
                         checkSponsorship(ltx, a1, 0, nullptr, 1, 2, 0, 0);
 
@@ -1052,7 +1052,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                                                            a2, {op}, {});
 
                         TransactionMetaFrame txm3(2);
-                        REQUIRE(tx3->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx3->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(!tx3->apply(*app, ltx, txm3));
 
                         REQUIRE(getRevokeSponsorshipResultCode(tx3, 0) ==
@@ -1105,7 +1105,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm1(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx1->apply(*app, ltx, txm1));
 
                         Operation middleOpTx2 =
@@ -1123,7 +1123,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                         TransactionMetaFrame txm2(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(!tx2->apply(*app, ltx, txm2));
 
                         REQUIRE(getRevokeSponsorshipResultCode(tx2, 1) ==
@@ -1147,7 +1147,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm1(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx1->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx1->apply(*app, ltx, txm1));
 
                         Operation opTx2 =
@@ -1161,7 +1161,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
                         TransactionMetaFrame txm2(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx2->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(!tx2->apply(*app, ltx, txm2));
 
                         REQUIRE(getRevokeSponsorshipResultCode(tx2, 0) ==
@@ -1197,7 +1197,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(!tx->apply(*app, ltx, txm));
 
                         REQUIRE(getRevokeSponsorshipResultCode(tx, 1) ==
@@ -1307,7 +1307,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                 {root.op(revokeSponsorship(trustlineKey(root, Asset{})))}, {});
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
                     REVOKE_SPONSORSHIP_MALFORMED);
         });
@@ -1322,7 +1322,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
                 {root.op(revokeSponsorship(trustlineKey(root, cur1)))}, {});
             LedgerTxn ltx(app->getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
                     REVOKE_SPONSORSHIP_MALFORMED);
         });
@@ -1338,7 +1338,7 @@ TEST_CASE_VERSIONS("update sponsorship", "[tx][sponsorship]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
 
-            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(getRevokeSponsorshipResultCode(tx, 0) ==
                     REVOKE_SPONSORSHIP_MALFORMED);
 

--- a/src/transactions/test/SetOptionsTests.cpp
+++ b/src/transactions/test/SetOptionsTests.cpp
@@ -358,7 +358,7 @@ TEST_CASE_VERSIONS("set options", "[tx][setoptions]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, acc1.getPublicKey(), 0, nullptr, 2, 2,
@@ -398,7 +398,7 @@ TEST_CASE_VERSIONS("set options", "[tx][setoptions]")
                     LedgerTxn ltx(app->getLedgerTxnRoot());
                     TransactionMetaFrame txm(
                         ltx.loadHeader().current().ledgerVersion);
-                    REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                     REQUIRE(tx->apply(*app, ltx, txm));
 
                     checkSponsorship(ltx, acc1.getPublicKey(), 0, nullptr, 2, 2,
@@ -497,7 +497,7 @@ TEST_CASE_VERSIONS("set options", "[tx][setoptions]")
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 TransactionMetaFrame txm(
                     ltx.loadHeader().current().ledgerVersion);
-                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                 REQUIRE(tx->apply(*app, ltx, txm));
                 ltx.commit();
 

--- a/src/transactions/test/SetTrustLineFlagsTests.cpp
+++ b/src/transactions/test/SetTrustLineFlagsTests.cpp
@@ -1150,7 +1150,7 @@ TEST_CASE_VERSIONS("revoke from pool",
                                 LedgerTxn ltx(app->getLedgerTxnRoot());
                                 TransactionMetaFrame txm(
                                     ltx.loadHeader().current().ledgerVersion);
-                                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                                 REQUIRE(tx->apply(*app, ltx, txm));
                                 REQUIRE(tx->getResultCode() == txSUCCESS);
                                 ltx.commit();
@@ -1247,7 +1247,7 @@ TEST_CASE_VERSIONS("revoke from pool",
                             LedgerTxn ltx(app->getLedgerTxnRoot());
                             TransactionMetaFrame txm(
                                 ltx.loadHeader().current().ledgerVersion);
-                            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                             REQUIRE(tx->apply(*app, ltx, txm) == success);
 
                             if (success)
@@ -1514,7 +1514,7 @@ TEST_CASE_VERSIONS("revoke from pool",
                         LedgerTxn ltx(app->getLedgerTxnRoot());
                         TransactionMetaFrame txm(
                             ltx.loadHeader().current().ledgerVersion);
-                        REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         REQUIRE(tx->apply(*app, ltx, txm));
                         REQUIRE(tx->getResultCode() == txSUCCESS);
 

--- a/src/transactions/test/SponsorshipTestUtils.cpp
+++ b/src/transactions/test/SponsorshipTestUtils.cpp
@@ -151,7 +151,7 @@ createSponsoredEntryButSponsorHasInsufficientBalance(
 
             LedgerTxn ltx(app.getLedgerTxnRoot());
             TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+            REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
             REQUIRE(!tx->apply(app, ltx, txm));
             REQUIRE(check(getOperationResult(tx, 1)));
             ltx.commit();
@@ -256,7 +256,7 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                 LedgerTxn ltx(app.getLedgerTxnRoot());
                 TransactionMetaFrame txm(
                     ltx.loadHeader().current().ledgerVersion);
-                REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
                 REQUIRE(tx->apply(app, ltx, txm));
 
                 check(ltx);
@@ -271,7 +271,7 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
                 LedgerTxn ltx2(app.getLedgerTxnRoot());
                 TransactionMetaFrame txm2(
                     ltx2.loadHeader().current().ledgerVersion);
-                REQUIRE(tx2->checkValid(ltx2, 0, 0, 0));
+                REQUIRE(tx2->checkValid(app, ltx2, 0, 0, 0));
                 REQUIRE(tx2->apply(app, ltx2, txm2));
 
                 check(ltx2);
@@ -285,7 +285,7 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
             {
                 LedgerTxn ltx3(app.getLedgerTxnRoot());
                 TransactionMetaFrame txm3(2);
-                REQUIRE(tx3->checkValid(ltx3, 0, 0, 0));
+                REQUIRE(tx3->checkValid(app, ltx3, 0, 0, 0));
                 REQUIRE(tx3->apply(app, ltx3, txm3));
 
                 check(ltx3);
@@ -300,7 +300,7 @@ createModifyAndRemoveSponsoredEntry(Application& app, TestAccount& sponsoredAcc,
             {
                 LedgerTxn ltx4(app.getLedgerTxnRoot());
                 TransactionMetaFrame txm4(2);
-                REQUIRE(tx4->checkValid(ltx4, 0, 0, 0));
+                REQUIRE(tx4->checkValid(app, ltx4, 0, 0, 0));
                 REQUIRE(tx4->apply(app, ltx4, txm4));
 
                 if (rso.type() == REVOKE_SPONSORSHIP_LEDGER_ENTRY)
@@ -398,7 +398,7 @@ submitTooManySponsoringTxs(Application& app, TestAccount& successfulOpAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm1(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx1->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(tx1->apply(app, ltx, txm1));
         ltx.commit();
     }
@@ -412,7 +412,7 @@ submitTooManySponsoringTxs(Application& app, TestAccount& successfulOpAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm2(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx2->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(!tx2->apply(app, ltx, txm2));
         REQUIRE(tx2->getResult().result.results()[1].code() ==
                 opTOO_MANY_SPONSORING);
@@ -541,7 +541,7 @@ submitTooManyNumSubEntries(Application& app, TestAccount& testAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm1(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx1->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx1->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(tx1->apply(app, ltx, txm1));
         ltx.commit();
     }
@@ -552,7 +552,7 @@ submitTooManyNumSubEntries(Application& app, TestAccount& testAcc,
 
         LedgerTxn ltx(app.getLedgerTxnRoot());
         TransactionMetaFrame txm2(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx2->checkValid(ltx, 0, 0, 0));
+        REQUIRE(tx2->checkValid(app, ltx, 0, 0, 0));
         REQUIRE(!tx2->apply(app, ltx, txm2));
         REQUIRE(tx2->getResult().result.results()[0].code() ==
                 opTOO_MANY_SUBENTRIES);

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -11,6 +11,7 @@
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
+#include "ledger/NetworkConfig.h"
 #include "lib/catch.hpp"
 #include "lib/json/json.h"
 #include "main/Application.h"
@@ -831,7 +832,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
                             setup();
                             {
                                 LedgerTxn ltx(app->getLedgerTxnRoot());
-                                REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+                                REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
                             }
                             REQUIRE(tx->getResultCode() == txBAD_SEQ);
                             REQUIRE(getAccountSigners(a1, *app).size() == 1);
@@ -1441,8 +1442,8 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
                                 LedgerTxn ltx(app->getLedgerTxnRoot());
                                 TransactionMetaFrame txm(
                                     ltx.loadHeader().current().ledgerVersion);
-                                REQUIRE(
-                                    insideSignerTx->checkValid(ltx, 0, 0, 0));
+                                REQUIRE(insideSignerTx->checkValid(*app, ltx, 0,
+                                                                   0, 0));
                                 REQUIRE(insideSignerTx->apply(*app, ltx, txm));
                                 REQUIRE(insideSignerTx->getResultCode() ==
                                         txSUCCESS);
@@ -1460,8 +1461,8 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
                                 LedgerTxn ltx(app->getLedgerTxnRoot());
                                 TransactionMetaFrame txm(
                                     ltx.loadHeader().current().ledgerVersion);
-                                REQUIRE(
-                                    outsideSignerTx->checkValid(ltx, 0, 0, 0));
+                                REQUIRE(outsideSignerTx->checkValid(*app, ltx,
+                                                                    0, 0, 0));
                                 REQUIRE(outsideSignerTx->apply(*app, ltx, txm));
                                 REQUIRE(outsideSignerTx->getResultCode() ==
                                         txSUCCESS);
@@ -1685,7 +1686,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                 {
                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                    REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+                    REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
                 }
 
                 applyCheck(tx, *app);
@@ -1709,7 +1710,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txFAILED);
@@ -1723,7 +1724,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -1740,7 +1741,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         }
                         applyCheck(tx, *app);
                         REQUIRE(tx->getResultCode() == txSUCCESS);
@@ -1765,7 +1766,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(!tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1792,7 +1793,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1818,7 +1819,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                         {
                             LedgerTxn ltx(app->getLedgerTxnRoot());
-                            REQUIRE(tx->checkValid(ltx, 0, 0, 0));
+                            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
                         }
 
                         applyCheck(tx, *app);
@@ -1910,7 +1911,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
                     setup();
                     {
                         LedgerTxn ltx(app->getLedgerTxnRoot());
-                        REQUIRE(!txFrame->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(!txFrame->checkValid(*app, ltx, 0, 0, 0));
                     }
                     REQUIRE(txFrame->getResultCode() == txBAD_SEQ);
                 });
@@ -1999,7 +2000,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
                                 {
                                     LedgerTxn ltx(app->getLedgerTxnRoot());
                                     REQUIRE(txFrame->checkValid(
-                                                ltx, 0, lowerBound, 0) ==
+                                                *app, ltx, 0, lowerBound, 0) ==
                                             expectSuccess);
                                 }
                                 REQUIRE(
@@ -2079,8 +2080,8 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                                 {
                                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                                    REQUIRE(
-                                        txFrame->checkValid(ltx, 0, 0, offset));
+                                    REQUIRE(txFrame->checkValid(*app, ltx, 0, 0,
+                                                                offset));
                                 }
 
                                 REQUIRE(txFrame->getResultCode() == txSUCCESS);
@@ -2092,8 +2093,8 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
 
                                 {
                                     LedgerTxn ltx(app->getLedgerTxnRoot());
-                                    REQUIRE(!txFrame->checkValid(ltx, 0, 0,
-                                                                 offset));
+                                    REQUIRE(!txFrame->checkValid(*app, ltx, 0,
+                                                                 0, offset));
                                 }
 
                                 REQUIRE(txFrame->getResultCode() == txTOO_LATE);
@@ -2121,7 +2122,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
                     setSeqNum(txFrame, txFrame->getSeqNum() - 1);
                     {
                         LedgerTxn ltx(app->getLedgerTxnRoot());
-                        REQUIRE(!txFrame->checkValid(ltx, 0, 0, 0));
+                        REQUIRE(!txFrame->checkValid(*app, ltx, 0, 0, 0));
                     }
 
                     REQUIRE(txFrame->getResultCode() == txBAD_SEQ);
@@ -2465,3 +2466,112 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
         for_versions_from(13, *app, [&] { doChecks(txSUCCESS); });
     }
 }
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+TEST_CASE("soroban txs not allowed before protocol upgrade",
+          "[tx][envelope][soroban]")
+{
+    VirtualClock clock;
+    auto cfg = getTestConfig();
+    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
+        static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION) - 1;
+    auto app = createTestApplication(clock, cfg);
+    auto root = TestAccount::createRoot(*app);
+    Operation op;
+    op.body.type(INVOKE_HOST_FUNCTION);
+    op.body.invokeHostFunctionOp().functions.emplace_back();
+
+    auto tx = sorobanTransactionFrameFromOps(app->getNetworkID(), root, {op},
+                                             {}, SorobanResources());
+    LedgerTxn ltx(app->getLedgerTxnRoot());
+    REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
+}
+
+TEST_CASE("soroban transaction validation", "[tx][envelope][soroban]")
+{
+    VirtualClock clock;
+    auto app = createTestApplication(clock, getTestConfig());
+    auto root = TestAccount::createRoot(*app);
+    Operation op;
+    op.body.type(INVOKE_HOST_FUNCTION);
+    auto& ihf = op.body.invokeHostFunctionOp().functions.emplace_back();
+    ihf.args.type(HOST_FUNCTION_TYPE_CREATE_CONTRACT);
+
+    auto validateResources = [&](SorobanResources const& resources,
+                                 bool valid) {
+        auto tx = sorobanTransactionFrameFromOps(app->getNetworkID(), root,
+                                                 {op}, {}, resources);
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0) == valid);
+    };
+
+    SECTION("no soroban extension")
+    {
+        auto tx = transactionFrameFromOps(app->getNetworkID(), root, {op}, {});
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
+    }
+    SECTION("no soroban resources in extension")
+    {
+        auto envelope =
+            transactionFrameFromOps(app->getNetworkID(), root, {op}, {})
+                ->getEnvelope();
+        envelope.v1().tx.ext.v(1);
+        auto tx = TransactionFrameBase::makeTransactionFromWire(
+            app->getNetworkID(), envelope);
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
+    }
+    SorobanResources resources;
+    SECTION("minimal resources are valid")
+    {
+        validateResources(resources, true);
+    }
+    resources.instructions = InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
+    resources.readBytes = InitialSorobanNetworkConfig::TX_MAX_READ_BYTES;
+    resources.writeBytes = InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
+    resources.extendedMetaDataSizeBytes =
+        InitialSorobanNetworkConfig::TX_MAX_EXTENDED_META_DATA_SIZE_BYTES;
+    resources.footprint.readOnly.resize(
+        InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES -
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES);
+    resources.footprint.readWrite.resize(
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES);
+    SECTION("instructions exceeded")
+    {
+        resources.instructions += 1;
+        validateResources(resources, false);
+    }
+    SECTION("read bytes exceeded")
+    {
+        resources.readBytes += 1;
+        validateResources(resources, false);
+    }
+    SECTION("write bytes exceeded")
+    {
+        resources.writeBytes += 1;
+        validateResources(resources, false);
+    }
+    SECTION("metadata size exceeded")
+    {
+        resources.extendedMetaDataSizeBytes += 1;
+        validateResources(resources, false);
+    }
+    SECTION("max read entries exceeded")
+    {
+        resources.footprint.readOnly.emplace_back();
+        validateResources(resources, false);
+    }
+    SECTION("max write entries exceeded")
+    {
+        // Make sure that read entries limit is not exceeded.
+        resources.footprint.readOnly.pop_back();
+        resources.footprint.readWrite.emplace_back();
+        validateResources(resources, false);
+    }
+    SECTION("maximal resources are valid")
+    {
+        validateResources(resources, true);
+    }
+}
+#endif


### PR DESCRIPTION
# Description

- Perform soroban transaction validation and ensure per-transaction limits aren't exceeded
- Plumb Soroban resources and network configuration to the host and enforce the resource limits at apply time
- Also contains supporting refactoring and minor fixes. The plumbing solution is not super elegant (pass `Application` to more functions), but is better

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
