### PR TITLE
Adds CLI tool to print BucketList archival stats

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -84,6 +84,7 @@ Command options can only by placed after command.
    See more examples in [ledger_query_examples.md](ledger_query_examples.md).
 
 * **dump-xdr <FILE-NAME>**:  Dumps the given XDR file and then exits.
+* **dump-archival-stats**:  Logs state archival statistics about the BucketList.
 * **encode-asset**: Prints a base-64 encoded asset built from  `--code <CODE>` and `--issuer <ISSUER>`. Prints the native asset if neither `--code` nor `--issuer` is given.
 * **fuzz <FILE-NAME>**: Run a single fuzz input and exit.
 * **gen-fuzz <FILE-NAME>**:  Generate a random fuzzer input file.

--- a/src/main/ApplicationUtils.h
+++ b/src/main/ApplicationUtils.h
@@ -24,6 +24,11 @@ void initializeDatabase(Config cfg);
 void httpCommand(std::string const& command, unsigned short port);
 int selfCheck(Config cfg);
 int mergeBucketList(Config cfg, std::string const& outputDir);
+
+// Logs state archival statistics, such as the number of expired entries
+// currently in the BucketList, number of bytes of evicted entries, etc.
+int dumpStateArchivalStatistics(Config cfg);
+
 int dumpLedger(Config cfg, std::string const& outputFile,
                std::optional<std::string> filterQuery,
                std::optional<uint32_t> lastModifiedLedgerCount,

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1169,6 +1169,15 @@ runMergeBucketList(CommandLineArgs const& args)
 }
 
 int
+runDumpStateArchivalStatistics(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+    return runWithHelp(args, {configurationParser(configOption)}, [&] {
+        return dumpStateArchivalStatistics(configOption.getConfig());
+    });
+}
+
+int
 runDumpLedger(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -1836,6 +1845,9 @@ handleCommandLine(int argc, char* const* argv)
          {"self-check", "performs diagnostic checks", runSelfCheck},
          {"merge-bucketlist", "writes diagnostic merged bucket list",
           runMergeBucketList},
+         {"dump-archival-stats",
+          "prints statistics about expired/evicted entries in the BucketList",
+          runDumpStateArchivalStatistics},
          {"new-db", "creates or restores the DB to the genesis ledger",
           runNewDB},
          {"new-hist", "initialize history archives", runNewHist},


### PR DESCRIPTION
# Description

Resolves #4138

Adds a CLI tool that logs some state archival related metrics from the BucketList. Specifically, the tool logs the amount of bytes currently consumed by temporary entries. It divides the temporary entries into three categories: live, expired but no evicted, and evicted.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
