### PR TITLE
rename getFeeBid -> getInclusionFee, bugfixes

### DIFF
--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -581,8 +581,8 @@ compareTxSets(TxSetFrameConstPtr l, TxSetFrameConstPtr r, Hash const& lh,
     if (protocolVersionStartsFrom(header.ledgerVersion,
                                   GENERALIZED_TX_SET_PROTOCOL_VERSION))
     {
-        auto lBids = l->getTotalBids();
-        auto rBids = r->getTotalBids();
+        auto lBids = l->getTotalInclusionFees();
+        auto rBids = r->getTotalInclusionFees();
         if (lBids != rBids)
         {
             return lBids < rBids;

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -14,6 +14,7 @@ namespace stellar
 namespace
 {
 
+// Use _inclusion_ fee to order transactions
 int
 feeRate3WayCompare(TransactionFrameBase const& l, TransactionFrameBase const& r)
 {
@@ -461,7 +462,8 @@ SurgePricingPriorityQueue::canFitWithEviction(
         {
             auto minFee = computeBetterFee(tx, evictTx.getInclusionFee(),
                                            evictTx.getNumOperations());
-            return std::make_pair(false, minFee);
+            return std::make_pair(
+                false, minFee + (tx.getFullFee() - tx.getInclusionFee()));
         }
         // Ensure that this transaction is not from the same account.
         if (tx.getSourceID() == evictTx.getSourceID())

--- a/src/herder/SurgePricingUtils.cpp
+++ b/src/herder/SurgePricingUtils.cpp
@@ -17,8 +17,9 @@ namespace
 int
 feeRate3WayCompare(TransactionFrameBase const& l, TransactionFrameBase const& r)
 {
-    return stellar::feeRate3WayCompare(l.getFeeBid(), l.getNumOperations(),
-                                       r.getFeeBid(), r.getNumOperations());
+    return stellar::feeRate3WayCompare(
+        l.getInclusionFee(), l.getNumOperations(), r.getInclusionFee(),
+        r.getNumOperations());
 }
 
 } // namespace
@@ -84,8 +85,8 @@ bool
 SurgePricingPriorityQueue::TxStackComparator::compareFeeOnly(
     TransactionFrameBase const& tx1, TransactionFrameBase const& tx2) const
 {
-    return compareFeeOnly(tx1.getFeeBid(), tx1.getNumOperations(),
-                          tx2.getFeeBid(), tx2.getNumOperations());
+    return compareFeeOnly(tx1.getInclusionFee(), tx1.getNumOperations(),
+                          tx2.getInclusionFee(), tx2.getNumOperations());
 }
 
 bool
@@ -458,7 +459,7 @@ SurgePricingPriorityQueue::canFitWithEviction(
         // computation is a no-op.
         if (!mComparator.compareFeeOnly(evictTx, tx))
         {
-            auto minFee = computeBetterFee(tx, evictTx.getFeeBid(),
+            auto minFee = computeBetterFee(tx, evictTx.getInclusionFee(),
                                            evictTx.getNumOperations());
             return std::make_pair(false, minFee);
         }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -104,9 +104,9 @@ static bool
 canReplaceByFee(TransactionFrameBasePtr tx, TransactionFrameBasePtr oldTx,
                 int64_t& minFee)
 {
-    int64_t newFee = tx->getFeeBid();
+    int64_t newFee = tx->getInclusionFee();
     uint32_t newNumOps = std::max<uint32_t>(1, tx->getNumOperations());
-    int64_t oldFee = oldTx->getFeeBid();
+    int64_t oldFee = oldTx->getInclusionFee();
     uint32_t oldNumOps = std::max<uint32_t>(1, oldTx->getNumOperations());
 
     // newFee / newNumOps >= FEE_MULTIPLIER * oldFee / oldNumOps
@@ -129,7 +129,7 @@ canReplaceByFee(TransactionFrameBasePtr tx, TransactionFrameBasePtr oldTx,
         else
         {
             // Add the potential flat component to the resulting min fee.
-            minFee += tx->getFullFee() - tx->getFeeBid();
+            minFee += tx->getFullFee() - tx->getInclusionFee();
         }
     }
     return res;
@@ -238,7 +238,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
         ltx.loadHeader().current().ledgerVersion,
         mApp.getLedgerManager().getSorobanNetworkConfig(ltx), mApp.getConfig());
 #endif
-    int64_t netFee = tx->getFeeBid();
+    int64_t netFee = tx->getInclusionFee();
     int64_t seqNum = 0;
     TransactionFrameBasePtr oldTx;
 
@@ -316,7 +316,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
                     }
 
                     oldTx = txToReplaceIter->mTx;
-                    int64_t oldFee = oldTx->getFeeBid();
+                    int64_t oldFee = oldTx->getInclusionFee();
                     if (oldTx->getFeeSourceID() == tx->getFeeSourceID())
                     {
                         netFee -= oldFee;

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -98,8 +98,9 @@ TransactionQueue::~TransactionQueue()
 }
 
 // returns true, if a transaction can be replaced by another
-// `minFee` is set when returning false, and is the smallest fee
+// `minFee` is set when returning false, and is the smallest _full_ fee
 // that would allow replace by fee to succeed in this situation
+// Note that replace-by-fee logic is done on _inclusion_ fee
 static bool
 canReplaceByFee(TransactionFrameBasePtr tx, TransactionFrameBasePtr oldTx,
                 int64_t& minFee)
@@ -238,7 +239,7 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
         ltx.loadHeader().current().ledgerVersion,
         mApp.getLedgerManager().getSorobanNetworkConfig(ltx), mApp.getConfig());
 #endif
-    int64_t netFee = tx->getInclusionFee();
+    int64_t newInclusionFee = tx->getInclusionFee();
     int64_t seqNum = 0;
     TransactionFrameBasePtr oldTx;
 
@@ -316,10 +317,10 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
                     }
 
                     oldTx = txToReplaceIter->mTx;
-                    int64_t oldFee = oldTx->getInclusionFee();
+                    int64_t oldInclusionFee = oldTx->getInclusionFee();
                     if (oldTx->getFeeSourceID() == tx->getFeeSourceID())
                     {
-                        netFee -= oldFee;
+                        newInclusionFee -= oldInclusionFee;
                     }
                 }
 
@@ -402,7 +403,8 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
     int64_t totalFees = feeStateIter == mAccountStates.end()
                             ? 0
                             : feeStateIter->second.mTotalFees;
-    if (getAvailableBalance(ltx.loadHeader(), feeSource) - netFee < totalFees)
+    if (getAvailableBalance(ltx.loadHeader(), feeSource) - newInclusionFee <
+        totalFees)
     {
         tx->getResult().result.code(txINSUFFICIENT_BALANCE);
         return TransactionQueue::AddResult::ADD_STATUS_ERROR;

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -164,9 +164,13 @@ TxQueueLimiter::canAddTx(TransactionFrameBasePtr const& newTx,
         computeBetterFee(
             mLaneEvictedFeeBid[SurgePricingPriorityQueue::GENERIC_LANE],
             *newTx));
+    // minFeeToBeatEvicted is the minimum _inclusion_ fee to evict txs. For
+    // reporting, return _full_ minimum fee
     if (minFeeToBeatEvicted > 0)
     {
-        return std::make_pair(false, minFeeToBeatEvicted);
+        return std::make_pair(
+            false, minFeeToBeatEvicted +
+                       (newTx->getFullFee() - newTx->getInclusionFee()));
     }
 
     uint32_t txOpsDiscount = 0;

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -18,8 +18,8 @@ computeBetterFee(std::pair<int64, uint32_t> const& evictedBid,
                  TransactionFrameBase const& tx)
 {
     if (evictedBid.second != 0 &&
-        feeRate3WayCompare(evictedBid.first, evictedBid.second, tx.getFeeBid(),
-                           tx.getNumOperations()) >= 0)
+        feeRate3WayCompare(evictedBid.first, evictedBid.second,
+                           tx.getInclusionFee(), tx.getNumOperations()) >= 0)
     {
         return computeBetterFee(tx, evictedBid.first, evictedBid.second);
     }
@@ -213,14 +213,14 @@ TxQueueLimiter::evictTransactions(
             // txs in this lane have to beat it. However, other txs could still
             // fit with a lower fee.
             mLaneEvictedFeeBid[mSurgePricingLaneConfig->getLane(*tx)] = {
-                tx->getFeeBid(), tx->getNumOperations()};
+                tx->getInclusionFee(), tx->getNumOperations()};
         }
         else
         {
             // If tx has been evicted before reaching the lane limit, we just
             // add it to generic lane, so that every new tx has to beat it.
             mLaneEvictedFeeBid[SurgePricingPriorityQueue::GENERIC_LANE] = {
-                tx->getFeeBid(), tx->getNumOperations()};
+                tx->getInclusionFee(), tx->getNumOperations()};
         }
 
         evict(tx);

--- a/src/herder/TxQueueLimiter.cpp
+++ b/src/herder/TxQueueLimiter.cpp
@@ -157,19 +157,19 @@ TxQueueLimiter::canAddTx(TransactionFrameBasePtr const& newTx,
     // that the new transaction is better (even if it fits otherwise). This
     // guarantees that we don't replace transactions with higher bids with
     // transactions with lower bids and less operations.
-    int64_t minFeeToBeatEvicted = std::max(
+    int64_t minInclusionFeeToBeatEvicted = std::max(
         computeBetterFee(
-            mLaneEvictedFeeBid[mSurgePricingLaneConfig->getLane(*newTx)],
+            mLaneEvictedInclusionFee[mSurgePricingLaneConfig->getLane(*newTx)],
             *newTx),
         computeBetterFee(
-            mLaneEvictedFeeBid[SurgePricingPriorityQueue::GENERIC_LANE],
+            mLaneEvictedInclusionFee[SurgePricingPriorityQueue::GENERIC_LANE],
             *newTx));
-    // minFeeToBeatEvicted is the minimum _inclusion_ fee to evict txs. For
-    // reporting, return _full_ minimum fee
-    if (minFeeToBeatEvicted > 0)
+    // minInclusionFeeToBeatEvicted is the minimum _inclusion_ fee to evict txs.
+    // For reporting, return _full_ minimum fee
+    if (minInclusionFeeToBeatEvicted > 0)
     {
         return std::make_pair(
-            false, minFeeToBeatEvicted +
+            false, minInclusionFeeToBeatEvicted +
                        (newTx->getFullFee() - newTx->getInclusionFee()));
     }
 
@@ -216,15 +216,15 @@ TxQueueLimiter::evictTransactions(
             // If tx has been evicted due to lane limit, then all the following
             // txs in this lane have to beat it. However, other txs could still
             // fit with a lower fee.
-            mLaneEvictedFeeBid[mSurgePricingLaneConfig->getLane(*tx)] = {
+            mLaneEvictedInclusionFee[mSurgePricingLaneConfig->getLane(*tx)] = {
                 tx->getInclusionFee(), tx->getNumOperations()};
         }
         else
         {
             // If tx has been evicted before reaching the lane limit, we just
             // add it to generic lane, so that every new tx has to beat it.
-            mLaneEvictedFeeBid[SurgePricingPriorityQueue::GENERIC_LANE] = {
-                tx->getInclusionFee(), tx->getNumOperations()};
+            mLaneEvictedInclusionFee[SurgePricingPriorityQueue::GENERIC_LANE] =
+                {tx->getInclusionFee(), tx->getNumOperations()};
         }
 
         evict(tx);
@@ -277,12 +277,12 @@ TxQueueLimiter::resetEvictionState()
 {
     if (mSurgePricingLaneConfig != nullptr)
     {
-        mLaneEvictedFeeBid.assign(
+        mLaneEvictedInclusionFee.assign(
             mSurgePricingLaneConfig->getLaneLimits().size(), {0, 0});
     }
     else
     {
-        releaseAssert(mLaneEvictedFeeBid.empty());
+        releaseAssert(mLaneEvictedInclusionFee.empty());
     }
 }
 }

--- a/src/herder/TxQueueLimiter.h
+++ b/src/herder/TxQueueLimiter.h
@@ -65,9 +65,9 @@ class TxQueueLimiter
     // When non-nullopt, limit the number dex operations by this value
     std::optional<Resource> mMaxDexOperations;
 
-    // Stores the maximum bid among the transactions evicted from every tx lane.
-    // Bids are stored as ratios (fee_bid / num_ops).
-    std::vector<std::pair<int64, uint32_t>> mLaneEvictedFeeBid;
+    // Stores the maximum inclusion fee among the transactions evicted from
+    // every tx lane. Inclusion fees are stored as ratios (fee_bid / num_ops).
+    std::vector<std::pair<int64, uint32_t>> mLaneEvictedInclusionFee;
 
     // Configuration of SurgePricingPriorityQueue with the per-lane operation
     // limits.

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -605,7 +605,8 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
                         hexAbbrev(mPreviousLedgerHash), *fee);
                     return false;
                 }
-                if (tx->getInclusionFee() < getMinInclusionFee(*tx, lcl.header, fee))
+                if (tx->getInclusionFee() <
+                    getMinInclusionFee(*tx, lcl.header, fee))
                 {
                     CLOG_DEBUG(
                         Herder,

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -605,14 +605,14 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
                         hexAbbrev(mPreviousLedgerHash), *fee);
                     return false;
                 }
-                if (tx->getInclusionFee() < getMinFee(*tx, lcl.header, fee))
+                if (tx->getInclusionFee() < getMinInclusionFee(*tx, lcl.header, fee))
                 {
                     CLOG_DEBUG(
                         Herder,
                         "Got bad txSet: {} has tx with fee bid ({}) lower "
                         "than base fee ({})",
                         hexAbbrev(mPreviousLedgerHash), tx->getInclusionFee(),
-                        getMinFee(*tx, lcl.header, fee));
+                        getMinInclusionFee(*tx, lcl.header, fee));
                     return false;
                 }
             }
@@ -956,7 +956,7 @@ TxSetFrame::getTotalFees(LedgerHeader const& lh) const
 }
 
 int64_t
-TxSetFrame::getTotalBids() const
+TxSetFrame::getTotalInclusionFees() const
 {
     ZoneScoped;
     int64_t total{0};

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -145,7 +145,7 @@ class TxSetFrame : public NonMovableOrCopyable
 
     // Returns the sum of all _inclusion fee_ bids for all transactions in this
     // set.
-    int64_t getTotalBids() const;
+    int64_t getTotalInclusionFees() const;
 
     // Returns whether this transaction set is generalized, i.e. representable
     // by GeneralizedTransactionSet XDR.

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -143,7 +143,8 @@ class TxSetFrame : public NonMovableOrCopyable
     // Returns the sum of all fees that this transaction set would take.
     int64_t getTotalFees(LedgerHeader const& lh) const;
 
-    // Returns the sum of all bids for all transactions in this set.
+    // Returns the sum of all _inclusion fee_ bids for all transactions in this
+    // set.
     int64_t getTotalBids() const;
 
     // Returns whether this transaction set is generalized, i.e. representable

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -266,7 +266,7 @@ makeMultiPayment(stellar::TestAccount& destAccount, stellar::TestAccount& src,
         ops.emplace_back(payment(destAccount, i + paymentBase));
     }
     auto tx = src.tx(ops);
-    setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) * feeMult + extraFee);
+    setFee(tx, static_cast<uint32_t>(tx->getInclusionFee()) * feeMult + extraFee);
     getSignatures(tx).clear();
     tx->addSignature(src);
     return tx;
@@ -1460,7 +1460,7 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
         for (uint32_t n = 0; n < nbTxs; n++)
         {
             auto tx = multiPaymentTx(accountB, n + 1, 10000 + 1000 * n);
-            setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
+            setFee(tx, static_cast<uint32_t>(tx->getInclusionFee()) - 1);
             getSignatures(tx).clear();
             tx->addSignature(accountB);
             rootTxs.push_back(tx);
@@ -1484,7 +1484,7 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
             REQUIRE(rTx->getNumOperations() == n + 1);
             REQUIRE(tx->getNumOperations() == n + 2);
             // use the same fee
-            setFee(tx, static_cast<uint32_t>(rTx->getFeeBid()));
+            setFee(tx, static_cast<uint32_t>(rTx->getInclusionFee()));
             getSignatures(tx).clear();
             tx->addSignature(accountB);
             rootTxs.push_back(tx);
@@ -1506,11 +1506,11 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
             auto tx = multiPaymentTx(accountB, n + 1, 10000 + 1000 * n);
             if (n == 2)
             {
-                setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
+                setFee(tx, static_cast<uint32_t>(tx->getInclusionFee()) - 1);
             }
             else
             {
-                setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) + 1);
+                setFee(tx, static_cast<uint32_t>(tx->getInclusionFee()) + 1);
             }
             getSignatures(tx).clear();
             tx->addSignature(accountB);
@@ -4545,7 +4545,7 @@ TEST_CASE("do not flood too many transactions", "[herder][transactionqueue]")
                 ops.emplace_back(payment(source, i));
             }
             auto tx = source.tx(ops);
-            auto txFee = static_cast<uint32_t>(tx->getFeeBid());
+            auto txFee = static_cast<uint32_t>(tx->getInclusionFee());
             if (highFee)
             {
                 txFee += 100000;
@@ -4598,7 +4598,7 @@ TEST_CASE("do not flood too many transactions", "[herder][transactionqueue]")
                 REQUIRE(expected == tx->getSeqNum());
             }
             // check if we have the expected fee
-            REQUIRE(tx->getFeeBid() == fees.front());
+            REQUIRE(tx->getInclusionFee() == fees.front());
             fees.pop_front();
             ++numBroadcast;
         };
@@ -4754,7 +4754,7 @@ TEST_CASE("do not flood too many transactions with DEX separation",
                 }
             }
             auto tx = source.tx(ops);
-            auto txFee = tx->getFeeBid();
+            auto txFee = tx->getInclusionFee();
             if (highFee)
             {
                 txFee += 100000;
@@ -4874,7 +4874,7 @@ TEST_CASE("do not flood too many transactions with DEX separation",
                     ->front()
                     .first;
 
-            REQUIRE(tx->getFeeBid() == expectedFee);
+            REQUIRE(tx->getInclusionFee() == expectedFee);
             accountFees[accountToIndex[tx->getSourceID()]].pop_front();
             if (tx->hasDexOperations())
             {

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -266,7 +266,8 @@ makeMultiPayment(stellar::TestAccount& destAccount, stellar::TestAccount& src,
         ops.emplace_back(payment(destAccount, i + paymentBase));
     }
     auto tx = src.tx(ops);
-    setFee(tx, static_cast<uint32_t>(tx->getInclusionFee()) * feeMult + extraFee);
+    setFee(tx,
+           static_cast<uint32_t>(tx->getInclusionFee()) * feeMult + extraFee);
     getSignatures(tx).clear();
     tx->addSignature(src);
     return tx;

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -142,9 +142,9 @@ class TransactionQueueTest
             for (auto const& tx : accountState.mAccountTransactions)
             {
                 auto& fee = expectedFees[tx->getFeeSourceID()];
-                if (INT64_MAX - fee > tx->getFeeBid())
+                if (INT64_MAX - fee > tx->getInclusionFee())
                 {
-                    fee += tx->getFeeBid();
+                    fee += tx->getInclusionFee();
                 }
                 else
                 {
@@ -158,9 +158,9 @@ class TransactionQueueTest
         for (auto const& tx : queueTxs)
         {
             auto& fee = fees[tx->getFeeSourceID()];
-            if (INT64_MAX - fee > tx->getFeeBid())
+            if (INT64_MAX - fee > tx->getInclusionFee())
             {
-                fee += tx->getFeeBid();
+                fee += tx->getInclusionFee();
             }
             else
             {
@@ -1814,8 +1814,8 @@ TEST_CASE("TransactionQueue limits", "[herder][transactionqueue]")
                     txsToEvict, *tx, [&](TransactionFrameBasePtr const& evict) {
                         // can't evict cheaper transactions
                         auto cmp3 = feeRate3WayCompare(
-                            evict->getFeeBid(), evict->getNumOperations(),
-                            tx->getFeeBid(), tx->getNumOperations());
+                            evict->getInclusionFee(), evict->getNumOperations(),
+                            tx->getInclusionFee(), tx->getNumOperations());
                         REQUIRE(cmp3 < 0);
                         // can't evict self
                         bool same = evict->getSourceID() == tx->getSourceID();
@@ -1967,9 +1967,9 @@ TEST_CASE("TransactionQueue limiter with DEX separation",
                 txsToEvict, *tx, [&](TransactionFrameBasePtr const& evict) {
                     // can't evict cheaper transactions (
                     // evict.bid/evict.ops < tx->bid/tx->ops)
-                    REQUIRE(bigMultiply(evict->getFeeBid(),
+                    REQUIRE(bigMultiply(evict->getInclusionFee(),
                                         tx->getNumOperations()) <
-                            bigMultiply(tx->getFeeBid(),
+                            bigMultiply(tx->getInclusionFee(),
                                         evict->getNumOperations()));
                     // can't evict self
                     bool same = evict->getSourceID() == tx->getSourceID();

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -541,7 +541,7 @@ LoadGenerator::submitTx(GeneratedLoadConfig const& cfg,
             // transaction.
             from->setSequenceNumber(from->getLastSequenceNumber() - 1);
             CLOG_INFO(LoadGen, "skipped low fee tx with fee {}",
-                      tx->getFeeBid());
+                      tx->getInclusionFee());
             return false;
         }
         if (++numTries >= TX_SUBMIT_MAX_TRIES ||

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -232,19 +232,19 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
         return false;
     }
 
-    if (getInclusionFee() < getMinFee(*this, header.current()))
+    if (getInclusionFee() < getMinInclusionFee(*this, header.current()))
     {
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;
     }
 
     auto const& lh = header.current();
-    uint128_t v1 = bigMultiply(getInclusionFee(), getMinFee(*mInnerTx, lh));
+    uint128_t v1 = bigMultiply(getInclusionFee(), getMinInclusionFee(*mInnerTx, lh));
     uint128_t v2 =
-        bigMultiply(mInnerTx->getInclusionFee(), getMinFee(*this, lh));
+        bigMultiply(mInnerTx->getInclusionFee(), getMinInclusionFee(*this, lh));
     if (v1 < v2)
     {
-        if (!bigDivide128(getResult().feeCharged, v2, getMinFee(*mInnerTx, lh),
+        if (!bigDivide128(getResult().feeCharged, v2, getMinInclusionFee(*mInnerTx, lh),
                           Rounding::ROUND_UP))
         {
             getResult().feeCharged = INT64_MAX;

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -232,15 +232,16 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
         return false;
     }
 
-    if (getFeeBid() < getMinFee(*this, header.current()))
+    if (getInclusionFee() < getMinFee(*this, header.current()))
     {
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;
     }
 
     auto const& lh = header.current();
-    uint128_t v1 = bigMultiply(getFeeBid(), getMinFee(*mInnerTx, lh));
-    uint128_t v2 = bigMultiply(mInnerTx->getFeeBid(), getMinFee(*this, lh));
+    uint128_t v1 = bigMultiply(getInclusionFee(), getMinFee(*mInnerTx, lh));
+    uint128_t v2 =
+        bigMultiply(mInnerTx->getInclusionFee(), getMinFee(*this, lh));
     if (v1 < v2)
     {
         if (!bigDivide128(getResult().feeCharged, v2, getMinFee(*mInnerTx, lh),
@@ -313,9 +314,9 @@ FeeBumpTransactionFrame::getFullFee() const
 }
 
 int64_t
-FeeBumpTransactionFrame::getFeeBid() const
+FeeBumpTransactionFrame::getInclusionFee() const
 {
-    int64_t flatFee = mInnerTx->getFullFee() - mInnerTx->getFeeBid();
+    int64_t flatFee = mInnerTx->getFullFee() - mInnerTx->getInclusionFee();
     return mEnvelope.feeBump().tx.fee - flatFee;
 }
 
@@ -328,11 +329,11 @@ FeeBumpTransactionFrame::getFee(LedgerHeader const& header,
     {
         return getFullFee();
     }
-    int64_t flatFee = mInnerTx->getFullFee() - mInnerTx->getFeeBid();
+    int64_t flatFee = mInnerTx->getFullFee() - mInnerTx->getInclusionFee();
     int64_t adjustedFee = *baseFee * std::max<int64_t>(1, getNumOperations());
     if (applying)
     {
-        return flatFee + std::min<int64_t>(getFeeBid(), adjustedFee);
+        return flatFee + std::min<int64_t>(getInclusionFee(), adjustedFee);
     }
     else
     {

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -239,12 +239,14 @@ FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
     }
 
     auto const& lh = header.current();
-    uint128_t v1 = bigMultiply(getInclusionFee(), getMinInclusionFee(*mInnerTx, lh));
+    uint128_t v1 =
+        bigMultiply(getInclusionFee(), getMinInclusionFee(*mInnerTx, lh));
     uint128_t v2 =
         bigMultiply(mInnerTx->getInclusionFee(), getMinInclusionFee(*this, lh));
     if (v1 < v2)
     {
-        if (!bigDivide128(getResult().feeCharged, v2, getMinInclusionFee(*mInnerTx, lh),
+        if (!bigDivide128(getResult().feeCharged, v2,
+                          getMinInclusionFee(*mInnerTx, lh),
                           Rounding::ROUND_UP))
         {
             getResult().feeCharged = INT64_MAX;

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -71,7 +71,7 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     TransactionEnvelope const& getEnvelope() const override;
 
     int64_t getFullFee() const override;
-    int64_t getFeeBid() const override;
+    int64_t getInclusionFee() const override;
     int64_t getFee(LedgerHeader const& header, std::optional<int64_t> baseFee,
                    bool applying) const override;
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -221,7 +221,7 @@ TransactionFrame::getFullFee() const
 }
 
 int64_t
-TransactionFrame::getFeeBid() const
+TransactionFrame::getInclusionFee() const
 {
     int64_t feeBid = getFullFee();
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
@@ -260,14 +260,14 @@ TransactionFrame::getFee(LedgerHeader const& header,
                                   ProtocolVersion::V_11) ||
         !applying)
     {
-        int64_t feeBid = getFeeBid();
+        int64_t feeBid = getInclusionFee();
         int64_t flatFee = getFullFee() - feeBid;
         int64_t adjustedFee =
             *baseFee * std::max<int64_t>(1, getNumOperations());
 
         if (applying)
         {
-            return flatFee + std::min<int64_t>(getFeeBid(), adjustedFee);
+            return flatFee + std::min<int64_t>(getInclusionFee(), adjustedFee);
         }
         else
         {
@@ -1038,12 +1038,12 @@ TransactionFrame::commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
         return false;
     }
 
-    if (chargeFee && getFeeBid() < getMinFee(*this, header.current()))
+    if (chargeFee && getInclusionFee() < getMinFee(*this, header.current()))
     {
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;
     }
-    if (!chargeFee && getFeeBid() < 0)
+    if (!chargeFee && getInclusionFee() < 0)
     {
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;
@@ -1239,7 +1239,7 @@ TransactionFrame::commonValid(Application& app,
         (applying && protocolVersionStartsFrom(header.current().ledgerVersion,
                                                ProtocolVersion::V_9))
             ? 0
-            : static_cast<uint32_t>(getFeeBid());
+            : static_cast<uint32_t>(getInclusionFee());
     // don't let the account go below the reserve after accounting for
     // liabilities
     if (chargeFee && getAvailableBalance(header, sourceAccount) < feeToPay)

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1038,7 +1038,7 @@ TransactionFrame::commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
         return false;
     }
 
-    if (chargeFee && getInclusionFee() < getMinFee(*this, header.current()))
+    if (chargeFee && getInclusionFee() < getMinInclusionFee(*this, header.current()))
     {
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1038,7 +1038,8 @@ TransactionFrame::commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
         return false;
     }
 
-    if (chargeFee && getInclusionFee() < getMinInclusionFee(*this, header.current()))
+    if (chargeFee &&
+        getInclusionFee() < getMinInclusionFee(*this, header.current()))
     {
         getResult().result.code(txINSUFFICIENT_FEE);
         return false;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1239,7 +1239,7 @@ TransactionFrame::commonValid(Application& app,
         (applying && protocolVersionStartsFrom(header.current().ledgerVersion,
                                                ProtocolVersion::V_9))
             ? 0
-            : static_cast<uint32_t>(getInclusionFee());
+            : static_cast<uint32_t>(getFullFee());
     // don't let the account go below the reserve after accounting for
     // liabilities
     if (chargeFee && getAvailableBalance(header, sourceAccount) < feeToPay)

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -211,7 +211,7 @@ class TransactionFrame : public TransactionFrameBase
     std::vector<Operation> const& getRawOperations() const override;
 
     int64_t getFullFee() const override;
-    int64_t getFeeBid() const override;
+    int64_t getInclusionFee() const override;
 
     virtual int64_t getFee(LedgerHeader const& header,
                            std::optional<int64_t> baseFee,

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -51,7 +51,7 @@ class TransactionFrameBase
     virtual int64_t getFullFee() const = 0;
     // Returns the part of the full fee used to make decisions as to
     // whether this transaction should be included into ledger.
-    virtual int64_t getFeeBid() const = 0;
+    virtual int64_t getInclusionFee() const = 0;
     virtual int64_t getFee(LedgerHeader const& header,
                            std::optional<int64_t> baseFee,
                            bool applying) const = 0;

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1829,7 +1829,7 @@ maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
 }
 
 int64_t
-getMinFee(TransactionFrameBase const& tx, LedgerHeader const& header,
+getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
           std::optional<int64_t> baseFee)
 {
     int64_t effectiveBaseFee = header.baseFee;

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1830,7 +1830,7 @@ maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
 
 int64_t
 getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
-          std::optional<int64_t> baseFee)
+                   std::optional<int64_t> baseFee)
 {
     int64_t effectiveBaseFee = header.baseFee;
     if (baseFee)

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -304,6 +304,7 @@ void maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
                                          LedgerTxnEntry& account);
 
 // Get min _inclusion_ fee needed for this transaction to get included
-int64_t getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
-                  std::optional<int64_t> baseFee = std::nullopt);
+int64_t getMinInclusionFee(TransactionFrameBase const& tx,
+                           LedgerHeader const& header,
+                           std::optional<int64_t> baseFee = std::nullopt);
 }

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -303,6 +303,7 @@ int64_t getPoolWithdrawalAmount(int64_t amountPoolShares,
 void maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
                                          LedgerTxnEntry& account);
 
+// Get min _inclusion_ fee needed for this transaction
 int64_t getMinFee(TransactionFrameBase const& tx, LedgerHeader const& header,
                   std::optional<int64_t> baseFee = std::nullopt);
 }

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -303,7 +303,7 @@ int64_t getPoolWithdrawalAmount(int64_t amountPoolShares,
 void maybeUpdateAccountOnLedgerSeqUpdate(LedgerTxnHeader const& header,
                                          LedgerTxnEntry& account);
 
-// Get min _inclusion_ fee needed for this transaction
-int64_t getMinFee(TransactionFrameBase const& tx, LedgerHeader const& header,
+// Get min _inclusion_ fee needed for this transaction to get included
+int64_t getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
                   std::optional<int64_t> baseFee = std::nullopt);
 }

--- a/src/transactions/test/InflationTests.cpp
+++ b/src/transactions/test/InflationTests.cpp
@@ -224,7 +224,7 @@ doInflation(Application& app, int ledgerVersion, int nbAccounts,
 
     auto root = TestAccount::createRoot(app);
     auto txFrame = root.tx({inflation()});
-    expectedFees += txFrame->getFeeBid();
+    expectedFees += txFrame->getInclusionFee();
 
     expectedBalances = simulateInflation(
         ledgerVersion, nbAccounts, expectedTotcoins, expectedFees,

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -322,11 +322,12 @@ TEST_CASE("basic contract invocation", "[tx][soroban]")
         if (success)
         {
             REQUIRE(tx->getFullFee() == 100'000);
-            REQUIRE(tx->getFeeBid() == 65'117);
+            REQUIRE(tx->getInclusionFee() == 65'117);
             // Initially we store in result the charge for resources plus
             // minimum inclusion  fee bid (currently equivalent to the network
             // `baseFee` of 100).
-            int64_t baseCharged = (tx->getFullFee() - tx->getFeeBid()) + 100;
+            int64_t baseCharged =
+                (tx->getFullFee() - tx->getInclusionFee()) + 100;
             REQUIRE(tx->getResult().feeCharged == baseCharged);
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
@@ -652,7 +653,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
         // Initially we store in result the charge for resources plus
         // minimum inclusion  fee bid (currently equivalent to the network
         // `baseFee` of 100).
-        int64_t baseCharged = (tx->getFullFee() - tx->getFeeBid()) + 100;
+        int64_t baseCharged = (tx->getFullFee() - tx->getInclusionFee()) + 100;
         REQUIRE(tx->getResult().feeCharged == baseCharged);
         // Charge the fee.
         {

--- a/src/transactions/test/MergeTests.cpp
+++ b/src/transactions/test/MergeTests.cpp
@@ -83,17 +83,19 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                        a1.op(accountMerge(b1))});
             txFrame->addSignature(b1.getSecretKey());
 
-            auto applyResult = expectedResult(
-                txfee * 3, 3, txSUCCESS,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()},
-                 CREATE_ACCOUNT_SUCCESS,
-                 {ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()}});
+            auto applyResult =
+                expectedResult(txfee * 3, 3, txSUCCESS,
+                               {{ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()},
+                                CREATE_ACCOUNT_SUCCESS,
+                                {ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()}});
             validateTxResults(txFrame, *app, {txfee * 3, txSUCCESS},
                               applyResult);
 
             REQUIRE(b1.getBalance() == 2 * a1Balance + b1Balance -
                                            createBalance -
-                                           2 * txFrame->getFeeBid());
+                                           2 * txFrame->getInclusionFee());
             REQUIRE(!doesAccountExist(*app, a1));
         });
 
@@ -104,16 +106,17 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                        a1.op(accountMerge(b1))});
             txFrame->addSignature(b1.getSecretKey());
 
-            auto applyResult = expectedResult(
-                txfee * 3, 3, txSUCCESS,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()},
-                 CREATE_ACCOUNT_SUCCESS,
-                 {ACCOUNT_MERGE_SUCCESS, createBalance}});
+            auto applyResult =
+                expectedResult(txfee * 3, 3, txSUCCESS,
+                               {{ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()},
+                                CREATE_ACCOUNT_SUCCESS,
+                                {ACCOUNT_MERGE_SUCCESS, createBalance}});
             validateTxResults(txFrame, *app, {txfee * 3, txSUCCESS},
                               applyResult);
 
             REQUIRE(b1.getBalance() ==
-                    a1Balance + b1Balance - txFrame->getFeeBid());
+                    a1Balance + b1Balance - txFrame->getInclusionFee());
             REQUIRE(!doesAccountExist(*app, a1));
         });
 
@@ -125,11 +128,12 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             txFrame->addSignature(b1.getSecretKey());
 
             // can't merge an account that just got created
-            auto applyResult = expectedResult(
-                txfee * 3, 3, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()},
-                 CREATE_ACCOUNT_SUCCESS,
-                 ACCOUNT_MERGE_SEQNUM_TOO_FAR});
+            auto applyResult =
+                expectedResult(txfee * 3, 3, txFAILED,
+                               {{ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()},
+                                CREATE_ACCOUNT_SUCCESS,
+                                ACCOUNT_MERGE_SEQNUM_TOO_FAR});
             validateTxResults(txFrame, *app, {txfee * 3, txSUCCESS},
                               applyResult);
         });
@@ -158,9 +162,9 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             REQUIRE(mergeResult.code() == ACCOUNT_MERGE_SUCCESS);
             REQUIRE(mergeResult.sourceAccountBalance() ==
                     a1Balance + b1Balance - createBalance -
-                        txFrame->getFeeBid());
+                        txFrame->getInclusionFee());
             REQUIRE(a1.getBalance() ==
-                    a1Balance + b1Balance - txFrame->getFeeBid());
+                    a1Balance + b1Balance - txFrame->getInclusionFee());
             REQUIRE(!doesAccountExist(*app, b1));
             // a1 gets recreated with a sequence number based on the current
             // ledger
@@ -182,14 +186,14 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
 
             auto applyResult = expectedResult(
                 txfee * 3, 3, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getFeeBid()},
+                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getInclusionFee()},
                  CREATE_ACCOUNT_ALREADY_EXIST,
-                 {ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getFeeBid()}});
+                 {ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getInclusionFee()}});
             validateTxResults(tx, *app, {txfee * 3, txSUCCESS}, applyResult);
 
             REQUIRE(doesAccountExist(*app, a1));
             REQUIRE(doesAccountExist(*app, b1));
-            REQUIRE(a1.getBalance() == a1Balance - tx->getFeeBid());
+            REQUIRE(a1.getBalance() == a1Balance - tx->getInclusionFee());
             REQUIRE(b1.getBalance() == b1Balance);
             REQUIRE(a1.loadSequenceNumber() == a1SeqNum + 1);
             REQUIRE(b1.loadSequenceNumber() == b1SeqNum);
@@ -201,14 +205,14 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
 
             auto applyResult = expectedResult(
                 txfee * 3, 3, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getFeeBid()},
+                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getInclusionFee()},
                  CREATE_ACCOUNT_ALREADY_EXIST,
                  ACCOUNT_MERGE_NO_ACCOUNT});
             validateTxResults(tx, *app, {txfee * 3, txSUCCESS}, applyResult);
 
             REQUIRE(doesAccountExist(*app, a1));
             REQUIRE(doesAccountExist(*app, b1));
-            REQUIRE(a1.getBalance() == a1Balance - tx->getFeeBid());
+            REQUIRE(a1.getBalance() == a1Balance - tx->getInclusionFee());
             REQUIRE(b1.getBalance() == b1Balance);
             REQUIRE(a1.loadSequenceNumber() == a1SeqNum + 1);
             REQUIRE(b1.loadSequenceNumber() == b1SeqNum);
@@ -220,14 +224,14 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
 
             auto applyResult = expectedResult(
                 txfee * 3, 3, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getFeeBid()},
+                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getInclusionFee()},
                  opNO_ACCOUNT,
                  opNO_ACCOUNT});
             validateTxResults(tx, *app, {txfee * 3, txSUCCESS}, applyResult);
 
             REQUIRE(doesAccountExist(*app, a1));
             REQUIRE(doesAccountExist(*app, b1));
-            REQUIRE(a1.getBalance() == a1Balance - tx->getFeeBid());
+            REQUIRE(a1.getBalance() == a1Balance - tx->getInclusionFee());
             REQUIRE(b1.getBalance() == b1Balance);
             REQUIRE(a1.loadSequenceNumber() == a1SeqNum + 1);
             REQUIRE(b1.loadSequenceNumber() == b1SeqNum);
@@ -254,7 +258,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             REQUIRE(doesAccountExist(*app, a1));
             REQUIRE(doesAccountExist(*app, b1));
             REQUIRE(!doesAccountExist(*app, c1.getPublicKey()));
-            REQUIRE(a1.getBalance() == a1Balance - tx->getFeeBid());
+            REQUIRE(a1.getBalance() == a1Balance - tx->getInclusionFee());
             REQUIRE(b1.getBalance() == b1Balance);
             REQUIRE(a1.loadSequenceNumber() == a1SeqNum + 1);
             REQUIRE(b1.loadSequenceNumber() == b1SeqNum);
@@ -267,7 +271,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
 
             auto applyResult = expectedResult(
                 txfee * 3, 3, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getFeeBid()},
+                {{ACCOUNT_MERGE_SUCCESS, a1Balance - tx->getInclusionFee()},
                  opNO_ACCOUNT,
                  opNO_ACCOUNT});
             validateTxResults(tx, *app, {txfee * 3, txSUCCESS}, applyResult);
@@ -275,7 +279,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             REQUIRE(doesAccountExist(*app, a1));
             REQUIRE(doesAccountExist(*app, b1));
             REQUIRE(!doesAccountExist(*app, c1.getPublicKey()));
-            REQUIRE(a1.getBalance() == a1Balance - tx->getFeeBid());
+            REQUIRE(a1.getBalance() == a1Balance - tx->getInclusionFee());
             REQUIRE(b1.getBalance() == b1Balance);
             REQUIRE(a1.loadSequenceNumber() == a1SeqNum + 1);
             REQUIRE(b1.loadSequenceNumber() == b1SeqNum);
@@ -290,14 +294,16 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
         for_versions_to(4, *app, [&] {
             auto txFrame = a1.tx({accountMerge(b1), accountMerge(b1)});
 
-            auto applyResult = expectedResult(
-                txfee * 2, 2, txSUCCESS,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()},
-                 {ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()}});
+            auto applyResult =
+                expectedResult(txfee * 2, 2, txSUCCESS,
+                               {{ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()},
+                                {ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()}});
             validateTxResults(txFrame, *app, {txfee * 2, txSUCCESS},
                               applyResult);
 
-            auto a1BalanceAfterFee = a1Balance - txFrame->getFeeBid();
+            auto a1BalanceAfterFee = a1Balance - txFrame->getInclusionFee();
             REQUIRE(b1Balance + a1BalanceAfterFee + a1BalanceAfterFee ==
                     b1.getBalance());
             REQUIRE(!doesAccountExist(*app, a1));
@@ -306,29 +312,33 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
         for_versions(5, 7, *app, [&] {
             auto txFrame = a1.tx({accountMerge(b1), accountMerge(b1)});
 
-            auto applyResult = expectedResult(
-                txfee * 2, 2, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()},
-                 ACCOUNT_MERGE_NO_ACCOUNT});
+            auto applyResult =
+                expectedResult(txfee * 2, 2, txFAILED,
+                               {{ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()},
+                                ACCOUNT_MERGE_NO_ACCOUNT});
             validateTxResults(txFrame, *app, {txfee * 2, txSUCCESS},
                               applyResult);
 
             REQUIRE(b1Balance == b1.getBalance());
-            REQUIRE((a1Balance - txFrame->getFeeBid()) == a1.getBalance());
+            REQUIRE((a1Balance - txFrame->getInclusionFee()) ==
+                    a1.getBalance());
         });
 
         for_versions_from(8, *app, [&] {
             auto txFrame = a1.tx({accountMerge(b1), accountMerge(b1)});
 
-            auto applyResult = expectedResult(
-                txfee * 2, 2, txFAILED,
-                {{ACCOUNT_MERGE_SUCCESS, a1Balance - txFrame->getFeeBid()},
-                 opNO_ACCOUNT});
+            auto applyResult =
+                expectedResult(txfee * 2, 2, txFAILED,
+                               {{ACCOUNT_MERGE_SUCCESS,
+                                 a1Balance - txFrame->getInclusionFee()},
+                                opNO_ACCOUNT});
             validateTxResults(txFrame, *app, {txfee * 2, txSUCCESS},
                               applyResult);
 
             REQUIRE(b1Balance == b1.getBalance());
-            REQUIRE((a1Balance - txFrame->getFeeBid()) == a1.getBalance());
+            REQUIRE((a1Balance - txFrame->getInclusionFee()) ==
+                    a1.getBalance());
         });
     }
 
@@ -346,7 +356,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             auto result = MergeOpFrame::getInnerCode(
                 txFrame->getResult().result.results()[1]);
 
-            auto a1BalanceAfterFee = a1Balance - txFrame->getFeeBid();
+            auto a1BalanceAfterFee = a1Balance - txFrame->getInclusionFee();
             REQUIRE(result == ACCOUNT_MERGE_NO_ACCOUNT);
             REQUIRE(a1BalanceAfterFee == a1.getBalance());
             REQUIRE(doesAccountExist(*app, a1));
@@ -377,7 +387,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             REQUIRE(doesAccountExist(*app, a1));
             REQUIRE(!doesAccountExist(*app, c.getPublicKey()));
             REQUIRE(!doesAccountExist(*app, d.getPublicKey()));
-            REQUIRE(a1Balance == a1.getBalance() + txFrame->getFeeBid());
+            REQUIRE(a1Balance == a1.getBalance() + txFrame->getInclusionFee());
         });
 
         for_versions_from(8, *app, [&] {
@@ -390,7 +400,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
                 txfee * 3, 3, txFAILED,
                 {CREATE_ACCOUNT_SUCCESS,
                  {ACCOUNT_MERGE_SUCCESS,
-                  a1Balance - createBalance - txFrame->getFeeBid()},
+                  a1Balance - createBalance - txFrame->getInclusionFee()},
                  opNO_ACCOUNT});
             validateTxResults(txFrame, *app, {txfee * 3, txSUCCESS},
                               applyResult);
@@ -400,7 +410,7 @@ TEST_CASE_VERSIONS("merge", "[tx][merge]")
             REQUIRE(!doesAccountExist(*app, d.getPublicKey()));
             REQUIRE(txFrame->getResultCode() == txFAILED);
 
-            REQUIRE(a1Balance == a1.getBalance() + txFrame->getFeeBid());
+            REQUIRE(a1Balance == a1.getBalance() + txFrame->getInclusionFee());
         });
     }
 

--- a/src/transactions/test/PaymentTests.cpp
+++ b/src/transactions/test/PaymentTests.cpp
@@ -114,7 +114,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(b1.exists());
             REQUIRE(txFrame->getResultCode() == txSUCCESS);
 
-            REQUIRE((a1Balance + b1Balance - txFrame->getFeeBid()) ==
+            REQUIRE((a1Balance + b1Balance - txFrame->getInclusionFee()) ==
                     b1.getBalance());
         });
     }
@@ -139,7 +139,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!b1.exists());
             REQUIRE(txFrame->getResultCode() == txSUCCESS);
 
-            REQUIRE((a1Balance + b1Balance - txFrame->getFeeBid()) ==
+            REQUIRE((a1Balance + b1Balance - txFrame->getInclusionFee()) ==
                     a1.getBalance());
         });
     }
@@ -162,7 +162,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(txFrame->getResultCode() == txINTERNAL_ERROR);
 
             REQUIRE(b1Balance == b1.getBalance());
-            REQUIRE((a1Balance - txFrame->getFeeBid()) == a1.getBalance());
+            REQUIRE((a1Balance - txFrame->getInclusionFee()) ==
+                    a1.getBalance());
         });
 
         for_versions_from(8, *app, [&] {
@@ -175,7 +176,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(txFrame->getResultCode() == txFAILED);
 
             REQUIRE(b1Balance == b1.getBalance());
-            REQUIRE((a1Balance - txFrame->getFeeBid()) == a1.getBalance());
+            REQUIRE((a1Balance - txFrame->getInclusionFee()) ==
+                    a1.getBalance());
         });
     }
 
@@ -318,7 +320,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, createSourceAccount));
             REQUIRE(createSourceAccount.getBalance() ==
-                    amount - tx->getFeeBid());
+                    amount - tx->getInclusionFee());
 
             REQUIRE(tx->getResult().result.code() == txSUCCESS);
             REQUIRE(tx->getResult().result.results()[0].code() == opINNER);
@@ -342,7 +344,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - createAmount - tx->getFeeBid());
+                    amount - createAmount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() == PAYMENT);
             REQUIRE(tx->getResult()
@@ -361,7 +363,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!applyCheck(tx, *app));
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(!doesAccountExist(*app, createSourceAccount));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
 
             REQUIRE(tx->getResult().result.code() == txFAILED);
@@ -386,7 +389,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - createAmount - tx->getFeeBid());
+                    amount - createAmount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opNO_ACCOUNT);
         });
     }
@@ -411,7 +414,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(!doesAccountExist(*app, createSourceAccount));
             REQUIRE(doesAccountExist(*app, payAccount));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(payAccount.getBalance() == amount);
 
             REQUIRE(tx->getResult().result.code() == txINTERNAL_ERROR);
@@ -427,7 +431,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(!doesAccountExist(*app, createSourceAccount));
             REQUIRE(doesAccountExist(*app, payAccount));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(payAccount.getBalance() == amount);
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
 
@@ -453,7 +458,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - createAmount - tx->getFeeBid());
+                    amount - createAmount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opNO_ACCOUNT);
         });
         // 10 and above, operation #2 fails (already covered in merge tests)
@@ -486,7 +491,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, payAndMergeDestination));
             REQUIRE(sourceAccount.getBalance() == createAmount);
             REQUIRE(payAndMergeDestination.getBalance() ==
-                    amount + amount - createAmount - tx->getFeeBid());
+                    amount + amount - createAmount - tx->getInclusionFee());
             REQUIRE(sourceAccount.loadSequenceNumber() == 0x700000000ull);
             REQUIRE(payAndMergeDestination.loadSequenceNumber() ==
                     payAndMergeDestinationSeqNum);
@@ -511,7 +516,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[1]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() ==
                     CREATE_ACCOUNT);
@@ -547,7 +553,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, payAndMergeDestination));
             REQUIRE(sourceAccount.getBalance() == createAmount);
             REQUIRE(payAndMergeDestination.getBalance() ==
-                    amount + amount - createAmount - tx->getFeeBid());
+                    amount + amount - createAmount - tx->getInclusionFee());
             REQUIRE(sourceAccount.loadSequenceNumber() == 0x700000000ull);
             REQUIRE(payAndMergeDestination.loadSequenceNumber() ==
                     payAndMergeDestinationSeqNum);
@@ -572,7 +578,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[1]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() ==
                     CREATE_ACCOUNT);
@@ -616,9 +623,9 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, payAndMergeDestination));
             REQUIRE(sourceAccount.getBalance() ==
-                    amount - pay1Amount - pay2Amount - tx->getFeeBid());
+                    amount - pay1Amount - pay2Amount - tx->getInclusionFee());
             REQUIRE(payAndMergeDestination.getBalance() ==
-                    amount + amount + pay2Amount - tx->getFeeBid() -
+                    amount + amount + pay2Amount - tx->getInclusionFee() -
                         createAmount);
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
             REQUIRE(payAndMergeDestination.loadSequenceNumber() ==
@@ -645,7 +652,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - pay1Amount - tx->getFeeBid());
+                    amount - pay1Amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() ==
                     CREATE_ACCOUNT);
@@ -679,7 +686,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, payAndMergeDestination));
             REQUIRE(sourceAccount.getBalance() == createAmount - pay2Amount);
             REQUIRE(payAndMergeDestination.getBalance() ==
-                    amount + amount + pay2Amount - tx->getFeeBid() -
+                    amount + amount + pay2Amount - tx->getInclusionFee() -
                         createAmount);
             REQUIRE(sourceAccount.loadSequenceNumber() == 0x700000000ull);
             REQUIRE(payAndMergeDestination.loadSequenceNumber() ==
@@ -706,7 +713,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - pay1Amount - tx->getFeeBid());
+                    amount - pay1Amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() ==
                     CREATE_ACCOUNT);
@@ -753,10 +760,10 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, secondSourceAccount));
             REQUIRE(doesAccountExist(*app, payAndMergeDestination));
             REQUIRE(sourceAccount.getBalance() ==
-                    amount - pay1Amount - pay2Amount - tx->getFeeBid());
+                    amount - pay1Amount - pay2Amount - tx->getInclusionFee());
             REQUIRE(secondSourceAccount.getBalance() == amount - createAmount);
             REQUIRE(payAndMergeDestination.getBalance() ==
-                    amount + amount + pay2Amount - tx->getFeeBid());
+                    amount + amount + pay2Amount - tx->getInclusionFee());
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
             REQUIRE(secondSourceAccount.loadSequenceNumber() ==
                     secondSourceSeqNum);
@@ -784,7 +791,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - pay1Amount - tx->getFeeBid());
+                    amount - pay1Amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() ==
                     CREATE_ACCOUNT);
@@ -820,7 +827,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(sourceAccount.getBalance() == createAmount - pay2Amount);
             REQUIRE(secondSourceAccount.getBalance() == amount - createAmount);
             REQUIRE(payAndMergeDestination.getBalance() ==
-                    amount + amount + pay2Amount - tx->getFeeBid());
+                    amount + amount + pay2Amount - tx->getInclusionFee());
             REQUIRE(sourceAccount.loadSequenceNumber() == 0x800000000ull);
             REQUIRE(secondSourceAccount.loadSequenceNumber() ==
                     secondSourceSeqNum);
@@ -848,7 +855,7 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .tr()
                         .accountMergeResult()
                         .sourceAccountBalance() ==
-                    amount - pay1Amount - tx->getFeeBid());
+                    amount - pay1Amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() ==
                     CREATE_ACCOUNT);
@@ -899,7 +906,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(doesAccountExist(*app, createSource));
             REQUIRE(doesAccountExist(*app, createDestination));
             REQUIRE(doesAccountExist(*app, payDestination));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(createSource.getBalance() == amount + amount -
                                                      create1Amount -
                                                      create2Amount + payAmount);
@@ -972,8 +980,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, mergeDestination));
             REQUIRE(mergeDestination.getBalance() == amount + amount + amount -
-                                                         tx->getFeeBid() -
-                                                         tx->getFeeBid());
+                                                         tx->getInclusionFee() -
+                                                         tx->getInclusionFee());
             REQUIRE(mergeDestination.loadSequenceNumber() ==
                     mergeDestinationSeqNum);
 
@@ -995,7 +1003,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[1]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() == PAYMENT);
             REQUIRE(tx->getResult()
@@ -1013,7 +1022,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[3]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
         });
 
         for_versions(5, 7, *app, [&] {
@@ -1025,7 +1035,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!applyCheck(tx, *app));
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, mergeDestination));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(mergeDestination.getBalance() == amount);
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
             REQUIRE(mergeDestination.loadSequenceNumber() ==
@@ -1049,7 +1060,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[1]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[2].tr().type() == PAYMENT);
             REQUIRE(tx->getResult()
@@ -1074,7 +1086,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!applyCheck(tx, *app));
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, mergeDestination));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(mergeDestination.getBalance() == amount);
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
             REQUIRE(mergeDestination.loadSequenceNumber() ==
@@ -1098,7 +1111,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[1]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[2].code() == opNO_ACCOUNT);
             REQUIRE(tx->getResult().result.results()[3].code() == opNO_ACCOUNT);
         });
@@ -1130,8 +1144,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, mergeDestination));
             REQUIRE(mergeDestination.getBalance() == amount + amount + amount -
-                                                         tx->getFeeBid() -
-                                                         tx->getFeeBid());
+                                                         tx->getInclusionFee() -
+                                                         tx->getInclusionFee());
             REQUIRE(mergeDestination.loadSequenceNumber() ==
                     mergeDestinationSeqNum);
 
@@ -1188,7 +1202,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[6]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[7].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[7].tr().type() == PAYMENT);
             REQUIRE(tx->getResult()
@@ -1213,7 +1228,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[9]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
         });
 
         for_versions(5, 7, *app, [&] {
@@ -1231,7 +1247,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!applyCheck(tx, *app));
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, mergeDestination));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(mergeDestination.getBalance() == amount);
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
             REQUIRE(mergeDestination.loadSequenceNumber() ==
@@ -1290,7 +1307,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[6]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[7].code() == opINNER);
             REQUIRE(tx->getResult().result.results()[7].tr().type() == PAYMENT);
             REQUIRE(tx->getResult()
@@ -1328,7 +1346,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
             REQUIRE(!applyCheck(tx, *app));
             REQUIRE(doesAccountExist(*app, sourceAccount));
             REQUIRE(doesAccountExist(*app, mergeDestination));
-            REQUIRE(sourceAccount.getBalance() == amount - tx->getFeeBid());
+            REQUIRE(sourceAccount.getBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(mergeDestination.getBalance() == amount);
             REQUIRE(sourceAccount.loadSequenceNumber() == sourceSeqNum + 1);
             REQUIRE(mergeDestination.loadSequenceNumber() ==
@@ -1387,7 +1406,8 @@ TEST_CASE_VERSIONS("payment", "[tx][payment]")
                         .result.results()[6]
                         .tr()
                         .accountMergeResult()
-                        .sourceAccountBalance() == amount - tx->getFeeBid());
+                        .sourceAccountBalance() ==
+                    amount - tx->getInclusionFee());
             REQUIRE(tx->getResult().result.results()[7].code() == opNO_ACCOUNT);
             REQUIRE(tx->getResult().result.results()[8].code() == opNO_ACCOUNT);
             REQUIRE(tx->getResult().result.results()[9].code() == opNO_ACCOUNT);

--- a/src/transactions/test/TxResultsTests.cpp
+++ b/src/transactions/test/TxResultsTests.cpp
@@ -117,7 +117,8 @@ TEST_CASE_VERSIONS("txresults", "[tx][txresults]")
             {
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({payment(root, 1)});
-                    setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
+                    setFee(tx,
+                           static_cast<uint32_t>(tx->getInclusionFee()) - 1);
                     validateTxResults(tx, *app, {baseFee, txINSUFFICIENT_FEE});
                 });
             }
@@ -185,7 +186,8 @@ TEST_CASE_VERSIONS("txresults", "[tx][txresults]")
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({payment(root, 1)});
                     getSignatures(tx).clear();
-                    setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
+                    setFee(tx,
+                           static_cast<uint32_t>(tx->getInclusionFee()) - 1);
                     validateTxResults(tx, *app, {baseFee, txINSUFFICIENT_FEE});
                 });
             }
@@ -266,7 +268,8 @@ TEST_CASE_VERSIONS("txresults", "[tx][txresults]")
                 for_all_versions(*app, [&] {
                     auto tx = a.tx({payment(root, 1)});
                     tx->addSignature(a);
-                    setFee(tx, static_cast<uint32_t>(tx->getFeeBid()) - 1);
+                    setFee(tx,
+                           static_cast<uint32_t>(tx->getInclusionFee()) - 1);
                     validateTxResults(tx, *app, {baseFee, txINSUFFICIENT_FEE});
                 });
             }
@@ -330,11 +333,12 @@ TEST_CASE_VERSIONS("txresults", "[tx][txresults]")
                     {payment(b, 1000), accountMerge(root), payment(c, 1000)});
                 validateTxResults(
                     tx, *app, {baseFee * 3, txSUCCESS},
-                    expectedResult(baseFee * 3, 3, txFAILED,
-                                   {PAYMENT_SUCCESS,
-                                    {ACCOUNT_MERGE_SUCCESS,
-                                     startAmount - tx->getFeeBid() - 1000},
-                                    opNO_ACCOUNT}));
+                    expectedResult(
+                        baseFee * 3, 3, txFAILED,
+                        {PAYMENT_SUCCESS,
+                         {ACCOUNT_MERGE_SUCCESS,
+                          startAmount - tx->getInclusionFee() - 1000},
+                         opNO_ACCOUNT}));
             });
         }
     }


### PR DESCRIPTION
Extracting these changes from my flooding tess as there is no reason to bundle them together. 
* rename getFeeBid -> getIncusionFee; this improves readability and helps spot inclusion fee better
* Resolves https://github.com/stellar/stellar-core/issues/3836
* Updates tx queue limiter to return minimum _full_ fee needed to evict, not just inclusion

I added some comments to help clarify when to use inclusion vs full fee. Reviewers, please help audit inclusion fee usage.