### PR TITLE
Correctly deinit logging before reinit when changed on the fly

### DIFF
--- a/src/util/Logging.cpp
+++ b/src/util/Logging.cpp
@@ -291,6 +291,7 @@ Logging::setLogLevel(LogLevel level, const char* partition)
         mPartitionLogLevels.clear();
     }
 #if defined(USE_SPDLOG)
+    deinit();
     init();
     auto slev = convert_loglevel(level);
     if (partition)


### PR DESCRIPTION
When we set the log level on the fly with, say, an http command `ll?partition=tx&level=trace`, we update a basic per-partition table and then (re)initialize the rest of the tracing subsystem. Unfortunately this only works correctly if we _deinitialize_ the logging subsystem before reinitializing it (as we do most places where dynamic tracing reconfiguration are allowed). In this one path we fail to deinit before reinit, and this ultimately means the max log level never gets propagated over the rust bridge, and the new tracing facility on the rust side never activates.

(It _does_ activate already if you set the initial log level to trace, just not if you reconfigure on the fly)

Anyway, this change fixes the reconfiguration path to deinit before reinit.