### PR TITLE
Avoid UB via a smaller number between uint32_t::max and int64_t::max

### DIFF
--- a/src/transactions/test/TxEnvelopeTests.cpp
+++ b/src/transactions/test/TxEnvelopeTests.cpp
@@ -2643,7 +2643,11 @@ TEST_CASE("soroban transaction validation", "[tx][envelope][soroban]")
             auto tx = sorobanTransactionFrameFromOpsWithTotalFee(
                 app->getNetworkID(), root, {op0}, {}, resources,
                 std::numeric_limits<uint32_t>::max(),
-                std::numeric_limits<int64_t>::max());
+                // An absurdly large resource fee, way beyond anything that
+                // could occur in practice and way beyond uint32_t::max, but not
+                // so bit that subsequent arithmetic overflows int64_t later on
+                // (and triggers UB).
+                std::numeric_limits<int64_t>::max() >> 1);
             LedgerTxn ltx(app->getLedgerTxnRoot());
             REQUIRE(!tx->checkValid(*app, ltx, 0, 0, 0));
             REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);


### PR DESCRIPTION
The testcase `soroban transaction validation` sub-case `resource fee exceeds uint32` recently introduced some UB into the tests. This is fairly artificial, as far as I can tell it is trying to exercise a "big" resource fee greater than u32::max and doing so by picking i64::max. Which is certainly a bigger number! But it's so big that adding anything to it overflows i64 and causes UB. So the fix is pretty easy, just pick a smaller number in the test (still absurdly larger than anything that could occur in practice, just small enough that you can add some other u32 numbers to it without overflowing; I picked `i64::max >> 1`).

cc @dmkozh 