### PR TITLE
Draft: Recover SCP messages when replaying from history

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -506,6 +506,7 @@ exit /b 0
     <ClCompile Include="..\..\src\herder\TxSetUtils.cpp" />
     <ClCompile Include="..\..\src\herder\Upgrades.cpp" />
     <ClCompile Include="..\..\src\historywork\BatchDownloadWork.cpp" />
+    <ClCompile Include="..\..\src\historywork\BestEffortBatchDownloadWork.cpp" />
     <ClCompile Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.cpp" />
     <ClCompile Include="..\..\src\historywork\DownloadBucketsWork.cpp" />
     <ClCompile Include="..\..\src\historywork\DownloadVerifyTxResultsWork.cpp" />
@@ -938,6 +939,7 @@ exit /b 0
     <ClInclude Include="..\..\src\herder\TxSetUtils.h" />
     <ClInclude Include="..\..\src\herder\Upgrades.h" />
     <ClInclude Include="..\..\src\historywork\BatchDownloadWork.h" />
+    <ClInclude Include="..\..\src\historywork\BestEffortBatchDownloadWork.h" />
     <ClInclude Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.h" />
     <ClInclude Include="..\..\src\historywork\DownloadBucketsWork.h" />
     <ClInclude Include="..\..\src\historywork\DownloadVerifyTxResultsWork.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -762,6 +762,9 @@
     <ClCompile Include="..\..\src\historywork\BatchDownloadWork.cpp">
       <Filter>historyWork</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\historywork\BestEffortBatchDownloadWork.cpp">
+      <Filter>historyWork</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.cpp">
       <Filter>historyWork</Filter>
     </ClCompile>
@@ -1914,6 +1917,9 @@
       <Filter>history</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\historywork\BatchDownloadWork.h">
+      <Filter>historyWork</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\historywork\BestEffortBatchDownloadWork.h">
       <Filter>historyWork</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\historywork\CheckSingleLedgerHeaderWork.h">

--- a/src/catchup/ApplyBufferedLedgersWork.cpp
+++ b/src/catchup/ApplyBufferedLedgersWork.cpp
@@ -55,7 +55,9 @@ ApplyBufferedLedgersWork::onRun()
         lcd.getTxSet()->sizeTxTotal(), lcd.getTxSet()->sizeOpTotalForLogging(),
         stellarValueToString(mApp.getConfig(), lcd.getValue()));
 
-    auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, lcd);
+    // Pass `nullptr` for `hEntries` because SCP messages of buffered ledgers
+    // have already been logged.
+    auto applyLedger = std::make_shared<ApplyLedgerWork>(mApp, lcd, nullptr);
 
     auto predicate = [](Application& app) {
         auto& bl = app.getBucketManager().getBucketList();

--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "catchup/ApplyLedgerWork.h"
 #include "herder/LedgerCloseData.h"
 #include "herder/TxSetFrame.h"
 #include "history/HistoryArchive.h"
@@ -19,6 +20,18 @@ namespace stellar
 
 class TmpDir;
 struct LedgerHeaderHistoryEntry;
+
+using TmpDirVec = std::vector<std::shared_ptr<TmpDir const>>;
+
+// This struct stores information about SCP messages in a single history
+// checkpoint
+struct SCPCheckpointInfo
+{
+    // Input stream holding `SCPHistoryEntry`s
+    XDRInputFileStream scpHistoryIn;
+    // Most recent SCP history entry read from `scpHistoryIn`
+    std::shared_ptr<SCPHistoryEntry> scpHistoryEntry;
+};
 
 /**
  * This class is responsible for applying transactions stored in files on
@@ -45,11 +58,17 @@ class ApplyCheckpointWork : public BasicWork
     TmpDir const& mDownloadDir;
     LedgerRange const mLedgerRange;
     uint32_t const mCheckpoint;
+    // The directories containing downloaded SCP history. May be null if no such
+    // directories exist.
+    std::shared_ptr<TmpDirVec const> mSCPDownloadDirs;
 
     XDRInputFileStream mHdrIn;
     XDRInputFileStream mTxIn;
     TransactionHistoryEntry mTxHistoryEntry;
     LedgerHeaderHistoryEntry mHeaderHistoryEntry;
+    // Vector containing each archive's SCP messages for the current checkpoint
+    // being processed
+    std::vector<SCPCheckpointInfo> mSCPCheckpointInfo;
     OnFailureCallback mOnFailure;
 
     bool mFilesOpen{false};
@@ -61,11 +80,17 @@ class ApplyCheckpointWork : public BasicWork
 
     std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();
 
+    // Returns a vector holding SCP messages from each archive for the ledger
+    // being processed.  This vector may be smaller than the total number of
+    // archives if some archives did not contain messages for the ledger.
+    std::unique_ptr<SCPHistoryEntryVec> getNextSCPHistoryEntries();
+
     void closeFiles();
 
   public:
     ApplyCheckpointWork(Application& app, TmpDir const& downloadDir,
-                        LedgerRange const& range, OnFailureCallback cb);
+                        LedgerRange const& range, OnFailureCallback cb,
+                        std::shared_ptr<TmpDirVec const>& scpDownloadDirs);
     ~ApplyCheckpointWork() = default;
     std::string getStatus() const override;
     void onFailureRaise() override;

--- a/src/catchup/ApplyLedgerWork.h
+++ b/src/catchup/ApplyLedgerWork.h
@@ -6,16 +6,23 @@
 
 #include "herder/LedgerCloseData.h"
 #include "work/Work.h"
+#include <memory>
 
 namespace stellar
 {
 
+using SCPHistoryEntryVec = std::vector<std::shared_ptr<SCPHistoryEntry>>;
+
 class ApplyLedgerWork : public BasicWork
 {
+    Application& mApp;
     LedgerCloseData const mLedgerCloseData;
+    // SCP messages for the ledger to be applied
+    std::unique_ptr<SCPHistoryEntryVec const> mHEntries;
 
   public:
-    ApplyLedgerWork(Application& app, LedgerCloseData const& ledgerCloseData);
+    ApplyLedgerWork(Application& app, LedgerCloseData const& ledgerCloseData,
+                    std::unique_ptr<SCPHistoryEntryVec const> hEntries);
 
     std::string getStatus() const override;
 

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "catchup/ApplyCheckpointWork.h"
 #include "catchup/CatchupConfiguration.h"
 #include "catchup/VerifyLedgerChainWork.h"
 #include "history/HistoryArchive.h"
@@ -46,8 +47,10 @@ class CatchupWork : public Work
 {
   protected:
     HistoryArchiveState mLocalState;
-    std::unique_ptr<TmpDir> mDownloadDir;
+    std::shared_ptr<TmpDir> mDownloadDir;
     std::map<std::string, std::shared_ptr<Bucket>> mBuckets;
+    // Download directories for SCP message history
+    std::shared_ptr<TmpDirVec> mSCPDownloadDirs = std::make_shared<TmpDirVec>();
 
     void doReset() override;
     BasicWork::State doWork() override;

--- a/src/catchup/DownloadApplyTxsWork.cpp
+++ b/src/catchup/DownloadApplyTxsWork.cpp
@@ -23,6 +23,7 @@ namespace stellar
 DownloadApplyTxsWork::DownloadApplyTxsWork(
     Application& app, TmpDir const& downloadDir, LedgerRange const& range,
     LedgerHeaderHistoryEntry& lastApplied, bool waitForPublish,
+    std::shared_ptr<TmpDirVec const> scpDownloadDirs,
     std::shared_ptr<HistoryArchive> archive)
     : BatchWork(app, "download-apply-ledgers")
     , mRange(range)
@@ -31,6 +32,7 @@ DownloadApplyTxsWork::DownloadApplyTxsWork(
     , mCheckpointToQueue(
           app.getHistoryManager().checkpointContainingLedger(range.mFirst))
     , mWaitForPublish(waitForPublish)
+    , mSCPDownloadDirs(std::move(scpDownloadDirs))
     , mArchive(archive)
 {
 }
@@ -76,7 +78,8 @@ DownloadApplyTxsWork::yieldMoreWork()
     };
 
     auto apply = std::make_shared<ApplyCheckpointWork>(
-        mApp, mDownloadDir, LedgerRange::inclusive(low, high), cb);
+        mApp, mDownloadDir, LedgerRange::inclusive(low, high), cb,
+        mSCPDownloadDirs);
 
     std::vector<std::shared_ptr<BasicWork>> seq{getAndUnzip};
 

--- a/src/catchup/DownloadApplyTxsWork.h
+++ b/src/catchup/DownloadApplyTxsWork.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "catchup/ApplyCheckpointWork.h"
 #include "ledger/LedgerRange.h"
 #include "util/XDRStream.h"
 #include "work/BatchWork.h"
@@ -29,6 +30,8 @@ class DownloadApplyTxsWork : public BatchWork
     uint32_t mCheckpointToQueue;
     std::shared_ptr<BasicWork> mLastYieldedWork;
     bool const mWaitForPublish;
+    // Download directories for SCP message history
+    std::shared_ptr<TmpDirVec const> mSCPDownloadDirs;
     std::shared_ptr<HistoryArchive> mArchive;
 
   public:
@@ -36,6 +39,7 @@ class DownloadApplyTxsWork : public BatchWork
                          LedgerRange const& range,
                          LedgerHeaderHistoryEntry& lastApplied,
                          bool waitForPublish,
+                         std::shared_ptr<TmpDirVec const> mSCPDownloadDirs,
                          std::shared_ptr<HistoryArchive> archive = nullptr);
 
     std::string getStatus() const override;

--- a/src/herder/HerderPersistence.h
+++ b/src/herder/HerderPersistence.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "catchup/ApplyLedgerWork.h"
 #include "herder/QuorumTracker.h"
 #include "overlay/Peer.h"
 #include "xdr/Stellar-SCP.h"
@@ -40,6 +41,13 @@ class HerderPersistence
                                          uint32_t ledgerSeq,
                                          uint32_t ledgerCount,
                                          XDROutputFileStream& scpHistory);
+
+    // Given a set of SCP history entries from multiple archives, merge the
+    // entries--taking the newest entry for each node--and store the result in
+    // the database.
+    virtual void copySCPHistoryFromEntries(SCPHistoryEntryVec const& hEntries,
+                                           uint32_t ledgerSeq) = 0;
+
     // quorum information lookup
     static std::optional<Hash>
     getNodeQuorumSet(Database& db, soci::session& sess, NodeID const& nodeID);

--- a/src/herder/HerderPersistenceImpl.h
+++ b/src/herder/HerderPersistenceImpl.h
@@ -20,7 +20,17 @@ class HerderPersistenceImpl : public HerderPersistence
     void saveSCPHistory(uint32_t seq, std::vector<SCPEnvelope> const& envs,
                         QuorumTracker::QuorumMap const& qmap) override;
 
+    void copySCPHistoryFromEntries(SCPHistoryEntryVec const& hEntries,
+                                   uint32_t ledgerSeq) override;
+
   private:
     Application& mApp;
+
+    // Save quorum sets at a given sequence number
+    void saveQuorumSets(uint32_t seq,
+                        UnorderedMap<Hash, SCPQuorumSetPtr> const& qsets);
+
+    // Delete `scphistory` entries at a given sequence number.
+    void clearSCPHistoryAtSeq(uint32_t seq);
 };
 }

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -188,6 +188,7 @@ class CatchupSimulation
     BucketList mBucketListAtLastPublish;
 
     std::vector<LedgerCloseData> mLedgerCloseDatas;
+    std::vector<std::vector<SCPEnvelope>> mEnvelopes;
 
     std::vector<uint32_t> mLedgerSeqs;
     std::vector<uint256> mLedgerHashes;

--- a/src/historywork/BatchDownloadWork.cpp
+++ b/src/historywork/BatchDownloadWork.cpp
@@ -16,7 +16,7 @@ namespace stellar
 {
 BatchDownloadWork::BatchDownloadWork(Application& app, CheckpointRange range,
                                      std::string const& type,
-                                     TmpDir const& downloadDir,
+                                     std::shared_ptr<TmpDir const> downloadDir,
                                      std::shared_ptr<HistoryArchive> archive)
     : BatchWork(app,
                 fmt::format(FMT_STRING("batch-download-{:s}-{:08x}-{:08x}"),
@@ -52,7 +52,7 @@ BatchDownloadWork::yieldMoreWork()
         return nullptr;
     }
 
-    FileTransferInfo ft(mDownloadDir, mFileType, mNext);
+    FileTransferInfo ft(*mDownloadDir, mFileType, mNext);
     CLOG_DEBUG(History, "Downloading and unzipping {} for checkpoint {}",
                mFileType, mNext);
     auto getAndUnzip =

--- a/src/historywork/BatchDownloadWork.h
+++ b/src/historywork/BatchDownloadWork.h
@@ -23,12 +23,13 @@ class BatchDownloadWork : public BatchWork
     CheckpointRange const mRange;
     uint32_t mNext;
     std::string const mFileType;
-    TmpDir const& mDownloadDir;
+    std::shared_ptr<TmpDir const> mDownloadDir;
     std::shared_ptr<HistoryArchive> mArchive;
 
   public:
     BatchDownloadWork(Application& app, CheckpointRange range,
-                      std::string const& type, TmpDir const& downloadDir,
+                      std::string const& type,
+                      std::shared_ptr<TmpDir const> downloadDir,
                       std::shared_ptr<HistoryArchive> archive = nullptr);
     ~BatchDownloadWork() = default;
     std::string getStatus() const override;

--- a/src/historywork/BestEffortBatchDownloadWork.cpp
+++ b/src/historywork/BestEffortBatchDownloadWork.cpp
@@ -1,0 +1,20 @@
+#include "historywork/BestEffortBatchDownloadWork.h"
+
+namespace stellar
+{
+BestEffortBatchDownloadWork::BestEffortBatchDownloadWork(
+    Application& app, CheckpointRange range, std::string const& type,
+    std::shared_ptr<TmpDir const> downloadDir,
+    std::shared_ptr<HistoryArchive> archive)
+    : BatchDownloadWork(app, range, type, downloadDir, archive)
+{
+}
+
+BasicWork::State
+BestEffortBatchDownloadWork::onChildFailure()
+{
+    // TODO: Emit a warning about the failed download
+    abortSuccess();
+    return State::WORK_RUNNING;
+}
+} // namespace stellar

--- a/src/historywork/BestEffortBatchDownloadWork.h
+++ b/src/historywork/BestEffortBatchDownloadWork.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// Copyright 2023 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "historywork/BatchDownloadWork.h"
+#include "work/BasicWork.h"
+#include <memory>
+
+namespace stellar
+{
+// A version of BatchDownloadWork that does not fail if a download fails.
+class BestEffortBatchDownloadWork : public BatchDownloadWork
+{
+  public:
+    BestEffortBatchDownloadWork(
+        Application& app, CheckpointRange range, std::string const& type,
+        std::shared_ptr<TmpDir const> downloadDir,
+        std::shared_ptr<HistoryArchive> archive = nullptr);
+    ~BestEffortBatchDownloadWork() = default;
+
+  protected:
+    State onChildFailure() override;
+};
+
+} // namespace stellar

--- a/src/historywork/FetchRecentQsetsWork.cpp
+++ b/src/historywork/FetchRecentQsetsWork.cpp
@@ -28,7 +28,7 @@ FetchRecentQsetsWork::doReset()
     mGetHistoryArchiveStateWork.reset();
     mDownloadSCPMessagesWork.reset();
     mDownloadDir =
-        std::make_unique<TmpDir>(mApp.getTmpDirManager().tmpDir(getName()));
+        std::make_shared<TmpDir>(mApp.getTmpDirManager().tmpDir(getName()));
 }
 
 BasicWork::State
@@ -62,7 +62,7 @@ FetchRecentQsetsWork::doWork()
                   firstSeq, lastSeq);
         auto range = CheckpointRange::inclusive(firstSeq, lastSeq, step);
         mDownloadSCPMessagesWork = addWork<BatchDownloadWork>(
-            range, HISTORY_FILE_TYPE_SCP, *mDownloadDir);
+            range, HISTORY_FILE_TYPE_SCP, mDownloadDir);
         return State::WORK_RUNNING;
     }
     else if (mDownloadSCPMessagesWork->getState() != State::WORK_SUCCESS)

--- a/src/historywork/FetchRecentQsetsWork.h
+++ b/src/historywork/FetchRecentQsetsWork.h
@@ -15,7 +15,7 @@ class TmpDir;
 
 class FetchRecentQsetsWork : public Work
 {
-    std::unique_ptr<TmpDir> mDownloadDir;
+    std::shared_ptr<TmpDir> mDownloadDir;
     uint32_t mLedgerNum;
     std::shared_ptr<GetHistoryArchiveStateWork> mGetHistoryArchiveStateWork;
     std::shared_ptr<BasicWork> mDownloadSCPMessagesWork;

--- a/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
+++ b/src/historywork/WriteVerifiedCheckpointHashesWork.cpp
@@ -122,7 +122,7 @@ WriteVerifiedCheckpointHashesWork::yieldMoreWork()
     auto tmpDir = std::make_shared<TmpDir>(
         mApp.getTmpDirManager().tmpDir("verify-" + checkpointStr));
     auto getWork = std::make_shared<BatchDownloadWork>(
-        mApp, checkpointRange, HISTORY_FILE_TYPE_LEDGER, *tmpDir, mArchive);
+        mApp, checkpointRange, HISTORY_FILE_TYPE_LEDGER, tmpDir, mArchive);
 
     // When we have a previous-work, we grab a future attached to the promise it
     // will fulfill when it runs. This promise might not have a value _yet_ but

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1349,6 +1349,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                     throw std::invalid_argument("incomplete HISTORY block");
                 }
             }
+            else if (item.first == "SCP_HISTORY_ARCHIVES")
+            {
+                // TODO: Check for entries that aren't in HISTORY
+                // TODO: Deduplicate. Maybe just make SCP_HISTORY_ARCHIVES a set
+                SCP_HISTORY_ARCHIVES = readArray<std::string>(item);
+            }
             else if (item.first == "DATABASE")
             {
                 DATABASE = SecretValue{readString(item)};

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -532,6 +532,10 @@ class Config : public std::enable_shared_from_this<Config>
     // History config
     std::map<std::string, HistoryArchiveConfiguration> HISTORY;
 
+    // Archives to use for downloading SCP history
+    // TODO: Document in user facing documentation
+    std::vector<std::string> SCP_HISTORY_ARCHIVES;
+
     // Database config
     SecretValue DATABASE;
 

--- a/src/work/BatchWork.cpp
+++ b/src/work/BatchWork.cpp
@@ -29,7 +29,7 @@ BatchWork::doWork()
     ZoneScoped;
     if (anyChildRaiseFailure())
     {
-        return State::WORK_FAILURE;
+        return onChildFailure();
     }
 
     // Clean up completed children
@@ -82,5 +82,11 @@ BatchWork::addMoreWorkIfNeeded()
         }
         mBatch.insert(std::make_pair(w->getName(), w));
     }
+}
+
+BasicWork::State
+BatchWork::onChildFailure()
+{
+    return State::WORK_FAILURE;
 }
 }

--- a/src/work/BatchWork.h
+++ b/src/work/BatchWork.h
@@ -41,5 +41,9 @@ class BatchWork : public Work
     virtual bool hasNext() const = 0;
     virtual std::shared_ptr<BasicWork> yieldMoreWork() = 0;
     virtual void resetIter() = 0;
+
+    // Function to call when child work fails. Returns the state that `doWork`
+    // should return.
+    virtual State onChildFailure();
 };
 }

--- a/src/work/Work.cpp
+++ b/src/work/Work.cpp
@@ -52,7 +52,22 @@ Work::onRun()
     if (mAbortChildrenButNotSelf)
     {
         // Stop whatever work was doing, just wait for children to abort
-        return onAbort() ? State::WORK_FAILURE : State::WORK_RUNNING;
+        if (onAbort())
+        {
+            if (mReportSuccessOnAbort)
+            {
+                clearChildren();
+                return State::WORK_SUCCESS;
+            }
+            else
+            {
+                return State::WORK_FAILURE;
+            }
+        }
+        else
+        {
+            return State::WORK_RUNNING;
+        }
     }
 
     auto child = yieldNextRunningChild();
@@ -83,6 +98,14 @@ Work::onRun()
         }
         return state;
     }
+}
+
+void
+Work::abortSuccess()
+{
+    mReportSuccessOnAbort = true;
+    mAbortChildrenButNotSelf = true;
+    shutdownChildren();
 }
 
 bool

--- a/src/work/Work.h
+++ b/src/work/Work.h
@@ -123,6 +123,9 @@ class Work : public BasicWork
     // Provide additional cleanup logic for reset
     virtual void doReset();
 
+    // Abort, but report success
+    void abortSuccess();
+
   private:
     std::list<std::shared_ptr<BasicWork>> mChildren;
     std::list<std::shared_ptr<BasicWork>>::const_iterator mNextChild;
@@ -136,6 +139,7 @@ class Work : public BasicWork
     void shutdownChildren();
 
     bool mAbortChildrenButNotSelf{false};
+    bool mReportSuccessOnAbort{false};
 };
 
 namespace WorkUtils


### PR DESCRIPTION

# Description

Resolves #3512 

This PR enables updating the `scphistory` table during catchup from history. It allows users to specify which archives to use via the `SCP_HISTORY_ARCHIVES` config option. If a user specifies multiple archives, stellar-core will merge the messages from the archives.

This is a draft PR because I'm looking for feedback on the approach, but still have some work to do before it is in a mergeable state. Most of the remaining work is to:

* Document the new functionality
* Write additional tests for:
  * Merging
  * Failed downloads
  * No `SCP_HISTORY_ARCHIVES`
  * Multiple `SCP_HISTORY_ARCHIVES`
  * Changes to `ReplayDebugMetaWork`
* Integrate changes from #4121
* Address other `TODO`s in the changes

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
