### PR TITLE
Add lifetime and type tests for upgrade entries

### DIFF
--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -1749,7 +1749,8 @@ executeUpgrade(Application& app, LedgerUpgrade const& lupgrade,
 };
 
 ConfigUpgradeSetFrameConstPtr
-makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet)
+makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet,
+                     bool expireSet, ContractDataDurability type)
 {
     // Make entry for the upgrade
     auto opaqueUpgradeSet = xdr::xdr_to_opaque(configUpgradeSet);
@@ -1770,14 +1771,14 @@ makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet)
     le.data.type(CONTRACT_DATA);
     le.data.contractData().contract.type(SC_ADDRESS_TYPE_CONTRACT);
     le.data.contractData().contract.contractId() = contractID;
-    le.data.contractData().durability = TEMPORARY;
+    le.data.contractData().durability = type;
     le.data.contractData().key = key;
     le.data.contractData().val = val;
 
     LedgerEntry ttl;
     ttl.data.type(TTL);
     ttl.data.ttl().keyHash = getTTLKey(le).ttl().keyHash;
-    ttl.data.ttl().liveUntilLedgerSeq = UINT32_MAX;
+    ttl.data.ttl().liveUntilLedgerSeq = expireSet ? 0 : UINT32_MAX;
 
     ltx.create(InternalLedgerEntry(le));
     ltx.create(InternalLedgerEntry(ttl));

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -298,8 +298,10 @@ TransactionFrameBasePtr sorobanTransactionFrameFromOpsWithTotalFee(
     SorobanResources const& resources, uint32_t totalFee, uint32_t resourceFee,
     std::optional<std::string> memo = std::nullopt);
 
-ConfigUpgradeSetFrameConstPtr
-makeConfigUpgradeSet(AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet);
+ConfigUpgradeSetFrameConstPtr makeConfigUpgradeSet(
+    AbstractLedgerTxn& ltx, ConfigUpgradeSet configUpgradeSet,
+    bool expireSet = false,
+    ContractDataDurability type = ContractDataDurability::TEMPORARY);
 LedgerUpgrade makeConfigUpgrade(ConfigUpgradeSetFrame const& configUpgradeSet);
 
 LedgerUpgrade makeBaseReserveUpgrade(int baseReserve);


### PR DESCRIPTION
# Description

Partially resolves #3798

Adds `ContractDataDurability` and lifetime enforcement tests for config upgrades.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
