### PR TITLE
Update `max_entries_to_archive` to be 1000.

### DIFF
--- a/soroban-settings/pubnet_phase1.json
+++ b/soroban-settings/pubnet_phase1.json
@@ -299,7 +299,7 @@
           "min_persistent_ttl": 2073600,
           "persistent_rent_rate_denominator": 1402,
           "temp_rent_rate_denominator": 2804,
-          "max_entries_to_archive": 100,
+          "max_entries_to_archive": 1000,
           "bucket_list_size_window_sample_size": 30,
           "bucket_list_window_sample_period": 64,
           "eviction_scan_size": 100000,

--- a/soroban-settings/testnet_settings.json
+++ b/soroban-settings/testnet_settings.json
@@ -299,7 +299,7 @@
           "min_persistent_ttl": 2073600,
           "persistent_rent_rate_denominator": 1402,
           "temp_rent_rate_denominator": 2804,
-          "max_entries_to_archive": 100,
+          "max_entries_to_archive": 1000,
           "bucket_list_size_window_sample_size": 30,
           "bucket_list_window_sample_period": 64,
           "eviction_scan_size": 100000,

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -1355,7 +1355,9 @@ TEST_CASE_VERSIONS("bucket persistence over app restart",
         cfg1.ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = true;
 
         auto batch_entries =
-            LedgerTestUtils::generateValidUniqueLedgerEntries(110);
+            LedgerTestUtils::generateValidUniqueLedgerEntries(111);
+        auto alice = batch_entries.back();
+        batch_entries.pop_back();
         std::vector<std::vector<LedgerEntry>> batches;
         for (auto const& batch_entry : batch_entries)
         {
@@ -1367,7 +1369,6 @@ TEST_CASE_VERSIONS("bucket persistence over app restart",
         // pause-merge (#64, where we stop and serialize) sensitive to
         // shadowing, and requires shadows be reconstituted when the merge
         // is restarted.
-        auto alice = LedgerTestUtils::generateValidLedgerEntry(1);
         uint32_t pause = 65;
         batches[2].push_back(alice);
         batches[pause - 2].push_back(alice);


### PR DESCRIPTION
# Description

Update `max_entries_to_archive` to be 1000.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
