### PR TITLE
No-op refactor of TxSetFrame.

### DIFF
--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -59,7 +59,7 @@ closeLedger(Application& app, std::optional<SecretKey> skToSignValue,
     CLOG_INFO(Bucket, "Artificially closing ledger {} with lcl={}, buckets={}",
               ledgerNum, hexAbbrev(lcl.hash),
               hexAbbrev(app.getBucketManager().getBucketList().getHash()));
-    app.getHerder().externalizeValue(TxSetFrame::makeEmpty(lcl), ledgerNum,
+    app.getHerder().externalizeValue(TxSetXDRFrame::makeEmpty(lcl), ledgerNum,
                                      lcl.header.scpValue.closeTime, upgrades,
                                      skToSignValue);
     return lm.getLastClosedLedgerHeader().hash;

--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -98,7 +98,7 @@ ApplyCheckpointWork::openInputFiles()
     mFilesOpen = true;
 }
 
-TxSetFrameConstPtr
+TxSetXDRFrameConstPtr
 ApplyCheckpointWork::getCurrentTxSet()
 {
     ZoneScoped;
@@ -126,18 +126,18 @@ ApplyCheckpointWork::getCurrentTxSet()
             CLOG_DEBUG(History, "Loaded txset for ledger {}", seq);
             if (mTxHistoryEntry.ext.v() == 0)
             {
-                return TxSetFrame::makeFromWire(mTxHistoryEntry.txSet);
+                return TxSetXDRFrame::makeFromWire(mTxHistoryEntry.txSet);
             }
             else
             {
-                return TxSetFrame::makeFromWire(
+                return TxSetXDRFrame::makeFromWire(
                     mTxHistoryEntry.ext.generalizedTxSet());
             }
         }
     } while (mTxIn && mTxIn.readOne(mTxHistoryEntry));
 
     CLOG_DEBUG(History, "Using empty txset for ledger {}", seq);
-    return TxSetFrame::makeEmpty(lm.getLastClosedLedgerHeader());
+    return TxSetXDRFrame::makeEmpty(lm.getLastClosedLedgerHeader());
 }
 
 std::shared_ptr<LedgerCloseData>

--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -56,7 +56,7 @@ class ApplyCheckpointWork : public BasicWork
 
     std::shared_ptr<ConditionalWork> mConditionalWork;
 
-    TxSetFrameConstPtr getCurrentTxSet();
+    TxSetXDRFrameConstPtr getCurrentTxSet();
     void openInputFiles();
 
     std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();

--- a/src/catchup/ReplayDebugMetaWork.cpp
+++ b/src/catchup/ReplayDebugMetaWork.cpp
@@ -108,14 +108,14 @@ class ApplyLedgersFromMetaWork : public Work
             return BasicWork::State::WORK_FAILURE;
         }
 
-        TxSetFrameConstPtr txSet;
+        TxSetXDRFrameConstPtr txSet;
         if (lcm.v() == 0)
         {
-            txSet = TxSetFrame::makeFromWire(lcm.v0().txSet);
+            txSet = TxSetXDRFrame::makeFromWire(lcm.v0().txSet);
         }
         else
         {
-            txSet = TxSetFrame::makeFromWire(lcm.v1().txSet);
+            txSet = TxSetXDRFrame::makeFromWire(lcm.v1().txSet);
         }
 
         LedgerCloseData ledgerCloseData(ledgerSeqToApply, txSet,

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -120,13 +120,13 @@ class Herder
 
     virtual bool recvSCPQuorumSet(Hash const& hash,
                                   SCPQuorumSet const& qset) = 0;
-    virtual bool recvTxSet(Hash const& hash, TxSetFrameConstPtr txset) = 0;
+    virtual bool recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset) = 0;
     // We are learning about a new transaction.
     virtual TransactionQueue::AddResult
     recvTransaction(TransactionFrameBasePtr tx, bool submittedFromSelf) = 0;
     virtual void peerDoesntHave(stellar::MessageType type,
                                 uint256 const& itemID, Peer::pointer peer) = 0;
-    virtual TxSetFrameConstPtr getTxSet(Hash const& hash) = 0;
+    virtual TxSetXDRFrameConstPtr getTxSet(Hash const& hash) = 0;
     virtual SCPQuorumSetPtr getQSet(Hash const& qSetHash) = 0;
 
     // We are learning about a new envelope.
@@ -138,13 +138,13 @@ class Herder
     // We are learning about a new fully-fetched envelope.
     virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
                                            const SCPQuorumSet& qset,
-                                           TxSetFrameConstPtr txset) = 0;
+                                           TxSetXDRFrameConstPtr txset) = 0;
     virtual EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
                                            const SCPQuorumSet& qset,
                                            StellarMessage const& txset) = 0;
 
     virtual void
-    externalizeValue(TxSetFrameConstPtr txSet, uint32_t ledgerSeq,
+    externalizeValue(TxSetXDRFrameConstPtr txSet, uint32_t ledgerSeq,
                      uint64_t closeTime,
                      xdr::xvector<UpgradeType, 6> const& upgrades,
                      std::optional<SecretKey> skToSignValue = std::nullopt) = 0;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -102,12 +102,12 @@ class HerderImpl : public Herder
 #ifdef BUILD_TESTS
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
                                    const SCPQuorumSet& qset,
-                                   TxSetFrameConstPtr txset) override;
+                                   TxSetXDRFrameConstPtr txset) override;
     EnvelopeStatus recvSCPEnvelope(SCPEnvelope const& envelope,
                                    const SCPQuorumSet& qset,
                                    StellarMessage const& txset) override;
 
-    void externalizeValue(TxSetFrameConstPtr txSet, uint32_t ledgerSeq,
+    void externalizeValue(TxSetXDRFrameConstPtr txSet, uint32_t ledgerSeq,
                           uint64_t closeTime,
                           xdr::xvector<UpgradeType, 6> const& upgrades,
                           std::optional<SecretKey> skToSignValue) override;
@@ -130,10 +130,10 @@ class HerderImpl : public Herder
     void sendSCPStateToPeer(uint32 ledgerSeq, Peer::pointer peer) override;
 
     bool recvSCPQuorumSet(Hash const& hash, const SCPQuorumSet& qset) override;
-    bool recvTxSet(Hash const& hash, TxSetFrameConstPtr txset) override;
+    bool recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset) override;
     void peerDoesntHave(MessageType type, uint256 const& itemID,
                         Peer::pointer peer) override;
-    TxSetFrameConstPtr getTxSet(Hash const& hash) override;
+    TxSetXDRFrameConstPtr getTxSet(Hash const& hash) override;
     SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;
 
     void processSCPQueue();
@@ -235,7 +235,7 @@ class HerderImpl : public Herder
     ClassicTransactionQueue mTransactionQueue;
     std::unique_ptr<SorobanTransactionQueue> mSorobanTransactionQueue;
 
-    void updateTransactionQueue(TxSetFrameConstPtr txSet);
+    void updateTransactionQueue(TxSetXDRFrameConstPtr txSet);
     void maybeSetupSorobanQueue(uint32_t protocolVersion);
 
     PendingEnvelopes mPendingEnvelopes;

--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -111,7 +111,7 @@ class SCPHerderEnvelopeWrapper : public SCPEnvelopeWrapper
     HerderImpl& mHerder;
 
     SCPQuorumSetPtr mQSet;
-    std::vector<TxSetFrameConstPtr> mTxSets;
+    std::vector<TxSetXDRFrameConstPtr> mTxSets;
 
   public:
     explicit SCPHerderEnvelopeWrapper(SCPEnvelope const& e, HerderImpl& herder)
@@ -306,7 +306,7 @@ HerderSCPDriver::validateValueHelper(uint64_t slotIndex, StellarValue const& b,
     }
 
     Hash const& txSetHash = b.txSetHash;
-    TxSetFrameConstPtr txSet = mPendingEnvelopes.getTxSet(txSetHash);
+    TxSetXDRFrameConstPtr txSet = mPendingEnvelopes.getTxSet(txSetHash);
 
     SCPDriver::ValidationLevel res;
 
@@ -719,7 +719,7 @@ HerderSCPDriver::combineCandidates(uint64_t slotIndex,
     // take the txSet with the biggest size, highest xored hash that we have
     {
         auto highest = candidateValues.cend();
-        TxSetFrameConstPtr highestTxSet;
+        TxSetXDRFrameConstPtr highestTxSet;
         ApplicableTxSetFrameConstPtr highestApplicableTxSet;
         for (auto it = candidateValues.cbegin(); it != candidateValues.cend();
              ++it)
@@ -890,7 +890,7 @@ HerderSCPDriver::logQuorumInformationAndUpdateMetrics(uint64_t index)
 
 void
 HerderSCPDriver::nominate(uint64_t slotIndex, StellarValue const& value,
-                          TxSetFrameConstPtr proposedSet,
+                          TxSetXDRFrameConstPtr proposedSet,
                           StellarValue const& previousValue)
 {
     ZoneScoped;
@@ -1191,7 +1191,7 @@ class SCPHerderValueWrapper : public ValueWrapper
 {
     HerderImpl& mHerder;
 
-    TxSetFrameConstPtr mTxSet;
+    TxSetXDRFrameConstPtr mTxSet;
 
   public:
     explicit SCPHerderValueWrapper(StellarValue const& sv, Value const& value,

--- a/src/herder/HerderSCPDriver.h
+++ b/src/herder/HerderSCPDriver.h
@@ -89,7 +89,7 @@ class HerderSCPDriver : public SCPDriver
     // Submit a value to consider for slotIndex
     // previousValue is the value from slotIndex-1
     void nominate(uint64_t slotIndex, StellarValue const& value,
-                  TxSetFrameConstPtr proposedSet,
+                  TxSetXDRFrameConstPtr proposedSet,
                   StellarValue const& previousValue);
 
     SCPQuorumSetPtr getQSet(Hash const& qSetHash) override;

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -14,7 +14,8 @@ using namespace std;
 namespace stellar
 {
 
-LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq, TxSetFrameConstPtr txSet,
+LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq,
+                                 TxSetXDRFrameConstPtr txSet,
                                  StellarValue const& v,
                                  std::optional<Hash> const& expectedLedgerHash)
     : mLedgerSeq(ledgerSeq)

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -25,7 +25,7 @@ class LedgerCloseData
 {
   public:
     LedgerCloseData(
-        uint32_t ledgerSeq, TxSetFrameConstPtr txSet, StellarValue const& v,
+        uint32_t ledgerSeq, TxSetXDRFrameConstPtr txSet, StellarValue const& v,
         std::optional<Hash> const& expectedLedgerHash = std::nullopt);
 
     uint32_t
@@ -33,7 +33,7 @@ class LedgerCloseData
     {
         return mLedgerSeq;
     }
-    TxSetFrameConstPtr
+    TxSetXDRFrameConstPtr
     getTxSet() const
     {
         return mTxSet;
@@ -64,22 +64,22 @@ class LedgerCloseData
     {
         if (sts.txSet.v() == 0)
         {
-            return LedgerCloseData(sts.ledgerSeq,
-                                   TxSetFrame::makeFromWire(sts.txSet.txSet()),
-                                   sts.scpValue);
+            return LedgerCloseData(
+                sts.ledgerSeq, TxSetXDRFrame::makeFromWire(sts.txSet.txSet()),
+                sts.scpValue);
         }
         else
         {
             return LedgerCloseData(
                 sts.ledgerSeq,
-                TxSetFrame::makeFromWire(sts.txSet.generalizedTxSet()),
+                TxSetXDRFrame::makeFromWire(sts.txSet.generalizedTxSet()),
                 sts.scpValue);
         }
     }
 
   private:
     uint32_t mLedgerSeq;
-    TxSetFrameConstPtr mTxSet;
+    TxSetXDRFrameConstPtr mTxSet;
     StellarValue mValue;
     std::optional<Hash> mExpectedLedgerHash;
 };

--- a/src/herder/PendingEnvelopes.cpp
+++ b/src/herder/PendingEnvelopes.cpp
@@ -180,9 +180,9 @@ PendingEnvelopes::updateMetrics()
     mReadyCount.set_count(ready);
 }
 
-TxSetFrameConstPtr
+TxSetXDRFrameConstPtr
 PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot,
-                           TxSetFrameConstPtr txset)
+                           TxSetXDRFrameConstPtr txset)
 {
     auto res = getKnownTxSet(hash, slot, true);
     if (!res)
@@ -197,12 +197,12 @@ PendingEnvelopes::putTxSet(Hash const& hash, uint64 slot,
 // tries to find a txset in memory, setting touch also touches the LRU,
 // extending the lifetime of the result *and* updating the slot number
 // to a greater value if needed
-TxSetFrameConstPtr
+TxSetXDRFrameConstPtr
 PendingEnvelopes::getKnownTxSet(Hash const& hash, uint64 slot, bool touch)
 {
     // slot is only used when `touch` is set
     releaseAssert(touch || (slot == 0));
-    TxSetFrameConstPtr res;
+    TxSetXDRFrameConstPtr res;
     auto it = mKnownTxSets.find(hash);
     if (it != mKnownTxSets.end())
     {
@@ -228,7 +228,7 @@ PendingEnvelopes::getKnownTxSet(Hash const& hash, uint64 slot, bool touch)
 
 void
 PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
-                           TxSetFrameConstPtr txset)
+                           TxSetXDRFrameConstPtr txset)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Add TxSet {}", hexAbbrev(hash));
@@ -238,7 +238,7 @@ PendingEnvelopes::addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
 }
 
 bool
-PendingEnvelopes::recvTxSet(Hash const& hash, TxSetFrameConstPtr txset)
+PendingEnvelopes::recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset)
 {
     ZoneScoped;
     CLOG_TRACE(Herder, "Got TxSet {}", hexAbbrev(hash));
@@ -722,7 +722,7 @@ PendingEnvelopes::forceRebuildQuorum()
     mRebuildQuorum = true;
 }
 
-TxSetFrameConstPtr
+TxSetXDRFrameConstPtr
 PendingEnvelopes::getTxSet(Hash const& hash)
 {
     return getKnownTxSet(hash, 0, false);

--- a/src/herder/PendingEnvelopes.h
+++ b/src/herder/PendingEnvelopes.h
@@ -60,11 +60,11 @@ class PendingEnvelopes
     ItemFetcher mTxSetFetcher;
     ItemFetcher mQuorumSetFetcher;
 
-    using TxSetFramCacheItem = std::pair<uint64, TxSetFrameConstPtr>;
+    using TxSetFramCacheItem = std::pair<uint64, TxSetXDRFrameConstPtr>;
     // recent txsets
     RandomEvictionCache<Hash, TxSetFramCacheItem> mTxSetCache;
     // weak references to all known txsets
-    UnorderedMap<Hash, std::weak_ptr<TxSetFrame const>> mKnownTxSets;
+    UnorderedMap<Hash, std::weak_ptr<TxSetXDRFrame const>> mKnownTxSets;
 
     // keep track of txset/qset hash -> size pairs for quick access
     RandomEvictionCache<Hash, size_t> mValueSizeCache;
@@ -103,7 +103,8 @@ class PendingEnvelopes
 
     // tries to find a txset in memory, setting touch also touches the LRU,
     // extending the lifetime of the result
-    TxSetFrameConstPtr getKnownTxSet(Hash const& hash, uint64 slot, bool touch);
+    TxSetXDRFrameConstPtr getKnownTxSet(Hash const& hash, uint64 slot,
+                                        bool touch);
 
     void cleanKnownData();
 
@@ -154,15 +155,15 @@ class PendingEnvelopes
      * in PendingEnvelopes.
      */
     void addTxSet(Hash const& hash, uint64 lastSeenSlotIndex,
-                  TxSetFrameConstPtr txset);
+                  TxSetXDRFrameConstPtr txset);
 
     /**
         Adds @p txset to the cache and returns the txset referenced by the cache
         NB: if caller wants to continue using txset after the call, it should
        use the returned value instead
     */
-    TxSetFrameConstPtr putTxSet(Hash const& hash, uint64 slot,
-                                TxSetFrameConstPtr txset);
+    TxSetXDRFrameConstPtr putTxSet(Hash const& hash, uint64 slot,
+                                   TxSetXDRFrameConstPtr txset);
 
     /**
      * Check if @p txset identified by @p hash was requested before from peers.
@@ -171,7 +172,7 @@ class PendingEnvelopes
      *
      * Return true if TxSet useful (was asked for).
      */
-    bool recvTxSet(Hash const& hash, TxSetFrameConstPtr txset);
+    bool recvTxSet(Hash const& hash, TxSetXDRFrameConstPtr txset);
 
     void peerDoesntHave(MessageType type, Hash const& itemID,
                         Peer::pointer peer);
@@ -188,7 +189,7 @@ class PendingEnvelopes
 
     Json::Value getJsonInfo(size_t limit);
 
-    TxSetFrameConstPtr getTxSet(Hash const& hash);
+    TxSetXDRFrameConstPtr getTxSet(Hash const& hash);
     SCPQuorumSetPtr getQSet(Hash const& hash);
 
     // returns true if we think that the node is in the transitive quorum for

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -920,11 +920,11 @@ TransactionQueue::isBanned(Hash const& hash) const
         });
 }
 
-TxSetFrame::Transactions
+TxSetTransactions
 TransactionQueue::getTransactions(LedgerHeader const& lcl) const
 {
     ZoneScoped;
-    TxSetFrame::Transactions txs;
+    TxSetTransactions txs;
 
     uint32_t const nextLedgerSeq = lcl.ledgerSeq + 1;
     int64_t const startingSeq = getStartingSequenceNumber(nextLedgerSeq);

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -145,7 +145,7 @@ class TransactionQueue
     bool isBanned(Hash const& hash) const;
     TransactionFrameBaseConstPtr getTx(Hash const& hash) const;
 
-    TxSetFrame::Transactions getTransactions(LedgerHeader const& lcl) const;
+    TxSetTransactions getTransactions(LedgerHeader const& lcl) const;
 
     struct ReplacedTransaction
     {

--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -34,9 +34,8 @@ namespace
 {
 // Target use case is to remove a subset of invalid transactions from a TxSet.
 // I.e. txSet.size() >= txsToRemove.size()
-TxSetFrame::Transactions
-removeTxs(TxSetFrame::Transactions const& txs,
-          TxSetFrame::Transactions const& txsToRemove)
+TxSetTransactions
+removeTxs(TxSetTransactions const& txs, TxSetTransactions const& txsToRemove)
 {
     UnorderedSet<Hash> txsToRemoveSet;
     txsToRemoveSet.reserve(txsToRemove.size());
@@ -45,7 +44,7 @@ removeTxs(TxSetFrame::Transactions const& txs,
         std::inserter(txsToRemoveSet, txsToRemoveSet.end()),
         [](TransactionFrameBasePtr const& tx) { return tx->getFullHash(); });
 
-    TxSetFrame::Transactions newTxs;
+    TxSetTransactions newTxs;
     newTxs.reserve(txs.size() - txsToRemove.size());
     for (auto const& tx : txs)
     {
@@ -124,17 +123,17 @@ TxSetUtils::hashTxSorter(TransactionFrameBasePtr const& tx1,
     return tx1->getFullHash() < tx2->getFullHash();
 }
 
-TxSetFrame::Transactions
-TxSetUtils::sortTxsInHashOrder(TxSetFrame::Transactions const& transactions)
+TxSetTransactions
+TxSetUtils::sortTxsInHashOrder(TxSetTransactions const& transactions)
 {
     ZoneScoped;
-    TxSetFrame::Transactions sortedTxs(transactions);
+    TxSetTransactions sortedTxs(transactions);
     std::sort(sortedTxs.begin(), sortedTxs.end(), TxSetUtils::hashTxSorter);
     return sortedTxs;
 }
 
 std::vector<std::shared_ptr<AccountTransactionQueue>>
-TxSetUtils::buildAccountTxQueues(TxSetFrame::Transactions const& txs)
+TxSetUtils::buildAccountTxQueues(TxSetTransactions const& txs)
 {
     ZoneScoped;
     UnorderedMap<AccountID, std::vector<TransactionFrameBasePtr>> actTxMap;
@@ -155,9 +154,8 @@ TxSetUtils::buildAccountTxQueues(TxSetFrame::Transactions const& txs)
     return queues;
 }
 
-TxSetFrame::Transactions
-TxSetUtils::getInvalidTxList(TxSetFrame::Transactions const& txs,
-                             Application& app,
+TxSetTransactions
+TxSetUtils::getInvalidTxList(TxSetTransactions const& txs, Application& app,
                              uint64_t lowerBoundCloseTimeOffset,
                              uint64_t upperBoundCloseTimeOffset,
                              bool returnEarlyOnFirstInvalidTx)
@@ -175,7 +173,7 @@ TxSetUtils::getInvalidTxList(TxSetFrame::Transactions const& txs,
     }
 
     UnorderedMap<AccountID, int64_t> accountFeeMap;
-    TxSetFrame::Transactions invalidTxs;
+    TxSetTransactions invalidTxs;
 
     auto accountTxQueues = buildAccountTxQueues(txs);
     for (auto& accountQueue : accountTxQueues)
@@ -273,11 +271,11 @@ TxSetUtils::getInvalidTxList(TxSetFrame::Transactions const& txs,
     return invalidTxs;
 }
 
-TxSetFrame::Transactions
-TxSetUtils::trimInvalid(TxSetFrame::Transactions const& txs, Application& app,
+TxSetTransactions
+TxSetUtils::trimInvalid(TxSetTransactions const& txs, Application& app,
                         uint64_t lowerBoundCloseTimeOffset,
                         uint64_t upperBoundCloseTimeOffset,
-                        TxSetFrame::Transactions& invalidTxs)
+                        TxSetTransactions& invalidTxs)
 {
     invalidTxs = getInvalidTxList(txs, app, lowerBoundCloseTimeOffset,
                                   upperBoundCloseTimeOffset, false);

--- a/src/herder/TxSetUtils.h
+++ b/src/herder/TxSetUtils.h
@@ -37,26 +37,26 @@ class TxSetUtils
     static bool hashTxSorter(TransactionFrameBasePtr const& tx1,
                              TransactionFrameBasePtr const& tx2);
 
-    static TxSetFrame::Transactions
-    sortTxsInHashOrder(TxSetFrame::Transactions const& transactions);
+    static TxSetTransactions
+    sortTxsInHashOrder(TxSetTransactions const& transactions);
 
     static std::vector<std::shared_ptr<AccountTransactionQueue>>
-    buildAccountTxQueues(TxSetFrame::Transactions const& txs);
+    buildAccountTxQueues(TxSetTransactions const& txs);
 
     // Returns transactions from a TxSet that are invalid. If
     // returnEarlyOnFirstInvalidTx is true, return immediately if an invalid
     // transaction is found (instead of finding all of them), this is useful for
     // checking if a TxSet is valid.
-    static TxSetFrame::Transactions
-    getInvalidTxList(TxSetFrame::Transactions const& txs, Application& app,
+    static TxSetTransactions
+    getInvalidTxList(TxSetTransactions const& txs, Application& app,
                      uint64_t lowerBoundCloseTimeOffset,
                      uint64_t upperBoundCloseTimeOffset,
                      bool returnEarlyOnFirstInvalidTx);
 
-    static TxSetFrame::Transactions
-    trimInvalid(TxSetFrame::Transactions const& txs, Application& app,
-                uint64_t lowerBoundCloseTimeOffset,
-                uint64_t upperBoundCloseTimeOffset,
-                TxSetFrame::Transactions& invalidTxs);
+    static TxSetTransactions trimInvalid(TxSetTransactions const& txs,
+                                         Application& app,
+                                         uint64_t lowerBoundCloseTimeOffset,
+                                         uint64_t upperBoundCloseTimeOffset,
+                                         TxSetTransactions& invalidTxs);
 }; // class TxSetUtils
 } // namespace stellar

--- a/src/herder/test/PendingEnvelopesTests.cpp
+++ b/src/herder/test/PendingEnvelopesTests.cpp
@@ -42,8 +42,8 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
         accs.push_back(TestAccount{*app, getAccount("A" + std::to_string(i))});
     }
 
-    using TxPair = std::pair<Value, TxSetFrameConstPtr>;
-    auto makeTxPair = [&](TxSetFrameConstPtr txSet, uint64_t closeTime,
+    using TxPair = std::pair<Value, TxSetXDRFrameConstPtr>;
+    auto makeTxPair = [&](TxSetXDRFrameConstPtr txSet, uint64_t closeTime,
                           StellarValueType svt) {
         StellarValue sv = herder.makeStellarValue(
             txSet->getContentsHash(), closeTime, emptyUpgradeSteps, s);
@@ -73,7 +73,7 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
         std::vector<TransactionFrameBasePtr> txs(n);
         std::generate(std::begin(txs), std::end(txs),
                       [&]() { return accs[index++].tx({payment(root, 1)}); });
-        return TxSetFrame::makeFromTransactions(txs, *app, 0, 0).first;
+        return makeTxSetFromTransactions(txs, *app, 0, 0).first;
     };
 
     auto makePublicKey = [](int i) {
@@ -344,7 +344,7 @@ TEST_CASE("PendingEnvelopes recvSCPEnvelope", "[herder]")
     SECTION("can receive malformed tx set")
     {
         GeneralizedTransactionSet malformedXdrSet(1);
-        auto malformedTxSet = TxSetFrame::makeFromWire(malformedXdrSet);
+        auto malformedTxSet = TxSetXDRFrame::makeFromWire(malformedXdrSet);
         auto p2 = makeTxPair(malformedTxSet, 10, STELLAR_VALUE_SIGNED);
         auto malformedEnvelope =
             makeEnvelope(p2, saneQSetHash, lcl.header.ledgerSeq + 1);

--- a/src/herder/test/QuorumTrackerTests.cpp
+++ b/src/herder/test/QuorumTrackerTests.cpp
@@ -56,7 +56,7 @@ testQuorumTracker()
     struct ValuesTxSet
     {
         Value mSignedV;
-        TxSetFrameConstPtr mTxSet;
+        TxSetXDRFrameConstPtr mTxSet;
     };
 
     auto recvEnvelope = [&](SCPEnvelope envelope, uint64 slotID,
@@ -109,7 +109,7 @@ testQuorumTracker()
     };
     auto makeValue = [&](int i) {
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         StellarValue sv = herder->makeStellarValue(
             txSet->getContentsHash(), lcl.header.scpValue.closeTime + i,
             emptyUpgradeSteps, valSigner);

--- a/src/herder/test/TestTxSetUtils.cpp
+++ b/src/herder/test/TestTxSetUtils.cpp
@@ -64,28 +64,28 @@ makeGeneralizedTxSetXDR(std::vector<ComponentPhases> const& txsPerBaseFeePhases,
     return xdrTxSet;
 }
 
-std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+std::pair<TxSetXDRFrameConstPtr, ApplicableTxSetFrameConstPtr>
 makeNonValidatedTxSet(std::vector<TransactionFrameBasePtr> const& txs,
                       Application& app, Hash const& previousLedgerHash)
 {
     auto xdrTxSet = makeTxSetXDR(txs, previousLedgerHash);
-    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
     auto applicableTxSet = txSet->prepareForApply(app);
     return std::make_pair(txSet, std::move(applicableTxSet));
 }
 } // namespace
 
-std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+std::pair<TxSetXDRFrameConstPtr, ApplicableTxSetFrameConstPtr>
 makeNonValidatedGeneralizedTxSet(
     std::vector<ComponentPhases> const& txsPerBaseFee, Application& app,
     Hash const& previousLedgerHash)
 {
     auto xdrTxSet = makeGeneralizedTxSetXDR(txsPerBaseFee, previousLedgerHash);
-    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
     return std::make_pair(txSet, txSet->prepareForApply(app));
 }
 
-std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+std::pair<TxSetXDRFrameConstPtr, ApplicableTxSetFrameConstPtr>
 makeNonValidatedTxSetBasedOnLedgerVersion(
     uint32_t ledgerVersion, std::vector<TransactionFrameBasePtr> const& txs,
     Application& app, Hash const& previousLedgerHash)

--- a/src/herder/test/TestTxSetUtils.h
+++ b/src/herder/test/TestTxSetUtils.h
@@ -14,12 +14,12 @@ namespace testtxset
 
 using ComponentPhases = std::vector<
     std::pair<std::optional<int64_t>, std::vector<TransactionFrameBasePtr>>>;
-std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+std::pair<TxSetXDRFrameConstPtr, ApplicableTxSetFrameConstPtr>
 makeNonValidatedGeneralizedTxSet(
     std::vector<ComponentPhases> const& txsPerBaseFee, Application& app,
     Hash const& previousLedgerHash);
 
-std::pair<TxSetFrameConstPtr, ApplicableTxSetFrameConstPtr>
+std::pair<TxSetXDRFrameConstPtr, ApplicableTxSetFrameConstPtr>
 makeNonValidatedTxSetBasedOnLedgerVersion(
     uint32_t ledgerVersion, std::vector<TransactionFrameBasePtr> const& txs,
     Application& app, Hash const& previousLedgerHash);

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -190,7 +190,7 @@ class TransactionQueueTest
 
         REQUIRE(fees == expectedFees);
 
-        TxSetFrame::Transactions expectedTxs;
+        TxSetTransactions expectedTxs;
         size_t totOps = 0;
         for (auto const& accountState : state.mAccountStates)
         {
@@ -2547,8 +2547,7 @@ TEST_CASE("remove applied", "[herder][transactionqueue]")
         auto ledgerSeq = lcl.header.ledgerSeq + 1;
 
         root.loadSequenceNumber();
-        auto [txSet, _] =
-            TxSetFrame::makeFromTransactions({tx1b, tx2}, *app, 0, 0);
+        auto [txSet, _] = makeTxSetFromTransactions({tx1b, tx2}, *app, 0, 0);
         herder.getPendingEnvelopes().putTxSet(txSet->getContentsHash(),
                                               ledgerSeq, txSet);
 

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -36,7 +36,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
     LedgerTxn ltx(app->getLedgerTxnRoot());
     SECTION("no phases")
     {
-        auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+        auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
         REQUIRE(txSet->prepareForApply(*app) == nullptr);
     }
     SECTION("too many phases")
@@ -44,7 +44,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
         xdrTxSet.v1TxSet().phases.emplace_back();
         xdrTxSet.v1TxSet().phases.emplace_back();
         xdrTxSet.v1TxSet().phases.emplace_back();
-        auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+        auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
         REQUIRE(txSet->prepareForApply(*app) == nullptr);
     }
     SECTION("incorrect base fee order")
@@ -103,7 +103,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("non-discounted component out of place")
@@ -142,7 +142,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                     xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
                         TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
 
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION(
@@ -187,7 +187,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
             }
@@ -257,7 +257,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("duplicate non-discounted components")
@@ -296,7 +296,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
 
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
             }
@@ -314,7 +314,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                 xdrTxSet.v1TxSet().phases[i].v0Components().emplace_back(
                     TXSET_COMP_TXS_MAYBE_DISCOUNTED_FEE);
 
-                auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                 REQUIRE(txSet->prepareForApply(*app) == nullptr);
             }
         }
@@ -354,7 +354,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
             txEnv.v0().tx.operations.emplace_back();
             txEnv.v0().tx.operations.back().body.type(INVOKE_HOST_FUNCTION);
         }
-        auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+        auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
         REQUIRE(txSet->prepareForApply(*app) == nullptr);
     }
     SECTION("valid XDR")
@@ -383,7 +383,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                 {
                     xdrTxSet.v1TxSet().phases.emplace_back();
                     xdrTxSet.v1TxSet().phases.emplace_back();
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("single component")
@@ -399,7 +399,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txsMaybeDiscountedFee()
                         .txs.emplace_back();
                     maybeAddSorobanOp(xdrTxSet);
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
                 SECTION("multiple components")
@@ -464,7 +464,7 @@ TEST_CASE("generalized tx set XDR validation", "[txset]")
                         .txs.emplace_back();
                     maybeAddSorobanOp(xdrTxSet);
 
-                    auto txSet = TxSetFrame::makeFromWire(xdrTxSet);
+                    auto txSet = TxSetXDRFrame::makeFromWire(xdrTxSet);
                     REQUIRE(txSet->prepareForApply(*app) == nullptr);
                 }
             }
@@ -516,7 +516,7 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
     };
 
     auto checkXdrRoundtrip = [&](GeneralizedTransactionSet const& txSetXdr) {
-        auto txSetFrame = TxSetFrame::makeFromWire(txSetXdr);
+        auto txSetFrame = TxSetXDRFrame::makeFromWire(txSetXdr);
         ApplicableTxSetFrameConstPtr applicableFrame;
         {
             LedgerTxn ltx(app->getLedgerTxnRoot(), false,
@@ -621,8 +621,7 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
 
         SECTION("classic only")
         {
-            auto txSet =
-                TxSetFrame::makeFromTransactions(txs, *app, 0, 0).first;
+            auto txSet = makeTxSetFromTransactions(txs, *app, 0, 0).first;
             GeneralizedTransactionSet txSetXdr;
             txSet->toXDR(txSetXdr);
             REQUIRE(txSetXdr.v1TxSet().phases.size() == 2);
@@ -645,9 +644,9 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
             {
                 SECTION("minimum base fee")
                 {
-                    auto txSet = TxSetFrame::makeFromTransactions(
-                                     {txs, sorobanTxs}, *app, 0, 0)
-                                     .first;
+                    auto txSet =
+                        makeTxSetFromTransactions({txs, sorobanTxs}, *app, 0, 0)
+                            .first;
                     GeneralizedTransactionSet txSetXdr;
                     txSet->toXDR(txSetXdr);
                     REQUIRE(txSetXdr.v1TxSet().phases.size() == 2);
@@ -674,8 +673,8 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
                     sorobanTxs.insert(sorobanTxs.begin(),
                                       higherFeeSorobanTxs.begin(),
                                       higherFeeSorobanTxs.end());
-                    auto txSet = TxSetFrame::makeFromTransactions(
-                                     {txs, sorobanTxs}, *app, 0, 100)
+                    auto txSet = makeTxSetFromTransactions({txs, sorobanTxs},
+                                                           *app, 0, 100)
                                      .first;
                     GeneralizedTransactionSet txSetXdr;
                     txSet->toXDR(txSetXdr);
@@ -700,18 +699,18 @@ TEST_CASE("generalized tx set XDR conversion", "[txset]")
             SECTION("invalid, soroban tx in wrong phase")
             {
                 sorobanTxs[4] = txs[0];
-                REQUIRE_THROWS_WITH(TxSetFrame::makeFromTransactions(
-                                        {txs, sorobanTxs}, *app, 0, 0),
-                                    "TxSetFrame::makeFromTransactions: phases "
-                                    "contain txs of wrong type");
+                REQUIRE_THROWS_WITH(
+                    makeTxSetFromTransactions({txs, sorobanTxs}, *app, 0, 0),
+                    "TxSetFrame::makeFromTransactions: phases "
+                    "contain txs of wrong type");
             }
             SECTION("invalid, classic tx in wrong phase")
             {
                 txs[4] = sorobanTxs[0];
-                REQUIRE_THROWS_WITH(TxSetFrame::makeFromTransactions(
-                                        {txs, sorobanTxs}, *app, 0, 0),
-                                    "TxSetFrame::makeFromTransactions: phases "
-                                    "contain txs of wrong type");
+                REQUIRE_THROWS_WITH(
+                    makeTxSetFromTransactions({txs, sorobanTxs}, *app, 0, 0),
+                    "TxSetFrame::makeFromTransactions: phases "
+                    "contain txs of wrong type");
             }
         }
     }
@@ -897,12 +896,11 @@ TEST_CASE("generalized tx set fees", "[txset][soroban]")
                 .second;
 
         REQUIRE(txSet->checkValid(*app, 0, 0));
-        for (auto i = 0;
-             i < static_cast<size_t>(TxSetFrame::Phase::PHASE_COUNT); ++i)
+        for (auto i = 0; i < static_cast<size_t>(TxSetPhase::PHASE_COUNT); ++i)
         {
             std::vector<std::optional<int64_t>> fees;
             for (auto const& tx :
-                 txSet->getTxsForPhase(static_cast<TxSetFrame::Phase>(i)))
+                 txSet->getTxsForPhase(static_cast<TxSetPhase>(i)))
             {
                 fees.push_back(
                     txSet->getTxBaseFee(tx, app->getLedgerManager()

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -1946,8 +1946,8 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
         uint64_t minBalance = lm.getLastMinBalance(5);
         uint64_t big = minBalance + ledgerSeq;
         uint64_t closeTime = 60 * 5 * ledgerSeq;
-        auto txSet = TxSetFrame::makeFromTransactions(
-                         TxSetFrame::Transactions{
+        auto txSet = makeTxSetFromTransactions(
+                         TxSetTransactions{
                              root.tx({txtest::createAccount(stranger, big)})},
                          *app, 0, 0)
                          .first;
@@ -2070,9 +2070,9 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
         uint64_t minBalance = lm.getLastMinBalance(5);
         uint64_t big = minBalance + ledgerSeq;
         uint64_t closeTime = 60 * 5 * ledgerSeq;
-        TxSetFrameConstPtr txSet =
-            TxSetFrame::makeFromTransactions(
-                TxSetFrame::Transactions{
+        TxSetXDRFrameConstPtr txSet =
+            makeTxSetFromTransactions(
+                TxSetTransactions{
                     root.tx({txtest::createAccount(stranger, big)})},
                 *app, 0, 0)
                 .first;
@@ -2185,7 +2185,7 @@ TEST_CASE("upgrade to version 13", "[upgrades]")
         auto const& lcl = lm.getLastClosedLedgerHeader();
         auto ledgerSeq = lcl.header.ledgerSeq + 1;
 
-        auto emptyTxSet = TxSetFrame::makeEmpty(lcl);
+        auto emptyTxSet = TxSetXDRFrame::makeEmpty(lcl);
         herder.getPendingEnvelopes().putTxSet(emptyTxSet->getContentsHash(),
                                               ledgerSeq, emptyTxSet);
 
@@ -3212,9 +3212,8 @@ TEST_CASE("upgrade to generalized tx set changes TxSetFrame format",
                              static_cast<int>(SOROBAN_PROTOCOL_VERSION) - 1));
 
     auto root = TestAccount::createRoot(*app);
-    TxSetFrame::Transactions txs = {root.tx({payment(root, 1)})};
-    auto [txSet, applicableTxSet] =
-        TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+    TxSetTransactions txs = {root.tx({payment(root, 1)})};
+    auto [txSet, applicableTxSet] = makeTxSetFromTransactions(txs, *app, 0, 0);
     REQUIRE(!txSet->isGeneralizedTxSet());
     REQUIRE(!applicableTxSet->isGeneralizedTxSet());
 
@@ -3222,7 +3221,7 @@ TEST_CASE("upgrade to generalized tx set changes TxSetFrame format",
                              static_cast<int>(SOROBAN_PROTOCOL_VERSION)));
 
     auto [newTxSet, newApplicableTxSet] =
-        TxSetFrame::makeFromTransactions(txs, *app, 0, 0);
+        makeTxSetFromTransactions(txs, *app, 0, 0);
     REQUIRE(newTxSet->isGeneralizedTxSet());
     REQUIRE(newApplicableTxSet->isGeneralizedTxSet());
 }
@@ -3325,7 +3324,7 @@ TEST_CASE("upgrade to generalized tx set in network", "[upgrades][overlay]")
                 return pe.getTxSet(sv.txSetHash);
             }
         }
-        return TxSetFrameConstPtr{};
+        return TxSetXDRFrameConstPtr{};
     };
 
     // Make sure tx set format switches to generalized after upgrade.

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1080,8 +1080,8 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
             uint64_t big = minBalance + ledgerSeq;
             uint64_t closeTime = 60 * 5 * ledgerSeq;
 
-            auto [txSet, applicableTxSet] = TxSetFrame::makeFromTransactions(
-                TxSetFrame::Transactions{
+            auto [txSet, applicableTxSet] = makeTxSetFromTransactions(
+                TxSetTransactions{
                     root.tx({txtest::createAccount(stranger, big)})},
                 *a, 0, 0);
 

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -501,10 +501,10 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
     auto phases = protocolVersionStartsFrom(
                       lm.getLastClosedLedgerHeader().header.ledgerVersion,
                       SOROBAN_PROTOCOL_VERSION)
-                      ? TxSetFrame::TxPhases{txs, sorobanTxs}
-                      : TxSetFrame::TxPhases{txs};
-    TxSetFrameConstPtr txSet =
-        TxSetFrame::makeFromTransactions(phases, mApp, 0, 0).first;
+                      ? TxSetPhaseTransactions{txs, sorobanTxs}
+                      : TxSetPhaseTransactions{txs};
+    TxSetXDRFrameConstPtr txSet =
+        makeTxSetFromTransactions(phases, mApp, 0, 0).first;
 
     CLOG_INFO(History, "Closing synthetic ledger {} with {} txs (txhash:{})",
               ledgerSeq, txSet->sizeTxTotal(),

--- a/src/ledger/LedgerCloseMetaFrame.cpp
+++ b/src/ledger/LedgerCloseMetaFrame.cpp
@@ -127,7 +127,7 @@ LedgerCloseMetaFrame::upgradesProcessing()
 }
 
 void
-LedgerCloseMetaFrame::populateTxSet(TxSetFrame const& txSet)
+LedgerCloseMetaFrame::populateTxSet(TxSetXDRFrame const& txSet)
 {
     switch (mVersion)
     {

--- a/src/ledger/LedgerCloseMetaFrame.h
+++ b/src/ledger/LedgerCloseMetaFrame.h
@@ -28,7 +28,7 @@ class LedgerCloseMetaFrame
 
     xdr::xvector<UpgradeEntryMeta>& upgradesProcessing();
 
-    void populateTxSet(TxSetFrame const& txSet);
+    void populateTxSet(TxSetXDRFrame const& txSet);
 
     void setTotalByteSizeOfBucketList(uint64_t size);
     void populateEvictedEntries(LedgerEntryChanges const& evictionChanges);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -717,7 +717,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     mLastClose = now;
     mLedgerAge.set_count(0);
 
-    TxSetFrameConstPtr txSet = ledgerData.getTxSet();
+    TxSetXDRFrameConstPtr txSet = ledgerData.getTxSet();
 
     // If we do not support ledger version, we can't apply that ledger, fail!
     if (header.current().ledgerVersion >

--- a/src/ledger/test/LedgerHeaderTests.cpp
+++ b/src/ledger/test/LedgerHeaderTests.cpp
@@ -69,7 +69,7 @@ TEST_CASE("ledgerheader", "[ledger]")
         app->start();
 
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
 
         // close this ledger
         StellarValue sv = app->getHerder().makeStellarValue(

--- a/src/ledger/test/LedgerTests.cpp
+++ b/src/ledger/test/LedgerTests.cpp
@@ -20,7 +20,7 @@ TEST_CASE("cannot close ledger with unsupported ledger version", "[ledger]")
 
     auto applyEmptyLedger = [&]() {
         auto const& lcl = app->getLedgerManager().getLastClosedLedgerHeader();
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         StellarValue sv = app->getHerder().makeStellarValue(
             txSet->getContentsHash(), 1, emptyUpgradeSteps,
             app->getConfig().NODE_SEED);

--- a/src/main/PersistentState.cpp
+++ b/src/main/PersistentState.cpp
@@ -222,7 +222,7 @@ PersistentState::upgradeSCPDataV1Format()
             std::unordered_map<Hash, std::string> txSets;
             for (auto const& txSet : scpState.v0().txSets)
             {
-                auto txSetPtr = TxSetFrame::makeFromStoredTxSet(txSet);
+                auto txSetPtr = TxSetXDRFrame::makeFromStoredTxSet(txSet);
                 txSets.emplace(txSetPtr->getContentsHash(),
                                decoder::encode_b64(xdr::xdr_to_opaque(txSet)));
             }

--- a/src/overlay/ItemFetcher.h
+++ b/src/overlay/ItemFetcher.h
@@ -23,7 +23,7 @@ namespace stellar
 {
 
 class Tracker;
-class TxSetFrame;
+class TxSetXDRFrame;
 struct SCPQuorumSet;
 using SCPQuorumSetPtr = std::shared_ptr<SCPQuorumSet>;
 using AskPeer = std::function<void(Peer::pointer, Hash)>;

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1089,7 +1089,7 @@ void
 Peer::recvTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
-    auto frame = TxSetFrame::makeFromWire(msg.txSet());
+    auto frame = TxSetXDRFrame::makeFromWire(msg.txSet());
     mApp.getHerder().recvTxSet(frame->getContentsHash(), frame);
 }
 
@@ -1097,7 +1097,7 @@ void
 Peer::recvGeneralizedTxSet(StellarMessage const& msg)
 {
     ZoneScoped;
-    auto frame = TxSetFrame::makeFromWire(msg.generalizedTxSet());
+    auto frame = TxSetXDRFrame::makeFromWire(msg.generalizedTxSet());
     mApp.getHerder().recvTxSet(frame->getContentsHash(), frame);
 }
 

--- a/src/overlay/test/FloodTests.cpp
+++ b/src/overlay/test/FloodTests.cpp
@@ -433,8 +433,7 @@ TEST_CASE("Flooding", "[flood][overlay][acceptance]")
 
             // create the transaction set containing this transaction
 
-            auto txSet =
-                TxSetFrame::makeFromTransactions({tx1}, *inApp, 0, 0).first;
+            auto txSet = makeTxSetFromTransactions({tx1}, *inApp, 0, 0).first;
             auto& herder = static_cast<HerderImpl&>(inApp->getHerder());
 
             // build the quorum set used by this message

--- a/src/test/TxTests.h
+++ b/src/test/TxTests.h
@@ -16,7 +16,7 @@ class AbstractLedgerTxn;
 class ConstLedgerTxnEntry;
 class TransactionFrame;
 class OperationFrame;
-class TxSetFrame;
+class TxSetXDRFrame;
 class TestAccount;
 
 namespace txtest
@@ -101,10 +101,10 @@ closeLedgerOn(Application& app, uint32 ledgerSeq, TimePoint closeTime,
               std::vector<TransactionFrameBasePtr> const& txs = {},
               bool strictOrder = false);
 
-TxSetResultMeta closeLedger(Application& app, TxSetFrameConstPtr txSet);
+TxSetResultMeta closeLedger(Application& app, TxSetXDRFrameConstPtr txSet);
 
 TxSetResultMeta closeLedgerOn(Application& app, uint32 ledgerSeq,
-                              time_t closeTime, TxSetFrameConstPtr txSet);
+                              time_t closeTime, TxSetXDRFrameConstPtr txSet);
 
 TxSetResultMeta
 closeLedgerOn(Application& app, uint32 ledgerSeq, int day, int month, int year,

--- a/src/transactions/TransactionSQL.cpp
+++ b/src/transactions/TransactionSQL.cpp
@@ -257,7 +257,7 @@ writeNonGeneralizedTxSetToStream(
         throw std::runtime_error("Could not find ledger");
     }
     auto txSet =
-        TxSetFrame::makeFromHistoryTransactions(lh->previousLedgerHash, txs);
+        TxSetXDRFrame::makeFromHistoryTransactions(lh->previousLedgerHash, txs);
     TransactionHistoryEntry hist;
     hist.ledgerSeq = ledgerSeq;
     txSet->toXDR(hist.txSet);
@@ -385,7 +385,7 @@ storeTransaction(Database& db, uint32_t ledgerSeq,
 }
 
 void
-storeTxSet(Database& db, uint32_t ledgerSeq, TxSetFrame const& txSet)
+storeTxSet(Database& db, uint32_t ledgerSeq, TxSetXDRFrame const& txSet)
 {
     ZoneScoped;
     if (!txSet.isGeneralizedTxSet())

--- a/src/transactions/TransactionSQL.h
+++ b/src/transactions/TransactionSQL.h
@@ -19,7 +19,7 @@ void storeTransaction(Database& db, uint32_t ledgerSeq,
                       TransactionMeta const& tm,
                       TransactionResultSet const& resultSet);
 
-void storeTxSet(Database& db, uint32_t ledgerSeq, TxSetFrame const& txSet);
+void storeTxSet(Database& db, uint32_t ledgerSeq, TxSetXDRFrame const& txSet);
 
 void storeTransactionFee(Database& db, uint32_t ledgerSeq,
                          TransactionFrameBasePtr const& tx,

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1278,7 +1278,7 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
 
         auto const& lcl =
             test.getApp()->getLedgerManager().getLastClosedLedgerHeader();
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         auto lastCloseTime = lcl.header.scpValue.closeTime;
 
         test.getApp()->getHerder().externalizeValue(
@@ -2389,7 +2389,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
         ledgerUpgrade.newConfig() = upgradeSetKey;
 
         auto const& lcl = lm.getLastClosedLedgerHeader();
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         auto lastCloseTime = lcl.header.scpValue.closeTime;
 
         app->getHerder().externalizeValue(
@@ -2421,7 +2421,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
         auto ledgerUpgrade = LedgerUpgrade{LEDGER_UPGRADE_CONFIG};
         ledgerUpgrade.newConfig() = upgradeSetKey;
 
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         auto lastCloseTime = lcl.header.scpValue.closeTime;
 
         app->getHerder().externalizeValue(
@@ -2444,7 +2444,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
         auto ledgerUpgrade = LedgerUpgrade{LEDGER_UPGRADE_CONFIG};
         ledgerUpgrade.newConfig() = upgradeSetKey;
 
-        auto txSet = TxSetFrame::makeEmpty(lcl);
+        auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         auto lastCloseTime = lcl.header.scpValue.closeTime;
 
         app->getHerder().externalizeValue(

--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -64,9 +64,9 @@ TEST_CASE("txset - correct apply order", "[tx][envelope]")
     auto tx1 = b1.tx({accountMerge(a1)});
     auto tx2 = a1.tx({a1.op(payment(root, 112)), a1.op(payment(root, 101))});
 
-    auto txSet = TxSetFrame::makeFromTransactions(
-                     TxSetFrame::Transactions{tx1, tx2}, *app, 0, 0)
-                     .second;
+    auto txSet =
+        makeTxSetFromTransactions(TxSetTransactions{tx1, tx2}, *app, 0, 0)
+            .second;
 
     auto txs = txSet->getTxsInApplyOrder();
     REQUIRE(txs.size() == 2);
@@ -1876,8 +1876,7 @@ TEST_CASE_VERSIONS("txenvelope", "[tx][envelope]")
         TransactionFramePtr txFrame;
         auto setup = [&]() {
             txFrame = root.tx({createAccount(a1, paymentAmount)});
-            auto txSet =
-                TxSetFrame::makeFromTransactions({txFrame}, *app, 0, 0).first;
+            auto txSet = makeTxSetFromTransactions({txFrame}, *app, 0, 0).first;
 
             // Close this ledger
             auto lastCloseTime = app->getLedgerManager()


### PR DESCRIPTION
# Description

Resolves #4017 

- Rename TxSetFrame to TxSetXDRFrame
- Move the factory functions that create 2 tx set frames (XDR and applicable) out of the TxSetFrame class as they don't make much semantic sense as member functions
- Same goes for the type aliases and `TxPhase` enum - moved all to be standalone types

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
