### PR TITLE
Core diagnostics improvements.

### DIFF
--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 use log::debug;
-use soroban_env_host_curr::xdr::{ExpirationEntry, LedgerEntryExt};
 use std::{fmt::Display, io::Cursor, panic, time::Instant};
 
 // This module (contract) is bound to _two separate locations_ in the module
@@ -28,8 +27,10 @@ use super::soroban_env_host::{
         LedgerEntryRentChange, RentFeeConfiguration, TransactionResources, WriteFeeConfiguration,
     },
     xdr::{
-        self, ContractCostParams, DiagnosticEvent, LedgerEntry, LedgerEntryData, ReadXdr,
-        ScErrorCode, ScErrorType, WriteXdr, XDR_FILES_SHA256,
+        self, ContractCostParams, ContractEvent, ContractEventBody, ContractEventType,
+        ContractEventV0, DiagnosticEvent, ExpirationEntry, ExtensionPoint, LedgerEntry,
+        LedgerEntryData, LedgerEntryExt, ReadXdr, ScError, ScErrorCode, ScErrorType, ScSymbol,
+        ScVal, WriteXdr, XDR_FILES_SHA256,
     },
     HostError, LedgerInfo,
 };
@@ -388,7 +389,29 @@ fn invoke_host_function_or_maybe_panic(
         },
         Err(e) => e,
     };
-
+    if enable_diagnostics {
+        diagnostic_events.push(DiagnosticEvent {
+            in_successful_contract_call: false,
+            event: ContractEvent {
+                ext: ExtensionPoint::V0,
+                contract_id: None,
+                type_: ContractEventType::Diagnostic,
+                body: ContractEventBody::V0(ContractEventV0 {
+                    topics: vec![
+                        ScVal::Symbol(ScSymbol("host_fn_failed".try_into().unwrap_or_default())),
+                        ScVal::Error(
+                            err.error
+                                .try_into()
+                                .unwrap_or(ScError::Context(ScErrorCode::InternalError)),
+                        ),
+                    ]
+                    .try_into()
+                    .unwrap_or_default(),
+                    data: ScVal::Void,
+                }),
+            },
+        })
+    }
     debug!(target: TX, "invocation failed: {}", err);
     return Ok(InvokeHostFunctionOutput {
         success: false,

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -503,7 +503,9 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             getLedgerInfo(ltx, cfg, sorobanConfig), ledgerEntryCxxBufs,
             expirationEntryCxxBufs, basePrngSeedBuf,
             sorobanConfig.rustBridgeRentFeeConfiguration());
-
+        metrics.mCpuInsn = static_cast<uint32>(out.cpu_insns);
+        metrics.mMemByte = static_cast<uint32>(out.mem_bytes);
+        metrics.mInvokeTimeNsecs = static_cast<uint32>(out.time_nsecs);
         if (!out.success)
         {
             maybePopulateDiagnosticEvents(cfg, out, metrics);
@@ -514,9 +516,6 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         CLOG_DEBUG(Tx, "Exception caught while invoking host fn: {}", e.what());
     }
 
-    metrics.mCpuInsn = static_cast<uint32>(out.cpu_insns);
-    metrics.mMemByte = static_cast<uint32>(out.mem_bytes);
-    metrics.mInvokeTimeNsecs = static_cast<uint32>(out.time_nsecs);
     if (!out.success)
     {
         if (resources.instructions < out.cpu_insns)


### PR DESCRIPTION
# Description

- Emit cpu/memory/runtime core metrics for failed calls
- Emit a diagnostic event with the host error to propagate the 'final' error and compensate for errors without corresponding diagnostic event (we should reduce the amount of these, but probably won't ever decorate every error with event).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
