### PR TITLE
Add offline-close command for establishing test network state in quickstart.

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -93,6 +93,10 @@ Command options can only by placed after command.
   HISTORY-LABEL. HISTORY-LABEL should be one of the history archives you have
   specified in the stellar-core.cfg. This will write a
   `.well-known/stellar-history.json` file in the archive root.
+* **offline-close**: Forces stellar-core to close a specified number of empty
+  ledgers, strictly offline and starting from its current state, generating and
+  publishing history as it goes. Should only be used for special scenarios like
+  setting up test networks with artificial history.
 * **offline-info**: Returns an output similar to `--c info` for an offline
   instance, but written directly to standard output (ignoring log levels).
 * **print-xdr <FILE-NAME>**:  Pretty-print a binary file containing an XDR

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -580,7 +580,7 @@ dbModeName(Config::TestDbMode mode)
 
 TEST_CASE("History catchup", "[history][catchup][acceptance]")
 {
-    // needs REAL_TIME here, as prepare-snapshot works will fail for one of the
+    // needs REAL_TIME here, as resolve-snapshot works will fail for one of the
     // sections again and again - as it is set to RETRY_FOREVER it can generate
     // megabytes of unnecessary log entries
     CatchupSimulation catchupSimulation{VirtualClock::REAL_TIME};

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -31,6 +31,7 @@ int dumpLedger(Config cfg, std::string const& outputFile,
                std::optional<std::string> groupBy,
                std::optional<std::string> aggregate);
 void showOfflineInfo(Config cfg, bool verbose);
+void closeLedgersOffline(Config cfg, bool verbose, size_t nLedgers);
 int reportLastHistoryCheckpoint(Config cfg, std::string const& outputFile);
 #ifdef BUILD_TESTS
 void loadXdr(Config cfg, std::string const& bucketFile);

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1207,6 +1207,23 @@ runOfflineInfo(CommandLineArgs const& args)
 }
 
 int
+runOfflineClose(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    size_t nLedgers{0};
+
+    ParserWithValidation numLedgersParser{
+        clara::Arg(nLedgers, "NUM_LEDGERS").required(),
+        [&] { return nLedgers > 0 ? "" : "Ledger count must be non-zero"; }};
+
+    return runWithHelp(
+        args, {configurationParser(configOption), numLedgersParser}, [&] {
+            closeLedgersOffline(configOption.getConfig(), true, nLedgers);
+            return 0;
+        });
+}
+
+int
 runPrintXdr(CommandLineArgs const& args)
 {
     std::string xdr;
@@ -1832,6 +1849,9 @@ handleCommandLine(int argc, char* const* argv)
          {"new-hist", "initialize history archives", runNewHist},
          {"offline-info", "return information for an offline instance",
           runOfflineInfo},
+         {"offline-close",
+          "close a number of ledgers offline, generating checkpoints",
+          runOfflineClose},
          {"print-xdr", "pretty-print one XDR envelope, then quit", runPrintXdr},
          {"publish",
           "execute publish of all items remaining in publish queue without "


### PR DESCRIPTION
This adds a new command `offline-close` which just cranks stellar-core forward from wherever it currently is by N ledgers, closing them with no content and waiting for publishes to complete. It's intended for setting up network state when booting the quickstart image, which really wants to start "after the first checkpoint" rather than at genesis. This is therefore an alternative to https://github.com/stellar/quickstart/pull/448 (and a cluster of related problems)

The only tricky part in here is that `ResolveSnapshotWork` had a 1-ledger delay in it (made by Rafał back in https://github.com/stellar/stellar-core/pull/1570) and it was applied unconditionally, which would make this wedge when trying to advance past a ledger-close and waiting for the publish associated with that close to complete. Rather than do acrobatics about going-one-past-and-waiting, I decided to just make this 1-ledger delay conditional on not-being-`STANDALONE`, since it's a meaningless check in that case anyways.