### PR TITLE
Add test override for MINIMUM_PERSISTENT_ENTRY_LIFETIME

### DIFF
--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -328,7 +328,7 @@ initialCpuCostParamsEntry(Config const& cfg)
 }
 
 ConfigSettingEntry
-initialStateExpirationSettings()
+initialStateExpirationSettings(Config const& cfg)
 {
     ConfigSettingEntry entry(CONFIG_SETTING_STATE_EXPIRATION);
 
@@ -336,8 +336,12 @@ initialStateExpirationSettings()
         InitialSorobanNetworkConfig::AUTO_BUMP_NUM_LEDGERS;
     entry.stateExpirationSettings().maxEntryExpiration =
         InitialSorobanNetworkConfig::MAXIMUM_ENTRY_LIFETIME;
+
+    // TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME defaults to
+    // InitialSorobanNetworkConfig::MINIMUM_PERSISTENT_ENTRY_LIFETIME
     entry.stateExpirationSettings().minPersistentEntryExpiration =
-        InitialSorobanNetworkConfig::MINIMUM_PERSISTENT_ENTRY_LIFETIME;
+        cfg.TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME;
+
     entry.stateExpirationSettings().minTempEntryExpiration =
         InitialSorobanNetworkConfig::MINIMUM_TEMP_ENTRY_LIFETIME;
     entry.stateExpirationSettings().bucketListSizeWindowSampleSize =
@@ -509,7 +513,7 @@ SorobanNetworkConfig::createLedgerEntriesForV20(AbstractLedgerTxn& ltx,
                              ltx);
     createConfigSettingEntry(initialCpuCostParamsEntry(cfg), ltx);
     createConfigSettingEntry(initialMemCostParamsEntry(cfg), ltx);
-    createConfigSettingEntry(initialStateExpirationSettings(), ltx);
+    createConfigSettingEntry(initialStateExpirationSettings(cfg), ltx);
 
     createConfigSettingEntry(initialbucketListSizeWindow(app), ltx);
 #endif

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -276,6 +276,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false;
+    TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME =
+        InitialSorobanNetworkConfig::MINIMUM_PERSISTENT_ENTRY_LIFETIME;
 #endif
 
 #ifdef BUILD_TESTS
@@ -1448,6 +1450,22 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "ENABLE_SOROBAN_DIAGNOSTIC_EVENTS")
             {
                 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = readBool(item);
+            }
+            else if (item.first == "TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME")
+            {
+                TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME =
+                    readInt<uint32_t>(item);
+                if (TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME == 0)
+                {
+                    throw std::invalid_argument(
+                        "TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME must be "
+                        "positive");
+                }
+
+                LOG_WARNING(
+                    DEFAULT_LOG,
+                    "Overriding MINIMUM_PERSISTENT_ENTRY_LIFETIME to {}",
+                    TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME);
             }
 #endif
             else if (item.first == "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING")

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -576,6 +576,10 @@ class Config : public std::enable_shared_from_this<Config>
     // events so ordering can be maintained between all events. The default
     // value is false, and this should not be enabled on validators.
     bool ENABLE_SOROBAN_DIAGNOSTIC_EVENTS;
+
+    // Override the initial hardcoded MINIMUM_PERSISTENT_ENTRY_LIFETIME
+    // for testing.
+    uint32_t TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME;
 #endif
 
 #ifdef BUILD_TESTS


### PR DESCRIPTION
# Description

This will allow downstream systems to decrease the persistent entry lifetime for testing. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
