### PR TITLE
Overlay: Do not initiate connections that will be immediately dropped

### DIFF
--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -235,5 +235,9 @@ class OverlayManagerImpl : public OverlayManager
                              std::vector<Peer::pointer>& result);
     void shufflePeerList(std::vector<Peer::pointer>& peerList);
     AdjustedFlowControlConfig getFlowControlBytesConfig() const override;
+
+    // Returns `true` iff the overlay can accept the outbound peer at `address`.
+    // Logs whenever a peer cannot be accepted.
+    bool canAcceptOutboundPeer(PeerBareAddress const& address) const;
 };
 }


### PR DESCRIPTION
# Description

This change ensures that the overlay does not initiate outbound connections when it is shutting down (and therefore `OverlayManagerImpl::addOutboundConnection` will immediately drop the connection).

This change also adds a line to the logs indicating how to increase the number of outbound pending slots when
`OverlayManagerImpl::connectToImpl` fails due to insufficient slots.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
