### PR TITLE
fix minor issue in BallotProtocol.h comments

### DIFF
--- a/src/scp/BallotProtocol.h
+++ b/src/scp/BallotProtocol.h
@@ -22,8 +22,8 @@ class Slot;
 typedef std::function<bool(SCPStatement const& st)> StatementPredicate;
 
 /**
- * The Slot object is in charge of maintaining the state of the SCP protocol
- * for a given slot index.
+ * The BallotProtocol object implements and maintains the relevant state for the
+ * ballot protocol.
  */
 class BallotProtocol
 {


### PR DESCRIPTION
# Description

The comment documentation for the BallotProtocol seems to refer to Slot.

```cpp
/**
 * The Slot object is in charge of maintaining the state of the SCP protocol
 * for a given slot index.
 */
class BallotProtocol
{
...
}

/**
 * The Slot object is in charge of maintaining the state of the SCP protocol
 * for a given slot index.
 */
class Slot : public std::enable_shared_from_this<Slot>
{
...
}

```


<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
