### PR TITLE
Fee bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,13 +940,13 @@ dependencies = [
 [[package]]
 name = "soroban-env-common"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0#eb5a9ba053a7b64a8eff605db625525378f7bea0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0)",
+ "soroban-env-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-xdr",
@@ -973,21 +973,17 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "tracy-client",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0#eb5a9ba053a7b64a8eff605db625525378f7bea0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 dependencies = [
  "backtrace",
- "curve25519-dalek",
  "ed25519-dalek",
  "getrandom",
- "hex",
  "k256",
- "log",
  "num-derive",
  "num-integer",
  "num-traits",
@@ -995,11 +991,12 @@ dependencies = [
  "rand_chacha",
  "sha2",
  "sha3",
- "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0)",
- "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0)",
+ "soroban-env-common 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64)",
+ "soroban-native-sdk-macros 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
+ "tracy-client",
 ]
 
 [[package]]
@@ -1019,7 +1016,7 @@ dependencies = [
 [[package]]
 name = "soroban-env-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0#eb5a9ba053a7b64a8eff605db625525378f7bea0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1044,7 +1041,7 @@ dependencies = [
 [[package]]
 name = "soroban-native-sdk-macros"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0#eb5a9ba053a7b64a8eff605db625525378f7bea0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -1055,7 +1052,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "0.0.17"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1101,7 +1098,7 @@ dependencies = [
  "log",
  "rustc-simple-version",
  "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537)",
- "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=eb5a9ba053a7b64a8eff605db625525378f7bea0)",
+ "soroban-env-host 0.0.17 (git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64)",
  "soroban-test-wasms",
  "tracy-client",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -28,7 +28,7 @@ rustc-simple-version = "0.1.0"
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "3d6c35d1308fc36a05d30d257756e42fc928b537"
+rev = "f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -52,11 +52,11 @@ optional = true
 version = "0.0.17"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "eb5a9ba053a7b64a8eff605db625525378f7bea0"
+rev = "3d6c35d1308fc36a05d30d257756e42fc928b537"
 
 [dependencies.soroban-test-wasms]
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "3d6c35d1308fc36a05d30d257756e42fc928b537"
+rev = "f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64"
 
 [dependencies.cargo-lock]
 git = "https://github.com/rustsec/rustsec"

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537
+soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64
 ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── tracy-client-sys 0.20.0 checksum:e8cf8aeb20e40d13be65a0b134f8d82d360e72b2793a11de8867d7fbc0f9d6f6
 │   │   └── cc 1.0.79 checksum:50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f
@@ -86,13 +86,13 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35
 │   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537
+├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64
 │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
 │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
 │       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
-├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537
+├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64
 │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=39904e09941046dab61e6e35fc89e31bf2dea1cd#39904e09941046dab61e6e35fc89e31bf2dea1cd
 │   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
 │   │   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
@@ -109,7 +109,7 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
 │   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
-│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537
+│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64#f2f48d7b43da3b47f60e9f11dcb7ef5c67fa7e64
 │   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
 │   │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=39904e09941046dab61e6e35fc89e31bf2dea1cd#39904e09941046dab61e6e35fc89e31bf2dea1cd
 │   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a

--- a/src/rust/src/host-dep-tree-prev.txt
+++ b/src/rust/src/host-dep-tree-prev.txt
@@ -1,4 +1,4 @@
-soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
+soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=3d6c35d1308fc36a05d30d257756e42fc928b537#3d6c35d1308fc36a05d30d257756e42fc928b537
 ├── stellar-strkey 0.0.7 git+https://github.com/stellar/rs-stellar-strkey?rev=e6ba45c60c16de28c7522586b80ed0150157df73#e6ba45c60c16de28c7522586b80ed0150157df73
 │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
 │   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
@@ -24,44 +24,6 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0
 │   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-native-sdk-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
-│   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
-│   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
-│   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
-│   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
-│       └── either 1.8.1 checksum:7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91
-├── soroban-env-common 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
-│   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567
-│   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
-│   │   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
-│   │   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a
-│   │   │   │   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
-│   │   │   │   │   └── serde_derive 1.0.164 checksum:d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68
-│   │   │   │   │       ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
-│   │   │   │   │       ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
-│   │   │   │   │       └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
-│   │   │   │   ├── ryu 1.0.13 checksum:f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041
-│   │   │   │   └── itoa 1.0.6 checksum:453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6
-│   │   │   ├── serde_derive 1.0.164 checksum:d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68
-│   │   │   └── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
-│   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
-│   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
-│   ├── soroban-wasmi 0.30.0-soroban git+https://github.com/stellar/wasmi?rev=284c963ba080703061797e2a3cba0853edee0dd4#284c963ba080703061797e2a3cba0853edee0dd4
-│   ├── soroban-env-macros 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0f42b4094481b7f32ecac825ce27c7114e0#f5c6c0f42b4094481b7f32ecac825ce27c7114e0
-│   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
-│   │   ├── stellar-xdr 0.0.17 git+https://github.com/stellar/rs-stellar-xdr?rev=e2a9cbf72d94941de1bde6ba34a38e1f49328567#e2a9cbf72d94941de1bde6ba34a38e1f49328567
-│   │   ├── serde_json 1.0.97 checksum:bdf3bf93142acad5821c99197022e170842cdbc1c30482b98750c688c640842a
-│   │   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
-│   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
-│   │   ├── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
-│   │   └── itertools 0.10.5 checksum:b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473
-│   ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
-│   ├── num-derive 0.4.0 checksum:9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e
-│   │   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
-│   │   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
-│   │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
-│   ├── ethnum 1.3.2 checksum:0198b9d0078e0f30dedc7acbb21c974e838fc8fae3ee170128658a98cb2c1c04
-│   └── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
 ├── sha3 0.10.8 checksum:75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60
 │   ├── keccak 0.1.4 checksum:8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940
 │   │   └── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
@@ -116,7 +78,9 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0
 │   ├── num-traits 0.2.15 checksum:578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd
 │   └── autocfg 1.1.0 checksum:d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa
 ├── num-derive 0.4.0 checksum:9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e
-├── log 0.4.19 checksum:b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4
+│   ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 ├── k256 0.13.1 checksum:cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc
 │   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
 │   │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
@@ -167,12 +131,15 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0
 │   │   ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
 │   │   └── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
 │   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
-├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
 ├── getrandom 0.2.10 checksum:be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427
 ├── ed25519-dalek 2.0.0 checksum:7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980
 │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
 │   ├── sha2 0.10.7 checksum:479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8
 │   ├── serde 1.0.164 checksum:9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d
+│   │   └── serde_derive 1.0.164 checksum:d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68
+│   │       ├── syn 2.0.18 checksum:32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e
+│   │       ├── quote 1.0.28 checksum:1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488
+│   │       └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
 │   ├── ed25519 2.2.2 checksum:60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d
 │   │   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
@@ -192,7 +159,6 @@ soroban-env-host 0.0.17 git+https://github.com/stellar/rs-soroban-env?rev=f5c6c0
 │       │   └── proc-macro2 1.0.60 checksum:dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406
 │       ├── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
 │       └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
-├── curve25519-dalek 4.0.0 checksum:f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2
 └── backtrace 0.3.67 checksum:233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca
     ├── rustc-demangle 0.1.23 checksum:d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76
     ├── object 0.30.4 checksum:03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -239,6 +239,11 @@ TransactionFrame::getResources() const
         int64_t txSize = xdr::xdr_size(mEnvelope.v1().tx);
         int64_t const opCount = 1;
 
+        // When doing fee calculation, the rust host will include readWrite
+        // entries in the read related fees. However, this resource calculation
+        // is used for constructing TX sets before invoking the host, so we need
+        // to sum readOnly size and readWrite size for correct resource limits
+        // here.
         return Resource({opCount, r.instructions, txSize, r.readBytes,
                          r.writeBytes,
                          static_cast<int64_t>(r.footprint.readOnly.size() +
@@ -789,8 +794,7 @@ TransactionFrame::computeSorobanResourceFee(
     cxxResources.instructions = txResources.instructions;
 
     cxxResources.read_entries =
-        static_cast<uint32>(txResources.footprint.readOnly.size() +
-                            txResources.footprint.readWrite.size());
+        static_cast<uint32>(txResources.footprint.readOnly.size());
     cxxResources.write_entries =
         static_cast<uint32>(txResources.footprint.readWrite.size());
 


### PR DESCRIPTION
# Description

Fixes Double counting readWrite.size when computing Soroban resource fees.

This PR fixes an error and fee accounting where entries in the readWrite set of the footprint were charged double readEntry fees. This also includes a testing overhaul where most fee literals are replaced in `InvokeHostFunctionTests.cpp`

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
