### PR TITLE
Adds poolshare index for BucketsDB

### DIFF
--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -117,16 +117,9 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     void loadKeys(std::set<LedgerKey, LedgerEntryIdCmp>& keys,
                   std::vector<LedgerEntry>& result);
 
-    // Loads all poolshare trustlines for the given account. Trustlines are
-    // stored with their corresponding liquidity pool key in
-    // liquidityPoolKeyToTrustline. All liquidity pool keys corresponding to
-    // loaded trustlines are also reduntantly stored in liquidityPoolKeys.
-    // If a trustline key is in seenTrustlines, it is not loaded. Whenever a
-    // dead trustline is found, its key is added to seenTrustlines.
-    void loadPoolShareTrustLinessByAccount(
-        AccountID const& accountID, UnorderedSet<LedgerKey>& seenTrustlines,
-        UnorderedMap<LedgerKey, LedgerEntry>& liquidityPoolKeyToTrustline,
-        LedgerKeySet& liquidityPoolKeys);
+    // Return all PoolIDs that contain the given asset on either side of the
+    // pool
+    std::vector<PoolID> const& getPoolIDsByAsset(Asset const& asset) const;
 
     // At version 11, we added support for INITENTRY and METAENTRY. Before this
     // we were only supporting LIVEENTRY and DEADENTRY.

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -74,7 +74,7 @@ class BucketIndex : public NonMovableOrCopyable
                                   IndividualIndex::const_iterator>;
 
     inline static const std::string DB_BACKEND_STATE = "bl";
-    inline static const uint32_t BUCKET_INDEX_VERSION = 1;
+    inline static const uint32_t BUCKET_INDEX_VERSION = 2;
 
     // Returns true if LedgerEntryType not supported by BucketListDB
     static bool typeNotSupported(LedgerEntryType t);
@@ -112,6 +112,11 @@ class BucketIndex : public NonMovableOrCopyable
     // returns nullopt
     virtual std::optional<std::pair<std::streamoff, std::streamoff>>
     getPoolshareTrustlineRange(AccountID const& accountID) const = 0;
+
+    // Return all PoolIDs that contain the given asset on either side of the
+    // pool
+    virtual std::vector<PoolID> const&
+    getPoolIDsByAsset(Asset const& asset) const = 0;
 
     // Returns page size for index. InidividualIndex returns 0 for page size
     virtual std::streamoff getPageSize() const = 0;

--- a/src/catchup/IndexBucketsWork.cpp
+++ b/src/catchup/IndexBucketsWork.cpp
@@ -63,11 +63,12 @@ IndexBucketsWork::IndexWork::postWork()
                                                  self->mBucket->getSize());
 
                 // If we could not load the index from the file, file is out of
-                // date and will be overwritten when we create a new index
+                // date. Delete and create a new index.
                 if (!self->mIndex)
                 {
                     CLOG_WARNING(Bucket, "Outdated index file: {}",
                                  indexFilename);
+                    std::remove(indexFilename.c_str());
                 }
                 else
                 {


### PR DESCRIPTION
# Description

Resolves #4223

This extends `BucketIndex` to include a map of `Asset -> poolID` in order to optimize `loadPoolShareTrustLinesByAccountAndAsset`. This change improves query performance by around ~2500x and minimally impacts memory overhead. I suspect the memory increase is approximately 1.5 MB, but this is so small that I was not able to measure a change during testing. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
