### PR TITLE
Limit the maximum Soroban resource fee.

### DIFF
--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -183,6 +183,11 @@ FeeBumpTransactionFrame::checkValid(Application& app,
                                     uint64_t lowerBoundCloseTimeOffset,
                                     uint64_t upperBoundCloseTimeOffset)
 {
+    if (!XDRProvidesValidFee())
+    {
+        getResult().result.code(txMALFORMED);
+        return false;
+    }
     LedgerTxn ltx(ltxOuter);
     int64_t minBaseFee = ltx.loadHeader().current().baseFee;
     resetResults(ltx.loadHeader().current(), minBaseFee, false);

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -47,6 +47,12 @@
 
 namespace stellar
 {
+namespace
+{
+// Limit to the maximum resource fee allowed for transaction,
+// roughly 112 million lumens.
+int64_t const MAX_RESOURCE_FEE = 1LL << 50;
+} // namespace
 
 using namespace std;
 using namespace stellar::txbridge;
@@ -1389,7 +1395,8 @@ TransactionFrame::XDRProvidesValidFee() const
         {
             return false;
         }
-        if (declaredSorobanResourceFee() < 0)
+        int64_t resourceFee = declaredSorobanResourceFee();
+        if (resourceFee < 0 || resourceFee > MAX_RESOURCE_FEE)
         {
             return false;
         }
@@ -1875,4 +1882,4 @@ TransactionFrame::getDiagnosticEvents() const
 {
     return mSorobanExtension->mDiagnosticEvents;
 }
-}
+} // namespace stellar


### PR DESCRIPTION
# Description

Limit the maximum Soroban resource fee to 2^50 (~112 million XLM), which is a high enough value to never be necessary, but low enough to make sure we don't have overflows in the processing code.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
