### PR TITLE
Validate fuzzer tx for soroban

### DIFF
--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -902,6 +902,15 @@ class FuzzTransactionFrame : public TransactionFrame
     void
     attemptApplication(Application& app, AbstractLedgerTxn& ltx)
     {
+        // Soroban op must be alone in tx
+        if (std::any_of(mOperations.begin(), mOperations.end(),
+                        [](auto const& x) { return x->isSoroban(); }) &&
+            mOperations.size() != 1)
+        {
+            markResultFailed();
+            return;
+        }
+
         // reset results of operations
         resetResults(ltx.getHeader(), 0, true);
 


### PR DESCRIPTION
# Description

Add on to https://github.com/stellar/stellar-core/pull/4032. That PR prevented the initial tests from including Soroban operations, but the fuzzer can still augment the testcases to create an invalid tx.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
