### PR TITLE
Fix broken nondeterministic tests

### DIFF
--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -101,13 +101,13 @@ TEST_CASE("skip list", "[bucket][bucketmanager]")
         test()
         {
             Hash h0;
-            Hash h1 = HashUtils::random();
-            Hash h2 = HashUtils::random();
-            Hash h3 = HashUtils::random();
-            Hash h4 = HashUtils::random();
-            Hash h5 = HashUtils::random();
-            Hash h6 = HashUtils::random();
-            Hash h7 = HashUtils::random();
+            Hash h1 = HashUtils::pseudoRandomForTesting();
+            Hash h2 = HashUtils::pseudoRandomForTesting();
+            Hash h3 = HashUtils::pseudoRandomForTesting();
+            Hash h4 = HashUtils::pseudoRandomForTesting();
+            Hash h5 = HashUtils::pseudoRandomForTesting();
+            Hash h6 = HashUtils::pseudoRandomForTesting();
+            Hash h7 = HashUtils::pseudoRandomForTesting();
 
             // up first entry
             LedgerHeader header;

--- a/src/crypto/test/CryptoTests.cpp
+++ b/src/crypto/test/CryptoTests.cpp
@@ -33,8 +33,8 @@ static std::map<std::vector<uint8_t>, std::string> hexTestVectors = {
 
 TEST_CASE("random", "[crypto]")
 {
-    SecretKey k1 = SecretKey::random();
-    SecretKey k2 = SecretKey::random();
+    SecretKey k1 = SecretKey::pseudoRandomForTesting();
+    SecretKey k2 = SecretKey::pseudoRandomForTesting();
     LOG_DEBUG(DEFAULT_LOG, "k1: {}", k1.getStrKeySeed().value);
     LOG_DEBUG(DEFAULT_LOG, "k2: {}", k2.getStrKeySeed().value);
     CHECK(k1.getStrKeySeed() != k2.getStrKeySeed());
@@ -270,7 +270,7 @@ TEST_CASE("HKDF test vector", "[crypto]")
 
 TEST_CASE("sign tests", "[crypto]")
 {
-    auto sk = SecretKey::random();
+    auto sk = SecretKey::pseudoRandomForTesting();
     auto pk = sk.getPublicKey();
     LOG_DEBUG(DEFAULT_LOG, "generated random secret key seed: {}",
               sk.getStrKeySeed().value);
@@ -456,7 +456,7 @@ TEST_CASE("StrKey tests", "[crypto]")
 TEST_CASE("key string roundtrip", "[crypto]")
 {
     SignerKey signer;
-    auto publicKey = SecretKey::random().getPublicKey();
+    auto publicKey = SecretKey::pseudoRandomForTesting().getPublicKey();
     uint256 rand256 = publicKey.ed25519();
     SECTION("SIGNER_KEY_TYPE_ED25519")
     {

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -310,7 +310,7 @@ TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
     {
         std::tie(lcl, last) = ledgerChainGenerator.makeLedgerChainFiles(
             HistoryManager::VERIFY_STATUS_OK);
-        lcl.hash = HashUtils::random();
+        lcl.hash = HashUtils::pseudoRandomForTesting();
         auto w =
             checkExpectedBehavior(BasicWork::State::WORK_FAILURE, lcl, last);
         REQUIRE(w);
@@ -319,7 +319,7 @@ TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
     {
         std::tie(lcl, last) = ledgerChainGenerator.makeLedgerChainFiles(
             HistoryManager::VERIFY_STATUS_OK);
-        lcl.hash = HashUtils::random();
+        lcl.hash = HashUtils::pseudoRandomForTesting();
         auto w = checkExpectedBehavior(BasicWork::State::WORK_FAILURE, lcl,
                                        last, false);
         REQUIRE(!w);
@@ -330,7 +330,7 @@ TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
             HistoryManager::VERIFY_STATUS_OK);
         lcl.header.ledgerSeq +=
             app->getHistoryManager().getCheckpointFrequency() - 1;
-        lcl.hash = HashUtils::random();
+        lcl.hash = HashUtils::pseudoRandomForTesting();
         auto w =
             checkExpectedBehavior(BasicWork::State::WORK_FAILURE, lcl, last);
         REQUIRE(w);
@@ -340,7 +340,7 @@ TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
         std::tie(lcl, last) = ledgerChainGenerator.makeLedgerChainFiles(
             HistoryManager::VERIFY_STATUS_OK);
         lcl.header.ledgerSeq -= 1;
-        lcl.hash = HashUtils::random();
+        lcl.hash = HashUtils::pseudoRandomForTesting();
         auto w =
             checkExpectedBehavior(BasicWork::State::WORK_FAILURE, lcl, last);
         REQUIRE(w);
@@ -349,7 +349,7 @@ TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
     {
         std::tie(lcl, last) = ledgerChainGenerator.makeLedgerChainFiles(
             HistoryManager::VERIFY_STATUS_OK);
-        last.hash = HashUtils::random();
+        last.hash = HashUtils::pseudoRandomForTesting();
         auto w =
             checkExpectedBehavior(BasicWork::State::WORK_FAILURE, lcl, last);
         REQUIRE(!w);
@@ -412,7 +412,7 @@ TEST_CASE("Tx results verification", "[batching][resultsverification]")
         res.close();
         REQUIRE_FALSE(entries.empty());
         auto& lastEntry = entries.at(entries.size() - 1);
-        lastEntry.header.txSetResultHash = HashUtils::random();
+        lastEntry.header.txSetResultHash = HashUtils::pseudoRandomForTesting();
         std::remove(ft.localPath_nogz().c_str());
 
         XDROutputFileStream out(

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -167,7 +167,7 @@ TestBucketGenerator::TestBucketGenerator(
 std::string
 TestBucketGenerator::generateBucket(TestBucketState state)
 {
-    uint256 hash = HashUtils::random();
+    uint256 hash = HashUtils::pseudoRandomForTesting();
     if (state == TestBucketState::FILE_NOT_UPLOADED)
     {
         // Skip uploading the file, return any hash
@@ -182,7 +182,7 @@ TestBucketGenerator::generateBucket(TestBucketState state)
 
     if (state == TestBucketState::HASH_MISMATCH)
     {
-        hash = HashUtils::random();
+        hash = HashUtils::pseudoRandomForTesting();
     }
 
     // Upload generated bucket to the archive
@@ -276,7 +276,7 @@ TestLedgerChainGenerator::CheckpointEnds
 TestLedgerChainGenerator::makeLedgerChainFiles(
     HistoryManager::LedgerVerificationStatus state)
 {
-    Hash hash = HashUtils::random();
+    Hash hash = HashUtils::pseudoRandomForTesting();
     LedgerHeaderHistoryEntry beginRange;
 
     LedgerHeaderHistoryEntry first, last;

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -8,6 +8,7 @@
 #include "ledger/LedgerHashUtils.h"
 #include "ledger/NetworkConfig.h"
 #include "main/Config.h"
+#include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/Math.h"
 #include "util/UnorderedSet.h"
@@ -390,7 +391,20 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
           LedgerHeaderHistoryEntry firstLedger,
           HistoryManager::LedgerVerificationStatus state)
 {
-    auto randomIndex = rand_uniform<size_t>(1, lhv.size() - 1);
+    // We want to avoid corrupting the 0th through 2nd entries, because we use
+    // these corrupt sequences in history tests that differentiate between
+    // failures that encounter local state, specifically the LCL (suggesting the
+    // local node has diverged), and those that don't (suggesting merely corrupt
+    // download material), and the LCL-encounters in these tests happen at
+    // ledger entry 64, entry 0 in the checkpoint.
+    //
+    // An undershot corruption at entry 2 will cause verification of to
+    // interpret it as entry 1 with a wrong prev-ptr pointing to entry 0 which
+    // is LCL, causing an LCL encounter. Any other corruption at entry 1 will
+    // similarly cause an LCL encounter. Corruptions at or beyond entry 3 are ok
+    // though.
+    releaseAssertOrThrow(lhv.size() > 3);
+    auto randomIndex = rand_uniform<size_t>(3, lhv.size() - 1);
     auto prevHash = firstLedger.header.previousLedgerHash;
     auto ledgerSeq = firstLedger.header.ledgerSeq;
 
@@ -423,7 +437,7 @@ makeValid(std::vector<LedgerHeaderHistoryEntry>& lhv,
                 break;
             }
         }
-        // On a coin flip, corrupt header content rather than previous link
+        // On a coin flip, corrupt header as well as previous link
         if (i == randomIndex &&
             state == HistoryManager::VERIFY_STATUS_ERR_BAD_HASH && rand_flip())
         {

--- a/src/overlay/test/OverlayTests.cpp
+++ b/src/overlay/test/OverlayTests.cpp
@@ -311,7 +311,8 @@ TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
         for (int i = 0; i < tx2.transaction().v1().signatures.max_size(); i++)
         {
             tx2.transaction().v1().signatures.emplace_back(
-                SignatureUtils::sign(SecretKey::random(), HashUtils::random()));
+                SignatureUtils::sign(SecretKey::pseudoRandomForTesting(),
+                                     HashUtils::pseudoRandomForTesting()));
         }
         auto txSize2 = getTxSize(tx2);
         REQUIRE(xdr::xdr_size(tx2.transaction()) >
@@ -385,8 +386,8 @@ TEST_CASE("flow control byte capacity", "[overlay][flowcontrol]")
                  i < feeBump.transaction().feeBump().signatures.max_size(); i++)
             {
                 feeBump.transaction().feeBump().signatures.emplace_back(
-                    SignatureUtils::sign(SecretKey::random(),
-                                         HashUtils::random()));
+                    SignatureUtils::sign(SecretKey::pseudoRandomForTesting(),
+                                         HashUtils::pseudoRandomForTesting()));
             }
             REQUIRE(xdr::xdr_size(feeBump) <
                     xdr::xdr_size(tx2.transaction()) +


### PR DESCRIPTION
CI is currently wedged because the RNG seed rolled over and exposed a nondeterministic test failure. This PR fixes it (the first change) as well as removing some sources of true nondeterminism (like calling /dev/random) that have snuck into the testsuite by accident.

cc @marta-lokhova since this is involving some of your test code -- would appreciate a double check of my work!