### PR TITLE
Increase eviction scan size to 1 mb

### DIFF
--- a/soroban-settings/phase1.json
+++ b/soroban-settings/phase1.json
@@ -301,7 +301,7 @@
           "temp_rent_rate_denominator": 5356800,
           "max_entries_to_archive": 100,
           "bucket_list_size_window_sample_size": 30,
-          "eviction_scan_size": 100000,
+          "eviction_scan_size": 1048576,
           "starting_eviction_scan_level": 6
       }
     },


### PR DESCRIPTION
# Description

Increases phase 1 eviction scan size to 1 mb.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
