### PR TITLE
Ensure we can always find txs to evict in tx limiter

### DIFF
--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -398,11 +398,11 @@ SurgePricingPriorityQueue::canFitWithEviction(
             // there is not enough ops to evict from limited lane to fit the
             // current transaction
             if (lane == GENERIC_LANE || lane == evictLane ||
-                neededLaneOps <= 0 || neededTotalOps > neededLaneOps)
+                neededTotalOps > neededLaneOps)
             {
                 canEvict = true;
             }
-            else if (neededTotalOps <= neededLaneOps)
+            else
             {
                 // When we need to evict more ops from the tx's lane than from
                 // the generic lane, then we can only evict from tx's lane (any

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -389,14 +389,16 @@ SurgePricingPriorityQueue::canFitWithEviction(
             auto const& evictTxStack = *iter;
             auto const& evictTx = *evictTxStack->getTopTx();
             auto evictLane = mLaneConfig->getLane(evictTx);
-            auto evictOps = evictTxStack->getNumOperations();
             bool canEvict = false;
             // Check if it makes sense to evict the current top tx stack.
             //
             // Simple cases: generic lane txs can evict anything; same lane txs
             // can evict each other; any transaction can be evicted if per-lane
-            // limit hasn't been reached.
-            if (lane == GENERIC_LANE || lane == evictLane || neededLaneOps <= 0)
+            // limit hasn't been reached; any transaction can be evicted if
+            // there is not enough ops to evict from limited lane to fit the
+            // current transaction
+            if (lane == GENERIC_LANE || lane == evictLane ||
+                neededLaneOps <= 0 || neededTotalOps > neededLaneOps)
             {
                 canEvict = true;
             }
@@ -406,13 +408,6 @@ SurgePricingPriorityQueue::canFitWithEviction(
                 // the generic lane, then we can only evict from tx's lane (any
                 // other evictions are pointless).
                 evictedDueToLaneLimit = true;
-            }
-            else
-            {
-                // In the final case `neededOps` is greater than `neededLaneOps`
-                // and the difference can be evicted from any lane.
-                int64_t nonLaneOpsToEvict = neededTotalOps - neededLaneOps;
-                canEvict = evictOps <= nonLaneOpsToEvict;
             }
             if (!canEvict)
             {

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1783,7 +1783,16 @@ TEST_CASE("TransactionQueue limiter with DEX separation",
         // non-DEX tx with bid 100, but DEX tx was evicted due to DEX limit).
         checkAndAddWithIncreasedBid(account1, false, 1, 100, 0);
     }
-
+    SECTION("DEX evicts non-DEX if DEX lane has not enough ops to evict")
+    {
+        // 8 non-DEX ops (bid 100/op) - fits
+        checkAndAddTx(account1, false, 8, 100 * 8, true, 0, 0);
+        // 1 DEX op (bid 200/op) - fits
+        checkAndAddTx(account1, true, 1, 200 * 1, true, 0, 0);
+        // 3 DEX ops with high fee (bid 10000/op) - fits by evicting 9 ops from
+        // both lanes
+        checkAndAddTx(account2, true, 3, 10000 * 3, true, 0, 9);
+    }
     SECTION("non-DEX transactions evict DEX transactions")
     {
         // Add 9 ops (2 + 1 DEX, 3 + 2 + 1 non-DEX)


### PR DESCRIPTION
Currently, it is possible to hit [this assert](https://github.com/stellar/stellar-core/blob/7fb6d5e8858fed6ea365f8717b0266635f578477/src/herder/SurgePricingUtils.cpp#L431) during tx limiting if we have a more expensive transaction, but not enough ops to evict from the limited lane. This is because we stop iterating over the generic lane too early, preventing the expensive transaction from fitting in the generic limit. Solution is to allow evicting cheaper transactions from the generic lane, therefore preserving the invariant that we can always find txs to evict (assuming pre-conditions pass). Adding an extra test to confirm the failure, and the fix.