### PR TITLE
Fix a main-thread assertion in the QuorumIntersectionChecker

### DIFF
--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -23,21 +23,24 @@ class QuorumIntersectionChecker
     static std::shared_ptr<QuorumIntersectionChecker>
     create(QuorumTracker::QuorumMap const& qmap,
            std::optional<stellar::Config> const& cfg,
-           std::atomic<bool>& interruptFlag, bool quiet = false);
+           std::atomic<bool>& interruptFlag,
+           stellar_default_random_engine::result_type seed, bool quiet = false);
 
     static std::shared_ptr<QuorumIntersectionChecker>
     create(QuorumSetMap const& qmap, std::optional<stellar::Config> const& cfg,
-           std::atomic<bool>& interruptFlag, bool quiet = false);
+           std::atomic<bool>& interruptFlag,
+           stellar_default_random_engine::result_type seed, bool quiet = false);
 
-    static std::set<std::set<NodeID>>
-    getIntersectionCriticalGroups(QuorumTracker::QuorumMap const& qmap,
-                                  std::optional<stellar::Config> const& cfg,
-                                  std::atomic<bool>& interruptFlag);
+    static std::set<std::set<NodeID>> getIntersectionCriticalGroups(
+        QuorumTracker::QuorumMap const& qmap,
+        std::optional<stellar::Config> const& cfg,
+        std::atomic<bool>& interruptFlag,
+        stellar_default_random_engine::result_type seed);
 
-    static std::set<std::set<NodeID>>
-    getIntersectionCriticalGroups(QuorumSetMap const& qmap,
-                                  std::optional<stellar::Config> const& cfg,
-                                  std::atomic<bool>& interruptFlag);
+    static std::set<std::set<NodeID>> getIntersectionCriticalGroups(
+        QuorumSetMap const& qmap, std::optional<stellar::Config> const& cfg,
+        std::atomic<bool>& interruptFlag,
+        stellar_default_random_engine::result_type seed);
 
     virtual ~QuorumIntersectionChecker(){};
     virtual bool networkEnjoysQuorumIntersection() const = 0;

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -534,7 +534,9 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     QuorumIntersectionCheckerImpl(
         stellar::QuorumIntersectionChecker::QuorumSetMap const& qmap,
         std::optional<stellar::Config> const& cfg,
-        std::atomic<bool>& interruptFlag, bool quiet = false);
+        std::atomic<bool>& interruptFlag,
+        stellar::stellar_default_random_engine::result_type seed,
+        bool quiet = false);
     bool networkEnjoysQuorumIntersection() const override;
 
     std::pair<std::vector<stellar::NodeID>, std::vector<stellar::NodeID>>

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -44,7 +44,8 @@ TEST_CASE("quorum intersection basic 4-node", "[herder][quorumintersection]")
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -69,7 +70,8 @@ TEST_CASE("quorum non intersection basic 4-node",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -99,7 +101,8 @@ TEST_CASE("quorum non intersection 6-node", "[herder][quorumintersection]")
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -146,7 +149,8 @@ TEST_CASE("quorum intersection 6-node with subquorums",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -177,7 +181,8 @@ TEST_CASE("quorum non intersection basic 6-node",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -227,7 +232,8 @@ TEST_CASE("quorum non intersection 6-node with subquorums",
 
     Config cfg(getTestConfig());
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -303,7 +309,8 @@ TEST_CASE("quorum plausible non intersection", "[herder][quorumintersection]")
     qm[pkCOINQVEST2] = QuorumTracker::NodeInfo{qsCOINQVEST, 0};
 
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -441,7 +448,8 @@ TEST_CASE("quorum intersection 4-org fully-connected - elide all minquorums",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -459,7 +467,8 @@ TEST_CASE("quorum intersection 3-org 3-node open line",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -476,7 +485,8 @@ TEST_CASE("quorum intersection 3-org 2-node open line",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -496,7 +506,8 @@ TEST_CASE("quorum intersection 3-org 3-node closed ring",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -521,7 +532,8 @@ TEST_CASE("quorum intersection 3-org 3-node closed one-way ring",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -546,7 +558,8 @@ TEST_CASE("quorum intersection 3-org 2-node closed one-way ring",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -576,7 +589,8 @@ TEST_CASE("quorum intersection 3-org 2-node 2-of-3 asymmetric",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -623,7 +637,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery dangling",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -676,7 +691,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery balanced",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -724,7 +740,8 @@ TEST_CASE("quorum intersection 8-org core-and-periphery unbalanced",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(!qic->networkEnjoysQuorumIntersection());
 }
 
@@ -777,7 +794,8 @@ TEST_CASE("quorum intersection 6-org 1-node 4-null qsets",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 }
@@ -823,7 +841,8 @@ TEST_CASE("quorum intersection 4-org 1-node 4-null qsets",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() == 0);
 }
@@ -836,7 +855,8 @@ TEST_CASE("quorum intersection 6-org 3-node fully-connected",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -850,7 +870,8 @@ TEST_CASE("quorum intersection scaling test",
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 }
 
@@ -861,7 +882,8 @@ TEST_CASE("quorum intersection interruption", "[herder][quorumintersection]")
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> interruptFlag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, interruptFlag);
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, interruptFlag,
+                                                 gRandomEngine());
     std::thread canceller([&interruptFlag]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         interruptFlag = true;
@@ -875,9 +897,9 @@ TEST_CASE("quorum intersection interruption", "[herder][quorumintersection]")
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         interruptFlag = true;
     });
-    REQUIRE_THROWS_AS(
-        qic->getIntersectionCriticalGroups(qm, cfg, interruptFlag),
-        QuorumIntersectionChecker::InterruptedException);
+    REQUIRE_THROWS_AS(qic->getIntersectionCriticalGroups(qm, cfg, interruptFlag,
+                                                         gRandomEngine()),
+                      QuorumIntersectionChecker::InterruptedException);
     canceller2.join();
 }
 
@@ -960,11 +982,12 @@ TEST_CASE("quorum intersection criticality",
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
-    auto groups =
-        QuorumIntersectionChecker::getIntersectionCriticalGroups(qm, cfg, flag);
+    auto groups = QuorumIntersectionChecker::getIntersectionCriticalGroups(
+        qm, cfg, flag, gRandomEngine());
     REQUIRE(groups.size() == 1);
     REQUIRE(groups == std::set<std::set<PublicKey>>{{orgs[3][0]}});
 }
@@ -1023,7 +1046,8 @@ TEST_CASE("quorum intersection finds smaller SCC with quorums",
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
     std::atomic<bool> flag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
+    auto qic =
+        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
     REQUIRE(qic->networkEnjoysQuorumIntersection());
     REQUIRE(qic->getMaxQuorumsFound() != 0);
 }

--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -861,7 +861,7 @@ OverlayManagerImpl::maybeAddInboundConnection(Peer::pointer peer)
     if (peer)
     {
         releaseAssert(peer->getRole() == Peer::REMOTE_CALLED_US);
-        bool haveSpace = haveSpaceForConnection(peer->getIP());
+        bool haveSpace = haveSpaceForConnection(peer->getAddress().getIP());
 
         if (mShuttingDown || !haveSpace)
         {

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -1413,7 +1413,9 @@ Peer::recvHello(Hello const& elo)
 
     mState = GOT_HELLO;
 
-    auto ip = getIP();
+    // mAddress is set in TCPPeer::initiate and TCPPeer::accept. It should
+    // contain valid IP (but not necessarily port yet)
+    auto ip = mAddress.getIP();
     if (ip.empty())
     {
         drop("failed to determine remote address",

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -401,7 +401,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     }
 
     std::string const& toString();
-    virtual std::string getIP() const = 0;
 
     // These exist mostly to be overridden in TCPPeer and callable via
     // shared_ptr<Peer> as a captured shared_from_this().

--- a/src/overlay/TCPPeer.h
+++ b/src/overlay/TCPPeer.h
@@ -99,13 +99,10 @@ class TCPPeer : public Peer
 
     static pointer initiate(Application& app, PeerBareAddress const& address);
     static pointer accept(Application& app, std::shared_ptr<SocketType> socket);
-    static std::string getIP(std::shared_ptr<SocketType> socket);
 
     virtual ~TCPPeer();
 
     virtual void drop(std::string const& reason, DropDirection dropDirection,
                       DropMode dropMode) override;
-
-    std::string getIP() const override;
 };
 }

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -139,7 +139,7 @@ class LoopbackPeer : public Peer
 
     bool checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const;
 
-    std::string getIP() const override;
+    std::string getIP() const;
 
     using Peer::recvMessage;
     using Peer::sendAuth;

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -59,12 +59,6 @@ class PeerStub : public Peer
         mAddress = address;
         mFlowControl = std::make_shared<FlowControlStub>(app);
     }
-    virtual std::string
-    getIP() const override
-    {
-        REQUIRE(false); // should not be called
-        return {};
-    }
     virtual void
     drop(std::string const&, DropDirection, DropMode) override
     {

--- a/src/util/LogSlowExecution.h
+++ b/src/util/LogSlowExecution.h
@@ -33,4 +33,11 @@ class LogSlowExecution
     std::string mMessage;
     std::chrono::milliseconds mThreshold;
 };
+
+// Helper class to emit rate-limited log messages without any threshold
+class RateLimitedLog : public LogSlowExecution
+{
+  public:
+    RateLimitedLog(std::string eventName, std::string message);
+};
 }


### PR DESCRIPTION
Change https://github.com/stellar/stellar-core/pull/4240 introduced a new call to `assertThreadIsMain();` in the QI constructor. This is correct for the top-level QI checker, but we then run that QI checker on a background thread and, if it _does_ enjoy intersection, we call `getIntersectionCriticalGroups` which then constructs a pile of QI checkers on the background thread.

The assertion only exists to guard access to the global PRNG to get a seed (the seed used here is a very light requirement that just helps perturb the algorithm's set-splitting path). So a simple solution is to not access the global PRNG in the constructor, but to access it in the scope outside and pass-in a seed. It's harmless to use the same seed in all the sub-checkers constructed in `getIntersectionCriticalGroups`, so I do that here.

cc @SirTyson 