### PR TITLE
Loadgen cleanup

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,6 +68,11 @@ loadgen.account.created                   | meter     | loadgenerator: account c
 loadgen.payment.native                    | meter     | loadgenerator: native payment submitted
 loadgen.pretend.submitted                 | meter     | loadgenerator: pretend ops submitted
 loadgen.run.complete                      | meter     | loadgenerator: run complete
+loadgen.soroban.create_upgrade            | meter     | loadgenerator: soroban create upgrade TXs submitted
+loadgen.soroban.invoke                    | meter     | loadgenerator: soroban invoke TXs submitted
+loadgen.soroban.setup_invoke              | meter     | loadgenerator: soroban setup invoke TXs submitted
+loadgen.soroban.setup_upgrade             | meter     | loadgenerator: soroban setup upgrades TXs submitted
+loadgen.soroban.upload                    | meter     | loadgenerator: soroban upload TXs submitted
 loadgen.step.count                        | meter     | loadgenerator: generated some transactions
 loadgen.step.submit                       | timer     | loadgenerator: time spent submiting transactions per step
 loadgen.txn.attempted                     | meter     | loadgenerator: transaction submitted

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -362,7 +362,7 @@ format.
 
 ### The following HTTP commands are exposed on test instances
 * **generateload** `generateload[?mode=
-    (create|pay|pretend|mixed_txs|soroban_upload|soroban_invoke_setup|soroban_invoke|upgrade_setup|create_upgrade)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&dataentrieslow=A&dataentrieshigh=B&kilobyteslow=C&kilobyteshigh=T&txsizelow=U&txsizehigh=V&cpulow=W&cpuhigh=X]`
+    (create|pay|pretend|mixed_txs|soroban_upload|soroban_invoke_setup|soroban_invoke|upgrade_setup|create_upgrade)&accounts=N&offset=K&txs=M&txrate=R&spikesize=S&spikeinterval=I&maxfeerate=F&skiplowfeetxs=(0|1)&dextxpercent=D&dataentrieslow=A&dataentrieshigh=B&kilobyteslow=C&kilobyteshigh=T&txsizelow=U&txsizehigh=V&cpulow=W&cpuhigh=X&instances=Y&wasms=Z]`
 
     Artificially generate load for testing; must be used with
     `ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING` set to true.
@@ -390,11 +390,13 @@ format.
     intensive contract. Each invocation picks a random amount of resources
     between some bound. Resource bounds can be set with the `dataentrieslow`,
     `dataentrieshigh`, `kilobyteslow`, `kilobyteshigh`, `txsizelow`, `txsizehigh`,
-    `cpulow`, `cpuhigh`, where CPU bounds correspond to instruction count.
+    `cpulow`, `cpuhigh`, where CPU bounds correspond to instruction count. `instances`
+    and `wasms` parameters determine how many unique contract instances and wasm entries
+    will be used.
   * `upgrade_setup` mode create soroban contract instance to be used by
     `create_upgrade`. This mode must be run before `create_upgrade`.
   * `create_upgrade` mode write a soroban upgrade set and returns the
-    ConfigUpgradeSetKey. Most network config settings are supports. If a given
+    ConfigUpgradeSetKey. Most network config settings are supported. If a given
     setting is ommited or set to 0, it is not upgraded and maintains the current
     value. To not exceed HTTP string limits, the names are very short. See
     `CommandHandler::generateLoad` for available options.

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -390,7 +390,8 @@ format.
     intensive contract. Each invocation picks a random amount of resources
     between some bound. Resource bounds can be set with the `dataentrieslow`,
     `dataentrieshigh`, `kilobyteslow`, `kilobyteshigh`, `txsizelow`, `txsizehigh`,
-    `cpulow`, `cpuhigh`, where CPU bounds correspond to instruction count. `instances`
+    `cpulow`, `cpuhigh`, where CPU bounds correspond to instruction count. `kilobytes*`
+    values indicate the total ammount of disk IO generated TXs require. `instances`
     and `wasms` parameters determine how many unique contract instances and wasm entries
     will be used.
   * `upgrade_setup` mode create soroban contract instance to be used by

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1145,7 +1145,6 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
         GeneratedLoadConfig cfg;
         cfg.mode = LoadGenerator::getMode(
             parseOptionalParamOrDefault<std::string>(map, "mode", "create"));
-        bool isCreate = cfg.mode == LoadGenMode::CREATE;
 
         cfg.nAccounts =
             parseOptionalParamOrDefault<uint32_t>(map, "accounts", 1000);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1193,9 +1193,9 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
                 parseOptionalParamOrDefault<uint32_t>(map, "dataentrieslow", 0);
             invokeCfg.nDataEntriesHigh = parseOptionalParamOrDefault<uint32_t>(
                 map, "dataentrieshigh", 0);
-            invokeCfg.kiloBytesPerDataEntryLow =
+            invokeCfg.ioKiloBytesLow =
                 parseOptionalParamOrDefault<uint32_t>(map, "kilobyteslow", 0);
-            invokeCfg.kiloBytesPerDataEntryHigh =
+            invokeCfg.ioKiloBytesHigh =
                 parseOptionalParamOrDefault<uint32_t>(map, "kilobyteshigh", 0);
             invokeCfg.txSizeBytesLow =
                 parseOptionalParamOrDefault<uint32_t>(map, "txsizelow", 0);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1264,12 +1264,8 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             }
         }
 
-        uint32_t numItems = isCreate ? cfg.nAccounts : cfg.nTxs;
-        std::string itemType = isCreate ? "accounts" : "txs";
         Json::Value res;
-        res["status"] =
-            fmt::format(FMT_STRING(" Generating load: {:d} {:s}, {:d} tx/s"),
-                        numItems, itemType, cfg.txRate);
+        res["status"] = cfg.getStatus();
         mApp.generateLoad(cfg);
 
         if (cfg.mode == LoadGenMode::SOROBAN_CREATE_UPGRADE)

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1170,74 +1170,88 @@ CommandHandler::generateLoad(std::string const& params, std::string& retStr)
             parseOptionalParam<uint32_t>(map, "maxfeerate");
         cfg.skipLowFeeTxs =
             parseOptionalParamOrDefault<bool>(map, "skiplowfeetxs", false);
-        // Only for MIXED_TX mode; fraction of DEX transactions.
-        cfg.dexTxPercent =
-            parseOptionalParamOrDefault<uint32_t>(map, "dextxpercent", 0);
 
-        // Only for SOROBAN_INVOKE mode, resource consumption bounds
-        cfg.nInstances =
-            parseOptionalParamOrDefault<uint32_t>(map, "instances", 0);
-        cfg.nWasms = parseOptionalParamOrDefault<uint32_t>(map, "wasms", 0);
-        cfg.nDataEntriesLow =
-            parseOptionalParamOrDefault<uint32_t>(map, "dataentrieslow", 0);
-        cfg.nDataEntriesHigh =
-            parseOptionalParamOrDefault<uint32_t>(map, "dataentrieshigh", 0);
-        cfg.kiloBytesPerDataEntryLow =
-            parseOptionalParamOrDefault<uint32_t>(map, "kilobyteslow", 0);
-        cfg.kiloBytesPerDataEntryHigh =
-            parseOptionalParamOrDefault<uint32_t>(map, "kilobyteshigh", 0);
-        cfg.txSizeBytesLow =
-            parseOptionalParamOrDefault<uint32_t>(map, "txsizelow", 0);
-        cfg.txSizeBytesHigh =
-            parseOptionalParamOrDefault<uint32_t>(map, "txsizehigh", 0);
-        cfg.instructionsLow =
-            parseOptionalParamOrDefault<uint64_t>(map, "cpulow", 0);
-        cfg.instructionsHigh =
-            parseOptionalParamOrDefault<uint64_t>(map, "cpuhigh", 0);
+        if (cfg.mode == LoadGenMode::MIXED_TXS)
+        {
+            cfg.getMutDexTxPercent() =
+                parseOptionalParamOrDefault<uint32_t>(map, "dextxpercent", 0);
+        }
 
-        // SOROBAN_CREATE_UPGRADE parameters
-        cfg.maxContractSizeBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctsz", 0);
-        cfg.maxContractDataKeySizeBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctkeysz", 0);
-        cfg.maxContractDataEntrySizeBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctdatasz", 0);
-        cfg.ledgerMaxInstructions =
-            parseOptionalParamOrDefault<uint64_t>(map, "ldgrmxinstrc", 0);
-        cfg.txMaxInstructions =
-            parseOptionalParamOrDefault<uint64_t>(map, "txmxinstrc", 0);
-        cfg.txMemoryLimit =
-            parseOptionalParamOrDefault<uint64_t>(map, "txmemlim", 0);
-        cfg.ledgerMaxReadLedgerEntries =
-            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdntry", 0);
-        cfg.ledgerMaxReadBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdbyt", 0);
-        cfg.ledgerMaxWriteLedgerEntries =
-            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrntry", 0);
-        cfg.ledgerMaxWriteBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrbyt", 0);
-        cfg.ledgerMaxTxCount =
-            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxcnt", 0);
-        cfg.txMaxReadLedgerEntries =
-            parseOptionalParamOrDefault<uint32_t>(map, "txmxrdntry", 0);
-        cfg.txMaxReadBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "txmxrdbyt", 0);
-        cfg.txMaxWriteLedgerEntries =
-            parseOptionalParamOrDefault<uint32_t>(map, "txmxwrntry", 0);
-        cfg.txMaxWriteBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "txmxwrbyt", 0);
-        cfg.txMaxContractEventsSizeBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "txmxevntsz", 0);
-        cfg.ledgerMaxTransactionsSizeBytes =
-            parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxsz", 0);
-        cfg.txMaxSizeBytes = parseOptionalParamOrDefault<uint32_t>(
-            map, "txmxsz", cfg.ledgerMaxTransactionsSizeBytes);
-        cfg.bucketListSizeWindowSampleSize =
-            parseOptionalParamOrDefault<uint32_t>(map, "wndowsz", 0);
-        cfg.evictionScanSize = parseOptionalParamOrDefault<uint64_t>(
-            map, "evctsz", cfg.bucketListSizeWindowSampleSize);
-        cfg.startingEvictionScanLevel =
-            parseOptionalParamOrDefault<uint32_t>(map, "evctlvl", 0);
+        if (cfg.isSoroban() && cfg.mode != LoadGenMode::SOROBAN_UPLOAD)
+        {
+            auto& sorobanCfg = cfg.getMutSorobanConfig();
+            sorobanCfg.nInstances =
+                parseOptionalParamOrDefault<uint32_t>(map, "instances", 0);
+            sorobanCfg.nWasms =
+                parseOptionalParamOrDefault<uint32_t>(map, "wasms", 0);
+        }
+
+        if (cfg.mode == LoadGenMode::SOROBAN_INVOKE)
+        {
+            auto& invokeCfg = cfg.getMutSorobanInvokeConfig();
+            invokeCfg.nDataEntriesLow =
+                parseOptionalParamOrDefault<uint32_t>(map, "dataentrieslow", 0);
+            invokeCfg.nDataEntriesHigh = parseOptionalParamOrDefault<uint32_t>(
+                map, "dataentrieshigh", 0);
+            invokeCfg.kiloBytesPerDataEntryLow =
+                parseOptionalParamOrDefault<uint32_t>(map, "kilobyteslow", 0);
+            invokeCfg.kiloBytesPerDataEntryHigh =
+                parseOptionalParamOrDefault<uint32_t>(map, "kilobyteshigh", 0);
+            invokeCfg.txSizeBytesLow =
+                parseOptionalParamOrDefault<uint32_t>(map, "txsizelow", 0);
+            invokeCfg.txSizeBytesHigh =
+                parseOptionalParamOrDefault<uint32_t>(map, "txsizehigh", 0);
+            invokeCfg.instructionsLow =
+                parseOptionalParamOrDefault<uint64_t>(map, "cpulow", 0);
+            invokeCfg.instructionsHigh =
+                parseOptionalParamOrDefault<uint64_t>(map, "cpuhigh", 0);
+        }
+        else if (cfg.mode == LoadGenMode::SOROBAN_CREATE_UPGRADE)
+        {
+            auto& upgradeCfg = cfg.getMutSorobanUpgradeConfig();
+            upgradeCfg.maxContractSizeBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctsz", 0);
+            upgradeCfg.maxContractDataKeySizeBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctkeysz", 0);
+            upgradeCfg.maxContractDataEntrySizeBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "mxcntrctdatasz", 0);
+            upgradeCfg.ledgerMaxInstructions =
+                parseOptionalParamOrDefault<uint64_t>(map, "ldgrmxinstrc", 0);
+            upgradeCfg.txMaxInstructions =
+                parseOptionalParamOrDefault<uint64_t>(map, "txmxinstrc", 0);
+            upgradeCfg.txMemoryLimit =
+                parseOptionalParamOrDefault<uint64_t>(map, "txmemlim", 0);
+            upgradeCfg.ledgerMaxReadLedgerEntries =
+                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdntry", 0);
+            upgradeCfg.ledgerMaxReadBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxrdbyt", 0);
+            upgradeCfg.ledgerMaxWriteLedgerEntries =
+                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrntry", 0);
+            upgradeCfg.ledgerMaxWriteBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxwrbyt", 0);
+            upgradeCfg.ledgerMaxTxCount =
+                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxcnt", 0);
+            upgradeCfg.txMaxReadLedgerEntries =
+                parseOptionalParamOrDefault<uint32_t>(map, "txmxrdntry", 0);
+            upgradeCfg.txMaxReadBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "txmxrdbyt", 0);
+            upgradeCfg.txMaxWriteLedgerEntries =
+                parseOptionalParamOrDefault<uint32_t>(map, "txmxwrntry", 0);
+            upgradeCfg.txMaxWriteBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "txmxwrbyt", 0);
+            upgradeCfg.txMaxContractEventsSizeBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "txmxevntsz", 0);
+            upgradeCfg.ledgerMaxTransactionsSizeBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "ldgrmxtxsz", 0);
+            upgradeCfg.txMaxSizeBytes =
+                parseOptionalParamOrDefault<uint32_t>(map, "txmxsz", 0);
+            upgradeCfg.bucketListSizeWindowSampleSize =
+                parseOptionalParamOrDefault<uint32_t>(map, "wndowsz", 0);
+            upgradeCfg.evictionScanSize =
+                parseOptionalParamOrDefault<uint64_t>(map, "evctsz", 0);
+            upgradeCfg.startingEvictionScanLevel =
+                parseOptionalParamOrDefault<uint32_t>(map, "evctlvl", 0);
+        }
 
         if (cfg.maxGeneratedFeeRate)
         {

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -328,6 +328,10 @@ LoadGenerator::scheduleLoadGeneration(GeneratedLoadConfig cfg)
 
             // Must include all TXs
             cfg.skipLowFeeTxs = false;
+
+            // No spikes during setup
+            cfg.spikeInterval = std::chrono::seconds(0);
+            cfg.spikeSize = 0;
         }
 
         if (cfg.mode == LoadGenMode::SOROBAN_INVOKE_SETUP ||

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1913,6 +1913,14 @@ LoadGenerator::TxMetrics::TxMetrics(medida::MetricsRegistry& m)
     , mNativePayment(m.NewMeter({"loadgen", "payment", "submitted"}, "op"))
     , mManageOfferOps(m.NewMeter({"loadgen", "manageoffer", "submitted"}, "op"))
     , mPretendOps(m.NewMeter({"loadgen", "pretend", "submitted"}, "op"))
+    , mSorobanUploadTxs(m.NewMeter({"loadgen", "soroban", "upload"}, "txn"))
+    , mSorobanSetupInvokeTxs(
+          m.NewMeter({"loadgen", "soroban", "setup_invoke"}, "txn"))
+    , mSorobanSetupUpgradeTxs(
+          m.NewMeter({"loadgen", "soroban", "setup_upgrade"}, "txn"))
+    , mSorobanInvokeTxs(m.NewMeter({"loadgen", "soroban", "invoke"}, "txn"))
+    , mSorobanCreateUpgradeTxs(
+          m.NewMeter({"loadgen", "soroban", "create_upgrade"}, "txn"))
     , mTxnAttempted(m.NewMeter({"loadgen", "txn", "attempted"}, "txn"))
     , mTxnRejected(m.NewMeter({"loadgen", "txn", "rejected"}, "txn"))
     , mTxnBytes(m.NewMeter({"loadgen", "txn", "bytes"}, "txn"))
@@ -1923,18 +1931,27 @@ void
 LoadGenerator::TxMetrics::report()
 {
     CLOG_DEBUG(LoadGen,
-               "Counts: {} tx, {} rj, {} by, {} ac ({} na, {} pr, {} dex",
+               "Counts: {} tx, {} rj, {} by, {} ac, {} na, {} pr, {} dex, {} "
+               "su, {} ssi, {} ssu, {} si, {} scu",
                mTxnAttempted.count(), mTxnRejected.count(), mTxnBytes.count(),
                mAccountCreated.count(), mNativePayment.count(),
-               mPretendOps.count(), mManageOfferOps.one_minute_rate());
+               mPretendOps.count(), mManageOfferOps.count(),
+               mSorobanUploadTxs.count(), mSorobanSetupInvokeTxs.count(),
+               mSorobanSetupUpgradeTxs.count(), mSorobanInvokeTxs.count(),
+               mSorobanCreateUpgradeTxs.count());
 
-    CLOG_DEBUG(
-        LoadGen,
-        "Rates/sec (1m EWMA): {} tx, {} rj, {} by, {} ac, {} na, {} pr, {} dex",
-        mTxnAttempted.one_minute_rate(), mTxnRejected.one_minute_rate(),
-        mTxnBytes.one_minute_rate(), mAccountCreated.one_minute_rate(),
-        mNativePayment.one_minute_rate(), mPretendOps.one_minute_rate(),
-        mManageOfferOps.one_minute_rate());
+    CLOG_DEBUG(LoadGen,
+               "Rates/sec (1m EWMA): {} tx, {} rj, {} by, {} ac, {} na, {} pr, "
+               "{} dex, {} su, {} ssi, {} ssu, {} si, {} scu",
+               mTxnAttempted.one_minute_rate(), mTxnRejected.one_minute_rate(),
+               mTxnBytes.one_minute_rate(), mAccountCreated.one_minute_rate(),
+               mNativePayment.one_minute_rate(), mPretendOps.one_minute_rate(),
+               mManageOfferOps.one_minute_rate(),
+               mSorobanUploadTxs.one_minute_rate(),
+               mSorobanSetupInvokeTxs.one_minute_rate(),
+               mSorobanSetupUpgradeTxs.one_minute_rate(),
+               mSorobanInvokeTxs.one_minute_rate(),
+               mSorobanCreateUpgradeTxs.one_minute_rate());
 }
 
 TransactionFramePtr
@@ -1988,6 +2005,21 @@ LoadGenerator::execute(TransactionFramePtr& txf, LoadGenMode mode,
         {
             txm.mNativePayment.Mark(txf->getNumOperations());
         }
+        break;
+    case LoadGenMode::SOROBAN_UPLOAD:
+        txm.mSorobanUploadTxs.Mark();
+        break;
+    case LoadGenMode::SOROBAN_INVOKE_SETUP:
+        txm.mSorobanSetupInvokeTxs.Mark();
+        break;
+    case LoadGenMode::SOROBAN_UPGRADE_SETUP:
+        txm.mSorobanSetupUpgradeTxs.Mark();
+        break;
+    case LoadGenMode::SOROBAN_INVOKE:
+        txm.mSorobanInvokeTxs.Mark();
+        break;
+    case LoadGenMode::SOROBAN_CREATE_UPGRADE:
+        txm.mSorobanCreateUpgradeTxs.Mark();
         break;
     }
 

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -384,7 +384,8 @@ class LoadGenerator
     // unique instance
     UnorderedMap<uint64_t, ContractInstance> mContractInstances;
 
-    void reset(bool resetSoroban);
+    void reset();
+    void resetSorobanState();
     void createRootAccount();
     int64_t getTxPerStep(uint32_t txRate, std::chrono::seconds spikeInterval,
                          uint32_t spikeSize);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -127,94 +127,19 @@ struct GeneratedLoadConfig
     txLoad(LoadGenMode mode, uint32_t nAccounts, uint32_t nTxs, uint32_t txRate,
            uint32_t offset = 0, std::optional<uint32_t> maxFee = std::nullopt);
 
-    SorobanConfig&
-    getMutSorobanConfig()
-    {
-        releaseAssert(isSoroban() && mode != LoadGenMode::SOROBAN_UPLOAD);
-        return sorobanConfig;
-    }
+    SorobanConfig& getMutSorobanConfig();
+    SorobanConfig const& getSorobanConfig() const;
+    SorobanInvokeConfig& getMutSorobanInvokeConfig();
+    SorobanInvokeConfig const& getSorobanInvokeConfig() const;
+    SorobanUpgradeConfig& getMutSorobanUpgradeConfig();
+    SorobanUpgradeConfig const& getSorobanUpgradeConfig() const;
+    uint32_t& getMutDexTxPercent();
+    uint32_t const& getDexTxPercent() const;
 
-    SorobanConfig const&
-    getSorobanConfig() const
-    {
-        releaseAssert(isSoroban() && mode != LoadGenMode::SOROBAN_UPLOAD);
-        return sorobanConfig;
-    }
-
-    SorobanInvokeConfig&
-    getMutSorobanInvokeConfig()
-    {
-        releaseAssert(mode == LoadGenMode::SOROBAN_INVOKE);
-        return sorobanInvokeConfig;
-    }
-
-    SorobanInvokeConfig const&
-    getSorobanInvokeConfig() const
-    {
-        releaseAssert(mode == LoadGenMode::SOROBAN_INVOKE);
-        return sorobanInvokeConfig;
-    }
-
-    SorobanUpgradeConfig&
-    getMutSorobanUpgradeConfig()
-    {
-        releaseAssert(mode == LoadGenMode::SOROBAN_CREATE_UPGRADE);
-        return sorobanUpgradeConfig;
-    }
-
-    SorobanUpgradeConfig const&
-    getSorobanUpgradeConfig() const
-    {
-        releaseAssert(mode == LoadGenMode::SOROBAN_CREATE_UPGRADE);
-        return sorobanUpgradeConfig;
-    }
-
-    uint32_t&
-    getMutDexTxPercent()
-    {
-        releaseAssert(mode == LoadGenMode::MIXED_TXS);
-        return dexTxPercent;
-    }
-
-    uint32_t const&
-    getDexTxPercent() const
-    {
-        releaseAssert(mode == LoadGenMode::MIXED_TXS);
-        return dexTxPercent;
-    }
-
-    bool
-    isCreate() const
-    {
-        return mode == LoadGenMode::CREATE;
-    }
-
-    bool
-    isSoroban() const
-    {
-        return mode == LoadGenMode::SOROBAN_INVOKE ||
-               mode == LoadGenMode::SOROBAN_INVOKE_SETUP ||
-               mode == LoadGenMode::SOROBAN_UPLOAD ||
-               mode == LoadGenMode::SOROBAN_UPGRADE_SETUP ||
-               mode == LoadGenMode::SOROBAN_CREATE_UPGRADE;
-    }
-
-    bool
-    isSorobanSetup() const
-    {
-        return mode == LoadGenMode::SOROBAN_INVOKE_SETUP ||
-               mode == LoadGenMode::SOROBAN_UPGRADE_SETUP;
-    }
-
-    bool
-    isLoad() const
-    {
-        return mode == LoadGenMode::PAY || mode == LoadGenMode::PRETEND ||
-               mode == LoadGenMode::MIXED_TXS ||
-               mode == LoadGenMode::SOROBAN_UPLOAD ||
-               mode == LoadGenMode::SOROBAN_INVOKE ||
-               mode == LoadGenMode::SOROBAN_CREATE_UPGRADE;
-    }
+    bool isCreate() const;
+    bool isSoroban() const;
+    bool isSorobanSetup() const;
+    bool isLoad() const;
 
     bool isDone() const;
     bool areTxsRemaining() const;

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -217,6 +217,7 @@ struct GeneratedLoadConfig
 
     bool isDone() const;
     bool areTxsRemaining() const;
+    Json::Value getStatus() const;
 
     LoadGenMode mode = LoadGenMode::CREATE;
     uint32_t nAccounts = 0;
@@ -445,8 +446,8 @@ class LoadGenerator
     std::pair<TestAccountPtr, TransactionFramePtr>
     creationTransaction(uint64_t startAccount, uint64_t numItems,
                         uint32_t ledgerNum);
-    void logProgress(std::chrono::nanoseconds submitTimer, LoadGenMode mode,
-                     uint32_t nAccounts, uint32_t nTxs, uint32_t txRate);
+    void logProgress(std::chrono::nanoseconds submitTimer,
+                     GeneratedLoadConfig const& cfg) const;
 
     uint32_t submitCreationTx(uint32_t nAccounts, uint32_t offset,
                               uint32_t ledgerNum);

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -61,11 +61,12 @@ struct GeneratedLoadConfig
     // Config parameters for SOROBAN_INVOKE
     struct SorobanInvokeConfig
     {
-        // Range of kilo bytes and num entries for disk IO
+        // Range of kilo bytes and num entries for disk IO, where ioKiloBytes is
+        // the total amount of disk IO that the TX requires
         uint32_t nDataEntriesLow = 0;
         uint32_t nDataEntriesHigh = 0;
-        uint32_t kiloBytesPerDataEntryLow = 0;
-        uint32_t kiloBytesPerDataEntryHigh = 0;
+        uint32_t ioKiloBytesLow = 0;
+        uint32_t ioKiloBytesHigh = 0;
 
         // Size of transactions
         int32_t txSizeBytesLow = 0;
@@ -299,6 +300,12 @@ class LoadGenerator
     getCodeKeyForTesting() const
     {
         return mCodeKey;
+    }
+
+    uint64_t
+    getContactOverheadBytesForTesting() const
+    {
+        return mContactOverheadBytes;
     }
 
   private:

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -308,6 +308,11 @@ class LoadGenerator
         medida::Meter& mNativePayment;
         medida::Meter& mManageOfferOps;
         medida::Meter& mPretendOps;
+        medida::Meter& mSorobanUploadTxs;
+        medida::Meter& mSorobanSetupInvokeTxs;
+        medida::Meter& mSorobanSetupUpgradeTxs;
+        medida::Meter& mSorobanInvokeTxs;
+        medida::Meter& mSorobanCreateUpgradeTxs;
         medida::Meter& mTxnAttempted;
         medida::Meter& mTxnRejected;
         medida::Meter& mTxnBytes;

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -196,16 +196,17 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
                                            nAccounts, numSorobanTxs,
                                            /* txRate */ 1);
 
-    cfg.nInstances = numInstances;
+    cfg.getMutSorobanConfig().nInstances = numInstances;
 
     // Use tight bounds to we can verify storage works properly
-    cfg.nDataEntriesLow = numDataEntries;
-    cfg.nDataEntriesHigh = numDataEntries;
-    cfg.kiloBytesPerDataEntryLow = kilobytesPerDataEntry;
-    cfg.kiloBytesPerDataEntryHigh = kilobytesPerDataEntry;
+    auto& invokeCfg = cfg.getMutSorobanInvokeConfig();
+    invokeCfg.nDataEntriesLow = numDataEntries;
+    invokeCfg.nDataEntriesHigh = numDataEntries;
+    invokeCfg.kiloBytesPerDataEntryLow = kilobytesPerDataEntry;
+    invokeCfg.kiloBytesPerDataEntryHigh = kilobytesPerDataEntry;
 
-    cfg.txSizeBytesHigh = 100'000;
-    cfg.instructionsHigh = 10'000'000;
+    invokeCfg.txSizeBytesHigh = 100'000;
+    invokeCfg.instructionsHigh = 10'000'000;
 
     loadGen.generateLoad(cfg);
     simulation->crankUntil(
@@ -334,49 +335,51 @@ TEST_CASE("soroban loadgen config upgrade", "[loadgen][soroban]")
     auto cfg =
         GeneratedLoadConfig::txLoad(LoadGenMode::SOROBAN_CREATE_UPGRADE, 1, 1,
                                     /* txRate */ 1);
+    auto& upgradeCfg = cfg.getMutSorobanUpgradeConfig();
 
-    cfg.maxContractSizeBytes =
+    upgradeCfg.maxContractSizeBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.maxContractDataKeySizeBytes =
+    upgradeCfg.maxContractDataKeySizeBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.maxContractDataEntrySizeBytes =
+    upgradeCfg.maxContractDataEntrySizeBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxInstructions =
+    upgradeCfg.ledgerMaxInstructions =
         rand_uniform<int64_t>(INT64_MAX - 10'000, INT64_MAX);
-    cfg.txMaxInstructions =
+    upgradeCfg.txMaxInstructions =
         rand_uniform<int64_t>(INT64_MAX - 10'000, INT64_MAX);
-    cfg.txMemoryLimit = rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxReadLedgerEntries =
+    upgradeCfg.txMemoryLimit =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxReadBytes =
+    upgradeCfg.ledgerMaxReadLedgerEntries =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxWriteLedgerEntries =
+    upgradeCfg.ledgerMaxReadBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxWriteBytes =
+    upgradeCfg.ledgerMaxWriteLedgerEntries =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxTxCount =
+    upgradeCfg.ledgerMaxWriteBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.txMaxReadLedgerEntries =
+    upgradeCfg.ledgerMaxTxCount =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.txMaxReadBytes =
+    upgradeCfg.txMaxReadLedgerEntries =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.txMaxWriteLedgerEntries =
+    upgradeCfg.txMaxReadBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.txMaxWriteBytes =
+    upgradeCfg.txMaxWriteLedgerEntries =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.txMaxContractEventsSizeBytes =
+    upgradeCfg.txMaxWriteBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.ledgerMaxTransactionsSizeBytes =
+    upgradeCfg.txMaxContractEventsSizeBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.txMaxSizeBytes =
+    upgradeCfg.ledgerMaxTransactionsSizeBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.bucketListSizeWindowSampleSize =
+    upgradeCfg.txMaxSizeBytes =
         rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
-    cfg.evictionScanSize = rand_uniform<int64_t>(INT64_MAX - 10'000, INT64_MAX);
-    cfg.startingEvictionScanLevel = rand_uniform<uint32_t>(4, 8);
+    upgradeCfg.bucketListSizeWindowSampleSize =
+        rand_uniform<uint32_t>(UINT32_MAX - 10'000, UINT32_MAX);
+    upgradeCfg.evictionScanSize =
+        rand_uniform<int64_t>(INT64_MAX - 10'000, INT64_MAX);
+    upgradeCfg.startingEvictionScanLevel = rand_uniform<uint32_t>(4, 8);
 
     auto upgradeSetKey = loadGen.getConfigUpgradeSetKey(cfg);
-    auto cfgCopy = cfg;
 
     loadGen.generateLoad(cfg);
     simulation->crankUntil(
@@ -428,70 +431,70 @@ TEST_CASE("soroban loadgen config upgrade", "[loadgen][soroban]")
         {
         case CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES:
             REQUIRE(setting.contractMaxSizeBytes() ==
-                    cfgCopy.maxContractSizeBytes);
+                    upgradeCfg.maxContractSizeBytes);
             break;
         case CONFIG_SETTING_CONTRACT_COMPUTE_V0:
             REQUIRE(setting.contractCompute().ledgerMaxInstructions ==
-                    cfgCopy.ledgerMaxInstructions);
+                    upgradeCfg.ledgerMaxInstructions);
             REQUIRE(setting.contractCompute().txMaxInstructions ==
-                    cfgCopy.txMaxInstructions);
+                    upgradeCfg.txMaxInstructions);
             REQUIRE(setting.contractCompute().txMemoryLimit ==
-                    cfg.txMemoryLimit);
+                    upgradeCfg.txMemoryLimit);
             break;
         case CONFIG_SETTING_CONTRACT_LEDGER_COST_V0:
             REQUIRE(setting.contractLedgerCost().ledgerMaxReadLedgerEntries ==
-                    cfgCopy.ledgerMaxReadLedgerEntries);
+                    upgradeCfg.ledgerMaxReadLedgerEntries);
             REQUIRE(setting.contractLedgerCost().ledgerMaxReadBytes ==
-                    cfgCopy.ledgerMaxReadBytes);
+                    upgradeCfg.ledgerMaxReadBytes);
             REQUIRE(setting.contractLedgerCost().ledgerMaxWriteLedgerEntries ==
-                    cfgCopy.ledgerMaxWriteLedgerEntries);
+                    upgradeCfg.ledgerMaxWriteLedgerEntries);
             REQUIRE(setting.contractLedgerCost().ledgerMaxWriteBytes ==
-                    cfgCopy.ledgerMaxWriteBytes);
+                    upgradeCfg.ledgerMaxWriteBytes);
             REQUIRE(setting.contractLedgerCost().txMaxReadLedgerEntries ==
-                    cfgCopy.txMaxReadLedgerEntries);
+                    upgradeCfg.txMaxReadLedgerEntries);
             REQUIRE(setting.contractLedgerCost().txMaxReadBytes ==
-                    cfgCopy.txMaxReadBytes);
+                    upgradeCfg.txMaxReadBytes);
             REQUIRE(setting.contractLedgerCost().txMaxWriteLedgerEntries ==
-                    cfgCopy.txMaxWriteLedgerEntries);
+                    upgradeCfg.txMaxWriteLedgerEntries);
             REQUIRE(setting.contractLedgerCost().txMaxWriteBytes ==
-                    cfg.txMaxWriteBytes);
+                    upgradeCfg.txMaxWriteBytes);
             break;
         case CONFIG_SETTING_CONTRACT_HISTORICAL_DATA_V0:
             break;
         case CONFIG_SETTING_CONTRACT_EVENTS_V0:
             REQUIRE(setting.contractEvents().txMaxContractEventsSizeBytes ==
-                    cfgCopy.txMaxContractEventsSizeBytes);
+                    upgradeCfg.txMaxContractEventsSizeBytes);
             break;
         case CONFIG_SETTING_CONTRACT_BANDWIDTH_V0:
             REQUIRE(setting.contractBandwidth().ledgerMaxTxsSizeBytes ==
-                    cfgCopy.ledgerMaxTransactionsSizeBytes);
+                    upgradeCfg.ledgerMaxTransactionsSizeBytes);
             REQUIRE(setting.contractBandwidth().txMaxSizeBytes ==
-                    cfgCopy.txMaxSizeBytes);
+                    upgradeCfg.txMaxSizeBytes);
             break;
         case CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS:
         case CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES:
             break;
         case CONFIG_SETTING_CONTRACT_DATA_KEY_SIZE_BYTES:
             REQUIRE(setting.contractDataKeySizeBytes() ==
-                    cfgCopy.maxContractDataKeySizeBytes);
+                    upgradeCfg.maxContractDataKeySizeBytes);
             break;
         case CONFIG_SETTING_CONTRACT_DATA_ENTRY_SIZE_BYTES:
             REQUIRE(setting.contractDataEntrySizeBytes() ==
-                    cfgCopy.maxContractDataEntrySizeBytes);
+                    upgradeCfg.maxContractDataEntrySizeBytes);
             break;
         case CONFIG_SETTING_STATE_ARCHIVAL:
         {
             auto& ses = setting.stateArchivalSettings();
             REQUIRE(ses.bucketListSizeWindowSampleSize ==
-                    cfgCopy.bucketListSizeWindowSampleSize);
-            REQUIRE(ses.evictionScanSize == cfgCopy.evictionScanSize);
+                    upgradeCfg.bucketListSizeWindowSampleSize);
+            REQUIRE(ses.evictionScanSize == upgradeCfg.evictionScanSize);
             REQUIRE(ses.startingEvictionScanLevel ==
-                    cfgCopy.startingEvictionScanLevel);
+                    upgradeCfg.startingEvictionScanLevel);
         }
         break;
         case CONFIG_SETTING_CONTRACT_EXECUTION_LANES:
             REQUIRE(setting.contractExecutionLanes().ledgerMaxTxCount ==
-                    cfgCopy.ledgerMaxTxCount);
+                    upgradeCfg.ledgerMaxTxCount);
             break;
         default:
             REQUIRE(false);
@@ -611,7 +614,7 @@ TEST_CASE("Multi-op mixed transactions are valid", "[loadgen]")
             3 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
         auto config = GeneratedLoadConfig::txLoad(LoadGenMode::MIXED_TXS,
                                                   numAccounts, 100, txRate);
-        config.dexTxPercent = 50;
+        config.getMutDexTxPercent() = 50;
         loadGen.generateLoad(config);
         simulation->crankUntil(
             [&]() {


### PR DESCRIPTION
# Description

Mostly resolves #4063.

Additionally, `SOROBAN_INVOKE` mode now takes the total amount of IO kilobytes as a parameter instead of kilobytes per data entry, making it possible to write tests that respect network config bounds while still having variance in the number of data entries written.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
