### PR TITLE
Parallel bl db

### DIFF
--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/Bucket.h"
 #include "bucket/FutureBucket.h"
 #include "bucket/LedgerCmp.h"
 #include "overlay/StellarXDR.h"
@@ -14,7 +15,6 @@
 
 namespace medida
 {
-class Meter;
 class Counter;
 }
 
@@ -352,7 +352,6 @@ class AbstractLedgerTxn;
 class Application;
 class Bucket;
 class Config;
-struct BucketListEvictionCounters;
 struct InflationWinner;
 
 namespace testutil
@@ -403,13 +402,24 @@ class BucketListDepth
     friend class testutil::BucketListDepthModifier;
 };
 
-struct EvictionMetrics
+struct EvictionStatistics
 {
     // Evicted entry "age" is the delta between its liveUntilLedger and the
     // ledger when the entry is actually evicted
     uint64_t evictedEntriesAgeSum{};
     uint64_t numEntriesEvicted{};
     uint32_t evictionCycleStartLedger{};
+};
+
+struct EvictionCounters
+{
+    medida::Counter& entriesEvicted;
+    medida::Counter& bytesScannedForEviction;
+    medida::Counter& incompleteBucketScan;
+    medida::Counter& evictionCyclePeriod;
+    medida::Counter& averageEvictedEntryAge;
+
+    EvictionCounters(Application& app);
 };
 
 class BucketList
@@ -419,12 +429,7 @@ class BucketList
     // To avoid noisy data, only count metrics that encompass a complete
     // eviction cycle. If a node joins the network mid cycle, metrics will be
     // nullopt and be initialized at the start of the next cycle.
-    std::optional<EvictionMetrics> mEvictionMetrics;
-
-    // Loops through all buckets, starting with curr at level 0, then snap at
-    // level 0, etc. Calls f on each bucket. Exits early if function
-    // returns true
-    void loopAllBuckets(std::function<bool(std::shared_ptr<Bucket>)> f) const;
+    std::optional<EvictionStatistics> mEvictionStatistics;
 
   public:
     // Number of bucket levels in the bucketlist. Every bucketlist in the system
@@ -481,17 +486,9 @@ class BucketList
     // of the concatenation of the hashes of the `curr` and `snap` buckets.
     Hash getHash() const;
 
-    std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k) const;
-
-    std::vector<LedgerEntry>
-    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const;
-
-    std::vector<LedgerEntry>
-    loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                             Asset const& asset) const;
-
-    std::vector<InflationWinner> loadInflationWinners(size_t maxWinners,
-                                                      int64_t minBalance) const;
+    void scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
+                                  uint32_t ledgerSeq,
+                                  EvictionCounters& counters);
 
     // Restart any merges that might be running on background worker threads,
     // merging buckets between levels. This needs to be called after forcing a
@@ -537,9 +534,5 @@ class BucketList
                   std::vector<LedgerEntry> const& initEntries,
                   std::vector<LedgerEntry> const& liveEntries,
                   std::vector<LedgerKey> const& deadEntries);
-
-    void scanForEviction(Application& app, AbstractLedgerTxn& ltx,
-                         uint32_t ledgerSeq,
-                         BucketListEvictionCounters& counters);
 };
 }

--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -1,0 +1,292 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketListSnapshot.h"
+#include "bucket/BucketInputIterator.h"
+#include "crypto/SecretKey.h"
+#include "ledger/LedgerTxn.h"
+
+#include "medida/meter.h"
+#include "medida/metrics_registry.h"
+
+namespace stellar
+{
+
+BucketListSnapshot::BucketListSnapshot(BucketList const& bl, uint32_t ledgerSeq)
+    : mLedgerSeq(ledgerSeq)
+{
+    releaseAssert(threadIsMain());
+
+    for (uint32_t i = 0; i < BucketList::kNumLevels; ++i)
+    {
+        auto const& level = bl.getLevel(i);
+        mLevels.emplace_back(BucketLevelSnapshot(level));
+    }
+}
+
+BucketListSnapshot::BucketListSnapshot(BucketListSnapshot const& snapshot)
+    : mLevels(snapshot.mLevels), mLedgerSeq(snapshot.mLedgerSeq)
+{
+}
+
+std::vector<BucketLevelSnapshot> const&
+BucketListSnapshot::getLevels() const
+{
+    return mLevels;
+}
+
+uint32_t
+BucketListSnapshot::getLedgerSeq() const
+{
+    return mLedgerSeq;
+}
+
+void
+SearchableBucketListSnapshot::loopAllBuckets(
+    std::function<bool(BucketSnapshot const&)> f) const
+{
+    releaseAssert(mSnapshot);
+
+    for (auto const& lev : mSnapshot->getLevels())
+    {
+        // Return true if we should exit loop early
+        auto processBucket = [f](BucketSnapshot const& b) {
+            if (b.isEmpty())
+            {
+                return false;
+            }
+
+            return f(b);
+        };
+
+        if (processBucket(lev.curr) || processBucket(lev.snap))
+        {
+            return;
+        }
+    }
+}
+
+std::shared_ptr<LedgerEntry>
+SearchableBucketListSnapshot::getLedgerEntry(LedgerKey const& k)
+{
+    ZoneScoped;
+    mSnapshotManager.maybeUpdateSnapshot(mSnapshot);
+
+    if (threadIsMain())
+    {
+        auto timer = mSnapshotManager.getPointLoadTimer(k.type()).TimeScope();
+        return getLedgerEntryInternal(k);
+    }
+    else
+    {
+        return getLedgerEntryInternal(k);
+    }
+}
+
+std::shared_ptr<LedgerEntry>
+SearchableBucketListSnapshot::getLedgerEntryInternal(LedgerKey const& k)
+{
+    std::shared_ptr<LedgerEntry> result{};
+
+    auto f = [&](BucketSnapshot const& b) {
+        auto be = b.getBucketEntry(k);
+        if (be.has_value())
+        {
+            result =
+                be.value().type() == DEADENTRY
+                    ? nullptr
+                    : std::make_shared<LedgerEntry>(be.value().liveEntry());
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    };
+
+    loopAllBuckets(f);
+    return result;
+}
+
+std::vector<LedgerEntry>
+SearchableBucketListSnapshot::loadKeysInternal(
+    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys)
+{
+    std::vector<LedgerEntry> entries;
+
+    // Make a copy of the key set, this loop is destructive
+    auto keys = inKeys;
+    auto f = [&](BucketSnapshot const& b) {
+        b.loadKeys(keys, entries);
+        return keys.empty();
+    };
+
+    loopAllBuckets(f);
+    return entries;
+}
+
+std::vector<LedgerEntry>
+SearchableBucketListSnapshot::loadKeys(
+    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys)
+{
+    ZoneScoped;
+    mSnapshotManager.maybeUpdateSnapshot(mSnapshot);
+
+    if (threadIsMain())
+    {
+        auto timer =
+            mSnapshotManager.recordBulkLoadMetrics("prefetch", inKeys.size())
+                .TimeScope();
+        return loadKeysInternal(inKeys);
+    }
+    else
+    {
+        return loadKeysInternal(inKeys);
+    }
+}
+
+// This query has two steps:
+//  1. For each bucket, determine what PoolIDs contain the target asset via the
+//     assetToPoolID index
+//  2. Perform a bulk lookup for all possible trustline keys, that is, all
+//     trustlines with the given accountID and poolID from step 1
+std::vector<LedgerEntry>
+SearchableBucketListSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
+    AccountID const& accountID, Asset const& asset)
+{
+    ZoneScoped;
+
+    // This query should only be called during TX apply
+    releaseAssert(threadIsMain());
+    mSnapshotManager.maybeUpdateSnapshot(mSnapshot);
+
+    LedgerKeySet trustlinesToLoad;
+
+    auto trustLineLoop = [&](BucketSnapshot const& b) {
+        for (auto const& poolID : b.getPoolIDsByAsset(asset))
+        {
+            LedgerKey trustlineKey(TRUSTLINE);
+            trustlineKey.trustLine().accountID = accountID;
+            trustlineKey.trustLine().asset.type(ASSET_TYPE_POOL_SHARE);
+            trustlineKey.trustLine().asset.liquidityPoolID() = poolID;
+            trustlinesToLoad.emplace(trustlineKey);
+        }
+
+        return false; // continue
+    };
+
+    loopAllBuckets(trustLineLoop);
+
+    auto timer = mSnapshotManager
+                     .recordBulkLoadMetrics("poolshareTrustlines",
+                                            trustlinesToLoad.size())
+                     .TimeScope();
+    return loadKeysInternal(trustlinesToLoad);
+}
+
+std::vector<InflationWinner>
+SearchableBucketListSnapshot::loadInflationWinners(size_t maxWinners,
+                                                   int64_t minBalance)
+{
+    ZoneScoped;
+    mSnapshotManager.maybeUpdateSnapshot(mSnapshot);
+
+    // This is a legacy query, should only be called by main thread during
+    // catchup
+    releaseAssert(threadIsMain());
+    auto timer = mSnapshotManager.recordBulkLoadMetrics("inflationWinners", 0)
+                     .TimeScope();
+
+    UnorderedMap<AccountID, int64_t> voteCount;
+    UnorderedSet<AccountID> seen;
+
+    auto countVotesInBucket = [&](BucketSnapshot const& b) {
+        for (BucketInputIterator in(b.getRawBucket()); in; ++in)
+        {
+            BucketEntry const& be = *in;
+            if (be.type() == DEADENTRY)
+            {
+                if (be.deadEntry().type() == ACCOUNT)
+                {
+                    seen.insert(be.deadEntry().account().accountID);
+                }
+                continue;
+            }
+
+            // Account are ordered first, so once we see a non-account entry, no
+            // other accounts are left in the bucket
+            LedgerEntry const& le = be.liveEntry();
+            if (le.data.type() != ACCOUNT)
+            {
+                break;
+            }
+
+            // Don't double count AccountEntry's seen in earlier levels
+            AccountEntry const& ae = le.data.account();
+            AccountID const& id = ae.accountID;
+            if (!seen.insert(id).second)
+            {
+                continue;
+            }
+
+            if (ae.inflationDest && ae.balance >= 1000000000)
+            {
+                voteCount[*ae.inflationDest] += ae.balance;
+            }
+        }
+
+        return false;
+    };
+
+    loopAllBuckets(countVotesInBucket);
+    std::vector<InflationWinner> winners;
+
+    // Check if we need to sort the voteCount by number of votes
+    if (voteCount.size() > maxWinners)
+    {
+
+        // Sort Inflation winners by vote count in descending order
+        std::map<int64_t, UnorderedMap<AccountID, int64_t>::const_iterator,
+                 std::greater<int64_t>>
+            voteCountSortedByCount;
+        for (auto iter = voteCount.cbegin(); iter != voteCount.cend(); ++iter)
+        {
+            voteCountSortedByCount[iter->second] = iter;
+        }
+
+        // Insert first maxWinners entries that are larger thanminBalance
+        for (auto iter = voteCountSortedByCount.cbegin();
+             winners.size() < maxWinners && iter->first >= minBalance; ++iter)
+        {
+            // push back {AccountID, voteCount}
+            winners.push_back({iter->second->first, iter->first});
+        }
+    }
+    else
+    {
+        for (auto const& [id, count] : voteCount)
+        {
+            if (count >= minBalance)
+            {
+                winners.push_back({id, count});
+            }
+        }
+    }
+
+    return winners;
+}
+
+BucketLevelSnapshot::BucketLevelSnapshot(BucketLevel const& level)
+    : curr(level.getCurr()), snap(level.getSnap())
+{
+}
+
+SearchableBucketListSnapshot::SearchableBucketListSnapshot(
+    BucketSnapshotManager const& snapshotManager)
+    : mSnapshotManager(snapshotManager)
+{
+    // Initialize snapshot from SnapshotManager
+    mSnapshotManager.maybeUpdateSnapshot(mSnapshot);
+}
+}

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -1,0 +1,91 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketList.h"
+#include "bucket/BucketManagerImpl.h"
+#include "bucket/BucketSnapshot.h"
+#include "bucket/BucketSnapshotManager.h"
+
+namespace medida
+{
+class Timer;
+}
+
+namespace stellar
+{
+
+struct BucketLevelSnapshot
+{
+    BucketSnapshot curr;
+    BucketSnapshot snap;
+
+    BucketLevelSnapshot(BucketLevel const& level);
+};
+
+class BucketListSnapshot : public NonMovable
+{
+  private:
+    std::vector<BucketLevelSnapshot> mLevels;
+
+    // ledgerSeq that this BucketList snapshot is based off of
+    uint32_t mLedgerSeq;
+
+  public:
+    BucketListSnapshot(BucketList const& bl, uint32_t ledgerSeq);
+
+    // Only allow copies via constructor
+    BucketListSnapshot(BucketListSnapshot const& snapshot);
+    BucketListSnapshot& operator=(BucketListSnapshot const&) = delete;
+
+    std::vector<BucketLevelSnapshot> const& getLevels() const;
+    uint32_t getLedgerSeq() const;
+};
+
+// A lightweight wrapper around BucketListSnapshot for thread safe BucketListDB
+// lookups.
+//
+// Any thread that needs to perform BucketList lookups should retrieve
+// a single SearchableBucketListSnapshot instance from
+// BucketListSnapshotManager. On each lookup, the SearchableBucketListSnapshot
+// instance will check that the current snapshot is up to date via the
+// BucketListSnapshotManager and will be refreshed accordingly. Callers can
+// assume SearchableBucketListSnapshot is always up to date.
+class SearchableBucketListSnapshot : public NonMovableOrCopyable
+{
+    BucketSnapshotManager const& mSnapshotManager;
+
+    // Snapshot managed by SnapshotManager
+    std::unique_ptr<BucketListSnapshot const> mSnapshot{};
+
+    // Loops through all buckets, starting with curr at level 0, then snap at
+    // level 0, etc. Calls f on each bucket. Exits early if function
+    // returns true
+    void loopAllBuckets(std::function<bool(BucketSnapshot const&)> f) const;
+
+    std::vector<LedgerEntry>
+    loadKeysInternal(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
+
+    std::shared_ptr<LedgerEntry> getLedgerEntryInternal(LedgerKey const& k);
+
+    SearchableBucketListSnapshot(BucketSnapshotManager const& snapshotManager);
+
+    friend std::unique_ptr<SearchableBucketListSnapshot>
+    BucketSnapshotManager::getSearchableBucketListSnapshot() const;
+
+  public:
+    std::vector<LedgerEntry>
+    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
+
+    std::vector<LedgerEntry>
+    loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
+                                             Asset const& asset);
+
+    std::vector<InflationWinner> loadInflationWinners(size_t maxWinners,
+                                                      int64_t minBalance);
+
+    std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k);
+};
+}

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -1,0 +1,155 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketSnapshot.h"
+#include "bucket/Bucket.h"
+#include "bucket/BucketListSnapshot.h"
+#include "ledger/LedgerTxn.h"
+#include "ledger/LedgerTypeUtils.h"
+
+#include "medida/counter.h"
+
+namespace stellar
+{
+BucketSnapshot::BucketSnapshot(std::shared_ptr<Bucket const> const b)
+    : mBucket(b)
+{
+    releaseAssert(mBucket);
+}
+
+BucketSnapshot::BucketSnapshot(BucketSnapshot const& b)
+    : mBucket(b.mBucket), mStream(nullptr)
+{
+    releaseAssert(mBucket);
+}
+
+bool
+BucketSnapshot::isEmpty() const
+{
+    releaseAssert(mBucket);
+    return mBucket->isEmpty();
+}
+
+std::optional<BucketEntry>
+BucketSnapshot::getEntryAtOffset(LedgerKey const& k, std::streamoff pos,
+                                 size_t pageSize) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return std::nullopt;
+    }
+
+    auto& stream = getStream();
+    stream.seek(pos);
+
+    BucketEntry be;
+    if (pageSize == 0)
+    {
+        if (stream.readOne(be))
+        {
+            return std::make_optional(be);
+        }
+    }
+    else if (stream.readPage(be, k, pageSize))
+    {
+        return std::make_optional(be);
+    }
+
+    // Mark entry miss for metrics
+    mBucket->getIndex().markBloomMiss();
+    return std::nullopt;
+}
+
+std::optional<BucketEntry>
+BucketSnapshot::getBucketEntry(LedgerKey const& k) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return std::nullopt;
+    }
+
+    auto pos = mBucket->getIndex().lookup(k);
+    if (pos.has_value())
+    {
+        return getEntryAtOffset(k, pos.value(),
+                                mBucket->getIndex().getPageSize());
+    }
+
+    return std::nullopt;
+}
+
+// When searching for an entry, BucketList calls this function on every bucket.
+// Since the input is sorted, we do a binary search for the first key in keys.
+// If we find the entry, we remove the found key from keys so that later buckets
+// do not load shadowed entries. If we don't find the entry, we do not remove it
+// from keys so that it will be searched for again at a lower level.
+void
+BucketSnapshot::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
+                         std::vector<LedgerEntry>& result) const
+{
+    ZoneScoped;
+    if (isEmpty())
+    {
+        return;
+    }
+
+    auto currKeyIt = keys.begin();
+    auto const& index = mBucket->getIndex();
+    auto indexIter = index.begin();
+    while (currKeyIt != keys.end() && indexIter != index.end())
+    {
+        auto [offOp, newIndexIter] = index.scan(indexIter, *currKeyIt);
+        indexIter = newIndexIter;
+        if (offOp)
+        {
+            auto entryOp = getEntryAtOffset(*currKeyIt, *offOp,
+                                            mBucket->getIndex().getPageSize());
+            if (entryOp)
+            {
+                if (entryOp->type() != DEADENTRY)
+                {
+                    result.push_back(entryOp->liveEntry());
+                }
+
+                currKeyIt = keys.erase(currKeyIt);
+                continue;
+            }
+        }
+
+        ++currKeyIt;
+    }
+}
+
+std::vector<PoolID> const&
+BucketSnapshot::getPoolIDsByAsset(Asset const& asset) const
+{
+    static std::vector<PoolID> const emptyVec = {};
+    if (isEmpty())
+    {
+        return emptyVec;
+    }
+
+    return mBucket->getIndex().getPoolIDsByAsset(asset);
+}
+
+XDRInputFileStream&
+BucketSnapshot::getStream() const
+{
+    releaseAssertOrThrow(!isEmpty());
+    if (!mStream)
+    {
+        mStream = std::make_unique<XDRInputFileStream>();
+        mStream->open(mBucket->getFilename().string());
+    }
+    return *mStream;
+}
+
+std::shared_ptr<Bucket const>
+BucketSnapshot::getRawBucket() const
+{
+    return mBucket;
+}
+}

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -1,0 +1,63 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "util/NonCopyable.h"
+#include "util/UnorderedMap.h"
+#include "util/UnorderedSet.h"
+#include "util/types.h"
+
+#include <optional>
+
+namespace stellar
+{
+
+class Bucket;
+class XDRInputFileStream;
+
+// A lightweight wrapper around Bucket for thread safe BucketListDB lookups
+class BucketSnapshot : public NonMovable
+{
+    std::shared_ptr<Bucket const> const mBucket;
+
+    // Lazily-constructed and retained for read path.
+    mutable std::unique_ptr<XDRInputFileStream> mStream{};
+
+    // Returns (lazily-constructed) file stream for bucket file. Note
+    // this might be in some random position left over from a previous read --
+    // must be seek()'ed before use.
+    XDRInputFileStream& getStream() const;
+
+    // Loads the bucket entry for LedgerKey k. Starts at file offset pos and
+    // reads until key is found or the end of the page.
+    std::optional<BucketEntry> getEntryAtOffset(LedgerKey const& k,
+                                                std::streamoff pos,
+                                                size_t pageSize) const;
+
+    BucketSnapshot(std::shared_ptr<Bucket const> const b);
+
+    // Only allow copy constructor, is threadsafe
+    BucketSnapshot(BucketSnapshot const& b);
+    BucketSnapshot& operator=(BucketSnapshot const&) = delete;
+
+  public:
+    bool isEmpty() const;
+    std::shared_ptr<Bucket const> getRawBucket() const;
+
+    // Loads bucket entry for LedgerKey k.
+    std::optional<BucketEntry> getBucketEntry(LedgerKey const& k) const;
+
+    // Loads LedgerEntry's for given keys. When a key is found, the
+    // entry is added to result and the key is removed from keys.
+    void loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
+                  std::vector<LedgerEntry>& result) const;
+
+    // Return all PoolIDs that contain the given asset on either side of the
+    // pool
+    std::vector<PoolID> const& getPoolIDsByAsset(Asset const& asset) const;
+
+    friend struct BucketLevelSnapshot;
+};
+}

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -1,0 +1,105 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketSnapshotManager.h"
+#include "bucket/BucketListSnapshot.h"
+#include "main/Application.h"
+
+#include "medida/meter.h"
+#include "medida/metrics_registry.h"
+
+namespace stellar
+{
+
+BucketSnapshotManager::BucketSnapshotManager(
+    medida::MetricsRegistry& metrics,
+    std::unique_ptr<BucketListSnapshot const>&& snapshot)
+    : mMetrics(metrics)
+    , mCurrentSnapshot(std::move(snapshot))
+    , mBulkLoadMeter(
+          mMetrics.NewMeter({"bucketlistDB", "query", "loads"}, "query"))
+    , mBloomMisses(
+          mMetrics.NewMeter({"bucketlistDB", "bloom", "misses"}, "bloom"))
+    , mBloomLookups(
+          mMetrics.NewMeter({"bucketlistDB", "bloom", "lookups"}, "bloom"))
+{
+    releaseAssert(threadIsMain());
+}
+
+std::unique_ptr<SearchableBucketListSnapshot>
+BucketSnapshotManager::getSearchableBucketListSnapshot() const
+{
+    // Can't use std::make_unique due to private constructor
+    return std::unique_ptr<SearchableBucketListSnapshot>(
+        new SearchableBucketListSnapshot(*this));
+}
+
+medida::Timer&
+BucketSnapshotManager::recordBulkLoadMetrics(std::string const& label,
+                                             size_t numEntries) const
+{
+    // For now, only keep metrics for the main thread. We can decide on what
+    // metrics make sense when more background services are added later.
+    releaseAssert(threadIsMain());
+
+    if (numEntries != 0)
+    {
+        mBulkLoadMeter.Mark(numEntries);
+    }
+
+    auto iter = mBulkTimers.find(label);
+    if (iter == mBulkTimers.end())
+    {
+        auto& metric = mMetrics.NewTimer({"bucketlistDB", "bulk", label});
+        iter = mBulkTimers.emplace(label, metric).first;
+    }
+
+    return iter->second;
+}
+
+medida::Timer&
+BucketSnapshotManager::getPointLoadTimer(LedgerEntryType t) const
+{
+    // For now, only keep metrics for the main thread. We can decide on what
+    // metrics make sense when more background services are added later.
+    releaseAssert(threadIsMain());
+
+    auto iter = mPointTimers.find(t);
+    if (iter == mPointTimers.end())
+    {
+        auto const& label = xdr::xdr_traits<LedgerEntryType>::enum_name(t);
+        auto& metric = mMetrics.NewTimer({"bucketlistDB", "point", label});
+        iter = mPointTimers.emplace(t, metric).first;
+    }
+
+    return iter->second;
+}
+
+void
+BucketSnapshotManager::maybeUpdateSnapshot(
+    std::unique_ptr<BucketListSnapshot const>& snapshot) const
+{
+    std::lock_guard<std::recursive_mutex> lock(mSnapshotMutex);
+    if (!snapshot ||
+        snapshot->getLedgerSeq() != mCurrentSnapshot->getLedgerSeq())
+    {
+        // Should only update with a newer snapshot
+        releaseAssert(!snapshot || snapshot->getLedgerSeq() <
+                                       mCurrentSnapshot->getLedgerSeq());
+        snapshot = std::make_unique<BucketListSnapshot>(*mCurrentSnapshot);
+    }
+}
+
+void
+BucketSnapshotManager::updateCurrentSnapshot(
+    std::unique_ptr<BucketListSnapshot const>&& newSnapshot)
+{
+    releaseAssert(newSnapshot);
+    releaseAssert(threadIsMain());
+    std::lock_guard<std::recursive_mutex> lock(mSnapshotMutex);
+    releaseAssert(!mCurrentSnapshot || newSnapshot->getLedgerSeq() >=
+                                           mCurrentSnapshot->getLedgerSeq());
+    mCurrentSnapshot.swap(newSnapshot);
+}
+}

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -1,0 +1,84 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "bucket/BucketManagerImpl.h"
+#include "util/NonCopyable.h"
+#include "util/UnorderedMap.h"
+#include "util/types.h"
+
+#include <memory>
+#include <mutex>
+
+namespace medida
+{
+class Meter;
+class MetricsRegistry;
+class Timer;
+}
+
+namespace stellar
+{
+
+class Application;
+class BucketList;
+class BucketListSnapshot;
+
+// This class serves as the boundary between non-threadsafe singleton classes
+// (BucketManager, BucketList, Metrics, etc) and threadsafe, parallel BucketList
+// snapshots.
+class BucketSnapshotManager : NonMovableOrCopyable
+{
+  private:
+    medida::MetricsRegistry& mMetrics;
+
+    // Snapshot that is maintained and periodically updated by BucketManager on
+    // the main thread. When background threads need to generate or refresh a
+    // snapshot, they will copy this snapshot.
+    std::unique_ptr<BucketListSnapshot const> mCurrentSnapshot{};
+
+    // Lock must be held when accessing mCurrentSnapshot
+    mutable std::recursive_mutex mSnapshotMutex;
+
+    mutable UnorderedMap<LedgerEntryType, medida::Timer&> mPointTimers{};
+    mutable UnorderedMap<std::string, medida::Timer&> mBulkTimers{};
+
+    medida::Meter& mBulkLoadMeter;
+    medida::Meter& mBloomMisses;
+    medida::Meter& mBloomLookups;
+
+    // Called by main thread to update mCurrentSnapshot whenever the BucketList
+    // is updated
+    void updateCurrentSnapshot(
+        std::unique_ptr<BucketListSnapshot const>&& newSnapshot);
+
+    friend void
+    BucketManagerImpl::addBatch(Application& app, uint32_t currLedger,
+                                uint32_t currLedgerProtocol,
+                                std::vector<LedgerEntry> const& initEntries,
+                                std::vector<LedgerEntry> const& liveEntries,
+                                std::vector<LedgerKey> const& deadEntries);
+    friend void BucketManagerImpl::assumeState(HistoryArchiveState const& has,
+                                               uint32_t maxProtocolVersion,
+                                               bool restartMerges);
+
+  public:
+    BucketSnapshotManager(medida::MetricsRegistry& metrics,
+                          std::unique_ptr<BucketListSnapshot const>&& snapshot);
+
+    std::unique_ptr<SearchableBucketListSnapshot>
+    getSearchableBucketListSnapshot() const;
+
+    // Checks if snapshot is out of date with mCurrentSnapshot and updates
+    // it accordingly
+    void maybeUpdateSnapshot(
+        std::unique_ptr<BucketListSnapshot const>& snapshot) const;
+
+    medida::Timer& recordBulkLoadMetrics(std::string const& label,
+                                         size_t numEntries) const;
+
+    medida::Timer& getPointLoadTimer(LedgerEntryType t) const;
+};
+}

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -7,6 +7,7 @@
 
 #include "bucket/BucketIndexImpl.h"
 #include "bucket/BucketList.h"
+#include "bucket/BucketListSnapshot.h"
 #include "bucket/BucketManager.h"
 #include "bucket/test/BucketTestUtils.h"
 #include "ledger/test/LedgerTestUtils.h"
@@ -197,15 +198,19 @@ class BucketIndexTest
     virtual void
     run()
     {
+        auto searchableBL = getBM()
+                                .getBucketSnapshotManager()
+                                .getSearchableBucketListSnapshot();
+
         // Test bulk load lookup
-        auto loadResult = getBM().loadKeys(mKeysToSearch);
+        auto loadResult = searchableBL->loadKeys(mKeysToSearch);
         validateResults(mTestEntries, loadResult);
 
         // Test individual entry lookup
         loadResult.clear();
         for (auto const& key : mKeysToSearch)
         {
-            auto entryPtr = getBM().getLedgerEntry(key);
+            auto entryPtr = searchableBL->getLedgerEntry(key);
             if (entryPtr)
             {
                 loadResult.emplace_back(*entryPtr);
@@ -219,6 +224,9 @@ class BucketIndexTest
     virtual void
     runPerf(size_t n)
     {
+        auto searchableBL = getBM()
+                                .getBucketSnapshotManager()
+                                .getSearchableBucketListSnapshot();
         for (size_t i = 0; i < n; ++i)
         {
             LedgerKeySet searchSubset;
@@ -247,7 +255,7 @@ class BucketIndexTest
                 searchSubset.insert(addKeys.begin(), addKeys.end());
             }
 
-            auto blLoad = getBM().loadKeys(searchSubset);
+            auto blLoad = searchableBL->loadKeys(searchSubset);
             validateResults(testEntriesSubset, blLoad);
         }
     }
@@ -255,6 +263,10 @@ class BucketIndexTest
     void
     testInvalidKeys()
     {
+        auto searchableBL = getBM()
+                                .getBucketSnapshotManager()
+                                .getSearchableBucketListSnapshot();
+
         // Load should return empty vector for keys not in bucket list
         auto keysNotInBL =
             LedgerTestUtils::generateValidLedgerEntryKeysWithExclusions(
@@ -262,12 +274,12 @@ class BucketIndexTest
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load
-        REQUIRE(getBM().loadKeys(invalidKeys).size() == 0);
+        REQUIRE(searchableBL->loadKeys(invalidKeys).size() == 0);
 
         // Test individual load
         for (auto const& key : invalidKeys)
         {
-            auto entryPtr = getBM().getLedgerEntry(key);
+            auto entryPtr = searchableBL->getLedgerEntry(key);
             REQUIRE(!entryPtr);
         }
     }
@@ -427,8 +439,12 @@ class BucketIndexPoolShareTest : public BucketIndexTest
     virtual void
     run() override
     {
-        auto loadResult = getBM().loadPoolShareTrustLinesByAccountAndAsset(
-            mAccountToSearch.accountID, mAssetToSearch);
+        auto searchableBL = getBM()
+                                .getBucketSnapshotManager()
+                                .getSearchableBucketListSnapshot();
+        auto loadResult =
+            searchableBL->loadPoolShareTrustLinesByAccountAndAsset(
+                mAccountToSearch.accountID, mAssetToSearch);
         validateResults(mTestEntries, loadResult);
     }
 };

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -119,8 +119,8 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
         {
             {
                 LedgerTxn ltxEvictions(ltx);
-                mApp.getBucketManager().scanForEviction(ltxEvictions,
-                                                        ledgerSeq);
+                mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
+                                                                 ledgerSeq);
                 if (ledgerCloseMeta)
                 {
                     ledgerCloseMeta->populateEvictedEntries(

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1624,7 +1624,8 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
     {
         {
             LedgerTxn ltxEvictions(ltx);
-            mApp.getBucketManager().scanForEviction(ltxEvictions, ledgerSeq);
+            mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
+                                                             ledgerSeq);
             if (ledgerCloseMeta)
             {
                 ledgerCloseMeta->populateEvictedEntries(

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/BucketList.h"
 #include "database/Database.h"
 #include "ledger/LedgerTxn.h"
 #include "util/RandomEvictionCache.h"
@@ -18,6 +19,8 @@
 
 namespace stellar
 {
+
+class SearchableBucketListSnapshot;
 
 // Precondition: The keys associated with entries are unique and constitute a
 // subset of keys
@@ -737,6 +740,8 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
+    mutable std::unique_ptr<SearchableBucketListSnapshot>
+        mSearchableBucketListSnapshot{};
 
     size_t mBulkLoadBatchSize;
     std::unique_ptr<soci::transaction> mTransaction;
@@ -868,6 +873,8 @@ class LedgerTxnRoot::Impl
         std::deque<LedgerEntry>::const_iterator const& end);
 
     bool areEntriesMissingInCacheForOffer(OfferEntry const& oe);
+
+    SearchableBucketListSnapshot& getSearchableBucketListSnapshot() const;
 
   public:
     // Constructor has the strong exception safety guarantee


### PR DESCRIPTION
# Description

Builds on top of #4172 to enable parallel loads for BucketListDB.

This is an experimental draft PR that makes BucketListDB thread safe. The interface is as follows:

Each thread should call `BucketManager::getSearchableBucketListSnapshot()` to initialize their local snapshot. All loads from the thread should go through this snapshot object. After initialization, the `BucketListSnapshot` object automatically stays in sync with the current BucketList.

This change has a very simple, single threaded unit test. I've also run a watcher node successfully, but have yet to do a significant multi-threaded test.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
