### PR TITLE
Emitting diagnostic event containing Soroban resource utilization metrics

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -71,6 +71,7 @@ mod rust_bridge {
         expiration_bumps: Vec<Bump>,
         cpu_insns: u64,
         mem_bytes: u64,
+        time_nsecs: u64,
     }
 
     // LogLevel declares to cxx.rs a shared type that both Rust and C+++ will

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -129,7 +129,7 @@ makeU64(uint64_t u)
 }
 
 DiagnosticEvent
-metrics_event(bool success, std::string const& topic, uint32 value)
+metricsEvent(bool success, std::string const& topic, uint32 value)
 {
     DiagnosticEvent de;
     de.inSuccessfulContractCall = success;
@@ -334,49 +334,49 @@ InvokeHostFunctionOpFrame::maybePopulateDiagnosticEvents(
 
         // add additional diagnostic events for metrics
         diagnosticEvents.emplace_back(
-            metrics_event(metrics.mSuccess, "read_entry", metrics.mReadEntry));
-        diagnosticEvents.emplace_back(metrics_event(
-            metrics.mSuccess, "write_entry", metrics.mWriteEntry));
-        diagnosticEvents.emplace_back(metrics_event(
+            metricsEvent(metrics.mSuccess, "read_entry", metrics.mReadEntry));
+        diagnosticEvents.emplace_back(
+            metricsEvent(metrics.mSuccess, "write_entry", metrics.mWriteEntry));
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "ledger_read_byte", metrics.mLedgerReadByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "ledger_write_byte", metrics.mLedgerWriteByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "read_key_byte", metrics.mReadKeyByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "write_key_byte", metrics.mWriteKeyByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "read_data_byte", metrics.mReadDataByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "write_data_byte", metrics.mWriteDataByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "read_code_byte", metrics.mReadCodeByte));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "write_code_byte", metrics.mWriteCodeByte));
         diagnosticEvents.emplace_back(
-            metrics_event(metrics.mSuccess, "emit_event", metrics.mEmitEvent));
-        diagnosticEvents.emplace_back(metrics_event(
+            metricsEvent(metrics.mSuccess, "emit_event", metrics.mEmitEvent));
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "emit_event_byte", metrics.mEmitEventByte));
         diagnosticEvents.emplace_back(
-            metrics_event(metrics.mSuccess, "cpu_insn", metrics.mCpuInsn));
+            metricsEvent(metrics.mSuccess, "cpu_insn", metrics.mCpuInsn));
         diagnosticEvents.emplace_back(
-            metrics_event(metrics.mSuccess, "mem_byte", metrics.mMemByte));
-        diagnosticEvents.emplace_back(metrics_event(
+            metricsEvent(metrics.mSuccess, "mem_byte", metrics.mMemByte));
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "invoke_time_nsecs", metrics.mInvokeTimeNsecs));
-        diagnosticEvents.emplace_back(metrics_event(
+        diagnosticEvents.emplace_back(metricsEvent(
             metrics.mSuccess, "max_rw_key_byte", metrics.mMaxReadWriteKeyByte));
         diagnosticEvents.emplace_back(
-            metrics_event(metrics.mSuccess, "max_rw_data_byte",
-                          metrics.mMaxReadWriteDataByte));
+            metricsEvent(metrics.mSuccess, "max_rw_data_byte",
+                         metrics.mMaxReadWriteDataByte));
         diagnosticEvents.emplace_back(
-            metrics_event(metrics.mSuccess, "max_rw_code_byte",
-                          metrics.mMaxReadWriteCodeByte));
-        diagnosticEvents.emplace_back(metrics_event(metrics.mSuccess,
-                                                    "max_emit_event_byte",
-                                                    metrics.mMaxEmitEventByte));
-        diagnosticEvents.emplace_back(metrics_event(metrics.mSuccess,
-                                                    "max_meta_data_size_byte",
-                                                    metrics.mMetadataSizeByte));
+            metricsEvent(metrics.mSuccess, "max_rw_code_byte",
+                         metrics.mMaxReadWriteCodeByte));
+        diagnosticEvents.emplace_back(metricsEvent(metrics.mSuccess,
+                                                   "max_emit_event_byte",
+                                                   metrics.mMaxEmitEventByte));
+        diagnosticEvents.emplace_back(metricsEvent(metrics.mSuccess,
+                                                   "max_meta_data_size_byte",
+                                                   metrics.mMetadataSizeByte));
 
         mParentTx.pushDiagnosticEvents(std::move(diagnosticEvents));
     }

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -26,7 +26,8 @@ class InvokeHostFunctionOpFrame : public OperationFrame
     }
 
     void maybePopulateDiagnosticEvents(Config const& cfg,
-                                       InvokeHostFunctionOutput const& output);
+                                       InvokeHostFunctionOutput const& output,
+                                       HostFunctionMetrics const& metrics);
 
     InvokeHostFunctionOp const& mInvokeHostFunction;
 


### PR DESCRIPTION
# Description

Resolves #https://github.com/stellar/stellar-core/issues/3759
This PR adds a few metrics to inform on network utilization and help answer the question "how close we are to the limits".
It adds the the metrics as diagnostic events, so that they can be consumed by the downstream. 
It also adds a new "invoke time" metric which is a better comparison to the cpu instructions than the current "exec time", resolving https://github.com/stellar/stellar-core/issues/3776#issuecomment-1624419267

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
