### PR TITLE
Don't generate diagnostic errors at all when diagnostics is disabled.

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -958,8 +958,8 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
                                      1);
                 resultBase64 = decoder::encode_b64(resultBin);
                 root["error"] = resultBase64;
-                if (transaction->getResultCode() == txSOROBAN_INVALID &&
-                    mApp.getConfig().ENABLE_SOROBAN_DIAGNOSTIC_EVENTS)
+                if (mApp.getConfig().ENABLE_SOROBAN_DIAGNOSTIC_EVENTS &&
+                    !transaction->getDiagnosticEvents().empty())
                 {
                     auto diagsBin =
                         xdr::xdr_to_opaque(transaction->getDiagnosticEvents());

--- a/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-20-soroban.json
@@ -1798,53 +1798,7 @@
                                     "type": "SCV_BOOL",
                                     "b": "FALSE"
                                 },
-                                "diagnosticEvents": [
-                                    {
-                                        "inSuccessfulContractCall": "FALSE",
-                                        "event": {
-                                            "ext": {
-                                                "v": 0
-                                            },
-                                            "contractID": null,
-                                            "type": "DIAGNOSTIC",
-                                            "body": {
-                                                "v": 0,
-                                                "v0": {
-                                                    "topics": [
-                                                        {
-                                                            "type": "SCV_SYMBOL",
-                                                            "sym": "error"
-                                                        },
-                                                        {
-                                                            "type": "SCV_ERROR",
-                                                            "error": {
-                                                                "type": "SCE_BUDGET",
-                                                                "code": "SCEC_EXCEEDED_LIMIT"
-                                                            }
-                                                        }
-                                                    ],
-                                                    "data": {
-                                                        "type": "SCV_VEC",
-                                                        "vec": [
-                                                            {
-                                                                "type": "SCV_STRING",
-                                                                "str": "operation instructions exceeds amount specified"
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 216850
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 200000
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
+                                "diagnosticEvents": []
                             }
                         }
                     }

--- a/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-21-soroban.json
@@ -2077,53 +2077,7 @@
                                     "type": "SCV_BOOL",
                                     "b": "FALSE"
                                 },
-                                "diagnosticEvents": [
-                                    {
-                                        "inSuccessfulContractCall": "FALSE",
-                                        "event": {
-                                            "ext": {
-                                                "v": 0
-                                            },
-                                            "contractID": null,
-                                            "type": "DIAGNOSTIC",
-                                            "body": {
-                                                "v": 0,
-                                                "v0": {
-                                                    "topics": [
-                                                        {
-                                                            "type": "SCV_SYMBOL",
-                                                            "sym": "error"
-                                                        },
-                                                        {
-                                                            "type": "SCV_ERROR",
-                                                            "error": {
-                                                                "type": "SCE_BUDGET",
-                                                                "code": "SCEC_EXCEEDED_LIMIT"
-                                                            }
-                                                        }
-                                                    ],
-                                                    "data": {
-                                                        "type": "SCV_VEC",
-                                                        "vec": [
-                                                            {
-                                                                "type": "SCV_STRING",
-                                                                "str": "operation instructions exceeds amount specified"
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 216850
-                                                            },
-                                                            {
-                                                                "type": "SCV_U64",
-                                                                "u64": 200000
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                ]
+                                "diagnosticEvents": []
                             }
                         }
                     }

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -153,9 +153,9 @@ ExtendFootprintTTLOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
 }
 
 bool
-ExtendFootprintTTLOpFrame::doCheckValid(SorobanNetworkConfig const& config,
-                                        Config const& appConfig,
-                                        uint32_t ledgerVersion)
+ExtendFootprintTTLOpFrame::doCheckValid(
+    SorobanNetworkConfig const& networkConfig, Config const& appConfig,
+    uint32_t ledgerVersion)
 {
     auto const& footprint = mParentTx.sorobanResources().footprint;
     if (!footprint.readWrite.empty())
@@ -176,13 +176,15 @@ ExtendFootprintTTLOpFrame::doCheckValid(SorobanNetworkConfig const& config,
             innerResult().code(EXTEND_FOOTPRINT_TTL_MALFORMED);
             mParentTx.pushSimpleDiagnosticError(
                 appConfig, SCE_STORAGE, SCEC_INVALID_INPUT,
-                "only entries with TTL can have it extended", {});
+                "only entries with TTL (contract data or code entries) can "
+                "have it extended",
+                {});
             return false;
         }
     }
 
     if (mExtendFootprintTTLOp.extendTo >
-        config.stateArchivalSettings().maxEntryTTL - 1)
+        networkConfig.stateArchivalSettings().maxEntryTTL - 1)
     {
         innerResult().code(EXTEND_FOOTPRINT_TTL_MALFORMED);
         mParentTx.pushSimpleDiagnosticError(
@@ -190,7 +192,8 @@ ExtendFootprintTTLOpFrame::doCheckValid(SorobanNetworkConfig const& config,
             "TTL extension is too large: {} > {}",
             {
                 makeU64SCVal(mExtendFootprintTTLOp.extendTo),
-                makeU64SCVal(config.stateArchivalSettings().maxEntryTTL - 1),
+                makeU64SCVal(networkConfig.stateArchivalSettings().maxEntryTTL -
+                             1),
             });
         return false;
     }

--- a/src/transactions/ExtendFootprintTTLOpFrame.h
+++ b/src/transactions/ExtendFootprintTTLOpFrame.h
@@ -31,8 +31,8 @@ class ExtendFootprintTTLOpFrame : public OperationFrame
     bool doApply(Application& app, AbstractLedgerTxn& ltx,
                  Hash const& sorobanBasePrngSeed) override;
 
-    bool doCheckValid(SorobanNetworkConfig const& config,
-                      uint32_t ledgerVersion) override;
+    bool doCheckValid(SorobanNetworkConfig const& networkConfig,
+                      Config const& appConfig, uint32_t ledgerVersion) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     void

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -342,7 +342,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
 {
     ZoneNamedN(applyZone, "InvokeHostFunctionOpFrame apply", true);
 
-    Config const& cfg = app.getConfig();
+    Config const& appConfig = app.getConfig();
     HostFunctionMetrics metrics(app.getMetrics());
     auto const& sorobanConfig =
         app.getLedgerManager().getSorobanNetworkConfig();
@@ -360,7 +360,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     ttlEntryCxxBufs.reserve(footprintLength);
 
     auto addReads = [&ledgerEntryCxxBufs, &ttlEntryCxxBufs, &ltx, &metrics,
-                     &resources, &sorobanConfig, &cfg,
+                     &resources, &sorobanConfig, &appConfig,
                      this](auto const& keys) -> bool {
         for (auto const& lk : keys)
         {
@@ -424,8 +424,8 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             }
 
             metrics.noteReadEntry(isCodeKey(lk), keySize, entrySize);
-            if (!validateContractLedgerEntry(lk, entrySize, sorobanConfig, cfg,
-                                             mParentTx))
+            if (!validateContractLedgerEntry(lk, entrySize, sorobanConfig,
+                                             appConfig, mParentTx))
             {
                 this->innerResult().code(
                     INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
@@ -435,7 +435,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             if (resources.readBytes < metrics.mLedgerReadByte)
             {
                 mParentTx.pushSimpleDiagnosticError(
-                    cfg, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                    appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                     "operation byte-read resources exceeds amount specified",
                     {makeU64SCVal(metrics.mLedgerReadByte),
                      makeU64SCVal(resources.readBytes)});
@@ -478,8 +478,8 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
                                      sorobanBasePrngSeed.end());
 
         out = rust_bridge::invoke_host_function(
-            cfg.CURRENT_LEDGER_PROTOCOL_VERSION,
-            cfg.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS, resources.instructions,
+            appConfig.CURRENT_LEDGER_PROTOCOL_VERSION,
+            appConfig.ENABLE_SOROBAN_DIAGNOSTIC_EVENTS, resources.instructions,
             toCxxBuf(mInvokeHostFunction.hostFunction), toCxxBuf(resources),
             toCxxBuf(getSourceID()), authEntryCxxBufs,
             getLedgerInfo(ltx, app, sorobanConfig), ledgerEntryCxxBufs,
@@ -493,7 +493,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             out.time_nsecs_excluding_vm_instantiation;
         if (!out.success)
         {
-            maybePopulateDiagnosticEvents(cfg, out, metrics);
+            maybePopulateDiagnosticEvents(appConfig, out, metrics);
         }
     }
     catch (std::exception& e)
@@ -514,7 +514,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         if (resources.instructions < out.cpu_insns)
         {
             mParentTx.pushSimpleDiagnosticError(
-                cfg, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                 "operation instructions exceeds amount specified",
                 {makeU64SCVal(out.cpu_insns),
                  makeU64SCVal(resources.instructions)});
@@ -523,7 +523,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         else if (sorobanConfig.txMemoryLimit() < out.mem_bytes)
         {
             mParentTx.pushSimpleDiagnosticError(
-                cfg, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                 "operation memory usage exceeds network config limit",
                 {makeU64SCVal(out.mem_bytes),
                  makeU64SCVal(sorobanConfig.txMemoryLimit())});
@@ -544,7 +544,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         LedgerEntry le;
         xdr::xdr_from_opaque(buf.data, le);
         if (!validateContractLedgerEntry(LedgerEntryKey(le), buf.data.size(),
-                                         sorobanConfig, cfg, mParentTx))
+                                         sorobanConfig, appConfig, mParentTx))
         {
             innerResult().code(INVOKE_HOST_FUNCTION_RESOURCE_LIMIT_EXCEEDED);
             return false;
@@ -564,7 +564,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             if (resources.writeBytes < metrics.mLedgerWriteByte)
             {
                 mParentTx.pushSimpleDiagnosticError(
-                    cfg, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                    appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                     "operation byte-write resources exceeds amount specified",
                     {makeU64SCVal(metrics.mLedgerWriteByte),
                      makeU64SCVal(resources.writeBytes)});
@@ -639,7 +639,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
             metrics.mEmitEventByte)
         {
             mParentTx.pushSimpleDiagnosticError(
-                cfg, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+                appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
                 "total events size exceeds network config maximum",
                 {makeU64SCVal(metrics.mEmitEventByte),
                  makeU64SCVal(sorobanConfig.txMaxContractEventsSizeBytes())});
@@ -651,13 +651,13 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
         success.events.emplace_back(evt);
     }
 
-    maybePopulateDiagnosticEvents(cfg, out, metrics);
+    maybePopulateDiagnosticEvents(appConfig, out, metrics);
 
     metrics.mEmitEventByte += static_cast<uint32>(out.result_value.data.size());
     if (sorobanConfig.txMaxContractEventsSizeBytes() < metrics.mEmitEventByte)
     {
         mParentTx.pushSimpleDiagnosticError(
-            cfg, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+            appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
             "return value pushes events size above network config maximum",
             {makeU64SCVal(metrics.mEmitEventByte),
              makeU64SCVal(sorobanConfig.txMaxContractEventsSizeBytes())});
@@ -667,7 +667,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
 
     if (!mParentTx.consumeRefundableSorobanResources(
             metrics.mEmitEventByte, out.rent_fee,
-            ltx.loadHeader().current().ledgerVersion, sorobanConfig, cfg))
+            ltx.loadHeader().current().ledgerVersion, sorobanConfig, appConfig))
     {
         innerResult().code(INVOKE_HOST_FUNCTION_INSUFFICIENT_REFUNDABLE_FEE);
         return false;
@@ -684,20 +684,20 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
 }
 
 bool
-InvokeHostFunctionOpFrame::doCheckValid(SorobanNetworkConfig const& config,
-                                        Config const& appConfig,
-                                        uint32_t ledgerVersion)
+InvokeHostFunctionOpFrame::doCheckValid(
+    SorobanNetworkConfig const& networkConfig, Config const& appConfig,
+    uint32_t ledgerVersion)
 {
     // check wasm size if uploading contract
     auto const& hostFn = mInvokeHostFunction.hostFunction;
     if (hostFn.type() == HOST_FUNCTION_TYPE_UPLOAD_CONTRACT_WASM &&
-        hostFn.wasm().size() > config.maxContractSizeBytes())
+        hostFn.wasm().size() > networkConfig.maxContractSizeBytes())
     {
         mParentTx.pushSimpleDiagnosticError(
             appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
             "uploaded WASM size exceeds network config maximum contract size",
             {makeU64SCVal(hostFn.wasm().size()),
-             makeU64SCVal(config.maxContractSizeBytes())});
+             makeU64SCVal(networkConfig.maxContractSizeBytes())});
         return false;
     }
     if (hostFn.type() == HOST_FUNCTION_TYPE_CREATE_CONTRACT)

--- a/src/transactions/InvokeHostFunctionOpFrame.h
+++ b/src/transactions/InvokeHostFunctionOpFrame.h
@@ -41,7 +41,7 @@ class InvokeHostFunctionOpFrame : public OperationFrame
                  Hash const& sorobanBasePrngSeed) override;
 
     bool doCheckValid(SorobanNetworkConfig const& config,
-                      uint32_t ledgerVersion) override;
+                      Config const& appConfig, uint32_t ledgerVersion) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     void

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -269,7 +269,7 @@ OperationFrame::checkValid(Application& app, SignatureChecker& signatureChecker,
         auto const& sorobanConfig =
             app.getLedgerManager().getSorobanNetworkConfig();
 
-        return doCheckValid(sorobanConfig, ledgerVersion);
+        return doCheckValid(sorobanConfig, app.getConfig(), ledgerVersion);
     }
     else
     {
@@ -279,7 +279,7 @@ OperationFrame::checkValid(Application& app, SignatureChecker& signatureChecker,
 
 bool
 OperationFrame::doCheckValid(SorobanNetworkConfig const& config,
-                             uint32_t ledgerVersion)
+                             Config const& appConfig, uint32_t ledgerVersion)
 {
     return doCheckValid(ledgerVersion);
 }

--- a/src/transactions/OperationFrame.h
+++ b/src/transactions/OperationFrame.h
@@ -42,7 +42,7 @@ class OperationFrame
     OperationResult& mResult;
 
     virtual bool doCheckValid(SorobanNetworkConfig const& config,
-                              uint32_t ledgerVersion);
+                              Config const& appConfig, uint32_t ledgerVersion);
     virtual bool doCheckValid(uint32_t ledgerVersion) = 0;
 
     virtual bool doApply(Application& app, AbstractLedgerTxn& ltx,

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -166,7 +166,7 @@ RestoreFootprintOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
 }
 
 bool
-RestoreFootprintOpFrame::doCheckValid(SorobanNetworkConfig const& config,
+RestoreFootprintOpFrame::doCheckValid(SorobanNetworkConfig const& networkConfig,
                                       Config const& appConfig,
                                       uint32_t ledgerVersion)
 {

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -31,7 +31,7 @@ class RestoreFootprintOpFrame : public OperationFrame
     bool doApply(Application& app, AbstractLedgerTxn& ltx,
                  Hash const& sorobanBasePrngSeed) override;
 
-    bool doCheckValid(SorobanNetworkConfig const& config,
+    bool doCheckValid(SorobanNetworkConfig const& networkConfig,
                       Config const& appConfig, uint32_t ledgerVersion) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 

--- a/src/transactions/RestoreFootprintOpFrame.h
+++ b/src/transactions/RestoreFootprintOpFrame.h
@@ -32,7 +32,7 @@ class RestoreFootprintOpFrame : public OperationFrame
                  Hash const& sorobanBasePrngSeed) override;
 
     bool doCheckValid(SorobanNetworkConfig const& config,
-                      uint32_t ledgerVersion) override;
+                      Config const& appConfig, uint32_t ledgerVersion) override;
     bool doCheckValid(uint32_t ledgerVersion) override;
 
     void

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -140,6 +140,7 @@ class TransactionFrame : public TransactionFrameBase
 
     bool validateSorobanOpsConsistency() const;
     bool validateSorobanResources(SorobanNetworkConfig const& config,
+                                  Config const& appConfig,
                                   uint32_t protocolVersion);
     void refundSorobanFee(AbstractLedgerTxn& ltx);
 #ifdef BUILD_TESTS
@@ -199,8 +200,8 @@ class TransactionFrame : public TransactionFrameBase
     void pushDiagnosticEvents(xdr::xvector<DiagnosticEvent>&& evts);
     void setReturnValue(SCVal&& returnValue);
     void pushDiagnosticEvent(DiagnosticEvent&& evt);
-    void pushSimpleDiagnosticError(SCErrorType ty, SCErrorCode code,
-                                   std::string&& message,
+    void pushSimpleDiagnosticError(Config const& cfg, SCErrorType ty,
+                                   SCErrorCode code, std::string&& message,
                                    xdr::xvector<SCVal>&& args = {});
     xdr::xvector<DiagnosticEvent> const& getDiagnosticEvents() const override;
 

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1834,13 +1834,13 @@ getMinInclusionFee(TransactionFrameBase const& tx, LedgerHeader const& header,
 bool
 validateContractLedgerEntry(LedgerKey const& lk, size_t entrySize,
                             SorobanNetworkConfig const& config,
-                            TransactionFrame& parentTx)
+                            Config const& appConfig, TransactionFrame& parentTx)
 {
     // check contract code size limit
     if (lk.type() == CONTRACT_CODE && config.maxContractSizeBytes() < entrySize)
     {
         parentTx.pushSimpleDiagnosticError(
-            SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+            appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
             "Wasm size exceeds network config maximum contract size",
             {makeU64SCVal(entrySize),
              makeU64SCVal(config.maxContractSizeBytes())});
@@ -1851,7 +1851,7 @@ validateContractLedgerEntry(LedgerKey const& lk, size_t entrySize,
         config.maxContractDataEntrySizeBytes() < entrySize)
     {
         parentTx.pushSimpleDiagnosticError(
-            SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
+            appConfig, SCE_BUDGET, SCEC_EXCEEDED_LIMIT,
             "ContractData size exceeds network config maximum size",
             {makeU64SCVal(entrySize),
              makeU64SCVal(config.maxContractDataEntrySizeBytes())});

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "main/Config.h"
 #include "util/NonCopyable.h"
 #include "util/ProtocolVersion.h"
 #include "xdr/Stellar-ledger-entries.h"
@@ -306,6 +307,7 @@ int64_t getMinInclusionFee(TransactionFrameBase const& tx,
 
 bool validateContractLedgerEntry(LedgerKey const& lk, size_t entrySize,
                                  SorobanNetworkConfig const& config,
+                                 Config const& appConfig,
                                  TransactionFrame& parentTx);
 
 struct LumenContractInfo

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -4,7 +4,6 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
-#include "main/Config.h"
 #include "util/NonCopyable.h"
 #include "util/ProtocolVersion.h"
 #include "xdr/Stellar-ledger-entries.h"
@@ -18,6 +17,7 @@ namespace stellar
 {
 
 class Application;
+class Config;
 class ConstLedgerTxnEntry;
 class ConstTrustLineWrapper;
 class AbstractLedgerTxn;


### PR DESCRIPTION
# Description

Don't generate diagnostic errors at all when diagnostics is disabled.

Also added diagnostic messages to a few errors that didn't have them.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
