### PR TITLE
Bump env curr and prev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -908,8 +908,8 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
-version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
+version = "20.1.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
 dependencies = [
  "itertools",
  "proc-macro2",
@@ -920,27 +920,12 @@ dependencies = [
 [[package]]
 name = "soroban-builtin-sdk-macros"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "soroban-env-common"
-version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
-dependencies = [
- "crate-git-revision",
- "ethnum",
- "num-derive",
- "num-traits",
- "soroban-env-macros 20.0.0-rc2",
- "soroban-wasmi 0.31.0-soroban1",
- "static_assertions",
- "stellar-xdr 20.0.0-rc1",
 ]
 
 [[package]]
@@ -952,36 +937,26 @@ dependencies = [
  "ethnum",
  "num-derive",
  "num-traits",
- "soroban-env-macros 20.1.0",
- "soroban-wasmi 0.31.1-soroban.20.0.0",
+ "soroban-env-macros 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523)",
+ "soroban-wasmi",
  "static_assertions",
- "stellar-xdr 20.0.2",
- "tracy-client",
+ "stellar-xdr",
 ]
 
 [[package]]
-name = "soroban-env-host"
-version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
+name = "soroban-env-common"
+version = "20.1.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 dependencies = [
- "curve25519-dalek",
- "ed25519-dalek",
- "getrandom",
- "hex-literal",
- "hmac",
- "k256",
+ "crate-git-revision",
+ "ethnum",
  "num-derive",
- "num-integer",
  "num-traits",
- "rand",
- "rand_chacha",
- "sha2",
- "sha3",
- "soroban-builtin-sdk-macros 20.0.0-rc2",
- "soroban-env-common 20.0.0-rc2",
- "soroban-wasmi 0.31.0-soroban1",
+ "soroban-env-macros 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0)",
+ "soroban-wasmi",
  "static_assertions",
- "stellar-strkey",
+ "stellar-xdr",
+ "tracy-client",
 ]
 
 [[package]]
@@ -1002,26 +977,37 @@ dependencies = [
  "rand_chacha",
  "sha2",
  "sha3",
- "soroban-builtin-sdk-macros 20.1.0",
- "soroban-env-common 20.1.0",
- "soroban-wasmi 0.31.1-soroban.20.0.0",
+ "soroban-builtin-sdk-macros 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523)",
+ "soroban-env-common 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523)",
+ "soroban-wasmi",
  "static_assertions",
  "stellar-strkey",
- "tracy-client",
 ]
 
 [[package]]
-name = "soroban-env-macros"
-version = "20.0.0-rc2"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
+name = "soroban-env-host"
+version = "20.1.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 dependencies = [
- "itertools",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "stellar-xdr 20.0.0-rc1",
- "syn",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "getrandom",
+ "hex-literal",
+ "hmac",
+ "k256",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "sha2",
+ "sha3",
+ "soroban-builtin-sdk-macros 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0)",
+ "soroban-env-common 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0)",
+ "soroban-wasmi",
+ "static_assertions",
+ "stellar-strkey",
+ "tracy-client",
 ]
 
 [[package]]
@@ -1034,18 +1020,32 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "stellar-xdr 20.0.2",
+ "stellar-xdr",
+ "syn",
+]
+
+[[package]]
+name = "soroban-env-macros"
+version = "20.1.0"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
+dependencies = [
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "stellar-xdr",
  "syn",
 ]
 
 [[package]]
 name = "soroban-synth-wasm"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 dependencies = [
  "arbitrary",
- "soroban-env-common 20.1.0",
- "soroban-env-macros 20.1.0",
+ "soroban-env-common 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0)",
+ "soroban-env-macros 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0)",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1053,19 +1053,7 @@ dependencies = [
 [[package]]
 name = "soroban-test-wasms"
 version = "20.1.0"
-source = "git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
-
-[[package]]
-name = "soroban-wasmi"
-version = "0.31.0-soroban1"
-source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
-dependencies = [
- "smallvec",
- "spin",
- "wasmi_arena 0.4.0 (git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be)",
- "wasmi_core 0.13.0 (git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be)",
- "wasmparser-nostd",
-]
+source = "git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 
 [[package]]
 name = "soroban-wasmi"
@@ -1074,8 +1062,8 @@ source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84
 dependencies = [
  "smallvec",
  "spin",
- "wasmi_arena 0.4.0 (git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721)",
- "wasmi_core 0.13.0 (git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721)",
+ "wasmi_arena",
+ "wasmi_core",
  "wasmparser-nostd",
 ]
 
@@ -1113,8 +1101,8 @@ dependencies = [
  "petgraph",
  "rand",
  "rustc-simple-version",
- "soroban-env-host 20.0.0-rc2",
- "soroban-env-host 20.1.0",
+ "soroban-env-host 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523)",
+ "soroban-env-host 20.1.0 (git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0)",
  "soroban-synth-wasm",
  "soroban-test-wasms",
  "toml",
@@ -1130,18 +1118,6 @@ dependencies = [
  "base32",
  "crate-git-revision",
  "thiserror",
-]
-
-[[package]]
-name = "stellar-xdr"
-version = "20.0.0-rc1"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746#97e52f17501fb058ee28bbca3da0ae7897492746"
-dependencies = [
- "base64",
- "crate-git-revision",
- "escape-bytes",
- "hex",
- "stellar-strkey",
 ]
 
 [[package]]
@@ -1461,23 +1437,7 @@ dependencies = [
 [[package]]
 name = "wasmi_arena"
 version = "0.4.0"
-source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
-
-[[package]]
-name = "wasmi_arena"
-version = "0.4.0"
 source = "git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721"
-
-[[package]]
-name = "wasmi_core"
-version = "0.13.0"
-source = "git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be"
-dependencies = [
- "downcast-rs",
- "libm",
- "num-traits",
- "paste",
-]
 
 [[package]]
 name = "wasmi_core"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -50,11 +50,12 @@ Upgrades are specified with:
 * protocolversion - upgrades value of ledgerVersion in ledger header, uses
   upgrade type LEDGER_UPGRADE_VERSION (when specified it has to match the
   supported version number)
-* configupgradesetkey - this key will be converted to a ContractData LedgerKey, and the
-  ContractData LedgerEntry retrieved with that will have a val of SCV_BYTES
-  containing a serialized ConfigUpgradeSet. Each ConfigSettingEntry in the
-  ConfigUpgradeSet will be used to update the existing network ConfigSettingEntry
-  that exists at the corresponding CONFIG_SETTING LedgerKey.
+* configupgradesetkey - this is a serialized ConfigUpgradeSetKey, which contains
+  a ContractData LedgerKey and a contractID. The ContractData LedgerEntry
+  retrieved with that will have a val of SCV_BYTES containing a serialized
+  ConfigUpgradeSet. Each ConfigSettingEntry in the ConfigUpgradeSet will be used
+  to update the existing network ConfigSettingEntry that exists at the
+  corresponding CONFIG_SETTING LedgerKey.
 
 #### Limitations of the current implementation
 There is an assumption that validator operators are either paying attention to network wide proposals

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -36,7 +36,7 @@ itertools = "=0.11.0"
 version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
+rev = "e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 
 # This copy of the soroban host is _optional_ and only enabled during protocol
 # transitions. When transitioning from protocol N to N+1, the `curr` copy
@@ -57,20 +57,20 @@ rev = "b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
 
 [dependencies.soroban-env-host-prev]
 optional = true
-version = "=20.0.0-rc2"
+version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-rev = "bed170cde09a53c85ae2e02f9278ef0dfa4e0900"
+rev = "b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
 
 [dependencies.soroban-test-wasms]
 version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
+rev = "e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 
 [dependencies.soroban-synth-wasm]
 version = "=20.1.0"
 git = "https://github.com/stellar/rs-soroban-env"
-rev = "b6ef8e32d86b008b2ecfdb2d7ca958e751190523"
+rev = "e6b597c20aeda9963798a74b14ec1dd51c3a72e0"
 
 [dependencies.cargo-lock]
 version = "=9.0.0"

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -1,4 +1,4 @@
-soroban-env-host 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
+soroban-env-host 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0
 ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── tracy-client-sys 0.20.0 checksum:e8cf8aeb20e40d13be65a0b134f8d82d360e72b2793a11de8867d7fbc0f9d6f6
 │   │   └── cc 1.0.79 checksum:50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f
@@ -97,7 +97,7 @@ soroban-env-host 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e
 │   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-env-common 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
+├── soroban-env-common 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0
 │   ├── tracy-client 0.15.2 checksum:434ecabbda9f67eeea1eab44d52f4a20538afa3e2c2770f2efc161142b25b608
 │   ├── stellar-xdr 20.0.2 checksum:e9f00a85bd9b1617d4cb7e741733889c9940e6bdeca360db81752b0ef04fe3a5
 │   │   ├── stellar-strkey 0.0.8 checksum:12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd
@@ -107,7 +107,7 @@ soroban-env-host 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
 │   ├── soroban-wasmi 0.31.1-soroban.20.0.0 git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721
-│   ├── soroban-env-macros 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
+│   ├── soroban-env-macros 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0
 │   │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
 │   │   ├── stellar-xdr 20.0.2 checksum:e9f00a85bd9b1617d4cb7e741733889c9940e6bdeca360db81752b0ef04fe3a5
 │   │   ├── serde_json 1.0.108 checksum:3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b
@@ -123,7 +123,7 @@ soroban-env-host 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e
 │   │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
 │   ├── ethnum 1.5.0 checksum:b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c
 │   └── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
-├── soroban-builtin-sdk-macros 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
+├── soroban-builtin-sdk-macros 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=e6b597c20aeda9963798a74b14ec1dd51c3a72e0#e6b597c20aeda9963798a74b14ec1dd51c3a72e0
 │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
 │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
 │   ├── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da

--- a/src/rust/src/host-dep-tree-prev.txt
+++ b/src/rust/src/host-dep-tree-prev.txt
@@ -1,4 +1,4 @@
-soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
+soroban-env-host 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
 ├── stellar-strkey 0.0.8 checksum:12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd
 │   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
 │   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
@@ -23,30 +23,30 @@ soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=be
 │   │   └── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001
 │   └── base32 0.4.0 checksum:23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa
 ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
-├── soroban-wasmi 0.31.0-soroban1 git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be
+├── soroban-wasmi 0.31.1-soroban.20.0.0 git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721
 │   ├── wasmparser-nostd 0.100.1 checksum:9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724
 │   │   └── indexmap-nostd 0.4.0 checksum:8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590
-│   ├── wasmi_core 0.13.0 git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be
+│   ├── wasmi_core 0.13.0 git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721
 │   │   ├── paste 1.0.12 checksum:9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79
 │   │   ├── num-traits 0.2.17 checksum:39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c
 │   │   │   └── autocfg 1.1.0 checksum:d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa
 │   │   ├── libm 0.2.7 checksum:f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4
 │   │   └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
-│   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be
+│   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721
 │   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
 │   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
-├── soroban-env-common 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
-│   ├── stellar-xdr 20.0.0-rc1 git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746#97e52f17501fb058ee28bbca3da0ae7897492746
+├── soroban-env-common 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
+│   ├── stellar-xdr 20.0.2 checksum:e9f00a85bd9b1617d4cb7e741733889c9940e6bdeca360db81752b0ef04fe3a5
 │   │   ├── stellar-strkey 0.0.8 checksum:12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd
 │   │   ├── hex 0.4.3 checksum:7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
 │   │   ├── escape-bytes 0.1.1 checksum:2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2
 │   │   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
 │   │   └── base64 0.13.1 checksum:9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8
 │   ├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
-│   ├── soroban-wasmi 0.31.0-soroban1 git+https://github.com/stellar/wasmi?rev=7e63b4c9e08c4163f417d118d81f7ea34789d0be#7e63b4c9e08c4163f417d118d81f7ea34789d0be
-│   ├── soroban-env-macros 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
+│   ├── soroban-wasmi 0.31.1-soroban.20.0.0 git+https://github.com/stellar/wasmi?rev=ab29800224d85ee64d4ac127bac84cdbb0276721#ab29800224d85ee64d4ac127bac84cdbb0276721
+│   ├── soroban-env-macros 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
 │   │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
-│   │   ├── stellar-xdr 20.0.0-rc1 git+https://github.com/stellar/rs-stellar-xdr?rev=97e52f17501fb058ee28bbca3da0ae7897492746#97e52f17501fb058ee28bbca3da0ae7897492746
+│   │   ├── stellar-xdr 20.0.2 checksum:e9f00a85bd9b1617d4cb7e741733889c9940e6bdeca360db81752b0ef04fe3a5
 │   │   ├── serde_json 1.0.108 checksum:3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b
 │   │   ├── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001
 │   │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
@@ -60,7 +60,7 @@ soroban-env-host 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=be
 │   │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
 │   ├── ethnum 1.5.0 checksum:b90ca2580b73ab6a1f724b76ca11ab632df820fd6040c336200d2c1df7b3c82c
 │   └── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
-├── soroban-builtin-sdk-macros 20.0.0-rc2 git+https://github.com/stellar/rs-soroban-env?rev=bed170cde09a53c85ae2e02f9278ef0dfa4e0900#bed170cde09a53c85ae2e02f9278ef0dfa4e0900
+├── soroban-builtin-sdk-macros 20.1.0 git+https://github.com/stellar/rs-soroban-env?rev=b6ef8e32d86b008b2ecfdb2d7ca958e751190523#b6ef8e32d86b008b2ecfdb2d7ca958e751190523
 │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
 │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
 │   ├── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da


### PR DESCRIPTION
# Description

Bump env curr to latest, and also bump prev because contract.rs makes the assumption that the tracing code is included, resulting in a compilation error when building with `--enable-protocol-upgrade-via-soroban-env-host-prev`.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
