### PR TITLE
Add BucketList size meter

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -31,6 +31,7 @@ bucket.batch.objectsadded                 | meter     | number of objects added 
 bucket.memory.shared                      | counter   | number of buckets referenced (excluding publish queue)
 bucket.merge-time.level-<X>               | timer     | time to merge two buckets on level <X>
 bucket.snap.merge                         | timer     | time to merge two buckets
+bucketlist.size.bytes                     | counter   | total size of the BucketList in bytes
 bucketlistDB.bloom.lookups                | meter     | number of bloom filter lookups
 bucketlistDB.bloom.misses                 | meter     | number of bloom filter false positives
 bucketlistDB.query.loads                  | meter     | number of BucketListDB load queries
@@ -148,6 +149,6 @@ scp.timing.self-to-others-externalize-lag | timer     | delay between local node
 scp.value.invalid                         | meter     | SCP value is invalid
 scp.value.valid                           | meter     | SCP value is valid
 scp.slot.values-referenced                | histogram | number of values referenced per consensus round
-state-archival.eviction.bytes-scanned   | counter   | number of bytes that eviction scan has read
-state-archival.eviction.entries-evicted | meter     | number of entries that have been evicted
-state-archival.eviction.incomplete-scan | counter   | number of buckets that were too large to be fully scanned for eviction
+state-archival.eviction.bytes-scanned     | counter   | number of bytes that eviction scan has read
+state-archival.eviction.entries-evicted   | meter     | number of entries that have been evicted
+state-archival.eviction.incomplete-scan   | counter   | number of buckets that were too large to be fully scanned for eviction

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -128,6 +128,8 @@ BucketManagerImpl::BucketManagerImpl(Application& app)
           {"state-archival", "eviction", "bytes-scanned"}))
     , mIncompleteBucketScans(app.getMetrics().NewCounter(
           {"state-archival", "eviction", "incomplete-scan"}))
+    , mBucketListSizeCounter(
+          app.getMetrics().NewCounter({"bucketlist", "size", "bytes"}))
     // Minimal DB is stored in the buckets dir, so delete it only when
     // mode does not use minimal DB
     , mDeleteEntireBucketDirInDtor(
@@ -828,6 +830,7 @@ BucketManagerImpl::addBatch(Application& app, uint32_t currLedger,
                                   deadEntries.size());
     mBucketList->addBatch(app, currLedger, currLedgerProtocol, initEntries,
                           liveEntries, deadEntries);
+    mBucketListSizeCounter.set_count(mBucketList->getSize());
 }
 
 #ifdef BUILD_TESTS

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -53,6 +53,7 @@ class BucketManagerImpl : public BucketManager
     medida::Meter& mEntriesEvicted;
     medida::Counter& mBytesScannedForEviction;
     medida::Counter& mIncompleteBucketScans;
+    medida::Counter& mBucketListSizeCounter;
     mutable UnorderedMap<LedgerEntryType, medida::Timer&>
         mBucketListDBPointTimers{};
     mutable UnorderedMap<std::string, medida::Timer&> mBucketListDBBulkTimers{};


### PR DESCRIPTION
# Description

Resolves #4085

Adds a meter to track BucketList size. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
