### PR TITLE
Set key size to initial value

### DIFF
--- a/soroban-settings/pubnet_phase1.json
+++ b/soroban-settings/pubnet_phase1.json
@@ -287,7 +287,7 @@
       ]
     },
     {
-      "contract_data_key_size_bytes": 300
+      "contract_data_key_size_bytes": 200
     },
     {
       "contract_data_entry_size_bytes": 65536

--- a/soroban-settings/testnet_settings.json
+++ b/soroban-settings/testnet_settings.json
@@ -287,7 +287,7 @@
       ]
     },
     {
-      "contract_data_key_size_bytes": 300
+      "contract_data_key_size_bytes": 200
     },
     {
       "contract_data_entry_size_bytes": 65536


### PR DESCRIPTION
# Description

200 (the default) is high enough for now.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
