### PR TITLE
Config params to test eviction

### DIFF
--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -357,12 +357,25 @@ initialStateExpirationSettings(Config const& cfg)
 
     entry.stateExpirationSettings().bucketListSizeWindowSampleSize =
         InitialSorobanNetworkConfig::BUCKET_LIST_SIZE_WINDOW_SAMPLE_SIZE;
-    entry.stateExpirationSettings().evictionScanSize =
-        InitialSorobanNetworkConfig::EVICTION_SCAN_SIZE;
-    entry.stateExpirationSettings().maxEntriesToExpire =
-        InitialSorobanNetworkConfig::MAX_ENTRIES_TO_EXPIRE;
-    entry.stateExpirationSettings().startingEvictionScanLevel =
-        InitialSorobanNetworkConfig::STARTING_EVICTION_SCAN_LEVEL;
+
+    if (cfg.OVERRIDE_EVICTION_PARAMS_FOR_TESTING)
+    {
+        entry.stateExpirationSettings().evictionScanSize =
+            cfg.TESTING_EVICTION_SCAN_SIZE;
+        entry.stateExpirationSettings().maxEntriesToExpire =
+            cfg.TESTING_MAX_ENTRIES_TO_EXPIRE;
+        entry.stateExpirationSettings().startingEvictionScanLevel =
+            cfg.TESTING_STARTING_EVICTION_SCAN_LEVEL;
+    }
+    else
+    {
+        entry.stateExpirationSettings().evictionScanSize =
+            InitialSorobanNetworkConfig::EVICTION_SCAN_SIZE;
+        entry.stateExpirationSettings().maxEntriesToExpire =
+            InitialSorobanNetworkConfig::MAX_ENTRIES_TO_EXPIRE;
+        entry.stateExpirationSettings().startingEvictionScanLevel =
+            InitialSorobanNetworkConfig::STARTING_EVICTION_SCAN_LEVEL;
+    }
 
     entry.stateExpirationSettings().persistentRentRateDenominator =
         InitialSorobanNetworkConfig::PERSISTENT_RENT_RATE_DENOMINATOR;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -4,6 +4,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "main/Config.h"
+#include "bucket/BucketList.h"
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
 #include "herder/Herder.h"
@@ -264,6 +265,13 @@ Config::Config() : NODE_SEED(SecretKey::random())
     ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = false;
     TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME = 0;
     TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = false;
+    OVERRIDE_EVICTION_PARAMS_FOR_TESTING = false;
+    TESTING_EVICTION_SCAN_SIZE =
+        InitialSorobanNetworkConfig::EVICTION_SCAN_SIZE;
+    TESTING_MAX_ENTRIES_TO_EXPIRE =
+        InitialSorobanNetworkConfig::MAX_ENTRIES_TO_EXPIRE;
+    TESTING_STARTING_EVICTION_SCAN_LEVEL =
+        InitialSorobanNetworkConfig::STARTING_EVICTION_SCAN_LEVEL;
 
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
@@ -1468,6 +1476,23 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                     DEFAULT_LOG,
                     "Overriding MINIMUM_PERSISTENT_ENTRY_LIFETIME to {}",
                     TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME);
+            }
+            else if (item.first == "OVERRIDE_EVICTION_PARAMS_FOR_TESTING")
+            {
+                OVERRIDE_EVICTION_PARAMS_FOR_TESTING = readBool(item);
+            }
+            else if (item.first == "TESTING_EVICTION_SCAN_SIZE")
+            {
+                TESTING_EVICTION_SCAN_SIZE = readInt<uint32_t>(item);
+            }
+            else if (item.first == "TESTING_STARTING_EVICTION_SCAN_LEVEL")
+            {
+                TESTING_STARTING_EVICTION_SCAN_LEVEL =
+                    readInt<uint32_t>(item, 1, BucketList::kNumLevels - 1);
+            }
+            else if (item.first == "TESTING_MAX_ENTRIES_TO_EXPIRE")
+            {
+                TESTING_MAX_ENTRIES_TO_EXPIRE = readInt<uint32_t>(item);
             }
             else if (item.first == "TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -577,6 +577,14 @@ class Config : public std::enable_shared_from_this<Config>
     // Increase all initial max limits to higher values for testing
     bool TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE;
 
+    // Override eviction parameters for testing. If
+    // OVERRIDE_EVICTION_PARAMS_FOR_TESTING is true, all the eviction TESTING_*
+    // parameters will be used instead of the default values.
+    bool OVERRIDE_EVICTION_PARAMS_FOR_TESTING;
+    uint32_t TESTING_EVICTION_SCAN_SIZE;
+    uint32_t TESTING_STARTING_EVICTION_SCAN_LEVEL;
+    uint32_t TESTING_MAX_ENTRIES_TO_EXPIRE;
+
 #ifdef BUILD_TESTS
     // If set to true, the application will be aware this run is for a test
     // case.  This is used right now in the signal handler to exit() instead of


### PR DESCRIPTION
# Description

Resolves #3921

Adds Config parameters so that downstream systems can test eviction. If a downstream system would like to evict entries immediately on expiration, the following should be added to the stellar-core/captive-core config file:
```
OVERRIDE_EVICTION_PARAMS_FOR_TESTING = true
TESTING_STARTING_EVICTION_SCAN_LEVEL = 1
TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME = 16
```

This should scan the entire BucketList and evict all expired entries on each ledger close. Depending on the size of the BucketList in the test and the number of entries that need to be expired, `TESTING_MAX_ENTRIES_TO_EXPIRE` and `TESTING_EVICTION_SCAN_SIZE` may also need to be modified. `TESTING_EVICTION_SCAN_SIZE` determines how much of the BucketList to scan each ledger close to evict entries. This defaults to 100 MB. If the BucketList in a given test is larger than 100 MB, this value needs to be updated. `TESTING_MAX_ENTRIES_TO_EXPIRE` determines the maximum number of entries that can expire in a single ledger. This defaults to 100. If a test has more than 100 entries that expire on a given ledger, this value will need to be increased. 

The configuration above should evict all expired entries. Another useful test may be the following:
```
OVERRIDE_EVICTION_PARAMS_FOR_TESTING = true
TESTING_STARTING_EVICTION_SCAN_LEVEL = 1
TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME = 16
TESTING_MAX_ENTRIES_TO_EXPIRE = 1
```

This configuration will evict one entry at a time, but will still scan the entire BucketList looking for expired entries. This may be helpful to make sure that downstream systems can properly handle "lazy" eviction behavior, where entries are evicted after they have expired.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
