### PR TITLE
Remove tag check

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -260,7 +260,8 @@ main(int argc, char* const* argv)
     randHash::initialize();
     xdr::marshaling_stack_limit = 1000;
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    checkStellarCoreMajorVersionProtocolIdentity();
+    // TODO: This should only be enabled after we tag a v20 version
+    // checkStellarCoreMajorVersionProtocolIdentity();
     rust_bridge::check_lockfile_has_expected_dep_trees(
         Config::CURRENT_LEDGER_PROTOCOL_VERSION);
     checkXDRFileIdentity();


### PR DESCRIPTION
# Description

The current tag on https://github.com/stellar/stellar-core/commit/2109a168a895349f87b502ae3d182380b378fa47 (v19.12.0rc2) is interfering with this check for the futurenet release because 19 != 20. If this fix is accepted, I'll open an issue to re-enable this check (and make sure it works correctly).

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
