### PR TITLE
Add blended classic+soroban mode to loadgen

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -57,6 +57,8 @@ ledger.age.closed                         | bucket    | time between ledgers
 ledger.age.current-seconds                | counter   | gap between last close ledger time and current time
 ledger.apply.success                      | counter   | count of successfully applied transactions
 ledger.apply.failure                      | counter   | count of failed applied transactions
+ledger.apply-soroban.success              | counter   | count of successfully applied soroban transactions
+ledger.apply-soroban.failure              | counter   | count of failed applied soroban transactions
 ledger.catchup.duration                   | timer     | time between entering LM_CATCHING_UP_STATE and entering LM_SYNCED_STATE
 ledger.invariant.failure                  | counter   | number of times invariants failed
 ledger.ledger.close                       | timer     | time to close a ledger (excluding consensus)

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -626,6 +626,39 @@ OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING=[]
 LOADGEN_OP_COUNT_FOR_TESTING=[]
 LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING=[]
 
+# Size of wasm blobs for SOROBAN_UPLOAD and MIX_CLASSIC_SOROBAN loadgen modes
+# The probability that wasm blobs will contain WASM_BYTES[i] bytes is
+# DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...) for each i.
+LOADGEN_WASM_BYTES_FOR_TESTING=[]
+LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING=[]
+
+# Number of data entries for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen
+# modes.  The probability that invocations will read/write NUM_DATA_ENTRIES[i]
+# data entries is DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...)
+# for each i.
+LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING=[]
+LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING=[]
+
+# Total kilobytes of reads and writes per transaction for SOROBAN_INVOKE and
+# MIX_CLASSIC_SOROBAN loadgen modes.  The probability that transactions will
+# perform IO_KILOBYTES[i] of IO is DISTRIBUTION[i] / (DISTRIBUTION[0] +
+# DISTRIBUTION[1] + ...) for each i.
+LOADGEN_IO_KILOBYTES_FOR_TESTING=[]
+LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING=[]
+
+# Transaction size in bytes for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN loadgen
+# modes.  The probability that transactions will contain TX_SIZE_BYTES[i] bytes
+# is DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...) for each i.
+LOADGEN_TX_SIZE_BYTES_FOR_TESTING=[]
+LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING=[]
+
+# Instructions per transaction for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN
+# loadgen modes.  The probability that invocations will execute INSTRUCTIONS[i]
+# instructions is DISTRIBUTION[i] / (DISTRIBUTION[0] + DISTRIBUTION[1] + ...)
+# for each i.
+LOADGEN_INSTRUCTIONS_FOR_TESTING=[]
+LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING=[]
+
 # HALT_ON_INTERNAL_TRANSACTION_ERROR defaults to false.
 # If set to true, the application will halt when an internal error is
 # encountered during applying a transaction. Otherwise, the txINTERNAL_ERROR 

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -62,6 +62,8 @@ class LedgerManagerImpl : public LedgerManager
     medida::Counter& mLedgerAge;
     medida::Counter& mTransactionApplySucceeded;
     medida::Counter& mTransactionApplyFailed;
+    medida::Counter& mSorobanTransactionApplySucceeded;
+    medida::Counter& mSorobanTransactionApplyFailed;
     medida::Meter& mMetaStreamBytes;
     medida::Timer& mMetaStreamWriteTime;
     VirtualClock::time_point mLastClose;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -53,6 +53,16 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING",
     "LOADGEN_OP_COUNT_FOR_TESTING",
     "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING",
+    "LOADGEN_WASM_BYTES_FOR_TESTING",
+    "LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING"
+    "LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING",
+    "LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING"
+    "LOADGEN_IO_KILOBYTES_FOR_TESTING",
+    "LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING"
+    "LOADGEN_TX_SIZE_BYTES_FOR_TESTING",
+    "LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING"
+    "LOADGEN_INSTRUCTIONS_FOR_TESTING",
+    "LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING"
     "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING",
     "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING",
     "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING",
@@ -120,6 +130,16 @@ Config::Config() : NODE_SEED(SecretKey::random())
     OP_APPLY_SLEEP_TIME_WEIGHT_FOR_TESTING = std::vector<uint32>();
     LOADGEN_OP_COUNT_FOR_TESTING = {};
     LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING = {};
+    LOADGEN_WASM_BYTES_FOR_TESTING = {};
+    LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING = {};
+    LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING = {};
+    LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING = {};
+    LOADGEN_IO_KILOBYTES_FOR_TESTING = {};
+    LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING = {};
+    LOADGEN_TX_SIZE_BYTES_FOR_TESTING = {};
+    LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING = {};
+    LOADGEN_INSTRUCTIONS_FOR_TESTING = {};
+    LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING = {};
     CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = false;
     ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING =
         std::chrono::microseconds::zero();
@@ -848,39 +868,51 @@ Config::verifyHistoryValidatorsBlocking(
     }
 }
 
+template <typename T>
 void
-Config::verifyLoadGenOpCountForTestingConfigs()
+Config::verifyLoadGenDistribution(std::vector<T> const& values,
+                                  std::vector<uint32_t> const& distribution,
+                                  std::string const& valuesName,
+                                  std::string const& distributionName)
 {
-    if (LOADGEN_OP_COUNT_FOR_TESTING.size() !=
-        LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING.size())
+    if (values.size() != distribution.size())
     {
-        throw std::invalid_argument("LOADGEN_OP_COUNT_FOR_TESTING and "
-                                    "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING "
-                                    "must be defined together and "
-                                    "must have the exact same size.");
+        throw std::invalid_argument(
+            fmt::format(FMT_STRING("{} and {} must be defined together and "
+                                   "must have the exact same size."),
+                        valuesName, distributionName));
     }
 
-    if (LOADGEN_OP_COUNT_FOR_TESTING.empty())
+    if (values.empty())
     {
         return;
     }
 
     if (!ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
     {
-        throw std::invalid_argument(
-            "When LOADGEN_OP_COUNT_FOR_TESTING and "
-            "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING are defined "
-            "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING must be set true");
+        throw std::invalid_argument(fmt::format(
+            FMT_STRING(
+                "When {} and {} are defined "
+                "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING must be set true"),
+            valuesName, distributionName));
     }
 
-    if (std::any_of(LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING.begin(),
-                    LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING.end(),
-                    [](uint32 i) { return i == 0; }))
+    if (std::any_of(distribution.begin(), distribution.end(),
+                    [](uint32_t i) { return i == 0; }))
     {
-        throw std::invalid_argument(
-            "All elements in LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING must be "
-            "positive integers");
+        throw std::invalid_argument(fmt::format(
+            FMT_STRING("All elements in {} must be positive integers"),
+            distributionName));
     }
+}
+
+void
+Config::verifyLoadGenOpCountForTestingConfigs()
+{
+    verifyLoadGenDistribution(LOADGEN_OP_COUNT_FOR_TESTING,
+                              LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING,
+                              "LOADGEN_OP_COUNT_FOR_TESTING",
+                              "LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING");
 
     if (!std::all_of(LOADGEN_OP_COUNT_FOR_TESTING.begin(),
                      LOADGEN_OP_COUNT_FOR_TESTING.end(),
@@ -1423,6 +1455,57 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING =
                     readIntArray<uint32>(item);
             }
+            else if (item.first == "LOADGEN_WASM_BYTES_FOR_TESTING")
+            {
+                LOADGEN_WASM_BYTES_FOR_TESTING = readIntArray<uint32>(item);
+            }
+            else if (item.first ==
+                     "LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING")
+            {
+                LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
+            else if (item.first == "LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING")
+            {
+                LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
+            else if (item.first ==
+                     "LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING")
+            {
+                LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
+            else if (item.first == "LOADGEN_IO_KILOBYTES_FOR_TESTING")
+            {
+                LOADGEN_IO_KILOBYTES_FOR_TESTING = readIntArray<uint32>(item);
+            }
+            else if (item.first ==
+                     "LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING")
+            {
+                LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
+            else if (item.first == "LOADGEN_TX_SIZE_BYTES_FOR_TESTING")
+            {
+                LOADGEN_TX_SIZE_BYTES_FOR_TESTING = readIntArray<uint32>(item);
+            }
+            else if (item.first ==
+                     "LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING")
+            {
+                LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
+            else if (item.first == "LOADGEN_INSTRUCTIONS_FOR_TESTING")
+            {
+                LOADGEN_INSTRUCTIONS_FOR_TESTING = readIntArray<uint64>(item);
+            }
+            else if (item.first ==
+                     "LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING")
+            {
+                LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING =
+                    readIntArray<uint32>(item);
+            }
             else if (item.first == "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING")
             {
                 CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = readBool(item);
@@ -1564,7 +1647,33 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             throw std::runtime_error(msg);
         }
 
+        // Check all loadgen distributions
         verifyLoadGenOpCountForTestingConfigs();
+        verifyLoadGenDistribution(
+            LOADGEN_WASM_BYTES_FOR_TESTING,
+            LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING,
+            "LOADGEN_WASM_BYTES_FOR_TESTING",
+            "LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING");
+        verifyLoadGenDistribution(
+            LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING,
+            LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING,
+            "LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING",
+            "LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING");
+        verifyLoadGenDistribution(
+            LOADGEN_IO_KILOBYTES_FOR_TESTING,
+            LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING,
+            "LOADGEN_IO_KILOBYTES_FOR_TESTING",
+            "LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING");
+        verifyLoadGenDistribution(
+            LOADGEN_TX_SIZE_BYTES_FOR_TESTING,
+            LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING,
+            "LOADGEN_TX_SIZE_BYTES_FOR_TESTING",
+            "LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING");
+        verifyLoadGenDistribution(
+            LOADGEN_INSTRUCTIONS_FOR_TESTING,
+            LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING,
+            "LOADGEN_INSTRUCTIONS_FOR_TESTING",
+            "LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING");
 
         gIsProductionNetwork = NETWORK_PASSPHRASE ==
                                "Public Global Stellar Network ; September 2015";

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -105,6 +105,12 @@ class Config : public std::enable_shared_from_this<Config>
 
     std::vector<std::chrono::microseconds> mOpApplySleepTimeForTesting;
 
+    template <typename T>
+    void verifyLoadGenDistribution(std::vector<T> const& values,
+                                   std::vector<uint32_t> const& distribution,
+                                   std::string const& valuesName,
+                                   std::string const& distributionName);
+
   public:
     static const uint32 CURRENT_LEDGER_PROTOCOL_VERSION;
 
@@ -233,6 +239,31 @@ class Config : public std::enable_shared_from_this<Config>
     // i.
     std::vector<unsigned short> LOADGEN_OP_COUNT_FOR_TESTING;
     std::vector<uint32> LOADGEN_OP_COUNT_DISTRIBUTION_FOR_TESTING;
+
+    // Size of wasm blobs for SOROBAN_UPLOAD and MIX_CLASSIC_SOROBAN loadgen
+    // modes
+    std::vector<uint32_t> LOADGEN_WASM_BYTES_FOR_TESTING;
+    std::vector<uint32_t> LOADGEN_WASM_BYTES_DISTRIBUTION_FOR_TESTING;
+
+    // Number of data entries for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN
+    // loadgen modes
+    std::vector<uint32_t> LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING;
+    std::vector<uint32_t> LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING;
+
+    // Total kilobytes of reads and writes per transaction for SOROBAN_INVOKE
+    // and MIX_CLASSIC_SOROBAN loadgen modes.
+    std::vector<uint32_t> LOADGEN_IO_KILOBYTES_FOR_TESTING;
+    std::vector<uint32_t> LOADGEN_IO_KILOBYTES_DISTRIBUTION_FOR_TESTING;
+
+    // Transaction size in bytes for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN
+    // loadgen modes
+    std::vector<uint32_t> LOADGEN_TX_SIZE_BYTES_FOR_TESTING;
+    std::vector<uint32_t> LOADGEN_TX_SIZE_BYTES_DISTRIBUTION_FOR_TESTING;
+
+    // Instructions per transaction for SOROBAN_INVOKE and MIX_CLASSIC_SOROBAN
+    // loadgen modes
+    std::vector<uint64_t> LOADGEN_INSTRUCTIONS_FOR_TESTING;
+    std::vector<uint32_t> LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING;
 
     // Waits for merges to complete before applying transactions during catchup
     bool CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING;


### PR DESCRIPTION
# Description

Resolves #4218

This change adds a mode `blend_classic_soroban` to the `generateload` command that generates load with a mix of classic pay transactions, soroban upload transactions, and soroban invoke transactions. The distribution of these transaction types is configurable.

This change also modifies the options for soroban invoke load to allow for more detailed specification of resource distributions. `doc/software/commands.md` contains an explanation of these modified options as well as details on how to set them.

NOTE: This PR because needs to be merged along with the supercluster changes in https://github.com/stellar/supercluster/pull/155.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
