### PR TITLE
Cleanup BucketList access

### DIFF
--- a/src/catchup/CatchupManagerImpl.cpp
+++ b/src/catchup/CatchupManagerImpl.cpp
@@ -177,7 +177,7 @@ CatchupManagerImpl::processLedger(LedgerCloseData const& ledgerData)
     std::string message;
     uint32_t firstLedgerInBuffer = mSyncingLedgers.begin()->first;
     uint32_t lastLedgerInBuffer = mSyncingLedgers.crbegin()->first;
-    if (mApp.getConfig().MODE_DOES_CATCHUP &&
+    if (mApp.getConfig().modeDoesCatchupWithBucketList() &&
         hm.isFirstLedgerInCheckpoint(firstLedgerInBuffer) &&
         firstLedgerInBuffer < lastLedgerInBuffer)
     {

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -220,8 +220,14 @@ HistoryManagerImpl::queueCurrentHistory()
 {
     ZoneScoped;
     auto ledger = mApp.getLedgerManager().getLastClosedLedgerNum();
-    HistoryArchiveState has(ledger, mApp.getBucketManager().getBucketList(),
-                            mApp.getConfig().NETWORK_PASSPHRASE);
+
+    BucketList bl;
+    if (mApp.getConfig().MODE_ENABLES_BUCKETLIST)
+    {
+        bl = mApp.getBucketManager().getBucketList();
+    }
+
+    HistoryArchiveState has(ledger, bl, mApp.getConfig().NETWORK_PASSPHRASE);
 
     CLOG_DEBUG(History, "Queueing publish state for ledger {}", ledger);
     mEnqueueTimes.emplace(ledger, std::chrono::steady_clock::now());

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -2079,6 +2079,12 @@ Config::setInMemoryMode()
 }
 
 bool
+Config::modeDoesCatchupWithBucketList() const
+{
+    return MODE_DOES_CATCHUP && MODE_ENABLES_BUCKETLIST;
+}
+
+bool
 Config::isInMemoryMode() const
 {
     return MODE_USES_IN_MEMORY_LEDGER;

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -619,6 +619,7 @@ class Config : public std::enable_shared_from_this<Config>
     std::chrono::seconds getExpectedLedgerCloseTime() const;
 
     void setInMemoryMode();
+    bool modeDoesCatchupWithBucketList() const;
     bool isInMemoryMode() const;
     bool isInMemoryModeWithoutMinimalDB() const;
     bool isUsingBucketListDB() const;


### PR DESCRIPTION
# Description

Resolves #3842

This PR adds an additional check for `MODE_ENABLES_BUCKETLIST` and disables catchup when `MODE_ENABLES_BUCKETLIST=false`. For some reason GitHub is convinced that the older PR for this has been merged, so I'm opening it again.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
