### PR TITLE
Cleanup deprecated LIMIT_TX_QUEUE_SOURCE_ACCOUNT

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -169,7 +169,6 @@ Config::Config() : NODE_SEED(SecretKey::random())
     USE_CONFIG_FOR_GENESIS = false;
     FAILURE_SAFETY = -1;
     UNSAFE_QUORUM = false;
-    LIMIT_TX_QUEUE_SOURCE_ACCOUNT = true;
     DISABLE_BUCKET_GC = false;
     DISABLE_XDR_FSYNC = false;
     MAX_SLOTS_TO_REMEMBER = 12;
@@ -1022,15 +1021,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "UNSAFE_QUORUM")
             {
                 UNSAFE_QUORUM = readBool(item);
-            }
-            else if (item.first == "LIMIT_TX_QUEUE_SOURCE_ACCOUNT")
-            {
-                LOG_WARNING(
-                    DEFAULT_LOG,
-                    "LIMIT_TX_QUEUE_SOURCE_ACCOUNT is deprecated: the limit is "
-                    "now always enforced and setting it to false will have no "
-                    "effect. Please remove this setting from the config file.");
-                LIMIT_TX_QUEUE_SOURCE_ACCOUNT = true;
             }
             else if (item.first == "DISABLE_XDR_FSYNC")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -372,12 +372,6 @@ class Config : public std::enable_shared_from_this<Config>
     //  aren't concerned with byzantine failures.
     bool UNSAFE_QUORUM;
 
-    // DEPRECATED: this flag is enabled by default, so setting it to false will
-    // have no effect. The node will limit its transaction queue
-    // to 1 transaction per source account. This impacts which transactions the
-    // node will nominate and flood to others.
-    bool LIMIT_TX_QUEUE_SOURCE_ACCOUNT;
-
     // If set to true, bucket GC will not be performed. It can lead to massive
     // disk usage, but it is useful for recovering of nodes.
     bool DISABLE_BUCKET_GC;


### PR DESCRIPTION
Resolves https://github.com/stellar/stellar-core/issues/3933

Merge only when downstream clients remove the dependency on this flag (see https://github.com/stellar/stellar-core/issues/3933#issuecomment-1718104865)
