### PR TITLE
Fix SCP driver test.

### DIFF
--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2456,6 +2456,11 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
 
     auto root = TestAccount::createRoot(*app);
     std::vector<TestAccount> accounts;
+    for (int i = 0; i < 1000; ++i)
+    {
+        std::string accountName = fmt::format("A{}", accounts.size());
+        accounts.push_back(root.create(accountName.c_str(), 500000000));
+    }
 
     using TxPair = std::pair<Value, TxSetFrameConstPtr>;
     auto makeTxUpgradePair = [&](HerderImpl& herder, TxSetFrameConstPtr txSet,
@@ -2494,11 +2499,6 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
     };
     auto makeTransactions = [&](int n, int nbOps, uint32 feeMulti) {
         std::vector<TransactionFrameBasePtr> txs(n);
-        while (accounts.size() < n)
-        {
-            std::string accountName = fmt::format("A{}", accounts.size());
-            accounts.push_back(root.create(accountName.c_str(), 500000000));
-        }
         size_t index = 0;
 
         std::generate(std::begin(txs), std::end(txs), [&]() {


### PR DESCRIPTION
# Description

Creating a test account also closes a ledger, so when it was called in the middle of the test we ended up comparing tx sets pointing at different ledger headers.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
