### PR TITLE
Background eviction

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -233,6 +233,11 @@ EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF = 20
 # this value is ingnored and indexes are never persisted.
 EXPERIMENTAL_BUCKETLIST_DB_PERSIST_INDEX = true
 
+# EXPERIMENTAL_BUCKETLIST_DB (bool) default false
+# Determines whether eviction scans occur in the background thread. Requires
+# that EXPERIMENTAL_BUCKETLIST_DB is set to true.
+EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = false
+
 # PREFERRED_PEERS (list of strings) default is empty
 # These are IP:port strings that this server will add to its DB of peers.
 # This server will try to always stay connected to the other peers on this list.

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -682,12 +682,13 @@ mergeCasesWithEqualKeys(MergeCounters& mc, BucketInputIterator& oi,
 }
 
 bool
-Bucket::scanForEvictionLegacySQL(
-    AbstractLedgerTxn& ltx, EvictionIterator& iter, uint32_t& bytesToScan,
-    uint32_t& remainingEntriesToEvict, uint32_t ledgerSeq,
-    medida::Counter& entriesEvictedCounter,
-    medida::Counter& bytesScannedForEvictionCounter,
-    std::optional<EvictionStatistics>& stats) const
+Bucket::scanForEvictionLegacy(AbstractLedgerTxn& ltx, EvictionIterator& iter,
+                              uint32_t& bytesToScan,
+                              uint32_t& remainingEntriesToEvict,
+                              uint32_t ledgerSeq,
+                              medida::Counter& entriesEvictedCounter,
+                              medida::Counter& bytesScannedForEvictionCounter,
+                              std::optional<EvictionStatistics>& stats) const
 {
     ZoneScoped;
     if (isEmpty() ||
@@ -772,97 +773,6 @@ Bucket::scanForEvictionLegacySQL(
     }
 
     // Hit eof
-    return false;
-}
-
-bool
-Bucket::scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
-                        uint32_t ledgerSeq,
-                        std::list<EvictionResultEntry>& evictableKeys,
-                        SearchableBucketListSnapshot& bl) const
-{
-    ZoneScoped;
-    if (isEmpty() ||
-        protocolVersionIsBefore(getBucketVersion(shared_from_this()),
-                                SOROBAN_PROTOCOL_VERSION))
-    {
-        // EOF, skip to next bucket
-        return false;
-    }
-
-    if (bytesToScan == 0)
-    {
-        // Reached end of scan region
-        return true;
-    }
-
-    std::list<EvictionResultEntry> maybeEvictQueue;
-    LedgerKeySet keysToSearch;
-
-    auto processQueue = [&]() {
-        auto loadResult =
-            populateLoadedEntries(keysToSearch, bl.loadKeys(keysToSearch));
-        for (auto& e : maybeEvictQueue)
-        {
-            // If TTL entry has not yet been deleted
-            if (auto ttl = loadResult.find(getTTLKey(e.key))->second;
-                ttl != nullptr)
-            {
-                // If TTL of entry is expired
-                if (!isLive(*ttl, ledgerSeq))
-                {
-                    // If entry is expired but not yet deleted, add it to
-                    // evictable keys
-                    e.liveUntilLedger = ttl->data.ttl().liveUntilLedgerSeq;
-                    evictableKeys.emplace_back(e);
-                }
-            }
-        }
-    };
-
-    XDRInputFileStream stream{};
-    stream.open(mFilename);
-    stream.seek(iter.bucketFileOffset);
-    BucketEntry be;
-
-    // First, scan the bucket region and record all temp entry keys in
-    // maybeEvictQueue. After scanning, we will load all the TTL keys for these
-    // entries in a single bulk load to determine
-    //   1. If the entry is expired
-    //   2. If the entry has already been deleted/evicted
-    while (stream.readOne(be))
-    {
-        auto newPos = stream.pos();
-        auto bytesRead = newPos - iter.bucketFileOffset;
-        iter.bucketFileOffset = newPos;
-
-        if (be.type() == INITENTRY || be.type() == LIVEENTRY)
-        {
-            auto const& le = be.liveEntry();
-            if (isTemporaryEntry(le.data))
-            {
-                keysToSearch.emplace(getTTLKey(le));
-
-                // Set lifetime to 0 as default, will be updated after TTL keys
-                // loaded
-                maybeEvictQueue.emplace_back(
-                    EvictionResultEntry(LedgerEntryKey(le), iter, 0));
-            }
-        }
-
-        if (bytesRead >= bytesToScan)
-        {
-            // Reached end of scan region
-            bytesToScan = 0;
-            processQueue();
-            return true;
-        }
-
-        bytesToScan -= bytesRead;
-    }
-
-    // Hit eof
-    processQueue();
     return false;
 }
 

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -132,12 +132,13 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     // after this function returns:
     // bytesToScan -= amount_bytes_scanned
     // maxEntriesToEvict -= entries_evicted
-    bool scanForEvictionLegacySQL(
-        AbstractLedgerTxn& ltx, EvictionIterator& iter, uint32_t& bytesToScan,
-        uint32_t& remainingEntriesToEvict, uint32_t ledgerSeq,
-        medida::Counter& entriesEvictedCounter,
-        medida::Counter& bytesScannedForEvictionCounter,
-        std::optional<EvictionStatistics>& stats) const;
+    bool scanForEvictionLegacy(AbstractLedgerTxn& ltx, EvictionIterator& iter,
+                               uint32_t& bytesToScan,
+                               uint32_t& remainingEntriesToEvict,
+                               uint32_t ledgerSeq,
+                               medida::Counter& entriesEvictedCounter,
+                               medida::Counter& bytesScannedForEvictionCounter,
+                               std::optional<EvictionStatistics>& stats) const;
 
     bool scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
                          uint32_t ledgerSeq,

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -138,7 +138,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
                                uint32_t ledgerSeq,
                                medida::Counter& entriesEvictedCounter,
                                medida::Counter& bytesScannedForEvictionCounter,
-                               std::optional<EvictionStatistics>& stats) const;
+                               std::shared_ptr<EvictionStatistics> stats) const;
 
     bool scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
                          uint32_t ledgerSeq,

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -38,6 +38,8 @@ namespace stellar
 class AbstractLedgerTxn;
 class Application;
 class BucketManager;
+class SearchableBucketListSnapshot;
+struct EvictionResultEntry;
 struct EvictionStatistics;
 
 class Bucket : public std::enable_shared_from_this<Bucket>,
@@ -136,6 +138,11 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
         medida::Counter& entriesEvictedCounter,
         medida::Counter& bytesScannedForEvictionCounter,
         std::optional<EvictionStatistics>& stats) const;
+
+    bool scanForEviction(EvictionIterator& iter, uint64_t& bytesToScan,
+                         uint32_t ledgerSeq,
+                         std::list<EvictionResultEntry>& evictableKeys,
+                         SearchableBucketListSnapshot& bl) const;
 
     // Create a fresh bucket from given vectors of init (created) and live
     // (updated) LedgerEntries, and dead LedgerEntryKeys. The bucket will

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -139,7 +139,7 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
         medida::Counter& bytesScannedForEvictionCounter,
         std::optional<EvictionStatistics>& stats) const;
 
-    bool scanForEviction(EvictionIterator& iter, uint64_t& bytesToScan,
+    bool scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
                          uint32_t ledgerSeq,
                          std::list<EvictionResultEntry>& evictableKeys,
                          SearchableBucketListSnapshot& bl) const;

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -640,146 +640,170 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
 }
 
 void
+BucketList::updateStartingEvictionIterator(EvictionIterator& iter,
+                                           uint32_t firstScanLevel,
+                                           uint32_t ledgerSeq)
+{
+    // Check if an upgrade has changed the starting scan level to below the
+    // current iterator level
+    if (iter.bucketListLevel < firstScanLevel)
+    {
+        // Reset iterator to the new minimum level
+        iter.bucketFileOffset = 0;
+        iter.isCurrBucket = true;
+        iter.bucketListLevel = firstScanLevel;
+    }
+
+    // Whenever a Bucket changes (spills or receives an incoming spill), the
+    // iterator offset in that bucket is invalidated. After scanning, we
+    // must write the iterator to the BucketList then close the ledger.
+    // Bucket spills occur on ledger close after we've already written the
+    // iterator, so the iterator may be invalidated. Because of this, we
+    // must check if the Bucket the iterator currently points to changed on
+    // the previous ledger, indicating the current iterator is invalid.
+    if (iter.isCurrBucket)
+    {
+        // Check if bucket received an incoming spill
+        releaseAssert(iter.bucketListLevel != 0);
+        if (BucketList::levelShouldSpill(ledgerSeq - 1,
+                                         iter.bucketListLevel - 1))
+        {
+            // If Bucket changed, reset to start of bucket
+            iter.bucketFileOffset = 0;
+        }
+    }
+    else
+    {
+        if (BucketList::levelShouldSpill(ledgerSeq - 1, iter.bucketListLevel))
+        {
+            // If Bucket changed, reset to start of bucket
+            iter.bucketFileOffset = 0;
+        }
+    }
+}
+
+bool
+BucketList::updateEvictionIterAndRecordStats(
+    EvictionIterator& iter, EvictionIterator startIter,
+    uint32_t configFirstScanLevel, uint32_t ledgerSeq,
+    std::optional<EvictionStatistics>& stats, EvictionCounters& counters)
+{
+    // If we reached eof in curr bucket, start scanning snap.
+    // Last level has no snap so cycle back to the initial level.
+    if (iter.isCurrBucket && iter.bucketListLevel != kNumLevels - 1)
+    {
+        iter.isCurrBucket = false;
+        iter.bucketFileOffset = 0;
+    }
+    else
+    {
+        // If we reached eof in snap, move to next level
+        ++iter.bucketListLevel;
+        iter.isCurrBucket = true;
+        iter.bucketFileOffset = 0;
+
+        // If we have scanned the last level, cycle back to initial
+        // level
+        if (iter.bucketListLevel == kNumLevels)
+        {
+            iter.bucketListLevel = configFirstScanLevel;
+
+            // If eviction metrics are not null, we have accounted for a
+            // complete cycle and should log the metrics
+            if (stats)
+            {
+                counters.evictionCyclePeriod.set_count(
+                    ledgerSeq - stats->evictionCycleStartLedger);
+
+                auto averageAge = stats->numEntriesEvicted == 0
+                                      ? 0
+                                      : stats->evictedEntriesAgeSum /
+                                            stats->numEntriesEvicted;
+                counters.averageEvictedEntryAge.set_count(averageAge);
+            }
+
+            // Reset metrics at beginning of new eviction cycle
+            stats = std::make_optional<EvictionStatistics>();
+            stats->evictionCycleStartLedger = ledgerSeq;
+        }
+    }
+
+    // If we are back to the bucket we started at, break
+    if (iter.bucketListLevel == startIter.bucketListLevel &&
+        iter.isCurrBucket == startIter.isCurrBucket)
+    {
+        return true;
+    }
+
+    return false;
+}
+
+void
+BucketList::checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
+                                       uint32_t scanSize,
+                                       std::shared_ptr<Bucket const> b,
+                                       EvictionCounters& counters)
+{
+    // Check to see if we can finish scanning the new bucket before it
+    // receives an update
+    auto period = bucketUpdatePeriod(evictionIter.bucketListLevel,
+                                     evictionIter.isCurrBucket);
+    if (period * scanSize < b->getSize())
+    {
+        CLOG_WARNING(Bucket,
+                     "Bucket too large for current eviction scan size.");
+        counters.incompleteBucketScan.inc();
+    }
+}
+
+// To avoid noisy data, only count metrics that encompass a complete
+// eviction cycle. If a node joins the network mid cycle, metrics will be
+// nullopt and be initialized at the start of the next cycle.
+void
 BucketList::scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
                                      uint32_t ledgerSeq,
-                                     EvictionCounters& counters)
+                                     EvictionCounters& counters,
+                                     std::optional<EvictionStatistics>& stats)
 {
     auto getBucketFromIter = [&levels = mLevels](EvictionIterator const& iter) {
         auto& level = levels.at(iter.bucketListLevel);
         return iter.isCurrBucket ? level.getCurr() : level.getSnap();
     };
 
-    if (protocolVersionStartsFrom(ltx.getHeader().ledgerVersion,
-                                  SOROBAN_PROTOCOL_VERSION))
+    auto const& networkConfig =
+        app.getLedgerManager().getSorobanNetworkConfig();
+    auto const firstScanLevel =
+        networkConfig.stateArchivalSettings().startingEvictionScanLevel;
+    auto evictionIter = networkConfig.evictionIterator();
+    auto scanSize = networkConfig.stateArchivalSettings().evictionScanSize;
+    auto maxEntriesToEvict =
+        networkConfig.stateArchivalSettings().maxEntriesToArchive;
+
+    updateStartingEvictionIterator(evictionIter, firstScanLevel, ledgerSeq);
+
+    auto startIter = evictionIter;
+    auto b = getBucketFromIter(evictionIter);
+
+    while (!b->scanForEvictionLegacySQL(
+        ltx, evictionIter, scanSize, maxEntriesToEvict, ledgerSeq,
+        counters.entriesEvicted, counters.bytesScannedForEviction, stats))
     {
-        auto const& networkConfig =
-            app.getLedgerManager().getSorobanNetworkConfig();
-        auto const firstScanLevel =
-            networkConfig.stateArchivalSettings().startingEvictionScanLevel;
-        auto evictionIter = networkConfig.evictionIterator();
 
-        // Check if an upgrade has changed the starting scan level to below the
-        // current iterator level
-        if (evictionIter.bucketListLevel < firstScanLevel)
+        if (updateEvictionIterAndRecordStats(evictionIter, startIter,
+                                             firstScanLevel, ledgerSeq, stats,
+                                             counters))
         {
-            // Reset iterator to the new minimum level
-            evictionIter.bucketFileOffset = 0;
-            evictionIter.isCurrBucket = true;
-            evictionIter.bucketListLevel = firstScanLevel;
+            break;
         }
 
-        // Whenever a Bucket changes (spills or receives an incoming spill), the
-        // iterator offset in that bucket is invalidated. After scanning, we
-        // must write the iterator to the BucketList then close the ledger.
-        // Bucket spills occur on ledger close after we've already written the
-        // iterator, so the iterator may be invalidated. Because of this, we
-        // must check if the Bucket the iterator currently points to changed on
-        // the previous ledger, indicating the current iterator is invalid.
-        if (evictionIter.isCurrBucket)
-        {
-            // Check if bucket received an incoming spill
-            releaseAssert(evictionIter.bucketListLevel != 0);
-            if (BucketList::levelShouldSpill(ledgerSeq - 1,
-                                             evictionIter.bucketListLevel - 1))
-            {
-                // If Bucket changed, reset to start of bucket
-                evictionIter.bucketFileOffset = 0;
-            }
-        }
-        else
-        {
-            if (BucketList::levelShouldSpill(ledgerSeq - 1,
-                                             evictionIter.bucketListLevel))
-            {
-                // If Bucket changed, reset to start of bucket
-                evictionIter.bucketFileOffset = 0;
-            }
-        }
-
-        auto scanSize = networkConfig.stateArchivalSettings().evictionScanSize;
-        auto maxEntriesToEvict =
-            networkConfig.stateArchivalSettings().maxEntriesToArchive;
-
-        auto initialLevel = evictionIter.bucketListLevel;
-        auto initialIsCurr = evictionIter.isCurrBucket;
-        auto b = getBucketFromIter(evictionIter);
-
-        // Check to see if we can finish scanning the bucket before it receives
-        // an update. To prevent noisy warnings, we assume we have the entire
-        // period to scan the bucket.
-        uint64_t period = bucketUpdatePeriod(evictionIter.bucketListLevel,
-                                             evictionIter.isCurrBucket);
-        if (period * scanSize < b->getSize())
-        {
-            CLOG_WARNING(Bucket,
-                         "Bucket too large for current eviction scan size: "
-                         "level {} isCurr {}, bucket {}.",
-                         evictionIter.bucketListLevel,
-                         evictionIter.isCurrBucket, hexAbbrev(b->getHash()));
-            counters.incompleteBucketScan.inc();
-        }
-
-        while (!b->scanForEvictionLegacySQL(
-            ltx, evictionIter, scanSize, maxEntriesToEvict, ledgerSeq,
-            counters.entriesEvicted, counters.bytesScannedForEviction,
-            mEvictionStatistics))
-        {
-            // If we reached eof in curr bucket, start scanning snap.
-            // Last level has no snap so cycle back to the initial level.
-            if (evictionIter.isCurrBucket &&
-                evictionIter.bucketListLevel != kNumLevels - 1)
-            {
-                evictionIter.isCurrBucket = false;
-                evictionIter.bucketFileOffset = 0;
-            }
-            else
-            {
-                // If we reached eof in snap, move to next level
-                evictionIter.bucketListLevel++;
-                evictionIter.isCurrBucket = true;
-                evictionIter.bucketFileOffset = 0;
-
-                // If we have scanned the last level, cycle back to initial
-                // level
-                if (evictionIter.bucketListLevel == kNumLevels)
-                {
-                    evictionIter.bucketListLevel = firstScanLevel;
-
-                    // If eviction metrics are not null, we have accounted for a
-                    // complete cycle and should log the metrics
-                    if (mEvictionStatistics)
-                    {
-                        counters.evictionCyclePeriod.set_count(
-                            ledgerSeq -
-                            mEvictionStatistics->evictionCycleStartLedger);
-
-                        auto averageAge =
-                            mEvictionStatistics->numEntriesEvicted == 0
-                                ? 0
-                                : mEvictionStatistics->evictedEntriesAgeSum /
-                                      mEvictionStatistics->numEntriesEvicted;
-                        counters.averageEvictedEntryAge.set_count(averageAge);
-                    }
-
-                    // Reset metrics at beginning of new eviction cycle
-                    mEvictionStatistics =
-                        std::make_optional<EvictionStatistics>();
-                    mEvictionStatistics->evictionCycleStartLedger = ledgerSeq;
-                }
-            }
-
-            // If we are back to the bucket we started at, break
-            if (evictionIter.bucketListLevel == initialLevel &&
-                evictionIter.isCurrBucket == initialIsCurr)
-            {
-                break;
-            }
-
-            b = getBucketFromIter(evictionIter);
-        }
-
-        networkConfig.updateEvictionIterator(ltx, evictionIter);
+        b = getBucketFromIter(evictionIter);
+        checkIfEvictionScanIsStuck(
+            evictionIter,
+            networkConfig.stateArchivalSettings().evictionScanSize, b,
+            counters);
     }
+
+    networkConfig.updateEvictionIterator(ltx, evictionIter);
 }
 
 void
@@ -852,20 +876,6 @@ BucketList::restartMerges(Application& app, uint32_t maxProtocolVersion,
                 !app.getConfig().ARTIFICIALLY_REDUCE_MERGE_COUNTS_FOR_TESTING);
         }
     }
-}
-
-EvictionCounters::EvictionCounters(Application& app)
-    : entriesEvicted(app.getMetrics().NewCounter(
-          {"state-archival", "eviction", "entries-evicted"}))
-    , bytesScannedForEviction(app.getMetrics().NewCounter(
-          {"state-archival", "eviction", "bytes-scanned"}))
-    , incompleteBucketScan(app.getMetrics().NewCounter(
-          {"state-archival", "eviction", "incomplete-scan"}))
-    , evictionCyclePeriod(
-          app.getMetrics().NewCounter({"state-archival", "eviction", "period"}))
-    , averageEvictedEntryAge(
-          app.getMetrics().NewCounter({"state-archival", "eviction", "age"}))
-{
 }
 
 BucketListDepth BucketList::kNumLevels = 11;

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -746,8 +746,8 @@ BucketList::checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
 {
     // Check to see if we can finish scanning the new bucket before it
     // receives an update
-    auto period = bucketUpdatePeriod(evictionIter.bucketListLevel,
-                                     evictionIter.isCurrBucket);
+    uint64_t period = bucketUpdatePeriod(evictionIter.bucketListLevel,
+                                         evictionIter.isCurrBucket);
     if (period * scanSize < b->getSize())
     {
         CLOG_WARNING(Bucket,
@@ -760,10 +760,10 @@ BucketList::checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
 // eviction cycle. If a node joins the network mid cycle, metrics will be
 // nullopt and be initialized at the start of the next cycle.
 void
-BucketList::scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
-                                     uint32_t ledgerSeq,
-                                     EvictionCounters& counters,
-                                     std::optional<EvictionStatistics>& stats)
+BucketList::scanForEvictionLegacy(Application& app, AbstractLedgerTxn& ltx,
+                                  uint32_t ledgerSeq,
+                                  EvictionCounters& counters,
+                                  std::optional<EvictionStatistics>& stats)
 {
     auto getBucketFromIter = [&levels = mLevels](EvictionIterator const& iter) {
         auto& level = levels.at(iter.bucketListLevel);
@@ -784,7 +784,7 @@ BucketList::scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
     auto startIter = evictionIter;
     auto b = getBucketFromIter(evictionIter);
 
-    while (!b->scanForEvictionLegacySQL(
+    while (!b->scanForEvictionLegacy(
         ltx, evictionIter, scanSize, maxEntriesToEvict, ledgerSeq,
         counters.entriesEvicted, counters.bytesScannedForEviction, stats))
     {

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -481,10 +481,9 @@ class BucketList
                                            std::shared_ptr<Bucket const> b,
                                            EvictionCounters& counters);
 
-    void scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
-                                  uint32_t ledgerSeq,
-                                  EvictionCounters& counters,
-                                  std::optional<EvictionStatistics>& stats);
+    void scanForEvictionLegacy(Application& app, AbstractLedgerTxn& ltx,
+                               uint32_t ledgerSeq, EvictionCounters& counters,
+                               std::optional<EvictionStatistics>& stats);
 
     // Restart any merges that might be running on background worker threads,
     // merging buckets between levels. This needs to be called after forcing a

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -474,7 +474,7 @@ class BucketList
     static bool updateEvictionIterAndRecordStats(
         EvictionIterator& iter, EvictionIterator startIter,
         uint32_t configFirstScanLevel, uint32_t ledgerSeq,
-        std::optional<EvictionStatistics>& stats, EvictionCounters& counters);
+        std::shared_ptr<EvictionStatistics> stats, EvictionCounters& counters);
 
     static void checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
                                            uint32_t scanSize,
@@ -483,7 +483,7 @@ class BucketList
 
     void scanForEvictionLegacy(Application& app, AbstractLedgerTxn& ltx,
                                uint32_t ledgerSeq, EvictionCounters& counters,
-                               std::optional<EvictionStatistics>& stats);
+                               std::shared_ptr<EvictionStatistics> stats);
 
     // Restart any merges that might be running on background worker threads,
     // merging buckets between levels. This needs to be called after forcing a

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -352,6 +352,7 @@ class AbstractLedgerTxn;
 class Application;
 class Bucket;
 class Config;
+class EvictionCounters;
 struct InflationWinner;
 
 namespace testutil
@@ -402,34 +403,9 @@ class BucketListDepth
     friend class testutil::BucketListDepthModifier;
 };
 
-struct EvictionStatistics
-{
-    // Evicted entry "age" is the delta between its liveUntilLedger and the
-    // ledger when the entry is actually evicted
-    uint64_t evictedEntriesAgeSum{};
-    uint64_t numEntriesEvicted{};
-    uint32_t evictionCycleStartLedger{};
-};
-
-struct EvictionCounters
-{
-    medida::Counter& entriesEvicted;
-    medida::Counter& bytesScannedForEviction;
-    medida::Counter& incompleteBucketScan;
-    medida::Counter& evictionCyclePeriod;
-    medida::Counter& averageEvictedEntryAge;
-
-    EvictionCounters(Application& app);
-};
-
 class BucketList
 {
     std::vector<BucketLevel> mLevels;
-
-    // To avoid noisy data, only count metrics that encompass a complete
-    // eviction cycle. If a node joins the network mid cycle, metrics will be
-    // nullopt and be initialized at the start of the next cycle.
-    std::optional<EvictionStatistics> mEvictionStatistics;
 
   public:
     // Number of bucket levels in the bucketlist. Every bucketlist in the system
@@ -486,9 +462,29 @@ class BucketList
     // of the concatenation of the hashes of the `curr` and `snap` buckets.
     Hash getHash() const;
 
+    // Reset Eviction Iterator position if an incoming spill or upgrade has
+    // invalidated the previous position
+    static void updateStartingEvictionIterator(EvictionIterator& iter,
+                                               uint32_t firstScanLevel,
+                                               uint32_t ledgerSeq);
+
+    // Update eviction iter and record stats after scanning a region in one
+    // bucket. Returns true if scan has looped back to startIter, false
+    // otherwise.
+    static bool updateEvictionIterAndRecordStats(
+        EvictionIterator& iter, EvictionIterator startIter,
+        uint32_t configFirstScanLevel, uint32_t ledgerSeq,
+        std::optional<EvictionStatistics>& stats, EvictionCounters& counters);
+
+    static void checkIfEvictionScanIsStuck(EvictionIterator const& evictionIter,
+                                           uint32_t scanSize,
+                                           std::shared_ptr<Bucket const> b,
+                                           EvictionCounters& counters);
+
     void scanForEvictionLegacySQL(Application& app, AbstractLedgerTxn& ltx,
                                   uint32_t ledgerSeq,
-                                  EvictionCounters& counters);
+                                  EvictionCounters& counters,
+                                  std::optional<EvictionStatistics>& stats);
 
     // Restart any merges that might be running on background worker threads,
     // merging buckets between levels. This needs to be called after forcing a

--- a/src/bucket/BucketListSnapshot.cpp
+++ b/src/bucket/BucketListSnapshot.cpp
@@ -70,10 +70,11 @@ SearchableBucketListSnapshot::loopAllBuckets(
 EvictionResult
 SearchableBucketListSnapshot::scanForEviction(
     uint32_t ledgerSeq, EvictionCounters& counters,
-    EvictionIterator evictionIter, std::optional<EvictionStatistics>& stats,
+    EvictionIterator evictionIter, std::shared_ptr<EvictionStatistics> stats,
     StateArchivalSettings const& sas)
 {
     releaseAssert(mSnapshot);
+    releaseAssert(stats);
 
     auto getBucketFromIter =
         [&levels = mSnapshot->getLevels()](

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -91,7 +91,7 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
     EvictionResult scanForEviction(uint32_t ledgerSeq,
                                    EvictionCounters& counters,
                                    EvictionIterator evictionIter,
-                                   uint32_t firstScanLevel, uint64_t scanSize,
-                                   std::optional<EvictionStatistics>& stats);
+                                   std::optional<EvictionStatistics>& stats,
+                                   StateArchivalSettings const& sas);
 };
 }

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -91,7 +91,7 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
     EvictionResult scanForEviction(uint32_t ledgerSeq,
                                    EvictionCounters& counters,
                                    EvictionIterator evictionIter,
-                                   std::optional<EvictionStatistics>& stats,
+                                   std::shared_ptr<EvictionStatistics> stats,
                                    StateArchivalSettings const& sas);
 };
 }

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -87,5 +87,11 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
                                                       int64_t minBalance);
 
     std::shared_ptr<LedgerEntry> getLedgerEntry(LedgerKey const& k);
+
+    EvictionResult scanForEviction(uint32_t ledgerSeq,
+                                   EvictionCounters& counters,
+                                   EvictionIterator evictionIter,
+                                   uint32_t firstScanLevel, uint64_t scanSize,
+                                   std::optional<EvictionStatistics>& stats);
 };
 }

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -277,8 +277,8 @@ class BucketManager : NonMovableOrCopyable
     // Scans BucketList for non-live entries to evict starting at the entry
     // pointed to by EvictionIterator. Scans until `maxEntriesToEvict` entries
     // have been evicted or maxEvictionScanSize bytes have been scanned.
-    virtual void scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
-                                          uint32_t ledgerSeq) = 0;
+    virtual void scanForEvictionLegacy(AbstractLedgerTxn& ltx,
+                                       uint32_t ledgerSeq) = 0;
 
     virtual void startBackgroundEvictionScan(uint32_t ledgerSeq) = 0;
     virtual void

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -942,13 +942,13 @@ BucketManagerImpl::maybeSetIndex(std::shared_ptr<Bucket> b,
 }
 
 void
-BucketManagerImpl::scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
-                                            uint32_t ledgerSeq)
+BucketManagerImpl::scanForEvictionLegacy(AbstractLedgerTxn& ltx,
+                                         uint32_t ledgerSeq)
 {
     ZoneScoped;
     releaseAssert(protocolVersionStartsFrom(ltx.getHeader().ledgerVersion,
                                             SOROBAN_PROTOCOL_VERSION));
-    mBucketList->scanForEvictionLegacySQL(
+    mBucketList->scanForEvictionLegacy(
         mApp, ltx, ledgerSeq, mBucketListEvictionCounters, mEvictionStatistics);
 }
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -58,6 +58,7 @@ class BucketManagerImpl : public BucketManager
     medida::Counter& mBucketListSizeCounter;
     EvictionCounters mBucketListEvictionCounters;
     MergeCounters mMergeCounters;
+    std::optional<EvictionStatistics> mEvictionStatistics{};
 
     bool const mDeleteEntireBucketDirInDtor;
 
@@ -140,6 +141,10 @@ class BucketManagerImpl : public BucketManager
                        std::unique_ptr<BucketIndex const>&& index) override;
     void scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
                                   uint32_t ledgerSeq) override;
+    // void startBackgroundEvictionScan(uint32_t ledgerSeq) override;
+    void
+    resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx, uint32_t ledgerSeq,
+                                  LedgerKeySet const& modifiedKeys) override;
 
     medida::Meter& getBloomMissMeter() const override;
     medida::Meter& getBloomLookupMeter() const override;

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -152,8 +152,8 @@ class BucketManagerImpl : public BucketManager
     void snapshotLedger(LedgerHeader& currentHeader) override;
     void maybeSetIndex(std::shared_ptr<Bucket> b,
                        std::unique_ptr<BucketIndex const>&& index) override;
-    void scanForEvictionLegacySQL(AbstractLedgerTxn& ltx,
-                                  uint32_t ledgerSeq) override;
+    void scanForEvictionLegacy(AbstractLedgerTxn& ltx,
+                               uint32_t ledgerSeq) override;
     void startBackgroundEvictionScan(uint32_t ledgerSeq) override;
     void
     resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx, uint32_t ledgerSeq,

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -58,7 +58,7 @@ class BucketManagerImpl : public BucketManager
     medida::Counter& mBucketListSizeCounter;
     EvictionCounters mBucketListEvictionCounters;
     MergeCounters mMergeCounters;
-    std::optional<EvictionStatistics> mEvictionStatistics{};
+    std::shared_ptr<EvictionStatistics> mEvictionStatistics{};
 
     std::future<EvictionResult> mEvictionFuture{};
 

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -62,17 +62,6 @@ class BucketManagerImpl : public BucketManager
 
     std::future<EvictionResult> mEvictionFuture{};
 
-    // Lock for managing raw Bucket files or the bucket directory. This lock is
-    // only required for file access, but is not required for logical changes to
-    // the BucketList (i.e. addBatch).
-    mutable std::recursive_mutex mBucketFileMutex;
-
-    // Lock for logical BucketList changes and snapshots (i.e. addBatch,
-    // getSearchableSnapshot). This lock is not required for raw Bucket file
-    // management.
-    mutable std::recursive_mutex mBucketSnapshotMutex;
-
-
     bool const mDeleteEntireBucketDirInDtor;
 
     // Records bucket-merges that are currently _live_ in some FutureBucket, in

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -16,6 +16,8 @@ namespace stellar
 
 class Bucket;
 class XDRInputFileStream;
+class SearchableBucketListSnapshot;
+struct EvictionResultEntry;
 
 // A lightweight wrapper around Bucket for thread safe BucketListDB lookups
 class BucketSnapshot : public NonMovable
@@ -57,6 +59,11 @@ class BucketSnapshot : public NonMovable
     // Return all PoolIDs that contain the given asset on either side of the
     // pool
     std::vector<PoolID> const& getPoolIDsByAsset(Asset const& asset) const;
+
+    bool scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
+                         uint32_t ledgerSeq,
+                         std::list<EvictionResultEntry>& evictableKeys,
+                         SearchableBucketListSnapshot& bl) const;
 
     friend struct BucketLevelSnapshot;
 };

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -118,7 +118,7 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                                       SOROBAN_PROTOCOL_VERSION))
         {
             {
-                auto keys = ltx.getAllKeysWithoutSealing();
+                auto keys = ltx.getAllTTLKeysWithoutSealing();
                 LedgerTxn ltxEvictions(ltx);
 
                 if (mApp.getConfig().isUsingBucketListDB()

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -121,11 +121,7 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                 auto keys = ltx.getAllTTLKeysWithoutSealing();
                 LedgerTxn ltxEvictions(ltx);
 
-                if (mApp.getConfig().isUsingBucketListDB()
-#ifdef BUILD_TESTS
-                    && !mUseLegacySQLEvictionScanForTesting
-#endif
-                )
+                if (mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
                 {
                     mApp.getBucketManager().resolveBackgroundEvictionScan(
                         ltxEvictions, ledgerSeq, keys);

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -154,8 +154,8 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                 }
                 else
                 {
-                    mApp.getBucketManager().scanForEvictionLegacySQL(
-                        ltxEvictions, ledgerSeq);
+                    mApp.getBucketManager().scanForEvictionLegacy(ltxEvictions,
+                                                                  ledgerSeq);
                 }
 
                 if (ledgerCloseMeta)

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -118,9 +118,24 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                                       SOROBAN_PROTOCOL_VERSION))
         {
             {
+                auto keys = ltx.getAllKeysWithoutSealing();
                 LedgerTxn ltxEvictions(ltx);
-                mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
-                                                                 ledgerSeq);
+
+                if (mApp.getConfig().isUsingBucketListDB()
+#ifdef BUILD_TESTS
+                    && !mUseLegacySQLEvictionScanForTesting
+#endif
+                )
+                {
+                    mApp.getBucketManager().resolveBackgroundEvictionScan(
+                        ltxEvictions, ledgerSeq, keys);
+                }
+                else
+                {
+                    mApp.getBucketManager().scanForEvictionLegacySQL(
+                        ltxEvictions, ledgerSeq);
+                }
+
                 if (ledgerCloseMeta)
                 {
                     ledgerCloseMeta->populateEvictedEntries(

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1041,11 +1041,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     // step 3
     if (protocolVersionStartsFrom(initialLedgerVers,
                                   SOROBAN_PROTOCOL_VERSION) &&
-        mApp.getConfig().isUsingBucketListDB()
-#ifdef BUILD_TESTS
-        && !mUseLegacySQLEvictionScanForTesting
-#endif
-    )
+        mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
     {
         mApp.getBucketManager().startBackgroundEvictionScan(ledgerSeq + 1);
     }
@@ -1659,11 +1655,7 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
             auto keys = ltx.getAllTTLKeysWithoutSealing();
             LedgerTxn ltxEvictions(ltx);
 
-            if (mApp.getConfig().isUsingBucketListDB()
-#ifdef BUILD_TESTS
-                && !mUseLegacySQLEvictionScanForTesting
-#endif
-            )
+            if (mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
             {
                 mApp.getBucketManager().resolveBackgroundEvictionScan(
                     ltxEvictions, ledgerSeq, keys);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1662,8 +1662,8 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
             }
             else
             {
-                mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
-                                                                 ledgerSeq);
+                mApp.getBucketManager().scanForEvictionLegacy(ltxEvictions,
+                                                              ledgerSeq);
             }
 
             if (ledgerCloseMeta)

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1639,9 +1639,24 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
         protocolVersionStartsFrom(initialLedgerVers, SOROBAN_PROTOCOL_VERSION))
     {
         {
+            auto keys = ltx.getAllKeysWithoutSealing();
             LedgerTxn ltxEvictions(ltx);
-            mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
-                                                             ledgerSeq);
+
+            if (mApp.getConfig().isUsingBucketListDB()
+#ifdef BUILD_TESTS
+                && !mUseLegacySQLEvictionScanForTesting
+#endif
+            )
+            {
+                mApp.getBucketManager().resolveBackgroundEvictionScan(
+                    ltxEvictions, ledgerSeq, keys);
+            }
+            else
+            {
+                mApp.getBucketManager().scanForEvictionLegacySQL(ltxEvictions,
+                                                                 ledgerSeq);
+            }
+
             if (ledgerCloseMeta)
             {
                 ledgerCloseMeta->populateEvictedEntries(

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -975,6 +975,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         }
     }
     auto maybeNewVersion = ltx.loadHeader().current().ledgerVersion;
+    auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
     if (protocolVersionStartsFrom(maybeNewVersion, SOROBAN_PROTOCOL_VERSION))
     {
         updateNetworkConfig(ltx);
@@ -1009,7 +1010,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
         }
     }
 
-    // The next 4 steps happen in a relatively non-obvious, subtle order.
+    // The next 5 steps happen in a relatively non-obvious, subtle order.
     // This is unfortunate and it would be nice if we could make it not
     // be so subtle, but for the time being this is where we are.
     //
@@ -1019,12 +1020,16 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     //
     // 2. Commit the current transaction.
     //
-    // 3. Start any queued checkpoint publishing, _after_ the commit so that
+    // 3. Start background eviction scan for the next ledger, _after_ the commit
+    //    so that it takes its snapshot of network setting from the
+    //    committed state.
+    //
+    // 4. Start any queued checkpoint publishing, _after_ the commit so that
     //    it takes its snapshot of history-rows from the committed state, but
     //    _before_ we GC any buckets (because this is the step where the
     //    bucket refcounts are incremented for the duration of the publish).
     //
-    // 4. GC unreferenced buckets. Only do this once publishes are in progress.
+    // 5. GC unreferenced buckets. Only do this once publishes are in progress.
 
     // step 1
     auto& hm = mApp.getHistoryManager();
@@ -1034,10 +1039,22 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     ltx.commit();
 
     // step 3
+    if (protocolVersionStartsFrom(initialLedgerVers,
+                                  SOROBAN_PROTOCOL_VERSION) &&
+        mApp.getConfig().isUsingBucketListDB()
+#ifdef BUILD_TESTS
+        && !mUseLegacySQLEvictionScanForTesting
+#endif
+    )
+    {
+        mApp.getBucketManager().startBackgroundEvictionScan(ledgerSeq + 1);
+    }
+
+    // step 4
     hm.publishQueuedHistory();
     hm.logAndUpdatePublishStatus();
 
-    // step 4
+    // step 5
     mApp.getBucketManager().forgetUnreferencedBuckets();
 
     if (!mApp.getConfig().OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING.empty())
@@ -1639,7 +1656,7 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
         protocolVersionStartsFrom(initialLedgerVers, SOROBAN_PROTOCOL_VERSION))
     {
         {
-            auto keys = ltx.getAllKeysWithoutSealing();
+            auto keys = ltx.getAllTTLKeysWithoutSealing();
             LedgerTxn ltxEvictions(ltx);
 
             if (mApp.getConfig().isUsingBucketListDB()

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -152,6 +152,8 @@ class LedgerManagerImpl : public LedgerManager
     bool hasSorobanNetworkConfig() const override;
 
 #ifdef BUILD_TESTS
+    bool mUseLegacySQLEvictionScanForTesting{};
+
     SorobanNetworkConfig& getMutableSorobanNetworkConfig() override;
 #endif
 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -152,8 +152,6 @@ class LedgerManagerImpl : public LedgerManager
     bool hasSorobanNetworkConfig() const override;
 
 #ifdef BUILD_TESTS
-    bool mUseLegacySQLEvictionScanForTesting{};
-
     SorobanNetworkConfig& getMutableSorobanNetworkConfig() override;
 #endif
 

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -1393,19 +1393,23 @@ LedgerTxn::Impl::getAllEntries(std::vector<LedgerEntry>& initEntries,
 }
 
 LedgerKeySet
-LedgerTxn::getAllKeysWithoutSealing() const
+LedgerTxn::getAllTTLKeysWithoutSealing() const
 {
-    return getImpl()->getAllKeysWithoutSealing();
+    return getImpl()->getAllTTLKeysWithoutSealing();
 }
 
 LedgerKeySet
-LedgerTxn::Impl::getAllKeysWithoutSealing() const
+LedgerTxn::Impl::getAllTTLKeysWithoutSealing() const
 {
     throwIfNotExactConsistency();
     LedgerKeySet result;
     for (auto const& [k, v] : mEntry)
     {
-        result.emplace(k.ledgerKey());
+        if (k.type() == InternalLedgerEntryType::LEDGER_ENTRY &&
+            k.ledgerKey().type() == TTL)
+        {
+            result.emplace(k.ledgerKey());
+        }
     }
 
     return result;

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -619,6 +619,10 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
                                std::vector<LedgerEntry>& liveEntries,
                                std::vector<LedgerKey>& deadEntries) = 0;
 
+    // Returns all keys that have been modified (create, update, and delete),
+    // but does not cause the AbstractLedgerTxn or update last modified.
+    virtual LedgerKeySet getAllKeysWithoutSealing() const = 0;
+
     // forAllWorstBestOffers allows a parent AbstractLedgerTxn to process the
     // worst best offers (an offer is a worst best offer if every better offer
     // in any parent AbstractLedgerTxn has already been loaded). This function
@@ -744,6 +748,7 @@ class LedgerTxn : public AbstractLedgerTxn
     void getAllEntries(std::vector<LedgerEntry>& initEntries,
                        std::vector<LedgerEntry>& liveEntries,
                        std::vector<LedgerKey>& deadEntries) override;
+    LedgerKeySet getAllKeysWithoutSealing() const override;
 
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const override;

--- a/src/ledger/LedgerTxn.h
+++ b/src/ledger/LedgerTxn.h
@@ -619,9 +619,10 @@ class AbstractLedgerTxn : public AbstractLedgerTxnParent
                                std::vector<LedgerEntry>& liveEntries,
                                std::vector<LedgerKey>& deadEntries) = 0;
 
-    // Returns all keys that have been modified (create, update, and delete),
-    // but does not cause the AbstractLedgerTxn or update last modified.
-    virtual LedgerKeySet getAllKeysWithoutSealing() const = 0;
+    // Returns all TTL keys that have been modified (create, update, and
+    // delete), but does not cause the AbstractLedgerTxn or update last
+    // modified.
+    virtual LedgerKeySet getAllTTLKeysWithoutSealing() const = 0;
 
     // forAllWorstBestOffers allows a parent AbstractLedgerTxn to process the
     // worst best offers (an offer is a worst best offer if every better offer
@@ -748,7 +749,7 @@ class LedgerTxn : public AbstractLedgerTxn
     void getAllEntries(std::vector<LedgerEntry>& initEntries,
                        std::vector<LedgerEntry>& liveEntries,
                        std::vector<LedgerKey>& deadEntries) override;
-    LedgerKeySet getAllKeysWithoutSealing() const override;
+    LedgerKeySet getAllTTLKeysWithoutSealing() const override;
 
     std::shared_ptr<InternalLedgerEntry const>
     getNewestVersion(InternalLedgerKey const& key) const override;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -22,13 +22,6 @@ namespace stellar
 
 class SearchableBucketListSnapshot;
 
-// Precondition: The keys associated with entries are unique and constitute a
-// subset of keys
-template <typename KeySetT>
-UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
-populateLoadedEntries(KeySetT const& keys,
-                      std::vector<LedgerEntry> const& entries);
-
 class EntryIterator::AbstractImpl
 {
   public:
@@ -557,6 +550,8 @@ class LedgerTxn::Impl
     void getAllEntries(std::vector<LedgerEntry>& initEntries,
                        std::vector<LedgerEntry>& liveEntries,
                        std::vector<LedgerKey>& deadEntries);
+
+    LedgerKeySet getAllKeysWithoutSealing() const;
 
     // getNewestVersion has the basic exception safety guarantee. If it throws
     // an exception, then

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -551,7 +551,7 @@ class LedgerTxn::Impl
                        std::vector<LedgerEntry>& liveEntries,
                        std::vector<LedgerKey>& deadEntries);
 
-    LedgerKeySet getAllKeysWithoutSealing() const;
+    LedgerKeySet getAllTTLKeysWithoutSealing() const;
 
     // getNewestVersion has the basic exception safety guarantee. If it throws
     // an exception, then

--- a/src/ledger/LedgerTypeUtils.cpp
+++ b/src/ledger/LedgerTypeUtils.cpp
@@ -5,10 +5,51 @@
 #include "ledger/LedgerTypeUtils.h"
 #include "crypto/SHA.h"
 #include "util/GlobalChecks.h"
+#include "util/UnorderedMap.h"
+#include "util/UnorderedSet.h"
 #include "util/types.h"
 
 namespace stellar
 {
+
+template <typename KeySetT>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
+populateLoadedEntries(KeySetT const& keys,
+                      std::vector<LedgerEntry> const& entries)
+{
+    UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>> res;
+
+    for (auto const& le : entries)
+    {
+        auto key = LedgerEntryKey(le);
+
+        // Abort if two entries for the same key appear.
+        releaseAssert(res.find(key) == res.end());
+
+        // Only return entries for keys that were actually requested.
+        if (keys.find(key) != keys.end())
+        {
+            res.emplace(key, std::make_shared<LedgerEntry const>(le));
+        }
+    }
+
+    for (auto const& key : keys)
+    {
+        if (res.find(key) == res.end())
+        {
+            res.emplace(key, nullptr);
+        }
+    }
+    return res;
+}
+
+template UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
+populateLoadedEntries(LedgerKeySet const& keys,
+                      std::vector<LedgerEntry> const& entries);
+
+template UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
+populateLoadedEntries(UnorderedSet<LedgerKey> const& keys,
+                      std::vector<LedgerEntry> const& entries);
 
 bool
 isLive(LedgerEntry const& e, uint32_t cutoffLedger)

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -4,7 +4,9 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "ledger/LedgerHashUtils.h"
 #include "overlay/StellarXDR.h"
+#include "util/UnorderedMap.h"
 #include "util/XDROperators.h"
 
 namespace stellar
@@ -13,6 +15,13 @@ bool isLive(LedgerEntry const& e, uint32_t cutoffLedger);
 
 LedgerKey getTTLKey(LedgerEntry const& e);
 LedgerKey getTTLKey(LedgerKey const& e);
+
+// Precondition: The keys associated with entries are unique and constitute a
+// subset of keys
+template <typename KeySetT>
+UnorderedMap<LedgerKey, std::shared_ptr<LedgerEntry const>>
+populateLoadedEntries(KeySetT const& keys,
+                      std::vector<LedgerEntry> const& entries);
 
 template <typename T>
 bool

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -409,7 +409,7 @@ class SorobanNetworkConfig
     uint64_t mAverageBucketListSize{0};
 
 #ifdef BUILD_TESTS
-    void writeAllSettings(AbstractLedgerTxn& ltx) const;
+    void writeAllSettings(AbstractLedgerTxn& ltx, Application& app) const;
 #endif
 
     // Host cost params

--- a/src/main/Application.h
+++ b/src/main/Application.h
@@ -226,12 +226,18 @@ class Application
     // this io_context will execute in parallel with the calling thread, so use
     // with caution.
     virtual asio::io_context& getWorkerIOContext() = 0;
+    virtual asio::io_context& getEvictionIOContext() = 0;
 
     virtual void postOnMainThread(
         std::function<void()>&& f, std::string&& name,
         Scheduler::ActionType type = Scheduler::ActionType::NORMAL_ACTION) = 0;
+
+    // While both are lower priority than the main thread, eviction threads have
+    // more priority than regular worker background threads
     virtual void postOnBackgroundThread(std::function<void()>&& f,
                                         std::string jobName) = 0;
+    virtual void postOnEvictionBackgroundThread(std::function<void()>&& f,
+                                                std::string jobName) = 0;
 
     // Perform actions necessary to transition from BOOTING_STATE to other
     // states. In particular: either reload or reinitialize the database, and

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -760,6 +760,14 @@ ApplicationImpl::validateAndLogConfig()
             "stellar-core new-db.");
     }
 
+    if (mConfig.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN &&
+        !mConfig.isUsingBucketListDB())
+    {
+        throw std::invalid_argument(
+            "EXPERIMENTAL_BUCKETLIST_DB must be enabled to use "
+            "EXPERIMENTAL_BACKGROUND_EVICTION_SCAN");
+    }
+
     if (isNetworkedValidator && mConfig.isInMemoryMode())
     {
         throw std::invalid_argument(

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -1331,7 +1331,7 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             }
             else if (item.first == "WORKER_THREADS")
             {
-                WORKER_THREADS = readInt<int>(item, 1, 1000);
+                WORKER_THREADS = readInt<int>(item, 2, 1000);
             }
             else if (item.first == "MAX_CONCURRENT_SUBPROCESSES")
             {

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -163,6 +163,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
     EXPERIMENTAL_BUCKETLIST_DB_PERSIST_INDEX = true;
+    EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = false;
     PUBLISH_TO_ARCHIVE_DELAY = std::chrono::seconds{0};
     // automatic maintenance settings:
     // short and prime with 1 hour which will cause automatic maintenance to
@@ -1073,6 +1074,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "EXPERIMENTAL_BUCKETLIST_DB")
             {
                 EXPERIMENTAL_BUCKETLIST_DB = readBool(item);
+            }
+            else if (item.first == "EXPERIMENTAL_BACKGROUND_EVICTION_SCAN")
+            {
+                EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = readBool(item);
             }
             else if (item.first ==
                      "EXPERIMENTAL_BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT")

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -365,6 +365,10 @@ class Config : public std::enable_shared_from_this<Config>
     // persisted.
     bool EXPERIMENTAL_BUCKETLIST_DB_PERSIST_INDEX;
 
+    // When set to true, eviction scans occur on the background thread,
+    // increasing performance. Requires EXPERIMENTAL_BUCKETLIST_DB.
+    bool EXPERIMENTAL_BACKGROUND_EVICTION_SCAN;
+
     // A config parameter that stores historical data, such as transactions,
     // fees, and scp history in the database
     bool MODE_STORES_HISTORY_MISC;

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -867,7 +867,7 @@ getFuzzConfig(int instanceNumber)
     cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
     cfg.ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = UINT32_MAX;
     cfg.HTTP_PORT = 0;
-    cfg.WORKER_THREADS = 1;
+    cfg.WORKER_THREADS = 2;
     cfg.QUORUM_INTERSECTION_CHECKER = false;
     cfg.PREFERRED_PEERS_ONLY = false;
     cfg.RUN_STANDALONE = true;

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -206,8 +206,14 @@ modifySorobanNetworkConfig(Application& app,
     app.getLedgerManager().updateNetworkConfig(ltx);
     auto& cfg = app.getLedgerManager().getMutableSorobanNetworkConfig();
     modifyFn(cfg);
-    cfg.writeAllSettings(ltx);
+    cfg.writeAllSettings(ltx, app);
     ltx.commit();
+
+    // Need to close a ledger following call to `addBatch` from config upgrade
+    if (app.getConfig().isUsingBucketListDB())
+    {
+        txtest::closeLedger(app);
+    }
 }
 
 void

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2499,117 +2499,168 @@ TEST_CASE("state archival", "[tx][soroban]")
 
 TEST_CASE("temp entry eviction", "[tx][soroban]")
 {
-    Config cfg = getTestConfig();
-    TmpDirManager tdm(std::string("soroban-storage-meta-") +
-                      binToHex(randomBytes(8)));
-    TmpDir td = tdm.tmpDir("soroban-meta-ok");
-    std::string metaPath = td.getName() + "/stream.xdr";
-
-    cfg.METADATA_OUTPUT_STREAM = metaPath;
-
-    SorobanTest test(cfg);
-    ContractStorageTestClient client(test);
-    auto const& contractKeys = client.getContract().getKeys();
-
-    // Extend Wasm and instance
-    test.invokeExtendOp(contractKeys, 10'000);
-
-    auto invocation = client.getContract().prepareInvocation(
-        "put_temporary", {makeSymbolSCVal("key"), makeU64SCVal(123)},
-        client.writeKeySpec("key", ContractDataDurability::TEMPORARY));
-    closeLedger(test.getApp(),
-                {invocation.withExactNonRefundableResourceFee().createTx()});
-    auto lk = client.getContract().getDataKey(
-        makeSymbolSCVal("key"), ContractDataDurability::TEMPORARY);
-
-    auto expectedLiveUntilLedger =
-        test.getLedgerSeq() +
-        test.getNetworkCfg().stateArchivalSettings().minTemporaryTTL - 1;
-    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
-    auto const evictionLedger = 4097;
-
-    // Close ledgers until temp entry is evicted
-    for (uint32_t i = test.getLedgerSeq(); i < evictionLedger; ++i)
-    {
-        closeLedgerOn(test.getApp(), i, 2, 1, 2016);
-    }
-
-    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
-
-    // This should be a noop
-    test.invokeExtendOp({lk}, 10'000, 0);
-    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
-
-    // This will fail because the entry is expired
-    REQUIRE(client.extend("key", ContractDataDurability::TEMPORARY, 10'000,
-                          10'000) == INVOKE_HOST_FUNCTION_TRAPPED);
-    REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
-
-    REQUIRE(!test.isEntryLive(lk, test.getLedgerSeq()));
-
-    SECTION("eviction")
-    {
-        // close one more ledger to trigger the eviction
-        closeLedgerOn(test.getApp(), evictionLedger, 2, 1, 2016);
-
+    auto test = [](bool enableBucketListDB, bool backgroundEviction) {
+        if (backgroundEviction && !enableBucketListDB)
         {
-            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
-            REQUIRE(!ltx.load(lk));
+            throw "testing error: backgroundEviction requires "
+                  "enableBucketListDB == true";
         }
 
-        XDRInputFileStream in;
-        in.open(metaPath);
-        LedgerCloseMeta lcm;
-        bool evicted = false;
-        while (in.readOne(lcm))
+        Config cfg = getTestConfig();
+        TmpDirManager tdm(std::string("soroban-storage-meta-") +
+                          binToHex(randomBytes(8)));
+        TmpDir td = tdm.tmpDir("soroban-meta-ok");
+        std::string metaPath = td.getName() + "/stream.xdr";
+
+        cfg.METADATA_OUTPUT_STREAM = metaPath;
+        cfg.EXPERIMENTAL_BUCKETLIST_DB = enableBucketListDB;
+        cfg.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = backgroundEviction;
+
+        // overrideSorobanNetworkConfigForTest commits directly to the database,
+        // will not work if BucketListDB is enabled so we must use the cfg
+        // override
+        if (enableBucketListDB)
         {
-            REQUIRE(lcm.v() == 1);
-            if (lcm.v1().ledgerHeader.header.ledgerSeq == evictionLedger)
+            cfg.TESTING_SOROBAN_HIGH_LIMIT_OVERRIDE = true;
+        }
+
+        SorobanTest test(cfg);
+        ContractStorageTestClient client(test);
+        auto const& contractKeys = client.getContract().getKeys();
+
+        // Extend Wasm and instance
+        test.invokeExtendOp(contractKeys, 10'000);
+
+        auto invocation = client.getContract().prepareInvocation(
+            "put_temporary", {makeSymbolSCVal("key"), makeU64SCVal(123)},
+            client.writeKeySpec("key", ContractDataDurability::TEMPORARY));
+        closeLedger(
+            test.getApp(),
+            {invocation.withExactNonRefundableResourceFee().createTx()});
+        auto lk = client.getContract().getDataKey(
+            makeSymbolSCVal("key"), ContractDataDurability::TEMPORARY);
+
+        auto expectedLiveUntilLedger =
+            test.getLedgerSeq() +
+            test.getNetworkCfg().stateArchivalSettings().minTemporaryTTL - 1;
+        REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+        auto const evictionLedger = 4097;
+
+        // Close ledgers until temp entry is evicted
+        for (uint32_t i = test.getLedgerSeq(); i < evictionLedger; ++i)
+        {
+            closeLedgerOn(test.getApp(), i, 2, 1, 2016);
+        }
+
+        REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+
+        // When BucketListDB is enabled, invoking any operation closes a ledger,
+        // messing up the eviction boundary we are trying to test. SQL commits
+        // directly to the DB without advancing the LCL, so only test this when
+        // SQL is enabled
+        if (!enableBucketListDB)
+        {
+            // This should be a noop
+            test.invokeExtendOp({lk}, 10'000, 0);
+            REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+
+            // This will fail because the entry is expired
+            REQUIRE(client.extend("key", ContractDataDurability::TEMPORARY,
+                                  10'000,
+                                  10'000) == INVOKE_HOST_FUNCTION_TRAPPED);
+            REQUIRE(test.getTTL(lk) == expectedLiveUntilLedger);
+
+            REQUIRE(!test.isEntryLive(lk, test.getLedgerSeq()));
+        }
+
+        SECTION("eviction")
+        {
+            // close one more ledger to trigger the eviction
+            closeLedgerOn(test.getApp(), evictionLedger, 2, 1, 2016);
+
             {
-                REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.size() == 2);
-                auto sortedKeys = lcm.v1().evictedTemporaryLedgerKeys;
-                std::sort(sortedKeys.begin(), sortedKeys.end());
-                REQUIRE(sortedKeys[0] == lk);
-                REQUIRE(sortedKeys[1] == getTTLKey(lk));
-                evicted = true;
+                LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
+                REQUIRE(!ltx.load(lk));
             }
-            else
+
+            XDRInputFileStream in;
+            in.open(metaPath);
+            LedgerCloseMeta lcm;
+            bool evicted = false;
+            while (in.readOne(lcm))
+            {
+                REQUIRE(lcm.v() == 1);
+                if (lcm.v1().ledgerHeader.header.ledgerSeq == evictionLedger)
+                {
+                    REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.size() == 2);
+                    auto sortedKeys = lcm.v1().evictedTemporaryLedgerKeys;
+                    std::sort(sortedKeys.begin(), sortedKeys.end());
+                    REQUIRE(sortedKeys[0] == lk);
+                    REQUIRE(sortedKeys[1] == getTTLKey(lk));
+                    evicted = true;
+                }
+                else
+                {
+                    REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.empty());
+                }
+            }
+
+            REQUIRE(evicted);
+        }
+
+        SECTION(
+            "Create temp entry with same key as an expired entry on eviction "
+            "ledger")
+        {
+            // When BucketListDB is enabled, client.put() will close the ledger,
+            // so no need to close an additional one here
+            if (!enableBucketListDB)
+            {
+                closeLedger(test.getApp(),
+                            {invocation.withExactNonRefundableResourceFee()
+                                 .createTx()});
+            }
+
+            REQUIRE(client.put("key", ContractDataDurability::TEMPORARY, 234) ==
+                    INVOKE_HOST_FUNCTION_SUCCESS);
+            {
+                LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
+                REQUIRE(ltx.load(lk));
+            }
+
+            // Verify that we're on the ledger where the entry would get evicted
+            // it wasn't recreated.
+            REQUIRE(test.getLedgerSeq() == evictionLedger);
+
+            // Entry is live again
+            REQUIRE(test.isEntryLive(lk, test.getLedgerSeq()));
+
+            // Verify that we didn't emit an eviction
+            XDRInputFileStream in;
+            in.open(metaPath);
+            LedgerCloseMeta lcm;
+            while (in.readOne(lcm))
             {
                 REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.empty());
             }
         }
+    };
 
-        REQUIRE(evicted);
+    SECTION("sql")
+    {
+        test(/*enableBucketListDB=*/false, /*backgroundEviction=*/false);
     }
 
-    SECTION("Create temp entry with same key as an expired entry on eviction "
-            "ledger")
+    SECTION("BucketListDB")
     {
-        closeLedger(
-            test.getApp(),
-            {invocation.withExactNonRefundableResourceFee().createTx()});
-
-        REQUIRE(client.put("key", ContractDataDurability::TEMPORARY, 234) ==
-                INVOKE_HOST_FUNCTION_SUCCESS);
+        SECTION("legacy main thread scan")
         {
-            LedgerTxn ltx(test.getApp().getLedgerTxnRoot());
-            REQUIRE(ltx.load(lk));
+            test(/*enableBucketListDB=*/true, /*backgroundEviction=*/false);
         }
 
-        // Verify that we're on the ledger where the entry would get evicted
-        // it wasn't recreated.
-        REQUIRE(test.getLedgerSeq() == evictionLedger);
-
-        // Entry is live again
-        REQUIRE(test.isEntryLive(lk, test.getLedgerSeq()));
-
-        // Verify that we didn't emit an eviction
-        XDRInputFileStream in;
-        in.open(metaPath);
-        LedgerCloseMeta lcm;
-        while (in.readOne(lcm))
+        SECTION("background scan")
         {
-            REQUIRE(lcm.v1().evictedTemporaryLedgerKeys.empty());
+            test(/*enableBucketListDB=*/true, /*backgroundEviction=*/true);
         }
     }
 }

--- a/src/util/Thread.h
+++ b/src/util/Thread.h
@@ -12,6 +12,7 @@ namespace stellar
 {
 
 void runCurrentThreadWithLowPriority();
+void runCurrentThreadWithMediumPriority();
 
 template <typename T>
 bool

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -1375,7 +1375,7 @@
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo="
 	],
-	"temp entry eviction" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"temp entry eviction|sql" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"transaction validation diagnostics" : [ "bKDF6V5IzTo=" ],
 	"version test" : [ "766L+TYsWqA=" ]
 }

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -1379,7 +1379,7 @@
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo="
 	],
-	"temp entry eviction" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"temp entry eviction|sql" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"transaction validation diagnostics" : [ "bKDF6V5IzTo=" ],
 	"version test" : [ "766L+TYsWqA=" ]
 }


### PR DESCRIPTION
# Description

This PR enables background eviction scans when running BucketListDB. This increases the time we have to scan for expired entries to evict and will improve eviction throughput.

It is currently in draft form, as it is based on #4172. This will also fail CI at the moment since it has not been updated with the new XDR changes.

TODO:
~~Additional test for entries that should be evicted in ledger N but are recreated during N tx application.~~ Done
~~Graceful shutdown for background eviction thread.~~ Not required, background eviction scan is sufficiently short lived.
~~Rebase on updated XDR.~~ Done

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
