### PR TITLE
Call `maybeComputeSorobanResourceFee` from the fee bump tx frames.

### DIFF
--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -53,6 +53,15 @@ FeeBumpTransactionFrame::sorobanResources() const
 {
     return mInnerTx->sorobanResources();
 }
+
+void
+FeeBumpTransactionFrame::maybeComputeSorobanResourceFee(
+    uint32_t protocolVersion, SorobanNetworkConfig const& sorobanConfig,
+    Config const& cfg)
+{
+    mInnerTx->maybeComputeSorobanResourceFee(protocolVersion, sorobanConfig,
+                                             cfg);
+}
 #endif
 
 FeeBumpTransactionFrame::FeeBumpTransactionFrame(

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -108,9 +108,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     void
     maybeComputeSorobanResourceFee(uint32_t protocolVersion,
                                    SorobanNetworkConfig const& sorobanConfig,
-                                   Config const& cfg) override
-    {
-    }
+                                   Config const& cfg) override;
 #endif
 };
 }


### PR DESCRIPTION
# Description

This fixes incorrect fee bids for the fee bump tx frames in certain contexts, but doesn't affect validation/application as these compute the resource fee via an internal call.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
