### PR TITLE
Squash DB schema upgrades pre-21

### DIFF
--- a/src/database/Database.cpp
+++ b/src/database/Database.cpp
@@ -62,7 +62,7 @@ using namespace std;
 bool Database::gDriversRegistered = false;
 
 // smallest schema version supported
-static unsigned long const MIN_SCHEMA_VERSION = 13;
+static unsigned long const MIN_SCHEMA_VERSION = 21;
 static unsigned long const SCHEMA_VERSION = 21;
 
 // These should always match our compiled version precisely, since we are
@@ -212,33 +212,11 @@ Database::applySchemaUpgrade(unsigned long vers)
     soci::transaction tx(mSession);
     switch (vers)
     {
-    case 14:
-        mApp.getPersistentState().setRebuildForType(OFFER);
-        break;
-    case 15:
-        mApp.getPersistentState().setRebuildForType(TRUSTLINE);
-        mApp.getPersistentState().setRebuildForType(LIQUIDITY_POOL);
-        break;
-    case 16:
-        mApp.getPersistentState().setRebuildForType(LIQUIDITY_POOL);
-        break;
-    case 17:
-        mApp.getPersistentState().setRebuildForType(OFFER);
-        break;
-    case 18:
-        createTxSetHistoryTable(*this);
-        mApp.getPersistentState().upgradeSCPDataFormat();
-        break;
-    case 19:
-        mApp.getPersistentState().upgradeSCPDataV1Format();
-        break;
-    case 20:
-        mApp.getPersistentState().setRebuildForType(CONFIG_SETTING);
-        mApp.getPersistentState().setRebuildForType(CONTRACT_DATA);
-        mApp.getPersistentState().setRebuildForType(CONTRACT_CODE);
-        break;
-    case 21:
-        mApp.getPersistentState().setRebuildForType(TTL);
+    case 22:
+        // Add schema upgrades for version 21 -> 22 here.
+        // Currently, this is empty as the schema is already at version 21 and
+        // there are no upgrades to apply. However, this case is left here to
+        // allow for future upgrades to be added.
         break;
     default:
         throw std::runtime_error("Unknown DB schema version");

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -3003,7 +3003,7 @@ TEST_CASE("SCP Driver", "[herder][acceptance]")
     }
 }
 
-TEST_CASE("SCP State", "[herder][acceptance]")
+TEST_CASE("SCP State", "[herder]")
 {
     SecretKey nodeKeys[3];
     PublicKey nodeIDs[3];

--- a/src/main/PersistentState.h
+++ b/src/main/PersistentState.h
@@ -33,7 +33,6 @@ class PersistentState
     };
 
     static void dropAll(Database& db);
-    static void upgradeSizeLimit(Database& db);
 
     std::string getState(Entry stateName);
     void setState(Entry stateName, std::string const& value);
@@ -50,11 +49,6 @@ class PersistentState
     bool shouldRebuildForType(LedgerEntryType let);
     void clearRebuildForType(LedgerEntryType let);
     void setRebuildForType(LedgerEntryType let);
-
-    // Upgrades storage from kLastSCPData to kLastSCPDataXDR entry format.
-    // Should only be called during the respective database schema upgrade.
-    void upgradeSCPDataFormat();
-    void upgradeSCPDataV1Format();
 
     bool hasTxSet(Hash const& txSetHash);
     void deleteTxSets(std::unordered_set<Hash> hashesToDelete);


### PR DESCRIPTION
# Description
Sets the min schema version to 21 and removes all upgrade logic.

Resolves https://github.com/stellar/stellar-core/issues/4225


<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
