### PR TITLE
Pin cargo deps more

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: cackle-rs/cackle-action@387fe459d8c037a0e7fbcd3d868f1aaba389d057
-      - run: cargo acl -n run
+      - run: cargo acl -n test
 
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,9 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a
       with:
         command: check ${{ matrix.checks }}
+        # leave arguments empty so we don't test --all-features
+        # which will see conflicting env versions
+        arguments:
 
   rust-check-git-rev-deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,43 @@ on:
 
 jobs:
 
+  complete:
+    if: always()
+    needs: [fmt, cackle, cargo-deny, check-git-rev-deps, build]
+    runs-on: ubuntu-latest
+    steps:
+    - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+      run: exit 1
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update
+    - run: cargo fmt --all --check
+
+  cackle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cackle-rs/cackle-action@387fe459d8c037a0e7fbcd3d868f1aaba389d057
+      - run: cargo acl -n run
+
+  cargo-deny:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
+    # Prevent sudden announcement of a new advisory from failing ci:
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a
+      with:
+        command: check ${{ matrix.checks }}
+
   rust-check-git-rev-deps:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - run: rustup component add rustfmt
     - run: rustup update
     - run: cargo fmt --all --check
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
         # leave arguments empty so we don't test --all-features
         # which will see conflicting env versions
         arguments:
-        rust-version: 1.74
 
   rust-check-git-rev-deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
     - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a
+    - uses: EmbarkStudios/cargo-deny-action@1e59595bed8fc55c969333d08d7817b36888f0c5
       with:
         command: check ${{ matrix.checks }}
         # leave arguments empty so we don't test --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
   complete:
     if: always()
-    needs: [fmt, cackle, cargo-deny, check-git-rev-deps, build]
+    needs: [fmt, cackle, cargo-deny, rust-check-git-rev-deps, build]
     runs-on: ubuntu-latest
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
         # leave arguments empty so we don't test --all-features
         # which will see conflicting env versions
         arguments:
+        rust-version: 1.74
 
   rust-check-git-rev-deps:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
           else
             sudo apt-get -y install clang-12 llvm-12
           fi
+      - name: install rustup components
+        run: rustup component add rustfmt
       - name: install dependencies
         run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev sed perl
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,12 +389,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
@@ -432,22 +426,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -636,12 +620,12 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "petgraph"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap",
 ]
 
 [[package]]
@@ -863,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
@@ -1105,12 +1089,14 @@ dependencies = [
  "cargo-lock",
  "cxx",
  "log",
+ "petgraph",
  "rand",
  "rustc-simple-version",
  "soroban-env-host 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=be04cf31e925ba5bacd9b22db7caf7b4f6dd8372)",
  "soroban-env-host 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=c6096cb1414cc1bedce59cef697c71a8bdd70ef3)",
  "soroban-synth-wasm",
  "soroban-test-wasms",
+ "toml",
  "tracy-client",
 ]
 
@@ -1200,9 +1186,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1212,20 +1198,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1459,7 +1445,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap",
  "semver",
 ]
 
@@ -1562,9 +1548,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]

--- a/cackle.toml
+++ b/cackle.toml
@@ -93,6 +93,9 @@ allow_unsafe = true
 
 [pkg.rand_chacha]
 allow_unsafe = true
+from.test.allow_apis = [
+    "rand",
+]
 
 [pkg.soroban-env-host]
 allow_unsafe = true
@@ -273,6 +276,9 @@ build.allow_apis = [
     "env",
 ]
 allow_unsafe = true
+from.test.allow_apis = [
+    "hash",
+]
 
 [pkg.getrandom]
 allow_unsafe = true
@@ -321,6 +327,9 @@ allow_unsafe = true
 
 [pkg.wasmparser]
 allow_unsafe = true
+from.test.allow_apis = [
+    "hash",
+]
 
 [pkg.crate-git-revision]
 from.build.allow_apis = [
@@ -387,3 +396,6 @@ allow_unsafe = true
 
 [pkg.stellar-core]
 allow_unsafe = true
+test.allow_apis = [
+    "rand",
+]

--- a/cackle.toml
+++ b/cackle.toml
@@ -1,0 +1,389 @@
+[common]
+version = 2
+build_flags = []
+
+# Import some predefined API groups that cackle supports. These are
+# equivalent to defining `[api.net]` and `[api.fs]` and so on, but
+# are baked-in to cackle.
+import_std =  ["net", "fs", "env", "process", "terminate"]
+
+# Define a few more API groups we want to be concerned with the use
+# of: those that risk nondeterminism in the program.
+[api.time]
+include = [
+    "std::time",
+]
+
+[api.hash]
+include = [
+    "core::hash",
+    "std::collections::HashMap",
+    "std::collections::hash",
+    "std::sys::unix::rand::hashmap_random_keys",
+    "hashbrown::raw",
+]
+
+[api.rand]
+include = [
+    "rand",
+    "rand_core"
+]
+exclude = [
+    "rand::distributions",
+    "rand::seq",
+]
+
+[api.thread]
+include = [
+    "std::thread",
+]
+no_auto_detect = [
+    "syn",
+]
+
+[api.env]
+no_auto_detect = [
+    "soroban-env-common",
+]
+
+[pkg.thiserror-impl]
+allow_proc_macro = true
+allow_apis = [
+    "hash",
+]
+
+[pkg.wasm-bindgen-macro]
+allow_proc_macro = true
+
+[pkg.soroban-builtin-sdk-macros]
+allow_proc_macro = true
+
+[pkg.paste]
+allow_proc_macro = true
+build.allow_apis = [
+    "process",
+]
+allow_apis = [
+    "env",
+]
+
+[pkg.num-derive]
+allow_proc_macro = true
+
+[pkg.serde_derive]
+allow_proc_macro = true
+allow_apis = [
+    "hash",
+    "thread",
+]
+
+[pkg.curve25519-dalek-derive]
+allow_proc_macro = true
+allow_unsafe = true
+
+[pkg.soroban-env-macros]
+allow_proc_macro = true
+allow_apis = [
+    "env",
+    "fs",
+]
+
+[pkg.rand]
+allow_unsafe = true
+
+[pkg.rand_chacha]
+allow_unsafe = true
+
+[pkg.soroban-env-host]
+allow_unsafe = true
+build.allow_apis = [
+    "env",
+]
+
+[pkg.unicode-ident]
+allow_unsafe = true
+
+[pkg.itoa]
+allow_unsafe = true
+
+[pkg.subtle]
+allow_unsafe = true
+
+[pkg.zeroize]
+allow_unsafe = true
+
+[pkg.cpufeatures]
+allow_unsafe = true
+
+[pkg.static_assertions]
+allow_unsafe = true
+
+[pkg.ryu]
+allow_unsafe = true
+
+[pkg.either]
+allow_unsafe = true
+
+[pkg.spin]
+allow_unsafe = true
+
+[pkg.wasmi_arena]
+allow_unsafe = true
+
+[pkg.base16ct]
+allow_unsafe = true
+
+[pkg.percent-encoding]
+allow_unsafe = true
+
+[pkg.smallvec]
+allow_unsafe = true
+
+[pkg.once_cell]
+allow_unsafe = true
+
+[pkg.ppv-lite86]
+allow_unsafe = true
+
+[pkg.keccak]
+allow_unsafe = true
+
+[pkg.hashbrown]
+allow_unsafe = true
+
+[pkg.ethnum]
+allow_unsafe = true
+
+[pkg.unicode-bidi]
+allow_unsafe = true
+
+[pkg.unicode-normalization]
+allow_unsafe = true
+
+[pkg.cc]
+allow_unsafe = true
+from.build.allow_apis = [
+    "env",
+    "fs",
+    "hash",
+    "process",
+    "terminate",
+    "thread",
+]
+
+[pkg.wasmparser-nostd]
+allow_unsafe = true
+
+[pkg.form_urlencoded]
+allow_unsafe = true
+
+[pkg.libm]
+build.allow_apis = [
+    "env",
+]
+allow_unsafe = true
+
+[pkg.platforms]
+build.allow_apis = [
+    "env",
+]
+
+[pkg.serde_json]
+build.allow_apis = [
+    "env",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.serde]
+build.allow_apis = [
+    "env",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.quote]
+build.allow_apis = [
+    "env",
+    "process",
+    "terminate",
+]
+
+[pkg.semver]
+build.allow_apis = [
+    "env",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.proc-macro2]
+build.allow_apis = [
+    "env",
+    "process",
+]
+allow_unsafe = true
+allow_apis = [
+    "terminate",
+]
+
+[pkg.thiserror]
+build.allow_apis = [
+    "env",
+    "fs",
+    "process",
+]
+
+[pkg.memchr]
+allow_unsafe = true
+
+[pkg.libc]
+build.allow_apis = [
+    "env",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.version_check]
+from.build.allow_apis = [
+    "env",
+    "process",
+]
+
+[pkg.typenum]
+build.allow_apis = [
+    "env",
+    "fs",
+]
+
+[pkg.num-traits]
+build.allow_apis = [
+    "env",
+]
+allow_unsafe = true
+
+[pkg.autocfg]
+from.build.allow_apis = [
+    "env",
+    "fs",
+    "process",
+]
+
+[pkg.indexmap]
+build.allow_apis = [
+    "env",
+]
+allow_unsafe = true
+
+[pkg.getrandom]
+allow_unsafe = true
+
+[pkg.generic-array]
+allow_unsafe = true
+
+[pkg.num-integer]
+build.allow_apis = [
+    "env",
+]
+
+[pkg.block-buffer]
+allow_unsafe = true
+
+[pkg.rand_core]
+allow_unsafe = true
+
+[pkg.rustc_version]
+from.build.allow_apis = [
+    "env",
+    "hash",
+    "process",
+]
+
+[pkg.sha2]
+allow_unsafe = true
+
+[pkg.curve25519-dalek]
+build.allow_apis = [
+    "env",
+]
+allow_unsafe = true
+
+[pkg.crypto-bigint]
+allow_unsafe = true
+
+[pkg.syn]
+allow_unsafe = true
+allow_apis = [
+    "thread",
+]
+
+[pkg.soroban-wasmi]
+allow_unsafe = true
+
+[pkg.wasmparser]
+allow_unsafe = true
+
+[pkg.crate-git-revision]
+from.build.allow_apis = [
+    "env",
+    "fs",
+    "process",
+]
+
+[pkg.soroban-env-common]
+allow_unsafe = true
+
+[pkg.derive_arbitrary]
+allow_proc_macro = true
+
+[pkg.arbitrary]
+allow_unsafe = true
+
+[pkg.itertools]
+allow_unsafe = true
+
+[pkg.cxxbridge-macro]
+allow_proc_macro = true
+allow_apis = [
+    "hash",
+]
+allow_unsafe = true
+
+[pkg.tracy-client-sys]
+allow_unsafe = true
+
+[pkg.log]
+allow_unsafe = true
+
+[pkg.fixedbitset]
+allow_unsafe = true
+
+[pkg.rustc-simple-version]
+allow_apis = [
+    "process",
+]
+
+[pkg.winnow]
+allow_unsafe = true
+
+[pkg.link-cplusplus]
+build.allow_apis = [
+    "env",
+    "fs",
+]
+
+[pkg.cxx]
+allow_apis = [
+    "env",
+    "fs",
+    "process",
+]
+allow_unsafe = true
+
+[pkg.petgraph]
+allow_unsafe = true
+
+[pkg.toml_edit]
+allow_unsafe = true
+
+[pkg.stellar-core]
+allow_unsafe = true

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,292 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "aarch64-unknown-linux-gnu" },
+    { triple = "wasm32-unknown-unknown" }
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #{ triple = "x86_64-unknown-linux-musl" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+
+exclude = [
+   # used only when doing CPU-calibration benchmarks, not worth worrying about
+   "ansi_term",
+   "textplots",
+   "linregress",
+   # the dep specs of tracy-client are weird and include "loom" which it
+   # totally doesn't depend on but in any case it's compiled-out in real
+   # production builds we care about.
+   "tracy-client",
+   # Somehow the tracking machinery of two different dev-dep tracing
+   # subsystems also winds up pulling in conflicts, but again, just
+   # dev-deps or non-produciton configs.
+   "tracking-allocator"
+]
+
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = true
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+# feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold =
+
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "Apache-2.0 WITH LLVM-exception",
+    "Unicode-DFS-2016",
+    # "MPL-2.0"
+]
+# List of explicitly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "deny"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = true
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "deny"
+# Lint level for when a crate version requirement is `*`
+wildcards = "deny"
+allow-wildcard-paths = true
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overriden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overriden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#name = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "deny"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "deny"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = [
+    "https://github.com/rustsec/rustsec"
+]
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = ["stellar"]
+# 1 or more gitlab.com organizations to allow git sources for
+# gitlab = [""]
+# 1 or more bitbucket.org organizations to allow git sources for
+# bitbucket = [""]

--- a/deny.toml
+++ b/deny.toml
@@ -57,7 +57,7 @@ exclude = [
 # If true, metadata will be collected with `--all-features`. Note that this can't
 # be toggled off if true, if you want to conditionally enable `--all-features` it
 # is recommended to pass `--all-features` on the cmd line instead
-all-features = true
+all-features = false
 # If true, metadata will be collected with `--no-default-features`. The same
 # caveat with `all-features` applies
 no-default-features = false

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,10 +130,11 @@ TESTS=test/selftest-nopg
 endif # !USE_POSTGRES
 TESTS += test/check-nondet
 
-if USE_CLANG_FORMAT
 format: always
+if USE_CLANG_FORMAT
 	cd $(srcdir) && $(CLANG_FORMAT) -style=file -i $(SRC_CXX_FILES) $(SRC_H_FILES) $(SRC_TEST_CXX_FILES) $(SRC_TEST_H_FILES)
 endif # USE_CLANG_FORMAT
+	cd $(srcdir) && $(CARGO) fmt --all
 
 if USE_AFL_FUZZ
 FUZZER_MODE ?= overlay

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,7 +86,7 @@ stellar_core_LDADD += $(LIBRUST_STELLAR_CORE) -ldl
 
 $(RUST_CXXBRIDGE):
 	mkdir -p $(RUST_BIN_DIR)
-	CARGO_HTTP_MULTIPLEXING=false $(CARGO) install --root $(RUST_BUILD_DIR) cxxbridge-cmd --version 1.0.68
+	CARGO_HTTP_MULTIPLEXING=false $(CARGO) install --locked --root $(RUST_BUILD_DIR) cxxbridge-cmd --version 1.0.68
 
 rust/RustBridge.h: rust/src/lib.rs $(SRC_RUST_FILES) Makefile $(RUST_CXXBRIDGE)
 	$(RUST_CXXBRIDGE) $< --header --output $@.tmp
@@ -97,7 +97,7 @@ rust/RustBridge.cpp: rust/src/lib.rs $(SRC_RUST_FILES) Makefile $(RUST_CXXBRIDGE
 	if cmp -s $@.tmp $@; then rm -v $@.tmp; else mv -v $@.tmp $@; fi
 
 $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile
-	cd $(RUST_BUILD_DIR) && cargo build --$(RUST_PROFILE) --target-dir $(abspath $(RUST_TARGET_DIR)) $(CARGO_FEATURES)
+	cd $(RUST_BUILD_DIR) && cargo build --locked --$(RUST_PROFILE) --target-dir $(abspath $(RUST_TARGET_DIR)) $(CARGO_FEATURES)
 	ranlib $@
 
 $(srcdir)/src.mk: $(top_srcdir)/make-mks

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -19,6 +19,9 @@ rustc-simple-version = "=0.1.0"
 # will complain if it does not match)
 rand = "=0.8.5"
 
+petgraph = "=0.6.4"
+toml = "=0.7.8"
+
 # This copy of the soroban host is always enabled, and should always point to a
 # version that supports stellar-core's Config::CURRENT_LEDGER_PROTOCOL_VERSION.
 # When upgrading from protocol N to N+1, this copy will therefore have its
@@ -59,14 +62,17 @@ package = "soroban-env-host"
 rev = "c6096cb1414cc1bedce59cef697c71a8bdd70ef3"
 
 [dependencies.soroban-test-wasms]
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "be04cf31e925ba5bacd9b22db7caf7b4f6dd8372"
 
 [dependencies.soroban-synth-wasm]
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 rev = "be04cf31e925ba5bacd9b22db7caf7b4f6dd8372"
 
 [dependencies.cargo-lock]
+version = "=9.0.0"
 git = "https://github.com/rustsec/rustsec"
 rev = "a5c69fc6e4b6068b43d7143f3a2f68c3f3de37d8"
 features = ["dependency-tree"]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,21 +2,22 @@
 name = "stellar-core"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.74"
+publish = false
 
 [lib]
 name = "rust_stellar_core"
 crate-type = ["staticlib"]
 
 [dependencies]
-log = "0.4.17"
+log = "=0.4.19"
 tracy-client = { version = "=0.15.2", features = ["enable"], default-features = false, optional = true}
-cxx = "1.0"
-base64 = "0.13.0"
-rustc-simple-version = "0.1.0"
+cxx = "=1.0.97"
+base64 = "=0.13.1"
+rustc-simple-version = "=0.1.0"
 # NB: this must match the same rand version used by soroban (but the tooling
 # will complain if it does not match)
-rand = "0.8.5"
+rand = "=0.8.5"
 
 # This copy of the soroban host is always enabled, and should always point to a
 # version that supports stellar-core's Config::CURRENT_LEDGER_PROTOCOL_VERSION.
@@ -28,7 +29,7 @@ rand = "0.8.5"
 # N.
 
 [dependencies.soroban-env-host-curr]
-version = "20.0.0-rc1"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
 rev = "be04cf31e925ba5bacd9b22db7caf7b4f6dd8372"
@@ -52,7 +53,7 @@ rev = "be04cf31e925ba5bacd9b22db7caf7b4f6dd8372"
 
 [dependencies.soroban-env-host-prev]
 optional = true
-version = "20.0.0-rc1"
+version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
 rev = "c6096cb1414cc1bedce59cef697c71a8bdd70ef3"

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -484,8 +484,7 @@ fn check_lockfile_has_expected_dep_tree(
     } else {
         // In non-vnext core builds, we're more strict about the versions
         // matching.
-        if stellar_core_proto_version != soroban_host_proto_version
-        {
+        if stellar_core_proto_version != soroban_host_proto_version {
             panic!(
                 "stellar-core \"{}\" protocol is {}, does not match soroban host \"{}\" protocol {}",
                 curr_or_prev, stellar_core_proto_version, curr_or_prev, soroban_host_proto_version

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -372,12 +372,14 @@ fn get_random_wasm(size: usize, seed: u64) -> Result<RustBuf, Box<dyn std::error
 
 #[test]
 fn test_get_random_wasm() {
-    // The header will grow to 96 bytes when the body is larger than 16k bytes
-    // but the first 10 sizes will all have a 94 byte header.
-    const HEADERSZ: usize = 94;
+    // HEADERSZ varies a bit as we fiddle with the definition of the wasm
+    // synthesis system we want to check that it hasn't grown unreasonable and
+    // we're _basically_ building something of the requested size, or at least
+    // right order of magnitude.
+    const HEADERSZ: usize = 150;
     for i in 1..10 {
         let wasm = get_random_wasm(1000 * i, i as u64).unwrap();
-        assert_eq!(wasm.data.len(), 1000 * i + HEADERSZ);
+        assert!(wasm.data.len() < 1000 * i + HEADERSZ);
     }
 }
 


### PR DESCRIPTION
This does the remaining part of stellar/rs-soroban-env#1222:

- pins versions with '=' constraints in core
- adds CI and workspace plumbing for `cargo-deny` and `cargo-acl`
- fixes issues they found
- uses `--locked` everywhere we issue `cargo` commands (in `Makefile.am`)

Note that there is a small lockfile change here but it doesn't impact the baked-in env dependency trees, it only reduces some divergence between those trees and dependencies of `cargo-lock`, which is one of core's dependencies _outside_ the env trees (we assume it has no effect on the part we care about: bit-precise stability of the env code)