### PR TITLE
Disable soroban ops in tx fuzzer

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -1989,6 +1989,15 @@ TransactionFuzzer::genFuzz(std::string const& filename)
     for (int i = 0; i < numops; ++i)
     {
         Operation op = gen(FUZZER_INITIAL_CORPUS_OPERATION_GEN_UPPERBOUND);
+        if (op.body.type() == INVOKE_HOST_FUNCTION ||
+            op.body.type() == EXTEND_FOOTPRINT_TTL ||
+            op.body.type() == RESTORE_FOOTPRINT)
+        {
+            // Skip soroban txs for now because setting them up to be valid will
+            // take some time.
+            continue;
+        }
+
         // Use account 0 for the base cases as it's more likely to be useful
         // right away.
         if (!op.sourceAccount)


### PR DESCRIPTION
# Description

The fuzzer is failing because it generates transactions with both soroban and non soroban transactions in a single tx. We should only allow one or the other when generating the ops, but I suspect additional work (like setting the resources in the extension) will be required. Testing these changes is also not trivial (I can't enable afl on my Mac) so I think fixing this should be a p1 issue.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
