### PR TITLE
Drop TxMeta column from TxHistory table

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -250,8 +250,51 @@ Database::upgradeToCurrentSchema()
         applySchemaUpgrade(vers);
         putSchemaVersion(vers);
     }
+
+    // While not really a schema upgrade, we need to upgrade the DB when
+    // BucketListDB is enabled.
+    if (mApp.getConfig().isUsingBucketListDB())
+    {
+        // Tx meta column no longer supported in BucketListDB
+        dropTxMetaIfExists();
+    }
+
     CLOG_INFO(Database, "DB schema is in current version");
     releaseAssert(vers == SCHEMA_VERSION);
+}
+
+void
+Database::dropTxMetaIfExists()
+{
+    int txMetaExists{};
+    std::string selectStr;
+    if (isSqlite())
+    {
+        selectStr = "SELECT EXISTS ("
+                    "SELECT 1 "
+                    "FROM pragma_table_info('txhistory') "
+                    "WHERE name = 'txmeta');";
+    }
+    else
+    {
+        selectStr = "SELECT EXISTS ("
+                    "SELECT 1 "
+                    "FROM information_schema.columns "
+                    "WHERE "
+                    "table_name = 'txhistory' AND "
+                    "column_name = 'txmeta');";
+    }
+
+    auto& st = getPreparedStatement(selectStr).statement();
+    st.exchange(soci::into(txMetaExists));
+    st.define_and_bind();
+    st.execute(true);
+
+    if (txMetaExists)
+    {
+        CLOG_INFO(Database, "Dropping txmeta column from txhistory table");
+        getSession() << "ALTER TABLE txhistory DROP COLUMN txmeta;";
+    }
 }
 
 void
@@ -431,7 +474,7 @@ Database::initialize()
     PersistentState::dropAll(*this);
     ExternalQueue::dropAll(*this);
     LedgerHeaderUtils::dropAll(*this);
-    dropTransactionHistory(*this);
+    dropTransactionHistory(*this, mApp.getConfig());
     HistoryManager::dropAll(*this);
     HerderPersistence::dropAll(*this);
     BanManager::dropAll(*this);

--- a/src/database/Database.h
+++ b/src/database/Database.h
@@ -173,6 +173,8 @@ class Database : NonMovableOrCopyable
     // Check schema version and apply any upgrades if necessary.
     void upgradeToCurrentSchema();
 
+    void dropTxMetaIfExists();
+
     // Access the underlying SOCI session object
     soci::session& getSession();
 

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1548,7 +1548,7 @@ LedgerManagerImpl::applyTransactions(
         {
             auto ledgerSeq = ltx.loadHeader().current().ledgerSeq;
             storeTransaction(mApp.getDatabase(), ledgerSeq, tx, tm.getXDR(),
-                             txResultSet);
+                             txResultSet, mApp.getConfig());
         }
     }
 

--- a/src/transactions/TransactionSQL.cpp
+++ b/src/transactions/TransactionSQL.cpp
@@ -350,7 +350,7 @@ writeTxSetToStream(
 void
 storeTransaction(Database& db, uint32_t ledgerSeq,
                  TransactionFrameBasePtr const& tx, TransactionMeta const& tm,
-                 TransactionResultSet const& resultSet)
+                 TransactionResultSet const& resultSet, Config const& cfg)
 {
     ZoneScoped;
     std::string txBody =
@@ -362,18 +362,34 @@ storeTransaction(Database& db, uint32_t ledgerSeq,
     std::string txIDString = binToHex(tx->getContentsHash());
     uint32_t txIndex = static_cast<uint32_t>(resultSet.results.size());
 
-    auto prep = db.getPreparedStatement(
-        "INSERT INTO txhistory "
-        "( txid, ledgerseq, txindex,  txbody, txresult, txmeta) VALUES "
-        "(:id,  :seq,      :txindex, :txb,   :txres,   :meta)");
+    std::string sqlStr;
+    if (cfg.isUsingBucketListDB())
+    {
+        sqlStr = "INSERT INTO txhistory "
+                 "( txid, ledgerseq, txindex,  txbody, txresult) VALUES "
+                 "(:id,  :seq,      :txindex, :txb,   :txres)";
+    }
+    else
+    {
+        sqlStr =
+            "INSERT INTO txhistory "
+            "( txid, ledgerseq, txindex,  txbody, txresult, txmeta) VALUES "
+            "(:id,  :seq,      :txindex, :txb,   :txres,   :meta)";
+    }
 
+    auto prep = db.getPreparedStatement(sqlStr);
     auto& st = prep.statement();
     st.exchange(soci::use(txIDString));
     st.exchange(soci::use(ledgerSeq));
     st.exchange(soci::use(txIndex));
     st.exchange(soci::use(txBody));
     st.exchange(soci::use(txResult));
-    st.exchange(soci::use(meta));
+
+    if (!cfg.isUsingBucketListDB())
+    {
+        st.exchange(soci::use(meta));
+    }
+
     st.define_and_bind();
     {
         auto timer = db.getInsertTimer("txhistory");
@@ -615,22 +631,26 @@ createTxSetHistoryTable(Database& db)
 }
 
 void
-dropTransactionHistory(Database& db)
+dropTransactionHistory(Database& db, Config const& cfg)
 {
     ZoneScoped;
     db.getSession() << "DROP TABLE IF EXISTS txhistory";
 
     db.getSession() << "DROP TABLE IF EXISTS txfeehistory";
 
+    // txmeta only supported when BucketListDB is not enabled
+    std::string txMetaColumn =
+        cfg.isUsingBucketListDB() ? "" : "txmeta      TEXT NOT NULL,";
+
     db.getSession() << "CREATE TABLE txhistory ("
                        "txid        CHARACTER(64) NOT NULL,"
                        "ledgerseq   INT NOT NULL CHECK (ledgerseq >= 0),"
                        "txindex     INT NOT NULL,"
                        "txbody      TEXT NOT NULL,"
-                       "txresult    TEXT NOT NULL,"
-                       "txmeta      TEXT NOT NULL,"
-                       "PRIMARY KEY (ledgerseq, txindex)"
-                       ")";
+                       "txresult    TEXT NOT NULL," +
+                           txMetaColumn +
+                           "PRIMARY KEY (ledgerseq, txindex)"
+                           ")";
 
     db.getSession() << "CREATE INDEX histbyseq ON txhistory (ledgerseq);";
 

--- a/src/transactions/TransactionSQL.h
+++ b/src/transactions/TransactionSQL.h
@@ -17,7 +17,7 @@ class XDROutputFileStream;
 void storeTransaction(Database& db, uint32_t ledgerSeq,
                       TransactionFrameBasePtr const& tx,
                       TransactionMeta const& tm,
-                      TransactionResultSet const& resultSet);
+                      TransactionResultSet const& resultSet, Config const& cfg);
 
 void storeTxSet(Database& db, uint32_t ledgerSeq, TxSetXDRFrame const& txSet);
 
@@ -38,7 +38,7 @@ size_t copyTransactionsToStream(Application& app, soci::session& sess,
 
 void createTxSetHistoryTable(Database& db);
 
-void dropTransactionHistory(Database& db);
+void dropTransactionHistory(Database& db, Config const& cfg);
 
 void deleteOldTransactionHistoryEntries(Database& db, uint32_t ledgerSeq,
                                         uint32_t count);


### PR DESCRIPTION
# Description

Rebased on #4226.

This change drops `txmeta` from the `txhistory` SQL table when BucketListDB is enabled.

Unfortunately, SQLite does not support conditional column deletion, so I've added a new persistent state field indicating whether or not `txmeta` is supported. This allows us to check if the `txmeta` column exists before executing the drop SQL transaction. 

Addresses #4211.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
