### PR TITLE
Ban ENABLE_SOROBAN_DIAGNOSTIC_EVENTS when isNetworkedValidator

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -670,6 +670,13 @@ ApplicationImpl::validateAndLogConfig()
     auto const isNetworkedValidator =
         mConfig.NODE_IS_VALIDATOR && !mConfig.RUN_STANDALONE;
 
+    if (mConfig.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS && isNetworkedValidator)
+    {
+        throw std::invalid_argument("ENABLE_SOROBAN_DIAGNOSTIC_EVENTS is set, "
+                                    "NODE_IS_VALIDATOR is set, and "
+                                    "RUN_STANDALONE is not set");
+    }
+
     if (mConfig.METADATA_OUTPUT_STREAM != "" && isNetworkedValidator)
     {
         throw std::invalid_argument(


### PR DESCRIPTION
This was omitted [in the original addition](https://github.com/stellar/stellar-core/pull/3678) of `ENABLE_SOROBAN_DIAGNOSTIC_EVENTS` due to concerns about quickstart. We discussed today and concluded that quickstart's _validator_ won't need this flag, only its captive, and it's a significant safety risk to allow this to be turned on on validators at all.