### PR TITLE
Adds script and backtraces for linux clang

### DIFF
--- a/scripts/ParseDump.py
+++ b/scripts/ParseDump.py
@@ -1,0 +1,60 @@
+import argparse
+import re
+import subprocess
+
+
+# input: ./src/stellar-core(+0xd9f6bd) [0x55ab4c2456bd]
+def extract_relative_offset(line):
+    if "stellar-core" not in line:
+        return ""
+
+    # extracts (+0xd9f6bd) by matching on (+ ... )
+    # ./src/stellar-core(+0xd9f6bd) [0x55ab4c2456bd] -> (+0xd9f6bd)
+    formated_offset = re.findall(r"\(\+.*?\)", line)
+
+    # Remove first two characters and final character to extract raw offset in 0x.. form
+    # (+0xd9f6bd) -> 0xd9f6bd
+    return formated_offset[0][2:-1]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Provide human readable stack trace for stellar-core traces."
+    )
+
+    parser.add_argument(
+        "exe",
+        type=argparse.FileType("r"),
+        help="Filepath to stellar-core executable with debug symbols installed",
+    )
+
+    parser.add_argument(
+        "stack_trace",
+        help="Stack trace reported by stellar-core (should start with something like: ./src/stellar-core(+0xd9f6bd) [0x55a1fcb7d6bd])",
+    )
+
+    args = parser.parse_args()
+    stack_traces = args.stack_trace.split("\n")
+
+    addr2line_base_args = [
+        "addr2line",
+        "-f",  # Display function names
+        "-C",  # Demangle function names
+        "-p",  # Pretty print to human readable form
+        "-s",  # Only show file base names
+        "-e",
+        args.exe.name,
+    ]
+
+    for line in stack_traces:
+        relative_offset = extract_relative_offset(line)
+        if not relative_offset:
+            print("??")
+        else:
+            command = addr2line_base_args.copy()
+            command.append(relative_offset)
+            subprocess.run(command)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,5 +31,25 @@ This folder is for storing any scripts that may be helpful for using stellar-cor
 - Description - A Python script that compares two CSV files produced by `tracy-csvexport` (which in turn reads output from `tracy-capture`). The purpose of this script is to detect significant performance impacts of changes to stellar-core by capturing before-and-after traces.
 - Usage - Ex. `tracy-capture -o old.tracy -s 10 -a 127.0.0.1` to capture a 10 second trace of stellar-core running on the local machine. Then run `tracy-csvexport -u old.tracy >old.csv`. Then make a change to stellar-core and repeat the process to capture `new.tracy` and `new.csv`. Finally, run `DiffTracyCSV.py --old old.csv --new new.csv` and inspect the differences.
 
+### Parse Backtrace Dump
+
+- Name - `ParseDump.py`
+- Description - A Python script that translates raw backtrace dumps to a human-readable format. If core crashes, on most compiler/OSes, a human readable stack trace is logged. This is not possible on linux clang. Instead, linux clang logs a raw stack trace that must be processed by the script.
+- Usage - Ex. `ParseDump.py ./src/stellar-core "./src/stellar-core(+0xd9f6d5) [0x55c7cdb506d5]"`. The first argument is the path to a `stellar-core` executable with debug symbols. This exe must be the same version of `stellar-core` that produced the stack trace. However, only the exe argument for `ParseDump.py` needs debug symbols. The `stellar-core` exe that produced the backtrace does not need debug symbols. The second argument is a single string containing the backtrace to process. This string should contain a series of new-line delimited raw traces as follows:
+
+```
+"./src/stellar-core(+0x1987a5) [0x55c7ccf497a5]
+./src/stellar-core(+0x4f538b) [0x55c7cd2a638b]
+./src/stellar-core(+0x8ace59) [0x55c7cd65de59]
+./src/stellar-core(+0x8a36d2) [0x55c7cd6546d2]
+./src/stellar-core(+0x9b1916) [0x55c7cd762916]
+./src/stellar-core(+0x9d0c10) [0x55c7cd781c10]
+./src/stellar-core(+0xa413ec) [0x55c7cd7f23ec]
+./src/stellar-core(+0xa3081a) [0x55c7cd7e181a]
+./src/stellar-core(+0xa3a0e4) [0x55c7cd7eb0e4]
+./src/stellar-core(+0xa44fe7) [0x55c7cd7f5fe7]
+./src/stellar-core(+0x34f0c1) [0x55c7cd1000c1]"
+```
+
 ## Style guide
 We follow [PEP-0008](https://www.python.org/dev/peps/pep-0008/).

--- a/src/util/Backtrace.cpp
+++ b/src/util/Backtrace.cpp
@@ -149,13 +149,44 @@ printCurrentBacktrace()
 }
 
 #else
+#include <execinfo.h>
+
 namespace stellar
 {
+
+static constexpr int MAX_SIZE = 1024;
 
 void
 printCurrentBacktrace()
 {
-    fprintf(stderr, "backtrace unavailable\n");
+    if (!threadIsMain())
+    {
+        return;
+    }
+
+    if (getenv("STELLAR_NO_BACKTRACE") != nullptr)
+    {
+        return;
+    }
+
+    void* array[MAX_SIZE];
+    size_t size = backtrace(array, MAX_SIZE);
+    char** strings = backtrace_symbols(array, size);
+    if (!strings)
+    {
+        fprintf(stderr, "backtrace unavailable\n");
+        return;
+    }
+
+    fprintf(stderr, "Cannot provide readable stack trace. Use ParseDump.py to "
+                    "translate stack.\n");
+
+    for (size_t i = 0; i < size; ++i)
+    {
+        fprintf(stderr, "%s\n", strings[i]);
+    }
+
+    free(strings);
     fflush(stderr);
 }
 }


### PR DESCRIPTION
# Description

Resolves #3882 

Previously, we added functionality to print stack traces to the console. However, this is broken on Linux Clang, which happens to be the chosen flavor for most validators (see [this](https://github.com/stellar/stellar-core/pull/2770)). Clang is still broken, but this PR adds functionality for printing the raw stack trace to console. This can then be retroactively parsed using the included Python script.

When failing an assert, the following is printed to the console:
```
false at catchup/AssumeStateWork.cpp:25
Cannot provide readable stack trace. Use parse-dump.py to translate stack.
./src/stellar-core(+0xd9f71c) [0x5560381f871c]
./src/stellar-core(+0x1987a5) [0x5560375f17a5]
./src/stellar-core(+0x4f538b) [0x55603794e38b]
./src/stellar-core(+0x8ace59) [0x556037d05e59]
./src/stellar-core(+0x8a36d2) [0x556037cfc6d2]
./src/stellar-core(+0x9b1916) [0x556037e0a916]
./src/stellar-core(+0x9d0c10) [0x556037e29c10]
./src/stellar-core(+0xa413ec) [0x556037e9a3ec]
./src/stellar-core(+0xa3081a) [0x556037e8981a]
./src/stellar-core(+0xa3a0e4) [0x556037e930e4]
./src/stellar-core(+0xa44fe7) [0x556037e9dfe7]
./src/stellar-core(+0x34f0c1) [0x5560377a80c1]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d8f) [0x7fdf96029d8f]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x7f) [0x7fdf96029e3f]
./src/stellar-core(+0x375c74) [0x5560377cec74]
[1]    331991 IOT instruction (core dumped)  ./src/stellar-core run --ll info --console --conf 
```

The script `parse-dump.py` will then translate this to the following trace:
```
stellar::printCurrentBacktrace() at Backtrace.cpp:185
stellar::printAssertFailureAndAbort(char const*, char const*, int) at GlobalChecks.cpp:68
stellar::AssumeStateWork::AssumeStateWork(stellar::Application&, stellar::HistoryArchiveState const&, unsigned int) at AssumeStateWork.cpp:25 (discriminator 1)
void __gnu_cxx::new_allocator<stellar::AssumeStateWork>::construct<stellar::AssumeStateWork, stellar::Application&, stellar::HistoryArchiveState&, unsigned int&>(stellar::AssumeStateWork*, stellar::Application&, stellar::HistoryArchiveState&, unsigned int&) at new_allocator.h:156
std::shared_ptr<stellar::AssumeStateWork> stellar::WorkScheduler::executeWork<stellar::AssumeStateWork, stellar::HistoryArchiveState&, unsigned int&>(stellar::HistoryArchiveState&, unsigned int&) at WorkScheduler.h:35 (discriminator 1)
stellar::ApplicationImpl::start() at ApplicationImpl.cpp:798
stellar::runApp(std::shared_ptr<stellar::Application>) at ApplicationUtils.cpp:278
stellar::run(stellar::CommandLineArgs const&)::{lambda()#1}::operator()() const at CommandLine.cpp:1412
std::function<int ()>::operator()() const at std_function.h:622
stellar::run(stellar::CommandLineArgs const&) at CommandLine.cpp:1320 (discriminator 11)
std::function<int (stellar::CommandLineArgs const&)>::operator()(stellar::CommandLineArgs const&) const at std_function.h:622
main at main.cpp:277
??
??
_start at ??:?
```

The first argument to the script is the path to a `stellar-core` executable that contains debug symbols. While the script needs the exe to contain debug symbols, the exe that generated the dump does not need symbols. As long as the exe originating the dump is built with the `-ggdb` flag, the offsets will be correct, even if debug symbols are stripped after the build. I believe our release builds currently do this, so the script should be compatible with release versions of core. It may be inconvenient to require a full exe with debug symbols instead of just the debug symbols on their own (which is how we currently package releases). While I couldn't find a tool like `addr2line` that was compatible with a stripped exe file and an external debug symbol table, I'm sure I could find something with a little more digging (or worst case we could un-strip the original exe).

The second argument is a single string containing a copy-paste of the raw stack trace. It assumes each line is newline delimited. This is currently in draft form just to see if this would be useful. If so, I'll add in some comments and make the code and script a bit more production worthy.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
