### PR TITLE
Expire entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,39 +837,39 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c#c1b8c41aef3bf762db74e8b40bfeaf629394c83c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-integer",
  "num-traits",
- "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c)",
+ "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=6279f81ba8eddcb87fbaad0b4ad8cc75b7ad51de)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-integer",
  "num-traits",
- "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0)",
+ "soroban-env-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=6750a11325a7c4eed1e79372d136106e5bfecaff)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c#c1b8c41aef3bf762db74e8b40bfeaf629394c83c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -885,8 +885,8 @@ dependencies = [
  "rand_chacha",
  "sha2 0.9.9",
  "sha3",
- "soroban-env-common 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c)",
- "soroban-native-sdk-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c)",
+ "soroban-env-common 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16)",
+ "soroban-native-sdk-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -911,8 +911,8 @@ dependencies = [
  "rand_chacha",
  "sha2 0.9.9",
  "sha3",
- "soroban-env-common 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0)",
- "soroban-native-sdk-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0)",
+ "soroban-env-common 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e)",
+ "soroban-native-sdk-macros 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
@@ -921,14 +921,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c#c1b8c41aef3bf762db74e8b40bfeaf629394c83c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=6279f81ba8eddcb87fbaad0b4ad8cc75b7ad51de)",
+ "stellar-xdr",
  "syn 2.0.18",
  "thiserror",
 ]
@@ -936,14 +936,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.16 (git+https://github.com/stellar/rs-stellar-xdr?rev=6750a11325a7c4eed1e79372d136106e5bfecaff)",
+ "stellar-xdr",
  "syn 2.0.18",
  "thiserror",
 ]
@@ -951,7 +951,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c#c1b8c41aef3bf762db74e8b40bfeaf629394c83c"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16#422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -962,7 +962,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.16"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1030,8 +1030,8 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=c1b8c41aef3bf762db74e8b40bfeaf629394c83c)",
- "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0)",
+ "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=422ce4110f26097e94835e0a70a4ed8c10b5bc16)",
+ "soroban-env-host 0.0.16 (git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e)",
  "soroban-test-wasms",
 ]
 
@@ -1042,16 +1042,6 @@ source = "git+https://github.com/stellar/rs-stellar-strkey?rev=e6ba45c60c16de28c
 dependencies = [
  "base32",
  "thiserror",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.16"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=6279f81ba8eddcb87fbaad0b4ad8cc75b7ad51de#6279f81ba8eddcb87fbaad0b4ad8cc75b7ad51de"
-dependencies = [
- "base64",
- "crate-git-revision",
- "hex",
 ]
 
 [[package]]

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1348,7 +1348,7 @@ ConfigUpgradeSetFrame::getLedgerKey(ConfigUpgradeSetKey const& upgradeKey)
     lk.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     lk.contractData().contract.contractId() = upgradeKey.contractID;
     lk.contractData().key = v;
-    lk.contractData().type = EXCLUSIVE;
+    lk.contractData().durability = PERSISTENT;
     return lk;
 }
 

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1249,7 +1249,8 @@ ConfigUpgradeSetFrame::makeFromKey(AbstractLedgerTxn& ltx,
     }
     auto const& contractData = ltxe.current().data.contractData();
     if (contractData.body.bodyType() != DATA_ENTRY ||
-        contractData.body.data().val.type() != SCV_BYTES)
+        contractData.body.data().val.type() != SCV_BYTES ||
+        contractData.durability != PERSISTENT)
     {
         return nullptr;
     }
@@ -1347,6 +1348,7 @@ ConfigUpgradeSetFrame::getLedgerKey(ConfigUpgradeSetKey const& upgradeKey)
     lk.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     lk.contractData().contract.contractId() = upgradeKey.contractID;
     lk.contractData().key = v;
+    lk.contractData().type = EXCLUSIVE;
     return lk;
 }
 

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -794,7 +794,7 @@ getAvailableLimitExcludingLiabilities(AccountID const& accountID,
         LedgerKey key(TRUSTLINE);
         key.trustLine().accountID = accountID;
         key.trustLine().asset = assetToTrustLineAsset(asset);
-        auto trust = ltx.loadWithoutRecord(key);
+        auto trust = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
         if (trust && isAuthorizedToMaintainLiabilities(trust))
         {
             auto const& tl = trust.current().data.trustLine();
@@ -1242,7 +1242,8 @@ ConfigUpgradeSetFrameConstPtr
 ConfigUpgradeSetFrame::makeFromKey(AbstractLedgerTxn& ltx,
                                    ConfigUpgradeSetKey const& key)
 {
-    auto ltxe = ltx.loadWithoutRecord(ConfigUpgradeSetFrame::getLedgerKey(key));
+    auto ltxe = ltx.loadWithoutRecord(ConfigUpgradeSetFrame::getLedgerKey(key),
+                                      /*loadExpiredEntry=*/false);
     if (!ltxe)
     {
         return nullptr;
@@ -1365,9 +1366,9 @@ ConfigUpgradeSetFrame::upgradeNeeded(AbstractLedgerTxn& ltx,
     {
         LedgerKey key(LedgerEntryType::CONFIG_SETTING);
         key.configSetting().configSettingID = updatedEntry.configSettingID();
-        bool isSame =
-            ltx.loadWithoutRecord(key).current().data.configSetting() ==
-            updatedEntry;
+        bool isSame = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false)
+                          .current()
+                          .data.configSetting() == updatedEntry;
         if (!isSame)
         {
             return true;

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -243,6 +243,8 @@ makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet)
     le.data.contractData().body.bodyType(DATA_ENTRY);
     le.data.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     le.data.contractData().contract.contractId() = contractID;
+    le.data.contractData().type = EXCLUSIVE;
+    le.data.contractData().expirationLedgerSeq = UINT32_MAX;
     le.data.contractData().key = key;
     le.data.contractData().body.data().val = val;
 
@@ -724,6 +726,8 @@ TEST_CASE("config upgrade validation", "[upgrades]")
                     le.data.contractData().contract.type(
                         SC_ADDRESS_TYPE_CONTRACT);
                     le.data.contractData().contract.contractId() = contractID;
+                    le.data.contractData().type = EXCLUSIVE;
+                    le.data.contractData().expirationLedgerSeq = UINT32_MAX;
                     le.data.contractData().key = key;
                     le.data.contractData().body.data().val = val;
 
@@ -826,6 +830,8 @@ TEST_CASE("config upgrades applied to ledger", "[upgrades]")
             configUpgradeSet = makeMaxContractSizeBytesTestUpgrade(ltx2, 32768);
             ltx2.commit();
         }
+
+        REQUIRE(configUpgradeSet);
         executeUpgrade(*app, makeConfigUpgrade(*configUpgradeSet));
 
         LedgerTxn ltx2(app->getLedgerTxnRoot());

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -243,7 +243,7 @@ makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet)
     le.data.contractData().body.bodyType(DATA_ENTRY);
     le.data.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     le.data.contractData().contract.contractId() = contractID;
-    le.data.contractData().type = EXCLUSIVE;
+    le.data.contractData().durability = PERSISTENT;
     le.data.contractData().expirationLedgerSeq = UINT32_MAX;
     le.data.contractData().key = key;
     le.data.contractData().body.data().val = val;
@@ -726,7 +726,7 @@ TEST_CASE("config upgrade validation", "[upgrades]")
                     le.data.contractData().contract.type(
                         SC_ADDRESS_TYPE_CONTRACT);
                     le.data.contractData().contract.contractId() = contractID;
-                    le.data.contractData().type = EXCLUSIVE;
+                    le.data.contractData().durability = PERSISTENT;
                     le.data.contractData().expirationLedgerSeq = UINT32_MAX;
                     le.data.contractData().key = key;
                     le.data.contractData().body.data().val = val;

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -28,7 +28,10 @@ namespace stellar
 static std::string
 checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
 {
-    auto fromDb = ltx.loadWithoutRecord(LedgerEntryKey(entry));
+    // Database should contain same expried entries as BucketList even if they
+    // are not accesible
+    auto fromDb =
+        ltx.loadWithoutRecord(LedgerEntryKey(entry), /*loadExpiredEntry=*/true);
     if (!fromDb)
     {
         std::string s{
@@ -53,7 +56,9 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
 static std::string
 checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerKey const& key)
 {
-    auto fromDb = ltx.loadWithoutRecord(key);
+    // Database should contain same expried entries as BucketList even if they
+    // are not accesible
+    auto fromDb = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/true);
     if (!fromDb)
     {
         return {};

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -295,8 +295,10 @@ struct SelectBucketListGenerator : public BucketListGenerator
                 auto iter = filteredKeys.begin();
                 std::advance(iter, dist(gRandomEngine));
 
+                // For BucketList generation, expirationLedger shouldn't matter
                 mSelected = std::make_shared<LedgerEntry>(
-                    ltx.loadWithoutRecord(*iter).current());
+                    ltx.loadWithoutRecord(*iter, /*loadExpiredEntry=*/true)
+                        .current());
             }
         }
         return BucketListGenerator::generateLiveEntries(ltx);

--- a/src/ledger/InMemoryLedgerTxn.cpp
+++ b/src/ledger/InMemoryLedgerTxn.cpp
@@ -233,6 +233,14 @@ InMemoryLedgerTxn::create(InternalLedgerEntry const& entry)
     throw std::runtime_error("called create on InMemoryLedgerTxn");
 }
 
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+LedgerTxnEntry
+InMemoryLedgerTxn::restore(InternalLedgerEntry const& entry)
+{
+    throw std::runtime_error("called restore on InMemoryLedgerTxn");
+}
+#endif
+
 void
 InMemoryLedgerTxn::erase(InternalLedgerKey const& key)
 {

--- a/src/ledger/InMemoryLedgerTxn.cpp
+++ b/src/ledger/InMemoryLedgerTxn.cpp
@@ -246,7 +246,8 @@ InMemoryLedgerTxn::load(InternalLedgerKey const& key)
 }
 
 ConstLedgerTxnEntry
-InMemoryLedgerTxn::loadWithoutRecord(InternalLedgerKey const& key)
+InMemoryLedgerTxn::loadWithoutRecord(InternalLedgerKey const& key,
+                                     bool loadExpiredEntry)
 {
     throw std::runtime_error("called loadWithoutRecord on InMemoryLedgerTxn");
 }
@@ -271,7 +272,7 @@ InMemoryLedgerTxn::getOffersByAccountAndAsset(AccountID const& account,
             continue;
         }
 
-        auto newest = getNewestVersion(key);
+        auto newest = getNewestVersion(key, /*loadExpiredEntry=*/false);
         if (!newest)
         {
             throw std::runtime_error("Invalid ledger state");
@@ -308,8 +309,10 @@ InMemoryLedgerTxn::getPoolShareTrustLinesByAccountAndAsset(
             continue;
         }
 
-        auto pool = getNewestVersion(liquidityPoolKey(
-            key.ledgerKey().trustLine().asset.liquidityPoolID()));
+        auto pool = getNewestVersion(
+            liquidityPoolKey(
+                key.ledgerKey().trustLine().asset.liquidityPoolID()),
+            /*loadExpiredEntry=*/false);
         if (!pool)
         {
             throw std::runtime_error("Invalid ledger state");
@@ -319,7 +322,7 @@ InMemoryLedgerTxn::getPoolShareTrustLinesByAccountAndAsset(
         auto const& cp = lp.body.constantProduct();
         if (cp.params.assetA == asset || cp.params.assetB == asset)
         {
-            auto newest = getNewestVersion(key);
+            auto newest = getNewestVersion(key, /*loadExpiredEntry=*/false);
             if (!newest)
             {
                 throw std::runtime_error("Invalid ledger state");

--- a/src/ledger/InMemoryLedgerTxn.h
+++ b/src/ledger/InMemoryLedgerTxn.h
@@ -88,6 +88,11 @@ class InMemoryLedgerTxn : public LedgerTxn
     void eraseWithoutLoading(InternalLedgerKey const& key) override;
 
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerTxnEntry restore(InternalLedgerEntry const& entry) override;
+#endif
+
     void erase(InternalLedgerKey const& key) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
     ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,

--- a/src/ledger/InMemoryLedgerTxn.h
+++ b/src/ledger/InMemoryLedgerTxn.h
@@ -90,8 +90,8 @@ class InMemoryLedgerTxn : public LedgerTxn
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
     void erase(InternalLedgerKey const& key) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
-    ConstLedgerTxnEntry
-    loadWithoutRecord(InternalLedgerKey const& key) override;
+    ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
+                                          bool loadExpiredEntry) override;
 
     UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -90,7 +90,8 @@ InMemoryLedgerTxnRoot::getInflationWinners(size_t maxWinners,
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-InMemoryLedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key) const
+InMemoryLedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key,
+                                        bool loadExpiredEntry) const
 {
     return nullptr;
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -62,7 +62,8 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     getInflationWinners(size_t maxWinners, int64_t minBalance) override;
 
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key) const override;
+    getNewestVersion(InternalLedgerKey const& key,
+                     bool loadExpiredEntry) const override;
 
     uint64_t countObjects(LedgerEntryType let) const override;
     uint64_t countObjects(LedgerEntryType let,

--- a/src/ledger/LedgerHashUtils.h
+++ b/src/ledger/LedgerHashUtils.h
@@ -6,6 +6,7 @@
 
 #include "crypto/ShortHash.h"
 #include "ledger/InternalLedgerEntry.h"
+#include "ledger/LedgerTypeUtils.h"
 #include "util/HashOfHash.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include "xdr/Stellar-ledger.h"
@@ -158,10 +159,14 @@ template <> class hash<stellar::LedgerKey>
             }
             stellar::hashMix(
                 res, stellar::shortHash::xdrComputeHash(lk.contractData().key));
+            stellar::hashMix(
+                res, std::hash<int32_t>()(lk.contractData().durability));
+            stellar::hashMix(res, std::hash<int32_t>()(getLeType(lk)));
             break;
         case stellar::CONTRACT_CODE:
             stellar::hashMix(
                 res, std::hash<stellar::uint256>()(lk.contractCode().hash));
+            stellar::hashMix(res, std::hash<int32_t>()(getLeType(lk)));
             break;
         case stellar::CONFIG_SETTING:
             stellar::hashMix(

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -612,7 +612,9 @@ LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
     throwIfChild();
 
     auto key = entry.toKey();
-    if (getNewestVersion(key))
+
+    // TODO: Enforce PErsistent collision resistance
+    if (getNewestVersion(key, /*loadExpiredEntry=*/false))
     {
         throw std::runtime_error("Key already exists");
     }
@@ -1148,7 +1150,8 @@ LedgerTxn::Impl::getChanges()
             }
             else
             {
-                auto previous = mParent.getNewestVersion(key);
+                auto previous =
+                    mParent.getNewestVersion(key, /*loadExpiredEntry=*/false);
                 // entry is not init, so previous must exist. If not, then
                 // we're modifying an entry that doesn't exist.
                 releaseAssert(previous);
@@ -1193,7 +1196,8 @@ LedgerTxn::Impl::getDelta()
                 continue;
             }
 
-            auto previous = mParent.getNewestVersion(key);
+            auto previous =
+                mParent.getNewestVersion(key, /*loadExpiredEntry=*/false);
 
             // Deep copy is not required here because getDelta causes
             // LedgerTxn to enter the sealed state, meaning subsequent
@@ -1255,7 +1259,8 @@ LedgerTxn::Impl::getDeltaVotes() const
             }
         }
 
-        auto previous = mParent.getNewestVersion(key);
+        auto previous =
+            mParent.getNewestVersion(key, /*loadExpiredEntry=*/false);
         if (previous)
         {
             auto const& acc = previous->ledgerEntry().data.account();
@@ -1433,20 +1438,22 @@ LedgerTxn::Impl::getAllEntries(std::vector<LedgerEntry>& initEntries,
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-LedgerTxn::getNewestVersion(InternalLedgerKey const& key) const
+LedgerTxn::getNewestVersion(InternalLedgerKey const& key,
+                            bool loadExpiredEntry) const
 {
-    return getImpl()->getNewestVersion(key);
+    return getImpl()->getNewestVersion(key, loadExpiredEntry);
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-LedgerTxn::Impl::getNewestVersion(InternalLedgerKey const& key) const
+LedgerTxn::Impl::getNewestVersion(InternalLedgerKey const& key,
+                                  bool loadExpiredEntry) const
 {
     auto iter = mEntry.find(key);
     if (iter != mEntry.end())
     {
         return iter->second.get();
     }
-    return mParent.getNewestVersion(key);
+    return mParent.getNewestVersion(key, loadExpiredEntry);
 }
 
 std::pair<std::shared_ptr<InternalLedgerEntry const>,
@@ -1458,7 +1465,8 @@ LedgerTxn::Impl::getNewestVersionEntryMap(InternalLedgerKey const& key)
     {
         return std::make_pair(iter->second.get(), iter);
     }
-    return std::make_pair(mParent.getNewestVersion(key), iter);
+    return std::make_pair(
+        mParent.getNewestVersion(key, /*loadExpiredEntry=*/false), iter);
 }
 
 UnorderedMap<LedgerKey, LedgerEntry>
@@ -1546,8 +1554,10 @@ LedgerTxn::Impl::getPoolShareTrustLinesByAccountAndAsset(
                     // The trust line wasn't in our result set, and was updated
                     // in self. We need to check the corresponding LiquidityPool
                     // to find its constituent assets.
-                    auto newest = getNewestVersion(liquidityPoolKey(
-                        key.trustLine().asset.liquidityPoolID()));
+                    auto newest = getNewestVersion(
+                        liquidityPoolKey(
+                            key.trustLine().asset.liquidityPoolID()),
+                        /*loadExpiredEntry=*/false);
                     if (!newest)
                     {
                         throw std::runtime_error("Invalid ledger state");
@@ -1839,14 +1849,16 @@ LedgerTxn::Impl::loadPoolShareTrustLinesByAccountAndAsset(
 }
 
 ConstLedgerTxnEntry
-LedgerTxn::loadWithoutRecord(InternalLedgerKey const& key)
+LedgerTxn::loadWithoutRecord(InternalLedgerKey const& key,
+                             bool loadExpiredEntry)
 {
-    return getImpl()->loadWithoutRecord(*this, key);
+    return getImpl()->loadWithoutRecord(*this, key, loadExpiredEntry);
 }
 
 ConstLedgerTxnEntry
 LedgerTxn::Impl::loadWithoutRecord(LedgerTxn& self,
-                                   InternalLedgerKey const& key)
+                                   InternalLedgerKey const& key,
+                                   bool loadExpiredEntry)
 {
     throwIfSealed();
     throwIfChild();
@@ -1855,7 +1867,7 @@ LedgerTxn::Impl::loadWithoutRecord(LedgerTxn& self,
         throw std::runtime_error("Key is active");
     }
 
-    auto newest = getNewestVersion(key);
+    auto newest = getNewestVersion(key, loadExpiredEntry);
     if (!newest)
     {
         return {};
@@ -2458,6 +2470,20 @@ LedgerTxnRoot::Impl::~Impl()
     {
         mChild->rollback();
     }
+}
+
+LedgerTxnRoot::Impl::CacheEntry
+LedgerTxnRoot::Impl::EntryCache::get(LedgerKey const& k,
+                                     std::optional<uint32_t> expirationCutoff)
+{
+    auto ce = RandomEvictionCache<LedgerKey, CacheEntry>::get(k);
+    if (expirationCutoff && ce.entry && !isLive(*ce.entry, *expirationCutoff))
+    {
+        // If the entry is expired, return null
+        ce.entry = nullptr;
+    }
+
+    return ce;
 }
 
 #ifdef BUILD_TESTS
@@ -3568,13 +3594,15 @@ LedgerTxnRoot::Impl::getInflationWinners(size_t maxWinners, int64_t minVotes)
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-LedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key) const
+LedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key,
+                                bool loadExpiredEntry) const
 {
-    return mImpl->getNewestVersion(key);
+    return mImpl->getNewestVersion(key, loadExpiredEntry);
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey) const
+LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey,
+                                      bool loadExpiredEntry) const
 {
     ZoneScoped;
     // Right now, only LEDGER_ENTRY are recorded in the SQL database
@@ -3583,12 +3611,11 @@ LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey) const
         return nullptr;
     }
     auto const& key = gkey.ledgerKey();
-
     if (mEntryCache.exists(key))
     {
         std::string zoneTxt("hit");
         ZoneText(zoneTxt.c_str(), zoneTxt.size());
-        return getFromEntryCache(key);
+        return getFromEntryCache(key, loadExpiredEntry);
     }
     else
     {
@@ -3596,6 +3623,10 @@ LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey) const
         ZoneText(zoneTxt.c_str(), zoneTxt.size());
         ++mPrefetchMisses;
     }
+
+    std::optional<uint32_t> expirationCutoff =
+        loadExpiredEntry ? std::nullopt
+                         : std::make_optional(mHeader->ledgerSeq);
 
     std::shared_ptr<LedgerEntry const> entry;
     try
@@ -3661,12 +3692,14 @@ LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey) const
     putInEntryCache(key, entry, LoadType::IMMEDIATE);
     if (entry)
     {
-        return std::make_shared<InternalLedgerEntry const>(*entry);
+        // Enforce expirationLedger
+        if (loadExpiredEntry || isLive(*entry, mHeader->ledgerSeq))
+        {
+            return std::make_shared<InternalLedgerEntry const>(*entry);
+        }
     }
-    else
-    {
-        return nullptr;
-    }
+
+    return nullptr;
 }
 
 void
@@ -3704,11 +3737,15 @@ LedgerTxnRoot::Impl::rollbackChild() noexcept
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-LedgerTxnRoot::Impl::getFromEntryCache(LedgerKey const& key) const
+LedgerTxnRoot::Impl::getFromEntryCache(LedgerKey const& key,
+                                       bool loadExpiredEntry) const
 {
     try
     {
-        auto cached = mEntryCache.get(key);
+        std::optional<uint32_t> expirationCutoff =
+            loadExpiredEntry ? std::nullopt
+                             : std::make_optional(mHeader->ledgerSeq);
+        auto cached = mEntryCache.get(key, expirationCutoff);
         if (cached.type == LoadType::PREFETCH)
         {
             ++mPrefetchHits;

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -605,20 +605,18 @@ LedgerTxn::create(InternalLedgerEntry const& entry)
     return getImpl()->create(*this, entry);
 }
 
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 LedgerTxnEntry
-LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
+LedgerTxn::restore(InternalLedgerEntry const& entry)
 {
-    throwIfSealed();
-    throwIfChild();
+    return getImpl()->restore(*this, entry);
+}
+#endif
 
-    auto key = entry.toKey();
-
-    // TODO: Enforce PErsistent collision resistance
-    if (getNewestVersion(key, /*loadExpiredEntry=*/false))
-    {
-        throw std::runtime_error("Key already exists");
-    }
-
+LedgerTxnEntry
+LedgerTxn::Impl::createRestoreCommon(LedgerTxn& self,
+                                     InternalLedgerEntry const& entry)
+{
     auto current = std::make_shared<InternalLedgerEntry>(entry);
     auto impl = LedgerTxnEntry::makeSharedImpl(self, *current);
 
@@ -626,7 +624,7 @@ LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
     // can throw and the LedgerTxnEntry destructor requires that mActive
     // contains key. LedgerTxnEntry constructor does not throw so this is
     // still exception safe.
-    mActive.emplace(key, toEntryImplBase(impl));
+    mActive.emplace(entry.toKey(), toEntryImplBase(impl));
     LedgerTxnEntry ltxe(impl);
 
     auto it = mEntry.end(); // hint that key is not in mEntry
@@ -635,10 +633,80 @@ LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
     // after this INIT entry is merged with the DELETED will be a LIVE. This is
     // because the entry would have been a LIVE before the delete. If it were an
     // INIT instead, the key would've been annihilated.
-    updateEntry(key, &it, LedgerEntryPtr::Init(current),
+    updateEntry(entry.toKey(), &it, LedgerEntryPtr::Init(current),
                 /* effectiveActive */ true);
     return ltxe;
 }
+
+LedgerTxnEntry
+LedgerTxn::Impl::create(LedgerTxn& self, InternalLedgerEntry const& entry)
+{
+    throwIfSealed();
+    throwIfChild();
+
+    auto key = entry.toKey();
+
+    // For entries that can be restored, we need to check the key for both
+    // expired entries and live entries
+    auto checkExpired = key.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
+                        isRestorableEntry(key.ledgerKey());
+    if (getNewestVersion(key, checkExpired))
+    {
+        throw std::runtime_error("Key already exists");
+    }
+
+    return createRestoreCommon(self, entry);
+}
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+LedgerTxnEntry
+LedgerTxn::Impl::restore(LedgerTxn& self, InternalLedgerEntry const& entry)
+{
+    throwIfSealed();
+    throwIfChild();
+
+    auto key = entry.toKey();
+
+    if (!isRestorableEntry(key.ledgerKey()))
+    {
+        throw std::runtime_error(
+            "Restored entry that is not a restorable type");
+    }
+
+    auto expiredVersion = getNewestVersion(key, /*loadExpiredEntry=*/true);
+    if (!expiredVersion)
+    {
+        throw std::runtime_error("Restored entry that does not exist");
+    }
+
+    if (getNewestVersion(key, /*loadExpiredEntry=*/false))
+    {
+        throw std::runtime_error("Restored live entry");
+    }
+
+    // Check that data fields of expired version and new version are identical.
+    bool integrityCheck;
+    auto const& expiredLE = expiredVersion->ledgerEntry();
+    if (key.ledgerKey().type() == CONTRACT_DATA)
+    {
+        integrityCheck = expiredLE.data.contractData().body ==
+                         entry.ledgerEntry().data.contractData().body;
+    }
+    else
+    {
+        integrityCheck = expiredLE.data.contractCode().body ==
+                         entry.ledgerEntry().data.contractCode().body;
+    }
+
+    if (!integrityCheck)
+    {
+        throw std::runtime_error(
+            "Restored version has different data than expired version");
+    }
+
+    return createRestoreCommon(self, entry);
+}
+#endif
 
 void
 LedgerTxn::createWithoutLoading(InternalLedgerEntry const& entry)

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -434,7 +434,8 @@ class AbstractLedgerTxnParent
     // invoking getNewestVersion on its parent. Returns nullptr if the key does
     // not exist or if the corresponding LedgerEntry has been erased.
     virtual std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key) const = 0;
+    getNewestVersion(InternalLedgerKey const& key,
+                     bool loadExpiredEntry) const = 0;
 
     // Return the count of the number of ledger objects of type `let`. Will
     // throw when called on anything other than a (real or stub) root LedgerTxn.
@@ -573,8 +574,8 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual LedgerTxnEntry create(InternalLedgerEntry const& entry) = 0;
     virtual void erase(InternalLedgerKey const& key) = 0;
     virtual LedgerTxnEntry load(InternalLedgerKey const& key) = 0;
-    virtual ConstLedgerTxnEntry
-    loadWithoutRecord(InternalLedgerKey const& key) = 0;
+    virtual ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
+                                                  bool loadExpiredEntry) = 0;
 
     // Somewhat unsafe, non-recommended access methods: for use only during
     // bulk-loading as in catchup from buckets. These methods set an entry
@@ -742,7 +743,8 @@ class LedgerTxn : public AbstractLedgerTxn
                        std::vector<LedgerKey>& deadEntries) override;
 
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key) const override;
+    getNewestVersion(InternalLedgerKey const& key,
+                     bool loadExpiredEntry) const override;
 
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
 
@@ -765,8 +767,8 @@ class LedgerTxn : public AbstractLedgerTxn
     loadPoolShareTrustLinesByAccountAndAsset(AccountID const& account,
                                              Asset const& asset) override;
 
-    ConstLedgerTxnEntry
-    loadWithoutRecord(InternalLedgerKey const& key) override;
+    ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
+                                          bool loadExpiredEntry) override;
 
     void rollback() noexcept override;
 
@@ -879,7 +881,8 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     getInflationWinners(size_t maxWinners, int64_t minBalance) override;
 
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key) const override;
+    getNewestVersion(InternalLedgerKey const& key,
+                     bool loadExpiredEntry) const override;
 
     void rollbackChild() noexcept override;
 

--- a/src/ledger/LedgerTxnContractDataSQL.cpp
+++ b/src/ledger/LedgerTxnContractDataSQL.cpp
@@ -154,9 +154,7 @@ class BulkLoadContractDataOperation
                           ") "
                           "SELECT ledgerentry "
                           "FROM contractdata "
-                          "WHERE contractid IN (SELECT value FROM r) "
-                          "AND key IN (SELECT value FROM r) "
-                          "AND type IN (SELECT value FROM r)";
+                          "WHERE (contractid, key, type) IN (SELECT * FROM r)";
 
         auto prep = mDb.getPreparedStatement(sql);
         auto be = prep.statement().get_backend();

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -439,6 +439,11 @@ class LedgerTxn::Impl
     std::pair<std::shared_ptr<InternalLedgerEntry const>, EntryMap::iterator>
     getNewestVersionEntryMap(InternalLedgerKey const& key);
 
+    // Common logic for create and restore code paths. Input correctness
+    // checking should be done before calling this function
+    LedgerTxnEntry createRestoreCommon(LedgerTxn& self,
+                                       InternalLedgerEntry const& entry);
+
   public:
     // Constructor has the strong exception safety guarantee
     Impl(LedgerTxn& self, AbstractLedgerTxnParent& parent,
@@ -457,6 +462,15 @@ class LedgerTxn::Impl
     //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     LedgerTxnEntry create(LedgerTxn& self, InternalLedgerEntry const& entry);
+
+    // restore has the basic exception safety guarantee. If it throws an
+    // exception, then
+    // - the prepared statement cache may be, but is not guaranteed to be,
+    //   modified
+    // - the entry cache may be, but is not guaranteed to be, cleared.
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    LedgerTxnEntry restore(LedgerTxn& self, InternalLedgerEntry const& entry);
+#endif
 
     // deactivate has the strong exception safety guarantee
     void deactivate(InternalLedgerKey const& key);

--- a/src/ledger/LedgerTypeUtils.cpp
+++ b/src/ledger/LedgerTypeUtils.cpp
@@ -110,6 +110,16 @@ expirationExtensionFromDataEntry(LedgerEntry const& le)
 #endif
 
 bool
+isLive(LedgerEntry const& e, uint32_t expirationCutoff)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    return !isSorobanEntry(e.data) ||
+           getExpirationLedger(e) >= expirationCutoff;
+#endif
+    return true;
+}
+
+bool
 autoBumpEnabled(LedgerEntry const& e)
 {
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION

--- a/src/ledger/LedgerTypeUtils.cpp
+++ b/src/ledger/LedgerTypeUtils.cpp
@@ -161,4 +161,20 @@ isSorobanDataEntry(T const& e)
 template bool
 isSorobanDataEntry<LedgerEntry::_data_t>(LedgerEntry::_data_t const& e);
 template bool isSorobanDataEntry<LedgerKey>(LedgerKey const& e);
+
+template <typename T>
+bool
+isRestorableEntry(T const& e)
+{
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    return e.type() == CONTRACT_CODE ||
+           (e.type() == CONTRACT_DATA &&
+            e.contractData().durability == PERSISTENT);
+#endif
+    return false;
+}
+
+template bool
+isRestorableEntry<LedgerEntry::_data_t>(LedgerEntry::_data_t const& e);
+template bool isRestorableEntry<LedgerKey>(LedgerKey const& e);
 };

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -29,6 +29,7 @@ bool autoBumpEnabled(LedgerEntry const& e);
 
 template <typename T> bool isSorobanExtEntry(T const& e);
 template <typename T> bool isSorobanDataEntry(T const& e);
+template <typename T> bool isRestorableEntry(T const& e);
 
 template <typename T>
 bool

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -24,6 +24,7 @@ void setLeType(LedgerKey& k, ContractEntryBodyType leType);
 LedgerEntry expirationExtensionFromDataEntry(LedgerEntry const& le);
 #endif
 
+bool isLive(LedgerEntry const& e, uint32_t expirationCutoff);
 bool autoBumpEnabled(LedgerEntry const& e);
 
 template <typename T> bool isSorobanExtEntry(T const& e);

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -451,7 +451,7 @@ SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     mMaxContractSizeBytes = le.data.configSetting().contractMaxSizeBytes();
 #endif
 }
@@ -463,7 +463,7 @@ SorobanNetworkConfig::loadMaxContractDataKeySize(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_DATA_KEY_SIZE_BYTES;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     mMaxContractDataKeySizeBytes =
         le.data.configSetting().contractDataKeySizeBytes();
 #endif
@@ -476,7 +476,7 @@ SorobanNetworkConfig::loadMaxContractDataEntrySize(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     mMaxContractDataEntrySizeBytes =
         le.data.configSetting().contractDataEntrySizeBytes();
 #endif
@@ -489,7 +489,7 @@ SorobanNetworkConfig::loadComputeSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_COMPUTE_V0;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     auto const& configSetting = le.data.configSetting().contractCompute();
     mLedgerMaxInstructions = configSetting.ledgerMaxInstructions;
     mTxMaxInstructions = configSetting.txMaxInstructions;
@@ -506,7 +506,7 @@ SorobanNetworkConfig::loadLedgerAccessSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     auto const& configSetting = le.data.configSetting().contractLedgerCost();
     mLedgerMaxReadLedgerEntries = configSetting.ledgerMaxReadLedgerEntries;
     mLedgerMaxReadBytes = configSetting.ledgerMaxReadBytes;
@@ -534,7 +534,7 @@ SorobanNetworkConfig::loadHistoricalSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     auto const& configSetting =
         le.data.configSetting().contractHistoricalData();
     mFeeHistorical1KB = configSetting.feeHistorical1KB;
@@ -548,7 +548,7 @@ SorobanNetworkConfig::loadMetaDataSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_META_DATA_V0;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     auto const& configSetting = le.data.configSetting().contractMetaData();
     mFeeExtendedMetaData1KB = configSetting.feeExtendedMetaData1KB;
     mTxMaxExtendedMetaDataSizeBytes =
@@ -563,7 +563,7 @@ SorobanNetworkConfig::loadBandwidthSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_BANDWIDTH_V0;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     auto const& configSetting = le.data.configSetting().contractBandwidth();
     mLedgerMaxPropagateSizeBytes = configSetting.ledgerMaxPropagateSizeBytes;
     mTxMaxSizeBytes = configSetting.txMaxSizeBytes;
@@ -578,7 +578,7 @@ SorobanNetworkConfig::loadCpuCostParams(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     mCpuCostParams = le.data.configSetting().contractCostParamsCpuInsns();
 #endif
 }
@@ -590,7 +590,7 @@ SorobanNetworkConfig::loadMemCostParams(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     mMemCostParams = le.data.configSetting().contractCostParamsMemBytes();
 #endif
 }
@@ -602,7 +602,7 @@ SorobanNetworkConfig::loadExecutionLanesSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_EXECUTION_LANES;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     auto const& configSetting =
         le.data.configSetting().contractExecutionLanes();
     mLedgerMaxTxCount = configSetting.ledgerMaxTxCount;
@@ -634,7 +634,7 @@ SorobanNetworkConfig::loadStateExpirationSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_STATE_EXPIRATION;
-    auto le = ltx.loadWithoutRecord(key).current();
+    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
     mStateExpirationSettings =
         le.data.configSetting().stateExpirationSettings();
 #endif

--- a/src/ledger/TrustLineWrapper.cpp
+++ b/src/ledger/TrustLineWrapper.cpp
@@ -420,7 +420,7 @@ ConstTrustLineWrapper::ConstTrustLineWrapper(AbstractLedgerTxn& ltx,
         LedgerKey key(TRUSTLINE);
         key.trustLine().accountID = accountID;
         key.trustLine().asset = assetToTrustLineAsset(asset);
-        auto entry = ltx.loadWithoutRecord(key);
+        auto entry = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
         if (entry)
         {
             mImpl = std::make_unique<NonIssuerImpl>(std::move(entry));

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -2784,7 +2784,6 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
             ltx4.commit();
         }
 #endif
-
     };
 
     SECTION("default")

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -718,7 +718,7 @@ CommandHandler::getLedgerEntry(std::string const& params, std::string& retStr)
 
         LedgerKey k;
         fromOpaqueBase64(k, key);
-        auto le = ltx.loadWithoutRecord(k);
+        auto le = ltx.loadWithoutRecord(k, /*loadExpiredEntry=*/false);
         if (le)
         {
             root["state"] = "live";

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -27,7 +27,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "e47a25e56af1a90421a7c64c54956ce216503bd0"
+rev = "49421693412bcd454a769d4caee600ee2c28132e"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -51,11 +51,11 @@ optional = true
 version = "0.0.16"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "c1b8c41aef3bf762db74e8b40bfeaf629394c83c"
+rev = "422ce4110f26097e94835e0a70a4ed8c10b5bc16"
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "e47a25e56af1a90421a7c64c54956ce216503bd0"
+rev = "49421693412bcd454a769d4caee600ee2c28132e"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -46,6 +46,7 @@ impl From<CxxLedgerInfo> for LedgerInfo {
             base_reserve: c.base_reserve,
             min_temp_entry_expiration: c.min_temp_entry_expiration,
             min_persistent_entry_expiration: c.min_persistent_entry_expiration,
+            max_entry_expiration: c.max_entry_expiration
         }
     }
 }
@@ -184,7 +185,7 @@ fn build_storage_footprint_from_xdr(
         read_only,
         read_write,
     } = footprint;
-    let mut access = FootprintMap::new()?;
+    let mut access = FootprintMap::new();
 
     populate_access_map(
         &mut access,
@@ -243,7 +244,7 @@ fn build_storage_map_from_xdr_ledger_entries(
     footprint: &storage::Footprint,
     ledger_entries: &Vec<CxxBuf>,
 ) -> Result<StorageMap, CoreHostError> {
-    let mut map = StorageMap::new()?;
+    let mut map = StorageMap::new();
     for buf in ledger_entries {
         let le = Rc::new(xdr_from_cxx_buf::<LedgerEntry>(buf)?);
         let key = Rc::new(ledger_entry_to_ledger_key(&le)?);
@@ -333,7 +334,6 @@ fn log_debug_events(events: &Events) {
 
 fn extract_bumps(bumps: &ExpirationLedgerBumps) -> Result<Vec<Bump>, HostError> {
     bumps
-        .0
         .iter()
         .map(|e| {
             Ok(Bump {

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0
+soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e
 ├── stellar-strkey 0.0.7 git+https://github.com/stellar/rs-stellar-strkey?rev=e6ba45c60c16de28c7522586b80ed0150157df73#e6ba45c60c16de28c7522586b80ed0150157df73
 │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
 │   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
@@ -25,13 +25,13 @@ soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=e47a25
 │   │   └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
 │   ├── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
 │   └── intx 0.1.0 checksum:f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75
-├── soroban-native-sdk-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0
+├── soroban-native-sdk-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e
 │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
 │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
 │       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
-├── soroban-env-common 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0
+├── soroban-env-common 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e
 │   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=6750a11325a7c4eed1e79372d136106e5bfecaff#6750a11325a7c4eed1e79372d136106e5bfecaff
 │   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
 │   │   ├── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
@@ -48,7 +48,7 @@ soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=e47a25
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
 │   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76
-│   ├── soroban-env-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=e47a25e56af1a90421a7c64c54956ce216503bd0#e47a25e56af1a90421a7c64c54956ce216503bd0
+│   ├── soroban-env-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=49421693412bcd454a769d4caee600ee2c28132e#49421693412bcd454a769d4caee600ee2c28132e
 │   │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
 │   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   │   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=6750a11325a7c4eed1e79372d136106e5bfecaff#6750a11325a7c4eed1e79372d136106e5bfecaff

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -75,6 +75,7 @@ mod rust_bridge {
         pub memory_limit: u32,
         pub min_temp_entry_expiration: u32,
         pub min_persistent_entry_expiration: u32,
+        pub max_entry_expiration: u32,
         pub cpu_cost_params: CxxBuf,
         pub mem_cost_params: CxxBuf,
     }

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -47,7 +47,8 @@ CreateAccountOpFrame::doApplyBeforeV14(AbstractLedgerTxn& ltx)
     bool doesAccountExist =
         protocolVersionStartsFrom(header.current().ledgerVersion,
                                   ProtocolVersion::V_8) ||
-        (bool)ltx.loadWithoutRecord(accountKey(getSourceID()));
+        (bool)ltx.loadWithoutRecord(accountKey(getSourceID()),
+                                    /*loadExpiredEntry=*/false);
 
     auto sourceAccount = loadSourceAccount(ltx, header);
     if (getAvailableBalance(header, sourceAccount) <

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -285,7 +285,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         for (auto const& lk : keys)
         {
             // Load without record for readOnly to avoid writing them later
-            auto ltxe = ltx.loadWithoutRecord(lk);
+            auto ltxe = ltx.loadWithoutRecord(lk, /*loadExpiredEntry=*/false);
             size_t nByte{0};
             if (ltxe)
             {

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -98,7 +98,8 @@ MergeOpFrame::doApplyBeforeV16(AbstractLedgerTxn& ltx)
         // in versions < 8, merge account could be called with a stale account
         LedgerKey key(ACCOUNT);
         key.account().accountID = getSourceID();
-        auto thisAccount = ltx.loadWithoutRecord(key);
+        auto thisAccount =
+            ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
         if (!thisAccount)
         {
             innerResult().code(ACCOUNT_MERGE_NO_ACCOUNT);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -362,7 +362,8 @@ TransactionFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
         // this is buggy caching that existed in old versions of the protocol
         if (res)
         {
-            auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()));
+            auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()),
+                                               /*loadExpiredEntry=*/false);
             mCachedAccount = newest;
         }
         else
@@ -395,7 +396,8 @@ TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
             res = ltx.create(*mCachedAccount);
         }
 
-        auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()));
+        auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()),
+                                           /*loadExpiredEntry=*/false);
         mCachedAccount = newest;
         return res;
     }

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -43,8 +43,6 @@
 #include <algorithm>
 #include <numeric>
 
-#include "util/XDRCereal.h"
-
 namespace stellar
 {
 
@@ -1602,7 +1600,6 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
 // specifies a expiration extension outside the bounds, the expiration will be
 // set to the bound and charged accordingly. So long as refundableFee is large
 // enough to cover the adjusted expirations, the tx still succeeds.
-
 bool
 TransactionFrame::applyExpirationBumps(Application& app, AbstractLedgerTxn& ltx)
 {
@@ -1614,16 +1611,17 @@ TransactionFrame::applyExpirationBumps(Application& app, AbstractLedgerTxn& ltx)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     LedgerTxn ltxTx(ltx);
     auto const& resources = sorobanResources();
-    auto lcl = app.getLedgerManager().getLastClosedLedgerNum();
+    auto ledgerSeq = ltxTx.loadHeader().current().ledgerSeq;
     auto const& expirationSettings = app.getLedgerManager()
                                          .getSorobanNetworkConfig(ltxTx)
                                          .stateExpirationSettings();
 
-    auto maxExpirationLedger = lcl + expirationSettings.maxEntryExpiration;
+    auto maxExpirationLedger =
+        ledgerSeq + expirationSettings.maxEntryExpiration;
     auto minRestorableExpirationLedger =
-        lcl + expirationSettings.minPersistentEntryExpiration;
+        ledgerSeq + expirationSettings.minPersistentEntryExpiration;
     auto minTempExpirationLedger =
-        lcl + expirationSettings.minTempEntryExpiration;
+        ledgerSeq + expirationSettings.minTempEntryExpiration;
     auto autoBumpLedgers = expirationSettings.autoBumpLedgers;
 
     // Applies the correct expiration to LE. If expiration has not changed from
@@ -1633,7 +1631,7 @@ TransactionFrame::applyExpirationBumps(Application& app, AbstractLedgerTxn& ltx)
         // expiration, so set it to lcl for fee calculation purposes
         auto iter = mOriginalExpirations.find(LedgerEntryKey(le));
         uint32_t preApplyExpiration =
-            iter == mOriginalExpirations.end() ? lcl : iter->second;
+            iter == mOriginalExpirations.end() ? ledgerSeq : iter->second;
         uint32_t postApplyExpiration = getExpirationLedger(le);
         uint32_t minimumForEntry = preApplyExpiration;
 

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -333,7 +333,8 @@ ConstLedgerTxnEntry
 loadAccountWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID)
 {
     ZoneScoped;
-    return ltx.loadWithoutRecord(accountKey(accountID));
+    return ltx.loadWithoutRecord(accountKey(accountID),
+                                 /*loadExpiredEntry=*/false);
 }
 
 LedgerTxnEntry
@@ -1403,8 +1404,10 @@ prefetchForRevokeFromPoolShareTrustLines(
     {
         // prefetching shouldn't affect the protocol, so use loadWithoutRecord
         // to not touch lastModified
-        auto pool = ltx.loadWithoutRecord(liquidityPoolKey(
-            trustLine.current().data.trustLine().asset.liquidityPoolID()));
+        auto pool = ltx.loadWithoutRecord(
+            liquidityPoolKey(
+                trustLine.current().data.trustLine().asset.liquidityPoolID()),
+            /*loadExpiredEntry=*/false);
 
         auto const& params =
             pool.current().data.liquidityPool().body.constantProduct().params;

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -834,7 +834,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
         for (auto const& key : contractKeys)
         {
             uint32_t mult = key.type() == CONTRACT_CODE ? 5 : 4;
-            auto ltxe = ltx.loadWithoutRecord(key);
+            auto ltxe = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
             REQUIRE(ltxe);
             REQUIRE(getExpirationLedger(ltxe.current()) ==
                     expectedInitialExpiration + (autoBump * mult));


### PR DESCRIPTION
# Description

Resolves #3778.

This PR enforces expiration such that an expired entry is not accessible. This is implemented at the DB level, where the DB by default will not return an entry that has expired. When it is necessary to load expired entries for key existence checks and RestorationOp, a flag can be supplied to load expired entries. BucketListDB supports this after this PR, but I still need to plumb the flag through `LedgerTxn` in a follow up update.

Additionally, I found a bug where `ContractData` was not properly loaded during prefetch on SQLite. It turns out that our current prefetch testing was insufficient and only check that the correct number of elements were prefetched. The tests did not actually check that the entries are correct. I've added a correctness prefetch test and fixed the SQLite bug. However, I don't have much SQLite experience and fixed it via a ChatGPT pair programming session, so some human eyes would be greatly appreciated. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
