### PR TITLE
Make sed usage more compat with git refs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,7 +125,7 @@ main/StellarCoreVersion.cpp: always
 	@vers=$$(cd "$(srcdir)" \
 		&& git describe --always --dirty --tags 2>/dev/null \
 		|| echo "$(PACKAGE) $(VERSION)"); \
-		sed -e "s/%%VERSION%%/$$vers/" \
+		sed -e "s@%%VERSION%%@$$vers@" \
 			< "$(srcdir)/main/StellarCoreVersion.cpp.in" > $@~
 	@if cmp -s $@~ $@; then rm -f $@~; else \
 	    mv -f $@~ $@ && printf "echo '%s' > $@\n" "$$(cat $@)"; fi


### PR DESCRIPTION
# Description

Make `sed` usage more compat with git refs where we use sed for setting the version, which is a git ref.

Git refs can contain `/`, and so if the version of stellar-core is a build of stellar-core from a branch that has `/` in the name, the sed command will value because the sed command is using `/` as the separator.

Using an alternative separator that is guaranteed to never be found in git refs eliminates this conflict.

Related discussion is at https://stellarfoundation.slack.com/archives/C0367MGFL/p1684881613131079.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
