### PR TITLE
Pin rust version to exact version 1.74.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.74"
+channel = "1.74.1"


### PR DESCRIPTION
# Description

### What
Pin the rust version using for building to exact the version 1.74.1.

### Why
It appears that the stable releases of stellar-core have been built with Rust version 1.74.1.

According to @graydon in https://github.com/stellar/rs-soroban-env/issues/1311#issuecomment-1881887051 the intent is to pin stellar-core to a version of Rust.

At the moment it is pinned to a minor version of Rust, but new patch releases of Rust will cause rebuilds of stellar-core, or new builds of new commits, to automatically use the newer patch releases.

I think it's likely we'd want to use newer releases, but we should remain in control of when they are adopted and ideally builds of past source using the rust-toolchain.toml file to select a version are as consistent and reproducible as possible. i.e. They should use the same version of Rust they were originally built with. e.g. 1.74.1, not 1.74.n.

This change doesn't prevent us from changing the version on new Rust releases. It just makes sure we're the ones making the decision on when the change occurs.

Close stellar/rs-soroban-env#1311

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] ~Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)~
- [ ] Compiles
- [ ] Ran all tests
- [ ] ~If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)~