### PR TITLE
Reduce extend/restore footprint op threshold to LOW.

### DIFF
--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -200,4 +200,11 @@ ExtendFootprintTTLOpFrame::isSoroban() const
 {
     return true;
 }
+
+ThresholdLevel
+ExtendFootprintTTLOpFrame::getThresholdLevel() const
+{
+    return ThresholdLevel::LOW;
+}
+
 }

--- a/src/transactions/ExtendFootprintTTLOpFrame.h
+++ b/src/transactions/ExtendFootprintTTLOpFrame.h
@@ -45,5 +45,7 @@ class ExtendFootprintTTLOpFrame : public OperationFrame
     }
 
     virtual bool isSoroban() const override;
+
+    ThresholdLevel getThresholdLevel() const override;
 };
 }

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -205,4 +205,10 @@ RestoreFootprintOpFrame::isSoroban() const
 {
     return true;
 }
+
+ThresholdLevel
+RestoreFootprintOpFrame::getThresholdLevel() const
+{
+    return ThresholdLevel::LOW;
+}
 }

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -45,5 +45,7 @@ class RestoreFootprintOpFrame : public OperationFrame
     }
 
     virtual bool isSoroban() const override;
+
+    ThresholdLevel getThresholdLevel() const override;
 };
 }


### PR DESCRIPTION
# Description

Reduce extend/restore footprint op threshold to LOW.

The threshold for these operations is actually irrelevant because the operation source account itself is irrelevant. For the sake of consistency, we make the threshold to match the transaction threshold itself.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
