### PR TITLE
Better error codes in tx queue

### DIFF
--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -278,6 +278,20 @@ TransactionQueue::canAdd(TransactionFrameBasePtr tx,
                 return TransactionQueue::AddResult::ADD_STATUS_ERROR;
             }
 
+            // Before rejecting Soroban transactions due to source account
+            // limit, check validity of its declared resources, and return an
+            // appropriate error message
+            if (tx->isSoroban())
+            {
+                if (!tx->checkSorobanResourceAndSetError(
+                        mApp, mApp.getLedgerManager()
+                                  .getLastClosedLedgerHeader()
+                                  .header.ledgerVersion))
+                {
+                    return TransactionQueue::AddResult::ADD_STATUS_ERROR;
+                }
+            }
+
             if (tx->getEnvelope().type() != ENVELOPE_TYPE_TX_FEE_BUMP)
             {
                 // If there's already a transaction in the queue, we reject

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1381,10 +1381,20 @@ TEST_CASE("Soroban TransactionQueue limits",
                 resources.instructions =
                     static_cast<uint32>(conf.txMaxInstructions() + 1);
 
-                // Double the fee
-                auto tx2 =
-                    createUploadWasmTx(*app, account2, initialInclusionFee * 2,
-                                       resourceFee, resources);
+                TransactionFrameBasePtr tx2;
+                SECTION("different source account")
+                {
+                    // Double the fee
+                    tx2 = createUploadWasmTx(*app, account2,
+                                             initialInclusionFee * 2,
+                                             resourceFee, resources);
+                }
+                SECTION("invalid resources kick in before source account limit")
+                {
+                    tx2 =
+                        createUploadWasmTx(*app, account1, initialInclusionFee,
+                                           resourceFee, resources);
+                }
 
                 REQUIRE(app->getHerder().recvTransaction(tx2, false) ==
                         TransactionQueue::AddResult::ADD_STATUS_ERROR);

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -241,6 +241,13 @@ FeeBumpTransactionFrame::checkValid(Application& app,
 }
 
 bool
+FeeBumpTransactionFrame::checkSorobanResourceAndSetError(Application& app,
+                                                         uint32_t ledgerVersion)
+{
+    return mInnerTx->checkSorobanResourceAndSetError(app, ledgerVersion);
+}
+
+bool
 FeeBumpTransactionFrame::commonValidPreSeqNum(AbstractLedgerTxn& ltx)
 {
     // this function does validations that are independent of the account state

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -67,6 +67,8 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
                     SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
+    bool checkSorobanResourceAndSetError(Application& app,
+                                         uint32_t ledgerVersion) override;
 
     TransactionEnvelope const& getEnvelope() const override;
 

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1119,12 +1119,9 @@ TransactionFrame::commonValidPreSeqNum(
             getResult().result.code(txMALFORMED);
             return false;
         }
-        auto const& sorobanConfig =
-            app.getLedgerManager().getSorobanNetworkConfig();
-        if (!validateSorobanResources(sorobanConfig, app.getConfig(),
-                                      ledgerVersion))
+
+        if (!checkSorobanResourceAndSetError(app, ledgerVersion))
         {
-            getResult().result.code(txSOROBAN_INVALID);
             return false;
         }
 
@@ -1602,6 +1599,21 @@ TransactionFrame::checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
     return checkValidWithOptionallyChargedFee(app, ltxOuter, current, true,
                                               lowerBoundCloseTimeOffset,
                                               upperBoundCloseTimeOffset);
+}
+
+bool
+TransactionFrame::checkSorobanResourceAndSetError(Application& app,
+                                                  uint32_t ledgerVersion)
+{
+    auto const& sorobanConfig =
+        app.getLedgerManager().getSorobanNetworkConfig();
+    if (!validateSorobanResources(sorobanConfig, app.getConfig(),
+                                  ledgerVersion))
+    {
+        getResult().result.code(txSOROBAN_INVALID);
+        return false;
+    }
+    return true;
 }
 
 void

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -257,6 +257,8 @@ class TransactionFrame : public TransactionFrameBase
     bool checkValid(Application& app, AbstractLedgerTxn& ltxOuter,
                     SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                     uint64_t upperBoundCloseTimeOffset) override;
+    bool checkSorobanResourceAndSetError(Application& app,
+                                         uint32_t ledgerVersion) override;
 
     void
     insertKeysForFeeProcessing(UnorderedSet<LedgerKey>& keys) const override;

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -43,6 +43,8 @@ class TransactionFrameBase
                             SequenceNumber current,
                             uint64_t lowerBoundCloseTimeOffset,
                             uint64_t upperBoundCloseTimeOffset) = 0;
+    virtual bool checkSorobanResourceAndSetError(Application& app,
+                                                 uint32_t ledgerVersion) = 0;
 
     virtual TransactionEnvelope const& getEnvelope() const = 0;
 


### PR DESCRIPTION
Resolves #4221 

Not certain if pushing diagnostic events in the new codepath is problematic (since it's not throttled/validated unlike tx queue limiter), so any input would be appreciated.