### PR TITLE
Add soroban metrics for selected network limits

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -186,3 +186,19 @@ soroban.host-fn-op.max-emit-event-byte       | meter     | bytes of the largest 
 soroban.host-fn-op.success                   | meter     | if `InvokeHostFunctionOp` results in a success
 soroban.host-fn-op.failure                   | meter     | if `InvokeHostFunctionOp` results in a failure
 soroban.host-fn-op.exec                      | timer     | time spent in `InvokeHostFunctionOp`
+soroban.config.contract-max-size-bytes           | meter     | soroban config setting `contract_max_size_bytes`
+soroban.config.ledger-max-instructions           | meter     | soroban config setting `ledger_max_instructions`
+soroban.config.tx-max-instructions               | meter     | soroban config setting `tx_max_instructions`
+soroban.config.tx-memory-limit                   | meter     | soroban config setting `tx_memory_limit`
+soroban.config.ledger-max-read-ledger-entries    | meter     | soroban config setting `ledger_max_read_ledger_entries`
+soroban.config.ledger-max-read-bytes             | meter     | soroban config setting `ledger_max_read_bytes`
+soroban.config.ledger-max-write-ledger-entries   | meter     | soroban config setting `ledger_max_write_ledger_entries`
+soroban.config.ledger-max-write-bytes            | meter     | soroban config setting `ledger_max_write_bytes`
+soroban.config.tx-max-read-ledger-entries        | meter     | soroban config setting `tx_max_read_ledger_entries`
+soroban.config.tx-max-read-bytes                 | meter     | soroban config setting `tx_max_read_bytes`
+soroban.config.tx-max-write-ledger-entries       | meter     | soroban config setting `tx_max_write_ledger_entries`
+soroban.config.tx-max-write-bytes                | meter     | soroban config setting `tx_max_write_bytes`
+soroban.config.bucket-list-target-size-bytes     | meter     | soroban config setting `bucket_list_target_size_bytes`
+soroban.config.tx-max-contract-events-size-bytes | meter     | soroban config setting `tx_max_contract_events_size_bytes`
+soroban.config.contract-data-key-size-bytes      | meter     | soroban config setting `contract_data_key_size_bytes`
+soroban.config.contract-data-entry-size-bytes    | meter     | soroban config setting `contract_data_entry_size_bytes`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -162,3 +162,27 @@ state-archival.eviction.bytes-scanned     | counter   | number of bytes that evi
 state-archival.eviction.entries-evicted   | counter   | number of entries that have been evicted
 state-archival.eviction.incomplete-scan   | counter   | number of buckets that were too large to be fully scanned for eviction
 state-archival.eviction.period            | counter   | number of ledgers to complete an eviction scan
+soroban.host-fn-op.read-entry                | meter     | number of entries read
+soroban.host-fn-op.write-entry               | meter     | number of entries written
+soroban.host-fn-op.read-key-byte             | meter     | number of key bytes in read entries
+soroban.host-fn-op.write-key-byte            | meter     | number of key bytes in written entries
+soroban.host-fn-op.read-ledger-byte          | meter     | number of data + code bytes in read entries
+soroban.host-fn-op.read-data-byte            | meter     | number of data bytes in read entries
+soroban.host-fn-op.read-code-byte            | meter     | number of code bytes in read entries
+soroban.host-fn-op.write-ledger-byte         | meter     | number of data + code bytes in written entries
+soroban.host-fn-op.write-data-byte           | meter     | number of data bytes in written entries
+soroban.host-fn-op.write-code-byte           | meter     | number of code bytes in written entries
+soroban.host-fn-op.emit-event                | meter     | number of events emitted
+soroban.host-fn-op.emit-event-byte           | meter     | number of event bytes emitted
+soroban.host-fn-op.cpu-insn                  | meter     | metered cpu instructions
+soroban.host-fn-op.mem-byte                  | meter     | metered memory bytes
+soroban.host-fn-op.invoke-time-nsecs         | meter     | time [nsecs] spent in `invoke_host_function`
+soroban.host-fn-op.cpu-insn-excl-vm          | meter     | metered cpu instructions excluding VM instantation
+soroban.host-fn-op.invoke-time-nsecs-excl-vm | meter     | time [nsecs] spent in `invoke_host_function` excluding VM instantation
+soroban.host-fn-op.max-rw-key-byte           | meter     | bytes of the largest key in entries read/written
+soroban.host-fn-op.max-rw-data-byte          | meter     | bytes of the largest data entry read/written
+soroban.host-fn-op.max-rw-code-byte          | meter     | bytes of the largest code entry read/written
+soroban.host-fn-op.max-emit-event-byte       | meter     | bytes of the largest event emitted
+soroban.host-fn-op.success                   | meter     | if `InvokeHostFunctionOp` results in a success
+soroban.host-fn-op.failure                   | meter     | if `InvokeHostFunctionOp` results in a failure
+soroban.host-fn-op.exec                      | timer     | time spent in `InvokeHostFunctionOp`

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -548,6 +548,84 @@ LedgerManagerImpl::getMutableSorobanNetworkConfig()
 }
 #endif
 
+void
+LedgerManagerImpl::publishSorobanNetworkConfigMetrics()
+{
+    releaseAssert(mSorobanNetworkConfig);
+    medida::MetricsRegistry& metrics = mApp.getMetrics();
+
+    auto contractMaxSizeBytes = mSorobanNetworkConfig->maxContractSizeBytes();
+    auto ledgerMaxInstructions = mSorobanNetworkConfig->ledgerMaxInstructions();
+    auto txMaxInstructions = mSorobanNetworkConfig->txMaxInstructions();
+    auto txMemoryLimit = mSorobanNetworkConfig->txMemoryLimit();
+    auto ledgerMaxReadLedgerEntries =
+        mSorobanNetworkConfig->ledgerMaxReadLedgerEntries();
+    auto ledgerMaxReadBytes = mSorobanNetworkConfig->ledgerMaxReadBytes();
+    auto ledgerMaxWriteLedgerEntries =
+        mSorobanNetworkConfig->ledgerMaxWriteLedgerEntries();
+    auto ledgerMaxWriteBytes = mSorobanNetworkConfig->ledgerMaxWriteBytes();
+    auto txMaxReadLedgerEntries =
+        mSorobanNetworkConfig->txMaxReadLedgerEntries();
+    auto txMaxReadBytes = mSorobanNetworkConfig->txMaxReadBytes();
+    auto txMaxWriteLedgerEntries =
+        mSorobanNetworkConfig->txMaxWriteLedgerEntries();
+    auto txMaxWriteBytes = mSorobanNetworkConfig->txMaxWriteBytes();
+    auto bucketListTargetSizeBytes =
+        mSorobanNetworkConfig->bucketListTargetSizeBytes();
+    auto txMaxContractEventsSizeBytes =
+        mSorobanNetworkConfig->txMaxContractEventsSizeBytes();
+    auto contractDataKeySizeBytes =
+        mSorobanNetworkConfig->maxContractDataKeySizeBytes();
+    auto contractDataEntrySizeBytes =
+        mSorobanNetworkConfig->maxContractDataEntrySizeBytes();
+
+    metrics.NewMeter({"soroban", "config", "contract-max-size-bytes"}, "byte")
+        .Mark(contractMaxSizeBytes);
+    metrics.NewMeter({"soroban", "config", "ledger-max-instructions"}, "insn")
+        .Mark(ledgerMaxInstructions);
+    metrics.NewMeter({"soroban", "config", "tx-max-instructions"}, "insn")
+        .Mark(txMaxInstructions);
+    metrics.NewMeter({"soroban", "config", "tx-memory-limit"}, "byte")
+        .Mark(txMemoryLimit);
+    metrics
+        .NewMeter({"soroban", "config", "ledger-max-read-ledger-entries"},
+                  "entry")
+        .Mark(ledgerMaxReadLedgerEntries);
+    metrics.NewMeter({"soroban", "config", "ledger-max-read-bytes"}, "byte")
+        .Mark(ledgerMaxReadBytes);
+    metrics
+        .NewMeter({"soroban", "config", "ledger-max-write-ledger-entries"},
+                  "entry")
+        .Mark(ledgerMaxWriteLedgerEntries);
+    metrics.NewMeter({"soroban", "config", "ledger-max-write-bytes"}, "byte")
+        .Mark(ledgerMaxWriteBytes);
+    metrics
+        .NewMeter({"soroban", "config", "tx-max-read-ledger-entries"}, "entry")
+        .Mark(txMaxReadLedgerEntries);
+    metrics.NewMeter({"soroban", "config", "tx-max-read-bytes"}, "byte")
+        .Mark(txMaxReadBytes);
+    metrics
+        .NewMeter({"soroban", "config", "tx-max-write-ledger-entries"}, "entry")
+        .Mark(txMaxWriteLedgerEntries);
+    metrics.NewMeter({"soroban", "config", "tx-max-write-bytes"}, "byte")
+        .Mark(txMaxWriteBytes);
+    metrics
+        .NewMeter({"soroban", "config", "bucket-list-target-size-bytes"},
+                  "byte")
+        .Mark(bucketListTargetSizeBytes);
+    metrics
+        .NewMeter({"soroban", "config", "tx-max-contract-events-size-bytes"},
+                  "byte")
+        .Mark(txMaxContractEventsSizeBytes);
+    metrics
+        .NewMeter({"soroban", "config", "contract-data-key-size-bytes"}, "byte")
+        .Mark(contractDataKeySizeBytes);
+    metrics
+        .NewMeter({"soroban", "config", "contract-data-entry-size-bytes"},
+                  "byte")
+        .Mark(contractDataEntrySizeBytes);
+}
+
 // called by txherder
 void
 LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
@@ -1222,6 +1300,7 @@ LedgerManagerImpl::updateNetworkConfig(AbstractLedgerTxn& rootLtx)
         mSorobanNetworkConfig->loadFromLedger(
             rootLtx, mApp.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION,
             ledgerVersion);
+        publishSorobanNetworkConfigMetrics();
     }
     else
     {

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -102,6 +102,11 @@ class LedgerManagerImpl : public LedgerManager
 
     SorobanNetworkConfig& getSorobanNetworkConfigInternal();
 
+    // Publishes selected network configured limits as medida metrics, useful
+    // for contextualizing the other live metrics. This does not include all
+    // settings, just includes ones relevant for display.
+    void publishSorobanNetworkConfigMetrics();
+
   protected:
     // initialLedgerVers must be the ledger version at the start of the ledger
     // and currLedgerVers is the ledger version in the current ltx header. These

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -1062,6 +1062,12 @@ SorobanNetworkConfig::feeWrite1KB() const
     return mFeeWrite1KB;
 }
 
+int64_t
+SorobanNetworkConfig::bucketListTargetSizeBytes() const
+{
+    return mBucketListTargetSizeBytes;
+}
+
 // Historical data (pushed to core archives) settings for contracts.
 int64_t
 SorobanNetworkConfig::feeHistorical1KB() const

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -260,6 +260,8 @@ class SorobanNetworkConfig
     int64_t feeRead1KB() const;
     // Fee for writing 1KB
     int64_t feeWrite1KB() const;
+    // Bucket list target size (in bytes)
+    int64_t bucketListTargetSizeBytes() const;
 
     // Historical data (pushed to core archives) settings for contracts.
     // Fee for storing 1KB in archives


### PR DESCRIPTION
# Description

Add some network limits to soroban Medida metrics, so that they can be displayed together with the other Soroban metrics and put them into context. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
