### PR TITLE
Add eviction cycle metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -156,6 +156,8 @@ scp.timing.self-to-others-externalize-lag | timer     | delay between local node
 scp.value.invalid                         | meter     | SCP value is invalid
 scp.value.valid                           | meter     | SCP value is valid
 scp.slot.values-referenced                | histogram | number of values referenced per consensus round
+state-archival.eviction.age               | counter   | the average of the delta between an entry's liveUntilLedger and the ledger when it is evicted
 state-archival.eviction.bytes-scanned     | counter   | number of bytes that eviction scan has read
 state-archival.eviction.entries-evicted   | counter   | number of entries that have been evicted
 state-archival.eviction.incomplete-scan   | counter   | number of buckets that were too large to be fully scanned for eviction
+state-archival.eviction.period            | counter   | number of ledgers to complete an eviction scan

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -38,6 +38,7 @@ namespace stellar
 class AbstractLedgerTxn;
 class Application;
 class BucketManager;
+struct EvictionMetrics;
 
 class Bucket : public std::enable_shared_from_this<Bucket>,
                public NonMovableOrCopyable
@@ -145,7 +146,8 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
                          uint64_t& bytesToScan, uint32_t& maxEntriesToEvict,
                          uint32_t ledgerSeq,
                          medida::Counter& entriesEvictedCounter,
-                         medida::Counter& bytesScannedForEvictionCounter);
+                         medida::Counter& bytesScannedForEvictionCounter,
+                         std::optional<EvictionMetrics>& metrics);
 
 #ifdef BUILD_TESTS
     // "Applies" the bucket to the database. For each entry in the bucket,

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -78,6 +78,17 @@ struct MergeCounters
     bool operator==(MergeCounters const& other) const;
 };
 
+struct BucketListEvictionCounters
+{
+    medida::Counter& entriesEvicted;
+    medida::Counter& bytesScannedForEviction;
+    medida::Counter& incompleteBucketScan;
+    medida::Counter& evictionCyclePeriod;
+    medida::Counter& averageEvictedEntryAge;
+
+    BucketListEvictionCounters(Application& app);
+};
+
 /**
  * BucketManager is responsible for maintaining a collection of Buckets of
  * ledger entries (each sorted, de-duplicated and identified by hash) and,

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -50,10 +50,8 @@ class BucketManagerImpl : public BucketManager
     medida::Meter& mBucketListDBBulkLoadMeter;
     medida::Meter& mBucketListDBBloomMisses;
     medida::Meter& mBucketListDBBloomLookups;
-    medida::Counter& mEntriesEvicted;
-    medida::Counter& mBytesScannedForEviction;
-    medida::Counter& mIncompleteBucketScans;
     medida::Counter& mBucketListSizeCounter;
+    BucketListEvictionCounters mBucketListEvictionCounters;
     mutable UnorderedMap<LedgerEntryType, medida::Timer&>
         mBucketListDBPointTimers{};
     mutable UnorderedMap<std::string, medida::Timer&> mBucketListDBBulkTimers{};


### PR DESCRIPTION
# Description

Resolves #4137

Adds additional metrics for eviction scans. Specifically, records the period of eviction scans in ledgers and the average amount of time it takes for an entry to get evicted after expiring.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
