### PR TITLE
Update Github actions to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,14 @@ jobs:
         run: |
           echo "id=$(( $(date +'%s') / 60 / 60 ))" >> $GITHUB_OUTPUT
       - name: Cache
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v3.3.1
         with:
           path: |
             /home/runner/.ccache
           key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-${{ steps.cache_extra_id.outputs.id }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-
-      - uses: actions/checkout@v3.2.0
+      - uses: actions/checkout@v3.5.2
         with:
            fetch-depth: 200
            submodules: true


### PR DESCRIPTION
# Description

Picking up updates to GH actions: [fixes](https://github.com/actions/cache/releases/tag/v3.2.6) related to cache misses in actions/cache -- this would explain why some of our builds are super slow (I suspect it depends on which image is used as it sometimes works).

See https://github.com/stellar/stellar-core/actions/runs/5006917405/jobs/8972833874
that claims "Cache not found for input keys: Linux-gcc-current-cacheID-467874, Linux-gcc-current-cacheID-" even though there should be plenty of candidate matches (as per the caches available https://github.com/stellar/stellar-core/actions/caches ), such as `Linux-gcc-current-cacheID-467857` at the time of the cache miss.
