### PR TITLE
Add ci check that rust git rev deps are unlikely to be orphaned

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,15 @@ on:
   push:
     branches:
       - auto
+
 jobs:
+
+  rust-check-git-rev-deps:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: stellar/actions/rust-check-git-rev-deps@main
+
   build:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### What
Add ci check that rust git rev deps are unlikely to be orphaned

### Why
Same reasons as stellar/actions#55.

It's been too easy for us to accidentally merge Rust dependencies that come from pull requests or temporary branches. We've done it a couple times. Not on this repo, that I know of, but other repos. It's time consuming to clean up when it happens because it can go undetected past the point where the dependency is several dependencies deep.

Seems potentially wise for us to check for this here too.