### PR TITLE
initialize app's prngs with sane defaults

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -259,8 +259,7 @@ main(int argc, char* const* argv)
         LOG_FATAL(DEFAULT_LOG, "Could not initialize crypto");
         return 1;
     }
-    shortHash::initialize();
-    randHash::initialize();
+    initializeAllGlobalState();
     xdr::marshaling_stack_limit = 1000;
 
     // TODO: This should only be enabled after we tag a v20 version

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -53,6 +53,10 @@ rand_element(std::vector<T>& v)
     return v.at(rand_uniform<size_t>(0, v.size() - 1));
 }
 
+// initializes all global state that depend on prngs
+// using sane default (pseudo) random values
+void initializeAllGlobalState();
+
 #ifdef BUILD_TESTS
 // This function should be called any time you need to reset stellar-core's
 // global state based on a seed value, such as before each fuzz run or each unit


### PR DESCRIPTION
# Description

Resolves #3917

This PR changes the way we initialize PRNGs in the default case.

The main difference is going to be that when running certain scenarios like `catchup`, we properly randomize which history archive is getting hit allowing to properly "round robin" between archives.
Scenarios like `test` should not be effected as they already "reseed" during execution and commands that require determinism should have options for this (`catchup` for example has an argument to force using a specific archive if needed).
