### PR TITLE
Restrict "prev" test to just the voting path, to allow catchup.

### DIFF
--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -561,15 +561,6 @@ Upgrades::isValidForApply(UpgradeType const& opaqueUpgrade,
         res = res && (newVersion <= app.getConfig().LEDGER_PROTOCOL_VERSION);
         // and enforce versions to be strictly monotonic
         res = res && (newVersion > header.ledgerVersion);
-
-        // and enforce that any soroban-era protocol upgrade has two copies of
-        // soroban compiled-in to this binary -- both `prev` and `curr` -- so
-        // the upgrade can do a prev-to-curr transition
-        if (protocolVersionStartsFrom(header.ledgerVersion,
-                                      SOROBAN_PROTOCOL_VERSION))
-        {
-            res = res && rust_bridge::compiled_with_soroban_prev();
-        }
     }
     break;
     case LEDGER_UPGRADE_BASE_FEE:
@@ -683,6 +674,39 @@ Upgrades::isValid(UpgradeType const& upgrade, LedgerUpgradeType& upgradeType,
     if (nomination)
     {
         res = res && isValidForNomination(lupgrade, ltx, header);
+    }
+
+    if (res && lupgrade.type() != LEDGER_UPGRADE_VERSION)
+    {
+        // We enforce here that _voting_ for any soroban-era protocol upgrade
+        // only happens from nodes that have two copies of soroban compiled-in
+        // to this binary -- both `prev` and `curr` -- so the upgrade can do a
+        // synchronized implementation transition between prev and curr.
+        //
+        // Suppose some node X that does not have both copies compiled-in, and
+        // so chooses not to vote for the upgrade here. X may be a minority, and
+        // may get pulled along for the vote by nodes that vote in favor. There
+        // are two cases to consider:
+        //
+        //   - If X supports the _new protocol at all_ X is implicitly running
+        //     that new-protocol-supporting soroban as `curr`, and most likely
+        //     has the exact same (or an only unobservably-newer) `curr` as the
+        //     majority who had both a `prev` and a `curr`. So X _shouldn't_
+        //     face any higher risk of divergence. X was at risk of divergence
+        //     _before_ the upgrade -- X deployed too-new a build for some
+        //     reason -- but not after the upgrade when the dual-build versions
+        //     of the majority have caught up with X's `curr`.
+        //
+        //   - If X doesn't support the new protocol at all, X is going to
+        //     diverge _anyway_ by rejecting the upgrade on the basis of the
+        //     protocol number, and the fact X doesn't have both copies of
+        //     soroban compiled-in doesn't make X's situation any worse.
+
+        if (protocolVersionStartsFrom(header.ledgerVersion,
+                                      SOROBAN_PROTOCOL_VERSION))
+        {
+            res = res && rust_bridge::compiled_with_soroban_prev();
+        }
     }
 
     if (res)

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -676,7 +676,7 @@ Upgrades::isValid(UpgradeType const& upgrade, LedgerUpgradeType& upgradeType,
         res = res && isValidForNomination(lupgrade, ltx, header);
     }
 
-    if (res && lupgrade.type() != LEDGER_UPGRADE_VERSION)
+    if (res && lupgrade.type() == LEDGER_UPGRADE_VERSION)
     {
         // We enforce here that _voting_ for any soroban-era protocol upgrade
         // only happens from nodes that have two copies of soroban compiled-in


### PR DESCRIPTION
This slightly weakens the conditions on which we judge a soroban-era upgrade invalid. It is motivated by bug #4193 in which a ledger that was voted-on in the past as a valid protocol-upgrade ledger, by a node with soroban `prev` compiled-in, becomes no longer replayable during catchup by a node without soroban `prev` compiled-in.

This only applies to soroban-era stuff, so without loss of generality we can talk about his only applying to the v20->v21 upgrade (it also applies to v21->v22 and so forth but that's even less relevant currently).

  - Before this change, a node lacking a `prev` build will judge a v20->v21 upgrade invalid for voting _or applying during catchup_.

  - With this change, a node lacking a `prev` build will judge a v20->v21 upgrade invalid for voting-on only.

This is accomplished by moving a conditional from `Upgrades::isValidForApply` (which is called by both `Upgrades::isValid` as well as `LedgerManagerImpl::closeLedger`) to its voting-phase caller `Upgrades::isValid`.  

While this does technically "change the protocol" in terms of the semantics of a given ledger -- some previously-invalid ledgers are now valid -- it does so in a very limited way that I believe does not pose any risk in the real world. Specifically: no builds currently in the field claim to support v21 yet at all, so all currently-deployed core builds will already judge all such upgrades invalid on the basis of their protocol number, regardless of `prev`-presence. So long as this change is made before we release anything claiming to speak v21, there should be no observable change to behaviour.

(I also added a bit more commentary to the code exploring what will happen to nodes that fail to satisfy the conditional, but get forced to accept the upgrade by a majority, which I think are actually not in a particularly bad position.)

I'd appreciate folks who know about this subsystem and set of conditions reasoning through the logic I'm presenting here for themselves and confirming that it makes sense!

Resolves #4193 