### PR TITLE
Add config flag to override all initial Soroban limits

### DIFF
--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -37,10 +37,10 @@ initialMaxContractSizeEntry(Config const& cfg)
 
     entry.contractMaxSizeBytes() =
         InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE;
-
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        entry.contractMaxSizeBytes() *= 32;
+        entry.contractMaxSizeBytes() =
+            TestOverrideSorobanNetworkConfig::MAX_CONTRACT_SIZE;
     }
 
     return entry;
@@ -55,7 +55,8 @@ initialMaxContractDataKeySizeEntry(Config const& cfg)
         InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES;
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        entry.contractDataKeySizeBytes() *= 10;
+        entry.contractDataKeySizeBytes() =
+            TestOverrideSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES;
     }
 
     return entry;
@@ -70,7 +71,8 @@ initialMaxContractDataEntrySizeEntry(Config const& cfg)
         InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES;
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        entry.contractDataEntrySizeBytes() *= 10;
+        entry.contractDataEntrySizeBytes() = TestOverrideSorobanNetworkConfig::
+            MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES;
     }
 
     return entry;
@@ -92,9 +94,11 @@ initialContractComputeSettingsEntry(Config const& cfg)
 
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        e.ledgerMaxInstructions *= 50;
-        e.txMaxInstructions *= 50;
-        e.txMemoryLimit *= 10;
+        e.ledgerMaxInstructions =
+            TestOverrideSorobanNetworkConfig::LEDGER_MAX_INSTRUCTIONS;
+        e.txMaxInstructions =
+            TestOverrideSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
+        e.txMemoryLimit = TestOverrideSorobanNetworkConfig::MEMORY_LIMIT;
     }
 
     return entry;
@@ -136,14 +140,21 @@ initialContractLedgerAccessSettingsEntry(Config const& cfg)
 
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        e.ledgerMaxReadLedgerEntries *= 10;
-        e.ledgerMaxReadBytes *= 10;
-        e.ledgerMaxWriteLedgerEntries *= 10;
-        e.ledgerMaxWriteBytes *= 10;
-        e.txMaxReadLedgerEntries *= 10;
-        e.txMaxReadBytes *= 10;
-        e.txMaxWriteLedgerEntries *= 10;
-        e.txMaxWriteBytes *= 10;
+        e.ledgerMaxReadLedgerEntries =
+            TestOverrideSorobanNetworkConfig::LEDGER_MAX_READ_LEDGER_ENTRIES;
+        e.ledgerMaxReadBytes =
+            TestOverrideSorobanNetworkConfig::LEDGER_MAX_READ_BYTES;
+        e.ledgerMaxWriteLedgerEntries =
+            TestOverrideSorobanNetworkConfig::LEDGER_MAX_WRITE_LEDGER_ENTRIES;
+        e.ledgerMaxWriteBytes =
+            TestOverrideSorobanNetworkConfig::LEDGER_MAX_WRITE_BYTES;
+        e.txMaxReadLedgerEntries =
+            TestOverrideSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES;
+        e.txMaxReadBytes = TestOverrideSorobanNetworkConfig::TX_MAX_READ_BYTES;
+        e.txMaxWriteLedgerEntries =
+            TestOverrideSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES;
+        e.txMaxWriteBytes =
+            TestOverrideSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
     }
 
     return entry;
@@ -173,7 +184,8 @@ initialContractEventsSettingsEntry(Config const& cfg)
 
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        e.txMaxContractEventsSizeBytes *= 20;
+        e.txMaxContractEventsSizeBytes =
+            TestOverrideSorobanNetworkConfig::TX_MAX_CONTRACT_EVENTS_SIZE_BYTES;
     }
     return entry;
 }
@@ -192,8 +204,9 @@ initialContractBandwidthSettingsEntry(Config const& cfg)
 
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        e.ledgerMaxTxsSizeBytes *= 5;
-        e.txMaxSizeBytes *= 5;
+        e.ledgerMaxTxsSizeBytes = TestOverrideSorobanNetworkConfig::
+            LEDGER_MAX_TRANSACTION_SIZES_BYTES;
+        e.txMaxSizeBytes = TestOverrideSorobanNetworkConfig::TX_MAX_SIZE_BYTES;
     }
 
     return entry;
@@ -208,7 +221,8 @@ initialContractExecutionLanesSettingsEntry(Config const& cfg)
 
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        e.ledgerMaxTxCount *= 5;
+        e.ledgerMaxTxCount =
+            TestOverrideSorobanNetworkConfig::LEDGER_MAX_TX_COUNT;
     }
 
     return entry;
@@ -360,7 +374,8 @@ initialStateExpirationSettings(Config const& cfg)
 
     if (cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
     {
-        entry.stateExpirationSettings().maxEntryExpiration = 6307200; // 1 year
+        entry.stateExpirationSettings().maxEntryExpiration =
+            TestOverrideSorobanNetworkConfig::MAXIMUM_ENTRY_LIFETIME;
     }
     return entry;
 }

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -110,7 +110,7 @@ struct InitialSorobanNetworkConfig
     static constexpr uint32_t TX_MAX_SIZE_BYTES =
         MinimumSorobanNetworkConfig::TX_MAX_SIZE_BYTES;
     static constexpr uint32_t LEDGER_MAX_TRANSACTION_SIZES_BYTES =
-        MinimumSorobanNetworkConfig::TX_MAX_SIZE_BYTES;
+        TX_MAX_SIZE_BYTES;
     static constexpr int64_t FEE_TRANSACTION_SIZE_1KB = 2'000;
 
     // Contract events settings
@@ -141,6 +141,61 @@ struct InitialSorobanNetworkConfig
 
     // General execution settings
     static constexpr uint32_t LEDGER_MAX_TX_COUNT = 1;
+};
+
+// Defines the subset of the `InitialSorobanNetworkConfig` to be overridden for
+// testing, enabled by `Config::TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE`.
+struct TestOverrideSorobanNetworkConfig
+{
+    // Contract size settings
+    static constexpr uint32_t MAX_CONTRACT_SIZE =
+        InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE * 32;
+
+    // Contract data settings
+    static constexpr uint32_t MAX_CONTRACT_DATA_KEY_SIZE_BYTES =
+        InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES * 10;
+    static constexpr uint32_t MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES =
+        InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES * 10;
+
+    // Compute settings
+    static constexpr int64_t TX_MAX_INSTRUCTIONS =
+        InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS * 50;
+    static constexpr int64_t LEDGER_MAX_INSTRUCTIONS = TX_MAX_INSTRUCTIONS;
+    static constexpr uint32_t MEMORY_LIMIT =
+        InitialSorobanNetworkConfig::MEMORY_LIMIT * 10;
+
+    // Ledger access settings
+    static constexpr uint32_t TX_MAX_READ_LEDGER_ENTRIES =
+        InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES * 10;
+    static constexpr uint32_t TX_MAX_READ_BYTES =
+        InitialSorobanNetworkConfig::TX_MAX_READ_BYTES * 10;
+    static constexpr uint32_t TX_MAX_WRITE_LEDGER_ENTRIES =
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES * 10;
+    static constexpr uint32_t TX_MAX_WRITE_BYTES =
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES * 10;
+    static constexpr uint32_t LEDGER_MAX_READ_LEDGER_ENTRIES =
+        TX_MAX_READ_LEDGER_ENTRIES;
+    static constexpr uint32_t LEDGER_MAX_READ_BYTES = TX_MAX_READ_BYTES;
+    static constexpr uint32_t LEDGER_MAX_WRITE_LEDGER_ENTRIES =
+        TX_MAX_WRITE_LEDGER_ENTRIES;
+    static constexpr uint32_t LEDGER_MAX_WRITE_BYTES = TX_MAX_WRITE_BYTES;
+
+    // Bandwidth settings
+    static constexpr uint32_t TX_MAX_SIZE_BYTES =
+        InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES * 5;
+    static constexpr uint32_t LEDGER_MAX_TRANSACTION_SIZES_BYTES =
+        TX_MAX_SIZE_BYTES;
+
+    // Contract events settings
+    static constexpr uint32_t TX_MAX_CONTRACT_EVENTS_SIZE_BYTES =
+        InitialSorobanNetworkConfig::TX_MAX_CONTRACT_EVENTS_SIZE_BYTES * 20;
+
+    // State expiration settings
+    static constexpr uint32_t MAXIMUM_ENTRY_LIFETIME = 6307200; // 1 year
+
+    // General execution settings
+    static constexpr uint32_t LEDGER_MAX_TX_COUNT =
+        InitialSorobanNetworkConfig::LEDGER_MAX_TX_COUNT * 5;
 };
 
 // Wrapper for the contract-related network configuration.

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1478,8 +1478,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = readBool(item);
 
-                LOG_WARNING(DEFAULT_LOG, "Overriding Soroban limits with "
-                                         "TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE");
+                if (TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE)
+                {
+                    LOG_WARNING(DEFAULT_LOG,
+                                "Overriding Soroban limits with "
+                                "TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE");
+                }
             }
 #endif
             else if (item.first == "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING")

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -264,6 +264,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 #ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false;
     TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME = 0;
+    TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = false;
 #endif
 
 #ifdef BUILD_TESTS
@@ -1472,6 +1473,13 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                     DEFAULT_LOG,
                     "Overriding MINIMUM_PERSISTENT_ENTRY_LIFETIME to {}",
                     TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME);
+            }
+            else if (item.first == "TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE")
+            {
+                TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = readBool(item);
+
+                LOG_WARNING(DEFAULT_LOG, "Overriding Soroban limits with "
+                                         "TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE");
             }
 #endif
             else if (item.first == "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING")

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -577,7 +577,7 @@ class Config : public std::enable_shared_from_this<Config>
     // for testing.
     uint32_t TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME;
 
-    //TODO: add comment
+    // Increase all initial max limits to higher values for testing
     bool TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE;
 #endif
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -576,6 +576,9 @@ class Config : public std::enable_shared_from_this<Config>
     // Override the initial hardcoded MINIMUM_PERSISTENT_ENTRY_LIFETIME
     // for testing.
     uint32_t TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME;
+
+    //TODO: add comment
+    bool TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE;
 #endif
 
 #ifdef BUILD_TESTS


### PR DESCRIPTION
# Description

Continues https://github.com/stellar/stellar-core/pull/3900
Resolves https://github.com/stellar/stellar-core/issues/3897

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
