### PR TITLE
Set recursion limit for SCval and SorobanAuthorizedInvocation

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -827,7 +827,7 @@ generator_t::operator()<stellar::SCVal>(stellar::SCVal& val) const
     const auto& vals = stellar::SCVal::_xdr_case_values();
     stellar::SCValType v;
 
-    uint32_t n;
+    uint32_t n = 0;
     (*this)(n);
     v = vals[n % vals.size()];
 


### PR DESCRIPTION
# Description

Solves an OOM issue with the fuzzer when we generate an InvokeHostFunctionOp with recursive xdr. I chose an arbitrary limit of 50, and use the same counter/limit for both objects. This fuzzer won't be very useful for soroban until we specialize it, so I think this is sufficient.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
