### PR TITLE
Reduce MINIMUM_PERSISTENT_ENTRY_LIFETIME

### DIFF
--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -37,7 +37,7 @@ struct MinimumSorobanNetworkConfig
     static constexpr uint32_t MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES = 2'000;
     static constexpr uint32_t MAX_CONTRACT_SIZE = 2'000;
 
-    static constexpr uint32_t MINIMUM_PERSISTENT_ENTRY_LIFETIME = 4'096;
+    static constexpr uint32_t MINIMUM_PERSISTENT_ENTRY_LIFETIME = 10;
     static constexpr uint32_t MAXIMUM_ENTRY_LIFETIME = 535'680; // 31 days
 
     static constexpr uint32_t TX_MAX_CONTRACT_EVENTS_SIZE_BYTES = 200;
@@ -115,9 +115,10 @@ struct InitialSorobanNetworkConfig
     static constexpr uint32_t MAXIMUM_ENTRY_LIFETIME =
         MinimumSorobanNetworkConfig::MAXIMUM_ENTRY_LIFETIME;
 
-    // Live until level 6
+    // Note that the initial MINIMUM_PERSISTENT_ENTRY_LIFETIME is greater
+    // than the minimum to allow for reductions during testing.
     static constexpr uint32_t MINIMUM_PERSISTENT_ENTRY_LIFETIME =
-        MinimumSorobanNetworkConfig::MINIMUM_PERSISTENT_ENTRY_LIFETIME;
+        4'096; // Live until level 6
     static constexpr uint32_t MINIMUM_TEMP_ENTRY_LIFETIME = 16;
 
     static constexpr uint32_t AUTO_BUMP_NUM_LEDGERS = 0;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1458,6 +1458,16 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                         "positive");
                 }
 
+                if (TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME <
+                    MinimumSorobanNetworkConfig::
+                        MINIMUM_PERSISTENT_ENTRY_LIFETIME)
+                {
+                    throw std::invalid_argument(
+                        "TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME < "
+                        "MinimumSorobanNetworkConfig::MINIMUM_PERSISTENT_ENTRY_"
+                        "LIFETIME");
+                }
+
                 LOG_WARNING(
                     DEFAULT_LOG,
                     "Overriding MINIMUM_PERSISTENT_ENTRY_LIFETIME to {}",


### PR DESCRIPTION
# Description

Reduce `MINIMUM_PERSISTENT_ENTRY_LIFETIME` to 10 to allow for lower `TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME`. This does also reduce the minimum value the settings upgrade will accept.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
