### PR TITLE
Add tests for trying to materialize non-serializable Soroban values.

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -140,10 +140,10 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\debug\rust_stellar_core.lib;C:\Program Files\PostgreSQL\15\lib\libpq.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\release\rust_stellar_core.lib;C:\Program Files\PostgreSQL\15\lib\libpq.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --target-dir $(OutDir)\rust\target --features tracy --features core-vnext</Command>
+      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --release --target-dir $(OutDir)\rust\target --features tracy --features core-vnext</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Rust</Message>
@@ -201,10 +201,10 @@ exit /b 0
     </ClCompile>
     <Link>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\debug\rust_stellar_core.lib;C:\Program Files\PostgreSQL\15\lib\libpq.lib;%(AdditionalDependencies);</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\release\rust_stellar_core.lib;C:\Program Files\PostgreSQL\15\lib\libpq.lib;%(AdditionalDependencies);</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --target-dir $(OutDir)\rust\target --features tracy</Command>
+      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --release --target-dir $(OutDir)\rust\target --features tracy</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Rust</Message>
@@ -263,12 +263,12 @@ exit /b 0
     </ClCompile>
     <Link>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\debug\rust_stellar_core.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;psapi.lib;Credui.lib;userenv.lib;bcrypt.lib;ntdll.lib;$(OutDir)\rust\target\release\rust_stellar_core.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>
     </Link>
     <PreBuildEvent>
-      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --target-dir $(OutDir)\rust\target --features tracy --features core-vnext</Command>
+      <Command>(set CFLAGS=-MDd) &amp; (set CXXFLAGS=-MDd) &amp; cargo build --release --target-dir $(OutDir)\rust\target --features tracy --features core-vnext</Command>
     </PreBuildEvent>
     <PreBuildEvent>
       <Message>Rust</Message>
@@ -1575,7 +1575,7 @@ $(OutDir)\bin\cxxbridge.exe ..\..\src\rust\src\lib.rs --output src\$(Configurati
       <Outputs>src\$(Configuration)\generated\rust\RustBridge.h;src\$(Configuration)\generated\rust\RustBridge.cpp</Outputs>
       <OutputItemType>ClInclude</OutputItemType>
       <AdditionalInputs>$(OutDir)\bin\cxxbridge.exe</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">$(OutDir)\bin\cxxbridge.exe;$(OutDir)\rust\target\debug\rust_stellar_core.lib</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">$(OutDir)\bin\cxxbridge.exe;$(OutDir)\rust\target\release\rust_stellar_core.lib</AdditionalInputs>
     </CustomBuild>
     <CustomBuild Include="..\..\src\rust\install-cxxbridge-cmd">
       <FileType>Document</FileType>

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -29,8 +29,8 @@ use super::soroban_env_host::{
     xdr::{
         self, ContractCostParams, ContractEvent, ContractEventBody, ContractEventType,
         ContractEventV0, DiagnosticEvent, ExtensionPoint, LedgerEntry, LedgerEntryData,
-        LedgerEntryExt, Limits, ReadXdr, ScError, ScErrorCode, ScErrorType, ScSymbol, ScVal, TtlEntry,
-        WriteXdr, XDR_FILES_SHA256,
+        LedgerEntryExt, Limits, ReadXdr, ScError, ScErrorCode, ScErrorType, ScSymbol, ScVal,
+        TtlEntry, WriteXdr, XDR_FILES_SHA256,
     },
     HostError, LedgerInfo,
 };
@@ -159,7 +159,10 @@ impl std::error::Error for CoreHostError {}
 fn non_metered_xdr_from_cxx_buf<T: ReadXdr>(buf: &CxxBuf) -> Result<T, HostError> {
     Ok(T::read_xdr(&mut xdr::Limited::new(
         Cursor::new(buf.data.as_slice()),
-        Limits {depth: MARSHALLING_STACK_LIMIT, len: buf.data.len()},
+        Limits {
+            depth: MARSHALLING_STACK_LIMIT,
+            len: buf.data.len(),
+        },
     ))
     // We only expect this to be called for safe, internal conversions, so this
     // should never happen.
@@ -170,7 +173,10 @@ fn non_metered_xdr_to_rust_buf<T: WriteXdr>(t: &T) -> Result<RustBuf, HostError>
     let mut vec: Vec<u8> = Vec::new();
     t.write_xdr(&mut xdr::Limited::new(
         Cursor::new(&mut vec),
-        Limits {depth: MARSHALLING_STACK_LIMIT, len: 5 * 1024 * 1024 /* 5MB */},
+        Limits {
+            depth: MARSHALLING_STACK_LIMIT,
+            len: 5 * 1024 * 1024, /* 5MB */
+        },
     ))
     .map_err(|_| (ScErrorType::Value, ScErrorCode::InvalidInput))?;
     Ok(vec.into())

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -234,6 +234,8 @@ overrideSorobanNetworkConfigForTest(Application& app)
         cfg.mStateArchivalSettings.minPersistentTTL = 20;
         cfg.mStateArchivalSettings.maxEntryTTL = 6'312'000;
         cfg.mLedgerMaxTxCount = 100;
+
+        cfg.mTxMaxContractEventsSizeBytes = 10'000;
     });
 }
 

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -79,7 +79,7 @@ getLedgerInfo(AbstractLedgerTxn& ltx, Application& app,
 }
 
 DiagnosticEvent
-metricsEvent(bool success, std::string&& topic, uint32 value)
+metricsEvent(bool success, std::string&& topic, uint64_t value)
 {
     DiagnosticEvent de;
     de.inSuccessfulContractCall = success;
@@ -99,34 +99,34 @@ struct HostFunctionMetrics
 {
     medida::MetricsRegistry& mMetrics;
 
-    uint32 mReadEntry{0};
-    uint32 mWriteEntry{0};
+    uint32_t mReadEntry{0};
+    uint32_t mWriteEntry{0};
 
-    uint32 mLedgerReadByte{0};
-    uint32 mLedgerWriteByte{0};
+    uint32_t mLedgerReadByte{0};
+    uint32_t mLedgerWriteByte{0};
 
-    uint32 mReadKeyByte{0};
-    uint32 mWriteKeyByte{0};
+    uint32_t mReadKeyByte{0};
+    uint32_t mWriteKeyByte{0};
 
-    uint32 mReadDataByte{0};
-    uint32 mWriteDataByte{0};
+    uint32_t mReadDataByte{0};
+    uint32_t mWriteDataByte{0};
 
-    uint32 mReadCodeByte{0};
-    uint32 mWriteCodeByte{0};
+    uint32_t mReadCodeByte{0};
+    uint32_t mWriteCodeByte{0};
 
-    uint32 mEmitEvent{0};
-    uint32 mEmitEventByte{0};
+    uint32_t mEmitEvent{0};
+    uint32_t mEmitEventByte{0};
 
     // host runtime metrics
-    uint32 mCpuInsn{0};
-    uint32 mMemByte{0};
-    uint32 mInvokeTimeNsecs{0};
+    uint64_t mCpuInsn{0};
+    uint64_t mMemByte{0};
+    uint64_t mInvokeTimeNsecs{0};
 
     // max single entity size metrics
-    uint32 mMaxReadWriteKeyByte{0};
-    uint32 mMaxReadWriteDataByte{0};
-    uint32 mMaxReadWriteCodeByte{0};
-    uint32 mMaxEmitEventByte{0};
+    uint32_t mMaxReadWriteKeyByte{0};
+    uint32_t mMaxReadWriteDataByte{0};
+    uint32_t mMaxReadWriteCodeByte{0};
+    uint32_t mMaxEmitEventByte{0};
 
     bool mSuccess{false};
 
@@ -135,7 +135,7 @@ struct HostFunctionMetrics
     }
 
     void
-    noteReadEntry(bool isCodeEntry, uint32 keySize, uint32 entrySize)
+    noteReadEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
     {
         mReadEntry++;
         mReadKeyByte += keySize;
@@ -154,7 +154,7 @@ struct HostFunctionMetrics
     }
 
     void
-    noteWriteEntry(bool isCodeEntry, uint32 keySize, uint32 entrySize)
+    noteWriteEntry(bool isCodeEntry, uint32_t keySize, uint32_t entrySize)
     {
         mWriteEntry++;
         mMaxReadWriteKeyByte = std::max(mMaxReadWriteKeyByte, keySize);
@@ -379,8 +379,8 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
                      &resources, this](auto const& keys) -> bool {
         for (auto const& lk : keys)
         {
-            uint32 keySize = static_cast<uint32>(xdr::xdr_size(lk));
-            uint32 entrySize = 0u;
+            uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
+            uint32_t entrySize = 0u;
             std::optional<TTLEntry> ttlEntry;
             bool sorobanEntryLive = false;
 
@@ -418,7 +418,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
                 if (ltxe)
                 {
                     auto leBuf = toCxxBuf(ltxe.current());
-                    entrySize = static_cast<uint32>(leBuf.data->size());
+                    entrySize = static_cast<uint32_t>(leBuf.data->size());
 
                     // For entry types that don't have an ttlEntry (i.e.
                     // Accounts), the rust host expects an "empty" CxxBuf such
@@ -493,9 +493,9 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             getLedgerInfo(ltx, app, sorobanConfig), ledgerEntryCxxBufs,
             ttlEntryCxxBufs, basePrngSeedBuf,
             sorobanConfig.rustBridgeRentFeeConfiguration());
-        metrics.mCpuInsn = static_cast<uint32>(out.cpu_insns);
-        metrics.mMemByte = static_cast<uint32>(out.mem_bytes);
-        metrics.mInvokeTimeNsecs = static_cast<uint32>(out.time_nsecs);
+        metrics.mCpuInsn = out.cpu_insns;
+        metrics.mMemByte = out.mem_bytes;
+        metrics.mInvokeTimeNsecs = out.time_nsecs;
         if (!out.success)
         {
             maybePopulateDiagnosticEvents(cfg, out, metrics);
@@ -549,8 +549,8 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         auto lk = LedgerEntryKey(le);
         createdAndModifiedKeys.insert(lk);
 
-        uint32 keySize = static_cast<uint32>(xdr::xdr_size(lk));
-        uint32 entrySize = static_cast<uint32>(buf.data.size());
+        uint32_t keySize = static_cast<uint32_t>(xdr::xdr_size(lk));
+        uint32_t entrySize = static_cast<uint32_t>(buf.data.size());
 
         // ttlEntry write fees come out of refundableFee, already
         // accounted for by the host
@@ -627,7 +627,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     for (auto const& buf : out.contract_events)
     {
         metrics.mEmitEvent++;
-        uint32 eventSize = static_cast<uint32>(buf.data.size());
+        uint32_t eventSize = static_cast<uint32_t>(buf.data.size());
         metrics.mEmitEventByte += eventSize;
         metrics.mMaxEmitEventByte =
             std::max(metrics.mMaxEmitEventByte, eventSize);


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/4004

Add tests for trying to materialize non-serializable Soroban values.

Also did some passing-by fixes: cleanup metric types a bit, enable release build in VS for all configurations.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
