### PR TITLE
Wire up soroban PRNG seed from txset hash, tx and op numbers.

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1294,6 +1294,9 @@ LedgerManagerImpl::applyTransactions(
 
     prefetchTransactionData(txs);
 
+    Hash sorobanBasePrngSeed = txSet.getContentsHash();
+    uint64_t txNum{0};
+
     for (auto tx : txs)
     {
         ZoneNamedN(txZone, "applyTransaction", true);
@@ -1303,7 +1306,19 @@ LedgerManagerImpl::applyTransactions(
                    hexAbbrev(tx->getContentsHash()), tx->getNumOperations(),
                    tx->getSeqNum(),
                    mApp.getConfig().toShortString(tx->getSourceID()));
-        tx->apply(mApp, ltx, tm);
+
+        Hash subSeed = sorobanBasePrngSeed;
+        // If tx can use the seed, we need to compute a sub-seed for it.
+        if (tx->isSoroban())
+        {
+            SHA256 subSeedSha;
+            subSeedSha.add(sorobanBasePrngSeed);
+            subSeedSha.add(xdr::xdr_to_opaque(txNum));
+            subSeed = subSeedSha.finish();
+        }
+        ++txNum;
+
+        tx->apply(mApp, ltx, tm, subSeed);
         tx->processPostApply(mApp, ltx, tm);
         TransactionResultPair results;
         results.transactionHash = tx->getContentsHash();

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -141,6 +141,7 @@ mod rust_bridge {
             auth_entries: &Vec<CxxBuf>,
             ledger_info: CxxLedgerInfo,
             ledger_entries: &Vec<CxxBuf>,
+            base_prng_seed: &CxxBuf,
         ) -> Result<InvokeHostFunctionOutput>;
         fn init_logging(maxLevel: LogLevel) -> Result<()>;
 
@@ -538,6 +539,7 @@ pub(crate) fn invoke_host_function(
     auth_entries: &Vec<CxxBuf>,
     ledger_info: CxxLedgerInfo,
     ledger_entries: &Vec<CxxBuf>,
+    base_prng_seed: &CxxBuf,
 ) -> Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>> {
     if ledger_info.protocol_version > config_max_protocol {
         return Err(Box::new(soroban_curr::contract::CoreHostError::General(
@@ -555,6 +557,7 @@ pub(crate) fn invoke_host_function(
                 auth_entries,
                 ledger_info,
                 ledger_entries,
+                base_prng_seed,
             );
         }
     }
@@ -566,6 +569,7 @@ pub(crate) fn invoke_host_function(
         auth_entries,
         ledger_info,
         ledger_entries,
+        base_prng_seed,
     )
 }
 

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -880,7 +880,7 @@ class FuzzTransactionFrame : public TransactionFrame
         loadSourceAccount(ltx, ltx.loadHeader());
         processSeqNum(ltx);
         TransactionMetaFrame tm(2);
-        applyOperations(signatureChecker, app, ltx, tm);
+        applyOperations(signatureChecker, app, ltx, tm, Hash{});
         if (getResultCode() == txINTERNAL_ERROR)
         {
             throw std::runtime_error("Internal error while fuzzing");

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -114,7 +114,8 @@ updateResult(TransactionResult& outerRes, TransactionFrameBasePtr innerTx)
 
 bool
 FeeBumpTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
-                               TransactionMetaFrame& meta)
+                               TransactionMetaFrame& meta,
+                               Hash const& sorobanBasePrngSeed)
 {
     try
     {
@@ -137,7 +138,7 @@ FeeBumpTransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
 
     try
     {
-        bool res = mInnerTx->apply(app, ltx, meta, false);
+        bool res = mInnerTx->apply(app, ltx, meta, false, sorobanBasePrngSeed);
         // If this throws, then we may not have the correct TransactionResult so
         // we must crash.
         updateResult(getResult(), mInnerTx);

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -58,7 +58,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     virtual ~FeeBumpTransactionFrame(){};
 
     bool apply(Application& app, AbstractLedgerTxn& ltx,
-               TransactionMetaFrame& meta) override;
+               TransactionMetaFrame& meta,
+               Hash const& sorobanBasePrngSeed) override;
 
     void processPostApply(Application& app, AbstractLedgerTxn& ltx,
                           TransactionMetaFrame& meta) override;

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -39,7 +39,8 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     bool isOpSupported(LedgerHeader const& header) const override;
 
     bool doApply(AbstractLedgerTxn& ltx) override;
-    bool doApply(Application& app, AbstractLedgerTxn& ltx) override;
+    bool doApply(Application& app, AbstractLedgerTxn& ltx,
+                 Hash const& sorobanBasePrngSeed) override;
 
     bool doCheckValid(SorobanNetworkConfig const& config,
                       uint32_t ledgerVersion) override;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -135,7 +135,7 @@ OperationFrame::OperationFrame(Operation const& op, OperationResult& res,
 
 bool
 OperationFrame::apply(Application& app, SignatureChecker& signatureChecker,
-                      AbstractLedgerTxn& ltx)
+                      AbstractLedgerTxn& ltx, Hash const& sorobanBasePrngSeed)
 {
     ZoneScoped;
     bool res;
@@ -143,7 +143,7 @@ OperationFrame::apply(Application& app, SignatureChecker& signatureChecker,
     res = checkValid(app, signatureChecker, ltx, true);
     if (res)
     {
-        res = doApply(app, ltx);
+        res = doApply(app, ltx, sorobanBasePrngSeed);
         CLOG_TRACE(Tx, "{}", xdr_to_string(mResult, "OperationResult"));
     }
 
@@ -151,10 +151,11 @@ OperationFrame::apply(Application& app, SignatureChecker& signatureChecker,
 }
 
 bool
-OperationFrame::doApply(Application& _app, AbstractLedgerTxn& ltx)
+OperationFrame::doApply(Application& _app, AbstractLedgerTxn& ltx,
+                        Hash const& sorobanBasePrngSeed)
 {
-    // By default we ignore the app, but subclasses can override to
-    // intercept and use it.
+    // By default we ignore the app and seed, but subclasses can override to
+    // intercept and use them.
     return doApply(ltx);
 }
 

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -45,7 +45,8 @@ class OperationFrame
                               uint32_t ledgerVersion);
     virtual bool doCheckValid(uint32_t ledgerVersion) = 0;
 
-    virtual bool doApply(Application& app, AbstractLedgerTxn& ltx);
+    virtual bool doApply(Application& app, AbstractLedgerTxn& ltx,
+                         Hash const& sorobanBasePrngSeed);
     virtual bool doApply(AbstractLedgerTxn& ltx) = 0;
 
     // returns the threshold this operation requires
@@ -88,7 +89,7 @@ class OperationFrame
                     AbstractLedgerTxn& ltxOuter, bool forApply);
 
     bool apply(Application& app, SignatureChecker& signatureChecker,
-               AbstractLedgerTxn& ltx);
+               AbstractLedgerTxn& ltx, Hash const& sorobanBasePrngSeed);
 
     Operation const&
     getOperation() const

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1335,16 +1335,18 @@ TransactionFrame::markResultFailed()
 }
 
 bool
-TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx)
+TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
+                        Hash const& sorobanBasePrngSeed)
 {
     TransactionMetaFrame tm(ltx.loadHeader().current().ledgerVersion);
-    return apply(app, ltx, tm);
+    return apply(app, ltx, tm, sorobanBasePrngSeed);
 }
 
 bool
 TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                                   Application& app, AbstractLedgerTxn& ltx,
-                                  TransactionMetaFrame& outerMeta)
+                                  TransactionMetaFrame& outerMeta,
+                                  Hash const& sorobanBasePrngSeed)
 {
     ZoneScoped;
     auto& internalErrorCounter = app.getMetrics().NewCounter(
@@ -1369,11 +1371,24 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
         auto& opTimer =
             app.getMetrics().NewTimer({"ledger", "operation", "apply"});
 
+        uint64_t opNum{0};
         for (auto& op : mOperations)
         {
             auto time = opTimer.TimeScope();
             LedgerTxn ltxOp(ltxTx);
-            bool txRes = op->apply(app, signatureChecker, ltxOp);
+
+            Hash subSeed = sorobanBasePrngSeed;
+            // If op can use the seed, we need to compute a sub-seed for it.
+            if (op->isSoroban())
+            {
+                SHA256 subSeedSha;
+                subSeedSha.add(sorobanBasePrngSeed);
+                subSeedSha.add(xdr::xdr_to_opaque(opNum));
+                subSeed = subSeedSha.finish();
+            }
+            ++opNum;
+
+            bool txRes = op->apply(app, signatureChecker, ltxOp, subSeed);
 
             if (!txRes)
             {
@@ -1690,7 +1705,8 @@ TransactionFrame::applyExpirationBumps(Application& app, AbstractLedgerTxn& ltx)
 
 bool
 TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
-                        TransactionMetaFrame& meta, bool chargeFee)
+                        TransactionMetaFrame& meta, bool chargeFee,
+                        Hash const& sorobanBasePrngSeed)
 {
     ZoneScoped;
     try
@@ -1724,7 +1740,8 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
             // have the correct TransactionResult so we must crash.
             if (ok)
             {
-                ok = applyOperations(signatureChecker, app, ltx, meta);
+                ok = applyOperations(signatureChecker, app, ltx, meta,
+                                     sorobanBasePrngSeed);
             }
             return ok;
         }
@@ -1753,9 +1770,10 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
 
 bool
 TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
-                        TransactionMetaFrame& meta)
+                        TransactionMetaFrame& meta,
+                        Hash const& sorobanBasePrngSeed)
 {
-    return apply(app, ltx, meta, true);
+    return apply(app, ltx, meta, true, sorobanBasePrngSeed);
 }
 
 void

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -119,7 +119,8 @@ class TransactionFrame : public TransactionFrameBase
     void markResultFailed();
 
     bool applyOperations(SignatureChecker& checker, Application& app,
-                         AbstractLedgerTxn& ltx, TransactionMetaFrame& meta);
+                         AbstractLedgerTxn& ltx, TransactionMetaFrame& meta,
+                         Hash const& sorobanBasePrngSeed);
 
     bool applyExpirationBumps(Application& app, AbstractLedgerTxn& ltx);
 
@@ -246,9 +247,11 @@ class TransactionFrame : public TransactionFrameBase
     // apply this transaction to the current ledger
     // returns true if successfully applied
     bool apply(Application& app, AbstractLedgerTxn& ltx,
-               TransactionMetaFrame& meta, bool chargeFee);
+               TransactionMetaFrame& meta, bool chargeFee,
+               Hash const& sorobanBasePrngSeed);
     bool apply(Application& app, AbstractLedgerTxn& ltx,
-               TransactionMetaFrame& meta) override;
+               TransactionMetaFrame& meta,
+               Hash const& sorobanBasePrngSeed = Hash{}) override;
 
     // Performs the necessary post-apply transaction processing.
     // This has to be called after both `processFeeSeqNum` and
@@ -258,7 +261,8 @@ class TransactionFrame : public TransactionFrameBase
                           TransactionMetaFrame& meta) override;
 
     // version without meta
-    bool apply(Application& app, AbstractLedgerTxn& ltx);
+    bool apply(Application& app, AbstractLedgerTxn& ltx,
+               Hash const& sorobanBasePrngSeed);
 
     StellarMessage toStellarMessage() const override;
 

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -35,7 +35,8 @@ class TransactionFrameBase
                             TransactionEnvelope const& env);
 
     virtual bool apply(Application& app, AbstractLedgerTxn& ltx,
-                       TransactionMetaFrame& meta) = 0;
+                       TransactionMetaFrame& meta,
+                       Hash const& sorobanBasePrngSeed = Hash{}) = 0;
 
     virtual bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
                             SequenceNumber current,


### PR DESCRIPTION
This does a very basic (and not at all tested) wiring-up of the soroban PRNG service based on the txset hash, tx and op numbers as we run a tx. I figured it's small enough to sneak in to the preview 10 release and, if there's a problem with it, it won't at this point be any worse than the current situation (which, being unseeded, will [just fault if someone tries to use it](https://github.com/stellar/rs-soroban-env/blob/main/soroban-env-host/src/host/frame.rs#L270-L275)).