### PR TITLE
Change test utility used by loadgen to not depend on Catch2.

### DIFF
--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -242,7 +242,7 @@ makeSorobanCreateContractTx(Application& app, TestAccount& source,
 {
     if (createResources.footprint.readWrite.empty())
     {
-        REQUIRE(createResources.footprint.readOnly.empty());
+        releaseAssert(createResources.footprint.readOnly.empty());
         auto contractID = xdrSha256(
             makeFullContractIdPreimage(app.getNetworkID(), idPreimage));
         if (executable.type() ==


### PR DESCRIPTION
# Description

Change test utility used by loadgen to not depend on Catch2.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
