### PR TITLE
Fix bug 3952 by normalizing LedgerCloseMeta on meta stream

### DIFF
--- a/src/ledger/LedgerCloseMetaFrame.cpp
+++ b/src/ledger/LedgerCloseMetaFrame.cpp
@@ -4,8 +4,10 @@
 
 #include "ledger/LedgerCloseMetaFrame.h"
 #include "crypto/SHA.h"
+#include "ledger/InMemoryLedgerTxn.h"
 #include "transactions/TransactionMetaFrame.h"
 #include "util/GlobalChecks.h"
+#include "util/MetaUtils.h"
 #include "util/ProtocolVersion.h"
 
 namespace stellar
@@ -38,6 +40,12 @@ LedgerCloseMetaFrame::ledgerHeader()
     default:
         releaseAssert(false);
     }
+}
+
+void
+LedgerCloseMetaFrame::normalize()
+{
+    stellar::normalizeMeta(mLedgerCloseMeta);
 }
 
 void

--- a/src/ledger/LedgerCloseMetaFrame.h
+++ b/src/ledger/LedgerCloseMetaFrame.h
@@ -18,6 +18,7 @@ class LedgerCloseMetaFrame
     LedgerCloseMetaFrame(uint32_t protocolVersion);
 
     LedgerHeaderHistoryEntry& ledgerHeader();
+    void normalize();
     void reserveTxProcessing(size_t n);
     void pushTxProcessingEntry();
     void

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -899,6 +899,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         // member variable: if we throw while committing below, we will at worst
         // emit duplicate meta, when retrying.
         mNextMetaToEmit = std::move(ledgerCloseMeta);
+        mNextMetaToEmit->normalize();
 
         // If the LedgerCloseData provided an expected hash, then we validated
         // it above.

--- a/src/testdata/ledger-close-meta-v2-protocol-20.json
+++ b/src/testdata/ledger-close-meta-v2-protocol-20.json
@@ -423,106 +423,6 @@
                                         {
                                             "type": "LEDGER_ENTRY_STATE",
                                             "state": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "ACCOUNT",
-                                                    "account": {
-                                                        "accountID": "GC4EFXBN6BEENDAX7PBW5PGIIIVH3INMD3OEPQASXOLGOHVVP7ZEMG7X",
-                                                        "balance": 999999998999989600,
-                                                        "seqNum": 4,
-                                                        "numSubEntries": 0,
-                                                        "inflationDest": null,
-                                                        "flags": 0,
-                                                        "homeDomain": "",
-                                                        "thresholds": "01000000",
-                                                        "signers": [],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "v1": {
-                                                                "liabilities": {
-                                                                    "buying": 0,
-                                                                    "selling": 0
-                                                                },
-                                                                "ext": {
-                                                                    "v": 2,
-                                                                    "v2": {
-                                                                        "numSponsored": 0,
-                                                                        "numSponsoring": 0,
-                                                                        "signerSponsoringIDs": [],
-                                                                        "ext": {
-                                                                            "v": 3,
-                                                                            "v3": {
-                                                                                "ext": {
-                                                                                    "v": 0
-                                                                                },
-                                                                                "seqLedger": 6,
-                                                                                "seqTime": 0
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "ACCOUNT",
-                                                    "account": {
-                                                        "accountID": "GC4EFXBN6BEENDAX7PBW5PGIIIVH3INMD3OEPQASXOLGOHVVP7ZEMG7X",
-                                                        "balance": 999999998999988600,
-                                                        "seqNum": 4,
-                                                        "numSubEntries": 0,
-                                                        "inflationDest": null,
-                                                        "flags": 0,
-                                                        "homeDomain": "",
-                                                        "thresholds": "01000000",
-                                                        "signers": [],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "v1": {
-                                                                "liabilities": {
-                                                                    "buying": 0,
-                                                                    "selling": 0
-                                                                },
-                                                                "ext": {
-                                                                    "v": 2,
-                                                                    "v2": {
-                                                                        "numSponsored": 0,
-                                                                        "numSponsoring": 0,
-                                                                        "signerSponsoringIDs": [],
-                                                                        "ext": {
-                                                                            "v": 3,
-                                                                            "v3": {
-                                                                                "ext": {
-                                                                                    "v": 0
-                                                                                },
-                                                                                "seqLedger": 6,
-                                                                                "seqTime": 0
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
                                                 "lastModifiedLedgerSeq": 5,
                                                 "data": {
                                                     "type": "ACCOUNT",
@@ -606,6 +506,106 @@
                                                                                     "v": 0
                                                                                 },
                                                                                 "seqLedger": 5,
+                                                                                "seqTime": 0
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "ACCOUNT",
+                                                    "account": {
+                                                        "accountID": "GC4EFXBN6BEENDAX7PBW5PGIIIVH3INMD3OEPQASXOLGOHVVP7ZEMG7X",
+                                                        "balance": 999999998999989600,
+                                                        "seqNum": 4,
+                                                        "numSubEntries": 0,
+                                                        "inflationDest": null,
+                                                        "flags": 0,
+                                                        "homeDomain": "",
+                                                        "thresholds": "01000000",
+                                                        "signers": [],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "v1": {
+                                                                "liabilities": {
+                                                                    "buying": 0,
+                                                                    "selling": 0
+                                                                },
+                                                                "ext": {
+                                                                    "v": 2,
+                                                                    "v2": {
+                                                                        "numSponsored": 0,
+                                                                        "numSponsoring": 0,
+                                                                        "signerSponsoringIDs": [],
+                                                                        "ext": {
+                                                                            "v": 3,
+                                                                            "v3": {
+                                                                                "ext": {
+                                                                                    "v": 0
+                                                                                },
+                                                                                "seqLedger": 6,
+                                                                                "seqTime": 0
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "ACCOUNT",
+                                                    "account": {
+                                                        "accountID": "GC4EFXBN6BEENDAX7PBW5PGIIIVH3INMD3OEPQASXOLGOHVVP7ZEMG7X",
+                                                        "balance": 999999998999988600,
+                                                        "seqNum": 4,
+                                                        "numSubEntries": 0,
+                                                        "inflationDest": null,
+                                                        "flags": 0,
+                                                        "homeDomain": "",
+                                                        "thresholds": "01000000",
+                                                        "signers": [],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "v1": {
+                                                                "liabilities": {
+                                                                    "buying": 0,
+                                                                    "selling": 0
+                                                                },
+                                                                "ext": {
+                                                                    "v": 2,
+                                                                    "v2": {
+                                                                        "numSponsored": 0,
+                                                                        "numSponsoring": 0,
+                                                                        "signerSponsoringIDs": [],
+                                                                        "ext": {
+                                                                            "v": 3,
+                                                                            "v3": {
+                                                                                "ext": {
+                                                                                    "v": 0
+                                                                                },
+                                                                                "seqLedger": 6,
                                                                                 "seqTime": 0
                                                                             }
                                                                         }

--- a/src/util/MetaUtils.cpp
+++ b/src/util/MetaUtils.cpp
@@ -79,6 +79,57 @@ namespace stellar
 {
 
 void
+normalizeMeta(LedgerCloseMeta& m)
+{
+    switch (m.v())
+    {
+    case 0:
+        for (auto& trm : m.v0().txProcessing)
+        {
+            normalizeMeta(trm);
+        }
+        for (auto& up : m.v0().upgradesProcessing)
+        {
+            sortChanges(up.changes);
+        }
+        break;
+    case 1:
+        for (auto& trm : m.v1().txProcessing)
+        {
+            normalizeMeta(trm);
+        }
+        for (auto& up : m.v1().upgradesProcessing)
+        {
+            sortChanges(up.changes);
+        }
+        break;
+    case 2:
+        for (auto& trm : m.v2().txProcessing)
+        {
+            normalizeMeta(trm);
+        }
+        for (auto& up : m.v2().upgradesProcessing)
+        {
+            sortChanges(up.changes);
+        }
+        std::sort(m.v2().evictedPersistentLedgerEntries.begin(),
+                  m.v2().evictedPersistentLedgerEntries.end());
+        std::sort(m.v2().evictedTemporaryLedgerKeys.begin(),
+                  m.v2().evictedTemporaryLedgerKeys.end());
+        break;
+    default:
+        releaseAssert(false);
+    }
+}
+
+void
+normalizeMeta(TransactionResultMeta& m)
+{
+    sortChanges(m.feeProcessing);
+    normalizeMeta(m.txApplyProcessing);
+}
+
+void
 normalizeMeta(TransactionMeta& m)
 {
     switch (m.v())

--- a/src/util/MetaUtils.h
+++ b/src/util/MetaUtils.h
@@ -7,5 +7,9 @@
 namespace stellar
 {
 struct TransactionMeta;
+struct TransactionResultMeta;
+struct LedgerCloseMeta;
+void normalizeMeta(LedgerCloseMeta& m);
+void normalizeMeta(TransactionResultMeta& m);
 void normalizeMeta(TransactionMeta& m);
 }


### PR DESCRIPTION
We weren't normalizing LedgerCloseMeta when writing to the meta stream. This should (I think) mostly do so.

I had to add some normalization logic to the outer structure -- it's worth careful review by a second pair of eyes that I got everything. Also I'm slightly surprised that the test-vector regeneration only updated one .json file (I did run with --all-versions). It passes tests though!

Fixes #3952 