### PR TITLE
Add Soroban transactions to catchup tests

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2204,19 +2204,17 @@ HerderImpl::updateTransactionQueue(TxSetFrameConstPtr externalizedTxSet)
     auto txsPerPhase =
         externalizedTxSet->createTransactionFrames(mApp.getNetworkID());
 
-    // Generate a transaction set from a random hash and drop invalid
     auto lhhe = mLedgerManager.getLastClosedLedgerHeader();
-    lhhe.hash = HashUtils::random();
 
     auto updateQueue = [&](auto& queue, auto const& applied) {
         queue.removeApplied(applied);
         queue.shift();
         queue.maybeVersionUpgraded();
 
-        auto txSet = queue.getTransactions(lhhe.header);
+        auto txs = queue.getTransactions(lhhe.header);
 
         auto invalidTxs = TxSetUtils::getInvalidTxList(
-            txSet, mApp, 0,
+            txs, mApp, 0,
             getUpperBoundCloseTimeOffset(mApp, lhhe.header.scpValue.closeTime),
             false);
         queue.ban(invalidTxs);

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -998,14 +998,13 @@ TEST_CASE("Catchup with protocol upgrade", "[catchup][history]")
             executeUpgrade(127);
         }
     };
-    SECTION("post-shadow-removal upgrade")
-    {
-        testUpgrade(Bucket::FIRST_PROTOCOL_SHADOWS_REMOVED);
-    }
     SECTION("generalized tx set upgrade")
     {
-
-        testUpgrade(SOROBAN_PROTOCOL_VERSION);
+        if (protocolVersionEquals(Config::CURRENT_LEDGER_PROTOCOL_VERSION,
+                                  SOROBAN_PROTOCOL_VERSION))
+        {
+            testUpgrade(SOROBAN_PROTOCOL_VERSION);
+        }
     }
 }
 

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -953,7 +953,10 @@ TEST_CASE("Catchup with protocol upgrade", "[catchup][history]")
             std::make_shared<RealGenesisTmpDirHistoryConfigurator>();
         CatchupSimulation catchupSimulation{VirtualClock::VIRTUAL_TIME,
                                             configurator};
-
+        REQUIRE(catchupSimulation.getApp()
+                    .getLedgerManager()
+                    .getLastClosedLedgerHeader()
+                    .header.ledgerVersion == 0);
         catchupSimulation.generateRandomLedger(oldVersion);
         std::vector<uint32_t> catchupLedgers = {
             0, std::numeric_limits<uint32_t>::max(), 32, 60};
@@ -969,7 +972,9 @@ TEST_CASE("Catchup with protocol upgrade", "[catchup][history]")
                     count, Config::TESTDB_IN_MEMORY_SQLITE,
                     std::string("full, ") + resumeModeName(count) + ", " +
                         dbModeName(Config::TESTDB_IN_MEMORY_SQLITE));
-
+                REQUIRE(a->getLedgerManager()
+                            .getLastClosedLedgerHeader()
+                            .header.ledgerVersion == 0);
                 REQUIRE(catchupSimulation.catchupOnline(a, checkpointLedger));
             }
         };
@@ -1000,11 +1005,7 @@ TEST_CASE("Catchup with protocol upgrade", "[catchup][history]")
     SECTION("generalized tx set upgrade")
     {
 
-        if (protocolVersionStartsFrom(Config::CURRENT_LEDGER_PROTOCOL_VERSION,
-                                      SOROBAN_PROTOCOL_VERSION))
-        {
-            testUpgrade(SOROBAN_PROTOCOL_VERSION);
-        }
+        testUpgrade(SOROBAN_PROTOCOL_VERSION);
     }
 }
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -64,6 +64,7 @@ TmpDirHistoryConfigurator::configure(Config& cfg, bool writable) const
     }
 
     cfg.HISTORY[d] = HistoryArchiveConfiguration{d, getCmd, putCmd, mkdirCmd};
+    cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = true;
     return cfg;
 }
 
@@ -421,16 +422,22 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
     auto alice = TestAccount{mApp, getAccount("alice")};
     auto bob = TestAccount{mApp, getAccount("bob")};
     auto carol = TestAccount{mApp, getAccount("carol")};
+    auto eve = TestAccount{mApp, getAccount("eve")};
+    auto stroopy = TestAccount{mApp, getAccount("stroopy")};
 
     std::vector<TransactionFrameBasePtr> txs;
+    std::vector<TransactionFrameBasePtr> sorobanTxs;
     if (ledgerSeq < 5)
     {
         txs.push_back(
             root.tx({createAccount(alice, big), createAccount(bob, big),
-                     createAccount(carol, big)}));
+                     createAccount(carol, big), createAccount(stroopy, big),
+                     createAccount(eve, big)}));
     }
-    // Allow an occasional empty ledger
-    else if (rand_flip() || rand_flip())
+    // Allow an occasional empty ledger (but always have some transactions in
+    // the upgrade ledger)
+    else if ((rand_flip() || rand_flip()) ||
+             lm.getLastClosedLedgerNum() + 1 == mUpgradeLedgerSeq)
     {
         // They all randomly send a little to one another every ledger after #4
         if (rand_flip())
@@ -468,16 +475,36 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
         {
             txs.push_back(carol.tx({payment(bob, small)}));
         }
-    }
-    TxSetFrameConstPtr txSet =
-        TxSetFrame::makeFromTransactions(txs, mApp, 0, 0).first;
 
-    CLOG_DEBUG(History, "Closing synthetic ledger {} with {} txs (txhash:{})",
-               ledgerSeq, txSet->sizeTxTotal(),
-               hexAbbrev(txSet->getContentsHash()));
+        // Add soroban transactions
+        if (protocolVersionStartsFrom(
+                lm.getLastClosedLedgerHeader().header.ledgerVersion,
+                SOROBAN_PROTOCOL_VERSION))
+        {
+            SorobanResources res;
+            res.instructions = InitialSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
+            uint32_t inclusion = 100;
+            sorobanTxs.push_back(createUploadWasmTx(
+                mApp, stroopy, inclusion, DEFAULT_TEST_RESOURCE_FEE, res));
+            sorobanTxs.push_back(createUploadWasmTx(
+                mApp, eve, inclusion * 5, DEFAULT_TEST_RESOURCE_FEE, res));
+        }
+    }
+
+    auto phases = protocolVersionStartsFrom(
+                      lm.getLastClosedLedgerHeader().header.ledgerVersion,
+                      SOROBAN_PROTOCOL_VERSION)
+                      ? TxSetFrame::TxPhases{txs, sorobanTxs}
+                      : TxSetFrame::TxPhases{txs};
+    TxSetFrameConstPtr txSet =
+        TxSetFrame::makeFromTransactions(phases, mApp, 0, 0).first;
+
+    CLOG_INFO(History, "Closing synthetic ledger {} with {} txs (txhash:{})",
+              ledgerSeq, txSet->sizeTxTotal(),
+              hexAbbrev(txSet->getContentsHash()));
 
     auto upgrades = xdr::xvector<UpgradeType, 6>{};
-    if (version > 0)
+    if (lm.getLastClosedLedgerHeader().header.ledgerVersion < version)
     {
         auto ledgerUpgrade = LedgerUpgrade{LEDGER_UPGRADE_VERSION};
         ledgerUpgrade.newLedgerVersion() = version;
@@ -511,11 +538,15 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
     aliceBalances.push_back(alice.getBalance());
     bobBalances.push_back(bob.getBalance());
     carolBalances.push_back(carol.getBalance());
+    eveBalances.push_back(eve.getBalance());
+    stroopyBalances.push_back(stroopy.getBalance());
 
     rootSeqs.push_back(root.loadSequenceNumber());
     aliceSeqs.push_back(alice.loadSequenceNumber());
     bobSeqs.push_back(bob.loadSequenceNumber());
     carolSeqs.push_back(carol.loadSequenceNumber());
+    eveSeqs.push_back(eve.loadSequenceNumber());
+    stroopySeqs.push_back(stroopy.loadSequenceNumber());
 }
 
 void
@@ -543,7 +574,8 @@ CatchupSimulation::ensureLedgerAvailable(uint32_t targetLedger)
         }
         else
         {
-            generateRandomLedger();
+            generateRandomLedger(
+                lm.getLastClosedLedgerHeader().header.ledgerVersion);
         }
 
         if (hm.publishCheckpointOnLedgerClose(lcl))
@@ -886,6 +918,8 @@ CatchupSimulation::validateCatchup(Application::pointer app)
     auto alice = TestAccount{*app, getAccount("alice")};
     auto bob = TestAccount{*app, getAccount("bob")};
     auto carol = TestAccount{*app, getAccount("carol")};
+    auto eve = TestAccount{*app, getAccount("eve")};
+    auto stroopy = TestAccount{*app, getAccount("stroopy")};
 
     auto wantSeq = mLedgerSeqs.at(i);
     auto wantHash = mLedgerHashes.at(i);
@@ -943,31 +977,43 @@ CatchupSimulation::validateCatchup(Application::pointer app)
     auto haveAliceBalance = aliceBalances.at(i);
     auto haveBobBalance = bobBalances.at(i);
     auto haveCarolBalance = carolBalances.at(i);
+    auto haveEveBalance = eveBalances.at(i);
+    auto haveStrpBalance = stroopyBalances.at(i);
 
     auto haveRootSeq = rootSeqs.at(i);
     auto haveAliceSeq = aliceSeqs.at(i);
     auto haveBobSeq = bobSeqs.at(i);
     auto haveCarolSeq = carolSeqs.at(i);
+    auto haveEveSeq = eveSeqs.at(i);
+    auto haveStrpSeq = stroopySeqs.at(i);
 
     auto wantRootBalance = root.getBalance();
     auto wantAliceBalance = alice.getBalance();
     auto wantBobBalance = bob.getBalance();
     auto wantCarolBalance = carol.getBalance();
+    auto wantEveBalance = eve.getBalance();
+    auto wantStrpBalance = stroopy.getBalance();
 
     auto wantRootSeq = root.loadSequenceNumber();
     auto wantAliceSeq = alice.loadSequenceNumber();
     auto wantBobSeq = bob.loadSequenceNumber();
     auto wantCarolSeq = carol.loadSequenceNumber();
+    auto wantEveSeq = eve.loadSequenceNumber();
+    auto wantStrpSeq = stroopy.loadSequenceNumber();
 
     CHECK(haveRootBalance == wantRootBalance);
     CHECK(haveAliceBalance == wantAliceBalance);
     CHECK(haveBobBalance == wantBobBalance);
     CHECK(haveCarolBalance == wantCarolBalance);
+    CHECK(haveEveBalance == wantEveBalance);
+    CHECK(haveStrpBalance == wantStrpBalance);
 
     CHECK(haveRootSeq == wantRootSeq);
     CHECK(haveAliceSeq == wantAliceSeq);
     CHECK(haveBobSeq == wantBobSeq);
     CHECK(haveCarolSeq == wantCarolSeq);
+    CHECK(haveEveSeq == wantEveSeq);
+    CHECK(haveStrpSeq == wantStrpSeq);
 }
 
 CatchupPerformedWork

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -199,11 +199,15 @@ class CatchupSimulation
     std::vector<int64_t> aliceBalances;
     std::vector<int64_t> bobBalances;
     std::vector<int64_t> carolBalances;
+    std::vector<int64_t> eveBalances;
+    std::vector<int64_t> stroopyBalances;
 
     std::vector<SequenceNumber> rootSeqs;
     std::vector<SequenceNumber> aliceSeqs;
     std::vector<SequenceNumber> bobSeqs;
     std::vector<SequenceNumber> carolSeqs;
+    std::vector<SequenceNumber> eveSeqs;
+    std::vector<SequenceNumber> stroopySeqs;
 
     uint32_t mUpgradeLedgerSeq{0};
     ProtocolVersion mUpgradeProtocolVersion;


### PR DESCRIPTION
Add basic Soroban transactions to random ledger generation logic to test publish/catchup. We can use @SirTyson's loadgen changes once we have them to generate more interesting Soroban txs in these tests as well