### PR TITLE
Move expiration enforcement to OpFrame level

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -919,44 +919,19 @@ mergeCasesWithEqualKeys(MergeCounters& mc, BucketInputIterator& oi,
 
     if (newEntry.type() == INITENTRY)
     {
-        // For all entries except TEMPORARY entries, the only legal new-is-INIT
-        // case is merging a delete+create to an update. For TEMPORARY entries,
-        // an INIT entry may merge with another INIT entry as long as the older
-        // INIT entry is expired. Because merging occurs on a background thread
-        // and different validators may start a merge at different times, it is
-        // not possible to accurately know the current ledgerSeq or to know if a
-        // given TEMPORARY entry has expired. Due to this, we don't check this
-        // invariant for TEMPORARY entries
-
-        // TODO: Add invariant check for TEMPORARY entries based on ledgerSeq
-        // when the given bucket started to merge
+        // The only legal new-is-INIT case is merging a delete+create to an
+        // update.
         if (oldEntry.type() != DEADENTRY)
         {
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-            if (auto type = oldEntry.liveEntry().data.type();
-                type == CONTRACT_DATA || type == CONTRACT_CODE)
-            {
-                // Treat merge as if old entry did not exist
-                ++mc.mNewEntriesDefaultAccepted;
-                Bucket::checkProtocolLegality(newEntry, protocolVersion);
-                countNewEntryType(mc, newEntry);
-                maybePut(out, newEntry, shadowIterators,
-                         keepShadowedLifecycleEntries, mc);
-            }
-            else
-#endif
-                throw std::runtime_error(
-                    "Malformed bucket: old non-DEAD + new INIT.");
+            throw std::runtime_error(
+                "Malformed bucket: old non-DEAD + new INIT.");
         }
-        else
-        {
-            BucketEntry newLive;
-            newLive.type(LIVEENTRY);
-            newLive.liveEntry() = newEntry.liveEntry();
-            ++mc.mNewInitEntriesMergedWithOldDead;
-            maybePut(out, newLive, shadowIterators,
-                     keepShadowedLifecycleEntries, mc);
-        }
+        BucketEntry newLive;
+        newLive.type(LIVEENTRY);
+        newLive.liveEntry() = newEntry.liveEntry();
+        ++mc.mNewInitEntriesMergedWithOldDead;
+        maybePut(out, newLive, shadowIterators, keepShadowedLifecycleEntries,
+                 mc);
     }
     else if (oldEntry.type() == INITENTRY)
     {

--- a/src/bucket/BucketApplicator.cpp
+++ b/src/bucket/BucketApplicator.cpp
@@ -125,10 +125,7 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
                     // Prior to protocol 11, INITENTRY didn't exist, so we need
                     // to check ltx to see if this is an update or a create
                     auto key = InternalLedgerEntry(e.liveEntry()).toKey();
-
-                    // Bucket Apply should process every entry in bucket
-                    // including expired ones to get the DB in the correct state
-                    if (ltx->getNewestVersion(key, /*loadExpiredEntry=*/true))
+                    if (ltx->getNewestVersion(key))
                     {
                         ltx->updateWithoutLoading(e.liveEntry());
                     }
@@ -158,8 +155,7 @@ BucketApplicator::advance(BucketApplicator::Counters& counters)
                 {
                     // Prior to protocol 11, DEAD entries could exist
                     // without LIVE entries in between
-                    if (ltx->getNewestVersion(e.deadEntry(),
-                                              /*loadExpiredEntry=*/true))
+                    if (ltx->getNewestVersion(e.deadEntry()))
                     {
                         ltx->eraseWithoutLoading(e.deadEntry());
                     }

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -674,7 +674,7 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
             LedgerKey key(CONFIG_SETTING);
             key.configSetting().configSettingID =
                 ConfigSettingID::CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW;
-            auto txle = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+            auto txle = ltx.loadWithoutRecord(key);
             releaseAssert(txle);
             auto const& leVector =
                 txle.current().data.configSetting().bucketListSizeWindow();

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -721,59 +721,6 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
         }
     });
 }
-
-TEST_CASE_VERSIONS("new temp entry merges with expired entry with same key",
-                   "[bucket][bucketlist]")
-{
-    VirtualClock clock;
-    Config cfg(getTestConfig());
-    Application::pointer app = createTestApplication(clock, cfg);
-    BucketList& bl = app->getBucketManager().getBucketList();
-    uint32_t ledgerSeq = 1;
-
-    for_versions_from(20, *app, [&] {
-        auto startingLedger = ledgerSeq;
-        auto tempEntry =
-            LedgerTestUtils::generateValidLedgerEntryOfType(CONTRACT_DATA);
-        setExpirationLedger(tempEntry, startingLedger + 4);
-        tempEntry.data.contractData().durability = TEMPORARY;
-
-        bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {tempEntry}, {},
-                    {});
-        ++ledgerSeq;
-
-        // Run BucketList until entry has expired
-        for (; ledgerSeq <= startingLedger + 4; ++ledgerSeq)
-        {
-            bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {}, {}, {});
-        }
-
-        setExpirationLedger(tempEntry, startingLedger + 500);
-        bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {tempEntry}, {},
-                    {});
-        ++ledgerSeq;
-
-        // Run BucketList until entry has expired
-        for (; ledgerSeq <= startingLedger + 1024; ++ledgerSeq)
-        {
-            bl.addBatch(*app, ledgerSeq, getAppLedgerVersion(app), {}, {}, {});
-        }
-
-        bool foundValidEntry = false;
-        auto b = bl.getLevel(5).getCurr();
-        for (BucketInputIterator iter(b); iter; ++iter)
-        {
-            auto entry = *iter;
-            if (entry.type() == INITENTRY && entry.liveEntry() == tempEntry)
-            {
-                foundValidEntry = true;
-                break;
-            }
-        }
-
-        REQUIRE(foundValidEntry);
-    });
-}
 #endif
 
 static std::string

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -125,7 +125,7 @@ readMaxSorobanTxSetSize(AbstractLedgerTxn& ltx)
     LedgerKey key(LedgerEntryType::CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_EXECUTION_LANES;
-    return ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false)
+    return ltx.loadWithoutRecord(key)
         .current()
         .data.configSetting()
         .contractExecutionLanes()
@@ -852,7 +852,7 @@ getAvailableLimitExcludingLiabilities(AccountID const& accountID,
         LedgerKey key(TRUSTLINE);
         key.trustLine().accountID = accountID;
         key.trustLine().asset = assetToTrustLineAsset(asset);
-        auto trust = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+        auto trust = ltx.loadWithoutRecord(key);
         if (trust && isAuthorizedToMaintainLiabilities(trust))
         {
             auto const& tl = trust.current().data.trustLine();
@@ -1300,8 +1300,7 @@ ConfigUpgradeSetFrameConstPtr
 ConfigUpgradeSetFrame::makeFromKey(AbstractLedgerTxn& ltx,
                                    ConfigUpgradeSetKey const& key)
 {
-    auto ltxe = ltx.loadWithoutRecord(ConfigUpgradeSetFrame::getLedgerKey(key),
-                                      /*loadExpiredEntry=*/false);
+    auto ltxe = ltx.loadWithoutRecord(ConfigUpgradeSetFrame::getLedgerKey(key));
     if (!ltxe)
     {
         return nullptr;
@@ -1424,9 +1423,9 @@ ConfigUpgradeSetFrame::upgradeNeeded(AbstractLedgerTxn& ltx,
     {
         LedgerKey key(LedgerEntryType::CONFIG_SETTING);
         key.configSetting().configSettingID = updatedEntry.configSettingID();
-        bool isSame = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false)
-                          .current()
-                          .data.configSetting() == updatedEntry;
+        bool isSame =
+            ltx.loadWithoutRecord(key).current().data.configSetting() ==
+            updatedEntry;
         if (!isSame)
         {
             return true;

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1301,14 +1301,14 @@ ConfigUpgradeSetFrame::makeFromKey(AbstractLedgerTxn& ltx,
                                    ConfigUpgradeSetKey const& key)
 {
     auto ltxe = ltx.loadWithoutRecord(ConfigUpgradeSetFrame::getLedgerKey(key));
-    if (!ltxe)
+    if (!ltxe || !isLive(ltxe.current(), ltx.getHeader().ledgerSeq))
     {
         return nullptr;
     }
     auto const& contractData = ltxe.current().data.contractData();
     if (contractData.body.bodyType() != DATA_ENTRY ||
         contractData.body.data().val.type() != SCV_BYTES ||
-        contractData.durability != PERSISTENT)
+        contractData.durability != TEMPORARY)
     {
         return nullptr;
     }
@@ -1406,7 +1406,7 @@ ConfigUpgradeSetFrame::getLedgerKey(ConfigUpgradeSetKey const& upgradeKey)
     lk.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     lk.contractData().contract.contractId() = upgradeKey.contractID;
     lk.contractData().key = v;
-    lk.contractData().durability = PERSISTENT;
+    lk.contractData().durability = TEMPORARY;
     return lk;
 }
 

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -876,7 +876,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             LedgerKey key(CONFIG_SETTING);
             key.configSetting().configSettingID =
                 ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0;
-            auto le = ltx2.loadWithoutRecord(key, false).current();
+            auto le = ltx2.loadWithoutRecord(key).current();
             auto configSetting = le.data.configSetting();
             configSetting.contractLedgerCost().txMaxWriteBytes = upgradeVal;
 

--- a/src/invariant/BucketListIsConsistentWithDatabase.cpp
+++ b/src/invariant/BucketListIsConsistentWithDatabase.cpp
@@ -28,10 +28,7 @@ namespace stellar
 static std::string
 checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
 {
-    // Database should contain same expried entries as BucketList even if they
-    // are not accesible
-    auto fromDb =
-        ltx.loadWithoutRecord(LedgerEntryKey(entry), /*loadExpiredEntry=*/true);
+    auto fromDb = ltx.loadWithoutRecord(LedgerEntryKey(entry));
     if (!fromDb)
     {
         std::string s{
@@ -56,9 +53,7 @@ checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerEntry const& entry)
 static std::string
 checkAgainstDatabase(AbstractLedgerTxn& ltx, LedgerKey const& key)
 {
-    // Database should contain same expried entries as BucketList even if they
-    // are not accesible
-    auto fromDb = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/true);
+    auto fromDb = ltx.loadWithoutRecord(key);
     if (!fromDb)
     {
         return {};

--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -295,10 +295,8 @@ struct SelectBucketListGenerator : public BucketListGenerator
                 auto iter = filteredKeys.begin();
                 std::advance(iter, dist(gRandomEngine));
 
-                // For BucketList generation, expirationLedger shouldn't matter
                 mSelected = std::make_shared<LedgerEntry>(
-                    ltx.loadWithoutRecord(*iter, /*loadExpiredEntry=*/true)
-                        .current());
+                    ltx.loadWithoutRecord(*iter).current());
             }
         }
         return BucketListGenerator::generateLiveEntries(ltx);

--- a/src/ledger/InMemoryLedgerTxn.cpp
+++ b/src/ledger/InMemoryLedgerTxn.cpp
@@ -233,14 +233,6 @@ InMemoryLedgerTxn::create(InternalLedgerEntry const& entry)
     throw std::runtime_error("called create on InMemoryLedgerTxn");
 }
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-LedgerTxnEntry
-InMemoryLedgerTxn::restore(InternalLedgerEntry const& entry)
-{
-    throw std::runtime_error("called restore on InMemoryLedgerTxn");
-}
-#endif
-
 void
 InMemoryLedgerTxn::erase(InternalLedgerKey const& key)
 {

--- a/src/ledger/InMemoryLedgerTxn.cpp
+++ b/src/ledger/InMemoryLedgerTxn.cpp
@@ -246,8 +246,7 @@ InMemoryLedgerTxn::load(InternalLedgerKey const& key)
 }
 
 ConstLedgerTxnEntry
-InMemoryLedgerTxn::loadWithoutRecord(InternalLedgerKey const& key,
-                                     bool loadExpiredEntry)
+InMemoryLedgerTxn::loadWithoutRecord(InternalLedgerKey const& key)
 {
     throw std::runtime_error("called loadWithoutRecord on InMemoryLedgerTxn");
 }
@@ -272,7 +271,7 @@ InMemoryLedgerTxn::getOffersByAccountAndAsset(AccountID const& account,
             continue;
         }
 
-        auto newest = getNewestVersion(key, /*loadExpiredEntry=*/false);
+        auto newest = getNewestVersion(key);
         if (!newest)
         {
             throw std::runtime_error("Invalid ledger state");
@@ -309,10 +308,8 @@ InMemoryLedgerTxn::getPoolShareTrustLinesByAccountAndAsset(
             continue;
         }
 
-        auto pool = getNewestVersion(
-            liquidityPoolKey(
-                key.ledgerKey().trustLine().asset.liquidityPoolID()),
-            /*loadExpiredEntry=*/false);
+        auto pool = getNewestVersion(liquidityPoolKey(
+            key.ledgerKey().trustLine().asset.liquidityPoolID()));
         if (!pool)
         {
             throw std::runtime_error("Invalid ledger state");
@@ -322,7 +319,7 @@ InMemoryLedgerTxn::getPoolShareTrustLinesByAccountAndAsset(
         auto const& cp = lp.body.constantProduct();
         if (cp.params.assetA == asset || cp.params.assetB == asset)
         {
-            auto newest = getNewestVersion(key, /*loadExpiredEntry=*/false);
+            auto newest = getNewestVersion(key);
             if (!newest)
             {
                 throw std::runtime_error("Invalid ledger state");

--- a/src/ledger/InMemoryLedgerTxn.h
+++ b/src/ledger/InMemoryLedgerTxn.h
@@ -90,8 +90,8 @@ class InMemoryLedgerTxn : public LedgerTxn
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
     void erase(InternalLedgerKey const& key) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
-    ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
-                                          bool loadExpiredEntry) override;
+    ConstLedgerTxnEntry
+    loadWithoutRecord(InternalLedgerKey const& key) override;
 
     UnorderedMap<LedgerKey, LedgerEntry>
     getOffersByAccountAndAsset(AccountID const& account,

--- a/src/ledger/InMemoryLedgerTxn.h
+++ b/src/ledger/InMemoryLedgerTxn.h
@@ -88,11 +88,6 @@ class InMemoryLedgerTxn : public LedgerTxn
     void eraseWithoutLoading(InternalLedgerKey const& key) override;
 
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
-
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    LedgerTxnEntry restore(InternalLedgerEntry const& entry) override;
-#endif
-
     void erase(InternalLedgerKey const& key) override;
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
     ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -90,8 +90,7 @@ InMemoryLedgerTxnRoot::getInflationWinners(size_t maxWinners,
 }
 
 std::shared_ptr<InternalLedgerEntry const>
-InMemoryLedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key,
-                                        bool loadExpiredEntry) const
+InMemoryLedgerTxnRoot::getNewestVersion(InternalLedgerKey const& key) const
 {
     return nullptr;
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -62,8 +62,7 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     getInflationWinners(size_t maxWinners, int64_t minBalance) override;
 
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key,
-                     bool loadExpiredEntry) const override;
+    getNewestVersion(InternalLedgerKey const& key) const override;
 
     uint64_t countObjects(LedgerEntryType let) const override;
     uint64_t countObjects(LedgerEntryType let,

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -434,8 +434,7 @@ class AbstractLedgerTxnParent
     // invoking getNewestVersion on its parent. Returns nullptr if the key does
     // not exist or if the corresponding LedgerEntry has been erased.
     virtual std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key,
-                     bool loadExpiredEntry) const = 0;
+    getNewestVersion(InternalLedgerKey const& key) const = 0;
 
     // Return the count of the number of ledger objects of type `let`. Will
     // throw when called on anything other than a (real or stub) root LedgerTxn.
@@ -574,8 +573,8 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual LedgerTxnEntry create(InternalLedgerEntry const& entry) = 0;
     virtual void erase(InternalLedgerKey const& key) = 0;
     virtual LedgerTxnEntry load(InternalLedgerKey const& key) = 0;
-    virtual ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
-                                                  bool loadExpiredEntry) = 0;
+    virtual ConstLedgerTxnEntry
+    loadWithoutRecord(InternalLedgerKey const& key) = 0;
 
     // Somewhat unsafe, non-recommended access methods: for use only during
     // bulk-loading as in catchup from buckets. These methods set an entry
@@ -743,8 +742,7 @@ class LedgerTxn : public AbstractLedgerTxn
                        std::vector<LedgerKey>& deadEntries) override;
 
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key,
-                     bool loadExpiredEntry) const override;
+    getNewestVersion(InternalLedgerKey const& key) const override;
 
     LedgerTxnEntry load(InternalLedgerKey const& key) override;
 
@@ -767,8 +765,8 @@ class LedgerTxn : public AbstractLedgerTxn
     loadPoolShareTrustLinesByAccountAndAsset(AccountID const& account,
                                              Asset const& asset) override;
 
-    ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
-                                          bool loadExpiredEntry) override;
+    ConstLedgerTxnEntry
+    loadWithoutRecord(InternalLedgerKey const& key) override;
 
     void rollback() noexcept override;
 
@@ -881,8 +879,7 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
     getInflationWinners(size_t maxWinners, int64_t minBalance) override;
 
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key,
-                     bool loadExpiredEntry) const override;
+    getNewestVersion(InternalLedgerKey const& key) const override;
 
     void rollbackChild() noexcept override;
 

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -119,9 +119,9 @@
 //    access this entry in this LedgerTxn." See below for the
 //    concurrency-control issues this is designed to trap.
 //
-//  - Entries are made-active by calling load(), create(), or restore(), each
-//    of which returns a LedgerTxnEntry which is a handle that can be used to
-//    get at the underlying LedgerEntry. References to the underlying
+//  - Entries are made-active by calling load() or create(), each of which
+//    returns a LedgerTxnEntry which is a handle that can be used to get at
+//    the underlying LedgerEntry. References to the underlying
 //    LedgerEntries should generally not be retained anywhere, because the
 //    LedgerTxnEntry handles may be "deactivated", and access to a
 //    deactivated entry is a _logic error_ in the client that this
@@ -541,10 +541,10 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     virtual void commit() noexcept = 0;
     virtual void rollback() noexcept = 0;
 
-    // loadHeader, create, restore, erase, load, and loadWithoutRecord provide
-    // the main interface to interact with data stored in the AbstractLedgerTxn.
-    // These functions only allow one instance of a particular data to be active
-    // at a time.
+    // loadHeader, create, erase, load, and loadWithoutRecord provide the main
+    // interface to interact with data stored in the AbstractLedgerTxn. These
+    // functions only allow one instance of a particular data to be active at a
+    // time.
     // - loadHeader
     //     Loads the current LedgerHeader. Throws if there is already an active
     //     LedgerTxnHeader.
@@ -552,11 +552,6 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     //     Creates a new LedgerTxnEntry from entry. Throws if the key
     //     associated with this entry is already associated with an entry in
     //     this AbstractLedgerTxn or any parent.
-    // - restore
-    //     Creates a new LedgerTxnEntry from expired entry. Throws if the key
-    //     associated with this entry is already associated with an entry in
-    //     this AbstractLedgerTxn or any parent or if the expired entry being
-    //     restored does not exist
     // - erase
     //     Erases the existing entry associated with key. Throws if the key is
     //     not already associated with an entry in this AbstractLedgerTxn or
@@ -577,11 +572,6 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
     // the AbstractLedgerTxn has a child.
     virtual LedgerTxnHeader loadHeader() = 0;
     virtual LedgerTxnEntry create(InternalLedgerEntry const& entry) = 0;
-
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    virtual LedgerTxnEntry restore(InternalLedgerEntry const& entry) = 0;
-#endif
-
     virtual void erase(InternalLedgerKey const& key) = 0;
     virtual LedgerTxnEntry load(InternalLedgerKey const& key) = 0;
     virtual ConstLedgerTxnEntry loadWithoutRecord(InternalLedgerKey const& key,
@@ -715,10 +705,6 @@ class LedgerTxn : public AbstractLedgerTxn
                      LedgerTxnConsistency cons) noexcept override;
 
     LedgerTxnEntry create(InternalLedgerEntry const& entry) override;
-
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    LedgerTxnEntry restore(InternalLedgerEntry const& entry) override;
-#endif
 
     void erase(InternalLedgerKey const& key) override;
 

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -440,11 +440,6 @@ class LedgerTxn::Impl
     std::pair<std::shared_ptr<InternalLedgerEntry const>, EntryMap::iterator>
     getNewestVersionEntryMap(InternalLedgerKey const& key);
 
-    // Common logic for create and restore code paths. Input correctness
-    // checking should be done before calling this function
-    LedgerTxnEntry createRestoreCommon(LedgerTxn& self,
-                                       InternalLedgerEntry const& entry);
-
   public:
     // Constructor has the strong exception safety guarantee
     Impl(LedgerTxn& self, AbstractLedgerTxnParent& parent,
@@ -463,15 +458,6 @@ class LedgerTxn::Impl
     //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     LedgerTxnEntry create(LedgerTxn& self, InternalLedgerEntry const& entry);
-
-    // restore has the basic exception safety guarantee. If it throws an
-    // exception, then
-    // - the prepared statement cache may be, but is not guaranteed to be,
-    //   modified
-    // - the entry cache may be, but is not guaranteed to be, cleared.
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-    LedgerTxnEntry restore(LedgerTxn& self, InternalLedgerEntry const& entry);
-#endif
 
     // deactivate has the strong exception safety guarantee
     void deactivate(InternalLedgerKey const& key);

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -13,7 +13,6 @@
 #include <iomanip>
 #include <libpq-fe.h>
 #include <limits>
-#include <optional>
 #include <sstream>
 #endif
 
@@ -552,7 +551,7 @@ class LedgerTxn::Impl
     //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key, bool loadExpiredEntry) const;
+    getNewestVersion(InternalLedgerKey const& key) const;
 
     // load has the basic exception safety guarantee. If it throws an exception,
     // then
@@ -618,8 +617,7 @@ class LedgerTxn::Impl
     //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     ConstLedgerTxnEntry loadWithoutRecord(LedgerTxn& self,
-                                          InternalLedgerKey const& key,
-                                          bool loadExpiredEntry);
+                                          InternalLedgerKey const& key);
 
     void rollback() noexcept;
     void rollbackChild() noexcept;
@@ -706,20 +704,7 @@ class LedgerTxnRoot::Impl
         LoadType type;
     };
 
-    // RandomEvictionCache, but override get to account for expiration behavior
-    class EntryCache : public RandomEvictionCache<LedgerKey, CacheEntry>
-    {
-      public:
-        // Load entry from cache. If expirationCutoff is not empty, only returns
-        // an entry if its expirationLedger > expirationCutoff
-        CacheEntry get(LedgerKey const& k,
-                       std::optional<uint32_t> expirationCutoff);
-
-        using RandomEvictionCache<LedgerKey, CacheEntry>::RandomEvictionCache;
-
-      private:
-        using RandomEvictionCache<LedgerKey, CacheEntry>::get;
-    };
+    typedef RandomEvictionCache<LedgerKey, CacheEntry> EntryCache;
 
     typedef AssetPair BestOffersKey;
 
@@ -836,7 +821,7 @@ class LedgerTxnRoot::Impl
     //    database for the keyset that it has entries for. It's a precise
     //    image of a subset of the database.
     std::shared_ptr<InternalLedgerEntry const>
-    getFromEntryCache(LedgerKey const& key, bool loadExpiredEntry) const;
+    getFromEntryCache(LedgerKey const& key) const;
     void putInEntryCache(LedgerKey const& key,
                          std::shared_ptr<LedgerEntry const> const& entry,
                          LoadType type) const;
@@ -965,7 +950,7 @@ class LedgerTxnRoot::Impl
     //   modified
     // - the entry cache may be, but is not guaranteed to be, cleared.
     std::shared_ptr<InternalLedgerEntry const>
-    getNewestVersion(InternalLedgerKey const& key, bool loadExpiredEntry) const;
+    getNewestVersion(InternalLedgerKey const& key) const;
 
     void rollbackChild() noexcept;
 

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -29,7 +29,6 @@ bool autoBumpEnabled(LedgerEntry const& e);
 
 template <typename T> bool isSorobanExtEntry(T const& e);
 template <typename T> bool isSorobanDataEntry(T const& e);
-template <typename T> bool isRestorableEntry(T const& e);
 
 template <typename T>
 bool

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -562,7 +562,7 @@ SorobanNetworkConfig::loadMaxContractSize(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     mMaxContractSizeBytes = le.data.configSetting().contractMaxSizeBytes();
 #endif
 }
@@ -574,7 +574,7 @@ SorobanNetworkConfig::loadMaxContractDataKeySize(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_DATA_KEY_SIZE_BYTES;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     mMaxContractDataKeySizeBytes =
         le.data.configSetting().contractDataKeySizeBytes();
 #endif
@@ -587,7 +587,7 @@ SorobanNetworkConfig::loadMaxContractDataEntrySize(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     mMaxContractDataEntrySizeBytes =
         le.data.configSetting().contractDataEntrySizeBytes();
 #endif
@@ -600,7 +600,7 @@ SorobanNetworkConfig::loadComputeSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_COMPUTE_V0;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting = le.data.configSetting().contractCompute();
     mLedgerMaxInstructions = configSetting.ledgerMaxInstructions;
     mTxMaxInstructions = configSetting.txMaxInstructions;
@@ -617,7 +617,7 @@ SorobanNetworkConfig::loadLedgerAccessSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting = le.data.configSetting().contractLedgerCost();
     mLedgerMaxReadLedgerEntries = configSetting.ledgerMaxReadLedgerEntries;
     mLedgerMaxReadBytes = configSetting.ledgerMaxReadBytes;
@@ -645,7 +645,7 @@ SorobanNetworkConfig::loadHistoricalSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting =
         le.data.configSetting().contractHistoricalData();
     mFeeHistorical1KB = configSetting.feeHistorical1KB;
@@ -659,7 +659,7 @@ SorobanNetworkConfig::loadMetaDataSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_META_DATA_V0;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting = le.data.configSetting().contractMetaData();
     mFeeExtendedMetaData1KB = configSetting.feeExtendedMetaData1KB;
     mTxMaxExtendedMetaDataSizeBytes =
@@ -674,7 +674,7 @@ SorobanNetworkConfig::loadBandwidthSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_BANDWIDTH_V0;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting = le.data.configSetting().contractBandwidth();
     mLedgerMaxPropagateSizeBytes = configSetting.ledgerMaxPropagateSizeBytes;
     mTxMaxSizeBytes = configSetting.txMaxSizeBytes;
@@ -689,7 +689,7 @@ SorobanNetworkConfig::loadCpuCostParams(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     mCpuCostParams = le.data.configSetting().contractCostParamsCpuInsns();
 #endif
 }
@@ -701,7 +701,7 @@ SorobanNetworkConfig::loadMemCostParams(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     mMemCostParams = le.data.configSetting().contractCostParamsMemBytes();
 #endif
 }
@@ -713,7 +713,7 @@ SorobanNetworkConfig::loadExecutionLanesSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_CONTRACT_EXECUTION_LANES;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     auto const& configSetting =
         le.data.configSetting().contractExecutionLanes();
     mLedgerMaxTxCount = configSetting.ledgerMaxTxCount;
@@ -727,7 +727,7 @@ SorobanNetworkConfig::loadBucketListSizeWindow(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW;
-    auto txle = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+    auto txle = ltx.loadWithoutRecord(key);
     releaseAssert(txle);
     auto const& leVector =
         txle.current().data.configSetting().bucketListSizeWindow();
@@ -807,7 +807,7 @@ SorobanNetworkConfig::loadStateExpirationSettings(AbstractLedgerTxn& ltx)
     LedgerKey key(CONFIG_SETTING);
     key.configSetting().configSettingID =
         ConfigSettingID::CONFIG_SETTING_STATE_EXPIRATION;
-    auto le = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false).current();
+    auto le = ltx.loadWithoutRecord(key).current();
     mStateExpirationSettings =
         le.data.configSetting().stateExpirationSettings();
 #endif

--- a/src/ledger/TrustLineWrapper.cpp
+++ b/src/ledger/TrustLineWrapper.cpp
@@ -420,7 +420,7 @@ ConstTrustLineWrapper::ConstTrustLineWrapper(AbstractLedgerTxn& ltx,
         LedgerKey key(TRUSTLINE);
         key.trustLine().accountID = accountID;
         key.trustLine().asset = assetToTrustLineAsset(asset);
-        auto entry = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+        auto entry = ltx.loadWithoutRecord(key);
         if (entry)
         {
             mImpl = std::make_unique<NonIssuerImpl>(std::move(entry));

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -532,7 +532,7 @@ TEST_CASE("LedgerTxn rollback and commit deactivate", "[ledgertxn]")
         {
             LedgerTxn ltx(root, false);
             ltx.create(le);
-            auto entry = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+            auto entry = ltx.loadWithoutRecord(key);
             REQUIRE(entry);
             f(ltx);
             REQUIRE_THROWS_AS(!entry, std::runtime_error);
@@ -871,9 +871,7 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
             LedgerTxn ltx1(app->getLedgerTxnRoot());
             REQUIRE_NOTHROW(ltx1.eraseWithoutLoading(key));
             REQUIRE_THROWS_AS(ltx1.getDelta(), std::runtime_error);
-            REQUIRE(
-                ltx1.getNewestVersion(key, /*loadExpiredEntry=*/false).get() ==
-                nullptr);
+            REQUIRE(ltx1.getNewestVersion(key).get() == nullptr);
         }
 
         SECTION("when key exists in parent")
@@ -884,9 +882,7 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
             LedgerTxn ltx2(ltx1);
             REQUIRE_NOTHROW(ltx2.eraseWithoutLoading(key));
             REQUIRE_THROWS_AS(ltx2.getDelta(), std::runtime_error);
-            REQUIRE(
-                ltx2.getNewestVersion(key, /*loadExpiredEntry=*/false).get() ==
-                nullptr);
+            REQUIRE(ltx2.getNewestVersion(key).get() == nullptr);
         }
 
         SECTION("when key exists in grandparent, erased in parent")
@@ -907,9 +903,7 @@ TEST_CASE("LedgerTxn eraseWithoutLoading", "[ledgertxn]")
             LedgerTxn ltx3(ltx2);
             REQUIRE_NOTHROW(ltx3.eraseWithoutLoading(key));
             REQUIRE_THROWS_AS(ltx3.getDelta(), std::runtime_error);
-            REQUIRE(
-                ltx3.getNewestVersion(key, /*loadExpiredEntry=*/false).get() ==
-                nullptr);
+            REQUIRE(ltx3.getNewestVersion(key).get() == nullptr);
         }
     };
 
@@ -1483,25 +1477,11 @@ TEST_CASE_VERSIONS("LedgerTxn load", "[ledgertxn]")
                 setExpirationLedger(dataEntry, 0);
                 LedgerTxn ltx1(app->getLedgerTxnRoot());
                 REQUIRE(ltx1.create(codeEntry));
-                REQUIRE(ltx1.create(dataEntry));
                 ltx1.commit();
 
                 LedgerTxn ltx2(app->getLedgerTxnRoot());
-                auto codeKey = LedgerEntryKey(codeEntry);
-                auto dataKey = LedgerEntryKey(dataEntry);
-                REQUIRE(!ltx2.load(codeKey));
-                REQUIRE(!ltx2.load(dataKey));
-
-                // Check that you can still load expired entry with flag set
-                auto loadedCode =
-                    ltx2.loadWithoutRecord(codeKey, /*loadExpiredEntry=*/true);
-                REQUIRE(loadedCode);
-                REQUIRE(loadedCode.current().data == codeEntry.data);
-
-                auto loadedData =
-                    ltx2.loadWithoutRecord(dataKey, /*loadExpiredEntry=*/true);
-                REQUIRE(loadedData);
-                REQUIRE(loadedData.current().data == dataEntry.data);
+                REQUIRE(!ltx2.load(LedgerEntryKey(codeEntry)));
+                REQUIRE(!ltx2.load(LedgerEntryKey(dataEntry)));
             }
 #endif
         }
@@ -1599,24 +1579,20 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
     {
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         LedgerTxn ltx2(ltx1);
-        REQUIRE_THROWS_AS(
-            ltx1.loadWithoutRecord(key, /*loadExpiredEntry=*/false),
-            std::runtime_error);
+        REQUIRE_THROWS_AS(ltx1.loadWithoutRecord(key), std::runtime_error);
     }
 
     SECTION("fails if sealed")
     {
         LedgerTxn ltx1(app->getLedgerTxnRoot());
         ltx1.getDelta();
-        REQUIRE_THROWS_AS(
-            ltx1.loadWithoutRecord(key, /*loadExpiredEntry=*/false),
-            std::runtime_error);
+        REQUIRE_THROWS_AS(ltx1.loadWithoutRecord(key), std::runtime_error);
     }
 
     SECTION("when key does not exist")
     {
         LedgerTxn ltx1(app->getLedgerTxnRoot());
-        REQUIRE(!ltx1.loadWithoutRecord(key, /*loadExpiredEntry=*/false));
+        REQUIRE(!ltx1.loadWithoutRecord(key));
         validate(ltx1, {});
     }
 
@@ -1626,7 +1602,7 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
         REQUIRE(ltx1.create(le));
 
         LedgerTxn ltx2(ltx1);
-        REQUIRE(ltx2.loadWithoutRecord(key, /*loadExpiredEntry=*/false));
+        REQUIRE(ltx2.loadWithoutRecord(key));
         validate(ltx2, {});
     }
 
@@ -1639,7 +1615,7 @@ TEST_CASE("LedgerTxn loadWithoutRecord", "[ledgertxn]")
         REQUIRE_NOTHROW(ltx2.erase(key));
 
         LedgerTxn ltx3(ltx2);
-        REQUIRE(!ltx3.loadWithoutRecord(key, /*loadExpiredEntry=*/false));
+        REQUIRE(!ltx3.loadWithoutRecord(key));
         validate(ltx3, {});
     }
 }
@@ -2628,25 +2604,20 @@ TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgertxn]")
             entry1 = std::move(entryRef);
             REQUIRE(entry1.current() == le1);
             REQUIRE_THROWS_AS(ltx.load(key1), std::runtime_error);
-            REQUIRE_THROWS_AS(
-                ltx.loadWithoutRecord(key1, /*loadExpiredEntry=*/false),
-                std::runtime_error);
+            REQUIRE_THROWS_AS(ltx.loadWithoutRecord(key1), std::runtime_error);
         }
 
         SECTION("const entry")
         {
             LedgerTxn ltx(root, false);
             ltx.create(le1);
-            auto entry1 =
-                ltx.loadWithoutRecord(key1, /*loadExpiredEntry=*/false);
+            auto entry1 = ltx.loadWithoutRecord(key1);
             // Avoid warning for explicit move-to-self
             ConstLedgerTxnEntry& entryRef = entry1;
             entry1 = std::move(entryRef);
             REQUIRE(entry1.current() == le1);
             REQUIRE_THROWS_AS(ltx.load(key1), std::runtime_error);
-            REQUIRE_THROWS_AS(
-                ltx.loadWithoutRecord(key1, /*loadExpiredEntry=*/false),
-                std::runtime_error);
+            REQUIRE_THROWS_AS(ltx.loadWithoutRecord(key1), std::runtime_error);
         }
 
         SECTION("header")
@@ -2672,8 +2643,7 @@ TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgertxn]")
             REQUIRE(entry1.current() == le2);
             REQUIRE_THROWS_AS(ltx.load(key2), std::runtime_error);
             REQUIRE(ltx.load(key1).current() == le1);
-            REQUIRE(ltx.loadWithoutRecord(key1, /*loadExpiredEntry=*/false)
-                        .current() == le1);
+            REQUIRE(ltx.loadWithoutRecord(key1).current() == le1);
         }
 
         SECTION("const entry")
@@ -2681,16 +2651,13 @@ TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgertxn]")
             LedgerTxn ltx(root, false);
             ltx.create(le1);
             ltx.create(le2);
-            auto entry1 =
-                ltx.loadWithoutRecord(key1, /*loadExpiredEntry=*/false);
-            auto entry2 =
-                ltx.loadWithoutRecord(key2, /*loadExpiredEntry=*/false);
+            auto entry1 = ltx.loadWithoutRecord(key1);
+            auto entry2 = ltx.loadWithoutRecord(key2);
             entry1 = std::move(entry2);
             REQUIRE(entry1.current() == le2);
             REQUIRE_THROWS_AS(ltx.load(key2), std::runtime_error);
             REQUIRE(ltx.load(key1).current() == le1);
-            REQUIRE(ltx.loadWithoutRecord(key1, /*loadExpiredEntry=*/false)
-                        .current() == le1);
+            REQUIRE(ltx.loadWithoutRecord(key1).current() == le1);
         }
 
         SECTION("header")
@@ -3655,8 +3622,7 @@ TEST_CASE("LedgerTxn in memory order book", "[ledgertxn]")
 
             LedgerTxn ltx(app->getLedgerTxnRoot());
             {
-                auto lte = ltx.loadWithoutRecord(LedgerEntryKey(le1a),
-                                                 /*loadExpiredEntry=*/false);
+                auto lte = ltx.loadWithoutRecord(LedgerEntryKey(le1a));
                 checkOrderBook(ltx, {});
             }
             checkOrderBook(ltx, {});
@@ -3668,8 +3634,7 @@ TEST_CASE("LedgerTxn in memory order book", "[ledgertxn]")
             checkOrderBook(ltx, {{assets, {le1a}}});
 
             {
-                auto lte = ltx.loadWithoutRecord(LedgerEntryKey(le1a),
-                                                 /*loadExpiredEntry=*/false);
+                auto lte = ltx.loadWithoutRecord(LedgerEntryKey(le1a));
                 checkOrderBook(ltx, {});
             }
             checkOrderBook(ltx, {{assets, {le1a}}});
@@ -3847,12 +3812,10 @@ TEST_CASE("Access deactivated entry", "[ledgertxn]")
 
         SECTION("loadWithoutRecord")
         {
-            auto entry =
-                ltx1.loadWithoutRecord(lk1, /*loadExpiredEntry=*/false);
+            auto entry = ltx1.loadWithoutRecord(lk1);
             REQUIRE(entry);
 
-            auto missingEntry = ltx1.loadWithoutRecord(
-                missingEntryKey, /*loadExpiredEntry=*/false);
+            auto missingEntry = ltx1.loadWithoutRecord(missingEntryKey);
             REQUIRE(!missingEntry);
 
             // this will deactivate entry
@@ -3892,7 +3855,7 @@ TEST_CASE("Access deactivated entry", "[ledgertxn]")
         SECTION("loadWithoutRecord and move assign")
         {
             ConstLedgerTxnEntry entry;
-            entry = ltx1.loadWithoutRecord(lk1, /*loadExpiredEntry=*/false);
+            entry = ltx1.loadWithoutRecord(lk1);
             REQUIRE(entry);
 
             ConstLedgerTxnEntry ltxe2;
@@ -3901,8 +3864,7 @@ TEST_CASE("Access deactivated entry", "[ledgertxn]")
         }
         SECTION("loadWithoutRecord and move construct")
         {
-            auto entry =
-                ltx1.loadWithoutRecord(lk1, /*loadExpiredEntry=*/false);
+            auto entry = ltx1.loadWithoutRecord(lk1);
             REQUIRE(entry);
 
             ConstLedgerTxnEntry ltxe2(std::move(entry));

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -720,7 +720,7 @@ CommandHandler::getLedgerEntry(std::string const& params, std::string& retStr)
 
         LedgerKey k;
         fromOpaqueBase64(k, key);
-        auto le = ltx.loadWithoutRecord(k, /*loadExpiredEntry=*/false);
+        auto le = ltx.loadWithoutRecord(k);
         if (le)
         {
             root["state"] = "live";

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -1726,7 +1726,7 @@ makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet)
     le.data.contractData().body.bodyType(DATA_ENTRY);
     le.data.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     le.data.contractData().contract.contractId() = contractID;
-    le.data.contractData().durability = PERSISTENT;
+    le.data.contractData().durability = TEMPORARY;
     le.data.contractData().expirationLedgerSeq = UINT32_MAX;
     le.data.contractData().key = key;
     le.data.contractData().body.data().val = val;

--- a/src/transactions/BumpFootprintExpirationOpFrame.cpp
+++ b/src/transactions/BumpFootprintExpirationOpFrame.cpp
@@ -68,10 +68,10 @@ BumpFootprintExpirationOpFrame::doApply(Application& app,
         ledgerSeq + mBumpFootprintExpirationOp.ledgersToExpire;
     for (auto const& lk : footprint.readOnly)
     {
-        // When we move to use EXPIRATION_EXTENSIONS, this should become a
+        // TODO: when we move to use EXPIRATION_EXTENSIONS, this should become a
         // loadWithoutRecord, and the metrics should be updated.
         auto ltxe = ltx.load(lk);
-        if (!ltxe)
+        if (!ltxe || !isLive(ltxe.current(), ledgerSeq))
         {
             // Skip the missing entries. Since this happens at apply
             // time and we refund the unspent fees, it is more beneficial

--- a/src/transactions/CreateAccountOpFrame.cpp
+++ b/src/transactions/CreateAccountOpFrame.cpp
@@ -47,8 +47,7 @@ CreateAccountOpFrame::doApplyBeforeV14(AbstractLedgerTxn& ltx)
     bool doesAccountExist =
         protocolVersionStartsFrom(header.current().ledgerVersion,
                                   ProtocolVersion::V_8) ||
-        (bool)ltx.loadWithoutRecord(accountKey(getSourceID()),
-                                    /*loadExpiredEntry=*/false);
+        (bool)ltx.loadWithoutRecord(accountKey(getSourceID()));
 
     auto sourceAccount = loadSourceAccount(ltx, header);
     if (getAvailableBalance(header, sourceAccount) <

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -312,7 +312,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             // accidentally override RW entry with RO flag.
             entryRentChange.readOnly = readOnly;
             // Load without record for readOnly to avoid writing them later
-            auto ltxe = ltx.loadWithoutRecord(lk, /*loadExpiredEntry=*/false);
+            auto ltxe = ltx.loadWithoutRecord(lk);
             if (ltxe)
             {
                 auto const& le = ltxe.current();
@@ -339,8 +339,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
                     }
                 }
             }
-            else if (!isTemporaryEntry(lk) &&
-                     ltx.loadWithoutRecord(lk, /*loadExpiredEntry=*/true))
+            else if (!isTemporaryEntry(lk) && ltx.loadWithoutRecord(lk))
             {
                 // Cannot access an expired entry
                 this->innerResult().code(INVOKE_HOST_FUNCTION_ENTRY_EXPIRED);

--- a/src/transactions/MergeOpFrame.cpp
+++ b/src/transactions/MergeOpFrame.cpp
@@ -98,8 +98,7 @@ MergeOpFrame::doApplyBeforeV16(AbstractLedgerTxn& ltx)
         // in versions < 8, merge account could be called with a stale account
         LedgerKey key(ACCOUNT);
         key.account().accountID = getSourceID();
-        auto thisAccount =
-            ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+        auto thisAccount = ltx.loadWithoutRecord(key);
         if (!thisAccount)
         {
             innerResult().code(ACCOUNT_MERGE_NO_ACCOUNT);

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -74,7 +74,7 @@ RestoreFootprintOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     for (auto const& lk : footprint.readWrite)
     {
         auto keySize = static_cast<uint32>(xdr::xdr_size(lk));
-        auto ltxe = ltx.loadWithoutRecord(lk, /*loadExpiredEntry=*/true);
+        auto ltxe = ltx.loadWithoutRecord(lk);
         if (!ltxe)
         {
             // Skip entries that don't exist.
@@ -116,7 +116,8 @@ RestoreFootprintOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         rustChange.new_size_bytes = keySize + entrySize;
         rustChange.new_expiration_ledger = restoredExpirationLedger;
         setExpirationLedger(restoredEntry, restoredExpirationLedger);
-        ltx.restore(restoredEntry);
+
+        // TODO: Fix
     }
     int64_t rentFee = rust_bridge::compute_rent_fee(
         app.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION,

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -361,8 +361,7 @@ TransactionFrame::loadSourceAccount(AbstractLedgerTxn& ltx,
         // this is buggy caching that existed in old versions of the protocol
         if (res)
         {
-            auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()),
-                                               /*loadExpiredEntry=*/false);
+            auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()));
             mCachedAccount = newest;
         }
         else
@@ -395,8 +394,7 @@ TransactionFrame::loadAccount(AbstractLedgerTxn& ltx,
             res = ltx.create(*mCachedAccount);
         }
 
-        auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()),
-                                           /*loadExpiredEntry=*/false);
+        auto newest = ltx.getNewestVersion(LedgerEntryKey(res.current()));
         mCachedAccount = newest;
         return res;
     }

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -333,8 +333,7 @@ ConstLedgerTxnEntry
 loadAccountWithoutRecord(AbstractLedgerTxn& ltx, AccountID const& accountID)
 {
     ZoneScoped;
-    return ltx.loadWithoutRecord(accountKey(accountID),
-                                 /*loadExpiredEntry=*/false);
+    return ltx.loadWithoutRecord(accountKey(accountID));
 }
 
 LedgerTxnEntry
@@ -436,21 +435,18 @@ loadLiquidityPool(AbstractLedgerTxn& ltx, PoolID const& poolID)
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 ConstLedgerTxnEntry
 loadContractData(AbstractLedgerTxn& ltx, SCAddress const& contract,
-                 SCVal const& dataKey, ContractDataDurability type,
-                 bool loadExpiredEntry)
+                 SCVal const& dataKey, ContractDataDurability type)
 {
     ZoneScoped;
     return ltx.loadWithoutRecord(
-        contractDataKey(contract, dataKey, type, DATA_ENTRY), loadExpiredEntry);
+        contractDataKey(contract, dataKey, type, DATA_ENTRY));
 }
 
 ConstLedgerTxnEntry
-loadContractCode(AbstractLedgerTxn& ltx, Hash const& hash,
-                 bool loadExpiredEntry)
+loadContractCode(AbstractLedgerTxn& ltx, Hash const& hash)
 {
     ZoneScoped;
-    return ltx.loadWithoutRecord(contractCodeKey(hash, DATA_ENTRY),
-                                 loadExpiredEntry);
+    return ltx.loadWithoutRecord(contractCodeKey(hash, DATA_ENTRY));
 }
 #endif
 
@@ -1408,10 +1404,8 @@ prefetchForRevokeFromPoolShareTrustLines(
     {
         // prefetching shouldn't affect the protocol, so use loadWithoutRecord
         // to not touch lastModified
-        auto pool = ltx.loadWithoutRecord(
-            liquidityPoolKey(
-                trustLine.current().data.trustLine().asset.liquidityPoolID()),
-            /*loadExpiredEntry=*/false);
+        auto pool = ltx.loadWithoutRecord(liquidityPoolKey(
+            trustLine.current().data.trustLine().asset.liquidityPoolID()));
 
         auto const& params =
             pool.current().data.liquidityPool().body.constantProduct().params;

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -148,10 +148,8 @@ LedgerTxnEntry loadLiquidityPool(AbstractLedgerTxn& ltx, PoolID const& poolID);
 ConstLedgerTxnEntry loadContractData(AbstractLedgerTxn& ltx,
                                      SCAddress const& contract,
                                      SCVal const& dataKey,
-                                     ContractDataDurability type,
-                                     bool loadExpiredEntry = false);
-ConstLedgerTxnEntry loadContractCode(AbstractLedgerTxn& ltx, Hash const& hash,
-                                     bool loadExpiredEntry = false);
+                                     ContractDataDurability type);
+ConstLedgerTxnEntry loadContractCode(AbstractLedgerTxn& ltx, Hash const& hash);
 #endif
 
 void acquireLiabilities(AbstractLedgerTxn& ltx, LedgerTxnHeader const& header,

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1262,6 +1262,13 @@ TEST_CASE("contract storage", "[tx][soroban]")
                          /*expectSuccess*/ false,
                          ContractDataDurability::PERSISTENT);
 
+        // Bump operation should skip expired entries
+        bumpOp(1'000, {lk}, 0);
+
+        // Make sure expirationLedger is unchanged by bumpOp
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT, initExpirationLedger);
+
         // Restore the entry
         restoreOp({lk}, 61);
 

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -516,8 +516,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
                            uint32_t ledgerSeq) {
         auto keySymbol = makeSymbolSCVal(key);
         LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto ltxe = loadContractData(ltx, contractID, keySymbol, type,
-                                     /*loadExpiredEntry*/ true);
+        auto ltxe = loadContractData(ltx, contractID, keySymbol, type);
         REQUIRE(ltxe);
         return isLive(ltxe.current(), ledgerSeq);
     };
@@ -945,7 +944,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
         for (auto const& key : contractKeys)
         {
             uint32_t mult = key.type() == CONTRACT_CODE ? 4 : 3;
-            auto ltxe = ltx.loadWithoutRecord(key, /*loadExpiredEntry=*/false);
+            auto ltxe = ltx.loadWithoutRecord(key);
             REQUIRE(ltxe);
             REQUIRE(getExpirationLedger(ltxe.current()) ==
                     expectedInitialExpiration + (autoBump * mult));

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -111,6 +111,24 @@ makeU32(uint32_t u32)
     return val;
 }
 
+static uint32_t
+getLedgerSeq(Application& app)
+{
+    LedgerTxn ltx(app.getLedgerTxnRoot());
+    return ltx.loadHeader().current().ledgerSeq;
+}
+
+static LedgerEntry
+loadStorageEntry(Application& app, SCAddress const& contractID,
+                 std::string const& key, ContractDataDurability type)
+{
+    auto keySymbol = makeSymbolSCVal(key);
+    LedgerTxn ltx(app.getLedgerTxnRoot());
+    auto ltxe = loadContractData(ltx, contractID, keySymbol, type);
+    REQUIRE(ltxe);
+    return ltxe.current();
+}
+
 static void
 submitTxToUploadWasm(Application& app, Operation const& op,
                      SorobanResources const& resources,
@@ -467,20 +485,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
     VirtualClock clock;
     auto app = createTestApplication(clock, getTestConfig());
     auto root = TestAccount::createRoot(*app);
-
-    {
-        // Autobump is disabled by default, so so enable it here for testing.
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto networkConfig =
-            app->getLedgerManager().getSorobanNetworkConfig(ltx);
-        auto stateExpirationSettings = networkConfig.stateExpirationSettings();
-        stateExpirationSettings.autoBumpLedgers = 10;
-        networkConfig.stateExpirationSettings() = stateExpirationSettings;
-        app->getLedgerManager().setSorobanNetworkConfig(networkConfig);
-    }
-
     auto const contractDataWasm = rust_bridge::get_test_wasm_contract_data();
-
     auto contractKeys = deployContractWithSourceAccount(*app, contractDataWasm);
     auto const& contractID = contractKeys[0].contractData().contract;
     auto checkContractData = [&](SCVal const& key, ContractDataDurability type,
@@ -499,26 +504,6 @@ TEST_CASE("contract storage", "[tx][soroban]")
         {
             REQUIRE(!ltxe);
         }
-    };
-
-    auto getContractDataExpiration = [&](std::string const& key,
-                                         ContractDataDurability type,
-                                         uint32_t flags = 0) {
-        auto keySymbol = makeSymbolSCVal(key);
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto ltxe = loadContractData(ltx, contractID, keySymbol, type);
-        REQUIRE(ltxe);
-        REQUIRE(ltxe.current().data.contractData().body.data().flags == flags);
-        return getExpirationLedger(ltxe.current());
-    };
-
-    auto isEntryLive = [&](std::string const& key, ContractDataDurability type,
-                           uint32_t ledgerSeq) {
-        auto keySymbol = makeSymbolSCVal(key);
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto ltxe = loadContractData(ltx, contractID, keySymbol, type);
-        REQUIRE(ltxe);
-        return isLive(ltxe.current(), ledgerSeq);
     };
 
     auto createTx = [&](xdr::xvector<LedgerKey> const& readOnly,
@@ -638,6 +623,47 @@ TEST_CASE("contract storage", "[tx][soroban]")
         return hasWithFootprint(key, readOnly, 0, true, type);
     };
 
+    auto getWithFootprint =
+        [&](std::string const& key, xdr::xvector<LedgerKey> const& readOnly,
+            xdr::xvector<LedgerKey> const& readWrite, uint32_t writeBytes,
+            bool expectSuccess, ContractDataDurability type) {
+            auto keySymbol = makeSymbolSCVal(key);
+
+            std::string funcStr;
+            switch (type)
+            {
+            case ContractDataDurability::TEMPORARY:
+                funcStr = "get_temporary";
+                break;
+            case ContractDataDurability::PERSISTENT:
+                funcStr = "get_persistent";
+                break;
+            }
+
+            auto [tx, ltx, txm] =
+                createTx(readOnly, readWrite, writeBytes, contractID,
+                         makeSymbol(funcStr), {keySymbol});
+
+            if (expectSuccess)
+            {
+                REQUIRE(tx->apply(*app, *ltx, *txm));
+                ltx->commit();
+            }
+            else
+            {
+                REQUIRE(!tx->apply(*app, *ltx, *txm));
+                ltx->commit();
+            }
+        };
+
+    auto get = [&](std::string const& key, ContractDataDurability type,
+                   bool expectSuccess) {
+        getWithFootprint(key, contractKeys,
+                         {contractDataKey(contractID, makeSymbolSCVal(key),
+                                          type, DATA_ENTRY)},
+                         1000, expectSuccess, type);
+    };
+
     auto bumpWithFootprint = [&](std::string const& key, uint32_t bumpAmount,
                                  xdr::xvector<LedgerKey> const& readOnly,
                                  xdr::xvector<LedgerKey> const& readWrite,
@@ -727,6 +753,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
         REQUIRE(root.getBalance() - balanceAfterFeeCharged ==
                 refundableFee - expectedRefundableFeeCharged);
     };
+
     auto bumpOp = [&](uint32_t bumpAmount,
                       xdr::xvector<LedgerKey> const& readOnly,
                       int64_t expectedRefundableFeeCharged) {
@@ -737,15 +764,15 @@ TEST_CASE("contract storage", "[tx][soroban]")
         SorobanResources bumpResources;
         bumpResources.footprint.readOnly = readOnly;
         bumpResources.instructions = 0;
-        bumpResources.readBytes = 1000;
+        bumpResources.readBytes = 5'000;
         bumpResources.writeBytes = 0;
-        bumpResources.extendedMetaDataSizeBytes = 1000;
+        bumpResources.extendedMetaDataSizeBytes = 10'000;
 
         auto tx =
             sorobanTransactionFrameFromOps(app->getNetworkID(), root, {bumpOp},
-                                           {}, bumpResources, 100'000, 1200);
+                                           {}, bumpResources, 100'000, 2'000);
 
-        runExpirationOp(root, tx, 1200, expectedRefundableFeeCharged);
+        runExpirationOp(root, tx, 2'000, expectedRefundableFeeCharged);
     };
 
     auto restoreOp = [&](xdr::xvector<LedgerKey> const& readWrite,
@@ -756,15 +783,15 @@ TEST_CASE("contract storage", "[tx][soroban]")
         SorobanResources bumpResources;
         bumpResources.footprint.readWrite = readWrite;
         bumpResources.instructions = 0;
-        bumpResources.readBytes = 1000;
-        bumpResources.writeBytes = 1000;
-        bumpResources.extendedMetaDataSizeBytes = 1000;
+        bumpResources.readBytes = 5'000;
+        bumpResources.writeBytes = 5'000;
+        bumpResources.extendedMetaDataSizeBytes = 10'000;
 
         // submit operation
         auto tx = sorobanTransactionFrameFromOps(app->getNetworkID(), root,
                                                  {restoreOp}, {}, bumpResources,
-                                                 100'000, 1'200);
-        runExpirationOp(root, tx, 1200, expectedRefundableFeeCharged);
+                                                 100'000, 2'000);
+        runExpirationOp(root, tx, 2'000, expectedRefundableFeeCharged);
     };
 
     auto delWithFootprint = [&](std::string const& key,
@@ -809,6 +836,34 @@ TEST_CASE("contract storage", "[tx][soroban]")
                          true, type);
     };
 
+    auto checkContractDataExpirationLedger =
+        [&](std::string const& key, ContractDataDurability type,
+            uint32_t expectedExpirationLedger, uint32_t flags = 0) {
+            auto le = loadStorageEntry(*app, contractID, key, type);
+            REQUIRE(le.data.contractData().body.data().flags == flags);
+            REQUIRE(getExpirationLedger(le) == expectedExpirationLedger);
+        };
+
+    auto checkContractDataExpirationState =
+        [&](std::string const& key, ContractDataDurability type,
+            uint32_t ledgerSeq, bool expectedIsLive) {
+            auto le = loadStorageEntry(*app, contractID, key, type);
+            REQUIRE(isLive(le, ledgerSeq) == expectedIsLive);
+
+            // Make sure entry is accessible/inaccessible
+            get(key, type, expectedIsLive);
+        };
+
+    auto checkKeyExpirationLedger = [&](LedgerKey const& key,
+                                        uint32_t ledgerSeq,
+                                        uint32_t expectedExpirationLedger) {
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        auto ltxe = ltx.load(key);
+        REQUIRE(ltxe);
+        REQUIRE(expectedExpirationLedger ==
+                getExpirationLedger(ltxe.current()));
+    };
+
     SECTION("default limits")
     {
         put("key1", 0, ContractDataDurability::PERSISTENT);
@@ -845,12 +900,14 @@ TEST_CASE("contract storage", "[tx][soroban]")
     }
 
     SorobanNetworkConfig refConfig;
-    uint32_t ledgerSeq;
     {
         LedgerTxn ltx(app->getLedgerTxnRoot());
         refConfig = app->getLedgerManager().getSorobanNetworkConfig(ltx);
-        ledgerSeq = ltx.loadHeader().current().ledgerSeq;
     }
+
+    auto const& stateExpirationSettings = refConfig.stateExpirationSettings();
+    auto ledgerSeq = getLedgerSeq(*app);
+
     SECTION("failure: entry exceeds max size")
     {
         refConfig.maxContractDataKeySizeBytes() = 300;
@@ -868,14 +925,15 @@ TEST_CASE("contract storage", "[tx][soroban]")
     {
         // Check that each type is in their own keyspace
         uint64_t uniqueVal = 0;
-        uint64_t recreatableVal = 1;
         uint64_t temporaryVal = 2;
+
         put("key", uniqueVal, ContractDataDurability::PERSISTENT);
         put("key", temporaryVal, TEMPORARY);
+
         auto uniqueScVal = makeU64(uniqueVal);
-        auto recreatableScVal = makeU64(recreatableVal);
         auto temporaryScVal = makeU64(temporaryVal);
         auto keySymbol = makeSymbolSCVal("key");
+
         checkContractData(keySymbol, ContractDataDurability::PERSISTENT,
                           &uniqueScVal);
         checkContractData(keySymbol, TEMPORARY, &temporaryScVal);
@@ -883,15 +941,115 @@ TEST_CASE("contract storage", "[tx][soroban]")
         put("key2", 3, ContractDataDurability::PERSISTENT);
         auto key2Symbol = makeSymbolSCVal("key2");
         auto uniqueScVal2 = makeU64(3);
+
         checkContractData(key2Symbol, ContractDataDurability::PERSISTENT,
                           &uniqueScVal2);
         checkContractData(key2Symbol, TEMPORARY, nullptr);
     }
 
-    auto const& stateExpirationSettings = refConfig.stateExpirationSettings();
-    auto autoBump = stateExpirationSettings.autoBumpLedgers;
+    SECTION("contract instance and wasm expiration")
+    {
+        auto originalExpectedExpiration =
+            stateExpirationSettings.minPersistentEntryExpiration + ledgerSeq -
+            1;
 
-    SECTION("Enforce rent minimums and expiration")
+        for (uint32_t i = app->getLedgerManager().getLastClosedLedgerNum();
+             i <= originalExpectedExpiration + 1; ++i)
+        {
+            closeLedgerOn(*app, i, 2, 1, 2016);
+        }
+
+        // Contract instance and code are expired, an TX should fail
+        putWithFootprint("temp", 0, contractKeys,
+                         {contractDataKey(contractID, makeSymbolSCVal("temp"),
+                                          TEMPORARY, DATA_ENTRY)},
+                         1000, /*expectSuccess*/ false,
+                         ContractDataDurability::TEMPORARY);
+
+        ledgerSeq = getLedgerSeq(*app);
+        auto newExpectedExpiration =
+            stateExpirationSettings.minPersistentEntryExpiration + ledgerSeq -
+            1;
+
+        SECTION("restore contract instance and wasm")
+        {
+            // Restore Instance and WASM
+            restoreOp(contractKeys, 1715);
+
+            // Instance should now be useable
+            putWithFootprint(
+                "temp", 0, contractKeys,
+                {contractDataKey(contractID, makeSymbolSCVal("temp"), TEMPORARY,
+                                 DATA_ENTRY)},
+                1000, /*expectSuccess*/ true,
+                ContractDataDurability::TEMPORARY);
+
+            checkKeyExpirationLedger(contractKeys[0], ledgerSeq,
+                                     newExpectedExpiration);
+            checkKeyExpirationLedger(contractKeys[1], ledgerSeq,
+                                     newExpectedExpiration);
+        }
+
+        SECTION("restore contract instance, not wasm")
+        {
+            // Only restore contract instance
+            restoreOp({contractKeys[0]}, 68);
+
+            // invocation should fail
+            putWithFootprint(
+                "temp", 0, contractKeys,
+                {contractDataKey(contractID, makeSymbolSCVal("temp"), TEMPORARY,
+                                 DATA_ENTRY)},
+                1000, /*expectSuccess*/ false,
+                ContractDataDurability::TEMPORARY);
+
+            checkKeyExpirationLedger(contractKeys[0], ledgerSeq,
+                                     newExpectedExpiration);
+            checkKeyExpirationLedger(contractKeys[1], ledgerSeq,
+                                     originalExpectedExpiration);
+        }
+
+        SECTION("restore contract wasm, not instance")
+        {
+            // Only restore WASM
+            restoreOp({contractKeys[1]}, 1648);
+
+            // invocation should fail
+            putWithFootprint(
+                "temp", 0, contractKeys,
+                {contractDataKey(contractID, makeSymbolSCVal("temp"), TEMPORARY,
+                                 DATA_ENTRY)},
+                1000, /*expectSuccess*/ false,
+                ContractDataDurability::TEMPORARY);
+
+            checkKeyExpirationLedger(contractKeys[0], ledgerSeq,
+                                     originalExpectedExpiration);
+            checkKeyExpirationLedger(contractKeys[1], ledgerSeq,
+                                     newExpectedExpiration);
+        }
+
+        SECTION("lifetime extensions")
+        {
+            // Restore Instance and WASM
+            restoreOp(contractKeys, 1715);
+
+            auto instanceBumpAmount = 10'000;
+            auto wasmBumpAmount = 15'000;
+
+            // bump instance
+            bumpOp(instanceBumpAmount, {contractKeys[0]}, 69);
+
+            // bump WASM
+            bumpOp(wasmBumpAmount, {contractKeys[1]}, 1754);
+
+            checkKeyExpirationLedger(contractKeys[0], ledgerSeq,
+                                     ledgerSeq + instanceBumpAmount);
+            checkKeyExpirationLedger(contractKeys[1], ledgerSeq,
+                                     ledgerSeq + wasmBumpAmount);
+        }
+    }
+
+    SECTION("contract storage expiration")
     {
         put("unique", 0, ContractDataDurability::PERSISTENT);
         put("temp", 0, TEMPORARY);
@@ -903,26 +1061,29 @@ TEST_CASE("contract storage", "[tx][soroban]")
             1;
 
         // Check for expected minimum lifetime values
-        REQUIRE(getContractDataExpiration("unique",
-                                          ContractDataDurability::PERSISTENT) ==
-                expectedPersistentExpiration);
-        REQUIRE(getContractDataExpiration("temp", TEMPORARY) ==
-                expectedTempExpiration);
+        checkContractDataExpirationLedger("unique",
+                                          ContractDataDurability::PERSISTENT,
+                                          expectedPersistentExpiration);
+        checkContractDataExpirationLedger("temp", TEMPORARY,
+                                          expectedTempExpiration);
 
         // Close ledgers until temp entry expires
-        uint32 ledger = app->getLedgerManager().getLastClosedLedgerNum();
-        for (; ledger <= expectedTempExpiration + 1; ++ledger)
+        uint32 currLedger = app->getLedgerManager().getLastClosedLedgerNum();
+        for (; currLedger <= expectedTempExpiration + 1; ++currLedger)
         {
-            closeLedgerOn(*app, ledger, 2, 1, 2016);
+            closeLedgerOn(*app, currLedger, 2, 1, 2016);
         }
-
-        // Check that temp entry is not live
         REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() ==
                 expectedTempExpiration + 1);
-        REQUIRE(!isEntryLive("temp", TEMPORARY,
-                             app->getLedgerManager().getLastClosedLedgerNum()));
-        REQUIRE(isEntryLive("unique", ContractDataDurability::PERSISTENT,
-                            app->getLedgerManager().getLastClosedLedgerNum()));
+
+        // Check that temp entry has expired
+        checkContractDataExpirationState(
+            "temp", TEMPORARY, app->getLedgerManager().getLastClosedLedgerNum(),
+            false);
+
+        checkContractDataExpirationState(
+            "unique", ContractDataDurability::PERSISTENT,
+            app->getLedgerManager().getLastClosedLedgerNum(), true);
 
         // Check that we can recreate an expired TEMPORARY entry
         putWithFootprint("temp", 0, contractKeys,
@@ -931,16 +1092,26 @@ TEST_CASE("contract storage", "[tx][soroban]")
                          1000, /*expectSuccess*/ true,
                          ContractDataDurability::TEMPORARY);
 
+        // Recreated entry should be live
+        ledgerSeq = getLedgerSeq(*app);
+        checkContractDataExpirationState(
+            "temp", TEMPORARY, app->getLedgerManager().getLastClosedLedgerNum(),
+            true);
+        checkContractDataExpirationLedger(
+            "temp", TEMPORARY,
+            stateExpirationSettings.minTempEntryExpiration + ledgerSeq - 1);
+
         // Close ledgers until PERSISTENT entry expires
-        for (; ledger <= expectedPersistentExpiration + 1; ++ledger)
+        for (; currLedger <= expectedPersistentExpiration + 1; ++currLedger)
         {
-            closeLedgerOn(*app, ledger, 2, 1, 2016);
+            closeLedgerOn(*app, currLedger, 2, 1, 2016);
         }
 
         REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() ==
                 expectedPersistentExpiration + 1);
-        REQUIRE(!isEntryLive("unique", ContractDataDurability::PERSISTENT,
-                             app->getLedgerManager().getLastClosedLedgerNum()));
+        checkContractDataExpirationState(
+            "unique", ContractDataDurability::PERSISTENT,
+            app->getLedgerManager().getLastClosedLedgerNum(), false);
 
         // Check that we can't recreate expired PERSISTENT
         putWithFootprint(
@@ -950,8 +1121,23 @@ TEST_CASE("contract storage", "[tx][soroban]")
             1000, /*expectSuccess*/ false, ContractDataDurability::PERSISTENT);
     }
 
+    // Autobump is disabled by default, enable it for some tests
+    auto enableAutobump = [&]() {
+        auto autobumpAmount = 10;
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        auto networkConfig =
+            app->getLedgerManager().getSorobanNetworkConfig(ltx);
+        auto newStateExpirationSettings = stateExpirationSettings;
+        newStateExpirationSettings.autoBumpLedgers = autobumpAmount;
+        networkConfig.stateExpirationSettings() = newStateExpirationSettings;
+        app->getLedgerManager().setSorobanNetworkConfig(networkConfig);
+        return autobumpAmount;
+    };
+
     SECTION("autobump")
     {
+        auto autobump = enableAutobump();
+
         put("rw", 0, ContractDataDurability::PERSISTENT);
         put("ro", 0, ContractDataDurability::PERSISTENT);
 
@@ -972,53 +1158,47 @@ TEST_CASE("contract storage", "[tx][soroban]")
             stateExpirationSettings.minPersistentEntryExpiration + ledgerSeq -
             1;
 
-        REQUIRE(getContractDataExpiration("rw",
-                                          ContractDataDurability::PERSISTENT) ==
-                expectedInitialExpiration + autoBump);
-        REQUIRE(getContractDataExpiration("ro",
-                                          ContractDataDurability::PERSISTENT) ==
-                expectedInitialExpiration + autoBump);
+        checkContractDataExpirationLedger("rw",
+                                          ContractDataDurability::PERSISTENT,
+                                          expectedInitialExpiration + autobump);
+        checkContractDataExpirationLedger("ro",
+                                          ContractDataDurability::PERSISTENT,
+                                          expectedInitialExpiration + autobump);
 
         // Contract instance and Wasm should have minimum life and 3 invocations
         // worth of autobumps
-        LedgerTxn ltx(app->getLedgerTxnRoot());
         for (auto const& key : contractKeys)
         {
-            uint32_t mult = key.type() == CONTRACT_CODE ? 4 : 3;
-            auto ltxe = ltx.loadWithoutRecord(key);
-            REQUIRE(ltxe);
-            REQUIRE(getExpirationLedger(ltxe.current()) ==
-                    expectedInitialExpiration + (autoBump * mult));
+            checkKeyExpirationLedger(
+                key, ledgerSeq, expectedInitialExpiration + (autobump * 3));
         }
     }
 
     SECTION("manual bump")
     {
+        // Large bump, followed by smaller bump
         put("key", 0, ContractDataDurability::PERSISTENT);
         bump("key", ContractDataDurability::PERSISTENT, 10'000);
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 10'000 - 1);
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'000 - 1);
 
-        // Expiration already above 5'000, should be a nop (other than autobump)
+        // Expiration already above 5'000, should be a no-op
         bump("key", ContractDataDurability::PERSISTENT, 5'000);
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 10'000 - 1 + autoBump);
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'000 - 1);
 
+        // Small bump followed by larger bump
         put("key2", 0, ContractDataDurability::PERSISTENT);
         bump("key2", ContractDataDurability::PERSISTENT, 5'000);
-        REQUIRE(getContractDataExpiration("key2",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 5'000 - 1);
+        checkContractDataExpirationLedger(
+            "key2", ContractDataDurability::PERSISTENT, ledgerSeq + 5'000 - 1);
 
         put("key3", 0, ContractDataDurability::PERSISTENT);
         bump("key3", ContractDataDurability::PERSISTENT, 50'000);
-        REQUIRE(getContractDataExpiration("key3",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 50'000 - 1);
+        checkContractDataExpirationLedger(
+            "key3", ContractDataDurability::PERSISTENT, ledgerSeq + 50'000 - 1);
 
-        // Bump to live 10100 ledger from now
+        // Bump multiple keys to live 10100 ledger from now
         bumpOp(
             10100,
             {contractDataKey(contractID, makeSymbolSCVal("key"),
@@ -1029,71 +1209,86 @@ TEST_CASE("contract storage", "[tx][soroban]")
                              ContractDataDurability::PERSISTENT, DATA_ENTRY)},
             178);
 
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 10'100);
-        REQUIRE(getContractDataExpiration("key2",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 10'100);
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'100);
+        checkContractDataExpirationLedger(
+            "key2", ContractDataDurability::PERSISTENT, ledgerSeq + 10'100);
 
         // No change for key3 since expiration is already past 10100 ledgers
         // from now
-        REQUIRE(getContractDataExpiration("key3",
-                                          ContractDataDurability::PERSISTENT) ==
-                ledgerSeq + 50'000 - 1);
+        checkContractDataExpirationLedger(
+            "key3", ContractDataDurability::PERSISTENT, ledgerSeq + 50'000 - 1);
     }
+
     SECTION("restore expired entry")
     {
-        auto minBump =
-            InitialSorobanNetworkConfig::MINIMUM_PERSISTENT_ENTRY_LIFETIME;
+        uint32_t initExpirationLedger =
+            stateExpirationSettings.minPersistentEntryExpiration + ledgerSeq -
+            1;
+
+        // Bump instance and WASM so that they don't expire during the test
+        bumpOp(10'000, contractKeys, 1744);
+
         put("key", 0, ContractDataDurability::PERSISTENT);
-        uint32_t initExpirationLedger = ledgerSeq + minBump - 1;
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::PERSISTENT) ==
-                initExpirationLedger);
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT, initExpirationLedger);
+
+        // Crank until entry expires
         for (uint32 i = app->getLedgerManager().getLastClosedLedgerNum();
              i <= initExpirationLedger + 1; ++i)
         {
             closeLedgerOn(*app, i, 2, 1, 2016);
         }
+
         REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() ==
                 initExpirationLedger + 1);
-        REQUIRE(!isEntryLive("key", ContractDataDurability::PERSISTENT,
-                             app->getLedgerManager().getLastClosedLedgerNum()));
 
-        // Trying to use this expired entry should fail.
-        putWithFootprint(
-            "key", 0, contractKeys,
-            {contractDataKey(contractID, makeSymbolSCVal("key"),
-                             ContractDataDurability::PERSISTENT, DATA_ENTRY)},
-            1000, /*expectSuccess*/ false, ContractDataDurability::PERSISTENT);
+        checkContractDataExpirationState(
+            "key", ContractDataDurability::PERSISTENT,
+            app->getLedgerManager().getLastClosedLedgerNum(), false);
 
-        // Restore the entry and then write to it.
-        restoreOp(
-            {contractDataKey(contractID, makeSymbolSCVal("key"),
-                             ContractDataDurability::PERSISTENT, DATA_ENTRY)},
-            61);
-        REQUIRE(
-            isEntryLive("key", ContractDataDurability::PERSISTENT,
-                        app->getLedgerManager().getLastClosedLedgerNum() + 1));
+        auto lk =
+            contractDataKey(contractID, makeSymbolSCVal("key"),
+                            ContractDataDurability::PERSISTENT, DATA_ENTRY);
+        auto roKeys = contractKeys;
+        roKeys.emplace_back(lk);
+
+        // Trying to read this expired entry should fail.
+        getWithFootprint("key", roKeys, {}, 1000, /*expectSuccess*/ false,
+                         ContractDataDurability::PERSISTENT);
+
+        // Recreation of persistent entries should fail.
+        putWithFootprint("key", 0, contractKeys, {lk}, 1000,
+                         /*expectSuccess*/ false,
+                         ContractDataDurability::PERSISTENT);
+
+        // Restore the entry
+        restoreOp({lk}, 61);
+
+        ledgerSeq = getLedgerSeq(*app);
+        checkContractDataExpirationState(
+            "key", ContractDataDurability::PERSISTENT, ledgerSeq, true);
+
         // Entry is considered to be restored on lclNum (as we didn't close an
         // additional ledger).
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::PERSISTENT) ==
-                app->getLedgerManager().getLastClosedLedgerNum() + minBump - 1);
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT,
+            ledgerSeq + stateExpirationSettings.minPersistentEntryExpiration -
+                1);
 
+        // Write to entry to check that is is live
         put("key", 1, ContractDataDurability::PERSISTENT);
     }
+
     SECTION("re-create expired temporary entry")
     {
         auto minBump = InitialSorobanNetworkConfig::MINIMUM_TEMP_ENTRY_LIFETIME;
         put("key", 0, ContractDataDurability::TEMPORARY);
         REQUIRE(has("key", ContractDataDurability::TEMPORARY));
 
-        uint32_t initExpirationLedger = ledgerSeq + minBump + autoBump - 1;
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::TEMPORARY) ==
-                initExpirationLedger);
+        uint32_t initExpirationLedger = ledgerSeq + minBump - 1;
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::TEMPORARY, initExpirationLedger);
 
         for (size_t i = app->getLedgerManager().getLastClosedLedgerNum();
              i <= initExpirationLedger + 1; ++i)
@@ -1102,8 +1297,9 @@ TEST_CASE("contract storage", "[tx][soroban]")
         }
         REQUIRE(app->getLedgerManager().getLastClosedLedgerNum() ==
                 initExpirationLedger + 1);
-        REQUIRE(!isEntryLive("key", ContractDataDurability::TEMPORARY,
-                             app->getLedgerManager().getLastClosedLedgerNum()));
+        checkContractDataExpirationState(
+            "key", ContractDataDurability::TEMPORARY,
+            app->getLedgerManager().getLastClosedLedgerNum(), false);
 
         // Entry has expired
         REQUIRE(!has("key", ContractDataDurability::TEMPORARY));
@@ -1113,38 +1309,37 @@ TEST_CASE("contract storage", "[tx][soroban]")
         REQUIRE(has("key", ContractDataDurability::TEMPORARY));
 
         uint32_t newExpirationLedger =
-            app->getLedgerManager().getLastClosedLedgerNum() + minBump +
-            autoBump - 1;
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::TEMPORARY) ==
-                newExpirationLedger);
+            app->getLedgerManager().getLastClosedLedgerNum() + minBump - 1;
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::TEMPORARY, newExpirationLedger);
     }
+
     SECTION("max expiration")
     {
+        auto autobump = enableAutobump();
+        REQUIRE(autobump > 1);
+
         // Check that manual bump doesn't go over max
         put("key", 0, ContractDataDurability::PERSISTENT);
         bump("key", ContractDataDurability::PERSISTENT, UINT32_MAX);
 
         auto maxExpiration =
             ledgerSeq + stateExpirationSettings.maxEntryExpiration - 1;
-        REQUIRE(getContractDataExpiration("key",
-                                          ContractDataDurability::PERSISTENT) ==
-                maxExpiration);
+        checkContractDataExpirationLedger(
+            "key", ContractDataDurability::PERSISTENT, maxExpiration);
 
         // Manual bump to almost max, then autobump to check that autobump
         // doesn't go over max
         put("key2", 0, ContractDataDurability::PERSISTENT);
         bump("key2", ContractDataDurability::PERSISTENT,
              stateExpirationSettings.maxEntryExpiration - 1);
-        REQUIRE(getContractDataExpiration("key2",
-                                          ContractDataDurability::PERSISTENT) ==
-                maxExpiration - 1);
+        checkContractDataExpirationLedger(
+            "key2", ContractDataDurability::PERSISTENT, maxExpiration - 1);
 
         // Autobump should only add a single ledger to bring expiration to max
         put("key2", 1, ContractDataDurability::PERSISTENT);
-        REQUIRE(getContractDataExpiration("key2",
-                                          ContractDataDurability::PERSISTENT) ==
-                maxExpiration);
+        checkContractDataExpirationLedger(
+            "key2", ContractDataDurability::PERSISTENT, maxExpiration);
     }
 }
 


### PR DESCRIPTION
# Description

Resolves #3854 and #3850.

This change moves state expiration enforcement to the `InvokeHostFunctionOpFrame` level. By doing so, the database and "ledger state" is agnostic to expiration semantics. This simplifies BucketList invariants and makes it easier for downstream systems to ingest state related meta. This resolves the issue that crashed preview 10.

This PR also adds more state expiration unit tests.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
