### PR TITLE
Make Wasm upload transactions generated for tests produce valid Wasm

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -143,7 +143,7 @@
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\debug\rust_stellar_core.lib;C:\Program Files\PostgreSQL\15\lib\libpq.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --target-dir $(OutDir)\rust\target --features tracy</Command>
+      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --target-dir $(OutDir)\rust\target --features tracy --features core-vnext</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Rust</Message>
@@ -330,7 +330,7 @@ exit /b 0
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\release\rust_stellar_core.lib;C:\Program Files\PostgreSQL\15\lib\libpq.lib;%(AdditionalDependencies);</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>cargo build --release --target-dir $(OutDir)\rust\target --features tracy</Command>
+      <Command>cargo build --release --target-dir $(OutDir)\rust\target --features tracy --features core-vnext</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Rust</Message>

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -52,6 +52,8 @@ history.publish.success                   | meter     | published completed succ
 history.publish.time                      | timer     | time to successfully publish history
 ledger.age.closed                         | bucket    | time between ledgers
 ledger.age.current-seconds                | counter   | gap between last close ledger time and current time
+ledger.apply.success                      | counter   | count of successfully applied transactions
+ledger.apply.failure                      | counter   | count of failed applied transactions
 ledger.catchup.duration                   | timer     | time between entering LM_CATCHING_UP_STATE and entering LM_SYNCED_STATE
 ledger.invariant.failure                  | counter   | number of times invariants failed
 ledger.ledger.close                       | timer     | time to close a ledger (excluding consensus)

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -58,6 +58,8 @@ class LedgerManagerImpl : public LedgerManager
     medida::Timer& mLedgerClose;
     medida::Buckets& mLedgerAgeClosed;
     medida::Counter& mLedgerAge;
+    medida::Counter& mTransactionApplySucceeded;
+    medida::Counter& mTransactionApplyFailed;
     medida::Timer& mMetaStreamWriteTime;
     VirtualClock::time_point mLastClose;
     bool mRebuildInMemoryState{false};

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -360,6 +360,19 @@ makeValid(ContractDataEntry& cde)
         val.bytes().assign(small_bytes.begin(), small_bytes.end());
         cde.key = val;
     }
+    // Fix the error values.
+    // NB: The internal SCErrors in maps/vecs still may be invalid.
+    // We might want to fix that eventually, but in general a significant
+    // (~80-90%) fraction of generated entries will be valid XDR.
+    if (cde.key.type() == SCV_ERROR)
+    {
+        if (cde.key.error().type() != SCErrorType::SCE_CONTRACT)
+        {
+            cde.key.error().code() = static_cast<SCErrorCode>(
+                std::abs(cde.key.error().code()) %
+                xdr::xdr_traits<SCErrorCode>::enum_values().size());
+        }
+    }
 }
 
 void

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -187,6 +187,12 @@ TransactionFramePtr createCreditPaymentTx(Application& app,
 TransactionFramePtr createSimpleDexTx(Application& app, TestAccount& account,
                                       uint32 nbOps, uint32_t fee);
 
+// Generates `UPLOAD_CONTRACT_WASM` host function operation with
+// valid Wasm of *roughly* `generatedWasmSize` (within a few bytes).
+// The output size deterministically depends on the input
+// `generatedWasmSize`.
+Operation createUploadWasmOperation(uint32_t generatedWasmSize);
+
 TransactionFramePtr createUploadWasmTx(
     Application& app, TestAccount& account, uint32_t inclusionFee,
     uint32_t resourceFee, SorobanResources resources,

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -282,6 +282,8 @@ InvokeHostFunctionOpFrame::maybePopulateDiagnosticEvents(
             DiagnosticEvent evt;
             xdr::xdr_from_opaque(e.data, evt);
             diagnosticEvents.emplace_back(evt);
+            CLOG_DEBUG(Tx, "Soroban diagnostic event: {}",
+                       xdr::xdr_to_string(evt));
         }
 
         // add additional diagnostic events for metrics


### PR DESCRIPTION
# Description

Make Wasm upload transactions generated for tests produce valid Wasm.

Also modified the load gen to generated Soroban transactions that can be successfully applied ~80-90% of time vs 0% currently. Also updated one test to actually make sure that some Soroban txs are applied to the ledger (involving two new counters in LedgerManager).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
