### PR TITLE
temp entry invariant fix

### DIFF
--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -721,6 +721,59 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
         }
     });
 }
+
+TEST_CASE_VERSIONS("new temp entry merges with expired entry with same key",
+                   "[bucket][bucketlist]")
+{
+    VirtualClock clock;
+    Config cfg(getTestConfig());
+    Application::pointer app = createTestApplication(clock, cfg);
+    BucketList& bl = app->getBucketManager().getBucketList();
+    uint32_t ledgerSeq = 1;
+
+    for_versions_from(20, *app, [&] {
+        auto startingLedger = ledgerSeq;
+        auto tempEntry =
+            LedgerTestUtils::generateValidLedgerEntryOfType(CONTRACT_DATA);
+        setExpirationLedger(tempEntry, startingLedger + 4);
+        tempEntry.data.contractData().durability = TEMPORARY;
+
+        bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {tempEntry}, {},
+                    {});
+        ++ledgerSeq;
+
+        // Run BucketList until entry has expired
+        for (; ledgerSeq <= startingLedger + 4; ++ledgerSeq)
+        {
+            bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {}, {}, {});
+        }
+
+        setExpirationLedger(tempEntry, startingLedger + 500);
+        bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {tempEntry}, {},
+                    {});
+        ++ledgerSeq;
+
+        // Run BucketList until entry has expired
+        for (; ledgerSeq <= startingLedger + 1024; ++ledgerSeq)
+        {
+            bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {}, {}, {});
+        }
+
+        bool foundValidEntry = false;
+        auto b = bl.getLevel(5).getCurr();
+        for (BucketInputIterator iter(b); iter; ++iter)
+        {
+            auto entry = *iter;
+            if (entry.type() == INITENTRY && entry.liveEntry() == tempEntry)
+            {
+                foundValidEntry = true;
+                break;
+            }
+        }
+
+        REQUIRE(foundValidEntry);
+    });
+}
 #endif
 
 static std::string


### PR DESCRIPTION
# Description

Fixes `TEMPORARY` entry invariant bug that killed preview 10 future net.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
