### PR TITLE
Properly support older overlay versions

### DIFF
--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -78,7 +78,7 @@ FlowControl::hasOutboundCapacity(StellarMessage const& msg) const
 void
 FlowControl::start(std::weak_ptr<Peer> peer,
                    std::function<void(StellarMessage const&)> sendCb,
-                   bool enableFCBytes)
+                   bool enableFCBytes, uint32_t remoteVersion)
 {
     auto peerPtr = peer.lock();
     if (!peerPtr)
@@ -91,8 +91,8 @@ FlowControl::start(std::weak_ptr<Peer> peer,
 
     if (enableFCBytes)
     {
-        mFlowControlBytesCapacity =
-            std::make_shared<FlowControlByteCapacity>(mApp, mNodeID);
+        mFlowControlBytesCapacity = std::make_shared<FlowControlByteCapacity>(
+            mApp, mNodeID, remoteVersion);
         sendSendMore(
             mApp.getConfig().PEER_FLOOD_READING_CAPACITY,
             mApp.getOverlayManager().getFlowControlBytesConfig().mTotal,

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -170,7 +170,7 @@ class FlowControl
 
     void start(std::weak_ptr<Peer> peer,
                std::function<void(StellarMessage const&)> sendCb,
-               bool enableFCBytes);
+               bool enableFCBytes, uint32_t remoteVersion);
 };
 
 }

--- a/src/overlay/FlowControlCapacity.h
+++ b/src/overlay/FlowControlCapacity.h
@@ -57,7 +57,8 @@ class FlowControlCapacity
 
     virtual bool canRead() const = 0;
 
-    static uint64_t msgBodySize(StellarMessage const& msg);
+    static uint64_t msgBodySize(StellarMessage const& msg,
+                                uint32_t remoteVersion, uint32_t localVersion);
 
 #ifdef BUILD_TESTS
     void
@@ -75,9 +76,11 @@ class FlowControlByteCapacity : public FlowControlCapacity
     // FlowControlByteCapacity capacity limits may change due to protocol
     // upgrades
     ReadingCapacity mCapacityLimits;
+    uint32_t const mRemoteOverlayVersion;
 
   public:
-    FlowControlByteCapacity(Application& app, NodeID const& nodeID);
+    FlowControlByteCapacity(Application& app, NodeID const& nodeID,
+                            uint32_t remoteVersion);
     virtual ~FlowControlByteCapacity() = default;
     virtual uint64_t
     getMsgResourceCount(StellarMessage const& msg) const override;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1565,7 +1565,7 @@ Peer::recvAuth(StellarMessage const& msg)
         msg.auth().flags == AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED &&
         mApp.getConfig().ENABLE_FLOW_CONTROL_BYTES;
 
-    mFlowControl->start(weakSelf, sendCb, bothWantBytes);
+    mFlowControl->start(weakSelf, sendCb, bothWantBytes, mRemoteOverlayVersion);
 
     // Ask for SCP data _after_ the flow control message
     auto low = mApp.getHerder().getMinLedgerSeqToAskPeers();

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -65,6 +65,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
         std::chrono::seconds(1);
     static constexpr uint32_t FIRST_VERSION_SUPPORTING_FLOW_CONTROL_IN_BYTES =
         28;
+    static constexpr uint32_t FIRST_VERSION_UPDATED_FLOW_CONTROL_ACCOUNTING =
+        30;
 
     // The reporting will be based on the previous
     // PEER_METRICS_WINDOW_SIZE-second time window.

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -137,24 +137,29 @@ TEST_CASE("loopback peer send auth before hello", "[overlay][connections]")
 
 TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
 {
-    StellarMessage tx1;
-    tx1.type(TRANSACTION);
-
-    // Make tx1 larger than the minimum we can set TX_MAX_SIZE_BYTES to.
-    tx1.transaction().v0().tx.operations.emplace_back(
-        getOperationGreaterThanMinMaxSizeBytes());
-    uint32 txSize = FlowControlCapacity::msgBodySize(tx1);
-    REQUIRE(txSize > MinimumSorobanNetworkConfig::TX_MAX_SIZE_BYTES);
-
     VirtualClock clock;
     auto cfg1 = getTestConfig(0);
     auto cfg2 = getTestConfig(1);
     REQUIRE(cfg1.PEER_FLOOD_READING_CAPACITY !=
             cfg1.PEER_FLOOD_READING_CAPACITY_BYTES);
 
+    StellarMessage tx1;
+    tx1.type(TRANSACTION);
+
+    // Make tx1 larger than the minimum we can set TX_MAX_SIZE_BYTES to.
+    tx1.transaction().v0().tx.operations.emplace_back(
+        getOperationGreaterThanMinMaxSizeBytes());
+    auto getTxSize = [&]() {
+        return FlowControlCapacity::msgBodySize(
+            tx1, cfg1.OVERLAY_PROTOCOL_VERSION, cfg2.OVERLAY_PROTOCOL_VERSION);
+    };
+
     auto test = [&](bool shouldRequestMore) {
         auto app1 = createTestApplication(clock, cfg1, true, false);
         auto app2 = createTestApplication(clock, cfg2, true, false);
+        auto txSize = getTxSize();
+        REQUIRE(txSize > MinimumSorobanNetworkConfig::TX_MAX_SIZE_BYTES);
+
         auto setupApp = [txSize](Application& app) {
             app.getHerder().setMaxClassicTxSize(txSize);
 
@@ -251,23 +256,46 @@ TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
 
     SECTION("batch size is less than message size")
     {
-        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * txSize;
-        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = txSize / 2;
+        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * getTxSize();
+        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = getTxSize() / 2;
         test(true);
     }
     SECTION("batch size is greater than message size")
     {
-        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * txSize;
-        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 2 * txSize;
+        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * getTxSize();
+        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 2 * getTxSize();
         // Invalid config, core will throw on startup
         REQUIRE_THROWS_AS(test(false), std::runtime_error);
     }
     SECTION("message count kicks in first")
     {
-        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 3 * txSize;
-        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 2 * txSize;
+        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 3 * getTxSize();
+        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 2 * getTxSize();
         cfg2.PEER_FLOOD_READING_CAPACITY = 1;
         cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE = 1;
+        test(true);
+    }
+    SECTION("mixed versions")
+    {
+        cfg1.OVERLAY_PROTOCOL_VERSION =
+            Peer::FIRST_VERSION_UPDATED_FLOW_CONTROL_ACCOUNTING - 1;
+        cfg1.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * getTxSize();
+        cfg1.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = getTxSize();
+
+        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * getTxSize();
+        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = getTxSize();
+        test(true);
+    }
+    SECTION("older versions")
+    {
+        cfg1.OVERLAY_PROTOCOL_VERSION =
+            Peer::FIRST_VERSION_UPDATED_FLOW_CONTROL_ACCOUNTING - 1;
+        cfg2.OVERLAY_PROTOCOL_VERSION =
+            Peer::FIRST_VERSION_UPDATED_FLOW_CONTROL_ACCOUNTING - 1;
+        cfg1.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * getTxSize();
+        cfg1.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = getTxSize();
+        cfg2.PEER_FLOOD_READING_CAPACITY_BYTES = 2 * getTxSize();
+        cfg2.FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = getTxSize();
         test(true);
     }
     SECTION("transaction size upgrades")
@@ -275,8 +303,9 @@ TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
         auto tx2 = tx1;
         tx2.transaction().v0().signatures.emplace_back(
             SignatureUtils::sign(SecretKey::random(), HashUtils::random()));
-
-        uint32 txSize2 = FlowControlCapacity::msgBodySize(tx2);
+        auto txSize = getTxSize();
+        uint32 txSize2 = FlowControlCapacity::msgBodySize(
+            tx2, cfg1.OVERLAY_PROTOCOL_VERSION, cfg2.OVERLAY_PROTOCOL_VERSION);
         REQUIRE(txSize2 > MinimumSorobanNetworkConfig::TX_MAX_SIZE_BYTES);
         REQUIRE(txSize2 > txSize + 1);
 
@@ -563,6 +592,12 @@ TEST_CASE("loopback peer flow control activation", "[overlay][flowcontrol]")
             SECTION("basic")
             {
                 // Successfully enabled flow control
+                runTest({cfg1, cfg2}, false);
+            }
+            SECTION("mix versions")
+            {
+                cfg1.OVERLAY_PROTOCOL_VERSION =
+                    Peer::FIRST_VERSION_UPDATED_FLOW_CONTROL_ACCOUNTING - 1;
                 runTest({cfg1, cfg2}, false);
             }
             SECTION("bad peer")


### PR DESCRIPTION
Potentially resolves https://github.com/stellar/stellar-core/issues/3967

Update latest overlay version to properly support tx envelope size calculation in earlier overlay versions (calculation changed from size of full stellar message to size of tx envelope only)