### PR TITLE
Treat Soroban host internal errors as `txINTERNAL_ERROR`.

### DIFF
--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -376,6 +376,7 @@ fn invoke_host_function_or_maybe_panic(
                 let modified_ledger_entries = extract_ledger_effects(res.ledger_changes)?;
                 return Ok(InvokeHostFunctionOutput {
                     success: true,
+                    is_internal_error: false,
                     diagnostic_events: encode_diagnostic_events(&diagnostic_events),
                     cpu_insns,
                     mem_bytes,
@@ -421,6 +422,7 @@ fn invoke_host_function_or_maybe_panic(
     debug!(target: TX, "invocation failed: {}", err);
     return Ok(InvokeHostFunctionOutput {
         success: false,
+        is_internal_error: err.error.is_code(ScErrorCode::InternalError),
         diagnostic_events: encode_diagnostic_events(&diagnostic_events),
         cpu_insns,
         mem_bytes,

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -59,8 +59,14 @@ mod rust_bridge {
     // and metering data will be populated, but result value and effects won't
     // be populated.
     struct InvokeHostFunctionOutput {
-        // Diagnostic information concerning the host function execution.
         success: bool,
+        // In case if `success` is `false` indicates whether the host has
+        // failed with an internal error.
+        // We don't otherwise observe the error codes, but internal errors are
+        // something that should never happen, so it's important to be able
+        // to act on them in Core.
+        is_internal_error: bool,
+        // Diagnostic information concerning the host function execution.
         diagnostic_events: Vec<RustBuf>,
         cpu_insns: u64,
         mem_bytes: u64,

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -503,11 +503,19 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     }
     catch (std::exception& e)
     {
+        // Host invocations should never throw an exception, so encountering
+        // one would be an internal error.
+        out.is_internal_error = true;
         CLOG_DEBUG(Tx, "Exception caught while invoking host fn: {}", e.what());
     }
 
     if (!out.success)
     {
+        if (out.is_internal_error)
+        {
+            throw std::runtime_error(
+                "Got internal error during Soroban host invocation.");
+        }
         if (resources.instructions < out.cpu_insns)
         {
             mParentTx.pushSimpleDiagnosticError(


### PR DESCRIPTION
# Description

Treat Soroban host internal errors as `txINTERNAL_ERROR`.

This will allow us to monitor and quickly react to them.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
