### PR TITLE
Don't rebuild tables after enabling BucketListDB

### DIFF
--- a/src/ledger/LedgerTxnContractCodeSQL.cpp
+++ b/src/ledger/LedgerTxnContractCodeSQL.cpp
@@ -364,17 +364,21 @@ LedgerTxnRoot::Impl::dropContractCode(bool rebuild)
     std::string coll = mApp.getDatabase().getSimpleCollationClause();
 
     mApp.getDatabase().getSession() << "DROP TABLE IF EXISTS contractcode;";
-    mApp.getDatabase().getSession()
-        << "CREATE TABLE contractcode ("
-        << "hash   TEXT " << coll << " NOT NULL, "
-        << "ledgerentry  TEXT " << coll << " NOT NULL, "
-        << "lastmodified INT NOT NULL, "
-        << "PRIMARY KEY (hash));";
-    if (!mApp.getDatabase().isSqlite())
+
+    if (rebuild)
     {
-        mApp.getDatabase().getSession() << "ALTER TABLE contractcode "
-                                        << "ALTER COLUMN hash "
-                                        << "TYPE TEXT COLLATE \"C\";";
+        mApp.getDatabase().getSession()
+            << "CREATE TABLE contractcode ("
+            << "hash   TEXT " << coll << " NOT NULL, "
+            << "ledgerentry  TEXT " << coll << " NOT NULL, "
+            << "lastmodified INT NOT NULL, "
+            << "PRIMARY KEY (hash));";
+        if (!mApp.getDatabase().isSqlite())
+        {
+            mApp.getDatabase().getSession() << "ALTER TABLE contractcode "
+                                            << "ALTER COLUMN hash "
+                                            << "TYPE TEXT COLLATE \"C\";";
+        }
     }
 }
 

--- a/src/ledger/LedgerTxnTTLSQL.cpp
+++ b/src/ledger/LedgerTxnTTLSQL.cpp
@@ -359,17 +359,21 @@ LedgerTxnRoot::Impl::dropTTL(bool rebuild)
     std::string coll = mApp.getDatabase().getSimpleCollationClause();
 
     mApp.getDatabase().getSession() << "DROP TABLE IF EXISTS ttl;";
-    mApp.getDatabase().getSession()
-        << "CREATE TABLE ttl ("
-        << "keyhash   TEXT " << coll << " NOT NULL, "
-        << "ledgerentry  TEXT " << coll << " NOT NULL, "
-        << "lastmodified INT NOT NULL, "
-        << "PRIMARY KEY (keyhash));";
-    if (!mApp.getDatabase().isSqlite())
+
+    if (rebuild)
     {
-        mApp.getDatabase().getSession() << "ALTER TABLE ttl "
-                                        << "ALTER COLUMN keyhash "
-                                        << "TYPE TEXT COLLATE \"C\";";
+        mApp.getDatabase().getSession()
+            << "CREATE TABLE ttl ("
+            << "keyhash   TEXT " << coll << " NOT NULL, "
+            << "ledgerentry  TEXT " << coll << " NOT NULL, "
+            << "lastmodified INT NOT NULL, "
+            << "PRIMARY KEY (keyhash));";
+        if (!mApp.getDatabase().isSqlite())
+        {
+            mApp.getDatabase().getSession() << "ALTER TABLE ttl "
+                                            << "ALTER COLUMN keyhash "
+                                            << "TYPE TEXT COLLATE \"C\";";
+        }
     }
 }
 

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -154,17 +154,17 @@ maybeRebuildLedger(Application& app, bool applyBuckets)
     auto bucketListDBEnabled = app.getConfig().isUsingBucketListDB();
     for (auto let : xdr::xdr_traits<LedgerEntryType>::enum_values())
     {
+        // If BucketListDB is enabled, drop all tables except for offers
         LedgerEntryType t = static_cast<LedgerEntryType>(let);
-        if (ps.shouldRebuildForType(t))
-        {
-            toRebuild.emplace(t);
-            continue;
-        }
-
-        // If bucketlist is enabled, drop all tables except for offers
         if (let != OFFER && bucketListDBEnabled)
         {
             toDrop.emplace(t);
+            continue;
+        }
+
+        if (ps.shouldRebuildForType(t))
+        {
+            toRebuild.emplace(t);
         }
     }
 


### PR DESCRIPTION
# Description

Resolves #4265

After migrating to BucketListDB, `TTL` and `CONTRACT_CODE` tables are rebuilt when they should not be. This PR fixes this.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
