### PR TITLE
Make tx size calculation consistent

### DIFF
--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -75,8 +75,7 @@ FlowControlByteCapacity::getCapacityLimits() const
 uint64_t
 FlowControlByteCapacity::getMsgResourceCount(StellarMessage const& msg) const
 {
-
-    return static_cast<uint64_t>(xdr::xdr_argpack_size(msg));
+    return msgBodySize(msg);
 }
 
 void
@@ -204,4 +203,12 @@ FlowControlCapacity::hasOutboundCapacity(StellarMessage const& msg) const
     ZoneScoped;
     return mOutboundCapacity >= getMsgResourceCount(msg);
 }
+
+uint64_t
+FlowControlCapacity::msgBodySize(StellarMessage const& msg)
+{
+    return static_cast<uint64_t>(xdr::xdr_size(msg) -
+                                 xdr::xdr_size(msg.type()));
+}
+
 }

--- a/src/overlay/FlowControlCapacity.h
+++ b/src/overlay/FlowControlCapacity.h
@@ -57,6 +57,8 @@ class FlowControlCapacity
 
     virtual bool canRead() const = 0;
 
+    static uint64_t msgBodySize(StellarMessage const& msg);
+
 #ifdef BUILD_TESTS
     void
     setOutboundCapacity(uint64_t newCapacity)

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -230,7 +230,7 @@ TransactionFrame::getResources() const
     if (isSoroban())
     {
         auto r = sorobanResources();
-        int64_t txSize = xdr::xdr_size(mEnvelope.v1().tx);
+        int64_t txSize = xdr::xdr_size(mEnvelope);
         int64_t const opCount = 1;
 
         // When doing fee calculation, the rust host will include readWrite
@@ -735,7 +735,7 @@ TransactionFrame::validateSorobanResources(SorobanNetworkConfig const& config,
             return false;
         }
     }
-    auto txSize = xdr::xdr_size(mEnvelope.v1().tx);
+    auto txSize = xdr::xdr_size(mEnvelope);
     if (txSize > config.txMaxSizeBytes())
     {
         pushSimpleDiagnosticError(


### PR DESCRIPTION
Follow-up to https://github.com/stellar/stellar-core/pull/3786 to resolve https://github.com/stellar/stellar-core/issues/3765. Also, I updated the calculation on the overlay side to not include XDR type overhead (4 bytes).