### PR TITLE
Skip refund if balance + liabilities is too large

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -764,9 +764,12 @@ TransactionFrame::refundSorobanFee(AbstractLedgerTxn& ltxOuter)
         return;
     }
 
-    auto& acc = sourceAccount.current().data.account();
+    if (!addBalance(header, sourceAccount, mFeeRefund))
+    {
+        // Liabilities in the way of the refund, just skip.
+        return;
+    }
 
-    stellar::addBalance(acc.balance, mFeeRefund);
     header.current().feePool -= mFeeRefund;
     ltx.commit();
 }

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -101,6 +101,7 @@
 		"3l7t9opHMbU=",
 		"3l7t9opHMbU="
 	],
+	"buying liabilities plus refund is greater than INT64_MAX" : [ "In1c4SdjNWI=", "2+RlWbLqNuA=", "4PFoNk2Q2xA=", "9ZuZsVhaOp0=" ],
 	"contract storage|footprint tests|unused readWrite key" : [ "PJ5bN6hAeFA=" ],
 	"refund account merged" : [ "In1c4SdjNWI=", "2+RlWbLqNuA=", "rNZHldKg7fk=" ]
 }


### PR DESCRIPTION
# Description

I ended up just skipping the refund instead of refunding as much as possible for simplicity since this is an edge case.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
