### PR TITLE
BucketListDB Bucket Apply Optimization

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -53,6 +53,12 @@ Bucket::isIndexed() const
     return static_cast<bool>(mIndex);
 }
 
+std::optional<std::pair<std::streamoff, std::streamoff>>
+Bucket::getOfferRange() const
+{
+    return getIndex().getOfferRange();
+}
+
 void
 Bucket::setIndex(std::unique_ptr<BucketIndex const>&& index)
 {
@@ -135,13 +141,14 @@ Bucket::apply(Application& app) const
 {
     ZoneScoped;
 
+    std::unordered_set<LedgerKey> emptySet;
     BucketApplicator applicator(
         app, app.getConfig().LEDGER_PROTOCOL_VERSION,
         0 /*set to 0 so we always load from the parent to check state*/,
         0 /*set to a level that's not the bottom so we don't treat live entries
              as init*/
         ,
-        shared_from_this(), [](LedgerEntryType) { return true; });
+        shared_from_this(), [](LedgerEntryType) { return true; }, emptySet);
     BucketApplicator::Counters counters(app.getClock().now());
     while (applicator)
     {

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -82,6 +82,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     // Returns true if bucket is indexed, false otherwise
     bool isIndexed() const;
 
+    // Returns [lowerBound, upperBound) of file offsets for all offers in the
+    // bucket, or std::nullopt if no offers exist
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getOfferRange() const;
+
     // Sets index, throws if index is already set
     void setIndex(std::unique_ptr<BucketIndex const>&& index);
 

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -118,6 +118,11 @@ class BucketIndex : public NonMovableOrCopyable
     virtual std::vector<PoolID> const&
     getPoolIDsByAsset(Asset const& asset) const = 0;
 
+    // Returns lower bound and upper bound for offer entry positions in the
+    // given bucket, or std::nullopt if no offers exist
+    virtual std::optional<std::pair<std::streamoff, std::streamoff>>
+    getOfferRange() const = 0;
+
     // Returns page size for index. InidividualIndex returns 0 for page size
     virtual std::streamoff getPageSize() const = 0;
 

--- a/src/bucket/BucketIndexImpl.h
+++ b/src/bucket/BucketIndexImpl.h
@@ -66,6 +66,12 @@ template <class IndexT> class BucketIndexImpl : public BucketIndex
     // Saves index to disk, overwriting any preexisting file for this index
     void saveToDisk(BucketManager& bm, Hash const& hash) const;
 
+    // Returns [lowFileOffset, highFileOffset) that contain the key ranges
+    // [lowerBound, upperBound]. If no file offsets exist, returns [0, 0]
+    std::optional<std::pair<std::streamoff, std::streamoff>>
+    getOffsetBounds(LedgerKey const& lowerBound,
+                    LedgerKey const& upperBound) const;
+
     friend BucketIndex;
 
   public:
@@ -80,6 +86,9 @@ template <class IndexT> class BucketIndexImpl : public BucketIndex
 
     virtual std::vector<PoolID> const&
     getPoolIDsByAsset(Asset const& asset) const override;
+
+    virtual std::optional<std::pair<std::streamoff, std::streamoff>>
+    getOfferRange() const override;
 
     virtual std::streamoff
     getPageSize() const override

--- a/src/bucket/BucketInputIterator.cpp
+++ b/src/bucket/BucketInputIterator.cpp
@@ -52,7 +52,7 @@ BucketInputIterator::loadEntry()
     }
 }
 
-size_t
+std::streamoff
 BucketInputIterator::pos()
 {
     return mIn.pos();
@@ -123,5 +123,12 @@ BucketInputIterator::operator++()
         mEntryPtr = nullptr;
     }
     return *this;
+}
+
+void
+BucketInputIterator::seek(std::streamoff offset)
+{
+    mIn.seek(offset);
+    loadEntry();
 }
 }

--- a/src/bucket/BucketInputIterator.h
+++ b/src/bucket/BucketInputIterator.h
@@ -52,7 +52,8 @@ class BucketInputIterator
 
     BucketInputIterator& operator++();
 
-    size_t pos();
+    std::streamoff pos();
     size_t size() const;
+    void seek(std::streamoff offset);
 };
 }


### PR DESCRIPTION
# Description

Resolves #4113

This change improves Bucket apply times by approximately 80% when BucketListDB is enabled. In the current catchup flow, we first apply buckets then index those buckets. The Bucket apply step scans the entire BucketList even though only offers need to be applied. This PR changes the ordering such that we index buckets then apply them. This allows us to use the index to only scan sections of the BucketList that contain offers.

Bucket apply currently writes every entry it sees to the SQL DB. Because the BucketList is implemented via a LSMT, many versions of a given entry may exist in the BucketList, with only the most recent version being valid. This means Bucket apply must iterate through the BucketList in reverse order such that the last version of a key written is the most recent. This causes significant write amplification, as many versions of the same entry are written to disk even though only the most recent version is valid.

When BucketListDB is enabled, this change now applies buckets in-order so that we must only write any key a single time. However, to avoid writing out of date entries to the DB, in-order application requires that every key written to the DB is recorded in an in-memory set. This set would be too large if all entry types are being applied. However, when BucketListDB is enabled, we must only apply offer entries, making this optimization possible. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
