### PR TITLE
Refactor for threadsafe BucketListDB

### DIFF
--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -77,18 +77,6 @@ Bucket::Bucket()
 {
 }
 
-XDRInputFileStream&
-Bucket::getStream()
-{
-    if (!mStream)
-    {
-        mStream = std::make_unique<XDRInputFileStream>();
-        releaseAssertOrThrow(!mFilename.empty());
-        mStream->open(mFilename.string());
-    }
-    return *mStream;
-}
-
 Hash const&
 Bucket::getHash() const
 {
@@ -139,157 +127,6 @@ void
 Bucket::freeIndex()
 {
     mIndex.reset(nullptr);
-    mStream.reset(nullptr);
-}
-
-std::optional<BucketEntry>
-Bucket::getEntryAtOffset(LedgerKey const& k, std::streamoff pos,
-                         size_t pageSize)
-{
-    ZoneScoped;
-    auto& stream = getStream();
-    stream.seek(pos);
-
-    BucketEntry be;
-    if (pageSize == 0)
-    {
-        if (stream.readOne(be))
-        {
-            return std::make_optional(be);
-        }
-    }
-    else if (stream.readPage(be, k, pageSize))
-    {
-        return std::make_optional(be);
-    }
-
-    // Mark entry miss for metrics
-    getIndex().markBloomMiss();
-    return std::nullopt;
-}
-
-std::optional<BucketEntry>
-Bucket::getBucketEntry(LedgerKey const& k)
-{
-    ZoneScoped;
-    auto pos = getIndex().lookup(k);
-    if (pos.has_value())
-    {
-        return getEntryAtOffset(k, pos.value(), getIndex().getPageSize());
-    }
-
-    return std::nullopt;
-}
-
-// When searching for an entry, BucketList calls this function on every bucket.
-// Since the input is sorted, we do a binary search for the first key in keys.
-// If we find the entry, we remove the found key from keys so that later buckets
-// do not load shadowed entries. If we don't find the entry, we do not remove it
-// from keys so that it will be searched for again at a lower level.
-void
-Bucket::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
-                 std::vector<LedgerEntry>& result)
-{
-    ZoneScoped;
-
-    auto currKeyIt = keys.begin();
-    auto const& index = getIndex();
-    auto indexIter = index.begin();
-    while (currKeyIt != keys.end() && indexIter != index.end())
-    {
-        auto [offOp, newIndexIter] = index.scan(indexIter, *currKeyIt);
-        indexIter = newIndexIter;
-        if (offOp)
-        {
-            auto entryOp =
-                getEntryAtOffset(*currKeyIt, *offOp, getIndex().getPageSize());
-            if (entryOp)
-            {
-                if (entryOp->type() != DEADENTRY)
-                {
-                    result.push_back(entryOp->liveEntry());
-                }
-
-                currKeyIt = keys.erase(currKeyIt);
-                continue;
-            }
-        }
-
-        ++currKeyIt;
-    }
-}
-
-void
-Bucket::loadPoolShareTrustLinessByAccount(
-    AccountID const& accountID, UnorderedSet<LedgerKey>& deadTrustlines,
-    UnorderedMap<LedgerKey, LedgerEntry>& liquidityPoolKeyToTrustline,
-    LedgerKeySet& liquidityPoolKeys)
-{
-    ZoneScoped;
-
-    // Takes a LedgerKey or LedgerEntry::_data_t, returns true if entry is a
-    // poolshare trusline for the given accountID
-    auto trustlineCheck = [&accountID](auto const& entry) {
-        return entry.type() == TRUSTLINE &&
-               entry.trustLine().asset.type() == ASSET_TYPE_POOL_SHARE &&
-               entry.trustLine().accountID == accountID;
-    };
-
-    // Get upper and lower bound for poolshare trustline range associated
-    // with this account
-    auto searchRange = getIndex().getPoolshareTrustlineRange(accountID);
-    if (searchRange.first == 0)
-    {
-        // No poolshare trustlines, exit
-        return;
-    }
-
-    BucketEntry be;
-    auto& stream = getStream();
-    stream.seek(searchRange.first);
-    while (stream && stream.pos() < searchRange.second && stream.readOne(be))
-    {
-        LedgerEntry entry;
-        switch (be.type())
-        {
-        case LIVEENTRY:
-        case INITENTRY:
-            entry = be.liveEntry();
-            break;
-        case DEADENTRY:
-        {
-            auto key = be.deadEntry();
-
-            // If we find a valid trustline key and we have not seen the
-            // key yet, mark it as dead so we do not load a shadowed version
-            // later
-            if (trustlineCheck(key))
-            {
-                deadTrustlines.emplace(key);
-            }
-            continue;
-        }
-        case METAENTRY:
-        default:
-            throw std::invalid_argument("Indexed METAENTRY");
-        }
-
-        // If this is a pool share trustline that matches the accountID and
-        // is not shadowed, add it to results
-        if (trustlineCheck(entry.data) &&
-            deadTrustlines.find(LedgerEntryKey(entry)) == deadTrustlines.end())
-        {
-            auto const& poolshareID =
-                entry.data.trustLine().asset.liquidityPoolID();
-
-            LedgerKey key;
-            key.type(LIQUIDITY_POOL);
-            key.liquidityPool().liquidityPoolID = poolshareID;
-
-            liquidityPoolKeyToTrustline.emplace(key, entry);
-            liquidityPoolKeys.emplace(key);
-        }
-    }
 }
 
 #ifdef BUILD_TESTS
@@ -837,12 +674,12 @@ mergeCasesWithEqualKeys(MergeCounters& mc, BucketInputIterator& oi,
 }
 
 bool
-Bucket::scanForEviction(AbstractLedgerTxn& ltx, EvictionIterator& iter,
-                        uint64_t& bytesToScan, uint32_t& maxEntriesToEvict,
-                        uint32_t ledgerSeq,
-                        medida::Counter& entriesEvictedCounter,
-                        medida::Counter& bytesScannedForEvictionCounter,
-                        std::optional<EvictionMetrics>& metrics)
+Bucket::scanForEvictionLegacySQL(
+    AbstractLedgerTxn& ltx, EvictionIterator& iter, uint64_t& bytesToScan,
+    uint32_t& maxEntriesToEvict, uint32_t ledgerSeq,
+    medida::Counter& entriesEvictedCounter,
+    medida::Counter& bytesScannedForEvictionCounter,
+    std::optional<EvictionStatistics>& stats) const
 {
     ZoneScoped;
     if (isEmpty())
@@ -857,7 +694,8 @@ Bucket::scanForEviction(AbstractLedgerTxn& ltx, EvictionIterator& iter,
         return true;
     }
 
-    auto& stream = getStream();
+    XDRInputFileStream stream{};
+    stream.open(mFilename);
     stream.seek(iter.bucketFileOffset);
 
     BucketEntry be;
@@ -898,10 +736,10 @@ Bucket::scanForEviction(AbstractLedgerTxn& ltx, EvictionIterator& iter,
                 if (shouldEvict())
                 {
                     ZoneNamedN(evict, "evict entry", true);
-                    if (metrics.has_value())
+                    if (stats.has_value())
                     {
-                        ++metrics->numEntriesEvicted;
-                        metrics->evictedEntriesAgeSum +=
+                        ++stats->numEntriesEvicted;
+                        stats->evictedEntriesAgeSum +=
                             ledgerSeq - liveUntilLedger;
                     }
 

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -7,6 +7,7 @@
 #include "bucket/BucketInputIterator.h"
 #include "bucket/BucketManager.h"
 #include "bucket/LedgerCmp.h"
+#include "bucket/SearchableBucketSnapshot.h"
 #include "crypto/Hex.h"
 #include "crypto/Random.h"
 #include "crypto/SHA.h"
@@ -23,6 +24,7 @@
 #include "util/types.h"
 
 #include "medida/counter.h"
+#include "medida/metrics_registry.h"
 
 #include <Tracy.hpp>
 #include <fmt/format.h>
@@ -376,198 +378,6 @@ BucketList::getHash() const
     return hsh.finish();
 }
 
-void
-BucketList::loopAllBuckets(std::function<bool(std::shared_ptr<Bucket>)> f) const
-{
-    for (auto const& lev : mLevels)
-    {
-        std::array<std::shared_ptr<Bucket>, 2> buckets = {lev.getCurr(),
-                                                          lev.getSnap()};
-        for (auto& b : buckets)
-        {
-            if (b->isEmpty())
-            {
-                continue;
-            }
-
-            if (f(b))
-            {
-                return;
-            }
-        }
-    }
-}
-
-std::shared_ptr<LedgerEntry>
-BucketList::getLedgerEntry(LedgerKey const& k) const
-{
-    ZoneScoped;
-    std::shared_ptr<LedgerEntry> result{};
-
-    auto f = [&](std::shared_ptr<Bucket> b) {
-        auto be = b->getBucketEntry(k);
-        if (be.has_value())
-        {
-            result =
-                be.value().type() == DEADENTRY
-                    ? nullptr
-                    : std::make_shared<LedgerEntry>(be.value().liveEntry());
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    };
-
-    loopAllBuckets(f);
-    return result;
-}
-
-std::vector<LedgerEntry>
-BucketList::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const
-{
-    ZoneScoped;
-    std::vector<LedgerEntry> entries;
-
-    // Make a copy of the key set, this loop is destructive
-    auto keys = inKeys;
-    auto f = [&](std::shared_ptr<Bucket> b) {
-        b->loadKeys(keys, entries);
-        return keys.empty();
-    };
-
-    loopAllBuckets(f);
-    return entries;
-}
-
-std::vector<LedgerEntry>
-BucketList::loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                                     Asset const& asset,
-                                                     Config const& cfg) const
-{
-    ZoneScoped;
-    UnorderedMap<LedgerKey, LedgerEntry> liquidityPoolToTrustline;
-    UnorderedSet<LedgerKey> deadTrustlines;
-    LedgerKeySet liquidityPoolKeysToSearch;
-
-    // First get all the poolshare trustlines for the given account
-    auto trustLineLoop = [&](std::shared_ptr<Bucket> b) {
-        b->loadPoolShareTrustLinessByAccount(accountID, deadTrustlines,
-                                             liquidityPoolToTrustline,
-                                             liquidityPoolKeysToSearch);
-        return false; // continue
-    };
-    loopAllBuckets(trustLineLoop);
-
-    // Load all the LiquidityPool entries that the account has a trustline for.
-    auto liquidityPoolEntries = loadKeys(liquidityPoolKeysToSearch);
-    // pools always exist when there are trustlines
-    releaseAssertOrThrow(liquidityPoolEntries.size() ==
-                         liquidityPoolKeysToSearch.size());
-    // Filter out liquidity pools that don't match the asset we're looking for
-    std::vector<LedgerEntry> result;
-    result.reserve(liquidityPoolEntries.size());
-    for (const auto& e : liquidityPoolEntries)
-    {
-        releaseAssert(e.data.type() == LIQUIDITY_POOL);
-        auto const& params =
-            e.data.liquidityPool().body.constantProduct().params;
-        if (compareAsset(params.assetA, asset) ||
-            compareAsset(params.assetB, asset))
-        {
-            auto trustlineIter =
-                liquidityPoolToTrustline.find(LedgerEntryKey(e));
-            releaseAssert(trustlineIter != liquidityPoolToTrustline.end());
-            result.emplace_back(trustlineIter->second);
-        }
-    }
-
-    return result;
-}
-
-std::vector<InflationWinner>
-BucketList::loadInflationWinners(size_t maxWinners, int64_t minBalance) const
-{
-    UnorderedMap<AccountID, int64_t> voteCount;
-    UnorderedSet<AccountID> seen;
-
-    auto countVotesInBucket = [&](std::shared_ptr<Bucket> b) {
-        for (BucketInputIterator in(b); in; ++in)
-        {
-            BucketEntry const& be = *in;
-            if (be.type() == DEADENTRY)
-            {
-                if (be.deadEntry().type() == ACCOUNT)
-                {
-                    seen.insert(be.deadEntry().account().accountID);
-                }
-                continue;
-            }
-
-            // Account are ordered first, so once we see a non-account entry, no
-            // other accounts are left in the bucket
-            LedgerEntry const& le = be.liveEntry();
-            if (le.data.type() != ACCOUNT)
-            {
-                break;
-            }
-
-            // Don't double count AccountEntry's seen in earlier levels
-            AccountEntry const& ae = le.data.account();
-            AccountID const& id = ae.accountID;
-            if (!seen.insert(id).second)
-            {
-                continue;
-            }
-
-            if (ae.inflationDest && ae.balance >= 1000000000)
-            {
-                voteCount[*ae.inflationDest] += ae.balance;
-            }
-        }
-
-        return false;
-    };
-
-    loopAllBuckets(countVotesInBucket);
-    std::vector<InflationWinner> winners;
-
-    // Check if we need to sort the voteCount by number of votes
-    if (voteCount.size() > maxWinners)
-    {
-
-        // Sort Inflation winners by vote count in descending order
-        std::map<int64_t, UnorderedMap<AccountID, int64_t>::const_iterator,
-                 std::greater<int64_t>>
-            voteCountSortedByCount;
-        for (auto iter = voteCount.cbegin(); iter != voteCount.cend(); ++iter)
-        {
-            voteCountSortedByCount[iter->second] = iter;
-        }
-
-        // Insert first maxWinners entries that are larger thanminBalance
-        for (auto iter = voteCountSortedByCount.cbegin();
-             winners.size() < maxWinners && iter->first >= minBalance; ++iter)
-        {
-            // push back {AccountID, voteCount}
-            winners.push_back({iter->second->first, iter->first});
-        }
-    }
-    else
-    {
-        for (auto const& [id, count] : voteCount)
-        {
-            if (count >= minBalance)
-            {
-                winners.push_back({id, count});
-            }
-        }
-    }
-
-    return winners;
-}
-
 // levelShouldSpill is the set of boundaries at which each level should
 // spill, it's not-entirely obvious which numbers these are by inspection,
 // so we list the first 3 values it's true on each level here for reference:
@@ -827,9 +637,9 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
 }
 
 void
-BucketList::scanForEviction(Application& app, AbstractLedgerTxn& ltx,
-                            uint32_t ledgerSeq,
-                            BucketListEvictionCounters& counters)
+BucketList::scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
+                                     uint32_t ledgerSeq,
+                                     EvictionCounters& counters)
 {
     auto getBucketFromIter = [&levels = mLevels](EvictionIterator const& iter) {
         auto& level = levels.at(iter.bucketListLevel);
@@ -890,10 +700,10 @@ BucketList::scanForEviction(Application& app, AbstractLedgerTxn& ltx,
         auto initialLevel = evictionIter.bucketListLevel;
         auto initialIsCurr = evictionIter.isCurrBucket;
         auto b = getBucketFromIter(evictionIter);
-        while (!b->scanForEviction(
+        while (!b->scanForEvictionLegacySQL(
             ltx, evictionIter, scanSize, maxEntriesToEvict, ledgerSeq,
             counters.entriesEvicted, counters.bytesScannedForEviction,
-            mEvictionMetrics))
+            mEvictionStatistics))
         {
             // If we reached eof in curr bucket, start scanning snap.
             // Last level has no snap so cycle back to the initial level.
@@ -918,23 +728,24 @@ BucketList::scanForEviction(Application& app, AbstractLedgerTxn& ltx,
 
                     // If eviction metrics are not null, we have accounted for a
                     // complete cycle and should log the metrics
-                    if (mEvictionMetrics)
+                    if (mEvictionStatistics)
                     {
                         counters.evictionCyclePeriod.set_count(
                             ledgerSeq -
-                            mEvictionMetrics->evictionCycleStartLedger);
+                            mEvictionStatistics->evictionCycleStartLedger);
 
                         auto averageAge =
-                            mEvictionMetrics->numEntriesEvicted == 0
+                            mEvictionStatistics->numEntriesEvicted == 0
                                 ? 0
-                                : mEvictionMetrics->evictedEntriesAgeSum /
-                                      mEvictionMetrics->numEntriesEvicted;
+                                : mEvictionStatistics->evictedEntriesAgeSum /
+                                      mEvictionStatistics->numEntriesEvicted;
                         counters.averageEvictedEntryAge.set_count(averageAge);
                     }
 
                     // Reset metrics at beginning of new eviction cycle
-                    mEvictionMetrics = std::make_optional<EvictionMetrics>();
-                    mEvictionMetrics->evictionCycleStartLedger = ledgerSeq;
+                    mEvictionStatistics =
+                        std::make_optional<EvictionStatistics>();
+                    mEvictionStatistics->evictionCycleStartLedger = ledgerSeq;
                 }
             }
 
@@ -1033,6 +844,20 @@ BucketList::restartMerges(Application& app, uint32_t maxProtocolVersion,
                 !app.getConfig().ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING);
         }
     }
+}
+
+EvictionCounters::EvictionCounters(Application& app)
+    : entriesEvicted(app.getMetrics().NewCounter(
+          {"state-archival", "eviction", "entries-evicted"}))
+    , bytesScannedForEviction(app.getMetrics().NewCounter(
+          {"state-archival", "eviction", "bytes-scanned"}))
+    , incompleteBucketScan(app.getMetrics().NewCounter(
+          {"state-archival", "eviction", "incomplete-scan"}))
+    , evictionCyclePeriod(
+          app.getMetrics().NewCounter({"state-archival", "eviction", "period"}))
+    , averageEvictedEntryAge(
+          app.getMetrics().NewCounter({"state-archival", "eviction", "age"}))
+{
 }
 
 BucketListDepth BucketList::kNumLevels = 11;

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -207,8 +207,10 @@ class BucketManager : NonMovableOrCopyable
     virtual void maybeSetIndex(std::shared_ptr<Bucket> b,
                                std::unique_ptr<BucketIndex const>&& index) = 0;
 
-    virtual std::unique_ptr<SearchableBucketListSnapshot const>
+    virtual std::unique_ptr<SearchableBucketListSnapshot>
     getSearchableBucketListSnapshot() const = 0;
+
+    virtual std::recursive_mutex& getBucketSnapshotMutex() const = 0;
 
     // Scans BucketList for non-live entries to evict starting at the entry
     // pointed to by EvictionIterator. Scans until `maxEntriesToEvict` entries

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -208,7 +208,7 @@ class BucketManager : NonMovableOrCopyable
                                std::unique_ptr<BucketIndex const>&& index) = 0;
 
     virtual std::unique_ptr<SearchableBucketListSnapshot const>
-    getSearchableBucketListSnapshot(bool isMainThread = false) const = 0;
+    getSearchableBucketListSnapshot() const = 0;
 
     // Scans BucketList for non-live entries to evict starting at the entry
     // pointed to by EvictionIterator. Scans until `maxEntriesToEvict` entries

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -907,7 +907,7 @@ BucketManagerImpl::scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
     }
 }
 
-std::unique_ptr<SearchableBucketListSnapshot const>
+std::unique_ptr<SearchableBucketListSnapshot>
 BucketManagerImpl::getSearchableBucketListSnapshot() const
 {
     releaseAssertOrThrow(mApp.getConfig().isUsingBucketListDB() && mBucketList);
@@ -917,6 +917,12 @@ BucketManagerImpl::getSearchableBucketListSnapshot() const
     // Note: cannot use make_unique due to private constructor
     return std::unique_ptr<SearchableBucketListSnapshot>(
         new SearchableBucketListSnapshot(mApp, *mBucketList));
+}
+
+std::recursive_mutex&
+BucketManagerImpl::getBucketSnapshotMutex() const
+{
+    return mBucketSnapshotMutex;
 }
 
 medida::Meter&

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -143,8 +143,9 @@ class BucketManagerImpl : public BucketManager
     void scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
                                   uint32_t ledgerSeq) override;
 
-    std::unique_ptr<SearchableBucketListSnapshot const>
+    std::unique_ptr<SearchableBucketListSnapshot>
     getSearchableBucketListSnapshot() const override;
+    std::recursive_mutex& getBucketSnapshotMutex() const override;
 
     medida::Meter& getBloomMissMeter() const override;
     medida::Meter& getBloomLookupMeter() const override;

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -47,14 +47,10 @@ class BucketManagerImpl : public BucketManager
     medida::Timer& mBucketAddBatch;
     medida::Timer& mBucketSnapMerge;
     medida::Counter& mSharedBucketsSize;
-    medida::Meter& mBucketListDBBulkLoadMeter;
     medida::Meter& mBucketListDBBloomMisses;
     medida::Meter& mBucketListDBBloomLookups;
     medida::Counter& mBucketListSizeCounter;
-    BucketListEvictionCounters mBucketListEvictionCounters;
-    mutable UnorderedMap<LedgerEntryType, medida::Timer&>
-        mBucketListDBPointTimers{};
-    mutable UnorderedMap<std::string, medida::Timer&> mBucketListDBBulkTimers{};
+    EvictionCounters mBucketListEvictionCounters;
     MergeCounters mMergeCounters;
 
     bool const mDeleteEntireBucketDirInDtor;
@@ -135,17 +131,12 @@ class BucketManagerImpl : public BucketManager
     void snapshotLedger(LedgerHeader& currentHeader) override;
     void maybeSetIndex(std::shared_ptr<Bucket> b,
                        std::unique_ptr<BucketIndex const>&& index) override;
-    void scanForEviction(AbstractLedgerTxn& ltx, uint32_t ledgerSeq) override;
+    void scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
+                                  uint32_t ledgerSeq) override;
 
-    std::shared_ptr<LedgerEntry>
-    getLedgerEntry(LedgerKey const& k) const override;
-    std::vector<LedgerEntry>
-    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& keys) const override;
-    std::vector<LedgerEntry>
-    loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                             Asset const& asset) const override;
-    std::vector<InflationWinner>
-    loadInflationWinners(size_t maxWinners, int64_t minBalance) const override;
+    std::unique_ptr<SearchableBucketListSnapshot const>
+    getSearchableBucketListSnapshot(bool isMainThread) const override;
+
     medida::Meter& getBloomMissMeter() const override;
     medida::Meter& getBloomLookupMeter() const override;
 

--- a/src/bucket/SearchableBucketListSnapshot.cpp
+++ b/src/bucket/SearchableBucketListSnapshot.cpp
@@ -1,0 +1,278 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketInputIterator.h"
+#include "bucket/SearchableBucketListSnapshot.h"
+#include "ledger/LedgerManager.h"
+#include "main/Application.h"
+
+#include "medida/meter.h"
+#include "medida/metrics_registry.h"
+
+namespace stellar
+{
+
+medida::Timer&
+SearchableBucketListSnapshot::recordBulkLoadMetrics(std::string const& label,
+                                                    size_t numEntries) const
+{
+    if (numEntries != 0)
+    {
+        mBulkLoadMeter.Mark(numEntries);
+    }
+
+    auto iter = mBulkTimers.find(label);
+    if (iter == mBulkTimers.end())
+    {
+        auto& metric =
+            mApp.getMetrics().NewTimer({"bucketlistDB", "bulk", label});
+        iter = mBulkTimers.emplace(label, metric).first;
+    }
+
+    return iter->second;
+}
+
+medida::Timer&
+SearchableBucketListSnapshot::getPointLoadTimer(LedgerEntryType t) const
+{
+    auto iter = mPointTimers.find(t);
+    if (iter == mPointTimers.end())
+    {
+        auto const& label = xdr::xdr_traits<LedgerEntryType>::enum_name(t);
+        auto& metric =
+            mApp.getMetrics().NewTimer({"bucketlistDB", "point", label});
+        iter = mPointTimers.emplace(t, metric).first;
+    }
+
+    return iter->second;
+}
+
+void
+SearchableBucketListSnapshot::loopAllBuckets(
+    std::function<bool(SearchableBucketSnapshot const&)> f) const
+{
+    for (auto const& lev : mLevels)
+    {
+        // Return true if we should exit loop early
+        auto processBucket = [f](SearchableBucketSnapshot const& b) {
+            if (b.isEmpty())
+            {
+                return false;
+            }
+
+            return f(b);
+        };
+
+        if (processBucket(lev.curr) || processBucket(lev.snap))
+        {
+            return;
+        }
+    }
+}
+
+std::shared_ptr<LedgerEntry>
+SearchableBucketListSnapshot::getLedgerEntry(LedgerKey const& k) const
+{
+    ZoneScoped;
+    auto timer = getPointLoadTimer(k.type()).TimeScope();
+
+    std::shared_ptr<LedgerEntry> result{};
+
+    auto f = [&](SearchableBucketSnapshot const& b) {
+        auto be = b.getBucketEntry(k);
+        if (be.has_value())
+        {
+            result =
+                be.value().type() == DEADENTRY
+                    ? nullptr
+                    : std::make_shared<LedgerEntry>(be.value().liveEntry());
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    };
+
+    loopAllBuckets(f);
+    return result;
+}
+
+std::vector<LedgerEntry>
+SearchableBucketListSnapshot::loadKeys(
+    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const
+{
+    ZoneScoped;
+    auto timer = recordBulkLoadMetrics("prefetch", inKeys.size()).TimeScope();
+
+    std::vector<LedgerEntry> entries;
+
+    // Make a copy of the key set, this loop is destructive
+    auto keys = inKeys;
+    auto f = [&](SearchableBucketSnapshot const& b) {
+        b.loadKeys(keys, entries);
+        return keys.empty();
+    };
+
+    loopAllBuckets(f);
+    return entries;
+}
+
+std::vector<LedgerEntry>
+SearchableBucketListSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
+    AccountID const& accountID, Asset const& asset) const
+{
+    ZoneScoped;
+    auto timer = recordBulkLoadMetrics("poolshareTrustlines", 0).TimeScope();
+
+    UnorderedMap<LedgerKey, LedgerEntry> liquidityPoolToTrustline;
+    UnorderedSet<LedgerKey> deadTrustlines;
+    LedgerKeySet liquidityPoolKeysToSearch;
+
+    // First get all the poolshare trustlines for the given account
+    auto trustLineLoop = [&](SearchableBucketSnapshot const& b) {
+        b.loadPoolShareTrustLinessByAccount(accountID, deadTrustlines,
+                                            liquidityPoolToTrustline,
+                                            liquidityPoolKeysToSearch);
+        return false; // continue
+    };
+    loopAllBuckets(trustLineLoop);
+
+    // Load all the LiquidityPool entries that the account has a trustline for.
+    auto liquidityPoolEntries = loadKeys(liquidityPoolKeysToSearch);
+    // pools always exist when there are trustlines
+    releaseAssertOrThrow(liquidityPoolEntries.size() ==
+                         liquidityPoolKeysToSearch.size());
+    // Filter out liquidity pools that don't match the asset we're looking for
+    std::vector<LedgerEntry> result;
+    result.reserve(liquidityPoolEntries.size());
+    for (const auto& e : liquidityPoolEntries)
+    {
+        releaseAssert(e.data.type() == LIQUIDITY_POOL);
+        auto const& params =
+            e.data.liquidityPool().body.constantProduct().params;
+        if (compareAsset(params.assetA, asset) ||
+            compareAsset(params.assetB, asset))
+        {
+            auto trustlineIter =
+                liquidityPoolToTrustline.find(LedgerEntryKey(e));
+            releaseAssert(trustlineIter != liquidityPoolToTrustline.end());
+            result.emplace_back(trustlineIter->second);
+        }
+    }
+
+    return result;
+}
+
+std::vector<InflationWinner>
+SearchableBucketListSnapshot::loadInflationWinners(size_t maxWinners,
+                                                   int64_t minBalance) const
+{
+    ZoneScoped;
+    auto timer = recordBulkLoadMetrics("inflationWinners", 0).TimeScope();
+
+    UnorderedMap<AccountID, int64_t> voteCount;
+    UnorderedSet<AccountID> seen;
+
+    auto countVotesInBucket = [&](SearchableBucketSnapshot const& b) {
+        for (BucketInputIterator in(b.getRawBucket()); in; ++in)
+        {
+            BucketEntry const& be = *in;
+            if (be.type() == DEADENTRY)
+            {
+                if (be.deadEntry().type() == ACCOUNT)
+                {
+                    seen.insert(be.deadEntry().account().accountID);
+                }
+                continue;
+            }
+
+            // Account are ordered first, so once we see a non-account entry, no
+            // other accounts are left in the bucket
+            LedgerEntry const& le = be.liveEntry();
+            if (le.data.type() != ACCOUNT)
+            {
+                break;
+            }
+
+            // Don't double count AccountEntry's seen in earlier levels
+            AccountEntry const& ae = le.data.account();
+            AccountID const& id = ae.accountID;
+            if (!seen.insert(id).second)
+            {
+                continue;
+            }
+
+            if (ae.inflationDest && ae.balance >= 1000000000)
+            {
+                voteCount[*ae.inflationDest] += ae.balance;
+            }
+        }
+
+        return false;
+    };
+
+    loopAllBuckets(countVotesInBucket);
+    std::vector<InflationWinner> winners;
+
+    // Check if we need to sort the voteCount by number of votes
+    if (voteCount.size() > maxWinners)
+    {
+
+        // Sort Inflation winners by vote count in descending order
+        std::map<int64_t, UnorderedMap<AccountID, int64_t>::const_iterator,
+                 std::greater<int64_t>>
+            voteCountSortedByCount;
+        for (auto iter = voteCount.cbegin(); iter != voteCount.cend(); ++iter)
+        {
+            voteCountSortedByCount[iter->second] = iter;
+        }
+
+        // Insert first maxWinners entries that are larger thanminBalance
+        for (auto iter = voteCountSortedByCount.cbegin();
+             winners.size() < maxWinners && iter->first >= minBalance; ++iter)
+        {
+            // push back {AccountID, voteCount}
+            winners.push_back({iter->second->first, iter->first});
+        }
+    }
+    else
+    {
+        for (auto const& [id, count] : voteCount)
+        {
+            if (count >= minBalance)
+            {
+                winners.push_back({id, count});
+            }
+        }
+    }
+
+    return winners;
+}
+
+SearchableBucketLevelSnapshot::SearchableBucketLevelSnapshot(
+    BucketLevel const& level)
+    : curr(level.getCurr()), snap(level.getSnap())
+{
+}
+
+SearchableBucketListSnapshot::SearchableBucketListSnapshot(Application& app,
+                                                           BucketList const& bl)
+    : mApp(app)
+    , mLCL(app.getLedgerManager().getLastClosedLedgerNum())
+    , mBulkLoadMeter(app.getMetrics().NewMeter(
+          {"bucketlistDB", "query", "loads"}, "query"))
+    , mBloomMisses(app.getMetrics().NewMeter(
+          {"bucketlistDB", "bloom", "misses"}, "bloom"))
+    , mBloomLookups(app.getMetrics().NewMeter(
+          {"bucketlistDB", "bloom", "lookups"}, "bloom"))
+    , mEvictionCounters(app)
+{
+    for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
+    {
+        auto const& level = bl.getLevel(i);
+        mLevels.emplace_back(SearchableBucketLevelSnapshot(level));
+    }
+}
+}

--- a/src/bucket/SearchableBucketListSnapshot.h
+++ b/src/bucket/SearchableBucketListSnapshot.h
@@ -21,7 +21,7 @@ struct SearchableBucketLevelSnapshot
 
 // A lightweight wrapper around the BucketList for thread safe BucketListDB
 // lookups
-class SearchableBucketListSnapshot : public NonMovable
+class SearchableBucketListSnapshot : public NonMovableOrCopyable
 {
     Application& mApp;
     std::vector<SearchableBucketLevelSnapshot> mLevels;
@@ -53,22 +53,25 @@ class SearchableBucketListSnapshot : public NonMovable
     // allowedLedgerDrift, lcl]
     bool isWithinAllowedLedgerDrift(uint32_t allowedLedgerDrift) const;
 
+    // Checks if snapshot is behind the current LCL and updates as necessary
+    void maybeUpdateSnapshot();
+
     SearchableBucketListSnapshot(Application& app, BucketList const& bl);
 
   public:
     std::vector<LedgerEntry>
-    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const;
+    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
 
     std::vector<LedgerEntry>
     loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                             Asset const& asset) const;
+                                             Asset const& asset);
 
     std::vector<InflationWinner> loadInflationWinners(size_t maxWinners,
-                                                      int64_t minBalance) const;
+                                                      int64_t minBalance);
 
-    std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k) const;
+    std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k);
 
-    friend std::unique_ptr<SearchableBucketListSnapshot const>
+    friend std::unique_ptr<SearchableBucketListSnapshot>
     BucketManagerImpl::getSearchableBucketListSnapshot() const;
 };
 }

--- a/src/bucket/SearchableBucketListSnapshot.h
+++ b/src/bucket/SearchableBucketListSnapshot.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketList.h"
+#include "bucket/SearchableBucketSnapshot.h"
+
+namespace stellar
+{
+
+struct SearchableBucketLevelSnapshot
+{
+    SearchableBucketSnapshot curr;
+    SearchableBucketSnapshot snap;
+
+    SearchableBucketLevelSnapshot(BucketLevel const& level);
+};
+
+// A lightweight wrapper around the BucketList for thread safe BucketListDB
+// lookups
+class SearchableBucketListSnapshot : public NonMovable
+{
+    Application& mApp;
+    std::vector<SearchableBucketLevelSnapshot> mLevels;
+
+    // Last closed ledger sequence that this BucketList snapshot is based off of
+    uint32_t mLCL;
+
+    mutable UnorderedMap<LedgerEntryType, medida::Timer&> mPointTimers{};
+    mutable UnorderedMap<std::string, medida::Timer&> mBulkTimers{};
+
+    medida::Meter& mBulkLoadMeter;
+    medida::Meter& mBloomMisses;
+    medida::Meter& mBloomLookups;
+
+    EvictionCounters mEvictionCounters;
+
+    // Loops through all buckets, starting with curr at level 0, then snap at
+    // level 0, etc. Calls f on each bucket. Exits early if function
+    // returns true
+    void loopAllBuckets(
+        std::function<bool(SearchableBucketSnapshot const&)> f) const;
+
+    medida::Timer& recordBulkLoadMetrics(std::string const& label,
+                                         size_t numEntries) const;
+
+    medida::Timer& getPointLoadTimer(LedgerEntryType t) const;
+
+  public:
+    // TODO: Private constructor so only BucketManager can create this class
+    // with a mutex check
+    SearchableBucketListSnapshot(Application& app, BucketList const& bl);
+
+    std::vector<LedgerEntry>
+    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const;
+
+    std::vector<LedgerEntry>
+    loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
+                                             Asset const& asset) const;
+
+    std::vector<InflationWinner> loadInflationWinners(size_t maxWinners,
+                                                      int64_t minBalance) const;
+
+    std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k) const;
+};
+}

--- a/src/bucket/SearchableBucketListSnapshot.h
+++ b/src/bucket/SearchableBucketListSnapshot.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "bucket/BucketList.h"
+#include "bucket/BucketManagerImpl.h"
 #include "bucket/SearchableBucketSnapshot.h"
 
 namespace stellar
@@ -48,11 +49,13 @@ class SearchableBucketListSnapshot : public NonMovable
 
     medida::Timer& getPointLoadTimer(LedgerEntryType t) const;
 
-  public:
-    // TODO: Private constructor so only BucketManager can create this class
-    // with a mutex check
+    // Return true is this snapshot is from a ledger within [lcl -
+    // allowedLedgerDrift, lcl]
+    bool isWithinAllowedLedgerDrift(uint32_t allowedLedgerDrift) const;
+
     SearchableBucketListSnapshot(Application& app, BucketList const& bl);
 
+  public:
     std::vector<LedgerEntry>
     loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const;
 
@@ -64,5 +67,8 @@ class SearchableBucketListSnapshot : public NonMovable
                                                       int64_t minBalance) const;
 
     std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k) const;
+
+    friend std::unique_ptr<SearchableBucketListSnapshot const>
+    BucketManagerImpl::getSearchableBucketListSnapshot() const;
 };
 }

--- a/src/bucket/SearchableBucketSnapshot.cpp
+++ b/src/bucket/SearchableBucketSnapshot.cpp
@@ -1,0 +1,221 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/Bucket.h"
+#include "bucket/SearchableBucketListSnapshot.h"
+#include "bucket/SearchableBucketSnapshot.h"
+#include "ledger/LedgerTxn.h"
+#include "ledger/LedgerTypeUtils.h"
+
+#include "medida/counter.h"
+
+namespace stellar
+{
+SearchableBucketSnapshot::SearchableBucketSnapshot(
+    std::shared_ptr<Bucket const> const b)
+    : mBucket(b)
+{
+}
+
+SearchableBucketSnapshot::SearchableBucketSnapshot(
+    SearchableBucketSnapshot const& b)
+    : mBucket(b.mBucket), mStream(nullptr)
+{
+}
+
+bool
+SearchableBucketSnapshot::isEmpty() const
+{
+    return mBucket && mBucket->isEmpty();
+}
+
+std::optional<BucketEntry>
+SearchableBucketSnapshot::getEntryAtOffset(LedgerKey const& k,
+                                           std::streamoff pos,
+                                           size_t pageSize) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return std::nullopt;
+    }
+
+    auto& stream = getStream();
+    stream.seek(pos);
+
+    BucketEntry be;
+    if (pageSize == 0)
+    {
+        if (stream.readOne(be))
+        {
+            return std::make_optional(be);
+        }
+    }
+    else if (stream.readPage(be, k, pageSize))
+    {
+        return std::make_optional(be);
+    }
+
+    // Mark entry miss for metrics
+    mBucket->getIndex().markBloomMiss();
+    return std::nullopt;
+}
+
+std::optional<BucketEntry>
+SearchableBucketSnapshot::getBucketEntry(LedgerKey const& k) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return std::nullopt;
+    }
+
+    auto pos = mBucket->getIndex().lookup(k);
+    if (pos.has_value())
+    {
+        return getEntryAtOffset(k, pos.value(),
+                                mBucket->getIndex().getPageSize());
+    }
+
+    return std::nullopt;
+}
+
+// When searching for an entry, BucketList calls this function on every bucket.
+// Since the input is sorted, we do a binary search for the first key in keys.
+// If we find the entry, we remove the found key from keys so that later buckets
+// do not load shadowed entries. If we don't find the entry, we do not remove it
+// from keys so that it will be searched for again at a lower level.
+void
+SearchableBucketSnapshot::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
+                                   std::vector<LedgerEntry>& result) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return;
+    }
+
+    auto currKeyIt = keys.begin();
+    auto const& index = mBucket->getIndex();
+    auto indexIter = index.begin();
+    while (currKeyIt != keys.end() && indexIter != index.end())
+    {
+        auto [offOp, newIndexIter] = index.scan(indexIter, *currKeyIt);
+        indexIter = newIndexIter;
+        if (offOp)
+        {
+            auto entryOp = getEntryAtOffset(*currKeyIt, *offOp,
+                                            mBucket->getIndex().getPageSize());
+            if (entryOp)
+            {
+                if (entryOp->type() != DEADENTRY)
+                {
+                    result.push_back(entryOp->liveEntry());
+                }
+
+                currKeyIt = keys.erase(currKeyIt);
+                continue;
+            }
+        }
+
+        ++currKeyIt;
+    }
+}
+
+void
+SearchableBucketSnapshot::loadPoolShareTrustLinessByAccount(
+    AccountID const& accountID, UnorderedSet<LedgerKey>& deadTrustlines,
+    UnorderedMap<LedgerKey, LedgerEntry>& liquidityPoolKeyToTrustline,
+    LedgerKeySet& liquidityPoolKeys) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return;
+    }
+
+    // Takes a LedgerKey or LedgerEntry::_data_t, returns true if entry is a
+    // poolshare trusline for the given accountID
+    auto trustlineCheck = [&accountID](auto const& entry) {
+        return entry.type() == TRUSTLINE &&
+               entry.trustLine().asset.type() == ASSET_TYPE_POOL_SHARE &&
+               entry.trustLine().accountID == accountID;
+    };
+
+    // Get upper and lower bound for poolshare trustline range associated
+    // with this account
+    auto searchRange =
+        mBucket->getIndex().getPoolshareTrustlineRange(accountID);
+    if (searchRange.first == 0)
+    {
+        // No poolshare trustlines, exit
+        return;
+    }
+
+    BucketEntry be;
+    auto& stream = getStream();
+    stream.seek(searchRange.first);
+    while (stream && stream.pos() < searchRange.second && stream.readOne(be))
+    {
+        LedgerEntry entry;
+        switch (be.type())
+        {
+        case LIVEENTRY:
+        case INITENTRY:
+            entry = be.liveEntry();
+            break;
+        case DEADENTRY:
+        {
+            auto key = be.deadEntry();
+
+            // If we find a valid trustline key and we have not seen the
+            // key yet, mark it as dead so we do not load a shadowed version
+            // later
+            if (trustlineCheck(key))
+            {
+                deadTrustlines.emplace(key);
+            }
+            continue;
+        }
+        case METAENTRY:
+        default:
+            throw std::invalid_argument("Indexed METAENTRY");
+        }
+
+        // If this is a pool share trustline that matches the accountID and
+        // is not shadowed, add it to results
+        if (trustlineCheck(entry.data) &&
+            deadTrustlines.find(LedgerEntryKey(entry)) == deadTrustlines.end())
+        {
+            auto const& poolshareID =
+                entry.data.trustLine().asset.liquidityPoolID();
+
+            LedgerKey key;
+            key.type(LIQUIDITY_POOL);
+            key.liquidityPool().liquidityPoolID = poolshareID;
+
+            liquidityPoolKeyToTrustline.emplace(key, entry);
+            liquidityPoolKeys.emplace(key);
+        }
+    }
+}
+
+XDRInputFileStream&
+SearchableBucketSnapshot::getStream() const
+{
+    if (!mStream)
+    {
+        mStream = std::make_unique<XDRInputFileStream>();
+        releaseAssertOrThrow(mBucket && !mBucket->isEmpty());
+        mStream->open(mBucket->getFilename().string());
+    }
+    return *mStream;
+}
+
+std::shared_ptr<Bucket const>
+SearchableBucketSnapshot::getRawBucket() const
+{
+    return mBucket;
+}
+}

--- a/src/bucket/SearchableBucketSnapshot.cpp
+++ b/src/bucket/SearchableBucketSnapshot.cpp
@@ -2,9 +2,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/SearchableBucketSnapshot.h"
 #include "bucket/Bucket.h"
 #include "bucket/SearchableBucketListSnapshot.h"
-#include "bucket/SearchableBucketSnapshot.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTypeUtils.h"
 

--- a/src/bucket/SearchableBucketSnapshot.h
+++ b/src/bucket/SearchableBucketSnapshot.h
@@ -1,0 +1,67 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/NonCopyable.h"
+#include "util/UnorderedMap.h"
+#include "util/UnorderedSet.h"
+#include "util/types.h"
+
+#include <optional>
+
+namespace stellar
+{
+
+class Bucket;
+class XDRInputFileStream;
+
+// A lightweight wrapper around Bucket for thread safe BucketListDB lookups
+class SearchableBucketSnapshot : public NonMovable
+{
+    std::shared_ptr<Bucket const> mBucket;
+
+    // Lazily-constructed and retained for read path.
+    mutable std::unique_ptr<XDRInputFileStream> mStream{};
+
+    // Returns (lazily-constructed) file stream for bucket file. Note
+    // this might be in some random position left over from a previous read --
+    // must be seek()'ed before use.
+    XDRInputFileStream& getStream() const;
+
+    // Loads the bucket entry for LedgerKey k. Starts at file offset pos and
+    // reads until key is found or the end of the page.
+    std::optional<BucketEntry> getEntryAtOffset(LedgerKey const& k,
+                                                std::streamoff pos,
+                                                size_t pageSize) const;
+
+  public:
+    SearchableBucketSnapshot(std::shared_ptr<Bucket const> const b);
+    SearchableBucketSnapshot(SearchableBucketSnapshot const& b);
+    SearchableBucketSnapshot&
+    operator=(SearchableBucketSnapshot const& b) = delete;
+
+    bool isEmpty() const;
+    std::shared_ptr<Bucket const> getRawBucket() const;
+
+    // Loads bucket entry for LedgerKey k.
+    std::optional<BucketEntry> getBucketEntry(LedgerKey const& k) const;
+
+    // Loads LedgerEntry's for given keys. When a key is found, the
+    // entry is added to result and the key is removed from keys.
+    void loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
+                  std::vector<LedgerEntry>& result) const;
+
+    // Loads all poolshare trustlines for the given account. Trustlines are
+    // stored with their corresponding liquidity pool key in
+    // liquidityPoolKeyToTrustline. All liquidity pool keys corresponding to
+    // loaded trustlines are also reduntantly stored in liquidityPoolKeys.
+    // If a trustline key is in deadTrustlines, it is not loaded. Whenever a
+    // dead trustline is found, its key is added to deadTrustlines.
+    void loadPoolShareTrustLinessByAccount(
+        AccountID const& accountID, UnorderedSet<LedgerKey>& deadTrustlines,
+        UnorderedMap<LedgerKey, LedgerEntry>& liquidityPoolKeyToTrustline,
+        LedgerKeySet& liquidityPoolKeys) const;
+};
+}

--- a/src/bucket/SearchableBucketSnapshot.h
+++ b/src/bucket/SearchableBucketSnapshot.h
@@ -36,12 +36,15 @@ class SearchableBucketSnapshot : public NonMovable
                                                 std::streamoff pos,
                                                 size_t pageSize) const;
 
-  public:
+    // Warning: constructor not thread safe
     SearchableBucketSnapshot(std::shared_ptr<Bucket const> const b);
+
+    // Only allow copy constructor, is threadsafe
     SearchableBucketSnapshot(SearchableBucketSnapshot const& b);
     SearchableBucketSnapshot&
     operator=(SearchableBucketSnapshot const& b) = delete;
 
+  public:
     bool isEmpty() const;
     std::shared_ptr<Bucket const> getRawBucket() const;
 
@@ -63,5 +66,7 @@ class SearchableBucketSnapshot : public NonMovable
         AccountID const& accountID, UnorderedSet<LedgerKey>& deadTrustlines,
         UnorderedMap<LedgerKey, LedgerEntry>& liquidityPoolKeyToTrustline,
         LedgerKeySet& liquidityPoolKeys) const;
+
+    friend struct SearchableBucketLevelSnapshot;
 };
 }

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -15,6 +15,7 @@
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketOutputIterator.h"
+#include "bucket/SearchableBucketListSnapshot.h"
 #include "bucket/test/BucketTestUtils.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
@@ -1109,6 +1110,47 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
             {
                 testIterReset(false);
             }
+        }
+    });
+}
+
+TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")
+{
+    VirtualClock clock;
+    Config cfg(getTestConfig(0, Config::TESTDB_IN_MEMORY_SQLITE));
+    cfg.EXPERIMENTAL_BUCKETLIST_DB = true;
+
+    auto app = createTestApplication<BucketTestApplication>(clock, cfg);
+    for_versions_from(20, *app, [&] {
+        LedgerManagerForBucketTests& lm = app->getLedgerManager();
+        auto& bm = app->getBucketManager();
+
+        auto entry =
+            LedgerTestUtils::generateValidLedgerEntryOfType(CLAIMABLE_BALANCE);
+        entry.data.claimableBalance().amount = 0;
+
+        auto searchableBL = bm.getSearchableBucketListSnapshot();
+
+        // Update entry every 5 ledgers so we can see bucket merge events
+        for (auto ledgerSeq = 1; ledgerSeq < 101; ++ledgerSeq)
+        {
+            if ((ledgerSeq - 1) % 5 == 0)
+            {
+                ++entry.data.claimableBalance().amount;
+                entry.lastModifiedLedgerSeq = ledgerSeq;
+                lm.setNextLedgerEntryBatchForBucketTesting({}, {entry}, {});
+            }
+            else
+            {
+                lm.setNextLedgerEntryBatchForBucketTesting({}, {}, {});
+            }
+
+            closeLedger(*app);
+
+            // Snapshot should automatically update with latest version
+            auto loadedEntry =
+                searchableBL->getLedgerEntry(LedgerEntryKey(entry));
+            REQUIRE((loadedEntry && *loadedEntry == entry));
         }
     });
 }

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -119,8 +119,8 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
         {
             {
                 LedgerTxn ltxEvictions(ltx);
-                mApp.getBucketManager().scanForEviction(ltxEvictions,
-                                                        ledgerSeq);
+                mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
+                                                                 ledgerSeq);
                 if (ledgerCloseMeta)
                 {
                     ledgerCloseMeta->populateEvictedEntries(

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -427,12 +427,14 @@ LedgerManagerImpl::getDatabase()
 uint32_t
 LedgerManagerImpl::getLastMaxTxSetSize() const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     return mLastClosedLedger.header.maxTxSetSize;
 }
 
 uint32_t
 LedgerManagerImpl::getLastMaxTxSetSizeOps() const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     auto n = mLastClosedLedger.header.maxTxSetSize;
     return protocolVersionStartsFrom(mLastClosedLedger.header.ledgerVersion,
                                      ProtocolVersion::V_11)
@@ -484,6 +486,7 @@ LedgerManagerImpl::maxSorobanTransactionResources()
 int64_t
 LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     auto const& lh = mLastClosedLedger.header;
     if (protocolVersionIsBefore(lh.ledgerVersion, ProtocolVersion::V_9))
         return (2 + ownerCount) * lh.baseReserve;
@@ -494,18 +497,21 @@ LedgerManagerImpl::getLastMinBalance(uint32_t ownerCount) const
 uint32_t
 LedgerManagerImpl::getLastReserve() const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     return mLastClosedLedger.header.baseReserve;
 }
 
 uint32_t
 LedgerManagerImpl::getLastTxFee() const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     return mLastClosedLedger.header.baseFee;
 }
 
 LedgerHeaderHistoryEntry const&
 LedgerManagerImpl::getLastClosedLedgerHeader() const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     return mLastClosedLedger;
 }
 
@@ -524,12 +530,14 @@ LedgerManagerImpl::getLastClosedLedgerHAS()
 uint32_t
 LedgerManagerImpl::getLastClosedLedgerNum() const
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     return mLastClosedLedger.header.ledgerSeq;
 }
 
 SorobanNetworkConfig&
 LedgerManagerImpl::getSorobanNetworkConfigInternal()
 {
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     releaseAssert(mSorobanNetworkConfig);
     return *mSorobanNetworkConfig;
 }
@@ -1275,6 +1283,7 @@ LedgerManagerImpl::advanceLedgerPointers(LedgerHeader const& header,
                    ledgerAbbrev(header, ledgerHash));
     }
 
+    std::lock_guard<std::mutex> lock(mLedgerPointerLock);
     mLastClosedLedger.hash = ledgerHash;
     mLastClosedLedger.header = header;
 }

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1622,7 +1622,8 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
     {
         {
             LedgerTxn ltxEvictions(ltx);
-            mApp.getBucketManager().scanForEviction(ltxEvictions, ledgerSeq);
+            mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
+                                                             ledgerSeq);
             if (ledgerCloseMeta)
             {
                 ledgerCloseMeta->populateEvictedEntries(

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -51,6 +51,8 @@ class LedgerManagerImpl : public LedgerManager
     LedgerHeaderHistoryEntry mLastClosedLedger;
     std::optional<SorobanNetworkConfig> mSorobanNetworkConfig;
 
+    mutable std::mutex mLedgerPointerLock;
+
     medida::Timer& mTransactionApply;
     medida::Histogram& mTransactionCount;
     medida::Histogram& mOperationCount;

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -3371,7 +3371,7 @@ LedgerTxnRoot::Impl::areEntriesMissingInCacheForOffer(OfferEntry const& oe)
     return false;
 }
 
-SearchableBucketListSnapshot const&
+SearchableBucketListSnapshot&
 LedgerTxnRoot::Impl::getSearchableBucketListSnapshot() const
 {
     releaseAssert(mApp.getConfig().isUsingBucketListDB());

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -5,6 +5,7 @@
 #include "ledger/LedgerTxn.h"
 #include "bucket/BucketList.h"
 #include "bucket/BucketManager.h"
+#include "bucket/SearchableBucketListSnapshot.h"
 #include "crypto/Hex.h"
 #include "crypto/KeyUtils.h"
 #include "crypto/SecretKey.h"
@@ -2781,6 +2782,7 @@ LedgerTxnRoot::Impl::commitChild(EntryIterator iter,
     // Clearing the cache does not throw
     mBestOffers.clear();
     mEntryCache.clear();
+    mSearchableBucketListSnapshot.reset();
 
     // std::unique_ptr<...>::reset does not throw
     mTransaction.reset();
@@ -2987,7 +2989,7 @@ LedgerTxnRoot::Impl::prefetch(UnorderedSet<LedgerKey> const& keys)
             insertIfNotLoaded(keysToSearch, key);
         }
 
-        auto blLoad = mApp.getBucketManager().loadKeys(keysToSearch);
+        auto blLoad = getSearchableBucketListSnapshot().loadKeys(keysToSearch);
         cacheResult(populateLoadedEntries(keysToSearch, blLoad));
     }
     else
@@ -3369,6 +3371,19 @@ LedgerTxnRoot::Impl::areEntriesMissingInCacheForOffer(OfferEntry const& oe)
     return false;
 }
 
+SearchableBucketListSnapshot const&
+LedgerTxnRoot::Impl::getSearchableBucketListSnapshot() const
+{
+    releaseAssert(mApp.getConfig().isUsingBucketListDB());
+    if (!mSearchableBucketListSnapshot)
+    {
+        mSearchableBucketListSnapshot =
+            mApp.getBucketManager().getSearchableBucketListSnapshot();
+    }
+
+    return *mSearchableBucketListSnapshot;
+}
+
 std::shared_ptr<LedgerEntry const>
 LedgerTxnRoot::Impl::getBestOffer(Asset const& buying, Asset const& selling,
                                   OfferDescriptor const* worseThan)
@@ -3505,7 +3520,7 @@ LedgerTxnRoot::Impl::getPoolShareTrustLinesByAccountAndAsset(
         if (mApp.getConfig().isUsingBucketListDB())
         {
             trustLines =
-                mApp.getBucketManager()
+                getSearchableBucketListSnapshot()
                     .loadPoolShareTrustLinesByAccountAndAsset(account, asset);
         }
         else
@@ -3568,8 +3583,8 @@ LedgerTxnRoot::Impl::getInflationWinners(size_t maxWinners, int64_t minVotes)
     {
         if (mApp.getConfig().isUsingBucketListDB())
         {
-            return mApp.getBucketManager().loadInflationWinners(maxWinners,
-                                                                minVotes);
+            return getSearchableBucketListSnapshot().loadInflationWinners(
+                maxWinners, minVotes);
         }
         else
         {
@@ -3624,7 +3639,7 @@ LedgerTxnRoot::Impl::getNewestVersion(InternalLedgerKey const& gkey) const
     {
         if (mApp.getConfig().isUsingBucketListDB() && key.type() != OFFER)
         {
-            entry = mApp.getBucketManager().getLedgerEntry(key);
+            entry = getSearchableBucketListSnapshot().getLedgerEntry(key);
         }
         else
         {

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -740,7 +740,7 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
-    mutable std::unique_ptr<SearchableBucketListSnapshot const>
+    mutable std::unique_ptr<SearchableBucketListSnapshot>
         mSearchableBucketListSnapshot{};
 
     size_t mBulkLoadBatchSize;
@@ -874,7 +874,7 @@ class LedgerTxnRoot::Impl
 
     bool areEntriesMissingInCacheForOffer(OfferEntry const& oe);
 
-    SearchableBucketListSnapshot const& getSearchableBucketListSnapshot() const;
+    SearchableBucketListSnapshot& getSearchableBucketListSnapshot() const;
 
   public:
     // Constructor has the strong exception safety guarantee

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/BucketList.h"
 #include "database/Database.h"
 #include "ledger/LedgerTxn.h"
 #include "util/RandomEvictionCache.h"
@@ -18,6 +19,8 @@
 
 namespace stellar
 {
+
+class SearchableBucketListSnapshot;
 
 // Precondition: The keys associated with entries are unique and constitute a
 // subset of keys
@@ -737,6 +740,8 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
+    mutable std::unique_ptr<SearchableBucketListSnapshot const>
+        mSearchableBucketListSnapshot{};
 
     size_t mBulkLoadBatchSize;
     std::unique_ptr<soci::transaction> mTransaction;
@@ -868,6 +873,8 @@ class LedgerTxnRoot::Impl
         std::deque<LedgerEntry>::const_iterator const& end);
 
     bool areEntriesMissingInCacheForOffer(OfferEntry const& oe);
+
+    SearchableBucketListSnapshot const& getSearchableBucketListSnapshot() const;
 
   public:
     // Constructor has the strong exception safety guarantee


### PR DESCRIPTION
# Description

First step towards #4127

This PR refactors BucketListDB code as a first step towards parallel BucketListDB access. This should have no observable changes.

Currently, BucketListDB is thread safe with the exception of `Bucket` file streams. This change refactors all BucketListDB code out of `BucketList` and `Bucket` and into `SearchableBucketListSnapshot` and `SearchableBucketSnapshot`. `SearchableBucketListSnapshot` is a lightweight wrapper around `BucketList` that stores `SearchableBucketSnapshot`. `SearchableBucketSnapshot` is another wrapper class that maintains a pointer to the underlying `Bucket` as well as a stream to read from the Bucket. In order to facilitate multi thread reads, all BucketList loads must go through these snapshot classes that maintain their own local stream object.

In addition to the refactor, a few mutexes have been added around adding entries to the BucketList and modifying ledger header pointers. While these locks are not currently necessary, further work will build on this and actually enable parallel access. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
