### PR TITLE
Add medida metrics for cpu_insn, time excluding VM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "soroban-builtin-sdk-macros"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a#3820e24add81de526d915d99593591e0ef18c06a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -940,23 +940,23 @@ dependencies = [
  "soroban-env-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 20.0.0-rc1 (git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746)",
- "tracy-client",
+ "stellar-xdr",
 ]
 
 [[package]]
 name = "soroban-env-common"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a#3820e24add81de526d915d99593591e0ef18c06a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 dependencies = [
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a)",
+ "soroban-env-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900)",
  "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 20.0.0-rc1 (git+https://github.com/stellar/rs-stellar-xdr?rev=d6f8ece2c89809d5e2800b9df64ae60787ee492b)",
+ "stellar-xdr",
+ "tracy-client",
 ]
 
 [[package]]
@@ -982,13 +982,12 @@ dependencies = [
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "tracy-client",
 ]
 
 [[package]]
 name = "soroban-env-host"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a#3820e24add81de526d915d99593591e0ef18c06a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -1003,11 +1002,12 @@ dependencies = [
  "rand_chacha",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a)",
- "soroban-env-common 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a)",
+ "soroban-builtin-sdk-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900)",
+ "soroban-env-common 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900)",
  "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
+ "tracy-client",
 ]
 
 [[package]]
@@ -1020,32 +1020,32 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 20.0.0-rc1 (git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746)",
+ "stellar-xdr",
  "syn",
 ]
 
 [[package]]
 name = "soroban-env-macros"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a#3820e24add81de526d915d99593591e0ef18c06a"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 20.0.0-rc1 (git+https://github.com/stellar/rs-stellar-xdr?rev=d6f8ece2c89809d5e2800b9df64ae60787ee492b)",
+ "stellar-xdr",
  "syn",
 ]
 
 [[package]]
 name = "soroban-synth-wasm"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3#2cb39e21bdc6941c55529e65988a31103173f4e3"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 dependencies = [
  "arbitrary",
- "soroban-env-common 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3)",
- "soroban-env-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3)",
+ "soroban-env-common 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900)",
+ "soroban-env-macros 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900)",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1053,7 +1053,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3#2cb39e21bdc6941c55529e65988a31103173f4e3"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1101,7 +1101,7 @@ dependencies = [
  "rand",
  "rustc-simple-version",
  "soroban-env-host 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3)",
- "soroban-env-host 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=3820e24add81de526d915d99593591e0ef18c06a)",
+ "soroban-env-host 20.0.0-rc2 (git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900)",
  "soroban-synth-wasm",
  "soroban-test-wasms",
  "toml",
@@ -1127,17 +1127,6 @@ dependencies = [
  "base64",
  "crate-git-revision",
  "escape-bytes",
- "hex",
- "stellar-strkey",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=d6f8ece2c89809d5e2800b9df64ae60787ee492b#d6f8ece2c89809d5e2800b9df64ae60787ee492b"
-dependencies = [
- "base64",
- "crate-git-revision",
  "hex",
  "stellar-strkey",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -35,7 +35,7 @@ toml = "=0.7.8"
 version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "2cb39e21bdc6941c55529e65988a31103173f4e3"
+rev = "bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -59,17 +59,17 @@ optional = true
 version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "3820e24add81de526d915d99593591e0ef18c06a"
+rev = "2cb39e21bdc6941c55529e65988a31103173f4e3"
 
 [dependencies.soroban-test-wasms]
 version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "2cb39e21bdc6941c55529e65988a31103173f4e3"
+rev = "bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 
 [dependencies.soroban-synth-wasm]
 version = "=20.0.0-rc2"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "2cb39e21bdc6941c55529e65988a31103173f4e3"
+rev = "bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
 
 [dependencies.cargo-lock]
 version = "=9.0.0"

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -353,6 +353,13 @@ fn invoke_host_function_or_maybe_panic(
 
     let cpu_insns = budget.get_cpu_insns_consumed()?;
     let mem_bytes = budget.get_mem_bytes_consumed()?;
+    let cpu_insns_excluding_vm_instantiation = cpu_insns.saturating_sub(
+        budget
+            .get_tracker(xdr::ContractCostType::VmInstantiation)?
+            .cpu,
+    );
+    let time_nsecs_excluding_vm_instantiation =
+        time_nsecs.saturating_sub(budget.get_time(xdr::ContractCostType::VmInstantiation)?);
     #[cfg(feature = "tracy")]
     {
         client.plot(
@@ -381,6 +388,8 @@ fn invoke_host_function_or_maybe_panic(
                     cpu_insns,
                     mem_bytes,
                     time_nsecs,
+                    cpu_insns_excluding_vm_instantiation,
+                    time_nsecs_excluding_vm_instantiation,
 
                     result_value: result_value.into(),
                     modified_ledger_entries,
@@ -427,6 +436,8 @@ fn invoke_host_function_or_maybe_panic(
         cpu_insns,
         mem_bytes,
         time_nsecs,
+        cpu_insns_excluding_vm_instantiation,
+        time_nsecs_excluding_vm_instantiation,
 
         result_value: vec![].into(),
         modified_ledger_entries: vec![],

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3#2cb39e21bdc6941c55529e65988a31103173f4e3
+soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
 ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── tracy-client-sys 0.20.0 checksum:e8cf8aeb20e40d13be65a0b134f8d82d360e72b2793a11de8867d7fbc0f9d6f6
 │   │   └── cc 1.0.79 checksum:50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f
@@ -97,7 +97,7 @@ soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2c
 │   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-env-common 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3#2cb39e21bdc6941c55529e65988a31103173f4e3
+├── soroban-env-common 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
 │   ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── stellar-xdr 20.0.0-rc1 git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746#97e52f17501fb058ee28bbca3da0ae7897492746
 │   │   ├── stellar-strkey 0.0.8 checksum:12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd
@@ -107,7 +107,7 @@ soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2c
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
 │   ├── soroban-wasmi 0.31.0-soroban1 git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be
-│   ├── soroban-env-macros 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3#2cb39e21bdc6941c55529e65988a31103173f4e3
+│   ├── soroban-env-macros 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
 │   │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
 │   │   ├── stellar-xdr 20.0.0-rc1 git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746#97e52f17501fb058ee28bbca3da0ae7897492746
 │   │   ├── serde_json 1.0.108 checksum:3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b
@@ -123,7 +123,7 @@ soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2c
 │   │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
 │   ├── ethnum 1.5.0 checksum:b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c
 │   └── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
-├── soroban-builtin-sdk-macros 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=2cb39e21bdc6941c55529e65988a31103173f4e3#2cb39e21bdc6941c55529e65988a31103173f4e3
+├── soroban-builtin-sdk-macros 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
 │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
 │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
 │   ├── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -71,6 +71,8 @@ mod rust_bridge {
         cpu_insns: u64,
         mem_bytes: u64,
         time_nsecs: u64,
+        cpu_insns_excluding_vm_instantiation: u64,
+        time_nsecs_excluding_vm_instantiation: u64,
 
         // Effects of the invocation that are only populated in case of success.
         result_value: RustBuf,


### PR DESCRIPTION
# Description

Add medida metrics for cpu_insn, time excluding VM instantiation. So that we monitor their ratio.
Since cpu cost is dominated by VM, the current cpu/time ratio is masked by the VM calibration (which we have overestimated a bit heavily), which doesn't tell how effective our metering is in general . This new metrics will hopefully solve that.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
