### PR TITLE
Harden refund code and add test

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -760,7 +760,8 @@ TransactionFrame::refundSorobanFee(AbstractLedgerTxn& ltxOuter)
     auto sourceAccount = loadSourceAccount(ltx, header);
     if (!sourceAccount)
     {
-        throw std::runtime_error("Unexpected database state");
+        // Account was merged (shouldn't be possible)
+        return;
     }
 
     auto& acc = sourceAccount.current().data.account();

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -101,5 +101,6 @@
 		"3l7t9opHMbU=",
 		"3l7t9opHMbU="
 	],
-	"contract storage|footprint tests|unused readWrite key" : [ "PJ5bN6hAeFA=" ]
+	"contract storage|footprint tests|unused readWrite key" : [ "PJ5bN6hAeFA=" ],
+	"refund account merged" : [ "In1c4SdjNWI=", "2+RlWbLqNuA=", "rNZHldKg7fk=" ]
 }


### PR DESCRIPTION
# Description

1. Add a test where classic merges the source account of a soroban tx in the same ledger.
2. Make refund code more defensive by only refunding if the account exists.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
