### PR TITLE
Make hash-xdr.h not fail silently during build

### DIFF
--- a/hash-xdrs.sh
+++ b/hash-xdrs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # This file generates a C++ file which contains (filename, hash) pairs for XDR
 # files included in the build. These are included in the stellar-core build to
@@ -7,6 +7,9 @@
 #
 # The goal is to detect the (unfortunately easy) condition of C++ and Rust code
 # communicating with each other using different XDR definitions.
+
+set -o errexit
+set -o pipefail
 
 if [ ! -d $1/xdr ]; then
     echo "usage: $0 XDR_PROTOCOL_DIR"


### PR DESCRIPTION
### What
In hash-xdr.h explicitly use bash and fail early on fail or pipefail at any command in the script.

### Why
Without enabling `errexit` or `pipefail` the script will continue to run as if nothing if an error occurs.

A case this happened to me recently is when `sha256sum` is not installed, as is the case commonly on macOS systems.

`pipefail` is not technically part of posix as far as I know, so I changed the hash-bang to reference bash explicitly. I noticed we use the bash hash-bang in another script in this repo too so I assume that is okay.

Close #4013