### PR TITLE
Publish a few missed config metrics

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -589,6 +589,8 @@ LedgerManagerImpl::publishSorobanMetrics()
         mSorobanNetworkConfig->maxContractDataEntrySizeBytes());
     mSorobanMetrics.mConfigMaxContractSizeBytes.set_count(
         mSorobanNetworkConfig->maxContractSizeBytes());
+    mSorobanMetrics.mConfigTxMaxSizeByte.set_count(
+        mSorobanNetworkConfig->txMaxSizeBytes());
     mSorobanMetrics.mConfigTxMaxCpuInsn.set_count(
         mSorobanNetworkConfig->txMaxInstructions());
     mSorobanMetrics.mConfigTxMemoryLimitBytes.set_count(
@@ -603,8 +605,12 @@ LedgerManagerImpl::publishSorobanMetrics()
         mSorobanNetworkConfig->txMaxWriteBytes());
     mSorobanMetrics.mConfigMaxContractEventsSizeBytes.set_count(
         mSorobanNetworkConfig->txMaxContractEventsSizeBytes());
+    mSorobanMetrics.mConfigLedgerMaxTxCount.set_count(
+        mSorobanNetworkConfig->ledgerMaxTxCount());
     mSorobanMetrics.mConfigLedgerMaxInstructions.set_count(
         mSorobanNetworkConfig->ledgerMaxInstructions());
+    mSorobanMetrics.mConfigLedgerMaxTxsSizeByte.set_count(
+        mSorobanNetworkConfig->ledgerMaxTransactionSizesBytes());
     mSorobanMetrics.mConfigLedgerMaxReadLedgerEntries.set_count(
         mSorobanNetworkConfig->ledgerMaxReadLedgerEntries());
     mSorobanMetrics.mConfigLedgerMaxReadBytes.set_count(

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -585,7 +585,7 @@ LedgerManagerImpl::publishSorobanMetrics()
     // first publish the network config limits
     mSorobanMetrics.mConfigContractDataKeySizeBytes.set_count(
         mSorobanNetworkConfig->maxContractDataKeySizeBytes());
-    mSorobanMetrics.mConfigMacContractDataEntrySizeBytes.set_count(
+    mSorobanMetrics.mConfigMaxContractDataEntrySizeBytes.set_count(
         mSorobanNetworkConfig->maxContractDataEntrySizeBytes());
     mSorobanMetrics.mConfigMaxContractSizeBytes.set_count(
         mSorobanNetworkConfig->maxContractSizeBytes());

--- a/src/ledger/SorobanMetrics.cpp
+++ b/src/ledger/SorobanMetrics.cpp
@@ -90,7 +90,7 @@ SorobanMetrics::SorobanMetrics(medida::MetricsRegistry& metrics)
     /* network config metrics */
     , mConfigContractDataKeySizeBytes(
           metrics.NewCounter({"soroban", "config", "contract-max-rw-key-byte"}))
-    , mConfigMacContractDataEntrySizeBytes(metrics.NewCounter(
+    , mConfigMaxContractDataEntrySizeBytes(metrics.NewCounter(
           {"soroban", "config", "contract-max-rw-data-byte"}))
     , mConfigMaxContractSizeBytes(metrics.NewCounter(
           {"soroban", "config", "contract-max-rw-code-byte"}))

--- a/src/ledger/SorobanMetrics.h
+++ b/src/ledger/SorobanMetrics.h
@@ -84,7 +84,7 @@ class SorobanMetrics
 
     // `NetworkConfig` metrics
     medida::Counter& mConfigContractDataKeySizeBytes;
-    medida::Counter& mConfigMacContractDataEntrySizeBytes;
+    medida::Counter& mConfigMaxContractDataEntrySizeBytes;
     medida::Counter& mConfigMaxContractSizeBytes;
     medida::Counter& mConfigTxMaxSizeByte;
     medida::Counter& mConfigTxMaxCpuInsn;


### PR DESCRIPTION
# Description

These metrics were added last time(soroban config setting `tx_max_size_bytes`, `ledger_max_txs_size_bytes`, `ledger_max_tx_count`), but forgot to be published. 
Also fixed a typo in a variable. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
