### PR TITLE
No longer serialize small indexes to disk

### DIFF
--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -542,8 +542,8 @@ TEST_CASE("serialize bucket indexes", "[bucket][bucketindex][!hide]")
 {
     Config cfg(getTestConfig(0, Config::TESTDB_ON_DISK_SQLITE));
 
-    // First 3 levels individual, last 3 range index
-    cfg.EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF = 1;
+    // All levels use range config
+    cfg.EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF = 0;
     cfg.EXPERIMENTAL_BUCKETLIST_DB = true;
     cfg.EXPERIMENTAL_BUCKETLIST_DB_PERSIST_INDEX = true;
 

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -186,6 +186,9 @@ TEST_CASE_VERSIONS("bucketmanager ownership", "[bucket][bucketmanager]")
     auto test = [&](bool bucketListDB) {
         VirtualClock clock;
         Config cfg = getTestConfig();
+
+        // Make sure all Buckets serialize indexes to disk for test
+        cfg.EXPERIMENTAL_BUCKETLIST_DB_INDEX_CUTOFF = 0;
         cfg.MANUAL_CLOSE = false;
 
         if (bucketListDB)


### PR DESCRIPTION
# Description

Resolves #4268

Previously, we serialized every BucketListDB index to disk, regardless of size. This created significant disk churn in small, top level buckets, where new indexes are being re-written constantly.

This change no longer serializes the `IndividualIndex` type to disk to reduce this churn. By default, all buckets with size < 20 MB have individual indexes, so this will remove disk churn on the small, top most buckets. This also removes writing indexes to disk on the main thread, as previously `Bucket::addBatch` needed to write indexes to disk as part of `ledgerClose`.

There are essentially no drawbacks to recreating individual indexes on startup. They are so small that recreating them takes about as long as deserializing them. This change adds approximately 100ms to node startup time.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
