### PR TITLE
Workaround entropy bug GitHub

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -80,6 +80,11 @@ RUN apt-get -y install postgresql
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && locale-gen
 
+# Asan in llvm provided in ubuntu 22.04 is incompatible with
+# high-entropy ASLR in much newer kernels that GitHub runners are
+# using leading to random crashes: https://reviews.llvm.org/D148280
+RUN sysctl vm.mmap_rnd_bits=28
+
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,11 @@ jobs:
         protocol: ["current", "next"]
         scenario: ["", "--check-test-tx-meta"]
     steps:
+      - name: Fix kernel mmap rnd bits
+        # Asan in llvm provided in ubuntu 22.04 is incompatible with
+        # high-entropy ASLR in much newer kernels that GitHub runners are
+        # using leading to random crashes: https://reviews.llvm.org/D148280
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - name: Compute cache key
         # this step works around a limitation in actions/cache
         # that does not allow updating a cache

--- a/docker/Dockerfile.testing
+++ b/docker/Dockerfile.testing
@@ -19,6 +19,11 @@ ARG CFLAGS='-O3 -g1 -fno-omit-frame-pointer'
 ARG CXXFLAGS='-O3 -g1 -fno-omit-frame-pointer -stdlib=libc++'
 ARG CONFIGURE_FLAGS='--enable-tracy --enable-sdfprefs --enable-next-protocol-version-unsafe-for-production'
 
+# Asan in llvm provided in ubuntu 22.04 is incompatible with
+# high-entropy ASLR in much newer kernels that GitHub runners are
+# using leading to random crashes: https://reviews.llvm.org/D148280
+RUN sysctl vm.mmap_rnd_bits=28
+
 RUN ./autogen.sh
 RUN ./install-rust.sh
 ENV PATH "/root/.cargo/bin:$PATH"


### PR DESCRIPTION
# Description

recent kernels seem to break llvm asan.

The fix seems to only be available in latest llvm https://reviews.llvm.org/D148280 which we cannot use yet.

As a workaround, we just run `sudo sysctl vm.mmap_rnd_bits=28`