### PR TITLE
Bump soroban-env-host versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,13 +925,13 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "soroban-env-common"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295#c2e1c21cf8d44db23a159090e3cbaab741860295"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295)",
+ "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
@@ -940,13 +940,13 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411)",
+ "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
@@ -955,7 +955,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-host"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295#c2e1c21cf8d44db23a159090e3cbaab741860295"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7"
 dependencies = [
  "backtrace",
  "curve25519-dalek",
@@ -971,34 +971,8 @@ dependencies = [
  "rand_chacha",
  "sha2",
  "sha3",
- "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295)",
- "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295)",
- "soroban-wasmi",
- "static_assertions",
- "stellar-strkey",
-]
-
-[[package]]
-name = "soroban-env-host"
-version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411"
-dependencies = [
- "backtrace",
- "curve25519-dalek",
- "ed25519-dalek",
- "getrandom",
- "hex",
- "k256",
- "log",
- "num-derive",
- "num-integer",
- "num-traits",
- "rand",
- "rand_chacha",
- "sha2",
- "sha3",
- "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411)",
- "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411)",
+ "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7)",
+ "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
@@ -1006,9 +980,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-env-host"
+version = "0.0.17"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0"
+dependencies = [
+ "backtrace",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "getrandom",
+ "hex",
+ "k256",
+ "log",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "sha2",
+ "sha3",
+ "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0)",
+ "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0)",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-strkey",
+]
+
+[[package]]
 name = "soroban-env-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295#c2e1c21cf8d44db23a159090e3cbaab741860295"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1022,7 +1022,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1036,7 +1036,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295#c2e1c21cf8d44db23a159090e3cbaab741860295"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1058,7 +1058,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1103,8 +1103,8 @@ dependencies = [
  "cxx",
  "log",
  "rustc-simple-version",
- "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=c2e1c21cf8d44db23a159090e3cbaab741860295)",
- "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411)",
+ "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7)",
+ "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0)",
  "soroban-test-wasms",
  "tracy-client",
 ]
@@ -1121,7 +1121,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=2d2526f515a476b1e3df70233a4cf9232287977e#2d2526f515a476b1e3df70233a4cf9232287977e"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567"
 dependencies = [
  "base64",
  "crate-git-revision",

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1590,9 +1590,8 @@ TEST_CASE("surge pricing", "[herder][txset]")
                 cfg.mLedgerMaxTxCount = 0;
             });
             SorobanResources resources;
-            auto sorobanTx =
-                createUploadWasmTx(*app, root, baseFee,
-                                   /* refundableFee */ 1200, resources);
+            auto sorobanTx = createUploadWasmTx(
+                *app, root, baseFee, DEFAULT_TEST_REFUNDABLE_FEE, resources);
 
             TxSetFrame::TxPhases invalidTxs;
             invalidTxs.resize(2);
@@ -1648,9 +1647,8 @@ TEST_CASE("surge pricing", "[herder][txset]")
         resources.instructions = 800'000;
         resources.readBytes = conf.txMaxReadBytes();
         resources.writeBytes = 1000;
-        auto sorobanTx =
-            createUploadWasmTx(*app, acc2, baseFee,
-                               /* refundableFee */ 1200, resources);
+        auto sorobanTx = createUploadWasmTx(
+            *app, acc2, baseFee, DEFAULT_TEST_REFUNDABLE_FEE, resources);
 
         auto generateTxs = [&](std::vector<TestAccount>& accounts,
                                SorobanNetworkConfig conf) {
@@ -1702,7 +1700,7 @@ TEST_CASE("surge pricing", "[herder][txset]")
             {
                 // Fee too small
                 invalidSoroban = createUploadWasmTx(
-                    *app, acc2, 100, /* refundableFee */ 1200, resources);
+                    *app, acc2, 100, DEFAULT_TEST_REFUNDABLE_FEE, resources);
             }
             SECTION("invalid resource")
             {
@@ -1710,7 +1708,7 @@ TEST_CASE("surge pricing", "[herder][txset]")
                 resources.instructions = UINT32_MAX;
                 invalidSoroban =
                     createUploadWasmTx(*app, acc2, baseFee,
-                                       /* refundableFee */ 1200, resources);
+                                       DEFAULT_TEST_REFUNDABLE_FEE, resources);
             }
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(2);
@@ -1750,8 +1748,9 @@ TEST_CASE("surge pricing", "[herder][txset]")
         SECTION("soroban surge pricing, classic unaffected")
         {
             // Another soroban tx with higher fee, which will be selected
-            auto sorobanTxHighFee = createUploadWasmTx(
-                *app, acc3, baseFee * 2, /* refundableFee */ 1200, resources);
+            auto sorobanTxHighFee =
+                createUploadWasmTx(*app, acc3, baseFee * 2,
+                                   DEFAULT_TEST_REFUNDABLE_FEE, resources);
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(2);
             TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
@@ -1776,8 +1775,9 @@ TEST_CASE("surge pricing", "[herder][txset]")
             // Another soroban tx with high fee and a bit less resources
             // Still half capacity available
             resources.readBytes = conf.txMaxReadBytes() / 2;
-            auto sorobanTxHighFee = createUploadWasmTx(
-                *app, acc3, baseFee * 2, /* refundableFee */ 1200, resources);
+            auto sorobanTxHighFee =
+                createUploadWasmTx(*app, acc3, baseFee * 2,
+                                   DEFAULT_TEST_REFUNDABLE_FEE, resources);
 
             // Create another small soroban tx, with small fee. It should be
             // picked up anyway since we can't fit sorobanTx (gaps are allowed)
@@ -1785,8 +1785,9 @@ TEST_CASE("surge pricing", "[herder][txset]")
             resources.readBytes = 1;
             resources.writeBytes = 1;
 
-            auto smallSorobanLowFee = createUploadWasmTx(
-                *app, acc4, baseFee / 10, /* refundableFee */ 1200, resources);
+            auto smallSorobanLowFee =
+                createUploadWasmTx(*app, acc4, baseFee / 10,
+                                   DEFAULT_TEST_REFUNDABLE_FEE, resources);
 
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(2);
@@ -4530,7 +4531,7 @@ TEST_CASE("do not flood too many soroban transactions",
         curFeeOffset--;
 
         auto tx = createUploadWasmTx(*app, source, txFee,
-                                     /* refundableFee */ 1200, resources);
+                                     DEFAULT_TEST_REFUNDABLE_FEE, resources);
         REQUIRE(herder.recvTransaction(tx, false) ==
                 TransactionQueue::AddResult::ADD_STATUS_PENDING);
         return tx;

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1121,7 +1121,7 @@ TEST_CASE("Soroban TransactionQueue limits",
     resources.readBytes = 2000;
     resources.writeBytes = 1000;
 
-    int refundableFee = 1200;
+    int refundableFee = DEFAULT_TEST_REFUNDABLE_FEE;
     int initialFee = 10'000'000;
 
     auto resAdjusted = resources;

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -502,9 +502,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
                 resources.instructions = 800'000;
                 resources.readBytes = 1000;
                 resources.writeBytes = 1000;
-                txs.emplace_back(createUploadWasmTx(*app, source, fee,
-                                                    /* refundableFee */ 1200,
-                                                    resources));
+                txs.emplace_back(createUploadWasmTx(
+                    *app, source, fee, DEFAULT_TEST_REFUNDABLE_FEE, resources));
             }
             else
             {

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -1187,6 +1187,7 @@ SorobanNetworkConfig::rustBridgeRentFeeConfiguration() const
     CxxRentFeeConfiguration res{};
     auto const& cfg = stateExpirationSettings();
     res.fee_per_write_1kb = feeWrite1KB();
+    res.fee_per_write_entry = feeWriteLedgerEntry();
     res.persistent_rent_rate_denominator = cfg.persistentRentRateDenominator;
     res.temporary_rent_rate_denominator = cfg.tempRentRateDenominator;
     return res;

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -28,7 +28,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "dd3d39571e9fdae9af34f7f46243d0794169b411"
+rev = "5dc7547a4b15028787d57a849a7684802d899fc7"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -52,11 +52,11 @@ optional = true
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "c2e1c21cf8d44db23a159090e3cbaab741860295"
+rev = "f5c6c0f42b4094481b7f32ecac825ce27c7114e0"
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "dd3d39571e9fdae9af34f7f46243d0794169b411"
+rev = "5dc7547a4b15028787d57a849a7684802d899fc7"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -95,6 +95,7 @@ impl From<CxxRentFeeConfiguration> for RentFeeConfiguration {
     fn from(value: CxxRentFeeConfiguration) -> Self {
         Self {
             fee_per_write_1kb: value.fee_per_write_1kb,
+            fee_per_write_entry: value.fee_per_write_entry,
             persistent_rent_rate_denominator: value.persistent_rent_rate_denominator,
             temporary_rent_rate_denominator: value.temporary_rent_rate_denominator,
         }

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411
+soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7
 ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── tracy-client-sys 0.20.0 checksum:e8cf8aeb20e40d13be65a0b134f8d82d360e72b2793a11de8867d7fbc0f9d6f6
 │   │   └── cc 1.0.79 checksum:50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f
@@ -86,14 +86,14 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=dd3d39
 │   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411
+├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7
 │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
 │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
 │       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
-├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411
-│   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=2d2526f515a476b1e3df70233a4cf9232287977e#2d2526f515a476b1e3df70233a4cf9232287977e
+├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7
+│   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567
 │   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
 │   │   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
 │   │   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a
@@ -109,9 +109,9 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=dd3d39
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
 │   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
-│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=dd3d39571e9fdae9af34f7f46243d0794169b411#dd3d39571e9fdae9af34f7f46243d0794169b411
+│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=5dc7547a4b15028787d57a849a7684802d899fc7#5dc7547a4b15028787d57a849a7684802d899fc7
 │   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
-│   │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=2d2526f515a476b1e3df70233a4cf9232287977e#2d2526f515a476b1e3df70233a4cf9232287977e
+│   │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567
 │   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a
 │   │   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
 │   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488

--- a/src/rust/src/host-dep-tree-prev.txt
+++ b/src/rust/src/host-dep-tree-prev.txt
@@ -1,131 +1,206 @@
-soroban-env-host 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=15acfa51705172b6f740aa4f169913945296634f#15acfa51705172b6f740aa4f169913945296634f
+soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
+├── stellar-strkey 0.0.7 git+https://github.com/stellar/rs-stellar-strkey?rev=e6ba45c60c16de28c7522586b80ed0150157df73#e6ba45c60c16de28c7522586b80ed0150157df73
+│   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
+│   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
+│   │       ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │       │   ├── unicode-ident 1.0.9 checksum:b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0
+│   │       │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │       │   │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
+│   │       │   │       └── unicode-ident 1.0.9 checksum:b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0
+│   │       │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
+│   │       ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │       └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
+│   └── base32 0.4.0 checksum:23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
-├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76
+├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
 │   ├── wasmparser-nostd 0.100.1 checksum:9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724
 │   │   └── indexmap-nostd 0.4.0 checksum:8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590
-│   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76
-│   ├── spin 0.9.6 checksum:b5d6e0250b93c8427a177b849d144a96d5acc57006149479403d7861ab721e34
-│   ├── soroban-wasmi_core 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76
+│   ├── wasmi_core 0.12.0 git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
 │   │   ├── paste 1.0.12 checksum:9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79
 │   │   ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
 │   │   │   └── autocfg 1.1.0 checksum:d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa
-│   │   ├── libm 0.2.6 checksum:348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb
+│   │   ├── libm 0.2.7 checksum:f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4
 │   │   └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
-│   ├── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-│   └── intx 0.1.0 checksum:f6f38a50a899dc47a6d0ed5508e7f601a2e34c3a85303514b5d137f3c10a0c75
-├── soroban-native-sdk-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=15acfa51705172b6f740aa4f169913945296634f#15acfa51705172b6f740aa4f169913945296634f
-│   ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
-│   │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
-│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │   │       └── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
-│   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   ├── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
+│   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
+│   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
+├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
+│   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
 │       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
-├── soroban-env-common 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=15acfa51705172b6f740aa4f169913945296634f#15acfa51705172b6f740aa4f169913945296634f
-│   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=ba1ff9231ae81793d470db93815ead664eb21fb2#ba1ff9231ae81793d470db93815ead664eb21fb2
+├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
+│   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567
 │   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
-│   │   ├── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
-│   │   │   ├── serde_json 1.0.94 checksum:1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea
-│   │   │   │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
-│   │   │   │   │   └── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
-│   │   │   │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
-│   │   │   │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   │   │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   │   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
+│   │   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a
+│   │   │   │   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
+│   │   │   │   │   └── serde_derive 1.0.164 checksum:d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68
+│   │   │   │   │       ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │   │   │   │       ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │   │   │   │       └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   │   │   │   ├── ryu 1.0.13 checksum:f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041
 │   │   │   │   └── itoa 1.0.6 checksum:453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6
-│   │   │   ├── serde_derive 1.0.158 checksum:e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad
-│   │   │   └── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
+│   │   │   ├── serde_derive 1.0.164 checksum:d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68
+│   │   │   └── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
-│   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=1a2bc7f#1a2bc7f3801c565c2dab22021255a164c05a7f76
-│   ├── soroban-env-macros 0.0.16 git+https://github.com/stellar/rs-soroban-env?rev=15acfa51705172b6f740aa4f169913945296634f#15acfa51705172b6f740aa4f169913945296634f
-│   │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
-│   │   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
-│   │   │       ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
-│   │   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │   ├── syn 2.0.10 checksum:5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40
-│   │   ├── stellar-xdr 0.0.16 git+https://github.com/stellar/rs-stellar-xdr?rev=ba1ff9231ae81793d470db93815ead664eb21fb2#ba1ff9231ae81793d470db93815ead664eb21fb2
-│   │   ├── serde_json 1.0.94 checksum:1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea
-│   │   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
-│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   ├── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
+│   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
+│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
+│   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567
+│   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a
+│   │   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
+│   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
+│   ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
+│   ├── num-derive 0.4.0 checksum:9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e
+│   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   ├── ethnum 1.3.2 checksum:0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04
-│   └── crate-git-revision 0.0.4 checksum:f998aef136a4e7833b0e4f0fc0939a59c40140b28e0ffbf524ad84fb2cc568c8
-├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
-│   ├── opaque-debug 0.3.0 checksum:624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5
-│   ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
-│   │   └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
-│   │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
-│   │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
-│   ├── cpufeatures 0.2.6 checksum:280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181
-│   │   └── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
-│   ├── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
-│   └── block-buffer 0.9.0 checksum:4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4
-│       └── generic-array 0.14.6 checksum:bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9
-├── rand_chacha 0.2.2 checksum:f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402
-│   ├── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
-│   │   └── getrandom 0.1.16 checksum:8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce
-│   │       ├── wasi 0.9.0+wasi-snapshot-preview1 checksum:cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519
-│   │       ├── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
+│   └── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
+├── sha3 0.10.8 checksum:75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60
+│   ├── keccak 0.1.4 checksum:8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940
+│   │   └── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
+│   │       └── libc 0.2.146 checksum:f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b
+│   └── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│       ├── crypto-common 0.1.6 checksum:1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3
+│       │   ├── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
+│       │   └── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│       │       ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│       │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
+│       │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
+│       ├── const-oid 0.9.2 checksum:520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913
+│       └── block-buffer 0.10.4 checksum:3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71
+│           └── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+├── sha2 0.10.7 checksum:479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8
+│   ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   ├── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
+│   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+├── rand_chacha 0.3.1 checksum:e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+│   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   └── getrandom 0.2.10 checksum:be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427
+│   │       ├── wasm-bindgen 0.2.87 checksum:7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342
+│   │       │   ├── wasm-bindgen-macro 0.2.87 checksum:dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d
+│   │       │   │   ├── wasm-bindgen-macro-support 0.2.87 checksum:54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b
+│   │       │   │   │   ├── wasm-bindgen-shared 0.2.87 checksum:ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1
+│   │       │   │   │   ├── wasm-bindgen-backend 0.2.87 checksum:5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd
+│   │       │   │   │   │   ├── wasm-bindgen-shared 0.2.87 checksum:ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1
+│   │       │   │   │   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │       │   │   │   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │       │   │   │   │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
+│   │       │   │   │   │   ├── once_cell 1.18.0 checksum:dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d
+│   │       │   │   │   │   ├── log 0.4.19 checksum:b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4
+│   │       │   │   │   │   └── bumpalo 3.13.0 checksum:a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1
+│   │       │   │   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │       │   │   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │       │   │   │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
+│   │       │   │   └── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │       │   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   │       ├── wasi 0.11.0+wasi-snapshot-preview1 checksum:9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423
+│   │       ├── libc 0.2.146 checksum:f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b
+│   │       ├── js-sys 0.3.64 checksum:c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a
+│   │       │   └── wasm-bindgen 0.2.87 checksum:7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342
 │   │       └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
 │   └── ppv-lite86 0.2.17 checksum:5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de
-├── rand 0.7.3 checksum:6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03
-│   ├── rand_hc 0.2.0 checksum:ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c
-│   │   └── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
-│   ├── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
-│   ├── rand_chacha 0.2.2 checksum:f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402
-│   ├── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
-│   └── getrandom 0.1.16 checksum:8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce
+├── rand 0.8.5 checksum:34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404
+│   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   ├── rand_chacha 0.3.1 checksum:e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+│   └── libc 0.2.146 checksum:f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b
 ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
 ├── num-integer 0.1.45 checksum:225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9
 │   ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
 │   └── autocfg 1.1.0 checksum:d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa
-├── num-derive 0.3.3 checksum:876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d
-│   ├── syn 1.0.109 checksum:72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237
-│   │   ├── unicode-ident 1.0.8 checksum:e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4
-│   │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-├── log 0.4.17 checksum:abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e
+├── num-derive 0.4.0 checksum:9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e
+├── log 0.4.19 checksum:b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4
+├── k256 0.13.1 checksum:cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc
+│   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
+│   │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   └── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   ├── sha2 0.10.7 checksum:479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8
+│   ├── once_cell 1.18.0 checksum:dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d
+│   ├── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+│   │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │   ├── sec1 0.7.2 checksum:f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e
+│   │   │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │   │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │   │   ├── pkcs8 0.10.2 checksum:f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7
+│   │   │   │   ├── spki 0.7.2 checksum:9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a
+│   │   │   │   │   ├── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+│   │   │   │   │   │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │   │   │   │   │   └── const-oid 0.9.2 checksum:520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913
+│   │   │   │   │   └── base64ct 1.6.0 checksum:8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b
+│   │   │   │   └── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+│   │   │   ├── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│   │   │   ├── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+│   │   │   └── base16ct 0.2.0 checksum:4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf
+│   │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   ├── pkcs8 0.10.2 checksum:f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7
+│   │   ├── group 0.13.0 checksum:f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63
+│   │   │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │   │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   │   └── ff 0.13.0 checksum:ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449
+│   │   │       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │   │       └── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   ├── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│   │   ├── ff 0.13.0 checksum:ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449
+│   │   ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   │   ├── crypto-bigint 0.5.2 checksum:cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15
+│   │   │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │   │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │   │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   │   └── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│   │   └── base16ct 0.2.0 checksum:4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf
+│   ├── ecdsa 0.16.7 checksum:0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428
+│   │   ├── spki 0.7.2 checksum:9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a
+│   │   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
+│   │   ├── rfc6979 0.4.0 checksum:f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2
+│   │   │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │   │   └── hmac 0.12.1 checksum:6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e
+│   │   │       └── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   │   ├── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+│   │   ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   │   └── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
 │   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
 ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
-├── ed25519-dalek 1.0.1 checksum:c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d
-│   ├── zeroize 1.3.0 checksum:4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd
-│   │   └── zeroize_derive 1.3.3 checksum:44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c
-│   │       ├── synstructure 0.12.6 checksum:f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f
-│   │       │   ├── unicode-xid 0.2.4 checksum:f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c
-│   │       │   ├── syn 1.0.109 checksum:72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237
-│   │       │   ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │       │   └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   │       ├── syn 1.0.109 checksum:72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237
-│   │       ├── quote 1.0.26 checksum:4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc
-│   │       └── proc-macro2 1.0.53 checksum:ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73
-│   ├── sha2 0.9.9 checksum:4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800
-│   ├── serde 1.0.158 checksum:771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9
-│   ├── rand 0.7.3 checksum:6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03
-│   ├── ed25519 1.5.3 checksum:91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7
-│   │   └── signature 1.6.4 checksum:74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c
-│   └── curve25519-dalek 3.2.1 checksum:90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0
-│       ├── zeroize 1.3.0 checksum:4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd
+├── getrandom 0.2.10 checksum:be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427
+├── ed25519-dalek 2.0.0 checksum:7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980
+│   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   ├── sha2 0.10.7 checksum:479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8
+│   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
+│   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   ├── ed25519 2.2.2 checksum:60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d
+│   │   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
+│   │   └── pkcs8 0.10.2 checksum:f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7
+│   └── curve25519-dalek 4.0.0 checksum:f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2
+│       ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
 │       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
-│       ├── rand_core 0.5.1 checksum:90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19
-│       ├── digest 0.9.0 checksum:d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066
-│       └── byteorder 1.4.3 checksum:14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610
-├── curve25519-dalek 3.2.1 checksum:90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0
+│       ├── rustc_version 0.4.0 checksum:bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366
+│       │   └── semver 1.0.17 checksum:bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed
+│       │       └── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
+│       ├── platforms 3.0.2 checksum:e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630
+│       ├── fiat-crypto 0.1.20 checksum:e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77
+│       ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       ├── curve25519-dalek-derive 0.1.0 checksum:83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b
+│       │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│       │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│       │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
+│       ├── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
+│       └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+├── curve25519-dalek 4.0.0 checksum:f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2
 └── backtrace 0.3.67 checksum:233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca
-    ├── rustc-demangle 0.1.22 checksum:d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b
-    ├── object 0.30.3 checksum:ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439
+    ├── rustc-demangle 0.1.23 checksum:d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76
+    ├── object 0.30.4 checksum:03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385
     │   └── memchr 2.5.0 checksum:2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d
     ├── miniz_oxide 0.6.2 checksum:b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa
     │   └── adler 1.0.2 checksum:f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe
-    ├── libc 0.2.140 checksum:99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c
+    ├── libc 0.2.146 checksum:f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b
     ├── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
     ├── cc 1.0.79 checksum:50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f
     └── addr2line 0.19.0 checksum:a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97
-        └── gimli 0.27.2 checksum:ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4
+        └── gimli 0.27.3 checksum:b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -159,6 +159,7 @@ mod rust_bridge {
 
     struct CxxRentFeeConfiguration {
         fee_per_write_1kb: i64,
+        fee_per_write_entry: i64,
         persistent_rent_rate_denominator: i64,
         temporary_rent_rate_denominator: i64,
     }

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -101,5 +101,9 @@ void overrideSorobanNetworkConfigForTest(Application& app);
 void
 modifySorobanNetworkConfig(Application& app,
                            std::function<void(SorobanNetworkConfig&)> modifyFn);
+
+// This is a rough guess at the refundable fee to include. 20k for a ledger
+// write plus 1000 for a little additional slop.
+constexpr uint32_t DEFAULT_TEST_REFUNDABLE_FEE = 21'000;
 #endif
 }


### PR DESCRIPTION
This just picks up recent changes in the soroban env (specifically the newest XDR as of today, including removal of ScSpecTypeSet)