### PR TITLE
Bucketlist size meta

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -718,6 +718,26 @@ BucketList::getMaxMergeLevel(uint32_t currLedger) const
     return i;
 }
 
+uint64_t
+BucketList::getSize() const
+{
+    uint64_t sum = 0;
+    for (auto const& lev : mLevels)
+    {
+        std::array<std::shared_ptr<Bucket>, 2> buckets = {lev.getCurr(),
+                                                          lev.getSnap()};
+        for (auto const& b : buckets)
+        {
+            if (b)
+            {
+                sum += b->getSize();
+            }
+        }
+    }
+
+    return sum;
+}
+
 void
 BucketList::addBatch(Application& app, uint32_t currLedger,
                      uint32_t currLedgerProtocol,

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -497,6 +497,10 @@ class BucketList
     // returns the largest level that this ledger will need to merge
     uint32_t getMaxMergeLevel(uint32_t currLedger) const;
 
+    // Returns the total size of the BucketList, in bytes, excluding all
+    // FutureBuckets
+    uint64_t getSize() const;
+
     // Add a batch of initial (created), live (updated) and dead entries to the
     // bucketlist, representing the entries effected by closing
     // `currLedger`. The bucketlist will incorporate these into the smallest

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -632,6 +632,95 @@ TEST_CASE("BucketList check bucket sizes", "[bucket][bucketlist][count]")
     }
 }
 
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
+{
+    VirtualClock clock;
+    Config cfg(getTestConfig(0, Config::TESTDB_IN_MEMORY_SQLITE));
+    cfg.USE_CONFIG_FOR_GENESIS = true;
+
+    auto app = createTestApplication<BucketTestApplication>(clock, cfg);
+    for_versions_from(20, *app, [&] {
+        LedgerManagerForBucketTests& lm = app->getLedgerManager();
+
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        auto& networkConfig =
+            app->getLedgerManager().getSorobanNetworkConfig(ltx);
+        ltx.~LedgerTxn();
+
+        uint32_t windowSize = networkConfig.stateExpirationSettings()
+                                  .bucketListSizeWindowSampleSize;
+        std::deque<uint64_t> correctWindow;
+        for (auto i = 0; i < windowSize; ++i)
+        {
+            correctWindow.push_back(0);
+        }
+
+        auto check = [&]() {
+            // Check in-memory average from BucketManager
+            uint64_t sum = 0;
+            for (auto e : correctWindow)
+            {
+                sum += e;
+            }
+
+            uint64_t correctAverage = sum / correctWindow.size();
+
+            LedgerTxn ltx(app->getLedgerTxnRoot(), false,
+                          TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
+            REQUIRE(networkConfig.getAverageBucketListSize() == correctAverage);
+
+            // Check on-disk sliding window
+            LedgerKey key(CONFIG_SETTING);
+            key.configSetting().configSettingID =
+                ConfigSettingID::CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW;
+            auto txle = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+            releaseAssert(txle);
+            auto const& leVector =
+                txle.current().data.configSetting().bucketListSizeWindow();
+            std::vector<uint64_t> correctWindowVec(correctWindow.begin(),
+                                                   correctWindow.end());
+            REQUIRE(correctWindowVec == leVector);
+        };
+
+        // Check initial conditions
+        check();
+
+        // Take snapshots more frequently for faster testing
+        networkConfig.setBucketListSnapshotPeriodForTesting(64);
+
+        // Generate enough ledgers to fill sliding window
+        auto ledgersToGenerate =
+            (windowSize + 1) * networkConfig.getBucketListSizeSnapshotPeriod();
+        for (uint32_t ledger = 1; ledger < ledgersToGenerate; ++ledger)
+        {
+            // Note: BucketList size in the sliding window is snapshotted before
+            // adding new sliding window config entry with the resulting
+            // snapshot, so we have to take the snapshot here before closing the
+            // ledger to avoid counting the new  snapshot config entry
+            if ((ledger + 1) %
+                    networkConfig.getBucketListSizeSnapshotPeriod() ==
+                0)
+            {
+                correctWindow.pop_front();
+                correctWindow.push_back(
+                    app->getBucketManager().getBucketList().getSize());
+            }
+
+            lm.setNextLedgerEntryBatchForBucketTesting(
+                {}, LedgerTestUtils::generateValidUniqueLedgerEntries(10), {});
+            closeLedger(*app);
+            if ((ledger + 1) %
+                    networkConfig.getBucketListSizeSnapshotPeriod() ==
+                0)
+            {
+                check();
+            }
+        }
+    });
+}
+#endif
+
 static std::string
 formatX32(uint32_t v)
 {

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -109,6 +109,11 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
         // Seal the ltx but throw its entries away.
         std::vector<LedgerEntry> init, live;
         std::vector<LedgerKey> dead;
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        mApp.getLedgerManager()
+            .getSorobanNetworkConfig(ltx)
+            .maybeSnapshotBucketListSize(ledgerSeq, ltx, mApp);
+#endif
         ltx.getAllEntries(init, live, dead);
         // Use the testing values.
         mApp.getBucketManager().addBatch(mApp, ledgerSeq, ledgerVers,

--- a/src/herder/Upgrades.h
+++ b/src/herder/Upgrades.h
@@ -169,7 +169,7 @@ class ConfigUpgradeSetFrame
     bool upgradeNeeded(AbstractLedgerTxn& ltx,
                        LedgerHeader const& lclHeader) const;
 
-    void applyTo(AbstractLedgerTxn& ltx) const;
+    void applyTo(AbstractLedgerTxn& ltx, Application& app) const;
 
     bool isConsistentWith(
         ConfigUpgradeSetFrameConstPtr const& scheduledUpgrade) const;

--- a/src/ledger/LedgerCloseMetaFrame.h
+++ b/src/ledger/LedgerCloseMetaFrame.h
@@ -30,6 +30,10 @@ class LedgerCloseMetaFrame
 
     void populateTxSet(TxSetFrame const& txSet);
 
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    void setTotalByteSizeOfBucketList(uint64_t size);
+#endif
+
     LedgerCloseMeta const& getXDR() const;
 
   private:

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -3692,10 +3692,6 @@ LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey,
         ++mPrefetchMisses;
     }
 
-    std::optional<uint32_t> expirationCutoff =
-        loadExpiredEntry ? std::nullopt
-                         : std::make_optional(mHeader->ledgerSeq);
-
     std::shared_ptr<LedgerEntry const> entry;
     try
     {

--- a/src/testdata/ledger-close-meta-v2-protocol-20.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-20.json
@@ -1,26 +1,29 @@
 {
     "LedgerCloseMeta": {
-        "v": 1,
-        "v1": {
+        "v": 2,
+        "v2": {
+            "ext": {
+                "v": 0
+            },
             "ledgerHeader": {
-                "hash": "9b9e270ec0c1e34913373f604341d2d37523a7d815c6aef00ee27552d983d05d",
+                "hash": "26532da399d20996ec4ae2b0f7c7338a5b5f4cd9f46eada59b5dc9c006d9b5f4",
                 "header": {
                     "ledgerVersion": 20,
-                    "previousLedgerHash": "d5cfe3d6e14e5f201435db5c7752e7727e1333035670ed1183119f659b8965e5",
+                    "previousLedgerHash": "b7a1aeb8f189a8f59cd4885fdcb03b789325da7dd742bcec4248702b590dd78b",
                     "scpValue": {
-                        "txSetHash": "74fdc660fa7088286e27b3302260a969eba5fc5ede1b521ad8705cf6fc2449ac",
+                        "txSetHash": "304491c635fe04983d64e1c6badd29af9c4002e73ff160135601badbe82a6aac",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "e6ef3b2563f17e3cc33163c7145709e6a9aff4aa8e9b0dfdcf3bb08d3a0437e261ab11fe31a2aca567d655e273a60d18e5d42258df4717303bf83166c295360e"
+                                "signature": "be8b0457cec8ffdbf9d1141c8f1cd4648d07bfde9652b1ca105e1500d44956ffc3d03a9e8fe9399e92dc8feafc36e7fa6de980a0de77e2d9d2dffbe4745d8201"
                             }
                         }
                     },
                     "txSetResultHash": "cf65fee29665ff0c2a6910b24c420a487a7416ccd79c683b48aac1d45ad21faa",
-                    "bucketListHash": "4051d0adeea1eb1037f44481d815f21459096dae6a70c2e70799dd850c577ae6",
+                    "bucketListHash": "4b6537b253d66f8a0fb0d72c21889f8b136208141e2c17e96c555f03d1a67d0c",
                     "ledgerSeq": 6,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -46,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "d5cfe3d6e14e5f201435db5c7752e7727e1333035670ed1183119f659b8965e5",
+                    "previousLedgerHash": "b7a1aeb8f189a8f59cd4885fdcb03b789325da7dd742bcec4248702b590dd78b",
                     "phases": [
                         {
                             "v": 0,
@@ -997,7 +1000,10 @@
                 }
             ],
             "upgradesProcessing": [],
-            "scpInfo": []
+            "scpInfo": [],
+            "totalByteSizeOfBucketList": 323,
+            "evictedTemporaryLedgerKeys": [],
+            "evictedPersistentLedgerEntries": []
         }
     }
 }


### PR DESCRIPTION
# Description

Resolves #3783

This PR emits `totalByteSizeOfBucketList` in ledger close meta so that downstream systems can properly calculate Soroban storage related fees. This value is the 30 day average of the size of the BucketList calculated via daily snapshots. These snapshots are stored on disk in a sliding window via `CONFIG_ENTRY`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
