### PR TITLE
Added BucketListSizeSnapshots upgrade test

### DIFF
--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -290,7 +290,6 @@ class SorobanNetworkConfig
 
 #ifdef BUILD_TESTS
     void setBucketListSnapshotPeriodForTesting(uint32_t period);
-    std::deque<uint64_t> const& getBucketListSizeWindowForTesting() const;
 #endif
 
     static bool isValidConfigSettingEntry(ConfigSettingEntry const& cfg);
@@ -342,8 +341,6 @@ class SorobanNetworkConfig
     // window until it has newSize entries.
     void maybeUpdateBucketListWindowSize(AbstractLedgerTxn& ltx);
 
-    void writeBucketListSizeWindow(AbstractLedgerTxn& ltxRoot) const;
-    void updateBucketListSizeAverage();
 // Expose all the fields for testing overrides in order to avoid using
 // special test-only field setters.
 // Access this via
@@ -354,6 +351,9 @@ class SorobanNetworkConfig
 #ifdef BUILD_TESTS
   public:
 #endif
+
+    void writeBucketListSizeWindow(AbstractLedgerTxn& ltxRoot) const;
+    void updateBucketListSizeAverage();
 
     uint32_t mMaxContractSizeBytes{};
     uint32_t mMaxContractDataKeySizeBytes{};


### PR DESCRIPTION
# Description

Resolves #3798

Adds upgrade tests for `BucketListSizeSnapshots` upgrades.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
