### PR TITLE
Try-catch in destructors

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1352,7 +1352,6 @@ getSettingsUpgradeTransactions(CommandLineArgs const& args)
                           << std::endl;
             }
 
-            std::cerr << "ConfigUpgradeSetKey  ";
             std::cout << decoder::encode_b64(xdr::xdr_to_opaque(upgradeSetKey))
                       << std::endl;
 

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -22,10 +22,17 @@ struct ExtendFootprintTTLMetrics
 
     ~ExtendFootprintTTLMetrics()
     {
-        mMetrics
-            .NewMeter({"soroban", "ext-fprint-ttl-op", "read-ledger-byte"},
-                      "byte")
-            .Mark(mLedgerReadByte);
+        try
+        {
+            mMetrics
+                .NewMeter({"soroban", "ext-fprint-ttl-op", "read-ledger-byte"},
+                          "byte")
+                .Mark(mLedgerReadByte);
+        }
+        catch (const std::exception& e)
+        {
+            CLOG_WARNING(Tx, "Caught ExtendFootprintTTLMetrics exception");
+        }
     }
 };
 

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -176,69 +176,92 @@ struct HostFunctionMetrics
 
     ~HostFunctionMetrics()
     {
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-entry"}, "entry")
-            .Mark(mReadEntry);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-entry"}, "entry")
-            .Mark(mWriteEntry);
-
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-key-byte"}, "byte")
-            .Mark(mReadKeyByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-key-byte"}, "byte")
-            .Mark(mWriteKeyByte);
-
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-ledger-byte"}, "byte")
-            .Mark(mLedgerReadByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-data-byte"}, "byte")
-            .Mark(mReadDataByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-code-byte"}, "byte")
-            .Mark(mReadCodeByte);
-
-        mMetrics
-            .NewMeter({"soroban", "host-fn-op", "write-ledger-byte"}, "byte")
-            .Mark(mLedgerWriteByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-data-byte"}, "byte")
-            .Mark(mWriteDataByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-code-byte"}, "byte")
-            .Mark(mWriteCodeByte);
-
-        mMetrics.NewMeter({"soroban", "host-fn-op", "emit-event"}, "event")
-            .Mark(mEmitEvent);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "emit-event-byte"}, "byte")
-            .Mark(mEmitEventByte);
-
-        mMetrics.NewMeter({"soroban", "host-fn-op", "cpu-insn"}, "insn")
-            .Mark(mCpuInsn);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "mem-byte"}, "byte")
-            .Mark(mMemByte);
-        mMetrics
-            .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs"}, "time")
-            .Mark(mInvokeTimeNsecs);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "cpu-insn-excl-vm"}, "insn")
-            .Mark(mCpuInsnExclVm);
-        mMetrics
-            .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs-excl-vm"},
-                      "time")
-            .Mark(mInvokeTimeNsecsExclVm);
-
-        mMetrics.NewMeter({"soroban", "host-fn-op", "max-rw-key-byte"}, "byte")
-            .Mark(mMaxReadWriteKeyByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "max-rw-data-byte"}, "byte")
-            .Mark(mMaxReadWriteDataByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "max-rw-code-byte"}, "byte")
-            .Mark(mMaxReadWriteCodeByte);
-        mMetrics
-            .NewMeter({"soroban", "host-fn-op", "max-emit-event-byte"}, "byte")
-            .Mark(mMaxEmitEventByte);
-
-        if (mSuccess)
+        try
         {
-            mMetrics.NewMeter({"soroban", "host-fn-op", "success"}, "call")
-                .Mark();
+            mMetrics.NewMeter({"soroban", "host-fn-op", "read-entry"}, "entry")
+                .Mark(mReadEntry);
+            mMetrics.NewMeter({"soroban", "host-fn-op", "write-entry"}, "entry")
+                .Mark(mWriteEntry);
+
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "read-key-byte"}, "byte")
+                .Mark(mReadKeyByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "write-key-byte"}, "byte")
+                .Mark(mWriteKeyByte);
+
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "read-ledger-byte"}, "byte")
+                .Mark(mLedgerReadByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "read-data-byte"}, "byte")
+                .Mark(mReadDataByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "read-code-byte"}, "byte")
+                .Mark(mReadCodeByte);
+
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "write-ledger-byte"},
+                          "byte")
+                .Mark(mLedgerWriteByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "write-data-byte"}, "byte")
+                .Mark(mWriteDataByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "write-code-byte"}, "byte")
+                .Mark(mWriteCodeByte);
+
+            mMetrics.NewMeter({"soroban", "host-fn-op", "emit-event"}, "event")
+                .Mark(mEmitEvent);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "emit-event-byte"}, "byte")
+                .Mark(mEmitEventByte);
+
+            mMetrics.NewMeter({"soroban", "host-fn-op", "cpu-insn"}, "insn")
+                .Mark(mCpuInsn);
+            mMetrics.NewMeter({"soroban", "host-fn-op", "mem-byte"}, "byte")
+                .Mark(mMemByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs"},
+                          "time")
+                .Mark(mInvokeTimeNsecs);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "cpu-insn-excl-vm"}, "insn")
+                .Mark(mCpuInsnExclVm);
+            mMetrics
+                .NewMeter(
+                    {"soroban", "host-fn-op", "invoke-time-nsecs-excl-vm"},
+                    "time")
+                .Mark(mInvokeTimeNsecsExclVm);
+
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "max-rw-key-byte"}, "byte")
+                .Mark(mMaxReadWriteKeyByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "max-rw-data-byte"}, "byte")
+                .Mark(mMaxReadWriteDataByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "max-rw-code-byte"}, "byte")
+                .Mark(mMaxReadWriteCodeByte);
+            mMetrics
+                .NewMeter({"soroban", "host-fn-op", "max-emit-event-byte"},
+                          "byte")
+                .Mark(mMaxEmitEventByte);
+
+            if (mSuccess)
+            {
+                mMetrics.NewMeter({"soroban", "host-fn-op", "success"}, "call")
+                    .Mark();
+            }
+            else
+            {
+                mMetrics.NewMeter({"soroban", "host-fn-op", "failure"}, "call")
+                    .Mark();
+            }
         }
-        else
+        catch (const std::exception& e)
         {
-            mMetrics.NewMeter({"soroban", "host-fn-op", "failure"}, "call")
-                .Mark();
+            CLOG_WARNING(Tx, "Caught HostFunctionMetrics exception");
         }
     }
     medida::TimerContext

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -23,14 +23,21 @@ struct RestoreFootprintMetrics
 
     ~RestoreFootprintMetrics()
     {
-        mMetrics
-            .NewMeter({"soroban", "restore-fprint-op", "read-ledger-byte"},
-                      "byte")
-            .Mark(mLedgerReadByte);
-        mMetrics
-            .NewMeter({"soroban", "restore-fprint-op", "write-ledger-byte"},
-                      "byte")
-            .Mark(mLedgerWriteByte);
+        try
+        {
+            mMetrics
+                .NewMeter({"soroban", "restore-fprint-op", "read-ledger-byte"},
+                          "byte")
+                .Mark(mLedgerReadByte);
+            mMetrics
+                .NewMeter({"soroban", "restore-fprint-op", "write-ledger-byte"},
+                          "byte")
+                .Mark(mLedgerWriteByte);
+        }
+        catch (const std::exception& e)
+        {
+            CLOG_WARNING(Tx, "Caught RestoreFootprintMetrics exception");
+        }
     }
 };
 


### PR DESCRIPTION
# Description

 It shouldn't be possible for an exception to be thrown as the code is written, but this is a defensive change to prevent an exception in the destructor from resulting in program termination. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
