### PR TITLE
3437 improve handling of slow archives

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -51,6 +51,8 @@ history.check.success                     | meter     | history archive status c
 history.publish.failure                   | meter     | published failed
 history.publish.success                   | meter     | published completed successfully
 history.publish.time                      | timer     | time to successfully publish history
+history.get.throughput                    | meter     | bytes per second of history archive retrieval
+history.get.failure                       | meter     | history archive downloads failed
 ledger.age.closed                         | bucket    | time between ledgers
 ledger.age.current-seconds                | counter   | gap between last close ledger time and current time
 ledger.apply.success                      | counter   | count of successfully applied transactions

--- a/src/historywork/GetRemoteFileWork.h
+++ b/src/historywork/GetRemoteFileWork.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "historywork/RunCommandWork.h"
+#include "medida/medida.h"
 
 namespace stellar
 {
@@ -18,6 +19,8 @@ class GetRemoteFileWork : public RunCommandWork
     std::shared_ptr<HistoryArchive> const mArchive;
     std::shared_ptr<HistoryArchive> mCurrentArchive;
     CommandInfo getCommand() override;
+    medida::Meter& mFailuresPerSecond;
+    medida::Meter& mBytesPerSecond;
 
   public:
     // Passing `nullptr` for the archive argument will cause the work to

--- a/src/ledger/readme.md
+++ b/src/ledger/readme.md
@@ -23,7 +23,7 @@ behaves just like pointers in typical data structures but with added
 security guarantees.
 
 See the protocol file for the object definitions.
-[`src/xdr/Stellar-ledger.x`](../xdr/Stellar-ledger.x)
+[`src/protocol-curr/xdr/Stellar-ledger.x`](../protocol-curr/xdr/Stellar-ledger.x)
 
 One can think of the historical chain as a linked list of LedgerHeaders:
 


### PR DESCRIPTION
# Description

Resolves #3437 

* Exposes config to control number of retries when fetching archives
* Adds metrics for retries and throughput of files downloaded
* Logs what commands are run as part of GetRemoteFileWork

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)

<img width="224" alt="Screenshot 2024-01-02 at 6 45 24 PM" src="https://github.com/stellar/stellar-core/assets/8569566/0616be59-f9b7-4503-97e2-0b3b53784614">
