### PR TITLE
Initial implementation of the fee support for Soroban.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,15 +54,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,23 +104,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
- "digest 0.9.0",
+ "digest",
  "rand_core",
  "subtle",
  "zeroize",
@@ -174,16 +155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
-dependencies = [
- "block-buffer 0.10.4",
- "crypto-common",
-]
-
-[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,7 +185,7 @@ dependencies = [
  "ed25519",
  "rand",
  "serde",
- "sha2 0.9.9",
+ "sha2",
  "zeroize",
 ]
 
@@ -598,22 +569,11 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer 0.9.0",
+ "block-buffer",
  "cfg-if",
  "cpufeatures",
- "digest 0.9.0",
+ "digest",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
 ]
 
 [[package]]
@@ -625,33 +585,33 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe#7e058436563cd688ae2667afc68e4fe2cf2ec6fe"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
+ "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=76a4fa1ada4d3e175c627b7d023ceca06f757289)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd#bad318a9805cf25ae64afb5122cb37af67a2edbd"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
+ "soroban-env-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=df3a145bfaf75504bc85f20eceb49b4536836e18)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe#7e058436563cd688ae2667afc68e4fe2cf2ec6fe"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -662,9 +622,9 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "sha2 0.10.6",
- "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
- "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
+ "sha2",
+ "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe)",
+ "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -673,7 +633,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd#bad318a9805cf25ae64afb5122cb37af67a2edbd"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -684,9 +644,9 @@ dependencies = [
  "num-derive",
  "num-integer",
  "num-traits",
- "sha2 0.10.6",
- "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
- "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
+ "sha2",
+ "soroban-env-common 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd)",
+ "soroban-native-sdk-macros 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -695,59 +655,59 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe#7e058436563cd688ae2667afc68e4fe2cf2ec6fe"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=76a4fa1ada4d3e175c627b7d023ceca06f757289)",
- "syn 1.0.109",
+ "stellar-xdr",
+ "syn 2.0.10",
  "thiserror",
 ]
 
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd#bad318a9805cf25ae64afb5122cb37af67a2edbd"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.15 (git+https://github.com/stellar/rs-stellar-xdr?rev=df3a145bfaf75504bc85f20eceb49b4536836e18)",
- "syn 1.0.109",
+ "stellar-xdr",
+ "syn 2.0.10",
  "thiserror",
 ]
 
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b#e5cdfd871093e002428f924162152df248a0e22b"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe#7e058436563cd688ae2667afc68e4fe2cf2ec6fe"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd#bad318a9805cf25ae64afb5122cb37af67a2edbd"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.15"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd#bad318a9805cf25ae64afb5122cb37af67a2edbd"
 
 [[package]]
 name = "soroban-wasmi"
@@ -792,19 +752,9 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=e5cdfd871093e002428f924162152df248a0e22b)",
- "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75)",
+ "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=7e058436563cd688ae2667afc68e4fe2cf2ec6fe)",
+ "soroban-env-host 0.0.15 (git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd)",
  "soroban-test-wasms",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.15"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=76a4fa1ada4d3e175c627b7d023ceca06f757289#76a4fa1ada4d3e175c627b7d023ceca06f757289"
-dependencies = [
- "base64",
- "crate-git-revision",
- "hex",
 ]
 
 [[package]]

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -211,13 +211,13 @@ TxSetUtils::getInvalidTxList(TxSetFrame::Transactions const& txs,
             {
                 lastSeq = tx->getSeqNum();
                 int64_t& accFee = accountFeeMap[tx->getFeeSourceID()];
-                if (INT64_MAX - accFee < tx->getFeeBid())
+                if (INT64_MAX - accFee < tx->getFullFee())
                 {
                     accFee = INT64_MAX;
                 }
                 else
                 {
-                    accFee += tx->getFeeBid();
+                    accFee += tx->getFullFee();
                 }
                 ++iter;
             }

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -654,5 +654,26 @@ SorobanNetworkConfig::isValidCostParams(ContractCostParams const& params)
     return true;
 }
 
-#endif
+CxxFeeConfiguration
+SorobanNetworkConfig::rustBridgeFeeConfiguration() const
+{
+    CxxFeeConfiguration res;
+    res.fee_per_instruction_increment = feeRatePerInstructionsIncrement();
+
+    res.fee_per_read_entry = feeReadLedgerEntry();
+    res.fee_per_write_entry = feeWriteLedgerEntry();
+    res.fee_per_read_1kb = feeRead1KB();
+    // This should be dependent on the ledger size, but initially
+    // we'll just use the flat rate here.
+    res.fee_per_write_1kb = feeWrite1KB();
+
+    res.fee_per_propagate_1kb = feePropagateData1KB();
+
+    res.fee_per_metadata_1kb = feeExtendedMetaData1KB();
+
+    res.fee_per_historical_1kb = feeHistorical1KB();
+
+    return res;
 }
+#endif
+} // namespace stellar

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -4,8 +4,11 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "ledger/LedgerTxn.h"
 #include <cstdint>
-#include <ledger/LedgerTxn.h>
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+#include "rust/RustBridge.h"
+#endif
 
 namespace stellar
 {
@@ -23,7 +26,8 @@ struct InitialSorobanNetworkConfig
     // Compute settings
     static constexpr int64_t LEDGER_MAX_INSTRUCTIONS = 1;
     static constexpr int64_t TX_MAX_INSTRUCTIONS = 200'000'000;
-    static constexpr int64_t FEE_RATE_PER_INSTRUCTIONS_INCREMENT = 1;
+    static constexpr int64_t FEE_RATE_PER_INSTRUCTIONS_INCREMENT =
+        100;                                                   // 0.2 XLM/max tx
     static constexpr uint32_t MEMORY_LIMIT = 50 * 1024 * 1024; // 50MB
 
     // Ledger access settings
@@ -32,29 +36,29 @@ struct InitialSorobanNetworkConfig
     static constexpr uint32_t LEDGER_MAX_WRITE_LEDGER_ENTRIES = 1;
     static constexpr uint32_t LEDGER_MAX_WRITE_BYTES = 1;
     static constexpr uint32_t TX_MAX_READ_LEDGER_ENTRIES = 40;
-    static constexpr uint32_t TX_MAX_READ_BYTES = 200'000;
+    static constexpr uint32_t TX_MAX_READ_BYTES = 200 * 1024;
     static constexpr uint32_t TX_MAX_WRITE_LEDGER_ENTRIES = 20;
-    static constexpr uint32_t TX_MAX_WRITE_BYTES = 100'000;
-    static constexpr int64_t FEE_READ_LEDGER_ENTRY = 1;
-    static constexpr int64_t FEE_WRITE_LEDGER_ENTRY = 1;
-    static constexpr int64_t FEE_READ_1KB = 1;
-    static constexpr int64_t FEE_WRITE_1KB = 1;
+    static constexpr uint32_t TX_MAX_WRITE_BYTES = 100 * 1024;
+    static constexpr int64_t FEE_READ_LEDGER_ENTRY = 5'000;   // 0.02 XLM/max tx
+    static constexpr int64_t FEE_WRITE_LEDGER_ENTRY = 20'000; // 0.04 XLM/max tx
+    static constexpr int64_t FEE_READ_1KB = 1'000;            // 0.02 XLM/max tx
+    static constexpr int64_t FEE_WRITE_1KB = 4'000;           // 0.04 XLM/max tx
     static constexpr int64_t BUCKET_LIST_SIZE_BYTES = 1;
     static constexpr int64_t BUCKET_LIST_FEE_RATE_LOW = 1;
     static constexpr int64_t BUCKET_LIST_FEE_RATE_HIGH = 1;
     static constexpr uint32_t BUCKET_LIST_GROWTH_FACTOR = 1;
 
     // Historical data settings
-    static constexpr int64_t FEE_HISTORICAL_1KB = 1;
+    static constexpr int64_t FEE_HISTORICAL_1KB = 100; // 0.001 XLM/max tx
 
     // Bandwidth settings
     static constexpr uint32_t LEDGER_MAX_PROPAGATE_SIZE_BYTES = 1;
-    static constexpr uint32_t TX_MAX_SIZE_BYTES = 100'000;
-    static constexpr int64_t FEE_PROPAGATE_DATA_1KB = 1;
+    static constexpr uint32_t TX_MAX_SIZE_BYTES = 100 * 1024;
+    static constexpr int64_t FEE_PROPAGATE_DATA_1KB = 2'000; // 0.02 XLM/max tx
 
     // Meta data settings
-    static constexpr uint32_t TX_MAX_EXTENDED_META_DATA_SIZE_BYTES = 500'000;
-    static constexpr int64_t FEE_EXTENDED_META_DATA_1KB = 1;
+    static constexpr uint32_t TX_MAX_EXTENDED_META_DATA_SIZE_BYTES = 500 * 1024;
+    static constexpr int64_t FEE_EXTENDED_META_DATA_1KB = 200;
 };
 
 // Wrapper for the contract-related network configuration.
@@ -146,6 +150,8 @@ class SorobanNetworkConfig
     ContractCostParams const& memCostParams() const;
 
     static bool isValidCostParams(ContractCostParams const& params);
+
+    CxxFeeConfiguration rustBridgeFeeConfiguration() const;
 #endif
 
   private:

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -27,7 +27,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "efffbbb9b5be442e58aecead3362bae2c9613c75"
+rev = "bad318a9805cf25ae64afb5122cb37af67a2edbd"
 features = ["vm"]
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
@@ -52,12 +52,12 @@ optional = true
 version = "0.0.15"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "e5cdfd871093e002428f924162152df248a0e22b"
+rev = "7e058436563cd688ae2667afc68e4fe2cf2ec6fe"
 features = ["vm"]
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "efffbbb9b5be442e58aecead3362bae2c9613c75"
+rev = "bad318a9805cf25ae64afb5122cb37af67a2edbd"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=efffbbb9b5be442e58aecead3362bae2c9613c75#efffbbb9b5be442e58aecead3362bae2c9613c75
+soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=bad318a9805cf25ae64afb5122cb37af67a2edbd#bad318a9805cf25ae64afb5122cb37af67a2edbd
 ├── tinyvec 1.6.0 checksum:87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50
 │   └── tinyvec_macros 0.1.1 checksum:1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
@@ -22,18 +22,17 @@ soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=efffbb
 │       ├── memory_units 0.4.0 checksum:8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3
 │       ├── libm 0.2.6 checksum:348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb
 │       └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
-├── sha2 0.10.6 checksum:82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0
-│   ├── digest 0.10.6 checksum:8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f
-│   │   ├── crypto-common 0.1.6 checksum:1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3
-│   │   │   ├── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
-│   │   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
-│   │   │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
-│   │   │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
-│   │   └── block-buffer 0.10.4 checksum:3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71
-│   │       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
+├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
+│   ├── opaque-debug 0.3.0 checksum:624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5
+│   ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
+│   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
+│   │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
+│   │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
 │   ├── cpufeatures 0.2.6 checksum:280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181
 │   │   └── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
-│   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   ├── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   └── block-buffer 0.9.0 checksum:4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4
+│       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
 ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
 ├── num-integer 0.1.45 checksum:225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9
 ├── num-derive 0.3.3 checksum:876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d
@@ -60,13 +59,6 @@ soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=efffbb
 │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
 │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
-│   │   ├── opaque-debug 0.3.0 checksum:624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5
-│   │   ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
-│   │   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
-│   │   ├── cpufeatures 0.2.6 checksum:280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181
-│   │   ├── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
-│   │   └── block-buffer 0.9.0 checksum:4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4
-│   │       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
 │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
 │   │   └── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
 │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -279,11 +279,10 @@ transactionFrameFromOps(Hash const& networkID, TestAccount& source,
                         std::vector<SecretKey> const& opKeys,
                         std::optional<PreconditionsV2> cond = std::nullopt);
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-TransactionFrameBasePtr
-sorobanTransactionFrameFromOps(Hash const& networkID, TestAccount& source,
-                               std::vector<Operation> const& ops,
-                               std::vector<SecretKey> const& opKeys,
-                               SorobanResources const& resources);
+TransactionFrameBasePtr sorobanTransactionFrameFromOps(
+    Hash const& networkID, TestAccount& source,
+    std::vector<Operation> const& ops, std::vector<SecretKey> const& opKeys,
+    SorobanResources const& resources, uint32_t fee, uint32_t refundableFee);
 #endif
 
 LedgerUpgrade makeBaseReserveUpgrade(int baseReserve);

--- a/src/testdata/ledger-close-meta-v2-protocol-20.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-20.json
@@ -3,24 +3,24 @@
         "v": 2,
         "v2": {
             "ledgerHeader": {
-                "hash": "1e4a1b7bf54f269d57611b1bbc0f6927e4f1ae114170a4c3a8bb67313dbb1c8c",
+                "hash": "31bbf4641b04c4551c0bc7582979a621034ad5a4a577ad693ef8dc20a55f8edd",
                 "header": {
                     "ledgerVersion": 20,
-                    "previousLedgerHash": "7718e2747a4acefbf98b797576559d280390cc432494d40cec33759c7118b541",
+                    "previousLedgerHash": "f8708176fc96a193031d87e0011fe53e57cbd794b33ef46325e0d51ce44acadd",
                     "scpValue": {
-                        "txSetHash": "5451be3e696676c83debf50276e884ed457a4f9dfd55e6c02b4f66850187e44b",
+                        "txSetHash": "7573abd239d89f79e43857ae82eb43e335de55f7082a935aaea50b6badf8394f",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "63971eba040ec8c4a1ff7a695dd915581fa66cbb004ab121f05a1c2360c36f6938413d1398c906e062be067fe3bc7af351aaee14bd07fe759ff22ffd1347bb0a"
+                                "signature": "98b4062f9916a028332ac002255e0f05e92bd8552dea42ecce8fe540c109d6ff32700121f828523823e9938a59562a2f66373ae25c341dbf967492515c15a60a"
                             }
                         }
                     },
                     "txSetResultHash": "cf65fee29665ff0c2a6910b24c420a487a7416ccd79c683b48aac1d45ad21faa",
-                    "bucketListHash": "77d8199347aafeba7e58252be3d927b2c9c9f02a32f01036f46d11727ee1526e",
+                    "bucketListHash": "bc7576449a994f3efb7621368edf444865dd42c4c2bdd4e3f33bb1ab4a7c3efe",
                     "ledgerSeq": 6,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -46,7 +46,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "7718e2747a4acefbf98b797576559d280390cc432494d40cec33759c7118b541",
+                    "previousLedgerHash": "f8708176fc96a193031d87e0011fe53e57cbd794b33ef46325e0d51ce44acadd",
                     "phases": [
                         {
                             "v": 0,

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -66,6 +66,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     TransactionEnvelope const& getEnvelope() const override;
 
+    int64_t getFullFee() const override;
     int64_t getFeeBid() const override;
     int64_t getFee(LedgerHeader const& header, std::optional<int64_t> baseFee,
                    bool applying) const override;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -6,12 +6,16 @@
 
 #include "ledger/InternalLedgerEntry.h"
 #include "ledger/NetworkConfig.h"
+#include "main/Config.h"
 #include "overlay/StellarXDR.h"
 #include "transactions/TransactionFrameBase.h"
 #include "transactions/TransactionMetaFrame.h"
 #include "util/GlobalChecks.h"
 #include "util/types.h"
 #include "xdr/Stellar-ledger.h"
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+#include "rust/RustBridge.h"
+#endif
 
 #include <memory>
 #include <optional>
@@ -51,6 +55,7 @@ class TransactionFrame : public TransactionFrameBase
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     xdr::xvector<OperationEvents> mEvents;
     xdr::xvector<OperationDiagnosticEvents> mDiagnosticEvents;
+    std::optional<FeePair> mSorobanResourceFee;
 #endif
 
     std::shared_ptr<InternalLedgerEntry const> mCachedAccount;
@@ -188,6 +193,7 @@ class TransactionFrame : public TransactionFrameBase
     uint32_t getNumOperations() const override;
     std::vector<Operation> const& getRawOperations() const override;
 
+    int64_t getFullFee() const override;
     int64_t getFeeBid() const override;
 
     virtual int64_t getFee(LedgerHeader const& header,
@@ -247,6 +253,10 @@ class TransactionFrame : public TransactionFrameBase
     bool isSoroban() const override;
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     SorobanResources const& sorobanResources() const override;
+    void
+    maybeComputeSorobanResourceFee(uint32_t protocolVersion,
+                                   SorobanNetworkConfig const& sorobanConfig,
+                                   Config const& cfg);
 #endif
 };
 }

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -42,6 +42,11 @@ class TransactionFrameBase
 
     virtual TransactionEnvelope const& getEnvelope() const = 0;
 
+    // Returns the total fee of this transaction, including the 'flat',
+    // non-market part.
+    virtual int64_t getFullFee() const = 0;
+    // Returns the part of the full fee used to make decisions as to
+    // whether this transaction should be included into ledger.
     virtual int64_t getFeeBid() const = 0;
     virtual int64_t getFee(LedgerHeader const& header,
                            std::optional<int64_t> baseFee,


### PR DESCRIPTION
# Description

Initial implementation of the fee support for Soroban.

Current limitations (all of these have the respective issues opened for the next releases):

- Soroban inclusion fee is treated as the classic fee bid for the regular transactions for all intents and purposes (so it has to be at least 100 stroops, is subject to surge pricing together with the classic txs etc.).
- The initial fee rates are pretty arbitrary
- Write bytes fee is set to a constant amount
- No actual refunds happen for the refundable fee (so currently it just has to be equal to metadata fee)
- Testing coverage can be improved

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
