### PR TITLE
Fix TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE limits

### DIFF
--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -144,30 +144,30 @@ struct TestOverrideSorobanNetworkConfig
 {
     // Contract size settings
     static constexpr uint32_t MAX_CONTRACT_SIZE =
-        InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE * 32;
+        InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE * 64;
 
     // Contract data settings
     static constexpr uint32_t MAX_CONTRACT_DATA_KEY_SIZE_BYTES =
-        InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES * 10;
+        InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_KEY_SIZE_BYTES * 1000;
     static constexpr uint32_t MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES =
-        InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES * 10;
+        InitialSorobanNetworkConfig::MAX_CONTRACT_DATA_ENTRY_SIZE_BYTES * 1000;
 
     // Compute settings
     static constexpr int64_t TX_MAX_INSTRUCTIONS =
-        InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS * 50;
+        InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS * 100;
     static constexpr int64_t LEDGER_MAX_INSTRUCTIONS = TX_MAX_INSTRUCTIONS;
     static constexpr uint32_t MEMORY_LIMIT =
-        InitialSorobanNetworkConfig::MEMORY_LIMIT * 10;
+        InitialSorobanNetworkConfig::MEMORY_LIMIT * 100;
 
     // Ledger access settings
     static constexpr uint32_t TX_MAX_READ_LEDGER_ENTRIES =
-        InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES * 10;
+        InitialSorobanNetworkConfig::TX_MAX_READ_LEDGER_ENTRIES * 100;
     static constexpr uint32_t TX_MAX_READ_BYTES =
-        InitialSorobanNetworkConfig::TX_MAX_READ_BYTES * 10;
+        InitialSorobanNetworkConfig::TX_MAX_READ_BYTES * 1000;
     static constexpr uint32_t TX_MAX_WRITE_LEDGER_ENTRIES =
-        InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES * 10;
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_LEDGER_ENTRIES * 100;
     static constexpr uint32_t TX_MAX_WRITE_BYTES =
-        InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES * 10;
+        InitialSorobanNetworkConfig::TX_MAX_WRITE_BYTES * 1000;
     static constexpr uint32_t LEDGER_MAX_READ_LEDGER_ENTRIES =
         TX_MAX_READ_LEDGER_ENTRIES;
     static constexpr uint32_t LEDGER_MAX_READ_BYTES = TX_MAX_READ_BYTES;
@@ -177,7 +177,7 @@ struct TestOverrideSorobanNetworkConfig
 
     // Bandwidth settings
     static constexpr uint32_t TX_MAX_SIZE_BYTES =
-        InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES * 5;
+        InitialSorobanNetworkConfig::TX_MAX_SIZE_BYTES * 50;
     static constexpr uint32_t LEDGER_MAX_TRANSACTION_SIZES_BYTES =
         TX_MAX_SIZE_BYTES;
 
@@ -190,7 +190,7 @@ struct TestOverrideSorobanNetworkConfig
 
     // General execution settings
     static constexpr uint32_t LEDGER_MAX_TX_COUNT =
-        InitialSorobanNetworkConfig::LEDGER_MAX_TX_COUNT * 5;
+        InitialSorobanNetworkConfig::LEDGER_MAX_TX_COUNT * 50;
 };
 
 // Wrapper for the contract-related network configuration.


### PR DESCRIPTION
# Description

Adds the change we made for the [v20.0.0-rc.2.1](https://github.com/stellar/stellar-core/releases/tag/v20.0.0-rc.2.1) release. We might end up removing the `TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE` option (I think @leighmcculloch has mentioned a desire to do this), but this PR at least fixes the values for now.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
