### PR TITLE
Remove ltx from network config getter.

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -842,7 +842,7 @@ BucketList::scanForEviction(Application& app, AbstractLedgerTxn& ltx,
                                   SOROBAN_PROTOCOL_VERSION))
     {
         auto const& networkConfig =
-            app.getLedgerManager().getSorobanNetworkConfig(ltx);
+            app.getLedgerManager().getSorobanNetworkConfig();
         auto const firstScanLevel =
             networkConfig.stateArchivalSettings().startingEvictionScanLevel;
         auto evictionIter = networkConfig.evictionIterator();

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -673,10 +673,7 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
     for_versions_from(20, *app, [&] {
         LedgerManagerForBucketTests& lm = app->getLedgerManager();
 
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto& networkConfig =
-            app->getLedgerManager().getSorobanNetworkConfig(ltx);
-        ltx.~LedgerTxn();
+        auto& networkConfig = app->getLedgerManager().getSorobanNetworkConfig();
 
         uint32_t windowSize = networkConfig.stateArchivalSettings()
                                   .bucketListSizeWindowSampleSize;
@@ -718,7 +715,7 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
 
         // Take snapshots more frequently for faster testing
         app->getLedgerManager()
-            .getMutableSorobanNetworkConfig(ltx)
+            .getMutableSorobanNetworkConfig()
             .setBucketListSnapshotPeriodForTesting(64);
 
         // Generate enough ledgers to fill sliding window
@@ -770,7 +767,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
 
         auto& networkCfg = [&]() -> SorobanNetworkConfig& {
             LedgerTxn ltx(app->getLedgerTxnRoot());
-            return app->getLedgerManager().getMutableSorobanNetworkConfig(ltx);
+            return app->getLedgerManager().getMutableSorobanNetworkConfig();
         }();
 
         auto& stateArchivalSettings = networkCfg.stateArchivalSettings();

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -129,7 +129,7 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                 ltxEvictions.commit();
             }
             mApp.getLedgerManager()
-                .getMutableSorobanNetworkConfig(ltx)
+                .getMutableSorobanNetworkConfig()
                 .maybeSnapshotBucketListSize(ledgerSeq, ltx, mApp);
         }
 

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -463,6 +463,14 @@ CatchupWork::runCatchupStep()
             return res;
         }
     }
+    {
+        LedgerTxn ltx(mApp.getLedgerTxnRoot());
+        if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                      SOROBAN_PROTOCOL_VERSION))
+        {
+            mApp.getLedgerManager().updateNetworkConfig(ltx);
+        }
+    }
 
     // Step 4: Download, verify and apply ledgers, buckets and transactions
 

--- a/src/catchup/CatchupWork.cpp
+++ b/src/catchup/CatchupWork.cpp
@@ -463,14 +463,6 @@ CatchupWork::runCatchupStep()
             return res;
         }
     }
-    {
-        LedgerTxn ltx(mApp.getLedgerTxnRoot());
-        if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
-                                      SOROBAN_PROTOCOL_VERSION))
-        {
-            mApp.getLedgerManager().updateNetworkConfig(ltx);
-        }
-    }
 
     // Step 4: Download, verify and apply ledgers, buckets and transactions
 

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2014,7 +2014,7 @@ HerderImpl::maybeHandleUpgrade()
             // no-op on any earlier protocol
             return;
         }
-        auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig(ltx);
+        auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig();
 
         if (conf.txMaxSizeBytes() > mMaxTxSize)
         {
@@ -2066,7 +2066,7 @@ HerderImpl::start()
         if (protocolVersionStartsFrom(version, SOROBAN_PROTOCOL_VERSION))
         {
             auto const& conf =
-                mApp.getLedgerManager().getSorobanNetworkConfig(ltx);
+                mApp.getLedgerManager().getSorobanNetworkConfig();
             mMaxTxSize = std::max(mMaxTxSize, conf.txMaxSizeBytes());
         }
 

--- a/src/herder/TxQueueLimiter.h
+++ b/src/herder/TxQueueLimiter.h
@@ -88,9 +88,12 @@ class TxQueueLimiter
     void removeTransaction(TransactionFrameBasePtr const& tx);
 #ifdef BUILD_TESTS
     size_t size() const;
+    std::pair<bool, int64>
+    canAddTx(TransactionFrameBasePtr const& tx,
+             TransactionFrameBasePtr const& oldTx,
+             std::vector<std::pair<TxStackPtr, bool>>& txsToEvict);
 #endif
-    Resource maxScaledLedgerResources(bool isSoroban,
-                                      AbstractLedgerTxn& ltxOuter) const;
+    Resource maxScaledLedgerResources(bool isSoroban) const;
 
     // Evict `txsToEvict` from the limiter by calling `evict`.
     // `txsToEvict` should be provided by the `canAddTx` call.
@@ -114,16 +117,12 @@ class TxQueueLimiter
     canAddTx(TransactionFrameBasePtr const& tx,
              TransactionFrameBasePtr const& oldTx,
              std::vector<std::pair<TxStackPtr, bool>>& txsToEvict,
-             AbstractLedgerTxn& ltxOuter);
-    std::pair<bool, int64>
-    canAddTx(TransactionFrameBasePtr const& tx,
-             TransactionFrameBasePtr const& oldTx,
-             std::vector<std::pair<TxStackPtr, bool>>& txsToEvict);
+             uint32_t ledgerVersion);
 
     // Resets the state related to evictions (maximum evicted bid).
     void resetEvictionState();
 
     // Resets the internal transaction container and the eviction state.
-    void reset(AbstractLedgerTxn& ltxOuter);
+    void reset(uint32_t ledgerVersion);
 };
 }

--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -928,7 +928,7 @@ ApplicableTxSetFrame::checkValid(Application& app,
         {
             LedgerTxn ltx(app.getLedgerTxnRoot());
             auto limits = app.getLedgerManager().maxLedgerResources(
-                /* isSoroban */ true, ltx);
+                /* isSoroban */ true);
             if (anyGreater(*totalTxSetRes, limits))
             {
                 CLOG_DEBUG(Herder,
@@ -1435,11 +1435,8 @@ ApplicableTxSetFrame::applySurgePricing(Application& app)
             releaseAssert(isGeneralizedTxSet());
             releaseAssert(phaseType == TxSetFrame::Phase::SOROBAN);
 
-            LedgerTxn ltx(app.getLedgerTxnRoot(), false,
-                          TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
-
             auto limits = app.getLedgerManager().maxLedgerResources(
-                /* isSoroban */ true, ltx);
+                /* isSoroban */ true);
 
             auto byteLimit =
                 std::min(static_cast<int64_t>(MAX_SOROBAN_BYTE_ALLOWANCE),

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1571,15 +1571,9 @@ TEST_CASE("tx set hits overlay byte limit during construction",
         cfg.mLedgerMaxInstructions = max;
     });
 
-    SorobanNetworkConfig conf;
+    auto const& conf = app->getLedgerManager().getSorobanNetworkConfig();
     uint32_t maxContractSize = 0;
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        conf = app->getLedgerManager().getSorobanNetworkConfig(ltx);
-        maxContractSize = app->getLedgerManager()
-                              .getSorobanNetworkConfig(ltx)
-                              .maxContractSizeBytes();
-    }
+    maxContractSize = conf.maxContractSizeBytes();
 
     auto makeTx = [&](TestAccount& acc, TxSetFrame::Phase const& phase) {
         if (phase == TxSetFrame::Phase::SOROBAN)
@@ -1739,11 +1733,8 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
         // Valid classic
         auto tx = makeMultiPayment(acc1, root, 1, 100, 0, 1);
 
-        SorobanNetworkConfig conf;
-        {
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            conf = app->getLedgerManager().getSorobanNetworkConfig(ltx);
-        }
+        SorobanNetworkConfig conf =
+            app->getLedgerManager().getSorobanNetworkConfig();
 
         uint32_t const baseFee = 10'000'000;
         SorobanResources resources;
@@ -3937,9 +3928,8 @@ TEST_CASE("soroban txs accepted by the network",
             simulation->crankForAtLeast(std::chrono::seconds(20), false);
             for (auto node : nodes)
             {
-                LedgerTxn ltx(node->getLedgerTxnRoot());
                 REQUIRE(node->getLedgerManager()
-                            .getSorobanNetworkConfig(ltx)
+                            .getSorobanNetworkConfig()
                             .ledgerMaxTxCount() == ledgerWideLimit * 10);
             }
 

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1158,11 +1158,8 @@ TEST_CASE("Soroban TransactionQueue limits",
     auto account1 = root.create("a1", minBalance2);
     auto account2 = root.create("a2", minBalance2);
 
-    SorobanNetworkConfig conf;
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        conf = app->getLedgerManager().getSorobanNetworkConfig(ltx);
-    }
+    SorobanNetworkConfig conf =
+        app->getLedgerManager().getSorobanNetworkConfig();
 
     SorobanResources resources;
     resources.instructions = 2'000'000;
@@ -1407,18 +1404,14 @@ TEST_CASE("Soroban TransactionQueue limits",
     }
     SECTION("limited lane eviction")
     {
-        std::shared_ptr<Resource> limits = nullptr;
-        {
-            LedgerTxn ltx(app->getLedgerTxnRoot());
-            limits = std::make_shared<Resource>(
-                app->getLedgerManager().maxLedgerResources(true, ltx));
-        }
+        Resource limits = app->getLedgerManager().maxLedgerResources(true);
+
         // Setup limits: generic fits 1 ledger worth of resources, while limited
         // lane fits 1/4 ledger
-        auto limitedLane = std::optional<Resource>(
-            bigDivideOrThrow(*limits, 1, 4, Rounding::ROUND_UP));
+        Resource limitedLane(
+            bigDivideOrThrow(limits, 1, 4, Rounding::ROUND_UP));
         auto config = std::make_shared<SorobanLimitingLaneConfigForTesting>(
-            *limits, limitedLane);
+            limits, limitedLane);
         auto queue = std::make_unique<SurgePricingPriorityQueue>(
             /* isHighestPriority */ false, config, 1);
 

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -252,7 +252,7 @@ makeBucketListSizeWindowSampleSizeTestUpgrade(Application& app,
 {
     // Modify window size
     auto sas = app.getLedgerManager()
-                   .getSorobanNetworkConfig(ltx)
+                   .getSorobanNetworkConfig()
                    .stateArchivalSettings();
     sas.bucketListSizeWindowSampleSize = newWindowSize;
 
@@ -825,10 +825,8 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
     // entries initialized.
     executeUpgrade(*app, makeProtocolVersionUpgrade(
                              static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION)));
-    LedgerTxn ltx(app->getLedgerTxnRoot());
     auto const& sorobanConfig =
-        app->getLedgerManager().getSorobanNetworkConfig(ltx);
-    ltx.commit();
+        app->getLedgerManager().getSorobanNetworkConfig();
     SECTION("unknown config upgrade set is ignored")
     {
         auto contractID = autocheck::generator<Hash>()(5);
@@ -870,8 +868,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             {
                 LedgerTxn ltx2(app->getLedgerTxnRoot());
                 auto& cfg =
-                    app->getLedgerManager().getMutableSorobanNetworkConfig(
-                        ltx2);
+                    app->getLedgerManager().getMutableSorobanNetworkConfig();
 
                 // Populate sliding window with interesting values
                 auto i = 0;
@@ -896,9 +893,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
         {
             auto const newSize = 20;
             populateValuesAndUpgradeSize(newSize);
-            LedgerTxn ltx2(app->getLedgerTxnRoot());
-            auto const& cfg =
-                app->getLedgerManager().getSorobanNetworkConfig(ltx2);
+            auto const& cfg = app->getLedgerManager().getSorobanNetworkConfig();
 
             // Verify that we popped the 10 oldest values
             auto sum = 0;
@@ -919,9 +914,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
         {
             auto const newSize = 40;
             populateValuesAndUpgradeSize(newSize);
-            LedgerTxn ltx2(app->getLedgerTxnRoot());
-            auto const& cfg =
-                app->getLedgerManager().getSorobanNetworkConfig(ltx2);
+            auto const& cfg = app->getLedgerManager().getSorobanNetworkConfig();
 
             // Verify that we backfill 10 copies of the oldest value
             auto sum = 0;
@@ -951,7 +944,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
                 LedgerTxn ltx2(app->getLedgerTxnRoot());
 
                 auto const& cfg =
-                    app->getLedgerManager().getSorobanNetworkConfig(ltx2);
+                    app->getLedgerManager().getSorobanNetworkConfig();
                 initialSize =
                     cfg.mStateArchivalSettings.bucketListSizeWindowSampleSize;
                 initialWindow = cfg.mBucketListSizeSnapshots;
@@ -966,10 +959,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             REQUIRE(configUpgradeSet);
             executeUpgrade(*app, makeConfigUpgrade(*configUpgradeSet));
 
-            LedgerTxn ltx2(app->getLedgerTxnRoot());
-
-            auto const& cfg =
-                app->getLedgerManager().getSorobanNetworkConfig(ltx2);
+            auto const& cfg = app->getLedgerManager().getSorobanNetworkConfig();
             REQUIRE(cfg.mStateArchivalSettings.bucketListSizeWindowSampleSize ==
                     initialSize);
             REQUIRE(cfg.mBucketListSizeSnapshots == initialWindow);
@@ -1082,10 +1072,8 @@ TEST_CASE("Soroban max tx set size upgrade applied to ledger",
     executeUpgrade(*app, makeProtocolVersionUpgrade(
                              static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION)));
 
-    LedgerTxn ltx(app->getLedgerTxnRoot());
     auto const& sorobanConfig =
-        app->getLedgerManager().getSorobanNetworkConfig(ltx);
-    ltx.commit();
+        app->getLedgerManager().getSorobanNetworkConfig();
 
     executeUpgrade(*app, makeMaxSorobanTxSizeUpgrade(123));
     REQUIRE(sorobanConfig.ledgerMaxTxCount() == 123);
@@ -2295,7 +2283,7 @@ TEST_CASE("configuration initialized in version upgrade", "[upgrades]")
             InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE);
 
     // Check that BucketList size window initialized with current BL size
-    auto& networkConfig = app->getLedgerManager().getSorobanNetworkConfig(ltx);
+    auto& networkConfig = app->getLedgerManager().getSorobanNetworkConfig();
     REQUIRE(networkConfig.getAverageBucketListSize() == blSize);
 
     // Check in memory window
@@ -3343,8 +3331,6 @@ TEST_CASE("upgrade to generalized tx set in network", "[upgrades][overlay]")
     {
         for (auto const& node : simulation->getNodes())
         {
-            LedgerTxn ltx(node->getLedgerTxnRoot(), false,
-                          TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
             auto txSet = getLedgerTxSet(*node, ledger);
             REQUIRE(txSet);
             REQUIRE(txSet->sizeTxTotal() > 0);

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -120,21 +120,17 @@ class LedgerManager
     // ledger expressed in number of operations
     virtual uint32_t getLastMaxTxSetSizeOps() const = 0;
 
-    virtual Resource maxLedgerResources(bool isSoroban,
-                                        AbstractLedgerTxn& ltxOuter) = 0;
-    virtual Resource
-    maxSorobanTransactionResources(AbstractLedgerTxn& ltxOuter) = 0;
-
+    virtual Resource maxLedgerResources(bool isSoroban) = 0;
+    virtual Resource maxSorobanTransactionResources() = 0;
+    virtual void updateNetworkConfig(AbstractLedgerTxn& ltx) = 0;
     // Return the network config for Soroban.
     // The config is automatically refreshed on protocol upgrades.
     // Ledger txn here is needed for the sake of lazy load; it won't be
     // used most of the time.
-    virtual SorobanNetworkConfig const&
-    getSorobanNetworkConfig(AbstractLedgerTxn& ltx) = 0;
+    virtual SorobanNetworkConfig const& getSorobanNetworkConfig() = 0;
 
 #ifdef BUILD_TESTS
-    virtual SorobanNetworkConfig&
-    getMutableSorobanNetworkConfig(AbstractLedgerTxn& ltx) = 0;
+    virtual SorobanNetworkConfig& getMutableSorobanNetworkConfig() = 0;
 #endif
 
     // Return the (changing) number of seconds since the LCL closed.

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -379,11 +379,6 @@ LedgerManagerImpl::loadLastKnownLedger(function<void()> handler)
                         }
                     }
                     advanceLedgerPointers(header.current());
-                    if (protocolVersionStartsFrom(ledgerVersion,
-                                                  SOROBAN_PROTOCOL_VERSION))
-                    {
-                        updateNetworkConfig(ltx);
-                    }
                 }
                 handler();
             }
@@ -392,8 +387,6 @@ LedgerManagerImpl::loadLastKnownLedger(function<void()> handler)
         {
             LedgerTxn ltx(mApp.getLedgerTxnRoot());
             advanceLedgerPointers(ltx.loadHeader().current());
-            // Ledger is not ready in this flow yet, so we can't update
-            // the network config.
         }
     }
 }
@@ -1025,6 +1018,13 @@ LedgerManagerImpl::setLastClosedLedger(
 
     mRebuildInMemoryState = false;
     advanceLedgerPointers(lastClosed.header);
+    LedgerTxn ltx2(mApp.getLedgerTxnRoot(), false,
+                   TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
+    if (protocolVersionStartsFrom(ltx2.loadHeader().current().ledgerVersion,
+                                  SOROBAN_PROTOCOL_VERSION))
+    {
+        mApp.getLedgerManager().updateNetworkConfig(ltx2);
+    }
 }
 
 void

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -358,12 +358,13 @@ LedgerManagerImpl::loadLastKnownLedger(function<void()> handler)
                 {
                     LedgerTxn ltx(mApp.getLedgerTxnRoot());
                     auto header = ltx.loadHeader();
+                    uint32_t ledgerVersion = header.current().ledgerVersion;
                     if (mApp.getConfig().MODE_ENABLES_BUCKETLIST)
                     {
                         auto assumeStateWork =
                             mApp.getWorkScheduler()
-                                .executeWork<AssumeStateWork>(
-                                    has, header.current().ledgerVersion);
+                                .executeWork<AssumeStateWork>(has,
+                                                              ledgerVersion);
                         if (assumeStateWork->getState() ==
                             BasicWork::State::WORK_SUCCESS)
                         {
@@ -378,6 +379,11 @@ LedgerManagerImpl::loadLastKnownLedger(function<void()> handler)
                         }
                     }
                     advanceLedgerPointers(header.current());
+                    if (protocolVersionStartsFrom(ledgerVersion,
+                                                  SOROBAN_PROTOCOL_VERSION))
+                    {
+                        updateNetworkConfig(ltx);
+                    }
                 }
                 handler();
             }
@@ -386,6 +392,8 @@ LedgerManagerImpl::loadLastKnownLedger(function<void()> handler)
         {
             LedgerTxn ltx(mApp.getLedgerTxnRoot());
             advanceLedgerPointers(ltx.loadHeader().current());
+            // Ledger is not ready in this flow yet, so we can't update
+            // the network config.
         }
     }
 }
@@ -437,12 +445,11 @@ LedgerManagerImpl::getLastMaxTxSetSizeOps() const
 }
 
 Resource
-LedgerManagerImpl::maxLedgerResources(bool isSoroban,
-                                      AbstractLedgerTxn& ltxOuter)
+LedgerManagerImpl::maxLedgerResources(bool isSoroban)
 {
     if (isSoroban)
     {
-        auto conf = getSorobanNetworkConfig(ltxOuter);
+        auto conf = getSorobanNetworkConfig();
         std::vector<int64_t> limits = {conf.ledgerMaxTxCount(),
                                        conf.ledgerMaxInstructions(),
                                        conf.ledgerMaxTransactionSizesBytes(),
@@ -460,10 +467,9 @@ LedgerManagerImpl::maxLedgerResources(bool isSoroban,
 }
 
 Resource
-LedgerManagerImpl::maxSorobanTransactionResources(AbstractLedgerTxn& ltxOuter)
+LedgerManagerImpl::maxSorobanTransactionResources()
 {
-    auto const& conf =
-        mApp.getLedgerManager().getSorobanNetworkConfig(ltxOuter);
+    auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig();
     int64_t const opCount = 1;
     std::vector<int64_t> limits = {opCount,
                                    conf.txMaxInstructions(),
@@ -520,28 +526,23 @@ LedgerManagerImpl::getLastClosedLedgerNum() const
 }
 
 SorobanNetworkConfig&
-LedgerManagerImpl::getSorobanNetworkConfigInternal(AbstractLedgerTxn& ltx)
+LedgerManagerImpl::getSorobanNetworkConfigInternal()
 {
-    // updateNetworkConfig will throw if protocol version is invalid
-    if (!mSorobanNetworkConfig)
-    {
-        updateNetworkConfig(ltx);
-    }
-
+    releaseAssert(mSorobanNetworkConfig);
     return *mSorobanNetworkConfig;
 }
 
 SorobanNetworkConfig const&
-LedgerManagerImpl::getSorobanNetworkConfig(AbstractLedgerTxn& ltx)
+LedgerManagerImpl::getSorobanNetworkConfig()
 {
-    return getSorobanNetworkConfigInternal(ltx);
+    return getSorobanNetworkConfigInternal();
 }
 
 #ifdef BUILD_TESTS
 SorobanNetworkConfig&
-LedgerManagerImpl::getMutableSorobanNetworkConfig(AbstractLedgerTxn& ltx)
+LedgerManagerImpl::getMutableSorobanNetworkConfig()
 {
-    return getSorobanNetworkConfigInternal(ltx);
+    return getSorobanNetworkConfigInternal();
 }
 #endif
 
@@ -883,9 +884,6 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
             CLOG_ERROR(Ledger, "Unknown exception during upgrade");
         }
     }
-    // Technically only a subset of upgrades affects network configuration, but
-    // it's simpler/safer to just refresh it for any upgrade (sometimes as a
-    // no-op).
     if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
                                   SOROBAN_PROTOCOL_VERSION))
     {
@@ -1533,7 +1531,7 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
             ltxEvictions.commit();
         }
 
-        getSorobanNetworkConfigInternal(ltx).maybeSnapshotBucketListSize(
+        getSorobanNetworkConfigInternal().maybeSnapshotBucketListSize(
             ledgerSeq, ltx, mApp);
     }
 
@@ -1582,7 +1580,7 @@ LedgerManagerImpl::ledgerClosed(
     if (ledgerCloseMeta &&
         protocolVersionStartsFrom(initialLedgerVers, SOROBAN_PROTOCOL_VERSION))
     {
-        auto blSize = getSorobanNetworkConfig(ltx).getAverageBucketListSize();
+        auto blSize = getSorobanNetworkConfig().getAverageBucketListSize();
         ledgerCloseMeta->setTotalByteSizeOfBucketList(blSize);
     }
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -99,8 +99,7 @@ class LedgerManagerImpl : public LedgerManager
 
     void emitNextMeta();
 
-    SorobanNetworkConfig&
-    getSorobanNetworkConfigInternal(AbstractLedgerTxn& ltx);
+    SorobanNetworkConfig& getSorobanNetworkConfigInternal();
 
   protected:
     // initialLedgerVers must be the ledger version at the start of the ledger
@@ -116,17 +115,16 @@ class LedgerManagerImpl : public LedgerManager
 
     void advanceLedgerPointers(LedgerHeader const& header,
                                bool debugLog = true);
-    // Reloads the network configuration from the ledger.
-    // This needs to be called after the protocol upgrades or once
-    // during the catchups/test setup etc.
-    // This call is read-only and hence `ltx` can be read-only.
-    void updateNetworkConfig(AbstractLedgerTxn& ltx);
     void logTxApplyMetrics(AbstractLedgerTxn& ltx, size_t numTxs,
                            size_t numOps);
 
   public:
     LedgerManagerImpl(Application& app);
 
+    // Reloads the network configuration from the ledger.
+    // This needs to be called every time a ledger is closed.
+    // This call is read-only and hence `ltx` can be read-only.
+    void updateNetworkConfig(AbstractLedgerTxn& ltx) override;
     void moveToSynced() override;
     State getState() const override;
     std::string getStateHuman() const override;
@@ -135,20 +133,16 @@ class LedgerManagerImpl : public LedgerManager
 
     uint32_t getLastMaxTxSetSize() const override;
     uint32_t getLastMaxTxSetSizeOps() const override;
-    Resource maxLedgerResources(bool isSoroban,
-                                AbstractLedgerTxn& ltxOuter) override;
-    Resource
-    maxSorobanTransactionResources(AbstractLedgerTxn& ltxOuter) override;
+    Resource maxLedgerResources(bool isSoroban) override;
+    Resource maxSorobanTransactionResources() override;
     int64_t getLastMinBalance(uint32_t ownerCount) const override;
     uint32_t getLastReserve() const override;
     uint32_t getLastTxFee() const override;
     uint32_t getLastClosedLedgerNum() const override;
-    SorobanNetworkConfig const&
-    getSorobanNetworkConfig(AbstractLedgerTxn& ltx) override;
+    SorobanNetworkConfig const& getSorobanNetworkConfig() override;
 
 #ifdef BUILD_TESTS
-    SorobanNetworkConfig&
-    getMutableSorobanNetworkConfig(AbstractLedgerTxn& ltx) override;
+    SorobanNetworkConfig& getMutableSorobanNetworkConfig() override;
 #endif
 
     uint64_t secondsSinceLastLedgerClose() const override;

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -350,7 +350,7 @@ class SorobanNetworkConfig
 // Expose all the fields for testing overrides in order to avoid using
 // special test-only field setters.
 // Access this via
-// `app.getLedgerManager().getMutableSorobanNetworkConfig(ltx)`.
+// `app.getLedgerManager().getMutableSorobanNetworkConfig()`.
 // Important: any manual updates to this will be overwritten in case of
 // **any** network upgrade - tests that perform updates should only update
 // settings via upgrades as well.

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -609,7 +609,7 @@ TEST_CASE_VERSIONS("meta stream contains reasonable meta", "[ledgerclosemeta]")
             {
                 LedgerTxn ltx(app->getLedgerTxnRoot());
                 app->getLedgerManager()
-                    .getMutableSorobanNetworkConfig(ltx)
+                    .getMutableSorobanNetworkConfig()
                     .setBucketListSnapshotPeriodForTesting(1);
             }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -545,6 +545,12 @@ void
 ApplicationImpl::reportInfo(bool verbose)
 {
     mLedgerManager->loadLastKnownLedger(nullptr);
+    LedgerTxn ltx(getLedgerTxnRoot());
+    if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                  SOROBAN_PROTOCOL_VERSION))
+    {
+        getLedgerManager().updateNetworkConfig(ltx);
+    }
     LOG_INFO(DEFAULT_LOG, "Reporting application info");
     std::cout << getJsonInfo(verbose).toStyledString() << std::endl;
 }

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -796,6 +796,17 @@ ApplicationImpl::start()
 
     bool done = false;
     mLedgerManager->loadLastKnownLedger([this, &done]() {
+        // Make sure to load Soroban network config before
+        // herder starts (tx queue configuration is based on it).
+        {
+            LedgerTxn ltx(getLedgerTxnRoot());
+            if (protocolVersionStartsFrom(
+                    ltx.loadHeader().current().ledgerVersion,
+                    SOROBAN_PROTOCOL_VERSION))
+            {
+                getLedgerManager().updateNetworkConfig(ltx);
+            }
+        }
         // restores Herder's state before starting overlay
         mHerder->start();
         // set known cursors before starting maintenance job

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -446,6 +446,14 @@ selfCheck(Config cfg)
     // We run self-checks from a "loaded but dormant" state where the
     // application is not started, but the LM has loaded the LCL.
     app->getLedgerManager().loadLastKnownLedger(nullptr);
+    {
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                      SOROBAN_PROTOCOL_VERSION))
+        {
+            app->getLedgerManager().updateNetworkConfig(ltx);
+        }
+    }
 
     // First we schedule the cheap, asynchronous "online" checks that get run by
     // the HTTP "self-check" endpoint, and crank until they're done.
@@ -525,6 +533,14 @@ mergeBucketList(Config cfg, std::string const& outputDir)
     Application::pointer app = Application::create(clock, cfg, false);
     app->getLedgerManager().loadLastKnownLedger(nullptr);
     auto& lm = app->getLedgerManager();
+    {
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                      SOROBAN_PROTOCOL_VERSION))
+        {
+            lm.updateNetworkConfig(ltx);
+        }
+    }
     auto& bm = app->getBucketManager();
     HistoryArchiveState has = lm.getLastClosedLedgerHAS();
     auto bucket = bm.mergeBuckets(has);
@@ -562,6 +578,14 @@ dumpLedger(Config cfg, std::string const& outputFile,
     Application::pointer app = Application::create(clock, cfg, false);
     app->getLedgerManager().loadLastKnownLedger(nullptr);
     auto& lm = app->getLedgerManager();
+    {
+        LedgerTxn ltx(app->getLedgerTxnRoot());
+        if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
+                                      SOROBAN_PROTOCOL_VERSION))
+        {
+            lm.updateNetworkConfig(ltx);
+        }
+    }
     HistoryArchiveState has = lm.getLastClosedLedgerHAS();
     std::optional<uint32_t> minLedger;
     if (lastModifiedLedgerCount)

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1279,7 +1279,7 @@ OverlayManagerImpl::getMaxAdvertSize() const
         if (protocolVersionStartsFrom(ltx.loadHeader().current().ledgerVersion,
                                       SOROBAN_PROTOCOL_VERSION))
         {
-            auto limits = mApp.getLedgerManager().getSorobanNetworkConfig(ltx);
+            auto limits = mApp.getLedgerManager().getSorobanNetworkConfig();
             opsToFloodPerLedger += getOpsFloodLedger(
                 limits.ledgerMaxTxCount(), cfg.FLOOD_SOROBAN_RATE_PER_LEDGER);
         }

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -472,18 +472,15 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
                     SorobanResources resources;
                     uint32_t wasmSize{};
                     {
-                        LedgerTxn ltx(
-                            mApp.getLedgerTxnRoot(), true,
-                            TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
                         Resource maxPerTx =
                             mApp.getLedgerManager()
-                                .maxSorobanTransactionResources(ltx);
+                                .maxSorobanTransactionResources();
 
                         resources.instructions = rand_uniform<uint32_t>(
                             1, maxPerTx.getVal(Resource::Type::INSTRUCTIONS));
                         wasmSize = rand_uniform<uint32_t>(
                             1, mApp.getLedgerManager()
-                                   .getSorobanNetworkConfig(ltx)
+                                   .getSorobanNetworkConfig()
                                    .maxContractSizeBytes());
                         resources.readBytes = rand_uniform<uint32_t>(
                             1, maxPerTx.getVal(Resource::Type::READ_BYTES));

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -199,7 +199,8 @@ modifySorobanNetworkConfig(Application& app,
                            std::function<void(SorobanNetworkConfig&)> modifyFn)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
-    auto& cfg = app.getLedgerManager().getMutableSorobanNetworkConfig(ltx);
+    app.getLedgerManager().updateNetworkConfig(ltx);
+    auto& cfg = app.getLedgerManager().getMutableSorobanNetworkConfig();
     modifyFn(cfg);
     cfg.writeAllSettings(ltx);
     ltx.commit();

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -916,7 +916,7 @@ sorobanResourceFee(Application& app, SorobanResources const& resources,
                   TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
     auto feePair = TransactionFrame::computeSorobanResourceFee(
         ltx.loadHeader().current().ledgerVersion, resources, txSize, eventsSize,
-        app.getLedgerManager().getSorobanNetworkConfig(ltx), app.getConfig());
+        app.getLedgerManager().getSorobanNetworkConfig(), app.getConfig());
     return feePair.non_refundable_fee + feePair.refundable_fee;
 }
 

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -129,13 +129,12 @@ ExtendFootprintTTLOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         app.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION, ledgerVersion,
         rustEntryRentChanges,
         app.getLedgerManager()
-            .getSorobanNetworkConfig(ltx)
+            .getSorobanNetworkConfig()
             .rustBridgeRentFeeConfiguration(),
         ledgerSeq);
     if (!mParentTx.consumeRefundableSorobanResources(
             0, rentFee, ledgerVersion,
-            app.getLedgerManager().getSorobanNetworkConfig(ltx),
-            app.getConfig()))
+            app.getLedgerManager().getSorobanNetworkConfig(), app.getConfig()))
     {
         innerResult().code(EXTEND_FOOTPRINT_TTL_INSUFFICIENT_REFUNDABLE_FEE);
         return false;

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -369,7 +369,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     Config const& cfg = app.getConfig();
     HostFunctionMetrics metrics(app.getMetrics());
     auto const& sorobanConfig =
-        app.getLedgerManager().getSorobanNetworkConfig(ltx);
+        app.getLedgerManager().getSorobanNetworkConfig();
 
     // Get the entries for the footprint
     rust::Vec<CxxBuf> ledgerEntryCxxBufs;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -267,7 +267,7 @@ OperationFrame::checkValid(Application& app, SignatureChecker& signatureChecker,
     if (protocolVersionStartsFrom(ledgerVersion, SOROBAN_PROTOCOL_VERSION))
     {
         auto const& sorobanConfig =
-            app.getLedgerManager().getSorobanNetworkConfig(ltx);
+            app.getLedgerManager().getSorobanNetworkConfig();
 
         return doCheckValid(sorobanConfig, ledgerVersion);
     }

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -64,7 +64,7 @@ RestoreFootprintOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
 
     auto const& archivalSettings = app.getLedgerManager()
-                                       .getSorobanNetworkConfig(ltx)
+                                       .getSorobanNetworkConfig()
                                        .stateArchivalSettings();
     rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
     // Extend the TTL on the restored entry to minimum TTL, including
@@ -140,13 +140,12 @@ RestoreFootprintOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         app.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION, ledgerVersion,
         rustEntryRentChanges,
         app.getLedgerManager()
-            .getSorobanNetworkConfig(ltx)
+            .getSorobanNetworkConfig()
             .rustBridgeRentFeeConfiguration(),
         ledgerSeq);
     if (!mParentTx.consumeRefundableSorobanResources(
             0, rentFee, ltx.loadHeader().current().ledgerVersion,
-            app.getLedgerManager().getSorobanNetworkConfig(ltx),
-            app.getConfig()))
+            app.getLedgerManager().getSorobanNetworkConfig(), app.getConfig()))
     {
         innerResult().code(RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
         return false;

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1016,7 +1016,7 @@ TransactionFrame::commonValidPreSeqNum(
             return false;
         }
         auto const& sorobanConfig =
-            app.getLedgerManager().getSorobanNetworkConfig(ltx);
+            app.getLedgerManager().getSorobanNetworkConfig();
         if (!validateSorobanResources(sorobanConfig, ledgerVersion))
         {
             getResult().result.code(txSOROBAN_INVALID);
@@ -1442,8 +1442,7 @@ TransactionFrame::checkValidWithOptionallyChargedFee(
     {
         sorobanResourceFee = computePreApplySorobanResourceFee(
             ltx.loadHeader().current().ledgerVersion,
-            app.getLedgerManager().getSorobanNetworkConfig(ltx),
-            app.getConfig());
+            app.getLedgerManager().getSorobanNetworkConfig(), app.getConfig());
     }
     bool res =
         commonValid(app, signatureChecker, ltx, current, false, chargeFee,
@@ -1649,7 +1648,7 @@ TransactionFrame::applyOperations(SignatureChecker& signatureChecker,
                 // refundable resources.
                 auto preApplyFee = computePreApplySorobanResourceFee(
                     ledgerVersion,
-                    app.getLedgerManager().getSorobanNetworkConfig(ltxTx),
+                    app.getLedgerManager().getSorobanNetworkConfig(),
                     app.getConfig());
                 mFeeRefund = declaredSorobanResourceFee() -
                              preApplyFee.non_refundable_fee;
@@ -1738,7 +1737,6 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
         SignatureChecker signatureChecker{ledgerVersion, getContentsHash(),
                                           getSignatures(mEnvelope)};
 
-        LedgerTxn ltxTx(ltx);
         //  when applying, a failure during tx validation means that
         //  we'll skip trying to apply operations but we'll still
         //  process the sequence number if needed
@@ -1748,10 +1746,10 @@ TransactionFrame::apply(Application& app, AbstractLedgerTxn& ltx,
             isSoroban())
         {
             sorobanResourceFee = computePreApplySorobanResourceFee(
-                ledgerVersion,
-                app.getLedgerManager().getSorobanNetworkConfig(ltxTx),
+                ledgerVersion, app.getLedgerManager().getSorobanNetworkConfig(),
                 app.getConfig());
         }
+        LedgerTxn ltxTx(ltx);
         auto cv = commonValid(app, signatureChecker, ltxTx, 0, true, chargeFee,
                               0, 0, sorobanResourceFee);
         if (cv >= ValidationType::kInvalidUpdateSeqNum)

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -828,12 +828,13 @@ TEST_CASE("non-refundable resource metering", "[tx][soroban]")
         test.txCheckValid(rootTX);
         {
             auto& app = *test.getApp();
-            LedgerTxn ltx(app.getLedgerTxnRoot());
             auto actualFeePair =
                 std::dynamic_pointer_cast<TransactionFrame>(rootTX)
                     ->computePreApplySorobanResourceFee(
-                        ltx.loadHeader().current().ledgerVersion,
-                        app.getLedgerManager().getSorobanNetworkConfig(ltx),
+                        app.getLedgerManager()
+                            .getLastClosedLedgerHeader()
+                            .header.ledgerVersion,
+                        app.getLedgerManager().getSorobanNetworkConfig(),
                         app.getConfig());
             REQUIRE(expectedNonRefundableFee ==
                     actualFeePair.non_refundable_fee);

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -372,8 +372,7 @@ ContractInvocationTest::getRoot()
 SorobanNetworkConfig const&
 ContractInvocationTest::getNetworkCfg()
 {
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    return mApp->getLedgerManager().getSorobanNetworkConfig(ltx);
+    return mApp->getLedgerManager().getSorobanNetworkConfig();
 }
 
 uint32_t


### PR DESCRIPTION
# Description

Remove ltx from network config getter.

There are just a few cases for when the config needs to be re-loaded:

- When closing any ledger (start with protocol 20)
- When restoring the ledger state that is already in protocol 20+ (catchup work and `loadLastKnownLedger` function).

Now the latter cases are handled explicitly, so that every other network config user no longer needs to pass ltx to the getter for 'lazy' loading.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
