### PR TITLE
Parse ENABLE_SOROBAN_DIAGNOSTIC_EVENTS config parameter.

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1444,6 +1444,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 ENABLE_SOROBAN_DIAGNOSTIC_EVENTS = readBool(item);
             }
+            else if (item.first == "ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION")
+            {
+                ENABLE_DIAGNOSTICS_FOR_TX_SUBMISSION = readBool(item);
+            }
             else if (item.first == "TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME")
             {
                 TESTING_MINIMUM_PERSISTENT_ENTRY_LIFETIME =


### PR DESCRIPTION
# Description

Parse ENABLE_SOROBAN_DIAGNOSTIC_EVENTS config parameter.

This should have been a part of https://github.com/stellar/stellar-core/pull/4104

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
