### PR TITLE
Fix divide by 0

### DIFF
--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1221,9 +1221,14 @@ LoadGenerator::invokeSorobanLoadTransaction(uint32_t ledgerNum,
         resources.footprint.readWrite.emplace_back(lk);
     }
 
-    uint32_t maxKiloBytesPerEntry =
-        (networkCfg.mTxMaxReadBytes - mContactOverheadBytes) / numEntries /
-        1024;
+    uint32_t maxKiloBytesPerEntry = 0;
+    if (networkCfg.mTxMaxReadBytes > mContactOverheadBytes && numEntries > 0)
+    {
+        maxKiloBytesPerEntry =
+            (networkCfg.mTxMaxReadBytes - mContactOverheadBytes) / numEntries /
+            1024;
+    }
+
     maxKiloBytesPerEntry =
         std::min(maxKiloBytesPerEntry, cfg.kiloBytesPerDataEntryHigh);
     uint32_t minKiloBytesPerEntry =


### PR DESCRIPTION
# Description

Fixes a divide by 0 bug in soroban loadgen missions.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
