### PR TITLE
Soroban loadgen v2

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -362,7 +362,7 @@ format.
 
 ### The following HTTP commands are exposed on test instances
 * **generateload** `generateload[?mode=
-    (create|pay|pretend|mixed_txs)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D]`
+    (create|pay|pretend|mixed_txs|soroban_upload|soroban_invoke_setup|soroban_invoke)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&dataentrieslow=A&dataentrieshigh=B&kilobyteslow=C&kilobyteshigh=T&txsizelow=U&txsizehigh=V&cpulow=W&cpuhigh=X]`
 
     Artificially generate load for testing; must be used with
     `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
@@ -381,6 +381,16 @@ format.
     (containing `PaymentOp` and `ManageBuyOfferOp` operations respectively).
     The fraction of DEX transactions generated is defined by the `dextxpercent`
     parameter (accepts integer value from 0 to 100).
+  * `soroban_upload` mode generates soroban TXs that upload random wasm blobs.
+    Many of these TXs are invalid and not applied, so this test is appropriate
+    for herder and overlay tests.
+  * `soroban_invoke_setup` mode create soroban contract instances to be used by
+    `soroban_invoke`. This mode must be run before `soroban_invoke`.
+  * `soroban_invoke` mode generates valid soroban TXs that invoke a resource
+    intensive contract. Each invocation picks a random amount of resources
+    between some bound. Resource bounds can be set with the `dataentrieslow`,
+    `dataentrieshigh`, `kilobyteslow`, `kilobyteshigh`, `txsizelow`, `txsizehigh`,
+    `cpulow`, `cpuhigh`, where CPU bounds correspond to instruction count.
 
   Non-`create` load generation makes use of the additional parameters:
   * when a nonzero `spikeinterval` is given, a spike will occur every

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -362,7 +362,7 @@ format.
 
 ### The following HTTP commands are exposed on test instances
 * **generateload** `generateload[?mode=
-    (create|pay|pretend|mixed_txs|soroban_upload|soroban_invoke_setup|soroban_invoke)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&dataentrieslow=A&dataentrieshigh=B&kilobyteslow=C&kilobyteshigh=T&txsizelow=U&txsizehigh=V&cpulow=W&cpuhigh=X]`
+    (create|pay|pretend|mixed_txs|soroban_upload|soroban_invoke_setup|soroban_invoke|upgrade_setup|create_upgrade)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&dataentrieslow=A&dataentrieshigh=B&kilobyteslow=C&kilobyteshigh=T&txsizelow=U&txsizehigh=V&cpulow=W&cpuhigh=X]`
 
     Artificially generate load for testing; must be used with
     `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
@@ -391,6 +391,13 @@ format.
     between some bound. Resource bounds can be set with the `dataentrieslow`,
     `dataentrieshigh`, `kilobyteslow`, `kilobyteshigh`, `txsizelow`, `txsizehigh`,
     `cpulow`, `cpuhigh`, where CPU bounds correspond to instruction count.
+  * `upgrade_setup` mode create soroban contract instance to be used by
+    `create_upgrade`. This mode must be run before `create_upgrade`.
+  * `create_upgrade` mode write a soroban upgrade set and returns the
+    ConfigUpgradeSetKey. Most network config settings are supports. If a given
+    setting is ommited or set to 0, it is not upgraded and maintains the current
+    value. To not exceed HTTP string limits, the names are very short. See
+    `CommandHandler::generateLoad` for available options.
 
   Non-`create` load generation makes use of the additional parameters:
   * when a nonzero `spikeinterval` is given, a spike will occur every

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3623,7 +3623,7 @@ TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
 
             uint32_t maxInclusionFee = 100'000;
             auto sorobanConfig =
-                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_WASM, 50,
+                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_UPLOAD, 50,
                                             /* nTxs */ 100, baseTxRate * 3,
                                             /* offset */ 0, maxInclusionFee);
 
@@ -3810,7 +3810,7 @@ TEST_CASE("accept soroban txs after network upgrade", "[soroban][herder]")
     }
     // Now generate Soroban txs
     auto sorobanConfig =
-        GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_WASM, 50,
+        GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_UPLOAD, 50,
                                     /* nTxs */ 15, 1, /* offset */ 0);
     sorobanConfig.skipLowFeeTxs = true;
     loadGen.generateLoad(sorobanConfig);
@@ -3891,7 +3891,7 @@ TEST_CASE("soroban txs accepted by the network",
         currLoadGenCount = loadGenDone.count();
         // Now generate soroban txs.
         loadGen.generateLoad(GeneratedLoadConfig::txLoad(
-            LoadGenMode::SOROBAN_WASM, numAccounts,
+            LoadGenMode::SOROBAN_UPLOAD, numAccounts,
             /* nTxs */ 100, desiredTxRate, /*offset*/ 0));
 
         simulation->crankUntil(
@@ -3936,7 +3936,7 @@ TEST_CASE("soroban txs accepted by the network",
             currLoadGenCount = loadGenDone.count();
             // Now generate soroban txs.
             auto loadCfg = GeneratedLoadConfig::txLoad(
-                LoadGenMode::SOROBAN_WASM, numAccounts,
+                LoadGenMode::SOROBAN_UPLOAD, numAccounts,
                 /* nTxs */ 100, desiredTxRate * 5, /*offset*/ 0);
             loadCfg.skipLowFeeTxs = true;
             loadGen.generateLoad(loadCfg);
@@ -3977,7 +3977,7 @@ TEST_CASE("soroban txs accepted by the network",
         {
             // Generate Soroban txs from one node
             loadGen.generateLoad(GeneratedLoadConfig::txLoad(
-                LoadGenMode::SOROBAN_WASM, 50,
+                LoadGenMode::SOROBAN_UPLOAD, 50,
                 /* nTxs */ 500, desiredTxRate, /* offset */ 0));
             // Generate classic txs from another node (with offset to prevent
             // overlapping accounts)
@@ -3989,7 +3989,7 @@ TEST_CASE("soroban txs accepted by the network",
         {
             uint32_t maxInclusionFee = 100'000;
             auto sorobanConfig =
-                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_WASM, 50,
+                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_UPLOAD, 50,
                                             /* nTxs */ 500, desiredTxRate * 3,
                                             /* offset */ 0, maxInclusionFee);
 

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3623,7 +3623,7 @@ TEST_CASE("soroban txs each parameter surge priced", "[soroban][herder]")
 
             uint32_t maxInclusionFee = 100'000;
             auto sorobanConfig =
-                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN, 50,
+                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_WASM, 50,
                                             /* nTxs */ 100, baseTxRate * 3,
                                             /* offset */ 0, maxInclusionFee);
 
@@ -3810,7 +3810,7 @@ TEST_CASE("accept soroban txs after network upgrade", "[soroban][herder]")
     }
     // Now generate Soroban txs
     auto sorobanConfig =
-        GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN, 50,
+        GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_WASM, 50,
                                     /* nTxs */ 15, 1, /* offset */ 0);
     sorobanConfig.skipLowFeeTxs = true;
     loadGen.generateLoad(sorobanConfig);
@@ -3891,7 +3891,7 @@ TEST_CASE("soroban txs accepted by the network",
         currLoadGenCount = loadGenDone.count();
         // Now generate soroban txs.
         loadGen.generateLoad(GeneratedLoadConfig::txLoad(
-            LoadGenMode::SOROBAN, numAccounts,
+            LoadGenMode::SOROBAN_WASM, numAccounts,
             /* nTxs */ 100, desiredTxRate, /*offset*/ 0));
 
         simulation->crankUntil(
@@ -3936,7 +3936,7 @@ TEST_CASE("soroban txs accepted by the network",
             currLoadGenCount = loadGenDone.count();
             // Now generate soroban txs.
             auto loadCfg = GeneratedLoadConfig::txLoad(
-                LoadGenMode::SOROBAN, numAccounts,
+                LoadGenMode::SOROBAN_WASM, numAccounts,
                 /* nTxs */ 100, desiredTxRate * 5, /*offset*/ 0);
             loadCfg.skipLowFeeTxs = true;
             loadGen.generateLoad(loadCfg);
@@ -3977,7 +3977,7 @@ TEST_CASE("soroban txs accepted by the network",
         {
             // Generate Soroban txs from one node
             loadGen.generateLoad(GeneratedLoadConfig::txLoad(
-                LoadGenMode::SOROBAN, 50,
+                LoadGenMode::SOROBAN_WASM, 50,
                 /* nTxs */ 500, desiredTxRate, /* offset */ 0));
             // Generate classic txs from another node (with offset to prevent
             // overlapping accounts)
@@ -3989,7 +3989,7 @@ TEST_CASE("soroban txs accepted by the network",
         {
             uint32_t maxInclusionFee = 100'000;
             auto sorobanConfig =
-                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN, 50,
+                GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_WASM, 50,
                                             /* nTxs */ 500, desiredTxRate * 3,
                                             /* offset */ 0, maxInclusionFee);
 

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1249,11 +1249,22 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
 
         uint32_t numItems = isCreate ? cfg.nAccounts : cfg.nTxs;
         std::string itemType = isCreate ? "accounts" : "txs";
-
-        retStr +=
+        Json::Value res;
+        res["status"] =
             fmt::format(FMT_STRING(" Generating load: {:d} {:s}, {:d} tx/s"),
                         numItems, itemType, cfg.txRate);
         mApp.generateLoad(cfg);
+
+        if (cfg.mode == LoadGenMode::SOROBAN_CREATE_UPGRADE)
+        {
+            auto configUpgradeKey =
+                mApp.getLoadGenerator().getConfigUpgradeSetKey(cfg);
+            auto configUpgradeKeyStr = stellar::decoder::encode_b64(
+                xdr::xdr_to_opaque(configUpgradeKey));
+            res["config_upgrade_set_key"] = configUpgradeKeyStr;
+        }
+
+        retStr = res.toStyledString();
     }
     else
     {

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1173,6 +1173,23 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         // Only for MIXED_TX mode; fraction of DEX transactions.
         cfg.dexTxPercent =
             parseOptionalParamOrDefault<uint32_t>(map, "dextxpercent", 0);
+        // Only for SOROBAN_INVOKE mode, resource consumption bounds
+        cfg.nDataEntriesLow =
+            parseOptionalParamOrDefault<uint32_t>(map, "dataentrieslow", 0);
+        cfg.nDataEntriesHigh =
+            parseOptionalParamOrDefault<uint32_t>(map, "dataentrieshigh", 0);
+        cfg.kiloBytesPerDataEntryLow =
+            parseOptionalParamOrDefault<uint32_t>(map, "kilobyteslow", 0);
+        cfg.kiloBytesPerDataEntryHigh =
+            parseOptionalParamOrDefault<uint32_t>(map, "kilobyteshigh", 0);
+        cfg.txSizeBytesLow =
+            parseOptionalParamOrDefault<uint32_t>(map, "txsizelow", 0);
+        cfg.txSizeBytesHigh =
+            parseOptionalParamOrDefault<uint32_t>(map, "txsizehigh", 0);
+        cfg.instructionsLow =
+            parseOptionalParamOrDefault<uint64_t>(map, "cpulow", 0);
+        cfg.instructionsHigh =
+            parseOptionalParamOrDefault<uint64_t>(map, "cpuhigh", 0);
 
         if (cfg.maxGeneratedFeeRate)
         {

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1173,6 +1173,7 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         // Only for MIXED_TX mode; fraction of DEX transactions.
         cfg.dexTxPercent =
             parseOptionalParamOrDefault<uint32_t>(map, "dextxpercent", 0);
+
         // Only for SOROBAN_INVOKE mode, resource consumption bounds
         cfg.nDataEntriesLow =
             parseOptionalParamOrDefault<uint32_t>(map, "dataentrieslow", 0);
@@ -1190,6 +1191,50 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             parseOptionalParamOrDefault<uint64_t>(map, "cpulow", 0);
         cfg.instructionsHigh =
             parseOptionalParamOrDefault<uint64_t>(map, "cpuhigh", 0);
+
+        // SOROBAN_CREATE_UPGRADE parameters
+        cfg.maxContractSizeBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctsz", 0);
+        cfg.maxContractDataKeySizeBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctkeysz", 0);
+        cfg.maxContractDataEntrySizeBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctdatasz", 0);
+        cfg.ledgerMaxInstructions =
+            parseOptionalParamOrDefault<uint64_t>(map, "ldgrmxinstrc", 0);
+        cfg.txMaxInstructions =
+            parseOptionalParamOrDefault<uint64_t>(map, "txmxinstrc", 0);
+        cfg.txMemoryLimit =
+            parseOptionalParamOrDefault<uint64_t>(map, "txmemlim", 0);
+        cfg.ledgerMaxReadLedgerEntries =
+            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdntry", 0);
+        cfg.ledgerMaxReadBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdbyt", 0);
+        cfg.ledgerMaxWriteLedgerEntries =
+            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrntry", 0);
+        cfg.ledgerMaxWriteBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrbyt", 0);
+        cfg.ledgerMaxTxCount =
+            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxcnt", 0);
+        cfg.txMaxReadLedgerEntries =
+            parseOptionalParamOrDefault<uint32_t>(map, "txmxrdntry", 0);
+        cfg.txMaxReadBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "txmxrdbyt", 0);
+        cfg.txMaxWriteLedgerEntries =
+            parseOptionalParamOrDefault<uint32_t>(map, "txmxwrntry", 0);
+        cfg.txMaxWriteBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "txmxwrbyt", 0);
+        cfg.txMaxContractEventsSizeBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "txmxevntsz", 0);
+        cfg.ledgerMaxTransactionsSizeBytes =
+            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxsz", 0);
+        cfg.txMaxSizeBytes = parseOptionalParamOrDefault<uint32_t>(
+            map, "txmxsz", cfg.ledgerMaxTransactionsSizeBytes);
+        cfg.bucketListSizeWindowSampleSize =
+            parseOptionalParamOrDefault<uint32_t>(map, "wndowsz", 0);
+        cfg.evictionScanSize = parseOptionalParamOrDefault<uint64_t>(
+            map, "evctsz", cfg.bucketListSizeWindowSampleSize);
+        cfg.startingEvictionScanLevel =
+            parseOptionalParamOrDefault<uint32_t>(map, "evctlvl", 0);
 
         if (cfg.maxGeneratedFeeRate)
         {

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1175,6 +1175,9 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             parseOptionalParamOrDefault<uint32_t>(map, "dextxpercent", 0);
 
         // Only for SOROBAN_INVOKE mode, resource consumption bounds
+        cfg.nInstances =
+            parseOptionalParamOrDefault<uint32_t>(map, "instances", 0);
+        cfg.nWasms = parseOptionalParamOrDefault<uint32_t>(map, "wasms", 0);
         cfg.nDataEntriesLow =
             parseOptionalParamOrDefault<uint32_t>(map, "dataentrieslow", 0);
         cfg.nDataEntriesHigh =

--- a/src/main/test/ApplicationUtilsTests.cpp
+++ b/src/main/test/ApplicationUtilsTests.cpp
@@ -219,7 +219,7 @@ class SimulationHelper
         if (soroban)
         {
             loadGen.generateLoad(GeneratedLoadConfig::txLoad(
-                LoadGenMode::SOROBAN, /* nAccounts */ 50, /* nTxs */ 10,
+                LoadGenMode::SOROBAN_UPLOAD, /* nAccounts */ 50, /* nTxs */ 10,
                 /*txRate*/ 1));
         }
         else

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -197,6 +197,7 @@ mod rust_bridge {
         fn get_test_wasm_add_i32() -> Result<RustBuf>;
         fn get_test_wasm_contract_data() -> Result<RustBuf>;
         fn get_test_wasm_complex() -> Result<RustBuf>;
+        fn get_test_wasm_loadgen() -> Result<RustBuf>;
         fn get_test_wasm_err() -> Result<RustBuf>;
         fn get_write_bytes() -> Result<RustBuf>;
 
@@ -303,6 +304,12 @@ pub(crate) fn get_test_wasm_complex() -> Result<RustBuf, Box<dyn std::error::Err
 pub(crate) fn get_test_wasm_err() -> Result<RustBuf, Box<dyn std::error::Error>> {
     Ok(RustBuf {
         data: soroban_test_wasms::ERR.iter().cloned().collect(),
+    })
+}
+
+pub(crate) fn get_test_wasm_loadgen() -> Result<RustBuf, Box<dyn std::error::Error>> {
+    Ok(RustBuf {
+        data: soroban_test_wasms::LOADGEN.iter().cloned().collect(),
     })
 }
 

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -268,7 +268,7 @@ LoadGenerator::reset(bool resetSoroban)
     mStartTime.reset();
 
     // If we fail during Soroban setup or find a state inconsistency during
-    // SOROBAN_INVOKE, reset persistent state
+    // soroban loadgen, reset persistent state
     if (resetSoroban)
     {
         mContractInstanceKeys.clear();

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -331,6 +331,16 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
             // Must include all TXs
             cfg.skipLowFeeTxs = false;
         }
+
+        if (cfg.mode == LoadGenMode::SOROBAN_INVOKE_SETUP ||
+            cfg.mode == LoadGenMode::SOROBAN_INVOKE)
+        {
+            // Default instances to number of accounts
+            if (cfg.nInstances == 0)
+            {
+                cfg.nInstances = cfg.nAccounts;
+            }
+        }
     }
 
     // During load submission, we must have enough unique source accounts (with

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -94,9 +94,13 @@ LoadGenerator::getMode(std::string const& mode)
     {
         return LoadGenMode::MIXED_TXS;
     }
-    else if (mode == "soroban")
+    else if (mode == "soroban_wasm")
     {
-        return LoadGenMode::SOROBAN;
+        return LoadGenMode::SOROBAN_WASM;
+    }
+    else if (mode == "soroban_invoke")
+    {
+        return LoadGenMode::SOROBAN_INVOKE;
     }
     else
     {
@@ -336,13 +340,14 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
             MIN_UNIQUE_ACCOUNT_MULTIPLIER);
     }
 
-    if (cfg.mode == LoadGenMode::SOROBAN &&
+    if ((cfg.mode == LoadGenMode::SOROBAN_INVOKE ||
+         cfg.mode == LoadGenMode::SOROBAN_WASM) &&
         protocolVersionIsBefore(mApp.getLedgerManager()
                                     .getLastClosedLedgerHeader()
                                     .header.ledgerVersion,
                                 SOROBAN_PROTOCOL_VERSION))
     {
-        errorMsg = "Soroban mode requires protocol version 20 or higher";
+        errorMsg = "Soroban modes require protocol version 20 or higher";
     }
 
     if (errorMsg)
@@ -567,6 +572,7 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
             break;
             case LoadGenMode::SOROBAN_WASM:
             {
+                uint64_t sourceAccountId = getNextAvailableAccount();
                 generateTx = [&]() {
                     SorobanResources resources;
                     uint32_t wasmSize{};
@@ -629,7 +635,8 @@ LoadGenerator::generateLoad(GeneratedLoadConfig cfg)
                 break;
             }
             case SOROBAN_INVOKE:
-                txGenerated = sorobanLoadGenStep(cfg, ledgerNum, generateTx);
+                txGenerated =
+                    sorobanInvokeLoadGenStep(cfg, ledgerNum, generateTx);
                 break;
             }
 
@@ -985,8 +992,9 @@ LoadGenerator::findAccount(uint64_t accountId, uint32_t ledgerNum)
 }
 
 bool
-LoadGenerator::sorobanLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
-                                  LoadGenFunc& generateTx)
+LoadGenerator::sorobanInvokeLoadGenStep(GeneratedLoadConfig& cfg,
+                                        uint32_t ledgerNum,
+                                        LoadGenFunc& generateTx)
 {
     switch (cfg.sorobanPhase)
     {
@@ -1000,8 +1008,10 @@ LoadGenerator::sorobanLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
                 if (accOp)
                 {
                     generateTx = [&]() {
-                        return uploadWasmTransaction(ledgerNum, *accOp,
-                                                     cfg.maxGeneratedFeeRate);
+                        return uploadWasmTransaction(
+                            ledgerNum, *accOp,
+                            generateFee(cfg.maxGeneratedFeeRate, mApp,
+                                        /* opsCnt */ 1));
                     };
 
                     return true;
@@ -1029,7 +1039,9 @@ LoadGenerator::sorobanLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
                 {
                     generateTx = [&]() {
                         return createContractTransaction(
-                            ledgerNum, *accOp, cfg.maxGeneratedFeeRate);
+                            ledgerNum, *accOp,
+                            generateFee(cfg.maxGeneratedFeeRate, mApp,
+                                        /* opsCnt */ 1));
                     };
 
                     return true;
@@ -1056,7 +1068,9 @@ LoadGenerator::sorobanLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
                 {
                     generateTx = [&]() {
                         return invokeStorageTransaction(
-                            ledgerNum, *accOp, cfg.maxGeneratedFeeRate);
+                            ledgerNum, *accOp,
+                            generateFee(cfg.maxGeneratedFeeRate, mApp,
+                                        /* opsCnt */ 1));
                     };
 
                     return true;
@@ -1077,8 +1091,10 @@ LoadGenerator::sorobanLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
         // always be available
         releaseAssert(accOp.has_value());
         generateTx = [&]() {
-            return invokeSorobanLoadTransaction(ledgerNum, *accOp,
-                                                cfg.maxGeneratedFeeRate);
+            return invokeSorobanLoadTransaction(
+                ledgerNum, *accOp,
+                generateFee(cfg.maxGeneratedFeeRate, mApp,
+                            /* opsCnt */ 1));
         };
 
         return true;
@@ -1132,10 +1148,38 @@ LoadGenerator::manageOfferTransaction(
                                            maxGeneratedFeeRate));
 }
 
+static void
+increaseOpSize(Operation& op, uint32_t increaseUpToBytes)
+{
+    if (increaseUpToBytes == 0)
+    {
+        return;
+    }
+
+    SorobanAuthorizationEntry auth;
+    auth.credentials.type(SOROBAN_CREDENTIALS_SOURCE_ACCOUNT);
+    auth.rootInvocation.function.type(
+        SOROBAN_AUTHORIZED_FUNCTION_TYPE_CONTRACT_FN);
+    SCVal val(SCV_BYTES);
+
+    auto const overheadBytes = xdr::xdr_size(auth) + xdr::xdr_size(val);
+    if (overheadBytes > increaseUpToBytes)
+    {
+        increaseUpToBytes = 0;
+    }
+    else
+    {
+        increaseUpToBytes -= overheadBytes;
+    }
+
+    val.bytes().resize(increaseUpToBytes);
+    auth.rootInvocation.function.contractFn().args = {val};
+    op.body.invokeHostFunctionOp().auth = {auth};
+}
+
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
-LoadGenerator::uploadWasmTransaction(
-    uint32_t ledgerNum, uint64_t accountId,
-    std::optional<uint32_t> maxGeneratedFeeRate)
+LoadGenerator::uploadWasmTransaction(uint32_t ledgerNum, uint64_t accountId,
+                                     uint32_t inclusionFee)
 {
     // TODO: Generate Unique WASMs
     auto wasm = rust_bridge::get_test_wasm_contract_data();
@@ -1162,17 +1206,16 @@ LoadGenerator::uploadWasmTransaction(
     resourceFee += 1'000'000;
     auto tx = std::dynamic_pointer_cast<TransactionFrame>(
         sorobanTransactionFrameFromOps(mApp.getNetworkID(), *account,
-                                       {uploadOp}, {}, uploadResources, 1'000,
-                                       resourceFee));
+                                       {uploadOp}, {}, uploadResources,
+                                       inclusionFee, resourceFee));
     mPendingEntries.emplace(accountId,
                             std::vector<LedgerKey>{contractCodeLedgerKey});
     return std::make_pair(account, tx);
 }
 
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
-LoadGenerator::createContractTransaction(
-    uint32_t ledgerNum, uint64_t accountId,
-    std::optional<uint32_t> maxGeneratedFeeRate)
+LoadGenerator::createContractTransaction(uint32_t ledgerNum, uint64_t accountId,
+                                         uint32_t inclusionFee)
 {
     releaseAssert(mCodeKey);
     releaseAssert(mIncompleteContractInstances.find(accountId) ==
@@ -1198,16 +1241,15 @@ LoadGenerator::createContractTransaction(
     resourceFee += 1'000'000;
     auto tx = std::dynamic_pointer_cast<TransactionFrame>(
         sorobanTransactionFrameFromOps(mApp.getNetworkID(), *account,
-                                       {createOp}, {}, createResources, 1'000,
-                                       resourceFee));
+                                       {createOp}, {}, createResources,
+                                       inclusionFee, resourceFee));
 
     return std::make_pair(account, tx);
 }
 
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
-LoadGenerator::invokeStorageTransaction(
-    uint32_t ledgerNum, uint64_t accountId,
-    std::optional<uint32_t> maxGeneratedFeeRate)
+LoadGenerator::invokeStorageTransaction(uint32_t ledgerNum, uint64_t accountId,
+                                        uint32_t inclusionFee)
 {
     auto account = findAccount(accountId, ledgerNum);
     auto instanceIter = mIncompleteContractInstances.find(accountId);
@@ -1244,15 +1286,15 @@ LoadGenerator::invokeStorageTransaction(
 
     auto tx = std::dynamic_pointer_cast<TransactionFrame>(
         sorobanTransactionFrameFromOps(mApp.getNetworkID(), *account, {op}, {},
-                                       resources, 1'000, resourceFee));
+                                       resources, inclusionFee, resourceFee));
 
     return std::make_pair(account, tx);
 }
 
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
-LoadGenerator::invokeSorobanLoadTransaction(
-    uint32_t ledgerNum, uint64_t accountId,
-    std::optional<uint32_t> maxGeneratedFeeRate)
+LoadGenerator::invokeSorobanLoadTransaction(uint32_t ledgerNum,
+                                            uint64_t accountId,
+                                            uint32_t inclusionFee)
 {
     auto account = findAccount(accountId, ledgerNum);
     auto instanceIter = mCompleteContractInstances.find(accountId);
@@ -1273,6 +1315,21 @@ LoadGenerator::invokeSorobanLoadTransaction(
     ihf.invokeContract().functionName = "has_temporary";
     ihf.invokeContract().args = {keySymbol};
 
+    uint32_t txMaxSizeBytes = 0;
+    {
+        LedgerTxn ltx(mApp.getLedgerTxnRoot());
+        txMaxSizeBytes = mApp.getLedgerManager()
+                             .getSorobanNetworkConfig(ltx)
+                             .txMaxSizeBytes();
+    }
+
+    // Approximate TX size before padding, slightly over estimated so we stay
+    // below limits
+    uint32_t const txOverheadBytes = 700;
+    auto paddingBytes =
+        rand_uniform<uint32_t>(0, txMaxSizeBytes - txOverheadBytes);
+    increaseOpSize(op, paddingBytes);
+
     SorobanResources resources;
     resources.footprint.readOnly = instance.readOnlyKeys;
     resources.footprint.readWrite = {storageLK};
@@ -1280,20 +1337,23 @@ LoadGenerator::invokeSorobanLoadTransaction(
     resources.readBytes = 10'000;
     resources.writeBytes = 0;
 
-    auto resourceFee = sorobanResourceFee(mApp, resources, 1000, 40);
+    auto resourceFee =
+        sorobanResourceFee(mApp, resources, txOverheadBytes + paddingBytes, 40);
     resourceFee += 1'000'000;
 
     auto tx = std::dynamic_pointer_cast<TransactionFrame>(
         sorobanTransactionFrameFromOps(mApp.getNetworkID(), *account, {op}, {},
-                                       resources, 1'000, resourceFee));
+                                       resources, inclusionFee, resourceFee));
 
     return std::make_pair(account, tx);
 }
 
 std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
-LoadGenerator::sorobanTransaction(uint32_t ledgerNum, uint64_t accountId,
-                                  SorobanResources resources, size_t wasmSize,
-                                  uint32_t inclusionFee)
+LoadGenerator::sorobanRandomWasmTransaction(uint32_t ledgerNum,
+                                            uint64_t accountId,
+                                            SorobanResources resources,
+                                            size_t wasmSize,
+                                            uint32_t inclusionFee)
 {
     auto account = findAccount(accountId, ledgerNum);
     Operation uploadOp =

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -32,7 +32,10 @@ enum class LoadGenMode
     PRETEND,
     // Mix of payments and DEX-related transactions.
     MIXED_TXS,
-    SOROBAN
+    // Deploy random WASM blobs, for overlay testing
+    SOROBAN_WASM,
+    // Invoke and apply resource intensive TXs
+    SOROBAN_INVOKE
 };
 
 // Soroban load gen occurs in 4 steps:
@@ -79,7 +82,6 @@ struct GeneratedLoadConfig
     uint32_t dexTxPercent = 0;
     // Number and size of ContractData entries that will loaded on each
     // invocation
-    // TODO: Programmatically determine this based on network config
     uint32_t nDataEntries = 0;
     uint32_t bytesPerDataEntry = 0;
 
@@ -231,8 +233,8 @@ class LoadGenerator
 
     // Sets generateTx to correct soroban loadgen function. Returns false if TX
     // could not be created due to pending TXs, true otherwise.
-    bool sorobanLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
-                            LoadGenFunc& generateTx);
+    bool sorobanInvokeLoadGenStep(GeneratedLoadConfig& cfg, uint32_t ledgerNum,
+                                  LoadGenFunc& generateTx);
 
     std::pair<TestAccountPtr, TransactionFramePtr>
     paymentTransaction(uint32_t numAccounts, uint32_t offset,
@@ -250,20 +252,20 @@ class LoadGenerator
                            std::optional<uint32_t> maxGeneratedFeeRate);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     uploadWasmTransaction(uint32_t ledgerNum, uint64_t accountId,
-                          std::optional<uint32_t> maxGeneratedFeeRate);
+                          uint32_t inclusionFee);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     createContractTransaction(uint32_t ledgerNum, uint64_t accountId,
-                              std::optional<uint32_t> maxGeneratedFeeRate);
+                              uint32_t inclusionFee);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     invokeStorageTransaction(uint32_t ledgerNum, uint64_t accountId,
-                             std::optional<uint32_t> maxGeneratedFeeRate);
+                             uint32_t inclusionFee);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     invokeSorobanLoadTransaction(uint32_t ledgerNum, uint64_t accountId,
-                                 std::optional<uint32_t> maxGeneratedFeeRate);
+                                 uint32_t inclusionFee);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
-    sorobanTransaction(uint32_t ledgerNum, uint64_t accountId,
-                       SorobanResources resources, size_t wasmSize,
-                       uint32_t inclusionFee);
+    sorobanRandomWasmTransaction(uint32_t ledgerNum, uint64_t accountId,
+                                 SorobanResources resources, size_t wasmSize,
+                                 uint32_t inclusionFee);
     void maybeHandleFailedTx(TransactionFramePtr tx,
                              TestAccountPtr sourceAccount,
                              TransactionQueue::AddResult status,

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -156,6 +156,9 @@ class LoadGenerator
     // with the remainder.
     void generateLoad(GeneratedLoadConfig cfg);
 
+    ConfigUpgradeSetKey
+    getConfigUpgradeSetKey(GeneratedLoadConfig const& cfg) const;
+
     // Verify cached accounts are properly reflected in the database
     // return any accounts that are inconsistent.
     std::vector<TestAccountPtr> checkAccountSynced(Application& app,
@@ -180,12 +183,6 @@ class LoadGenerator
     getCodeKeyForTesting() const
     {
         return mCodeKey;
-    }
-
-    std::optional<ConfigUpgradeSetKey>
-    getConfigUpgradeSetKeyForTesting() const
-    {
-        return mConfigUpgradeSetKey;
     }
 
   private:
@@ -272,8 +269,6 @@ class LoadGenerator
     std::optional<LedgerKey> mPendingCodeKey{};
     inline static std::optional<LedgerKey> mCodeKey = std::nullopt;
     inline static uint64_t mCodeSize = 0;
-
-    std::optional<ConfigUpgradeSetKey> mConfigUpgradeSetKey{};
 
     // Maps account ID to it's contract instance, where each account has a
     // unique instance

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -39,6 +39,10 @@ enum class LoadGenMode
     // Invoke and apply resource intensive TXs, must run SOROBAN_INVOKE_SETUP
     // first
     SOROBAN_INVOKE,
+    // Setup contract instance for Soroban Network Config Upgrade
+    SOROBAN_UPGRADE_SETUP,
+    // Create upgrade entry
+    SOROBAN_CREATE_UPGRADE
 };
 
 struct GeneratedLoadConfig
@@ -48,6 +52,8 @@ struct GeneratedLoadConfig
 
     static GeneratedLoadConfig createSorobanInvokeSetupLoad(uint32_t nAccounts,
                                                             uint32_t txRate);
+
+    static GeneratedLoadConfig createSorobanUpgradeSetupLoad();
 
     static GeneratedLoadConfig
     txLoad(LoadGenMode mode, uint32_t nAccounts, uint32_t nTxs, uint32_t txRate,
@@ -268,7 +274,7 @@ class LoadGenerator
                            std::optional<uint32_t> maxGeneratedFeeRate);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     uploadWasmTransaction(uint32_t ledgerNum, uint64_t accountId,
-                          uint32_t inclusionFee);
+                          uint32_t inclusionFee, LoadGenMode mode);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     createContractTransaction(uint32_t ledgerNum, uint64_t accountId,
                               uint32_t inclusionFee);
@@ -291,9 +297,8 @@ class LoadGenerator
 
     uint32_t submitCreationTx(uint32_t nAccounts, uint32_t offset,
                               uint32_t ledgerNum);
-    uint32_t submitSorobanPrepareInvokeTX(uint32_t nInstances,
-                                          uint32_t ledgerNum,
-                                          uint32_t inclusionFee);
+    uint32_t submitSorobanSetupTX(uint32_t nInstances, uint32_t ledgerNum,
+                                  uint32_t inclusionFee, LoadGenMode mode);
     bool submitTx(GeneratedLoadConfig const& cfg,
                   std::function<std::pair<LoadGenerator::TestAccountPtr,
                                           TransactionFramePtr>()>

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -55,8 +55,6 @@ struct GeneratedLoadConfig
 
     static GeneratedLoadConfig createSorobanUpgradeSetupLoad();
 
-    static GeneratedLoadConfig createSorobanCreateUpgradeLoad();
-
     static GeneratedLoadConfig
     txLoad(LoadGenMode mode, uint32_t nAccounts, uint32_t nTxs, uint32_t txRate,
            uint32_t offset = 0, std::optional<uint32_t> maxFee = std::nullopt);
@@ -101,6 +99,39 @@ struct GeneratedLoadConfig
     // Instruction count
     uint64_t instructionsLow = 0;
     uint64_t instructionsHigh = 0;
+
+    // Network Upgrade Parameters
+    uint32_t maxContractSizeBytes{};
+    uint32_t maxContractDataKeySizeBytes{};
+    uint32_t maxContractDataEntrySizeBytes{};
+
+    // Compute settings for contracts (instructions and memory).
+    int64_t ledgerMaxInstructions{};
+    int64_t txMaxInstructions{};
+    uint32_t txMemoryLimit{};
+
+    // Ledger access settings for contracts.
+    uint32_t ledgerMaxReadLedgerEntries{};
+    uint32_t ledgerMaxReadBytes{};
+    uint32_t ledgerMaxWriteLedgerEntries{};
+    uint32_t ledgerMaxWriteBytes{};
+    uint32_t ledgerMaxTxCount{};
+    uint32_t txMaxReadLedgerEntries{};
+    uint32_t txMaxReadBytes{};
+    uint32_t txMaxWriteLedgerEntries{};
+    uint32_t txMaxWriteBytes{};
+
+    // Contract events settings.
+    uint32_t txMaxContractEventsSizeBytes{};
+
+    // Bandwidth related data settings for contracts
+    uint32_t ledgerMaxTransactionsSizeBytes{};
+    uint32_t txMaxSizeBytes{};
+
+    // State Expiration setting
+    uint32_t bucketListSizeWindowSampleSize{};
+    uint64_t evictionScanSize{};
+    uint32_t startingEvictionScanLevel{};
 };
 
 class LoadGenerator

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -32,7 +32,7 @@ enum class LoadGenMode
     PRETEND,
     // Mix of payments and DEX-related transactions.
     MIXED_TXS,
-    // Deploy random WASM blobs, for overlay/herder testing
+    // Deploy random Wasm blobs, for overlay/herder testing
     SOROBAN_UPLOAD,
     // Deploy contracts to be used by SOROBAN_INVOKE
     SOROBAN_INVOKE_SETUP,
@@ -90,10 +90,8 @@ struct GeneratedLoadConfig
     int32_t txSizeBytesHigh = 0;
 
     // Instruction count
-    uint64_t guestCyclesLow = 0;
-    uint64_t guestCyclesHigh = 0;
-    uint64_t hostCyclesLow = 0;
-    uint64_t hostCyclesHigh = 0;
+    uint64_t instructionsLow = 0;
+    uint64_t instructionsHigh = 0;
 };
 
 class LoadGenerator
@@ -206,6 +204,7 @@ class LoadGenerator
     // mCodeKey.
     std::optional<LedgerKey> mPendingCodeKey{};
     std::optional<LedgerKey> mCodeKey{};
+    uint64_t mCodeSize{};
 
     // Maps account ID to it's contract instance, where each account has a
     // unique instance

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -55,6 +55,8 @@ struct GeneratedLoadConfig
 
     static GeneratedLoadConfig createSorobanUpgradeSetupLoad();
 
+    static GeneratedLoadConfig createSorobanCreateUpgradeLoad();
+
     static GeneratedLoadConfig
     txLoad(LoadGenMode mode, uint32_t nAccounts, uint32_t nTxs, uint32_t txRate,
            uint32_t offset = 0, std::optional<uint32_t> maxFee = std::nullopt);
@@ -149,6 +151,12 @@ class LoadGenerator
         return mCodeKey;
     }
 
+    std::optional<ConfigUpgradeSetKey>
+    getConfigUpgradeSetKeyForTesting() const
+    {
+        return mConfigUpgradeSetKey;
+    }
+
   private:
     struct TxMetrics
     {
@@ -234,6 +242,8 @@ class LoadGenerator
     inline static std::optional<LedgerKey> mCodeKey = std::nullopt;
     inline static uint64_t mCodeSize = 0;
 
+    std::optional<ConfigUpgradeSetKey> mConfigUpgradeSetKey{};
+
     // Maps account ID to it's contract instance, where each account has a
     // unique instance
     UnorderedMap<uint64_t, ContractInstance> mContractInstances;
@@ -252,6 +262,9 @@ class LoadGenerator
                                           bool initialAccounts);
     bool loadAccount(TestAccount& account, Application& app);
     bool loadAccount(TestAccountPtr account, Application& app);
+
+    SCBytes
+    getConfigUpgradeSetFromLoadConfig(GeneratedLoadConfig const& cfg) const;
 
     std::pair<TestAccountPtr, TestAccountPtr>
     pickAccountPair(uint32_t numAccounts, uint32_t offset, uint32_t ledgerNum,
@@ -281,6 +294,10 @@ class LoadGenerator
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     invokeSorobanLoadTransaction(uint32_t ledgerNum, uint64_t accountId,
                                  GeneratedLoadConfig const& cfg);
+    std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
+    invokeSorobanCreateUpgradeTransaction(uint32_t ledgerNum,
+                                          uint64_t accountId,
+                                          GeneratedLoadConfig const& cfg);
     std::pair<LoadGenerator::TestAccountPtr, TransactionFramePtr>
     sorobanRandomWasmTransaction(uint32_t ledgerNum, uint64_t accountId,
                                  SorobanResources resources, size_t wasmSize,

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -304,7 +304,7 @@ class LoadGenerator
     // mContractInstances at the start of each SOROBAN_INVOKE run
     inline static UnorderedSet<LedgerKey> mContractInstanceKeys = {};
     inline static std::optional<LedgerKey> mCodeKey = std::nullopt;
-    inline static uint64_t mCodeSize = 0;
+    inline static uint64_t mContactOverheadBytes = 0;
 
     // Maps account ID to it's contract instance, where each account has a
     // unique instance

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -88,6 +88,7 @@ struct GeneratedLoadConfig
     {
         return mode == LoadGenMode::PAY || mode == LoadGenMode::PRETEND ||
                mode == LoadGenMode::MIXED_TXS ||
+               mode == LoadGenMode::SOROBAN_UPLOAD ||
                mode == LoadGenMode::SOROBAN_INVOKE ||
                mode == LoadGenMode::SOROBAN_CREATE_UPGRADE;
     }

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -110,6 +110,16 @@ TEST_CASE("generate soroban load", "[loadgen]")
     {
         overrideSorobanNetworkConfigForTest(*node);
         modifySorobanNetworkConfig(*node, [&](SorobanNetworkConfig& cfg) {
+            // Entries should never expire
+            cfg.mStateArchivalSettings.maxEntryTTL = UINT32_MAX;
+            cfg.mStateArchivalSettings.minPersistentTTL = 5'000'000;
+
+            // Set memory and write limits so that we can write all keys in a
+            // single TX during setup
+            cfg.mTxMemoryLimit = UINT32_MAX;
+            cfg.mTxMaxWriteLedgerEntries = cfg.mTxMaxReadLedgerEntries;
+            cfg.mTxMaxWriteBytes = cfg.mTxMaxReadBytes;
+
             // Allow every TX to have the maximum TX resources
             cfg.mLedgerMaxInstructions =
                 cfg.mTxMaxInstructions * cfg.mLedgerMaxTxCount;
@@ -123,10 +133,6 @@ TEST_CASE("generate soroban load", "[loadgen]")
                 cfg.mTxMaxWriteBytes * cfg.mLedgerMaxTxCount;
             cfg.mLedgerMaxTransactionsSizeBytes =
                 cfg.mTxMaxSizeBytes * cfg.mLedgerMaxTxCount;
-
-            // Entries should never expire
-            cfg.mStateArchivalSettings.maxEntryTTL = UINT32_MAX;
-            cfg.mStateArchivalSettings.minPersistentTTL = 5'000'000;
         });
     }
 
@@ -155,8 +161,8 @@ TEST_CASE("generate soroban load", "[loadgen]")
 
     auto const numSorobanTxs = 300;
     auto const numDataEntries = 5;
-    auto cfg = GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN, nAccounts,
-                                           numSorobanTxs,
+    auto cfg = GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_INVOKE,
+                                           nAccounts, numSorobanTxs,
                                            /* txRate */ 1);
     cfg.nDataEntries = numDataEntries;
     cfg.sorobanNoResetForTesting = true;

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -265,6 +265,130 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
     }
 }
 
+TEST_CASE("soroban loadgen config upgrade", "[loadgen][soroban]")
+{
+    Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    Simulation::pointer simulation =
+        Topologies::pair(Simulation::OVER_LOOPBACK, networkID, [](int i) {
+            auto cfg = getTestConfig(i);
+            cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 5000;
+            return cfg;
+        });
+
+    simulation->startAllNodes();
+    simulation->crankUntil(
+        [&]() { return simulation->haveAllExternalized(3, 1); },
+        2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    auto nodes = simulation->getNodes();
+    auto& app = *nodes[0]; // pick a node to generate load
+    auto& loadGen = app.getLoadGenerator();
+
+    auto nAccounts = 5;
+    loadGen.generateLoad(GeneratedLoadConfig::createAccountsLoad(
+        /* nAccounts */ nAccounts,
+        /* txRate */ 1));
+    simulation->crankUntil(
+        [&]() {
+            return app.getMetrics()
+                       .NewMeter({"loadgen", "run", "complete"}, "run")
+                       .count() == 1;
+        },
+        100 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    auto numTxsBefore = nodes[0]
+                            ->getMetrics()
+                            .NewCounter({"ledger", "apply", "success"})
+                            .count();
+
+    loadGen.generateLoad(GeneratedLoadConfig::createSorobanUpgradeSetupLoad());
+    simulation->crankUntil(
+        [&]() {
+            return app.getMetrics()
+                       .NewMeter({"loadgen", "run", "complete"}, "run")
+                       .count() == 2;
+        },
+        100 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    // // Check that Soroban TXs were successfully applied
+    // for (auto node : nodes)
+    // {
+    //     auto& txsSucceeded =
+    //         node->getMetrics().NewCounter({"ledger", "apply", "success"});
+    //     auto& txsFailed =
+    //         node->getMetrics().NewCounter({"ledger", "apply", "failure"});
+
+    //     // Should be 1 upload wasm TX followed by one instance deploy TX per
+    //     // account
+    //     REQUIRE(txsSucceeded.count() == numTxsBefore + nAccounts + 1);
+    //     REQUIRE(txsFailed.count() == 0);
+    // }
+
+    // loadGen.generateLoad(cfg);
+    // simulation->crankUntil(
+    //     [&]() {
+    //         return app.getMetrics()
+    //                    .NewMeter({"loadgen", "run", "complete"}, "run")
+    //                    .count() == 3;
+    //     },
+    //     300 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    // // Check that Soroban TXs were successfully applied
+    // for (auto node : nodes)
+    // {
+    //     auto& txsSucceeded =
+    //         node->getMetrics().NewCounter({"ledger", "apply", "success"});
+    //     auto& txsFailed =
+    //         node->getMetrics().NewCounter({"ledger", "apply", "failure"});
+
+    //     // Because we can't preflight TXs, some invocations will fail due to
+    //     too
+    //     // few resources. This is expected, as our instruction counts are
+    //     // approximations. The following checks will make sure all set up
+    //     // phases succeeded, so only the invoke phase may have acceptable
+    //     failed
+    //     // TXs
+    //     REQUIRE(txsSucceeded.count() > numTxsBefore + numSorobanTxs - 5);
+    //     REQUIRE(txsFailed.count() < 5);
+    // }
+
+    // auto instanceKeys = loadGen.getContractInstanceKeysForTesting();
+    // auto codeKeyOp = loadGen.getCodeKeyForTesting();
+    // REQUIRE(codeKeyOp);
+    // REQUIRE(codeKeyOp->type() == CONTRACT_CODE);
+    // REQUIRE(instanceKeys.size() == static_cast<size_t>(nAccounts));
+
+    // // Check that each key is unique and exists in the DB
+    // UnorderedSet<LedgerKey> keys;
+    // for (auto const& instanceKey : instanceKeys)
+    // {
+    //     REQUIRE(instanceKey.type() == CONTRACT_DATA);
+    //     REQUIRE(instanceKey.contractData().key.type() ==
+    //             SCV_LEDGER_KEY_CONTRACT_INSTANCE);
+    //     REQUIRE(keys.find(instanceKey) == keys.end());
+    //     keys.insert(instanceKey);
+
+    //     auto const& contractID = instanceKey.contractData().contract;
+    //     for (auto i = 0; i < numDataEntries; ++i)
+    //     {
+    //         auto lk = contractDataKey(contractID, txtest::makeU32(i),
+    //                                   ContractDataDurability::PERSISTENT);
+
+    //         LedgerTxn ltx(app.getLedgerTxnRoot());
+    //         auto entry = ltx.load(lk);
+    //         REQUIRE(entry);
+    //         uint32_t sizeBytes = xdr::xdr_size(entry.current());
+    //         uint32_t expectedSize = kilobytesPerDataEntry * 1024;
+    //         REQUIRE(
+    //             (sizeBytes > expectedSize && sizeBytes < 100 +
+    //             expectedSize));
+
+    //         REQUIRE(keys.find(lk) == keys.end());
+    //         keys.insert(lk);
+    //     }
+    // }
+}
+
 TEST_CASE("Multi-op pretend transactions are valid", "[loadgen]")
 {
     Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -371,6 +371,7 @@ TEST_CASE("soroban loadgen config upgrade", "[loadgen][soroban]")
     cfg.evictionScanSize = rand_uniform<int64_t>(INT64_MAX - 10'000, INT64_MAX);
     cfg.startingEvictionScanLevel = rand_uniform<uint32_t>(4, 8);
 
+    auto upgradeSetKey = loadGen.getConfigUpgradeSetKey(cfg);
     auto cfgCopy = cfg;
 
     loadGen.generateLoad(cfg);
@@ -395,14 +396,11 @@ TEST_CASE("soroban loadgen config upgrade", "[loadgen][soroban]")
     }
 
     // Check that the upgrade entry was properly written
-    auto upgradeKeySetOp = loadGen.getConfigUpgradeSetKeyForTesting();
-    REQUIRE(upgradeKeySetOp);
-
     SCVal upgradeHashBytes(SCV_BYTES);
-    upgradeHashBytes.bytes() = xdr::xdr_to_opaque(upgradeKeySetOp->contentHash);
+    upgradeHashBytes.bytes() = xdr::xdr_to_opaque(upgradeSetKey.contentHash);
 
     SCAddress addr(SC_ADDRESS_TYPE_CONTRACT);
-    addr.contractId() = upgradeKeySetOp->contractID;
+    addr.contractId() = upgradeSetKey.contractID;
 
     LedgerKey upgradeLK(CONTRACT_DATA);
     upgradeLK.contractData().durability = TEMPORARY;

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -157,7 +157,7 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
                             .NewCounter({"ledger", "apply", "success"})
                             .count();
 
-    auto const numInstances = 20;
+    auto const numInstances = 10;
 
     loadGen.generateLoad(GeneratedLoadConfig::createSorobanInvokeSetupLoad(
         /* nAccounts */ nAccounts, numInstances,
@@ -196,7 +196,7 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
                                            nAccounts, numSorobanTxs,
                                            /* txRate */ 1);
 
-    cfg.nInstances = 20;
+    cfg.nInstances = numInstances;
 
     // Use tight bounds to we can verify storage works properly
     cfg.nDataEntriesLow = numDataEntries;

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1244,81 +1244,54 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
     }
 }
 
-TEST_CASE("loadgen WASM", "[soroban]")
+TEST_CASE("loadgen Wasm executes properly", "[soroban][loadgen]")
 {
     ContractInvocationTest test(rust_bridge::get_test_wasm_loadgen());
 
-    SECTION("do_work")
+    auto scFunc = makeSymbol("do_work");
+    auto guestCycles = 10;
+    auto hostCycles = 5;
+    auto numEntries = 2;
+    auto sizeKiloBytes = 3;
+
+    // This function should write numEntries keys, where each key ID is
+    // a U32 that starts at startingIndex and is incremented for each key
+    std::vector<LedgerKey> keys;
+    for (auto i = 0; i < numEntries; ++i)
     {
-        auto scFunc = makeSymbol("do_work");
-        auto guestCycles = 10;
-        auto hostCycles = 5;
-
-        SorobanResources resources;
-        resources.footprint.readOnly = test.getContractKeys();
-        resources.instructions = 2'000'000;
-        resources.readBytes = 2'000;
-        resources.writeBytes = 0;
-
-        auto tx = test.createInvokeTx(
-            resources, scFunc, {makeU64(guestCycles), makeU64(hostCycles)},
-            1'000, 3'000'000);
-        test.txCheckValid(tx);
-        auto txm = test.invokeTx(tx, true);
-        auto const& ret = txm->getXDR().v3().sorobanMeta->returnValue.u256();
-
-        // Return value is total number of cycles completed
-        REQUIRE(ret.lo_lo == guestCycles + hostCycles);
+        auto lk = contractDataKey(test.getContractID(), makeU32(i),
+                                  ContractDataDurability::PERSISTENT);
+        keys.emplace_back(lk);
     }
 
-    SECTION("write")
+    SorobanResources resources;
+    resources.footprint.readOnly = test.getContractKeys();
+    resources.instructions = 10'000'000;
+    resources.readBytes = 20'000;
+    resources.writeBytes = 20'000;
+    resources.footprint.readWrite.assign(keys.begin(), keys.end());
+
+    auto tx = test.createInvokeTx(resources, scFunc,
+                                  {makeU64(guestCycles), makeU64(hostCycles),
+                                   makeU32(numEntries), makeU32(sizeKiloBytes)},
+                                  1'000, 10'000'000);
+    test.txCheckValid(tx);
+    auto txm = test.invokeTx(tx, /*expectSuccess*/ true);
+    auto const& ret = txm->getXDR().v3().sorobanMeta->returnValue.u256();
+
+    // Return value is total number of cycles completed
+    REQUIRE(ret.lo_lo == guestCycles + hostCycles);
+
+    for (auto const& key : keys)
     {
-        auto scFunc = makeSymbol("write");
-        auto startingIndex = 2;
-        auto numEntries = 5;
-        auto sizeKiloBytes = 3;
+        LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+        auto ltxe = ltx.load(key);
+        REQUIRE(ltxe);
+        auto size = xdr::xdr_size(ltxe.current());
 
-        // This function should write numEntries keys, where each key ID is
-        // a U32 that starts at startingIndex and is incremented for each key
-        std::vector<LedgerKey> keys;
-        for (auto i = startingIndex; i < startingIndex + numEntries; ++i)
-        {
-            auto lk = contractDataKey(test.getContractID(), makeU32(i),
-                                      ContractDataDurability::PERSISTENT);
-            keys.emplace_back(lk);
-        }
-
-        SorobanResources resources;
-        resources.footprint.readOnly = test.getContractKeys();
-        resources.instructions = 10'000'000;
-        resources.readBytes = 20'000;
-        resources.writeBytes = 20'000;
-        resources.footprint.readWrite.assign(keys.begin(), keys.end());
-
-        auto tx =
-            test.createInvokeTx(resources, scFunc,
-                                {makeU32(startingIndex), makeU32(numEntries),
-                                 makeU32(sizeKiloBytes)},
-                                1'000, 10'000'000);
-        test.txCheckValid(tx);
-        auto txm = test.invokeTx(tx, /*expectSuccess*/ true);
-
-        for (auto const& key : keys)
-        {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
-            auto ltxe = ltx.load(key);
-            REQUIRE(ltxe);
-            auto size = xdr::xdr_size(ltxe.current());
-
-            // Check that size is correct, plus some overhead
-            REQUIRE((size > sizeKiloBytes * 1024 &&
-                     size < sizeKiloBytes * 1024 + 100));
-
-            auto ttlKey = getTTLKey(key);
-            auto ttlxe = ltx.load(ttlKey);
-            REQUIRE(ttlxe);
-            REQUIRE(ttlxe.current().data.ttl().liveUntilLedgerSeq == 5'000'002);
-        }
+        // Check that size is correct, plus some overhead
+        REQUIRE(
+            (size > sizeKiloBytes * 1024 && size < sizeKiloBytes * 1024 + 100));
     }
 }
 

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1244,6 +1244,84 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
     }
 }
 
+TEST_CASE("loadgen WASM", "[soroban]")
+{
+    ContractInvocationTest test(rust_bridge::get_test_wasm_loadgen());
+
+    SECTION("do_work")
+    {
+        auto scFunc = makeSymbol("do_work");
+        auto guestCycles = 10;
+        auto hostCycles = 5;
+
+        SorobanResources resources;
+        resources.footprint.readOnly = test.getContractKeys();
+        resources.instructions = 2'000'000;
+        resources.readBytes = 2'000;
+        resources.writeBytes = 0;
+
+        auto tx = test.createInvokeTx(
+            resources, scFunc, {makeU64(guestCycles), makeU64(hostCycles)},
+            1'000, 3'000'000);
+        test.txCheckValid(tx);
+        auto txm = test.invokeTx(tx, true);
+        auto const& ret = txm->getXDR().v3().sorobanMeta->returnValue.u256();
+
+        // Return value is total number of cycles completed
+        REQUIRE(ret.lo_lo == guestCycles + hostCycles);
+    }
+
+    SECTION("write")
+    {
+        auto scFunc = makeSymbol("write");
+        auto startingIndex = 2;
+        auto numEntries = 5;
+        auto sizeKiloBytes = 3;
+
+        // This function should write numEntries keys, where each key ID is
+        // a U32 that starts at startingIndex and is incremented for each key
+        std::vector<LedgerKey> keys;
+        for (auto i = startingIndex; i < startingIndex + numEntries; ++i)
+        {
+            auto lk = contractDataKey(test.getContractID(), makeU32(i),
+                                      ContractDataDurability::PERSISTENT);
+            keys.emplace_back(lk);
+        }
+
+        SorobanResources resources;
+        resources.footprint.readOnly = test.getContractKeys();
+        resources.instructions = 10'000'000;
+        resources.readBytes = 20'000;
+        resources.writeBytes = 20'000;
+        resources.footprint.readWrite.assign(keys.begin(), keys.end());
+
+        auto tx =
+            test.createInvokeTx(resources, scFunc,
+                                {makeU32(startingIndex), makeU32(numEntries),
+                                 makeU32(sizeKiloBytes)},
+                                1'000, 10'000'000);
+        test.txCheckValid(tx);
+        auto txm = test.invokeTx(tx, /*expectSuccess*/ true);
+
+        for (auto const& key : keys)
+        {
+            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+            auto ltxe = ltx.load(key);
+            REQUIRE(ltxe);
+            auto size = xdr::xdr_size(ltxe.current());
+
+            // Check that size is correct, plus some overhead
+            REQUIRE((size > sizeKiloBytes * 1024 &&
+                     size < sizeKiloBytes * 1024 + 100));
+
+            auto ttlKey = getTTLKey(key);
+            auto ttlxe = ltx.load(ttlKey);
+            REQUIRE(ttlxe);
+            REQUIRE(ttlxe.current().data.ttl().liveUntilLedgerSeq == 5'000'002);
+        }
+    }
+}
+
 TEST_CASE("complex contract", "[tx][soroban]")
 {
     auto complexTest = [&](bool enableDiagnostics) {

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1246,7 +1246,7 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
 
 TEST_CASE("loadgen Wasm executes properly", "[soroban][loadgen]")
 {
-    ContractInvocationTest test(rust_bridge::get_test_wasm_loadgen());
+    WasmContractInvocationTest test(rust_bridge::get_test_wasm_loadgen());
 
     auto scFunc = makeSymbol("do_work");
     auto guestCycles = 10;

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -369,30 +369,6 @@ WasmContractInvocationTest::deployContractWithSourceAccountWithResources(
     mContractID = mContractKeys[0].contractData().contract;
 }
 
-TransactionFrameBasePtr
-ContractInvocationTest::getCreateTx(TestAccount& acc)
-{
-    if (mContractKeys.empty())
-    {
-        throw "Must deploy test contract before calling getCreateTx";
-    }
-
-    SorobanResources createResources{};
-    createResources.instructions = 200'000;
-    createResources.readBytes = 5000;
-    createResources.writeBytes = 5000;
-
-    SCVal scContractSourceRefKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
-    auto [createOp, contractID] = createSorobanCreateOp(
-        *mApp, createResources, mContractKeys[1], acc, scContractSourceRefKey);
-    auto createResourceFee =
-        sorobanResourceFee(*mApp, createResources, 1000, 40) + 40'000;
-
-    return sorobanTransactionFrameFromOps(mApp->getNetworkID(), acc, {createOp},
-                                          {}, createResources, 1000,
-                                          createResourceFee);
-}
-
 ContractInvocationTest::ContractInvocationTest(
     Config cfg, bool useTestLimits,
     std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
@@ -430,20 +406,6 @@ ContractInvocationTest::getLedgerSeq()
 {
     LedgerTxn ltx(mApp->getLedgerTxnRoot());
     return ltx.loadHeader().current().ledgerSeq;
-}
-
-void
-ContractInvocationTest::deployWithResources(
-    SorobanResources const& uploadResources,
-    SorobanResources const& createResources)
-{
-    if (!mContractKeys.empty())
-    {
-        throw "Wasm already uploaded";
-    }
-
-    deployContractWithSourceAccountWithResources(uploadResources,
-                                                 createResources);
 }
 
 int64_t
@@ -644,7 +606,7 @@ WasmContractInvocationTest::getCreateTx(TestAccount& acc)
     createResources.writeBytes = 5000;
 
     SCVal scContractSourceRefKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
-    auto [createOp, contractID] = createOpCommon(
+    auto [createOp, contractID] = createSorobanCreateOp(
         *mApp, createResources, mContractKeys[1], acc, scContractSourceRefKey);
     auto createResourceFee =
         sorobanResourceFee(*mApp, createResources, 1000, 40) + 40'000;

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -78,6 +78,14 @@ makeSymbol(std::string const& str)
 }
 
 SCVal
+makeU64(uint64_t u64)
+{
+    SCVal val(SCV_U64);
+    val.u64() = u64;
+    return val;
+}
+
+SCVal
 makeU32(uint32_t u32)
 {
     SCVal val(SCV_U32);

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -267,9 +267,10 @@ ContractInvocationTest::invokeArchivalOp(TransactionFrameBasePtr tx,
 
 // Returns createOp, contractID pair
 std::pair<Operation, Hash>
-getSorobanCreateOp(Application& app, SorobanResources& createResources,
-                   LedgerKey const& contractCodeLedgerKey, TestAccount& source,
-                   SCVal& scContractSourceRefKey, uint256 salt)
+createSorobanCreateOp(Application& app, SorobanResources& createResources,
+                      LedgerKey const& contractCodeLedgerKey,
+                      TestAccount& source, SCVal& scContractSourceRefKey,
+                      uint256 salt)
 {
     // Deploy the contract instance
     ContractIDPreimage idPreimage(CONTRACT_ID_PREIMAGE_FROM_ADDRESS);
@@ -350,8 +351,8 @@ WasmContractInvocationTest::deployContractWithSourceAccountWithResources(
     // Deploy the contract instance
     SCVal scContractSourceRefKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
     auto [createOp, contractID] =
-        getSorobanCreateOp(*mApp, createResources, contractCodeLedgerKey, mRoot,
-                           scContractSourceRefKey);
+        createSorobanCreateOp(*mApp, createResources, contractCodeLedgerKey,
+                              mRoot, scContractSourceRefKey);
 
     auto createResourceFee =
         sorobanResourceFee(*mApp, createResources, 1000, 40) + 40'000;
@@ -382,7 +383,7 @@ ContractInvocationTest::getCreateTx(TestAccount& acc)
     createResources.writeBytes = 5000;
 
     SCVal scContractSourceRefKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
-    auto [createOp, contractID] = getSorobanCreateOp(
+    auto [createOp, contractID] = createSorobanCreateOp(
         *mApp, createResources, mContractKeys[1], acc, scContractSourceRefKey);
     auto createResourceFee =
         sorobanResourceFee(*mApp, createResources, 1000, 40) + 40'000;
@@ -429,6 +430,20 @@ ContractInvocationTest::getLedgerSeq()
 {
     LedgerTxn ltx(mApp->getLedgerTxnRoot());
     return ltx.loadHeader().current().ledgerSeq;
+}
+
+void
+ContractInvocationTest::deployWithResources(
+    SorobanResources const& uploadResources,
+    SorobanResources const& createResources)
+{
+    if (!mContractKeys.empty())
+    {
+        throw "Wasm already uploaded";
+    }
+
+    deployContractWithSourceAccountWithResources(uploadResources,
+                                                 createResources);
 }
 
 int64_t

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -24,6 +24,7 @@ SCVal makeContractAddressSCVal(SCAddress const& address);
 SCVal makeI32(int32_t i32);
 SCVal makeI128(uint64_t u64);
 SCSymbol makeSymbol(std::string const& str);
+SCVal makeU64(uint64_t u64);
 SCVal makeU32(uint32_t u32);
 SCVal makeBytes(SCBytes bytes);
 

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -47,6 +47,12 @@ void submitTxToCreateContract(Application& app, Operation const& op,
                               Hash const& expectedWasmHash,
                               uint32_t inclusionFee, uint32_t resourceFee);
 
+std::pair<Operation, Hash>
+getSorobanCreateOp(Application& app, SorobanResources& createResources,
+                   LedgerKey const& contractCodeLedgerKey, TestAccount& source,
+                   SCVal& scContractSourceRefKey,
+                   uint256 salt = sha256("salt"));
+
 class ContractInvocationTest
 {
     // Fee constants from rs-soroban-env/soroban-env-host/src/fees.rs

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -49,10 +49,10 @@ void submitTxToCreateContract(Application& app, Operation const& op,
                               uint32_t inclusionFee, uint32_t resourceFee);
 
 std::pair<Operation, Hash>
-getSorobanCreateOp(Application& app, SorobanResources& createResources,
-                   LedgerKey const& contractCodeLedgerKey, TestAccount& source,
-                   SCVal& scContractSourceRefKey,
-                   uint256 salt = sha256("salt"));
+createSorobanCreateOp(Application& app, SorobanResources& createResources,
+                      LedgerKey const& contractCodeLedgerKey,
+                      TestAccount& source, SCVal& scContractSourceRefKey,
+                      uint256 salt = sha256("salt"));
 
 class ContractInvocationTest
 {


### PR DESCRIPTION
# Description

Resolves #3706

Adds `SOROBAN_INVOKE` mode to LoadGen tests, where generated Soroban invoke TXs  applied. Generated TXs are valid and applied by validators in order to test the Soroban TX subsystem. The generated TXs are of arbitrary size and require an arbitrary amount of disk IO and CPU work at apply time. The `GeneratedLoadConfig` `nDataEntries` and `kiloBytesPerDataEntry` determine how much disk IO each TX will require. Currently, for each TX loadgen picks a random TX size and amount of CPU work such that the TX respects NetworkConfig limits, but additional parameters can be added to control this if required.

For each source account, loadgen sets up a unique contract instance and a set of `ContractData` entries that  the TX will load on each invocation. Each account has its own instance and keys to produce the most work possible, but share the same WASM entry. A future update will add support for unique WASM entries. Due to Soroban TX op limits, it takes several dependent TXs across multiple ledgers to set up these contract instances (see `SorobanPhase` for setup).

The previous lodagen Soroban test produces random WASM upload operations, most of which are invalid and never applied. This is still useful for herder and overlay testing and has been renamed to `SOROBAN_WASM`.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
