### PR TITLE
Improve the error for the duplicate footprint keys.

### DIFF
--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1086,7 +1086,13 @@ TransactionFrame::commonValidPreSeqNum(
             {
                 if (!set.emplace(lk).second)
                 {
-                    getResult().result.code(txMALFORMED);
+                    pushSimpleDiagnosticError(
+                        SCE_STORAGE, SCEC_INVALID_INPUT,
+                        "Found duplicate key in the Soroban footprint; every "
+                        "key across read-only and read-write footprints has to "
+                        "be unique.",
+                        {});
+                    getResult().result.code(txSOROBAN_INVALID);
                     return false;
                 }
             }


### PR DESCRIPTION
# Description

Improve the error for the duplicate footprint keys.

This now has a diagnostic event, consistently with other Soroban errors.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
