### PR TITLE
Update to version of cargo-lock without bug, regenerate dep trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,8 +61,8 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cargo-lock"
-version = "8.0.3"
-source = "git+https://github.com/rustsec/rustsec?rev=dcc72b697e10a2d1e3d1ce70d7d7b0d5cbc41dc4#dcc72b697e10a2d1e3d1ce70d7d7b0d5cbc41dc4"
+version = "9.0.0"
+source = "git+https://github.com/rustsec/rustsec?rev=a5c69fc6e4b6068b43d7143f3a2f68c3f3de37d8#a5c69fc6e4b6068b43d7143f3a2f68c3f3de37d8"
 dependencies = [
  "petgraph",
  "semver",
@@ -585,14 +585,14 @@ checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e#0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 dependencies = [
  "crate-git-revision",
  "ethnum",
- "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e)",
+ "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=53e1a9cf2335aff29305c72deb6f075e78915dad)",
+ "stellar-xdr",
 ]
 
 [[package]]
@@ -605,13 +605,13 @@ dependencies = [
  "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=89df4ca73dce2a45127b2fded3ef9c02f8bda665)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e#0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -623,8 +623,8 @@ dependencies = [
  "num-integer",
  "num-traits",
  "sha2",
- "soroban-env-common 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e)",
- "soroban-native-sdk-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e)",
+ "soroban-env-common 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b)",
+ "soroban-native-sdk-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b)",
  "soroban-wasmi",
  "static_assertions",
  "tinyvec",
@@ -655,14 +655,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e#0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=53e1a9cf2335aff29305c72deb6f075e78915dad)",
+ "stellar-xdr",
  "syn 2.0.10",
  "thiserror",
 ]
@@ -677,7 +677,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=89df4ca73dce2a45127b2fded3ef9c02f8bda665)",
+ "stellar-xdr",
  "syn 2.0.10",
  "thiserror",
 ]
@@ -685,7 +685,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e#0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -707,7 +707,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c#27e2e3ea9b964ad2fce9893037193e0f4fa0521c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 
 [[package]]
 name = "soroban-wasmi"
@@ -752,19 +752,9 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e)",
+ "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b)",
  "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c)",
  "soroban-test-wasms",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=53e1a9cf2335aff29305c72deb6f075e78915dad#53e1a9cf2335aff29305c72deb6f075e78915dad"
-dependencies = [
- "base64",
- "crate-git-revision",
- "hex",
 ]
 
 [[package]]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -27,8 +27,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "27e2e3ea9b964ad2fce9893037193e0f4fa0521c"
-features = ["vm"]
+rev = "1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -52,16 +51,16 @@ optional = true
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "0c0cae6fa22b751e7fd95d7ce7556ac6d7b7010e"
+rev = "27e2e3ea9b964ad2fce9893037193e0f4fa0521c"
 features = ["vm"]
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "27e2e3ea9b964ad2fce9893037193e0f4fa0521c"
+rev = "1572d43328bcf4ab90f63f7cdd1a438134034b8b"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"
-rev = "dcc72b697e10a2d1e3d1ce70d7d7b0d5cbc41dc4"
+rev = "a5c69fc6e4b6068b43d7143f3a2f68c3f3de37d8"
 features = ["dependency-tree"]
 
 # This feature definition is implied by the optional=true line in the dep, but

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c#27e2e3ea9b964ad2fce9893037193e0f4fa0521c
+soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b
 ├── tinyvec 1.6.0 checksum:87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50
 │   └── tinyvec_macros 0.1.1 checksum:1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
@@ -22,6 +22,49 @@ soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3
 │       ├── memory_units 0.4.0 checksum:8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3
 │       ├── libm 0.2.6 checksum:348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb
 │       └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
+├── soroban-native-sdk-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b
+│   ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
+│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   │       └── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
+│   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   ├── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
+│       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
+├── soroban-env-common 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b
+│   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=89df4ca73dce2a45127b2fded3ef9c02f8bda665#89df4ca73dce2a45127b2fded3ef9c02f8bda665
+│   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
+│   │   ├── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
+│   │   │   ├── serde_json 1.0.94 checksum:1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea
+│   │   │   │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   │   │   │   └── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
+│   │   │   │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   │   │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   │   │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   │   │   ├── ryu 1.0.13 checksum:f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041
+│   │   │   │   └── itoa 1.0.6 checksum:453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6
+│   │   │   ├── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
+│   │   │   └── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
+│   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
+│   ├── soroban-wasmi 0.16.0-soroban2 git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c
+│   ├── soroban-env-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=1572d43328bcf4ab90f63f7cdd1a438134034b8b#1572d43328bcf4ab90f63f7cdd1a438134034b8b
+│   │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
+│   │   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
+│   │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=89df4ca73dce2a45127b2fded3ef9c02f8bda665#89df4ca73dce2a45127b2fded3ef9c02f8bda665
+│   │   ├── serde_json 1.0.94 checksum:1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea
+│   │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   ├── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
+│   ├── ethnum 1.3.2 checksum:0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04
+│   └── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
 ├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
 │   ├── opaque-debug 0.3.0 checksum:624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5
 │   ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
@@ -39,8 +82,6 @@ soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3
 │   ├── syn 1.0.109 checksum:72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237
 │   │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
 │   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │   │       └── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
 │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
 │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
@@ -60,13 +101,6 @@ soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3
 │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
 │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
-│   │   └── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
-│   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
-│   │       │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
-│   │       │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │       │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── rand 0.7.3 checksum:6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03
 │   │   ├── rand_hc 0.2.0 checksum:ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c
 │   │   │   └── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19

--- a/src/rust/src/host-dep-tree-prev.txt
+++ b/src/rust/src/host-dep-tree-prev.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=b79db4cee33016b11a9329abdf56da873dbaf802#b79db4cee33016b11a9329abdf56da873dbaf802
+soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c#27e2e3ea9b964ad2fce9893037193e0f4fa0521c
 ├── tinyvec 1.6.0 checksum:87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50
 │   └── tinyvec_macros 0.1.1 checksum:1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
@@ -22,26 +22,66 @@ soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=b79db4
 │       ├── memory_units 0.4.0 checksum:8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3
 │       ├── libm 0.2.6 checksum:348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb
 │       └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
-├── sha2 0.10.6 checksum:82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0
-│   ├── digest 0.10.6 checksum:8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f
-│   │   ├── crypto-common 0.1.6 checksum:1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3
-│   │   │   ├── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
-│   │   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
-│   │   │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
-│   │   │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
-│   │   └── block-buffer 0.10.4 checksum:3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71
-│   │       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
+├── soroban-native-sdk-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c#27e2e3ea9b964ad2fce9893037193e0f4fa0521c
+│   ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
+│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   │       └── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
+│   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   ├── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
+│       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
+├── soroban-env-common 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c#27e2e3ea9b964ad2fce9893037193e0f4fa0521c
+│   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=89df4ca73dce2a45127b2fded3ef9c02f8bda665#89df4ca73dce2a45127b2fded3ef9c02f8bda665
+│   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
+│   │   ├── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
+│   │   │   ├── serde_json 1.0.94 checksum:1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea
+│   │   │   │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   │   │   │   └── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
+│   │   │   │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   │   │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   │   │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   │   │   ├── ryu 1.0.13 checksum:f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041
+│   │   │   │   └── itoa 1.0.6 checksum:453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6
+│   │   │   ├── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
+│   │   │   └── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
+│   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
+│   ├── soroban-wasmi 0.16.0-soroban2 git+https://github.com/stellar/wasmi?rev=862b32f5#862b32f53f9c6223911e79e0b0fc8592fb3bb04c
+│   ├── soroban-env-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=27e2e3ea9b964ad2fce9893037193e0f4fa0521c#27e2e3ea9b964ad2fce9893037193e0f4fa0521c
+│   │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
+│   │   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
+│   │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
+│   │   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=89df4ca73dce2a45127b2fded3ef9c02f8bda665#89df4ca73dce2a45127b2fded3ef9c02f8bda665
+│   │   ├── serde_json 1.0.94 checksum:1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea
+│   │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
+│   │   ├── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
+│   ├── ethnum 1.3.2 checksum:0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04
+│   └── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
+├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
+│   ├── opaque-debug 0.3.0 checksum:624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5
+│   ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
+│   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
+│   │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
+│   │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
 │   ├── cpufeatures 0.2.6 checksum:280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181
 │   │   └── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
-│   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   ├── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   └── block-buffer 0.9.0 checksum:4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4
+│       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
 ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
 ├── num-integer 0.1.45 checksum:225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9
 ├── num-derive 0.3.3 checksum:876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d
 │   ├── syn 1.0.109 checksum:72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237
 │   │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
 │   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │   │       └── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
 │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
 │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
@@ -60,21 +100,7 @@ soroban-env-host 0.0.15 git+https://github.com/stellar/rs-soroban-env?rev=b79db4
 │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
 │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
-│   │   ├── opaque-debug 0.3.0 checksum:624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5
-│   │   ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
-│   │   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
-│   │   ├── cpufeatures 0.2.6 checksum:280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181
-│   │   ├── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
-│   │   └── block-buffer 0.9.0 checksum:4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4
-│   │       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
 │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
-│   │   └── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
-│   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
-│   │       │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
-│   │       │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │       │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
 │   ├── rand 0.7.3 checksum:6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03
 │   │   ├── rand_hc 0.2.0 checksum:ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c
 │   │   │   └── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -299,8 +299,8 @@ fn check_lockfile_has_expected_dep_tree(
     // For now we ignore this, but should tighten the test up before final.
     if soroban_host_proto_version != 0 && stellar_core_proto_version != soroban_host_proto_version {
         panic!(
-            "stellar-core supports protocol {} but soroban host supports {}",
-            stellar_core_proto_version, soroban_host_proto_version
+            "stellar-core \"{}\" protocol is {}, does not match soroban host \"{}\" protocol {}",
+            curr_or_prev, stellar_core_proto_version, curr_or_prev, soroban_host_proto_version
         );
     }
 


### PR DESCRIPTION
This takes a fix for a a bug in `cargo-lock tree` (that I fixed today: PR pending here https://github.com/rustsec/rustsec/pull/889) that caused our dep trees to lose much of their content in previous commits. This will need to be updated when the rustsec change above lands and the referenced version of `cargo-lock` goes away with the merge, but in the meantime this will at least set the dependencies on our side right.