### PR TITLE
Refactor core to use `e2e_invoke` host module.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,39 +968,39 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766#1412a9fd2747776e035327ae5b3cc194b4104766"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99#14f485683048eb78314cb5f43fcc05d5086f4e99"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-integer",
  "num-traits",
- "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766)",
+ "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.17 (git+https://github.com/stellar/rs-stellar-xdr?rev=e5ece22d187f9822b6e0da7264ca5606d9cbee33)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-integer",
  "num-traits",
- "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53)",
+ "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 0.0.17 (git+https://github.com/stellar/rs-stellar-xdr?rev=d6e02584ac9f4046bf38eaf445ced0d4f33631fd)",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766#1412a9fd2747776e035327ae5b3cc194b4104766"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99#14f485683048eb78314cb5f43fcc05d5086f4e99"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1016,8 +1016,8 @@ dependencies = [
  "rand_chacha",
  "sha2 0.9.9",
  "sha3",
- "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766)",
- "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766)",
+ "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99)",
+ "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -1042,8 +1042,8 @@ dependencies = [
  "rand_chacha",
  "sha2 0.9.9",
  "sha3",
- "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53)",
- "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53)",
+ "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f)",
+ "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
@@ -1053,14 +1053,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766#1412a9fd2747776e035327ae5b3cc194b4104766"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99#14f485683048eb78314cb5f43fcc05d5086f4e99"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.17 (git+https://github.com/stellar/rs-stellar-xdr?rev=e5ece22d187f9822b6e0da7264ca5606d9cbee33)",
+ "stellar-xdr",
  "syn 2.0.18",
  "thiserror",
 ]
@@ -1068,14 +1068,14 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 0.0.17 (git+https://github.com/stellar/rs-stellar-xdr?rev=d6e02584ac9f4046bf38eaf445ced0d4f33631fd)",
+ "stellar-xdr",
  "syn 2.0.18",
  "thiserror",
 ]
@@ -1083,7 +1083,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766#1412a9fd2747776e035327ae5b3cc194b4104766"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99#14f485683048eb78314cb5f43fcc05d5086f4e99"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1094,7 +1094,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1150,8 +1150,8 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=1412a9fd2747776e035327ae5b3cc194b4104766)",
- "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53)",
+ "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=14f485683048eb78314cb5f43fcc05d5086f4e99)",
+ "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f)",
  "soroban-test-wasms",
  "tracy-client",
 ]
@@ -1169,16 +1169,6 @@ dependencies = [
 name = "stellar-xdr"
 version = "0.0.17"
 source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d6e02584ac9f4046bf38eaf445ced0d4f33631fd#d6e02584ac9f4046bf38eaf445ced0d4f33631fd"
-dependencies = [
- "base64",
- "crate-git-revision",
- "hex",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "0.0.17"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e5ece22d187f9822b6e0da7264ca5606d9cbee33#e5ece22d187f9822b6e0da7264ca5606d9cbee33"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -788,7 +788,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
     auto const& sorobanConfig =
         app->getLedgerManager().getSorobanNetworkConfig(ltx);
     ltx.commit();
-    SECTION("unknown config upgrade set results in exception")
+    SECTION("unknown config upgrade set is ignored")
     {
         auto contractID = autocheck::generator<Hash>()(5);
         auto upgradeHash = autocheck::generator<Hash>()(5);

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -28,7 +28,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "33912e6a43cf6a87ff4a177b481a4281b269ae53"
+rev = "75c043970e9098952848c8dd97e532b86ce78a8f"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -52,11 +52,11 @@ optional = true
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "1412a9fd2747776e035327ae5b3cc194b4104766"
+rev = "14f485683048eb78314cb5f43fcc05d5086f4e99"
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "33912e6a43cf6a87ff4a177b481a4281b269ae53"
+rev = "75c043970e9098952848c8dd97e532b86ce78a8f"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -5,13 +5,13 @@
 use crate::{
     log::partition::TX,
     rust_bridge::{
-        Bump, CxxBuf, CxxFeeConfiguration, CxxLedgerEntryRentChange, CxxLedgerInfo,
+        CxxBuf, CxxFeeConfiguration, CxxLedgerEntryRentChange, CxxLedgerInfo,
         CxxRentFeeConfiguration, CxxTransactionResources, CxxWriteFeeConfiguration, FeePair,
-        InvokeHostFunctionOutput, RustBuf, XDRFileHash,
+        InvokeHostFunctionOutput, ReadOnlyBump, RustBuf, XDRFileHash,
     },
 };
 use log::debug;
-use std::{fmt::Display, io::Cursor, panic, rc::Rc, time::Instant};
+use std::{fmt::Display, io::Cursor, panic, time::Instant};
 
 // This module (contract) is bound to _two separate locations_ in the module
 // tree: crate::lo::contract and crate::hi::contract, each of which has a (lo or
@@ -19,23 +19,18 @@ use std::{fmt::Display, io::Cursor, panic, rc::Rc, time::Instant};
 // import it from our _parent_ module rather than from the crate root.
 use super::soroban_env_host::{
     budget::Budget,
-    events::Events,
-    expiration_ledger_bumps::ExpirationLedgerBumps,
+    e2e_invoke::{self, extract_rent_changes, LedgerEntryChange},
     fees::{
         compute_rent_fee as host_compute_rent_fee,
         compute_transaction_resource_fee as host_compute_transaction_resource_fee,
         compute_write_fee_per_1kb as host_compute_write_fee_per_1kb, FeeConfiguration,
         LedgerEntryRentChange, RentFeeConfiguration, TransactionResources, WriteFeeConfiguration,
     },
-    storage::{self, AccessType, Footprint, FootprintMap, Storage, StorageMap},
     xdr::{
-        self, AccountId, ContractCodeEntryBody, ContractCostParams, ContractDataEntryBody,
-        ContractEntryBodyType, ContractEvent, ContractEventType, DiagnosticEvent, HostFunction,
-        LedgerEntry, LedgerEntryData, LedgerKey, LedgerKeyAccount, LedgerKeyContractCode,
-        LedgerKeyContractData, LedgerKeyTrustLine, ReadXdr, ScErrorCode, ScErrorType,
-        SorobanAuthorizationEntry, SorobanResources, WriteXdr, XDR_FILES_SHA256,
+        self, ContractCostParams, DiagnosticEvent, ReadXdr, ScErrorCode, ScErrorType, WriteXdr,
+        XDR_FILES_SHA256,
     },
-    DiagnosticLevel, Host, HostError, LedgerInfo,
+    HostError, LedgerInfo,
 };
 use std::error::Error;
 
@@ -50,6 +45,7 @@ impl From<CxxLedgerInfo> for LedgerInfo {
             min_temp_entry_expiration: c.min_temp_entry_expiration,
             min_persistent_entry_expiration: c.min_persistent_entry_expiration,
             max_entry_expiration: c.max_entry_expiration,
+            autobump_ledgers: c.autobump_ledgers,
         }
     }
 }
@@ -116,6 +112,18 @@ impl From<CxxWriteFeeConfiguration> for WriteFeeConfiguration {
     }
 }
 
+impl From<Vec<u8>> for RustBuf {
+    fn from(value: Vec<u8>) -> Self {
+        Self { data: value }
+    }
+}
+
+impl AsRef<[u8]> for CxxBuf {
+    fn as_ref(&self) -> &[u8] {
+        self.data.as_slice()
+    }
+}
+
 // FIXME: plumb this through from the limit xdrpp uses.
 // Currently they are just two same-valued constants.
 const MARSHALLING_STACK_LIMIT: u32 = 1000;
@@ -146,42 +154,24 @@ impl From<xdr::Error> for CoreHostError {
 
 impl std::error::Error for CoreHostError {}
 
-fn xdr_from_slice<T: ReadXdr>(v: &[u8]) -> Result<T, HostError> {
+fn non_metered_xdr_from_cxx_buf<T: ReadXdr>(buf: &CxxBuf) -> Result<T, HostError> {
     Ok(T::read_xdr(&mut xdr::DepthLimitedRead::new(
-        Cursor::new(v),
+        Cursor::new(buf.data.as_slice()),
         MARSHALLING_STACK_LIMIT,
     ))
-    .map_err(|_| (ScErrorType::Value, ScErrorCode::InvalidInput))?)
+    // We only expect this to be called for safe, internal conversions, so this
+    // should never happen.
+    .map_err(|_| (ScErrorType::Value, ScErrorCode::InternalError))?)
 }
 
-fn xdr_to_vec_u8<T: WriteXdr>(t: &T) -> Result<Vec<u8>, HostError> {
+fn non_metered_xdr_to_rust_buf<T: WriteXdr>(t: &T) -> Result<RustBuf, HostError> {
     let mut vec: Vec<u8> = Vec::new();
     t.write_xdr(&mut xdr::DepthLimitedWrite::new(
         Cursor::new(&mut vec),
         MARSHALLING_STACK_LIMIT,
     ))
     .map_err(|_| (ScErrorType::Value, ScErrorCode::InvalidInput))?;
-    Ok(vec)
-}
-
-fn xdr_to_rust_buf<T: WriteXdr>(t: &T) -> Result<RustBuf, HostError> {
-    let data = xdr_to_vec_u8(t)?;
-    Ok(RustBuf { data })
-}
-
-fn event_to_diagnostic_event_rust_buf(
-    ev: &ContractEvent,
-    failed_call: bool,
-) -> Result<RustBuf, HostError> {
-    let dev = DiagnosticEvent {
-        in_successful_contract_call: !failed_call,
-        event: ev.clone(),
-    };
-    xdr_to_rust_buf(&dev)
-}
-
-fn xdr_from_cxx_buf<T: ReadXdr>(buf: &CxxBuf) -> Result<T, HostError> {
-    xdr_from_slice(buf.data.as_slice())
+    Ok(vec.into())
 }
 
 /// Returns a vec of [`XDRFileHash`] structs each representing one .x file
@@ -198,196 +188,51 @@ pub fn get_xdr_hashes() -> Vec<XDRFileHash> {
         .collect()
 }
 
-/// Helper for [`build_storage_footprint_from_xdr`] that inserts a copy of some
-/// [`AccessType`] `ty` into a [`storage::Footprint`] for every [`LedgerKey`] in
-/// `keys`.
-fn populate_access_map(
-    access: &mut FootprintMap,
-    keys: Vec<LedgerKey>,
-    ty: AccessType,
-    budget: &Budget,
-) -> Result<(), CoreHostError> {
-    for lk in keys {
-        match lk {
-            LedgerKey::Account(_)
-            | LedgerKey::Trustline(_)
-            | LedgerKey::ContractData(_)
-            | LedgerKey::ContractCode(_) => (),
-            _ => return Err(CoreHostError::General("unexpected ledger entry type")),
-        };
-        *access = access.insert(Rc::new(lk), ty.clone(), budget)?;
-    }
-    Ok(())
-}
-
-/// Deserializes an [`xdr::LedgerFootprint`] from the provided [`CxxBuf`], converts
-/// its entries to an [`OrdMap`], and returns a [`storage::Footprint`]
-/// containing that map.
-fn build_storage_footprint_from_xdr(
-    budget: &Budget,
-    footprint: &xdr::LedgerFootprint,
-) -> Result<Footprint, CoreHostError> {
-    let xdr::LedgerFootprint {
-        read_only,
-        read_write,
-    } = footprint;
-    let mut access = FootprintMap::new();
-
-    populate_access_map(
-        &mut access,
-        read_only.to_vec(),
-        AccessType::ReadOnly,
-        budget,
-    )?;
-    populate_access_map(
-        &mut access,
-        read_write.to_vec(),
-        AccessType::ReadWrite,
-        budget,
-    )?;
-    Ok(storage::Footprint(access))
-}
-
-fn ledger_entry_to_ledger_key(le: &LedgerEntry) -> Result<LedgerKey, CoreHostError> {
-    match &le.data {
-        LedgerEntryData::Account(a) => Ok(LedgerKey::Account(LedgerKeyAccount {
-            account_id: a.account_id.clone(),
-        })),
-        LedgerEntryData::Trustline(tl) => Ok(LedgerKey::Trustline(LedgerKeyTrustLine {
-            account_id: tl.account_id.clone(),
-            asset: tl.asset.clone(),
-        })),
-        LedgerEntryData::ContractData(cd) => Ok(LedgerKey::ContractData(LedgerKeyContractData {
-            contract: cd.contract.clone(),
-            key: cd.key.clone(),
-            durability: cd.durability.clone(),
-            body_type: match &cd.body {
-                ContractDataEntryBody::DataEntry(_data) => ContractEntryBodyType::DataEntry,
-                ContractDataEntryBody::ExpirationExtension => {
-                    ContractEntryBodyType::ExpirationExtension
-                }
-            },
-        })),
-        LedgerEntryData::ContractCode(code) => Ok(LedgerKey::ContractCode(LedgerKeyContractCode {
-            hash: code.hash.clone(),
-            body_type: match &code.body {
-                ContractCodeEntryBody::DataEntry(_data) => ContractEntryBodyType::DataEntry,
-                ContractCodeEntryBody::ExpirationExtension => {
-                    ContractEntryBodyType::ExpirationExtension
-                }
-            },
-        })),
-        _ => Err(CoreHostError::General("unexpected ledger key")),
+fn log_diagnostic_events(events: &Vec<DiagnosticEvent>) {
+    for e in events {
+        debug!("Diagnostic event: {:?}", e);
     }
 }
 
-/// Deserializes a sequence of [`xdr::LedgerEntry`] structures from a vector of
-/// [`CxxBuf`] buffers, inserts them into an [`OrdMap`] with entries
-/// additionally keyed by the provided contract ID, checks that the entries
-/// match the provided [`storage::Footprint`], and returns the constructed map.
-fn build_storage_map_from_xdr_ledger_entries(
-    budget: &Budget,
-    footprint: &storage::Footprint,
-    ledger_entries: &Vec<CxxBuf>,
-) -> Result<StorageMap, CoreHostError> {
-    let mut map = StorageMap::new();
-    for buf in ledger_entries {
-        let le = Rc::new(xdr_from_cxx_buf::<LedgerEntry>(buf)?);
-        let key = Rc::new(ledger_entry_to_ledger_key(&le)?);
-        if !footprint.0.contains_key::<LedgerKey>(&key, budget)? {
-            return Err(CoreHostError::General(
-                "ledger entry not found in footprint",
-            ));
-        }
-        map = map.insert(key, Some(le), budget)?;
-    }
-    for k in footprint.0.keys(budget)? {
-        if !map.contains_key::<LedgerKey>(k, budget)? {
-            map = map.insert(k.clone(), None, budget)?;
-        }
-    }
-    Ok(map)
-}
-
-fn build_auth_entries_from_xdr(
-    contract_auth_entries_xdr: &Vec<CxxBuf>,
-) -> Result<Vec<SorobanAuthorizationEntry>, CoreHostError> {
-    let mut res = vec![];
-    for buf in contract_auth_entries_xdr {
-        res.push(xdr_from_cxx_buf::<SorobanAuthorizationEntry>(buf)?);
-    }
-    Ok(res)
-}
-
-/// Iterates over the storage map and serializes the read-write ledger entries
-/// back to XDR.
-fn build_xdr_ledger_entries_from_storage_map(
-    footprint: &storage::Footprint,
-    storage_map: &StorageMap,
-    budget: &Budget,
-) -> Result<Vec<RustBuf>, CoreHostError> {
-    let mut res = Vec::new();
-    for (lk, ole) in storage_map {
-        match footprint.0.get::<LedgerKey>(lk, budget)? {
-            Some(AccessType::ReadOnly) => (),
-            Some(AccessType::ReadWrite) => {
-                if let Some(le) = ole {
-                    res.push(xdr_to_rust_buf(&**le)?)
-                }
-            }
-            None => return Err(CoreHostError::General("ledger entry not in footprint")),
-        }
-    }
-    Ok(res)
-}
-
-fn extract_contract_events(events: &Events) -> Result<Vec<RustBuf>, HostError> {
+fn encode_diagnostic_events(events: &Vec<DiagnosticEvent>) -> Vec<RustBuf> {
     events
-        .0
         .iter()
         .filter_map(|e| {
-            if e.failed_call || e.event.type_ == ContractEventType::Diagnostic {
-                return None;
+            if let Ok(encoded) = non_metered_xdr_to_rust_buf(e) {
+                Some(encoded)
+            } else {
+                None
             }
-
-            Some(xdr_to_rust_buf(&e.event))
         })
         .collect()
 }
 
-// Note that this also includes Contract events so the ordering between
-// Contract and StructuredDebug events can be preserved. This does mean that
-// the Contract events will be duplicated in the meta if diagnostics are on - in
-// the hashed portion of the meta, and in the non-hashed diagnostic events.
-fn extract_diagnostic_events(events: &Events) -> Result<Vec<RustBuf>, HostError> {
-    events
-        .0
-        .iter()
-        .map(|e| event_to_diagnostic_event_rust_buf(&e.event, e.failed_call))
-        .collect()
-}
+fn extract_ledger_effects(
+    entry_changes: Vec<LedgerEntryChange>,
+) -> (Vec<RustBuf>, Vec<ReadOnlyBump>) {
+    let mut modified_entries = vec![];
+    let mut read_only_bumps = vec![];
 
-fn log_debug_events(events: &Events) {
-    for e in events.0.iter() {
-        match &e.event.type_ {
-            ContractEventType::Contract | ContractEventType::System => (),
-            ContractEventType::Diagnostic => {
-                debug!("Diagnostic event: {:?}", e.event)
+    for change in entry_changes {
+        if change.read_only {
+            // Only return expiration bumps for read-only entries (if any).
+            if let Some(expiration_change) = change.expiration_change {
+                if expiration_change.new_expiration_ledger > expiration_change.old_expiration_ledger
+                {
+                    read_only_bumps.push(ReadOnlyBump {
+                        ledger_key: change.encoded_key.into(),
+                        min_expiration: expiration_change.new_expiration_ledger,
+                    });
+                }
+            }
+        } else {
+            if let Some(encoded_new_value) = change.encoded_new_value {
+                modified_entries.push(encoded_new_value.into());
             }
         }
     }
-}
 
-fn extract_bumps(bumps: &ExpirationLedgerBumps) -> Result<Vec<Bump>, HostError> {
-    bumps
-        .iter()
-        .map(|e| {
-            Ok(Bump {
-                ledger_key: xdr_to_rust_buf(e.key.as_ref())?,
-                min_expiration: e.min_expiration,
-            })
-        })
-        .collect()
+    (modified_entries, read_only_bumps)
 }
 
 /// Deserializes an [`xdr::HostFunction`] host function XDR object an
@@ -398,6 +243,7 @@ fn extract_bumps(bumps: &ExpirationLedgerBumps) -> Result<Vec<Bump>, HostError> 
 /// been deleted.
 pub(crate) fn invoke_host_function(
     enable_diagnostics: bool,
+    instruction_limit: u32,
     hf_buf: &CxxBuf,
     resources_buf: &CxxBuf,
     source_account_buf: &CxxBuf,
@@ -405,10 +251,12 @@ pub(crate) fn invoke_host_function(
     ledger_info: CxxLedgerInfo,
     ledger_entries: &Vec<CxxBuf>,
     base_prng_seed: &CxxBuf,
+    rent_fee_configuration: CxxRentFeeConfiguration,
 ) -> Result<InvokeHostFunctionOutput, Box<dyn Error>> {
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         invoke_host_function_or_maybe_panic(
             enable_diagnostics,
+            instruction_limit,
             hf_buf,
             resources_buf,
             source_account_buf,
@@ -416,6 +264,7 @@ pub(crate) fn invoke_host_function(
             ledger_info,
             ledger_entries,
             base_prng_seed,
+            rent_fee_configuration,
         )
     }));
     match res {
@@ -426,6 +275,7 @@ pub(crate) fn invoke_host_function(
 
 fn invoke_host_function_or_maybe_panic(
     enable_diagnostics: bool,
+    instruction_limit: u32,
     hf_buf: &CxxBuf,
     resources_buf: &CxxBuf,
     source_account_buf: &CxxBuf,
@@ -433,52 +283,47 @@ fn invoke_host_function_or_maybe_panic(
     ledger_info: CxxLedgerInfo,
     ledger_entries: &Vec<CxxBuf>,
     base_prng_seed: &CxxBuf,
+    rent_fee_configuration: CxxRentFeeConfiguration,
 ) -> Result<InvokeHostFunctionOutput, Box<dyn Error>> {
     #[cfg(feature = "tracy")]
     let client = tracy_client::Client::start();
     let _span0 = tracy_span!("invoke_host_function_or_maybe_panic");
 
-    let hf = xdr_from_cxx_buf::<HostFunction>(&hf_buf)?;
-    let source_account = xdr_from_cxx_buf::<AccountId>(&source_account_buf)?;
-    let resources = xdr_from_cxx_buf::<SorobanResources>(&resources_buf)?;
-
     let budget = Budget::from_configs(
-        resources.instructions as u64,
+        instruction_limit as u64,
         ledger_info.memory_limit as u64,
-        xdr_from_cxx_buf::<ContractCostParams>(&ledger_info.cpu_cost_params)?,
-        xdr_from_cxx_buf::<ContractCostParams>(&ledger_info.mem_cost_params)?,
+        // These are the only non-metered XDR conversions that we perform. They
+        // have a small constant cost that is independent of the user-provided
+        // data.
+        non_metered_xdr_from_cxx_buf::<ContractCostParams>(&ledger_info.cpu_cost_params)?,
+        non_metered_xdr_from_cxx_buf::<ContractCostParams>(&ledger_info.mem_cost_params)?,
     );
-    let footprint = build_storage_footprint_from_xdr(&budget, &resources.footprint)?;
-    let map = build_storage_map_from_xdr_ledger_entries(&budget, &footprint, ledger_entries)?;
-    let storage = Storage::with_enforcing_footprint_and_map(footprint, map);
-    let auth_entries = build_auth_entries_from_xdr(auth_entries)?;
-    let host = Host::with_storage_and_budget(storage, budget);
-    host.set_source_account(source_account)?;
-    host.set_ledger_info(ledger_info.into())?;
-    host.set_authorization_entries(auth_entries)?;
-    let seed32: [u8; 32] = base_prng_seed
-        .data
-        .as_slice()
-        .try_into()
-        .map_err(|_| CoreHostError::General("Wrong base PRNG seed size"))?;
-    host.set_base_prng_seed(seed32)?;
-    if enable_diagnostics {
-        host.set_diagnostic_level(DiagnosticLevel::Debug)?;
-    }
-
+    let mut diagnostic_events = vec![];
+    let ledger_seq_num = ledger_info.sequence_number;
     let (res, time_nsecs) = {
-        let _span1 = tracy_span!("Host::invoke_function");
+        let _span1 = tracy_span!("e2e_invoke::invoke_function");
         let start_time = Instant::now();
-        let res = host.invoke_function(hf);
+        let res = e2e_invoke::invoke_host_function(
+            &budget,
+            enable_diagnostics,
+            hf_buf,
+            resources_buf,
+            source_account_buf,
+            auth_entries.iter(),
+            ledger_info.into(),
+            ledger_entries.iter(),
+            base_prng_seed,
+            &mut diagnostic_events,
+        );
         let stop_time = Instant::now();
         let time_nsecs = stop_time.duration_since(start_time).as_nanos() as u64;
         (res, time_nsecs)
     };
 
-    let (storage, budget, events, bumps) = host
-        .try_finish()
-        .map_err(|_h| CoreHostError::General("could not finalize host"))?;
-    log_debug_events(&events);
+    // Unconditionally log diagnostic events (there won't be any if diagnostics
+    // is disabled).
+    log_diagnostic_events(&diagnostic_events);
+
     let cpu_insns = budget.get_cpu_insns_consumed()?;
     let mem_bytes = budget.get_mem_bytes_consumed()?;
     #[cfg(feature = "tracy")]
@@ -492,41 +337,54 @@ fn invoke_host_function_or_maybe_panic(
             mem_bytes as f64,
         );
     }
-    let result_value = match res {
-        Ok(rv) => xdr_to_rust_buf(&rv)?,
-        Err(err) => {
-            debug!(target: TX, "invocation failed: {}", err);
-            return Ok(InvokeHostFunctionOutput {
-                success: false,
-                result_value: RustBuf { data: vec![] },
-                contract_events: vec![],
-                diagnostic_events: extract_diagnostic_events(&events)?,
-                modified_ledger_entries: vec![],
-                expiration_bumps: vec![],
-                cpu_insns,
-                mem_bytes,
-                time_nsecs,
-            });
-        }
+    let err = match res {
+        Ok(res) => match res.encoded_invoke_result {
+            Ok(result_value) => {
+                let rent_changes = extract_rent_changes(&res.ledger_changes);
+                let rent_fee = host_compute_rent_fee(
+                    &rent_changes,
+                    &rent_fee_configuration.into(),
+                    ledger_seq_num,
+                );
+                let (modified_ledger_entries, read_only_bumps) =
+                    extract_ledger_effects(res.ledger_changes);
+                return Ok(InvokeHostFunctionOutput {
+                    success: true,
+                    diagnostic_events: encode_diagnostic_events(&diagnostic_events),
+                    cpu_insns,
+                    mem_bytes,
+                    time_nsecs,
+
+                    result_value: result_value.into(),
+                    modified_ledger_entries,
+                    read_only_bumps,
+                    contract_events: res
+                        .encoded_contract_events
+                        .into_iter()
+                        .map(RustBuf::from)
+                        .collect(),
+                    rent_fee,
+                });
+            }
+            Err(e) => e,
+        },
+        Err(e) => e,
     };
 
-    let modified_ledger_entries =
-        build_xdr_ledger_entries_from_storage_map(&storage.footprint, &storage.map, &budget)?;
-    let contract_events = extract_contract_events(&events)?;
-    let diagnostic_events = extract_diagnostic_events(&events)?;
-    let expiration_bumps = extract_bumps(&bumps)?;
-
-    Ok(InvokeHostFunctionOutput {
-        success: true,
-        result_value,
-        contract_events,
-        diagnostic_events,
-        modified_ledger_entries,
-        expiration_bumps,
+    debug!(target: TX, "invocation failed: {}", err);
+    return Ok(InvokeHostFunctionOutput {
+        success: false,
+        diagnostic_events: encode_diagnostic_events(&diagnostic_events),
         cpu_insns,
         mem_bytes,
         time_nsecs,
-    })
+
+        result_value: vec![].into(),
+        modified_ledger_entries: vec![],
+        read_only_bumps: vec![],
+        contract_events: vec![],
+        rent_fee: 0,
+    });
 }
 
 pub(crate) fn compute_transaction_resource_fee(

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53
+soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f
 ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── tracy-client-sys 0.20.0 checksum:e8cf8aeb20e40d13be65a0b134f8d82d360e72b2793a11de8867d7fbc0f9d6f6
 │   │   └── cc 1.0.79 checksum:50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f
@@ -86,13 +86,13 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=33912e
 │   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53
+├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f
 │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
 │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
 │       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
-├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53
+├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f
 │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=d6e02584ac9f4046bf38eaf445ced0d4f33631fd#d6e02584ac9f4046bf38eaf445ced0d4f33631fd
 │   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
 │   │   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
@@ -109,7 +109,7 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=33912e
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
 │   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
-│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=33912e6a43cf6a87ff4a177b481a4281b269ae53#33912e6a43cf6a87ff4a177b481a4281b269ae53
+│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=75c043970e9098952848c8dd97e532b86ce78a8f#75c043970e9098952848c8dd97e532b86ce78a8f
 │   │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
 │   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=d6e02584ac9f4046bf38eaf445ced0d4f33631fd#d6e02584ac9f4046bf38eaf445ced0d4f33631fd

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -782,19 +782,13 @@ TransactionFrame::maybeComputeSorobanResourceFee(
                                   /* useConsumedRefundableResources */ false));
 }
 
-void
+bool
 TransactionFrame::consumeRefundableSorobanResources(
-    uint32_t contractEventSizeBytes, int64_t rentFee)
+    uint32_t contractEventSizeBytes, int64_t rentFee, uint32_t protocolVersion,
+    SorobanNetworkConfig const& sorobanConfig, Config const& cfg)
 {
     mConsumedContractEventsSizeBytes += contractEventSizeBytes;
     mConsumedRentFee += rentFee;
-}
-
-bool
-TransactionFrame::computeSorobanFeeRefund(
-    uint32_t protocolVersion, SorobanNetworkConfig const& sorobanConfig,
-    Config const& cfg)
-{
     mFeeRefund = sorobanRefundableFee();
     if (mFeeRefund < mConsumedRentFee)
     {
@@ -812,6 +806,7 @@ TransactionFrame::computeSorobanFeeRefund(
     mFeeRefund -= consumedFee.refundable_fee;
     return true;
 }
+
 #endif
 
 bool
@@ -1514,17 +1509,6 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                 ltxOp.commit();
             }
         }
-
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-        if (isSoroban())
-        {
-            success = success &&
-                      computeSorobanFeeRefund(
-                          ledgerVersion,
-                          app.getLedgerManager().getSorobanNetworkConfig(ltx),
-                          app.getConfig());
-        }
-#endif
 
         if (success)
         {

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -284,11 +284,11 @@ class TransactionFrame : public TransactionFrameBase
     maybeComputeSorobanResourceFee(uint32_t protocolVersion,
                                    SorobanNetworkConfig const& sorobanConfig,
                                    Config const& cfg) override;
-    void consumeRefundableSorobanResources(uint32_t contractEventSizeBytes,
-                                           int64_t rentFee);
-    bool computeSorobanFeeRefund(uint32_t protocolVersion,
-                                 SorobanNetworkConfig const& sorobanConfig,
-                                 Config const& cfg);
+    bool
+    consumeRefundableSorobanResources(uint32_t contractEventSizeBytes,
+                                      int64_t rentFee, uint32_t protocolVersion,
+                                      SorobanNetworkConfig const& sorobanConfig,
+                                      Config const& cfg);
 #endif
 };
 }

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1180,23 +1180,23 @@ TEST_CASE("contract storage", "[tx][soroban]")
         put("key", 0, ContractDataDurability::PERSISTENT);
         bump("key", ContractDataDurability::PERSISTENT, 10'000);
         checkContractDataExpirationLedger(
-            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'000 - 1);
+            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'000);
 
         // Expiration already above 5'000, should be a no-op
         bump("key", ContractDataDurability::PERSISTENT, 5'000);
         checkContractDataExpirationLedger(
-            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'000 - 1);
+            "key", ContractDataDurability::PERSISTENT, ledgerSeq + 10'000);
 
         // Small bump followed by larger bump
         put("key2", 0, ContractDataDurability::PERSISTENT);
         bump("key2", ContractDataDurability::PERSISTENT, 5'000);
         checkContractDataExpirationLedger(
-            "key2", ContractDataDurability::PERSISTENT, ledgerSeq + 5'000 - 1);
+            "key2", ContractDataDurability::PERSISTENT, ledgerSeq + 5'000);
 
         put("key3", 0, ContractDataDurability::PERSISTENT);
         bump("key3", ContractDataDurability::PERSISTENT, 50'000);
         checkContractDataExpirationLedger(
-            "key3", ContractDataDurability::PERSISTENT, ledgerSeq + 50'000 - 1);
+            "key3", ContractDataDurability::PERSISTENT, ledgerSeq + 50'000);
 
         // Bump multiple keys to live 10100 ledger from now
         bumpOp(
@@ -1217,7 +1217,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
         // No change for key3 since expiration is already past 10100 ledgers
         // from now
         checkContractDataExpirationLedger(
-            "key3", ContractDataDurability::PERSISTENT, ledgerSeq + 50'000 - 1);
+            "key3", ContractDataDurability::PERSISTENT, ledgerSeq + 50'000);
     }
 
     SECTION("restore expired entry")
@@ -1341,7 +1341,7 @@ TEST_CASE("contract storage", "[tx][soroban]")
         bump("key2", ContractDataDurability::PERSISTENT,
              stateExpirationSettings.maxEntryExpiration - 1);
         checkContractDataExpirationLedger(
-            "key2", ContractDataDurability::PERSISTENT, maxExpiration - 1);
+            "key2", ContractDataDurability::PERSISTENT, maxExpiration);
 
         // Autobump should only add a single ledger to bring expiration to max
         put("key2", 1, ContractDataDurability::PERSISTENT);
@@ -1553,22 +1553,6 @@ TEST_CASE("Stellar asset contract XLM transfer",
     createResources.writeBytes = 1000;
     createResources.contractEventsSizeBytes = 0;
 
-    auto metadataKey = LedgerKey(CONTRACT_DATA);
-    metadataKey.contractData().contract = contractID;
-    metadataKey.contractData().key = makeSymbolSCVal("METADATA");
-    metadataKey.contractData().durability = ContractDataDurability::PERSISTENT;
-    metadataKey.contractData().bodyType = DATA_ENTRY;
-
-    LedgerKey assetInfoLedgerKey(CONTRACT_DATA);
-    assetInfoLedgerKey.contractData().contract = contractID;
-    SCVec assetInfo = {makeSymbolSCVal("AssetInfo")};
-    SCVal assetInfoSCVal(SCValType::SCV_VEC);
-    assetInfoSCVal.vec().activate() = assetInfo;
-    assetInfoLedgerKey.contractData().key = assetInfoSCVal;
-    assetInfoLedgerKey.contractData().durability =
-        ContractDataDurability::PERSISTENT;
-    assetInfoLedgerKey.contractData().bodyType = DATA_ENTRY;
-
     LedgerKey contractExecutableKey(CONTRACT_DATA);
     contractExecutableKey.contractData().contract = contractID;
     contractExecutableKey.contractData().key =
@@ -1577,8 +1561,7 @@ TEST_CASE("Stellar asset contract XLM transfer",
         ContractDataDurability::PERSISTENT;
     contractExecutableKey.contractData().bodyType = DATA_ENTRY;
 
-    createResources.footprint.readWrite = {contractExecutableKey, metadataKey,
-                                           assetInfoLedgerKey};
+    createResources.footprint.readWrite = {contractExecutableKey};
 
     {
         // submit operation
@@ -1640,8 +1623,7 @@ TEST_CASE("Stellar asset contract XLM transfer",
         ContractDataDurability::PERSISTENT;
     balanceLedgerKey.contractData().bodyType = DATA_ENTRY;
 
-    resources.footprint.readOnly = {metadataKey, assetInfoLedgerKey,
-                                    contractExecutableKey};
+    resources.footprint.readOnly = {contractExecutableKey};
 
     resources.footprint.readWrite = {accountLedgerKey, balanceLedgerKey};
 


### PR DESCRIPTION
# Description

Refactor core to use `e2e_invoke` host module.

This simplifies the 'glue' layer between Core and host a bit and (more importantly) uses shared code that can also be re-used by the preflight.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
