### PR TITLE
Confirm soroban errors fail ops and txs, fix stellar/rs-soroban-env#522

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -202,6 +202,7 @@ mod rust_bridge {
         fn get_test_wasm_add_i32() -> Result<RustBuf>;
         fn get_test_wasm_contract_data() -> Result<RustBuf>;
         fn get_test_wasm_complex() -> Result<RustBuf>;
+        fn get_test_wasm_err() -> Result<RustBuf>;
 
         // Return the rustc version used to build this binary.
         fn get_rustc_version() -> String;
@@ -297,6 +298,12 @@ pub(crate) fn get_test_wasm_contract_data() -> Result<RustBuf, Box<dyn std::erro
 pub(crate) fn get_test_wasm_complex() -> Result<RustBuf, Box<dyn std::error::Error>> {
     Ok(RustBuf {
         data: soroban_test_wasms::COMPLEX.iter().cloned().collect(),
+    })
+}
+
+pub(crate) fn get_test_wasm_err() -> Result<RustBuf, Box<dyn std::error::Error>> {
+    Ok(RustBuf {
+        data: soroban_test_wasms::ERR.iter().cloned().collect(),
     })
 }
 


### PR DESCRIPTION
This just adds an end-to-end test that checks that the various ways a soroban contract can return an error will all result in the enclosing stellar op and transaction failing. I _believe_ this addresses the substance of bug stellar/rs-soroban-env#522 though it'll require confirmation from @leighmcculloch and/or @paulbellamy when they're back.