### PR TITLE
3651 prefetch entries in soroban ops

### DIFF
--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -166,14 +166,15 @@ SearchableBucketListSnapshot::getLedgerEntryInternal(LedgerKey const& k)
 
 std::vector<LedgerEntry>
 SearchableBucketListSnapshot::loadKeysInternal(
-    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys)
+    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
+    LedgerKeyMeter* lkMeter)
 {
     std::vector<LedgerEntry> entries;
 
     // Make a copy of the key set, this loop is destructive
     auto keys = inKeys;
     auto f = [&](BucketSnapshot const& b) {
-        b.loadKeys(keys, entries);
+        b.loadKeysWithLimits(keys, entries, lkMeter);
         return keys.empty();
     };
 
@@ -182,8 +183,9 @@ SearchableBucketListSnapshot::loadKeysInternal(
 }
 
 std::vector<LedgerEntry>
-SearchableBucketListSnapshot::loadKeys(
-    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys)
+SearchableBucketListSnapshot::loadKeysWithLimits(
+    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
+    LedgerKeyMeter* lkMeter)
 {
     ZoneScoped;
     mSnapshotManager.maybeUpdateSnapshot(mSnapshot);
@@ -193,11 +195,11 @@ SearchableBucketListSnapshot::loadKeys(
         auto timer =
             mSnapshotManager.recordBulkLoadMetrics("prefetch", inKeys.size())
                 .TimeScope();
-        return loadKeysInternal(inKeys);
+        return loadKeysInternal(inKeys, lkMeter);
     }
     else
     {
-        return loadKeysInternal(inKeys);
+        return loadKeysInternal(inKeys, lkMeter);
     }
 }
 
@@ -237,7 +239,7 @@ SearchableBucketListSnapshot::loadPoolShareTrustLinesByAccountAndAsset(
                      .recordBulkLoadMetrics("poolshareTrustlines",
                                             trustlinesToLoad.size())
                      .TimeScope();
-    return loadKeysInternal(trustlinesToLoad);
+    return loadKeysInternal(trustlinesToLoad, nullptr);
 }
 
 std::vector<InflationWinner>

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -66,7 +66,8 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
     void loopAllBuckets(std::function<bool(BucketSnapshot const&)> f) const;
 
     std::vector<LedgerEntry>
-    loadKeysInternal(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
+    loadKeysInternal(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
+                     LedgerKeyMeter* lkMeter);
 
     // Loads bucket entry for LedgerKey k. Returns <LedgerEntry, bloomMiss>,
     // where bloomMiss is true if a bloom miss occurred during the load.
@@ -80,7 +81,8 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
 
   public:
     std::vector<LedgerEntry>
-    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
+    loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
+                       LedgerKeyMeter* lkMeter = nullptr);
 
     std::vector<LedgerEntry>
     loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -86,8 +86,9 @@ BucketSnapshot::getBucketEntry(LedgerKey const& k) const
 // do not load shadowed entries. If we don't find the entry, we do not remove it
 // from keys so that it will be searched for again at a lower level.
 void
-BucketSnapshot::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
-                         std::vector<LedgerEntry>& result) const
+BucketSnapshot::loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
+                                   std::vector<LedgerEntry>& result,
+                                   LedgerKeyMeter* lkMeter) const
 {
     ZoneScoped;
     if (isEmpty())
@@ -100,6 +101,24 @@ BucketSnapshot::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
     auto indexIter = index.begin();
     while (currKeyIt != keys.end() && indexIter != index.end())
     {
+        if (lkMeter)
+        {
+            auto keySize = xdr::xdr_size(*currKeyIt);
+            if (!lkMeter->canLoad(*currKeyIt, keySize))
+            {
+                // If the transactions containing this key have a remaining
+                // quota less than the size of the key, we cannot load the
+                // entry, as xdr_size(key) <= xdr_size(entry). Here we consume
+                // keySize bytes from the quotas of transactions containing the
+                // key so that they will have zero remaining quota and
+                // additional entries belonging to only those same transactions
+                // will not be loaded even if they would fit in the remaining
+                // quota before this update.
+                lkMeter->updateReadQuotasForKey(*currKeyIt, keySize);
+                currKeyIt = keys.erase(currKeyIt);
+                continue;
+            }
+        }
         auto [offOp, newIndexIter] = index.scan(indexIter, *currKeyIt);
         indexIter = newIndexIter;
         if (offOp)
@@ -110,9 +129,22 @@ BucketSnapshot::loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
             {
                 if (entryOp->type() != DEADENTRY)
                 {
-                    result.push_back(entryOp->liveEntry());
+                    bool addEntry = true;
+                    if (lkMeter)
+                    {
+                        // Here, we are metering after the entry has been
+                        // loaded. This is because we need to know the size of
+                        // the entry to meter it. Future work will add metering
+                        // at the xdr level.
+                        auto entrySize = xdr::xdr_size(entryOp->liveEntry());
+                        addEntry = lkMeter->canLoad(*currKeyIt, entrySize);
+                        lkMeter->updateReadQuotasForKey(*currKeyIt, entrySize);
+                    }
+                    if (addEntry)
+                    {
+                        result.push_back(entryOp->liveEntry());
+                    }
                 }
-
                 currKeyIt = keys.erase(currKeyIt);
                 continue;
             }
@@ -158,8 +190,8 @@ BucketSnapshot::scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
     LedgerKeySet keysToSearch;
 
     auto processQueue = [&]() {
-        auto loadResult =
-            populateLoadedEntries(keysToSearch, bl.loadKeys(keysToSearch));
+        auto loadResult = populateLoadedEntries(
+            keysToSearch, bl.loadKeysWithLimits(keysToSearch));
         for (auto& e : maybeEvictQueue)
         {
             // If TTL entry has not yet been deleted

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -18,6 +18,7 @@ class Bucket;
 class XDRInputFileStream;
 class SearchableBucketListSnapshot;
 struct EvictionResultEntry;
+class LedgerKeyMeter;
 
 // A lightweight wrapper around Bucket for thread safe BucketListDB lookups
 class BucketSnapshot : public NonMovable
@@ -57,8 +58,11 @@ class BucketSnapshot : public NonMovable
 
     // Loads LedgerEntry's for given keys. When a key is found, the
     // entry is added to result and the key is removed from keys.
-    void loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
-                  std::vector<LedgerEntry>& result) const;
+    // If a pointer to a LedgerKeyMeter is provided, a key will only be loaded
+    // if the meter has a transaction with sufficient read quota for the key.
+    void loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
+                            std::vector<LedgerEntry>& result,
+                            LedgerKeyMeter* lkMeter) const;
 
     // Return all PoolIDs that contain the given asset on either side of the
     // pool

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -203,7 +203,8 @@ class BucketIndexTest
                                 .getSearchableBucketListSnapshot();
 
         // Test bulk load lookup
-        auto loadResult = searchableBL->loadKeys(mKeysToSearch);
+        auto loadResult =
+            searchableBL->loadKeysWithLimits(mKeysToSearch, nullptr);
         validateResults(mTestEntries, loadResult);
 
         // Test individual entry lookup
@@ -255,7 +256,8 @@ class BucketIndexTest
                 searchSubset.insert(addKeys.begin(), addKeys.end());
             }
 
-            auto blLoad = searchableBL->loadKeys(searchSubset);
+            auto blLoad =
+                searchableBL->loadKeysWithLimits(searchSubset, nullptr);
             validateResults(testEntriesSubset, blLoad);
         }
     }
@@ -274,7 +276,8 @@ class BucketIndexTest
         LedgerKeySet invalidKeys(keysNotInBL.begin(), keysNotInBL.end());
 
         // Test bulk load
-        REQUIRE(searchableBL->loadKeys(invalidKeys).size() == 0);
+        REQUIRE(searchableBL->loadKeysWithLimits(invalidKeys, nullptr).size() ==
+                0);
 
         // Test individual load
         for (auto const& key : invalidKeys)

--- a/src/ledger/InMemoryLedgerTxnRoot.cpp
+++ b/src/ledger/InMemoryLedgerTxnRoot.cpp
@@ -172,7 +172,15 @@ InMemoryLedgerTxnRoot::getPrefetchHitRate() const
 }
 
 uint32_t
-InMemoryLedgerTxnRoot::prefetch(UnorderedSet<LedgerKey> const&)
+InMemoryLedgerTxnRoot::prefetchClassic(UnorderedSet<LedgerKey> const&)
+{
+    return 0;
+}
+
+uint32_t
+InMemoryLedgerTxnRoot::prefetchSoroban(UnorderedSet<LedgerKey> const&,
+                                       LedgerKeyMeter*)
+
 {
     return 0;
 }

--- a/src/ledger/InMemoryLedgerTxnRoot.h
+++ b/src/ledger/InMemoryLedgerTxnRoot.h
@@ -81,7 +81,10 @@ class InMemoryLedgerTxnRoot : public AbstractLedgerTxnParent
     void dropConfigSettings(bool rebuild) override;
     void dropTTL(bool rebuild) override;
     double getPrefetchHitRate() const override;
-    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
+    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) override;
+    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
+                             LedgerKeyMeter* lkMeter) override;
+
     void prepareNewObjects(size_t s) override;
 
 #ifdef BUILD_TESTS

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -331,6 +331,36 @@ struct LedgerTxnDelta
     UnorderedMap<InternalLedgerKey, EntryDelta> entry;
     HeaderDelta header;
 };
+// An abstraction for storing and applying per-txn read bytes metering limits
+// when loading keys.
+class LedgerKeyMeter : public NonMovableOrCopyable
+{
+  public:
+    // Adds a transaction with a read quota and the keys it will read.
+    void addTxn(SorobanResources const& resources);
+    // Conumes entrySizeBytes from the read quotas of all transactions with this
+    // key.
+    void updateReadQuotasForKey(LedgerKey const& key, size_t entrySizeBytes);
+    // Returns true if a transaction with sufficient read quota exists for this
+    // key.
+    bool canLoad(LedgerKey const& key, size_t entrySizeBytes) const;
+    // Returns true if a key was not loaded due to insufficient read quota.
+    bool loadFailed(LedgerKey const& key) const;
+
+  private:
+    // Returns the maximum read quota across all transactions with this key.
+    uint32_t maxReadQuotaForKey(LedgerKey const& key) const;
+
+    // Stores the read quota for each transaction.
+    std::vector<uint32_t> mTxReadBytes{};
+    // Stores the keys that each transaction will read. i.e.
+    // mLedgerKeyToTxs[key] is a vector containing  the indices of
+    // mTxReadBytes corresponding to the transactions which have
+    // the key in their footprint.
+    UnorderedMap<LedgerKey, std::vector<size_t>> mLedgerKeyToTxs{};
+    // Stores the keys that were not loaded due to insufficient read quota.
+    LedgerKeySet mNotLoadedKeys{};
+};
 
 // An abstraction for an object that is iterator-like and permits enumerating
 // the LedgerTxnEntry objects managed by an AbstractLedgerTxn. This enables
@@ -500,7 +530,11 @@ class AbstractLedgerTxnParent
     // This is purely advisory and can be a no-op, or do any level of actual
     // work, while still being correct. Will throw when called on anything other
     // than a (real or stub) root LedgerTxn.
-    virtual uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) = 0;
+    virtual uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) = 0;
+    // Prefetch a set of ledger entries into memory, while accounting for
+    // the read byte footprint of the transactions using the keys.
+    virtual uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
+                                     LedgerKeyMeter* lkMeter) = 0;
 
     // prepares to increase the capacity of pending changes by up to "s" changes
     virtual void prepareNewObjects(size_t s) = 0;
@@ -800,7 +834,10 @@ class LedgerTxn : public AbstractLedgerTxn
     void dropTTL(bool rebuild) override;
 
     double getPrefetchHitRate() const override;
-    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
+    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) override;
+
+    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
+                             LedgerKeyMeter* lkMeter) override;
     void prepareNewObjects(size_t s) override;
 
     bool hasSponsorshipEntry() const override;
@@ -892,9 +929,11 @@ class LedgerTxnRoot : public AbstractLedgerTxnParent
 
     void rollbackChild() noexcept override;
 
-    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys) override;
-    double getPrefetchHitRate() const override;
+    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys) override;
+    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
+                             LedgerKeyMeter* lkMeter) override;
 
+    double getPrefetchHitRate() const override;
     void prepareNewObjects(size_t s) override;
 
 #ifdef BEST_OFFER_DEBUGGING

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -633,7 +633,9 @@ class LedgerTxn::Impl
     // unsealHeader has the same exception safety guarantee as f
     void unsealHeader(LedgerTxn& self, std::function<void(LedgerHeader&)> f);
 
-    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
+    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys);
+    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
+                             LedgerKeyMeter* lkMeter);
 
     double getPrefetchHitRate() const;
 
@@ -871,6 +873,9 @@ class LedgerTxnRoot::Impl
 
     SearchableBucketListSnapshot& getSearchableBucketListSnapshot() const;
 
+    uint32_t prefetchInternal(UnorderedSet<LedgerKey> const& keys,
+                              LedgerKeyMeter* lkMeter = nullptr);
+
   public:
     // Constructor has the strong exception safety guarantee
     Impl(Application& app, size_t entryCacheSize, size_t prefetchBatchSize
@@ -968,7 +973,9 @@ class LedgerTxnRoot::Impl
     // Prefetch some or all of given keys in batches. Note that no prefetching
     // could occur if the cache is at its fill ratio. Returns number of keys
     // prefetched.
-    uint32_t prefetch(UnorderedSet<LedgerKey> const& keys);
+    uint32_t prefetchClassic(UnorderedSet<LedgerKey> const& keys);
+    uint32_t prefetchSoroban(UnorderedSet<LedgerKey> const& keys,
+                             LedgerKeyMeter* lkMeter);
 
     double getPrefetchHitRate() const;
 

--- a/src/ledger/test/LedgerTestUtils.cpp
+++ b/src/ledger/test/LedgerTestUtils.cpp
@@ -691,6 +691,29 @@ generateValidUniqueLedgerEntryKeysWithExclusions(
     return res;
 }
 
+std::vector<LedgerEntry>
+generateValidUniqueLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n)
+{
+    UnorderedSet<LedgerKey> keys;
+    std::vector<LedgerEntry> res;
+    keys.reserve(n);
+    res.reserve(n);
+    while (keys.size() < n)
+    {
+        auto entry = generateValidLedgerEntryWithExclusions(excludedTypes, n);
+        auto key = LedgerEntryKey(entry);
+        if (keys.find(key) != keys.end())
+        {
+            continue;
+        }
+
+        keys.insert(key);
+        res.emplace_back(entry);
+    }
+    return res;
+}
+
 LedgerEntry
 generateValidLedgerEntryWithTypes(
     std::unordered_set<LedgerEntryType> const& types, size_t b)

--- a/src/ledger/test/LedgerTestUtils.h
+++ b/src/ledger/test/LedgerTestUtils.h
@@ -50,6 +50,9 @@ std::vector<LedgerKey> generateUniqueValidSorobanLedgerEntryKeys(size_t n);
 std::vector<LedgerKey> generateValidUniqueLedgerEntryKeysWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
 
+std::vector<LedgerEntry> generateValidUniqueLedgerEntriesWithExclusions(
+    std::unordered_set<LedgerEntryType> const& excludedTypes, size_t n);
+
 LedgerEntry generateValidLedgerEntryWithExclusions(
     std::unordered_set<LedgerEntryType> const& excludedTypes, size_t b = 3);
 std::vector<LedgerEntry> generateValidLedgerEntriesWithExclusions(

--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -2,9 +2,11 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/BucketManager.h"
 #include "ledger/LedgerTxn.h"
 #include "ledger/LedgerTxnEntry.h"
 #include "ledger/LedgerTxnHeader.h"
+#include "ledger/LedgerTypeUtils.h"
 #include "ledger/NonSociRelatedException.h"
 #include "ledger/test/LedgerTestUtils.h"
 #include "lib/catch.hpp"
@@ -16,6 +18,8 @@
 #include "test/test.h"
 #include "transactions/TransactionUtils.h"
 #include "util/Math.h"
+#include "util/UnorderedMap.h"
+#include "util/UnorderedSet.h"
 #include "util/XDROperators.h"
 #include <algorithm>
 #include <fmt/format.h>
@@ -2600,11 +2604,10 @@ TEST_CASE("LedgerTxnEntry and LedgerTxnHeader move assignment", "[ledgertxn]")
     }
 }
 
-TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
+TEST_CASE("LedgerTxnRoot prefetch classic entries", "[ledgertxn]")
 {
-    auto runTest = [&](Config::TestDbMode mode) {
+    auto runTest = [&](Config cfg) {
         VirtualClock clock;
-        auto cfg = getTestConfig(0, mode);
         cfg.ENTRY_CACHE_SIZE = 1000;
         cfg.PREFETCH_BATCH_SIZE = cfg.ENTRY_CACHE_SIZE / 10;
 
@@ -2613,7 +2616,7 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
 
         auto& root = app->getLedgerTxnRoot();
 
-        auto entries = LedgerTestUtils::generateValidLedgerEntries(
+        auto entries = LedgerTestUtils::generateValidUniqueLedgerEntries(
             cfg.ENTRY_CACHE_SIZE + 1);
         std::set<LedgerEntry> entrySet;
         LedgerTxn ltx(root);
@@ -2626,6 +2629,12 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
             // we can check prefetch results later
             e.lastModifiedLedgerSeq = 1;
             entrySet.emplace(e);
+        }
+        if (cfg.isUsingBucketListDB())
+        {
+            std::vector<LedgerEntry> ledgerVect{entrySet.begin(),
+                                                entrySet.end()};
+            app->getBucketManager().addBatch(*app, 2, 20, {}, ledgerVect, {});
         }
         ltx.commit();
 
@@ -2642,7 +2651,7 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
                 }
             }
 
-            REQUIRE(root.prefetch(smallSet) == smallSet.size());
+            REQUIRE(root.prefetchClassic(smallSet) == smallSet.size());
 
             // Check that prefetch results are actually correct
             for (auto const& k : smallSet)
@@ -2653,26 +2662,36 @@ TEST_CASE("LedgerTxnRoot prefetch", "[ledgertxn]")
             }
 
             // 100% hit rate but make it floating point
-            REQUIRE(fabs(ltx2.getPrefetchHitRate() - 1.0f) < 0.0001f);
+            REQUIRE(fabs(ltx2.getPrefetchHitRate() - 1.0f) <
+                    std::numeric_limits<float>::epsilon());
             ltx2.commit();
         }
         SECTION("prefetch more than ENTRY_CACHE_SIZE entries")
         {
             LedgerTxn ltx2(root);
-            REQUIRE(root.prefetch(keysToPrefetch) == keysToPrefetch.size());
+            REQUIRE(root.prefetchClassic(keysToPrefetch) ==
+                    keysToPrefetch.size());
             ltx2.commit();
         }
     };
 
     SECTION("default")
     {
-        runTest(Config::TESTDB_DEFAULT);
+        auto cfg = getTestConfig();
+        cfg.DEPRECATED_SQL_LEDGER_STATE = false;
+        runTest(cfg);
+    }
+    SECTION("bucketlistdb")
+    {
+        auto cfg = getTestConfig();
+        cfg.DEPRECATED_SQL_LEDGER_STATE = false;
+        runTest(cfg);
     }
 
 #ifdef USE_POSTGRES
     SECTION("postgresql")
     {
-        runTest(Config::TESTDB_POSTGRESQL);
+        runTest(getTestConfig(0, Config::TESTDB_POSTGRESQL));
     }
 #endif
 }
@@ -2804,6 +2823,201 @@ TEST_CASE("Erase performance benchmark", "[!hide][erasebench]")
 #endif
 }
 
+TEST_CASE("LedgerTxnRoot prefetch soroban entries", "[ledgertxn]")
+{
+    Config cfg = getTestConfig();
+    cfg.ENTRY_CACHE_SIZE = 10;
+
+    // Test setup.
+    VirtualClock clock;
+    cfg.DEPRECATED_SQL_LEDGER_STATE = false;
+    Application::pointer app = createTestApplication(clock, cfg);
+    UnorderedSet<LedgerKey> keysToPrefetch;
+    auto& root = app->getLedgerTxnRoot();
+    LedgerTxn ltx(root);
+
+    auto lkMeterCold = std::make_unique<LedgerKeyMeter>();
+    auto lkMeterHot = std::make_unique<LedgerKeyMeter>();
+
+    auto contractDataEntry =
+        LedgerTestUtils::generateValidLedgerEntryOfType(CONTRACT_DATA);
+    contractDataEntry.lastModifiedLedgerSeq = 1;
+    ltx.createWithoutLoading(contractDataEntry);
+
+    auto classicEntry = LedgerTestUtils::generateValidLedgerEntryOfType(OFFER);
+    classicEntry.lastModifiedLedgerSeq = 1;
+    ltx.createWithoutLoading(classicEntry);
+
+    LedgerEntry TTLEntry;
+    TTLEntry.data.type(TTL);
+    TTLEntry.data.ttl().keyHash = getTTLKey(contractDataEntry).ttl().keyHash;
+    TTLEntry.data.ttl().liveUntilLedgerSeq =
+        contractDataEntry.lastModifiedLedgerSeq + 1;
+
+    auto deadEntry =
+        LedgerTestUtils::generateValidLedgerEntryOfType(CONTRACT_DATA);
+    auto deadKey = LedgerEntryKey(deadEntry);
+    ltx.eraseWithoutLoading(deadKey);
+
+    // Insert all entries into the database.
+    std::vector<LedgerEntry> ledgerVect{classicEntry, contractDataEntry,
+                                        TTLEntry};
+    std::vector<LedgerKey> deadKeyVect{deadKey};
+    app->getBucketManager().addBatch(*app, 2, 20, {}, ledgerVect, deadKeyVect);
+    ltx.commit();
+
+    auto addTxn = [&](bool enoughQuota, std::vector<LedgerEntry> entries,
+                      std::vector<LedgerKey> deadKeys = {}) {
+        SorobanResources resources;
+
+        for (auto const& e : entries)
+        {
+            auto k = LedgerEntryKey(e);
+            keysToPrefetch.emplace(k);
+            if (k.type() != TTL)
+            {
+                resources.readBytes += xdr::xdr_size(e);
+                // Randomly add the key to either the read or write set.
+                if (stellar::rand_flip())
+                {
+                    resources.footprint.readOnly.emplace_back(k);
+                }
+                else
+                {
+                    resources.footprint.readWrite.emplace_back(k);
+                }
+            }
+        }
+        if (!enoughQuota)
+        {
+            resources.readBytes -= 1;
+        }
+
+        for (auto& k : deadKeys)
+        {
+            resources.footprint.readOnly.emplace_back(k);
+        }
+
+        lkMeterHot->addTxn(resources);
+        lkMeterCold->addTxn(resources);
+    };
+
+    auto checkPrefetch = [&](std::set<LedgerKey> const& expectedSuccessKeys) {
+        LedgerTxn ltx2(root);
+        auto numLoadedCold =
+            root.prefetchSoroban(keysToPrefetch, lkMeterCold.get());
+        REQUIRE(numLoadedCold == expectedSuccessKeys.size());
+
+        auto preLoadPrefetchHitRate = root.getPrefetchHitRate();
+        REQUIRE(preLoadPrefetchHitRate == 0);
+        for (auto const& k : expectedSuccessKeys)
+        {
+            ltx2.load(k);
+        }
+
+        auto numLoadedHot =
+            root.prefetchSoroban(keysToPrefetch, lkMeterHot.get());
+        REQUIRE(numLoadedHot == 0);
+        // 100% hit rate but make it floating point
+        REQUIRE(fabs(ltx2.getPrefetchHitRate() - 1.0f) <
+                std::numeric_limits<float>::epsilon());
+    };
+
+    SECTION("all keys have quota")
+    {
+        auto tx1Entries =
+            std::vector<LedgerEntry>{classicEntry, contractDataEntry, TTLEntry};
+        auto tx2Entries =
+            std::vector<LedgerEntry>{classicEntry, contractDataEntry, TTLEntry};
+        addTxn(true /* enough quota */, tx1Entries);
+        addTxn(false, tx2Entries);
+        std::set<LedgerKey> expectedSuccessKeys;
+        for (auto const& e : tx1Entries)
+        {
+            expectedSuccessKeys.emplace(LedgerEntryKey(e));
+        }
+        checkPrefetch(expectedSuccessKeys);
+    }
+
+    SECTION("dead keys don't affect quota")
+    {
+        auto deadKeys = std::vector<LedgerKey>{deadKey};
+        auto tx1Entries =
+            std::vector<LedgerEntry>{classicEntry, contractDataEntry, TTLEntry};
+        addTxn(true /* enough quota */, tx1Entries, deadKeys);
+        std::set<LedgerKey> expectedSuccessKeys;
+        for (auto const& e : tx1Entries)
+        {
+            expectedSuccessKeys.emplace(LedgerEntryKey(e));
+        }
+        checkPrefetch(expectedSuccessKeys);
+    }
+
+    SECTION("don't load entries without quota")
+    {
+        auto tx1Entries =
+            std::vector<LedgerEntry>{classicEntry, contractDataEntry, TTLEntry};
+        addTxn(false /* enough quota */, tx1Entries);
+        std::set<LedgerKey> expectedSuccessKeys;
+        expectedSuccessKeys.emplace(LedgerEntryKey(TTLEntry));
+        // Keys are loaded according to the iteration order of the set.
+        // Whichever entry is loaded first will succeed. The other will fail.
+        // Classic entries are strictly less than soroban entries, so we expect
+        // classicEntry will be loaded and contractDataEntry will not.
+        expectedSuccessKeys.emplace(LedgerEntryKey(classicEntry));
+        checkPrefetch(expectedSuccessKeys);
+    }
+}
+
+TEST_CASE("LedgerKeyMeter tests")
+{
+    LedgerKeyMeter lkMeter{};
+    auto entry = LedgerTestUtils::generateValidLedgerEntryWithTypes(
+        {CONTRACT_CODE, CONTRACT_DATA}, 1);
+    auto key = LedgerEntryKey(entry);
+    auto entrySize = xdr::xdr_size(entry);
+    UnorderedSet<LedgerKey> keys;
+    keys.emplace(key);
+    SorobanResources resources;
+    resources.readBytes = entrySize;
+    resources.footprint.readOnly = {key};
+    lkMeter.addTxn(resources);
+
+    REQUIRE(lkMeter.canLoad(key, entrySize));
+    REQUIRE(!lkMeter.canLoad(key, entrySize + 1));
+    REQUIRE(lkMeter.canLoad(key, entrySize - 1));
+    REQUIRE(lkMeter.canLoad(key, 0));
+
+    // Adding another txn with less readQuota should not change the
+    // fact the key can be loaded.
+    resources.readBytes = 0;
+    resources.footprint.readOnly = {key};
+    lkMeter.addTxn(resources);
+    REQUIRE(lkMeter.canLoad(key, entrySize));
+    // Consume size(entry) of the read quota of each transaction which
+    // contains key.
+    lkMeter.updateReadQuotasForKey(key, entrySize);
+    // After updating, the read quota for the key should be zero.
+    REQUIRE(!lkMeter.canLoad(key, 1));
+    // Add another transaction with the same key and 2 * entrySize read quota.
+    resources.readBytes = 2 * entrySize;
+    resources.footprint.readOnly = {key};
+    lkMeter.addTxn(resources);
+    REQUIRE(lkMeter.canLoad(key, 2 * entrySize));
+    lkMeter.updateReadQuotasForKey(key, entrySize);
+    // After updating, the read quota should be equal the entry size (as
+    // the original quota was double)
+    REQUIRE(lkMeter.canLoad(key, entrySize));
+    // TTL keys are not part of the footprint and therefore not metered (i.e.
+    // always loadable).
+    auto ttlKey = getTTLKey(key);
+    REQUIRE(lkMeter.canLoad(ttlKey, std::numeric_limits<uint32_t>::max()));
+    // The ttlKey is not metered, so this should not have any effect.
+    lkMeter.updateReadQuotasForKey(ttlKey,
+                                   std::numeric_limits<uint32_t>::max());
+    REQUIRE(lkMeter.canLoad(ttlKey, std::numeric_limits<std::uint32_t>::max()));
+}
+
 TEST_CASE("Bulk load batch size benchmark", "[!hide][bulkbatchsizebench]")
 {
     size_t floor = 1000;
@@ -2837,7 +3051,7 @@ TEST_CASE("Bulk load batch size benchmark", "[!hide][bulkbatchsizebench]")
             LedgerTxn ltx2(root);
             {
                 m.TimeScope();
-                root.prefetch(keys);
+                root.prefetchClassic(keys);
             }
             ltx2.commit();
 
@@ -3627,7 +3841,7 @@ TEST_CASE_VERSIONS("LedgerTxn bulk-load offers", "[ledgertxn]")
         }
 
         for_all_versions(*app, [&]() {
-            app->getLedgerTxnRoot().prefetch({lk1, lk2});
+            app->getLedgerTxnRoot().prefetchClassic({lk1, lk2});
             LedgerTxn ltx(app->getLedgerTxnRoot());
             REQUIRE(ltx.load(lk1));
         });

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -510,10 +510,10 @@ FeeBumpTransactionFrame::insertKeysForFeeProcessing(
 }
 
 void
-FeeBumpTransactionFrame::insertKeysForTxApply(
-    UnorderedSet<LedgerKey>& keys) const
+FeeBumpTransactionFrame::insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
+                                              LedgerKeyMeter* lkMeter) const
 {
-    mInnerTx->insertKeysForTxApply(keys);
+    mInnerTx->insertKeysForTxApply(keys, lkMeter);
 }
 
 void

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -98,7 +98,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
 
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
-    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
+                              LedgerKeyMeter* lkMeter) const override;
 
     void processFeeSeqNum(AbstractLedgerTxn& ltx,
                           std::optional<int64_t> baseFee) override;

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -264,7 +264,8 @@ class TransactionFrame : public TransactionFrameBase
 
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;
-    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const override;
+    void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
+                              LedgerKeyMeter* lkMeter) const override;
 
     // collect fee, consume sequence number
     void processFeeSeqNum(AbstractLedgerTxn& ltx,

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -78,7 +78,8 @@ class TransactionFrameBase
 
     virtual void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const = 0;
-    virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys) const = 0;
+    virtual void insertKeysForTxApply(UnorderedSet<LedgerKey>& keys,
+                                      LedgerKeyMeter* lkMeter) const = 0;
 
     virtual void processFeeSeqNum(AbstractLedgerTxn& ltx,
                                   std::optional<int64_t> baseFee) = 0;

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1393,7 +1393,7 @@ prefetchForRevokeFromPoolShareTrustLines(
             keys.emplace(accountKey(sponsor));
         }
     }
-    ltx.prefetch(keys);
+    ltx.prefetchClassic(keys);
 
     // now prefetch the asset trustlines
     keys.clear();
@@ -1419,7 +1419,7 @@ prefetchForRevokeFromPoolShareTrustLines(
             keys.emplace(trustlineKey(accountID, params.assetB));
         }
     }
-    ltx.prefetch(keys);
+    ltx.prefetchClassic(keys);
 }
 
 static ClaimableBalanceID


### PR DESCRIPTION
# Description
Adds `LedgerKeyMeter` to track the allowance of read bytes for each transaction when prefetching soroban ops.

Resolves #3651 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
