### PR TITLE
Bucket cleanup

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -255,7 +255,7 @@ Bucket::loadPoolShareTrustLinessByAccount(
     // Get upper and lower bound for poolshare trustline range associated
     // with this account
     auto searchRange = getIndex().getPoolshareTrustlineRange(accountID);
-    if (searchRange.first == 0 && searchRange.second == 0)
+    if (!searchRange)
     {
         // No poolshare trustlines, exit
         return;
@@ -263,8 +263,8 @@ Bucket::loadPoolShareTrustLinessByAccount(
 
     BucketEntry be;
     auto& stream = getIndexStream();
-    stream.seek(searchRange.first);
-    while (stream && stream.pos() < searchRange.second && stream.readOne(be))
+    stream.seek(searchRange->first);
+    while (stream && stream.pos() < searchRange->second && stream.readOne(be))
     {
         LedgerEntry entry;
         switch (be.type())
@@ -292,7 +292,7 @@ Bucket::loadPoolShareTrustLinessByAccount(
         }
 
         // If this is a pool share trustline that matches the accountID and
-        // is not shadowed, add it to results
+        // is the newest version of the key, add it to results
         if (trustlineCheck(entry.data) &&
             seenTrustlines.find(LedgerEntryKey(entry)) == seenTrustlines.end())
         {

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -49,21 +49,32 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
 
     std::unique_ptr<BucketIndex const> mIndex{};
 
-    // Lazily-constructed and retained for read path.
-    std::unique_ptr<XDRInputFileStream> mStream;
+    // Lazily-constructed and retained for read path, one for BucketListDB reads
+    // and one for eviction scans
+    std::unique_ptr<XDRInputFileStream> mIndexStream;
+    std::unique_ptr<XDRInputFileStream> mEvictionStream;
 
     // Returns index, throws if index not yet initialized
     BucketIndex const& getIndex() const;
 
-    // Returns (lazily-constructed) file stream for bucket file. Note
+    // Returns (lazily-constructed) file stream for bucketDB search. Note
     // this might be in some random position left over from a previous read --
     // must be seek()'ed before use.
-    XDRInputFileStream& getStream();
+    XDRInputFileStream& getIndexStream();
+
+    // Returns (lazily-constructed) file stream for eviction scans. Unlike the
+    // indexStream, this should retain its position in-between calls. However, a
+    // node performing catchup or joining the network may need to begin evicting
+    // mid-bucket, so this stream should still be seeked to the proper position
+    // before reading.
+    XDRInputFileStream& getEvictionStream();
 
     // Loads the bucket entry for LedgerKey k. Starts at file offset pos and
     // reads until key is found or the end of the page.
     std::optional<BucketEntry>
     getEntryAtOffset(LedgerKey const& k, std::streamoff pos, size_t pageSize);
+
+    std::unique_ptr<XDRInputFileStream> openStream();
 
     static std::string randomFileName(std::string const& tmpDir,
                                       std::string ext);

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -110,10 +110,10 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     // stored with their corresponding liquidity pool key in
     // liquidityPoolKeyToTrustline. All liquidity pool keys corresponding to
     // loaded trustlines are also reduntantly stored in liquidityPoolKeys.
-    // If a trustline key is in deadTrustlines, it is not loaded. Whenever a
-    // dead trustline is found, its key is added to deadTrustlines.
+    // If a trustline key is in seenTrustlines, it is not loaded. Whenever a
+    // dead trustline is found, its key is added to seenTrustlines.
     void loadPoolShareTrustLinessByAccount(
-        AccountID const& accountID, UnorderedSet<LedgerKey>& deadTrustlines,
+        AccountID const& accountID, UnorderedSet<LedgerKey>& seenTrustlines,
         UnorderedMap<LedgerKey, LedgerEntry>& liquidityPoolKeyToTrustline,
         LedgerKeySet& liquidityPoolKeys);
 

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -109,8 +109,8 @@ class BucketIndex : public NonMovableOrCopyable
 
     // Returns lower bound and upper bound for poolshare trustline entry
     // positions associated with the given accountID. If no trustlines found,
-    // returns std::pair<0, 0>
-    virtual std::pair<std::streamoff, std::streamoff>
+    // returns nullopt
+    virtual std::optional<std::pair<std::streamoff, std::streamoff>>
     getPoolshareTrustlineRange(AccountID const& accountID) const = 0;
 
     // Returns page size for index. InidividualIndex returns 0 for page size

--- a/src/bucket/BucketIndexImpl.cpp
+++ b/src/bucket/BucketIndexImpl.cpp
@@ -413,7 +413,7 @@ BucketIndexImpl<IndexT>::scan(Iterator start, LedgerKey const& k) const
 }
 
 template <class IndexT>
-std::pair<std::streamoff, std::streamoff>
+std::optional<std::pair<std::streamoff, std::streamoff>>
 BucketIndexImpl<IndexT>::getPoolshareTrustlineRange(
     AccountID const& accountID) const
 {
@@ -430,7 +430,7 @@ BucketIndexImpl<IndexT>::getPoolshareTrustlineRange(
         lower_bound_pred<typename IndexT::value_type>);
     if (startIter == mData.keysToOffset.end())
     {
-        return {};
+        return std::nullopt;
     }
 
     auto endIter =

--- a/src/bucket/BucketIndexImpl.h
+++ b/src/bucket/BucketIndexImpl.h
@@ -71,7 +71,7 @@ template <class IndexT> class BucketIndexImpl : public BucketIndex
     virtual std::pair<std::optional<std::streamoff>, Iterator>
     scan(Iterator start, LedgerKey const& k) const override;
 
-    virtual std::pair<std::streamoff, std::streamoff>
+    virtual std::optional<std::pair<std::streamoff, std::streamoff>>
     getPoolshareTrustlineRange(AccountID const& accountID) const override;
 
     virtual std::streamoff

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -443,17 +443,16 @@ BucketList::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const
 
 std::vector<LedgerEntry>
 BucketList::loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                                     Asset const& asset,
-                                                     Config const& cfg) const
+                                                     Asset const& asset) const
 {
     ZoneScoped;
     UnorderedMap<LedgerKey, LedgerEntry> liquidityPoolToTrustline;
-    UnorderedSet<LedgerKey> deadTrustlines;
+    UnorderedSet<LedgerKey> seenTrustlines;
     LedgerKeySet liquidityPoolKeysToSearch;
 
     // First get all the poolshare trustlines for the given account
     auto trustLineLoop = [&](std::shared_ptr<Bucket> b) {
-        b->loadPoolShareTrustLinessByAccount(accountID, deadTrustlines,
+        b->loadPoolShareTrustLinessByAccount(accountID, seenTrustlines,
                                              liquidityPoolToTrustline,
                                              liquidityPoolKeysToSearch);
         return false; // continue

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -889,6 +889,22 @@ BucketList::scanForEviction(Application& app, AbstractLedgerTxn& ltx,
         auto initialLevel = evictionIter.bucketListLevel;
         auto initialIsCurr = evictionIter.isCurrBucket;
         auto b = getBucketFromIter(evictionIter);
+
+        // Check to see if we can finish scanning the bucket before it receives
+        // an update
+        auto period = bucketUpdatePeriod(evictionIter.bucketListLevel,
+                                         evictionIter.isCurrBucket);
+
+        // Ledgers remaining until the current Bucket changes
+        auto ledgersRemainingToScanBucket = period - (ledgerSeq % period);
+        auto bytesRemaining = b->getSize() - evictionIter.bucketFileOffset;
+        if (ledgersRemainingToScanBucket * scanSize < bytesRemaining)
+        {
+            CLOG_WARNING(Bucket,
+                         "Bucket too large for current eviction scan size.");
+            counters.incompleteBucketScan.inc();
+        }
+
         while (!b->scanForEviction(
             ltx, evictionIter, scanSize, maxEntriesToEvict, ledgerSeq,
             counters.entriesEvicted, counters.bytesScannedForEviction,
@@ -945,17 +961,6 @@ BucketList::scanForEviction(Application& app, AbstractLedgerTxn& ltx,
             }
 
             b = getBucketFromIter(evictionIter);
-
-            // Check to see if we can finish scanning the new bucket before it
-            // receives an update
-            auto period = bucketUpdatePeriod(evictionIter.bucketListLevel,
-                                             evictionIter.isCurrBucket);
-            if (period * scanSize < b->getSize())
-            {
-                CLOG_WARNING(
-                    Bucket, "Bucket too large for current eviction scan size.");
-                counters.incompleteBucketScan.inc();
-            }
         }
 
         networkConfig.updateEvictionIterator(ltx, evictionIter);

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -488,8 +488,7 @@ class BucketList
 
     std::vector<LedgerEntry>
     loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                             Asset const& asset,
-                                             Config const& cfg) const;
+                                             Asset const& asset) const;
 
     std::vector<InflationWinner> loadInflationWinners(size_t maxWinners,
                                                       int64_t minBalance) const;

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -978,8 +978,8 @@ BucketManagerImpl::loadPoolShareTrustLinesByAccountAndAsset(
     // This query needs to do a linear scan of certain regions of the
     // BucketList, so the number of entries loaded is meaningless
     auto timer = recordBulkLoadMetrics("poolshareTrustlines", 0).TimeScope();
-    return mBucketList->loadPoolShareTrustLinesByAccountAndAsset(
-        accountID, asset, getConfig());
+    return mBucketList->loadPoolShareTrustLinesByAccountAndAsset(accountID,
+                                                                 asset);
 }
 
 std::vector<InflationWinner>

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -352,6 +352,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                 entries.emplace_back(trustlineToSearch);
                 entries.emplace_back(trustline2);
             }
+            // Shadow via delete
             else if (shouldShadow && mDist(gRandomEngine) < 10 &&
                      !mTestEntries.empty())
             {
@@ -359,6 +360,15 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                 auto iter = mTestEntries.begin();
                 toShadow.emplace_back(iter->first);
                 mTestEntries.erase(iter);
+            }
+            // Shadow via modify
+            else if (shouldShadow && mDist(gRandomEngine) < 10 &&
+                     !mTestEntries.empty())
+            {
+                // Arbitrarily shadow first entry of map
+                auto iter = mTestEntries.begin();
+                iter->second.data.trustLine().balance += 10;
+                entries.emplace_back(iter->second);
             }
 
             mApp->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -111,7 +111,7 @@ class BucketIndexTest
     }
 
     virtual void
-    buildShadowTest()
+    buildMultiVersionTest()
     {
         std::vector<LedgerKey> toDestroy;
         std::vector<LedgerEntry> toUpdate;
@@ -308,10 +308,10 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     }
 
     void
-    buildTest(bool shouldShadow)
+    buildTest(bool shouldMultiVersion)
     {
         auto f = [&](std::vector<LedgerEntry>& entries) {
-            std::vector<LedgerKey> toShadow;
+            std::vector<LedgerKey> toWriteNewVersion;
             if (mDist(gRandomEngine) < 30)
             {
                 auto pool = LedgerTestUtils::generateValidLiquidityPoolEntry();
@@ -352,27 +352,27 @@ class BucketIndexPoolShareTest : public BucketIndexTest
                 entries.emplace_back(trustlineToSearch);
                 entries.emplace_back(trustline2);
             }
-            // Shadow via delete
-            else if (shouldShadow && mDist(gRandomEngine) < 10 &&
+            // Write new version via delete
+            else if (shouldMultiVersion && mDist(gRandomEngine) < 10 &&
                      !mTestEntries.empty())
             {
-                // Arbitrarily shadow first entry of map
+                // Arbitrarily pcik first entry of map
                 auto iter = mTestEntries.begin();
-                toShadow.emplace_back(iter->first);
+                toWriteNewVersion.emplace_back(iter->first);
                 mTestEntries.erase(iter);
             }
-            // Shadow via modify
-            else if (shouldShadow && mDist(gRandomEngine) < 10 &&
+            // Write new version via modify
+            else if (shouldMultiVersion && mDist(gRandomEngine) < 10 &&
                      !mTestEntries.empty())
             {
-                // Arbitrarily shadow first entry of map
+                // Arbitrarily pick first entry of map
                 auto iter = mTestEntries.begin();
                 iter->second.data.trustLine().balance += 10;
                 entries.emplace_back(iter->second);
             }
 
             mApp->getLedgerManager().setNextLedgerEntryBatchForBucketTesting(
-                {}, entries, toShadow);
+                {}, entries, toWriteNewVersion);
         };
 
         BucketIndexTest::buildBucketList(f);
@@ -400,7 +400,7 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     }
 
     virtual void
-    buildShadowTest() override
+    buildMultiVersionTest() override
     {
         buildTest(true);
     }
@@ -456,11 +456,11 @@ TEST_CASE("key-value lookup", "[bucket][bucketindex]")
     testAllIndexTypes(f);
 }
 
-TEST_CASE("do not load shadowed values", "[bucket][bucketindex]")
+TEST_CASE("do not load outdated values", "[bucket][bucketindex]")
 {
     auto f = [&](Config& cfg) {
         auto test = BucketIndexTest(cfg);
-        test.buildShadowTest();
+        test.buildMultiVersionTest();
         test.run();
     };
 
@@ -478,12 +478,13 @@ TEST_CASE("loadPoolShareTrustLinesByAccountAndAsset", "[bucket][bucketindex]")
     testAllIndexTypes(f);
 }
 
-TEST_CASE("loadPoolShareTrustLinesByAccountAndAsset does not load shadows",
-          "[bucket][bucketindex]")
+TEST_CASE(
+    "loadPoolShareTrustLinesByAccountAndAsset does not load outdated versions",
+    "[bucket][bucketindex]")
 {
     auto f = [&](Config& cfg) {
         auto test = BucketIndexPoolShareTest(cfg);
-        test.buildShadowTest();
+        test.buildMultiVersionTest();
         test.run();
     };
 


### PR DESCRIPTION
# Description

Resolves #4031

This PR includes cleanups and hardening of `Bucket` related code.

- `loadPoolShareTrustlinesByAccountAndAsset`: Extended a test to make sure this function does not return outdated entries. This was working properly, but did not have an explicit test. I've also added an explicit `seenKeys` set instead of relying on the fact that `unordered_map::emplace` will not update a key if it already exists for more defensive programming. Finally, there was an edge case where if a `Bucket` only contained offers and did not contain a `METAENTRY`, the scan would return early. This should never happen in practice, but it has been fixed.
- XDRStream audit: I took a deep dive into `ifstream` and ran several experiments such as disabling stream buffering. I've concluded that `ifstream` with buffering is still the optimal file IO interface for BucketsDB. I've also checked that we're handling EOF and bad bits properly, and could not find any dependencies on out-of-spec behavior. The only code change was a minor scoping issue on a tracy metric.
- Added separate stream for BucketDB scans and eviction scans.
- Warn more aggressively if eviction scans get stuck. Previously, there was only a single warning per stuck bucket, and there we certain edge cases where the warning would not be triggered, such as if a large bucket was almost entirely TEMPORARY entries. Now, we warn on every ledger and check much more aggressively.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
