### PR TITLE
Only interpret `TxSetFrame` with correct ledger state

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -688,6 +688,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\test\SetOptionsTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\SetTrustLineFlagsTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\SignatureUtilsTest.cpp" />
+    <ClCompile Include="..\..\src\transactions\test\SorobanTxTestUtils.cpp" />
     <ClCompile Include="..\..\src\transactions\test\SponsorshipTestUtils.cpp" />
     <ClCompile Include="..\..\src\transactions\test\TxEnvelopeTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\TxResultsTests.cpp" />
@@ -1061,6 +1062,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\SignatureChecker.h" />
     <ClInclude Include="..\..\src\transactions\SignatureUtils.h" />
     <ClInclude Include="..\..\src\transactions\SponsorshipUtils.h" />
+    <ClInclude Include="..\..\src\transactions\test\SorobanTxTestUtils.h" />
     <ClInclude Include="..\..\src\transactions\test\SponsorshipTestUtils.h" />
     <ClInclude Include="..\..\src\transactions\TransactionBridge.h" />
     <ClInclude Include="..\..\src\transactions\TransactionFrame.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1312,6 +1312,9 @@
     <ClCompile Include="..\..\src\catchup\ReplayDebugMetaWork.cpp">
       <Filter>catchup</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\transactions\test\SorobanTxTestUtils.cpp">
+      <Filter>transactions\tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2280,6 +2283,9 @@
     </ClInclude>
     <ClInclude Include="..\..\src\catchup\ReplayDebugMetaWork.h">
       <Filter>catchup</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\transactions\test\SorobanTxTestUtils.h">
+      <Filter>transactions\tests</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -47,13 +47,13 @@ ApplyBufferedLedgersWork::onRun()
     }
     auto const& lcd = maybeLcd.value();
 
-    CLOG_INFO(History,
-              "Scheduling buffered ledger-close: [seq={}, prev={}, txs={}, "
-              "ops={}, sv: {}]",
-              lcd.getLedgerSeq(),
-              hexAbbrev(lcd.getTxSet()->previousLedgerHash()),
-              lcd.getTxSet()->sizeTxTotal(), lcd.getTxSet()->sizeOpTotal(),
-              stellarValueToString(mApp.getConfig(), lcd.getValue()));
+    CLOG_INFO(
+        History,
+        "Scheduling buffered ledger-close: [seq={}, prev={}, txs={}, "
+        "ops={}, sv: {}]",
+        lcd.getLedgerSeq(), hexAbbrev(lcd.getTxSet()->previousLedgerHash()),
+        lcd.getTxSet()->sizeTxTotal(), lcd.getTxSet()->sizeOpTotalForLogging(),
+        stellarValueToString(mApp.getConfig(), lcd.getValue()));
 
     auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, lcd);
 

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -126,12 +126,12 @@ ApplyCheckpointWork::getCurrentTxSet()
             CLOG_DEBUG(History, "Loaded txset for ledger {}", seq);
             if (mTxHistoryEntry.ext.v() == 0)
             {
-                return TxSetFrame::makeFromWire(mApp, mTxHistoryEntry.txSet);
+                return TxSetFrame::makeFromWire(mTxHistoryEntry.txSet);
             }
             else
             {
                 return TxSetFrame::makeFromWire(
-                    mApp, mTxHistoryEntry.ext.generalizedTxSet());
+                    mTxHistoryEntry.ext.generalizedTxSet());
             }
         }
     } while (mTxIn && mTxIn.readOne(mTxHistoryEntry));

--- a/src/catchup/ReplayDebugMetaWork.cpp
+++ b/src/catchup/ReplayDebugMetaWork.cpp
@@ -111,11 +111,11 @@ class ApplyLedgersFromMetaWork : public Work
         TxSetFrameConstPtr txSet;
         if (lcm.v() == 0)
         {
-            txSet = TxSetFrame::makeFromWire(mApp, lcm.v0().txSet);
+            txSet = TxSetFrame::makeFromWire(lcm.v0().txSet);
         }
         else
         {
-            txSet = TxSetFrame::makeFromWire(mApp, lcm.v1().txSet);
+            txSet = TxSetFrame::makeFromWire(lcm.v1().txSet);
         }
 
         LedgerCloseData ledgerCloseData(ledgerSeqToApply, txSet,
@@ -164,7 +164,7 @@ ReplayDebugMetaWork::applyLastLedger()
     if (lcl + 1 == debugTxSet.ledgerSeq)
     {
         mApp.getLedgerManager().closeLedger(
-            LedgerCloseData::toLedgerCloseData(debugTxSet, mApp));
+            LedgerCloseData::toLedgerCloseData(debugTxSet));
     }
     else
     {

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -139,6 +139,9 @@ class Herder
     virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
                                            const SCPQuorumSet& qset,
                                            TxSetFrameConstPtr txset) = 0;
+    virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
+                                           const SCPQuorumSet& qset,
+                                           StellarMessage const& txset) = 0;
 
     virtual void
     externalizeValue(TxSetFrameConstPtr txSet, uint32_t ledgerSeq,

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -103,6 +103,9 @@ class HerderImpl : public Herder
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
                                    const SCPQuorumSet& qset,
                                    TxSetFrameConstPtr txset) override;
+    EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
+                                   const SCPQuorumSet& qset,
+                                   StellarMessage const& txset) override;
 
     void externalizeValue(TxSetFrameConstPtr txSet, uint32_t ledgerSeq,
                           uint64_t closeTime,

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -226,7 +226,7 @@ class HerderSCPDriver : public SCPDriver
                          std::chrono::nanoseconds threshold,
                          uint64_t slotIndex);
 
-    bool checkAndCacheTxSetValid(TxSetFrameConstPtr TxSet,
+    bool checkAndCacheTxSetValid(ApplicableTxSetFrame const& txSet,
                                  uint64_t closeTimeOffset) const;
 };
 }

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -53,39 +53,26 @@ class LedgerCloseData
     toXDR() const
     {
         StoredDebugTransactionSet sts;
-
-        StoredTransactionSet tempTxSet;
-        if (mTxSet->isGeneralizedTxSet())
-        {
-            tempTxSet.v(1);
-            mTxSet->toXDR(tempTxSet.generalizedTxSet());
-        }
-        else
-        {
-            mTxSet->toXDR(tempTxSet.txSet());
-        }
-
-        sts.txSet = tempTxSet;
+        mTxSet->storeXDR(sts.txSet);
         sts.scpValue = mValue;
         sts.ledgerSeq = mLedgerSeq;
-
         return sts;
     }
 
     static LedgerCloseData
-    toLedgerCloseData(StoredDebugTransactionSet const& sts, Application& app)
+    toLedgerCloseData(StoredDebugTransactionSet const& sts)
     {
         if (sts.txSet.v() == 0)
         {
-            return LedgerCloseData(
-                sts.ledgerSeq, TxSetFrame::makeFromWire(app, sts.txSet.txSet()),
-                sts.scpValue);
+            return LedgerCloseData(sts.ledgerSeq,
+                                   TxSetFrame::makeFromWire(sts.txSet.txSet()),
+                                   sts.scpValue);
         }
         else
         {
             return LedgerCloseData(
                 sts.ledgerSeq,
-                TxSetFrame::makeFromWire(app, sts.txSet.generalizedTxSet()),
+                TxSetFrame::makeFromWire(sts.txSet.generalizedTxSet()),
                 sts.scpValue);
         }
     }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -596,7 +596,7 @@ TxSetFrame::sizeTxTotal() const
 }
 
 size_t
-TxSetFrame::sizeOpTotal() const
+TxSetFrame::sizeOpTotalForLogging() const
 {
     auto accumulateTxsFn = [](size_t sz, TransactionEnvelope const& tx) {
         size_t txOps = 0;
@@ -609,7 +609,9 @@ TxSetFrame::sizeOpTotal() const
             txOps = tx.v1().tx.operations.size();
             break;
         case ENVELOPE_TYPE_TX_FEE_BUMP:
-            txOps = tx.feeBump().tx.innerTx.v1().tx.operations.size();
+            txOps = 1 + tx.feeBump().tx.innerTx.v1().tx.operations.size();
+            break;
+        default:
             break;
         }
         return sz + txOps;
@@ -1076,7 +1078,7 @@ ApplicableTxSetFrame::computeTxFees(
     TxSetFrame::Phase phase, LedgerHeader const& ledgerHeader,
     SurgePricingLaneConfig const& surgePricingConfig,
     std::vector<int64_t> const& lowestLaneFee,
-    std::vector<bool> const& hadTxNotFittingLane)
+    std::vector<bool> const& hadTxNotFittingLane) const
 {
     releaseAssert(!mFeesComputed[static_cast<size_t>(phase)]);
     releaseAssert(isGeneralizedTxSet());

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -36,62 +36,6 @@ namespace stellar
 
 namespace
 {
-// The frame created around malformed transaction set XDR received over the
-// wire.
-// This does not initialize the internal data structures, but does store the XDR
-// message itself. This is needed to support a specific use-case: transaction
-// sets may be requested by the peers even when they are malformed and we need
-// to provide the message they requested for.
-class InvalidTxSetFrame : public TxSetFrame
-{
-  public:
-    template <typename T>
-    InvalidTxSetFrame(T const& xdrTxSet, Hash const& hash, size_t encodedSize)
-        : TxSetFrame(std::is_same_v<T, GeneralizedTransactionSet>, {},
-                     std::is_same_v<T, GeneralizedTransactionSet>
-                         ? TxSetFrame::TxPhases{TxSetFrame::Transactions{},
-                                                TxSetFrame::Transactions{}}
-                         : TxSetFrame::TxPhases{TxSetFrame::Transactions{}})
-        , mXDRTxSet(xdrTxSet)
-    {
-        mHash = hash;
-        mEncodedSize = encodedSize;
-    }
-
-    bool
-    checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
-               uint64_t upperBoundCloseTimeOffset) const override
-    {
-        return false;
-    }
-
-    void
-    toXDR(TransactionSet& txSet) const override
-    {
-        releaseAssert(std::holds_alternative<TransactionSet>(mXDRTxSet));
-        txSet = std::get<TransactionSet>(mXDRTxSet);
-    }
-
-    void
-    toXDR(GeneralizedTransactionSet& generalizedTxSet) const override
-    {
-        releaseAssert(
-            std::holds_alternative<GeneralizedTransactionSet>(mXDRTxSet));
-        generalizedTxSet = std::get<GeneralizedTransactionSet>(mXDRTxSet);
-    }
-
-#ifdef BUILD_TESTS
-    bool
-    checkValidStructure() const override
-    {
-        return false;
-    }
-#endif
-
-  private:
-    std::variant<TransactionSet, GeneralizedTransactionSet> mXDRTxSet;
-};
-
 bool
 validateTxSetXDRStructure(GeneralizedTransactionSet const& txSet)
 {
@@ -213,76 +157,117 @@ computePerOpFee(TransactionFrameBase const& tx, uint32_t ledgerVersion)
                             static_cast<int64_t>(txOps), rounding);
 }
 
+void
+transactionsToTransactionSetXDR(TxSetFrame::Transactions const& txs,
+                                Hash const& previousLedgerHash,
+                                TransactionSet& txSet)
+{
+    ZoneScoped;
+    txSet.txs.resize(xdr::size32(txs.size()));
+    auto sortedTxs = TxSetUtils::sortTxsInHashOrder(txs);
+    for (unsigned int n = 0; n < sortedTxs.size(); n++)
+    {
+        txSet.txs[n] = sortedTxs[n]->getEnvelope();
+    }
+    txSet.previousLedgerHash = previousLedgerHash;
+}
+
+void
+transactionsToGeneralizedTransactionSetXDR(
+    TxSetFrame::TxPhases const& phaseTxs,
+    std::vector<std::unordered_map<TransactionFrameBaseConstPtr,
+                                   std::optional<int64_t>>> const&
+        phaseInclusionFeeMap,
+    Hash const& previousLedgerHash, GeneralizedTransactionSet& generalizedTxSet)
+{
+    ZoneScoped;
+    releaseAssert(phaseTxs.size() == phaseInclusionFeeMap.size());
+
+    generalizedTxSet.v(1);
+    generalizedTxSet.v1TxSet().previousLedgerHash = previousLedgerHash;
+
+    for (int i = 0; i < phaseTxs.size(); ++i)
+    {
+        auto const& txPhase = phaseTxs[i];
+        auto& phase =
+            generalizedTxSet.v1TxSet().phases.emplace_back().v0Components();
+
+        auto const& feeMap = phaseInclusionFeeMap[i];
+        std::map<std::optional<int64_t>, size_t> feeTxCount;
+        for (auto const& [tx, fee] : feeMap)
+        {
+            ++feeTxCount[fee];
+        }
+        // Reserve a component per unique base fee in order to have the correct
+        // pointers in componentPerBid map.
+        phase.reserve(feeTxCount.size());
+
+        std::map<std::optional<int64_t>, xdr::xvector<TransactionEnvelope>*>
+            componentPerBid;
+        for (auto const& [fee, txCount] : feeTxCount)
+        {
+            phase.emplace_back(TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
+            auto& discountedFeeComponent = phase.back().txsMaybeDiscountedFee();
+            if (fee)
+            {
+                discountedFeeComponent.baseFee.activate() = *fee;
+            }
+            componentPerBid[fee] = &discountedFeeComponent.txs;
+            componentPerBid[fee]->reserve(txCount);
+        }
+        auto sortedTxs = TxSetUtils::sortTxsInHashOrder(txPhase);
+        for (auto const& tx : sortedTxs)
+        {
+            componentPerBid[feeMap.find(tx)->second]->push_back(
+                tx->getEnvelope());
+        }
+    }
+}
 } // namespace
 
-TxSetFrame::TxSetFrame(bool isGeneralized, Hash const& previousLedgerHash,
-                       TxPhases const& txs)
-    : mIsGeneralized(isGeneralized)
-    , mPreviousLedgerHash(previousLedgerHash)
-    , mTxPhases(txs)
+TxSetFrame::TxSetFrame(TransactionSet const& xdrTxSet)
+    : mXDRTxSet(xdrTxSet)
+    , mEncodedSize(xdr::xdr_argpack_size(xdrTxSet))
+    , mHash(computeNonGenericTxSetContentsHash(xdrTxSet))
 {
-    mFeesComputed.resize(mTxPhases.size(), false);
 }
 
-#ifdef BUILD_TESTS
-bool
-TxSetFrame::checkValidStructure() const
+TxSetFrame::TxSetFrame(GeneralizedTransactionSet const& xdrTxSet)
+    : mXDRTxSet(xdrTxSet)
+    , mEncodedSize(xdr::xdr_argpack_size(xdrTxSet))
+    , mHash(xdrSha256(xdrTxSet))
 {
-    return true;
-}
-
-TxSetFrameConstPtr
-TxSetFrame::makeFromTransactions(TxSetFrame::Transactions txs, Application& app,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset,
-                                 bool enforceTxsApplyOrder)
-{
-    Transactions invalid;
-    return TxSetFrame::makeFromTransactions(txs, app, lowerBoundCloseTimeOffset,
-                                            upperBoundCloseTimeOffset, invalid,
-                                            enforceTxsApplyOrder);
 }
 
 TxSetFrameConstPtr
-TxSetFrame::makeFromTransactions(Transactions txs, Application& app,
-                                 uint64_t lowerBoundCloseTimeOffset,
-                                 uint64_t upperBoundCloseTimeOffset,
-                                 Transactions& invalidTxs,
-                                 bool enforceTxsApplyOrder)
+TxSetFrame::makeFromWire(TransactionSet const& xdrTxSet)
 {
-    TxSetFrame::TxPhases phases;
-    phases.emplace_back(txs);
-    auto lclHeader = app.getLedgerManager().getLastClosedLedgerHeader();
-    if (protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
-                                  SOROBAN_PROTOCOL_VERSION))
+    ZoneScoped;
+    std::shared_ptr<TxSetFrame> txSet(new TxSetFrame(xdrTxSet));
+    return txSet;
+}
+
+TxSetFrameConstPtr
+TxSetFrame::makeFromWire(GeneralizedTransactionSet const& xdrTxSet)
+{
+    ZoneScoped;
+    std::shared_ptr<TxSetFrame> txSet(new TxSetFrame(xdrTxSet));
+    return txSet;
+}
+
+TxSetFrameConstPtr
+TxSetFrame::makeFromStoredTxSet(StoredTransactionSet const& storedSet)
+{
+    if (storedSet.v() == 0)
     {
-        // Empty soroban phase
-        phases.emplace_back();
+        return TxSetFrame::makeFromWire(storedSet.txSet());
     }
-    TxSetFrame::TxPhases invalid;
-    invalid.resize(phases.size());
-    auto res = TxSetFrame::makeFromTransactions(
-        phases, app, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
-        invalid, enforceTxsApplyOrder);
-    invalidTxs = invalid[0];
-    if (enforceTxsApplyOrder)
-    {
-        res->mApplyOrderOverride = std::make_optional(txs);
-    }
-    return res;
-}
-#endif
-
-TxSetFrame::TxSetFrame(LedgerHeaderHistoryEntry const& lclHeader,
-                       TxPhases const& txs)
-    : TxSetFrame(protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
-                                           SOROBAN_PROTOCOL_VERSION),
-                 lclHeader.hash, txs)
-{
+    return TxSetFrame::makeFromWire(storedSet.generalizedTxSet());
 }
 
-TxSetFrameConstPtr
-TxSetFrame::makeFromTransactions(TxPhases const& txPhases, Application& app,
+std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+TxSetFrame::makeFromTransactions(TxSetFrame::TxPhases const& txPhases,
+                                 Application& app,
                                  uint64_t lowerBoundCloseTimeOffset,
                                  uint64_t upperBoundCloseTimeOffset
 #ifdef BUILD_TESTS
@@ -302,11 +287,12 @@ TxSetFrame::makeFromTransactions(TxPhases const& txPhases, Application& app,
     );
 }
 
-TxSetFrameConstPtr
-TxSetFrame::makeFromTransactions(TxPhases const& txPhases, Application& app,
+std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+TxSetFrame::makeFromTransactions(TxSetFrame::TxPhases const& txPhases,
+                                 Application& app,
                                  uint64_t lowerBoundCloseTimeOffset,
                                  uint64_t upperBoundCloseTimeOffset,
-                                 TxPhases& invalidTxs
+                                 TxSetFrame::TxPhases& invalidTxs
 #ifdef BUILD_TESTS
                                  ,
                                  bool skipValidation
@@ -317,11 +303,12 @@ TxSetFrame::makeFromTransactions(TxPhases const& txPhases, Application& app,
     releaseAssert(txPhases.size() <=
                   static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
 
-    TxPhases validatedPhases;
+    TxSetFrame::TxPhases validatedPhases;
     for (int i = 0; i < txPhases.size(); ++i)
     {
         auto& txs = txPhases[i];
-        bool expectSoroban = static_cast<Phase>(i) == Phase::SOROBAN;
+        bool expectSoroban =
+            static_cast<TxSetFrame::Phase>(i) == TxSetFrame::Phase::SOROBAN;
         if (!std::all_of(txs.begin(), txs.end(), [&](auto const& tx) {
                 return tx->isSoroban() == expectSoroban;
             }))
@@ -348,207 +335,422 @@ TxSetFrame::makeFromTransactions(TxPhases const& txPhases, Application& app,
     }
 
     auto const& lclHeader = app.getLedgerManager().getLastClosedLedgerHeader();
-    // We can't use `std::make_shared` here as the constructors are protected.
-    // This may cause leaks in case of exceptions, so keep the constructors
-    // simple and exception-safe.
-    std::shared_ptr<TxSetFrame> txSet(
-        new TxSetFrame(lclHeader, validatedPhases));
-    txSet->applySurgePricing(app);
-
+    // Preliminary applicable frame - we don't know the contents hash yet, but
+    // we also don't return this.
+    std::unique_ptr<ApplicableTxSetFrame> preliminaryApplicableTxSet(
+        new ApplicableTxSetFrame(app, lclHeader, validatedPhases,
+                                 std::nullopt));
+    preliminaryApplicableTxSet->applySurgePricing(app);
     // Do the roundtrip through XDR to ensure we never build an incorrect tx set
     // for nomination.
-    TxSetFrameConstPtr outputTxSet;
-    if (txSet->isGeneralizedTxSet())
-    {
-        GeneralizedTransactionSet xdrTxSet;
-        txSet->toXDR(xdrTxSet);
-        outputTxSet = TxSetFrame::makeFromWire(app, xdrTxSet);
-    }
-    else
-    {
-        TransactionSet xdrTxSet;
-        txSet->toXDR(xdrTxSet);
-        outputTxSet = TxSetFrame::makeFromWire(app, xdrTxSet);
-    }
+    auto outputTxSet = preliminaryApplicableTxSet->toWireTxSetFrame();
 #ifdef BUILD_TESTS
     if (skipValidation)
     {
-        // Return the initially built `txSet` in order to preserve
-        // the original tx frames passed in `phases`.
-        txSet->mHash = outputTxSet->mHash;
-        txSet->mEncodedSize = outputTxSet->mEncodedSize;
-        return txSet;
+        // Fill in the contents hash if we're skipping the normal roundtrip
+        // and validation flow.
+        preliminaryApplicableTxSet->mContentsHash =
+            outputTxSet->getContentsHash();
+        return std::make_pair(outputTxSet,
+                              std::move(preliminaryApplicableTxSet));
     }
 #endif
+
+    ApplicableTxSetFrameConstPtr outputApplicableTxSet =
+        outputTxSet->prepareForApply(app);
+
+    if (!outputApplicableTxSet)
+    {
+        throw std::runtime_error(
+            "Couldn't prepare created tx set frame for apply");
+    }
+
     // Make sure no transactions were lost during the roundtrip and the output
     // tx set is valid.
-    bool valid = txSet->numPhases() == outputTxSet->numPhases();
+    bool valid = preliminaryApplicableTxSet->numPhases() ==
+                 outputApplicableTxSet->numPhases();
     if (valid)
     {
-        for (int i = 0; i < txSet->numPhases(); ++i)
+        for (int i = 0; i < preliminaryApplicableTxSet->numPhases(); ++i)
         {
-            valid = valid && txSet->sizeTx(static_cast<Phase>(i)) ==
-                                 outputTxSet->sizeTx(static_cast<Phase>(i));
+            valid = valid &&
+                    preliminaryApplicableTxSet->sizeTx(static_cast<Phase>(i)) ==
+                        outputApplicableTxSet->sizeTx(static_cast<Phase>(i));
         }
     }
-    valid = valid && outputTxSet->checkValid(app, lowerBoundCloseTimeOffset,
-                                             upperBoundCloseTimeOffset);
+
+    valid = valid &&
+            outputApplicableTxSet->checkValid(app, lowerBoundCloseTimeOffset,
+                                              upperBoundCloseTimeOffset);
     if (!valid)
     {
         throw std::runtime_error("Created invalid tx set frame");
     }
-    return outputTxSet;
-}
 
-TxSetFrameConstPtr
-TxSetFrame::makeFromHistoryTransactions(Hash const& previousLedgerHash,
-                                        Transactions const& txs)
-{
-    // We can't use `std::make_shared` here as the constructors are protected.
-    // This may cause leaks in case of exceptions, so keep the constructors
-    // simple and exception-safe.
-    return std::shared_ptr<TxSetFrame>(
-        new TxSetFrame(false, previousLedgerHash, TxSetFrame::TxPhases{txs}));
+    return std::make_pair(outputTxSet, std::move(outputApplicableTxSet));
 }
 
 TxSetFrameConstPtr
 TxSetFrame::makeEmpty(LedgerHeaderHistoryEntry const& lclHeader)
 {
-    // We can't use `std::make_shared` here as the constructors are protected.
-    // This may cause leaks in case of exceptions, so keep the constructors
-    // simple and exception-safe.
-    TxPhases phases;
-    phases.resize(protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
-                                            SOROBAN_PROTOCOL_VERSION)
-                      ? static_cast<size_t>(Phase::PHASE_COUNT)
-                      : 1);
-    std::shared_ptr<TxSetFrame> txSet(new TxSetFrame(lclHeader, phases));
-    for (int i = 0; i < txSet->mFeesComputed.size(); i++)
+    if (protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
+                                  SOROBAN_PROTOCOL_VERSION))
     {
-        txSet->mFeesComputed[i] = true;
+        TxSetFrame::TxPhases emptyPhases(
+            static_cast<size_t>(Phase::PHASE_COUNT));
+        std::vector<std::unordered_map<TransactionFrameBaseConstPtr,
+                                       std::optional<int64_t>>>
+            emptyFeeMap(static_cast<size_t>(Phase::PHASE_COUNT));
+        GeneralizedTransactionSet txSet;
+        transactionsToGeneralizedTransactionSetXDR(emptyPhases, emptyFeeMap,
+                                                   lclHeader.hash, txSet);
+        return TxSetFrame::makeFromWire(txSet);
     }
-    txSet->computeContentsHash();
-    return txSet;
+    TransactionSet txSet;
+    transactionsToTransactionSetXDR({}, lclHeader.hash, txSet);
+    return TxSetFrame::makeFromWire(txSet);
 }
 
 TxSetFrameConstPtr
-TxSetFrame::makeFromWire(Application& app, TransactionSet const& xdrTxSet)
+TxSetFrame::makeFromHistoryTransactions(Hash const& previousLedgerHash,
+                                        TxSetFrame::Transactions const& txs)
 {
-    ZoneScoped;
-    std::shared_ptr<TxSetFrame> txSet(new TxSetFrame(
-        false, xdrTxSet.previousLedgerHash, {TxSetFrame::Transactions{}}));
-    size_t encodedSize = xdr::xdr_argpack_size(xdrTxSet);
-    if (!txSet->addTxsFromXdr(app, xdrTxSet.txs, false, std::nullopt,
-                              Phase::CLASSIC))
-    {
-        CLOG_DEBUG(Herder,
-                   "Got bad txSet: transactions are not "
-                   "ordered correctly or contain invalid phase transactions");
-        return std::make_shared<InvalidTxSetFrame const>(
-            xdrTxSet, computeNonGenericTxSetContentsHash(xdrTxSet),
-            encodedSize);
-    }
-    txSet->computeContentsHash();
-    txSet->mEncodedSize = encodedSize;
-    return txSet;
+    TransactionSet txSet;
+    transactionsToTransactionSetXDR(txs, previousLedgerHash, txSet);
+    return TxSetFrame::makeFromWire(txSet);
 }
 
-TxSetFrameConstPtr
-TxSetFrame::makeFromWire(Application& app,
-                         GeneralizedTransactionSet const& xdrTxSet)
+#ifdef BUILD_TESTS
+std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+TxSetFrame::makeFromTransactions(TxSetFrame::Transactions txs, Application& app,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset,
+                                 bool enforceTxsApplyOrder)
 {
+    Transactions invalid;
+    return TxSetFrame::makeFromTransactions(txs, app, lowerBoundCloseTimeOffset,
+                                            upperBoundCloseTimeOffset, invalid,
+                                            enforceTxsApplyOrder);
+}
+
+std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+TxSetFrame::makeFromTransactions(Transactions txs, Application& app,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset,
+                                 Transactions& invalidTxs,
+                                 bool enforceTxsApplyOrder)
+{
+    TxSetFrame::TxPhases phases;
+    phases.emplace_back(txs);
+    auto lclHeader = app.getLedgerManager().getLastClosedLedgerHeader();
+    if (protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
+                                  SOROBAN_PROTOCOL_VERSION))
+    {
+        // Empty soroban phase
+        phases.emplace_back();
+    }
+    TxSetFrame::TxPhases invalid;
+    invalid.resize(phases.size());
+    auto res = TxSetFrame::makeFromTransactions(
+        phases, app, lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
+        invalid, enforceTxsApplyOrder);
+    if (enforceTxsApplyOrder)
+    {
+        res.second->mApplyOrderOverride = txs;
+        res.first->mApplicableTxSetOverride = std::move(res.second);
+    }
+    invalidTxs = invalid[0];
+    return res;
+}
+#endif
+
+ApplicableTxSetFrameConstPtr
+TxSetFrame::prepareForApply(Application& app) const
+{
+#ifdef BUILD_TESTS
+    if (mApplicableTxSetOverride)
+    {
+        return ApplicableTxSetFrameConstPtr(
+            new ApplicableTxSetFrame(*mApplicableTxSetOverride));
+    }
+#endif
     ZoneScoped;
-    auto hash = xdrSha256(xdrTxSet);
-    size_t encodedSize = xdr::xdr_argpack_size(xdrTxSet);
-    if (!validateTxSetXDRStructure(xdrTxSet))
+    std::unique_ptr<ApplicableTxSetFrame> txSet{};
+    if (isGeneralizedTxSet())
     {
-        return std::make_shared<InvalidTxSetFrame const>(xdrTxSet, hash,
-                                                         encodedSize);
-    }
-
-    auto const& phases = xdrTxSet.v1TxSet().phases;
-    TxPhases defaultPhases;
-    defaultPhases.resize(phases.size(), TxSetFrame::Transactions{});
-
-    std::shared_ptr<TxSetFrame> txSet(new TxSetFrame(
-        true, xdrTxSet.v1TxSet().previousLedgerHash, defaultPhases));
-    // Mark fees as already computed as we read them from the XDR.
-    for (int i = 0; i < txSet->mFeesComputed.size(); i++)
-    {
-        txSet->mFeesComputed[i] = true;
-    }
-    txSet->mHash = hash;
-    releaseAssert(phases.size() <= static_cast<size_t>(Phase::PHASE_COUNT));
-    for (auto phaseId = 0; phaseId < phases.size(); phaseId++)
-    {
-        auto const& phase = phases[phaseId];
-        auto const& components = phase.v0Components();
-        for (auto const& component : components)
+        auto const& xdrTxSet = std::get<GeneralizedTransactionSet>(mXDRTxSet);
+        if (!validateTxSetXDRStructure(xdrTxSet))
         {
-            switch (component.type())
+            CLOG_DEBUG(Herder,
+                       "Got bad generalized txSet with invalid XDR structure");
+            return nullptr;
+        }
+        auto const& phases = xdrTxSet.v1TxSet().phases;
+        TxSetFrame::TxPhases defaultPhases;
+        defaultPhases.resize(phases.size());
+
+        txSet = std::unique_ptr<ApplicableTxSetFrame>(new ApplicableTxSetFrame(
+            app, true, previousLedgerHash(), defaultPhases, mHash));
+        // Mark fees as already computed as we read them from the XDR.
+        for (int i = 0; i < txSet->mFeesComputed.size(); i++)
+        {
+            txSet->mFeesComputed[i] = true;
+        }
+
+        releaseAssert(phases.size() <=
+                      static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
+        for (auto phaseId = 0; phaseId < phases.size(); phaseId++)
+        {
+            auto const& phase = phases[phaseId];
+            auto const& components = phase.v0Components();
+            for (auto const& component : components)
             {
-            case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
-                std::optional<int64_t> baseFee;
-                if (component.txsMaybeDiscountedFee().baseFee)
+                switch (component.type())
                 {
-                    baseFee = *component.txsMaybeDiscountedFee().baseFee;
+                case TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE:
+                    std::optional<int64_t> baseFee;
+                    if (component.txsMaybeDiscountedFee().baseFee)
+                    {
+                        baseFee = *component.txsMaybeDiscountedFee().baseFee;
+                    }
+                    if (!txSet->addTxsFromXdr(
+                            app.getNetworkID(),
+                            component.txsMaybeDiscountedFee().txs, true,
+                            baseFee, static_cast<TxSetFrame::Phase>(phaseId)))
+                    {
+                        CLOG_DEBUG(Herder,
+                                   "Got bad txSet: transactions are not "
+                                   "ordered correctly or contain invalid phase "
+                                   "transactions");
+                        return nullptr;
+                    }
+                    break;
                 }
-                if (!txSet->addTxsFromXdr(
-                        app, component.txsMaybeDiscountedFee().txs, true,
-                        baseFee, static_cast<Phase>(phaseId)))
-                {
-                    CLOG_DEBUG(Herder, "Got bad txSet: transactions are not "
-                                       "ordered correctly or contain invalid "
-                                       "phase transactions");
-                    return std::make_shared<InvalidTxSetFrame const>(
-                        xdrTxSet, hash, encodedSize);
-                }
-                break;
             }
+        }
+    }
+    else
+    {
+        auto const& xdrTxSet = std::get<TransactionSet>(mXDRTxSet);
+        txSet = std::unique_ptr<ApplicableTxSetFrame>(
+            new ApplicableTxSetFrame(app, false, previousLedgerHash(),
+                                     {TxSetFrame::Transactions{}}, mHash));
+        if (!txSet->addTxsFromXdr(app.getNetworkID(), xdrTxSet.txs, false,
+                                  std::nullopt, TxSetFrame::Phase::CLASSIC))
+        {
+            CLOG_DEBUG(
+                Herder,
+                "Got bad txSet: transactions are not "
+                "ordered correctly or contain invalid phase transactions");
+            return nullptr;
         }
     }
     return txSet;
 }
 
-TxSetFrameConstPtr
-TxSetFrame::makeFromStoredTxSet(StoredTransactionSet const& storedSet,
-                                Application& app)
+bool
+TxSetFrame::isGeneralizedTxSet() const
 {
-    TxSetFrameConstPtr cur;
-    if (storedSet.v() == 0)
-    {
-        cur = TxSetFrame::makeFromWire(app, storedSet.txSet());
-    }
-    else
-    {
-        cur = TxSetFrame::makeFromWire(app, storedSet.generalizedTxSet());
-    }
-
-    return cur;
+    return std::holds_alternative<GeneralizedTransactionSet>(mXDRTxSet);
 }
 
 Hash const&
 TxSetFrame::getContentsHash() const
 {
-    releaseAssert(mHash);
-    return *mHash;
+    return mHash;
 }
 
 Hash const&
 TxSetFrame::previousLedgerHash() const
 {
-    return mPreviousLedgerHash;
+    if (isGeneralizedTxSet())
+    {
+        return std::get<GeneralizedTransactionSet>(mXDRTxSet)
+            .v1TxSet()
+            .previousLedgerHash;
+    }
+    return std::get<TransactionSet>(mXDRTxSet).previousLedgerHash;
+}
+
+size_t
+TxSetFrame::sizeTxTotal() const
+{
+    if (isGeneralizedTxSet())
+    {
+        auto const& txSet =
+            std::get<GeneralizedTransactionSet>(mXDRTxSet).v1TxSet();
+        size_t totalSize = 0;
+        for (auto const& phase : txSet.phases)
+        {
+            for (auto const& component : phase.v0Components())
+            {
+                totalSize += component.txsMaybeDiscountedFee().txs.size();
+            }
+        }
+        return totalSize;
+    }
+    else
+    {
+        return std::get<TransactionSet>(mXDRTxSet).txs.size();
+    }
+}
+
+size_t
+TxSetFrame::sizeOpTotal() const
+{
+    auto accumulateTxsFn = [](size_t sz, TransactionEnvelope const& tx) {
+        size_t txOps = 0;
+        switch (tx.type())
+        {
+        case ENVELOPE_TYPE_TX_V0:
+            txOps = tx.v0().tx.operations.size();
+            break;
+        case ENVELOPE_TYPE_TX:
+            txOps = tx.v1().tx.operations.size();
+            break;
+        case ENVELOPE_TYPE_TX_FEE_BUMP:
+            txOps = tx.feeBump().tx.innerTx.v1().tx.operations.size();
+            break;
+        }
+        return sz + txOps;
+    };
+    if (isGeneralizedTxSet())
+    {
+        auto const& txSet =
+            std::get<GeneralizedTransactionSet>(mXDRTxSet).v1TxSet();
+        size_t totalSize = 0;
+        for (auto const& phase : txSet.phases)
+        {
+            for (auto const& component : phase.v0Components())
+            {
+                totalSize += std::accumulate(
+                    component.txsMaybeDiscountedFee().txs.begin(),
+                    component.txsMaybeDiscountedFee().txs.end(), 0,
+                    accumulateTxsFn);
+            }
+        }
+        return totalSize;
+    }
+    else
+    {
+        auto const& txs = std::get<TransactionSet>(mXDRTxSet).txs;
+        return std::accumulate(txs.begin(), txs.end(), 0, accumulateTxsFn);
+    }
+}
+
+TxSetFrame::TxPhases
+TxSetFrame::createTransactionFrames(Hash const& networkID) const
+{
+    TxPhases phaseTxs;
+    if (isGeneralizedTxSet())
+    {
+        auto const& txSet =
+            std::get<GeneralizedTransactionSet>(mXDRTxSet).v1TxSet();
+        for (auto const& phase : txSet.phases)
+        {
+            auto& txs = phaseTxs.emplace_back();
+            for (auto const& component : phase.v0Components())
+            {
+                for (auto const& tx : component.txsMaybeDiscountedFee().txs)
+                {
+                    txs.emplace_back(
+                        TransactionFrameBase::makeTransactionFromWire(networkID,
+                                                                      tx));
+                }
+            }
+        }
+    }
+    else
+    {
+        auto& txs = phaseTxs.emplace_back();
+        auto const& txSet = std::get<TransactionSet>(mXDRTxSet).txs;
+        for (auto const& tx : txSet)
+        {
+            txs.emplace_back(
+                TransactionFrameBase::makeTransactionFromWire(networkID, tx));
+        }
+    }
+    return phaseTxs;
+}
+
+size_t
+TxSetFrame::encodedSize() const
+{
+    return mEncodedSize;
+}
+
+void
+TxSetFrame::toXDR(TransactionSet& txSet) const
+{
+    releaseAssert(!isGeneralizedTxSet());
+    txSet = std::get<TransactionSet>(mXDRTxSet);
+}
+
+void
+TxSetFrame::toXDR(GeneralizedTransactionSet& txSet) const
+{
+    releaseAssert(isGeneralizedTxSet());
+    txSet = std::get<GeneralizedTransactionSet>(mXDRTxSet);
+}
+
+void
+TxSetFrame::storeXDR(StoredTransactionSet& txSet) const
+{
+    if (isGeneralizedTxSet())
+    {
+        txSet.v(1);
+        txSet.generalizedTxSet() =
+            std::get<GeneralizedTransactionSet>(mXDRTxSet);
+    }
+    else
+    {
+        txSet.v(0);
+        txSet.txSet() = std::get<TransactionSet>(mXDRTxSet);
+    }
+}
+
+ApplicableTxSetFrame::ApplicableTxSetFrame(Application& app, bool isGeneralized,
+                                           Hash const& previousLedgerHash,
+                                           TxSetFrame::TxPhases const& txs,
+                                           std::optional<Hash> contentsHash)
+    : mIsGeneralized(isGeneralized)
+    , mPreviousLedgerHash(previousLedgerHash)
+    , mTxPhases(txs)
+    , mFeesComputed(mTxPhases.size(), false)
+    , mPhaseInclusionFeeMap(mTxPhases.size())
+    , mContentsHash(contentsHash)
+{
+    releaseAssert(previousLedgerHash ==
+                  app.getLedgerManager().getLastClosedLedgerHeader().hash);
+}
+
+ApplicableTxSetFrame::ApplicableTxSetFrame(
+    Application& app, LedgerHeaderHistoryEntry const& lclHeader,
+    TxSetFrame::TxPhases const& txs, std::optional<Hash> contentsHash)
+    : ApplicableTxSetFrame(
+          app,
+          protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
+                                    SOROBAN_PROTOCOL_VERSION),
+          lclHeader.hash, txs, contentsHash)
+{
+}
+
+Hash const&
+ApplicableTxSetFrame::getContentsHash() const
+{
+    releaseAssert(mContentsHash);
+    return *mContentsHash;
 }
 
 TxSetFrame::Transactions const&
-TxSetFrame::getTxsForPhase(Phase phase) const
+ApplicableTxSetFrame::getTxsForPhase(TxSetFrame::Phase phase) const
 {
     releaseAssert(static_cast<size_t>(phase) < mTxPhases.size());
     return mTxPhases.at(static_cast<size_t>(phase));
 }
 
 TxSetFrame::Transactions
-TxSetFrame::getTxsInApplyOrder() const
+ApplicableTxSetFrame::getTxsInApplyOrder() const
 {
 #ifdef BUILD_TESTS
     if (mApplyOrderOverride)
@@ -613,8 +815,9 @@ TxSetFrame::getTxsInApplyOrder() const
 // the fees of all the tx it has submitted in this set
 // check seq num
 bool
-TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
-                       uint64_t upperBoundCloseTimeOffset) const
+ApplicableTxSetFrame::checkValid(Application& app,
+                                 uint64_t lowerBoundCloseTimeOffset,
+                                 uint64_t upperBoundCloseTimeOffset) const
 {
     ZoneScoped;
     auto& lcl = app.getLedgerManager().getLastClosedLedgerHeader();
@@ -673,20 +876,21 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
             return true;
         };
 
-        if (!checkFeeMap(getInclusionFeeMap(Phase::CLASSIC)))
+        if (!checkFeeMap(getInclusionFeeMap(TxSetFrame::Phase::CLASSIC)))
         {
             return false;
         }
-        if (!checkFeeMap(getInclusionFeeMap(Phase::SOROBAN)))
+        if (!checkFeeMap(getInclusionFeeMap(TxSetFrame::Phase::SOROBAN)))
         {
             return false;
         }
     }
 
-    if (this->size(lcl.header, Phase::CLASSIC) > lcl.header.maxTxSetSize)
+    if (this->size(lcl.header, TxSetFrame::Phase::CLASSIC) >
+        lcl.header.maxTxSetSize)
     {
         CLOG_DEBUG(Herder, "Got bad txSet: too many classic txs {} > {}",
-                   this->size(lcl.header, Phase::CLASSIC),
+                   this->size(lcl.header, TxSetFrame::Phase::CLASSIC),
                    lcl.header.maxTxSetSize);
         return false;
     }
@@ -749,31 +953,32 @@ TxSetFrame::checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
 }
 
 size_t
-TxSetFrame::size(LedgerHeader const& lh, std::optional<Phase> phase) const
+ApplicableTxSetFrame::size(LedgerHeader const& lh,
+                           std::optional<TxSetFrame::Phase> phase) const
 {
     size_t sz = 0;
     if (!phase)
     {
-        if (numPhases() > static_cast<size_t>(Phase::SOROBAN))
+        if (numPhases() > static_cast<size_t>(TxSetFrame::Phase::SOROBAN))
         {
-            sz += sizeOp(Phase::SOROBAN);
+            sz += sizeOp(TxSetFrame::Phase::SOROBAN);
         }
     }
-    else if (phase.value() == Phase::SOROBAN)
+    else if (phase.value() == TxSetFrame::Phase::SOROBAN)
     {
-        sz += sizeOp(Phase::SOROBAN);
+        sz += sizeOp(TxSetFrame::Phase::SOROBAN);
     }
-    if (!phase || phase.value() == Phase::CLASSIC)
+    if (!phase || phase.value() == TxSetFrame::Phase::CLASSIC)
     {
         sz += protocolVersionStartsFrom(lh.ledgerVersion, ProtocolVersion::V_11)
-                  ? sizeOp(Phase::CLASSIC)
-                  : sizeTx(Phase::CLASSIC);
+                  ? sizeOp(TxSetFrame::Phase::CLASSIC)
+                  : sizeTx(TxSetFrame::Phase::CLASSIC);
     }
     return sz;
 }
 
 size_t
-TxSetFrame::sizeOp(Phase phase) const
+ApplicableTxSetFrame::sizeOp(TxSetFrame::Phase phase) const
 {
     ZoneScoped;
     auto const& txs = mTxPhases.at(static_cast<size_t>(phase));
@@ -784,54 +989,31 @@ TxSetFrame::sizeOp(Phase phase) const
 }
 
 size_t
-TxSetFrame::sizeOpTotal() const
+ApplicableTxSetFrame::sizeOpTotal() const
 {
     ZoneScoped;
     size_t total = 0;
     for (int i = 0; i < mTxPhases.size(); i++)
     {
-        total += sizeOp(static_cast<Phase>(i));
+        total += sizeOp(static_cast<TxSetFrame::Phase>(i));
     }
     return total;
 }
 
 size_t
-TxSetFrame::sizeTxTotal() const
+ApplicableTxSetFrame::sizeTxTotal() const
 {
     ZoneScoped;
     size_t total = 0;
     for (int i = 0; i < mTxPhases.size(); i++)
     {
-        total += sizeTx(static_cast<Phase>(i));
+        total += sizeTx(static_cast<TxSetFrame::Phase>(i));
     }
     return total;
-}
-
-size_t
-TxSetFrame::encodedSize() const
-{
-    if (mEncodedSize)
-    {
-        return *mEncodedSize;
-    }
-    ZoneScoped;
-    if (isGeneralizedTxSet())
-    {
-        GeneralizedTransactionSet encoded;
-        toXDR(encoded);
-        mEncodedSize = xdr::xdr_argpack_size(encoded);
-    }
-    else
-    {
-        TransactionSet encoded;
-        toXDR(encoded);
-        mEncodedSize = xdr::xdr_argpack_size(encoded);
-    }
-    return *mEncodedSize;
 }
 
 void
-TxSetFrame::computeTxFeesForNonGeneralizedSet(
+ApplicableTxSetFrame::computeTxFeesForNonGeneralizedSet(
     LedgerHeader const& lclHeader) const
 {
     ZoneScoped;
@@ -848,9 +1030,9 @@ TxSetFrame::computeTxFeesForNonGeneralizedSet(
 }
 
 void
-TxSetFrame::computeTxFeesForNonGeneralizedSet(LedgerHeader const& lclHeader,
-                                              int64_t lowestBaseFee,
-                                              bool enableLogging) const
+ApplicableTxSetFrame::computeTxFeesForNonGeneralizedSet(
+    LedgerHeader const& lclHeader, int64_t lowestBaseFee,
+    bool enableLogging) const
 {
     ZoneScoped;
     releaseAssert(std::none_of(mFeesComputed.begin(), mFeesComputed.end(),
@@ -865,35 +1047,38 @@ TxSetFrame::computeTxFeesForNonGeneralizedSet(LedgerHeader const& lclHeader,
         {
             surgeOpsCutoff = lclHeader.maxTxSetSize - MAX_OPS_PER_TX;
         }
-        if (sizeOp(Phase::CLASSIC) > surgeOpsCutoff)
+        if (sizeOp(TxSetFrame::Phase::CLASSIC) > surgeOpsCutoff)
         {
             baseFee = lowestBaseFee;
             if (enableLogging)
             {
                 CLOG_WARNING(Herder, "surge pricing in effect! {} > {}",
-                             sizeOp(Phase::CLASSIC), surgeOpsCutoff);
+                             sizeOp(TxSetFrame::Phase::CLASSIC),
+                             surgeOpsCutoff);
             }
         }
     }
 
     releaseAssert(mTxPhases.size() == 1);
-    auto const& phase = mTxPhases[0];
-
+    releaseAssert(mPhaseInclusionFeeMap.size() == 1);
+    auto const& phase =
+        mTxPhases[static_cast<size_t>(TxSetFrame::Phase::CLASSIC)];
+    auto& feeMap = getInclusionFeeMap(TxSetFrame::Phase::CLASSIC);
     for (auto const& tx : phase)
     {
-        mTxBaseInclusionFeeClassic[tx] = baseFee;
+        feeMap[tx] = baseFee;
     }
     mFeesComputed[0] = true;
 }
 
 void
-TxSetFrame::computeTxFees(TxSetFrame::Phase phase,
-                          LedgerHeader const& ledgerHeader,
-                          SurgePricingLaneConfig const& surgePricingConfig,
-                          std::vector<int64_t> const& lowestLaneFee,
-                          std::vector<bool> const& hadTxNotFittingLane)
+ApplicableTxSetFrame::computeTxFees(
+    TxSetFrame::Phase phase, LedgerHeader const& ledgerHeader,
+    SurgePricingLaneConfig const& surgePricingConfig,
+    std::vector<int64_t> const& lowestLaneFee,
+    std::vector<bool> const& hadTxNotFittingLane)
 {
-    releaseAssert(!mFeesComputed[phase]);
+    releaseAssert(!mFeesComputed[static_cast<size_t>(phase)]);
     releaseAssert(isGeneralizedTxSet());
     releaseAssert(lowestLaneFee.size() == hadTxNotFittingLane.size());
     std::vector<int64_t> laneBaseFee(lowestLaneFee.size(),
@@ -923,25 +1108,25 @@ TxSetFrame::computeTxFees(TxSetFrame::Phase phase,
                 Herder,
                 "{} phase: surge pricing for '{}' lane is in effect with base "
                 "fee={}, baseFee={}",
-                getPhaseName(phase),
+                TxSetFrame::getPhaseName(phase),
                 lane == SurgePricingPriorityQueue::GENERIC_LANE ? "generic"
                                                                 : "DEX",
                 laneBaseFee[lane], ledgerHeader.baseFee);
         }
     }
 
-    auto const& txs = mTxPhases.at(phase);
+    auto const& txs = mTxPhases.at(static_cast<size_t>(phase));
     auto& feeMap = getInclusionFeeMap(phase);
     for (auto const& tx : txs)
     {
         feeMap[tx] = laneBaseFee[surgePricingConfig.getLane(*tx)];
     }
-    mFeesComputed[phase] = true;
+    mFeesComputed[static_cast<size_t>(phase)] = true;
 }
 
 std::optional<int64_t>
-TxSetFrame::getTxBaseFee(TransactionFrameBaseConstPtr const& tx,
-                         LedgerHeader const& lclHeader) const
+ApplicableTxSetFrame::getTxBaseFee(TransactionFrameBaseConstPtr const& tx,
+                                   LedgerHeader const& lclHeader) const
 {
     if (std::any_of(mFeesComputed.begin(), mFeesComputed.end(),
                     [](bool comp) { return !comp; }))
@@ -949,28 +1134,25 @@ TxSetFrame::getTxBaseFee(TransactionFrameBaseConstPtr const& tx,
         releaseAssert(!isGeneralizedTxSet());
         computeTxFeesForNonGeneralizedSet(lclHeader);
     }
-
-    auto getTxBaseFeeHelper = [](auto const& feeMap,
-                                 TransactionFrameBaseConstPtr const& tx) {
-        auto it = feeMap.find(tx);
-        if (it == feeMap.end())
+    for (auto const& phaseMap : mPhaseInclusionFeeMap)
+    {
+        if (auto it = phaseMap.find(tx); it != phaseMap.end())
         {
-            throw std::runtime_error("Transaction not found in tx set");
+            return it->second;
         }
-        return it->second;
-    };
-
-    auto const& map = tx->isSoroban() ? mTxBaseInclusionFeeSoroban
-                                      : mTxBaseInclusionFeeClassic;
-    return getTxBaseFeeHelper(map, tx);
+    }
+    throw std::runtime_error("Transaction not found in tx set");
+    return std::nullopt;
 }
 
 std::optional<Resource>
-TxSetFrame::getTxSetSorobanResource() const
+ApplicableTxSetFrame::getTxSetSorobanResource() const
 {
-    releaseAssert(mTxPhases.size() > static_cast<size_t>(Phase::SOROBAN));
+    releaseAssert(mTxPhases.size() >
+                  static_cast<size_t>(TxSetFrame::Phase::SOROBAN));
     auto total = Resource::makeEmptySoroban();
-    for (auto const& tx : mTxPhases[static_cast<size_t>(Phase::SOROBAN)])
+    for (auto const& tx :
+         mTxPhases[static_cast<size_t>(TxSetFrame::Phase::SOROBAN)])
     {
         if (total.canAdd(tx->getResources(/* useByteLimitInClassic */ false)))
         {
@@ -985,29 +1167,30 @@ TxSetFrame::getTxSetSorobanResource() const
 }
 
 int64_t
-TxSetFrame::getTotalFees(LedgerHeader const& lh) const
+ApplicableTxSetFrame::getTotalFees(LedgerHeader const& lh) const
 {
     ZoneScoped;
     int64_t total{0};
-    std::for_each(
-        mTxPhases.begin(), mTxPhases.end(), [&](Transactions const& phase) {
-            total += std::accumulate(
-                phase.begin(), phase.end(), int64_t(0),
-                [&](int64_t t, TransactionFrameBasePtr const& tx) {
-                    return t + tx->getFee(lh, getTxBaseFee(tx, lh), true);
-                });
-        });
+    std::for_each(mTxPhases.begin(), mTxPhases.end(),
+                  [&](TxSetFrame::Transactions const& phase) {
+                      total += std::accumulate(
+                          phase.begin(), phase.end(), int64_t(0),
+                          [&](int64_t t, TransactionFrameBasePtr const& tx) {
+                              return t +
+                                     tx->getFee(lh, getTxBaseFee(tx, lh), true);
+                          });
+                  });
 
     return total;
 }
 
 int64_t
-TxSetFrame::getTotalInclusionFees() const
+ApplicableTxSetFrame::getTotalInclusionFees() const
 {
     ZoneScoped;
     int64_t total{0};
     std::for_each(mTxPhases.begin(), mTxPhases.end(),
-                  [&](Transactions const& phase) {
+                  [&](TxSetFrame::Transactions const& phase) {
                       total += std::accumulate(
                           phase.begin(), phase.end(), int64_t(0),
                           [&](int64_t t, TransactionFrameBasePtr const& tx) {
@@ -1019,178 +1202,140 @@ TxSetFrame::getTotalInclusionFees() const
 }
 
 std::string
-TxSetFrame::summary() const
+ApplicableTxSetFrame::summary() const
 {
     if (empty())
     {
         return "empty tx set";
     }
-    if (isGeneralizedTxSet())
+    if (!isGeneralizedTxSet())
     {
-        auto feeStats = [&](auto const& feeMap) {
-            std::map<std::optional<int64_t>, std::pair<int, int>>
-                componentStats;
-            for (auto const& [tx, fee] : feeMap)
-            {
-                ++componentStats[fee].first;
-                componentStats[fee].second += tx->getNumOperations();
-            }
-            std::string res = fmt::format(FMT_STRING("{} component(s): ["),
-                                          componentStats.size());
+        return fmt::format(
+            FMT_STRING("txs:{}, ops:{}, base_fee:{}"), sizeTxTotal(),
+            sizeOpTotal(),
+            // NB: fee map can't be empty at this stage (checked above).
+            getInclusionFeeMap(TxSetFrame::Phase::CLASSIC)
+                .begin()
+                ->second.value_or(0));
+    }
 
-            for (auto const& [fee, stats] : componentStats)
-            {
-                if (fee != componentStats.begin()->first)
-                {
-                    res += ", ";
-                }
-                if (fee)
-                {
-                    res += fmt::format(
-                        FMT_STRING(
-                            "{{discounted txs:{}, ops:{}, base_fee:{}}}"),
-                        stats.first, stats.second, *fee);
-                }
-                else
-                {
-                    res += fmt::format(
-                        FMT_STRING("{{non-discounted txs:{}, ops:{}}}"),
-                        stats.first, stats.second);
-                }
-            }
-            res += "]";
-            return res;
-        };
-
-        std::string status;
-        releaseAssert(mTxPhases.size() <=
-                      static_cast<size_t>(Phase::PHASE_COUNT));
-        for (auto i = 0; i != mTxPhases.size(); i++)
+    auto feeStats = [&](auto const& feeMap) {
+        std::map<std::optional<int64_t>, std::pair<int, int>> componentStats;
+        for (auto const& [tx, fee] : feeMap)
         {
-            if (!status.empty())
-            {
-                status += ", ";
-            }
-            status += fmt::format(
-                FMT_STRING("{} phase: {}"), getPhaseName(static_cast<Phase>(i)),
-                feeStats(getInclusionFeeMap(static_cast<Phase>(i))));
+            ++componentStats[fee].first;
+            componentStats[fee].second += tx->getNumOperations();
         }
-        return status;
-    }
-    else
+        std::string res = fmt::format(FMT_STRING("{} component(s): ["),
+                                      componentStats.size());
+
+        for (auto const& [fee, stats] : componentStats)
+        {
+            if (fee != componentStats.begin()->first)
+            {
+                res += ", ";
+            }
+            if (fee)
+            {
+                res += fmt::format(
+                    FMT_STRING("{{discounted txs:{}, ops:{}, base_fee:{}}}"),
+                    stats.first, stats.second, *fee);
+            }
+            else
+            {
+                res +=
+                    fmt::format(FMT_STRING("{{non-discounted txs:{}, ops:{}}}"),
+                                stats.first, stats.second);
+            }
+        }
+        res += "]";
+        return res;
+    };
+
+    std::string status;
+    releaseAssert(mTxPhases.size() <=
+                  static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
+    for (auto i = 0; i != mTxPhases.size(); i++)
     {
-        return fmt::format(FMT_STRING("txs:{}, ops:{}, base_fee:{}"),
-                           sizeTxTotal(), sizeOpTotal(),
-                           *mTxBaseInclusionFeeClassic.begin()->second);
+        if (!status.empty())
+        {
+            status += ", ";
+        }
+        status += fmt::format(
+            FMT_STRING("{} phase: {}"),
+            TxSetFrame::getPhaseName(static_cast<TxSetFrame::Phase>(i)),
+            feeStats(getInclusionFeeMap(static_cast<TxSetFrame::Phase>(i))));
     }
+    return status;
 }
 
 void
-TxSetFrame::toXDR(TransactionSet& txSet) const
+ApplicableTxSetFrame::toXDR(TransactionSet& txSet) const
 {
     ZoneScoped;
     releaseAssert(!isGeneralizedTxSet());
     releaseAssert(mTxPhases.size() == 1);
-    auto& txs = mTxPhases[0];
-    txSet.txs.resize(xdr::size32(txs.size()));
-    auto sortedTxs = TxSetUtils::sortTxsInHashOrder(txs);
-    for (unsigned int n = 0; n < sortedTxs.size(); n++)
-    {
-        txSet.txs[n] = sortedTxs[n]->getEnvelope();
-    }
-    txSet.previousLedgerHash = mPreviousLedgerHash;
+    transactionsToTransactionSetXDR(mTxPhases[0], mPreviousLedgerHash, txSet);
 }
 
 void
-TxSetFrame::toXDR(GeneralizedTransactionSet& generalizedTxSet) const
+ApplicableTxSetFrame::toXDR(GeneralizedTransactionSet& generalizedTxSet) const
 {
     ZoneScoped;
     releaseAssert(isGeneralizedTxSet());
     releaseAssert(std::all_of(mFeesComputed.begin(), mFeesComputed.end(),
                               [](bool comp) { return comp; }));
-    releaseAssert(mTxPhases.size() <= static_cast<size_t>(Phase::PHASE_COUNT));
+    releaseAssert(mTxPhases.size() <=
+                  static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
+    transactionsToGeneralizedTransactionSetXDR(mTxPhases, mPhaseInclusionFeeMap,
+                                               mPreviousLedgerHash,
+                                               generalizedTxSet);
+}
 
-    generalizedTxSet.v(1);
-    generalizedTxSet.v1TxSet().previousLedgerHash = mPreviousLedgerHash;
-
-    for (int i = 0; i < mTxPhases.size(); ++i)
+TxSetFrameConstPtr
+ApplicableTxSetFrame::toWireTxSetFrame() const
+{
+    TxSetFrameConstPtr outputTxSet;
+    if (mIsGeneralized)
     {
-        auto const& txPhase = mTxPhases[i];
-        auto& phase =
-            generalizedTxSet.v1TxSet().phases.emplace_back().v0Components();
-
-        auto const& feeMap = getInclusionFeeMap(static_cast<Phase>(i));
-        std::map<std::optional<int64_t>, size_t> feeTxCount;
-        for (auto const& [tx, fee] : feeMap)
-        {
-            ++feeTxCount[fee];
-        }
-        // Reserve a component per unique base fee in order to have the correct
-        // pointers in componentPerBid map.
-        phase.reserve(feeTxCount.size());
-
-        std::map<std::optional<int64_t>, xdr::xvector<TransactionEnvelope>*>
-            componentPerBid;
-        for (auto const& [fee, txCount] : feeTxCount)
-        {
-            phase.emplace_back(TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
-            auto& discountedFeeComponent = phase.back().txsMaybeDiscountedFee();
-            if (fee)
-            {
-                discountedFeeComponent.baseFee.activate() = *fee;
-            }
-            componentPerBid[fee] = &discountedFeeComponent.txs;
-            componentPerBid[fee]->reserve(txCount);
-        }
-        auto sortedTxs = TxSetUtils::sortTxsInHashOrder(txPhase);
-        for (auto const& tx : sortedTxs)
-        {
-            componentPerBid[feeMap.find(tx)->second]->push_back(
-                tx->getEnvelope());
-        }
+        GeneralizedTransactionSet xdrTxSet;
+        toXDR(xdrTxSet);
+        outputTxSet = TxSetFrame::makeFromWire(xdrTxSet);
     }
+    else
+    {
+        TransactionSet xdrTxSet;
+        toXDR(xdrTxSet);
+        outputTxSet = TxSetFrame::makeFromWire(xdrTxSet);
+    }
+    return outputTxSet;
 }
 
 bool
-TxSetFrame::isGeneralizedTxSet() const
+ApplicableTxSetFrame::isGeneralizedTxSet() const
 {
     return mIsGeneralized;
 }
 
 bool
-TxSetFrame::addTxsFromXdr(Application& app,
-                          xdr::xvector<TransactionEnvelope> const& txs,
-                          bool useBaseFee, std::optional<int64_t> baseFee,
-                          Phase phase)
+ApplicableTxSetFrame::addTxsFromXdr(
+    Hash const& networkID, xdr::xvector<TransactionEnvelope> const& txs,
+    bool useBaseFee, std::optional<int64_t> baseFee, TxSetFrame::Phase phase)
 {
     auto& phaseTxs = mTxPhases.at(static_cast<int>(phase));
     size_t oldSize = phaseTxs.size();
     phaseTxs.reserve(oldSize + txs.size());
 
-    LedgerTxn ltx(app.getLedgerTxnRoot(), false,
-                  TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
-    auto ledgerVersion = ltx.loadHeader().current().ledgerVersion;
-
     for (auto const& env : txs)
     {
-        auto tx = TransactionFrameBase::makeTransactionFromWire(
-            app.getNetworkID(), env);
-
+        auto tx = TransactionFrameBase::makeTransactionFromWire(networkID, env);
         if (!tx->XDRProvidesValidFee())
         {
             return false;
         }
-
-        if (protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
-        {
-            tx->maybeComputeSorobanResourceFee(
-                ledgerVersion,
-                app.getLedgerManager().getSorobanNetworkConfig(ltx),
-                app.getConfig());
-        }
         // Phase should be consistent with the tx we're trying to add
-        if ((tx->isSoroban() && phase != Phase::SOROBAN) ||
-            (!tx->isSoroban() && phase != Phase::CLASSIC))
+        if ((tx->isSoroban() && phase != TxSetFrame::Phase::SOROBAN) ||
+            (!tx->isSoroban() && phase != TxSetFrame::Phase::CLASSIC))
         {
             return false;
         }
@@ -1206,7 +1351,7 @@ TxSetFrame::addTxsFromXdr(Application& app,
 }
 
 void
-TxSetFrame::applySurgePricing(Application& app)
+ApplicableTxSetFrame::applySurgePricing(Application& app)
 {
     ZoneScoped;
 
@@ -1328,34 +1473,12 @@ TxSetFrame::applySurgePricing(Application& app)
     }
 }
 
-void
-TxSetFrame::computeContentsHash()
-{
-    ZoneScoped;
-    releaseAssert(!mHash);
-    if (!isGeneralizedTxSet())
-    {
-        TransactionSet xdrTxSet;
-        toXDR(xdrTxSet);
-        mHash = computeNonGenericTxSetContentsHash(xdrTxSet);
-    }
-    else
-    {
-        GeneralizedTransactionSet xdrTxSet;
-        toXDR(xdrTxSet);
-        mHash = xdrSha256(xdrTxSet);
-    }
-}
-
 std::unordered_map<TransactionFrameBaseConstPtr, std::optional<int64_t>>&
-TxSetFrame::getInclusionFeeMap(Phase phase) const
+ApplicableTxSetFrame::getInclusionFeeMap(TxSetFrame::Phase phase) const
 {
-    if (phase == Phase::SOROBAN)
-    {
-        return mTxBaseInclusionFeeSoroban;
-    }
-    releaseAssert(phase == Phase::CLASSIC);
-    return mTxBaseInclusionFeeClassic;
+    size_t phaseId = static_cast<size_t>(phase);
+    releaseAssert(phaseId < mPhaseInclusionFeeMap.size());
+    return mPhaseInclusionFeeMap[phaseId];
 }
 
 std::string

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -15,17 +15,32 @@
 #include <functional>
 #include <optional>
 #include <unordered_map>
+#include <variant>
 
 namespace stellar
 {
 class Application;
 class TxSetFrame;
+class ApplicableTxSetFrame;
 using TxSetFrameConstPtr = std::shared_ptr<TxSetFrame const>;
+using ApplicableTxSetFrameConstPtr =
+    std::unique_ptr<ApplicableTxSetFrame const>;
 
+// `TxSetFrame` is a wrapper around `TransactionSet` or
+// `GeneralizedTransactionSet` XDR.
+//
+// TxSetFrame doesn't try to interpret the XDR it wraps and might even
+// store structurally invalid XDR. Thus its safe to use at
+// overlay layer to simply exchange the messages, cache them etc.
+//
+// Before even trying to validate and apply a TxSetFrame it has
+// to be interpreted and prepared for apply using the ledger state
+// this TxSetFrame refers to. This is typically performed by
+// `prepareForApply` method.
 class TxSetFrame : public NonMovableOrCopyable
 {
   public:
-    enum Phase
+    enum class Phase
     {
         CLASSIC,
         SOROBAN,
@@ -37,16 +52,19 @@ class TxSetFrame : public NonMovableOrCopyable
 
     static std::string getPhaseName(Phase phase);
 
-    // Creates a valid TxSetFrame from the provided transactions.
+    // Creates a valid ApplicableTxSetFrame and corresponding TxSetFrame
+    // from the provided transactions.
+    //
     // Not all the transactions will be included in the result: invalid
     // transactions are trimmed and optionally returned via `invalidTxs` and if
     // there are too many remaining transactions surge pricing is applied.
     // The result is guaranteed to pass `checkValid` check with the same
     // arguments as in this method, so additional validation is not needed.
     //
-    // **Note**: the output `TxSetFrame` will *not* contain the input
+    // **Note**: the output `ApplicableTxSetFrame` will *not* contain the input
     // transaction pointers.
-    static TxSetFrameConstPtr makeFromTransactions(
+    static std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+    makeFromTransactions(
         TxPhases const& txPhases, Application& app,
         uint64_t lowerBoundCloseTimeOffset,
         uint64_t upperBoundCloseTimeOffset
@@ -58,7 +76,8 @@ class TxSetFrame : public NonMovableOrCopyable
         bool skipValidation = false
 #endif
     );
-    static TxSetFrameConstPtr makeFromTransactions(
+    static std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+    makeFromTransactions(
         TxPhases const& txPhases, Application& app,
         uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
         TxPhases& invalidTxsPerPhase
@@ -71,67 +90,136 @@ class TxSetFrame : public NonMovableOrCopyable
 #endif
     );
 
-    // Creates a legacy (non-generalized) TxSetFrame from the transactions that
-    // are trusted to be valid. Validation and filtering are not performed.
+    // Creates a valid empty TxSetFrame pointing at provided `lclHeader`.
+    static TxSetFrameConstPtr
+    makeEmpty(LedgerHeaderHistoryEntry const& lclHeader);
+
+    // `makeFromWire` methods create a TxSetFrame from the XDR messages.
+    // These methods don't perform any validation on the XDR.
+    static TxSetFrameConstPtr makeFromWire(TransactionSet const& xdrTxSet);
+    static TxSetFrameConstPtr
+    makeFromWire(GeneralizedTransactionSet const& xdrTxSet);
+
+    static TxSetFrameConstPtr
+    makeFromStoredTxSet(StoredTransactionSet const& storedSet);
+
+    // Creates a legacy (non-generalized) TxSetFrame from the
+    // transactions that are trusted to be valid. Validation and filtering
+    // are not performed.
     // This should be *only* used for building the legacy TxSetFrames from
     // historical transactions.
     static TxSetFrameConstPtr
     makeFromHistoryTransactions(Hash const& previousLedgerHash,
-                                Transactions const& txs);
+                                TxSetFrame::Transactions const& txs);
 
-    // Creates a valid empty TxSetFrame.
-    static TxSetFrameConstPtr
-    makeEmpty(LedgerHeaderHistoryEntry const& lclHeader);
+    void toXDR(TransactionSet& set) const;
+    void toXDR(GeneralizedTransactionSet& generalizedTxSet) const;
+    void storeXDR(StoredTransactionSet& txSet) const;
 
-    // Creates a TxSetFrame from the XDR message.
-    // As the message is not trusted, it has to be validated via `checkValid`.
-    static TxSetFrameConstPtr makeFromWire(Application& app,
-                                           TransactionSet const& xdrTxSet);
-    static TxSetFrameConstPtr
-    makeFromWire(Application& app, GeneralizedTransactionSet const& xdrTxSet);
+    ~TxSetFrame() = default;
 
-    // Creates a TxSetFrame from StoredTransactionSet (internally persisted tx
-    // set format).
-    static TxSetFrameConstPtr
-    makeFromStoredTxSet(StoredTransactionSet const& storedSet,
-                        Application& app);
+    // Interprets this transaction set using the current ledger state and
+    // returns a frame suitable for being applied to the ledger.
+    //
+    // Returns `nullptr` in case if transaction set can't be interpreted,
+    // for example if XDR of this `TxSetFrame` is malformed.
+    //
+    // Note, that the output tx set is still not necessarily valid; it is
+    // only truly safe to be applied when `applicableTxSetFrame->checkValid()`
+    // returns `true`.
+    //
+    // This may *only* be called when LCL hash matches the `previousLedgerHash`
+    // of this `TxSetFrame` - tx sets with a wrong ledger hash shouldn't even
+    // be attempted to be interpreted.
+    ApplicableTxSetFrameConstPtr prepareForApply(Application& app) const;
 
-    virtual ~TxSetFrame(){};
-
-    // Returns the base fee for the transaction or std::nullopt when the
-    // transaction is not discounted.
-    std::optional<int64_t> getTxBaseFee(TransactionFrameBaseConstPtr const& tx,
-                                        LedgerHeader const& lclHeader) const;
+    bool isGeneralizedTxSet() const;
 
     // Returns the hash of this tx set.
     Hash const& getContentsHash() const;
 
     Hash const& previousLedgerHash() const;
 
+    size_t sizeTxTotal() const;
+
+    size_t sizeOpTotal() const;
+
+    // Returns the size of this transaction set when encoded to XDR.
+    size_t encodedSize() const;
+
+    // Creates transaction frames for all the transactions in the set, grouped
+    // by phase.
+    // This is only necessary to serve a very specific use case of updating
+    // the transaction queue with wired tx sets. Otherwise, use
+    // getTransactionsForPhase() in `ApplicableTxSetFrame`.
+    TxPhases createTransactionFrames(Hash const& networkID) const;
+
+#ifdef BUILD_TESTS
+    static std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+    makeFromTransactions(Transactions txs, Application& app,
+                         uint64_t lowerBoundCloseTimeOffset,
+                         uint64_t upperBoundCloseTimeOffset,
+                         bool enforceTxsApplyOrder = false);
+    static std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+    makeFromTransactions(Transactions txs, Application& app,
+                         uint64_t lowerBoundCloseTimeOffset,
+                         uint64_t upperBoundCloseTimeOffset,
+                         Transactions& invalidTxs,
+                         bool enforceTxsApplyOrder = false);
+    mutable ApplicableTxSetFrameConstPtr mApplicableTxSetOverride;
+#endif
+
+  private:
+    TxSetFrame(TransactionSet const& xdrTxSet);
+    TxSetFrame(GeneralizedTransactionSet const& xdrTxSet);
+
+    std::variant<TransactionSet, GeneralizedTransactionSet> mXDRTxSet;
+    size_t mEncodedSize{};
+    Hash mHash;
+};
+
+// Transaction set that is suitable for being applied to the ledger.
+//
+// This is not necessarily a fully *valid* transaction set: further validation
+// should typically be performed via `checkValid` before actual application.
+//
+// `ApplicableTxSetFrame` can only be built from `TxSetFrame`, either via
+// constructing it with `makeFromTransactions` (for the transaction sets
+// generated for nomination), or via `prepareForApply` (for arbitrary
+// transaction sets).
+class ApplicableTxSetFrame
+{
+  public:
+    // Returns the base fee for the transaction or std::nullopt when the
+    // transaction is not discounted.
+    std::optional<int64_t> getTxBaseFee(TransactionFrameBaseConstPtr const& tx,
+                                        LedgerHeader const& lclHeader) const;
+
     // Gets all the transactions belonging to this frame in arbitrary order.
-    Transactions const& getTxsForPhase(Phase phase) const;
+    TxSetFrame::Transactions const&
+    getTxsForPhase(TxSetFrame::Phase phase) const;
 
-    /*
-    Build a list of transaction ready to be applied to the last closed ledger,
-    based on the transaction set.
+    // Build a list of transaction ready to be applied to the last closed
+    // ledger, based on the transaction set.
+    //
+    // The order satisfies:
+    // * transactions for an account are sorted by sequence number (ascending)
+    // * the order between accounts is randomized
+    TxSetFrame::Transactions getTxsInApplyOrder() const;
 
-    The order satisfies:
-    * transactions for an account are sorted by sequence number (ascending)
-    * the order between accounts is randomized
-    */
-    Transactions getTxsInApplyOrder() const;
-
-    virtual bool checkValid(Application& app,
-                            uint64_t lowerBoundCloseTimeOffset,
-                            uint64_t upperBoundCloseTimeOffset) const;
+    // Checks if this tx set frame is valid in the context of the current LCL.
+    // This can be called when LCL does not match `previousLedgerHash`, but
+    // then validation will never pass.
+    bool checkValid(Application& app, uint64_t lowerBoundCloseTimeOffset,
+                    uint64_t upperBoundCloseTimeOffset) const;
 
     size_t size(LedgerHeader const& lh,
-                std::optional<Phase> phase = std::nullopt) const;
+                std::optional<TxSetFrame::Phase> phase = std::nullopt) const;
 
     size_t
-    sizeTx(Phase phase) const
+    sizeTx(TxSetFrame::Phase phase) const
     {
-        return mTxPhases.at(phase).size();
+        return mTxPhases.at(static_cast<size_t>(phase)).size();
     }
     size_t sizeTxTotal() const;
 
@@ -147,11 +235,8 @@ class TxSetFrame : public NonMovableOrCopyable
         return mTxPhases.size();
     }
 
-    size_t sizeOp(Phase phase) const;
+    size_t sizeOp(TxSetFrame::Phase phase) const;
     size_t sizeOpTotal() const;
-
-    // Returns the size of this transaction set when encoded to XDR.
-    size_t encodedSize() const;
 
     // Returns the sum of all fees that this transaction set would take.
     int64_t getTotalFees(LedgerHeader const& lh) const;
@@ -167,30 +252,28 @@ class TxSetFrame : public NonMovableOrCopyable
     // Returns a short description of this transaction set.
     std::string summary() const;
 
-    virtual void toXDR(TransactionSet& set) const;
-    virtual void toXDR(GeneralizedTransactionSet& generalizedTxSet) const;
+    Hash const& getContentsHash() const;
 
-#ifdef BUILD_TESTS
-    // Test helper that only checks the XDR structure validitiy without
-    // validating internal transactions.
-    virtual bool checkValidStructure() const;
-    static TxSetFrameConstPtr makeFromTransactions(
-        Transactions txs, Application& app, uint64_t lowerBoundCloseTimeOffset,
-        uint64_t upperBoundCloseTimeOffset, bool enforceTxsApplyOrder = false);
-    static TxSetFrameConstPtr makeFromTransactions(
-        Transactions txs, Application& app, uint64_t lowerBoundCloseTimeOffset,
-        uint64_t upperBoundCloseTimeOffset, Transactions& invalidTxs,
-        bool enforceTxsApplyOrder = false);
+    // This shouldn't be needed for the regular flows, but is useful
+    // to cover XDR roundtrips in tests.
+#ifndef BUILD_TESTS
+  private:
 #endif
-  protected:
-    TxSetFrame(LedgerHeaderHistoryEntry const& lclHeader, TxPhases const& txs);
-    TxSetFrame(bool isGeneralized, Hash const& previousLedgerHash,
-               TxPhases const& txs);
-
-    std::optional<Hash> mHash;
-    std::optional<size_t> mutable mEncodedSize;
+    TxSetFrameConstPtr toWireTxSetFrame() const;
 
   private:
+    friend class TxSetFrame;
+
+    ApplicableTxSetFrame(Application& app,
+                         LedgerHeaderHistoryEntry const& lclHeader,
+                         TxSetFrame::TxPhases const& txs,
+                         std::optional<Hash> contentsHash);
+    ApplicableTxSetFrame(Application& app, bool isGeneralized,
+                         Hash const& previousLedgerHash,
+                         TxSetFrame::TxPhases const& txs,
+                         std::optional<Hash> contentsHash);
+    ApplicableTxSetFrame(ApplicableTxSetFrame const&) = default;
+    ApplicableTxSetFrame(ApplicableTxSetFrame&&) = default;
     // Computes the fees for transactions in this set based on information from
     // the non-generalized tx set.
     // This has to be `const` in combination with `mutable` fee-related fields
@@ -202,12 +285,10 @@ class TxSetFrame : public NonMovableOrCopyable
     // sets won't exist in the network anymore.
     void computeTxFeesForNonGeneralizedSet(LedgerHeader const& lclHeader) const;
 
-    void computeContentsHash();
-
-    bool addTxsFromXdr(Application& app,
+    bool addTxsFromXdr(Hash const& networkID,
                        xdr::xvector<TransactionEnvelope> const& txs,
                        bool useBaseFee, std::optional<int64_t> baseFee,
-                       Phase phase);
+                       TxSetFrame::Phase phase);
     void applySurgePricing(Application& app);
 
     void computeTxFeesForNonGeneralizedSet(LedgerHeader const& lclHeader,
@@ -219,32 +300,31 @@ class TxSetFrame : public NonMovableOrCopyable
                        SurgePricingLaneConfig const& surgePricingConfig,
                        std::vector<int64_t> const& lowestLaneFee,
                        std::vector<bool> const& hadTxNotFittingLane);
-
     std::optional<Resource> getTxSetSorobanResource() const;
 
     // Get _inclusion_ fee map for a given phase. The map contains lowest base
     // fee for each transaction (lowest base fee is identical for all
     // transactions in the same lane)
     std::unordered_map<TransactionFrameBaseConstPtr, std::optional<int64_t>>&
-    getInclusionFeeMap(Phase phase) const;
+    getInclusionFeeMap(TxSetFrame::Phase phase) const;
+
+    void toXDR(TransactionSet& set) const;
+    void toXDR(GeneralizedTransactionSet& generalizedTxSet) const;
 
     bool const mIsGeneralized;
-
     Hash const mPreviousLedgerHash;
     // There can only be 1 phase (classic) prior to protocol 20.
     // Starting protocol 20, there will be 2 phases (classic and soroban).
-    std::vector<Transactions> mTxPhases;
+    std::vector<TxSetFrame::Transactions> mTxPhases;
 
     mutable std::vector<bool> mFeesComputed;
-    mutable std::unordered_map<TransactionFrameBaseConstPtr,
-                               std::optional<int64_t>>
-        mTxBaseInclusionFeeClassic;
-    mutable std::unordered_map<TransactionFrameBaseConstPtr,
-                               std::optional<int64_t>>
-        mTxBaseInclusionFeeSoroban;
+    mutable std::vector<std::unordered_map<TransactionFrameBaseConstPtr,
+                                           std::optional<int64_t>>>
+        mPhaseInclusionFeeMap;
 
+    std::optional<Hash> mContentsHash;
 #ifdef BUILD_TESTS
-    mutable std::optional<Transactions> mApplyOrderOverride;
+    mutable std::optional<TxSetFrame::Transactions> mApplyOrderOverride;
 #endif
 };
 

--- a/src/herder/TxSetFrame.h
+++ b/src/herder/TxSetFrame.h
@@ -142,7 +142,11 @@ class TxSetFrame : public NonMovableOrCopyable
 
     size_t sizeTxTotal() const;
 
-    size_t sizeOpTotal() const;
+    // Gets the size of this transaction set in operations.
+    // Since this isn't guaranteed to even be valid XDR, this should
+    // only be used for the logging (or testing) purpose. In any other
+    // context, `ApplicableTxSetFrame::sizeOpTotal()` should be used.
+    size_t sizeOpTotalForLogging() const;
 
     // Returns the size of this transaction set when encoded to XDR.
     size_t encodedSize() const;
@@ -299,7 +303,7 @@ class ApplicableTxSetFrame
                        LedgerHeader const& ledgerHeader,
                        SurgePricingLaneConfig const& surgePricingConfig,
                        std::vector<int64_t> const& lowestLaneFee,
-                       std::vector<bool> const& hadTxNotFittingLane);
+                       std::vector<bool> const& hadTxNotFittingLane) const;
     std::optional<Resource> getTxSetSorobanResource() const;
 
     // Get _inclusion_ fee map for a given phase. The map contains lowest base

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3961,7 +3961,7 @@ TEST_CASE("soroban txs accepted by the network",
                                           ->getLedgerManager()
                                           .getLastClosedLedgerHeader()
                                           .header.scpValue.txSetHash)
-                            ->sizeOpTotal();
+                            ->sizeOpTotalForLogging();
                     upgradeApplied =
                         upgradeApplied || txSetSize > ledgerWideLimit;
                     return loadGenDone.count() > currLoadGenCount;

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -333,7 +333,7 @@ testTxSet(uint32 protocolVersion)
     }
     SECTION("valid set")
     {
-        auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+        auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0).second;
         REQUIRE(txSet->sizeTxTotal() == (nbAccounts * nbTransactions));
     }
 
@@ -343,7 +343,7 @@ testTxSet(uint32 protocolVersion)
         {
             genTx(1);
         }
-        auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+        auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0).second;
         REQUIRE(txSet->sizeTxTotal() == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
     }
     SECTION("invalid tx")
@@ -354,7 +354,8 @@ testTxSet(uint32 protocolVersion)
             txs.push_back(newUser.tx({payment(root, 1)}));
             TxSetFrame::Transactions removed;
             auto txSet =
-                TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed);
+                TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed)
+                    .second;
             REQUIRE(removed.size() == 1);
             REQUIRE(txSet->sizeTxTotal() == (nbAccounts * nbTransactions));
         }
@@ -368,7 +369,8 @@ testTxSet(uint32 protocolVersion)
 
                 TxSetFrame::Transactions removed;
                 auto txSet =
-                    TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed);
+                    TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed)
+                        .second;
                 REQUIRE(removed.size() == 1);
                 REQUIRE(txSet->sizeTxTotal() == (nbAccounts * nbTransactions));
             }
@@ -378,7 +380,8 @@ testTxSet(uint32 protocolVersion)
 
                 TxSetFrame::Transactions removed;
                 auto txSet =
-                    TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed);
+                    TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed)
+                        .second;
 
                 // one of the account lost all its transactions
                 REQUIRE(removed.size() == (nbTransactions - 1));
@@ -396,7 +399,8 @@ testTxSet(uint32 protocolVersion)
 
                     TxSetFrame::Transactions removed;
                     auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0,
-                                                                  0, removed);
+                                                                  0, removed)
+                                     .second;
 
                     // one account has all its transactions,
                     // the other, we removed transactions after remIdx
@@ -415,7 +419,8 @@ testTxSet(uint32 protocolVersion)
 
             TxSetFrame::Transactions removed;
             auto txSet =
-                TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed);
+                TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed)
+                    .second;
             REQUIRE(removed.size() == (nbTransactions + 1));
             REQUIRE(txSet->sizeTxTotal() == nbTransactions * (nbAccounts - 1));
         }
@@ -426,7 +431,8 @@ testTxSet(uint32 protocolVersion)
             tx->clearCached();
             TxSetFrame::Transactions removed;
             auto txSet =
-                TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed);
+                TxSetFrame::makeFromTransactions(txs, *app, 0, 0, removed)
+                    .second;
             REQUIRE(removed.size() == nbTransactions);
             REQUIRE(txSet->sizeTxTotal() == nbTransactions * (nbAccounts - 1));
         }
@@ -800,7 +806,8 @@ TEST_CASE_VERSIONS("txset with PreconditionsV2", "[herder][txset]")
                     *app, a1, 1, 100, minSeqLedgerGapCond(minGap + 2));
                 TxSetFrame::Transactions removed;
                 auto txSet = TxSetFrame::makeFromTransactions({txInvalid}, *app,
-                                                              0, 0, removed);
+                                                              0, 0, removed)
+                                 .second;
 
                 REQUIRE(removed.back() == txInvalid);
                 REQUIRE(txSet->sizeTxTotal() == 0);
@@ -820,12 +827,14 @@ TEST_CASE_VERSIONS("txset with PreconditionsV2", "[herder][txset]")
                 if (minSeqNumTxIsFeeBump)
                 {
                     txSet = TxSetFrame::makeFromTransactions(
-                        {fb1, fb2Invalid}, *app, 0, 0, removed);
+                                {fb1, fb2Invalid}, *app, 0, 0, removed)
+                                .second;
                 }
                 else
                 {
                     txSet = TxSetFrame::makeFromTransactions(
-                        {tx1, tx2Invalid}, *app, 0, 0, removed);
+                                {tx1, tx2Invalid}, *app, 0, 0, removed)
+                                .second;
                 }
 
                 REQUIRE(removed.size() == 1);
@@ -880,7 +889,8 @@ TEST_CASE_VERSIONS("txset with PreconditionsV2", "[herder][txset]")
                     *app, a1, 1, 100, minSeqAgeCond(minGap + 1));
                 TxSetFrame::Transactions removed;
                 auto txSet = TxSetFrame::makeFromTransactions({txInvalid}, *app,
-                                                              0, 0, removed);
+                                                              0, 0, removed)
+                                 .second;
                 REQUIRE(removed.back() == txInvalid);
                 REQUIRE(txSet->sizeTxTotal() == 0);
 
@@ -898,12 +908,14 @@ TEST_CASE_VERSIONS("txset with PreconditionsV2", "[herder][txset]")
                 if (minSeqNumTxIsFeeBump)
                 {
                     txSet = TxSetFrame::makeFromTransactions(
-                        {fb1, fb2Invalid}, *app, 0, 0, removed);
+                                {fb1, fb2Invalid}, *app, 0, 0, removed)
+                                .second;
                 }
                 else
                 {
                     txSet = TxSetFrame::makeFromTransactions(
-                        {tx1, tx2Invalid}, *app, 0, 0, removed);
+                                {tx1, tx2Invalid}, *app, 0, 0, removed)
+                                .second;
                 }
 
                 REQUIRE(removed.size() == 1);
@@ -1146,9 +1158,9 @@ TEST_CASE("txset base fee", "[herder][txset]")
             auto tx = makeMultiPayment(aI, aI, 2, 1000, k, 100);
             txs.push_back(tx);
         }
-        TxSetFrameConstPtr txSet =
+        auto [txSet, applicableTxSet] =
             TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
-        REQUIRE(txSet->size(lhCopy) == lim);
+        REQUIRE(applicableTxSet->size(lhCopy) == lim);
         REQUIRE(extraAccounts >= 2);
 
         // fetch balances
@@ -1424,7 +1436,8 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
 
     SECTION("basic single account")
     {
-        auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
+        auto txSet =
+            TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0).second;
         REQUIRE(txSet->size(lhCopy) == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
         // check that the expected tx are there
         auto txs = txSet->getTxsInApplyOrder();
@@ -1445,7 +1458,8 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
             tx->addSignature(accountB);
             rootTxs.push_back(tx);
         }
-        auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
+        auto txSet =
+            TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0).second;
         REQUIRE(txSet->size(lhCopy) == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
         // check that the expected tx are there
         for (auto const& tx : txSet->getTxsForPhase(TxSetFrame::Phase::CLASSIC))
@@ -1469,7 +1483,8 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
             tx->addSignature(accountB);
             rootTxs.push_back(tx);
         }
-        auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
+        auto txSet =
+            TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0).second;
         REQUIRE(txSet->size(lhCopy) == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
         // check that the expected tx are there
         for (auto const& tx : txSet->getTxsForPhase(TxSetFrame::Phase::CLASSIC))
@@ -1496,7 +1511,8 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
             tx->addSignature(accountB);
             rootTxs.push_back(tx);
         }
-        auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
+        auto txSet =
+            TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0).second;
         REQUIRE(txSet->size(lhCopy) == expectedReduced);
         // check that the expected tx are there
         int nbAccountB = 0;
@@ -1525,13 +1541,15 @@ surgeTest(uint32 protocolVersion, uint32_t nbTxs, uint32_t maxTxSetSize,
             rootTxs.push_back(accountB.tx({payment(destAccount, n + 10)}));
             rootTxs.push_back(accountC.tx({payment(destAccount, n + 10)}));
         }
-        auto txSet = TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0);
+        auto txSet =
+            TxSetFrame::makeFromTransactions(rootTxs, *app, 0, 0).second;
         REQUIRE(txSet->size(lhCopy) == cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE);
         REQUIRE(txSet->checkValid(*app, 0, 0));
     }
 }
 
-TEST_CASE("tx set hits overlay byte limit during construction")
+TEST_CASE("tx set hits overlay byte limit during construction",
+          "[transactionqueue][soroban]")
 {
     Config cfg(getTestConfig());
     cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
@@ -1607,17 +1625,17 @@ TEST_CASE("tx set hits overlay byte limit during construction")
             phases = TxSetFrame::TxPhases{txs, {}};
         }
 
-        TxSetFrameConstPtr txSet =
+        auto [txSet, applicableTxSet] =
             TxSetFrame::makeFromTransactions(phases, *app, 0, 0, invalidPhases);
+        REQUIRE(txSet->encodedSize() <= MAX_MESSAGE_SIZE);
 
         REQUIRE(invalidPhases[static_cast<size_t>(phase)].empty());
-        auto const& phaseTxs = txSet->getTxsForPhase(phase);
+        auto const& phaseTxs = applicableTxSet->getTxsForPhase(phase);
         auto trimmedSize =
             std::accumulate(phaseTxs.begin(), phaseTxs.end(), size_t(0),
                             [&](size_t a, TransactionFrameBasePtr const& tx) {
                                 return a += xdr::xdr_size(tx->getEnvelope());
                             });
-        REQUIRE(txSet->encodedSize() <= MAX_MESSAGE_SIZE);
 
         auto byteAllowance = phase == TxSetFrame::Phase::SOROBAN
                                  ? MAX_SOROBAN_BYTE_ALLOWANCE
@@ -1659,8 +1677,9 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
             auto tx = makeMultiPayment(destAccount, root, 1, 100, 0, 1);
 
             TxSetFrame::Transactions invalidTxs;
-            TxSetFrameConstPtr txSet =
-                TxSetFrame::makeFromTransactions({tx}, *app, 0, 0, invalidTxs);
+            auto txSet =
+                TxSetFrame::makeFromTransactions({tx}, *app, 0, 0, invalidTxs)
+                    .second;
 
             // Transaction is valid, but trimmed by surge pricing.
             REQUIRE(invalidTxs.empty());
@@ -1679,8 +1698,10 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
             TxSetFrame::TxPhases invalidTxs;
             invalidTxs.resize(
                 static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-            TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
-                TxSetFrame::TxPhases{{}, {sorobanTx}}, *app, 0, 0, invalidTxs);
+            auto txSet = TxSetFrame::makeFromTransactions(
+                             TxSetFrame::TxPhases{{}, {sorobanTx}}, *app, 0, 0,
+                             invalidTxs)
+                             .second;
 
             // Transaction is valid, but trimmed by surge pricing.
             REQUIRE(std::all_of(invalidTxs.begin(), invalidTxs.end(),
@@ -1794,9 +1815,10 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(
                 static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-            TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
-                TxSetFrame::TxPhases{{tx}, {invalidSoroban}}, *app, 0, 0,
-                invalidPhases);
+            auto txSet = TxSetFrame::makeFromTransactions(
+                             TxSetFrame::TxPhases{{tx}, {invalidSoroban}}, *app,
+                             0, 0, invalidPhases)
+                             .second;
 
             // Soroban tx is rejected
             REQUIRE(txSet->sizeTxTotal() == 1);
@@ -1810,9 +1832,10 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(
                 static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-            TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
-                TxSetFrame::TxPhases{{tx}, {sorobanTx}}, *app, 0, 0,
-                invalidPhases);
+            auto txSet = TxSetFrame::makeFromTransactions(
+                             TxSetFrame::TxPhases{{tx}, {sorobanTx}}, *app, 0,
+                             0, invalidPhases)
+                             .second;
 
             // Everything fits
             REQUIRE(std::all_of(invalidPhases.begin(), invalidPhases.end(),
@@ -1836,9 +1859,11 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(
                 static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-            TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
-                TxSetFrame::TxPhases{{tx}, {sorobanTx, sorobanTxHighFee}}, *app,
-                0, 0, invalidPhases);
+            auto txSet =
+                TxSetFrame::makeFromTransactions(
+                    TxSetFrame::TxPhases{{tx}, {sorobanTx, sorobanTxHighFee}},
+                    *app, 0, 0, invalidPhases)
+                    .second;
 
             REQUIRE(std::all_of(invalidPhases.begin(), invalidPhases.end(),
                                 [](auto const& txs) { return txs.empty(); }));
@@ -1873,10 +1898,13 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
             TxSetFrame::TxPhases invalidPhases;
             invalidPhases.resize(
                 static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-            TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
-                TxSetFrame::TxPhases{
-                    {tx}, {sorobanTxHighFee, smallSorobanLowFee, sorobanTx}},
-                *app, 0, 0, invalidPhases);
+            auto txSet =
+                TxSetFrame::makeFromTransactions(
+                    TxSetFrame::TxPhases{
+                        {tx},
+                        {sorobanTxHighFee, smallSorobanLowFee, sorobanTx}},
+                    *app, 0, 0, invalidPhases)
+                    .second;
 
             REQUIRE(std::all_of(invalidPhases.begin(), invalidPhases.end(),
                                 [](auto const& txs) { return txs.empty(); }));
@@ -1905,9 +1933,11 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
                     TxSetFrame::TxPhases invalidPhases;
                     invalidPhases.resize(
                         static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT));
-                    TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
-                        TxSetFrame::TxPhases{{tx}, generateTxs(accounts, conf)},
-                        *app, 0, 0, invalidPhases);
+                    auto txSet = TxSetFrame::makeFromTransactions(
+                                     TxSetFrame::TxPhases{
+                                         {tx}, generateTxs(accounts, conf)},
+                                     *app, 0, 0, invalidPhases)
+                                     .second;
 
                     REQUIRE(std::all_of(
                         invalidPhases.begin(), invalidPhases.end(),
@@ -1929,9 +1959,11 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
         SECTION("tx sets over limits are invalid")
         {
             TxSetFrame::Transactions txs = generateTxs(accounts, conf);
-            auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-                {{}, {std::make_pair(500, txs)}}, *app,
-                app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            auto txSet =
+                testtxset::makeNonValidatedGeneralizedTxSet(
+                    {{}, {std::make_pair(500, txs)}}, *app,
+                    app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                    .second;
 
             REQUIRE(!txSet->checkValid(*app, 0, 0));
         }
@@ -1977,7 +2009,7 @@ TEST_CASE("surge pricing with DEX separation", "[herder][txset]")
                        size_t expectedTxsC, size_t expectedTxsD,
                        int64_t expectedNonDexBaseFee,
                        int64_t expectedDexBaseFee) {
-        auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+        auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0).second;
         size_t cntA = 0, cntB = 0, cntC = 0, cntD = 0;
         auto resTxs = txSet->getTxsInApplyOrder();
         for (auto const& tx : resTxs)
@@ -2185,7 +2217,8 @@ TEST_CASE("surge pricing with DEX separation holds invariants",
         for (int iter = 0; iter < 50; ++iter)
         {
             auto txs = genTxs(txCountDistr(Catch::rng()));
-            auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+            auto txSet =
+                TxSetFrame::makeFromTransactions(txs, *app, 0, 0).second;
 
             auto resTxs = txSet->getTxsInApplyOrder();
             std::array<uint32_t, 2> opsCounts{};
@@ -2258,16 +2291,14 @@ TEST_CASE("surge pricing with DEX separation holds invariants",
     }
 }
 
-TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
+TEST_CASE("generalized tx set applied to ledger", "[herder][txset][soroban]")
 {
     Config cfg(getTestConfig());
-    cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION =
-        static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION);
-    cfg.LEDGER_PROTOCOL_VERSION =
-        static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION);
+    cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
     VirtualClock clock;
     Application::pointer app = createTestApplication(clock, cfg);
     auto root = TestAccount::createRoot(*app);
+    overrideSorobanNetworkConfigForTest(*app);
     int64 startingBalance =
         app->getLedgerManager().getLastMinBalance(0) + 10000000;
 
@@ -2279,9 +2310,37 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
         return makeSelfPayment(account, nbOps, fee);
     };
 
-    auto checkFees = [&](TxSetFrameConstPtr txSet,
-                         std::vector<int64_t> const& expectedFeeCharged) {
-        REQUIRE(txSet->checkValid(*app, 0, 0));
+    SorobanResources resources;
+    resources.instructions = 3'000'000;
+    resources.readBytes = 0;
+    resources.writeBytes = 2000;
+    auto dummyAccount = root.create("dummy", startingBalance);
+    auto dummyUploadTx =
+        createUploadWasmTx(*app, dummyAccount, 100, 1000, resources);
+    resources.footprint.readWrite.emplace_back();
+    uint32_t resourceFee = sorobanResourceFee(
+        *app, resources, xdr::xdr_size(dummyUploadTx->getEnvelope()), 40);
+    // This value should not be changed for the test setup, but if it ever
+    // is changed,/ then we'd need to compute the rent fee via the rust bridge
+    // function (which is a bit verbose).
+    uint32_t const rentFee = 20'048;
+    resourceFee += rentFee;
+    resources.footprint.readWrite.pop_back();
+    auto addSorobanTx = [&](uint32_t inclusionFee) {
+        auto account = root.create(std::to_string(txCnt++), startingBalance);
+        accounts.push_back(account);
+        return createUploadWasmTx(*app, account, inclusionFee, resourceFee,
+                                  resources);
+    };
+
+    auto checkFees = [&](std::pair<TxSetFrameConstPtr,
+                                   ApplicableTxSetFrameConstPtr> const& txSet,
+                         std::vector<int64_t> const& expectedFeeCharged,
+                         bool validateTxSet = true) {
+        if (validateTxSet)
+        {
+            REQUIRE(txSet.second->checkValid(*app, 0, 0));
+        }
 
         auto getBalances = [&]() {
             std::vector<int64_t> balances;
@@ -2294,7 +2353,7 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
 
         closeLedgerOn(*app,
                       app->getLedgerManager().getLastClosedLedgerNum() + 1,
-                      getTestDate(13, 4, 2022), txSet);
+                      getTestDate(13, 4, 2022), txSet.first);
 
         auto balancesAfter = getBalances();
         std::vector<int64_t> feeCharged;
@@ -2348,6 +2407,30 @@ TEST_CASE("generalized tx set applied to ledger", "[herder][txset]")
             {components, {}}, *app,
             app->getLedgerManager().getLastClosedLedgerHeader().hash);
         checkFees(txSet, {3000, 2000, 500, 2500, 8000, 35000, 10000});
+    }
+    SECTION("soroban")
+    {
+        auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
+            {
+                {std::make_pair(1000,
+                                std::vector<TransactionFrameBasePtr>{
+                                    addTx(3, 3500), addTx(2, 5000)})},
+                {std::make_pair(2000,
+                                std::vector<TransactionFrameBasePtr>{
+                                    addSorobanTx(5000), addSorobanTx(10000)})},
+            },
+            *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        SECTION("with validation")
+        {
+            checkFees(txSet,
+                      {3000, 2000, 2000 + resourceFee, 2000 + resourceFee});
+        }
+        SECTION("without validation")
+        {
+            checkFees(txSet,
+                      {3000, 2000, 2000 + resourceFee, 2000 + resourceFee},
+                      /* validateTxSet */ false);
+        }
     }
 }
 
@@ -2469,11 +2552,11 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
             // candidates so far.  (We're using base fees simply as one example
             // of a type of upgrade, whose expected result is the maximum of all
             // candidates'.)
-            TxSetFrameConstPtr txSet =
+            auto [txSet, applicableTxSet] =
                 makeTransactions(spec.n, spec.nbOps, spec.feeMulti);
             txSetHashes.push_back(txSet->getContentsHash());
-            txSetSizes.push_back(txSet->size(lcl.header));
-            txSetOpSizes.push_back(txSet->sizeOpTotal());
+            txSetSizes.push_back(applicableTxSet->size(lcl.header));
+            txSetOpSizes.push_back(applicableTxSet->sizeOpTotal());
             closeTimes.push_back(spec.closeTime);
             if (spec.baseFeeIncrement)
             {
@@ -2546,9 +2629,9 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
             std::max_element(txSetSizes.begin(), txSetSizes.end()));
         REQUIRE(txSetOpSizes[bestTxSetIndex] == expectedOps);
 
-        TxSetFrameConstPtr txSetL = makeTransactions(maxTxSetSize, 1, 101);
+        auto txSetL = makeTransactions(maxTxSetSize, 1, 101).first;
         addToCandidates(makeTxPair(herder, txSetL, 20));
-        TxSetFrameConstPtr txSetL2 = makeTransactions(maxTxSetSize, 1, 1000);
+        auto txSetL2 = makeTransactions(maxTxSetSize, 1, 1000).first;
         addToCandidates(makeTxPair(herder, txSetL2, 20));
         auto v = herder.getHerderSCPDriver().combineCandidates(1, candidates);
         StellarValue sv;
@@ -2564,7 +2647,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
         auto seq = herder.trackingConsensusLedgerIndex() + 1;
         auto ct = app->timeNow() + 1;
 
-        TxSetFrameConstPtr txSet0 = makeTransactions(0, 1, 100);
+        auto txSet0 = makeTransactions(0, 1, 100).first;
         {
             // make sure that txSet0 is loaded
             auto p = makeTxPair(herder, txSet0, ct);
@@ -2659,9 +2742,10 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
                             : tx->getEnvelope().v1().signatures;
             sig.clear();
             tx->addSignature(root.getSecretKey());
-            auto txSet = testtxset::makeNonValidatedTxSetBasedOnLedgerVersion(
-                protocolVersion, {tx}, *app,
-                app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            auto [txSet, applicableTxSet] =
+                testtxset::makeNonValidatedTxSetBasedOnLedgerVersion(
+                    protocolVersion, {tx}, *app,
+                    app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
             // Build a StellarValue containing the transaction set we just
             // built and the given next closeTime.
@@ -2683,8 +2767,8 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
             auto closeTimeOffset = nextCloseTime - lclCloseTime;
             TxSetFrame::Transactions removed;
             TxSetUtils::trimInvalid(
-                txSet->getTxsForPhase(TxSetFrame::Phase::CLASSIC), *app,
-                closeTimeOffset, closeTimeOffset, removed);
+                applicableTxSet->getTxsForPhase(TxSetFrame::Phase::CLASSIC),
+                *app, closeTimeOffset, closeTimeOffset, removed);
             REQUIRE(removed.size() == (expectValid ? 0 : 1));
         };
 
@@ -2745,8 +2829,8 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
         auto bigQSetHash = sha256(xdr::xdr_to_opaque(bigQSet));
 
         auto& herder = static_cast<HerderImpl&>(app->getHerder());
-        auto transactions1 = makeTransactions(5, 1, 100);
-        auto transactions2 = makeTransactions(4, 1, 100);
+        auto transactions1 = makeTransactions(5, 1, 100).first;
+        auto transactions2 = makeTransactions(4, 1, 100).first;
 
         auto p1 = makeTxPair(herder, transactions1, 10);
         auto p2 = makeTxPair(herder, transactions1, 10);
@@ -2771,7 +2855,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
                             .txsMaybeDiscountedFee()
                             .txs;
             std::swap(txs[0], txs[1]);
-            malformedTxSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+            malformedTxSet = TxSetFrame::makeFromWire(xdrTxSet);
         }
         else
         {
@@ -2779,7 +2863,7 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
             transactions1->toXDR(xdrTxSet);
             auto& txs = xdrTxSet.txs;
             std::swap(txs[0], txs[1]);
-            malformedTxSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
+            malformedTxSet = TxSetFrame::makeFromWire(xdrTxSet);
         }
         auto malformedTxSetPair = makeTxPair(herder, malformedTxSet, 10);
         auto malformedTxSetEnvelope =
@@ -3493,7 +3577,7 @@ TEST_CASE("tx queue source account limit", "[herder][transactionqueue]")
     }
 }
 
-TEST_CASE("soroban txs each parameter surge priced")
+TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
 {
     auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     uint32_t baseTxRate = 1;
@@ -3574,13 +3658,19 @@ TEST_CASE("soroban txs each parameter surge priced")
                                           .header;
                     auto txSet = nodes[0]->getHerder().getTxSet(
                         lclHeader.scpValue.txSetHash);
-                    auto const& sorobanTxs =
-                        txSet->getTxsForPhase(TxSetFrame::Phase::SOROBAN);
-                    if (!sorobanTxs.empty())
+                    GeneralizedTransactionSet xdrTxSet;
+                    txSet->toXDR(xdrTxSet);
+                    auto const& components =
+                        xdrTxSet.v1TxSet()
+                            .phases
+                            .at(static_cast<size_t>(TxSetFrame::Phase::SOROBAN))
+                            .v0Components();
+                    if (!components.empty())
                     {
-                        hadSorobanSurgePricing =
-                            hadSorobanSurgePricing ||
-                            txSet->getTxBaseFee(sorobanTxs[0], lclHeader) > 100;
+                        auto baseFee =
+                            components.at(0).txsMaybeDiscountedFee().baseFee;
+                        hadSorobanSurgePricing = hadSorobanSurgePricing ||
+                                                 (baseFee && *baseFee > 100);
                     }
 
                     return loadGenDone.count() > currLoadGenCount &&
@@ -3660,7 +3750,7 @@ TEST_CASE("soroban txs each parameter surge priced")
     }
 }
 
-TEST_CASE("accept soroban txs after network upgrade")
+TEST_CASE("accept soroban txs after network upgrade", "[soroban][herder]")
 {
     auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
 
@@ -3990,8 +4080,8 @@ TEST_CASE("herder externalizes values", "[herder]")
     qset.validators.push_back(validatorBKey.getPublicKey());
     qset.validators.push_back(validatorCKey.getPublicKey());
 
-    simulation->addNode(validatorAKey, qset);
-    simulation->addNode(validatorBKey, qset);
+    auto A = simulation->addNode(validatorAKey, qset);
+    auto B = simulation->addNode(validatorBKey, qset);
     simulation->addNode(validatorCKey, qset);
 
     simulation->addPendingConnection(validatorAKey.getPublicKey(),
@@ -4013,9 +4103,6 @@ TEST_CASE("herder externalizes values", "[herder]")
     REQUIRE(getC()->getHerder().getState() ==
             Herder::State::HERDER_TRACKING_NETWORK_STATE);
 
-    auto A = simulation->getNode(validatorAKey.getPublicKey());
-    auto B = simulation->getNode(validatorBKey.getPublicKey());
-
     auto currentALedger = [&]() {
         return A->getLedgerManager().getLastClosedLedgerNum();
     };
@@ -4036,10 +4123,26 @@ TEST_CASE("herder externalizes values", "[herder]")
         return std::min(currentALedger(), currentCLedger());
     };
 
+    HerderImpl& herderA = *static_cast<HerderImpl*>(&A->getHerder());
+    HerderImpl& herderB = *static_cast<HerderImpl*>(&B->getHerder());
+    HerderImpl& herderC = *static_cast<HerderImpl*>(&getC()->getHerder());
+    auto const& lmC = getC()->getLedgerManager();
+
     auto waitForAB = [&](int nLedgers, bool waitForB) {
         auto destinationLedger = currentALedger() + nLedgers;
+        bool submitted = false;
         simulation->crankUntil(
             [&]() {
+                if (currentALedger() == (destinationLedger - 1) && !submitted)
+                {
+                    auto root = TestAccount::createRoot(*A);
+                    SorobanResources resources;
+                    auto sorobanTx = createUploadWasmTx(
+                        *A, root, 100, DEFAULT_TEST_RESOURCE_FEE, resources);
+                    REQUIRE(herderA.recvTransaction(sorobanTx, true) ==
+                            TransactionQueue::AddResult::ADD_STATUS_PENDING);
+                    submitted = true;
+                }
                 return currentALedger() >= destinationLedger &&
                        (!waitForB || currentBLedger() >= destinationLedger);
             },
@@ -4063,16 +4166,33 @@ TEST_CASE("herder externalizes values", "[herder]")
     simulation->dropConnection(validatorAKey.getPublicKey(),
                                validatorCKey.getPublicKey());
 
-    HerderImpl& herderA = *static_cast<HerderImpl*>(&A->getHerder());
-    HerderImpl& herderB = *static_cast<HerderImpl*>(&B->getHerder());
-    HerderImpl& herderC = *static_cast<HerderImpl*>(&getC()->getHerder());
-    auto const& lmC = getC()->getLedgerManager();
-
     // Advance A and B a bit further, and collect externalize messages
-    std::map<uint32_t, std::pair<SCPEnvelope, TxSetFrameConstPtr>>
+    std::map<uint32_t, std::pair<SCPEnvelope, StellarMessage>>
         validatorSCPMessagesA;
-    std::map<uint32_t, std::pair<SCPEnvelope, TxSetFrameConstPtr>>
+    std::map<uint32_t, std::pair<SCPEnvelope, StellarMessage>>
         validatorSCPMessagesB;
+
+    for (auto& node : {A, B, getC()})
+    {
+        ConfigUpgradeSetFrameConstPtr configUpgradeSet;
+        LedgerTxn ltx(node->getLedgerTxnRoot());
+        ConfigUpgradeSet configUpgradeSetXdr;
+        auto& configEntry = configUpgradeSetXdr.updatedEntry.emplace_back();
+        configEntry.configSettingID(CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0);
+        configEntry.contractHistoricalData().feeHistorical1KB = 1234;
+        configUpgradeSet = makeConfigUpgradeSet(ltx, configUpgradeSetXdr);
+
+        Upgrades::UpgradeParameters scheduledUpgrades;
+        scheduledUpgrades.mUpgradeTime =
+            VirtualClock::from_time_t(node->getLedgerManager()
+                                          .getLastClosedLedgerHeader()
+                                          .header.scpValue.closeTime +
+                                      5);
+        scheduledUpgrades.mConfigUpgradeSetKey = configUpgradeSet->getKey();
+        // C won't upgrade until it's on the right LCL
+        node->getHerder().setUpgrades(scheduledUpgrades);
+        ltx.commit();
+    }
 
     auto destinationLedger = waitForAB(4, true);
     for (auto start = currentLedger + 1; start <= destinationLedger; start++)
@@ -4087,7 +4207,10 @@ TEST_CASE("herder externalizes values", "[herder]")
                     env.statement.pledges.externalize().commit.value, sv);
                 auto txset = pe.getTxSet(sv.txSetHash);
                 REQUIRE(txset);
-                validatorSCPMessagesA[start] = std::make_pair(env, txset);
+                StellarMessage newMsg;
+                newMsg.type(GENERALIZED_TX_SET);
+                txset->toXDR(newMsg.generalizedTxSet());
+                validatorSCPMessagesA[start] = std::make_pair(env, newMsg);
             }
         }
 
@@ -4101,7 +4224,10 @@ TEST_CASE("herder externalizes values", "[herder]")
                     env.statement.pledges.externalize().commit.value, sv);
                 auto txset = pe.getTxSet(sv.txSetHash);
                 REQUIRE(txset);
-                validatorSCPMessagesB[start] = std::make_pair(env, txset);
+                StellarMessage newMsg;
+                newMsg.type(GENERALIZED_TX_SET);
+                txset->toXDR(newMsg.generalizedTxSet());
+                validatorSCPMessagesB[start] = std::make_pair(env, newMsg);
             }
         }
     }
@@ -4134,6 +4260,8 @@ TEST_CASE("herder externalizes values", "[herder]")
 
         // Externalize future ledger
         // This should trigger CatchupManager to start buffering ledgers
+        // Ensure C processes future tx set and its fees correctly (even though
+        // its own ledger state isn't upgraded yet)
         receiveLedger(fourth, herderC);
 
         // Wait until C goes out of sync, and processes future slots
@@ -4208,6 +4336,12 @@ TEST_CASE("herder externalizes values", "[herder]")
                 return false;
             },
             2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+        // C landed on the same hash as A and B
+        REQUIRE(A->getLedgerManager().getLastClosedLedgerHeader().hash ==
+                getC()->getLedgerManager().getLastClosedLedgerHeader().hash);
+        REQUIRE(B->getLedgerManager().getLastClosedLedgerHeader().hash ==
+                getC()->getLedgerManager().getLastClosedLedgerHeader().hash);
     };
 
     SECTION("newer ledgers externalize in order")
@@ -4641,7 +4775,8 @@ externalize(SecretKey const& sk, LedgerManager& lm, HerderImpl& herder,
 
     txsPhases.emplace_back(sorobanTxs);
 
-    auto txSet = TxSetFrame::makeFromTransactions(txsPhases, app, 0, 0);
+    auto [txSet, applicableTxSet] =
+        TxSetFrame::makeFromTransactions(txsPhases, app, 0, 0);
     herder.getPendingEnvelopes().putTxSet(txSet->getContentsHash(), ledgerSeq,
                                           txSet);
 
@@ -4690,7 +4825,7 @@ TEST_CASE("do not flood invalid transactions", "[herder]")
 
     auto const& lhhe = lm.getLastClosedLedgerHeader();
     auto txs = tq.getTransactions(lhhe.header);
-    auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+    auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0).second;
     REQUIRE(txSet->sizeTxTotal() == 1);
     REQUIRE(txSet->getTxsForPhase(TxSetFrame::Phase::CLASSIC)
                 .front()

--- a/src/herder/test/PendingEnvelopesTests.cpp
+++ b/src/herder/test/PendingEnvelopesTests.cpp
@@ -73,7 +73,7 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
         std::vector<TransactionFrameBasePtr> txs(n);
         std::generate(std::begin(txs), std::end(txs),
                       [&]() { return accs[index++].tx({payment(root, 1)}); });
-        return TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+        return TxSetFrame::makeFromTransactions(txs, *app, 0, 0).first;
     };
 
     auto makePublicKey = [](int i) {
@@ -344,7 +344,7 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
     SECTION("can receive malformed tx set")
     {
         GeneralizedTransactionSet malformedXdrSet(1);
-        auto malformedTxSet = TxSetFrame::makeFromWire(*app, malformedXdrSet);
+        auto malformedTxSet = TxSetFrame::makeFromWire(malformedXdrSet);
         auto p2 = makeTxPair(malformedTxSet, 10, STELLAR_VALUE_SIGNED);
         auto malformedEnvelope =
             makeEnvelope(p2, saneQSetHash, lcl.header.ledgerSeq + 1);

--- a/src/herder/test/TestTxSetUtils.h
+++ b/src/herder/test/TestTxSetUtils.h
@@ -14,11 +14,13 @@ namespace testtxset
 
 using ComponentPhases = std::vector<
     std::pair<std::optional<int64_t>, std::vector<TransactionFrameBasePtr>>>;
-TxSetFrameConstPtr makeNonValidatedGeneralizedTxSet(
+std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+makeNonValidatedGeneralizedTxSet(
     std::vector<ComponentPhases> const& txsPerBaseFee, Application& app,
     Hash const& previousLedgerHash);
 
-TxSetFrameConstPtr makeNonValidatedTxSetBasedOnLedgerVersion(
+std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+makeNonValidatedTxSetBasedOnLedgerVersion(
     uint32_t ledgerVersion, std::vector<TransactionFrameBasePtr> const& txs,
     Application& app, Hash const& previousLedgerHash);
 } // namespace testtxset

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1113,7 +1113,8 @@ class SorobanLimitingLaneConfigForTesting : public SurgePricingLaneConfig
     std::vector<Resource> mLaneOpsLimits;
 };
 
-TEST_CASE("Soroban TransactionQueue pre-protocol-20")
+TEST_CASE("Soroban TransactionQueue pre-protocol-20",
+          "[soroban][transactionqueue]")
 {
     VirtualClock clock;
     auto cfg = getTestConfig();
@@ -2552,7 +2553,8 @@ TEST_CASE("remove applied", "[herder][transactionqueue]")
         auto ledgerSeq = lcl.header.ledgerSeq + 1;
 
         root.loadSequenceNumber();
-        auto txSet = TxSetFrame::makeFromTransactions({tx1b, tx2}, *app, 0, 0);
+        auto [txSet, _] =
+            TxSetFrame::makeFromTransactions({tx1b, tx2}, *app, 0, 0);
         herder.getPendingEnvelopes().putTxSet(txSet->getContentsHash(),
                                               ledgerSeq, txSet);
 

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -33,19 +33,19 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
     GeneralizedTransactionSet xdrTxSet(1);
     xdrTxSet.v1TxSet().previousLedgerHash =
         app->getLedgerManager().getLastClosedLedgerHeader().hash;
-
+    LedgerTxn ltx(app->getLedgerTxnRoot());
     SECTION("no phases")
     {
-        auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-        REQUIRE(!txSet->checkValidStructure());
+        auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+        REQUIRE(txSet->prepareForApply(*app) == nullptr);
     }
     SECTION("too many phases")
     {
         xdrTxSet.v1TxSet().phases.emplace_back();
         xdrTxSet.v1TxSet().phases.emplace_back();
         xdrTxSet.v1TxSet().phases.emplace_back();
-        auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-        REQUIRE(!txSet->checkValidStructure());
+        auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+        REQUIRE(txSet->prepareForApply(*app) == nullptr);
     }
     SECTION("incorrect base fee order")
     {
@@ -103,8 +103,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("non-discounted component out of place")
                 {
@@ -142,8 +142,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                     xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
                         TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
 
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION(
                     "with non-discounted component, discounted out of place")
@@ -187,8 +187,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
             }
         }
@@ -257,8 +257,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("duplicate non-discounted components")
                 {
@@ -296,8 +296,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(!txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
             }
         }
@@ -314,8 +314,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                 xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
                     TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
 
-                auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                REQUIRE(!txSet->checkValidStructure());
+                auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                REQUIRE(txSet->prepareForApply(*app) == nullptr);
             }
         }
     }
@@ -354,8 +354,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
             txEnv.v0().tx.operations.emplace_back();
             txEnv.v0().tx.operations.back().body.type(INVOKE_HOST_FUNCTION);
         }
-        auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-        REQUIRE(!txSet->checkValidStructure());
+        auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+        REQUIRE(txSet->prepareForApply(*app) == nullptr);
     }
     SECTION("valid XDR")
     {
@@ -383,8 +383,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                 {
                     xdrTxSet.v1TxSet().phases.emplace_back();
                     xdrTxSet.v1TxSet().phases.emplace_back();
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("single component")
                 {
@@ -399,8 +399,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
                     maybeAddSorobanOp(xdrTxSet);
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("multiple components")
                 {
@@ -464,8 +464,8 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txs.emplace_back();
                     maybeAddSorobanOp(xdrTxSet);
 
-                    auto txSet = TxSetFrame::makeFromWire(*app, xdrTxSet);
-                    REQUIRE(txSet->checkValidStructure());
+                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
             }
         }
@@ -516,32 +516,40 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     };
 
     auto checkXdrRoundtrip = [&](GeneralizedTransactionSet const& txSetXdr) {
-        auto frame = TxSetFrame::makeFromWire(*app, txSetXdr);
-        REQUIRE(frame->checkValid(*app, 0, 0));
+        auto txSetFrame = TxSetFrame::makeFromWire(txSetXdr);
+        ApplicableTxSetFrameConstPtr applicableFrame;
+        {
+            LedgerTxn ltx(app->getLedgerTxnRoot(), false,
+                          TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
+            applicableFrame = txSetFrame->prepareForApply(*app);
+        }
+        REQUIRE(applicableFrame->checkValid(*app, 0, 0));
         GeneralizedTransactionSet newXdr;
-        frame->toXDR(newXdr);
+        applicableFrame->toWireTxSetFrame()->toXDR(newXdr);
         REQUIRE(newXdr == txSetXdr);
     };
 
     SECTION("empty set")
     {
-        auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{}, {}}, *app,
-            app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto [_, ApplicableTxSetFrame] =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{}, {}}, *app,
+                app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
-        txSetFrame->toXDR(txSetXdr);
+        ApplicableTxSetFrame->toWireTxSetFrame()->toXDR(txSetXdr);
         REQUIRE(txSetXdr.v1TxSet().phases[0].v0Components().empty());
         checkXdrRoundtrip(txSetXdr);
     }
     SECTION("one discounted component set")
     {
-        auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(1234LL, createTxs(5, 1234))}, {}}, *app,
-            app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto [_, ApplicableTxSetFrame] =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(1234LL, createTxs(5, 1234))}, {}}, *app,
+                app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
-        txSetFrame->toXDR(txSetXdr);
+        ApplicableTxSetFrame->toWireTxSetFrame()->toXDR(txSetXdr);
         REQUIRE(txSetXdr.v1TxSet().phases[0].v0Components().size() == 1);
         REQUIRE(*txSetXdr.v1TxSet()
                      .phases[0]
@@ -557,12 +565,13 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     }
     SECTION("one non-discounted component set")
     {
-        auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(std::nullopt, createTxs(5, 4321))}, {}}, *app,
-            app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto [_, ApplicableTxSetFrame] =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(std::nullopt, createTxs(5, 4321))}, {}}, *app,
+                app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
-        txSetFrame->toXDR(txSetXdr);
+        ApplicableTxSetFrame->toWireTxSetFrame()->toXDR(txSetXdr);
         REQUIRE(txSetXdr.v1TxSet().phases[0].v0Components().size() == 1);
         REQUIRE(!txSetXdr.v1TxSet()
                      .phases[0]
@@ -578,16 +587,17 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     }
     SECTION("multiple component sets")
     {
-        auto txSetFrame = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(12345LL, createTxs(3, 12345)),
-              std::make_pair(123LL, createTxs(1, 123)),
-              std::make_pair(1234LL, createTxs(2, 1234)),
-              std::make_pair(std::nullopt, createTxs(4, 4321))},
-             {}},
-            *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto [_, ApplicableTxSetFrame] =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(12345LL, createTxs(3, 12345)),
+                  std::make_pair(123LL, createTxs(1, 123)),
+                  std::make_pair(1234LL, createTxs(2, 1234)),
+                  std::make_pair(std::nullopt, createTxs(4, 4321))},
+                 {}},
+                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
 
         GeneralizedTransactionSet txSetXdr;
-        txSetFrame->toXDR(txSetXdr);
+        ApplicableTxSetFrame->toWireTxSetFrame()->toXDR(txSetXdr);
         auto const& comps = txSetXdr.v1TxSet().phases[0].v0Components();
         REQUIRE(comps.size() == 4);
         REQUIRE(!comps[0].txsMaybeDiscountedFee().baseFee);
@@ -611,7 +621,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
 
         SECTION("classic only")
         {
-            auto txSet = TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+            auto txSet =
+                TxSetFrame::makeFromTransactions(txs, *app, 0, 0).first;
             GeneralizedTransactionSet txSetXdr;
             txSet->toXDR(txSetXdr);
             REQUIRE(txSetXdr.v1TxSet().phases.size() == 2);
@@ -635,7 +646,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
                 SECTION("minimum base fee")
                 {
                     auto txSet = TxSetFrame::makeFromTransactions(
-                        {txs, sorobanTxs}, *app, 0, 0);
+                                     {txs, sorobanTxs}, *app, 0, 0)
+                                     .first;
                     GeneralizedTransactionSet txSetXdr;
                     txSet->toXDR(txSetXdr);
                     REQUIRE(txSetXdr.v1TxSet().phases.size() == 2);
@@ -663,7 +675,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
                                       higherFeeSorobanTxs.begin(),
                                       higherFeeSorobanTxs.end());
                     auto txSet = TxSetFrame::makeFromTransactions(
-                        {txs, sorobanTxs}, *app, 0, 100);
+                                     {txs, sorobanTxs}, *app, 0, 100)
+                                     .first;
                     GeneralizedTransactionSet txSetXdr;
                     txSet->toXDR(txSetXdr);
                     REQUIRE(txSetXdr.v1TxSet().phases.size() == 2);
@@ -744,25 +757,29 @@ TEST_CASE("generalized tx set with multiple txs per source account",
 
     SECTION("invalid")
     {
-        auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(
-                 500,
-                 std::vector<TransactionFrameBasePtr>{
-                     createTx(1, 1000, false), createTx(3, 1500, false)})},
-             {}},
-            *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto txSet =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(
+                     500,
+                     std::vector<TransactionFrameBasePtr>{
+                         createTx(1, 1000, false), createTx(3, 1500, false)})},
+                 {}},
+                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                .second;
 
         REQUIRE(!txSet->checkValid(*app, 0, 0));
     }
     SECTION("valid")
     {
-        auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(
-                 500,
-                 std::vector<TransactionFrameBasePtr>{
-                     createTx(1, 1000, true), createTx(3, 1500, true)})},
-             {}},
-            *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto txSet =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(
+                     500,
+                     std::vector<TransactionFrameBasePtr>{
+                         createTx(1, 1000, true), createTx(3, 1500, true)})},
+                 {}},
+                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                .second;
 
         REQUIRE(txSet->checkValid(*app, 0, 0));
     }
@@ -779,14 +796,16 @@ TEST_CASE("generalized tx set with multiple txs per source account",
         // Make sure fees got computed correctly
         REQUIRE(sorobanTx->getInclusionFee() == inclusionFee);
 
-        auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(
-                 500,
-                 std::vector<TransactionFrameBasePtr>{
-                     createTx(1, 1000, false), createTx(3, 1500, false)})},
-             {std::make_pair(500,
-                             std::vector<TransactionFrameBasePtr>{sorobanTx})}},
-            *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto txSet =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(
+                     500,
+                     std::vector<TransactionFrameBasePtr>{
+                         createTx(1, 1000, false), createTx(3, 1500, false)})},
+                 {std::make_pair(
+                     500, std::vector<TransactionFrameBasePtr>{sorobanTx})}},
+                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                .second;
 
         REQUIRE(!txSet->checkValid(*app, 0, 0));
     }
@@ -809,7 +828,8 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
     auto root = TestAccount::createRoot(*app);
     int accountId = 1;
 
-    auto createTx = [&](int opCnt, int inclusionFee, bool isSoroban = false) {
+    auto createTx = [&](int opCnt, int inclusionFee, bool isSoroban = false,
+                        bool validateTx = true) {
         auto source = root.create("unique " + std::to_string(accountId++),
                                   app->getLedgerManager().getLastMinBalance(2));
         if (isSoroban)
@@ -826,7 +846,10 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
                                          resourceFee, resources);
             REQUIRE(tx->getInclusionFee() == inclusionFee);
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
+            if (validateTx)
+            {
+                REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
+            }
             return tx;
         }
         else
@@ -845,34 +868,38 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
 
     SECTION("valid txset")
     {
-        auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-            {{std::make_pair(
-                  500, std::vector<TransactionFrameBasePtr>{createTx(1, 1000),
-                                                            createTx(3, 1500)}),
-              std::make_pair(
-                  1000,
-                  std::vector<TransactionFrameBasePtr>{
-                      createTx(4, 5000), createTx(1, 1000), createTx(5, 6000)}),
-              std::make_pair(std::nullopt,
-                             std::vector<TransactionFrameBasePtr>{
-                                 createTx(2, 10000), createTx(5, 100000)})},
-             {std::make_pair(500,
-                             std::vector<TransactionFrameBasePtr>{
-                                 createTx(1, 1000, /* isSoroban */ true),
-                                 createTx(1, 500, /* isSoroban */ true)}),
-              std::make_pair(1000,
-                             std::vector<TransactionFrameBasePtr>{
-                                 createTx(1, 1250, /* isSoroban */ true),
-                                 createTx(1, 1000, /* isSoroban */ true),
-                                 createTx(1, 1200, /* isSoroban */ true)}),
-              std::make_pair(std::nullopt,
-                             std::vector<TransactionFrameBasePtr>{
-                                 createTx(1, 5000, /* isSoroban */ true),
-                                 createTx(1, 20000, /* isSoroban */ true)})}},
-            *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+        auto txSet =
+            testtxset::makeNonValidatedGeneralizedTxSet(
+                {{std::make_pair(500,
+                                 std::vector<TransactionFrameBasePtr>{
+                                     createTx(1, 1000), createTx(3, 1500)}),
+                  std::make_pair(1000,
+                                 std::vector<TransactionFrameBasePtr>{
+                                     createTx(4, 5000), createTx(1, 1000),
+                                     createTx(5, 6000)}),
+                  std::make_pair(std::nullopt,
+                                 std::vector<TransactionFrameBasePtr>{
+                                     createTx(2, 10000), createTx(5, 100000)})},
+                 {std::make_pair(500,
+                                 std::vector<TransactionFrameBasePtr>{
+                                     createTx(1, 1000, /* isSoroban */ true),
+                                     createTx(1, 500, /* isSoroban */ true)}),
+                  std::make_pair(1000,
+                                 std::vector<TransactionFrameBasePtr>{
+                                     createTx(1, 1250, /* isSoroban */ true),
+                                     createTx(1, 1000, /* isSoroban */ true),
+                                     createTx(1, 1200, /* isSoroban */ true)}),
+                  std::make_pair(
+                      std::nullopt,
+                      std::vector<TransactionFrameBasePtr>{
+                          createTx(1, 5000, /* isSoroban */ true),
+                          createTx(1, 20000, /* isSoroban */ true)})}},
+                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                .second;
 
         REQUIRE(txSet->checkValid(*app, 0, 0));
-        for (int i = 0; i < TxSetFrame::Phase::PHASE_COUNT; ++i)
+        for (auto i = 0;
+             i < static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT); ++i)
         {
             std::vector<std::optional<int64_t>> fees;
             for (auto const& tx :
@@ -893,23 +920,29 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
     {
         SECTION("classic")
         {
-            auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-                {{std::make_pair(
-                     500,
-                     std::vector<TransactionFrameBasePtr>{createTx(2, 999)})},
-                 {}},
-                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            auto txSet =
+                testtxset::makeNonValidatedGeneralizedTxSet(
+                    {{std::make_pair(500,
+                                     std::vector<TransactionFrameBasePtr>{
+                                         createTx(2, 999)})},
+                     {}},
+                    *app,
+                    app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                    .second;
 
             REQUIRE(!txSet->checkValid(*app, 0, 0));
         }
         SECTION("soroban")
         {
-            auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-                {{},
-                 {std::make_pair(500,
-                                 std::vector<TransactionFrameBasePtr>{
-                                     createTx(1, 499, /* isSoroban */ true)})}},
-                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            auto txSet =
+                testtxset::makeNonValidatedGeneralizedTxSet(
+                    {{},
+                     {std::make_pair(
+                         500, std::vector<TransactionFrameBasePtr>{createTx(
+                                  1, 499, /* isSoroban */ true)})}},
+                    *app,
+                    app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                    .second;
 
             REQUIRE(!txSet->checkValid(*app, 0, 0));
         }
@@ -919,23 +952,29 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
     {
         SECTION("classic")
         {
-            auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-                {{std::make_pair(
-                     std::nullopt,
-                     std::vector<TransactionFrameBasePtr>{createTx(2, 199)})},
-                 {}},
-                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            auto txSet =
+                testtxset::makeNonValidatedGeneralizedTxSet(
+                    {{std::make_pair(std::nullopt,
+                                     std::vector<TransactionFrameBasePtr>{
+                                         createTx(2, 199)})},
+                     {}},
+                    *app,
+                    app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                    .second;
 
             REQUIRE(!txSet->checkValid(*app, 0, 0));
         }
         SECTION("soroban")
         {
-            auto txSet = testtxset::makeNonValidatedGeneralizedTxSet(
-                {{},
-                 {std::make_pair(
-                     std::nullopt,
-                     std::vector<TransactionFrameBasePtr>{createTx(1, 199)})}},
-                *app, app->getLedgerManager().getLastClosedLedgerHeader().hash);
+            auto txSet =
+                testtxset::makeNonValidatedGeneralizedTxSet(
+                    {{},
+                     {std::make_pair(std::nullopt,
+                                     std::vector<TransactionFrameBasePtr>{
+                                         createTx(1, 99, true, false)})}},
+                    *app,
+                    app->getLedgerManager().getLastClosedLedgerHeader().hash)
+                    .second;
 
             REQUIRE(!txSet->checkValid(*app, 0, 0));
         }

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1080,7 +1080,7 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
             uint64_t big = minBalance + ledgerSeq;
             uint64_t closeTime = 60 * 5 * ledgerSeq;
 
-            TxSetFrameConstPtr txSet = TxSetFrame::makeFromTransactions(
+            auto [txSet, applicableTxSet] = TxSetFrame::makeFromTransactions(
                 TxSetFrame::Transactions{
                     root.tx({txtest::createAccount(stranger, big)})},
                 *a, 0, 0);
@@ -1097,7 +1097,8 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
             }
             CLOG_DEBUG(
                 History, "Closing synthetic ledger {} with {} txs (txhash:{})",
-                ledgerSeq, txSet->size(lm.getLastClosedLedgerHeader().header),
+                ledgerSeq,
+                applicableTxSet->size(lm.getLastClosedLedgerHeader().header),
                 hexAbbrev(txSet->getContentsHash()));
             StellarValue sv = a->getHerder().makeStellarValue(
                 txSet->getContentsHash(), closeTime, upgrades,

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -470,7 +470,7 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
         }
     }
     TxSetFrameConstPtr txSet =
-        TxSetFrame::makeFromTransactions(txs, mApp, 0, 0);
+        TxSetFrame::makeFromTransactions(txs, mApp, 0, 0).first;
 
     CLOG_DEBUG(History, "Closing synthetic ledger {} with {} txs (txhash:{})",
                ledgerSeq, txSet->sizeTxTotal(),

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -767,6 +767,18 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     header.current().scpValue = sv;
 
     maybeResetLedgerCloseMetaDebugStream(header.current().ledgerSeq);
+    auto applicableTxSet = txSet->prepareForApply(mApp);
+
+    if (applicableTxSet == nullptr)
+    {
+        CLOG_ERROR(
+            Ledger,
+            "Corrupt transaction set: TxSet cannot be prepared for apply",
+            binToHex(txSet->getContentsHash()),
+            binToHex(ledgerData.getValue().txSetHash));
+        CLOG_ERROR(Ledger, "{}", POSSIBLY_CORRUPTED_QUORUM_SET);
+        throw std::runtime_error("transaction set cannot be processed");
+    }
 
     // In addition to the _canonical_ LedgerResultSet hashed into the
     // LedgerHeader, we optionally collect an even-more-fine-grained record of
@@ -787,7 +799,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         // this method throw.
         ledgerCloseMeta = std::make_unique<LedgerCloseMetaFrame>(
             header.current().ledgerVersion);
-        ledgerCloseMeta->reserveTxProcessing(txSet->sizeTxTotal());
+        ledgerCloseMeta->reserveTxProcessing(applicableTxSet->sizeTxTotal());
         ledgerCloseMeta->populateTxSet(*txSet);
     }
 
@@ -795,15 +807,15 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     // was sorted by hash; we reorder it so that transactions are
     // sorted such that sequence numbers are respected
     std::vector<TransactionFrameBasePtr> const txs =
-        txSet->getTxsInApplyOrder();
+        applicableTxSet->getTxsInApplyOrder();
 
     // first, prefetch source accounts for txset, then charge fees
     prefetchTxSourceIds(txs);
-    processFeesSeqNums(txs, ltx, *txSet, ledgerCloseMeta);
+    processFeesSeqNums(txs, ltx, *applicableTxSet, ledgerCloseMeta);
 
     TransactionResultSet txResultSet;
     txResultSet.results.reserve(txs.size());
-    applyTransactions(*txSet, txs, ltx, txResultSet, ledgerCloseMeta);
+    applyTransactions(*applicableTxSet, txs, ltx, txResultSet, ledgerCloseMeta);
     if (mApp.getConfig().MODE_STORES_HISTORY_MISC)
     {
         storeTxSet(mApp.getDatabase(), ltx.loadHeader().current().ledgerSeq,
@@ -945,7 +957,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             mApp.getConfig().OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.begin(),
             mApp.getConfig().OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.end());
         std::chrono::microseconds sleepFor{0};
-        auto txSetSizeOp = txSet->sizeOpTotal();
+        auto txSetSizeOp = applicableTxSet->sizeOpTotal();
         for (size_t i = 0; i < txSetSizeOp; i++)
         {
             sleepFor +=
@@ -1215,7 +1227,7 @@ mergeOpInTx(std::vector<Operation> const& ops)
 void
 LedgerManagerImpl::processFeesSeqNums(
     std::vector<TransactionFrameBasePtr> const& txs,
-    AbstractLedgerTxn& ltxOuter, TxSetFrame const& txSet,
+    AbstractLedgerTxn& ltxOuter, ApplicableTxSetFrame const& txSet,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta)
 {
     ZoneScoped;
@@ -1347,8 +1359,9 @@ LedgerManagerImpl::prefetchTransactionData(
 
 void
 LedgerManagerImpl::applyTransactions(
-    TxSetFrame const& txSet, std::vector<TransactionFrameBasePtr> const& txs,
-    AbstractLedgerTxn& ltx, TransactionResultSet& txResultSet,
+    ApplicableTxSetFrame const& txSet,
+    std::vector<TransactionFrameBasePtr> const& txs, AbstractLedgerTxn& ltx,
+    TransactionResultSet& txResultSet,
     std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta)
 {
     ZoneNamedN(txsZone, "applyTransactions", true);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -559,7 +559,7 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
               ledgerData.getLedgerSeq(),
               hexAbbrev(ledgerData.getTxSet()->previousLedgerHash()),
               ledgerData.getTxSet()->sizeTxTotal(),
-              ledgerData.getTxSet()->sizeOpTotal(),
+              ledgerData.getTxSet()->sizeOpTotalForLogging(),
               stellarValueToString(mApp.getConfig(), ledgerData.getValue()));
 
     auto st = getState();

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -71,11 +71,11 @@ class LedgerManagerImpl : public LedgerManager
 
     void processFeesSeqNums(
         std::vector<TransactionFrameBasePtr> const& txs,
-        AbstractLedgerTxn& ltxOuter, TxSetFrame const& txSet,
+        AbstractLedgerTxn& ltxOuter, ApplicableTxSetFrame const& txSet,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta);
 
     void applyTransactions(
-        TxSetFrame const& txSet,
+        ApplicableTxSetFrame const& txSet,
         std::vector<TransactionFrameBasePtr> const& txs, AbstractLedgerTxn& ltx,
         TransactionResultSet& txResultSet,
         std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta);

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -221,7 +221,7 @@ PersistentState::upgradeSCPDataV1Format()
             std::unordered_map<Hash, std::string> txSets;
             for (auto const& txSet : scpState.v0().txSets)
             {
-                auto txSetPtr = TxSetFrame::makeFromStoredTxSet(txSet, mApp);
+                auto txSetPtr = TxSetFrame::makeFromStoredTxSet(txSet);
                 txSets.emplace(txSetPtr->getContentsHash(),
                                decoder::encode_b64(xdr::xdr_to_opaque(txSet)));
             }

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1089,7 +1089,7 @@ void
 Peer::recvTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
-    auto frame = TxSetFrame::makeFromWire(mApp, msg.txSet());
+    auto frame = TxSetFrame::makeFromWire(msg.txSet());
     mApp.getHerder().recvTxSet(frame->getContentsHash(), frame);
 }
 
@@ -1097,7 +1097,7 @@ void
 Peer::recvGeneralizedTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
-    auto frame = TxSetFrame::makeFromWire(mApp, msg.generalizedTxSet());
+    auto frame = TxSetFrame::makeFromWire(msg.generalizedTxSet());
     mApp.getHerder().recvTxSet(frame->getContentsHash(), frame);
 }
 

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -433,7 +433,8 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
 
             // create the transaction set containing this transaction
 
-            auto txSet = TxSetFrame::makeFromTransactions({tx1}, *inApp, 0, 0);
+            auto txSet =
+                TxSetFrame::makeFromTransactions({tx1}, *inApp, 0, 0).first;
             auto& herder = static_cast<HerderImpl&>(inApp->getHerder());
 
             // build the quorum set used by this message

--- a/src/overlay/test/ItemFetcherTests.cpp
+++ b/src/overlay/test/ItemFetcherTests.cpp
@@ -5,6 +5,7 @@
 #include "util/asio.h"
 #include "crypto/Hex.h"
 #include "crypto/SHA.h"
+#include "herder/Herder.h"
 #include "herder/HerderImpl.h"
 #include "lib/catch.hpp"
 #include "main/ApplicationImpl.h"

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -494,7 +494,7 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
         closeTime = lastCloseTime;
     }
 
-    TxSetFrameConstPtr txSet;
+    std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr> txSet;
     if (strictOrder)
     {
         txSet = TxSetFrame::makeFromTransactions(txs, app, 0, 0, true);
@@ -529,9 +529,9 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
         // `strictOrder` means the txs in the txSet will be applied in the exact
         // same order as they were constructed. It could also imply the txs
         // themselves maybe intentionally invalid for testing purpose.
-        REQUIRE(txSet->checkValid(app, 0, 0));
+        REQUIRE(txSet.second->checkValid(app, 0, 0));
     }
-    app.getHerder().externalizeValue(txSet, ledgerSeq, closeTime,
+    app.getHerder().externalizeValue(txSet.first, ledgerSeq, closeTime,
                                      emptyUpgradeSteps);
     auto z1 = getTransactionHistoryResults(app.getDatabase(), ledgerSeq);
     auto z2 = getTransactionFeeMeta(app.getDatabase(), ledgerSeq);

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -58,14 +58,6 @@ FeeBumpTransactionFrame::getDiagnosticEvents() const
 {
     return mInnerTx->getDiagnosticEvents();
 }
-void
-FeeBumpTransactionFrame::maybeComputeSorobanResourceFee(
-    uint32_t protocolVersion, SorobanNetworkConfig const& sorobanConfig,
-    Config const& cfg)
-{
-    mInnerTx->maybeComputeSorobanResourceFee(protocolVersion, sorobanConfig,
-                                             cfg);
-}
 
 FeeBumpTransactionFrame::FeeBumpTransactionFrame(
     Hash const& networkID, TransactionEnvelope const& envelope)
@@ -193,14 +185,6 @@ FeeBumpTransactionFrame::checkValid(Application& app,
 {
     LedgerTxn ltx(ltxOuter);
     int64_t minBaseFee = ltx.loadHeader().current().baseFee;
-    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
-                                  SOROBAN_PROTOCOL_VERSION))
-    {
-        mInnerTx->maybeComputeSorobanResourceFee(
-            ltx.loadHeader().current().ledgerVersion,
-            app.getLedgerManager().getSorobanNetworkConfig(ltx),
-            app.getConfig());
-    }
     resetResults(ltx.loadHeader().current(), minBaseFee, false);
 
     SignatureChecker signatureChecker{ltx.loadHeader().current().ledgerVersion,

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -111,10 +111,6 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     bool isSoroban() const override;
     SorobanResources const& sorobanResources() const override;
     xdr::xvector<DiagnosticEvent> const& getDiagnosticEvents() const override;
-    void
-    maybeComputeSorobanResourceFee(uint32_t protocolVersion,
-                                   SorobanNetworkConfig const& sorobanConfig,
-                                   Config const& cfg) override;
     virtual int64 declaredSorobanResourceFee() const override;
     virtual bool XDRProvidesValidFee() const override;
 };

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -70,9 +70,6 @@ TransactionFrame::TransactionFrame(Hash const& networkID,
         mOperations.push_back(
             makeOperation(ops[i], getResult().result.results()[i], i));
     }
-
-    // Initialize the fee to 0, callers will compute the fee appropriately
-    mSorobanResourceFee = std::make_optional<FeePair>();
 }
 
 Hash const&
@@ -779,6 +776,8 @@ TransactionFrame::computeSorobanResourceFee(
     uint32_t txSize, uint32_t eventsSize,
     SorobanNetworkConfig const& sorobanConfig, Config const& cfg)
 {
+    releaseAssertOrThrow(
+        protocolVersionStartsFrom(protocolVersion, SOROBAN_PROTOCOL_VERSION));
     CxxTransactionResources cxxResources{};
     cxxResources.instructions = txResources.instructions;
 
@@ -806,34 +805,18 @@ TransactionFrame::declaredSorobanResourceFee() const
     return mEnvelope.v1().tx.ext.sorobanData().resourceFee;
 }
 
-void
-TransactionFrame::maybeComputeSorobanResourceFee(
+FeePair
+TransactionFrame::computePreApplySorobanResourceFee(
     uint32_t protocolVersion, SorobanNetworkConfig const& sorobanConfig,
     Config const& cfg)
 {
-    // NB: We recompute the resource fee on-demand in case if the fees change
-    // between the ledger where the transaction has been accepted and the ledger
-    // where it is being applied.
-    if (!isSoroban())
-    {
-        return;
-    }
-    // At this point the frame might not have been validated yet, so
-    // the resources might not be present or Soroban might not be supported
-    // at all. Hence just set the resource fees to 0 and rely on validation
-    // checks to not use this.
-    if (protocolVersionIsBefore(protocolVersion, SOROBAN_PROTOCOL_VERSION))
-    {
-        mSorobanResourceFee = std::make_optional<FeePair>();
-        return;
-    }
+    releaseAssertOrThrow(isSoroban());
     // We always use the declared resource value for the resource fee
     // computation. The refunds are performed as a separate operation that
     // doesn't involve modifying any transaction fees.
-    mSorobanResourceFee = std::make_optional<FeePair>(computeSorobanResourceFee(
+    return computeSorobanResourceFee(
         protocolVersion, sorobanResources(),
-        static_cast<uint32_t>(xdr::xdr_size(mEnvelope)), 0, sorobanConfig,
-        cfg));
+        static_cast<uint32_t>(xdr::xdr_size(mEnvelope)), 0, sorobanConfig, cfg);
 }
 
 bool
@@ -844,8 +827,9 @@ TransactionFrame::consumeRefundableSorobanResources(
     releaseAssertOrThrow(isSoroban());
     mConsumedContractEventsSizeBytes += contractEventSizeBytes;
     mConsumedRentFee += rentFee;
-    mFeeRefund =
-        declaredSorobanResourceFee() - mSorobanResourceFee->non_refundable_fee;
+    auto preApplyFee =
+        computePreApplySorobanResourceFee(protocolVersion, sorobanConfig, cfg);
+    mFeeRefund = declaredSorobanResourceFee() - preApplyFee.non_refundable_fee;
     if (mFeeRefund < mConsumedRentFee)
     {
         return false;
@@ -962,10 +946,10 @@ TransactionFrame::isTooEarlyForAccount(LedgerTxnHeader const& header,
 }
 
 bool
-TransactionFrame::commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
-                                       bool chargeFee,
-                                       uint64_t lowerBoundCloseTimeOffset,
-                                       uint64_t upperBoundCloseTimeOffset)
+TransactionFrame::commonValidPreSeqNum(
+    Application& app, AbstractLedgerTxn& ltx, bool chargeFee,
+    uint64_t lowerBoundCloseTimeOffset, uint64_t upperBoundCloseTimeOffset,
+    std::optional<FeePair> sorobanResourceFee)
 {
     ZoneScoped;
     // this function does validations that are independent of the account state
@@ -1050,17 +1034,18 @@ TransactionFrame::commonValidPreSeqNum(Application& app, AbstractLedgerTxn& ltx,
             getResult().result.code(txSOROBAN_INVALID);
             return false;
         }
+        releaseAssertOrThrow(sorobanResourceFee);
         if (sorobanData.resourceFee <
-            mSorobanResourceFee->refundable_fee +
-                mSorobanResourceFee->non_refundable_fee)
+            sorobanResourceFee->refundable_fee +
+                sorobanResourceFee->non_refundable_fee)
         {
             pushSimpleDiagnosticError(
                 SCE_STORAGE, SCEC_EXCEEDED_LIMIT,
                 "transaction `sorobanData.resourceFee` is lower than the "
                 "actual Soroban resource fee",
                 {makeU64SCVal(sorobanData.resourceFee),
-                 makeU64SCVal(mSorobanResourceFee->refundable_fee +
-                              mSorobanResourceFee->non_refundable_fee)});
+                 makeU64SCVal(sorobanResourceFee->refundable_fee +
+                              sorobanResourceFee->non_refundable_fee)});
             getResult().result.code(txSOROBAN_INVALID);
             return false;
         }
@@ -1229,7 +1214,8 @@ TransactionFrame::commonValid(Application& app,
                               SequenceNumber current, bool applying,
                               bool chargeFee,
                               uint64_t lowerBoundCloseTimeOffset,
-                              uint64_t upperBoundCloseTimeOffset)
+                              uint64_t upperBoundCloseTimeOffset,
+                              std::optional<FeePair> sorobanResourceFee)
 {
     ZoneScoped;
     LedgerTxn ltx(ltxOuter);
@@ -1243,7 +1229,7 @@ TransactionFrame::commonValid(Application& app,
     }
 
     if (!commonValidPreSeqNum(app, ltx, chargeFee, lowerBoundCloseTimeOffset,
-                              upperBoundCloseTimeOffset))
+                              upperBoundCloseTimeOffset, sorobanResourceFee))
     {
         return res;
     }
@@ -1443,24 +1429,25 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
         minBaseFee = 0;
     }
 
-    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
-                                  SOROBAN_PROTOCOL_VERSION))
-    {
-        maybeComputeSorobanResourceFee(
-            ltx.loadHeader().current().ledgerVersion,
-            app.getLedgerManager().getSorobanNetworkConfig(ltx),
-            app.getConfig());
-    }
-
     resetResults(ltx.loadHeader().current(), minBaseFee, false);
 
     SignatureChecker signatureChecker{ltx.loadHeader().current().ledgerVersion,
                                       getContentsHash(),
                                       getSignatures(mEnvelope)};
+    std::optional<FeePair> sorobanResourceFee;
+    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                  SOROBAN_PROTOCOL_VERSION) &&
+        isSoroban())
+    {
+        sorobanResourceFee = computePreApplySorobanResourceFee(
+            ltx.loadHeader().current().ledgerVersion,
+            app.getLedgerManager().getSorobanNetworkConfig(ltx),
+            app.getConfig());
+    }
     bool res =
         commonValid(app, signatureChecker, ltx, current, false, chargeFee,
-                    lowerBoundCloseTimeOffset,
-                    upperBoundCloseTimeOffset) == ValidationType::kMaybeValid;
+                    lowerBoundCloseTimeOffset, upperBoundCloseTimeOffset,
+                    sorobanResourceFee) == ValidationType::kMaybeValid;
     if (res)
     {
         for (auto& op : mOperations)
@@ -1659,8 +1646,12 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
             {
                 // If transaction fails, we don't charge for any
                 // refundable resources.
+                auto preApplyFee = computePreApplySorobanResourceFee(
+                    ledgerVersion,
+                    app.getLedgerManager().getSorobanNetworkConfig(ltxTx),
+                    app.getConfig());
                 mFeeRefund = declaredSorobanResourceFee() -
-                             mSorobanResourceFee->non_refundable_fee;
+                             preApplyFee.non_refundable_fee;
                 outerMeta.pushDiagnosticEvents(std::move(mDiagnosticEvents));
             }
         }
@@ -1750,8 +1741,18 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
         //  when applying, a failure during tx validation means that
         //  we'll skip trying to apply operations but we'll still
         //  process the sequence number if needed
-        auto cv =
-            commonValid(app, signatureChecker, ltxTx, 0, true, chargeFee, 0, 0);
+        std::optional<FeePair> sorobanResourceFee;
+        if (protocolVersionStartsFrom(ledgerVersion,
+                                      SOROBAN_PROTOCOL_VERSION) &&
+            isSoroban())
+        {
+            sorobanResourceFee = computePreApplySorobanResourceFee(
+                ledgerVersion,
+                app.getLedgerManager().getSorobanNetworkConfig(ltxTx),
+                app.getConfig());
+        }
+        auto cv = commonValid(app, signatureChecker, ltxTx, 0, true, chargeFee,
+                              0, 0, sorobanResourceFee);
         if (cv >= ValidationType::kInvalidUpdateSeqNum)
         {
             processSeqNum(ltxTx);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -816,7 +816,8 @@ TransactionFrame::computePreApplySorobanResourceFee(
     // doesn't involve modifying any transaction fees.
     return computeSorobanResourceFee(
         protocolVersion, sorobanResources(),
-        static_cast<uint32_t>(xdr::xdr_size(mEnvelope)), 0, sorobanConfig, cfg);
+        getResources(false).getVal(Resource::Type::TX_BYTE_SIZE), 0,
+        sorobanConfig, cfg);
 }
 
 bool
@@ -838,7 +839,7 @@ TransactionFrame::consumeRefundableSorobanResources(
 
     FeePair consumedFee = computeSorobanResourceFee(
         protocolVersion, sorobanResources(),
-        static_cast<uint32_t>(xdr::xdr_size(mEnvelope)),
+        getResources(false).getVal(Resource::Type::TX_BYTE_SIZE),
         mConsumedContractEventsSizeBytes, sorobanConfig, cfg);
     if (mFeeRefund < consumedFee.refundable_fee)
     {

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -92,10 +92,6 @@ class TransactionFrameBase
     virtual SorobanResources const& sorobanResources() const = 0;
     virtual xdr::xvector<DiagnosticEvent> const&
     getDiagnosticEvents() const = 0;
-    virtual void
-    maybeComputeSorobanResourceFee(uint32_t protocolVersion,
-                                   SorobanNetworkConfig const& sorobanConfig,
-                                   Config const& cfg) = 0;
     virtual int64 declaredSorobanResourceFee() const = 0;
     virtual bool XDRProvidesValidFee() const = 0;
 };

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -623,7 +623,6 @@ ContractInvocationTest::txCheckValid(TransactionFrameBasePtr tx)
 {
     LedgerTxn ltx(mApp->getLedgerTxnRoot());
     REQUIRE(tx->checkValid(*mApp, ltx, 0, 0, 0));
-    ltx.commit();
 }
 
 bool

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -65,7 +65,8 @@ TEST_CASE("txset - correct apply order", "[tx][envelope]")
     auto tx2 = a1.tx({a1.op(payment(root, 112)), a1.op(payment(root, 101))});
 
     auto txSet = TxSetFrame::makeFromTransactions(
-        TxSetFrame::Transactions{tx1, tx2}, *app, 0, 0);
+                     TxSetFrame::Transactions{tx1, tx2}, *app, 0, 0)
+                     .second;
 
     auto txs = txSet->getTxsInApplyOrder();
     REQUIRE(txs.size() == 2);
@@ -1876,7 +1877,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
         auto setup = [&]() {
             txFrame = root.tx({createAccount(a1, paymentAmount)});
             auto txSet =
-                TxSetFrame::makeFromTransactions({txFrame}, *app, 0, 0);
+                TxSetFrame::makeFromTransactions({txFrame}, *app, 0, 0).first;
 
             // Close this ledger
             auto lastCloseTime = app->getLedgerManager()


### PR DESCRIPTION
# Description

Resolves #3958 

Refactor `TxSetFrame` to distinguish between operations that are dependent on the ledger state vs those that aren't.

Most of the time we just process tx sets as XDR blobs. We only need to further interpret tx sets in a few cases (when validating the SCP nominees and applying the final tx set). These cases now have to explicitly use a different tx set interface `ResolvedTxSetFrame` which can only be created when TxSet points at current LCL.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
