### PR TITLE
Seperate metrics for bloom miss loads

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,7 +38,7 @@ bucketlistDB.bulk.loads                   | meter     | number of entries Bucket
 bucketlistDB.bulk.inflationWinners        | timer     | time to load inflation winners
 bucketlistDB.bulk.poolshareTrustlines     | timer     | time to load poolshare trustlines by accountID and assetID
 bucketlistDB.bulk.prefetch                | timer     | time to prefetch
-bucketlistDB.point.<X>                    | timer     | time to load single entry of type <X>
+bucketlistDB.point.<X>                    | timer     | time to load single entry of type <X> (if no bloom miss occurred)
 herder.pending[-soroban]-txs.age0         | counter   | number of gen0 pending transactions
 herder.pending[-soroban]-txs.age1         | counter   | number of gen1 pending transactions
 herder.pending[-soroban]-txs.age2         | counter   | number of gen2 pending transactions

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -68,7 +68,10 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
     std::vector<LedgerEntry>
     loadKeysInternal(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
 
-    std::shared_ptr<LedgerEntry> getLedgerEntryInternal(LedgerKey const& k);
+    // Loads bucket entry for LedgerKey k. Returns <LedgerEntry, bloomMiss>,
+    // where bloomMiss is true if a bloom miss occurred during the load.
+    std::pair<std::shared_ptr<LedgerEntry>, bool>
+    getLedgerEntryInternal(LedgerKey const& k);
 
     SearchableBucketListSnapshot(BucketSnapshotManager const& snapshotManager);
 

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -93,8 +93,7 @@ BucketManagerImpl::initialize()
         if (mApp.getConfig().isUsingBucketListDB())
         {
             mSnapshotManager = std::make_unique<BucketSnapshotManager>(
-                mApp.getMetrics(),
-                std::make_unique<BucketListSnapshot>(*mBucketList, 0));
+                mApp, std::make_unique<BucketListSnapshot>(*mBucketList, 0));
         }
     }
 }

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -31,10 +31,12 @@ class BucketSnapshot : public NonMovable
     XDRInputFileStream& getStream() const;
 
     // Loads the bucket entry for LedgerKey k. Starts at file offset pos and
-    // reads until key is found or the end of the page.
-    std::optional<BucketEntry> getEntryAtOffset(LedgerKey const& k,
-                                                std::streamoff pos,
-                                                size_t pageSize) const;
+    // reads until key is found or the end of the page. Returns <BucketEntry,
+    // bloomMiss>, where bloomMiss is true if a bloomMiss occurred during the
+    // load.
+    std::pair<std::optional<BucketEntry>, bool>
+    getEntryAtOffset(LedgerKey const& k, std::streamoff pos,
+                     size_t pageSize) const;
 
     BucketSnapshot(std::shared_ptr<Bucket const> const b);
 
@@ -46,8 +48,10 @@ class BucketSnapshot : public NonMovable
     bool isEmpty() const;
     std::shared_ptr<Bucket const> getRawBucket() const;
 
-    // Loads bucket entry for LedgerKey k.
-    std::optional<BucketEntry> getBucketEntry(LedgerKey const& k) const;
+    // Loads bucket entry for LedgerKey k. Returns <BucketEntry, bloomMiss>,
+    // where bloomMiss is true if a bloomMiss occurred during the load.
+    std::pair<std::optional<BucketEntry>, bool>
+    getBucketEntry(LedgerKey const& k) const;
 
     // Loads LedgerEntry's for given keys. When a key is found, the
     // entry is added to result and the key is removed from keys.


### PR DESCRIPTION
# Description

Resolves #4269

Separates metrics for BucketListDB loads that incur a bloom miss from loads that did not have a miss. While non-miss metrics are measured per `LedgerEntry` type, there is no type separation for bloom miss metrics. Since bloom misses are rare, the sample size is too small for type separation to be meaningful. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
