### PR TITLE
Refactor Soroban test framework.

### DIFF
--- a/src/herder/TxSetFrame.cpp
+++ b/src/herder/TxSetFrame.cpp
@@ -437,14 +437,22 @@ makeTxSetFromTransactions(TxSetTransactions txs, Application& app,
                           TxSetTransactions& invalidTxs,
                           bool enforceTxsApplyOrder)
 {
-    TxSetPhaseTransactions phases;
-    phases.emplace_back(txs);
     auto lclHeader = app.getLedgerManager().getLastClosedLedgerHeader();
-    if (protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
-                                  SOROBAN_PROTOCOL_VERSION))
+    TxSetPhaseTransactions phases;
+    phases.resize(protocolVersionStartsFrom(lclHeader.header.ledgerVersion,
+                                            SOROBAN_PROTOCOL_VERSION)
+                      ? 2
+                      : 1);
+    for (auto& tx : txs)
     {
-        // Empty soroban phase
-        phases.emplace_back();
+        if (tx->isSoroban())
+        {
+            phases[static_cast<size_t>(TxSetPhase::SOROBAN)].push_back(tx);
+        }
+        else
+        {
+            phases[static_cast<size_t>(TxSetPhase::CLASSIC)].push_back(tx);
+        }
     }
     TxSetPhaseTransactions invalid;
     invalid.resize(phases.size());

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -579,10 +579,11 @@ TEST_CASE_VERSIONS("meta stream contains reasonable meta", "[ledgerclosemeta]")
                                .setReadBytes(10'000)
                                .setWriteBytes(1'000)
                                .setInclusionFee(1'000)
-                               .setNonRefundableResourceFee(40'000)
+                               .setRefundableResourceFee(40'000)
                                .setReadWriteFootprint({liveLk});
 
             auto tx3 = contract.prepareInvocation(fnName, args, putSpec)
+                           .withExactNonRefundableResourceFee()
                            .createTx(&acc3);
 
             // Same put TX from before, but this one should fail due to invalid
@@ -590,6 +591,7 @@ TEST_CASE_VERSIONS("meta stream contains reasonable meta", "[ledgerclosemeta]")
             auto tx4 = contract
                            .prepareInvocation(fnName, args,
                                               putSpec.setReadWriteFootprint({}))
+                           .withExactNonRefundableResourceFee()
                            .createTx(&acc4);
             SorobanResources createResources;
             createResources.instructions = 200'000;

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -510,14 +510,18 @@ TEST_CASE_VERSIONS("meta stream contains reasonable meta", "[ledgerclosemeta]")
             // 5. Create contract instance
 
             // Deploy and extend contract so it won't be archived during test
-            ContractStorageInvocationTest test(cfg);
-            test.extendOp(test.getContractKeys(), 10'000);
+            SorobanTest test(cfg);
+            ContractStorageTestClient client(test);
+            auto& contract = client.getContract();
+
+            test.invokeExtendOp(contract.getKeys(), 10'000);
 
             // Write key that we will restore later
-            test.put("archived", ContractDataDurability::PERSISTENT, 42);
+            REQUIRE(client.put("archived", ContractDataDurability::PERSISTENT,
+                               42) == INVOKE_HOST_FUNCTION_SUCCESS);
             auto archivedKeySymbol = makeSymbolSCVal("archived");
             auto archivedLk =
-                contractDataKey(test.getContractID(), archivedKeySymbol,
+                contractDataKey(contract.getAddress(), archivedKeySymbol,
                                 ContractDataDurability::PERSISTENT);
 
             uint32_t liveUntilLedger =
@@ -527,24 +531,20 @@ TEST_CASE_VERSIONS("meta stream contains reasonable meta", "[ledgerclosemeta]")
 
             // Generate a few accounts so we can send multiple TXs in a single
             // ledger.
-            auto bal = test.getApp()->getLedgerManager().getLastMinBalance(2);
-            auto acc1 = std::make_shared<TestAccount>(
-                test.getRoot().create("acc1", bal));
-            auto acc2 = std::make_shared<TestAccount>(
-                test.getRoot().create("acc2", bal));
-            auto acc3 = std::make_shared<TestAccount>(
-                test.getRoot().create("acc3", bal));
-            auto acc4 = std::make_shared<TestAccount>(
-                test.getRoot().create("acc4", bal));
+            auto bal = test.getApp().getLedgerManager().getLastMinBalance(2);
+            auto acc1 = test.getRoot().create("acc1", bal);
+            auto acc2 = test.getRoot().create("acc2", bal);
+            auto acc3 = test.getRoot().create("acc3", bal);
+            auto acc4 = test.getRoot().create("acc4", bal);
             auto acc5 = test.getRoot().create("acc5", bal);
 
             // Close ledgers until out contract expires. These ledgers won't
             // emit meta
             for (uint32_t i =
-                     test.getApp()->getLedgerManager().getLastClosedLedgerNum();
+                     test.getApp().getLedgerManager().getLastClosedLedgerNum();
                  i <= liveUntilLedger + 1; ++i)
             {
-                closeLedgerOn(*test.getApp(), i, 2, 1, 2016);
+                closeLedgerOn(test.getApp(), i, 2, 1, 2016);
             }
             REQUIRE(!test.isEntryLive(archivedLk, test.getLedgerSeq()));
 
@@ -555,46 +555,54 @@ TEST_CASE_VERSIONS("meta stream contains reasonable meta", "[ledgerclosemeta]")
             restoreResources.readBytes = 5'000;
             restoreResources.writeBytes = 1'000;
             auto tx1 = test.createRestoreTx(restoreResources, 1'000,
-                                            DEFAULT_TEST_RESOURCE_FEE, acc1);
+                                            DEFAULT_TEST_RESOURCE_FEE, &acc1);
 
-            // Extend TTL of WASM and instance
+            // Extend TTL of Wasm and instance
             SorobanResources extendResources;
-            extendResources.footprint.readOnly = test.getContractKeys();
+            extendResources.footprint.readOnly = contract.getKeys();
             extendResources.instructions = 0;
             extendResources.readBytes = 10'000;
             extendResources.writeBytes = 0;
             auto tx2 =
                 test.createExtendOpTx(extendResources, /*extendTo*/ 10'000,
-                                      1'000, DEFAULT_TEST_RESOURCE_FEE, acc2);
+                                      1'000, DEFAULT_TEST_RESOURCE_FEE, &acc2);
 
             // Write new entry with key PERSISTENT("key")
             auto liveKeySymbol = makeSymbolSCVal("key");
-            auto funcSymbol = makeSymbol("put_persistent");
+            auto fnName = "put_persistent";
             auto args = {liveKeySymbol, makeU64SCVal(42)};
-            auto liveLk = contractDataKey(test.getContractID(), liveKeySymbol,
+            auto liveLk = contractDataKey(client.getContract().getAddress(),
+                                          liveKeySymbol,
                                           ContractDataDurability::PERSISTENT);
-            SorobanResources putResources;
-            putResources.footprint.readOnly = test.getContractKeys();
-            putResources.footprint.readWrite = {liveLk};
-            putResources.instructions = 4'000'000;
-            putResources.readBytes = 10'000;
-            putResources.writeBytes = 1'000;
-            auto resourceFee =
-                test.computeResourceFee(putResources, funcSymbol, args);
+            auto putSpec = SorobanInvocationSpec()
+                               .setInstructions(4'000'000)
+                               .setReadBytes(10'000)
+                               .setWriteBytes(1'000)
+                               .setInclusionFee(1'000)
+                               .setNonRefundableResourceFee(40'000)
+                               .setReadWriteFootprint({liveLk});
 
-            auto tx3 = test.createInvokeTx(putResources, funcSymbol, args,
-                                           1'000, resourceFee + 40'000, acc3);
+            auto tx3 = contract.prepareInvocation(fnName, args, putSpec)
+                           .createTx(&acc3);
 
             // Same put TX from before, but this one should fail due to invalid
             // footprint
-            SorobanResources badPutResources = putResources;
-            badPutResources.footprint.readWrite.clear();
-            auto tx4 = test.createInvokeTx(badPutResources, funcSymbol, args,
-                                           1'000, resourceFee + 40'000, acc4);
+            auto tx4 = contract
+                           .prepareInvocation(fnName, args,
+                                              putSpec.setReadWriteFootprint({}))
+                           .createTx(&acc4);
+            SorobanResources createResources;
+            createResources.instructions = 200'000;
+            createResources.readBytes = 5000;
+            createResources.writeBytes = 5000;
 
-            auto tx5 = test.getCreateTx(acc5);
+            auto tx5 = makeSorobanCreateContractTx(
+                test.getApp(), acc5,
+                makeContractIDPreimage(acc5, sha256("salt")),
+                makeWasmExecutable(contract.getKeys()[0].contractCode().hash),
+                createResources, 1000);
 
-            closeLedger(*test.getApp(), {tx1, tx2, tx3, tx4, tx5});
+            closeLedger(test.getApp(), {tx1, tx2, tx3, tx4, tx5});
             targetSeq = 23;
         }
         else

--- a/src/test/TestUtils.h
+++ b/src/test/TestUtils.h
@@ -105,7 +105,6 @@ modifySorobanNetworkConfig(Application& app,
 bool appProtocolVersionStartsFrom(Application& app,
                                   ProtocolVersion fromVersion);
 
-// This is a rough guess at the refundable fee to include. 20k for a ledger
-// write plus 1000 for a little additional slop.
+// Large enough fee to cover most of the Soroban transactions.
 constexpr uint32_t DEFAULT_TEST_RESOURCE_FEE = 1'000'000;
 }

--- a/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "ddd1d9588393d5ca18044c39d2e4fcc77be62c93aff8cf33c13e45227c688010",
+                "hash": "587e4d9960d05547496365f7754453124089cdef9dec464aa9d0d54d7c405704",
                 "header": {
                     "ledgerVersion": 20,
                     "previousLedgerHash": "b850b65d9a3a03b243ca7b4ed236492e3508ff389828db6d8452ae2590bf6610",
                     "scpValue": {
-                        "txSetHash": "dd9aa7d0a9604d76d7b6ff8d7d80ef370c7ad9a619b2d2498c19763b4132884e",
+                        "txSetHash": "e9dba6cb2fb8c42261dfc9d7135615267269401cacff641737d6134d02c68828",
                         "closeTime": 1451692800,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "101782f28e1e0e507374375fceee4d0d1b372b8f91917ba36f83612995d896441db89fd084bd9d1e4fdfb00f8f2e3fbbe6b632d87b57d80c35e1381644b48604"
+                                "signature": "083cff6ed597bf2a7b431c1c84bb0fb397a8e322bf8468c2ef7675a67bb10390d9bfffb543dfee45e767feb5bf4448c8762c72b382637a6cb27c8d9457f70a07"
                             }
                         }
                     },
-                    "txSetResultHash": "c0ce8015e394780df127e542a19ddc84bb4b2fe56d175cd1b933e6d7409fb7b3",
-                    "bucketListHash": "1300cd42035fa1034eb84d5d72b05093238b77f670720e4d941ae2594e0ce3ed",
+                    "txSetResultHash": "5aea98b7f8dfe11515507fd8cc3fb828247ab76292edcc9845caafec8e036ab9",
+                    "bucketListHash": "c444193e9d77d45d2a393ab073bf2cfbf6f3079f9e273466fb7622fcba5708f6",
                     "ledgerSeq": 23,
                     "totalCoins": 1000000000000000000,
                     "feePool": 384917,
@@ -68,7 +68,7 @@
                                                 "v1": {
                                                     "tx": {
                                                         "sourceAccount": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                        "fee": 127626,
+                                                        "fee": 102512,
                                                         "seqNum": 25769803777,
                                                         "cond": {
                                                             "type": "PRECOND_NONE"
@@ -87,7 +87,7 @@
                                                                             "invokeContract": {
                                                                                 "contractAddress": {
                                                                                     "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                    "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
+                                                                                    "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
                                                                                 },
                                                                                 "functionName": "put_persistent",
                                                                                 "args": [
@@ -117,22 +117,22 @@
                                                                     "footprint": {
                                                                         "readOnly": [
                                                                             {
+                                                                                "type": "CONTRACT_CODE",
+                                                                                "contractCode": {
+                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
+                                                                                }
+                                                                            },
+                                                                            {
                                                                                 "type": "CONTRACT_DATA",
                                                                                 "contractData": {
                                                                                     "contract": {
                                                                                         "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
                                                                                     },
                                                                                     "key": {
                                                                                         "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
                                                                                     },
                                                                                     "durability": "PERSISTENT"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "type": "CONTRACT_CODE",
-                                                                                "contractCode": {
-                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
                                                                                 }
                                                                             }
                                                                         ],
@@ -142,262 +142,14 @@
                                                                     "readBytes": 10000,
                                                                     "writeBytes": 1000
                                                                 },
-                                                                "resourceFee": 126626
+                                                                "resourceFee": 101512
                                                             }
                                                         }
                                                     },
                                                     "signatures": [
                                                         {
                                                             "hint": "477df904",
-                                                            "signature": "5662570c0f5c0f2466bde3020857c19f3470f6ec3e0103876e65a372ccaf84b4affe3d099946582485ece1114081c6093244fc030154504ed9c49c9f3ef88c03"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "ENVELOPE_TYPE_TX",
-                                                "v1": {
-                                                    "tx": {
-                                                        "sourceAccount": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "fee": 1001000,
-                                                        "seqNum": 12884901889,
-                                                        "cond": {
-                                                            "type": "PRECOND_NONE"
-                                                        },
-                                                        "memo": {
-                                                            "type": "MEMO_NONE"
-                                                        },
-                                                        "operations": [
-                                                            {
-                                                                "sourceAccount": null,
-                                                                "body": {
-                                                                    "type": "RESTORE_FOOTPRINT",
-                                                                    "restoreFootprintOp": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        ],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "sorobanData": {
-                                                                "ext": {
-                                                                    "v": 0
-                                                                },
-                                                                "resources": {
-                                                                    "footprint": {
-                                                                        "readOnly": [],
-                                                                        "readWrite": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_SYMBOL",
-                                                                                        "sym": "archived"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    "instructions": 0,
-                                                                    "readBytes": 5000,
-                                                                    "writeBytes": 1000
-                                                                },
-                                                                "resourceFee": 1000000
-                                                            }
-                                                        }
-                                                    },
-                                                    "signatures": [
-                                                        {
-                                                            "hint": "5099a12e",
-                                                            "signature": "56e40b70e809b606b7a9160a2bac19ac688857066b320f94c78d182f27017e8fcfdeb2b13615b818b52c66fb8502720b3c41971544734e9697a32612165f0608"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "ENVELOPE_TYPE_TX",
-                                                "v1": {
-                                                    "tx": {
-                                                        "sourceAccount": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                        "fee": 1001000,
-                                                        "seqNum": 17179869185,
-                                                        "cond": {
-                                                            "type": "PRECOND_NONE"
-                                                        },
-                                                        "memo": {
-                                                            "type": "MEMO_NONE"
-                                                        },
-                                                        "operations": [
-                                                            {
-                                                                "sourceAccount": null,
-                                                                "body": {
-                                                                    "type": "EXTEND_FOOTPRINT_TTL",
-                                                                    "extendFootprintTTLOp": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "extendTo": 10000
-                                                                    }
-                                                                }
-                                                            }
-                                                        ],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "sorobanData": {
-                                                                "ext": {
-                                                                    "v": 0
-                                                                },
-                                                                "resources": {
-                                                                    "footprint": {
-                                                                        "readOnly": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "type": "CONTRACT_CODE",
-                                                                                "contractCode": {
-                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
-                                                                                }
-                                                                            }
-                                                                        ],
-                                                                        "readWrite": []
-                                                                    },
-                                                                    "instructions": 0,
-                                                                    "readBytes": 10000,
-                                                                    "writeBytes": 0
-                                                                },
-                                                                "resourceFee": 1000000
-                                                            }
-                                                        }
-                                                    },
-                                                    "signatures": [
-                                                        {
-                                                            "hint": "f7f60229",
-                                                            "signature": "a1fbcb30c12554ac9cf914720b8d427f43a2f6ffc011e581264675f75a5e8eac786bc54369b9f87e1dd78e090cf87546ff83c46998106e7fa05758a16708720d"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "ENVELOPE_TYPE_TX",
-                                                "v1": {
-                                                    "tx": {
-                                                        "sourceAccount": "GDWWCIR2FIWTY2D3CEDXZYRTRNTFZCC5PBCGC6XPMKCLUV7BRG2AT3RD",
-                                                        "fee": 127626,
-                                                        "seqNum": 21474836481,
-                                                        "cond": {
-                                                            "type": "PRECOND_NONE"
-                                                        },
-                                                        "memo": {
-                                                            "type": "MEMO_NONE"
-                                                        },
-                                                        "operations": [
-                                                            {
-                                                                "sourceAccount": null,
-                                                                "body": {
-                                                                    "type": "INVOKE_HOST_FUNCTION",
-                                                                    "invokeHostFunctionOp": {
-                                                                        "hostFunction": {
-                                                                            "type": "HOST_FUNCTION_TYPE_INVOKE_CONTRACT",
-                                                                            "invokeContract": {
-                                                                                "contractAddress": {
-                                                                                    "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                    "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                },
-                                                                                "functionName": "put_persistent",
-                                                                                "args": [
-                                                                                    {
-                                                                                        "type": "SCV_SYMBOL",
-                                                                                        "sym": "key"
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "SCV_U64",
-                                                                                        "u64": 42
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "auth": []
-                                                                    }
-                                                                }
-                                                            }
-                                                        ],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "sorobanData": {
-                                                                "ext": {
-                                                                    "v": 0
-                                                                },
-                                                                "resources": {
-                                                                    "footprint": {
-                                                                        "readOnly": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "type": "CONTRACT_CODE",
-                                                                                "contractCode": {
-                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
-                                                                                }
-                                                                            }
-                                                                        ],
-                                                                        "readWrite": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_SYMBOL",
-                                                                                        "sym": "key"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    "instructions": 4000000,
-                                                                    "readBytes": 10000,
-                                                                    "writeBytes": 1000
-                                                                },
-                                                                "resourceFee": 126626
-                                                            }
-                                                        }
-                                                    },
-                                                    "signatures": [
-                                                        {
-                                                            "hint": "e189b409",
-                                                            "signature": "a956f23f90bca86e49191d30d17aa1d7a70550722fcb70cb8d1d76eb440c1cc4d88093a231b99a6a33d6508ed24b15743045b3c3b05d4d4740df30ccc4a0ec0c"
+                                                            "signature": "23252dd4e8cc38c37904e893d7b045ec0593b1c1a9580cdf8a34677663135da84d18cb7f11826d165994f6c30c08bbb64fa8e3ee9a0f05d4d459591e76274207"
                                                         }
                                                     ]
                                                 }
@@ -407,7 +159,7 @@
                                                 "v1": {
                                                     "tx": {
                                                         "sourceAccount": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                        "fee": 84855,
+                                                        "fee": 1044855,
                                                         "seqNum": 30064771073,
                                                         "cond": {
                                                             "type": "PRECOND_NONE"
@@ -509,14 +261,262 @@
                                                                     "readBytes": 5000,
                                                                     "writeBytes": 5000
                                                                 },
-                                                                "resourceFee": 83855
+                                                                "resourceFee": 1043855
                                                             }
                                                         }
                                                     },
                                                     "signatures": [
                                                         {
                                                             "hint": "4b80097b",
-                                                            "signature": "c94b4f7dd440b7fe398cb5519c2ac418b3e7ded0d06ce9a25c155c1f940f77c6301d6d200e2251c77b40ae6ce097f16bc7f0d6f421a5e7fa2d090677165cde08"
+                                                            "signature": "45b39cc150bff6e89ff81279c0e39c8a7660d359dcc7bf4220ca1ab9e6cbc2eb07fea3a741c1c4dc50428b15f7c6f3011dc25ca8b4975c2f24019ae42c939b04"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ENVELOPE_TYPE_TX",
+                                                "v1": {
+                                                    "tx": {
+                                                        "sourceAccount": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                        "fee": 1001000,
+                                                        "seqNum": 17179869185,
+                                                        "cond": {
+                                                            "type": "PRECOND_NONE"
+                                                        },
+                                                        "memo": {
+                                                            "type": "MEMO_NONE"
+                                                        },
+                                                        "operations": [
+                                                            {
+                                                                "sourceAccount": null,
+                                                                "body": {
+                                                                    "type": "EXTEND_FOOTPRINT_TTL",
+                                                                    "extendFootprintTTLOp": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "extendTo": 10000
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "sorobanData": {
+                                                                "ext": {
+                                                                    "v": 0
+                                                                },
+                                                                "resources": {
+                                                                    "footprint": {
+                                                                        "readOnly": [
+                                                                            {
+                                                                                "type": "CONTRACT_CODE",
+                                                                                "contractCode": {
+                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "readWrite": []
+                                                                    },
+                                                                    "instructions": 0,
+                                                                    "readBytes": 10000,
+                                                                    "writeBytes": 0
+                                                                },
+                                                                "resourceFee": 1000000
+                                                            }
+                                                        }
+                                                    },
+                                                    "signatures": [
+                                                        {
+                                                            "hint": "f7f60229",
+                                                            "signature": "115131e2aa61cc0ed5783b1978acced5450d548ee75f474968199736872b449573f39ae7ac11b6ec78a6cc1ab84171c0430666f7e17ecd6084f1770256ad9e0b"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ENVELOPE_TYPE_TX",
+                                                "v1": {
+                                                    "tx": {
+                                                        "sourceAccount": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "fee": 1001000,
+                                                        "seqNum": 12884901889,
+                                                        "cond": {
+                                                            "type": "PRECOND_NONE"
+                                                        },
+                                                        "memo": {
+                                                            "type": "MEMO_NONE"
+                                                        },
+                                                        "operations": [
+                                                            {
+                                                                "sourceAccount": null,
+                                                                "body": {
+                                                                    "type": "RESTORE_FOOTPRINT",
+                                                                    "restoreFootprintOp": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "sorobanData": {
+                                                                "ext": {
+                                                                    "v": 0
+                                                                },
+                                                                "resources": {
+                                                                    "footprint": {
+                                                                        "readOnly": [],
+                                                                        "readWrite": [
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_SYMBOL",
+                                                                                        "sym": "archived"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "instructions": 0,
+                                                                    "readBytes": 5000,
+                                                                    "writeBytes": 1000
+                                                                },
+                                                                "resourceFee": 1000000
+                                                            }
+                                                        }
+                                                    },
+                                                    "signatures": [
+                                                        {
+                                                            "hint": "5099a12e",
+                                                            "signature": "c9e283810f469c92769251263ae22cfceab70f822a274b506bf22651b23e55c998d93e679c52fe95d74182bc0021adc75baa72a2bcf00430840876e3dd028300"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ENVELOPE_TYPE_TX",
+                                                "v1": {
+                                                    "tx": {
+                                                        "sourceAccount": "GDWWCIR2FIWTY2D3CEDXZYRTRNTFZCC5PBCGC6XPMKCLUV7BRG2AT3RD",
+                                                        "fee": 127626,
+                                                        "seqNum": 21474836481,
+                                                        "cond": {
+                                                            "type": "PRECOND_NONE"
+                                                        },
+                                                        "memo": {
+                                                            "type": "MEMO_NONE"
+                                                        },
+                                                        "operations": [
+                                                            {
+                                                                "sourceAccount": null,
+                                                                "body": {
+                                                                    "type": "INVOKE_HOST_FUNCTION",
+                                                                    "invokeHostFunctionOp": {
+                                                                        "hostFunction": {
+                                                                            "type": "HOST_FUNCTION_TYPE_INVOKE_CONTRACT",
+                                                                            "invokeContract": {
+                                                                                "contractAddress": {
+                                                                                    "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                    "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                },
+                                                                                "functionName": "put_persistent",
+                                                                                "args": [
+                                                                                    {
+                                                                                        "type": "SCV_SYMBOL",
+                                                                                        "sym": "key"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "SCV_U64",
+                                                                                        "u64": 42
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "auth": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "sorobanData": {
+                                                                "ext": {
+                                                                    "v": 0
+                                                                },
+                                                                "resources": {
+                                                                    "footprint": {
+                                                                        "readOnly": [
+                                                                            {
+                                                                                "type": "CONTRACT_CODE",
+                                                                                "contractCode": {
+                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "readWrite": [
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_SYMBOL",
+                                                                                        "sym": "key"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "instructions": 4000000,
+                                                                    "readBytes": 10000,
+                                                                    "writeBytes": 1000
+                                                                },
+                                                                "resourceFee": 126626
+                                                            }
+                                                        }
+                                                    },
+                                                    "signatures": [
+                                                        {
+                                                            "hint": "e189b409",
+                                                            "signature": "f2a733956cdfcf5d20feb848d5104c69d732d607ccfc7091c939d4786d68188c12975cc623a283b8df5f2b6cd804f6b7cb87a075ac2015aba91554196bfefb09"
                                                         }
                                                     ]
                                                 }
@@ -532,7 +532,7 @@
             "txProcessing": [
                 {
                     "result": {
-                        "transactionHash": "cc428f2d03a9b97d8d1b83d06a1fd1af50257f765b237ac2a12ed13c7c6d5375",
+                        "transactionHash": "f2ff59ab9afd48f7d7d8a8207bec84dbcee87a1338da7896ee8c46e09958e76f",
                         "result": {
                             "feeCharged": 126726,
                             "result": {
@@ -708,7 +708,7 @@
                                                         },
                                                         "contract": {
                                                             "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                            "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
+                                                            "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
                                                         },
                                                         "key": {
                                                             "type": "SCV_SYMBOL",
@@ -733,7 +733,7 @@
                                                 "data": {
                                                     "type": "TTL",
                                                     "ttl": {
-                                                        "keyHash": "080881c96969f824d14c5da4fe3a028502b42e6fd5c0ab356b837db730e3f619",
+                                                        "keyHash": "764f4e59e20ac1a357f9f26ab0eaf46d196ab74822db44f039353a6f114864aa",
                                                         "liveUntilLedgerSeq": 42
                                                     }
                                                 },
@@ -862,680 +862,7 @@
                 },
                 {
                     "result": {
-                        "transactionHash": "2a2b316a55eddaecc42c0db95eec09d94b992ccf769435e68866ea2011c42c1f",
-                        "result": {
-                            "feeCharged": 83955,
-                            "result": {
-                                "code": "txFAILED",
-                                "results": [
-                                    {
-                                        "code": "opINNER",
-                                        "tr": {
-                                            "type": "INVOKE_HOST_FUNCTION",
-                                            "invokeHostFunctionResult": {
-                                                "code": "INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED"
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "ext": {
-                                "v": 0
-                            }
-                        }
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 7,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                        "balance": 400000000,
-                                        "seqNum": 30064771072,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 23,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                        "balance": 399916045,
-                                        "seqNum": 30064771072,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "ext": {
-                                "v": 0
-                            },
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399916045,
-                                                "seqNum": 30064771072,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399916045,
-                                                "seqNum": 30064771073,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [],
-                            "txChangesAfter": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399916045,
-                                                "seqNum": 30064771073,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399957054,
-                                                "seqNum": 30064771073,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "sorobanMeta": {
-                                "ext": {
-                                    "v": 0
-                                },
-                                "events": [],
-                                "returnValue": {
-                                    "type": "SCV_BOOL",
-                                    "b": "FALSE"
-                                },
-                                "diagnosticEvents": [
-                                    {
-                                        "inSuccessfulContractCall": "FALSE",
-                                        "event": {
-                                            "ext": {
-                                                "v": 0
-                                            },
-                                            "contractID": null,
-                                            "type": "DIAGNOSTIC",
-                                            "body": {
-                                                "v": 0,
-                                                "v0": {
-                                                    "topics": [
-                                                        {
-                                                            "type": "SCV_SYMBOL",
-                                                            "sym": "error"
-                                                        },
-                                                        {
-                                                            "type": "SCV_ERROR",
-                                                            "error": {
-                                                                "type": "SCE_BUDGET",
-                                                                "code": "SCEC_EXCEEDED_LIMIT"
-                                                            }
-                                                        }
-                                                    ],
-                                                    "data": {
-                                                        "type": "SCV_VEC",
-                                                        "vec": [
-                                                            {
-                                                                "type": "SCV_STRING",
-                                                                "str": "operation instructions exceeds amount specified"
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 216850
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 200000
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                },
-                {
-                    "result": {
-                        "transactionHash": "66dc90645a7de11bf78ab96ce326dc8f9e83ffee718cad550bd0f2dcf551de5e",
-                        "result": {
-                            "feeCharged": 1000100,
-                            "result": {
-                                "code": "txSUCCESS",
-                                "results": [
-                                    {
-                                        "code": "opINNER",
-                                        "tr": {
-                                            "type": "EXTEND_FOOTPRINT_TTL",
-                                            "extendFootprintTTLResult": {
-                                                "code": "EXTEND_FOOTPRINT_TTL_SUCCESS"
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "ext": {
-                                "v": 0
-                            }
-                        }
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 4,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 400000000,
-                                        "seqNum": 17179869184,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 23,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 398999900,
-                                        "seqNum": 17179869184,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "ext": {
-                                "v": 0
-                            },
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 398999900,
-                                                "seqNum": 17179869184,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 398999900,
-                                                "seqNum": 17179869185,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 2,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "1d18c12182450a63a05a6782f93b205c2af961cd6bf3a42a5ec35308a4e6df8c",
-                                                        "liveUntilLedgerSeq": 10002
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 23,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "1d18c12182450a63a05a6782f93b205c2af961cd6bf3a42a5ec35308a4e6df8c",
-                                                        "liveUntilLedgerSeq": 10023
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 2,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "60313f9b273db0b14c3e503cf6cc152dd14a0c57e5e81a23e86b4e27a23a2c06",
-                                                        "liveUntilLedgerSeq": 10002
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 23,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "60313f9b273db0b14c3e503cf6cc152dd14a0c57e5e81a23e86b4e27a23a2c06",
-                                                        "liveUntilLedgerSeq": 10023
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "txChangesAfter": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 398999900,
-                                                "seqNum": 17179869185,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399939441,
-                                                "seqNum": 17179869185,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "sorobanMeta": {
-                                "ext": {
-                                    "v": 0
-                                },
-                                "events": [],
-                                "returnValue": {
-                                    "type": "SCV_BOOL",
-                                    "b": "FALSE"
-                                },
-                                "diagnosticEvents": []
-                            }
-                        }
-                    }
-                },
-                {
-                    "result": {
-                        "transactionHash": "763098624f5b2544dbaf78bf116834f23d57e3eae61e84227fa4ea282377d8ef",
+                        "transactionHash": "05981a6913d1a3ccaee718b21e837fa36b7dbb6c4382209ee7e4b98cf4a112b1",
                         "result": {
                             "feeCharged": 1000100,
                             "result": {
@@ -1705,7 +1032,7 @@
                                                 "data": {
                                                     "type": "TTL",
                                                     "ttl": {
-                                                        "keyHash": "f72277c05fd248e9073e3ce93fb93a102cc7efd76b0da4a13f0e041dbd2febb9",
+                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
                                                         "liveUntilLedgerSeq": 21
                                                     }
                                                 },
@@ -1721,7 +1048,7 @@
                                                 "data": {
                                                     "type": "TTL",
                                                     "ttl": {
-                                                        "keyHash": "f72277c05fd248e9073e3ce93fb93a102cc7efd76b0da4a13f0e041dbd2febb9",
+                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
                                                         "liveUntilLedgerSeq": 42
                                                     }
                                                 },
@@ -1851,9 +1178,682 @@
                 },
                 {
                     "result": {
-                        "transactionHash": "03776f7c91e241582f9af847a368be20f6dc882080e78e0ddec7f97b77b93fef",
+                        "transactionHash": "df60206f668bf546432dd37e734d01d6fb886ac8e17af2abd3a7ac742ce4559f",
                         "result": {
-                            "feeCharged": 126726,
+                            "feeCharged": 1000100,
+                            "result": {
+                                "code": "txSUCCESS",
+                                "results": [
+                                    {
+                                        "code": "opINNER",
+                                        "tr": {
+                                            "type": "EXTEND_FOOTPRINT_TTL",
+                                            "extendFootprintTTLResult": {
+                                                "code": "EXTEND_FOOTPRINT_TTL_SUCCESS"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "v": 0
+                            }
+                        }
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 4,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 400000000,
+                                        "seqNum": 17179869184,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 23,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 398999900,
+                                        "seqNum": 17179869184,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "ext": {
+                                "v": 0
+                            },
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 398999900,
+                                                "seqNum": 17179869184,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 398999900,
+                                                "seqNum": 17179869185,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 2,
+                                                "data": {
+                                                    "type": "TTL",
+                                                    "ttl": {
+                                                        "keyHash": "091ddece931776a53f93869b82c24e132cc12d00d961fac09bc3b9cb9021c62d",
+                                                        "liveUntilLedgerSeq": 10002
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 23,
+                                                "data": {
+                                                    "type": "TTL",
+                                                    "ttl": {
+                                                        "keyHash": "091ddece931776a53f93869b82c24e132cc12d00d961fac09bc3b9cb9021c62d",
+                                                        "liveUntilLedgerSeq": 10023
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 2,
+                                                "data": {
+                                                    "type": "TTL",
+                                                    "ttl": {
+                                                        "keyHash": "60313f9b273db0b14c3e503cf6cc152dd14a0c57e5e81a23e86b4e27a23a2c06",
+                                                        "liveUntilLedgerSeq": 10002
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 23,
+                                                "data": {
+                                                    "type": "TTL",
+                                                    "ttl": {
+                                                        "keyHash": "60313f9b273db0b14c3e503cf6cc152dd14a0c57e5e81a23e86b4e27a23a2c06",
+                                                        "liveUntilLedgerSeq": 10023
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "txChangesAfter": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 398999900,
+                                                "seqNum": 17179869185,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399939441,
+                                                "seqNum": 17179869185,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "sorobanMeta": {
+                                "ext": {
+                                    "v": 0
+                                },
+                                "events": [],
+                                "returnValue": {
+                                    "type": "SCV_BOOL",
+                                    "b": "FALSE"
+                                },
+                                "diagnosticEvents": []
+                            }
+                        }
+                    }
+                },
+                {
+                    "result": {
+                        "transactionHash": "dc7b999613ade2e947b8ed0e831036976f1529fa7489088e4b70ea0f5ba2e920",
+                        "result": {
+                            "feeCharged": 1043955,
+                            "result": {
+                                "code": "txFAILED",
+                                "results": [
+                                    {
+                                        "code": "opINNER",
+                                        "tr": {
+                                            "type": "INVOKE_HOST_FUNCTION",
+                                            "invokeHostFunctionResult": {
+                                                "code": "INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "v": 0
+                            }
+                        }
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 7,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                        "balance": 400000000,
+                                        "seqNum": 30064771072,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 23,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                        "balance": 398956045,
+                                        "seqNum": 30064771072,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "ext": {
+                                "v": 0
+                            },
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 398956045,
+                                                "seqNum": 30064771072,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 398956045,
+                                                "seqNum": 30064771073,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [],
+                            "txChangesAfter": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 398956045,
+                                                "seqNum": 30064771073,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 399957054,
+                                                "seqNum": 30064771073,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "sorobanMeta": {
+                                "ext": {
+                                    "v": 0
+                                },
+                                "events": [],
+                                "returnValue": {
+                                    "type": "SCV_BOOL",
+                                    "b": "FALSE"
+                                },
+                                "diagnosticEvents": [
+                                    {
+                                        "inSuccessfulContractCall": "FALSE",
+                                        "event": {
+                                            "ext": {
+                                                "v": 0
+                                            },
+                                            "contractID": null,
+                                            "type": "DIAGNOSTIC",
+                                            "body": {
+                                                "v": 0,
+                                                "v0": {
+                                                    "topics": [
+                                                        {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "error"
+                                                        },
+                                                        {
+                                                            "type": "SCV_ERROR",
+                                                            "error": {
+                                                                "type": "SCE_BUDGET",
+                                                                "code": "SCEC_EXCEEDED_LIMIT"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "data": {
+                                                        "type": "SCV_VEC",
+                                                        "vec": [
+                                                            {
+                                                                "type": "SCV_STRING",
+                                                                "str": "operation instructions exceeds amount specified"
+                                                            },
+                                                            {
+                                                                "type": "SCV_U64",
+                                                                "u64": 216850
+                                                            },
+                                                            {
+                                                                "type": "SCV_U64",
+                                                                "u64": 200000
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                {
+                    "result": {
+                        "transactionHash": "c9cd0abaad9ddeee41c162e4fd0c88a8127611a5ad3184f455bee186e6fcc5dc",
+                        "result": {
+                            "feeCharged": 101612,
                             "result": {
                                 "code": "txFAILED",
                                 "results": [
@@ -1908,7 +1908,7 @@
                                     "type": "ACCOUNT",
                                     "account": {
                                         "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                        "balance": 399873274,
+                                        "balance": 399898388,
                                         "seqNum": 25769803776,
                                         "numSubEntries": 0,
                                         "inflationDest": null,
@@ -1942,7 +1942,7 @@
                                             "type": "ACCOUNT",
                                             "account": {
                                                 "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399873274,
+                                                "balance": 399898388,
                                                 "seqNum": 25769803776,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,
@@ -1968,7 +1968,7 @@
                                             "type": "ACCOUNT",
                                             "account": {
                                                 "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399873274,
+                                                "balance": 399898388,
                                                 "seqNum": 25769803777,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,
@@ -2021,7 +2021,7 @@
                                             "type": "ACCOUNT",
                                             "account": {
                                                 "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399873274,
+                                                "balance": 399898388,
                                                 "seqNum": 25769803777,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,

--- a/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "7a78ebc202df7a1b67beb358eb49d093bfaf7b24b7e416741d23914c7d996b52",
+                "hash": "7e766b09e460ec6b7ddf3cc507aaf4c0fbbebe33fbb79859eb767dcea77979f2",
                 "header": {
                     "ledgerVersion": 21,
                     "previousLedgerHash": "ab369b64c4b6847a2b34a70ae0adc87e1e0994e747e00a9705c7602e98774c09",
                     "scpValue": {
-                        "txSetHash": "39655e30757a2725fd0779c61fa27693866f83d37db8e8b069b3ebf3e993bc34",
+                        "txSetHash": "98ea9ad1ef9042df8d1bebd99eaa92bacc5806f7855e0a5d46271954fe7c0495",
                         "closeTime": 1451692800,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "cbd43283a17675636b0e9387050f8a97fe2d1bd7066ee44cda90adf3ee112682c787dadd820e2b1e80854f11cc90b61aecf7217efb685280e833b7ec57dd9d0b"
+                                "signature": "e13525c4790ac37dbc16a6ba28efad338fadb675071a943e6fd7aa0dc2e8c0d8057f0123f8274c3a48d6d6e1a58a6c5fbf5e93671726a23e8ac329615f96d100"
                             }
                         }
                     },
-                    "txSetResultHash": "d8c2b26bccb527d87ea491f3487ffa30071d309059a6c5472ed5347439eabb72",
-                    "bucketListHash": "e7e4e90c54e1656659e0591be1d5cf741d3af502799a526c60a725396ac68c8b",
+                    "txSetResultHash": "16a377020ac233772c676b4339415ebe1a5fca5d87a4a9d98e2bd858865d5de1",
+                    "bucketListHash": "2f3c3e8d96ab9fa011c95443e62700b0a9983fc877f9b251c2735cf430737bcb",
                     "ledgerSeq": 23,
                     "totalCoins": 1000000000000000000,
                     "feePool": 384917,
@@ -68,7 +68,7 @@
                                                 "v1": {
                                                     "tx": {
                                                         "sourceAccount": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                        "fee": 127626,
+                                                        "fee": 102512,
                                                         "seqNum": 25769803777,
                                                         "cond": {
                                                             "type": "PRECOND_NONE"
@@ -87,7 +87,7 @@
                                                                             "invokeContract": {
                                                                                 "contractAddress": {
                                                                                     "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                    "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
+                                                                                    "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
                                                                                 },
                                                                                 "functionName": "put_persistent",
                                                                                 "args": [
@@ -117,22 +117,22 @@
                                                                     "footprint": {
                                                                         "readOnly": [
                                                                             {
+                                                                                "type": "CONTRACT_CODE",
+                                                                                "contractCode": {
+                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
+                                                                                }
+                                                                            },
+                                                                            {
                                                                                 "type": "CONTRACT_DATA",
                                                                                 "contractData": {
                                                                                     "contract": {
                                                                                         "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
                                                                                     },
                                                                                     "key": {
                                                                                         "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
                                                                                     },
                                                                                     "durability": "PERSISTENT"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "type": "CONTRACT_CODE",
-                                                                                "contractCode": {
-                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
                                                                                 }
                                                                             }
                                                                         ],
@@ -142,262 +142,14 @@
                                                                     "readBytes": 10000,
                                                                     "writeBytes": 1000
                                                                 },
-                                                                "resourceFee": 126626
+                                                                "resourceFee": 101512
                                                             }
                                                         }
                                                     },
                                                     "signatures": [
                                                         {
                                                             "hint": "477df904",
-                                                            "signature": "5662570c0f5c0f2466bde3020857c19f3470f6ec3e0103876e65a372ccaf84b4affe3d099946582485ece1114081c6093244fc030154504ed9c49c9f3ef88c03"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "ENVELOPE_TYPE_TX",
-                                                "v1": {
-                                                    "tx": {
-                                                        "sourceAccount": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "fee": 1001000,
-                                                        "seqNum": 12884901889,
-                                                        "cond": {
-                                                            "type": "PRECOND_NONE"
-                                                        },
-                                                        "memo": {
-                                                            "type": "MEMO_NONE"
-                                                        },
-                                                        "operations": [
-                                                            {
-                                                                "sourceAccount": null,
-                                                                "body": {
-                                                                    "type": "RESTORE_FOOTPRINT",
-                                                                    "restoreFootprintOp": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        ],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "sorobanData": {
-                                                                "ext": {
-                                                                    "v": 0
-                                                                },
-                                                                "resources": {
-                                                                    "footprint": {
-                                                                        "readOnly": [],
-                                                                        "readWrite": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_SYMBOL",
-                                                                                        "sym": "archived"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    "instructions": 0,
-                                                                    "readBytes": 5000,
-                                                                    "writeBytes": 1000
-                                                                },
-                                                                "resourceFee": 1000000
-                                                            }
-                                                        }
-                                                    },
-                                                    "signatures": [
-                                                        {
-                                                            "hint": "5099a12e",
-                                                            "signature": "56e40b70e809b606b7a9160a2bac19ac688857066b320f94c78d182f27017e8fcfdeb2b13615b818b52c66fb8502720b3c41971544734e9697a32612165f0608"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "ENVELOPE_TYPE_TX",
-                                                "v1": {
-                                                    "tx": {
-                                                        "sourceAccount": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                        "fee": 1001000,
-                                                        "seqNum": 17179869185,
-                                                        "cond": {
-                                                            "type": "PRECOND_NONE"
-                                                        },
-                                                        "memo": {
-                                                            "type": "MEMO_NONE"
-                                                        },
-                                                        "operations": [
-                                                            {
-                                                                "sourceAccount": null,
-                                                                "body": {
-                                                                    "type": "EXTEND_FOOTPRINT_TTL",
-                                                                    "extendFootprintTTLOp": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "extendTo": 10000
-                                                                    }
-                                                                }
-                                                            }
-                                                        ],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "sorobanData": {
-                                                                "ext": {
-                                                                    "v": 0
-                                                                },
-                                                                "resources": {
-                                                                    "footprint": {
-                                                                        "readOnly": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "type": "CONTRACT_CODE",
-                                                                                "contractCode": {
-                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
-                                                                                }
-                                                                            }
-                                                                        ],
-                                                                        "readWrite": []
-                                                                    },
-                                                                    "instructions": 0,
-                                                                    "readBytes": 10000,
-                                                                    "writeBytes": 0
-                                                                },
-                                                                "resourceFee": 1000000
-                                                            }
-                                                        }
-                                                    },
-                                                    "signatures": [
-                                                        {
-                                                            "hint": "f7f60229",
-                                                            "signature": "a1fbcb30c12554ac9cf914720b8d427f43a2f6ffc011e581264675f75a5e8eac786bc54369b9f87e1dd78e090cf87546ff83c46998106e7fa05758a16708720d"
-                                                        }
-                                                    ]
-                                                }
-                                            },
-                                            {
-                                                "type": "ENVELOPE_TYPE_TX",
-                                                "v1": {
-                                                    "tx": {
-                                                        "sourceAccount": "GDWWCIR2FIWTY2D3CEDXZYRTRNTFZCC5PBCGC6XPMKCLUV7BRG2AT3RD",
-                                                        "fee": 127626,
-                                                        "seqNum": 21474836481,
-                                                        "cond": {
-                                                            "type": "PRECOND_NONE"
-                                                        },
-                                                        "memo": {
-                                                            "type": "MEMO_NONE"
-                                                        },
-                                                        "operations": [
-                                                            {
-                                                                "sourceAccount": null,
-                                                                "body": {
-                                                                    "type": "INVOKE_HOST_FUNCTION",
-                                                                    "invokeHostFunctionOp": {
-                                                                        "hostFunction": {
-                                                                            "type": "HOST_FUNCTION_TYPE_INVOKE_CONTRACT",
-                                                                            "invokeContract": {
-                                                                                "contractAddress": {
-                                                                                    "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                    "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                },
-                                                                                "functionName": "put_persistent",
-                                                                                "args": [
-                                                                                    {
-                                                                                        "type": "SCV_SYMBOL",
-                                                                                        "sym": "key"
-                                                                                    },
-                                                                                    {
-                                                                                        "type": "SCV_U64",
-                                                                                        "u64": 42
-                                                                                    }
-                                                                                ]
-                                                                            }
-                                                                        },
-                                                                        "auth": []
-                                                                    }
-                                                                }
-                                                            }
-                                                        ],
-                                                        "ext": {
-                                                            "v": 1,
-                                                            "sorobanData": {
-                                                                "ext": {
-                                                                    "v": 0
-                                                                },
-                                                                "resources": {
-                                                                    "footprint": {
-                                                                        "readOnly": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            },
-                                                                            {
-                                                                                "type": "CONTRACT_CODE",
-                                                                                "contractCode": {
-                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
-                                                                                }
-                                                                            }
-                                                                        ],
-                                                                        "readWrite": [
-                                                                            {
-                                                                                "type": "CONTRACT_DATA",
-                                                                                "contractData": {
-                                                                                    "contract": {
-                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                                                        "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
-                                                                                    },
-                                                                                    "key": {
-                                                                                        "type": "SCV_SYMBOL",
-                                                                                        "sym": "key"
-                                                                                    },
-                                                                                    "durability": "PERSISTENT"
-                                                                                }
-                                                                            }
-                                                                        ]
-                                                                    },
-                                                                    "instructions": 4000000,
-                                                                    "readBytes": 10000,
-                                                                    "writeBytes": 1000
-                                                                },
-                                                                "resourceFee": 126626
-                                                            }
-                                                        }
-                                                    },
-                                                    "signatures": [
-                                                        {
-                                                            "hint": "e189b409",
-                                                            "signature": "a956f23f90bca86e49191d30d17aa1d7a70550722fcb70cb8d1d76eb440c1cc4d88093a231b99a6a33d6508ed24b15743045b3c3b05d4d4740df30ccc4a0ec0c"
+                                                            "signature": "23252dd4e8cc38c37904e893d7b045ec0593b1c1a9580cdf8a34677663135da84d18cb7f11826d165994f6c30c08bbb64fa8e3ee9a0f05d4d459591e76274207"
                                                         }
                                                     ]
                                                 }
@@ -407,7 +159,7 @@
                                                 "v1": {
                                                     "tx": {
                                                         "sourceAccount": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                        "fee": 84855,
+                                                        "fee": 1044855,
                                                         "seqNum": 30064771073,
                                                         "cond": {
                                                             "type": "PRECOND_NONE"
@@ -509,14 +261,262 @@
                                                                     "readBytes": 5000,
                                                                     "writeBytes": 5000
                                                                 },
-                                                                "resourceFee": 83855
+                                                                "resourceFee": 1043855
                                                             }
                                                         }
                                                     },
                                                     "signatures": [
                                                         {
                                                             "hint": "4b80097b",
-                                                            "signature": "c94b4f7dd440b7fe398cb5519c2ac418b3e7ded0d06ce9a25c155c1f940f77c6301d6d200e2251c77b40ae6ce097f16bc7f0d6f421a5e7fa2d090677165cde08"
+                                                            "signature": "45b39cc150bff6e89ff81279c0e39c8a7660d359dcc7bf4220ca1ab9e6cbc2eb07fea3a741c1c4dc50428b15f7c6f3011dc25ca8b4975c2f24019ae42c939b04"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ENVELOPE_TYPE_TX",
+                                                "v1": {
+                                                    "tx": {
+                                                        "sourceAccount": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                        "fee": 1001000,
+                                                        "seqNum": 17179869185,
+                                                        "cond": {
+                                                            "type": "PRECOND_NONE"
+                                                        },
+                                                        "memo": {
+                                                            "type": "MEMO_NONE"
+                                                        },
+                                                        "operations": [
+                                                            {
+                                                                "sourceAccount": null,
+                                                                "body": {
+                                                                    "type": "EXTEND_FOOTPRINT_TTL",
+                                                                    "extendFootprintTTLOp": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "extendTo": 10000
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "sorobanData": {
+                                                                "ext": {
+                                                                    "v": 0
+                                                                },
+                                                                "resources": {
+                                                                    "footprint": {
+                                                                        "readOnly": [
+                                                                            {
+                                                                                "type": "CONTRACT_CODE",
+                                                                                "contractCode": {
+                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "readWrite": []
+                                                                    },
+                                                                    "instructions": 0,
+                                                                    "readBytes": 10000,
+                                                                    "writeBytes": 0
+                                                                },
+                                                                "resourceFee": 1000000
+                                                            }
+                                                        }
+                                                    },
+                                                    "signatures": [
+                                                        {
+                                                            "hint": "f7f60229",
+                                                            "signature": "115131e2aa61cc0ed5783b1978acced5450d548ee75f474968199736872b449573f39ae7ac11b6ec78a6cc1ab84171c0430666f7e17ecd6084f1770256ad9e0b"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ENVELOPE_TYPE_TX",
+                                                "v1": {
+                                                    "tx": {
+                                                        "sourceAccount": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "fee": 1001000,
+                                                        "seqNum": 12884901889,
+                                                        "cond": {
+                                                            "type": "PRECOND_NONE"
+                                                        },
+                                                        "memo": {
+                                                            "type": "MEMO_NONE"
+                                                        },
+                                                        "operations": [
+                                                            {
+                                                                "sourceAccount": null,
+                                                                "body": {
+                                                                    "type": "RESTORE_FOOTPRINT",
+                                                                    "restoreFootprintOp": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "sorobanData": {
+                                                                "ext": {
+                                                                    "v": 0
+                                                                },
+                                                                "resources": {
+                                                                    "footprint": {
+                                                                        "readOnly": [],
+                                                                        "readWrite": [
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_SYMBOL",
+                                                                                        "sym": "archived"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "instructions": 0,
+                                                                    "readBytes": 5000,
+                                                                    "writeBytes": 1000
+                                                                },
+                                                                "resourceFee": 1000000
+                                                            }
+                                                        }
+                                                    },
+                                                    "signatures": [
+                                                        {
+                                                            "hint": "5099a12e",
+                                                            "signature": "c9e283810f469c92769251263ae22cfceab70f822a274b506bf22651b23e55c998d93e679c52fe95d74182bc0021adc75baa72a2bcf00430840876e3dd028300"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ENVELOPE_TYPE_TX",
+                                                "v1": {
+                                                    "tx": {
+                                                        "sourceAccount": "GDWWCIR2FIWTY2D3CEDXZYRTRNTFZCC5PBCGC6XPMKCLUV7BRG2AT3RD",
+                                                        "fee": 127626,
+                                                        "seqNum": 21474836481,
+                                                        "cond": {
+                                                            "type": "PRECOND_NONE"
+                                                        },
+                                                        "memo": {
+                                                            "type": "MEMO_NONE"
+                                                        },
+                                                        "operations": [
+                                                            {
+                                                                "sourceAccount": null,
+                                                                "body": {
+                                                                    "type": "INVOKE_HOST_FUNCTION",
+                                                                    "invokeHostFunctionOp": {
+                                                                        "hostFunction": {
+                                                                            "type": "HOST_FUNCTION_TYPE_INVOKE_CONTRACT",
+                                                                            "invokeContract": {
+                                                                                "contractAddress": {
+                                                                                    "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                    "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                },
+                                                                                "functionName": "put_persistent",
+                                                                                "args": [
+                                                                                    {
+                                                                                        "type": "SCV_SYMBOL",
+                                                                                        "sym": "key"
+                                                                                    },
+                                                                                    {
+                                                                                        "type": "SCV_U64",
+                                                                                        "u64": 42
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        },
+                                                                        "auth": []
+                                                                    }
+                                                                }
+                                                            }
+                                                        ],
+                                                        "ext": {
+                                                            "v": 1,
+                                                            "sorobanData": {
+                                                                "ext": {
+                                                                    "v": 0
+                                                                },
+                                                                "resources": {
+                                                                    "footprint": {
+                                                                        "readOnly": [
+                                                                            {
+                                                                                "type": "CONTRACT_CODE",
+                                                                                "contractCode": {
+                                                                                    "hash": "fc644715caaead746e6145f4331ff75c427c965c20d2995a9942b01247515962"
+                                                                                }
+                                                                            },
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_LEDGER_KEY_CONTRACT_INSTANCE"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ],
+                                                                        "readWrite": [
+                                                                            {
+                                                                                "type": "CONTRACT_DATA",
+                                                                                "contractData": {
+                                                                                    "contract": {
+                                                                                        "type": "SC_ADDRESS_TYPE_CONTRACT",
+                                                                                        "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
+                                                                                    },
+                                                                                    "key": {
+                                                                                        "type": "SCV_SYMBOL",
+                                                                                        "sym": "key"
+                                                                                    },
+                                                                                    "durability": "PERSISTENT"
+                                                                                }
+                                                                            }
+                                                                        ]
+                                                                    },
+                                                                    "instructions": 4000000,
+                                                                    "readBytes": 10000,
+                                                                    "writeBytes": 1000
+                                                                },
+                                                                "resourceFee": 126626
+                                                            }
+                                                        }
+                                                    },
+                                                    "signatures": [
+                                                        {
+                                                            "hint": "e189b409",
+                                                            "signature": "f2a733956cdfcf5d20feb848d5104c69d732d607ccfc7091c939d4786d68188c12975cc623a283b8df5f2b6cd804f6b7cb87a075ac2015aba91554196bfefb09"
                                                         }
                                                     ]
                                                 }
@@ -532,602 +532,7 @@
             "txProcessing": [
                 {
                     "result": {
-                        "transactionHash": "03776f7c91e241582f9af847a368be20f6dc882080e78e0ddec7f97b77b93fef",
-                        "result": {
-                            "feeCharged": 126726,
-                            "result": {
-                                "code": "txFAILED",
-                                "results": [
-                                    {
-                                        "code": "opINNER",
-                                        "tr": {
-                                            "type": "INVOKE_HOST_FUNCTION",
-                                            "invokeHostFunctionResult": {
-                                                "code": "INVOKE_HOST_FUNCTION_TRAPPED"
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "ext": {
-                                "v": 0
-                            }
-                        }
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 6,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                        "balance": 400000000,
-                                        "seqNum": 25769803776,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 23,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                        "balance": 399873274,
-                                        "seqNum": 25769803776,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "ext": {
-                                "v": 0
-                            },
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399873274,
-                                                "seqNum": 25769803776,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399873274,
-                                                "seqNum": 25769803777,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [],
-                            "txChangesAfter": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399873274,
-                                                "seqNum": 25769803777,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
-                                                "balance": 399938388,
-                                                "seqNum": 25769803777,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "sorobanMeta": {
-                                "ext": {
-                                    "v": 0
-                                },
-                                "events": [],
-                                "returnValue": {
-                                    "type": "SCV_BOOL",
-                                    "b": "FALSE"
-                                },
-                                "diagnosticEvents": []
-                            }
-                        }
-                    }
-                },
-                {
-                    "result": {
-                        "transactionHash": "763098624f5b2544dbaf78bf116834f23d57e3eae61e84227fa4ea282377d8ef",
-                        "result": {
-                            "feeCharged": 1000100,
-                            "result": {
-                                "code": "txSUCCESS",
-                                "results": [
-                                    {
-                                        "code": "opINNER",
-                                        "tr": {
-                                            "type": "RESTORE_FOOTPRINT",
-                                            "restoreFootprintResult": {
-                                                "code": "RESTORE_FOOTPRINT_SUCCESS"
-                                            }
-                                        }
-                                    }
-                                ]
-                            },
-                            "ext": {
-                                "v": 0
-                            }
-                        }
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 3,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                        "balance": 400000000,
-                                        "seqNum": 12884901888,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 23,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                        "balance": 398999900,
-                                        "seqNum": 12884901888,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "ext": {
-                                "v": 0
-                            },
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                "balance": 398999900,
-                                                "seqNum": 12884901888,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                "balance": 398999900,
-                                                "seqNum": 12884901889,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 2,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "f72277c05fd248e9073e3ce93fb93a102cc7efd76b0da4a13f0e041dbd2febb9",
-                                                        "liveUntilLedgerSeq": 21
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 23,
-                                                "data": {
-                                                    "type": "TTL",
-                                                    "ttl": {
-                                                        "keyHash": "f72277c05fd248e9073e3ce93fb93a102cc7efd76b0da4a13f0e041dbd2febb9",
-                                                        "liveUntilLedgerSeq": 42
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "txChangesAfter": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                "balance": 398999900,
-                                                "seqNum": 12884901889,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 23,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                "balance": 399948453,
-                                                "seqNum": 12884901889,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 23,
-                                                                        "seqTime": 1451692800
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "sorobanMeta": {
-                                "ext": {
-                                    "v": 0
-                                },
-                                "events": [],
-                                "returnValue": {
-                                    "type": "SCV_BOOL",
-                                    "b": "FALSE"
-                                },
-                                "diagnosticEvents": []
-                            }
-                        }
-                    }
-                },
-                {
-                    "result": {
-                        "transactionHash": "66dc90645a7de11bf78ab96ce326dc8f9e83ffee718cad550bd0f2dcf551de5e",
+                        "transactionHash": "df60206f668bf546432dd37e734d01d6fb886ac8e17af2abd3a7ac742ce4559f",
                         "result": {
                             "feeCharged": 1000100,
                             "result": {
@@ -1297,7 +702,7 @@
                                                 "data": {
                                                     "type": "TTL",
                                                     "ttl": {
-                                                        "keyHash": "1d18c12182450a63a05a6782f93b205c2af961cd6bf3a42a5ec35308a4e6df8c",
+                                                        "keyHash": "091ddece931776a53f93869b82c24e132cc12d00d961fac09bc3b9cb9021c62d",
                                                         "liveUntilLedgerSeq": 10002
                                                     }
                                                 },
@@ -1313,7 +718,7 @@
                                                 "data": {
                                                     "type": "TTL",
                                                     "ttl": {
-                                                        "keyHash": "1d18c12182450a63a05a6782f93b205c2af961cd6bf3a42a5ec35308a4e6df8c",
+                                                        "keyHash": "091ddece931776a53f93869b82c24e132cc12d00d961fac09bc3b9cb9021c62d",
                                                         "liveUntilLedgerSeq": 10023
                                                     }
                                                 },
@@ -1475,18 +880,18 @@
                 },
                 {
                     "result": {
-                        "transactionHash": "2a2b316a55eddaecc42c0db95eec09d94b992ccf769435e68866ea2011c42c1f",
+                        "transactionHash": "05981a6913d1a3ccaee718b21e837fa36b7dbb6c4382209ee7e4b98cf4a112b1",
                         "result": {
-                            "feeCharged": 83955,
+                            "feeCharged": 1000100,
                             "result": {
-                                "code": "txFAILED",
+                                "code": "txSUCCESS",
                                 "results": [
                                     {
                                         "code": "opINNER",
                                         "tr": {
-                                            "type": "INVOKE_HOST_FUNCTION",
-                                            "invokeHostFunctionResult": {
-                                                "code": "INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED"
+                                            "type": "RESTORE_FOOTPRINT",
+                                            "restoreFootprintResult": {
+                                                "code": "RESTORE_FOOTPRINT_SUCCESS"
                                             }
                                         }
                                     }
@@ -1501,13 +906,13 @@
                         {
                             "type": "LEDGER_ENTRY_STATE",
                             "state": {
-                                "lastModifiedLedgerSeq": 7,
+                                "lastModifiedLedgerSeq": 3,
                                 "data": {
                                     "type": "ACCOUNT",
                                     "account": {
-                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
                                         "balance": 400000000,
-                                        "seqNum": 30064771072,
+                                        "seqNum": 12884901888,
                                         "numSubEntries": 0,
                                         "inflationDest": null,
                                         "flags": 0,
@@ -1531,9 +936,9 @@
                                 "data": {
                                     "type": "ACCOUNT",
                                     "account": {
-                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                        "balance": 399916045,
-                                        "seqNum": 30064771072,
+                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                        "balance": 398999900,
+                                        "seqNum": 12884901888,
                                         "numSubEntries": 0,
                                         "inflationDest": null,
                                         "flags": 0,
@@ -1565,9 +970,9 @@
                                         "data": {
                                             "type": "ACCOUNT",
                                             "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399916045,
-                                                "seqNum": 30064771072,
+                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                "balance": 398999900,
+                                                "seqNum": 12884901888,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,
                                                 "flags": 0,
@@ -1591,9 +996,9 @@
                                         "data": {
                                             "type": "ACCOUNT",
                                             "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399916045,
-                                                "seqNum": 30064771073,
+                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                "balance": 398999900,
+                                                "seqNum": 12884901889,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,
                                                 "flags": 0,
@@ -1635,7 +1040,44 @@
                                     }
                                 }
                             ],
-                            "operations": [],
+                            "operations": [
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 2,
+                                                "data": {
+                                                    "type": "TTL",
+                                                    "ttl": {
+                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
+                                                        "liveUntilLedgerSeq": 21
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 23,
+                                                "data": {
+                                                    "type": "TTL",
+                                                    "ttl": {
+                                                        "keyHash": "4791962cd1e2c7b8f8af3f96514f9777f0156a48261fb885a571a7f69b33a058",
+                                                        "liveUntilLedgerSeq": 42
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
                             "txChangesAfter": [
                                 {
                                     "type": "LEDGER_ENTRY_STATE",
@@ -1644,9 +1086,9 @@
                                         "data": {
                                             "type": "ACCOUNT",
                                             "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399916045,
-                                                "seqNum": 30064771073,
+                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                "balance": 398999900,
+                                                "seqNum": 12884901889,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,
                                                 "flags": 0,
@@ -1694,9 +1136,9 @@
                                         "data": {
                                             "type": "ACCOUNT",
                                             "account": {
-                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
-                                                "balance": 399957054,
-                                                "seqNum": 30064771073,
+                                                "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                "balance": 399948453,
+                                                "seqNum": 12884901889,
                                                 "numSubEntries": 0,
                                                 "inflationDest": null,
                                                 "flags": 0,
@@ -1747,60 +1189,14 @@
                                     "type": "SCV_BOOL",
                                     "b": "FALSE"
                                 },
-                                "diagnosticEvents": [
-                                    {
-                                        "inSuccessfulContractCall": "FALSE",
-                                        "event": {
-                                            "ext": {
-                                                "v": 0
-                                            },
-                                            "contractID": null,
-                                            "type": "DIAGNOSTIC",
-                                            "body": {
-                                                "v": 0,
-                                                "v0": {
-                                                    "topics": [
-                                                        {
-                                                            "type": "SCV_SYMBOL",
-                                                            "sym": "error"
-                                                        },
-                                                        {
-                                                            "type": "SCV_ERROR",
-                                                            "error": {
-                                                                "type": "SCE_BUDGET",
-                                                                "code": "SCEC_EXCEEDED_LIMIT"
-                                                            }
-                                                        }
-                                                    ],
-                                                    "data": {
-                                                        "type": "SCV_VEC",
-                                                        "vec": [
-                                                            {
-                                                                "type": "SCV_STRING",
-                                                                "str": "operation instructions exceeds amount specified"
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 216850
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 200000
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
+                                "diagnosticEvents": []
                             }
                         }
                     }
                 },
                 {
                     "result": {
-                        "transactionHash": "cc428f2d03a9b97d8d1b83d06a1fd1af50257f765b237ac2a12ed13c7c6d5375",
+                        "transactionHash": "f2ff59ab9afd48f7d7d8a8207bec84dbcee87a1338da7896ee8c46e09958e76f",
                         "result": {
                             "feeCharged": 126726,
                             "result": {
@@ -1976,7 +1372,7 @@
                                                         },
                                                         "contract": {
                                                             "type": "SC_ADDRESS_TYPE_CONTRACT",
-                                                            "contractId": "df06d62447fd25da07c0135eed7557e5a5497ee7d15b7fe345bd47e191d8f577"
+                                                            "contractId": "01b8290fd49b5bd1330f0ea718bdea6729320620f65ce1a763657c57638c580b"
                                                         },
                                                         "key": {
                                                             "type": "SCV_SYMBOL",
@@ -2001,7 +1397,7 @@
                                                 "data": {
                                                     "type": "TTL",
                                                     "ttl": {
-                                                        "keyHash": "080881c96969f824d14c5da4fe3a028502b42e6fd5c0ab356b837db730e3f619",
+                                                        "keyHash": "764f4e59e20ac1a357f9f26ab0eaf46d196ab74822db44f039353a6f114864aa",
                                                         "liveUntilLedgerSeq": 42
                                                     }
                                                 },
@@ -2124,6 +1520,610 @@
                                     "type": "SCV_VOID"
                                 },
                                 "diagnosticEvents": []
+                            }
+                        }
+                    }
+                },
+                {
+                    "result": {
+                        "transactionHash": "c9cd0abaad9ddeee41c162e4fd0c88a8127611a5ad3184f455bee186e6fcc5dc",
+                        "result": {
+                            "feeCharged": 101612,
+                            "result": {
+                                "code": "txFAILED",
+                                "results": [
+                                    {
+                                        "code": "opINNER",
+                                        "tr": {
+                                            "type": "INVOKE_HOST_FUNCTION",
+                                            "invokeHostFunctionResult": {
+                                                "code": "INVOKE_HOST_FUNCTION_TRAPPED"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "v": 0
+                            }
+                        }
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 6,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
+                                        "balance": 400000000,
+                                        "seqNum": 25769803776,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 23,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
+                                        "balance": 399898388,
+                                        "seqNum": 25769803776,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "ext": {
+                                "v": 0
+                            },
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
+                                                "balance": 399898388,
+                                                "seqNum": 25769803776,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
+                                                "balance": 399898388,
+                                                "seqNum": 25769803777,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [],
+                            "txChangesAfter": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
+                                                "balance": 399898388,
+                                                "seqNum": 25769803777,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GAM4XNEHJUHN7VE3ZWJI23R2WS3SJS2BTUHZAC6XICXLXO2HPX4QI2IR",
+                                                "balance": 399938388,
+                                                "seqNum": 25769803777,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "sorobanMeta": {
+                                "ext": {
+                                    "v": 0
+                                },
+                                "events": [],
+                                "returnValue": {
+                                    "type": "SCV_BOOL",
+                                    "b": "FALSE"
+                                },
+                                "diagnosticEvents": []
+                            }
+                        }
+                    }
+                },
+                {
+                    "result": {
+                        "transactionHash": "dc7b999613ade2e947b8ed0e831036976f1529fa7489088e4b70ea0f5ba2e920",
+                        "result": {
+                            "feeCharged": 1043955,
+                            "result": {
+                                "code": "txFAILED",
+                                "results": [
+                                    {
+                                        "code": "opINNER",
+                                        "tr": {
+                                            "type": "INVOKE_HOST_FUNCTION",
+                                            "invokeHostFunctionResult": {
+                                                "code": "INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED"
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            "ext": {
+                                "v": 0
+                            }
+                        }
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 7,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                        "balance": 400000000,
+                                        "seqNum": 30064771072,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 23,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                        "balance": 398956045,
+                                        "seqNum": 30064771072,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "ext": {
+                                "v": 0
+                            },
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 398956045,
+                                                "seqNum": 30064771072,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 398956045,
+                                                "seqNum": 30064771073,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [],
+                            "txChangesAfter": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 398956045,
+                                                "seqNum": 30064771073,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 23,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GA2NXNEE2MHWGQP5XXACPYG2BDZFPKGYPFNST5V3ZZN75NSLQAEXX7CU",
+                                                "balance": 399957054,
+                                                "seqNum": 30064771073,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 23,
+                                                                        "seqTime": 1451692800
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "sorobanMeta": {
+                                "ext": {
+                                    "v": 0
+                                },
+                                "events": [],
+                                "returnValue": {
+                                    "type": "SCV_BOOL",
+                                    "b": "FALSE"
+                                },
+                                "diagnosticEvents": [
+                                    {
+                                        "inSuccessfulContractCall": "FALSE",
+                                        "event": {
+                                            "ext": {
+                                                "v": 0
+                                            },
+                                            "contractID": null,
+                                            "type": "DIAGNOSTIC",
+                                            "body": {
+                                                "v": 0,
+                                                "v0": {
+                                                    "topics": [
+                                                        {
+                                                            "type": "SCV_SYMBOL",
+                                                            "sym": "error"
+                                                        },
+                                                        {
+                                                            "type": "SCV_ERROR",
+                                                            "error": {
+                                                                "type": "SCE_BUDGET",
+                                                                "code": "SCEC_EXCEEDED_LIMIT"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "data": {
+                                                        "type": "SCV_VEC",
+                                                        "vec": [
+                                                            {
+                                                                "type": "SCV_STRING",
+                                                                "str": "operation instructions exceeds amount specified"
+                                                            },
+                                                            {
+                                                                "type": "SCV_U64",
+                                                                "u64": 216850
+                                                            },
+                                                            {
+                                                                "type": "SCV_U64",
+                                                                "u64": 200000
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -13,7 +13,7 @@ namespace stellar
 {
 class AbstractLedgerTxn;
 
-static constexpr ContractDataDurability CONTRACT_INSTANCE_CONTRACT_DURABILITY =
+static constexpr ContractDataDurability CONTRACT_INSTANCE_ENTRY_DURABILITY =
     ContractDataDurability::PERSISTENT;
 
 class InvokeHostFunctionOpFrame : public OperationFrame

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2156,7 +2156,8 @@ TEST_CASE("temp entry eviction", "[tx][soroban]")
     auto invocation = client.getContract().prepareInvocation(
         "put_temporary", {makeSymbolSCVal("key"), makeU64SCVal(123)},
         client.writeKeySpec("key", ContractDataDurability::TEMPORARY));
-    closeLedger(test.getApp(), {invocation.createTx()});
+    closeLedger(test.getApp(),
+                {invocation.withExactNonRefundableResourceFee().createTx()});
     auto lk = client.getContract().getDataKey(
         makeSymbolSCVal("key"), ContractDataDurability::TEMPORARY);
 
@@ -2223,7 +2224,9 @@ TEST_CASE("temp entry eviction", "[tx][soroban]")
     SECTION("Create temp entry with same key as an expired entry on eviction "
             "ledger")
     {
-        closeLedger(test.getApp(), {invocation.createTx()});
+        closeLedger(
+            test.getApp(),
+            {invocation.withExactNonRefundableResourceFee().createTx()});
 
         REQUIRE(client.put("key", ContractDataDurability::TEMPORARY, 234) ==
                 INVOKE_HOST_FUNCTION_SUCCESS);

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -41,176 +41,9 @@
 using namespace stellar;
 using namespace stellar::txtest;
 
-TEST_CASE("Trustline stellar asset contract",
-          "[tx][soroban][invariant][conservationoflumens]")
+namespace
 {
-    auto issuerKey = getAccount("issuer");
-    Asset idr = makeAsset(issuerKey, "IDR");
-
-    auto cfg = getTestConfig();
-    cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = true;
-    cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
-
-    AssetContractInvocationTest test(idr, cfg);
-    auto app = test.getApp();
-
-    auto& root = test.getRoot();
-
-    auto const minBalance = app->getLedgerManager().getLastMinBalance(2);
-    auto issuer = root.create(issuerKey, minBalance);
-
-    // Enable clawback
-    issuer.setOptions(
-        setFlags(AUTH_CLAWBACK_ENABLED_FLAG | AUTH_REVOCABLE_FLAG));
-
-    auto acc = root.create("acc", minBalance);
-    auto acc2 = root.create("acc2", minBalance);
-    auto sponsor = root.create("sponsor", minBalance * 2);
-
-    root.changeTrust(idr, 100);
-    {
-        auto tx = transactionFrameFromOps(
-            app->getNetworkID(), sponsor,
-            {sponsor.op(beginSponsoringFutureReserves(acc)),
-             acc.op(changeTrust(idr, 100)),
-             acc.op(endSponsoringFutureReserves())},
-            {acc});
-
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
-        REQUIRE(tx->apply(*app, ltx, txm));
-        REQUIRE(tx->getResultCode() == txSUCCESS);
-        ltx.commit();
-    }
-
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto tlAsset = assetToTrustLineAsset(idr);
-        checkSponsorship(ltx, trustlineKey(acc, tlAsset), 1,
-                         &sponsor.getPublicKey());
-        checkSponsorship(ltx, acc, 0, nullptr, 1, 2, 0, 1);
-        checkSponsorship(ltx, sponsor, 0, nullptr, 0, 2, 1, 0);
-    }
-
-    issuer.pay(root, idr, 100);
-
-    auto accAddr = makeAccountAddress(acc.getPublicKey());
-
-    // Transfer and mint to account
-    test.transfer(root, accAddr, 10, true);
-    test.mint(issuer, accAddr, 10, true);
-
-    // Now mint by transfering from issuer
-    test.transfer(issuer, accAddr, 10, true);
-
-    // Now burn by transfering to the issuer and by using burn function
-    test.transfer(acc, makeAccountAddress(issuer.getPublicKey()), 10, true);
-    test.burn(acc, 10, true);
-
-    // Can't burn an issuers balance because it doesn't exist
-    test.burn(issuer, 10, false);
-
-    // Now transfer and mint to contractAddress
-    auto contractAddr = makeContractAddress(sha256("contract"));
-    test.transfer(root, contractAddr, 10, true);
-    test.mint(issuer, contractAddr, 10, true);
-
-    // Now mint by transfering from issuer
-    test.transfer(issuer, contractAddr, 10, true);
-
-    // Now clawback
-    test.clawback(issuer, accAddr, 2, true);
-    test.clawback(issuer, contractAddr, 2, true);
-
-    // Try to clawback more than available
-    test.clawback(issuer, accAddr, 100, false);
-    test.clawback(issuer, contractAddr, 100, false);
-
-    // Clear clawback, create new balances, and try to clawback
-    issuer.setOptions(clearFlags(AUTH_CLAWBACK_ENABLED_FLAG));
-
-    acc2.changeTrust(idr, 100);
-
-    auto acc2Addr = makeAccountAddress(acc2.getPublicKey());
-    auto contract2Addr = makeContractAddress(sha256("contract2"));
-    test.mint(issuer, acc2Addr, 10, true);
-    test.mint(issuer, contract2Addr, 10, true);
-
-    // Clawback not allowed because trustline and contract balance
-    // was created when issuer did not have AUTH_CLAWBACK_ENABLED_FLAG set.
-    test.clawback(issuer, acc2Addr, 1, false);
-    test.clawback(issuer, contract2Addr, 1, false);
-
-    // Make sure sponsorship info hasn't changed
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        auto tlAsset = assetToTrustLineAsset(idr);
-        checkSponsorship(ltx, trustlineKey(acc, tlAsset), 1,
-                         &sponsor.getPublicKey());
-        checkSponsorship(ltx, acc, 0, nullptr, 1, 2, 0, 1);
-        checkSponsorship(ltx, sponsor, 0, nullptr, 0, 2, 1, 0);
-    }
-}
-
-TEST_CASE("Native stellar asset contract",
-          "[tx][soroban][invariant][conservationoflumens]")
-{
-    auto cfg = getTestConfig();
-    cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = true;
-
-    AssetContractInvocationTest test(txtest::makeNativeAsset(), cfg);
-    auto app = test.getApp();
-    auto& root = test.getRoot();
-
-    auto const minBalance = app->getLedgerManager().getLastMinBalance(2);
-    auto a2 = root.create("a2", minBalance);
-
-    auto key = SecretKey::pseudoRandomForTesting();
-    TestAccount a1(*app, key);
-    auto tx = transactionFrameFromOps(
-        app->getNetworkID(), root,
-        {root.op(beginSponsoringFutureReserves(a1)),
-         root.op(
-             createAccount(a1, app->getLedgerManager().getLastMinBalance(10))),
-         a1.op(endSponsoringFutureReserves())},
-        {key});
-
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-        REQUIRE(tx->checkValid(*app, ltx, 0, 0, 0));
-        REQUIRE(tx->apply(*app, ltx, txm));
-        ltx.commit();
-    }
-
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        checkSponsorship(ltx, a1.getPublicKey(), 1, &root.getPublicKey(), 0, 2,
-                         0, 2);
-        checkSponsorship(ltx, root.getPublicKey(), 0, nullptr, 0, 2, 2, 0);
-    }
-
-    // transfer 10 XLM from a1 to contractID
-    auto contractAddr = makeContractAddress(sha256("contract"));
-    test.transfer(a1, contractAddr, 10, true);
-
-    // Now do an account to account transfer
-    test.transfer(a1, makeAccountAddress(a2), 100, true);
-
-    // Now try to mint native
-    test.mint(root, contractAddr, 10, false);
-
-    // Make sure sponsorship info hasn't changed
-    {
-        LedgerTxn ltx(app->getLedgerTxnRoot());
-        checkSponsorship(ltx, a1.getPublicKey(), 1, &root.getPublicKey(), 0, 2,
-                         0, 2);
-        checkSponsorship(ltx, root.getPublicKey(), 0, nullptr, 0, 2, 2, 0);
-    }
-}
-
-static void
+void
 overrideNetworkSettingsToMin(Application& app)
 {
     LedgerTxn ltx(app.getLedgerTxnRoot());
@@ -311,245 +144,422 @@ overrideNetworkSettingsToMin(Application& app)
     upgrade.newMaxSorobanTxSetSize() = 1;
     executeUpgrade(app, upgrade);
 }
+} // namespace
+
+TEST_CASE("Trustline stellar asset contract",
+          "[tx][soroban][invariant][conservationoflumens]")
+{
+    auto issuerKey = getAccount("issuer");
+    Asset idr = makeAsset(issuerKey, "IDR");
+
+    auto cfg = getTestConfig();
+    cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
+
+    SorobanTest test(cfg);
+    auto& app = test.getApp();
+    auto const minBalance = app.getLedgerManager().getLastMinBalance(2);
+    auto& root = test.getRoot();
+    auto issuer = root.create(issuerKey, minBalance);
+    // Enable clawback
+    issuer.setOptions(
+        setFlags(AUTH_CLAWBACK_ENABLED_FLAG | AUTH_REVOCABLE_FLAG));
+
+    auto acc = root.create("acc", minBalance);
+    auto acc2 = root.create("acc2", minBalance);
+    auto sponsor = root.create("sponsor", minBalance * 2);
+    root.changeTrust(idr, 100);
+
+    {
+        auto tx = transactionFrameFromOps(
+            app.getNetworkID(), sponsor,
+            {sponsor.op(beginSponsoringFutureReserves(acc)),
+             acc.op(changeTrust(idr, 100)),
+             acc.op(endSponsoringFutureReserves())},
+            {acc});
+        REQUIRE(test.invokeTx(tx));
+    }
+
+    {
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        auto tlAsset = assetToTrustLineAsset(idr);
+        checkSponsorship(ltx, trustlineKey(acc, tlAsset), 1,
+                         &sponsor.getPublicKey());
+        checkSponsorship(ltx, acc, 0, nullptr, 1, 2, 0, 1);
+        checkSponsorship(ltx, sponsor, 0, nullptr, 0, 2, 1, 0);
+    }
+
+    issuer.pay(root, idr, 100);
+
+    auto accAddr = makeAccountAddress(acc.getPublicKey());
+
+    AssetContractTestClient client(test, idr);
+    // Transfer and mint to account
+    REQUIRE(client.transfer(root, accAddr, 10));
+    REQUIRE(client.mint(issuer, accAddr, 10));
+
+    // Now mint by transfering from issuer
+    REQUIRE(client.transfer(issuer, accAddr, 10));
+
+    // Now burn by transfering to the issuer and by using burn function
+    REQUIRE(
+        client.transfer(acc, makeAccountAddress(issuer.getPublicKey()), 10));
+    REQUIRE(client.burn(acc, 10));
+
+    // Can't burn an issuers balance because it doesn't exist
+    REQUIRE(!client.burn(issuer, 10));
+
+    // Now transfer and mint to contractAddress
+    auto contractAddr = makeContractAddress(sha256("contract"));
+    REQUIRE(client.transfer(root, contractAddr, 10));
+    REQUIRE(client.mint(issuer, contractAddr, 10));
+
+    // Now mint by transfering from issuer
+    REQUIRE(client.transfer(issuer, contractAddr, 10));
+
+    // Now clawback
+    REQUIRE(client.clawback(issuer, accAddr, 2));
+    REQUIRE(client.clawback(issuer, contractAddr, 2));
+
+    // Try to clawback more than available
+    REQUIRE(!client.clawback(issuer, accAddr, 100));
+    REQUIRE(!client.clawback(issuer, contractAddr, 100));
+
+    // Clear clawback, create new balances, and try to clawback
+    issuer.setOptions(clearFlags(AUTH_CLAWBACK_ENABLED_FLAG));
+
+    acc2.changeTrust(idr, 100);
+
+    auto acc2Addr = makeAccountAddress(acc2.getPublicKey());
+    auto contract2Addr = makeContractAddress(sha256("contract2"));
+    REQUIRE(client.mint(issuer, acc2Addr, 10));
+    REQUIRE(client.mint(issuer, contract2Addr, 10));
+
+    // Clawback not allowed because trustline and client balance
+    // was created when issuer did not have AUTH_CLAWBACK_ENABLED_FLAG set.
+    REQUIRE(!client.clawback(issuer, acc2Addr, 1));
+    REQUIRE(!client.clawback(issuer, contract2Addr, 1));
+
+    // Make sure sponsorship info hasn't changed
+    {
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        auto tlAsset = assetToTrustLineAsset(idr);
+        checkSponsorship(ltx, trustlineKey(acc, tlAsset), 1,
+                         &sponsor.getPublicKey());
+        checkSponsorship(ltx, acc, 0, nullptr, 1, 2, 0, 1);
+        checkSponsorship(ltx, sponsor, 0, nullptr, 0, 2, 1, 0);
+    }
+}
+
+TEST_CASE("Native stellar asset contract",
+          "[tx][soroban][invariant][conservationoflumens]")
+{
+    auto cfg = getTestConfig();
+    cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = true;
+
+    SorobanTest test(cfg);
+    auto& app = test.getApp();
+    auto& root = test.getRoot();
+
+    auto const minBalance = app.getLedgerManager().getLastMinBalance(2);
+    auto a2 = root.create("a2", minBalance);
+
+    auto key = SecretKey::pseudoRandomForTesting();
+    TestAccount a1(app, key);
+    auto tx = transactionFrameFromOps(
+        app.getNetworkID(), root,
+        {root.op(beginSponsoringFutureReserves(a1)),
+         root.op(
+             createAccount(a1, app.getLedgerManager().getLastMinBalance(10))),
+         a1.op(endSponsoringFutureReserves())},
+        {key});
+    REQUIRE(test.invokeTx(tx));
+
+    {
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        checkSponsorship(ltx, a1.getPublicKey(), 1, &root.getPublicKey(), 0, 2,
+                         0, 2);
+        checkSponsorship(ltx, root.getPublicKey(), 0, nullptr, 0, 2, 2, 0);
+    }
+
+    AssetContractTestClient client(test, txtest::makeNativeAsset());
+    // transfer 10 XLM from a1 to contractID
+    auto contractAddr = makeContractAddress(sha256("contract"));
+    REQUIRE(client.transfer(a1, contractAddr, 10));
+
+    // Now do an account to account transfer
+    REQUIRE(client.transfer(a1, makeAccountAddress(a2), 100));
+
+    // Now try to mint native
+    REQUIRE(!client.mint(root, contractAddr, 10));
+
+    // Make sure sponsorship info hasn't changed
+    {
+        LedgerTxn ltx(app.getLedgerTxnRoot());
+        checkSponsorship(ltx, a1.getPublicKey(), 1, &root.getPublicKey(), 0, 2,
+                         0, 2);
+        checkSponsorship(ltx, root.getPublicKey(), 0, nullptr, 0, 2, 2, 0);
+    }
+}
 
 TEST_CASE("basic contract invocation", "[tx][soroban]")
 {
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_add_i32());
+    SorobanTest test;
+    TestContract& addContract =
+        test.deployWasmContract(rust_bridge::get_test_wasm_add_i32());
+    auto& hostFnExecTimer =
+        test.getApp().getMetrics().NewTimer({"soroban", "host-fn-op", "exec"});
+    auto& hostFnSuccessMeter = test.getApp().getMetrics().NewMeter(
+        {"soroban", "host-fn-op", "success"}, "call");
+    auto& hostFnFailureMeter = test.getApp().getMetrics().NewMeter(
+        {"soroban", "host-fn-op", "failure"}, "call");
 
-    int64_t const INCLUSION_FEE = 12'345;
-
-    auto checkRefund = [&test](auto const& txm, int64_t balanceAfterFeeCharged,
-                               int64_t expectedRefund) {
-        auto changesAfter = txm->getChangesAfter();
-        REQUIRE(changesAfter.size() == 2);
-        REQUIRE(changesAfter[1].updated().data.account().balance -
-                    changesAfter[0].state().data.account().balance ==
-                expectedRefund);
-
-        // Make sure account receives expected refund
-        REQUIRE(test.getRoot().getBalance() - balanceAfterFeeCharged ==
-                expectedRefund);
-    };
-
-    auto const expectedRefund = 267'298;
-    auto successfulInvoke = [&](TransactionFrameBasePtr tx,
-                                uint32_t resourceFee,
-                                SorobanResources const& resources) {
+    auto invoke = [&](TestContract& contract, std::string const& functionName,
+                      std::vector<SCVal> const& args,
+                      SorobanInvocationSpec const& spec,
+                      std::optional<uint32_t> expectedRefund = std::nullopt,
+                      bool expectHostFnCall = true,
+                      bool addContractKeys = true) {
         int64_t initBalance = test.getRoot().getBalance();
-        test.txCheckValid(tx);
+        auto invocation = contract.prepareInvocation(functionName, args, spec,
+                                                     addContractKeys);
+        auto tx =
+            std::dynamic_pointer_cast<TransactionFrame>(invocation.createTx());
 
-        REQUIRE(tx->getFullFee() == INCLUSION_FEE + resourceFee);
-        REQUIRE(tx->getInclusionFee() == INCLUSION_FEE);
+        REQUIRE(test.isTxValid(tx));
+
+        REQUIRE(tx->getFullFee() ==
+                spec.getInclusionFee() + spec.getResourceFee());
+        REQUIRE(tx->getInclusionFee() == spec.getInclusionFee());
 
         // Initially we store in result the charge for resources plus
         // minimum inclusion  fee bid (currently equivalent to the
         // network `baseFee` of 100).
-        int64_t baseCharged = (tx->getFullFee() - tx->getInclusionFee()) + 100;
+        int64_t baseCharged = tx->declaredSorobanResourceFee() + 100;
+        // Imitate surge pricing by charging at a higher rate than
+        // base fee.
+        uint32_t const surgePricedFee = 300;
         REQUIRE(tx->getResult().feeCharged == baseCharged);
         {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
-            // Imitate surge pricing by charging at a higher rate than
-            // base fee.
-            tx->processFeeSeqNum(ltx, 300);
+            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
+            tx->processFeeSeqNum(ltx, surgePricedFee);
             ltx.commit();
         }
         // The resource and the base fee are charged, with additional
         // surge pricing fee.
         int64_t balanceAfterFeeCharged = test.getRoot().getBalance();
         REQUIRE(initBalance - balanceAfterFeeCharged ==
-                baseCharged + /* surge pricing additional fee */ 200);
+                tx->declaredSorobanResourceFee() + surgePricedFee);
 
-        auto txm = test.invokeTx(tx, /*expectSuccess=*/true);
+        TransactionMetaFrame txm(test.getLedgerVersion());
+        auto timerBefore = hostFnExecTimer.count();
+        bool success = test.invokeTx(tx, &txm);
+        if (expectHostFnCall)
+        {
+            REQUIRE(hostFnExecTimer.count() - timerBefore > 0);
+        }
+        else
+        {
+            REQUIRE(hostFnExecTimer.count() - timerBefore == 0);
+        }
 
-        auto changesAfter = txm->getChangesAfter();
-        checkRefund(txm, balanceAfterFeeCharged, expectedRefund);
+        {
+            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
+            tx->processPostApply(test.getApp(), ltx, txm);
+            ltx.commit();
+        }
 
-        // Sanity-check the expected refund value. The exact computation is
-        // tricky because of the rent fee.
-        // NB: We don't use the computed value here in order
-        // to check possible changes in fee computation algorithm (so that
-        // the conditions above would fail, while this still succeeds).
-        REQUIRE(sorobanResourceFee(
-                    *test.getApp(), resources, xdr::xdr_size(tx->getEnvelope()),
-                    100 /* size of event emitted by the test contract */) ==
-                resourceFee - expectedRefund);
+        auto changesAfter = txm.getChangesAfter();
 
+        // In case of failure we simply refund the whole refundable fee portion.
+        if (!expectedRefund)
+        {
+            REQUIRE(!success);
+            // Compute the exact refundable fee (so we don't need spec
+            // to have the exact refundable fee set).
+            auto nonRefundableFee =
+                sorobanResourceFee(test.getApp(), tx->sorobanResources(),
+                                   xdr::xdr_size(tx->getEnvelope()), 0);
+            expectedRefund = spec.getResourceFee() - nonRefundableFee;
+        }
+
+        // Verify refund meta
+        REQUIRE(changesAfter.size() == 2);
+        REQUIRE(changesAfter[1].updated().data.account().balance -
+                    changesAfter[0].state().data.account().balance ==
+                *expectedRefund);
+
+        // Make sure account receives expected refund
+        REQUIRE(test.getRoot().getBalance() - balanceAfterFeeCharged ==
+                *expectedRefund);
+
+        return std::make_pair(tx, txm);
+    };
+
+    auto failedInvoke =
+        [&](TestContract& contract, std::string const& functionName,
+            std::vector<SCVal> const& args, SorobanInvocationSpec const& spec,
+            bool expectHostFnCall = true, bool addContractKeys = true) {
+            auto successesBefore = hostFnSuccessMeter.count();
+            auto failuresBefore = hostFnFailureMeter.count();
+            auto [tx, txm] =
+                invoke(contract, functionName, args, spec, std::nullopt,
+                       expectHostFnCall, addContractKeys);
+            REQUIRE(hostFnSuccessMeter.count() - successesBefore == 0);
+            REQUIRE(hostFnFailureMeter.count() - failuresBefore == 1);
+            REQUIRE(tx->getResult().result.code() == txFAILED);
+            return tx->getResult()
+                .result.results()[0]
+                .tr()
+                .invokeHostFunctionResult()
+                .code();
+        };
+
+    auto fnName = "add";
+    auto sc7 = makeI32(7);
+    auto sc16 = makeI32(16);
+
+    auto invocationSpec = SorobanInvocationSpec()
+                              .setInstructions(2'000'000)
+                              .setReadBytes(2000)
+                              .setInclusionFee(12345);
+
+    uint32_t const expectedResourceFee = 32'702;
+    SECTION("correct invocation")
+    {
+        // NB: We use a hard-coded fees to smoke-test the fee
+        // computation logic stability.
+        uint32_t const expectedRefund = 100'000;
+        auto spec = invocationSpec
+                        // Since in tx we don't really distinguish between
+                        // refundable and non-refundable fee, set the fee that
+                        // we expect to be charged as 'non-refundable'.
+                        .setNonRefundableResourceFee(expectedResourceFee)
+                        .setRefundableResourceFee(expectedRefund);
+        auto successesBefore = hostFnSuccessMeter.count();
+        auto failuresBefore = hostFnFailureMeter.count();
+
+        auto [tx, txm] =
+            invoke(addContract, fnName, {sc7, sc16}, spec, expectedRefund);
+
+        REQUIRE(hostFnSuccessMeter.count() - successesBefore == 1);
+        REQUIRE(hostFnFailureMeter.count() - failuresBefore == 0);
         REQUIRE(tx->getResult().result.code() == txSUCCESS);
-        REQUIRE(!tx->getResult().result.results().empty());
 
         auto const& ores = tx->getResult().result.results().at(0);
         REQUIRE(ores.tr().type() == INVOKE_HOST_FUNCTION);
         REQUIRE(ores.tr().invokeHostFunctionResult().code() ==
                 INVOKE_HOST_FUNCTION_SUCCESS);
 
-        SCVal resultVal = txm->getXDR().v3().sorobanMeta->returnValue;
+        SCVal resultVal = txm.getXDR().v3().sorobanMeta->returnValue;
+        REQUIRE(resultVal.i32() == 7 + 16);
 
-        InvokeHostFunctionSuccessPreImage success2;
-        success2.returnValue = resultVal;
-        success2.events = txm->getXDR().v3().sorobanMeta->events;
+        InvokeHostFunctionSuccessPreImage successPreImage;
+        successPreImage.returnValue = resultVal;
+        successPreImage.events = txm.getXDR().v3().sorobanMeta->events;
 
         REQUIRE(ores.tr().invokeHostFunctionResult().success() ==
-                xdrSha256(success2));
+                xdrSha256(successPreImage));
+    }
+
+    auto badAddressTest = [&](SCAddress const& address) {
+        auto keys = addContract.getKeys();
+        keys[1].contractData().contract = address;
+        TestContract badContract(test, address, keys);
+        REQUIRE(failedInvoke(badContract, fnName, {sc7, sc16},
+                             invocationSpec) == INVOKE_HOST_FUNCTION_TRAPPED);
     };
-
-    auto failedInvoke = [&](TransactionFrameBasePtr tx, int64_t resourceFee,
-                            SorobanResources const& resources,
-                            InvokeHostFunctionResultCode code) {
-        test.txCheckValid(tx);
-        auto nonRefundableResourceFee = sorobanResourceFee(
-            *test.getApp(), resources, xdr::xdr_size(tx->getEnvelope()), 0);
-
-        // Imitate surge pricing by charging at a higher rate than base fee.
-        {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
-            tx->processFeeSeqNum(ltx, 300);
-            ltx.commit();
-        }
-
-        int64_t balanceAfterFeeCharged = test.getRoot().getBalance();
-        auto txm = test.invokeTx(tx, /*expectSuccess=*/false);
-
-        // The account should receive a full refund in case of tx failure.
-        if (resourceFee > 0)
-        {
-            checkRefund(txm, balanceAfterFeeCharged,
-                        /*expectedRefund=*/resourceFee -
-                            nonRefundableResourceFee);
-        }
-        REQUIRE(tx->getResult().result.code() != txSUCCESS);
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .invokeHostFunctionResult()
-                    .code() == code);
-    };
-
-    auto scFunc = makeSymbol("add");
-    auto sc7 = makeI32(7);
-    auto sc16 = makeI32(16);
-    SorobanResources resources;
-    resources.footprint.readOnly = test.getContractKeys();
-    resources.instructions = 2'000'000;
-    resources.readBytes = 2000;
-    resources.writeBytes = 0;
-
-    SECTION("correct invocation")
+    SECTION("non-existent contract id")
     {
-        auto tx = test.createInvokeTx(resources, scFunc, {sc7, sc16},
-                                      INCLUSION_FEE, 300'000);
-        successfulInvoke(tx, 300'000, resources);
-
-        REQUIRE(test.getApp()
-                    ->getMetrics()
-                    .NewTimer({"soroban", "host-fn-op", "exec"})
-                    .count() != 0);
-        REQUIRE(test.getApp()
-                    ->getMetrics()
-                    .NewMeter({"soroban", "host-fn-op", "success"}, "call")
-                    .count() != 0);
+        auto badContractAddress = addContract.getAddress();
+        badContractAddress.contractId()[0] = 0;
+        badAddressTest(badContractAddress);
+    }
+    SECTION("account address")
+    {
+        auto accountAddress = makeAccountAddress(test.getRoot().getPublicKey());
+        badAddressTest(accountAddress);
     }
 
     SECTION("incorrect invocation parameters")
     {
-        SECTION("non-existent contract id")
-        {
-            test.getContractID().contractId()[0] = 1;
-            auto tx =
-                test.createInvokeTx(resources, scFunc, {sc7, sc16},
-                                    INCLUSION_FEE, DEFAULT_TEST_RESOURCE_FEE);
-            failedInvoke(tx, DEFAULT_TEST_RESOURCE_FEE, resources,
-                         INVOKE_HOST_FUNCTION_TRAPPED);
-        }
-        SECTION("account address")
-        {
-            SCAddress address(SC_ADDRESS_TYPE_ACCOUNT);
-            address.accountId() = test.getRoot().getPublicKey();
-            test.getContractID() = address;
-            auto tx =
-                test.createInvokeTx(resources, scFunc, {sc7, sc16},
-                                    INCLUSION_FEE, DEFAULT_TEST_RESOURCE_FEE);
-            failedInvoke(tx, DEFAULT_TEST_RESOURCE_FEE, resources,
-                         INVOKE_HOST_FUNCTION_TRAPPED);
-        }
         SECTION("too few parameters")
         {
-            auto tx =
-                test.createInvokeTx(resources, scFunc, {sc7}, INCLUSION_FEE,
-                                    DEFAULT_TEST_RESOURCE_FEE);
-            failedInvoke(tx, DEFAULT_TEST_RESOURCE_FEE, resources,
-                         INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(failedInvoke(addContract, fnName, {sc7}, invocationSpec) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
         }
         SECTION("too many parameters")
         {
-            auto tx =
-                test.createInvokeTx(resources, scFunc, {sc7, sc16, makeI32(0)},
-                                    INCLUSION_FEE, DEFAULT_TEST_RESOURCE_FEE);
-            failedInvoke(tx, DEFAULT_TEST_RESOURCE_FEE, resources,
-                         INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(failedInvoke(addContract, fnName, {sc7, sc16, makeI32(0)},
+                                 invocationSpec) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
         }
     }
 
     SECTION("insufficient instructions")
     {
-        resources.instructions = 10000;
-        auto tx = test.createInvokeTx(resources, scFunc, {sc7, sc16},
-                                      INCLUSION_FEE, DEFAULT_TEST_RESOURCE_FEE);
-        failedInvoke(tx, DEFAULT_TEST_RESOURCE_FEE, resources,
-                     INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        REQUIRE(failedInvoke(addContract, fnName, {sc7, sc16},
+                             invocationSpec.setInstructions(10000)) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
     }
     SECTION("insufficient read bytes")
     {
-        resources.readBytes = 100;
-        auto tx = test.createInvokeTx(resources, scFunc, {sc7, sc16},
-                                      INCLUSION_FEE, DEFAULT_TEST_RESOURCE_FEE);
-        failedInvoke(tx, DEFAULT_TEST_RESOURCE_FEE, resources,
-                     INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        // We fail while reading the footprint, before the host function
+        // is called.
+        REQUIRE(failedInvoke(addContract, fnName, {sc7, sc16},
+                             invocationSpec.setReadBytes(100),
+                             /* expectHostFnCall */ false) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
     }
-    SECTION("insufficient resource fee")
+    SECTION("incorrect footprint")
     {
-        auto tx = test.createInvokeTx(resources, scFunc, {sc7, sc16},
-                                      INCLUSION_FEE, 32'701);
-        failedInvoke(tx, 32'701, resources,
-                     INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
+        REQUIRE(
+            failedInvoke(
+                addContract, fnName, {sc7, sc16},
+                invocationSpec.setReadOnlyFootprint({addContract.getKeys()[0]}),
+                /* expectHostFnCall */ true,
+                /* addContractKeys */ false) == INVOKE_HOST_FUNCTION_TRAPPED);
+        REQUIRE(
+            failedInvoke(
+                addContract, fnName, {sc7, sc16},
+                invocationSpec.setReadOnlyFootprint({addContract.getKeys()[1]}),
+                /* expectHostFnCall */ true,
+                /* addContractKeys */ false) == INVOKE_HOST_FUNCTION_TRAPPED);
+    }
+    SECTION("insufficient refundable resource fee")
+    {
+        REQUIRE(failedInvoke(
+                    addContract, fnName, {sc7, sc16},
+                    invocationSpec
+                        .setNonRefundableResourceFee(expectedResourceFee - 1)
+                        .setRefundableResourceFee(0)) ==
+                INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
     }
 }
 
-TEST_CASE("invalid footprint keys", "[tx][soroban]")
+TEST_CASE("Soroban footprint validation", "[tx][soroban]")
 {
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_add_i32());
+    SorobanTest test;
     auto const& cfg = test.getNetworkCfg();
 
+    auto& addContract =
+        test.deployWasmContract(rust_bridge::get_test_wasm_add_i32());
+
     SorobanResources resources;
-    resources.footprint.readOnly = test.getContractKeys();
     resources.instructions = 2'000'000;
     resources.readBytes = 2000;
-    resources.writeBytes = 0;
 
     // Tests for each Soroban op
     auto testValidInvoke = [&](bool shouldBeValid) {
-        auto scFunc = makeSymbol("add");
-        auto sc7 = makeI32(7);
-        auto sc16 = makeI32(16);
-
-        auto tx = test.createInvokeTx(resources, scFunc, {sc7, sc16}, 100,
-                                      DEFAULT_TEST_RESOURCE_FEE);
+        SorobanInvocationSpec spec(resources, DEFAULT_TEST_RESOURCE_FEE,
+                                   DEFAULT_TEST_RESOURCE_FEE, 100);
+        auto tx = addContract
+                      .prepareInvocation("add", {makeI32(7), makeI32(16)}, spec)
+                      .createTx();
 
         REQUIRE(test.isTxValid(tx) == shouldBeValid);
         if (!shouldBeValid)
         {
-            auto const& txCode = tx->getResult().result.code();
-            if (txCode == txFAILED)
-            {
-                REQUIRE(tx->getResult()
-                            .result.results()[0]
-                            .tr()
-                            .invokeHostFunctionResult()
-                            .code() == INVOKE_HOST_FUNCTION_MALFORMED);
-            }
-            else
-            {
-                REQUIRE(txCode == txSOROBAN_INVALID);
-            }
+            REQUIRE(tx->getResult().result.code() == txSOROBAN_INVALID);
         }
     };
 
@@ -601,10 +611,11 @@ TEST_CASE("invalid footprint keys", "[tx][soroban]")
 
     // Keys to test
     auto acc = test.getRoot().create(
-        "acc", test.getApp()->getLedgerManager().getLastMinBalance(1));
-    auto persistentKey =
-        contractDataKey(test.getContractID(), makeSymbolSCVal("key1"),
-                        ContractDataDurability::PERSISTENT);
+        "acc", test.getApp().getLedgerManager().getLastMinBalance(1));
+    auto persistentKey = addContract.getDataKey(
+        makeSymbolSCVal("key1"), ContractDataDurability::PERSISTENT);
+    auto tempKey = addContract.getDataKey(makeSymbolSCVal("key1"),
+                                          ContractDataDurability::TEMPORARY);
     auto ttlKey = getTTLKey(persistentKey);
 
     // This function adds every invalid type to footprint and then runs f,
@@ -670,8 +681,8 @@ TEST_CASE("invalid footprint keys", "[tx][soroban]")
             SCVal key;
             key.type(SCV_BYTES);
             key.bytes().resize(cfg.maxContractDataKeySizeBytes());
-            footprint.emplace_back(contractDataKey(
-                test.getContractID(), key, ContractDataDurability::PERSISTENT));
+            footprint.emplace_back(addContract.getDataKey(
+                key, ContractDataDurability::PERSISTENT));
             f(false);
         }
     };
@@ -733,9 +744,14 @@ TEST_CASE("invalid footprint keys", "[tx][soroban]")
         {
             testValidRestoreOp(true);
         }
-        SECTION("readOnly set with Soroban key")
+        SECTION("readOnly footprint not empty")
         {
             resources.footprint.readOnly.emplace_back(persistentKey);
+            testValidRestoreOp(false);
+        }
+        SECTION("temp entries are not allowed")
+        {
+            resources.footprint.readWrite.emplace_back(tempKey);
             testValidRestoreOp(false);
         }
         SECTION("invalid readOnly keys")
@@ -751,223 +767,175 @@ TEST_CASE("invalid footprint keys", "[tx][soroban]")
     }
 }
 
-TEST_CASE("non-refundable resource metering", "[tx][soroban]")
+TEST_CASE("Soroban non-refundable resource fees are stable", "[tx][soroban]")
 {
-    uniform_int_distribution<uint64_t> feeDist(1, 100'000);
-    auto cfgModifyFn = [&feeDist](SorobanNetworkConfig& cfg) {
-        cfg.mFeeRatePerInstructionsIncrement = feeDist(Catch::rng());
-        cfg.mFeeReadLedgerEntry = feeDist(Catch::rng());
-        cfg.mFeeWriteLedgerEntry = feeDist(Catch::rng());
-        cfg.mFeeRead1KB = feeDist(Catch::rng());
-        cfg.mFeeWrite1KB = feeDist(Catch::rng());
-        cfg.mFeeHistorical1KB = feeDist(Catch::rng());
-        cfg.mFeeTransactionSize1KB = feeDist(Catch::rng());
+    auto cfgModifyFn = [](SorobanNetworkConfig& cfg) {
+        cfg.mFeeRatePerInstructionsIncrement = 1000;
+        cfg.mFeeReadLedgerEntry = 2000;
+        cfg.mFeeWriteLedgerEntry = 3000;
+        cfg.mFeeRead1KB = 4000;
+        cfg.mFeeWrite1KB = 5000;
+        cfg.mFeeHistorical1KB = 6000;
+        cfg.mFeeTransactionSize1KB = 8000;
+    };
+    // Historical fee is always paid for 300 byte of transaction result.
+    // ceil(6000 * 300 / 1024) == 1758
+    int64_t const baseHistoricalFee = 1758;
+    // Base valid tx size is 1196 bytes
+    // ceil(1196 * 6000 / 1024) + ceil(1196 * 8000 / 1024) == 16'352
+    int64_t const baseSizeFee = 16'352;
+    int64_t const baseTxFee = baseHistoricalFee + baseSizeFee;
+    uint32_t const minInclusionFee = 100;
+
+    SorobanTest test(getTestConfig(),
+                     /*useTestLimits=*/true, cfgModifyFn);
+    auto makeTx = [&test](SorobanResources const& resources,
+                          uint32_t inclusionFee, int64_t resourceFee) {
+        Operation uploadOp;
+        uploadOp.body.type(INVOKE_HOST_FUNCTION);
+        auto& uploadHF = uploadOp.body.invokeHostFunctionOp().hostFunction;
+        uploadHF.type(HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM);
+        uploadHF.wasm().resize(1000);
+        return sorobanTransactionFrameFromOps(
+            test.getApp().getNetworkID(), test.getRoot(), {uploadOp}, {},
+            resources, inclusionFee, resourceFee);
     };
 
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_add_i32(),
-                                    /*deployContract=*/false, getTestConfig(),
-                                    /*useTestLimits=*/true, cfgModifyFn);
+    auto checkFees = [&](SorobanResources const& resources,
+                         int64_t expectedNonRefundableFee) {
+        auto validTx =
+            makeTx(resources, minInclusionFee, expectedNonRefundableFee);
+        auto txSize = xdr::xdr_size(validTx->getEnvelope());
+        auto& app = test.getApp();
+        // Sanity check the tx fee computation logic.
+        auto actualFeePair =
+            std::dynamic_pointer_cast<TransactionFrame>(validTx)
+                ->computePreApplySorobanResourceFee(
+                    app.getLedgerManager()
+                        .getLastClosedLedgerHeader()
+                        .header.ledgerVersion,
+                    app.getLedgerManager().getSorobanNetworkConfig(),
+                    app.getConfig());
+        REQUIRE(expectedNonRefundableFee == actualFeePair.non_refundable_fee);
 
-    auto scFunc = makeSymbol("add");
-    auto scArgs = {makeI32(7), makeI32(16)};
-
-    SorobanResources resources;
-    resources.instructions = 0;
-    resources.readBytes = 0;
-    resources.writeBytes = 0;
-
-    auto checkFees = [&](int64_t expectedNonRefundableFee,
-                         std::shared_ptr<TransactionFrameBase> rootTX) {
-        test.txCheckValid(rootTX);
-        {
-            auto& app = *test.getApp();
-            auto actualFeePair =
-                std::dynamic_pointer_cast<TransactionFrame>(rootTX)
-                    ->computePreApplySorobanResourceFee(
-                        app.getLedgerManager()
-                            .getLastClosedLedgerHeader()
-                            .header.ledgerVersion,
-                        app.getLedgerManager().getSorobanNetworkConfig(),
-                        app.getConfig());
-            REQUIRE(expectedNonRefundableFee ==
-                    actualFeePair.non_refundable_fee);
-        }
-
-        auto inclusionFee = [&] {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
-            return static_cast<uint32>(
-                getMinInclusionFee(*rootTX, ltx.getHeader()));
-        }();
-
-        // Check that minimum fee succeeds
-        auto minimalTX = test.createInvokeTx(
-            resources, scFunc, scArgs, inclusionFee, expectedNonRefundableFee);
-        REQUIRE(test.isTxValid(minimalTX));
+        REQUIRE(test.isTxValid(validTx));
 
         // Check that just below minimum resource fee fails
-        auto badTX =
-            test.createInvokeTx(resources, scFunc, scArgs, inclusionFee,
-                                expectedNonRefundableFee - 1);
-        REQUIRE(!test.isTxValid(badTX));
+        auto notEnoughResourceFeeTx =
+            makeTx(resources,
+                   // It doesn't matter how high inclusion fee is.
+                   1'000'000'000, expectedNonRefundableFee - 1);
+        REQUIRE(!test.isTxValid(notEnoughResourceFeeTx));
 
         // check that just below minimum inclusion fee fails
-        auto badTX2 = test.createInvokeTx(
-            resources, scFunc, scArgs, inclusionFee - 1,
-            // It doesn't matter how high the resource fee is.
-            expectedNonRefundableFee + 1'000'000);
-        REQUIRE(!test.isTxValid(badTX2));
+        auto notEnoughInclusionFeeTx =
+            makeTx(resources, minInclusionFee - 1,
+                   // It doesn't matter how high the resource fee is.
+                   1'000'000'000);
+        REQUIRE(!test.isTxValid(notEnoughInclusionFeeTx));
     };
 
     // In the following tests, we isolate a single fee to test by zeroing out
     // every other resource, as much as is possible
     SECTION("tx size fees")
     {
-        auto tx =
-            test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                std::numeric_limits<uint32_t>::max() - 100);
-
-        // Resources are all null, only include TX size based fees
-        auto expectedFee = test.getTxSizeFees(tx);
-        checkFees(expectedFee, tx);
+        SorobanResources resources;
+        checkFees(resources, baseTxFee);
     }
-
     SECTION("compute fee")
     {
-        resources.instructions = feeDist(Catch::rng());
-        auto tx =
-            test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                std::numeric_limits<uint32_t>::max() - 100);
-
-        // Should only have instruction and TX size fees
-        auto expectedFee =
-            test.getTxSizeFees(tx) + test.getComputeFee(resources);
-        checkFees(expectedFee, tx);
+        SorobanResources resources;
+        resources.instructions = 12'345'678;
+        checkFees(resources, 1'234'568 + baseTxFee);
     }
 
-    uniform_int_distribution<> numKeysDist(1, 10);
-    SECTION("entry read/write fee")
+    SECTION("footprint entries")
     {
-        SECTION("RO Only")
+        // Fee for additonal 6 footprint entries (6 * 36 = 216 bytes)
+        // ceil(216 * 6000 / 1024) + ceil(216 * 8000 / 1024) == 2954
+        const int64_t additionalTxSizeFee = 2954;
+        SECTION("RO only")
         {
-            auto size = numKeysDist(Catch::rng());
-            for (auto const& e :
-                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                     {CONTRACT_DATA, CONTRACT_CODE}, size))
+            SorobanResources resources;
+            LedgerKey lk(LedgerEntryType::CONTRACT_CODE);
+            for (int i = 0; i < 6; ++i)
             {
-                resources.footprint.readOnly.emplace_back(LedgerEntryKey(e));
+                lk.contractCode().hash[0] = i;
+                resources.footprint.readOnly.push_back(lk);
             }
 
-            auto tx =
-                test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                    std::numeric_limits<uint32_t>::max() - 100);
-
-            // Only read entry fees and TX size fees
-            auto expectedFee =
-                test.getTxSizeFees(tx) + test.getEntryReadFee(resources);
-            checkFees(expectedFee, tx);
+            checkFees(resources, 2000 * 6 + baseTxFee + additionalTxSizeFee);
         }
-
-        SECTION("RW Only")
+        SECTION("RW only")
         {
-            auto size = numKeysDist(Catch::rng());
-            for (auto const& e :
-                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                     {CONTRACT_DATA, CONTRACT_CODE}, size))
+            SorobanResources resources;
+            LedgerKey lk(LedgerEntryType::CONTRACT_CODE);
+            for (int i = 0; i < 6; ++i)
             {
-                resources.footprint.readWrite.emplace_back(LedgerEntryKey(e));
+                lk.contractCode().hash[0] = i;
+                resources.footprint.readWrite.push_back(lk);
             }
 
-            auto tx =
-                test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                    std::numeric_limits<uint32_t>::max() - 100);
-
-            // Only read entry, write entry, and TX size fees
-            auto expectedFee = test.getTxSizeFees(tx) +
-                               test.getEntryReadFee(resources) +
-                               test.getEntryWriteFee(resources);
-            checkFees(expectedFee, tx);
+            // RW entries are also counted towards reads.
+            checkFees(resources,
+                      2000 * 6 + 3000 * 6 + baseTxFee + additionalTxSizeFee);
         }
-
         SECTION("RW and RO")
         {
-            auto size = numKeysDist(Catch::rng());
-            for (auto const& e :
-                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                     {CONTRACT_DATA, CONTRACT_CODE}, size))
+            SorobanResources resources;
+            LedgerKey lk(LedgerEntryType::CONTRACT_CODE);
+            for (int i = 0; i < 3; ++i)
             {
-                resources.footprint.readOnly.emplace_back(LedgerEntryKey(e));
+                lk.contractCode().hash[0] = i;
+                resources.footprint.readOnly.push_back(lk);
             }
-
-            size = numKeysDist(Catch::rng());
-            for (auto const& e :
-                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                     {CONTRACT_DATA, CONTRACT_CODE}, size))
+            for (int i = 3; i < 6; ++i)
             {
-                resources.footprint.readWrite.emplace_back(LedgerEntryKey(e));
+                lk.contractCode().hash[0] = i;
+                resources.footprint.readWrite.push_back(lk);
             }
-
-            auto tx =
-                test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                    std::numeric_limits<uint32_t>::max() - 100);
-
-            // Only read entry, write entry, and TX size fees
-            auto expectedFee = test.getTxSizeFees(tx) +
-                               test.getEntryReadFee(resources) +
-                               test.getEntryWriteFee(resources);
-            checkFees(expectedFee, tx);
+            // RW entries are also counted towards reads.
+            checkFees(resources, 2000 * (3 + 3) + 3000 * 3 + baseTxFee +
+                                     additionalTxSizeFee);
         }
     }
 
-    uniform_int_distribution<uint32_t> bytesDist(1, 100'000);
     SECTION("readBytes fee")
     {
-        resources.readBytes = bytesDist(Catch::rng());
-
-        auto tx =
-            test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                std::numeric_limits<uint32_t>::max() - 100);
-
-        // Only readBytes and TX size fees
-        auto expectedFee =
-            test.getTxSizeFees(tx) + test.getReadBytesFee(resources);
-        checkFees(expectedFee, tx);
+        SorobanResources resources;
+        resources.readBytes = 5 * 1024 + 1;
+        checkFees(resources, 20'004 + baseTxFee);
     }
 
     SECTION("writeBytes fee")
     {
-        resources.writeBytes = bytesDist(Catch::rng());
-        auto tx =
-            test.createInvokeTx(resources, scFunc, scArgs, 100,
-                                std::numeric_limits<uint32_t>::max() - 100);
-
-        // Only writeBytes and TX size fees
-        auto expectedFee =
-            test.getTxSizeFees(tx) + test.getWriteBytesFee(resources);
-        checkFees(expectedFee, tx);
+        SorobanResources resources;
+        resources.writeBytes = 5 * 1024 + 1;
+        checkFees(resources, 25'005 + baseTxFee);
     }
 }
 
 TEST_CASE("refund account merged", "[tx][soroban][merge]")
 {
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_add_i32(),
-                                    /*deployContact=*/false);
+    SorobanTest test;
 
     const int64_t startingBalance =
-        test.getApp()->getLedgerManager().getLastMinBalance(50);
+        test.getApp().getLedgerManager().getLastMinBalance(50);
 
     auto a1 = test.getRoot().create("A", startingBalance);
     auto b1 = test.getRoot().create("B", startingBalance);
     auto c1 = test.getRoot().create("C", startingBalance);
-
-    auto tx = test.createUploadWasmTx(a1, DEFAULT_TEST_RESOURCE_FEE);
+    auto wasm = rust_bridge::get_test_wasm_add_i32();
+    auto resources = defaultUploadWasmResourcesWithoutFootprint(wasm);
+    auto tx = makeSorobanWasmUploadTx(test.getApp(), a1, wasm, resources, 1000);
 
     auto mergeOp = accountMerge(b1);
     mergeOp.sourceAccount.activate() = toMuxedAccount(a1);
 
     auto classicMergeTx = c1.tx({mergeOp});
     classicMergeTx->addSignature(a1.getSecretKey());
-
-    auto r = closeLedger(*test.getApp(), {classicMergeTx, tx});
+    std::vector<TransactionFrameBasePtr> txs = {classicMergeTx, tx};
+    auto r = closeLedger(test.getApp(), txs);
     checkTx(0, r, txSUCCESS);
 
     // The source account of the soroban tx was merged during the classic phase
@@ -977,11 +945,10 @@ TEST_CASE("refund account merged", "[tx][soroban][merge]")
 TEST_CASE("buying liabilities plus refund is greater than INT64_MAX",
           "[tx][soroban][offer]")
 {
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_add_i32(),
-                                    /*deployContact=*/false);
+    SorobanTest test;
 
     const int64_t startingBalance =
-        test.getApp()->getLedgerManager().getLastMinBalance(50);
+        test.getApp().getLedgerManager().getLastMinBalance(50);
 
     auto a1 = test.getRoot().create("A", startingBalance);
     auto b1 = test.getRoot().create("B", startingBalance);
@@ -992,8 +959,11 @@ TEST_CASE("buying liabilities plus refund is greater than INT64_MAX",
     test.getRoot().pay(a1, cur1, INT64_MAX);
 
     auto a1PreBalance = a1.getBalance();
+    auto wasm = rust_bridge::get_test_wasm_add_i32();
+    auto resources = defaultUploadWasmResourcesWithoutFootprint(wasm);
+    auto tx =
+        makeSorobanWasmUploadTx(test.getApp(), a1, wasm, resources, 300'000);
 
-    auto tx = test.createUploadWasmTx(a1, 300'000);
     // There is no surge pricing, so only 100 stroops are charged from the
     // inclusion fee.
     auto feeChargedBeforeRefund =
@@ -1008,11 +978,12 @@ TEST_CASE("buying liabilities plus refund is greater than INT64_MAX",
     offer.sourceAccount.activate() = toMuxedAccount(a1);
 
     // Create an offer on behalf of `a1`, but paid for from `b1`, so that
-    // the offer fee doesn't need to be accounted for in fee computations.
+    // the offer fee doesn't need to be accounted for in fee
+    // computations.
     auto offerTx = b1.tx({offer});
     offerTx->addSignature(a1.getSecretKey());
-
-    auto r = closeLedger(*test.getApp(), {offerTx, tx});
+    std::vector<TransactionFrameBasePtr> txs = {offerTx, tx};
+    auto r = closeLedger(test.getApp(), txs);
     checkTx(0, r, txSUCCESS);
     checkTx(1, r, txSUCCESS);
 
@@ -1026,30 +997,28 @@ TEST_CASE("failure diagnostics", "[tx][soroban]")
 {
     auto cfg = getTestConfig();
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_add_i32(),
-                                    /*deployContact=*/true, cfg);
+    SorobanTest test(cfg);
+    auto& addContract =
+        test.deployWasmContract(rust_bridge::get_test_wasm_add_i32());
 
-    auto scFunc = makeSymbol("add");
-    auto sc1 = makeI32(7);
+    auto fnName = "add";
+    auto sc7 = makeI32(7);
     auto scMax = makeI32(INT32_MAX);
-    SorobanResources resources;
-    resources.footprint.readOnly = test.getContractKeys();
-    resources.instructions = 2'000'000;
-    resources.readBytes = 2000;
-    resources.writeBytes = 1000;
+    auto invocationSpec =
+        SorobanInvocationSpec().setInstructions(2'000'000).setReadBytes(2000);
 
-    // This test calls the add_i32 contract with two numbers that cause an
+    // This test calls the add_i32 client with two numbers that cause an
     // overflow. Because we have diagnostics on, we will see two events - The
-    // diagnostic "fn_call" event, and the event that the add_i32 contract
+    // diagnostic "fn_call" event, and the event that the add_i32 client
     // emits.
     SECTION("failed invocation")
     {
-        auto tx = test.createInvokeTx(resources, scFunc, {sc1, scMax}, 1000,
-                                      DEFAULT_TEST_RESOURCE_FEE);
-        test.txCheckValid(tx);
-        auto txm = test.invokeTx(tx, /*expectSuccess=*/false);
+        auto invocation =
+            addContract.prepareInvocation(fnName, {sc7, scMax}, invocationSpec);
+        REQUIRE(!invocation.invoke());
 
-        auto const& opEvents = txm->getXDR().v3().sorobanMeta->diagnosticEvents;
+        auto const& opEvents =
+            invocation.getTxMeta().getXDR().v3().sorobanMeta->diagnosticEvents;
         REQUIRE(opEvents.size() == 23);
 
         auto const& callEv = opEvents.at(0);
@@ -1097,11 +1066,12 @@ TEST_CASE("failure diagnostics", "[tx][soroban]")
     // it ever makes it to the soroban host.
     SECTION("invalid tx")
     {
-        // Instructions beyond max
-        resources.instructions = 2'000'000'000;
-
-        auto tx = test.createInvokeTx(resources, scFunc, {sc1, scMax}, 1000,
-                                      DEFAULT_TEST_RESOURCE_FEE);
+        auto tx = std::dynamic_pointer_cast<TransactionFrame>(
+            addContract
+                .prepareInvocation(
+                    fnName, {sc7, scMax},
+                    invocationSpec.setInstructions(2'000'000'000))
+                .createTx());
         REQUIRE(!test.isTxValid(tx));
 
         auto const& diagEvents = tx->getDiagnosticEvents();
@@ -1117,36 +1087,27 @@ TEST_CASE("failure diagnostics", "[tx][soroban]")
     }
 }
 
-TEST_CASE("errors roll back", "[tx][soroban]")
+TEST_CASE("contract errors cause transaction to fail", "[tx][soroban]")
 {
-    // This tests that various sorts of error created inside a contract
-    // cause the invocation to fail and that in turn aborts the tx.
-    auto call_fn_check_failure = [](std::string const& name) {
-        WasmContractInvocationTest test(rust_bridge::get_test_wasm_err());
-
-        SorobanResources resources;
-        resources.footprint.readOnly = test.getContractKeys();
-        resources.instructions = 3'000'000;
-        resources.readBytes = 3000;
-
-        auto tx = test.createInvokeTx(resources, makeSymbol(name), {}, 100,
-                                      DEFAULT_TEST_RESOURCE_FEE);
-        test.txCheckValid(tx);
-        test.invokeTx(tx, /*expectSuccess=*/false);
-
-        REQUIRE(tx->getResult()
-                    .result.results()
-                    .at(0)
-                    .tr()
-                    .invokeHostFunctionResult()
-                    .code() == INVOKE_HOST_FUNCTION_TRAPPED);
-        REQUIRE(tx->getResultCode() == txFAILED);
+    SorobanTest test;
+    auto errContract =
+        test.deployWasmContract(rust_bridge::get_test_wasm_err());
+    auto runTest = [&](std::string const& name) {
+        auto invocation = errContract.prepareInvocation(
+            name, {},
+            SorobanInvocationSpec().setInstructions(3'000'000).setReadBytes(
+                3000));
+        REQUIRE(!invocation.invoke());
+        REQUIRE(invocation.getResultCode() == INVOKE_HOST_FUNCTION_TRAPPED);
     };
 
     for (auto const& name :
          {"err_eek", "err_err", "ok_err", "ok_val_err", "err", "val"})
     {
-        call_fn_check_failure(name);
+        SECTION(name)
+        {
+            runTest(name);
+        }
     }
 }
 
@@ -1154,10 +1115,7 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
 {
     auto cfg = getTestConfig();
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
-    WasmContractInvocationTest test(rust_bridge::get_write_bytes(),
-                                    /*deployContract=*/false, cfg,
-                                    /*useTestLimits=*/false);
-
+    SorobanTest test(cfg, /* useTestLimits*/ false);
     auto runTest = [&]() {
         {
             // make sure LedgerManager picked up cached values by looking at
@@ -1169,23 +1127,12 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
                     networkConfig.txMaxReadBytes());
         }
 
-        SorobanResources uploadResources{};
-        uploadResources.instructions =
+        SorobanResources maxResources;
+        maxResources.instructions =
             MinimumSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
-        uploadResources.readBytes =
-            MinimumSorobanNetworkConfig::TX_MAX_READ_BYTES;
-        uploadResources.writeBytes =
+        maxResources.readBytes = MinimumSorobanNetworkConfig::TX_MAX_READ_BYTES;
+        maxResources.writeBytes =
             MinimumSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
-
-        SorobanResources createResources{};
-        createResources.instructions =
-            MinimumSorobanNetworkConfig::TX_MAX_INSTRUCTIONS;
-        createResources.readBytes =
-            MinimumSorobanNetworkConfig::TX_MAX_READ_BYTES;
-        createResources.writeBytes =
-            MinimumSorobanNetworkConfig::TX_MAX_WRITE_BYTES;
-
-        test.deployWithResources(uploadResources, createResources);
 
         // build upgrade
 
@@ -1197,7 +1144,7 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
              i < static_cast<uint32_t>(CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW);
              ++i)
         {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
             auto costEntry =
                 ltx.load(configSettingKey(static_cast<ConfigSettingID>(i)));
             updatedEntries.emplace_back(
@@ -1206,7 +1153,7 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
 
         // Update one of the settings. The rest will be the same so will not get
         // upgraded, but this will still test that the limits work when writing
-        // all settings to the contract.
+        // all settings to the client.
         auto& cost = updatedEntries.at(static_cast<uint32_t>(
             ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0));
         // check a couple settings to make sure they're at the minimum
@@ -1230,38 +1177,36 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
         auto xdr = xdr::xdr_to_opaque(upgradeSet);
         auto upgrade_hash = sha256(xdr);
 
+        auto& writeContract = test.deployWasmContract(
+            rust_bridge::get_write_bytes(), maxResources, maxResources);
+
         LedgerKey upgrade(CONTRACT_DATA);
         upgrade.contractData().durability = TEMPORARY;
-        upgrade.contractData().contract = test.getContractID();
+        upgrade.contractData().contract = writeContract.getAddress();
         upgrade.contractData().key =
             makeBytes(xdr::xdr_to_opaque(upgrade_hash));
 
-        SorobanResources resources{};
-        resources.footprint.readOnly = test.getContractKeys();
-        resources.footprint.readWrite = {upgrade};
-        resources.instructions = 2'000'000;
-        resources.readBytes = 3000;
-        resources.writeBytes = 2000;
-
-        auto tx = test.createInvokeTx(resources, makeSymbol("write"),
-                                      {makeBytes(xdr)}, 1000, 20'000'000);
-
-        test.txCheckValid(tx);
-        test.invokeTx(tx, /*expectSuccess=*/true, /*processPostApply=*/false);
+        REQUIRE(writeContract
+                    .prepareInvocation("write", {makeBytes(xdr)},
+                                       SorobanInvocationSpec(maxResources,
+                                                             20'000'000,
+                                                             20'000'000, 1000)
+                                           .extendReadWriteFootprint({upgrade}))
+                    .invoke());
 
         {
-            // verify that the contract code, contract instance, and upgrade
+            // verify that the client code, client instance, and upgrade
             // entry were all extended by
             // 1036800 ledgers (60 days) -
             // https://github.com/stellar/rs-soroban-env/blob/main/soroban-test-wasms/wasm-workspace/write_upgrade_bytes/src/lib.rs#L3-L5
             auto ledgerSeq = test.getLedgerSeq();
-            auto extendedKeys = test.getContractKeys();
+            auto extendedKeys = writeContract.getKeys();
             extendedKeys.emplace_back(upgrade);
 
             REQUIRE(extendedKeys.size() == 3);
             for (auto const& key : extendedKeys)
             {
-                test.checkTTL(key, ledgerSeq + 1036800);
+                REQUIRE(test.getTTL(key) == ledgerSeq + 1036800);
             }
         }
 
@@ -1270,9 +1215,9 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
         // this will test the submission and deserialization code.
         ConfigUpgradeSetKey key;
         key.contentHash = upgrade_hash;
-        key.contractID = test.getContractID().contractId();
+        key.contractID = writeContract.getAddress().contractId();
 
-        auto& commandHandler = test.getApp()->getCommandHandler();
+        auto& commandHandler = test.getApp().getCommandHandler();
 
         std::string command = "mode=set&configupgradesetkey=";
         command += decoder::encode_b64(xdr::xdr_to_opaque(key));
@@ -1287,11 +1232,11 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
         ledgerUpgrade.newConfig() = key;
 
         auto const& lcl =
-            test.getApp()->getLedgerManager().getLastClosedLedgerHeader();
+            test.getApp().getLedgerManager().getLastClosedLedgerHeader();
         auto txSet = TxSetXDRFrame::makeEmpty(lcl);
         auto lastCloseTime = lcl.header.scpValue.closeTime;
 
-        test.getApp()->getHerder().externalizeValue(
+        test.getApp().getHerder().externalizeValue(
             txSet, lcl.header.ledgerSeq + 1, lastCloseTime,
             {LedgerTestUtils::toUpgradeType(ledgerUpgrade)});
 
@@ -1299,7 +1244,7 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
         {
             auto costKey = configSettingKey(
                 ConfigSettingID::CONFIG_SETTING_CONTRACT_LEDGER_COST_V0);
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
             auto costEntry = ltx.load(costKey);
             REQUIRE(costEntry.current()
                         .data.configSetting()
@@ -1313,52 +1258,52 @@ TEST_CASE("settings upgrade", "[tx][soroban][upgrades]")
     }
     SECTION("from min settings")
     {
-        overrideNetworkSettingsToMin(*test.getApp());
+        overrideNetworkSettingsToMin(test.getApp());
         runTest();
     }
 }
 
 TEST_CASE("loadgen Wasm executes properly", "[soroban][loadgen]")
 {
-    WasmContractInvocationTest test(rust_bridge::get_test_wasm_loadgen());
-
-    auto scFunc = makeSymbol("do_work");
-    auto guestCycles = 10;
-    auto hostCycles = 5;
-    auto numEntries = 2;
-    auto sizeKiloBytes = 3;
+    SorobanTest test;
+    auto& loadgenContract =
+        test.deployWasmContract(rust_bridge::get_test_wasm_loadgen());
+    std::string fnName = "do_work";
+    uint64_t guestCycles = 10;
+    uint64_t hostCycles = 5;
+    uint32_t numEntries = 2;
+    uint32_t sizeKiloBytes = 3;
 
     // This function should write numEntries keys, where each key ID is
     // a U32 that starts at startingIndex and is incremented for each key
-    std::vector<LedgerKey> keys;
+    xdr::xvector<LedgerKey> keys;
     for (auto i = 0; i < numEntries; ++i)
     {
-        auto lk = contractDataKey(test.getContractID(), makeU32(i),
-                                  ContractDataDurability::PERSISTENT);
+        auto lk = loadgenContract.getDataKey(
+            makeU32(i), ContractDataDurability::PERSISTENT);
         keys.emplace_back(lk);
     }
 
-    SorobanResources resources;
-    resources.footprint.readOnly = test.getContractKeys();
-    resources.instructions = 10'000'000;
-    resources.readBytes = 20'000;
-    resources.writeBytes = 20'000;
-    resources.footprint.readWrite.assign(keys.begin(), keys.end());
+    auto invocationSpec = SorobanInvocationSpec()
+                              .setInstructions(10'000'000)
+                              .setReadBytes(20'000)
+                              .setWriteBytes(20'000)
+                              .extendReadWriteFootprint(keys);
 
-    auto tx = test.createInvokeTx(resources, scFunc,
-                                  {makeU64(guestCycles), makeU64(hostCycles),
-                                   makeU32(numEntries), makeU32(sizeKiloBytes)},
-                                  1'000, 10'000'000);
-    test.txCheckValid(tx);
-    auto txm = test.invokeTx(tx, /*expectSuccess*/ true);
-    auto const& ret = txm->getXDR().v3().sorobanMeta->returnValue.u256();
+    auto invocation = loadgenContract.prepareInvocation(
+        fnName,
+        {makeU64(guestCycles), makeU64(hostCycles), makeU32(numEntries),
+         makeU32(sizeKiloBytes)},
+        invocationSpec);
+    REQUIRE(invocation.invoke());
 
     // Return value is total number of cycles completed
-    REQUIRE(ret.lo_lo == guestCycles + hostCycles);
+    REQUIRE(invocation.getReturnValue().u256().lo_lo ==
+            guestCycles + hostCycles);
 
     for (auto const& key : keys)
     {
-        LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+        LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
         auto ltxe = ltx.load(key);
         REQUIRE(ltxe);
         auto size = xdr::xdr_size(ltxe.current());
@@ -1374,70 +1319,61 @@ TEST_CASE("complex contract", "[tx][soroban]")
     auto complexTest = [&](bool enableDiagnostics) {
         auto cfg = getTestConfig();
         cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = enableDiagnostics;
-        WasmContractInvocationTest test(rust_bridge::get_test_wasm_complex(),
-                                        /*deployContact=*/true, cfg);
+        SorobanTest test(cfg);
+        auto& contract =
+            test.deployWasmContract(rust_bridge::get_test_wasm_complex());
 
         // Contract writes a single `data` CONTRACT_DATA entry.
-        LedgerKey dataKey(LedgerEntryType::CONTRACT_DATA);
-        dataKey.contractData().contract = test.getContractID();
-        dataKey.contractData().key = makeSymbolSCVal("data");
+        LedgerKey dataKey = contract.getDataKey(
+            makeSymbolSCVal("data"), ContractDataDurability::TEMPORARY);
 
-        SorobanResources resources;
-        resources.footprint.readOnly = test.getContractKeys();
-        resources.footprint.readWrite = {dataKey};
-        resources.instructions = 4'000'000;
-        resources.readBytes = 3000;
-        resources.writeBytes = 1000;
+        auto invocationSpec = SorobanInvocationSpec()
+                                  .setReadWriteFootprint({dataKey})
+                                  .setInstructions(4'000'000)
+                                  .setReadBytes(3000)
+                                  .setWriteBytes(1000);
 
-        auto verifyDiagnosticEvents =
-            [&](xdr::xvector<DiagnosticEvent> events) {
-                REQUIRE(events.size() == 22);
-
-                auto call_ev = events.at(0);
-                REQUIRE(call_ev.event.type == ContractEventType::DIAGNOSTIC);
-                REQUIRE(call_ev.event.body.v0().data.type() == SCV_VOID);
-
-                auto contract_ev = events.at(1);
-                REQUIRE(contract_ev.event.type == ContractEventType::CONTRACT);
-                REQUIRE(contract_ev.event.body.v0().data.type() == SCV_BYTES);
-
-                auto return_ev = events.at(2);
-                REQUIRE(return_ev.event.type == ContractEventType::DIAGNOSTIC);
-                REQUIRE(return_ev.event.body.v0().data.type() == SCV_VOID);
-
-                auto const& metrics_ev = events.back();
-                REQUIRE(metrics_ev.event.type == ContractEventType::DIAGNOSTIC);
-                auto const& v0 = metrics_ev.event.body.v0();
-                REQUIRE(v0.topics.size() == 2);
-                REQUIRE(v0.topics.at(0).sym() == "core_metrics");
-                REQUIRE(v0.topics.at(1).sym() == "max_emit_event_byte");
-                REQUIRE(v0.data.type() == SCV_U64);
-            };
-
-        auto tx = test.createInvokeTx(resources, makeSymbol("go"), {}, 100,
-                                      DEFAULT_TEST_RESOURCE_FEE);
-        test.txCheckValid(tx);
-        auto txm = test.invokeTx(tx, /*expectSuccess=*/true);
-
+        auto invocation = contract.prepareInvocation("go", {}, invocationSpec);
+        REQUIRE(invocation.invoke());
+        auto const& txm = invocation.getTxMeta();
         // Contract should have emitted a single event carrying a `Bytes`
         // value.
-        REQUIRE(txm->getXDR().v3().sorobanMeta->events.size() == 1);
-        REQUIRE(txm->getXDR().v3().sorobanMeta->events.at(0).type ==
+        REQUIRE(txm.getXDR().v3().sorobanMeta->events.size() == 1);
+        REQUIRE(txm.getXDR().v3().sorobanMeta->events.at(0).type ==
                 ContractEventType::CONTRACT);
-        REQUIRE(txm->getXDR()
-                    .v3()
-                    .sorobanMeta->events.at(0)
-                    .body.v0()
-                    .data.type() == SCV_BYTES);
+        REQUIRE(
+            txm.getXDR().v3().sorobanMeta->events.at(0).body.v0().data.type() ==
+            SCV_BYTES);
 
         if (enableDiagnostics)
         {
-            verifyDiagnosticEvents(
-                txm->getXDR().v3().sorobanMeta->diagnosticEvents);
+            auto const& events =
+                txm.getXDR().v3().sorobanMeta->diagnosticEvents;
+            REQUIRE(events.size() == 22);
+
+            auto call_ev = events.at(0);
+            REQUIRE(call_ev.event.type == ContractEventType::DIAGNOSTIC);
+            REQUIRE(call_ev.event.body.v0().data.type() == SCV_VOID);
+
+            auto contract_ev = events.at(1);
+            REQUIRE(contract_ev.event.type == ContractEventType::CONTRACT);
+            REQUIRE(contract_ev.event.body.v0().data.type() == SCV_BYTES);
+
+            auto return_ev = events.at(2);
+            REQUIRE(return_ev.event.type == ContractEventType::DIAGNOSTIC);
+            REQUIRE(return_ev.event.body.v0().data.type() == SCV_VOID);
+
+            auto const& metrics_ev = events.back();
+            REQUIRE(metrics_ev.event.type == ContractEventType::DIAGNOSTIC);
+            auto const& v0 = metrics_ev.event.body.v0();
+            REQUIRE(v0.topics.size() == 2);
+            REQUIRE(v0.topics.at(0).sym() == "core_metrics");
+            REQUIRE(v0.topics.at(1).sym() == "max_emit_event_byte");
+            REQUIRE(v0.data.type() == SCV_U64);
         }
         else
         {
-            REQUIRE(txm->getXDR().v3().sorobanMeta->diagnosticEvents.size() ==
+            REQUIRE(txm.getXDR().v3().sorobanMeta->diagnosticEvents.size() ==
                     0);
         }
     };
@@ -1455,8 +1391,9 @@ TEST_CASE("complex contract", "[tx][soroban]")
 
 TEST_CASE("ledger entry size limit enforced", "[tx][soroban]")
 {
-    ContractStorageInvocationTest test{};
+    SorobanTest test;
     auto const& cfg = test.getNetworkCfg();
+    ContractStorageTestClient client(test);
 
     uint32_t originalExpectedLiveUntilLedger =
         cfg.stateArchivalSettings().minPersistentTTL + test.getLedgerSeq() - 1;
@@ -1470,8 +1407,7 @@ TEST_CASE("ledger entry size limit enforced", "[tx][soroban]")
         auto resourceFee = 1'000'000;
 
         auto restoreTX = test.createRestoreTx(resources, 1'000, resourceFee);
-        test.invokeTx(restoreTX, /*shouldSucceed*/ false,
-                      /*processPostApply*/ false);
+        REQUIRE(!test.invokeTx(restoreTX));
         REQUIRE(restoreTX->getResult()
                     .result.results()[0]
                     .tr()
@@ -1489,8 +1425,7 @@ TEST_CASE("ledger entry size limit enforced", "[tx][soroban]")
 
         auto extendTx =
             test.createExtendOpTx(resources, 100, 1'000, resourceFee);
-        test.invokeTx(extendTx, /*shouldSucceed*/ false,
-                      /*processPostApply*/ false);
+        REQUIRE(!test.invokeTx(extendTx));
         REQUIRE(extendTx->getResult()
                     .result.results()[0]
                     .tr()
@@ -1500,53 +1435,52 @@ TEST_CASE("ledger entry size limit enforced", "[tx][soroban]")
 
     SECTION("contract data limits")
     {
-        // Instance and wasm should not expire
-        test.extendOp(test.getContractKeys(), 1'000);
-
-        // Approximately 75 bytes of overhead for the contract data entry
+        // Approximately 100 bytes of overhead for the client data entry
         auto maxWriteSizeKiloBytes =
             (cfg.maxContractDataEntrySizeBytes() - 100) / 1024;
+        auto maxWriteSpec =
+            client.writeKeySpec("key", ContractDataDurability::PERSISTENT)
+                .setWriteBytes(cfg.txMaxWriteBytes());
+        // Maximum valid write should succeed
+        REQUIRE(client.resizeStorageAndExtend("key", maxWriteSizeKiloBytes, 0,
+                                              0, maxWriteSpec) ==
+                INVOKE_HOST_FUNCTION_SUCCESS);
 
-        // Check that ledger entry writes above max fail
-        test.resizeStorageAndExtend(
-            "key", maxWriteSizeKiloBytes + 1, 0, 0, cfg.txMaxWriteBytes(),
-            40'000, INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        // 1KB above max should fail
+        REQUIRE(client.resizeStorageAndExtend("key", maxWriteSizeKiloBytes + 1,
+                                              0, 0, maxWriteSpec) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
 
-        test.resizeStorageAndExtend("key", maxWriteSizeKiloBytes, 0, 0,
-                                    cfg.txMaxWriteBytes(), 40'000);
-
-        REQUIRE(test.has("key", ContractDataDurability::PERSISTENT));
+        REQUIRE(client.has("key", ContractDataDurability::PERSISTENT, true));
 
         // Reduce max ledger entry size
         modifySorobanNetworkConfig(
-            *test.getApp(), [](SorobanNetworkConfig& cfg) {
+            test.getApp(), [](SorobanNetworkConfig& cfg) {
                 cfg.mMaxContractDataEntrySizeBytes -= 1024;
             });
 
-        // Refresh cached settings
-        closeLedgerOn(*test.getApp(), test.getLedgerSeq() + 1, 2, 1, 2016);
+        // Check that max write now fails
+        REQUIRE(client.resizeStorageAndExtend("key", maxWriteSizeKiloBytes, 0,
+                                              0, maxWriteSpec) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
 
-        // Check that write now fails
-        test.resizeStorageAndExtend(
-            "key2", maxWriteSizeKiloBytes, 0, 0, cfg.txMaxWriteBytes(), 40'000,
-            INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
-
-        auto lk = contractDataKey(test.getContractID(), makeSymbolSCVal("key"),
-                                  PERSISTENT);
+        auto lk = client.getContract().getDataKey(
+            makeSymbolSCVal("key"), ContractDataDurability::PERSISTENT);
 
         // Extend should fail
         failedExtendOp(lk);
 
         // Reads should fail
-        test.has("key", ContractDataDurability::PERSISTENT,
-                 INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        REQUIRE(client.has("key", ContractDataDurability::PERSISTENT,
+                           std::nullopt) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
 
         // Archive entry
         for (uint32_t i =
-                 test.getApp()->getLedgerManager().getLastClosedLedgerNum();
+                 test.getApp().getLedgerManager().getLastClosedLedgerNum();
              i <= originalExpectedLiveUntilLedger + 1; ++i)
         {
-            closeLedgerOn(*test.getApp(), i, 2, 1, 2016);
+            closeLedgerOn(test.getApp(), i, 2, 1, 2016);
         }
         REQUIRE(!test.isEntryLive({lk}, test.getLedgerSeq()));
 
@@ -1557,29 +1491,29 @@ TEST_CASE("ledger entry size limit enforced", "[tx][soroban]")
     SECTION("contract code limits")
     {
         // Reduce max ledger entry size
-        modifySorobanNetworkConfig(*test.getApp(),
+        modifySorobanNetworkConfig(test.getApp(),
                                    [](SorobanNetworkConfig& cfg) {
                                        cfg.mMaxContractSizeBytes = 2000;
                                    });
 
         // Refresh cached settings
-        closeLedgerOn(*test.getApp(), test.getLedgerSeq() + 1, 2, 1, 2016);
+        closeLedgerOn(test.getApp(), test.getLedgerSeq() + 1, 2, 1, 2016);
 
-        // Check that contract invocation now fails
-        test.has("key", ContractDataDurability::PERSISTENT,
-                 INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        // Check that client invocation now fails
+        REQUIRE(client.has("key", ContractDataDurability::PERSISTENT,
+                           std::nullopt) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
 
-        auto const& lk = test.getContractKeys().at(1);
-
-        // Extend should fail
+        auto lk = client.getContract().getKeys()[0];
+        // Extend should fail on Wasm key.
         failedExtendOp(lk);
 
         // Archive entry
         for (uint32_t i =
-                 test.getApp()->getLedgerManager().getLastClosedLedgerNum();
+                 test.getApp().getLedgerManager().getLastClosedLedgerNum();
              i <= originalExpectedLiveUntilLedger + 1; ++i)
         {
-            closeLedgerOn(*test.getApp(), i, 2, 1, 2016);
+            closeLedgerOn(test.getApp(), i, 2, 1, 2016);
         }
         REQUIRE(!test.isEntryLive({lk}, test.getLedgerSeq()));
 
@@ -1590,87 +1524,196 @@ TEST_CASE("ledger entry size limit enforced", "[tx][soroban]")
 
 TEST_CASE("contract storage", "[tx][soroban]")
 {
-    ContractStorageInvocationTest test{};
-
-    // Increase write fee so the fee will be greater than 1
-    modifySorobanNetworkConfig(*test.getApp(), [](SorobanNetworkConfig& cfg) {
+    auto modifyCfg = [](SorobanNetworkConfig& cfg) {
+        // Increase write fee so the fee will be greater than 1
         cfg.mWriteFee1KBBucketListLow = 20'000;
         cfg.mWriteFee1KBBucketListHigh = 1'000'000;
-    });
-
-    // Refresh cached settings
-    closeLedgerOn(*test.getApp(), test.getLedgerSeq() + 1, 2, 1, 2016);
-
-    auto const& stateArchivalSettings =
-        test.getNetworkCfg().stateArchivalSettings();
-
+    };
+    auto appCfg = getTestConfig();
+    appCfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
+    SorobanTest test(appCfg, true, modifyCfg);
     auto ledgerSeq = test.getLedgerSeq();
 
-    SECTION("default limits")
+    auto isSuccess = [](auto resultCode) {
+        return resultCode == INVOKE_HOST_FUNCTION_SUCCESS;
+    };
+    ContractStorageTestClient client(test);
+
+    SECTION("successful storage operations")
     {
         // Test writing an entry
-        test.put("key1", ContractDataDurability::PERSISTENT, 0);
-        REQUIRE(test.get("key1", ContractDataDurability::PERSISTENT) == 0);
-        test.put("key2", ContractDataDurability::PERSISTENT, 21);
-        REQUIRE(test.get("key2", ContractDataDurability::PERSISTENT) == 21);
+        REQUIRE(isSuccess(
+            client.put("key1", ContractDataDurability::PERSISTENT, 0)));
+        REQUIRE(isSuccess(
+            client.get("key1", ContractDataDurability::PERSISTENT, 0)));
+        REQUIRE(isSuccess(
+            client.put("key2", ContractDataDurability::PERSISTENT, 21)));
+        REQUIRE(isSuccess(
+            client.get("key2", ContractDataDurability::PERSISTENT, 21)));
 
         // Test overwriting an entry
-        test.put("key1", ContractDataDurability::PERSISTENT, 9);
-        REQUIRE(test.get("key1", ContractDataDurability::PERSISTENT) == 9);
-        test.put("key2", ContractDataDurability::PERSISTENT, UINT64_MAX);
-        REQUIRE(test.get("key2", ContractDataDurability::PERSISTENT) ==
-                UINT64_MAX);
+        REQUIRE(isSuccess(
+            client.put("key1", ContractDataDurability::PERSISTENT, 9)));
+        REQUIRE(isSuccess(
+            client.get("key1", ContractDataDurability::PERSISTENT, 9)));
+        REQUIRE(isSuccess(client.put("key2", ContractDataDurability::PERSISTENT,
+                                     UINT64_MAX)));
+        REQUIRE(isSuccess(client.get("key2", ContractDataDurability::PERSISTENT,
+                                     UINT64_MAX)));
 
         // Test deleting an entry
-        test.del("key1", ContractDataDurability::PERSISTENT);
-        REQUIRE(!test.has("key1", ContractDataDurability::PERSISTENT));
-        test.del("key2", ContractDataDurability::PERSISTENT);
-        REQUIRE(!test.has("key2", ContractDataDurability::PERSISTENT));
+        REQUIRE(
+            isSuccess(client.del("key1", ContractDataDurability::PERSISTENT)));
+        REQUIRE(isSuccess(
+            client.has("key1", ContractDataDurability::PERSISTENT, false)));
+        REQUIRE(
+            isSuccess(client.del("key2", ContractDataDurability::PERSISTENT)));
+        REQUIRE(isSuccess(
+            client.has("key2", ContractDataDurability::PERSISTENT, false)));
     }
 
-    SECTION("failure: entry size exceeds write bytes")
+    SECTION("read bytes limit enforced")
     {
+        // Write 5 KB entry.
+        REQUIRE(isSuccess(client.resizeStorageAndExtend("key", 5, 1, 1)));
+
+        auto readSpec =
+            client.readKeySpec("key", ContractDataDurability::PERSISTENT)
+                .setReadBytes(5000);
+        REQUIRE(client.has("key", ContractDataDurability::PERSISTENT,
+                           std::nullopt, readSpec) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        REQUIRE(
+            isSuccess(client.has("key", ContractDataDurability::PERSISTENT,
+                                 std::nullopt, readSpec.setReadBytes(10'000))));
+    }
+
+    SECTION("write bytes limit enforced")
+    {
+        auto writeSpec =
+            client.writeKeySpec("key", ContractDataDurability::PERSISTENT)
+                .setWriteBytes(5000);
         // 5kb write should fail because it exceeds the write bytes
-        test.resizeStorageAndExtend(
-            "key", 5, 1, 1, 5'000, 40'000,
-            INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        REQUIRE(client.resizeStorageAndExtend("key", 5, 1, 1, writeSpec) ==
+                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
 
         // 5kb write should succeed with high write bytes value
-        test.resizeStorageAndExtend("key", 5, 1, 1, 10'000, 40'000);
+        REQUIRE(isSuccess(client.resizeStorageAndExtend(
+            "key", 5, 1, 1, writeSpec.setWriteBytes(10'000))));
     }
 
     SECTION("Same ScVal key, different types")
     {
         // Check that each type is in their own keyspace
-        test.put("key", ContractDataDurability::PERSISTENT, 1);
-        test.put("key", ContractDataDurability::TEMPORARY, 2);
-        REQUIRE(test.get("key", ContractDataDurability::PERSISTENT) == 1);
-        REQUIRE(test.get("key", ContractDataDurability::TEMPORARY) == 2);
+        REQUIRE(isSuccess(
+            client.put("key", ContractDataDurability::PERSISTENT, 1)));
+        REQUIRE(
+            isSuccess(client.put("key", ContractDataDurability::TEMPORARY, 2)));
+        REQUIRE(isSuccess(
+            client.get("key", ContractDataDurability::PERSISTENT, 1)));
+        REQUIRE(
+            isSuccess(client.get("key", ContractDataDurability::TEMPORARY, 2)));
     }
 
-    SECTION("contract instance and wasm archival")
+    SECTION("footprint")
+    {
+        REQUIRE(isSuccess(
+            client.put("key", ContractDataDurability::PERSISTENT, 0)));
+        auto lk = client.getContract().getDataKey(
+            makeSymbolSCVal("key"), ContractDataDurability::PERSISTENT);
+
+        SECTION("unused readWrite key")
+        {
+            auto acc = test.getRoot().create(
+                "acc", test.getApp().getLedgerManager().getLastMinBalance(1));
+            auto loadAccount = [&]() {
+                LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
+                auto ltxe = stellar::loadAccountWithoutRecord(ltx, acc);
+                REQUIRE(ltxe);
+                return ltxe.current();
+            };
+            LedgerEntry accountEntry = loadAccount();
+
+            REQUIRE(isSuccess(
+                client.put("key", ContractDataDurability::PERSISTENT, 0,
+                           client.defaultSpecWithoutFootprint()
+                               .setReadWriteFootprint({lk, accountKey(acc)})
+                               .setWriteBytes(5000))));
+
+            // make sure account still exists and hasn't changed
+            REQUIRE(accountEntry == loadAccount());
+        }
+
+        SECTION("no footprint")
+        {
+            // Failure: client data isn't in footprint
+            REQUIRE(client.put("key", ContractDataDurability::PERSISTENT, 88,
+                               client.defaultSpecWithoutFootprint()) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(client.get("key", ContractDataDurability::PERSISTENT,
+                               std::nullopt,
+                               client.defaultSpecWithoutFootprint()) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(client.has("key", ContractDataDurability::PERSISTENT,
+                               std::nullopt,
+                               client.defaultSpecWithoutFootprint()) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(client.del("key", ContractDataDurability::PERSISTENT,
+                               client.defaultSpecWithoutFootprint()) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
+        }
+
+        SECTION("RO footprint for RW entry")
+        {
+            REQUIRE(
+                client.put(
+                    "key", ContractDataDurability::PERSISTENT, 88,
+                    client.defaultSpecWithoutFootprint().setReadOnlyFootprint(
+                        {lk})) == INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(
+                client.del(
+                    "key", ContractDataDurability::PERSISTENT,
+                    client.defaultSpecWithoutFootprint().setReadOnlyFootprint(
+                        {lk})) == INVOKE_HOST_FUNCTION_TRAPPED);
+        }
+    }
+}
+
+TEST_CASE("state archival", "[tx][soroban]")
+{
+    SorobanTest test(getTestConfig(), true, [](SorobanNetworkConfig& cfg) {
+        cfg.mWriteFee1KBBucketListLow = 20'000;
+        cfg.mWriteFee1KBBucketListHigh = 1'000'000;
+    });
+    auto ledgerSeq = test.getLedgerSeq();
+    auto const& stateArchivalSettings =
+        test.getNetworkCfg().stateArchivalSettings();
+
+    auto isSuccess = [](auto resultCode) {
+        return resultCode == INVOKE_HOST_FUNCTION_SUCCESS;
+    };
+    ContractStorageTestClient client(test);
+    SECTION("contract instance and Wasm archival")
     {
         uint32_t originalExpectedLiveUntilLedger =
-            stateArchivalSettings.minPersistentTTL + ledgerSeq -
-            2; //-2 because we need to account for the closeLedger at the top
-               // after the contract was created.
+            stateArchivalSettings.minPersistentTTL + ledgerSeq - 1;
 
         for (uint32_t i =
-                 test.getApp()->getLedgerManager().getLastClosedLedgerNum();
+                 test.getApp().getLedgerManager().getLastClosedLedgerNum();
              i <= originalExpectedLiveUntilLedger + 1; ++i)
         {
-            closeLedgerOn(*test.getApp(), i, 2, 1, 2016);
+            closeLedgerOn(test.getApp(), i, 2, 1, 2016);
         }
 
         // Contract instance and code should be expired
         ledgerSeq = test.getLedgerSeq();
-        auto const& contractKeys = test.getContractKeys();
+        auto const& contractKeys = client.getContract().getKeys();
         REQUIRE(!test.isEntryLive(contractKeys[0], ledgerSeq));
         REQUIRE(!test.isEntryLive(contractKeys[1], ledgerSeq));
 
         // Contract instance and code are expired, any TX should fail
-        test.put("temp", ContractDataDurability::TEMPORARY, 0,
-                 INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
+        REQUIRE(client.put("temp", ContractDataDurability::TEMPORARY, 0) ==
+                INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
 
         auto newExpectedLiveUntilLedger =
             stateArchivalSettings.minPersistentTTL + ledgerSeq - 1;
@@ -1678,68 +1721,68 @@ TEST_CASE("contract storage", "[tx][soroban]")
         SECTION("restore contract instance and wasm")
         {
             // Restore Instance and Wasm
-            test.restoreOp(contractKeys,
-                           1881 /* rent bump */ + 40000 /* two LE-writes */);
+            test.invokeRestoreOp(contractKeys, 1881 /* rent bump */ +
+                                                    40000 /* two LE-writes
+                                                    */);
 
             // Instance should now be useable
-            test.put("temp", ContractDataDurability::TEMPORARY, 0);
-            test.checkTTL(contractKeys[0], newExpectedLiveUntilLedger);
-            test.checkTTL(contractKeys[1], newExpectedLiveUntilLedger);
+            REQUIRE(isSuccess(
+                client.put("temp", ContractDataDurability::TEMPORARY, 0)));
+            REQUIRE(test.getTTL(contractKeys[0]) == newExpectedLiveUntilLedger);
+            REQUIRE(test.getTTL(contractKeys[1]) == newExpectedLiveUntilLedger);
         }
 
         SECTION("restore contract instance, not wasm")
         {
-            // Only restore contract instance
-            test.restoreOp({contractKeys[0]},
-                           939 /* rent bump */ + 20000 /* one LE write */);
+            // Only restore client instance
+            test.invokeRestoreOp({contractKeys[1]},
+                                 939 /* rent bump */ +
+                                     20000 /* one LE write */);
 
             // invocation should fail
-            test.put("temp", ContractDataDurability::TEMPORARY, 0,
-                     INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
-            test.checkTTL(contractKeys[0], newExpectedLiveUntilLedger);
-            test.checkTTL(contractKeys[1], originalExpectedLiveUntilLedger);
+            REQUIRE(client.put("temp", ContractDataDurability::TEMPORARY, 0) ==
+                    INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
+            REQUIRE(test.getTTL(contractKeys[0]) ==
+                    originalExpectedLiveUntilLedger);
+            REQUIRE(test.getTTL(contractKeys[1]) == newExpectedLiveUntilLedger);
         }
 
-        SECTION("restore contract wasm, not instance")
+        SECTION("restore contract Wasm, not instance")
         {
             // Only restore Wasm
-            test.restoreOp({contractKeys[1]},
-                           943 /* rent bump */ + 20000 /* one LE write */);
+            test.invokeRestoreOp({contractKeys[0]},
+                                 943 /* rent bump */ +
+                                     20000 /* one LE write */);
 
             // invocation should fail
-            test.put("temp", ContractDataDurability::TEMPORARY, 0,
-                     INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
-            test.checkTTL(contractKeys[0], originalExpectedLiveUntilLedger);
-            test.checkTTL(contractKeys[1], newExpectedLiveUntilLedger);
+            REQUIRE(client.put("temp", ContractDataDurability::TEMPORARY, 0) ==
+                    INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
+            REQUIRE(test.getTTL(contractKeys[0]) == newExpectedLiveUntilLedger);
+            REQUIRE(test.getTTL(contractKeys[1]) ==
+                    originalExpectedLiveUntilLedger);
         }
 
         SECTION("lifetime extensions")
         {
             // Restore Instance and Wasm
-            test.restoreOp(contractKeys,
-                           1881 /* rent bump */ + 40000 /* two LE writes */);
-
-            auto instanceExtendTo = 10'000;
-            auto wasmExtendTo = 15'000;
-
-            // extend instance
-            test.extendOp({contractKeys[0]}, instanceExtendTo);
-
-            // extend Wasm
-            test.extendOp({contractKeys[1]}, wasmExtendTo);
-
-            test.checkTTL(contractKeys[0], ledgerSeq + instanceExtendTo);
-            test.checkTTL(contractKeys[1], ledgerSeq + wasmExtendTo);
+            test.invokeRestoreOp(contractKeys, 1881 /* rent bump */ +
+                                                   40000 /* two LE writes */);
+            test.invokeExtendOp({contractKeys[0]}, 10'000);
+            test.invokeExtendOp({contractKeys[1]}, 15'000);
+            REQUIRE(test.getTTL(contractKeys[0]) == ledgerSeq + 10'000);
+            REQUIRE(test.getTTL(contractKeys[1]) == ledgerSeq + 15'000);
         }
     }
 
     SECTION("contract storage archival")
     {
         // Wasm and instance should not expire during test
-        test.extendOp(test.getContractKeys(), 10'000);
+        test.invokeExtendOp(client.getContract().getKeys(), 10'000);
 
-        test.put("persistent", ContractDataDurability::PERSISTENT, 10);
-        test.put("temp", ContractDataDurability::TEMPORARY, 0);
+        REQUIRE(isSuccess(
+            client.put("persistent", ContractDataDurability::PERSISTENT, 10)));
+        REQUIRE(isSuccess(
+            client.put("temp", ContractDataDurability::TEMPORARY, 0)));
 
         auto expectedTempLiveUntilLedger =
             stateArchivalSettings.minTemporaryTTL + ledgerSeq - 1;
@@ -1747,18 +1790,18 @@ TEST_CASE("contract storage", "[tx][soroban]")
             stateArchivalSettings.minPersistentTTL + ledgerSeq - 1;
 
         // Check for expected minimum lifetime values
-        test.checkTTL("persistent", ContractDataDurability::PERSISTENT,
-                      expectedPersistentLiveUntilLedger);
-
-        test.checkTTL("temp", ContractDataDurability::TEMPORARY,
-                      expectedTempLiveUntilLedger);
+        REQUIRE(
+            client.getTTL("persistent", ContractDataDurability::PERSISTENT) ==
+            expectedPersistentLiveUntilLedger);
+        REQUIRE(client.getTTL("temp", ContractDataDurability::TEMPORARY) ==
+                expectedTempLiveUntilLedger);
 
         // Close ledgers until temp entry expires
         uint32 nextLedgerSeq =
-            test.getApp()->getLedgerManager().getLastClosedLedgerNum();
+            test.getApp().getLedgerManager().getLastClosedLedgerNum();
         for (; nextLedgerSeq <= expectedTempLiveUntilLedger; ++nextLedgerSeq)
         {
-            closeLedgerOn(*test.getApp(), nextLedgerSeq, 2, 1, 2016);
+            closeLedgerOn(test.getApp(), nextLedgerSeq, 2, 1, 2016);
         }
 
         ledgerSeq = test.getLedgerSeq();
@@ -1768,193 +1811,205 @@ TEST_CASE("contract storage", "[tx][soroban]")
         {
             // Entry should still be accessible when currentLedger ==
             // liveUntilLedgerSeq
-            REQUIRE(test.has("temp", ContractDataDurability::TEMPORARY));
+            REQUIRE(isSuccess(
+                client.has("temp", ContractDataDurability::TEMPORARY, true)));
         }
 
         SECTION("write does not increase TTL")
         {
-            test.put("temp", ContractDataDurability::TEMPORARY, 42);
+            REQUIRE(isSuccess(
+                client.put("temp", ContractDataDurability::TEMPORARY, 42)));
             // TTL should not be network minimum since entry already exists
-            test.checkTTL("temp", ContractDataDurability::TEMPORARY,
-                          expectedTempLiveUntilLedger);
+            REQUIRE(client.getTTL("temp", ContractDataDurability::TEMPORARY) ==
+                    expectedTempLiveUntilLedger);
         }
 
         SECTION("extendOp when currentLedger == liveUntilLedger")
         {
-            auto tempKey =
-                contractDataKey(test.getContractID(), makeSymbolSCVal("temp"),
-                                ContractDataDurability::TEMPORARY);
-            test.extendOp({tempKey}, 10'000);
-            test.checkTTL("temp", ContractDataDurability::TEMPORARY,
-                          ledgerSeq + 10'000);
+            test.invokeExtendOp({client.getContract().getDataKey(
+                                    makeSymbolSCVal("temp"),
+                                    ContractDataDurability::TEMPORARY)},
+                                10'000);
+            REQUIRE(client.getTTL("temp", ContractDataDurability::TEMPORARY) ==
+                    ledgerSeq + 10'000);
         }
 
         SECTION("TTL enforcement")
         {
             // Close one more ledger so entry is expired
-            closeLedgerOn(*test.getApp(), nextLedgerSeq++, 2, 1, 2016);
+            closeLedgerOn(test.getApp(), nextLedgerSeq++, 2, 1, 2016);
             ledgerSeq = test.getLedgerSeq();
             REQUIRE(ledgerSeq == expectedTempLiveUntilLedger + 1);
 
             // Check that temp entry has expired
-            REQUIRE(!test.isEntryLive("temp", ContractDataDurability::TEMPORARY,
-                                      ledgerSeq));
+            REQUIRE(!client.isEntryLive(
+                "temp", ContractDataDurability::TEMPORARY, ledgerSeq));
 
             // Get should fail since entry no longer exists
-            test.get("temp", ContractDataDurability::TEMPORARY,
-                     INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(client.get("temp", ContractDataDurability::TEMPORARY,
+                               std::nullopt) == INVOKE_HOST_FUNCTION_TRAPPED);
 
             // Has should succeed since the entry is TEMPORARY, but should
             // return false
-            REQUIRE(!test.has("temp", ContractDataDurability::TEMPORARY));
+            REQUIRE(isSuccess(
+                client.has("temp", ContractDataDurability::TEMPORARY, false)));
 
             // PERSISTENT entry is still live, has higher minimum TTL
-            REQUIRE(test.isEntryLive(
+            REQUIRE(client.isEntryLive(
                 "persistent", ContractDataDurability::PERSISTENT, ledgerSeq));
-            REQUIRE(test.has("persistent", ContractDataDurability::PERSISTENT));
+            REQUIRE(isSuccess(client.has(
+                "persistent", ContractDataDurability::PERSISTENT, true)));
 
             // Check that we can recreate an expired TEMPORARY entry
-            test.put("temp", ContractDataDurability::TEMPORARY, 42);
+            REQUIRE(isSuccess(
+                client.put("temp", ContractDataDurability::TEMPORARY, 42)));
 
             // Recreated entry should be live
-            REQUIRE(test.get("temp", ContractDataDurability::TEMPORARY) == 42);
-            test.checkTTL("temp", ContractDataDurability::TEMPORARY,
-                          stateArchivalSettings.minTemporaryTTL + ledgerSeq -
-                              1);
+            REQUIRE(isSuccess(
+                client.get("temp", ContractDataDurability::TEMPORARY, 42)));
+            REQUIRE(client.getTTL("temp", ContractDataDurability::TEMPORARY) ==
+                    stateArchivalSettings.minTemporaryTTL + ledgerSeq - 1);
 
             // Close ledgers until PERSISTENT entry liveUntilLedger
             for (; nextLedgerSeq <= expectedPersistentLiveUntilLedger;
                  ++nextLedgerSeq)
             {
-                closeLedgerOn(*test.getApp(), nextLedgerSeq, 2, 1, 2016);
+                closeLedgerOn(test.getApp(), nextLedgerSeq, 2, 1, 2016);
             }
 
             // Entry should still be accessible when currentLedger ==
             // liveUntilLedgerSeq
-            REQUIRE(test.has("persistent", ContractDataDurability::PERSISTENT));
+            REQUIRE(isSuccess(client.has(
+                "persistent", ContractDataDurability::PERSISTENT, true)));
 
-            auto lk = contractDataKey(test.getContractID(),
-                                      makeSymbolSCVal("persistent"),
-                                      ContractDataDurability::PERSISTENT);
+            auto lk = client.getContract().getDataKey(
+                makeSymbolSCVal("persistent"),
+                ContractDataDurability::PERSISTENT);
             SECTION("restoreOp skips when currentLedger == liveUntilLedger")
             {
                 // Restore should skip entry, refund all of refundableFee
-                test.restoreOp({lk}, 0);
+                test.invokeRestoreOp({lk}, 0);
 
                 // TTL should be unchanged
-                test.checkTTL("persistent", ContractDataDurability::PERSISTENT,
-                              expectedPersistentLiveUntilLedger);
+                REQUIRE(client.getTTL("persistent",
+                                      ContractDataDurability::PERSISTENT) ==
+                        expectedPersistentLiveUntilLedger);
             }
 
             // Close one more ledger so entry is expired
-            closeLedgerOn(*test.getApp(), nextLedgerSeq++, 2, 1, 2016);
-            REQUIRE(
-                test.getApp()->getLedgerManager().getLastClosedLedgerNum() ==
-                expectedPersistentLiveUntilLedger + 1);
+            closeLedgerOn(test.getApp(), nextLedgerSeq++, 2, 1, 2016);
+            REQUIRE(test.getApp().getLedgerManager().getLastClosedLedgerNum() ==
+                    expectedPersistentLiveUntilLedger + 1);
             ledgerSeq = test.getLedgerSeq();
 
             // Check that persistent entry has expired
-            REQUIRE(!test.isEntryLive(
+            REQUIRE(!client.isEntryLive(
                 "persistent", ContractDataDurability::PERSISTENT, ledgerSeq));
 
             // Check that we can't recreate expired PERSISTENT
-            test.put("persistent", ContractDataDurability::PERSISTENT, 42,
-                     INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
+            REQUIRE(client.put("persistent", ContractDataDurability::PERSISTENT,
+                               42) == INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
 
             // Since entry is PERSISTENT, has should fail
-            test.has("persistent", ContractDataDurability::PERSISTENT,
-                     INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
+            REQUIRE(client.has("persistent", ContractDataDurability::PERSISTENT,
+                               std::nullopt) ==
+                    INVOKE_HOST_FUNCTION_ENTRY_ARCHIVED);
 
-            test.put("persistent2", ContractDataDurability::PERSISTENT, 0);
-            auto lk2 = contractDataKey(test.getContractID(),
-                                       makeSymbolSCVal("persistent2"),
-                                       ContractDataDurability::PERSISTENT);
-            test.checkTTL("persistent2", ContractDataDurability::PERSISTENT,
-                          stateArchivalSettings.minPersistentTTL + ledgerSeq -
-                              1);
+            client.put("persistent2", ContractDataDurability::PERSISTENT, 0);
+            auto lk2 = client.getContract().getDataKey(
+                makeSymbolSCVal("persistent2"),
+                ContractDataDurability::PERSISTENT);
+            REQUIRE(client.getTTL("persistent2",
+                                  ContractDataDurability::PERSISTENT) ==
+                    stateArchivalSettings.minPersistentTTL + ledgerSeq - 1);
 
-            // Restore ARCHIVED key and LIVE key, should only be charged for one
-            test.restoreOp({lk, lk2}, /*charge for one entry*/ 20939);
+            // Restore ARCHIVED key and LIVE key, should only be charged for
+            // one
+            test.invokeRestoreOp({lk, lk2}, /*charge for one entry*/
+                                 20939);
 
             // Live entry TTL should be unchanged
-            test.checkTTL("persistent2", ContractDataDurability::PERSISTENT,
-                          stateArchivalSettings.minPersistentTTL + ledgerSeq -
-                              1);
+            REQUIRE(client.getTTL("persistent2",
+                                  ContractDataDurability::PERSISTENT) ==
+                    stateArchivalSettings.minPersistentTTL + ledgerSeq - 1);
 
             // Check value and TTL of restored entry
-            test.checkTTL("persistent", ContractDataDurability::PERSISTENT,
-                          stateArchivalSettings.minPersistentTTL + ledgerSeq -
-                              1);
-            REQUIRE(test.get("persistent",
-                             ContractDataDurability::PERSISTENT) == 10);
+            REQUIRE(client.getTTL("persistent",
+                                  ContractDataDurability::PERSISTENT) ==
+                    stateArchivalSettings.minPersistentTTL + ledgerSeq - 1);
+            REQUIRE(isSuccess(client.get(
+                "persistent", ContractDataDurability::PERSISTENT, 10)));
         }
     }
 
     SECTION("conditional TTL extension")
     {
         // Large bump, followed by smaller bump
-        test.put("key", ContractDataDurability::PERSISTENT, 0);
-        test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                10'000, 10'000);
-        test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                      ledgerSeq + 10'000);
+        REQUIRE(isSuccess(
+            client.put("key", ContractDataDurability::PERSISTENT, 0)));
+        REQUIRE(isSuccess(client.extend(
+            "key", ContractDataDurability::PERSISTENT, 10'000, 10'000)));
+        REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                ledgerSeq + 10'000);
 
         // Expiration already above 5'000, should be a no-op
-        test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                5'000, 5'000);
-        test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                      ledgerSeq + 10'000);
+        REQUIRE(isSuccess(client.extend(
+            "key", ContractDataDurability::PERSISTENT, 5'000, 5'000)));
+        REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                ledgerSeq + 10'000);
 
         // Small bump followed by larger bump
-        test.put("key2", ContractDataDurability::PERSISTENT, 0);
-        test.extendHostFunction("key2", ContractDataDurability::PERSISTENT,
-                                10'000, 10'000);
-        test.checkTTL("key2", ContractDataDurability::PERSISTENT,
-                      ledgerSeq + 10'000);
+        REQUIRE(isSuccess(
+            client.put("key2", ContractDataDurability::PERSISTENT, 0)));
+        REQUIRE(isSuccess(client.extend(
+            "key2", ContractDataDurability::PERSISTENT, 10'000, 10'000)));
+        REQUIRE(client.getTTL("key2", ContractDataDurability::PERSISTENT) ==
+                ledgerSeq + 10'000);
 
-        test.put("key3", ContractDataDurability::PERSISTENT, 0);
-        test.extendHostFunction("key3", ContractDataDurability::PERSISTENT,
-                                50'000, 50'000);
-        test.checkTTL("key3", ContractDataDurability::PERSISTENT,
-                      ledgerSeq + 50'000);
+        REQUIRE(isSuccess(
+            client.put("key3", ContractDataDurability::PERSISTENT, 0)));
+        REQUIRE(isSuccess(client.extend(
+            "key3", ContractDataDurability::PERSISTENT, 50'000, 50'000)));
+        REQUIRE(client.getTTL("key3", ContractDataDurability::PERSISTENT) ==
+                ledgerSeq + 50'000);
 
         // Bump multiple keys to live 10100 ledger from now
         xdr::xvector<LedgerKey> keysToExtend = {
-            contractDataKey(test.getContractID(), makeSymbolSCVal("key"),
-                            ContractDataDurability::PERSISTENT),
-            contractDataKey(test.getContractID(), makeSymbolSCVal("key2"),
-                            ContractDataDurability::PERSISTENT),
-            contractDataKey(test.getContractID(), makeSymbolSCVal("key3"),
-                            ContractDataDurability::PERSISTENT)};
+            client.getContract().getDataKey(makeSymbolSCVal("key"),
+                                            ContractDataDurability::PERSISTENT),
+            client.getContract().getDataKey(makeSymbolSCVal("key2"),
+                                            ContractDataDurability::PERSISTENT),
+            client.getContract().getDataKey(
+                makeSymbolSCVal("key3"), ContractDataDurability::PERSISTENT)};
 
         SECTION("calculate refund")
         {
-            test.extendOp(keysToExtend, 10'100);
-            test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                          ledgerSeq + 10'100);
-            test.checkTTL("key2", ContractDataDurability::PERSISTENT,
-                          ledgerSeq + 10'100);
+            test.invokeExtendOp(keysToExtend, 10'100);
+            REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                    ledgerSeq + 10'100);
+            REQUIRE(client.getTTL("key2", ContractDataDurability::PERSISTENT) ==
+                    ledgerSeq + 10'100);
 
-            // No change for key3 since expiration is already past 10100 ledgers
-            // from now
-            test.checkTTL("key3", ContractDataDurability::PERSISTENT,
-                          ledgerSeq + 50'000);
+            // No change for key3 since expiration is already past 10100
+            // ledgers from now
+            REQUIRE(client.getTTL("key3", ContractDataDurability::PERSISTENT) ==
+                    ledgerSeq + 50'000);
         }
 
         // Check same extendOp with hardcoded expected refund to detect if
         // refund logic changes unexpectedly
         SECTION("absolute refund")
         {
-            test.extendOp(keysToExtend, 10'100, /*expectSuccess=*/true, 41877);
-            test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                          ledgerSeq + 10'100);
-            test.checkTTL("key2", ContractDataDurability::PERSISTENT,
-                          ledgerSeq + 10'100);
+            test.invokeExtendOp(keysToExtend, 10'100, 40'096);
+            REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                    ledgerSeq + 10'100);
+            REQUIRE(client.getTTL("key2", ContractDataDurability::PERSISTENT) ==
+                    ledgerSeq + 10'100);
 
-            // No change for key3 since expiration is already past 10100 ledgers
-            // from now
-            test.checkTTL("key3", ContractDataDurability::PERSISTENT,
-                          ledgerSeq + 50'000);
+            // No change for key3 since expiration is already past 10100
+            // ledgers from now
+            REQUIRE(client.getTTL("key3", ContractDataDurability::PERSISTENT) ==
+                    ledgerSeq + 50'000);
         }
     }
 
@@ -1963,265 +2018,120 @@ TEST_CASE("contract storage", "[tx][soroban]")
 
     SECTION("TTL threshold")
     {
-        test.put("key", ContractDataDurability::PERSISTENT, 0);
-        test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                      initialLiveUntilLedger);
+        REQUIRE(isSuccess(
+            client.put("key", ContractDataDurability::PERSISTENT, 0)));
+        REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                initialLiveUntilLedger);
 
         // After the put op, key4's lifetime will be minimumLifetime - 1.
         // Set low lifetime to minimumLifetime - 2 so bump does not occur
-        test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                stateArchivalSettings.minPersistentTTL - 2,
-                                50'000);
-        test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                      initialLiveUntilLedger);
+        REQUIRE(isSuccess(
+            client.extend("key", ContractDataDurability::PERSISTENT,
+                          stateArchivalSettings.minPersistentTTL - 2, 50'000)));
+        REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                initialLiveUntilLedger);
 
-        closeLedgerOn(*test.getApp(), ++ledgerSeq, 2, 1, 2016);
+        closeLedgerOn(test.getApp(), ++ledgerSeq, 2, 1, 2016);
 
         // Lifetime is now at low threshold, should be bumped
-        test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                stateArchivalSettings.minPersistentTTL - 2,
-                                50'000);
-        test.checkTTL("key", ContractDataDurability::PERSISTENT,
-                      50'000 + ledgerSeq);
+        REQUIRE(isSuccess(
+            client.extend("key", ContractDataDurability::PERSISTENT,
+                          stateArchivalSettings.minPersistentTTL - 2, 50'000)));
+        REQUIRE(client.getTTL("key", ContractDataDurability::PERSISTENT) ==
+                50'000 + ledgerSeq);
 
         // Check that threshold > extendTo fails
-        test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                60'001, 60'000,
-                                /*expectSuccess=*/false);
+        REQUIRE(client.extend("key", ContractDataDurability::PERSISTENT, 60'001,
+                              60'000) == INVOKE_HOST_FUNCTION_TRAPPED);
     }
 
     SECTION("max TTL extension")
     {
-        test.put("key", ContractDataDurability::PERSISTENT, 0);
-        auto lk = contractDataKey(test.getContractID(), makeSymbolSCVal("key"),
-                                  ContractDataDurability::PERSISTENT);
+        REQUIRE(isSuccess(
+            client.put("key", ContractDataDurability::PERSISTENT, 0)));
+        auto lk = client.getContract().getDataKey(
+            makeSymbolSCVal("key"), ContractDataDurability::PERSISTENT);
 
         SECTION("extension op")
         {
-            test.extendOp({lk}, stateArchivalSettings.maxEntryTTL, false);
-            test.checkTTL(lk, initialLiveUntilLedger);
-
             // Max TTL includes current ledger, so subtract 1
-            test.extendOp({lk}, stateArchivalSettings.maxEntryTTL - 1);
-            test.checkTTL(lk,
-                          stateArchivalSettings.maxEntryTTL - 1 + ledgerSeq);
+            test.invokeExtendOp({lk}, stateArchivalSettings.maxEntryTTL - 1);
+            REQUIRE(test.getTTL(lk) ==
+                    stateArchivalSettings.maxEntryTTL - 1 + ledgerSeq);
         }
 
         SECTION("extend host function persistent")
         {
-            test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                    100, 100,
-                                    /*expectSuccess=*/true);
-            test.checkTTL(lk, 100 + ledgerSeq);
+            REQUIRE(isSuccess(client.extend(
+                "key", ContractDataDurability::PERSISTENT, 100, 100)));
+            REQUIRE(test.getTTL(lk) == 100 + ledgerSeq);
 
-            test.extendHostFunction("key", ContractDataDurability::PERSISTENT,
-                                    stateArchivalSettings.maxEntryTTL + 10,
-                                    stateArchivalSettings.maxEntryTTL + 10,
-                                    /*expectSuccess=*/true);
+            REQUIRE(isSuccess(
+                client.extend("key", ContractDataDurability::PERSISTENT,
+                              stateArchivalSettings.maxEntryTTL + 10,
+                              stateArchivalSettings.maxEntryTTL + 10)));
 
             // Capped at max (Max TTL includes current ledger, so subtract 1)
-            test.checkTTL(lk,
-                          stateArchivalSettings.maxEntryTTL - 1 + ledgerSeq);
+            REQUIRE(test.getTTL(lk) ==
+                    stateArchivalSettings.maxEntryTTL - 1 + ledgerSeq);
         }
 
         SECTION("extend host function temp")
         {
-            test.put("key", ContractDataDurability::TEMPORARY, 0);
-            auto lkTemp =
-                contractDataKey(test.getContractID(), makeSymbolSCVal("key"),
-                                ContractDataDurability::TEMPORARY);
+            REQUIRE(isSuccess(
+                client.put("key", ContractDataDurability::TEMPORARY, 0)));
+            auto lkTemp = client.getContract().getDataKey(
+                makeSymbolSCVal("key"), ContractDataDurability::TEMPORARY);
 
-            test.extendHostFunction("key", ContractDataDurability::TEMPORARY,
-                                    stateArchivalSettings.maxEntryTTL,
-                                    stateArchivalSettings.maxEntryTTL,
-                                    /*expectSuccess=*/false);
-            test.checkTTL(lkTemp, stateArchivalSettings.minTemporaryTTL +
-                                      ledgerSeq - 1);
+            REQUIRE(client.extend("key", ContractDataDurability::TEMPORARY,
+                                  stateArchivalSettings.maxEntryTTL,
+                                  stateArchivalSettings.maxEntryTTL) ==
+                    INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(test.getTTL(lkTemp) ==
+                    stateArchivalSettings.minTemporaryTTL + ledgerSeq - 1);
 
             // Max TTL includes current ledger, so subtract 1
-            test.extendHostFunction("key", ContractDataDurability::TEMPORARY,
-                                    stateArchivalSettings.maxEntryTTL - 1,
-                                    stateArchivalSettings.maxEntryTTL - 1,
-                                    /*expectSuccess=*/true);
-            test.checkTTL(lkTemp,
-                          stateArchivalSettings.maxEntryTTL - 1 + ledgerSeq);
+            REQUIRE(isSuccess(
+                client.extend("key", ContractDataDurability::TEMPORARY,
+                              stateArchivalSettings.maxEntryTTL - 1,
+                              stateArchivalSettings.maxEntryTTL - 1)));
+            REQUIRE(test.getTTL(lkTemp) ==
+                    stateArchivalSettings.maxEntryTTL - 1 + ledgerSeq);
         }
     }
-
     SECTION("charge rent fees for storage resize")
     {
-        auto resizeKilobytes = 1;
-        test.put("key1", ContractDataDurability::PERSISTENT, 0);
-        auto key1lk = contractDataKey(test.getContractID(),
-                                      makeSymbolSCVal("key1"), PERSISTENT);
-
-        auto startingSizeBytes = 0;
-        {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
-            auto txle = ltx.loadWithoutRecord(key1lk);
-            REQUIRE(txle);
-            startingSizeBytes = xdr::xdr_size(txle.current());
-        }
-
-        // First, resize a key with large fee to guarantee success
-        test.resizeStorageAndExtend("key1", resizeKilobytes, 0, 0, 10'000,
-                                    40'000);
-
-        auto sizeDeltaBytes = 0;
-        {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
-            auto txle = ltx.loadWithoutRecord(key1lk);
-            REQUIRE(txle);
-            sizeDeltaBytes = xdr::xdr_size(txle.current()) - startingSizeBytes;
-        }
-
-        // Now that we know the size delta, we can calculate the expected rent
-        // and check that another entry resize charges fee correctly
-        test.put("key2", ContractDataDurability::PERSISTENT, 0);
-
-        auto initialLifetime = stateArchivalSettings.minPersistentTTL;
+        auto spec =
+            client.writeKeySpec("key", ContractDataDurability::PERSISTENT)
+                .setWriteBytes(10'000);
+        // Create 1 KB entry extended to live for 10000 ledgers
+        REQUIRE(isSuccess(client.resizeStorageAndExtend("key", 1, 1'000'000,
+                                                        1'000'000, spec)));
 
         SECTION("resize with no extend")
         {
-            auto expectedRentFee =
-                test.getRentFeeForBytes(sizeDeltaBytes, initialLifetime,
-                                        /*isPersistent=*/true);
-
-            // We increased network settings so the fee would have some
-            // variation.
-            REQUIRE(expectedRentFee > 1);
-
-            // resourceFee = rent fee + (event size + return val) fee. So in
-            // order to success resourceFee needs to be expectedRentFee
-            // + 1 to account for the return val size. We are not changing
-            // the liveUntilLedgerSeq, so there is no TTL Entry write
-            // charge
-            auto resourceFee = expectedRentFee + 1;
-            test.resizeStorageAndExtend(
-                "key2", resizeKilobytes, 0, 0, 3'000, resourceFee - 1,
+            uint32_t const expectedRefundableFee = 15'844;
+            REQUIRE(
+                client.resizeStorageAndExtend(
+                    "key", 5, 1'000'000, 1'000'000,
+                    spec.setRefundableResourceFee(expectedRefundableFee - 1)) ==
                 INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
-
-            // Size change should succeed with enough refundable fee
-            test.resizeStorageAndExtend("key2", resizeKilobytes, 0, 0, 3'000,
-                                        resourceFee);
+            REQUIRE(isSuccess(client.resizeStorageAndExtend(
+                "key", 5, 1'000'000, 1'000'000,
+                spec.setRefundableResourceFee(expectedRefundableFee))));
         }
 
         SECTION("resize and extend")
         {
-            auto newLifetime = initialLifetime + 1000;
-
-            // New bytes are charged rent for previous lifetime and new lifetime
-            auto resizeRentFee =
-                test.getRentFeeForBytes(sizeDeltaBytes, newLifetime,
-                                        /*isPersistent=*/true);
-
-            // Initial bytes just charged for new lifetime
-            auto rentFee = test.getRentFeeForBytes(
-                startingSizeBytes, newLifetime - initialLifetime,
-                /*isPersistent=*/true);
-
-            // We increased network settings so the fee would have some
-            // variation.
-            REQUIRE(resizeRentFee > 1);
-            REQUIRE(rentFee > 1);
-
-            // refundableFee = rent fee + (event size + return val) fee. So in
-            // order to success refundableFee needs to be expectedRentFee +
-            // 1 to  account for the return val size.
-            auto refundableFee =
-                resizeRentFee + rentFee + test.getTTLEntryWriteFee() + 1;
-
-            test.resizeStorageAndExtend(
-                "key2", resizeKilobytes, newLifetime, newLifetime, 3'000,
-                refundableFee - 1,
+            uint32_t const expectedRefundableFee = 55'989;
+            REQUIRE(
+                client.resizeStorageAndExtend(
+                    "key", 5, 2'000'000, 2'000'000,
+                    spec.setRefundableResourceFee(expectedRefundableFee - 1)) ==
                 INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
-
-            // Size change should succeed with enough refundable fee
-            test.resizeStorageAndExtend("key2", resizeKilobytes, newLifetime,
-                                        newLifetime, 3'000, refundableFee);
-        }
-    }
-
-    SECTION("footprint tests")
-    {
-        test.put("key", ContractDataDurability::PERSISTENT, 0);
-        auto lk = contractDataKey(test.getContractID(), makeSymbolSCVal("key"),
-                                  ContractDataDurability::PERSISTENT);
-
-        SECTION("unused readWrite key")
-        {
-            auto acc = test.getRoot().create(
-                "acc", test.getApp()->getLedgerManager().getLastMinBalance(1));
-
-            REQUIRE(doesAccountExist(*test.getApp(), acc));
-            test.putWithFootprint("key", ContractDataDurability::PERSISTENT, 0,
-                                  test.getContractKeys(),
-                                  {lk, accountKey(acc)});
-
-            // make sure account still exists and hasn't change
-            REQUIRE(doesAccountExist(*test.getApp(), acc));
-        }
-
-        SECTION("incorrect footprint")
-        {
-            // Failure: contract data isn't in footprint
-            test.putWithFootprint("key", ContractDataDurability::PERSISTENT, 88,
-                                  test.getContractKeys(), {},
-                                  INVOKE_HOST_FUNCTION_TRAPPED);
-            test.getWithFootprint("key", ContractDataDurability::PERSISTENT,
-                                  test.getContractKeys(), {},
-                                  INVOKE_HOST_FUNCTION_TRAPPED);
-            test.hasWithFootprint("key", ContractDataDurability::PERSISTENT,
-                                  test.getContractKeys(), {},
-                                  INVOKE_HOST_FUNCTION_TRAPPED);
-            test.delWithFootprint("key", ContractDataDurability::PERSISTENT,
-                                  test.getContractKeys(), {}, false);
-
-            // Failure: contract data is read only
-            auto readOnlyFootprint = test.getContractKeys();
-            readOnlyFootprint.push_back(lk);
-            test.putWithFootprint("key", ContractDataDurability::PERSISTENT, 88,
-                                  readOnlyFootprint, {},
-                                  INVOKE_HOST_FUNCTION_TRAPPED);
-            test.delWithFootprint("key", ContractDataDurability::PERSISTENT,
-                                  readOnlyFootprint, {}, false);
-
-            // Failure: Contract Wasm/instance not included
-            test.putWithFootprint("key", ContractDataDurability::PERSISTENT, 88,
-                                  {}, {lk}, INVOKE_HOST_FUNCTION_TRAPPED);
-            test.putWithFootprint("key", ContractDataDurability::PERSISTENT, 88,
-                                  {test.getContractKeys()[0]}, {lk},
-                                  INVOKE_HOST_FUNCTION_TRAPPED);
-            test.putWithFootprint("key", ContractDataDurability::PERSISTENT, 88,
-                                  {test.getContractKeys()[1]}, {lk},
-                                  INVOKE_HOST_FUNCTION_TRAPPED);
-        }
-
-        SECTION("resource limits")
-        {
-            // Too few write bytes, should fail
-            test.putWithFootprint(
-                "key2", ContractDataDurability::PERSISTENT, 42,
-                {test.getContractKeys()},
-                {contractDataKey(test.getContractID(), makeSymbolSCVal("key2"),
-                                 ContractDataDurability::PERSISTENT)},
-                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED, /*writeBytes=*/1);
-            REQUIRE(!test.has("key2", ContractDataDurability::PERSISTENT));
-
-            // Resize with too few writeBytes
-            test.resizeStorageAndExtend(
-                "key", /*numKiloBytes=*/5, 0, 0, 4'000, 300'000,
-                INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
-
-            // Resize with enough writeBytes
-            test.resizeStorageAndExtend("key", /*numKiloBytes=*/5, 0, 0, 6'000,
-                                        300'000);
-
-            // Reading the entry should fail with insufficient readBytes
-            test.getWithFootprint("key", ContractDataDurability::PERSISTENT,
-                                  {test.getContractKeys()}, {lk},
-                                  INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED,
-                                  /*readBytes=*/5'000);
+            REQUIRE(isSuccess(client.resizeStorageAndExtend(
+                "key", 5, 2'000'000, 2'000'000,
+                spec.setRefundableResourceFee(expectedRefundableFee))));
         }
     }
 }
@@ -2236,73 +2146,52 @@ TEST_CASE("temp entry eviction", "[tx][soroban]")
 
     cfg.METADATA_OUTPUT_STREAM = metaPath;
 
-    ContractStorageInvocationTest test{cfg};
-    auto const& contractKeys = test.getContractKeys();
+    SorobanTest test(cfg);
+    ContractStorageTestClient client(test);
+    auto const& contractKeys = client.getContract().getKeys();
 
-    // extend Wasm and instance
-    test.extendOp({contractKeys[0]}, 10'000);
-    test.extendOp({contractKeys[1]}, 10'000);
+    // Extend Wasm and instance
+    test.invokeExtendOp(contractKeys, 10'000);
 
-    auto keySym = makeSymbolSCVal("temp");
-    auto funcSym = makeSymbol("put_temporary");
-    auto valU64 = makeU64SCVal(0);
-
-    auto lk = contractDataKey(test.getContractID(), keySym, TEMPORARY);
-
-    SorobanResources resources;
-    resources.footprint.readOnly = test.getContractKeys();
-    resources.footprint.readWrite = {lk};
-    resources.instructions = 4'000'000;
-    resources.readBytes = 10'000;
-    resources.writeBytes = 1000;
-
-    auto tx = test.createInvokeTx(resources, funcSym, {keySym, valU64}, 1000,
-                                  340'000);
-    closeLedger(*test.getApp(), {tx});
+    auto invocation = client.getContract().prepareInvocation(
+        "put_temporary", {makeSymbolSCVal("key"), makeU64SCVal(123)},
+        client.writeKeySpec("key", ContractDataDurability::TEMPORARY));
+    closeLedger(test.getApp(), {invocation.createTx()});
+    auto lk = client.getContract().getDataKey(
+        makeSymbolSCVal("key"), ContractDataDurability::TEMPORARY);
 
     auto expectedLiveUntilLedger =
-        test.getApp()->getLedgerManager().getLastClosedLedgerNum() +
-        InitialSorobanNetworkConfig::MINIMUM_TEMP_ENTRY_LIFETIME - 1;
-
+        test.getLedgerSeq() +
+        test.getNetworkCfg().stateArchivalSettings().minTemporaryTTL - 1;
+    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
     auto const evictionLedger = 4097;
 
     // Close ledgers until temp entry is evicted
-    for (uint32_t i =
-             test.getApp()->getLedgerManager().getLastClosedLedgerNum();
-         i < evictionLedger; ++i)
+    for (uint32_t i = test.getLedgerSeq(); i < evictionLedger; ++i)
     {
-        closeLedgerOn(*test.getApp(), i, 2, 1, 2016);
+        closeLedgerOn(test.getApp(), i, 2, 1, 2016);
     }
 
-    test.checkTTL(lk, expectedLiveUntilLedger);
+    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
 
     // This should be a noop
-    test.extendOp({lk}, 10'000);
+    test.invokeExtendOp({lk}, 10'000, 0);
+    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
 
     // This will fail because the entry is expired
-    test.extendHostFunction("key", ContractDataDurability::TEMPORARY, 10'000,
-                            10'000,
-                            /*expectSuccess=*/false);
+    REQUIRE(client.extend("key", ContractDataDurability::TEMPORARY, 10'000,
+                          10'000) == INVOKE_HOST_FUNCTION_TRAPPED);
+    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
 
-    test.checkTTL(lk, expectedLiveUntilLedger);
-
-    // This should fail because the temp entry is expired
-    test.extendHostFunction("temp", ContractDataDurability::TEMPORARY, 10'000,
-                            10'000, false);
-    test.checkTTL(lk, expectedLiveUntilLedger);
-
-    // Check that temp entry has expired
-    auto ledgerSeq = test.getLedgerSeq();
-    REQUIRE(!test.isEntryLive("temp", ContractDataDurability::TEMPORARY,
-                              ledgerSeq));
+    REQUIRE(!test.isEntryLive(lk, test.getLedgerSeq()));
 
     SECTION("eviction")
     {
         // close one more ledger to trigger the eviction
-        closeLedgerOn(*test.getApp(), evictionLedger, 2, 1, 2016);
+        closeLedgerOn(test.getApp(), evictionLedger, 2, 1, 2016);
 
         {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
             REQUIRE(!ltx.load(lk));
         }
 
@@ -2334,24 +2223,21 @@ TEST_CASE("temp entry eviction", "[tx][soroban]")
     SECTION("Create temp entry with same key as an expired entry on eviction "
             "ledger")
     {
-        auto tx2 = test.createInvokeTx(resources, funcSym, {keySym, valU64},
-                                       1000, 340'000);
-        closeLedger(*test.getApp(), {tx2});
+        closeLedger(test.getApp(), {invocation.createTx()});
 
+        REQUIRE(client.put("key", ContractDataDurability::TEMPORARY, 234) ==
+                INVOKE_HOST_FUNCTION_SUCCESS);
         {
-            LedgerTxn ltx(test.getApp()->getLedgerTxnRoot());
+            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
             REQUIRE(ltx.load(lk));
         }
 
-        auto ledgerSeq2 = test.getLedgerSeq();
-
-        // Verify that we're on the ledger where the entry would get evicted if
+        // Verify that we're on the ledger where the entry would get evicted
         // it wasn't recreated.
-        REQUIRE(ledgerSeq2 == evictionLedger);
+        REQUIRE(test.getLedgerSeq() == evictionLedger);
 
         // Entry is live again
-        REQUIRE(test.isEntryLive("temp", ContractDataDurability::TEMPORARY,
-                                 ledgerSeq2));
+        REQUIRE(test.isEntryLive(lk, test.getLedgerSeq()));
 
         // Verify that we didn't emit an eviction
         XDRInputFileStream in;
@@ -2364,123 +2250,141 @@ TEST_CASE("temp entry eviction", "[tx][soroban]")
     }
 }
 
-TEST_CASE("error codes", "[tx][soroban]")
+TEST_CASE("state archival operation errors", "[tx][soroban]")
 {
-    ContractStorageInvocationTest test{};
+    SorobanTest test;
+    ContractStorageTestClient client(test);
     auto const& stateArchivalSettings =
         test.getNetworkCfg().stateArchivalSettings();
-    auto ledgerSeq = test.getLedgerSeq();
 
-    uint32_t originalExpectedLiveUntilLedger =
-        stateArchivalSettings.minPersistentTTL + ledgerSeq - 1;
+    REQUIRE(client.resizeStorageAndExtend("k1", 5, 0, 0) ==
+            INVOKE_HOST_FUNCTION_SUCCESS);
+    REQUIRE(client.resizeStorageAndExtend("k2", 3, 0, 0) ==
+            INVOKE_HOST_FUNCTION_SUCCESS);
+    xdr::xvector<LedgerKey> dataKeys = {
+        client.getContract().getDataKey(makeSymbolSCVal("k1"),
+                                        ContractDataDurability::PERSISTENT),
+        client.getContract().getDataKey(makeSymbolSCVal("k2"),
+                                        ContractDataDurability::PERSISTENT)};
 
-    for (uint32_t i =
-             test.getApp()->getLedgerManager().getLastClosedLedgerNum();
-         i <= originalExpectedLiveUntilLedger + 1; ++i)
+    SECTION("restore operation")
     {
-        closeLedgerOn(*test.getApp(), i, 2, 1, 2016);
+        uint32_t originalExpectedLiveUntilLedger =
+            stateArchivalSettings.minPersistentTTL + test.getLedgerSeq() - 1;
+        for (uint32_t i =
+                 test.getApp().getLedgerManager().getLastClosedLedgerNum();
+             i <= originalExpectedLiveUntilLedger + 1; ++i)
+        {
+            closeLedgerOn(test.getApp(), i, 2, 1, 2016);
+        }
+        SorobanResources restoreResources;
+        restoreResources.footprint.readWrite = dataKeys;
+        restoreResources.readBytes = 9'000;
+        restoreResources.writeBytes = 9'000;
+
+        auto const resourceFee = 300'000 + 40'000 * dataKeys.size();
+
+        SECTION("insufficient refundable fee")
+        {
+            auto tx = test.createRestoreTx(restoreResources, 1'000,
+                                           40'000 * dataKeys.size());
+            REQUIRE(!test.invokeTx(tx));
+            REQUIRE(tx->getResult()
+                        .result.results()[0]
+                        .tr()
+                        .restoreFootprintResult()
+                        .code() ==
+                    RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
+        }
+
+        SECTION("exceeded readBytes")
+        {
+            auto resourceCopy = restoreResources;
+            resourceCopy.readBytes = 8'000;
+            auto tx = test.createRestoreTx(resourceCopy, 1'000, resourceFee);
+            REQUIRE(!test.invokeTx(tx));
+            REQUIRE(tx->getResult()
+                        .result.results()[0]
+                        .tr()
+                        .restoreFootprintResult()
+                        .code() == RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+        }
+
+        SECTION("exceeded writeBytes")
+        {
+            auto resourceCopy = restoreResources;
+            resourceCopy.writeBytes = 8'000;
+            auto tx = test.createRestoreTx(resourceCopy, 1'000, resourceFee);
+            REQUIRE(!test.invokeTx(tx));
+            REQUIRE(tx->getResult()
+                        .result.results()[0]
+                        .tr()
+                        .restoreFootprintResult()
+                        .code() == RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
+        }
+        SECTION("success")
+        {
+            auto tx =
+                test.createRestoreTx(restoreResources, 1'000, resourceFee);
+            REQUIRE(test.invokeTx(tx));
+            REQUIRE(test.isEntryLive(dataKeys[0], test.getLedgerSeq()));
+            REQUIRE(test.isEntryLive(dataKeys[1], test.getLedgerSeq()));
+        }
     }
 
-    auto const& contractKeys = test.getContractKeys();
-
-    SorobanResources restoreResources;
-    restoreResources.footprint.readWrite = contractKeys;
-    restoreResources.instructions = 0;
-    restoreResources.readBytes = 10'000;
-    restoreResources.writeBytes = 10'000;
-
-    auto const resourceFee = 300'000 + 40'000 * contractKeys.size();
-
-    // insufficient refundable fee
+    SECTION("extend operation")
     {
-        auto tx = test.createRestoreTx(restoreResources, 1'000,
-                                       40'000 * contractKeys.size());
-        test.invokeTx(tx, false);
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .restoreFootprintResult()
-                    .code() == RESTORE_FOOTPRINT_INSUFFICIENT_REFUNDABLE_FEE);
-    }
 
-    // exceeded readBytes
-    {
-        auto resourceCopy = restoreResources;
-        resourceCopy.readBytes = 1;
-        auto tx = test.createRestoreTx(resourceCopy, 1'000, resourceFee);
-        test.invokeTx(tx, false);
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .restoreFootprintResult()
-                    .code() == RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-    }
+        SorobanResources extendResources;
+        extendResources.footprint.readOnly = dataKeys;
+        extendResources.readBytes = 9'000;
+        SECTION("too large extension")
+        {
+            auto tx = test.createExtendOpTx(extendResources,
+                                            stateArchivalSettings.maxEntryTTL,
+                                            1'000, DEFAULT_TEST_RESOURCE_FEE);
+            REQUIRE(!test.isTxValid(tx));
+        }
+        SECTION("exceeded readBytes")
+        {
+            auto resourceCopy = extendResources;
+            resourceCopy.readBytes = 8'000;
 
-    // exceeded writeBytes
-    {
-        auto resourceCopy = restoreResources;
-        resourceCopy.writeBytes = 1;
-        auto tx = test.createRestoreTx(resourceCopy, 1'000, resourceFee);
-        test.invokeTx(tx, false);
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .restoreFootprintResult()
-                    .code() == RESTORE_FOOTPRINT_RESOURCE_LIMIT_EXCEEDED);
-    }
-
-    {
-        // restore entries
-        auto tx = test.createRestoreTx(restoreResources, 1'000, resourceFee);
-        test.invokeTx(tx, true);
-    }
-
-    ledgerSeq = test.getLedgerSeq();
-    REQUIRE(test.isEntryLive(contractKeys[0], ledgerSeq));
-    REQUIRE(test.isEntryLive(contractKeys[1], ledgerSeq));
-
-    SorobanResources extendResources;
-    extendResources.footprint.readOnly = contractKeys;
-    extendResources.instructions = 0;
-    extendResources.readBytes = 10'000;
-    extendResources.writeBytes = 0;
-
-    // exceeded readBytes
-    {
-        auto resourceCopy = extendResources;
-        resourceCopy.readBytes = 10;
-
-        auto resourceFee = DEFAULT_TEST_RESOURCE_FEE * contractKeys.size();
-        auto tx =
-            test.createExtendOpTx(resourceCopy, 10'000, 1'000, resourceFee);
-        test.invokeTx(tx, false);
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .extendFootprintTTLResult()
-                    .code() == EXTEND_FOOTPRINT_TTL_RESOURCE_LIMIT_EXCEEDED);
-    }
-
-    // insufficient refundable fee
-    {
-        auto resourceCopy = extendResources;
-
-        auto tx =
-            test.createExtendOpTx(extendResources, 10'000, 30'000, 30'000);
-        test.invokeTx(tx, false);
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .extendFootprintTTLResult()
-                    .code() ==
-                EXTEND_FOOTPRINT_TTL_INSUFFICIENT_REFUNDABLE_FEE);
+            auto tx = test.createExtendOpTx(resourceCopy, 10'000, 1'000,
+                                            DEFAULT_TEST_RESOURCE_FEE);
+            REQUIRE(!test.invokeTx(tx));
+            REQUIRE(tx->getResult()
+                        .result.results()[0]
+                        .tr()
+                        .extendFootprintTTLResult()
+                        .code() ==
+                    EXTEND_FOOTPRINT_TTL_RESOURCE_LIMIT_EXCEEDED);
+        }
+        SECTION("insufficient refundable fee")
+        {
+            auto tx =
+                test.createExtendOpTx(extendResources, 10'000, 30'000, 30'000);
+            REQUIRE(!test.invokeTx(tx));
+            REQUIRE(tx->getResult()
+                        .result.results()[0]
+                        .tr()
+                        .extendFootprintTTLResult()
+                        .code() ==
+                    EXTEND_FOOTPRINT_TTL_INSUFFICIENT_REFUNDABLE_FEE);
+        }
+        SECTION("success")
+        {
+            auto tx = test.createExtendOpTx(extendResources, 10'000, 1'000,
+                                            DEFAULT_TEST_RESOURCE_FEE);
+            REQUIRE(test.invokeTx(tx));
+        }
     }
 }
 
 /*
-This test uses the same utils (SettingsUpgradeUtils.h) as the
-get-settings-upgrade-txs command to make sure the transactions have the proper
-resources set.
+ This test uses the same utils (SettingsUpgradeUtils.h) as the
+ get-settings-upgrade-txs command to make sure the transactions have the
+ proper resources set.
 */
 TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
 {
@@ -2673,67 +2577,55 @@ TEST_CASE("overly large soroban values are handled gracefully", "[soroban]")
 {
     Config cfg = getTestConfig();
     cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = true;
-    WasmContractInvocationTest test(rust_bridge::get_hostile_large_val_wasm(),
-                                    true, cfg);
-    SorobanResources resources;
-    resources.instructions = test.getNetworkCfg().txMaxInstructions();
-    resources.readBytes = test.getNetworkCfg().txMaxReadBytes();
-    resources.writeBytes = test.getNetworkCfg().txMaxWriteBytes();
-    LedgerKey storageKey(CONTRACT_DATA);
-    storageKey.contractData().durability = ContractDataDurability::PERSISTENT;
-    storageKey.contractData().contract = test.getContractID();
-    storageKey.contractData().key = makeSymbolSCVal("val");
-    // Put contract instance to RW footprint in order to be able to
-    // use the instance storage.
-    resources.footprint.readWrite = test.getContractKeys();
-    resources.footprint.readWrite.push_back(storageKey);
+    SorobanTest test(cfg);
+    auto& contract =
+        test.deployWasmContract(rust_bridge::get_hostile_large_val_wasm());
 
-    auto invoke =
-        [&](std::string const& fnName, uint32_t width, uint32_t depth,
-            std::optional<InvokeHostFunctionResultCode> expectedError) {
-            auto scFunc = makeSymbol(fnName);
-            auto scDepth = makeU32(depth);
-            auto scWidth = makeU32(width);
-            uint32_t const inclusionFee = 1000;
-            uint32_t const resourceFee = 200'000'000;
+    auto spec =
+        SorobanInvocationSpec()
+            .setInstructions(test.getNetworkCfg().txMaxInstructions())
+            .setReadBytes(test.getNetworkCfg().txMaxReadBytes())
+            .setWriteBytes(test.getNetworkCfg().txMaxWriteBytes())
+            // Put client instance to RW footprint in order to be able to
+            // use the instance storage.
+            .setReadWriteFootprint(contract.getKeys())
+            .extendReadWriteFootprint({contract.getDataKey(
+                makeSymbolSCVal("val"), ContractDataDurability::PERSISTENT)})
+            .setRefundableResourceFee(200'000'000);
 
-            auto tx = test.createInvokeTx(resources, scFunc, {scWidth, scDepth},
-                                          inclusionFee, resourceFee);
-            auto meta =
-                test.invokeTx(tx, !expectedError, /*processPostApply=*/false);
-            if (expectedError)
-            {
-                REQUIRE(tx->getResult()
-                            .result.results()[0]
-                            .tr()
-                            .invokeHostFunctionResult()
-                            .code() == *expectedError);
-            }
-        };
+    auto invoke = [&](std::string const& fnName, uint32_t width,
+                      uint32_t depth) {
+        auto invocation =
+            contract.prepareInvocation(fnName, {makeU32(width), makeU32(depth)},
+                                       spec, /* addContractKeys */ false);
+        invocation.invoke();
+        return invocation.getResultCode();
+    };
 
     auto runTest = [&](std::string const& fnName, bool omitSuccess = false) {
         if (!omitSuccess)
         {
             // Successful call (5^2 entries)
-            invoke(fnName, 30, 2, std::nullopt);
+            REQUIRE(invoke(fnName, 30, 2) ==
+                    InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_SUCCESS);
         }
         // Non-serializable value, but not too deep -
         // should run out of budget (2^99 entries).
-        invoke(fnName, 2, 99,
-               InvokeHostFunctionResultCode::
-                   INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        REQUIRE(invoke(fnName, 2, 99) ==
+                InvokeHostFunctionResultCode::
+                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
         // A wide and not so deep value should exceed budget as well.
-        invoke(fnName, 10000, 50,
-               InvokeHostFunctionResultCode::
-                   INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
+        REQUIRE(invoke(fnName, 10000, 50) ==
+                InvokeHostFunctionResultCode::
+                    INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
         // One more depth level, now we've exceeded the host depth
         // limit of 100 and should fail well before running of budget
         // due to reaching the depth limit.
-        invoke(fnName, 2, 100,
-               InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_TRAPPED);
+        REQUIRE(invoke(fnName, 2, 100) ==
+                InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_TRAPPED);
         // Sanity-check with even bigger depth.
-        invoke(fnName, 2, 1000,
-               InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_TRAPPED);
+        REQUIRE(invoke(fnName, 2, 1000) ==
+                InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_TRAPPED);
     };
     SECTION("serialize")
     {
@@ -2773,7 +2665,9 @@ TEST_CASE("overly large soroban values are handled gracefully", "[soroban]")
     {
         // Excessive serialization for diagnostics call shouldn't
         // affect the function result.
-        invoke("diagnostics", 2, 50, std::nullopt);
-        invoke("diagnostics", 2, 1000, std::nullopt);
+        REQUIRE(invoke("diagnostics", 2, 50) ==
+                InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_SUCCESS);
+        REQUIRE(invoke("diagnostics", 2, 1000) ==
+                InvokeHostFunctionResultCode::INVOKE_HOST_FUNCTION_SUCCESS);
     }
 }

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -4,6 +4,7 @@
 
 #include "SorobanTxTestUtils.h"
 #include "lib/catch.hpp"
+#include "rust/RustBridge.h"
 #include "test/TestAccount.h"
 #include "test/TestUtils.h"
 #include "test/TxTests.h"
@@ -15,15 +16,11 @@ namespace stellar
 
 namespace txtest
 {
-SCVal
-makeWasmRefScContractCode(Hash const& hash)
+namespace
 {
-    SCVal val(SCValType::SCV_CONTRACT_INSTANCE);
-    val.instance().executable.type(
-        ContractExecutableType::CONTRACT_EXECUTABLE_WASM);
-    val.instance().executable.wasm_hash() = hash;
-    return val;
-}
+// Fee constants from rs-soroban-env/soroban-env-host/src/fees.rs
+constexpr int64_t DATA_SIZE_1KB_INCREMENT_FOR_FEES = 1024;
+} // namespace
 
 SCAddress
 makeContractAddress(Hash const& hash)
@@ -143,73 +140,432 @@ getContractBalance(Application& app, SCAddress const& contractID,
     return balance.lo;
 }
 
-void
-submitTx(Application& app, Operation const& op,
-         SorobanResources const& resources, uint32_t inclusionFee,
-         uint32_t resourceFee)
+ContractIDPreimage
+makeContractIDPreimage(TestAccount& source, uint256 salt)
 {
-    // submit operation
-    auto root = TestAccount::createRoot(app);
-    auto tx =
-        sorobanTransactionFrameFromOps(app.getNetworkID(), root, {op}, {},
-                                       resources, inclusionFee, resourceFee);
-    LedgerTxn ltx(app.getLedgerTxnRoot());
-    TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-    REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
-    REQUIRE(tx->apply(app, ltx, txm));
-    ltx.commit();
+    ContractIDPreimage idPreimage(CONTRACT_ID_PREIMAGE_FROM_ADDRESS);
+    idPreimage.fromAddress().address.type(SC_ADDRESS_TYPE_ACCOUNT);
+    idPreimage.fromAddress().address.accountId().ed25519() =
+        source.getPublicKey().ed25519();
+    idPreimage.fromAddress().salt = salt;
+    return idPreimage;
 }
 
-void
-submitTxToUploadWasm(Application& app, Operation const& op,
-                     SorobanResources const& resources,
-                     Hash const& expectedWasmHash,
-                     xdr::opaque_vec<> const& expectedWasm,
-                     uint32_t inclusionFee, uint32_t resourceFee)
+ContractIDPreimage
+makeContractIDPreimage(Asset const& asset)
 {
-    submitTx(app, op, resources, inclusionFee, resourceFee);
-
-    // verify contract code is correct
-    LedgerTxn ltx2(app.getLedgerTxnRoot());
-    auto ltxe = loadContractCode(ltx2, expectedWasmHash);
-    REQUIRE(ltxe);
-    REQUIRE(ltxe.current().data.contractCode().code == expectedWasm);
+    ContractIDPreimage idPreimage(CONTRACT_ID_PREIMAGE_FROM_ASSET);
+    idPreimage.fromAsset() = asset;
+    return idPreimage;
 }
 
-void
-submitTxToCreateContract(Application& app, Operation const& op,
-                         SorobanResources const& resources,
-                         Hash const& contractID, SCVal const& executableKey,
-                         Hash const& expectedWasmHash, uint32_t inclusionFee,
-                         uint32_t resourceFee)
+HashIDPreimage
+makeFullContractIdPreimage(Hash const& networkID,
+                           ContractIDPreimage const& contractIDPreimage)
 {
-    // submit operation
-    auto root = TestAccount::createRoot(app);
-    auto tx =
-        sorobanTransactionFrameFromOps(app.getNetworkID(), root, {op}, {},
-                                       resources, inclusionFee, resourceFee);
-    LedgerTxn ltx(app.getLedgerTxnRoot());
-    TransactionMetaFrame txm(ltx.loadHeader().current().ledgerVersion);
-    REQUIRE(tx->checkValid(app, ltx, 0, 0, 0));
-    REQUIRE(tx->apply(app, ltx, txm));
-    ltx.commit();
+    HashIDPreimage fullPreImage;
+    fullPreImage.type(ENVELOPE_TYPE_CONTRACT_ID);
+    fullPreImage.contractID().contractIDPreimage = contractIDPreimage;
+    fullPreImage.contractID().networkID = networkID;
+    return fullPreImage;
+}
 
-    // verify contract code reference is correct
-    LedgerTxn ltx2(app.getLedgerTxnRoot());
-    SCAddress contract = makeContractAddress(contractID);
-    auto ltxe = loadContractData(ltx2, contract, executableKey,
-                                 CONTRACT_INSTANCE_CONTRACT_DURABILITY);
-    REQUIRE(ltxe);
+ContractExecutable
+makeWasmExecutable(Hash const& wasmHash)
+{
+    ContractExecutable executable(CONTRACT_EXECUTABLE_WASM);
+    executable.wasm_hash() = wasmHash;
+    return executable;
+}
 
-    auto const& cd = ltxe.current().data.contractData();
-    REQUIRE(cd.durability == CONTRACT_INSTANCE_CONTRACT_DURABILITY);
-    REQUIRE(cd.val == makeWasmRefScContractCode(expectedWasmHash));
+ContractExecutable
+makeAssetExecutable(Asset const& asset)
+{
+    ContractExecutable executable(CONTRACT_EXECUTABLE_STELLAR_ASSET);
+    return executable;
+}
+
+LedgerKey
+makeContractInstanceKey(SCAddress const& contractAddress)
+{
+    SCVal instanceContractDataKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
+    return contractDataKey(contractAddress, instanceContractDataKey,
+                           CONTRACT_INSTANCE_ENTRY_DURABILITY);
+}
+
+TransactionFrameBasePtr
+makeSorobanWasmUploadTx(Application& app, TestAccount& source,
+                        RustBuf const& wasm, SorobanResources& uploadResources,
+                        uint32_t inclusionFee)
+{
+    Operation uploadOp;
+    uploadOp.body.type(INVOKE_HOST_FUNCTION);
+    auto& uploadHF = uploadOp.body.invokeHostFunctionOp().hostFunction;
+    uploadHF.type(HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM);
+    uploadHF.wasm().assign(wasm.data.begin(), wasm.data.end());
+    if (uploadResources.footprint.readWrite.empty())
+    {
+        REQUIRE(uploadResources.footprint.readOnly.empty());
+        uploadResources.footprint.readWrite = {
+            contractCodeKey(sha256(uploadHF.wasm()))};
+    }
+    auto uploadResourceFee =
+        sorobanResourceFee(app, uploadResources, 1000 + wasm.data.size(), 40) +
+        DEFAULT_TEST_RESOURCE_FEE;
+    return sorobanTransactionFrameFromOps(app.getNetworkID(), source,
+                                          {uploadOp}, {}, uploadResources,
+                                          inclusionFee, uploadResourceFee);
+}
+
+SorobanResources
+defaultUploadWasmResourcesWithoutFootprint(RustBuf const& wasm)
+{
+    SorobanResources resources;
+    resources.instructions = 500'000 + (wasm.data.size() * 1000);
+    resources.readBytes = 1000;
+    resources.writeBytes = wasm.data.size() + 100;
+    return resources;
+}
+
+SorobanResources
+defaultCreateWasmContractResources(RustBuf const& wasm)
+{
+    return SorobanResources();
+}
+
+TransactionFrameBasePtr
+makeSorobanCreateContractTx(Application& app, TestAccount& source,
+                            ContractIDPreimage const& idPreimage,
+                            ContractExecutable const& executable,
+                            SorobanResources& createResources,
+                            uint32_t inclusionFee)
+{
+    if (createResources.footprint.readWrite.empty())
+    {
+        REQUIRE(createResources.footprint.readOnly.empty());
+        auto contractID = xdrSha256(
+            makeFullContractIdPreimage(app.getNetworkID(), idPreimage));
+        if (executable.type() ==
+            ContractExecutableType::CONTRACT_EXECUTABLE_WASM)
+        {
+            createResources.footprint.readOnly = {
+                contractCodeKey(executable.wasm_hash())};
+        }
+        createResources.footprint.readWrite = {
+            makeContractInstanceKey(makeContractAddress(contractID))};
+    }
+
+    Operation createOp;
+    createOp.body.type(INVOKE_HOST_FUNCTION);
+    auto& createHF = createOp.body.invokeHostFunctionOp().hostFunction;
+    createHF.type(HOST_FUNCTION_TYPE_CREATE_CONTRACT);
+    auto& createContractArgs = createHF.createContract();
+    createContractArgs.contractIDPreimage = idPreimage;
+    createContractArgs.executable = executable;
+
+    if (executable.type() !=
+        ContractExecutableType::CONTRACT_EXECUTABLE_STELLAR_ASSET)
+    {
+        SorobanAuthorizationEntry auth;
+        auth.credentials.type(SOROBAN_CREDENTIALS_SOURCE_ACCOUNT);
+        auth.rootInvocation.function.type(
+            SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN);
+        auth.rootInvocation.function.createContractHostFn().contractIDPreimage =
+            idPreimage;
+
+        auth.rootInvocation.function.createContractHostFn().executable =
+            executable;
+        createOp.body.invokeHostFunctionOp().auth = {auth};
+    }
+
+    auto createResourceFee =
+        sorobanResourceFee(app, createResources, 1000, 40) +
+        DEFAULT_TEST_RESOURCE_FEE;
+    return sorobanTransactionFrameFromOps(app.getNetworkID(), source,
+                                          {createOp}, {}, createResources,
+                                          inclusionFee, createResourceFee);
+}
+
+TransactionFrameBasePtr
+sorobanTransactionFrameFromOps(Hash const& networkID, TestAccount& source,
+                               std::vector<Operation> const& ops,
+                               std::vector<SecretKey> const& opKeys,
+                               SorobanInvocationSpec const& spec,
+                               std::optional<std::string> memo,
+                               std::optional<SequenceNumber> seq)
+{
+    return sorobanTransactionFrameFromOps(
+        networkID, source, ops, opKeys, spec.getResources(),
+        spec.getInclusionFee(), spec.getResourceFee());
+}
+
+SorobanInvocationSpec::SorobanInvocationSpec(SorobanResources const& resources,
+                                             uint32_t nonRefundableResourceFee,
+                                             uint32_t refundableResourceFee,
+                                             uint32_t inclusionFee)
+    : mResources(resources)
+    , mNonRefundableResourceFee(nonRefundableResourceFee)
+    , mRefundableResourceFee(refundableResourceFee)
+    , mInclusionFee(inclusionFee)
+{
+}
+
+SorobanResources const&
+SorobanInvocationSpec::getResources() const
+{
+    return mResources;
+}
+
+uint32_t
+SorobanInvocationSpec::getFee() const
+{
+    return mInclusionFee + getResourceFee();
+}
+
+uint32_t
+SorobanInvocationSpec::getResourceFee() const
+{
+    return mNonRefundableResourceFee + mRefundableResourceFee;
+}
+
+uint32_t
+SorobanInvocationSpec::getInclusionFee() const
+{
+    return mInclusionFee;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setInstructions(int64_t instructions) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.instructions = instructions;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setReadOnlyFootprint(
+    xdr::xvector<LedgerKey> const& keys) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.footprint.readOnly = keys;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setReadWriteFootprint(
+    xdr::xvector<LedgerKey> const& keys) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.footprint.readWrite = keys;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::extendReadOnlyFootprint(
+    xdr::xvector<LedgerKey> const& keys) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.footprint.readOnly.insert(
+        newSpec.mResources.footprint.readOnly.end(), keys.begin(), keys.end());
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::extendReadWriteFootprint(
+    xdr::xvector<LedgerKey> const& keys) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.footprint.readWrite.insert(
+        newSpec.mResources.footprint.readWrite.end(), keys.begin(), keys.end());
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setReadBytes(uint32_t readBytes) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.readBytes = readBytes;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setWriteBytes(uint32_t writeBytes) const
+{
+    auto newSpec = *this;
+    newSpec.mResources.writeBytes = writeBytes;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setRefundableResourceFee(uint32_t fee) const
+{
+    auto newSpec = *this;
+    newSpec.mRefundableResourceFee = fee;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setNonRefundableResourceFee(uint32_t fee) const
+{
+    auto newSpec = *this;
+    newSpec.mNonRefundableResourceFee = fee;
+    return newSpec;
+}
+
+SorobanInvocationSpec
+SorobanInvocationSpec::setInclusionFee(uint32_t fee) const
+{
+    auto newSpec = *this;
+    newSpec.mInclusionFee = fee;
+    return newSpec;
+}
+
+TestContract::TestContract(SorobanTest& test, SCAddress const& address,
+                           xdr::xvector<LedgerKey> const& contractKeys)
+    : mTest(test), mAddress(address), mContractKeys(contractKeys)
+{
+}
+
+xdr::xvector<LedgerKey> const&
+TestContract::getKeys() const
+{
+    return mContractKeys;
+}
+
+SCAddress const&
+TestContract::getAddress() const
+{
+    return mAddress;
+}
+
+SorobanTest&
+TestContract::getTest() const
+{
+    return mTest;
+}
+
+LedgerKey
+TestContract::getDataKey(SCVal const& key, ContractDataDurability durability)
+{
+    return stellar::contractDataKey(mAddress, key, durability);
+}
+
+TestContract::Invocation
+TestContract::prepareInvocation(std::string const& functionName,
+                                std::vector<SCVal> const& args,
+                                SorobanInvocationSpec const& spec,
+                                bool addContractKeys) const
+{
+    return Invocation(*this, functionName, args, spec, addContractKeys);
+}
+
+TestContract::Invocation::Invocation(TestContract const& contract,
+                                     std::string const& functionName,
+                                     std::vector<SCVal> const& args,
+                                     SorobanInvocationSpec const& spec,
+                                     bool addContractKeys)
+    : mTest(contract.getTest()), mSpec(spec)
+{
+    mOp.body.type(INVOKE_HOST_FUNCTION);
+    auto& ihf = mOp.body.invokeHostFunctionOp().hostFunction;
+    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
+    ihf.invokeContract().contractAddress = contract.getAddress();
+    ihf.invokeContract().functionName = makeSymbol(functionName);
+    ihf.invokeContract().args.assign(args.begin(), args.end());
+
+    if (addContractKeys)
+    {
+        mSpec = mSpec.extendReadOnlyFootprint(contract.getKeys());
+    }
+}
+
+TestContract::Invocation&
+TestContract::Invocation::withAuthorizedTopCall()
+{
+    mOp.body.invokeHostFunctionOp().auth = {getInvocationAuth(
+        mOp.body.invokeHostFunctionOp().hostFunction.invokeContract())};
+    return *this;
+}
+
+TransactionFrameBasePtr
+TestContract::Invocation::createTx(TestAccount* source)
+{
+    auto& acc = source ? *source : mTest.getRoot();
+
+    return sorobanTransactionFrameFromOps(mTest.getApp().getNetworkID(), acc,
+                                          {mOp}, {}, mSpec);
+}
+
+TestContract::Invocation&
+TestContract::Invocation::withExactNonRefundableResourceFee()
+{
+    // Compute tx frame size before finalizing the resource fee via a dummy TX.
+    // This is a bit hacky, but we need the exact tx size in order to
+    // enable tests that rely on the exact refundable fee value.
+    // Note, that we don't use the root account here in order to not mess up
+    // the sequence numbers.
+    auto dummyTx = sorobanTransactionFrameFromOps(mTest.getApp().getNetworkID(),
+                                                  mTest.getDummyAccount(),
+                                                  {mOp}, {}, mSpec);
+    auto txSize = xdr::xdr_size(dummyTx->getEnvelope());
+    mSpec = mSpec.setNonRefundableResourceFee(
+        sorobanResourceFee(mTest.getApp(), mSpec.getResources(), txSize, 0));
+    return *this;
+}
+
+bool
+TestContract::Invocation::invoke(TestAccount* source)
+{
+    auto tx = createTx(source);
+    mTxMeta.emplace(mTest.getLedgerVersion());
+    bool success = mTest.invokeTx(tx, &*mTxMeta);
+    mResultCode = tx->getResult()
+                      .result.results()[0]
+                      .tr()
+                      .invokeHostFunctionResult()
+                      .code();
+    return success;
+}
+
+SCVal
+TestContract::Invocation::getReturnValue() const
+{
+    REQUIRE(mTxMeta);
+    return mTxMeta->getXDR().v3().sorobanMeta->returnValue;
+}
+
+TransactionMetaFrame const&
+TestContract::Invocation::getTxMeta() const
+{
+    REQUIRE(mTxMeta);
+    return *mTxMeta;
+}
+
+InvokeHostFunctionResultCode
+TestContract::Invocation::getResultCode() const
+{
+    REQUIRE(mResultCode);
+    return *mResultCode;
+}
+
+SorobanTest::SorobanTest(Config cfg, bool useTestLimits,
+                         std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
+    : mApp(createTestApplication(mClock, cfg))
+    , mRoot(TestAccount::createRoot(getApp()))
+    , mDummyAccount(mRoot.create(
+          "dummyAcc", getApp().getLedgerManager().getLastMinBalance(1)))
+{
+    if (useTestLimits)
+    {
+        overrideSorobanNetworkConfigForTest(getApp());
+    }
+
+    modifySorobanNetworkConfig(getApp(), cfgModifyFn);
 }
 
 int64_t
-ContractInvocationTest::computeFeePerIncrement(int64_t resourceVal,
-                                               int64_t feeRate,
-                                               int64_t increment)
+SorobanTest::computeFeePerIncrement(int64_t resourceVal, int64_t feeRate,
+                                    int64_t increment)
 {
     // ceiling division for (resourceVal * feeRate) / increment
     int64_t num = (resourceVal * feeRate);
@@ -217,18 +573,11 @@ ContractInvocationTest::computeFeePerIncrement(int64_t resourceVal,
 };
 
 void
-ContractInvocationTest::invokeArchivalOp(TransactionFrameBasePtr tx,
-                                         int64_t expectedRefundableFeeCharged,
-                                         bool expectSuccess)
+SorobanTest::invokeArchivalOp(TransactionFrameBasePtr tx,
+                              int64_t expectedRefundableFeeCharged)
 {
-    if (!expectSuccess)
-    {
-        REQUIRE(!isTxValid(tx));
-        return;
-    }
-
+    REQUIRE(isTxValid(tx));
     int64_t initBalance = getRoot().getBalance();
-    txCheckValid(tx);
 
     // Initially we store in result the charge for resources plus
     // minimum inclusion  fee bid (currently equivalent to the network
@@ -237,7 +586,7 @@ ContractInvocationTest::invokeArchivalOp(TransactionFrameBasePtr tx,
     REQUIRE(tx->getResult().feeCharged == baseCharged);
     // Charge the fee.
     {
-        LedgerTxn ltx(mApp->getLedgerTxnRoot());
+        LedgerTxn ltx(getApp().getLedgerTxnRoot());
         // Imitate surge pricing by charging at a higher rate than base
         // fee.
         tx->processFeeSeqNum(ltx, 300);
@@ -249,12 +598,19 @@ ContractInvocationTest::invokeArchivalOp(TransactionFrameBasePtr tx,
     auto actuallyCharged = baseCharged + /* surge pricing additional fee */ 200;
     REQUIRE(initBalance - balanceAfterFeeCharged == actuallyCharged);
     auto nonRefundableResourceFee = sorobanResourceFee(
-        *mApp, tx->sorobanResources(), xdr::xdr_size(tx->getEnvelope()), 0);
+        getApp(), tx->sorobanResources(), xdr::xdr_size(tx->getEnvelope()), 0);
     auto expectedChargedAfterRefund =
         nonRefundableResourceFee + expectedRefundableFeeCharged + 300;
 
-    auto txm = invokeTx(tx, /*expectSuccess=*/true);
-    auto changesAfter = txm->getChangesAfter();
+    TransactionMetaFrame txm(getLedgerVersion());
+    REQUIRE(invokeTx(tx, &txm));
+    {
+        LedgerTxn ltx(getApp().getLedgerTxnRoot());
+        tx->processPostApply(getApp(), ltx, txm);
+        ltx.commit();
+    }
+
+    auto changesAfter = txm.getChangesAfter();
     REQUIRE(changesAfter.size() == 2);
     REQUIRE(changesAfter[1].updated().data.account().balance -
                 changesAfter[0].state().data.account().balance ==
@@ -265,128 +621,146 @@ ContractInvocationTest::invokeArchivalOp(TransactionFrameBasePtr tx,
             actuallyCharged - expectedChargedAfterRefund);
 }
 
-// Returns createOp, contractID pair
-std::pair<Operation, Hash>
-createSorobanCreateOp(Application& app, SorobanResources& createResources,
-                      LedgerKey const& contractCodeLedgerKey,
-                      TestAccount& source, SCVal& scContractSourceRefKey,
-                      uint256 salt)
+Hash
+SorobanTest::uploadWasm(RustBuf const& wasm, SorobanResources& uploadResources)
 {
-    // Deploy the contract instance
-    ContractIDPreimage idPreimage(CONTRACT_ID_PREIMAGE_FROM_ADDRESS);
-    idPreimage.fromAddress().address.type(SC_ADDRESS_TYPE_ACCOUNT);
-    idPreimage.fromAddress().address.accountId().ed25519() =
-        source.getPublicKey().ed25519();
-    idPreimage.fromAddress().salt = salt;
-    HashIDPreimage fullPreImage;
-    fullPreImage.type(ENVELOPE_TYPE_CONTRACT_ID);
-    fullPreImage.contractID().contractIDPreimage = idPreimage;
-    fullPreImage.contractID().networkID = app.getNetworkID();
-    auto contractID = xdrSha256(fullPreImage);
+    auto tx =
+        makeSorobanWasmUploadTx(getApp(), mRoot, wasm, uploadResources, 1000);
+    REQUIRE(invokeTx(tx));
 
-    Operation createOp;
-    createOp.body.type(INVOKE_HOST_FUNCTION);
-    auto& createHF = createOp.body.invokeHostFunctionOp().hostFunction;
-    createHF.type(HOST_FUNCTION_TYPE_CREATE_CONTRACT);
-    auto& createContractArgs = createHF.createContract();
-    createContractArgs.contractIDPreimage = idPreimage;
-    createContractArgs.executable.type(CONTRACT_EXECUTABLE_WASM);
-    createContractArgs.executable.wasm_hash() =
-        contractCodeLedgerKey.contractCode().hash;
-
-    SorobanAuthorizationEntry auth;
-    auth.credentials.type(SOROBAN_CREDENTIALS_SOURCE_ACCOUNT);
-    auth.rootInvocation.function.type(
-        SOROBAN_AUTHORIZED_FUNCTION_TYPE_CREATE_CONTRACT_HOST_FN);
-    auth.rootInvocation.function.createContractHostFn().contractIDPreimage =
-        idPreimage;
-    auth.rootInvocation.function.createContractHostFn().executable.type(
-        CONTRACT_EXECUTABLE_WASM);
-    auth.rootInvocation.function.createContractHostFn().executable.wasm_hash() =
-        contractCodeLedgerKey.contractCode().hash;
-    createOp.body.invokeHostFunctionOp().auth = {auth};
-
-    LedgerKey contractSourceRefLedgerKey;
-    contractSourceRefLedgerKey.type(CONTRACT_DATA);
-    contractSourceRefLedgerKey.contractData().contract.type(
-        SC_ADDRESS_TYPE_CONTRACT);
-    contractSourceRefLedgerKey.contractData().contract.contractId() =
-        contractID;
-    contractSourceRefLedgerKey.contractData().key = scContractSourceRefKey;
-    contractSourceRefLedgerKey.contractData().durability =
-        CONTRACT_INSTANCE_CONTRACT_DURABILITY;
-
-    createResources.footprint.readOnly = {contractCodeLedgerKey};
-    createResources.footprint.readWrite = {contractSourceRefLedgerKey};
-    return {createOp, contractID};
-}
-
-void
-WasmContractInvocationTest::deployContractWithSourceAccountWithResources(
-    SorobanResources uploadResources, SorobanResources createResources)
-{
-    // Upload contract code
-    Operation uploadOp;
-    uploadOp.body.type(INVOKE_HOST_FUNCTION);
-    auto& uploadHF = uploadOp.body.invokeHostFunctionOp().hostFunction;
-    uploadHF.type(HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM);
-    uploadHF.wasm().assign(mWasm.data.begin(), mWasm.data.end());
-
-    LedgerKey contractCodeLedgerKey;
-    contractCodeLedgerKey.type(CONTRACT_CODE);
-    contractCodeLedgerKey.contractCode().hash = sha256(uploadHF.wasm());
-    uploadResources.footprint.readWrite = {contractCodeLedgerKey};
-    auto uploadResourceFee = sorobanResourceFee(*mApp, uploadResources,
-                                                1000 + mWasm.data.size(), 40) +
-                             40'000;
-    submitTxToUploadWasm(*mApp, uploadOp, uploadResources,
-                         contractCodeLedgerKey.contractCode().hash,
-                         uploadHF.wasm(), 1'000, uploadResourceFee);
-
-    // Check TTLs for contract code
-    auto const& ses = getNetworkCfg().stateArchivalSettings();
-    auto expectedLiveUntilLedger = ses.minPersistentTTL + getLedgerSeq() - 1;
-    checkTTL(contractCodeLedgerKey, expectedLiveUntilLedger);
-
-    // Deploy the contract instance
-    SCVal scContractSourceRefKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
-    auto [createOp, contractID] =
-        createSorobanCreateOp(*mApp, createResources, contractCodeLedgerKey,
-                              mRoot, scContractSourceRefKey);
-
-    auto createResourceFee =
-        sorobanResourceFee(*mApp, createResources, 1000, 40) + 40'000;
-    submitTxToCreateContract(
-        *mApp, createOp, createResources, contractID, scContractSourceRefKey,
-        contractCodeLedgerKey.contractCode().hash, 1000, createResourceFee);
-
-    // Check TTLs for contract instance
-    checkTTL(contractCodeLedgerKey, expectedLiveUntilLedger);
-
-    // ContractSourceRefLedgerKey == readWrite[0]
-    mContractKeys.emplace_back(createResources.footprint.readWrite[0]);
-    mContractKeys.emplace_back(contractCodeLedgerKey);
-    mContractID = mContractKeys[0].contractData().contract;
-}
-
-ContractInvocationTest::ContractInvocationTest(
-    Config cfg, bool useTestLimits,
-    std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
-    : mApp(createTestApplication(mClock, cfg))
-    , mRoot(TestAccount::createRoot(*mApp))
-    , mDummyAccount(mRoot.create("dummyAcc",
-                                 mApp->getLedgerManager().getLastMinBalance(1)))
-{
-    if (useTestLimits)
+    // Verify the uploaded contract code is correct.
+    SCBytes expectedWasm(wasm.data.begin(), wasm.data.end());
+    Hash expectedWasmHash = sha256(expectedWasm);
+    auto contractCodeLedgerKey = contractCodeKey(expectedWasmHash);
     {
-        overrideSorobanNetworkConfigForTest(*mApp);
+        LedgerTxn ltx(getApp().getLedgerTxnRoot());
+        auto ltxe = ltx.loadWithoutRecord(contractCodeLedgerKey);
+        REQUIRE(ltxe);
+        REQUIRE(ltxe.current().data.contractCode().code == expectedWasm);
+    }
+    // Check TTLs for contract code
+    auto expectedLiveUntilLedger =
+        getNetworkCfg().stateArchivalSettings().minPersistentTTL +
+        getLedgerSeq() - 1;
+    REQUIRE(getTTL(contractCodeLedgerKey) == expectedLiveUntilLedger);
+    return expectedWasmHash;
+}
+
+SCAddress
+SorobanTest::createContract(ContractIDPreimage const& idPreimage,
+                            ContractExecutable const& executable,
+                            SorobanResources& createResources)
+{
+    auto salt = sha256(std::to_string(mContracts.size()));
+    auto tx = makeSorobanCreateContractTx(getApp(), mRoot, idPreimage,
+                                          executable, createResources, 1000);
+    REQUIRE(invokeTx(tx));
+    Hash contractID = xdrSha256(
+        makeFullContractIdPreimage(getApp().getNetworkID(), idPreimage));
+    SCAddress contractAddress = makeContractAddress(contractID);
+    auto contractInstanceKey = makeContractInstanceKey(contractAddress);
+    {
+        // Verify the created instance.
+        LedgerTxn ltx(getApp().getLedgerTxnRoot());
+        auto ltxe = ltx.load(contractInstanceKey);
+        REQUIRE(ltxe);
+
+        auto const& cd = ltxe.current().data.contractData();
+        REQUIRE(cd.durability == CONTRACT_INSTANCE_ENTRY_DURABILITY);
+        REQUIRE(cd.val.instance().executable == executable);
     }
 
-    modifySorobanNetworkConfig(*mApp, cfgModifyFn);
+    // Check TTLs for the contract instance.
+    auto const& ses = getNetworkCfg().stateArchivalSettings();
+    auto expectedLiveUntilLedger = ses.minPersistentTTL + getLedgerSeq() - 1;
+    REQUIRE(getTTL(contractInstanceKey) == expectedLiveUntilLedger);
+    return contractAddress;
+}
+
+int64_t
+SorobanTest::getRentFeeForExtension(xdr::xvector<LedgerKey> const& keys,
+                                    uint32_t newLifetime)
+
+{
+    rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
+    LedgerTxn ltx(getApp().getLedgerTxnRoot());
+    for (auto const& key : keys)
+    {
+        auto ltxe = ltx.loadWithoutRecord(key);
+        REQUIRE(ltxe);
+        size_t entrySize = xdr::xdr_size(ltxe.current());
+        rustEntryRentChanges.emplace_back();
+        auto& rustChange = rustEntryRentChanges.back();
+        rustChange.is_persistent = !isTemporaryEntry(key);
+        rustChange.old_size_bytes = static_cast<uint32>(entrySize);
+        rustChange.new_size_bytes = rustChange.old_size_bytes;
+        auto ttlLtxe = ltx.loadWithoutRecord(getTTLKey(key));
+        REQUIRE(ttlLtxe);
+        rustChange.old_live_until_ledger =
+            ttlLtxe.current().data.ttl().liveUntilLedgerSeq;
+        rustChange.new_live_until_ledger = getLedgerSeq() + newLifetime;
+    }
+    return rust_bridge::compute_rent_fee(
+        getApp().getConfig().CURRENT_LEDGER_PROTOCOL_VERSION,
+        getLedgerVersion(), rustEntryRentChanges,
+        getNetworkCfg().rustBridgeRentFeeConfiguration(), getLedgerSeq());
+}
+
+Application&
+SorobanTest::getApp() const
+{
+    return *mApp;
+}
+
+TestContract&
+SorobanTest::deployWasmContract(RustBuf const& wasm,
+                                std::optional<SorobanResources> uploadResources,
+                                std::optional<SorobanResources> createResources)
+{
+    if (!uploadResources)
+    {
+        uploadResources = defaultUploadWasmResourcesWithoutFootprint(wasm);
+    }
+
+    if (!createResources)
+    {
+        createResources.emplace();
+        createResources->instructions = 600'000;
+        createResources->readBytes = wasm.data.size() + 1000;
+        createResources->writeBytes = 1000;
+    }
+    Hash wasmHash = uploadWasm(wasm, *uploadResources);
+    SCAddress contractAddress =
+        createContract(makeContractIDPreimage(
+                           mRoot, sha256(std::to_string(mContracts.size()))),
+                       makeWasmExecutable(wasmHash), *createResources);
+    xdr::xvector<LedgerKey> contractKeys = {
+        contractCodeKey(wasmHash), makeContractInstanceKey(contractAddress)};
+    mContracts.emplace_back(
+        std::make_unique<TestContract>(*this, contractAddress, contractKeys));
+    return *mContracts.back();
+}
+
+TestContract&
+SorobanTest::deployAssetContract(Asset const& asset)
+{
+    SorobanResources createResources;
+    createResources.instructions = 400'000;
+    createResources.readBytes = 1000;
+    createResources.writeBytes = 1000;
+
+    SCAddress contractAddress =
+        createContract(makeContractIDPreimage(asset),
+                       makeAssetExecutable(asset), createResources);
+    xdr::xvector<LedgerKey> contractKeys = {
+        makeContractInstanceKey(contractAddress)};
+    mContracts.emplace_back(
+        std::make_unique<TestContract>(*this, contractAddress, contractKeys));
+    return *mContracts.back();
 }
 
 TestAccount&
-ContractInvocationTest::getRoot()
+SorobanTest::getRoot()
 {
     // TestAccount caches the next seqno in-memory, assuming all invoked TXs
     // succeed. This is not true for these tests, so we load the seqno from
@@ -395,317 +769,148 @@ ContractInvocationTest::getRoot()
     return mRoot;
 }
 
+TestAccount&
+SorobanTest::getDummyAccount()
+{
+    return mDummyAccount;
+}
+
 SorobanNetworkConfig const&
-ContractInvocationTest::getNetworkCfg()
+SorobanTest::getNetworkCfg()
 {
-    return mApp->getLedgerManager().getSorobanNetworkConfig();
+    return getApp().getLedgerManager().getSorobanNetworkConfig();
 }
 
 uint32_t
-ContractInvocationTest::getLedgerSeq()
+SorobanTest::getLedgerVersion() const
 {
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    return ltx.loadHeader().current().ledgerSeq;
-}
-
-int64_t
-ContractInvocationTest::getRentFeeForBytes(int64_t entrySize, uint32_t extendTo,
-                                           bool isPersistent)
-{
-    auto const& cfg = getNetworkCfg();
-    auto num = entrySize * cfg.feeWrite1KB() * extendTo;
-    auto storageCoef =
-        isPersistent ? cfg.stateArchivalSettings().persistentRentRateDenominator
-                     : cfg.stateArchivalSettings().tempRentRateDenominator;
-
-    auto denom = DATA_SIZE_1KB_INCREMENT * storageCoef;
-
-    // Ceiling division
-    return (num + denom - 1) / denom;
-}
-
-int64_t
-ContractInvocationTest::getTTLEntryWriteFee()
-{
-    auto const& cfg = getNetworkCfg();
-    LedgerEntry le;
-    le.data.type(TTL);
-
-    auto writeSize = xdr::xdr_size(le);
-    auto writeFee = computeFeePerIncrement(writeSize, cfg.feeWrite1KB(),
-                                           DATA_SIZE_1KB_INCREMENT);
-    writeFee += cfg.feeWriteLedgerEntry();
-    return writeFee;
-}
-
-int64_t
-ContractInvocationTest::getRentFeeForExtension(
-    xdr::xvector<LedgerKey> const& keys, uint32_t newLifetime)
-{
-    int64_t rentFee = 0;
-    int64_t ttlBytes = 0;
-    size_t numExtensions = 0;
-
-    for (auto const& key : keys)
-    {
-        LedgerTxn ltx(mApp->getLedgerTxnRoot());
-        auto ledgerSeq = ltx.getHeader().ledgerSeq;
-
-        auto ttlKey = getTTLKey(key);
-        auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
-        releaseAssert(ttlLtxe);
-
-        uint32_t extendTo = 0;
-
-        TTLEntry const& ttlEntry = ttlLtxe.current().data.ttl();
-
-        if (isLive(ttlLtxe.current(), ledgerSeq))
-        {
-            auto newLiveUntilLedger = ledgerSeq + newLifetime;
-            if (ttlEntry.liveUntilLedgerSeq >= newLiveUntilLedger)
-            {
-                continue;
-            }
-
-            extendTo = newLiveUntilLedger - ttlEntry.liveUntilLedgerSeq;
-
-            LedgerEntry le;
-            le.data.type(TTL);
-            ttlBytes += xdr::xdr_size(le);
-            ++numExtensions;
-        }
-        else
-        {
-            // Non-live entries are skipped, pay no rent fee
-            continue;
-        }
-
-        auto txle = ltx.loadWithoutRecord(key);
-        releaseAssert(txle);
-
-        auto entrySize = xdr::xdr_size(txle.current());
-
-        rentFee +=
-            getRentFeeForBytes(entrySize, extendTo, isPersistentEntry(key));
-    }
-
-    // Now charge for the TTL writes
-    auto const& cfg = getNetworkCfg();
-    rentFee += (cfg.feeWriteLedgerEntry() * numExtensions);
-    rentFee += computeFeePerIncrement(ttlBytes, cfg.feeWrite1KB(),
-                                      DATA_SIZE_1KB_INCREMENT);
-
-    return rentFee;
-}
-
-int64_t
-ContractInvocationTest::getTxSizeFees(TransactionFrameBasePtr tx)
-{
-    auto const& cfg = getNetworkCfg();
-    int64_t txSize = static_cast<uint32>(xdr::xdr_size(tx->getEnvelope()));
-    int64_t historicalFee =
-        computeFeePerIncrement(txSize + TX_BASE_RESULT_SIZE,
-                               cfg.mFeeHistorical1KB, DATA_SIZE_1KB_INCREMENT);
-
-    int64_t bandwidthFee = computeFeePerIncrement(
-        txSize, cfg.feeTransactionSize1KB(), DATA_SIZE_1KB_INCREMENT);
-
-    return historicalFee + bandwidthFee;
-}
-
-int64_t
-ContractInvocationTest::getComputeFee(SorobanResources const& resources)
-{
-    auto const& cfg = getNetworkCfg();
-    return computeFeePerIncrement(resources.instructions,
-                                  cfg.feeRatePerInstructionsIncrement(),
-                                  INSTRUCTION_INCREMENT);
-}
-
-int64_t
-ContractInvocationTest::getEntryReadFee(SorobanResources const& resources)
-{
-    auto const& cfg = getNetworkCfg();
-    return (resources.footprint.readOnly.size() +
-            resources.footprint.readWrite.size()) *
-           cfg.feeReadLedgerEntry();
-}
-
-int64_t
-ContractInvocationTest::getEntryWriteFee(SorobanResources const& resources)
-{
-    auto const& cfg = getNetworkCfg();
-    return resources.footprint.readWrite.size() * cfg.feeWriteLedgerEntry();
-}
-
-int64_t
-ContractInvocationTest::getReadBytesFee(SorobanResources const& resources)
-{
-    auto const& cfg = getNetworkCfg();
-    return computeFeePerIncrement(resources.readBytes, cfg.feeRead1KB(),
-                                  DATA_SIZE_1KB_INCREMENT);
-}
-
-int64_t
-ContractInvocationTest::getWriteBytesFee(SorobanResources const& resources)
-{
-    auto const& cfg = getNetworkCfg();
-    return computeFeePerIncrement(resources.writeBytes, cfg.feeWrite1KB(),
-                                  DATA_SIZE_1KB_INCREMENT);
+    return getApp()
+        .getLedgerManager()
+        .getLastClosedLedgerHeader()
+        .header.ledgerVersion;
 }
 
 uint32_t
-ContractInvocationTest::computeResourceFee(SorobanResources const& resources,
-                                           SCSymbol const& functionName,
-                                           std::vector<SCVal> const& args)
+SorobanTest::getLedgerSeq() const
+{
+    return getApp().getLedgerManager().getLastClosedLedgerNum();
+}
+
+TransactionFrameBasePtr
+SorobanTest::createExtendOpTx(SorobanResources const& resources,
+                              uint32_t extendTo, uint32_t fee,
+                              uint32_t refundableFee, TestAccount* source)
 {
     Operation op;
-    op.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
-    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-    ihf.invokeContract().contractAddress = mContractID;
-    ihf.invokeContract().functionName = functionName;
-    ihf.invokeContract().args.assign(args.begin(), args.end());
-
-    auto dummyTx = sorobanTransactionFrameFromOps(
-        mApp->getNetworkID(), mDummyAccount, {op}, {}, resources, 1000, 123);
-    auto txSize = xdr::xdr_size(dummyTx->getEnvelope());
-    return sorobanResourceFee(*mApp, resources, txSize, 0);
+    op.body.type(EXTEND_FOOTPRINT_TTL);
+    op.body.extendFootprintTTLOp().extendTo = extendTo;
+    auto& acc = source ? *source : getRoot();
+    return sorobanTransactionFrameFromOps(getApp().getNetworkID(), acc, {op},
+                                          {}, resources, fee, refundableFee);
 }
 
-WasmContractInvocationTest::WasmContractInvocationTest(
-    RustBuf const& wasm, bool deployContract, Config cfg, bool useTestLimits,
-    std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
-    : ContractInvocationTest(cfg, useTestLimits, cfgModifyFn), mWasm(wasm)
+TransactionFrameBasePtr
+SorobanTest::createRestoreTx(SorobanResources const& resources, uint32_t fee,
+                             uint32_t refundableFee, TestAccount* source)
 {
-    if (deployContract)
+    Operation op;
+    op.body.type(RESTORE_FOOTPRINT);
+    auto& acc = source ? *source : getRoot();
+    return sorobanTransactionFrameFromOps(getApp().getNetworkID(), acc, {op},
+                                          {}, resources, fee, refundableFee);
+}
+
+bool
+SorobanTest::isTxValid(TransactionFrameBasePtr tx)
+{
+    LedgerTxn ltx(getApp().getLedgerTxnRoot());
+    auto ret = tx->checkValid(getApp(), ltx, 0, 0, 0);
+    return ret;
+}
+
+bool
+SorobanTest::invokeTx(TransactionFrameBasePtr tx, TransactionMetaFrame* txMeta)
+{
+    LedgerTxn ltx(getApp().getLedgerTxnRoot());
+    TransactionMetaFrame dummyMeta(getLedgerVersion());
+    if (txMeta == nullptr)
     {
-        // Deploy with default resources
-        SorobanResources uploadResources{};
-        uploadResources.instructions = 200'000 + (mWasm.data.size() * 6000);
-        uploadResources.readBytes = 1000;
-        uploadResources.writeBytes = 5000;
-
-        SorobanResources createResources{};
-        createResources.instructions = 600'000;
-        createResources.readBytes = 5000;
-        createResources.writeBytes = 5000;
-
-        deployWithResources(uploadResources, createResources);
+        txMeta = &dummyMeta;
     }
+    REQUIRE(tx->checkValid(getApp(), ltx, 0, 0, 0));
+    bool res = tx->apply(getApp(), ltx, *txMeta);
+    ltx.commit();
+    return res;
+}
+
+uint32_t
+SorobanTest::getTTL(LedgerKey const& k)
+{
+    LedgerTxn ltx(getApp().getLedgerTxnRoot());
+    auto ltxe = ltx.loadWithoutRecord(k);
+    REQUIRE(ltxe);
+
+    auto ttlKey = getTTLKey(k);
+    auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
+    REQUIRE(ttlLtxe);
+    return ttlLtxe.current().data.ttl().liveUntilLedgerSeq;
+}
+
+bool
+SorobanTest::isEntryLive(LedgerKey const& k, uint32_t ledgerSeq)
+{
+    auto ttlKey = getTTLKey(k);
+    LedgerTxn ltx(getApp().getLedgerTxnRoot());
+    auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
+    REQUIRE(ttlLtxe);
+    return isLive(ttlLtxe.current(), ledgerSeq);
 }
 
 void
-WasmContractInvocationTest::deployWithResources(
-    SorobanResources const& uploadResources,
-    SorobanResources const& createResources)
+SorobanTest::invokeRestoreOp(xdr::xvector<LedgerKey> const& readWrite,
+                             int64_t expectedRefundableFeeCharged)
 {
-    if (!mContractKeys.empty())
+    SorobanResources resources;
+    resources.footprint.readWrite = readWrite;
+    resources.instructions = 0;
+    resources.readBytes = 10'000;
+    resources.writeBytes = 10'000;
+
+    auto resourceFee = 300'000 + 40'000 * readWrite.size();
+    auto tx = createRestoreTx(resources, 1'000, resourceFee);
+    invokeArchivalOp(tx, expectedRefundableFeeCharged);
+}
+
+void
+SorobanTest::invokeExtendOp(xdr::xvector<LedgerKey> const& readOnly,
+                            uint32_t extendTo,
+                            std::optional<int64_t> expectedRefundableFeeCharged)
+{
+    if (!expectedRefundableFeeCharged)
     {
-        throw "Wasm already uploaded";
+        expectedRefundableFeeCharged =
+            getRentFeeForExtension(readOnly, extendTo);
     }
 
-    deployContractWithSourceAccountWithResources(uploadResources,
-                                                 createResources);
+    SorobanResources extendResources;
+    extendResources.footprint.readOnly = readOnly;
+    extendResources.readBytes = 10'000;
+
+    auto resourceFee = DEFAULT_TEST_RESOURCE_FEE * readOnly.size();
+    auto tx = createExtendOpTx(extendResources, extendTo, 1'000, resourceFee);
+    invokeArchivalOp(tx, *expectedRefundableFeeCharged);
 }
 
-TransactionFrameBasePtr
-WasmContractInvocationTest::getCreateTx(TestAccount& acc)
+AssetContractTestClient::AssetContractTestClient(SorobanTest& test,
+                                                 Asset const& asset)
+    : mContract(test.deployAssetContract(asset))
+    , mAsset(asset)
+    , mApp(mContract.getTest().getApp())
 {
-    if (mContractKeys.empty())
-    {
-        throw "Must deploy test contract before calling getCreateTx";
-    }
-
-    SorobanResources createResources{};
-    createResources.instructions = 200'000;
-    createResources.readBytes = 5000;
-    createResources.writeBytes = 5000;
-
-    SCVal scContractSourceRefKey(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
-    auto [createOp, contractID] = createSorobanCreateOp(
-        *mApp, createResources, mContractKeys[1], acc, scContractSourceRefKey);
-    auto createResourceFee =
-        sorobanResourceFee(*mApp, createResources, 1000, 40) + 40'000;
-
-    return sorobanTransactionFrameFromOps(mApp->getNetworkID(), acc, {createOp},
-                                          {}, createResources, 1000,
-                                          createResourceFee);
-}
-
-TransactionFrameBasePtr
-WasmContractInvocationTest::createUploadWasmTx(TestAccount& source,
-                                               uint32_t resourceFee)
-{
-    SorobanResources uploadResources{};
-    uploadResources.instructions = 200'000 + (mWasm.data.size() * 6000);
-    uploadResources.readBytes = 1000;
-    uploadResources.writeBytes = 5000;
-
-    // Upload contract code
-    Operation uploadOp;
-    uploadOp.body.type(INVOKE_HOST_FUNCTION);
-    auto& uploadHF = uploadOp.body.invokeHostFunctionOp().hostFunction;
-    uploadHF.type(HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM);
-    uploadHF.wasm().assign(mWasm.data.begin(), mWasm.data.end());
-
-    LedgerKey contractCodeLedgerKey;
-    contractCodeLedgerKey.type(CONTRACT_CODE);
-    contractCodeLedgerKey.contractCode().hash = sha256(uploadHF.wasm());
-    uploadResources.footprint.readWrite = {contractCodeLedgerKey};
-
-    return sorobanTransactionFrameFromOps(mApp->getNetworkID(), source,
-                                          {uploadOp}, {}, uploadResources, 100,
-                                          resourceFee);
-}
-
-AssetContractInvocationTest::AssetContractInvocationTest(
-    Asset const& asset, Config cfg, bool useTestLimits,
-    std::function<void(SorobanNetworkConfig&)> cfgModifyFn)
-    : ContractInvocationTest(cfg, useTestLimits, cfgModifyFn), mAsset(asset)
-{
-    HashIDPreimage preImage;
-    preImage.type(ENVELOPE_TYPE_CONTRACT_ID);
-    preImage.contractID().contractIDPreimage.type(
-        CONTRACT_ID_PREIMAGE_FROM_ASSET);
-    preImage.contractID().contractIDPreimage.fromAsset() = mAsset;
-    preImage.contractID().networkID = mApp->getNetworkID();
-    auto contractID = makeContractAddress(xdrSha256(preImage));
-
-    Operation createOp;
-    createOp.body.type(INVOKE_HOST_FUNCTION);
-    auto& createHF = createOp.body.invokeHostFunctionOp();
-    createHF.hostFunction.type(HOST_FUNCTION_TYPE_CREATE_CONTRACT);
-    auto& createContractArgs = createHF.hostFunction.createContract();
-
-    ContractExecutable exec;
-    exec.type(CONTRACT_EXECUTABLE_STELLAR_ASSET);
-    createContractArgs.contractIDPreimage.type(CONTRACT_ID_PREIMAGE_FROM_ASSET);
-    createContractArgs.contractIDPreimage.fromAsset() = mAsset;
-    createContractArgs.executable = exec;
-
-    SorobanResources createResources;
-    createResources.instructions = 400'000;
-    createResources.readBytes = 1000;
-    createResources.writeBytes = 1000;
-
-    LedgerKey contractExecutableKey(CONTRACT_DATA);
-    contractExecutableKey.contractData().contract = contractID;
-    contractExecutableKey.contractData().key =
-        SCVal(SCValType::SCV_LEDGER_KEY_CONTRACT_INSTANCE);
-    contractExecutableKey.contractData().durability =
-        ContractDataDurability::PERSISTENT;
-
-    createResources.footprint.readWrite = {contractExecutableKey};
-
-    submitTx(*mApp, createOp, createResources, 100, DEFAULT_TEST_RESOURCE_FEE);
-
-    mContractKeys.emplace_back(contractExecutableKey);
-    mContractID = contractID;
 }
 
 LedgerKey
-AssetContractInvocationTest::makeBalanceKey(AccountID const& acc)
+AssetContractTestClient::makeBalanceKey(AccountID const& acc)
 {
     LedgerKey balanceKey;
     if (mAsset.type() == ASSET_TYPE_NATIVE)
@@ -724,13 +929,13 @@ AssetContractInvocationTest::makeBalanceKey(AccountID const& acc)
 }
 
 LedgerKey
-AssetContractInvocationTest::makeContractDataBalanceKey(SCAddress const& addr)
+AssetContractTestClient::makeContractDataBalanceKey(SCAddress const& addr)
 {
     SCVal val(SCV_ADDRESS);
     val.address() = addr;
 
     LedgerKey balanceKey(CONTRACT_DATA);
-    balanceKey.contractData().contract = mContractID;
+    balanceKey.contractData().contract = mContract.getAddress();
 
     SCVec balance = {makeSymbolSCVal("Balance"), val};
     SCVal balanceVal(SCValType::SCV_VEC);
@@ -742,7 +947,7 @@ AssetContractInvocationTest::makeContractDataBalanceKey(SCAddress const& addr)
 }
 
 LedgerKey
-AssetContractInvocationTest::makeBalanceKey(SCAddress const& addr)
+AssetContractTestClient::makeBalanceKey(SCAddress const& addr)
 {
     if (addr.type() == SC_ADDRESS_TYPE_ACCOUNT)
     {
@@ -754,21 +959,37 @@ AssetContractInvocationTest::makeBalanceKey(SCAddress const& addr)
     }
 }
 
+LedgerKey
+AssetContractTestClient::makeIssuerKey(Asset const& mAsset)
+{
+    LedgerKey issuerLedgerKey(ACCOUNT);
+    issuerLedgerKey.account().accountID = getIssuer(mAsset);
+    return issuerLedgerKey;
+}
+
 int64_t
-AssetContractInvocationTest::getBalance(SCAddress const& addr)
+AssetContractTestClient::getBalance(SCAddress const& addr)
 {
     SCVal val(SCV_ADDRESS);
     val.address() = addr;
 
     return addr.type() == SC_ADDRESS_TYPE_ACCOUNT
-               ? txtest::getBalance(*mApp, addr.accountId(), mAsset)
-               : getContractBalance(*mApp, mContractID, val);
+               ? txtest::getBalance(mApp, addr.accountId(), mAsset)
+               : getContractBalance(mApp, mContract.getAddress(), val);
 }
 
-void
-AssetContractInvocationTest::transfer(TestAccount& fromAcc,
-                                      SCAddress const& toAddr, int64_t amount,
-                                      bool expectSuccess)
+SorobanInvocationSpec
+AssetContractTestClient::defaultSpec() const
+{
+    return SorobanInvocationSpec()
+        .setInstructions(2'000'000)
+        .setReadBytes(2000)
+        .setWriteBytes(2000);
+}
+
+bool
+AssetContractTestClient::transfer(TestAccount& fromAcc, SCAddress const& toAddr,
+                                  int64_t amount)
 {
     SCVal toVal(SCV_ADDRESS);
     toVal.address() = toAddr;
@@ -779,32 +1000,13 @@ AssetContractInvocationTest::transfer(TestAccount& fromAcc,
     LedgerKey fromBalanceKey = makeBalanceKey(fromAcc.getPublicKey());
     LedgerKey toBalanceKey = makeBalanceKey(toAddr);
 
-    auto fn = makeSymbol("transfer");
-    Operation transfer;
-    transfer.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf = transfer.body.invokeHostFunctionOp().hostFunction;
-    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-    ihf.invokeContract().contractAddress = mContractID;
-    ihf.invokeContract().functionName = fn;
-    ihf.invokeContract().args = {fromVal, toVal, makeI128(amount)};
-
-    transfer.body.invokeHostFunctionOp().auth = {
-        getInvocationAuth(ihf.invokeContract())};
-
-    SorobanResources resources;
-    resources.instructions = 2'000'000;
-    resources.readBytes = 2000;
-    resources.writeBytes = 1072;
-
-    resources.footprint.readOnly = mContractKeys;
+    auto spec = defaultSpec();
 
     bool fromIsIssuer = false;
     bool toIsIssuer = false;
     if (mAsset.type() != ASSET_TYPE_NATIVE)
     {
-        LedgerKey issuerLedgerKey(ACCOUNT);
-        issuerLedgerKey.account().accountID = getIssuer(mAsset);
-        resources.footprint.readOnly.emplace_back(issuerLedgerKey);
+        spec = spec.extendReadOnlyFootprint({makeIssuerKey(mAsset)});
 
         if (getIssuer(mAsset) == fromAcc.getPublicKey())
         {
@@ -812,7 +1014,7 @@ AssetContractInvocationTest::transfer(TestAccount& fromAcc,
         }
         else
         {
-            resources.footprint.readWrite.emplace_back(fromBalanceKey);
+            spec = spec.extendReadWriteFootprint({fromBalanceKey});
         }
 
         if (toAddr.type() == SC_ADDRESS_TYPE_ACCOUNT &&
@@ -822,33 +1024,30 @@ AssetContractInvocationTest::transfer(TestAccount& fromAcc,
         }
         else
         {
-            resources.footprint.readWrite.emplace_back(toBalanceKey);
+            spec = spec.extendReadWriteFootprint({toBalanceKey});
         }
     }
     else
     {
-        resources.footprint.readWrite = {fromBalanceKey, toBalanceKey};
+        spec = spec.setReadWriteFootprint({fromBalanceKey, toBalanceKey});
     }
 
     auto preTransferFromBalance = mAsset.type() == ASSET_TYPE_NATIVE
                                       ? fromAcc.getBalance()
                                       : fromAcc.getTrustlineBalance(mAsset);
     auto preTransferToBalance = getBalance(toAddr);
+    bool success = mContract
+                       .prepareInvocation(
+                           "transfer", {fromVal, toVal, makeI128(amount)}, spec)
+                       .withAuthorizedTopCall()
+                       .invoke(&fromAcc);
+    auto postTransferFromBalance = mAsset.type() == ASSET_TYPE_NATIVE
+                                       ? fromAcc.getBalance()
+                                       : fromAcc.getTrustlineBalance(mAsset);
 
-    // submit operation
-    auto tx = sorobanTransactionFrameFromOps(mApp->getNetworkID(), fromAcc,
-                                             {transfer}, {}, resources, 100,
-                                             DEFAULT_TEST_RESOURCE_FEE);
-    invokeTx(tx, expectSuccess, false);
-    if (expectSuccess)
+    auto postTransferToBalance = getBalance(toAddr);
+    if (success)
     {
-        auto postTransferFromBalance =
-            mAsset.type() == ASSET_TYPE_NATIVE
-                ? fromAcc.getBalance()
-                : fromAcc.getTrustlineBalance(mAsset);
-
-        auto postTransferToBalance = getBalance(toAddr);
-
         REQUIRE((fromIsIssuer ||
                  postTransferFromBalance == preTransferFromBalance - amount));
         REQUIRE((toIsIssuer ||
@@ -857,74 +1056,63 @@ AssetContractInvocationTest::transfer(TestAccount& fromAcc,
         {
             // From is an account so it should never have a contract data
             // balance
-            LedgerTxn ltx(mApp->getLedgerTxnRoot());
+            LedgerTxn ltx(mApp.getLedgerTxnRoot());
             REQUIRE(!ltx.load(makeContractDataBalanceKey(fromVal.address())));
         }
 
         if (toIsIssuer)
         {
             // make sure we didn't create an entry for the issuer
-            LedgerTxn ltx(mApp->getLedgerTxnRoot());
+            LedgerTxn ltx(mApp.getLedgerTxnRoot());
             REQUIRE(!ltx.load(makeContractDataBalanceKey(toAddr)));
         }
     }
+    else
+    {
+        REQUIRE(postTransferFromBalance == preTransferFromBalance);
+        REQUIRE(postTransferToBalance == preTransferToBalance);
+    }
+    return success;
 }
 
-void
-AssetContractInvocationTest::mint(TestAccount& admin, SCAddress const& toAddr,
-                                  int64_t amount, bool expectSuccess)
+bool
+AssetContractTestClient::mint(TestAccount& admin, SCAddress const& toAddr,
+                              int64_t amount)
 {
     SCVal toVal(SCV_ADDRESS);
     toVal.address() = toAddr;
 
     LedgerKey toBalanceKey = makeBalanceKey(toAddr);
 
-    auto fn = makeSymbol("mint");
-    Operation mint;
-    mint.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf = mint.body.invokeHostFunctionOp().hostFunction;
-    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-    ihf.invokeContract().contractAddress = mContractID;
-    ihf.invokeContract().functionName = fn;
-    ihf.invokeContract().args = {toVal, makeI128(amount)};
-
-    mint.body.invokeHostFunctionOp().auth = {
-        getInvocationAuth(ihf.invokeContract())};
-
-    SorobanResources resources;
-    resources.instructions = 2'000'000;
-    resources.readBytes = 2000;
-    resources.writeBytes = 1072;
-
-    resources.footprint.readOnly = mContractKeys;
+    auto spec = defaultSpec().setReadWriteFootprint({toBalanceKey});
 
     if (mAsset.type() != ASSET_TYPE_NATIVE)
     {
         LedgerKey issuerLedgerKey(ACCOUNT);
         issuerLedgerKey.account().accountID = getIssuer(mAsset);
-        resources.footprint.readOnly.emplace_back(issuerLedgerKey);
+        spec = spec.extendReadOnlyFootprint({issuerLedgerKey});
     }
-
-    resources.footprint.readWrite = {toBalanceKey};
 
     auto preMintBalance = getBalance(toAddr);
 
-    // submit operation
-    auto tx = sorobanTransactionFrameFromOps(mApp->getNetworkID(), admin,
-                                             {mint}, {}, resources, 100,
-                                             DEFAULT_TEST_RESOURCE_FEE);
-
-    invokeTx(tx, expectSuccess, false);
-    if (expectSuccess)
+    bool success =
+        mContract.prepareInvocation("mint", {toVal, makeI128(amount)}, spec)
+            .withAuthorizedTopCall()
+            .invoke(&admin);
+    auto postMintBalance = getBalance(toAddr);
+    if (success)
     {
-        auto postMintBalance = getBalance(toAddr);
         REQUIRE(postMintBalance - amount == preMintBalance);
     }
+    else
+    {
+        REQUIRE(postMintBalance == preMintBalance);
+    }
+    return success;
 }
 
-void
-AssetContractInvocationTest::burn(TestAccount& from, int64_t amount,
-                                  bool expectSuccess)
+bool
+AssetContractTestClient::burn(TestAccount& from, int64_t amount)
 {
     auto fromAddr = makeAccountAddress(from.getPublicKey());
 
@@ -944,558 +1132,254 @@ AssetContractInvocationTest::burn(TestAccount& from, int64_t amount,
         fromBalanceKey.trustLine().asset = assetToTrustLineAsset(mAsset);
     }
 
-    auto fn = makeSymbol("burn");
-    Operation burn;
-    burn.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf = burn.body.invokeHostFunctionOp().hostFunction;
-    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-    ihf.invokeContract().contractAddress = mContractID;
-    ihf.invokeContract().functionName = fn;
-    ihf.invokeContract().args = {fromVal, makeI128(amount)};
-
-    burn.body.invokeHostFunctionOp().auth = {
-        getInvocationAuth(ihf.invokeContract())};
-
-    SorobanResources resources;
-    resources.instructions = 2'000'000;
-    resources.readBytes = 2000;
-    resources.writeBytes = 1072;
-
-    resources.footprint.readOnly = mContractKeys;
+    auto spec = defaultSpec();
 
     bool isIssuer = getIssuer(mAsset) == from.getPublicKey();
     if (!isIssuer)
     {
-        resources.footprint.readWrite = {fromBalanceKey};
+        spec = spec.extendReadWriteFootprint({fromBalanceKey});
     }
 
     auto preBurnBalance = getBalance(fromAddr);
 
-    // submit operation
-    auto tx = sorobanTransactionFrameFromOps(mApp->getNetworkID(), from, {burn},
-                                             {}, resources, 100,
-                                             DEFAULT_TEST_RESOURCE_FEE);
-
-    invokeTx(tx, expectSuccess, false);
-
-    if (expectSuccess)
+    bool success =
+        mContract.prepareInvocation("burn", {fromVal, makeI128(amount)}, spec)
+            .withAuthorizedTopCall()
+            .invoke(&from);
+    auto postBurnBalance = getBalance(fromAddr);
+    if (success)
     {
-        auto postBurnBalance = getBalance(fromAddr);
         REQUIRE(preBurnBalance - amount == postBurnBalance);
     }
+    else
+    {
+        REQUIRE(preBurnBalance == postBurnBalance);
+    }
+    return success;
 }
 
-void
-AssetContractInvocationTest::clawback(TestAccount& admin,
-                                      SCAddress const& fromAddr, int64_t amount,
-                                      bool expectSuccess)
+bool
+AssetContractTestClient::clawback(TestAccount& admin, SCAddress const& fromAddr,
+                                  int64_t amount)
 {
     SCVal fromVal(SCV_ADDRESS);
     fromVal.address() = fromAddr;
 
     LedgerKey fromBalanceKey = makeBalanceKey(fromAddr);
-
-    auto fn = makeSymbol("clawback");
-    Operation clawback;
-    clawback.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf = clawback.body.invokeHostFunctionOp().hostFunction;
-    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-    ihf.invokeContract().contractAddress = mContractID;
-    ihf.invokeContract().functionName = fn;
-    ihf.invokeContract().args = {fromVal, makeI128(amount)};
-
-    clawback.body.invokeHostFunctionOp().auth = {
-        getInvocationAuth(ihf.invokeContract())};
-
-    SorobanResources resources;
-    resources.instructions = 2'000'000;
-    resources.readBytes = 2000;
-    resources.writeBytes = 1072;
-
-    resources.footprint.readOnly = mContractKeys;
+    auto spec = defaultSpec().setReadWriteFootprint({fromBalanceKey});
 
     if (mAsset.type() != ASSET_TYPE_NATIVE)
     {
-        LedgerKey issuerLedgerKey(ACCOUNT);
-        issuerLedgerKey.account().accountID = getIssuer(mAsset);
-        resources.footprint.readOnly.emplace_back(issuerLedgerKey);
+        spec = spec.extendReadOnlyFootprint({makeIssuerKey(mAsset)});
     }
 
-    resources.footprint.readWrite = {fromBalanceKey};
     auto preClawbackBalance = getBalance(fromAddr);
 
-    // submit operation
-    auto tx = sorobanTransactionFrameFromOps(mApp->getNetworkID(), admin,
-                                             {clawback}, {}, resources, 100,
-                                             DEFAULT_TEST_RESOURCE_FEE);
-
-    invokeTx(tx, expectSuccess, false);
-    if (expectSuccess)
+    bool success =
+        mContract
+            .prepareInvocation("clawback", {fromVal, makeI128(amount)}, spec)
+            .withAuthorizedTopCall()
+            .invoke(&admin);
+    auto postClawbackBalance = getBalance(fromAddr);
+    if (success)
     {
-        auto postClawbackBalance = getBalance(fromAddr);
         REQUIRE(preClawbackBalance - amount == postClawbackBalance);
     }
+    else
+    {
+        REQUIRE(preClawbackBalance == postClawbackBalance);
+    }
+    return success;
 }
 
-TransactionFrameBasePtr
-ContractInvocationTest::createInvokeTx(SorobanResources const& resources,
-                                       SCSymbol const& functionName,
-                                       std::vector<SCVal> const& args,
-                                       uint32_t inclusionFee,
-                                       uint32_t resourceFee,
-                                       std::shared_ptr<TestAccount> source)
+ContractStorageTestClient::ContractStorageTestClient(SorobanTest& test)
+    : mContract(
+          test.deployWasmContract(rust_bridge::get_test_wasm_contract_data()))
 {
-    Operation op;
-    op.body.type(INVOKE_HOST_FUNCTION);
-    auto& ihf = op.body.invokeHostFunctionOp().hostFunction;
-    ihf.type(HOST_FUNCTION_TYPE_INVOKE_CONTRACT);
-    ihf.invokeContract().contractAddress = mContractID;
-    ihf.invokeContract().functionName = functionName;
-    ihf.invokeContract().args.assign(args.begin(), args.end());
-    auto& acc = source ? *source : getRoot();
-
-    return sorobanTransactionFrameFromOps(mApp->getNetworkID(), acc, {op}, {},
-                                          resources, inclusionFee, resourceFee);
 }
 
-TransactionFrameBasePtr
-ContractInvocationTest::createExtendOpTx(SorobanResources const& resources,
-                                         uint32_t extendTo, uint32_t fee,
-                                         uint32_t refundableFee,
-                                         std::shared_ptr<TestAccount> source)
+TestContract&
+ContractStorageTestClient::getContract() const
 {
-    Operation op;
-    op.body.type(EXTEND_FOOTPRINT_TTL);
-    op.body.extendFootprintTTLOp().extendTo = extendTo;
-    auto& acc = source ? *source : getRoot();
-    return sorobanTransactionFrameFromOps(mApp->getNetworkID(), acc, {op}, {},
-                                          resources, fee, refundableFee);
+    return mContract;
 }
 
-TransactionFrameBasePtr
-ContractInvocationTest::createRestoreTx(SorobanResources const& resources,
-                                        uint32_t fee, uint32_t refundableFee,
-                                        std::shared_ptr<TestAccount> source)
+SorobanInvocationSpec
+ContractStorageTestClient::defaultSpecWithoutFootprint() const
 {
-    Operation op;
-    op.body.type(RESTORE_FOOTPRINT);
-    auto& acc = source ? *source : getRoot();
-    return sorobanTransactionFrameFromOps(mApp->getNetworkID(), acc, {op}, {},
-                                          resources, fee, refundableFee);
+    return SorobanInvocationSpec()
+        .setInstructions(4'000'000)
+        .setReadBytes(10'000)
+        .setNonRefundableResourceFee(0)
+        .setRefundableResourceFee(40'000);
 }
 
-void
-ContractInvocationTest::txCheckValid(TransactionFrameBasePtr tx)
+SorobanInvocationSpec
+ContractStorageTestClient::readKeySpec(std::string const& key,
+                                       ContractDataDurability durability) const
 {
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    REQUIRE(tx->checkValid(*mApp, ltx, 0, 0, 0));
+    return defaultSpecWithoutFootprint().setReadOnlyFootprint(
+        {mContract.getDataKey(makeSymbolSCVal(key), durability)});
+}
+
+SorobanInvocationSpec
+ContractStorageTestClient::writeKeySpec(std::string const& key,
+                                        ContractDataDurability durability) const
+{
+    return defaultSpecWithoutFootprint()
+        .setReadWriteFootprint(
+            {mContract.getDataKey(makeSymbolSCVal(key), durability)})
+        .setWriteBytes(1000);
+}
+
+uint32_t
+ContractStorageTestClient::getTTL(std::string const& key,
+                                  ContractDataDurability durability)
+{
+    return mContract.getTest().getTTL(
+        mContract.getDataKey(makeSymbolSCVal(key), durability));
 }
 
 bool
-ContractInvocationTest::isTxValid(TransactionFrameBasePtr tx)
+ContractStorageTestClient::isEntryLive(std::string const& key,
+                                       ContractDataDurability durability,
+                                       uint32_t ledgerSeq)
 {
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    auto ret = tx->checkValid(*mApp, ltx, 0, 0, 0);
-    return ret;
+    return mContract.getTest().isEntryLive(
+        mContract.getDataKey(makeSymbolSCVal(key), durability), ledgerSeq);
 }
 
-std::shared_ptr<TransactionMetaFrame>
-ContractInvocationTest::invokeTx(TransactionFrameBasePtr tx, bool expectSuccess,
-                                 bool processPostApply)
+InvokeHostFunctionResultCode
+ContractStorageTestClient::put(std::string const& key,
+                               ContractDataDurability durability, uint64_t val,
+                               std::optional<SorobanInvocationSpec> spec)
 {
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    auto txm = std::make_shared<TransactionMetaFrame>(
-        ltx.loadHeader().current().ledgerVersion);
-
-    REQUIRE(tx->checkValid(*mApp, ltx, 0, 0, 0));
-    if (expectSuccess)
+    if (!spec)
     {
-        REQUIRE(tx->apply(*mApp, ltx, *txm));
-    }
-    else
-    {
-        REQUIRE(!tx->apply(*mApp, ltx, *txm));
+        spec = writeKeySpec(key, durability);
     }
 
-    if (processPostApply)
-    {
-        tx->processPostApply(*mApp, ltx, *txm);
-    }
-
-    ltx.commit();
-    return txm;
-}
-
-void
-ContractInvocationTest::checkTTL(LedgerKey const& k,
-                                 uint32_t expectedLiveUntilLedger)
-{
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    auto ltxe = ltx.loadWithoutRecord(k);
-    REQUIRE(ltxe);
-
-    auto ttlKey = getTTLKey(k);
-    auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
-    REQUIRE(ttlLtxe);
-    REQUIRE(ttlLtxe.current().data.ttl().liveUntilLedgerSeq ==
-            expectedLiveUntilLedger);
-}
-
-bool
-ContractInvocationTest::isEntryLive(LedgerKey const& k, uint32_t ledgerSeq)
-{
-    auto ttlKey = getTTLKey(k);
-    LedgerTxn ltx(mApp->getLedgerTxnRoot());
-    auto ttlLtxe = ltx.loadWithoutRecord(ttlKey);
-    REQUIRE(ttlLtxe);
-    return isLive(ttlLtxe.current(), ledgerSeq);
-}
-
-void
-ContractInvocationTest::restoreOp(xdr::xvector<LedgerKey> const& readWrite,
-                                  int64_t expectedRefundableFeeCharged,
-                                  bool expectSuccess)
-{
-    SorobanResources resources;
-    resources.footprint.readWrite = readWrite;
-    resources.instructions = 0;
-    resources.readBytes = 10'000;
-    resources.writeBytes = 10'000;
-
-    auto resourceFee = 300'000 + 40'000 * readWrite.size();
-    auto tx = createRestoreTx(resources, 1'000, resourceFee);
-    invokeArchivalOp(tx, expectedRefundableFeeCharged, expectSuccess);
-}
-
-void
-ContractInvocationTest::extendOp(
-    xdr::xvector<LedgerKey> const& readOnly, uint32_t extendTo,
-    bool expectSuccess,
-    std::optional<uint32_t> expectedRefundableChargeOverride)
-{
-    int64_t expectedRefundableFeeCharged = 0;
-    if (expectedRefundableChargeOverride)
-    {
-        expectedRefundableFeeCharged = *expectedRefundableChargeOverride;
-    }
-    else
-    {
-        expectedRefundableFeeCharged +=
-            getRentFeeForExtension(readOnly, extendTo);
-    }
-
-    SorobanResources extendResources;
-    extendResources.footprint.readOnly = readOnly;
-    extendResources.instructions = 0;
-    extendResources.readBytes = 10'000;
-    extendResources.writeBytes = 0;
-
-    auto resourceFee = DEFAULT_TEST_RESOURCE_FEE * readOnly.size();
-    auto tx = createExtendOpTx(extendResources, extendTo, 1'000, resourceFee);
-    invokeArchivalOp(tx, expectedRefundableFeeCharged, expectSuccess);
-}
-
-void
-ContractStorageInvocationTest::put(std::string const& key,
-                                   ContractDataDurability type, uint64_t val,
-                                   InvokeHostFunctionResultCode result)
-{
-    auto keySymbol = makeSymbolSCVal(key);
-    auto storageLK = contractDataKey(mContractID, keySymbol, type);
-    putWithFootprint(key, type, val, mContractKeys, {storageLK}, result);
-}
-
-void
-ContractStorageInvocationTest::putWithFootprint(
-    std::string const& key, ContractDataDurability type, uint64_t val,
-    xdr::xvector<LedgerKey> const& readOnly,
-    xdr::xvector<LedgerKey> const& readWrite,
-    InvokeHostFunctionResultCode result, uint32_t writeBytes,
-    uint32_t refundableFee)
-{
-    std::string funcStr = type == ContractDataDurability::TEMPORARY
+    std::string funcStr = durability == ContractDataDurability::TEMPORARY
                               ? "put_temporary"
                               : "put_persistent";
+    auto invocation = mContract.prepareInvocation(
+        funcStr, {makeSymbolSCVal(key), makeU64SCVal(val)}, *spec);
+    invocation.withExactNonRefundableResourceFee().invoke();
+    return invocation.getResultCode();
+}
 
-    auto keySymbol = makeSymbolSCVal(key);
-    auto valU64 = makeU64SCVal(val);
-    auto storageLK = contractDataKey(mContractID, keySymbol, type);
-
-    SorobanResources resources;
-    resources.footprint.readOnly = readOnly;
-    resources.footprint.readWrite = readWrite;
-    resources.instructions = 4'000'000;
-    resources.readBytes = 10'000;
-    resources.writeBytes = writeBytes;
-
-    auto resourceFee =
-        computeResourceFee(resources, makeSymbol(funcStr), {keySymbol, valU64});
-    resourceFee += refundableFee;
-    auto tx = createInvokeTx(resources, makeSymbol(funcStr),
-                             {keySymbol, valU64}, 1'000, resourceFee);
-
-    bool isSuccess = result == INVOKE_HOST_FUNCTION_SUCCESS;
-    invokeTx(tx, isSuccess, false);
-
-    if (!isSuccess)
+InvokeHostFunctionResultCode
+ContractStorageTestClient::get(std::string const& key,
+                               ContractDataDurability durability,
+                               std::optional<uint64_t> expectValue,
+                               std::optional<SorobanInvocationSpec> spec)
+{
+    if (!spec)
     {
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .invokeHostFunctionResult()
-                    .code() == result);
+        spec = readKeySpec(key, durability);
     }
-}
 
-uint64_t
-ContractStorageInvocationTest::get(std::string const& key,
-                                   ContractDataDurability type,
-                                   InvokeHostFunctionResultCode result)
-{
-    auto lk = contractDataKey(mContractID, makeSymbolSCVal(key), type);
-    auto readOnly = mContractKeys;
-    readOnly.emplace_back(lk);
-    return getWithFootprint(key, type, readOnly, {}, result);
-}
-
-uint64_t
-ContractStorageInvocationTest::getWithFootprint(
-    std::string const& key, ContractDataDurability type,
-    xdr::xvector<LedgerKey> const& readOnly,
-    xdr::xvector<LedgerKey> const& readWrite,
-    InvokeHostFunctionResultCode result, uint32_t readBytes)
-{
-    std::string funcStr = type == ContractDataDurability::TEMPORARY
+    std::string funcStr = durability == ContractDataDurability::TEMPORARY
                               ? "get_temporary"
                               : "get_persistent";
-
-    auto keySymbol = makeSymbolSCVal(key);
-    auto storageLK = contractDataKey(mContractID, keySymbol, type);
-
-    SorobanResources resources;
-    resources.footprint.readOnly = readOnly;
-    resources.footprint.readWrite = readWrite;
-    resources.instructions = 4'000'000;
-    resources.readBytes = readBytes;
-    resources.writeBytes = 0;
-
-    auto resourceFee =
-        computeResourceFee(resources, makeSymbol(funcStr), {keySymbol});
-    // Default refundable fee
-    resourceFee += 40'000;
-    auto tx = createInvokeTx(resources, makeSymbol(funcStr), {keySymbol}, 1'000,
-                             resourceFee);
-    bool isSuccess = result == INVOKE_HOST_FUNCTION_SUCCESS;
-    auto txm = invokeTx(tx, isSuccess, false);
-    if (isSuccess)
+    auto invocation =
+        mContract.prepareInvocation(funcStr, {makeSymbolSCVal(key)}, *spec);
+    bool isSuccess = invocation.withExactNonRefundableResourceFee().invoke();
+    if (isSuccess && expectValue)
     {
-        return txm->getXDR().v3().sorobanMeta->returnValue.u64();
+        REQUIRE(*expectValue == invocation.getReturnValue().u64());
     }
-    else
-    {
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .invokeHostFunctionResult()
-                    .code() == result);
-    }
-
-    return 0;
+    return invocation.getResultCode();
 }
 
-bool
-ContractStorageInvocationTest::has(std::string const& key,
-                                   ContractDataDurability type,
-                                   InvokeHostFunctionResultCode result)
+InvokeHostFunctionResultCode
+ContractStorageTestClient::has(std::string const& key,
+                               ContractDataDurability durability,
+                               std::optional<bool> expectHas,
+                               std::optional<SorobanInvocationSpec> spec)
 {
-    auto lk = contractDataKey(mContractID, makeSymbolSCVal(key), type);
-    auto readOnly = mContractKeys;
-    readOnly.emplace_back(lk);
-    return hasWithFootprint(key, type, readOnly, {}, result);
-}
+    if (!spec)
+    {
+        spec = readKeySpec(key, durability);
+    }
 
-bool
-ContractStorageInvocationTest::hasWithFootprint(
-    std::string const& key, ContractDataDurability type,
-    xdr::xvector<LedgerKey> const& readOnly,
-    xdr::xvector<LedgerKey> const& readWrite,
-    InvokeHostFunctionResultCode result)
-{
-    std::string funcStr = type == ContractDataDurability::TEMPORARY
+    std::string funcStr = durability == ContractDataDurability::TEMPORARY
                               ? "has_temporary"
                               : "has_persistent";
 
-    auto keySymbol = makeSymbolSCVal(key);
-    auto storageLK = contractDataKey(mContractID, keySymbol, type);
-
-    SorobanResources resources;
-    resources.footprint.readOnly = readOnly;
-    resources.footprint.readWrite = readWrite;
-    resources.instructions = 4'500'000;
-    resources.readBytes = getNetworkCfg().txMaxReadBytes();
-    resources.writeBytes = 0;
-
-    auto resourceFee =
-        computeResourceFee(resources, makeSymbol(funcStr), {keySymbol});
-    // Default refundable fee
-    resourceFee += 40'000;
-
-    auto tx = createInvokeTx(resources, makeSymbol(funcStr), {keySymbol}, 1'000,
-                             resourceFee);
-
-    bool isSuccess = result == INVOKE_HOST_FUNCTION_SUCCESS;
-    auto txm = invokeTx(tx, /*expectSuccess=*/isSuccess, false);
-    if (isSuccess)
+    auto invocation =
+        mContract.prepareInvocation(funcStr, {makeSymbolSCVal(key)}, *spec);
+    bool isSuccess = invocation.withExactNonRefundableResourceFee().invoke();
+    if (isSuccess && expectHas)
     {
-        return txm->getXDR().v3().sorobanMeta->returnValue.b();
+        REQUIRE(invocation.getReturnValue().b() == expectHas);
     }
-    else
-    {
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .invokeHostFunctionResult()
-                    .code() == result);
-    }
-
-    return false;
+    return invocation.getResultCode();
 }
 
-void
-ContractStorageInvocationTest::del(std::string const& key,
-                                   ContractDataDurability type)
+InvokeHostFunctionResultCode
+ContractStorageTestClient::del(std::string const& key,
+                               ContractDataDurability durability,
+                               std::optional<SorobanInvocationSpec> spec)
 {
-    auto lk = contractDataKey(mContractID, makeSymbolSCVal(key), type);
-    delWithFootprint(key, type, mContractKeys, {lk}, true);
-}
+    if (!spec)
+    {
+        // Even though deletion is technically a write, we don't charge any
+        // bytes for it and thus don't need to add write bytes to resources.
+        spec = writeKeySpec(key, durability).setWriteBytes(0);
+    }
 
-void
-ContractStorageInvocationTest::delWithFootprint(
-    std::string const& key, ContractDataDurability type,
-    xdr::xvector<LedgerKey> const& readOnly,
-    xdr::xvector<LedgerKey> const& readWrite, bool expectSuccess)
-{
-    std::string funcStr = type == ContractDataDurability::TEMPORARY
+    std::string funcStr = durability == ContractDataDurability::TEMPORARY
                               ? "del_temporary"
                               : "del_persistent";
 
-    auto keySymbol = makeSymbolSCVal(key);
-    auto storageLK = contractDataKey(mContractID, keySymbol, type);
-
-    SorobanResources resources;
-    resources.footprint.readOnly = readOnly;
-    resources.footprint.readWrite = readWrite;
-    resources.instructions = 4'000'000;
-    resources.readBytes = 10'000;
-    resources.writeBytes = 0;
-
-    auto resourceFee =
-        computeResourceFee(resources, makeSymbol(funcStr), {keySymbol});
-    // Default refundable fee
-    resourceFee += 40'000;
-    auto tx = createInvokeTx(resources, makeSymbol(funcStr), {keySymbol}, 1'000,
-                             resourceFee);
-    invokeTx(tx, expectSuccess, false);
+    auto invocation =
+        mContract.prepareInvocation(funcStr, {makeSymbolSCVal(key)}, *spec);
+    invocation.withExactNonRefundableResourceFee().invoke();
+    return invocation.getResultCode();
 }
 
-void
-ContractStorageInvocationTest::checkTTL(std::string const& key,
-                                        ContractDataDurability type,
-                                        uint32_t expectedLiveUntilLedger)
+InvokeHostFunctionResultCode
+ContractStorageTestClient::extend(std::string const& key,
+                                  ContractDataDurability durability,
+                                  uint32_t threshold, uint32_t extendTo,
+                                  std::optional<SorobanInvocationSpec> spec)
 {
-    auto keySymbol = makeSymbolSCVal(key);
-    auto lk = contractDataKey(mContractID, keySymbol, type);
-    checkTTL(lk, expectedLiveUntilLedger);
-}
+    if (!spec)
+    {
+        spec = readKeySpec(key, durability);
+    }
 
-bool
-ContractStorageInvocationTest::isEntryLive(std::string const& key,
-                                           ContractDataDurability type,
-                                           uint32_t ledgerSeq)
-{
-    auto keySymbol = makeSymbolSCVal(key);
-    auto lk = contractDataKey(mContractID, keySymbol, type);
-    return isEntryLive(lk, ledgerSeq);
-}
-
-void
-ContractStorageInvocationTest::extendHostFunction(std::string const& key,
-                                                  ContractDataDurability type,
-                                                  uint32_t threshold,
-                                                  uint32_t extendTo,
-                                                  bool expectSuccess)
-{
-    auto keySymbol = makeSymbolSCVal(key);
-    auto thresholdU32 = makeU32(threshold);
-    auto extendToU32 = makeU32(extendTo);
-
-    std::string funcStr = type == ContractDataDurability::TEMPORARY
+    std::string funcStr = durability == ContractDataDurability::TEMPORARY
                               ? "extend_temporary"
                               : "extend_persistent";
-
-    SorobanResources resources;
-    resources.footprint.readOnly = mContractKeys;
-    resources.footprint.readOnly.emplace_back(
-        contractDataKey(mContractID, keySymbol, type));
-    resources.instructions = 4'000'000;
-    resources.readBytes = 10'000;
-    resources.writeBytes = 1000;
-
-    auto resourceFee = computeResourceFee(
-        resources, makeSymbol(funcStr), {keySymbol, thresholdU32, extendToU32});
-    // Default refundable fee
-    resourceFee += 40'000;
-
-    auto tx = createInvokeTx(resources, makeSymbol(funcStr),
-                             {keySymbol, thresholdU32, extendToU32}, 1'000,
-                             resourceFee);
-    invokeTx(tx, expectSuccess, /*processPostApply=*/false);
+    auto invocation = mContract.prepareInvocation(
+        funcStr, {makeSymbolSCVal(key), makeU32(threshold), makeU32(extendTo)},
+        *spec);
+    invocation.withExactNonRefundableResourceFee().invoke();
+    return invocation.getResultCode();
 }
 
-void
-ContractStorageInvocationTest::resizeStorageAndExtend(
+InvokeHostFunctionResultCode
+ContractStorageTestClient::resizeStorageAndExtend(
     std::string const& key, uint32_t numKiloBytes, uint32_t thresh,
-    uint32_t extendTo, uint32_t writeBytes, uint32_t refundableFee,
-    InvokeHostFunctionResultCode result)
+    uint32_t extendTo, std::optional<SorobanInvocationSpec> spec)
 {
-    auto keySymbol = makeSymbolSCVal(key);
-    auto storageLK = contractDataKey(mContractID, keySymbol,
-                                     ContractDataDurability::PERSISTENT);
-
-    auto numKiloBytesU32 = makeU32(numKiloBytes);
-    auto threshU32 = makeU32(thresh);
-    auto extendToU32 = makeU32(extendTo);
+    if (!spec)
+    {
+        spec = writeKeySpec(key, ContractDataDurability::PERSISTENT)
+                   .setWriteBytes(numKiloBytes * 1024 + 200);
+    }
 
     std::string funcStr = "replace_with_bytes_and_extend";
-
-    SorobanResources resources;
-    resources.footprint.readOnly = mContractKeys;
-    resources.footprint.readWrite = {storageLK};
-    resources.instructions = 4'000'000;
-    resources.readBytes = 10'000;
-    resources.writeBytes = writeBytes;
-
-    auto resourceFee = computeResourceFee(
-        resources, makeSymbol(funcStr),
-        {keySymbol, numKiloBytesU32, threshU32, extendToU32});
-    resourceFee += refundableFee;
-
-    auto tx =
-        createInvokeTx(resources, makeSymbol(funcStr),
-                       {keySymbol, numKiloBytesU32, threshU32, extendToU32},
-                       1'000, resourceFee);
-
-    bool expectSuccess = result == INVOKE_HOST_FUNCTION_SUCCESS;
-    invokeTx(tx, expectSuccess, false);
-
-    if (!expectSuccess)
-    {
-        REQUIRE(tx->getResult()
-                    .result.results()[0]
-                    .tr()
-                    .invokeHostFunctionResult()
-                    .code() == result);
-    }
+    auto invocation = mContract.prepareInvocation(
+        funcStr,
+        {makeSymbolSCVal(key), makeU32(numKiloBytes), makeU32(thresh),
+         makeU32(extendTo)},
+        *spec);
+    invocation.withExactNonRefundableResourceFee().invoke();
+    return invocation.getResultCode();
 }
-}
-}
+
+} // namespace txtext
+} // namespace stellar

--- a/src/transactions/test/SorobanTxTestUtils.h
+++ b/src/transactions/test/SorobanTxTestUtils.h
@@ -17,7 +17,6 @@ namespace stellar
 namespace txtest
 {
 
-SCVal makeWasmRefScContractCode(Hash const& hash);
 SCAddress makeContractAddress(Hash const& hash);
 SCAddress makeAccountAddress(AccountID const& accountID);
 SCVal makeContractAddressSCVal(SCAddress const& address);
@@ -28,251 +27,292 @@ SCVal makeU64(uint64_t u64);
 SCVal makeU32(uint32_t u32);
 SCVal makeBytes(SCBytes bytes);
 
-int64_t getContractBalance(Application& app, SCAddress const& contractID,
-                           SCVal const& toVal);
+ContractIDPreimage makeContractIDPreimage(TestAccount& source, uint256 salt);
+ContractIDPreimage makeContractIDPreimage(Asset const& asset);
+HashIDPreimage
+makeFullContractIdPreimage(Hash const& networkID,
+                           ContractIDPreimage const& contractIDPreimage);
 
-void submitTx(Application& app, Operation const& op,
-              SorobanResources const& resources, uint32_t inclusionFee,
-              uint32_t resourceFee);
+LedgerKey makeContractInstanceKey(SCAddress const& contractAddress);
 
-void submitTxToUploadWasm(Application& app, Operation const& op,
-                          SorobanResources const& resources,
-                          Hash const& expectedWasmHash,
-                          xdr::opaque_vec<> const& expectedWasm,
-                          uint32_t inclusionFee, uint32_t resourceFee);
+ContractExecutable makeWasmExecutable(Hash const& wasmHash);
+ContractExecutable makeAssetExecutable(Asset const& asset);
 
-void submitTxToCreateContract(Application& app, Operation const& op,
-                              SorobanResources const& resources,
-                              Hash const& contractID,
-                              SCVal const& executableKey,
-                              Hash const& expectedWasmHash,
-                              uint32_t inclusionFee, uint32_t resourceFee);
+SorobanResources
+defaultUploadWasmResourcesWithoutFootprint(RustBuf const& wasm);
 
-std::pair<Operation, Hash>
-createSorobanCreateOp(Application& app, SorobanResources& createResources,
-                      LedgerKey const& contractCodeLedgerKey,
-                      TestAccount& source, SCVal& scContractSourceRefKey,
-                      uint256 salt = sha256("salt"));
+// Creates a valid transaction for uploading provided Wasm.
+// Fills in the valid footprint automatically in case if `uploadResources`
+// doesn't contain it.
+TransactionFrameBasePtr
+makeSorobanWasmUploadTx(Application& app, TestAccount& source,
+                        RustBuf const& wasm, SorobanResources& uploadResources,
+                        uint32_t inclusionFee);
 
-class ContractInvocationTest
+// Creates a valid transaction for creating a contract.
+// Fills in the valid footprint automatically in case if `createResources`
+// doesn't contain it.
+TransactionFrameBasePtr makeSorobanCreateContractTx(
+    Application& app, TestAccount& source, ContractIDPreimage const& idPreimage,
+    ContractExecutable const& executable, SorobanResources& createResources,
+    uint32_t inclusionFee);
+
+// Builder-style configuration necessary for building a Soroban
+// transaction invocation.
+// The specs can be built using method chaining
+// (`spec.setInstructions(...).setReadBytes(...)`).
+// Note, that the spec itself is immutable, so that it's not possible
+// to mess up the test setup by accidentally modifying the spec
+// that is also used by another part of the test.
+class SorobanInvocationSpec
 {
-    // Fee constants from rs-soroban-env/soroban-env-host/src/fees.rs
-    static constexpr int64_t INSTRUCTION_INCREMENT = 10000;
-    static constexpr int64_t DATA_SIZE_1KB_INCREMENT = 1024;
-    static constexpr int64_t TX_BASE_RESULT_SIZE = 300;
+  private:
+    SorobanResources mResources;
+    // Set reasonable defaults for the fees so that tests that don't
+    // care about fees could completely omit them.
+    uint32_t mNonRefundableResourceFee = DEFAULT_TEST_RESOURCE_FEE;
+    uint32_t mRefundableResourceFee = DEFAULT_TEST_RESOURCE_FEE;
+    uint32_t mInclusionFee = 100;
+
+  public:
+    SorobanInvocationSpec() = default;
+    SorobanInvocationSpec(SorobanResources const& resources,
+                          uint32_t nonRefundableResourceFee,
+                          uint32_t refundableResourceFee,
+                          uint32_t inclusionFee);
+
+    SorobanResources const& getResources() const;
+    uint32_t getFee() const;
+    uint32_t getResourceFee() const;
+    uint32_t getInclusionFee() const;
+
+    SorobanInvocationSpec setInstructions(int64_t instructions) const;
+    SorobanInvocationSpec
+    setReadOnlyFootprint(xdr::xvector<LedgerKey> const& keys) const;
+    SorobanInvocationSpec
+    setReadWriteFootprint(xdr::xvector<LedgerKey> const& keys) const;
+    SorobanInvocationSpec
+    extendReadOnlyFootprint(xdr::xvector<LedgerKey> const& keys) const;
+    SorobanInvocationSpec
+    extendReadWriteFootprint(xdr::xvector<LedgerKey> const& keys) const;
+    SorobanInvocationSpec setReadBytes(uint32_t readBytes) const;
+    SorobanInvocationSpec setWriteBytes(uint32_t writeBytes) const;
+
+    SorobanInvocationSpec setRefundableResourceFee(uint32_t fee) const;
+    SorobanInvocationSpec setNonRefundableResourceFee(uint32_t fee) const;
+    SorobanInvocationSpec setInclusionFee(uint32_t fee) const;
+};
+
+TransactionFrameBasePtr sorobanTransactionFrameFromOps(
+    Hash const& networkID, TestAccount& source,
+    std::vector<Operation> const& ops, std::vector<SecretKey> const& opKeys,
+    SorobanInvocationSpec const& spec,
+    std::optional<std::string> memo = std::nullopt,
+    std::optional<SequenceNumber> seq = std::nullopt);
+
+class SorobanTest;
+
+// Test wrapper for a deployed contract, owned by the `SorobanTest`.
+// Normally this should be created with `SorobanTest::deployWasmContract` or
+// `SorobanTest::deployAssetContract` methods.
+class TestContract
+{
+  private:
+    SorobanTest& mTest;
+    xdr::xvector<LedgerKey> mContractKeys;
+    SCAddress mAddress;
+
+  public:
+    // Wrapper for a single invocation of a contract.
+    // The wrapper can be used to modify the invocations in generic
+    // fashion (e.g. compute the exact fee or authorize top invocation),
+    // and to either build/invoke the respective transaction.
+    class Invocation
+    {
+      private:
+        SorobanTest& mTest;
+        SorobanInvocationSpec mSpec;
+        Operation mOp;
+
+        std::optional<InvokeHostFunctionResultCode> mResultCode;
+        std::optional<TransactionMetaFrame> mTxMeta;
+
+      public:
+        Invocation(TestContract const& contract,
+                   std::string const& functionName,
+                   std::vector<SCVal> const& args,
+                   SorobanInvocationSpec const& spec,
+                   bool addContractKeys = true);
+
+        Invocation& withAuthorizedTopCall();
+        Invocation& withExactNonRefundableResourceFee();
+
+        TransactionFrameBasePtr createTx(TestAccount* source = nullptr);
+        bool invoke(TestAccount* source = nullptr);
+
+        SCVal getReturnValue() const;
+        TransactionMetaFrame const& getTxMeta() const;
+        InvokeHostFunctionResultCode getResultCode() const;
+    };
+
+    TestContract(SorobanTest& test, SCAddress const& address,
+                 xdr::xvector<LedgerKey> const& contractKeys);
+
+    xdr::xvector<LedgerKey> const& getKeys() const;
+    SCAddress const& getAddress() const;
+    SorobanTest& getTest() const;
+    LedgerKey getDataKey(SCVal const& key, ContractDataDurability durability);
+
+    Invocation prepareInvocation(std::string const& functionName,
+                                 std::vector<SCVal> const& args,
+                                 SorobanInvocationSpec const& spec,
+                                 bool addContractKeys = true) const;
+};
+
+// Helper for building Soroban tests.
+// Encapsulates the necessary state and helpers for deploying the
+// contracts and invoking the common Soroban transactions.
+class SorobanTest
+{
+  private:
+    VirtualClock mClock;
+    Application::pointer mApp;
+    TestAccount mRoot;
+    TestAccount mDummyAccount;
+    std::vector<std::unique_ptr<TestContract>> mContracts;
 
     static int64_t computeFeePerIncrement(int64_t resourceVal, int64_t feeRate,
                                           int64_t increment);
 
     void invokeArchivalOp(TransactionFrameBasePtr tx,
-                          int64_t expectedRefundableFeeCharged,
-                          bool expectSuccess);
+                          int64_t expectedRefundableFeeCharged);
 
-  protected:
-    VirtualClock mClock;
-    Application::pointer mApp;
-    TestAccount mRoot;
-    TestAccount mDummyAccount;
+    Hash uploadWasm(RustBuf const& wasm, SorobanResources& uploadResources);
+    SCAddress createContract(ContractIDPreimage const& idPreimage,
+                             ContractExecutable const& executable,
+                             SorobanResources& createResources);
 
-    xdr::xvector<LedgerKey> mContractKeys{};
-    SCAddress mContractID{};
-
-  public:
-    ContractInvocationTest(
-        Config cfg = getTestConfig(), bool useTestLimits = true,
-        std::function<void(SorobanNetworkConfig&)> cfgModifyFn =
-            [](SorobanNetworkConfig&) {});
-
-    Application::pointer
-    getApp()
-    {
-        return mApp;
-    }
-
-    xdr::xvector<LedgerKey>&
-    getContractKeys()
-    {
-        return mContractKeys;
-    }
-
-    SCAddress&
-    getContractID()
-    {
-        return mContractID;
-    }
-
-    TestAccount& getRoot();
-    SorobanNetworkConfig const& getNetworkCfg();
-    uint32_t getLedgerSeq();
-
-    // The following computations are copies of compute_transaction_resource_fee
-    // in rs-soroban-env/soroban-env-host/src/fees.rs. This is reimplemented
-    // here so that we can check if the Cxx bridge introduced any fee related
-    // bugs.
-    int64_t getRentFeeForBytes(int64_t entrySize, uint32_t extendTo,
-                               bool isPersistent);
-    int64_t getTTLEntryWriteFee();
     int64_t getRentFeeForExtension(xdr::xvector<LedgerKey> const& keys,
                                    uint32_t newLifetime);
 
-    // Fees that depend on TX size, historicalFee and bandwidthFee
-    int64_t getTxSizeFees(TransactionFrameBasePtr tx);
-
-    int64_t getComputeFee(SorobanResources const& resources);
-    int64_t getEntryReadFee(SorobanResources const& resources);
-    int64_t getEntryWriteFee(SorobanResources const& resources);
-    int64_t getReadBytesFee(SorobanResources const& resources);
-    int64_t getWriteBytesFee(SorobanResources const& resources);
-
-    // Compute tx frame size before finalizing the resource fee via a dummy TX.
-    // This is a bit hacky, but we need the exact tx size in order to
-    // enable tests that rely on the exact refundable fee value.
-    uint32_t computeResourceFee(SorobanResources const& resources,
-                                SCSymbol const& functionName,
-                                std::vector<SCVal> const& args);
-
-    TransactionFrameBasePtr
-    createInvokeTx(SorobanResources const& resources,
-                   SCSymbol const& functionName, std::vector<SCVal> const& args,
-                   uint32_t inclusionFee, uint32_t resourceFee,
-                   std::shared_ptr<TestAccount> source = nullptr);
-    TransactionFrameBasePtr
-    createExtendOpTx(SorobanResources const& resources, uint32_t extendTo,
-                     uint32_t fee, uint32_t refundableFee,
-                     std::shared_ptr<TestAccount> source = nullptr);
-    TransactionFrameBasePtr
-    createRestoreTx(SorobanResources const& resources, uint32_t fee,
-                    uint32_t refundableFee,
-                    std::shared_ptr<TestAccount> source = nullptr);
-
-    void txCheckValid(TransactionFrameBasePtr tx);
-    bool isTxValid(TransactionFrameBasePtr tx);
-
-    std::shared_ptr<TransactionMetaFrame>
-    invokeTx(TransactionFrameBasePtr tx, bool expectSuccess,
-             bool processPostApply = true);
-
-    void checkTTL(LedgerKey const& k, uint32_t expectedLiveUntilLedger);
-    bool isEntryLive(LedgerKey const& k, uint32_t ledgerSeq);
-
-    void restoreOp(xdr::xvector<LedgerKey> const& readWrite,
-                   int64_t expectedRefundableFeeCharged,
-                   bool expectSuccess = true);
-    void extendOp(xdr::xvector<LedgerKey> const& readOnly, uint32_t extendTo,
-                  bool expectSuccess = true,
-                  std::optional<uint32_t> expectedRefundableChargeOverride =
-                      std::nullopt);
-};
-
-class WasmContractInvocationTest : public ContractInvocationTest
-{
-    void deployContractWithSourceAccountWithResources(
-        SorobanResources uploadResources, SorobanResources createResources);
-
-  protected:
-    RustBuf const mWasm;
-
   public:
-    WasmContractInvocationTest(
-        RustBuf const& wasm, bool deployContract = true,
+    SorobanTest(
         Config cfg = getTestConfig(), bool useTestLimits = true,
         std::function<void(SorobanNetworkConfig&)> cfgModifyFn =
             [](SorobanNetworkConfig&) {});
 
-    void deployWithResources(SorobanResources const& uploadResources,
-                             SorobanResources const& createResources);
+    Application& getApp() const;
 
-    TransactionFrameBasePtr createUploadWasmTx(TestAccount& source,
-                                               uint32_t resourceFee);
-    TransactionFrameBasePtr getCreateTx(TestAccount& acc);
+    TestContract& deployWasmContract(
+        RustBuf const& wasm,
+        std::optional<SorobanResources> uploadResources = std::nullopt,
+        std::optional<SorobanResources> createResources = std::nullopt);
+    TestContract& deployAssetContract(Asset const& asset);
+
+    TestAccount& getRoot();
+    TestAccount& getDummyAccount();
+    SorobanNetworkConfig const& getNetworkCfg();
+    uint32_t getLedgerSeq() const;
+    uint32_t getLedgerVersion() const;
+
+    TransactionFrameBasePtr createExtendOpTx(SorobanResources const& resources,
+                                             uint32_t extendTo, uint32_t fee,
+                                             uint32_t refundableFee,
+                                             TestAccount* source = nullptr);
+    TransactionFrameBasePtr createRestoreTx(SorobanResources const& resources,
+                                            uint32_t fee,
+                                            uint32_t refundableFee,
+                                            TestAccount* source = nullptr);
+
+    bool isTxValid(TransactionFrameBasePtr tx);
+
+    bool invokeTx(TransactionFrameBasePtr tx,
+                  TransactionMetaFrame* txMeta = nullptr);
+
+    uint32_t getTTL(LedgerKey const& k);
+    bool isEntryLive(LedgerKey const& k, uint32_t ledgerSeq);
+
+    void invokeRestoreOp(xdr::xvector<LedgerKey> const& readWrite,
+                         int64_t expectedRefundableFeeCharged);
+    void invokeExtendOp(
+        xdr::xvector<LedgerKey> const& readOnly, uint32_t extendTo,
+        std::optional<int64_t> expectedRefundableFeeCharged = std::nullopt);
 };
 
-class AssetContractInvocationTest : public ContractInvocationTest
+class AssetContractTestClient
 {
-  protected:
+  private:
+    TestContract& mContract;
+    Asset mAsset;
+    Application& mApp;
+
     LedgerKey makeBalanceKey(AccountID const& acc);
     LedgerKey makeBalanceKey(SCAddress const& addr);
+    LedgerKey makeIssuerKey(Asset const& mAsset);
     LedgerKey makeContractDataBalanceKey(SCAddress const& addr);
     int64_t getBalance(SCAddress const& addr);
 
-    Asset const mAsset;
+    SorobanInvocationSpec defaultSpec() const;
 
   public:
-    AssetContractInvocationTest(
-        Asset const& asset, Config cfg = getTestConfig(),
-        bool useTestLimits = true,
-        std::function<void(SorobanNetworkConfig&)> cfgModifyFn =
-            [](SorobanNetworkConfig&) {});
+    AssetContractTestClient(SorobanTest& test, Asset const& asset);
 
-    void transfer(TestAccount& from, SCAddress const& toAddr, int64_t amount,
-                  bool expectSuccess);
-    void mint(TestAccount& admin, SCAddress const& toAddr, int64_t amount,
-              bool expectSuccess);
-    void burn(TestAccount& from, int64_t amount, bool expectSuccess);
-    void clawback(TestAccount& admin, SCAddress const& fromAddr, int64_t amount,
-                  bool expectSuccess);
+    bool transfer(TestAccount& from, SCAddress const& toAddr, int64_t amount);
+    bool mint(TestAccount& admin, SCAddress const& toAddr, int64_t amount);
+    bool burn(TestAccount& from, int64_t amount);
+    bool clawback(TestAccount& admin, SCAddress const& fromAddr,
+                  int64_t amount);
 };
 
-class ContractStorageInvocationTest : public WasmContractInvocationTest
+class ContractStorageTestClient
 {
+  private:
+    TestContract& mContract;
+
   public:
-    ContractStorageInvocationTest(Config cfg = getTestConfig())
-        : WasmContractInvocationTest(rust_bridge::get_test_wasm_contract_data(),
-                                     /*deployContract=*/true, cfg)
-    {
-    }
+    ContractStorageTestClient(SorobanTest& test);
 
-    void
-    put(std::string const& key, ContractDataDurability type, uint64_t val,
-        InvokeHostFunctionResultCode result = INVOKE_HOST_FUNCTION_SUCCESS);
-    void putWithFootprint(
-        std::string const& key, ContractDataDurability type, uint64_t val,
-        xdr::xvector<LedgerKey> const& readOnly,
-        xdr::xvector<LedgerKey> const& readWrite,
-        InvokeHostFunctionResultCode result = INVOKE_HOST_FUNCTION_SUCCESS,
-        uint32_t writeBytes = 1000, uint32_t refundableFee = 40'000);
+    TestContract& getContract() const;
 
-    uint64_t
-    get(std::string const& key, ContractDataDurability type,
-        InvokeHostFunctionResultCode result = INVOKE_HOST_FUNCTION_SUCCESS);
-    uint64_t getWithFootprint(std::string const& key,
-                              ContractDataDurability type,
-                              xdr::xvector<LedgerKey> const& readOnly,
-                              xdr::xvector<LedgerKey> const& readWrite,
-                              InvokeHostFunctionResultCode result,
-                              uint32_t readBytes = 10'000);
+    SorobanInvocationSpec defaultSpecWithoutFootprint() const;
 
-    bool
-    has(std::string const& key, ContractDataDurability type,
-        InvokeHostFunctionResultCode result = INVOKE_HOST_FUNCTION_SUCCESS);
-    bool hasWithFootprint(
-        std::string const& key, ContractDataDurability type,
-        xdr::xvector<LedgerKey> const& readOnly,
-        xdr::xvector<LedgerKey> const& readWrite,
-        InvokeHostFunctionResultCode result = INVOKE_HOST_FUNCTION_SUCCESS);
+    SorobanInvocationSpec readKeySpec(std::string const& key,
+                                      ContractDataDurability durability) const;
 
-    void del(std::string const& key, ContractDataDurability type);
-    void delWithFootprint(std::string const& key, ContractDataDurability type,
-                          xdr::xvector<LedgerKey> const& readOnly,
-                          xdr::xvector<LedgerKey> const& readWrite,
-                          bool expectSuccess);
+    SorobanInvocationSpec writeKeySpec(std::string const& key,
+                                       ContractDataDurability durability) const;
 
-    using ContractInvocationTest::checkTTL;
-    void checkTTL(std::string const& key, ContractDataDurability type,
-                  uint32_t expectedLiveUntilLedger);
-
-    using ContractInvocationTest::isEntryLive;
-    bool isEntryLive(std::string const& key, ContractDataDurability type,
+    uint32_t getTTL(std::string const& key, ContractDataDurability durability);
+    bool isEntryLive(std::string const& key, ContractDataDurability durability,
                      uint32_t ledgerSeq);
 
-    void extendHostFunction(std::string const& key, ContractDataDurability type,
-                            uint32_t threshold, uint32_t extendTo,
-                            bool expectSuccess = true);
+    InvokeHostFunctionResultCode
+    put(std::string const& key, ContractDataDurability durability, uint64_t val,
+        std::optional<SorobanInvocationSpec> spec = std::nullopt);
 
-    void resizeStorageAndExtend(
+    InvokeHostFunctionResultCode
+    get(std::string const& key, ContractDataDurability durability,
+        std::optional<uint64_t> expectValue,
+        std::optional<SorobanInvocationSpec> spec = std::nullopt);
+
+    InvokeHostFunctionResultCode
+    has(std::string const& key, ContractDataDurability durability,
+        std::optional<bool> expectHas,
+        std::optional<SorobanInvocationSpec> spec = std::nullopt);
+
+    InvokeHostFunctionResultCode
+    del(std::string const& key, ContractDataDurability durability,
+        std::optional<SorobanInvocationSpec> spec = std::nullopt);
+
+    InvokeHostFunctionResultCode
+    extend(std::string const& key, ContractDataDurability durability,
+           uint32_t threshold, uint32_t extendTo,
+           std::optional<SorobanInvocationSpec> spec = std::nullopt);
+
+    InvokeHostFunctionResultCode resizeStorageAndExtend(
         std::string const& key, uint32_t numKiloBytes, uint32_t thresh,
-        uint32_t extendTo, uint32_t writeBytes, uint32_t refundableFee,
-        InvokeHostFunctionResultCode result = INVOKE_HOST_FUNCTION_SUCCESS);
+        uint32_t extendTo,
+        std::optional<SorobanInvocationSpec> spec = std::nullopt);
 };
 }
 }

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -27,80 +27,11 @@
 		19,
 		20
 	],
-	"Native stellar asset contract" : [ "bKDF6V5IzTo=", "WG81K/VZUaU=" ],
-	"Trustline stellar asset contract" : 
+	"Native stellar asset contract" : [ "bKDF6V5IzTo=", "i7kalOBorks=" ],
+	"Soroban footprint validation" : 
 	[
 		"bKDF6V5IzTo=",
-		"pIksSdCXjaM=",
-		"DfaSsPVmc0I=",
-		"7rni3KPd6EQ=",
-		"CV1g3ijy688=",
-		"AsxHuDcTPiA=",
-		"59oy+4KNTrw=",
-		"iNRxbcDGHRA=",
-		"eueWEr2Qk5M=",
-		"ohJUyhoisZs="
-	],
-	"basic contract invocation" : 
-	[
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo="
-	],
-	"buying liabilities plus refund is greater than INT64_MAX" : 
-	[
-		"bKDF6V5IzTo=",
-		"y0mODi4DFnM=",
-		"o9mb+GfjtK8=",
-		"H+TcXmSmbqc=",
-		"tNCAjT/JOkE="
-	],
-	"complex contract|diagnostics disabled" : [ "bKDF6V5IzTo=" ],
-	"complex contract|diagnostics enabled" : [ "bKDF6V5IzTo=" ],
-	"contract storage" : 
-	[
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo="
-	],
-	"contract storage|footprint tests|unused readWrite key" : [ "FCzY8suZB0A=" ],
-	"error codes" : [ "bKDF6V5IzTo=" ],
-	"errors roll back" : 
-	[
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo="
-	],
-	"failure diagnostics" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"invalid footprint keys" : 
-	[
+		"Qsf8PDR92oU=",
 		"bKDF6V5IzTo=",
 		"Qsf8PDR92oU=",
 		"bKDF6V5IzTo=",
@@ -474,8 +405,7 @@
 		"bKDF6V5IzTo=",
 		"Qsf8PDR92oU="
 	],
-	"ledger entry size limit enforced" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"non-refundable resource metering" : 
+	"Soroban non-refundable resource fees are stable" : 
 	[
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo=",
@@ -485,8 +415,95 @@
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo="
 	],
+	"Trustline stellar asset contract" : 
+	[
+		"bKDF6V5IzTo=",
+		"NGLSADCnfp4=",
+		"DfaSsPVmc0I=",
+		"/77WrMl+rn0=",
+		"JW+Z8Qc2C4E=",
+		"w0ru88cpqE4=",
+		"AN1LYP0s9qQ=",
+		"iNRxbcDGHRA=",
+		"eueWEr2Qk5M=",
+		"ohJUyhoisZs="
+	],
+	"basic contract invocation" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"buying liabilities plus refund is greater than INT64_MAX" : 
+	[
+		"bKDF6V5IzTo=",
+		"y0mODi4DFnM=",
+		"o9mb+GfjtK8=",
+		"H+TcXmSmbqc=",
+		"tNCAjT/JOkE="
+	],
+	"complex contract|diagnostics disabled" : [ "bKDF6V5IzTo=" ],
+	"complex contract|diagnostics enabled" : [ "bKDF6V5IzTo=" ],
+	"contract errors cause transaction to fail" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"contract storage" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"contract storage|footprint|unused readWrite key" : [ "ZKxMUP1fxqo=" ],
+	"failure diagnostics" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"ledger entry size limit enforced" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"refund account merged" : [ "bKDF6V5IzTo=", "y0mODi4DFnM=", "o9mb+GfjtK8=", "HG7OrQT/Ofg=" ],
 	"settings upgrade" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"settings upgrade command line utils" : [ "TByXElZpITE=", "TByXElZpITE=", "TByXElZpITE=", "TByXElZpITE=" ],
+	"state archival" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"state archival operation errors" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
 	"temp entry eviction" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ]
 }

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -28,80 +28,11 @@
 		20,
 		21
 	],
-	"Native stellar asset contract" : [ "bKDF6V5IzTo=", "WG81K/VZUaU=" ],
-	"Trustline stellar asset contract" : 
+	"Native stellar asset contract" : [ "bKDF6V5IzTo=", "i7kalOBorks=" ],
+	"Soroban footprint validation" : 
 	[
 		"bKDF6V5IzTo=",
-		"pIksSdCXjaM=",
-		"DfaSsPVmc0I=",
-		"7rni3KPd6EQ=",
-		"CV1g3ijy688=",
-		"AsxHuDcTPiA=",
-		"59oy+4KNTrw=",
-		"iNRxbcDGHRA=",
-		"eueWEr2Qk5M=",
-		"ohJUyhoisZs="
-	],
-	"basic contract invocation" : 
-	[
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo="
-	],
-	"buying liabilities plus refund is greater than INT64_MAX" : 
-	[
-		"bKDF6V5IzTo=",
-		"y0mODi4DFnM=",
-		"o9mb+GfjtK8=",
-		"H+TcXmSmbqc=",
-		"tNCAjT/JOkE="
-	],
-	"complex contract|diagnostics disabled" : [ "bKDF6V5IzTo=" ],
-	"complex contract|diagnostics enabled" : [ "bKDF6V5IzTo=" ],
-	"contract storage" : 
-	[
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo="
-	],
-	"contract storage|footprint tests|unused readWrite key" : [ "FCzY8suZB0A=" ],
-	"error codes" : [ "bKDF6V5IzTo=" ],
-	"errors roll back" : 
-	[
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo=",
-		"bKDF6V5IzTo="
-	],
-	"failure diagnostics" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"invalid footprint keys" : 
-	[
+		"Qsf8PDR92oU=",
 		"bKDF6V5IzTo=",
 		"Qsf8PDR92oU=",
 		"bKDF6V5IzTo=",
@@ -475,8 +406,7 @@
 		"bKDF6V5IzTo=",
 		"Qsf8PDR92oU="
 	],
-	"ledger entry size limit enforced" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
-	"non-refundable resource metering" : 
+	"Soroban non-refundable resource fees are stable" : 
 	[
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo=",
@@ -486,8 +416,95 @@
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo="
 	],
+	"Trustline stellar asset contract" : 
+	[
+		"bKDF6V5IzTo=",
+		"NGLSADCnfp4=",
+		"DfaSsPVmc0I=",
+		"/77WrMl+rn0=",
+		"JW+Z8Qc2C4E=",
+		"w0ru88cpqE4=",
+		"AN1LYP0s9qQ=",
+		"iNRxbcDGHRA=",
+		"eueWEr2Qk5M=",
+		"ohJUyhoisZs="
+	],
+	"basic contract invocation" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"buying liabilities plus refund is greater than INT64_MAX" : 
+	[
+		"bKDF6V5IzTo=",
+		"y0mODi4DFnM=",
+		"o9mb+GfjtK8=",
+		"H+TcXmSmbqc=",
+		"tNCAjT/JOkE="
+	],
+	"complex contract|diagnostics disabled" : [ "bKDF6V5IzTo=" ],
+	"complex contract|diagnostics enabled" : [ "bKDF6V5IzTo=" ],
+	"contract errors cause transaction to fail" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"contract storage" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"contract storage|footprint|unused readWrite key" : [ "ZKxMUP1fxqo=" ],
+	"failure diagnostics" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"ledger entry size limit enforced" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"refund account merged" : [ "bKDF6V5IzTo=", "y0mODi4DFnM=", "o9mb+GfjtK8=", "HG7OrQT/Ofg=" ],
 	"settings upgrade" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"settings upgrade command line utils" : [ "TByXElZpITE=", "TByXElZpITE=", "TByXElZpITE=", "TByXElZpITE=" ],
+	"state archival" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
+	"state archival operation errors" : 
+	[
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo=",
+		"bKDF6V5IzTo="
+	],
 	"temp entry eviction" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ]
 }


### PR DESCRIPTION
# Description

Refactor Soroban test framework.

- Allow deploying an arbitrary number of different contracts within a test
- Provide a wrapper for the contracts and invocations to allow building/invoking transactions with less code
- Provide a wrapper for the Soroban resources and fees for easier and more readable resource/fee overrides
- Move the invocation/results to return values for more precise `REQUIRE` locations
- Update InvokeHostFunctionTests to use the updated utils and re-organize/rename a few tests
- Remove functions that re-implement the fee computation logic (these simply didn't cover anything and are no longer useful for iteration given that protocol is finalized)

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
