### PR TITLE
Make sorobaninfo basic more consistent with underlying network settings

### DIFF
--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -752,124 +752,39 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
             return;
         }
 
+        std::set<uint32_t> excluded;
         auto format =
             parseOptionalParamOrDefault<std::string>(retMap, "format", "basic");
         if (format == "basic")
         {
-            Json::Value res;
-            auto const& conf = lm.getSorobanNetworkConfig();
-
-            // Contract size
-            res["max_contract_size"] = conf.maxContractSizeBytes();
-
-            // Contract data
-            res["max_contract_data_key_size"] =
-                conf.maxContractDataKeySizeBytes();
-            res["max_contract_data_entry_size"] =
-                conf.maxContractDataEntrySizeBytes();
-
-            // Compute settings
-            res["tx"]["max_instructions"] =
-                static_cast<Json::Int64>(conf.txMaxInstructions());
-            res["ledger"]["max_instructions"] =
-                static_cast<Json::Int64>(conf.ledgerMaxInstructions());
-            res["fee_rate_per_instructions_increment"] =
-                static_cast<Json::Int64>(
-                    conf.feeRatePerInstructionsIncrement());
-            res["tx"]["memory_limit"] = conf.txMemoryLimit();
-
-            // Ledger access settings
-            res["ledger"]["max_read_ledger_entries"] =
-                conf.ledgerMaxReadLedgerEntries();
-            res["ledger"]["max_read_bytes"] = conf.ledgerMaxReadBytes();
-            res["ledger"]["max_write_ledger_entries"] =
-                conf.ledgerMaxWriteLedgerEntries();
-            res["ledger"]["max_write_bytes"] = conf.ledgerMaxWriteBytes();
-            res["tx"]["max_read_ledger_entries"] =
-                conf.txMaxReadLedgerEntries();
-            res["tx"]["max_read_bytes"] = conf.txMaxReadBytes();
-            res["tx"]["max_write_ledger_entries"] =
-                conf.txMaxWriteLedgerEntries();
-            res["tx"]["max_write_bytes"] = conf.txMaxWriteBytes();
-
-            // Fees
-            res["fee_read_ledger_entry"] =
-                static_cast<Json::Int64>(conf.feeReadLedgerEntry());
-            res["fee_write_ledger_entry"] =
-                static_cast<Json::Int64>(conf.feeWriteLedgerEntry());
-            res["fee_read_1kb"] = static_cast<Json::Int64>(conf.feeRead1KB());
-            res["fee_write_1kb"] = static_cast<Json::Int64>(conf.feeWrite1KB());
-            res["fee_historical_1kb"] =
-                static_cast<Json::Int64>(conf.feeHistorical1KB());
-
-            // Contract events settings
-            res["tx"]["max_contract_events_size_bytes"] =
-                conf.txMaxContractEventsSizeBytes();
-            res["fee_contract_events_size_1kb"] =
-                static_cast<Json::Int64>(conf.feeContractEventsSize1KB());
-
-            // Bandwidth related data settings
-            res["ledger"]["max_tx_size_bytes"] =
-                conf.ledgerMaxTransactionSizesBytes();
-            res["tx"]["max_size_bytes"] = conf.txMaxSizeBytes();
-            res["fee_transaction_size_1kb"] =
-                static_cast<Json::Int64>(conf.feeTransactionSize1KB());
-
-            // General execution ledger settings
-            res["ledger"]["max_tx_count"] = conf.ledgerMaxTxCount();
-
-            // State archival settings
-            auto& archivalInfo = res["state_archival"];
-            auto const& stateArchivalSettings = conf.stateArchivalSettings();
-            archivalInfo["max_entry_ttl"] = stateArchivalSettings.maxEntryTTL;
-            archivalInfo["min_temporary_ttl"] =
-                stateArchivalSettings.minTemporaryTTL;
-            archivalInfo["min_persistent_ttl"] =
-                stateArchivalSettings.minPersistentTTL;
-
-            archivalInfo["persistent_rent_rate_denominator"] =
-                static_cast<Json::Int64>(
-                    stateArchivalSettings.persistentRentRateDenominator);
-            archivalInfo["temp_rent_rate_denominator"] =
-                static_cast<Json::Int64>(
-                    stateArchivalSettings.tempRentRateDenominator);
-
-            archivalInfo["max_entries_to_archive"] =
-                stateArchivalSettings.maxEntriesToArchive;
-            archivalInfo["bucketlist_size_window_sample_size"] =
-                stateArchivalSettings.bucketListSizeWindowSampleSize;
-
-            archivalInfo["eviction_scan_size"] = static_cast<Json::UInt64>(
-                stateArchivalSettings.evictionScanSize);
-            archivalInfo["starting_eviction_scan_level"] =
-                stateArchivalSettings.startingEvictionScanLevel;
-            archivalInfo["bucket_list_size_snapshot_period"] =
-                stateArchivalSettings.bucketListSizeWindowSampleSize;
-
-            // non-configurable settings
-            archivalInfo["average_bucket_list_size"] =
-                static_cast<Json::UInt64>(conf.getAverageBucketListSize());
-            retStr = res.toStyledString();
+            excluded.insert(
+                {CONFIG_SETTING_CONTRACT_COST_PARAMS_CPU_INSTRUCTIONS,
+                 CONFIG_SETTING_CONTRACT_COST_PARAMS_MEMORY_BYTES,
+                 CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW,
+                 CONFIG_SETTING_EVICTION_ITERATOR});
         }
         else if (format == "detailed")
         {
-            LedgerTxn ltx(mApp.getLedgerTxnRoot(),
-                          /* shouldUpdateLastModified */ false,
-                          TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
-            xdr::xvector<ConfigSettingEntry> entries;
-            for (auto c : xdr::xdr_traits<ConfigSettingID>::enum_values())
+        }
+        else
+        {
+            retStr = "Invalid format option";
+            return;
+        }
+        LedgerTxn ltx(mApp.getLedgerTxnRoot(),
+                      /* shouldUpdateLastModified */ false,
+                      TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
+        xdr::xvector<ConfigSettingEntry> entries;
+        for (auto c : xdr::xdr_traits<ConfigSettingID>::enum_values())
+        {
+            if (excluded.find(c) == excluded.end())
             {
                 auto entry =
                     ltx.load(configSettingKey(static_cast<ConfigSettingID>(c)));
                 entries.emplace_back(entry.current().data.configSetting());
             }
-
-            retStr = xdr_to_string(entries, "ConfigSettingsEntries");
         }
-        else
-        {
-            retStr = "Invalid format option";
-        }
+        retStr = xdr_to_string(entries, "ConfigSettingsEntries");
     }
     else
     {

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1409,7 +1409,7 @@ runCheckQuorumIntersection(CommandLineArgs const& args)
                     return 1;
                 }
             }
-            catch (KeyUtils::InvalidStrKey const& e)
+            catch (KeyUtils::InvalidStrKey const&)
             {
                 CLOG_FATAL(
                     SCP,


### PR DESCRIPTION
The default output of `sorobaninfo` (aka "basic") uses custom names that don't correspond to what is xdr (making it hard to know which setting is what, and also creates a maintenance burden) and is also missing information on ledger fee related settings.

This PR aims to simplify code and address both issues.

Old output:
```json
{
   "fee_contract_events_size_1kb" : 10000,
   "fee_historical_1kb" : 16235,
   "fee_rate_per_instructions_increment" : 25,
   "fee_read_1kb" : 1786,
   "fee_read_ledger_entry" : 6250,
   "fee_transaction_size_1kb" : 1624,
   "fee_write_1kb" : 1000,
   "fee_write_ledger_entry" : 10000,
   "ledger" : {
      "max_instructions" : 100000000,
      "max_read_bytes" : 133120,
      "max_read_ledger_entries" : 40,
      "max_tx_count" : 100,
      "max_tx_size_bytes" : 71680,
      "max_write_bytes" : 66560,
      "max_write_ledger_entries" : 25
   },
   "max_contract_data_entry_size" : 65536,
   "max_contract_data_key_size" : 200,
   "max_contract_size" : 65536,
   "state_archival" : {
      "average_bucket_list_size" : 10285954422,
      "bucket_list_size_snapshot_period" : 30,
      "bucketlist_size_window_sample_size" : 30,
      "eviction_scan_size" : 100000,
      "max_entries_to_archive" : 1000,
      "max_entry_ttl" : 3110400,
      "min_persistent_ttl" : 2073600,
      "min_temporary_ttl" : 17280,
      "persistent_rent_rate_denominator" : 1402,
      "starting_eviction_scan_level" : 7,
      "temp_rent_rate_denominator" : 2804
   },
   "tx" : {
      "max_contract_events_size_bytes" : 8198,
      "max_instructions" : 100000000,
      "max_read_bytes" : 133120,
      "max_read_ledger_entries" : 40,
      "max_size_bytes" : 71680,
      "max_write_bytes" : 66560,
      "max_write_ledger_entries" : 25,
      "memory_limit" : 41943040
   }
}
```

New:
```json
{
    "ConfigSettingsEntries": [
        {
            "configSettingID": 0,
            "contractMaxSizeBytes": 65536
        },
        {
            "configSettingID": 1,
            "contractCompute": {
                "ledgerMaxInstructions": 100000000,
                "txMaxInstructions": 100000000,
                "feeRatePerInstructionsIncrement": 25,
                "txMemoryLimit": 41943040
            }
        },
        {
            "configSettingID": 2,
            "contractLedgerCost": {
                "ledgerMaxReadLedgerEntries": 40,
                "ledgerMaxReadBytes": 133120,
                "ledgerMaxWriteLedgerEntries": 25,
                "ledgerMaxWriteBytes": 66560,
                "txMaxReadLedgerEntries": 40,
                "txMaxReadBytes": 133120,
                "txMaxWriteLedgerEntries": 25,
                "txMaxWriteBytes": 66560,
                "feeReadLedgerEntry": 6250,
                "feeWriteLedgerEntry": 10000,
                "feeRead1KB": 1786,
                "bucketListTargetSizeBytes": 13000000000,
                "writeFee1KBBucketListLow": -1234673,
                "writeFee1KBBucketListHigh": 115390,
                "bucketListWriteFeeGrowthFactor": 1000
            }
        },
        {
            "configSettingID": 3,
            "contractHistoricalData": {
                "feeHistorical1KB": 16235
            }
        },
        {
            "configSettingID": 4,
            "contractEvents": {
                "txMaxContractEventsSizeBytes": 8198,
                "feeContractEvents1KB": 10000
            }
        },
        {
            "configSettingID": 5,
            "contractBandwidth": {
                "ledgerMaxTxsSizeBytes": 71680,
                "txMaxSizeBytes": 71680,
                "feeTxSize1KB": 1624
            }
        },
        {
            "configSettingID": 8,
            "contractDataKeySizeBytes": 200
        },
        {
            "configSettingID": 9,
            "contractDataEntrySizeBytes": 65536
        },
        {
            "configSettingID": 10,
            "stateArchivalSettings": {
                "maxEntryTTL": 3110400,
                "minTemporaryTTL": 17280,
                "minPersistentTTL": 2073600,
                "persistentRentRateDenominator": 1402,
                "tempRentRateDenominator": 2804,
                "maxEntriesToArchive": 1000,
                "bucketListSizeWindowSampleSize": 30,
                "bucketListWindowSamplePeriod": 64,
                "evictionScanSize": 100000,
                "startingEvictionScanLevel": 7
            }
        },
        {
            "configSettingID": 11,
            "contractExecutionLanes": {
                "ledgerMaxTxCount": 100
            }
        }
    ]
}
```

It's a bit annoying that our default json marshaller does not use strings for enum values (unlike when using `xdrpp/printer.h` but that one is not json compliant), but as fields are already unique it does not seem to be much of a problem.

I think supercluster needs to be updated if we decide to merge this.
