### PR TITLE
Soroban metrics improvement

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -196,19 +196,19 @@ soroban.ledger.read-entry                    | histogram | number of entries rea
 soroban.ledger.read-byte                     | histogram | number of entry bytes in read entries per ledger
 soroban.ledger.write-entry                   | histogram | number of entries written per ledger
 soroban.ledger.write-byte                    | histogram | number of entry bytes in written entries per ledger
-soroban.config.contract-max-size-bytes           | counter     | soroban config setting `contract_max_size_bytes`
-soroban.config.ledger-max-instructions           | counter     | soroban config setting `ledger_max_instructions`
-soroban.config.tx-max-instructions               | counter     | soroban config setting `tx_max_instructions`
-soroban.config.tx-memory-limit                   | counter     | soroban config setting `tx_memory_limit`
-soroban.config.ledger-max-read-ledger-entries    | counter     | soroban config setting `ledger_max_read_ledger_entries`
-soroban.config.ledger-max-read-bytes             | counter     | soroban config setting `ledger_max_read_bytes`
-soroban.config.ledger-max-write-ledger-entries   | counter     | soroban config setting `ledger_max_write_ledger_entries`
-soroban.config.ledger-max-write-bytes            | counter     | soroban config setting `ledger_max_write_bytes`
-soroban.config.tx-max-read-ledger-entries        | counter     | soroban config setting `tx_max_read_ledger_entries`
-soroban.config.tx-max-read-bytes                 | counter     | soroban config setting `tx_max_read_bytes`
-soroban.config.tx-max-write-ledger-entries       | counter     | soroban config setting `tx_max_write_ledger_entries`
-soroban.config.tx-max-write-bytes                | counter     | soroban config setting `tx_max_write_bytes`
-soroban.config.bucket-list-target-size-bytes     | counter     | soroban config setting `bucket_list_target_size_bytes`
-soroban.config.tx-max-contract-events-size-bytes | counter     | soroban config setting `tx_max_contract_events_size_bytes`
-soroban.config.contract-data-key-size-bytes      | counter     | soroban config setting `contract_data_key_size_bytes`
-soroban.config.contract-data-entry-size-bytes    | counter     | soroban config setting `contract_data_entry_size_bytes`
+soroban.config.contract-max-rw-key-byte      | counter   | soroban config setting `contract_data_key_size_bytes`
+soroban.config.contract-max-rw-data-byte     | counter   | soroban config setting `contract_data_entry_size_bytes`
+soroban.config.contract-max-rw-code-byte     | counter   | soroban config setting `contract_max_size_bytes`
+soroban.config.tx-max-cpu-insn               | counter   | soroban config setting `tx_max_instructions`
+soroban.config.tx-max-mem-byte               | counter   | soroban config setting `tx_memory_limit`
+soroban.config.tx-max-read-entry             | counter   | soroban config setting `tx_max_read_ledger_entries`
+soroban.config.tx-max-read-ledger-byte       | counter   | soroban config setting `tx_max_read_bytes`
+soroban.config.tx-max-write-entry            | counter   | soroban config setting `tx_max_write_ledger_entries`
+soroban.config.tx-max-write-ledger-byte      | counter   | soroban config setting `tx_max_write_bytes`
+soroban.config.tx-max-emit-event-byte        | counter   | soroban config setting `tx_max_contract_events_size_bytes`
+soroban.config.ledger-max-cpu-insn           | counter   | soroban config setting `ledger_max_instructions`
+soroban.config.ledger-max-read-entry         | counter   | soroban config setting `ledger_max_read_ledger_entries`
+soroban.config.ledger-max-read-ledger-byte   | counter   | soroban config setting `ledger_max_read_bytes`
+soroban.config.ledger-max-write-entry        | counter   | soroban config setting `ledger_max_write_ledger_entries`
+soroban.config.ledger-max-write-ledger-byte  | counter   | soroban config setting `ledger_max_write_bytes`
+soroban.config.bucket-list-target-size-byte  | counter   | soroban config setting `bucket_list_target_size_bytes`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -166,10 +166,10 @@ soroban.host-fn-op.read-entry                | meter     | number of entries rea
 soroban.host-fn-op.write-entry               | meter     | number of entries written
 soroban.host-fn-op.read-key-byte             | meter     | number of key bytes in read entries
 soroban.host-fn-op.write-key-byte            | meter     | number of key bytes in written entries
-soroban.host-fn-op.read-ledger-byte          | meter     | number of data + code bytes in read entries
+soroban.host-fn-op.read-ledger-byte          | meter     | number of entry (data + code) bytes in read entries
 soroban.host-fn-op.read-data-byte            | meter     | number of data bytes in read entries
 soroban.host-fn-op.read-code-byte            | meter     | number of code bytes in read entries
-soroban.host-fn-op.write-ledger-byte         | meter     | number of data + code bytes in written entries
+soroban.host-fn-op.write-ledger-byte         | meter     | number of entry (data + code) bytes in written entries
 soroban.host-fn-op.write-data-byte           | meter     | number of data bytes in written entries
 soroban.host-fn-op.write-code-byte           | meter     | number of code bytes in written entries
 soroban.host-fn-op.emit-event                | meter     | number of events emitted
@@ -186,11 +186,14 @@ soroban.host-fn-op.max-emit-event-byte       | meter     | bytes of the largest 
 soroban.host-fn-op.success                   | meter     | if `InvokeHostFunctionOp` results in a success
 soroban.host-fn-op.failure                   | meter     | if `InvokeHostFunctionOp` results in a failure
 soroban.host-fn-op.exec                      | timer     | time spent in `InvokeHostFunctionOp`
+soroban.restore-fprint-op.read-ledger-byte   | meter     | number of entry bytes in read entries
+soroban.restore-fprint-op.write-ledger-byte  | meter     | number of entry bytes in written entries
+soroban.ext-fprint-ttl-op.read-ledger-byte   | meter     | number of entry bytes in read entries
 soroban.ledger.cpu-insn                      | histogram | metered cpu instructions per ledger
 soroban.ledger.read-entry                    | histogram | number of entries read per ledger
-soroban.ledger.read-byte                     | histogram | number of data + code bytes in read entries per ledger
+soroban.ledger.read-byte                     | histogram | number of entry bytes in read entries per ledger
 soroban.ledger.write-entry                   | histogram | number of entries written per ledger
-soroban.ledger.write-byte                    | histogram | number of data + code bytes in written entries per ledger
+soroban.ledger.write-byte                    | histogram | number of entry bytes in written entries per ledger
 soroban.config.contract-max-size-bytes           | counter     | soroban config setting `contract_max_size_bytes`
 soroban.config.ledger-max-instructions           | counter     | soroban config setting `ledger_max_instructions`
 soroban.config.tx-max-instructions               | counter     | soroban config setting `tx_max_instructions`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -186,19 +186,19 @@ soroban.host-fn-op.max-emit-event-byte       | meter     | bytes of the largest 
 soroban.host-fn-op.success                   | meter     | if `InvokeHostFunctionOp` results in a success
 soroban.host-fn-op.failure                   | meter     | if `InvokeHostFunctionOp` results in a failure
 soroban.host-fn-op.exec                      | timer     | time spent in `InvokeHostFunctionOp`
-soroban.config.contract-max-size-bytes           | meter     | soroban config setting `contract_max_size_bytes`
-soroban.config.ledger-max-instructions           | meter     | soroban config setting `ledger_max_instructions`
-soroban.config.tx-max-instructions               | meter     | soroban config setting `tx_max_instructions`
-soroban.config.tx-memory-limit                   | meter     | soroban config setting `tx_memory_limit`
-soroban.config.ledger-max-read-ledger-entries    | meter     | soroban config setting `ledger_max_read_ledger_entries`
-soroban.config.ledger-max-read-bytes             | meter     | soroban config setting `ledger_max_read_bytes`
-soroban.config.ledger-max-write-ledger-entries   | meter     | soroban config setting `ledger_max_write_ledger_entries`
-soroban.config.ledger-max-write-bytes            | meter     | soroban config setting `ledger_max_write_bytes`
-soroban.config.tx-max-read-ledger-entries        | meter     | soroban config setting `tx_max_read_ledger_entries`
-soroban.config.tx-max-read-bytes                 | meter     | soroban config setting `tx_max_read_bytes`
-soroban.config.tx-max-write-ledger-entries       | meter     | soroban config setting `tx_max_write_ledger_entries`
-soroban.config.tx-max-write-bytes                | meter     | soroban config setting `tx_max_write_bytes`
-soroban.config.bucket-list-target-size-bytes     | meter     | soroban config setting `bucket_list_target_size_bytes`
-soroban.config.tx-max-contract-events-size-bytes | meter     | soroban config setting `tx_max_contract_events_size_bytes`
-soroban.config.contract-data-key-size-bytes      | meter     | soroban config setting `contract_data_key_size_bytes`
-soroban.config.contract-data-entry-size-bytes    | meter     | soroban config setting `contract_data_entry_size_bytes`
+soroban.config.contract-max-size-bytes           | counter     | soroban config setting `contract_max_size_bytes`
+soroban.config.ledger-max-instructions           | counter     | soroban config setting `ledger_max_instructions`
+soroban.config.tx-max-instructions               | counter     | soroban config setting `tx_max_instructions`
+soroban.config.tx-memory-limit                   | counter     | soroban config setting `tx_memory_limit`
+soroban.config.ledger-max-read-ledger-entries    | counter     | soroban config setting `ledger_max_read_ledger_entries`
+soroban.config.ledger-max-read-bytes             | counter     | soroban config setting `ledger_max_read_bytes`
+soroban.config.ledger-max-write-ledger-entries   | counter     | soroban config setting `ledger_max_write_ledger_entries`
+soroban.config.ledger-max-write-bytes            | counter     | soroban config setting `ledger_max_write_bytes`
+soroban.config.tx-max-read-ledger-entries        | counter     | soroban config setting `tx_max_read_ledger_entries`
+soroban.config.tx-max-read-bytes                 | counter     | soroban config setting `tx_max_read_bytes`
+soroban.config.tx-max-write-ledger-entries       | counter     | soroban config setting `tx_max_write_ledger_entries`
+soroban.config.tx-max-write-bytes                | counter     | soroban config setting `tx_max_write_bytes`
+soroban.config.bucket-list-target-size-bytes     | counter     | soroban config setting `bucket_list_target_size_bytes`
+soroban.config.tx-max-contract-events-size-bytes | counter     | soroban config setting `tx_max_contract_events_size_bytes`
+soroban.config.contract-data-key-size-bytes      | counter     | soroban config setting `contract_data_key_size_bytes`
+soroban.config.contract-data-entry-size-bytes    | counter     | soroban config setting `contract_data_entry_size_bytes`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -176,9 +176,11 @@ soroban.host-fn-op.emit-event                | meter     | number of events emit
 soroban.host-fn-op.emit-event-byte           | meter     | number of event bytes emitted
 soroban.host-fn-op.cpu-insn                  | meter     | metered cpu instructions
 soroban.host-fn-op.mem-byte                  | meter     | metered memory bytes
-soroban.host-fn-op.invoke-time-nsecs         | meter     | time [nsecs] spent in `invoke_host_function`
+soroban.host-fn-op.invoke-time-nsecs         | timer     | time spent in `invoke_host_function`
 soroban.host-fn-op.cpu-insn-excl-vm          | meter     | metered cpu instructions excluding VM instantation
-soroban.host-fn-op.invoke-time-nsecs-excl-vm | meter     | time [nsecs] spent in `invoke_host_function` excluding VM instantation
+soroban.host-fn-op.invoke-time-nsecs-excl-vm | timer     | time spent in `invoke_host_function` excluding VM instantation
+soroban.host-fn-op.invoke-time-fsecs-cpu-insn-ratio         | histogram | ratio between invoke_time (femto-seconds) and cpu instructions
+soroban.host-fn-op.invoke-time-fsecs-cpu-insn-ratio-excl-vm | histogram | ratio between invoke_time (femto-seconds) and cpu instructions excluding VM instantation
 soroban.host-fn-op.max-rw-key-byte           | meter     | bytes of the largest key in entries read/written
 soroban.host-fn-op.max-rw-data-byte          | meter     | bytes of the largest data entry read/written
 soroban.host-fn-op.max-rw-code-byte          | meter     | bytes of the largest code entry read/written

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -186,6 +186,11 @@ soroban.host-fn-op.max-emit-event-byte       | meter     | bytes of the largest 
 soroban.host-fn-op.success                   | meter     | if `InvokeHostFunctionOp` results in a success
 soroban.host-fn-op.failure                   | meter     | if `InvokeHostFunctionOp` results in a failure
 soroban.host-fn-op.exec                      | timer     | time spent in `InvokeHostFunctionOp`
+soroban.ledger.cpu-insn                      | histogram | metered cpu instructions per ledger
+soroban.ledger.read-entry                    | histogram | number of entries read per ledger
+soroban.ledger.read-byte                     | histogram | number of data + code bytes in read entries per ledger
+soroban.ledger.write-entry                   | histogram | number of entries written per ledger
+soroban.ledger.write-byte                    | histogram | number of data + code bytes in written entries per ledger
 soroban.config.contract-max-size-bytes           | counter     | soroban config setting `contract_max_size_bytes`
 soroban.config.ledger-max-instructions           | counter     | soroban config setting `ledger_max_instructions`
 soroban.config.tx-max-instructions               | counter     | soroban config setting `tx_max_instructions`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -78,7 +78,7 @@ loadgen.soroban.setup_invoke              | meter     | loadgenerator: soroban s
 loadgen.soroban.setup_upgrade             | meter     | loadgenerator: soroban setup upgrades TXs submitted
 loadgen.soroban.upload                    | meter     | loadgenerator: soroban upload TXs submitted
 loadgen.step.count                        | meter     | loadgenerator: generated some transactions
-loadgen.step.submit                       | timer     | loadgenerator: time spent submiting transactions per step
+loadgen.step.submit                       | timer     | loadgenerator: time spent submitting transactions per step
 loadgen.txn.attempted                     | meter     | loadgenerator: transaction submitted
 loadgen.txn.bytes                         | meter     | loadgenerator: size of transactions submitted
 loadgen.txn.rejected                      | meter     | loadgenerator: transaction rejected
@@ -162,40 +162,40 @@ state-archival.eviction.bytes-scanned     | counter   | number of bytes that evi
 state-archival.eviction.entries-evicted   | counter   | number of entries that have been evicted
 state-archival.eviction.incomplete-scan   | counter   | number of buckets that were too large to be fully scanned for eviction
 state-archival.eviction.period            | counter   | number of ledgers to complete an eviction scan
-soroban.host-fn-op.read-entry                | meter     | number of entries read
-soroban.host-fn-op.write-entry               | meter     | number of entries written
-soroban.host-fn-op.read-key-byte             | meter     | number of key bytes in read entries
-soroban.host-fn-op.write-key-byte            | meter     | number of key bytes in written entries
-soroban.host-fn-op.read-ledger-byte          | meter     | number of entry (data + code) bytes in read entries
-soroban.host-fn-op.read-data-byte            | meter     | number of data bytes in read entries
-soroban.host-fn-op.read-code-byte            | meter     | number of code bytes in read entries
-soroban.host-fn-op.write-ledger-byte         | meter     | number of entry (data + code) bytes in written entries
-soroban.host-fn-op.write-data-byte           | meter     | number of data bytes in written entries
-soroban.host-fn-op.write-code-byte           | meter     | number of code bytes in written entries
-soroban.host-fn-op.emit-event                | meter     | number of events emitted
-soroban.host-fn-op.emit-event-byte           | meter     | number of event bytes emitted
-soroban.host-fn-op.cpu-insn                  | meter     | metered cpu instructions
-soroban.host-fn-op.mem-byte                  | meter     | metered memory bytes
-soroban.host-fn-op.invoke-time-nsecs         | timer     | time spent in `invoke_host_function`
-soroban.host-fn-op.cpu-insn-excl-vm          | meter     | metered cpu instructions excluding VM instantation
-soroban.host-fn-op.invoke-time-nsecs-excl-vm | timer     | time spent in `invoke_host_function` excluding VM instantation
-soroban.host-fn-op.invoke-time-fsecs-cpu-insn-ratio         | histogram | ratio between invoke_time (femto-seconds) and cpu instructions
-soroban.host-fn-op.invoke-time-fsecs-cpu-insn-ratio-excl-vm | histogram | ratio between invoke_time (femto-seconds) and cpu instructions excluding VM instantation
-soroban.host-fn-op.max-rw-key-byte           | meter     | bytes of the largest key in entries read/written
-soroban.host-fn-op.max-rw-data-byte          | meter     | bytes of the largest data entry read/written
-soroban.host-fn-op.max-rw-code-byte          | meter     | bytes of the largest code entry read/written
-soroban.host-fn-op.max-emit-event-byte       | meter     | bytes of the largest event emitted
-soroban.host-fn-op.success                   | meter     | if `InvokeHostFunctionOp` results in a success
-soroban.host-fn-op.failure                   | meter     | if `InvokeHostFunctionOp` results in a failure
-soroban.host-fn-op.exec                      | timer     | time spent in `InvokeHostFunctionOp`
-soroban.restore-fprint-op.read-ledger-byte   | meter     | number of entry bytes in read entries
-soroban.restore-fprint-op.write-ledger-byte  | meter     | number of entry bytes in written entries
-soroban.ext-fprint-ttl-op.read-ledger-byte   | meter     | number of entry bytes in read entries
+soroban.host-fn-op.read-entry                | meter     | number of entries accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.write-entry               | meter     | number of entries modified during the `InvokeHostFunctionOp`
+soroban.host-fn-op.read-key-byte             | meter     | number of `LedgerKey` bytes in entries accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.write-key-byte            | meter     | number of `LedgerKey` bytes in entries modified during the `InvokeHostFunctionOp`
+soroban.host-fn-op.read-ledger-byte          | meter     | number of `LedgerEntry` bytes accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.read-data-byte            | meter     | number of `ContractDataEntry` bytes accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.read-code-byte            | meter     | number of `ContractCodeEntry` bytes accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.write-ledger-byte         | meter     | number of `LedgerEntry` bytes modified during the `InvokeHostFunctionOp`
+soroban.host-fn-op.write-data-byte           | meter     | number of `ContractDataEntry` bytes modified during the `InvokeHostFunctionOp`
+soroban.host-fn-op.write-code-byte           | meter     | number of `ContractCodeEntry` bytes modified during the `InvokeHostFunctionOp`
+soroban.host-fn-op.emit-event                | meter     | number of events emitted during the `InvokeHostFunctionOp`
+soroban.host-fn-op.emit-event-byte           | meter     | number of event bytes emitted during the `InvokeHostFunctionOp`
+soroban.host-fn-op.cpu-insn                  | meter     | number of metered cpu instructions during the `InvokeHostFunctionOp`
+soroban.host-fn-op.mem-byte                  | meter     | number of metered memory bytes during the `InvokeHostFunctionOp`
+soroban.host-fn-op.invoke-time-nsecs         | timer     | time spent on the soroban host invocation. Note: this is **not** the total time of the operation, which is tracked under "soroban.host-fn-op.exec".
+soroban.host-fn-op.cpu-insn-excl-vm          | meter     | number of metered cpu instructions excluding VM instantiation during the `InvokeHostFunctionOp`
+soroban.host-fn-op.invoke-time-nsecs-excl-vm | timer     | time spent in soroban host invocation excluding VM instantiation
+soroban.host-fn-op.invoke-time-fsecs-cpu-insn-ratio         | histogram | ratio between soroban host invocation time (femto-seconds) and metered cpu instructions
+soroban.host-fn-op.invoke-time-fsecs-cpu-insn-ratio-excl-vm | histogram | ratio between soroban host invocation time (femto-seconds) and metered cpu instructions, excluding VM instantiation
+soroban.host-fn-op.max-rw-key-byte           | meter     | size of the largest `LedgerKey` (in bytes) among all entires accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.max-rw-data-byte          | meter     | size of the largest `ContractDataEntry` (in bytes) among all entires accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.max-rw-code-byte          | meter     | size of the largest `ContractCodeEntry` (in bytes) among all entires accessed (read or modified) during the `InvokeHostFunctionOp`
+soroban.host-fn-op.max-emit-event-byte       | meter     | size of the largest event emitted during the `InvokeHostFunctionOp`
+soroban.host-fn-op.success                   | meter     | number of successful `InvokeHostFunctionOp` operations
+soroban.host-fn-op.failure                   | meter     | number of failed `InvokeHostFunctionOp` operations
+soroban.host-fn-op.exec                      | timer     | total time spent during the `InvokeHostFunctionOp`
+soroban.restore-fprint-op.read-ledger-byte   | meter     | number of `LedgerEntry` bytes accessed (read or modified) during the `RestoreFootprintOp`
+soroban.restore-fprint-op.write-ledger-byte  | meter     | number of `LedgerEntry` bytes modified during the `RestoreFootprintOp`
+soroban.ext-fprint-ttl-op.read-ledger-byte   | meter     | number of `LedgerEntry` bytes accessed (read or modified) during the `ExtendFootprintTTLOp`
 soroban.ledger.cpu-insn                      | histogram | metered cpu instructions per ledger
-soroban.ledger.read-entry                    | histogram | number of entries read per ledger
-soroban.ledger.read-byte                     | histogram | number of entry bytes in read entries per ledger
-soroban.ledger.write-entry                   | histogram | number of entries written per ledger
-soroban.ledger.write-byte                    | histogram | number of entry bytes in written entries per ledger
+soroban.ledger.read-entry                    | histogram | number of entries accessed (read or modified) per ledger
+soroban.ledger.read-ledger-byte              | histogram | number of `LedgerEntry` bytes accessed (read or modified) per ledger
+soroban.ledger.write-entry                   | histogram | number of entries modified per ledger
+soroban.ledger.write-ledger-byte             | histogram | number of `LedgerEntry` bytes modified per ledger
 soroban.config.contract-max-rw-key-byte      | counter   | soroban config setting `contract_data_key_size_bytes`
 soroban.config.contract-max-rw-data-byte     | counter   | soroban config setting `contract_data_entry_size_bytes`
 soroban.config.contract-max-rw-code-byte     | counter   | soroban config setting `contract_max_size_bytes`

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -14,6 +14,7 @@ namespace stellar
 
 class LedgerCloseData;
 class Database;
+class SorobanLedgerMetrics;
 
 /**
  * LedgerManager maintains, in memory, a logical pair of ledgers:
@@ -186,6 +187,8 @@ class LedgerManager
                                      bool storeInDB) = 0;
 
     virtual void manuallyAdvanceLedgerHeader(LedgerHeader const& header) = 0;
+
+    virtual SorobanLedgerMetrics& getSorobanMetrics() = 0;
 
     virtual ~LedgerManager()
     {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -645,40 +645,38 @@ LedgerManagerImpl::publishSorobanMetrics()
     auto contractDataEntrySizeBytes =
         mSorobanNetworkConfig->maxContractDataEntrySizeBytes();
 
-    registry.NewCounter({"soroban", "config", "contract-max-size-bytes"})
-        .set_count(contractMaxSizeBytes);
-    registry.NewCounter({"soroban", "config", "ledger-max-instructions"})
-        .set_count(ledgerMaxInstructions);
-    registry.NewCounter({"soroban", "config", "tx-max-instructions"})
-        .set_count(txMaxInstructions);
-    registry.NewCounter({"soroban", "config", "tx-memory-limit"})
-        .set_count(txMemoryLimit);
-    registry.NewCounter({"soroban", "config", "ledger-max-read-ledger-entries"})
-        .set_count(ledgerMaxReadLedgerEntries);
-    registry.NewCounter({"soroban", "config", "ledger-max-read-bytes"})
-        .set_count(ledgerMaxReadBytes);
-    registry
-        .NewCounter({"soroban", "config", "ledger-max-write-ledger-entries"})
-        .set_count(ledgerMaxWriteLedgerEntries);
-    registry.NewCounter({"soroban", "config", "ledger-max-write-bytes"})
-        .set_count(ledgerMaxWriteBytes);
-    registry.NewCounter({"soroban", "config", "tx-max-read-ledger-entries"})
-        .set_count(txMaxReadLedgerEntries);
-    registry.NewCounter({"soroban", "config", "tx-max-read-bytes"})
-        .set_count(txMaxReadBytes);
-    registry.NewCounter({"soroban", "config", "tx-max-write-ledger-entries"})
-        .set_count(txMaxWriteLedgerEntries);
-    registry.NewCounter({"soroban", "config", "tx-max-write-bytes"})
-        .set_count(txMaxWriteBytes);
-    registry.NewCounter({"soroban", "config", "bucket-list-target-size-bytes"})
-        .set_count(bucketListTargetSizeBytes);
-    registry
-        .NewCounter({"soroban", "config", "tx-max-contract-events-size-bytes"})
-        .set_count(txMaxContractEventsSizeBytes);
-    registry.NewCounter({"soroban", "config", "contract-data-key-size-bytes"})
+    registry.NewCounter({"soroban", "config", "contract-max-rw-key-byte"})
         .set_count(contractDataKeySizeBytes);
-    registry.NewCounter({"soroban", "config", "contract-data-entry-size-bytes"})
+    registry.NewCounter({"soroban", "config", "contract-max-rw-data-byte"})
         .set_count(contractDataEntrySizeBytes);
+    registry.NewCounter({"soroban", "config", "contract-max-rw-code-byte"})
+        .set_count(contractMaxSizeBytes);
+    registry.NewCounter({"soroban", "config", "tx-max-cpu-insn"})
+        .set_count(txMaxInstructions);
+    registry.NewCounter({"soroban", "config", "tx-max-mem-byte"})
+        .set_count(txMemoryLimit);
+    registry.NewCounter({"soroban", "config", "tx-max-read-entry"})
+        .set_count(txMaxReadLedgerEntries);
+    registry.NewCounter({"soroban", "config", "tx-max-read-ledger-byte"})
+        .set_count(txMaxReadBytes);
+    registry.NewCounter({"soroban", "config", "tx-max-write-entry"})
+        .set_count(txMaxWriteLedgerEntries);
+    registry.NewCounter({"soroban", "config", "tx-max-write-ledger-byte"})
+        .set_count(txMaxWriteBytes);
+    registry.NewCounter({"soroban", "config", "tx-max-emit-event-byte"})
+        .set_count(txMaxContractEventsSizeBytes);
+    registry.NewCounter({"soroban", "config", "ledger-max-cpu-insn"})
+        .set_count(ledgerMaxInstructions);
+    registry.NewCounter({"soroban", "config", "ledger-max-read-entry"})
+        .set_count(ledgerMaxReadLedgerEntries);
+    registry.NewCounter({"soroban", "config", "ledger-max-read-ledger-byte"})
+        .set_count(ledgerMaxReadBytes);
+    registry.NewCounter({"soroban", "config", "ledger-max-write-entry"})
+        .set_count(ledgerMaxWriteLedgerEntries);
+    registry.NewCounter({"soroban", "config", "ledger-max-write-ledger-byte"})
+        .set_count(ledgerMaxWriteBytes);
+    registry.NewCounter({"soroban", "config", "bucket-list-target-size-byte"})
+        .set_count(bucketListTargetSizeBytes);
 
     // then publish the actual ledger usage
     mSorobanLedgerMetrics.publishAndResetMetrics();

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -127,11 +127,11 @@ SorobanLedgerMetrics::publishAndResetMetrics()
         .Update(mLedgerCpuInsn);
     mMetrics.NewHistogram({"soroban", "ledger", "read-entry"})
         .Update(mLedgerReadEntry);
-    mMetrics.NewHistogram({"soroban", "ledger", "read-byte"})
+    mMetrics.NewHistogram({"soroban", "ledger", "read-ledger-byte"})
         .Update(mLedgerReadByte);
     mMetrics.NewHistogram({"soroban", "ledger", "write-entry"})
         .Update(mLedgerWriteEntry);
-    mMetrics.NewHistogram({"soroban", "ledger", "write-byte"})
+    mMetrics.NewHistogram({"soroban", "ledger", "write-ledger-byte"})
         .Update(mLedgerWriteByte);
     mLedgerCpuInsn = 0;
     mLedgerReadEntry = 0;

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -585,51 +585,46 @@ LedgerManagerImpl::publishSorobanNetworkConfigMetrics()
     auto contractDataEntrySizeBytes =
         mSorobanNetworkConfig->maxContractDataEntrySizeBytes();
 
-    metrics.NewMeter({"soroban", "config", "contract-max-size-bytes"}, "byte")
-        .Mark(contractMaxSizeBytes);
-    metrics.NewMeter({"soroban", "config", "ledger-max-instructions"}, "insn")
-        .Mark(ledgerMaxInstructions);
-    metrics.NewMeter({"soroban", "config", "tx-max-instructions"}, "insn")
-        .Mark(txMaxInstructions);
-    metrics.NewMeter({"soroban", "config", "tx-memory-limit"}, "byte")
-        .Mark(txMemoryLimit);
+    metrics.NewCounter({"soroban", "config", "contract-max-size-bytes"})
+        .set_count(contractMaxSizeBytes);
+    metrics.NewCounter({"soroban", "config", "ledger-max-instructions"})
+        .set_count(ledgerMaxInstructions);
+    metrics.NewCounter({"soroban", "config", "tx-max-instructions"})
+        .set_count(txMaxInstructions);
+    metrics.NewCounter({"soroban", "config", "tx-memory-limit"})
+        .set_count(txMemoryLimit);
     metrics
-        .NewMeter({"soroban", "config", "ledger-max-read-ledger-entries"},
-                  "entry")
-        .Mark(ledgerMaxReadLedgerEntries);
-    metrics.NewMeter({"soroban", "config", "ledger-max-read-bytes"}, "byte")
-        .Mark(ledgerMaxReadBytes);
+        .NewCounter({"soroban", "config", "ledger-max-read-ledger-entries"})
+        .set_count(ledgerMaxReadLedgerEntries);
+    metrics.NewCounter({"soroban", "config", "ledger-max-read-bytes"})
+        .set_count(ledgerMaxReadBytes);
     metrics
-        .NewMeter({"soroban", "config", "ledger-max-write-ledger-entries"},
-                  "entry")
-        .Mark(ledgerMaxWriteLedgerEntries);
-    metrics.NewMeter({"soroban", "config", "ledger-max-write-bytes"}, "byte")
-        .Mark(ledgerMaxWriteBytes);
+        .NewCounter({"soroban", "config", "ledger-max-write-ledger-entries"})
+        .set_count(ledgerMaxWriteLedgerEntries);
+    metrics.NewCounter({"soroban", "config", "ledger-max-write-bytes"})
+        .set_count(ledgerMaxWriteBytes);
     metrics
-        .NewMeter({"soroban", "config", "tx-max-read-ledger-entries"}, "entry")
-        .Mark(txMaxReadLedgerEntries);
-    metrics.NewMeter({"soroban", "config", "tx-max-read-bytes"}, "byte")
-        .Mark(txMaxReadBytes);
+        .NewCounter({"soroban", "config", "tx-max-read-ledger-entries"})
+        .set_count(txMaxReadLedgerEntries);
+    metrics.NewCounter({"soroban", "config", "tx-max-read-bytes"})
+        .set_count(txMaxReadBytes);
     metrics
-        .NewMeter({"soroban", "config", "tx-max-write-ledger-entries"}, "entry")
-        .Mark(txMaxWriteLedgerEntries);
-    metrics.NewMeter({"soroban", "config", "tx-max-write-bytes"}, "byte")
-        .Mark(txMaxWriteBytes);
+        .NewCounter({"soroban", "config", "tx-max-write-ledger-entries"})
+        .set_count(txMaxWriteLedgerEntries);
+    metrics.NewCounter({"soroban", "config", "tx-max-write-bytes"})
+        .set_count(txMaxWriteBytes);
     metrics
-        .NewMeter({"soroban", "config", "bucket-list-target-size-bytes"},
-                  "byte")
-        .Mark(bucketListTargetSizeBytes);
+        .NewCounter({"soroban", "config", "bucket-list-target-size-bytes"})
+        .set_count(bucketListTargetSizeBytes);
     metrics
-        .NewMeter({"soroban", "config", "tx-max-contract-events-size-bytes"},
-                  "byte")
-        .Mark(txMaxContractEventsSizeBytes);
+        .NewCounter({"soroban", "config", "tx-max-contract-events-size-bytes"})
+        .set_count(txMaxContractEventsSizeBytes);
     metrics
-        .NewMeter({"soroban", "config", "contract-data-key-size-bytes"}, "byte")
-        .Mark(contractDataKeySizeBytes);
+        .NewCounter({"soroban", "config", "contract-data-key-size-bytes"})
+        .set_count(contractDataKeySizeBytes);
     metrics
-        .NewMeter({"soroban", "config", "contract-data-entry-size-bytes"},
-                  "byte")
-        .Mark(contractDataEntrySizeBytes);
+        .NewCounter({"soroban", "config", "contract-data-entry-size-bytes"})
+        .set_count(contractDataEntrySizeBytes);
 }
 
 // called by txherder

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -225,15 +225,24 @@ struct HostFunctionMetrics
             .NewMeter({"soroban", "host-fn-op", "mem-byte"}, "byte")
             .Mark(mMemByte);
         mMetrics.registry()
-            .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs"}, "time")
-            .Mark(mInvokeTimeNsecs);
+            .NewTimer({"soroban", "host-fn-op", "invoke-time-nsecs"})
+            .Update(std::chrono::nanoseconds(mInvokeTimeNsecs));
         mMetrics.registry()
             .NewMeter({"soroban", "host-fn-op", "cpu-insn-excl-vm"}, "insn")
             .Mark(mCpuInsnExclVm);
         mMetrics.registry()
-            .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs-excl-vm"},
-                      "time")
-            .Mark(mInvokeTimeNsecsExclVm);
+            .NewTimer({"soroban", "host-fn-op", "invoke-time-nsecs-excl-vm"})
+            .Update(std::chrono::nanoseconds(mInvokeTimeNsecsExclVm));
+        mMetrics.registry()
+            .NewHistogram(
+                {"soroban", "host-fn-op", "invoke-time-fsecs-cpu-insn-ratio"})
+            .Update(mInvokeTimeNsecs * 1000000 /
+                    std::max(mCpuInsn, uint64_t(1)));
+        mMetrics.registry()
+            .NewHistogram({"soroban", "host-fn-op",
+                           "invoke-time-fsecs-cpu-insn-ratio-excl-vm"})
+            .Update(mInvokeTimeNsecsExclVm * 1000000 /
+                    std::max(mCpuInsnExclVm, uint64_t(1)));
 
         mMetrics.registry()
             .NewMeter({"soroban", "host-fn-op", "max-rw-key-byte"}, "byte")

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -21,6 +21,7 @@
 #include <stdexcept>
 #include <xdrpp/xdrpp/printer.h>
 
+#include "ledger/LedgerManagerImpl.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "rust/RustBridge.h"
@@ -98,7 +99,7 @@ metricsEvent(bool success, std::string&& topic, uint64_t value)
 
 struct HostFunctionMetrics
 {
-    medida::MetricsRegistry& mMetrics;
+    SorobanLedgerMetrics& mMetrics;
 
     uint32_t mReadEntry{0};
     uint32_t mWriteEntry{0};
@@ -133,7 +134,7 @@ struct HostFunctionMetrics
 
     bool mSuccess{false};
 
-    HostFunctionMetrics(medida::MetricsRegistry& metrics) : mMetrics(metrics)
+    HostFunctionMetrics(SorobanLedgerMetrics& metrics) : mMetrics(metrics)
     {
     }
 
@@ -176,75 +177,103 @@ struct HostFunctionMetrics
 
     ~HostFunctionMetrics()
     {
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-entry"}, "entry")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "read-entry"}, "entry")
             .Mark(mReadEntry);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-entry"}, "entry")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "write-entry"}, "entry")
             .Mark(mWriteEntry);
 
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-key-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "read-key-byte"}, "byte")
             .Mark(mReadKeyByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-key-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "write-key-byte"}, "byte")
             .Mark(mWriteKeyByte);
 
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-ledger-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "read-ledger-byte"}, "byte")
             .Mark(mLedgerReadByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-data-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "read-data-byte"}, "byte")
             .Mark(mReadDataByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "read-code-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "read-code-byte"}, "byte")
             .Mark(mReadCodeByte);
 
-        mMetrics
+        mMetrics.registry()
             .NewMeter({"soroban", "host-fn-op", "write-ledger-byte"}, "byte")
             .Mark(mLedgerWriteByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-data-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "write-data-byte"}, "byte")
             .Mark(mWriteDataByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "write-code-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "write-code-byte"}, "byte")
             .Mark(mWriteCodeByte);
 
-        mMetrics.NewMeter({"soroban", "host-fn-op", "emit-event"}, "event")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "emit-event"}, "event")
             .Mark(mEmitEvent);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "emit-event-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "emit-event-byte"}, "byte")
             .Mark(mEmitEventByte);
 
-        mMetrics.NewMeter({"soroban", "host-fn-op", "cpu-insn"}, "insn")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "cpu-insn"}, "insn")
             .Mark(mCpuInsn);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "mem-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "mem-byte"}, "byte")
             .Mark(mMemByte);
-        mMetrics
+        mMetrics.registry()
             .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs"}, "time")
             .Mark(mInvokeTimeNsecs);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "cpu-insn-excl-vm"}, "insn")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "cpu-insn-excl-vm"}, "insn")
             .Mark(mCpuInsnExclVm);
-        mMetrics
+        mMetrics.registry()
             .NewMeter({"soroban", "host-fn-op", "invoke-time-nsecs-excl-vm"},
                       "time")
             .Mark(mInvokeTimeNsecsExclVm);
 
-        mMetrics.NewMeter({"soroban", "host-fn-op", "max-rw-key-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "max-rw-key-byte"}, "byte")
             .Mark(mMaxReadWriteKeyByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "max-rw-data-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "max-rw-data-byte"}, "byte")
             .Mark(mMaxReadWriteDataByte);
-        mMetrics.NewMeter({"soroban", "host-fn-op", "max-rw-code-byte"}, "byte")
+        mMetrics.registry()
+            .NewMeter({"soroban", "host-fn-op", "max-rw-code-byte"}, "byte")
             .Mark(mMaxReadWriteCodeByte);
-        mMetrics
+        mMetrics.registry()
             .NewMeter({"soroban", "host-fn-op", "max-emit-event-byte"}, "byte")
             .Mark(mMaxEmitEventByte);
 
         if (mSuccess)
         {
-            mMetrics.NewMeter({"soroban", "host-fn-op", "success"}, "call")
+            mMetrics.registry()
+                .NewMeter({"soroban", "host-fn-op", "success"}, "call")
                 .Mark();
         }
         else
         {
-            mMetrics.NewMeter({"soroban", "host-fn-op", "failure"}, "call")
+            mMetrics.registry()
+                .NewMeter({"soroban", "host-fn-op", "failure"}, "call")
                 .Mark();
         }
+
+        // populate ledger-wise resource metrics
+        mMetrics.accumulateLedgerCpuInsn(mCpuInsn);
+        mMetrics.accumulateLedgerReadEntry(mReadEntry);
+        mMetrics.accumulateLedgerReadByte(mLedgerReadByte);
+        mMetrics.accumulateLedgerWriteEntry(mWriteEntry);
+        mMetrics.accumulateLedgerWriteByte(mLedgerWriteByte);
     }
     medida::TimerContext
     getExecTimer()
     {
-        return mMetrics.NewTimer({"soroban", "host-fn-op", "exec"}).TimeScope();
+        return mMetrics.registry()
+            .NewTimer({"soroban", "host-fn-op", "exec"})
+            .TimeScope();
     }
 };
 
@@ -343,7 +372,7 @@ InvokeHostFunctionOpFrame::doApply(Application& app, AbstractLedgerTxn& ltx,
     ZoneNamedN(applyZone, "InvokeHostFunctionOpFrame apply", true);
 
     Config const& appConfig = app.getConfig();
-    HostFunctionMetrics metrics(app.getMetrics());
+    HostFunctionMetrics metrics(app.getLedgerManager().getSorobanMetrics());
     auto const& sorobanConfig =
         app.getLedgerManager().getSorobanNetworkConfig();
 

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -1552,7 +1552,7 @@ ContractStorageTestClient::resizeStorageAndExtend(
 SorobanSigner::SorobanSigner(SorobanTest& test, SCAddress const& address,
                              xdr::xvector<LedgerKey> const& keys,
                              std::function<SCVal(uint256)> signFn)
-    : mTest(test), mAddress(address), mKeys(keys), mSignFn(signFn)
+    : mTest(test), mSignFn(signFn), mAddress(address), mKeys(keys)
 {
 }
 


### PR DESCRIPTION
# Description

Resolves all the items in this checklist: https://github.com/stellar/stellar-core-internal/issues/236#issuecomment-1915049419

Most of them are just some naming and types change. There is one structural change:

A new `SorobanLedgerMetrics` was added in `LedgerManager` which tracks soroban resource usage per ledger across all soroban ops (invoke_host_fn, restore_footprint, extend_ttl), and publishes them to new metrics "soroban.ledger.xxx".

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
