### PR TITLE
Set upper bound on scan size in the upgrade utils

### DIFF
--- a/src/main/SettingsUpgradeUtils.cpp
+++ b/src/main/SettingsUpgradeUtils.cpp
@@ -160,6 +160,15 @@ validateConfigUpgradeSet(ConfigUpgradeSet const& upgradeSet)
                 throw std::runtime_error("Invalid contractLedgerCost");
             }
         }
+        else if (entry.configSettingID() == CONFIG_SETTING_STATE_ARCHIVAL)
+        {
+            // 1048576 is our current phase1 scan size, and we don't expect to
+            // go past this anytime soon.
+            if (entry.stateArchivalSettings().evictionScanSize > 1048576)
+            {
+                throw std::runtime_error("Invalid evictionScanSize");
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Description

Set upper bound on scan size in the upgrade utils as a safety check.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
