### PR TITLE
Continue to capture SCP messages for previous ledger in database

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -307,6 +307,18 @@ HerderImpl::processExternalized(uint64 slotIndex, StellarValue const& value,
     // save the SCP messages in the database
     if (mApp.getConfig().MODE_STORES_HISTORY_MISC)
     {
+        ZoneNamedN(updateSCPHistoryZone, "update SCP history", true);
+        if (slotIndex != 0)
+        {
+            // Save any new SCP messages received about the previous ledger.
+            // NOTE: This call uses an empty `QuorumTracker::QuorumMap` because
+            // there is no new quorum map for the previous ledger.
+            mApp.getHerderPersistence().saveSCPHistory(
+                static_cast<uint32>(slotIndex - 1),
+                getSCP().getExternalizingState(slotIndex - 1),
+                QuorumTracker::QuorumMap());
+        }
+        // Store SCP messages received about the current ledger being closed.
         mApp.getHerderPersistence().saveSCPHistory(
             static_cast<uint32>(slotIndex),
             getSCP().getExternalizingState(slotIndex),


### PR DESCRIPTION

# Description

Resolves #3769

Upon closing a ledger, nodes record SCP messages received during the ledger period in the `scphistory` database table. However, any messages about that ledger heard *after* close were ignored. This change captures more of those messages by modifying the `processExternalized` function (which is responsible for recording SCP messages on ledger close) to also record any new messages heard about the previous ledger.

## Performance impact

As this change adds additional database interactions to the main thread, it does have a performance impact. I've mitigated this by [wrapping the new and old `saveSCPHistory` calls in a single transaction](https://github.com/stellar/stellar-core/blob/23aa763b643375322271496dea7f5be633b7a67f/src/herder/HerderImpl.cpp#L316). I measured the performance impacts using Tracy and have summarized the results for SQLite and Postgres below.

On SQLite, the use of a single transaction for both `saveSCPHistory` calls effectively negates the performance impact of the additional call. I suspect this is because it saves an expensive write to disk, which dominates the call.

On Postgres the performance improvement from using a single transaction is minimal, and does not entirely make up for the additional saveSCPHistory call. On average, saving the SCP history now takes 10% longer than before (averaging 0.82 miliseconds more on my machine). For reference, 0.82 milliseconds makes up 0.5% of the average `processExternalized` call when using the Postgres backend.

A 0.5% impact on one of two backends seemed like a good place to stop tweaking and measuring performance impacts, but if that's too large an impact I have a couple more ideas I can try:
1. Using a single multi-row insert into `scphistory` may be faster than the multiple single row inserts `saveSCPHistory` currently performs.
2. At first glance, it seems like saving SCP history could be moved off the main thread and onto a worker thread.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [x] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
