### PR TITLE
Soroban flooding and tx set construction followup

### DIFF
--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -209,6 +209,8 @@ class Herder
     getCurrentlyTrackedQuorum() const = 0;
 
     virtual size_t getMaxQueueSizeOps() const = 0;
+    virtual size_t getMaxQueueSizeSorobanOps() const = 0;
+
     virtual bool isBannedTx(Hash const& hash) const = 0;
     virtual TransactionFrameBaseConstPtr getTx(Hash const& hash) const = 0;
 };

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -209,8 +209,9 @@ class Herder
     getCurrentlyTrackedQuorum() const = 0;
 
     virtual size_t getMaxQueueSizeOps() const = 0;
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     virtual size_t getMaxQueueSizeSorobanOps() const = 0;
-
+#endif
     virtual bool isBannedTx(Hash const& hash) const = 0;
     virtual TransactionFrameBaseConstPtr getTx(Hash const& hash) const = 0;
 };

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2176,11 +2176,13 @@ HerderImpl::getMaxQueueSizeOps() const
     return mTransactionQueue.getMaxQueueSizeOps();
 }
 
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 size_t
 HerderImpl::getMaxQueueSizeSorobanOps() const
 {
     return mSorobanTransactionQueue.getMaxQueueSizeOps();
 }
+#endif
 
 bool
 HerderImpl::isBannedTx(Hash const& hash) const

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -51,6 +51,7 @@ namespace stellar
 constexpr uint32 const TRANSACTION_QUEUE_TIMEOUT_LEDGERS = 4;
 constexpr uint32 const TRANSACTION_QUEUE_BAN_LEDGERS = 10;
 constexpr uint32 const TRANSACTION_QUEUE_SIZE_MULTIPLIER = 2;
+constexpr uint32 const SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER = 2;
 
 std::unique_ptr<Herder>
 Herder::create(Application& app)
@@ -78,11 +79,9 @@ HerderImpl::HerderImpl(Application& app)
                         TRANSACTION_QUEUE_BAN_LEDGERS,
                         TRANSACTION_QUEUE_SIZE_MULTIPLIER)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    , mSorobanTransactionQueue(
-          app, TRANSACTION_QUEUE_TIMEOUT_LEDGERS, TRANSACTION_QUEUE_BAN_LEDGERS,
-          // Use the same multipler at the classic tx queue for now. Might need
-          // to tune this parameter later
-          TRANSACTION_QUEUE_SIZE_MULTIPLIER)
+    , mSorobanTransactionQueue(app, TRANSACTION_QUEUE_TIMEOUT_LEDGERS,
+                               TRANSACTION_QUEUE_BAN_LEDGERS,
+                               SOROBAN_TRANSACTION_QUEUE_SIZE_MULTIPLIER)
 #endif
     , mPendingEnvelopes(app, *this)
     , mHerderSCPDriver(app, *this, mUpgrades, mPendingEnvelopes)

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2176,6 +2176,12 @@ HerderImpl::getMaxQueueSizeOps() const
     return mTransactionQueue.getMaxQueueSizeOps();
 }
 
+size_t
+HerderImpl::getMaxQueueSizeSorobanOps() const
+{
+    return mSorobanTransactionQueue.getMaxQueueSizeOps();
+}
+
 bool
 HerderImpl::isBannedTx(Hash const& hash) const
 {

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -186,8 +186,9 @@ class HerderImpl : public Herder
     bool verifyStellarValueSignature(StellarValue const& sv);
 
     size_t getMaxQueueSizeOps() const override;
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     size_t getMaxQueueSizeSorobanOps() const override;
-
+#endif
     bool isBannedTx(Hash const& hash) const override;
     TransactionFrameBaseConstPtr getTx(Hash const& hash) const override;
 

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -186,6 +186,8 @@ class HerderImpl : public Herder
     bool verifyStellarValueSignature(StellarValue const& sv);
 
     size_t getMaxQueueSizeOps() const override;
+    size_t getMaxQueueSizeSorobanOps() const override;
+
     bool isBannedTx(Hash const& hash) const override;
     TransactionFrameBaseConstPtr getTx(Hash const& hash) const override;
 

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -370,6 +370,12 @@ SurgePricingPriorityQueue::canFitWithEviction(
     }
     Resource total = totalResources();
 
+    if (!canAdd(total, txNewResources) ||
+        !canAdd(mLaneCurrentCount[lane], txNewResources))
+    {
+        return std::make_pair(false, 0ll);
+    }
+
     Resource newTotalResources = total + txNewResources;
     Resource newLaneResources = mLaneCurrentCount[lane] + txNewResources;
     // To fit the eviction, tx has to both fit into 'generic' lane's limit

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -370,8 +370,8 @@ SurgePricingPriorityQueue::canFitWithEviction(
     }
     Resource total = totalResources();
 
-    if (!canAdd(total, txNewResources) ||
-        !canAdd(mLaneCurrentCount[lane], txNewResources))
+    if (!total.canAdd(txNewResources) ||
+        !(mLaneCurrentCount[lane].canAdd(txNewResources)))
     {
         return std::make_pair(false, 0ll);
     }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -1333,6 +1333,15 @@ SorobanTransactionQueue::broadcastSome()
     return !totalResToFlood.isZero();
 }
 
+size_t
+SorobanTransactionQueue::getMaxQueueSizeOps() const
+{
+    LedgerTxn ltx(mApp.getLedgerTxnRoot());
+    auto res = mTxQueueLimiter->maxScaledLedgerResources(true, ltx);
+    releaseAssert(res.size() == NUM_SOROBAN_TX_RESOURCES);
+    return res.getVal(NUM_SOROBAN_TX_RESOURCES - 1);
+}
+
 #endif
 
 bool

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -1315,8 +1315,8 @@ SorobanTransactionQueue::broadcastSome()
         LedgerTxn ltx(mApp.getLedgerTxnRoot(), false,
                       TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
         auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig(ltx);
-        int64_t const txCount = 1;
-        std::vector<int64_t> limits = {txCount,
+        int64_t const opCount = 1;
+        std::vector<int64_t> limits = {opCount,
                                        conf.txMaxInstructions(),
                                        conf.txMaxSizeBytes(),
                                        conf.txMaxReadBytes(),
@@ -1339,7 +1339,7 @@ SorobanTransactionQueue::getMaxQueueSizeOps() const
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     auto res = mTxQueueLimiter->maxScaledLedgerResources(true, ltx);
     releaseAssert(res.size() == NUM_SOROBAN_TX_RESOURCES);
-    return res.getVal(Resource::Type::TRANSACTIONS);
+    return res.getVal(Resource::Type::OPERATIONS);
 }
 
 #endif
@@ -1544,7 +1544,7 @@ ClassicTransactionQueue::getMaxQueueSizeOps() const
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     auto res = mTxQueueLimiter->maxScaledLedgerResources(false, ltx);
     releaseAssert(res.size() == NUM_CLASSIC_TX_RESOURCES);
-    return res.getVal(Resource::Type::TRANSACTIONS);
+    return res.getVal(Resource::Type::OPERATIONS);
 }
 
 }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -1316,13 +1316,13 @@ SorobanTransactionQueue::broadcastSome()
                       TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
         auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig(ltx);
         int64_t const txCount = 1;
-        std::vector<int64_t> limits = {conf.txMaxInstructions(),
+        std::vector<int64_t> limits = {txCount,
+                                       conf.txMaxInstructions(),
                                        conf.txMaxSizeBytes(),
                                        conf.txMaxReadBytes(),
                                        conf.txMaxWriteBytes(),
                                        conf.txMaxReadLedgerEntries(),
-                                       conf.txMaxWriteLedgerEntries(),
-                                       txCount};
+                                       conf.txMaxWriteLedgerEntries()};
         maxPerTx = Resource(limits);
     }
     for (auto& resLeft : mBroadcastOpCarryover)
@@ -1339,7 +1339,7 @@ SorobanTransactionQueue::getMaxQueueSizeOps() const
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     auto res = mTxQueueLimiter->maxScaledLedgerResources(true, ltx);
     releaseAssert(res.size() == NUM_SOROBAN_TX_RESOURCES);
-    return res.getVal(NUM_SOROBAN_TX_RESOURCES - 1);
+    return res.getVal(Resource::Type::TRANSACTIONS);
 }
 
 #endif
@@ -1544,7 +1544,7 @@ ClassicTransactionQueue::getMaxQueueSizeOps() const
     LedgerTxn ltx(mApp.getLedgerTxnRoot());
     auto res = mTxQueueLimiter->maxScaledLedgerResources(false, ltx);
     releaseAssert(res.size() == NUM_CLASSIC_TX_RESOURCES);
-    return res.getVal(0);
+    return res.getVal(Resource::Type::TRANSACTIONS);
 }
 
 }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -1017,7 +1017,7 @@ ClassicTransactionQueue::getMaxResourcesToFloodThisPeriod() const
     auto opsToFlood =
         mBroadcastOpCarryover[SurgePricingPriorityQueue::GENERIC_LANE] +
         Resource(
-            bigDivideOrThrow(opsToFloodLedger, cfg.FLOOD_TX_PERIOD_MS,
+            bigDivideOrThrow(opsToFloodLedger, getFloodPeriod(),
                              cfg.getExpectedLedgerCloseTime().count() * 1000,
                              Rounding::ROUND_UP));
     releaseAssertOrThrow(Resource(0) <= opsToFlood &&
@@ -1038,7 +1038,7 @@ ClassicTransactionQueue::getMaxResourcesToFloodThisPeriod() const
         auto dexOpsToFloodUint =
             dexOpsCarryover +
             static_cast<uint32>(bigDivideOrThrow(
-                dexOpsToFloodLedger, cfg.FLOOD_TX_PERIOD_MS,
+                dexOpsToFloodLedger, getFloodPeriod(),
                 cfg.getExpectedLedgerCloseTime().count() * 1000ll,
                 Rounding::ROUND_UP));
         dexOpsToFlood = dexOpsToFloodUint;
@@ -1238,8 +1238,7 @@ std::pair<Resource, std::optional<Resource>>
 SorobanTransactionQueue::getMaxResourcesToFloodThisPeriod() const
 {
     auto const& cfg = mApp.getConfig();
-    // TODO: should be its own config
-    double ratePerLedger = cfg.FLOOD_OP_RATE_PER_LEDGER;
+    double ratePerLedger = cfg.FLOOD_SOROBAN_RATE_PER_LEDGER;
 
     LedgerTxn ltx(mApp.getLedgerTxnRoot(), false,
                   TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
@@ -1249,7 +1248,7 @@ SorobanTransactionQueue::getMaxResourcesToFloodThisPeriod() const
 
     Resource resToFlood =
         mBroadcastOpCarryover[SurgePricingPriorityQueue::GENERIC_LANE] +
-        bigDivideOrThrow(totalFloodPerLedger, cfg.FLOOD_TX_PERIOD_MS,
+        bigDivideOrThrow(totalFloodPerLedger, getFloodPeriod(),
                          cfg.getExpectedLedgerCloseTime().count() * 1000,
                          Rounding::ROUND_UP);
     return std::make_pair(resToFlood, std::nullopt);
@@ -1265,7 +1264,7 @@ SorobanTransactionQueue::broadcastSome()
     // propagation.
     auto resToFlood = getMaxResourcesToFloodThisPeriod().first;
 
-    Resource totalResToFlood(std::vector<int64_t>(resToFlood.size(), 0));
+    auto totalResToFlood = Resource::makeEmpty(true);
     std::vector<TxStackPtr> trackersToBroadcast;
     for (auto& [_, accountState] : mAccountStates)
     {
@@ -1316,15 +1315,19 @@ SorobanTransactionQueue::broadcastSome()
         LedgerTxn ltx(mApp.getLedgerTxnRoot(), false,
                       TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
         auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig(ltx);
-        std::vector<int64_t> limits = {
-            conf.txMaxInstructions(),      conf.txMaxSizeBytes(),
-            conf.txMaxReadBytes(),         conf.txMaxWriteBytes(),
-            conf.txMaxReadLedgerEntries(), conf.txMaxWriteLedgerEntries()};
+        int64_t const txCount = 1;
+        std::vector<int64_t> limits = {conf.txMaxInstructions(),
+                                       conf.txMaxSizeBytes(),
+                                       conf.txMaxReadBytes(),
+                                       conf.txMaxWriteBytes(),
+                                       conf.txMaxReadLedgerEntries(),
+                                       conf.txMaxWriteLedgerEntries(),
+                                       txCount};
         maxPerTx = Resource(limits);
     }
     for (auto& resLeft : mBroadcastOpCarryover)
     {
-        // Limit each resource in carry-over to max per tx limit to avoid spikes
+        // Limit carry-over to 1 maximum resource transaction
         resLeft = limitTo(resLeft, maxPerTx);
     }
     return !totalResToFlood.isZero();
@@ -1431,7 +1434,7 @@ TransactionQueue::broadcast(bool fromCallback)
     {
         mWaiting = true;
         mBroadcastTimer.expires_from_now(
-            std::chrono::milliseconds(mApp.getConfig().FLOOD_TX_PERIOD_MS));
+            std::chrono::milliseconds(getFloodPeriod()));
         mBroadcastTimer.async_wait([&]() { broadcast(true); },
                                    &VirtualTimer::onFailureNoop);
     }

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -201,6 +201,7 @@ class TransactionQueue
     getMaxResourcesToFloodThisPeriod() const = 0;
     virtual bool broadcastSome() = 0;
     virtual int getFloodPeriod() const = 0;
+    virtual size_t getMaxQueueSizeOps() const = 0;
 
     void broadcast(bool fromCallback);
     // broadcasts a single transaction
@@ -256,6 +257,8 @@ class SorobanTransactionQueue : public TransactionQueue
         return mApp.getConfig().FLOOD_SOROBAN_TX_PERIOD_MS;
     }
 
+    size_t getMaxQueueSizeOps() const override;
+
   private:
     virtual std::pair<Resource, std::optional<Resource>>
     getMaxResourcesToFloodThisPeriod() const override;
@@ -276,7 +279,7 @@ class ClassicTransactionQueue : public TransactionQueue
         return mApp.getConfig().FLOOD_TX_PERIOD_MS;
     }
 
-    size_t getMaxQueueSizeOps() const;
+    size_t getMaxQueueSizeOps() const override;
 
   private:
     virtual std::pair<Resource, std::optional<Resource>>

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -200,7 +200,7 @@ class TransactionQueue
     virtual std::pair<Resource, std::optional<Resource>>
     getMaxResourcesToFloodThisPeriod() const = 0;
     virtual bool broadcastSome() = 0;
-    virtual bool isSoroban() const = 0;
+    virtual int getFloodPeriod() const = 0;
 
     void broadcast(bool fromCallback);
     // broadcasts a single transaction
@@ -250,10 +250,10 @@ class SorobanTransactionQueue : public TransactionQueue
   public:
     SorobanTransactionQueue(Application& app, uint32 pendingDepth,
                             uint32 banDepth, uint32 poolLedgerMultiplier);
-    bool
-    isSoroban() const override
+    int
+    getFloodPeriod() const override
     {
-        return mSoroban;
+        return mApp.getConfig().FLOOD_SOROBAN_TX_PERIOD_MS;
     }
 
   private:
@@ -261,7 +261,6 @@ class SorobanTransactionQueue : public TransactionQueue
     getMaxResourcesToFloodThisPeriod() const override;
     virtual bool broadcastSome() override;
     std::vector<Resource> mBroadcastOpCarryover;
-    bool const mSoroban{true};
 };
 #endif
 
@@ -271,10 +270,10 @@ class ClassicTransactionQueue : public TransactionQueue
     ClassicTransactionQueue(Application& app, uint32 pendingDepth,
                             uint32 banDepth, uint32 poolLedgerMultiplier);
 
-    bool
-    isSoroban() const override
+    int
+    getFloodPeriod() const override
     {
-        return mSoroban;
+        return mApp.getConfig().FLOOD_TX_PERIOD_MS;
     }
 
     size_t getMaxQueueSizeOps() const;
@@ -284,7 +283,6 @@ class ClassicTransactionQueue : public TransactionQueue
     getMaxResourcesToFloodThisPeriod() const override;
     virtual bool broadcastSome() override;
     std::vector<Resource> mBroadcastOpCarryover;
-    bool const mSoroban{false};
 };
 
 extern std::array<const char*,

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -59,7 +59,7 @@ size_t
 TxQueueLimiter::size() const
 {
     releaseAssert(!mIsSoroban);
-    return mTxs->totalResources().getVal(Resource::Type::TRANSACTIONS);
+    return mTxs->totalResources().getVal(Resource::Type::OPERATIONS);
 }
 #endif
 

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -59,7 +59,7 @@ size_t
 TxQueueLimiter::size() const
 {
     releaseAssert(!mIsSoroban);
-    return mTxs->totalResources().getVal(0);
+    return mTxs->totalResources().getVal(Resource::Type::TRANSACTIONS);
 }
 #endif
 

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -918,7 +918,7 @@ TxSetFrame::getTxSetSorobanResource() const
     auto total = Resource::makeEmpty(/* isSoroban */ true);
     for (auto const& tx : mTxPhases[static_cast<size_t>(Phase::SOROBAN)])
     {
-        if (canAdd(total, tx->getResources()))
+        if (total.canAdd(tx->getResources()))
         {
             total += tx->getResources();
         }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -642,21 +642,24 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
         // account
         // FIXME: Our test suite relies on tx chains per source account, so
         // introducing this invariant causes a fallout. When the test suite is
-        // updated to accomodate 1 tx/source account, uncomment this block
-        // std::unordered_set<AccountID> seenAccounts;
-        // for (auto const& phase : mTxPhases)
-        // {
-        //     for (auto const& tx : phase)
-        //     {
-        //         if (!seenAccounts.insert(tx->getSourceID()).second)
-        //         {
-        //             CLOG_DEBUG(Herder,
-        //                        "Got bad txSet: multiple txs per source
-        //                        account");
-        //             return false;
-        //         }
-        //     }
-        // }
+        // updated to accommodate 1 tx/source account, remove this flag.
+        if (app.getConfig().LIMIT_TX_QUEUE_SOURCE_ACCOUNT)
+        {
+            std::unordered_set<AccountID> seenAccounts;
+            for (auto const& phase : mTxPhases)
+            {
+                for (auto const& tx : phase)
+                {
+                    if (!seenAccounts.insert(tx->getSourceID()).second)
+                    {
+                        CLOG_DEBUG(
+                            Herder,
+                            "Got bad txSet: multiple txs per source account");
+                        return false;
+                    }
+                }
+            }
+        }
 
         // Second, ensure total resources are not over ledger limit
         auto totalTxSetRes = getTxSetSorobanResource();

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -33,9 +33,6 @@
 namespace stellar
 {
 
-// FIXME: this should be a soroban network config, not a const
-constexpr uint32 const SOROBAN_TX_LIMIT_PER_LEDGER = 2;
-
 namespace
 {
 // The frame created around malformed transaction set XDR received over the
@@ -95,8 +92,7 @@ class InvalidTxSetFrame : public TxSetFrame
 };
 
 bool
-validateTxSetXDRStructure(GeneralizedTransactionSet const& txSet,
-                          uint32_t ledgerVersion)
+validateTxSetXDRStructure(GeneralizedTransactionSet const& txSet)
 {
     if (txSet.v() != 1)
     {
@@ -114,9 +110,6 @@ validateTxSetXDRStructure(GeneralizedTransactionSet const& txSet,
         return false;
     }
 
-    // TODO: this logic is extended to validate each phase the same way the
-    // initial phase described in CAP-0042 is validated. Is this correct? I.e.
-    // is there additional inter-phase validation needed?
     for (auto const& phase : txSetV1.phases)
     {
         if (phase.v() != 0)
@@ -306,7 +299,7 @@ TxSetFrame::makeFromTransactions(TxPhases const& txPhases, Application& app,
     {
         auto& txs = txPhases[i];
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-        bool expectSoroban = static_cast<Phase>(i);
+        bool expectSoroban = static_cast<Phase>(i) == Phase::SOROBAN;
         if (!std::all_of(txs.begin(), txs.end(), [&](auto const& tx) {
                 return tx->isSoroban() == expectSoroban;
             }))
@@ -420,9 +413,7 @@ TxSetFrame::makeFromWire(Application& app,
     ZoneScoped;
     auto hash = xdrSha256(xdrTxSet);
     size_t encodedSize = xdr::xdr_argpack_size(xdrTxSet);
-    if (!validateTxSetXDRStructure(xdrTxSet, app.getLedgerManager()
-                                                 .getLastClosedLedgerHeader()
-                                                 .header.ledgerVersion))
+    if (!validateTxSetXDRStructure(xdrTxSet))
     {
         return std::make_shared<InvalidTxSetFrame const>(xdrTxSet, hash,
                                                          encodedSize);
@@ -645,12 +636,50 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
         return false;
     }
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    if (this->size(lcl.header, Phase::SOROBAN) > SOROBAN_TX_LIMIT_PER_LEDGER)
+    if (needGeneralizedTxSet)
     {
-        CLOG_DEBUG(Herder, "Got bad txSet: too many soroban txs {} > {}",
-                   this->size(lcl.header, Phase::SOROBAN),
-                   SOROBAN_TX_LIMIT_PER_LEDGER);
-        return false;
+        // First, ensure the tx set does not contain multiple txs per source
+        // account
+        // FIXME: Our test suite relies on tx chains per source account, so
+        // introducing this invariant causes a fallout. When the test suite is
+        // updated to accomodate 1 tx/source account, uncomment this block
+        // std::unordered_set<AccountID> seenAccounts;
+        // for (auto const& phase : mTxPhases)
+        // {
+        //     for (auto const& tx : phase)
+        //     {
+        //         if (!seenAccounts.insert(tx->getSourceID()).second)
+        //         {
+        //             CLOG_DEBUG(Herder,
+        //                        "Got bad txSet: multiple txs per source
+        //                        account");
+        //             return false;
+        //         }
+        //     }
+        // }
+
+        // Second, ensure total resources are not over ledger limit
+        auto totalTxSetRes = getTxSetSorobanResource();
+        if (!totalTxSetRes.second)
+        {
+            CLOG_DEBUG(Herder,
+                       "Got bad txSet: total Soroban resources overflow");
+            return false;
+        }
+
+        {
+            LedgerTxn ltx(app.getLedgerTxnRoot());
+            auto limits = app.getLedgerManager().maxLedgerResources(
+                /* isSoroban */ true, ltx);
+            if (anyGreater(totalTxSetRes.first, limits))
+            {
+                CLOG_DEBUG(Herder,
+                           "Got bad txSet: needed resources exceed ledger "
+                           "limits {} > {}",
+                           totalTxSetRes.first.toString(), limits.toString());
+                return false;
+            }
+        }
     }
 #endif
 
@@ -877,6 +906,27 @@ TxSetFrame::getTxBaseFee(TransactionFrameBaseConstPtr const& tx,
     }
     return it->second;
 }
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+std::pair<Resource, bool>
+TxSetFrame::getTxSetSorobanResource() const
+{
+    releaseAssert(mTxPhases.size() > static_cast<size_t>(Phase::SOROBAN));
+    auto total = Resource::makeEmpty(/* isSoroban */ true);
+    for (auto const& tx : mTxPhases[static_cast<size_t>(Phase::SOROBAN)])
+    {
+        if (canAdd(total, tx->getResources()))
+        {
+            total += tx->getResources();
+        }
+        else
+        {
+            return {Resource::makeEmpty(/* isSoroban */ true), false};
+        }
+    }
+    return {total, true};
+}
+#endif
 
 int64_t
 TxSetFrame::getTotalFees(LedgerHeader const& lh) const

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -220,6 +220,7 @@ class TxSetFrame : public NonMovableOrCopyable
     mutable std::unordered_map<TransactionFrameBaseConstPtr,
                                std::optional<int64_t>>
         mTxBaseFeeSoroban;
+    std::pair<Resource, bool> getTxSetSorobanResource() const;
 #endif
     std::unordered_map<TransactionFrameBaseConstPtr, std::optional<int64_t>>&
     getFeeMap(Phase phase) const;

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -220,7 +220,7 @@ class TxSetFrame : public NonMovableOrCopyable
     mutable std::unordered_map<TransactionFrameBaseConstPtr,
                                std::optional<int64_t>>
         mTxBaseFeeSoroban;
-    std::pair<Resource, bool> getTxSetSorobanResource() const;
+    std::optional<Resource> getTxSetSorobanResource() const;
 #endif
     std::unordered_map<TransactionFrameBaseConstPtr, std::optional<int64_t>>&
     getFeeMap(Phase phase) const;

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1426,6 +1426,9 @@ ConfigUpgradeSetFrame::isValidForApply() const
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES:
             valid = configEntry.contractDataEntrySizeBytes() > 0;
             break;
+        case ConfigSettingID::CONFIG_SETTING_CONTRACT_EXECUTION_LANES:
+            valid = configEntry.contractExecutionLanes().ledgerMaxTxCount >= 0;
+            break;
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_COMPUTE_V0:
         case ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2279,8 +2279,9 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
     {
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
             {{std::make_pair(
-                1000, std::vector<TransactionFrameBasePtr>{addTx(3, 3500),
-                                                           addTx(2, 5000)})}},
+                 1000, std::vector<TransactionFrameBasePtr>{addTx(3, 3500),
+                                                            addTx(2, 5000)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
         checkFees(txSet, {3000, 2000});
     }
@@ -2289,7 +2290,8 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
             {{std::make_pair(std::nullopt,
                              std::vector<TransactionFrameBasePtr>{
-                                 addTx(3, 3500), addTx(2, 5000)})}},
+                                 addTx(3, 3500), addTx(2, 5000)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
         checkFees(txSet, {3500, 5000});
     }
@@ -2312,7 +2314,7 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
                                std::vector<TransactionFrameBasePtr>{
                                    addTx(5, 35000), addTx(1, 10000)})};
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-            {components}, *app,
+            {components, {}}, *app,
             app->getLedgerManager().getLastClosedLedgerHeader().hash);
         checkFees(txSet, {3000, 2000, 500, 2500, 8000, 35000, 10000});
     }

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3318,6 +3318,11 @@ TEST_CASE("tx queue source account limit", "[herder][transactionqueue]")
         simulation = std::make_shared<Simulation>(
             Simulation::OVER_LOOPBACK, networkID, [mix](int i) {
                 auto cfg = getTestConfig(i, Config::TESTDB_ON_DISK_SQLITE);
+                // Mixed setup does not work in protocol 20 and onward (tx set
+                // with multiple source accounts are invalid)
+                cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
+                    mix ? static_cast<uint32_t>(ProtocolVersion::V_19)
+                        : Config::CURRENT_LEDGER_PROTOCOL_VERSION;
                 if (!mix || i % 2 == 1)
                 {
                     cfg.LIMIT_TX_QUEUE_SOURCE_ACCOUNT = true;

--- a/src/herder/test/TestTxSetUtils.cpp
+++ b/src/herder/test/TestTxSetUtils.cpp
@@ -31,12 +31,6 @@ GeneralizedTransactionSet
 makeGeneralizedTxSetXDR(std::vector<ComponentPhases> const& txsPerBaseFeePhases,
                         Hash const& previousLedgerHash)
 {
-    if (txsPerBaseFeePhases.size() !=
-        static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT))
-    {
-        throw std::runtime_error(
-            "makeGeneralizedTxSetXDR: invalid number of phases");
-    }
     GeneralizedTransactionSet xdrTxSet(1);
     for (auto& txsPerBaseFee : txsPerBaseFeePhases)
     {
@@ -82,18 +76,7 @@ makeNonValidatedGeneralizedTxSet(
     std::vector<ComponentPhases> const& txsPerBaseFee, Application& app,
     Hash const& previousLedgerHash)
 {
-    if (txsPerBaseFee.size() >
-        static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT))
-    {
-        throw std::runtime_error("makeNonValidatedGeneralizedTxSet: invalid "
-                                 "parameter, too many phases");
-    }
-    // Potentially add any empty phases to make the tx set valid
-    auto normalizedTxsPerBaseFee = txsPerBaseFee;
-    normalizedTxsPerBaseFee.resize(
-        static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-    auto xdrTxSet =
-        makeGeneralizedTxSetXDR(normalizedTxsPerBaseFee, previousLedgerHash);
+    auto xdrTxSet = makeGeneralizedTxSetXDR(txsPerBaseFee, previousLedgerHash);
     return TxSetFrame::makeFromWire(app, xdrTxSet);
 }
 
@@ -105,8 +88,8 @@ makeNonValidatedTxSetBasedOnLedgerVersion(
     if (protocolVersionStartsFrom(ledgerVersion,
                                   GENERALIZED_TX_SET_PROTOCOL_VERSION))
     {
-        return makeNonValidatedGeneralizedTxSet({{std::make_pair(100LL, txs)}},
-                                                app, previousLedgerHash);
+        return makeNonValidatedGeneralizedTxSet(
+            {{std::make_pair(100LL, txs)}, {}}, app, previousLedgerHash);
     }
     else
     {

--- a/src/herder/test/TestTxSetUtils.h
+++ b/src/herder/test/TestTxSetUtils.h
@@ -11,11 +11,12 @@ namespace stellar
 {
 namespace testtxset
 {
+
+using ComponentPhases = std::vector<
+    std::pair<std::optional<int64_t>, std::vector<TransactionFrameBasePtr>>>;
 TxSetFrameConstPtr makeNonValidatedGeneralizedTxSet(
-    std::vector<std::pair<std::optional<int64_t>,
-                          std::vector<TransactionFrameBasePtr>>> const&
-        txsPerBaseFee,
-    Application& app, Hash const& previousLedgerHash);
+    std::vector<ComponentPhases> const& txsPerBaseFee, Application& app,
+    Hash const& previousLedgerHash);
 
 TxSetFrameConstPtr makeNonValidatedTxSetBasedOnLedgerVersion(
     uint32_t ledgerVersion, std::vector<TransactionFrameBasePtr> const& txs,

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1458,6 +1458,8 @@ TEST_CASE("Soroban TransactionQueue limits",
     VirtualClock clock;
     auto cfg = getTestConfig();
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 4;
+    cfg.TESTING_LEDGER_MAX_SOROBAN_TX_COUNT = 4;
+
     cfg.FLOOD_TX_PERIOD_MS = 100;
     cfg.LIMIT_TX_QUEUE_SOURCE_ACCOUNT = true;
     auto app = createTestApplication(clock, cfg);

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -469,7 +469,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     SECTION("empty set")
     {
         auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {}, *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            {{}, {}}, *app,
+            app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
         txSetFrame->toXDR(txSetXdr);
@@ -479,7 +480,7 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     SECTION("one discounted component set")
     {
         auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(1234LL, createTxs(5, 1234))}}, *app,
+            {{std::make_pair(1234LL, createTxs(5, 1234))}, {}}, *app,
             app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
@@ -500,7 +501,7 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     SECTION("one non-discounted component set")
     {
         auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(std::nullopt, createTxs(5, 4321))}}, *app,
+            {{std::make_pair(std::nullopt, createTxs(5, 4321))}, {}}, *app,
             app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
@@ -524,7 +525,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
             {{std::make_pair(12345LL, createTxs(3, 12345)),
               std::make_pair(123LL, createTxs(1, 123)),
               std::make_pair(1234LL, createTxs(2, 1234)),
-              std::make_pair(std::nullopt, createTxs(4, 4321))}},
+              std::make_pair(std::nullopt, createTxs(4, 4321))},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
@@ -612,9 +614,10 @@ TEST_CASE("generalized tx set with multiple txs per source account", "[txset]")
     {
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
             {{std::make_pair(
-                500,
-                std::vector<TransactionFrameBasePtr>{
-                    createTx(1, 1000, false), createTx(3, 1500, false)})}},
+                 500,
+                 std::vector<TransactionFrameBasePtr>{
+                     createTx(1, 1000, false), createTx(3, 1500, false)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         REQUIRE(!txSet->checkValid(*app, 0, 0));
@@ -623,9 +626,10 @@ TEST_CASE("generalized tx set with multiple txs per source account", "[txset]")
     {
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
             {{std::make_pair(
-                500,
-                std::vector<TransactionFrameBasePtr>{
-                    createTx(1, 1000, true), createTx(3, 1500, true)})}},
+                 500,
+                 std::vector<TransactionFrameBasePtr>{
+                     createTx(1, 1000, true), createTx(3, 1500, true)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         REQUIRE(txSet->checkValid(*app, 0, 0));
@@ -667,7 +671,8 @@ TEST_CASE("generalized tx set fees", "[txset]")
                       createTx(4, 5000), createTx(1, 1000), createTx(5, 6000)}),
               std::make_pair(std::nullopt,
                              std::vector<TransactionFrameBasePtr>{
-                                 createTx(2, 10000), createTx(5, 100000)})}},
+                                 createTx(2, 10000), createTx(5, 100000)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         REQUIRE(txSet->checkValid(*app, 0, 0));
@@ -687,7 +692,8 @@ TEST_CASE("generalized tx set fees", "[txset]")
     {
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
             {{std::make_pair(
-                500, std::vector<TransactionFrameBasePtr>{createTx(2, 999)})}},
+                 500, std::vector<TransactionFrameBasePtr>{createTx(2, 999)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         REQUIRE(!txSet->checkValid(*app, 0, 0));
@@ -697,8 +703,9 @@ TEST_CASE("generalized tx set fees", "[txset]")
     {
         auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
             {{std::make_pair(
-                std::nullopt,
-                std::vector<TransactionFrameBasePtr>{createTx(2, 199)})}},
+                 std::nullopt,
+                 std::vector<TransactionFrameBasePtr>{createTx(2, 199)})},
+             {}},
             *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         REQUIRE(!txSet->checkValid(*app, 0, 0));

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -51,346 +51,386 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
     SECTION("incorrect base fee order")
     {
         xdrTxSet.v1TxSet().phases.emplace_back();
-        // Second phase is empty
         xdrTxSet.v1TxSet().phases.emplace_back();
-        SECTION("all components discounted")
+        for (int i = 0; i < xdrTxSet.v1TxSet().phases.size(); ++i)
         {
+            SECTION("phase " + std::to_string(i))
+            {
+                SECTION("all components discounted")
+                {
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1400;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1400;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1600;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1600;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(!txSet->checkValidStructure());
-        }
-        SECTION("non-discounted component out of place")
-        {
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(!txSet->checkValidStructure());
+                }
+                SECTION("non-discounted component out of place")
+                {
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1600;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1600;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
 
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(!txSet->checkValidStructure());
-        }
-        SECTION("with non-discounted component, discounted out of place")
-        {
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(!txSet->checkValidStructure());
+                }
+                SECTION(
+                    "with non-discounted component, discounted out of place")
+                {
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1400;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1400;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(!txSet->checkValidStructure());
+                }
+            }
         }
     }
     SECTION("duplicate base fee")
     {
         xdrTxSet.v1TxSet().phases.emplace_back();
-        // Second phase is empty
         xdrTxSet.v1TxSet().phases.emplace_back();
-        SECTION("duplicate discounts")
+        for (int i = 0; i < xdrTxSet.v1TxSet().phases.size(); ++i)
         {
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+            SECTION("phase " + std::to_string(i))
+            {
+                SECTION("duplicate discounts")
+                {
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1600;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1600;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(!txSet->checkValidStructure());
-        }
-        SECTION("duplicate non-discounted components")
-        {
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(!txSet->checkValidStructure());
+                }
+                SECTION("duplicate non-discounted components")
+                {
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
 
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(!txSet->checkValidStructure());
+                }
+            }
         }
     }
     SECTION("empty component")
     {
         xdrTxSet.v1TxSet().phases.emplace_back();
-        // Second phase is empty
         xdrTxSet.v1TxSet().phases.emplace_back();
 
-        xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-            TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+        for (int i = 0; i < xdrTxSet.v1TxSet().phases.size(); ++i)
+        {
+            SECTION("phase " + std::to_string(i))
+            {
+                xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                    TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
 
-        auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-        REQUIRE(!txSet->checkValidStructure());
+                auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                REQUIRE(!txSet->checkValidStructure());
+            }
+        }
     }
     SECTION("valid XDR")
     {
-        SECTION("no transactions")
+
+        for (int i = 0; i < xdrTxSet.v1TxSet().phases.size(); ++i)
         {
-            xdrTxSet.v1TxSet().phases.emplace_back();
-            // Second phase is empty
-            xdrTxSet.v1TxSet().phases.emplace_back();
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(txSet->checkValidStructure());
-        }
-        SECTION("single component")
-        {
-            xdrTxSet.v1TxSet().phases.emplace_back();
-            // Second phase is empty
-            xdrTxSet.v1TxSet().phases.emplace_back();
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(txSet->checkValidStructure());
-        }
-        SECTION("multiple components")
-        {
-            xdrTxSet.v1TxSet().phases.emplace_back();
-            // Second phase is empty
-            xdrTxSet.v1TxSet().phases.emplace_back();
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+            auto maybeAddSorobanOp = [&](GeneralizedTransactionSet& txSet) {
+                if (i == 1)
+                {
+                    auto& txEnv = xdrTxSet.v1TxSet()
+                                      .phases[i]
+                                      .v0Components()
+                                      .back()
+                                      .txsMaybeDiscountedFee()
+                                      .txs.back();
+                    txEnv.v0().tx.operations.emplace_back();
+                    txEnv.v0().tx.operations.back().body.type(
+                        INVOKE_HOST_FUNCTION); // tx->isSoroban() ==
+                                               // true
+                }
+            };
+            SECTION("phase " + std::to_string(i))
+            {
+                SECTION("no transactions")
+                {
+                    xdrTxSet.v1TxSet().phases.emplace_back();
+                    xdrTxSet.v1TxSet().phases.emplace_back();
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(txSet->checkValidStructure());
+                }
+                SECTION("single component")
+                {
+                    xdrTxSet.v1TxSet().phases.emplace_back();
+                    xdrTxSet.v1TxSet().phases.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
+                    maybeAddSorobanOp(xdrTxSet);
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(txSet->checkValidStructure());
+                }
+                SECTION("multiple components")
+                {
+                    xdrTxSet.v1TxSet().phases.emplace_back();
+                    xdrTxSet.v1TxSet().phases.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
+                    maybeAddSorobanOp(xdrTxSet);
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1400;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1400;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
+                    maybeAddSorobanOp(xdrTxSet);
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1500;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1500;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
+                    maybeAddSorobanOp(xdrTxSet);
 
-            xdrTxSet.v1TxSet().phases[0].v0Components().emplace_back(
-                TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .baseFee.activate() = 1600;
-            xdrTxSet.v1TxSet()
-                .phases[0]
-                .v0Components()
-                .back()
-                .txsMaybeDiscountedFee()
-                .txs.emplace_back();
+                    xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
+                        TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .baseFee.activate() = 1600;
+                    xdrTxSet.v1TxSet()
+                        .phases[i]
+                        .v0Components()
+                        .back()
+                        .txsMaybeDiscountedFee()
+                        .txs.emplace_back();
+                    maybeAddSorobanOp(xdrTxSet);
 
-            auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-            REQUIRE(txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+                    REQUIRE(txSet->checkValidStructure());
+                }
+            }
         }
     }
 }

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -595,7 +595,7 @@ TEST_CASE("generalized tx set with multiple txs per source account", "[txset]")
         {
             // Create a new unique accounts to ensure there are no collisions
             auto source =
-                root.create("unique " + std::to_string(accountId * -1),
+                root.create("unique " + std::to_string(accountId),
                             app->getLedgerManager().getLastMinBalance(2));
             return transactionFromOperations(*app, source.getSecretKey(),
                                              source.nextSequenceNumber(), ops,

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -438,13 +438,13 @@ LedgerManagerImpl::maxLedgerResources(bool isSoroban,
     if (isSoroban)
     {
         auto conf = getSorobanNetworkConfig(ltxOuter);
-        std::vector<int64_t> limits = {conf.ledgerMaxInstructions(),
+        std::vector<int64_t> limits = {conf.ledgerMaxTxCount(),
+                                       conf.ledgerMaxInstructions(),
                                        conf.ledgerMaxPropagateSizeBytes(),
                                        conf.ledgerMaxReadBytes(),
                                        conf.ledgerMaxWriteBytes(),
                                        conf.ledgerMaxReadLedgerEntries(),
-                                       conf.ledgerMaxWriteLedgerEntries(),
-                                       conf.ledgerMaxTxCount()};
+                                       conf.ledgerMaxWriteLedgerEntries()};
         return Resource(limits);
     }
     else

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -443,7 +443,8 @@ LedgerManagerImpl::maxLedgerResources(bool isSoroban,
                                        conf.ledgerMaxReadBytes(),
                                        conf.ledgerMaxWriteBytes(),
                                        conf.ledgerMaxReadLedgerEntries(),
-                                       conf.ledgerMaxWriteLedgerEntries()};
+                                       conf.ledgerMaxWriteLedgerEntries(),
+                                       conf.ledgerMaxTxCount()};
         return Resource(limits);
     }
     else

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -227,6 +227,10 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
     FLOOD_OP_RATE_PER_LEDGER = 1.0;
     FLOOD_TX_PERIOD_MS = 200;
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    FLOOD_SOROBAN_RATE_PER_LEDGER = 1.0;
+    FLOOD_SOROBAN_TX_PERIOD_MS = 200;
+#endif
     FLOOD_ARB_TX_BASE_ALLOWANCE = 5;
     FLOOD_ARB_TX_DAMPING_FACTOR = 0.8;
 
@@ -1221,6 +1225,21 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 FLOOD_TX_PERIOD_MS = readInt<int>(item, 1);
             }
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+            else if (item.first == "FLOOD_SOROBAN_RATE_PER_LEDGER")
+            {
+                FLOOD_SOROBAN_RATE_PER_LEDGER = readDouble(item);
+                if (FLOOD_SOROBAN_RATE_PER_LEDGER <= 0.0)
+                {
+                    throw std::invalid_argument(
+                        "bad value for FLOOD_SOROBAN_RATE_PER_LEDGER");
+                }
+            }
+            else if (item.first == "FLOOD_SOROBAN_TX_PERIOD_MS")
+            {
+                FLOOD_SOROBAN_TX_PERIOD_MS = readInt<int>(item, 1);
+            }
+#endif
             else if (item.first == "FLOOD_DEMAND_PERIOD_MS")
             {
                 FLOOD_DEMAND_PERIOD_MS =

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1506,9 +1506,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
         if (!LIMIT_TX_QUEUE_SOURCE_ACCOUNT)
         {
-            throw std::runtime_error(
-                "Invalid configuration: "
-                "LIMIT_TX_QUEUE_SOURCE_ACCOUNT must be set");
+            std::string msg =
+                "Invalid configuration: disabling "
+                "LIMIT_TX_QUEUE_SOURCE_ACCOUNT is not allowed. Starting core "
+                "with LIMIT_TX_QUEUE_SOURCE_ACCOUNT=true";
+            LOG_WARNING(DEFAULT_LOG, "{}", msg);
+            LIMIT_TX_QUEUE_SOURCE_ACCOUNT = true;
         }
 #endif
         // PEER_FLOOD_READING_CAPACITY_BYTES (C): This is the initial credit

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -465,6 +465,10 @@ class Config : public std::enable_shared_from_this<Config>
     int MAX_BATCH_WRITE_BYTES;
     double FLOOD_OP_RATE_PER_LEDGER;
     int FLOOD_TX_PERIOD_MS;
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    double FLOOD_SOROBAN_RATE_PER_LEDGER;
+    int FLOOD_SOROBAN_TX_PERIOD_MS;
+#endif
     int32_t FLOOD_ARB_TX_BASE_ALLOWANCE;
     double FLOOD_ARB_TX_DAMPING_FACTOR;
 

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -837,11 +837,14 @@ createUploadWasmTx(Application& app, TestAccount& account, uint32_t fee,
     std::generate(uploadHF.wasm().begin(), uploadHF.wasm().end(),
                   [&byteDistr]() { return byteDistr(gRandomEngine); });
 
-    LedgerKey contractCodeLedgerKey;
-    contractCodeLedgerKey.type(CONTRACT_CODE);
-    contractCodeLedgerKey.contractCode().hash = xdrSha256(uploadHF.wasm());
-
-    resources.footprint.readWrite = {contractCodeLedgerKey};
+    if (resources.footprint.readWrite.empty() &&
+        resources.footprint.readOnly.empty())
+    {
+        LedgerKey contractCodeLedgerKey;
+        contractCodeLedgerKey.type(CONTRACT_CODE);
+        contractCodeLedgerKey.contractCode().hash = xdrSha256(uploadHF.wasm());
+        resources.footprint.readWrite = {contractCodeLedgerKey};
+    }
 
     auto tx =
         sorobanTransactionFrameFromOps(app.getNetworkID(), account, {deployOp},

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -205,10 +205,9 @@ TransactionFrame::getResources() const
         int64_t txSize = xdr::xdr_size(mEnvelope.v1().tx);
         int64_t const txCount = 1;
 
-        return Resource({r.instructions, txSize, r.readBytes, r.writeBytes,
+        return Resource({txCount, r.instructions, txSize, r.readBytes, r.writeBytes,
                          static_cast<int64_t>(r.footprint.readOnly.size()),
-                         static_cast<int64_t>(r.footprint.readWrite.size()),
-                         txCount});
+                         static_cast<int64_t>(r.footprint.readWrite.size())});
     }
 #endif
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -203,10 +203,12 @@ TransactionFrame::getResources() const
     {
         auto r = sorobanResources();
         int64_t txSize = xdr::xdr_size(mEnvelope.v1().tx);
+        int64_t const txCount = 1;
 
         return Resource({r.instructions, txSize, r.readBytes, r.writeBytes,
                          static_cast<int64_t>(r.footprint.readOnly.size()),
-                         static_cast<int64_t>(r.footprint.readWrite.size())});
+                         static_cast<int64_t>(r.footprint.readWrite.size()),
+                         txCount});
     }
 #endif
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -203,9 +203,9 @@ TransactionFrame::getResources() const
     {
         auto r = sorobanResources();
         int64_t txSize = xdr::xdr_size(mEnvelope.v1().tx);
-        int64_t const txCount = 1;
+        int64_t const opCount = 1;
 
-        return Resource({txCount, r.instructions, txSize, r.readBytes,
+        return Resource({opCount, r.instructions, txSize, r.readBytes,
                          r.writeBytes,
                          static_cast<int64_t>(r.footprint.readOnly.size()),
                          static_cast<int64_t>(r.footprint.readWrite.size())});

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -205,7 +205,8 @@ TransactionFrame::getResources() const
         int64_t txSize = xdr::xdr_size(mEnvelope.v1().tx);
         int64_t const txCount = 1;
 
-        return Resource({txCount, r.instructions, txSize, r.readBytes, r.writeBytes,
+        return Resource({txCount, r.instructions, txSize, r.readBytes,
+                         r.writeBytes,
                          static_cast<int64_t>(r.footprint.readOnly.size()),
                          static_cast<int64_t>(r.footprint.readWrite.size())});
     }

--- a/src/util/TxResource.cpp
+++ b/src/util/TxResource.cpp
@@ -130,7 +130,7 @@ operator>(Resource const& lhs, Resource const& rhs)
 Resource&
 Resource::operator+=(Resource const& other)
 {
-    releaseAssert(canAdd(*this, other));
+    releaseAssert(canAdd(other));
     for (size_t i = 0; i < mResources.size(); i++)
     {
         mResources[i] += other.mResources[i];
@@ -164,12 +164,12 @@ limitTo(Resource const& curr, Resource const& limit)
 }
 
 bool
-canAdd(Resource const& lhs, Resource const& rhs)
+Resource::canAdd(Resource const& other) const
 {
-    releaseAssert(lhs.size() == rhs.size());
-    for (size_t i = 0; i < lhs.size(); i++)
+    releaseAssert(size() == other.size());
+    for (size_t i = 0; i < size(); i++)
     {
-        if (INT64_MAX - lhs.mResources[i] < rhs.mResources[i])
+        if (INT64_MAX - mResources[i] < other.mResources[i])
         {
             return false;
         }

--- a/src/util/TxResource.cpp
+++ b/src/util/TxResource.cpp
@@ -130,10 +130,9 @@ operator>(Resource const& lhs, Resource const& rhs)
 Resource&
 Resource::operator+=(Resource const& other)
 {
-    releaseAssert(mResources.size() == other.mResources.size());
+    releaseAssert(canAdd(*this, other));
     for (size_t i = 0; i < mResources.size(); i++)
     {
-        releaseAssert(INT64_MAX - mResources[i] >= other.mResources[i]);
         mResources[i] += other.mResources[i];
     }
     return *this;
@@ -162,6 +161,20 @@ limitTo(Resource const& curr, Resource const& limit)
             std::min<int64_t>(curr.mResources[i], limit.mResources[i]);
     }
     return limited;
+}
+
+bool
+canAdd(Resource const& lhs, Resource const& rhs)
+{
+    releaseAssert(lhs.size() == rhs.size());
+    for (size_t i = 0; i < lhs.size(); i++)
+    {
+        if (INT64_MAX - lhs.mResources[i] < rhs.mResources[i])
+        {
+            return false;
+        }
+    }
+    return true;
 }
 
 } // namespace stellar

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -22,6 +22,17 @@ class Resource
     std::vector<int64_t> mResources;
 
   public:
+    enum class Type
+    {
+        TRANSACTIONS = 0,
+        INSTRUCTIONS = 1,
+        BYTE_SIZE = 2,
+        READ_BYTES = 3,
+        WRITE_BYTES = 4,
+        READ_LEDGER_ENTRIES = 5,
+        WRITE_LEDGER_ENTRIES = 6
+    };
+
     Resource(std::vector<int64_t> args)
     {
         if (args.size() != NUM_CLASSIC_TX_RESOURCES &&
@@ -81,9 +92,9 @@ class Resource
     }
 
     int64_t
-    getVal(size_t index) const
+    getVal(Resource::Type valType) const
     {
-        return mResources.at(index);
+        return mResources.at(static_cast<size_t>(valType));
     }
 
     bool canAdd(Resource const& other) const;

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -86,11 +86,12 @@ class Resource
         return mResources.at(index);
     }
 
+    bool canAdd(Resource const& other) const;
+
     friend Resource multiplyByDouble(Resource const& res, double m);
     friend Resource bigDivideOrThrow(Resource const& res, int64_t B, int64_t C,
                                      Rounding rounding);
     friend Resource operator+(Resource const& lhs, Resource const& rhs);
-    friend bool canAdd(Resource const& lhs, Resource const& rhs);
     friend Resource operator-(Resource const& lhs, Resource const& rhs);
     friend bool anyLessThan(Resource const& lhs, Resource const& rhs);
     friend bool anyGreater(Resource const& lhs, Resource const& rhs);

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -90,6 +90,7 @@ class Resource
     friend Resource bigDivideOrThrow(Resource const& res, int64_t B, int64_t C,
                                      Rounding rounding);
     friend Resource operator+(Resource const& lhs, Resource const& rhs);
+    friend bool canAdd(Resource const& lhs, Resource const& rhs);
     friend Resource operator-(Resource const& lhs, Resource const& rhs);
     friend bool anyLessThan(Resource const& lhs, Resource const& rhs);
     friend bool anyGreater(Resource const& lhs, Resource const& rhs);

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -24,7 +24,7 @@ class Resource
   public:
     enum class Type
     {
-        TRANSACTIONS = 0,
+        OPERATIONS = 0,
         INSTRUCTIONS = 1,
         BYTE_SIZE = 2,
         READ_BYTES = 3,

--- a/src/util/TxResource.h
+++ b/src/util/TxResource.h
@@ -14,7 +14,7 @@ namespace stellar
 {
 
 constexpr size_t NUM_CLASSIC_TX_RESOURCES(1);
-constexpr size_t NUM_SOROBAN_TX_RESOURCES(6);
+constexpr size_t NUM_SOROBAN_TX_RESOURCES(7);
 
 // Small helper class to allow arithmetic operations on tuples
 class Resource


### PR DESCRIPTION
Various improvements to https://github.com/stellar/stellar-core/pull/3766. Most significant additions are:
* Incorporate Soroban tx limit into flooding, tx limiting, and tx set construction (now that https://github.com/stellar/stellar-core/pull/3767 is merged)
* Tx set validity checks: ensure we do not go over Soroban ledger limits, enforce 1 tx per source account (caveat is that we can't enable this on all tests yet, see comment)
* Tests for tx set validity and limits
* Cleanups, Soroban-specific flooding configs as opposed to re-using classic, incorporating Soroban tx limit into pull mode