### PR TITLE
Define custom cereal override for ConfigUpgradeSetKey and use it

### DIFF
--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -24,6 +24,7 @@
 #include "util/Logging.h"
 #include "util/ProtocolVersion.h"
 #include "util/Timer.h"
+#include "util/XDRCereal.h"
 #include "util/types.h"
 #include "xdrpp/printer.h"
 #include <Tracy.hpp>
@@ -33,7 +34,6 @@
 #include <fmt/format.h>
 #include <optional>
 #include <regex>
-#include <xdrpp/cereal.h>
 #include <xdrpp/marshal.h>
 
 namespace cereal
@@ -393,7 +393,7 @@ Upgrades::toString(LedgerUpgrade const& upgrade)
     case LEDGER_UPGRADE_CONFIG:
         return fmt::format(
             FMT_STRING("{}"),
-            xdr::xdr_to_string(upgrade.newConfig(), "configupgradesetkey"));
+            xdr_to_string(upgrade.newConfig(), "configupgradesetkey"));
     case LEDGER_UPGRADE_MAX_SOROBAN_TX_SET_SIZE:
         return fmt::format(FMT_STRING("maxsorobantxsetsize={:d}"),
                            upgrade.newMaxSorobanTxSetSize());
@@ -436,8 +436,8 @@ Upgrades::toString() const
     {
         maybePrintUpgradeTime();
         r << fmt::format(FMT_STRING(", {}"),
-                         xdr::xdr_to_string(*mParams.mConfigUpgradeSetKey,
-                                            "configupgradesetkey"));
+                         xdr_to_string(*mParams.mConfigUpgradeSetKey,
+                                       "configupgradesetkey"));
     }
     return r.str();
 }

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -3058,7 +3058,7 @@ TEST_CASE("upgrades serialization roundtrip", "[upgrades]")
       "configupgradeset" : {
          "updatedEntry" : [
             {
-               "configSettingID" : 0,
+               "configSettingID" : "CONFIG_SETTING_CONTRACT_MAX_SIZE_BYTES",
                "contractMaxSizeBytes" : 32768
             }
          ]

--- a/src/util/XDRCereal.cpp
+++ b/src/util/XDRCereal.cpp
@@ -37,6 +37,23 @@ cereal_override(cereal::JSONOutputArchive& ar, const stellar::SCAddress& addr,
 
 void
 cereal_override(cereal::JSONOutputArchive& ar,
+                const stellar::ConfigUpgradeSetKey& key, const char* field)
+{
+    ar.setNextName(field);
+    ar.startNode();
+
+    xdr::archive(ar,
+                 stellar::strKey::toStrKey(stellar::strKey::STRKEY_CONTRACT,
+                                           key.contractID)
+                     .value,
+                 "contractID");
+    xdr::archive(ar, key.contentHash, "contentHash");
+
+    ar.finishNode();
+}
+
+void
+cereal_override(cereal::JSONOutputArchive& ar,
                 const stellar::MuxedAccount& muxedAccount, const char* field)
 {
     switch (muxedAccount.type())

--- a/src/util/XDRCereal.h
+++ b/src/util/XDRCereal.h
@@ -82,6 +82,10 @@ void cereal_override(cereal::JSONOutputArchive& ar,
                      const stellar::SCAddress& addr, const char* field);
 
 void cereal_override(cereal::JSONOutputArchive& ar,
+                     const stellar::ConfigUpgradeSetKey& key,
+                     const char* field);
+
+void cereal_override(cereal::JSONOutputArchive& ar,
                      const stellar::MuxedAccount& muxedAccount,
                      const char* field);
 


### PR DESCRIPTION
# Description

Resolves #4246 

The new output now looks like - 
```
[Herder INFO] Armed with network upgrades: upgradetime=2000-07-21T22:04:00Z, {
    "configupgradesetkey": {
        "contractID": "CDEWOG5BY6RL6HPKAO5GUPMZDEW2Y22V3J7PHI3WZN7HASTWGTMI6ITO",
        "contentHash": "7fa751106b2a7988dea3af733ca86484f1581f97c2ec9553bb36d402c612847d"
    }
}
```
<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
