### PR TITLE
Add new time sliced overlay survey

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -613,6 +613,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\PeerManager.cpp" />
     <ClCompile Include="..\..\src\overlay\PeerSharedKeyId.cpp" />
     <ClCompile Include="..\..\src\overlay\RandomPeerSource.cpp" />
+    <ClCompile Include="..\..\src\overlay\SurveyDataManager.cpp" />
     <ClCompile Include="..\..\src\overlay\SurveyManager.cpp" />
     <ClCompile Include="..\..\src\overlay\SurveyMessageLimiter.cpp" />
     <ClCompile Include="..\..\src\overlay\TCPPeer.cpp" />
@@ -1031,6 +1032,7 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\PeerSharedKeyId.h" />
     <ClInclude Include="..\..\src\overlay\RandomPeerSource.h" />
     <ClInclude Include="..\..\src\overlay\StellarXDR.h" />
+    <ClInclude Include="..\..\src\overlay\SurveyDataManager.h" />
     <ClInclude Include="..\..\src\overlay\SurveyManager.h" />
     <ClInclude Include="..\..\src\overlay\SurveyMessageLimiter.h" />
     <ClInclude Include="..\..\src\overlay\TCPPeer.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1065,6 +1065,9 @@
     <ClCompile Include="..\..\src\overlay\RandomPeerSource.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\overlay\SurveyDataManager.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\overlay\SurveyManager.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
@@ -2154,6 +2157,9 @@
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\StellarXDR.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\SurveyDataManager.h">
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\SurveyManager.h">

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -133,8 +133,12 @@ overlay.outbound.establish                | meter     | outbound connection esta
 overlay.recv.<X>                          | timer     | received message <X>
 overlay.send.<X>                          | meter     | sent message <X>
 overlay.timeout.idle                      | meter     | idle peer timeout
+overlay.recv.start-survey-collecting      | timer     | time spent in processing request to start survey collecting phase
+overlay.recv.stop-survey-collecting       | timer     | time spent in processing request to stop survey collecting phase
 overlay.recv.survey-request               | timer     | time spent in processing survey request
 overlay.recv.survey-response              | timer     | time spent in processing survey response
+overlay.send.start-survey-collecting      | timer     | sent request to start survey collecting phase
+overlay.send.stop-survey-collecting       | timer     | sent request to stop survey collecting phase
 overlay.send.survey-request               | meter     | sent survey request
 overlay.send.survey-response              | meter     | sent survey response
 process.action.queue                      | counter   | number of items waiting in internal action-queue

--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -357,25 +357,66 @@ format.
 
 * **surveytopology**
   `surveytopology?duration=DURATION&node=NODE_ID`<br>
+  **This command is deprecated and will be removed in a future release. Use the
+  new time sliced survey interface instead (`startsurveycollecting`,
+  `stopsurveycollecting`, `surveytopologytimesliced`, and `getsurveyresults`).**
   Starts a survey that will request peer connectivity information from nodes
   in the backlog. `DURATION` is the number of seconds this survey will run
   for, and `NODE_ID` is the public key you will add to the backlog to survey.
   Running this command while the survey is running will add the node to the
-  backlog and reset the timer to run for `DURATION` seconds. By default, this
-  node will respond to/relay a survey message if the message originated 
-  from a node in it's transitive quorum. This behaviour can be overridden by adding 
-  keys to `SURVEYOR_KEYS` in the config file, which will be the set of keys to check
-  instead of the transitive quorum. If you would like to opt-out of this survey mechanism,
-  just set `SURVEYOR_KEYS` to `$self` or a bogus key
+  backlog and reset the timer to run for `DURATION` seconds.  See [Changing
+  default survey behavior](#changing-default-survey-behavior) for details about
+  the default survey behavior, as well as how to change that behavior or opt-out
+  entirely.
 
 * **stopsurvey**
   `stopsurvey`<br>
+  **This command is deprecated and will be removed in a future release. It is no
+  longer necessary to explicitly stop a survey in the new time sliced survey
+  interface as these surveys expire automatically.**
   Will stop the survey if one is running. Noop if no survey is running
+
+* **startsurveycollecting**
+  `startsurveycollecting?nonce=NONCE`<br>
+  Start a survey in the collecting phase with a given nonce. Does nothing if a
+  survey is already running on the network as only one survey may run at a time.
+  See [Changing default survey behavior](#changing-default-survey-behavior) for
+  details about the default survey behavior, as well as how to change that
+  behavior or opt-out entirely.
+
+* **stopsurveycollecting**
+  `stopsurveycollecting`<br>
+  Stop the collecting phase of the survey started in the previous
+  `startsurveycollecting` command. Moves the survey into the reporting phase.
+  Does nothing if no survey is running, or if a different node is running the
+  active survey.
+
+* **surveytopologytimesliced**
+  `surveytopologytimesliced?node=NODE_ID&inboundpeerindex=INBOUND_INDEX&outboundpeerindex=OUTBOUND_INDEX`<br>
+  During the reporting phase of a survey, invoke this command to request
+  information recorded during the collecting phase from `NODE_ID`. This command
+  adds the survey request to a backlog; it does not immediately send the
+  request. Use `getsurveyresult` to see the response. A response will include
+  information about up to 25 inbound and outbound peers respectively. If a node
+  has more than 25 inbound and/or outbound peers, you will need to survey the
+  node multiple times to get the complete peer list. You can request peers
+  starting from a specific index in each peer list by setting `INBOUND_INDEX`
+  and `OUTBOUND_INDEX` appropriately.  See [Changing default survey
+  behavior](#changing-default-survey-behavior) for details about the default
+  survey behavior, as well as how to change that behavior or opt-out entirely.
 
 * **getsurveyresult**
   `getsurveyresult`<br>
   Returns the current survey results. The results will be reset every time a new survey
-  is started
+  is started. Use this command for both the time sliced survey interface as well
+  as the old deprecated survey interface.
+
+#### Changing default survey behavior
+By default, this node will respond to/relay a survey message if the message
+originated from a node in its transitive quorum. This behavior can be overridden
+by adding keys to `SURVEYOR_KEYS` in the config file, which will be the set of
+keys to check instead of the transitive quorum. If you would like to opt-out of
+this survey mechanism, just set `SURVEYOR_KEYS` to `$self` or a bogus key
 
 ### The following HTTP commands are exposed on test instances
 * **generateload** `generateload[?mode=

--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -495,6 +495,13 @@ ALLOW_LOCALHOST_FOR_TESTING=false
 # before applying transactions.
 CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING=false
 
+# ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING (in minutes), defaults to
+# no override. Overrides the maximum survey phase duration for both the
+# collecting and reporting phase to the specified value. Performs no override if
+# set to 0.  Do not use in production. This option is ignored in builds without
+# tests enabled.
+ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING=0
+
 # PEER_READING_CAPACITY defaults to 200
 # Controls how many messages from a particular peer
 # core can process simultaneously, and throttles reading from a peer when at

--- a/hash-xdrs.sh
+++ b/hash-xdrs.sh
@@ -25,7 +25,11 @@ namespace stellar {
 extern const std::vector<std::pair<std::filesystem::path, std::string>> XDR_FILES_SHA256 = {
 EOF
 
-sha256sum -b $1/xdr/*.x | grep -v Stellar-internal | perl -pe 's/([a-f0-9]+)[ \*]+(.*)/{"$2", "$1"},/'
+# Hashes to ignore
+IGNORE="Stellar-internal\|Stellar-overlay\|Stellar-contract-spec\|Stellar-contract-meta\|Stellar-contract-env-meta"
 
-echo '{"", ""}};'
+sha256sum -b $1/xdr/*.x | grep -v "${IGNORE}" | perl -pe 's/([a-f0-9]+)[ \*]+(.*)/{"$2", "$1"},/'
+
+# Add empty entries for the 5 skipped files
+echo '{"", ""}, {"", ""}, {"", ""}, {"", ""}, {"", ""}};'
 echo '}'

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -68,6 +68,13 @@ class CommandHandler
     void stopSurvey(std::string const&, std::string& retStr);
     void getSurveyResult(std::string const&, std::string& retStr);
     void sorobanInfo(std::string const&, std::string& retStr);
+    void startSurveyCollecting(std::string const& params, std::string& retStr);
+    void stopSurveyCollecting(std::string const& params, std::string& retStr);
+    void surveyTopologyTimeSliced(std::string const& params,
+                                  std::string& retStr);
+
+    // Checks if stellar-core is booted and throws an exception if not.
+    void checkBooted() const;
 
 #ifdef BUILD_TESTS
     void generateLoad(std::string const& params, std::string& retStr);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -64,6 +64,7 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "LOADGEN_INSTRUCTIONS_FOR_TESTING",
     "LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING"
     "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING",
+    "ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING",
     "ARTIFICIALLY_DELAY_BUCKET_APPLICATION_FOR_TESTING",
     "ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING",
     "ARTIFICIALLY_SKIP_CONNECTION_ADJUSTMENT_FOR_TESTING"};
@@ -141,6 +142,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     LOADGEN_INSTRUCTIONS_FOR_TESTING = {};
     LOADGEN_INSTRUCTIONS_DISTRIBUTION_FOR_TESTING = {};
     CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = false;
+    ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING =
+        std::chrono::minutes::zero();
     ARTIFICIALLY_SLEEP_MAIN_THREAD_FOR_TESTING =
         std::chrono::microseconds::zero();
 
@@ -149,7 +152,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     LEDGER_PROTOCOL_MIN_VERSION_INTERNAL_ERROR_REPORT = 18;
 
     OVERLAY_PROTOCOL_MIN_VERSION = 32;
-    OVERLAY_PROTOCOL_VERSION = 33;
+    OVERLAY_PROTOCOL_VERSION = 34;
 
     VERSION_STR = STELLAR_CORE_VERSION;
 
@@ -1547,6 +1550,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING")
             {
                 CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING = readBool(item);
+            }
+            else if (item.first ==
+                     "ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING")
+            {
+                ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING =
+                    std::chrono::minutes(readInt<uint32_t>(item));
             }
             else if (item.first == "HISTOGRAM_WINDOW_SIZE")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -268,6 +268,12 @@ class Config : public std::enable_shared_from_this<Config>
     // Waits for merges to complete before applying transactions during catchup
     bool CATCHUP_WAIT_MERGES_TX_APPLY_FOR_TESTING;
 
+    // Overrides the maximum survey phase duration for both the collecting and
+    // reporting phase to the specified value. Performs no override if set to 0.
+    // Do not use in production. This option is ignored in builds without tests
+    // enabled.
+    std::chrono::minutes ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING;
+
     // A config parameter that controls how many messages from a particular peer
     // core can process simultaneously. If core is at capacity, it temporarily
     // stops reading from a peer until it completes processing of at least one

--- a/src/overlay/Floodgate.h
+++ b/src/overlay/Floodgate.h
@@ -61,8 +61,11 @@ class Floodgate
 
     // returns true if msg was sent to at least one peer
     // The hash required for transactions
+    // `minOverlayVersion` is the minimum overlay version a peer must have in
+    // order to be sent the message.
     bool broadcast(std::shared_ptr<StellarMessage const> msg,
-                   std::optional<Hash> const& hash = std::nullopt);
+                   std::optional<Hash> const& hash = std::nullopt,
+                   uint32_t minOverlayVersion = 0);
 
     // returns the list of peers that sent us the item with hash `msgID`
     // NB: `msgID` is the hash of a `StellarMessage`

--- a/src/overlay/OverlayManager.h
+++ b/src/overlay/OverlayManager.h
@@ -77,9 +77,11 @@ class OverlayManager
     // returns true if message was sent to at least one peer
     // When passing a transaction message,
     // the hash of TransactionEnvelope must be passed also for pull mode.
-    virtual bool
-    broadcastMessage(std::shared_ptr<StellarMessage const> msg,
-                     std::optional<Hash> const hash = std::nullopt) = 0;
+    // `minOverlayVersion` is the minimum overlay version a peer must have in
+    // order to be sent the message.
+    virtual bool broadcastMessage(std::shared_ptr<StellarMessage const> msg,
+                                  std::optional<Hash> const hash = std::nullopt,
+                                  uint32_t minOverlayVersion = 0) = 0;
 
     // Make a note in the FloodGate that a given peer has provided us with a
     // given broadcast message, so that it is inhibited from being resent to

--- a/src/overlay/OverlayManagerImpl.h
+++ b/src/overlay/OverlayManagerImpl.h
@@ -48,7 +48,8 @@ class OverlayManagerImpl : public OverlayManager
                            medida::MetricsRegistry& metricsRegistry,
                            std::string const& directionString,
                            std::string const& cancelledName,
-                           int maxAuthenticatedCount);
+                           int maxAuthenticatedCount,
+                           std::shared_ptr<SurveyManager> sm);
 
         medida::Meter& mConnectionsAttempted;
         medida::Meter& mConnectionsEstablished;
@@ -58,6 +59,7 @@ class OverlayManagerImpl : public OverlayManager
         OverlayManagerImpl& mOverlayManager;
         std::string mDirectionString;
         size_t mMaxAuthenticatedCount;
+        std::shared_ptr<SurveyManager> mSurveyManager;
 
         std::vector<Peer::pointer> mPending;
         std::map<NodeID, Peer::pointer> mAuthenticated;
@@ -68,9 +70,6 @@ class OverlayManagerImpl : public OverlayManager
         bool acceptAuthenticatedPeer(Peer::pointer peer);
         void shutdown();
     };
-
-    PeersList mInboundPeers;
-    PeersList mOutboundPeers;
 
     std::shared_ptr<int> mLiveInboundPeersCounter;
 
@@ -99,6 +98,8 @@ class OverlayManagerImpl : public OverlayManager
 
     std::shared_ptr<SurveyManager> mSurveyManager;
 
+    PeersList mInboundPeers;
+    PeersList mOutboundPeers;
     int availableOutboundPendingSlots() const;
 
   public:
@@ -112,9 +113,9 @@ class OverlayManagerImpl : public OverlayManager
                          Peer::pointer peer) override;
     void forgetFloodedMsg(Hash const& msgID) override;
     void recvTxDemand(FloodDemand const& dmd, Peer::pointer peer) override;
-    bool
-    broadcastMessage(std::shared_ptr<StellarMessage const> msg,
-                     std::optional<Hash> const hash = std::nullopt) override;
+    bool broadcastMessage(std::shared_ptr<StellarMessage const> msg,
+                          std::optional<Hash> const hash = std::nullopt,
+                          uint32_t minOverlayVersion = 0) override;
     void connectTo(PeerBareAddress const& address) override;
 
     void maybeAddInboundConnection(Peer::pointer peer) override;

--- a/src/overlay/OverlayMetrics.cpp
+++ b/src/overlay/OverlayMetrics.cpp
@@ -75,6 +75,10 @@ OverlayMetrics::OverlayMetrics(Application& app)
           app.getMetrics().NewTimer({"overlay", "recv", "survey-request"}))
     , mRecvSurveyResponseTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "survey-response"}))
+    , mRecvStartSurveyCollectingTimer(app.getMetrics().NewTimer(
+          {"overlay", "recv", "start-survey-collecting"}))
+    , mRecvStopSurveyCollectingTimer(app.getMetrics().NewTimer(
+          {"overlay", "recv", "stop-survey-collecting"}))
 
     , mRecvFloodAdvertTimer(
           app.getMetrics().NewTimer({"overlay", "recv", "flood-advert"}))
@@ -134,6 +138,10 @@ OverlayMetrics::OverlayMetrics(Application& app)
           {"overlay", "send", "survey-request"}, "message"))
     , mSendSurveyResponseMeter(app.getMetrics().NewMeter(
           {"overlay", "send", "survey-response"}, "message"))
+    , mSendStartSurveyCollectingMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "start-survey-collecting"}, "message"))
+    , mSendStopSurveyCollectingMeter(app.getMetrics().NewMeter(
+          {"overlay", "send", "stop-survey-collecting"}, "message"))
     , mSendFloodAdvertMeter(app.getMetrics().NewMeter(
           {"overlay", "send", "flood-advert"}, "message"))
     , mSendFloodDemandMeter(app.getMetrics().NewMeter(

--- a/src/overlay/OverlayMetrics.h
+++ b/src/overlay/OverlayMetrics.h
@@ -61,6 +61,8 @@ struct OverlayMetrics
 
     medida::Timer& mRecvSurveyRequestTimer;
     medida::Timer& mRecvSurveyResponseTimer;
+    medida::Timer& mRecvStartSurveyCollectingTimer;
+    medida::Timer& mRecvStopSurveyCollectingTimer;
 
     medida::Timer& mRecvFloodAdvertTimer;
     medida::Timer& mRecvFloodDemandTimer;
@@ -94,6 +96,8 @@ struct OverlayMetrics
 
     medida::Meter& mSendSurveyRequestMeter;
     medida::Meter& mSendSurveyResponseMeter;
+    medida::Meter& mSendStartSurveyCollectingMeter;
+    medida::Meter& mSendStopSurveyCollectingMeter;
 
     medida::Meter& mSendFloodAdvertMeter;
     medida::Meter& mSendFloodDemandMeter;

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -247,6 +247,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     void recvPeers(StellarMessage const& msg);
     void recvSurveyRequestMessage(StellarMessage const& msg);
     void recvSurveyResponseMessage(StellarMessage const& msg);
+    void recvSurveyStartCollectingMessage(StellarMessage const& msg);
+    void recvSurveyStopCollectingMessage(StellarMessage const& msg);
     void recvSendMore(StellarMessage const& msg);
 
     void recvGetTxSet(StellarMessage const& msg);
@@ -369,13 +371,19 @@ class Peer : public std::enable_shared_from_this<Peer>,
     }
 
     NodeID
-    getPeerID()
+    getPeerID() const
     {
         return mPeerID;
     }
 
     PeerMetrics&
     getPeerMetrics()
+    {
+        return mPeerMetrics;
+    }
+
+    PeerMetrics const&
+    getPeerMetrics() const
     {
         return mPeerMetrics;
     }

--- a/src/overlay/SurveyDataManager.cpp
+++ b/src/overlay/SurveyDataManager.cpp
@@ -1,0 +1,534 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "overlay/SurveyDataManager.h"
+
+#include "crypto/SecretKey.h"
+#include "overlay/Peer.h"
+#include "util/Logging.h"
+
+#include <Tracy.hpp>
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace stellar
+{
+namespace
+{
+// Collecting phase is limited to 30 minutes. If 30 minutes pass without
+// receiving a StopSurveyCollecting message the `SurveyDataManager` will
+// automatically transition to the reporting phase.
+constexpr std::chrono::minutes COLLECTING_PHASE_MAX_DURATION{30};
+
+// Reporting phase is limited to 3 hours, after which the
+// `SurveyDataManager` will reset all data and transition to the `INACTIVE`
+// phase.
+constexpr std::chrono::hours REPORTING_PHASE_MAX_DURATION{3};
+
+// Fill a TimeSlicedPeerDataList with elements from `peerData` starting from
+// index `idx` and respecting the max size of the TimeSlicedPeerDataList.
+TimeSlicedPeerDataList
+fillTimeSlicedPeerDataList(std::vector<TimeSlicedPeerData> const& peerData,
+                           size_t idx)
+{
+    TimeSlicedPeerDataList result;
+    if (idx >= peerData.size())
+    {
+        CLOG_DEBUG(Overlay,
+                   "fillTimeSlicedPeerDataList: Received request for peer data "
+                   "starting from index {}, but the peers list contains only "
+                   "{} peers.",
+                   idx, peerData.size());
+        return result;
+    }
+    size_t maxEnd = std::min(peerData.size(), idx + result.max_size());
+    result.insert(result.end(), peerData.begin() + idx,
+                  peerData.begin() + maxEnd);
+    return result;
+}
+
+// Initialize a map of peer data with the initial metrics from `peers`
+void
+initializeCollectingPeerData(
+    std::map<NodeID, Peer::pointer> const& peers,
+    std::unordered_map<NodeID, CollectingPeerData>& peerData)
+{
+    releaseAssert(peerData.empty());
+    for (auto const& [id, peer] : peers)
+    {
+        // Copy initial peer metrics
+        peerData.try_emplace(id, peer->getPeerMetrics());
+    }
+}
+
+} // namespace
+
+CollectingNodeData::CollectingNodeData(uint64_t initialLostSyncCount,
+                                       Application::State initialState)
+    : mSCPFirstToSelfLatencyNsHistogram(
+          medida::SamplingInterface::SampleType::kSliding)
+    , mSCPSelfToOtherLatencyNsHistogram(
+          medida::SamplingInterface::SampleType::kSliding)
+    , mInitialLostSyncCount(initialLostSyncCount)
+    , mInitialState(initialState)
+{
+}
+
+CollectingPeerData::CollectingPeerData(Peer::PeerMetrics const& peerMetrics)
+    : mInitialMessageRead(peerMetrics.mMessageRead)
+    , mInitialMessageWrite(peerMetrics.mMessageWrite)
+    , mInitialByteRead(peerMetrics.mByteRead)
+    , mInitialByteWrite(peerMetrics.mByteWrite)
+    , mInitialUniqueFloodBytesRecv(peerMetrics.mUniqueFloodBytesRecv)
+    , mInitialDuplicateFloodBytesRecv(peerMetrics.mDuplicateFloodBytesRecv)
+    , mInitialUniqueFetchBytesRecv(peerMetrics.mUniqueFetchBytesRecv)
+    , mInitialDuplicateFetchBytesRecv(peerMetrics.mDuplicateFetchBytesRecv)
+    , mInitialUniqueFloodMessageRecv(peerMetrics.mUniqueFloodMessageRecv)
+    , mInitialDuplicateFloodMessageRecv(peerMetrics.mDuplicateFloodMessageRecv)
+    , mInitialUniqueFetchMessageRecv(peerMetrics.mUniqueFetchMessageRecv)
+    , mInitialDuplicateFetchMessageRecv(peerMetrics.mDuplicateFetchMessageRecv)
+    , mLatencyMsHistogram(medida::SamplingInterface::SampleType::kSliding)
+{
+}
+
+SurveyDataManager::SurveyDataManager(
+    std::function<VirtualClock::time_point()> const& getNow,
+    medida::Meter const& lostSyncMeter, Config const& cfg)
+    : mGetNow(getNow), mLostSyncMeter(lostSyncMeter)
+{
+#ifdef BUILD_TESTS
+    // Override phase durations if set in the config and this build has tests
+    // enabled
+    std::chrono::minutes maxPhaseDuration =
+        cfg.ARTIFICIALLY_SET_SURVEY_PHASE_DURATION_FOR_TESTING;
+    if (maxPhaseDuration != 0min)
+    {
+        setPhaseMaxDurationsForTesting(maxPhaseDuration);
+    }
+#endif
+}
+
+bool
+SurveyDataManager::startSurveyCollecting(
+    TimeSlicedSurveyStartCollectingMessage const& msg,
+    std::map<NodeID, Peer::pointer> const& inboundPeers,
+    std::map<NodeID, Peer::pointer> const& outboundPeers,
+    Application::State const initialState)
+{
+    ZoneScoped;
+
+    if (mPhase == SurveyPhase::INACTIVE)
+    {
+        CLOG_TRACE(Overlay, "Starting survey collecting with nonce {}",
+                   msg.nonce);
+        mPhase = SurveyPhase::COLLECTING;
+        mCollectStartTime = mGetNow();
+        mNonce = msg.nonce;
+        mSurveyor = msg.surveyorID;
+        mCollectingNodeData.emplace(mLostSyncMeter.count(), initialState);
+        if (mCollectingInboundPeerData.empty() &&
+            mCollectingOutboundPeerData.empty())
+        {
+            initializeCollectingPeerData(inboundPeers,
+                                         mCollectingInboundPeerData);
+            initializeCollectingPeerData(outboundPeers,
+                                         mCollectingOutboundPeerData);
+            return true;
+        }
+
+        emitInconsistencyError("startSurveyCollecting");
+        return false;
+    }
+
+    CLOG_TRACE(Overlay,
+               "Ignoring request to start survey collecting with nonce {} "
+               "because there is already an active survey",
+               msg.nonce);
+    return false;
+}
+
+bool
+SurveyDataManager::startReportingPhase(
+    std::map<NodeID, Peer::pointer> const& inboundPeers,
+    std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
+{
+    if (mPhase != SurveyPhase::COLLECTING || !mFinalInboundPeerData.empty() ||
+        !mFinalOutboundPeerData.empty())
+    {
+        emitInconsistencyError("startReportingPhase");
+        return false;
+    }
+
+    mPhase = SurveyPhase::REPORTING;
+    mCollectEndTime = mGetNow();
+
+    // Finalize peer and node data
+    finalizePeerData(inboundPeers, mCollectingInboundPeerData,
+                     mFinalInboundPeerData);
+    finalizePeerData(outboundPeers, mCollectingOutboundPeerData,
+                     mFinalOutboundPeerData);
+    finalizeNodeData(config);
+
+    // Clear collecting data
+    mCollectingInboundPeerData.clear();
+    mCollectingOutboundPeerData.clear();
+
+    return true;
+}
+
+bool
+SurveyDataManager::stopSurveyCollecting(
+    TimeSlicedSurveyStopCollectingMessage const& msg,
+    std::map<NodeID, Peer::pointer> const& inboundPeers,
+    std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
+{
+    ZoneScoped;
+
+    uint32_t const nonce = msg.nonce;
+    if (mPhase == SurveyPhase::COLLECTING && mNonce == nonce &&
+        mSurveyor == msg.surveyorID)
+    {
+        CLOG_TRACE(Overlay, "Stopping survey collecting with nonce {}", nonce);
+        return startReportingPhase(inboundPeers, outboundPeers, config);
+    }
+    CLOG_TRACE(Overlay,
+               "Ignoring request to stop survey collecting with nonce {} "
+               "because there is no active survey or the nonce does not "
+               "match the active survey's nonce",
+               nonce);
+    return false;
+}
+
+void
+SurveyDataManager::modifyNodeData(std::function<void(CollectingNodeData&)> f)
+{
+    ZoneScoped;
+
+    if (mPhase == SurveyPhase::COLLECTING)
+    {
+        if (mCollectingNodeData.has_value())
+        {
+            f(mCollectingNodeData.value());
+        }
+        else
+        {
+            emitInconsistencyError("modifyNodeData");
+        }
+    }
+}
+
+void
+SurveyDataManager::modifyPeerData(Peer const& peer,
+                                  std::function<void(CollectingPeerData&)> f)
+{
+    ZoneScoped;
+
+    if (mPhase == SurveyPhase::COLLECTING)
+    {
+        auto it = mCollectingInboundPeerData.find(peer.getPeerID());
+        if (it != mCollectingInboundPeerData.end())
+        {
+            f(it->second);
+            return;
+        }
+
+        it = mCollectingOutboundPeerData.find(peer.getPeerID());
+        if (it != mCollectingOutboundPeerData.end())
+        {
+            f(it->second);
+        }
+    }
+}
+
+void
+SurveyDataManager::recordDroppedPeer(Peer const& peer)
+{
+    ZoneScoped;
+
+    if (mPhase == SurveyPhase::COLLECTING)
+    {
+        if (mCollectingInboundPeerData.erase(peer.getPeerID()) == 0)
+        {
+            mCollectingOutboundPeerData.erase(peer.getPeerID());
+        }
+
+        if (mCollectingNodeData.has_value())
+        {
+            ++mCollectingNodeData.value().mDroppedAuthenticatedPeers;
+        }
+        else
+        {
+            emitInconsistencyError("recordDroppedPeer");
+        }
+    }
+}
+
+std::optional<uint32_t>
+SurveyDataManager::getNonce() const
+{
+    return mNonce;
+}
+
+bool
+SurveyDataManager::nonceIsReporting(uint32_t nonce) const
+{
+    return mPhase == SurveyPhase::REPORTING && mNonce == nonce;
+}
+
+bool
+SurveyDataManager::fillSurveyData(TimeSlicedSurveyRequestMessage const& request,
+                                  TopologyResponseBodyV2& response)
+{
+    ZoneScoped;
+
+    if (mPhase == SurveyPhase::REPORTING && mNonce == request.nonce &&
+        mSurveyor == request.request.surveyorPeerID)
+    {
+        if (!mFinalNodeData.has_value())
+        {
+            emitInconsistencyError("getSurveyData");
+            return false;
+        }
+
+        response.nodeData = mFinalNodeData.value();
+        response.inboundPeers = fillTimeSlicedPeerDataList(
+            mFinalInboundPeerData,
+            static_cast<size_t>(request.inboundPeersIndex));
+        response.outboundPeers = fillTimeSlicedPeerDataList(
+            mFinalOutboundPeerData,
+            static_cast<size_t>(request.outboundPeersIndex));
+        return true;
+    }
+    return false;
+}
+
+bool
+SurveyDataManager::surveyIsActive() const
+{
+    return mPhase != SurveyPhase::INACTIVE;
+}
+
+#ifdef BUILD_TESTS
+void
+SurveyDataManager::setPhaseMaxDurationsForTesting(
+    std::chrono::minutes maxPhaseDuration)
+{
+    mMaxPhaseDurationForTesting = maxPhaseDuration;
+}
+#endif
+
+void
+SurveyDataManager::updateSurveyPhase(
+    std::map<NodeID, Peer::pointer> const& inboundPeers,
+    std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
+{
+    switch (mPhase)
+    {
+    case SurveyPhase::COLLECTING:
+        if (!mCollectStartTime.has_value() || mCollectEndTime.has_value())
+        {
+            emitInconsistencyError("updateSurveyPhase");
+            return;
+        }
+        if (mGetNow() >
+            mCollectStartTime.value() + getCollectingPhaseMaxDuration())
+        {
+            CLOG_TRACE(Overlay, "Survey collecting phase has expired. "
+                                "Advancing to reporting phase.");
+            startReportingPhase(inboundPeers, outboundPeers, config);
+        }
+        break;
+    case SurveyPhase::REPORTING:
+        if (!mCollectStartTime.has_value() || !mCollectEndTime.has_value())
+        {
+            emitInconsistencyError("updateSurveyPhase");
+            return;
+        }
+        if (mGetNow() >
+            mCollectEndTime.value() + getReportingPhaseMaxDuration())
+        {
+            CLOG_TRACE(
+                Overlay,
+                "Survey reporting phase has expired. Resetting survey data.");
+            reset();
+        }
+        break;
+    case SurveyPhase::INACTIVE:
+        if (mCollectStartTime.has_value() || mCollectEndTime.has_value())
+        {
+            emitInconsistencyError("updateSurveyPhase");
+            return;
+        }
+        // Nothing to do
+        break;
+    }
+}
+
+void
+SurveyDataManager::reset()
+{
+    mPhase = SurveyPhase::INACTIVE;
+    mCollectStartTime.reset();
+    mCollectEndTime.reset();
+    mNonce.reset();
+    mSurveyor.reset();
+    mCollectingNodeData.reset();
+    mCollectingInboundPeerData.clear();
+    mCollectingOutboundPeerData.clear();
+    mFinalNodeData.reset();
+    mFinalInboundPeerData.clear();
+    mFinalOutboundPeerData.clear();
+}
+
+void
+SurveyDataManager::emitInconsistencyError(std::string const& where)
+{
+#ifdef BUILD_TESTS
+    // Throw an exception when testing to make the error more visible
+    throw std::runtime_error("Encountered inconsistent survey data while "
+                             "executing `" +
+                             where + "`.");
+#endif
+    CLOG_ERROR(Overlay,
+               "Encountered inconsistent survey data while executing "
+               "`{}`. Resetting survey state.",
+               where);
+    reset();
+}
+
+void
+SurveyDataManager::finalizeNodeData(Config const& config)
+{
+    if (mFinalNodeData.has_value() || !mCollectingNodeData.has_value())
+    {
+        emitInconsistencyError("finalizeNodeData");
+        return;
+    }
+
+    // Fill in node data
+    mFinalNodeData.emplace();
+    mFinalNodeData->addedAuthenticatedPeers =
+        mCollectingNodeData->mAddedAuthenticatedPeers;
+    mFinalNodeData->droppedAuthenticatedPeers =
+        mCollectingNodeData->mDroppedAuthenticatedPeers;
+    mFinalNodeData->totalInboundPeerCount =
+        static_cast<uint32_t>(mFinalInboundPeerData.size());
+    mFinalNodeData->totalOutboundPeerCount =
+        static_cast<uint32_t>(mFinalOutboundPeerData.size());
+    mFinalNodeData->p75SCPFirstToSelfLatencyNs =
+        mCollectingNodeData->mSCPFirstToSelfLatencyNsHistogram.GetSnapshot()
+            .get75thPercentile();
+    mFinalNodeData->p75SCPSelfToOtherLatencyNs =
+        mCollectingNodeData->mSCPSelfToOtherLatencyNsHistogram.GetSnapshot()
+            .get75thPercentile();
+    mFinalNodeData->lostSyncCount = static_cast<uint32_t>(
+        mLostSyncMeter.count() - mCollectingNodeData->mInitialLostSyncCount);
+    switch (mCollectingNodeData->mInitialState)
+    {
+    case Application::APP_ACQUIRING_CONSENSUS_STATE:
+    case Application::APP_CATCHING_UP_STATE:
+        // Node was out-of-sync at the start of the survey
+        ++mFinalNodeData->lostSyncCount;
+        break;
+    default:
+        break;
+    }
+    mFinalNodeData->isValidator = config.NODE_IS_VALIDATOR;
+    mFinalNodeData->maxInboundPeerCount =
+        config.MAX_ADDITIONAL_PEER_CONNECTIONS;
+    mFinalNodeData->maxOutboundPeerCount = config.TARGET_PEER_CONNECTIONS;
+
+    // Clear collecting data
+    mCollectingNodeData.reset();
+}
+
+void
+SurveyDataManager::finalizePeerData(
+    std::map<NodeID, Peer::pointer> const peers,
+    std::unordered_map<NodeID, CollectingPeerData> const& collectingPeerData,
+    std::vector<TimeSlicedPeerData>& finalPeerData)
+{
+    for (auto const& [id, peer] : peers)
+    {
+        auto const it = collectingPeerData.find(id);
+        if (it != collectingPeerData.end())
+        {
+            CollectingPeerData const& collectingData = it->second;
+            Peer::PeerMetrics const& peerMetrics = peer->getPeerMetrics();
+
+            TimeSlicedPeerData& finalData = finalPeerData.emplace_back();
+            PeerStats& finalStats = finalData.peerStats;
+
+            finalStats.id = id;
+            finalStats.versionStr = peer->getRemoteVersion();
+            finalStats.messagesRead =
+                peerMetrics.mMessageRead - collectingData.mInitialMessageRead;
+            finalStats.messagesWritten =
+                peerMetrics.mMessageWrite - collectingData.mInitialMessageWrite;
+            finalStats.bytesRead =
+                peerMetrics.mByteRead - collectingData.mInitialByteRead;
+            finalStats.bytesWritten =
+                peerMetrics.mByteWrite - collectingData.mInitialByteWrite;
+            finalStats.secondsConnected = static_cast<uint64>(
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    mGetNow() - peerMetrics.mConnectedTime)
+                    .count());
+            finalStats.uniqueFloodBytesRecv =
+                peerMetrics.mUniqueFloodBytesRecv -
+                collectingData.mInitialUniqueFloodBytesRecv;
+            finalStats.duplicateFloodBytesRecv =
+                peerMetrics.mDuplicateFloodBytesRecv -
+                collectingData.mInitialDuplicateFloodBytesRecv;
+            finalStats.uniqueFetchBytesRecv =
+                peerMetrics.mUniqueFetchBytesRecv -
+                collectingData.mInitialUniqueFetchBytesRecv;
+            finalStats.duplicateFetchBytesRecv =
+                peerMetrics.mDuplicateFetchBytesRecv -
+                collectingData.mInitialDuplicateFetchBytesRecv;
+            finalStats.uniqueFloodMessageRecv =
+                peerMetrics.mUniqueFloodMessageRecv -
+                collectingData.mInitialUniqueFloodMessageRecv;
+            finalStats.duplicateFloodMessageRecv =
+                peerMetrics.mDuplicateFloodMessageRecv -
+                collectingData.mInitialDuplicateFloodMessageRecv;
+            finalStats.uniqueFetchMessageRecv =
+                peerMetrics.mUniqueFetchMessageRecv -
+                collectingData.mInitialUniqueFetchMessageRecv;
+            finalStats.duplicateFetchMessageRecv =
+                peerMetrics.mDuplicateFetchMessageRecv -
+                collectingData.mInitialDuplicateFetchMessageRecv;
+            finalData.averageLatencyMs = static_cast<uint32_t>(
+                collectingData.mLatencyMsHistogram.GetSnapshot().getMedian());
+        }
+    }
+}
+
+std::chrono::minutes
+SurveyDataManager::getCollectingPhaseMaxDuration() const
+{
+#ifdef BUILD_TESTS
+    if (mMaxPhaseDurationForTesting.has_value())
+    {
+        return mMaxPhaseDurationForTesting.value();
+    }
+#endif
+    return std::chrono::duration_cast<std::chrono::minutes>(
+        COLLECTING_PHASE_MAX_DURATION);
+}
+
+std::chrono::minutes
+SurveyDataManager::getReportingPhaseMaxDuration() const
+{
+#ifdef BUILD_TESTS
+    if (mMaxPhaseDurationForTesting.has_value())
+    {
+        return mMaxPhaseDurationForTesting.value();
+    }
+#endif
+    return std::chrono::duration_cast<std::chrono::minutes>(
+        REPORTING_PHASE_MAX_DURATION);
+}
+
+} // namespace stellar

--- a/src/overlay/SurveyDataManager.h
+++ b/src/overlay/SurveyDataManager.h
@@ -1,0 +1,223 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/Application.h"
+#include "main/Config.h"
+#include "overlay/Peer.h"
+#include "util/NonCopyable.h"
+#include "util/Timer.h"
+
+#include "medida/histogram.h"
+#include "medida/meter.h"
+#include "xdr/Stellar-overlay.h"
+#include "xdr/Stellar-types.h"
+
+#include <chrono>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
+namespace stellar
+{
+
+enum class SurveyPhase
+{
+    // Survey is currently collecting data
+    COLLECTING,
+    // Collecting complete. Survey data is available for reporting.
+    REPORTING,
+    // No active survey in progress. No data is being collected or reported.
+    INACTIVE
+};
+
+struct CollectingNodeData
+{
+    CollectingNodeData(uint64_t initialLostSyncCount,
+                       Application::State initialState);
+
+    // Peer change data
+    uint32_t mAddedAuthenticatedPeers = 0;
+    uint32_t mDroppedAuthenticatedPeers = 0;
+
+    // SCP stats (in nanoseconds)
+    medida::Histogram mSCPFirstToSelfLatencyNsHistogram;
+    medida::Histogram mSCPSelfToOtherLatencyNsHistogram;
+
+    // To compute how many times the node lost sync in the time slice
+    uint64_t const mInitialLostSyncCount;
+
+    // State of the node at the start of the survey
+    Application::State const mInitialState;
+};
+
+// Data about a peer
+struct CollectingPeerData
+{
+    CollectingPeerData(Peer::PeerMetrics const& peerMetrics);
+
+    // Metrics at the start of the survey
+    uint64_t const mInitialMessageRead;
+    uint64_t const mInitialMessageWrite;
+    uint64_t const mInitialByteRead;
+    uint64_t const mInitialByteWrite;
+    uint64_t const mInitialUniqueFloodBytesRecv;
+    uint64_t const mInitialDuplicateFloodBytesRecv;
+    uint64_t const mInitialUniqueFetchBytesRecv;
+    uint64_t const mInitialDuplicateFetchBytesRecv;
+    uint64_t const mInitialUniqueFloodMessageRecv;
+    uint64_t const mInitialDuplicateFloodMessageRecv;
+    uint64_t const mInitialUniqueFetchMessageRecv;
+    uint64_t const mInitialDuplicateFetchMessageRecv;
+
+    // For computing average latency (in milliseconds)
+    medida::Histogram mLatencyMsHistogram;
+};
+
+/*
+ * Manage data collection during time sliced overlay surveys. This class is
+ * thread-safe.
+ */
+class SurveyDataManager : public NonMovableOrCopyable
+{
+  public:
+    // Create a survey manager. `clock` must be the Application's clock.
+    // `lostSyncMeter` is a meter to track how many times the node lost sync.
+    SurveyDataManager(std::function<VirtualClock::time_point()> const& getNow,
+                      medida::Meter const& lostSyncMeter, Config const& cfg);
+
+    // Start the collecting phase of a survey. Ignores requests if a survey is
+    // already active. `inboundPeers` and `outboundPeers` should collectively
+    // contain the `NodeID`s of all connected peers. Returns `true` if this
+    // successfully starts a survey.
+    bool
+    startSurveyCollecting(TimeSlicedSurveyStartCollectingMessage const& msg,
+                          std::map<NodeID, Peer::pointer> const& inboundPeers,
+                          std::map<NodeID, Peer::pointer> const& outboundPeers,
+                          Application::State initialState);
+
+    // Stop the collecting phase of a survey and enter the reporting phase.
+    // Ignores request if no survey is active or if nonce does not match the
+    // active survey. Returns `true` if this successfully stops a survey.
+    bool
+    stopSurveyCollecting(TimeSlicedSurveyStopCollectingMessage const& msg,
+                         std::map<NodeID, Peer::pointer> const& inboundPeers,
+                         std::map<NodeID, Peer::pointer> const& outboundPeers,
+                         Config const& config);
+
+    // Apply `f` to the data for this node. Does nothing if the survey is not in
+    // the collecting phase.
+    void modifyNodeData(std::function<void(CollectingNodeData&)> f);
+
+    // Apply `f` to the data for `peer`. Does nothing if the survey is not in
+    // the collecting phase or if `peer` is not in the current time slice data.
+    void modifyPeerData(Peer const& peer,
+                        std::function<void(CollectingPeerData&)> f);
+
+    // Record that `peer` was dropped from the overlay. Does nothing if the
+    // survey is not in the collecting phase.
+    void recordDroppedPeer(Peer const& peer);
+
+    // Get nonce of current survey, if one is active.
+    std::optional<uint32_t> getNonce() const;
+
+    // Returns `true` if the `nonce` matches the survey in the reporting phase.
+    bool nonceIsReporting(uint32_t nonce) const;
+
+    // Fills `response` with the results of the survey, provided that the survey
+    // corresponding to the request's nonce is in the reporting phase. Returns
+    // `true` on success.
+    bool fillSurveyData(TimeSlicedSurveyRequestMessage const& request,
+                        TopologyResponseBodyV2& response);
+
+    // Returns `true` iff there is currently an active survey
+    bool surveyIsActive() const;
+
+    // Checks and updates the phase of the survey if necessary. Resets the
+    // survey state upon transition to `SurveyPhase::INACTIVE`. Takes peer and
+    // config info in case the collecting phase times out and the survey
+    // automatically transitions to the reporting phase.
+    void updateSurveyPhase(std::map<NodeID, Peer::pointer> const& inboundPeers,
+                           std::map<NodeID, Peer::pointer> const& outboundPeers,
+                           Config const& config);
+
+#ifdef BUILD_TESTS
+    // Call to use the provided duration as max for both collecting and
+    // reporting phase instead of the normal max phase durations
+    void setPhaseMaxDurationsForTesting(std::chrono::minutes maxPhaseDuration);
+#endif // BUILD_TESTS
+
+  private:
+    // Get the current time
+    std::function<VirtualClock::time_point()> const mGetNow;
+
+    // Metric tracking sync status
+    medida::Meter const& mLostSyncMeter;
+
+    // Start and stop times for the collecting phase
+    std::optional<VirtualClock::time_point> mCollectStartTime = std::nullopt;
+    std::optional<VirtualClock::time_point> mCollectEndTime = std::nullopt;
+
+    // Nonce of the active survey (if any)
+    std::optional<uint32_t> mNonce = std::nullopt;
+
+    // Surveyor running active survey (if any)
+    std::optional<NodeID> mSurveyor = std::nullopt;
+
+    // Data about this node captured during the collecting phase
+    std::optional<CollectingNodeData> mCollectingNodeData = std::nullopt;
+
+    // Finalized reporting phase data about this node
+    std::optional<TimeSlicedNodeData> mFinalNodeData = std::nullopt;
+
+    // Data about peers during collecting phase
+    std::unordered_map<NodeID, CollectingPeerData> mCollectingInboundPeerData;
+    std::unordered_map<NodeID, CollectingPeerData> mCollectingOutboundPeerData;
+
+    // Finalized reporting phase data about peers
+    std::vector<TimeSlicedPeerData> mFinalInboundPeerData;
+    std::vector<TimeSlicedPeerData> mFinalOutboundPeerData;
+
+    // The current survey phase
+    SurveyPhase mPhase = SurveyPhase::INACTIVE;
+
+#ifdef BUILD_TESTS
+    // Override maximum phase durations for testing
+    std::optional<std::chrono::minutes> mMaxPhaseDurationForTesting =
+        std::nullopt;
+#endif // BUILD_TESTS
+
+    // Reset survey data. Intended to be called when survey data expires.
+    void reset();
+
+    // Transition to the reporting phase. Should only be called from the
+    // collecting phase. Returns `false` if transition fails.
+    bool
+    startReportingPhase(std::map<NodeID, Peer::pointer> const& inboundPeers,
+                        std::map<NodeID, Peer::pointer> const& outboundPeers,
+                        Config const& config);
+
+    // Function to call when the impossible occurs. Logs an error and resets
+    // the survey. Use instead of `releaseAssert` as an overlay survey
+    // failure is not important enough to crash the program.
+    void emitInconsistencyError(std::string const& where);
+
+    // Finalize node data into `mFinalNodeData`. Should only be called after
+    // finalizing peer data.
+    void finalizeNodeData(Config const& config);
+
+    // Finalize peer data into `finalPeerData`
+    void finalizePeerData(std::map<NodeID, Peer::pointer> const peers,
+                          std::unordered_map<NodeID, CollectingPeerData> const&
+                              collectingPeerData,
+                          std::vector<TimeSlicedPeerData>& finalPeerData);
+
+    // Get the max phase durations for the collecting and reporting phases
+    // respectively
+    std::chrono::minutes getCollectingPhaseMaxDuration() const;
+    std::chrono::minutes getReportingPhaseMaxDuration() const;
+};
+
+} // namespace stellar

--- a/src/overlay/SurveyManager.cpp
+++ b/src/overlay/SurveyManager.cpp
@@ -7,7 +7,9 @@
 #include "herder/Herder.h"
 #include "main/Application.h"
 #include "main/ErrorMessages.h"
+#include "medida/metrics_registry.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/SurveyDataManager.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "xdrpp/marshal.h"
@@ -16,6 +18,74 @@ namespace stellar
 {
 
 uint32_t const SurveyManager::SURVEY_THROTTLE_TIMEOUT_MULT(3);
+
+uint32_t constexpr TIME_SLICED_SURVEY_MIN_OVERLAY_PROTOCOL_VERSION = 33;
+
+namespace
+{
+// Generate JSON for a single peer
+Json::Value
+peerStatsToJson(PeerStats const& peer)
+{
+    Json::Value peerInfo;
+    peerInfo["nodeId"] = KeyUtils::toStrKey(peer.id);
+    peerInfo["version"] = peer.versionStr;
+    peerInfo["messagesRead"] = static_cast<Json::UInt64>(peer.messagesRead);
+    peerInfo["messagesWritten"] =
+        static_cast<Json::UInt64>(peer.messagesWritten);
+    peerInfo["bytesRead"] = static_cast<Json::UInt64>(peer.bytesRead);
+    peerInfo["bytesWritten"] = static_cast<Json::UInt64>(peer.bytesWritten);
+    peerInfo["secondsConnected"] =
+        static_cast<Json::UInt64>(peer.secondsConnected);
+
+    peerInfo["uniqueFloodBytesRecv"] =
+        static_cast<Json::UInt64>(peer.uniqueFloodBytesRecv);
+    peerInfo["duplicateFloodBytesRecv"] =
+        static_cast<Json::UInt64>(peer.duplicateFloodBytesRecv);
+    peerInfo["uniqueFetchBytesRecv"] =
+        static_cast<Json::UInt64>(peer.uniqueFetchBytesRecv);
+    peerInfo["duplicateFetchBytesRecv"] =
+        static_cast<Json::UInt64>(peer.duplicateFetchBytesRecv);
+
+    peerInfo["uniqueFloodMessageRecv"] =
+        static_cast<Json::UInt64>(peer.uniqueFloodMessageRecv);
+    peerInfo["duplicateFloodMessageRecv"] =
+        static_cast<Json::UInt64>(peer.duplicateFloodMessageRecv);
+    peerInfo["uniqueFetchMessageRecv"] =
+        static_cast<Json::UInt64>(peer.uniqueFetchMessageRecv);
+    peerInfo["duplicateFetchMessageRecv"] =
+        static_cast<Json::UInt64>(peer.duplicateFetchMessageRecv);
+    return peerInfo;
+}
+
+// Generate JSON for each peer in `peerList` and append to `jsonResultList`
+void
+recordTimeSlicedLinkResults(Json::Value& jsonResultList,
+                            TimeSlicedPeerDataList const& peerList)
+{
+    for (auto const& peer : peerList)
+    {
+        Json::Value peerInfo = peerStatsToJson(peer.peerStats);
+        peerInfo["averageLatencyMs"] = peer.averageLatencyMs;
+        jsonResultList.append(peerInfo);
+    }
+}
+
+// Extract a reference to the SurveyRequestMessage within a StellarMessage
+SurveyRequestMessage const&
+extractSurveyRequestMessage(StellarMessage const& msg)
+{
+    switch (msg.type())
+    {
+    case SURVEY_REQUEST:
+        return msg.signedSurveyRequestMessage().request;
+    case TIME_SLICED_SURVEY_REQUEST:
+        return msg.signedTimeSlicedSurveyRequestMessage().request.request;
+    default:
+        releaseAssert(false);
+    }
+}
+} // namespace
 
 SurveyManager::SurveyManager(Application& app)
     : mApp(app)
@@ -27,14 +97,19 @@ SurveyManager::SurveyManager(Application& app)
     , SURVEY_THROTTLE_TIMEOUT_SEC(
           mApp.getConfig().getExpectedLedgerCloseTime() *
           SURVEY_THROTTLE_TIMEOUT_MULT)
+    , mSurveyDataManager(
+          [this]() { return mApp.getClock().now(); },
+          mApp.getMetrics().NewMeter({"scp", "sync", "lost"}, "sync"),
+          mApp.getConfig())
 {
 }
 
 bool
-SurveyManager::startSurvey(SurveyMessageCommandType type,
-                           std::chrono::seconds surveyDuration)
+SurveyManager::startSurveyReporting(
+    SurveyMessageCommandType type,
+    std::optional<std::chrono::seconds> surveyDuration)
 {
-    if (mRunningSurveyType)
+    if (mRunningSurveyReportingPhaseType)
     {
         return false;
     }
@@ -49,12 +124,35 @@ SurveyManager::startSurvey(SurveyMessageCommandType type,
     mPeersToSurvey.clear();
     mPeersToSurveyQueue = std::queue<NodeID>();
 
-    mRunningSurveyType = std::make_optional<SurveyMessageCommandType>(type);
+    mRunningSurveyReportingPhaseType =
+        std::make_optional<SurveyMessageCommandType>(type);
 
     mCurve25519SecretKey = curve25519RandomSecret();
     mCurve25519PublicKey = curve25519DerivePublic(mCurve25519SecretKey);
 
-    updateSurveyExpiration(surveyDuration);
+    // Check surveyDuration (should only be set for old style surveys; time
+    // sliced surveys use a builtin timeout)
+    switch (type)
+    {
+    case SURVEY_TOPOLOGY:
+        if (!surveyDuration.has_value())
+        {
+            throw std::runtime_error(
+                "startSurveyReporting failed: missing survey duration");
+        }
+        updateOldStyleSurveyExpiration(surveyDuration.value());
+        break;
+    case TIME_SLICED_SURVEY_TOPOLOGY:
+        // Time sliced surveys have a built-in timeout, so one should not be
+        // passed in.
+        if (surveyDuration.has_value())
+        {
+            throw std::runtime_error(
+                "startSurveyReporting failed: unexpected survey duration");
+        }
+        break;
+    }
+
     // starts timer
     topOffRequests(type);
 
@@ -62,15 +160,15 @@ SurveyManager::startSurvey(SurveyMessageCommandType type,
 }
 
 void
-SurveyManager::stopSurvey()
+SurveyManager::stopSurveyReporting()
 {
-    // do nothing if survey isn't running
-    if (!mRunningSurveyType)
+    // do nothing if survey isn't running in reporting phase
+    if (!mRunningSurveyReportingPhaseType)
     {
         return;
     }
 
-    mRunningSurveyType.reset();
+    mRunningSurveyReportingPhaseType.reset();
     mSurveyThrottleTimer->cancel();
 
     clearCurve25519Keys(mCurve25519PublicKey, mCurve25519SecretKey);
@@ -78,22 +176,210 @@ SurveyManager::stopSurvey()
     CLOG_INFO(Overlay, "SurveyResults {}", getJsonResults().toStyledString());
 }
 
+bool
+SurveyManager::broadcastStartSurveyCollecting(uint32_t nonce)
+{
+    if (mSurveyDataManager.surveyIsActive())
+    {
+        CLOG_ERROR(
+            Overlay,
+            "Cannot start survey with nonce {} because another survey is "
+            "already active",
+            nonce);
+        return false;
+    }
+    StellarMessage newMsg;
+    newMsg.type(TIME_SLICED_SURVEY_START_COLLECTING);
+    auto& signedStartCollecting =
+        newMsg.signedTimeSlicedSurveyStartCollectingMessage();
+    auto& startCollecting = signedStartCollecting.startCollecting;
+
+    startCollecting.surveyorID = mApp.getConfig().NODE_SEED.getPublicKey();
+    startCollecting.nonce = nonce;
+    startCollecting.ledgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
+
+    auto sigBody = xdr::xdr_to_opaque(startCollecting);
+    signedStartCollecting.signature = mApp.getConfig().NODE_SEED.sign(sigBody);
+
+    relayStartSurveyCollecting(newMsg, nullptr);
+    return true;
+}
+
+void
+SurveyManager::relayStartSurveyCollecting(StellarMessage const& msg,
+                                          Peer::pointer peer)
+{
+    releaseAssert(msg.type() == TIME_SLICED_SURVEY_START_COLLECTING);
+    auto const& signedStartCollecting =
+        msg.signedTimeSlicedSurveyStartCollectingMessage();
+    auto const& startCollecting = signedStartCollecting.startCollecting;
+
+    auto surveyorIsSelf =
+        startCollecting.surveyorID == mApp.getConfig().NODE_SEED.getPublicKey();
+    if (!surveyorIsSelf)
+    {
+        releaseAssert(peer);
+
+        if (!surveyorPermitted(startCollecting.surveyorID))
+        {
+            return;
+        }
+    }
+
+    auto onSuccessValidation = [&]() -> bool {
+        // Check signature
+        return dropPeerIfSigInvalid(startCollecting.surveyorID,
+                                    signedStartCollecting.signature,
+                                    xdr::xdr_to_opaque(startCollecting), peer);
+    };
+
+    if (!mMessageLimiter.validateStartSurveyCollecting(
+            startCollecting, mSurveyDataManager, onSuccessValidation))
+    {
+        return;
+    }
+
+    OverlayManager& om = mApp.getOverlayManager();
+    if (!mSurveyDataManager.startSurveyCollecting(
+            startCollecting, om.getInboundAuthenticatedPeers(),
+            om.getOutboundAuthenticatedPeers(), mApp.getState()))
+    {
+        return;
+    }
+
+    if (peer)
+    {
+        om.recvFloodedMsg(msg, peer);
+    }
+
+    broadcast(msg);
+}
+
+bool
+SurveyManager::broadcastStopSurveyCollecting()
+{
+    std::optional<uint32_t> maybeNonce = mSurveyDataManager.getNonce();
+    if (!maybeNonce.has_value())
+    {
+        return false;
+    }
+
+    StellarMessage newMsg;
+    newMsg.type(TIME_SLICED_SURVEY_STOP_COLLECTING);
+    auto& signedStopCollecting =
+        newMsg.signedTimeSlicedSurveyStopCollectingMessage();
+    auto& stopCollecting = signedStopCollecting.stopCollecting;
+
+    stopCollecting.surveyorID = mApp.getConfig().NODE_SEED.getPublicKey();
+    stopCollecting.nonce = maybeNonce.value();
+    stopCollecting.ledgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
+
+    auto sigBody = xdr::xdr_to_opaque(stopCollecting);
+    signedStopCollecting.signature = mApp.getConfig().NODE_SEED.sign(sigBody);
+
+    relayStopSurveyCollecting(newMsg, nullptr);
+
+    return true;
+}
+
+void
+SurveyManager::relayStopSurveyCollecting(StellarMessage const& msg,
+                                         Peer::pointer peer)
+{
+    releaseAssert(msg.type() == TIME_SLICED_SURVEY_STOP_COLLECTING);
+    auto const& signedStopCollecting =
+        msg.signedTimeSlicedSurveyStopCollectingMessage();
+    auto const& stopCollecting = signedStopCollecting.stopCollecting;
+
+    auto surveyorIsSelf =
+        stopCollecting.surveyorID == mApp.getConfig().NODE_SEED.getPublicKey();
+    if (!surveyorIsSelf)
+    {
+        releaseAssert(peer);
+
+        if (!surveyorPermitted(stopCollecting.surveyorID))
+        {
+            return;
+        }
+    }
+
+    auto onSuccessValidation = [&]() -> bool {
+        // Check signature
+        return dropPeerIfSigInvalid(stopCollecting.surveyorID,
+                                    signedStopCollecting.signature,
+                                    xdr::xdr_to_opaque(stopCollecting), peer);
+    };
+
+    if (!mMessageLimiter.validateStopSurveyCollecting(stopCollecting,
+                                                      onSuccessValidation))
+    {
+        return;
+    }
+
+    OverlayManager& om = mApp.getOverlayManager();
+    if (!mSurveyDataManager.stopSurveyCollecting(
+            stopCollecting, om.getInboundAuthenticatedPeers(),
+            om.getOutboundAuthenticatedPeers(), mApp.getConfig()))
+    {
+        return;
+    }
+
+    if (peer)
+    {
+        mApp.getOverlayManager().recvFloodedMsg(msg, peer);
+    }
+
+    broadcast(msg);
+}
+
 void
 SurveyManager::addNodeToRunningSurveyBacklog(
-    SurveyMessageCommandType type, std::chrono::seconds surveyDuration,
-    NodeID const& nodeToSurvey)
+    SurveyMessageCommandType type,
+    std::optional<std::chrono::seconds> surveyDuration,
+    NodeID const& nodeToSurvey, std::optional<uint32_t> inboundPeersIndex,
+    std::optional<uint32_t> outboundPeersIndex)
 {
-    if (!mRunningSurveyType || *mRunningSurveyType != type)
+    if (!mRunningSurveyReportingPhaseType ||
+        *mRunningSurveyReportingPhaseType != type)
     {
         throw std::runtime_error("addNodeToRunningSurveyBacklog failed");
     }
 
     addPeerToBacklog(nodeToSurvey);
-    updateSurveyExpiration(surveyDuration);
+
+    switch (type)
+    {
+    case SURVEY_TOPOLOGY:
+        if (!surveyDuration.has_value())
+        {
+            throw std::runtime_error("addNodeToRunningSurveyBacklog failed: "
+                                     "missing survey duration");
+        }
+        updateOldStyleSurveyExpiration(surveyDuration.value());
+        break;
+    case TIME_SLICED_SURVEY_TOPOLOGY:
+        // Time sliced surveys have a built-in timeout, so one should not be
+        // passed in.
+        if (surveyDuration.has_value())
+        {
+            throw std::runtime_error("addNodeToRunningSurveyBacklog failed: "
+                                     "unexpected survey duration");
+        }
+
+        if (!inboundPeersIndex.has_value() || !outboundPeersIndex.has_value())
+        {
+            throw std::runtime_error(
+                "addNodeToRunningSurveyBacklog failed: missing peer indices");
+        }
+
+        mInboundPeerIndices[nodeToSurvey] = inboundPeersIndex.value();
+        mOutboundPeerIndices[nodeToSurvey] = outboundPeersIndex.value();
+        break;
+    }
 }
 
-void
-SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
+std::optional<SurveyResponseMessage>
+SurveyManager::validateSurveyResponse(StellarMessage const& msg,
                                       Peer::pointer peer)
 {
     releaseAssert(msg.type() == SURVEY_RESPONSE);
@@ -106,11 +392,73 @@ SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
                                     xdr::xdr_to_opaque(response), peer);
     };
 
-    if (!mMessageLimiter.recordAndValidateResponse(response,
-                                                   onSuccessValidation))
+    if (mMessageLimiter.recordAndValidateResponse(response,
+                                                  onSuccessValidation))
     {
+        return response;
+    }
+    else
+    {
+        return std::nullopt;
+    }
+}
+
+std::optional<SurveyResponseMessage>
+SurveyManager::validateTimeSlicedSurveyResponse(StellarMessage const& msg,
+                                                Peer::pointer peer)
+{
+    releaseAssert(msg.type() == TIME_SLICED_SURVEY_RESPONSE);
+    auto const& signedResponse = msg.signedTimeSlicedSurveyResponseMessage();
+    auto const& response = signedResponse.response.response;
+
+    auto onSuccessValidation = [&]() -> bool {
+        // Check nonce
+        if (!mSurveyDataManager.nonceIsReporting(signedResponse.response.nonce))
+        {
+            return false;
+        }
+
+        // Check signature
+        return dropPeerIfSigInvalid(
+            response.surveyedPeerID, signedResponse.responseSignature,
+            xdr::xdr_to_opaque(signedResponse.response), peer);
+    };
+
+    if (mMessageLimiter.recordAndValidateResponse(response,
+                                                  onSuccessValidation))
+    {
+        return response;
+    }
+    else
+    {
+        return std::nullopt;
+    }
+}
+
+void
+SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
+                                      Peer::pointer peer)
+{
+    std::optional<SurveyResponseMessage> maybeResponse;
+    switch (msg.type())
+    {
+    case SURVEY_RESPONSE:
+        maybeResponse = validateSurveyResponse(msg, peer);
+        break;
+    case TIME_SLICED_SURVEY_RESPONSE:
+        maybeResponse = validateTimeSlicedSurveyResponse(msg, peer);
+        break;
+    default:
+        releaseAssert(false);
+    }
+
+    if (!maybeResponse.has_value())
+    {
+        // Validation failed
         return;
     }
+
+    auto const& response = maybeResponse.value();
 
     // mMessageLimiter filters out duplicates, so here we are guaranteed
     // to record the message for the first time
@@ -120,7 +468,8 @@ SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
     {
         // only process if survey is still running and we haven't seen the
         // response
-        if (mRunningSurveyType && *mRunningSurveyType == response.commandType)
+        if (mRunningSurveyReportingPhaseType &&
+            *mRunningSurveyReportingPhaseType == response.commandType)
         {
             try
             {
@@ -130,8 +479,23 @@ SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
 
                 SurveyResponseBody body;
                 xdr::xdr_from_opaque(opaqueDecrypted, body);
-
-                processTopologyResponse(response.surveyedPeerID, body);
+                switch (msg.type())
+                {
+                case SURVEY_RESPONSE:
+                {
+                    processOldStyleTopologyResponse(response.surveyedPeerID,
+                                                    body);
+                }
+                break;
+                case TIME_SLICED_SURVEY_RESPONSE:
+                {
+                    processTimeSlicedTopologyResponse(response.surveyedPeerID,
+                                                      body);
+                }
+                break;
+                default:
+                    releaseAssert(false);
+                }
             }
             catch (std::exception const& e)
             {
@@ -145,8 +509,8 @@ SurveyManager::relayOrProcessResponse(StellarMessage const& msg,
     }
     else
     {
-        // messageLimiter guarantees we only flood the response if we've seen
-        // the request
+        // messageLimiter guarantees we only flood the response if we've
+        // seen the request
         broadcast(msg);
     }
 }
@@ -155,11 +519,7 @@ void
 SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
                                      Peer::pointer peer)
 {
-    releaseAssert(msg.type() == SURVEY_REQUEST);
-    SignedSurveyRequestMessage const& signedRequest =
-        msg.signedSurveyRequestMessage();
-
-    SurveyRequestMessage const& request = signedRequest.request;
+    SurveyRequestMessage const& request = extractSurveyRequestMessage(msg);
 
     auto surveyorIsSelf =
         request.surveyorPeerID == mApp.getConfig().NODE_SEED.getPublicKey();
@@ -167,32 +527,41 @@ SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
     {
         releaseAssert(peer);
 
-        // perform all validation checks before signature validation so we don't
-        // waste time verifying signatures
-        auto const& surveyorKeys = mApp.getConfig().SURVEYOR_KEYS;
-
-        if (surveyorKeys.empty())
+        if (!surveyorPermitted(request.surveyorPeerID))
         {
-            auto const& quorumMap =
-                mApp.getHerder().getCurrentlyTrackedQuorum();
-            if (quorumMap.count(request.surveyorPeerID) == 0)
-            {
-                return;
-            }
-        }
-        else
-        {
-            if (surveyorKeys.count(request.surveyorPeerID) == 0)
-            {
-                return;
-            }
+            return;
         }
     }
 
     auto onSuccessValidation = [&]() -> bool {
-        auto res = dropPeerIfSigInvalid(request.surveyorPeerID,
-                                        signedRequest.requestSignature,
-                                        xdr::xdr_to_opaque(request), peer);
+        bool res;
+        switch (msg.type())
+        {
+        case SURVEY_REQUEST:
+            res = dropPeerIfSigInvalid(
+                request.surveyorPeerID,
+                msg.signedSurveyRequestMessage().requestSignature,
+                xdr::xdr_to_opaque(request), peer);
+            break;
+        case TIME_SLICED_SURVEY_REQUEST:
+        {
+            SignedTimeSlicedSurveyRequestMessage const& signedRequest =
+                msg.signedTimeSlicedSurveyRequestMessage();
+            // check nonce
+            res = mSurveyDataManager.nonceIsReporting(
+                signedRequest.request.nonce);
+            if (res)
+            {
+                // Check signature
+                res = dropPeerIfSigInvalid(
+                    request.surveyorPeerID, signedRequest.requestSignature,
+                    xdr::xdr_to_opaque(signedRequest.request), peer);
+            }
+        }
+        break;
+        default:
+            releaseAssert(false);
+        }
         if (!res && surveyorIsSelf)
         {
             CLOG_ERROR(Overlay, "Unexpected invalid survey request: {} ",
@@ -213,7 +582,18 @@ SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
 
     if (request.surveyedPeerID == mApp.getConfig().NODE_SEED.getPublicKey())
     {
-        processTopologyRequest(request);
+        switch (msg.type())
+        {
+        case SURVEY_REQUEST:
+            processOldStyleTopologyRequest(request);
+            break;
+        case TIME_SLICED_SURVEY_REQUEST:
+            processTimeSlicedTopologyRequest(
+                msg.signedTimeSlicedSurveyRequestMessage().request);
+            break;
+        default:
+            releaseAssert(false);
+        }
     }
     else
     {
@@ -221,8 +601,21 @@ SurveyManager::relayOrProcessRequest(StellarMessage const& msg,
     }
 }
 
+void
+SurveyManager::populateSurveyRequestMessage(NodeID const& nodeToSurvey,
+                                            SurveyMessageCommandType type,
+                                            SurveyRequestMessage& request) const
+{
+    request.ledgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
+    request.surveyorPeerID = mApp.getConfig().NODE_SEED.getPublicKey();
+
+    request.surveyedPeerID = nodeToSurvey;
+    request.encryptionKey = mCurve25519PublicKey;
+    request.commandType = type;
+}
+
 StellarMessage
-SurveyManager::makeSurveyRequest(NodeID const& nodeToSurvey) const
+SurveyManager::makeOldStyleSurveyRequest(NodeID const& nodeToSurvey) const
 {
     StellarMessage newMsg;
     newMsg.type(SURVEY_REQUEST);
@@ -230,13 +623,7 @@ SurveyManager::makeSurveyRequest(NodeID const& nodeToSurvey) const
     auto& signedRequest = newMsg.signedSurveyRequestMessage();
 
     auto& request = signedRequest.request;
-    request.ledgerNum = mApp.getHerder().trackingConsensusLedgerIndex();
-    request.surveyorPeerID = mApp.getConfig().NODE_SEED.getPublicKey();
-
-    request.surveyedPeerID = nodeToSurvey;
-    request.encryptionKey = mCurve25519PublicKey;
-    request.commandType = SURVEY_TOPOLOGY;
-
+    populateSurveyRequestMessage(nodeToSurvey, SURVEY_TOPOLOGY, request);
     auto sigBody = xdr::xdr_to_opaque(request);
     signedRequest.requestSignature = mApp.getConfig().NODE_SEED.sign(sigBody);
 
@@ -246,14 +633,58 @@ SurveyManager::makeSurveyRequest(NodeID const& nodeToSurvey) const
 void
 SurveyManager::sendTopologyRequest(NodeID const& nodeToSurvey)
 {
+    if (!mRunningSurveyReportingPhaseType.has_value())
+    {
+        CLOG_ERROR(Overlay, "Tried to send survey request when no survey is "
+                            "running in reporting phase");
+        return;
+    }
+
+    StellarMessage newMsg;
+    switch (mRunningSurveyReportingPhaseType.value())
+    {
+    case SURVEY_TOPOLOGY:
+        newMsg = makeOldStyleSurveyRequest(nodeToSurvey);
+        break;
+    case TIME_SLICED_SURVEY_TOPOLOGY:
+    {
+        newMsg.type(TIME_SLICED_SURVEY_REQUEST);
+
+        auto& signedRequest = newMsg.signedTimeSlicedSurveyRequestMessage();
+        auto& outerRequest = signedRequest.request;
+        auto& innerRequest = outerRequest.request;
+        populateSurveyRequestMessage(nodeToSurvey, TIME_SLICED_SURVEY_TOPOLOGY,
+                                     innerRequest);
+
+        auto maybeNonce = mSurveyDataManager.getNonce();
+        if (!maybeNonce.has_value())
+        {
+            // Reporting phase has ended. Drop the request.
+            return;
+        }
+
+        outerRequest.nonce = maybeNonce.value();
+        outerRequest.inboundPeersIndex = mInboundPeerIndices.at(nodeToSurvey);
+        outerRequest.outboundPeersIndex = mOutboundPeerIndices.at(nodeToSurvey);
+
+        auto sigBody = xdr::xdr_to_opaque(outerRequest);
+        signedRequest.requestSignature =
+            mApp.getConfig().NODE_SEED.sign(sigBody);
+    }
+    break;
+    default:
+        releaseAssert(false);
+    }
     // Record the request in message limiter and broadcast
-    relayOrProcessRequest(makeSurveyRequest(nodeToSurvey), nullptr);
+    relayOrProcessRequest(newMsg, nullptr);
 }
 
 void
-SurveyManager::processTopologyResponse(NodeID const& surveyedPeerID,
-                                       SurveyResponseBody const& body)
+SurveyManager::processOldStyleTopologyResponse(NodeID const& surveyedPeerID,
+                                               SurveyResponseBody const& body)
 {
+    releaseAssert(body.type() == SURVEY_TOPOLOGY_RESPONSE_V0 ||
+                  body.type() == SURVEY_TOPOLOGY_RESPONSE_V1);
     auto& peerResults =
         mResults["topology"][KeyUtils::toStrKey(surveyedPeerID)];
     auto populatePeerResults = [&](auto const& topologyBody) {
@@ -285,7 +716,60 @@ SurveyManager::processTopologyResponse(NodeID const& surveyedPeerID,
 }
 
 void
-SurveyManager::processTopologyRequest(SurveyRequestMessage const& request) const
+SurveyManager::processTimeSlicedTopologyResponse(NodeID const& surveyedPeerID,
+                                                 SurveyResponseBody const& body)
+{
+    releaseAssert(body.type() == SURVEY_TOPOLOGY_RESPONSE_V2);
+    auto& peerResults =
+        mResults["topology"][KeyUtils::toStrKey(surveyedPeerID)];
+
+    // Fill in node data
+    auto const& topologyBody = body.topologyResponseBodyV2();
+    TimeSlicedNodeData const& node = topologyBody.nodeData;
+    peerResults["addedAuthenticatedPeers"] = node.addedAuthenticatedPeers;
+    peerResults["droppedAuthenticatedPeers"] = node.droppedAuthenticatedPeers;
+    peerResults["numTotalInboundPeers"] = node.totalInboundPeerCount;
+    peerResults["numTotalOutboundPeers"] = node.totalOutboundPeerCount;
+    peerResults["p75SCPFirstToSelfLatencyNs"] = node.p75SCPFirstToSelfLatencyNs;
+    peerResults["p75SCPSelfToOtherLatencyNs"] = node.p75SCPSelfToOtherLatencyNs;
+    peerResults["lostSyncCount"] = node.lostSyncCount;
+    peerResults["isValidator"] = node.isValidator;
+    peerResults["maxInboundPeerCount"] = node.maxInboundPeerCount;
+    peerResults["maxOutboundPeerCount"] = node.maxOutboundPeerCount;
+
+    // Fill in link data
+    auto& inboundResults = peerResults["inboundPeers"];
+    auto& outboundResults = peerResults["outboundPeers"];
+    recordTimeSlicedLinkResults(inboundResults, topologyBody.inboundPeers);
+    recordTimeSlicedLinkResults(outboundResults, topologyBody.outboundPeers);
+}
+
+bool
+SurveyManager::populateSurveyResponseMessage(
+    SurveyRequestMessage const& request, SurveyMessageCommandType type,
+    SurveyResponseBody const& body, SurveyResponseMessage& response) const
+{
+    response.ledgerNum = request.ledgerNum;
+    response.surveyorPeerID = request.surveyorPeerID;
+    response.surveyedPeerID = mApp.getConfig().NODE_SEED.getPublicKey();
+    response.commandType = type;
+
+    try
+    {
+        response.encryptedBody = curve25519Encrypt<EncryptedBody::max_size()>(
+            request.encryptionKey, xdr::xdr_to_opaque(body));
+    }
+    catch (std::exception const& e)
+    {
+        CLOG_ERROR(Overlay, "curve25519Encrypt failed: {}", e.what());
+        return false;
+    }
+    return true;
+}
+
+void
+SurveyManager::processOldStyleTopologyRequest(
+    SurveyRequestMessage const& request) const
 {
     CLOG_TRACE(Overlay, "Responding to Topology request from {}",
                mApp.getConfig().toShortString(request.surveyorPeerID));
@@ -294,12 +778,6 @@ SurveyManager::processTopologyRequest(SurveyRequestMessage const& request) const
     newMsg.type(SURVEY_RESPONSE);
 
     auto& signedResponse = newMsg.signedSurveyResponseMessage();
-    auto& response = signedResponse.response;
-
-    response.ledgerNum = request.ledgerNum;
-    response.surveyorPeerID = request.surveyorPeerID;
-    response.surveyedPeerID = mApp.getConfig().NODE_SEED.getPublicKey();
-    response.commandType = SURVEY_TOPOLOGY;
 
     SurveyResponseBody body;
     body.type(SURVEY_TOPOLOGY_RESPONSE_V1);
@@ -326,14 +804,10 @@ SurveyManager::processTopologyRequest(SurveyRequestMessage const& request) const
     topologyBody.maxOutboundPeerCount =
         mApp.getConfig().TARGET_PEER_CONNECTIONS;
 
-    try
+    auto& response = signedResponse.response;
+    if (!populateSurveyResponseMessage(request, SURVEY_TOPOLOGY, body,
+                                       response))
     {
-        response.encryptedBody = curve25519Encrypt<EncryptedBody::max_size()>(
-            request.encryptionKey, xdr::xdr_to_opaque(body));
-    }
-    catch (std::exception const& e)
-    {
-        CLOG_ERROR(Overlay, "curve25519Encrypt failed: {}", e.what());
         return;
     }
 
@@ -344,10 +818,70 @@ SurveyManager::processTopologyRequest(SurveyRequestMessage const& request) const
 }
 
 void
+SurveyManager::processTimeSlicedTopologyRequest(
+    TimeSlicedSurveyRequestMessage const& request)
+{
+    std::string const peerIdStr =
+        mApp.getConfig().toShortString(request.request.surveyorPeerID);
+    CLOG_TRACE(Overlay, "Responding to Topology request from {}", peerIdStr);
+
+    SurveyResponseBody body;
+    body.type(SURVEY_TOPOLOGY_RESPONSE_V2);
+    if (!mSurveyDataManager.fillSurveyData(request,
+                                           body.topologyResponseBodyV2()))
+    {
+        // This shouldn't happen because nonce and phase should have already
+        // been checked prior to calling this function
+        CLOG_ERROR(Overlay,
+                   "Failed to respond to TimeSlicedTopology request from {} "
+                   "due to unexpected nonce mismatch or survey phase mismatch",
+                   peerIdStr);
+        return;
+    }
+
+    StellarMessage newMsg;
+    newMsg.type(TIME_SLICED_SURVEY_RESPONSE);
+    auto& signedResponse = newMsg.signedTimeSlicedSurveyResponseMessage();
+
+    auto& outerResponse = signedResponse.response;
+    outerResponse.nonce = request.nonce;
+
+    auto& innerResponse = outerResponse.response;
+    if (!populateSurveyResponseMessage(
+            request.request, TIME_SLICED_SURVEY_TOPOLOGY, body, innerResponse))
+    {
+        return;
+    }
+
+    auto sigBody = xdr::xdr_to_opaque(outerResponse);
+    signedResponse.responseSignature = mApp.getConfig().NODE_SEED.sign(sigBody);
+
+    broadcast(newMsg);
+}
+
+void
 SurveyManager::broadcast(StellarMessage const& msg) const
 {
+    uint32_t minOverlayVersion = 0;
+    switch (msg.type())
+    {
+    case SURVEY_REQUEST:
+    case SURVEY_RESPONSE:
+        // Do nothing. All nodes on the network can understand these messages.
+        break;
+    case TIME_SLICED_SURVEY_START_COLLECTING:
+    case TIME_SLICED_SURVEY_STOP_COLLECTING:
+    case TIME_SLICED_SURVEY_REQUEST:
+    case TIME_SLICED_SURVEY_RESPONSE:
+        // Only send messages to nodes that can understand them.
+        minOverlayVersion = TIME_SLICED_SURVEY_MIN_OVERLAY_PROTOCOL_VERSION;
+        break;
+    default:
+        releaseAssert(false);
+    }
     mApp.getOverlayManager().broadcastMessage(
-        std::make_shared<StellarMessage const>(msg));
+        std::make_shared<StellarMessage const>(msg), /*hash*/ std::nullopt,
+        minOverlayVersion);
 }
 
 void
@@ -398,36 +932,7 @@ SurveyManager::recordResults(Json::Value& jsonResultList,
 {
     for (auto const& peer : peerList)
     {
-        Json::Value peerInfo;
-        peerInfo["nodeId"] = KeyUtils::toStrKey(peer.id);
-        peerInfo["version"] = peer.versionStr;
-        peerInfo["messagesRead"] = static_cast<Json::UInt64>(peer.messagesRead);
-        peerInfo["messagesWritten"] =
-            static_cast<Json::UInt64>(peer.messagesWritten);
-        peerInfo["bytesRead"] = static_cast<Json::UInt64>(peer.bytesRead);
-        peerInfo["bytesWritten"] = static_cast<Json::UInt64>(peer.bytesWritten);
-        peerInfo["secondsConnected"] =
-            static_cast<Json::UInt64>(peer.secondsConnected);
-
-        peerInfo["uniqueFloodBytesRecv"] =
-            static_cast<Json::UInt64>(peer.uniqueFloodBytesRecv);
-        peerInfo["duplicateFloodBytesRecv"] =
-            static_cast<Json::UInt64>(peer.duplicateFloodBytesRecv);
-        peerInfo["uniqueFetchBytesRecv"] =
-            static_cast<Json::UInt64>(peer.uniqueFetchBytesRecv);
-        peerInfo["duplicateFetchBytesRecv"] =
-            static_cast<Json::UInt64>(peer.duplicateFetchBytesRecv);
-
-        peerInfo["uniqueFloodMessageRecv"] =
-            static_cast<Json::UInt64>(peer.uniqueFloodMessageRecv);
-        peerInfo["duplicateFloodMessageRecv"] =
-            static_cast<Json::UInt64>(peer.duplicateFloodMessageRecv);
-        peerInfo["uniqueFetchMessageRecv"] =
-            static_cast<Json::UInt64>(peer.uniqueFetchMessageRecv);
-        peerInfo["duplicateFetchMessageRecv"] =
-            static_cast<Json::UInt64>(peer.duplicateFetchMessageRecv);
-
-        jsonResultList.append(peerInfo);
+        jsonResultList.append(peerStatsToJson(peer));
     }
 }
 
@@ -440,7 +945,7 @@ SurveyManager::clearOldLedgers(uint32_t lastClosedledgerSeq)
 Json::Value const&
 SurveyManager::getJsonResults()
 {
-    mResults["surveyInProgress"] = mRunningSurveyType.has_value();
+    mResults["surveyInProgress"] = mRunningSurveyReportingPhaseType.has_value();
 
     auto& jsonBacklog = mResults["backlog"];
     jsonBacklog.clear();
@@ -476,6 +981,20 @@ SurveyManager::getMsgSummary(StellarMessage const& msg)
         summary = "SURVEY_RESPONSE:";
         commandType = msg.signedSurveyResponseMessage().response.commandType;
         break;
+    case TIME_SLICED_SURVEY_REQUEST:
+        summary = "TIME_SLICED_SURVEY_REQUEST:";
+        commandType = msg.signedTimeSlicedSurveyRequestMessage()
+                          .request.request.commandType;
+        break;
+    case TIME_SLICED_SURVEY_RESPONSE:
+        summary = "TIME_SLICED_SURVEY_RESPONSE:";
+        commandType = msg.signedTimeSlicedSurveyResponseMessage()
+                          .response.response.commandType;
+        break;
+    case TIME_SLICED_SURVEY_START_COLLECTING:
+        return "TIME_SLICED_SURVEY_START_COLLECTING";
+    case TIME_SLICED_SURVEY_STOP_COLLECTING:
+        return "TIME_SLICED_SURVEY_STOP_COLLECTING";
     default:
         throw std::runtime_error(
             "invalid call of SurveyManager::getMsgSummary");
@@ -486,10 +1005,9 @@ SurveyManager::getMsgSummary(StellarMessage const& msg)
 void
 SurveyManager::topOffRequests(SurveyMessageCommandType type)
 {
-    // Only stop the survey if all pending requests have been processed
-    if (mApp.getClock().now() > mSurveyExpirationTime && mPeersToSurvey.empty())
+    if (surveyIsFinishedReporting())
     {
-        stopSurvey();
+        stopSurveyReporting();
         return;
     }
 
@@ -500,7 +1018,7 @@ SurveyManager::topOffRequests(SurveyMessageCommandType type)
     // happen if some connections get congested)
 
     uint32_t requestsSentInSchedule = 0;
-    while (mRunningSurveyType &&
+    while (mRunningSurveyReportingPhaseType &&
            requestsSentInSchedule < MAX_REQUEST_LIMIT_PER_LEDGER &&
            !mPeersToSurvey.empty())
     {
@@ -534,8 +1052,11 @@ SurveyManager::topOffRequests(SurveyMessageCommandType type)
 }
 
 void
-SurveyManager::updateSurveyExpiration(std::chrono::seconds surveyDuration)
+SurveyManager::updateOldStyleSurveyExpiration(
+    std::chrono::seconds surveyDuration)
 {
+    // This function should only be called for old style surveys
+    releaseAssert(mRunningSurveyReportingPhaseType.value() == SURVEY_TOPOLOGY);
     mSurveyExpirationTime = mApp.getClock().now() + surveyDuration;
 }
 
@@ -549,7 +1070,8 @@ SurveyManager::addPeerToBacklog(NodeID const& nodeToSurvey)
     if (mPeersToSurvey.count(nodeToSurvey) != 0 ||
         nodeToSurvey == mApp.getConfig().NODE_SEED.getPublicKey())
     {
-        return;
+        throw std::runtime_error("addPeerToBacklog failed: Peer is already in "
+                                 "the backlog, or peer is self.");
     }
 
     mBadResponseNodes.erase(nodeToSurvey);
@@ -586,4 +1108,82 @@ SurveyManager::commandTypeName(SurveyMessageCommandType type)
 {
     return xdr::xdr_traits<SurveyMessageCommandType>::enum_name(type);
 }
+
+bool
+SurveyManager::surveyorPermitted(NodeID const& surveyorID) const
+{
+    auto const& surveyorKeys = mApp.getConfig().SURVEYOR_KEYS;
+
+    if (surveyorKeys.empty())
+    {
+        auto const& quorumMap = mApp.getHerder().getCurrentlyTrackedQuorum();
+        return quorumMap.count(surveyorID) != 0;
+    }
+
+    return surveyorKeys.count(surveyorID) != 0;
+}
+
+void
+SurveyManager::modifyNodeData(std::function<void(CollectingNodeData&)> f)
+{
+    mSurveyDataManager.modifyNodeData(f);
+}
+
+void
+SurveyManager::modifyPeerData(Peer const& peer,
+                              std::function<void(CollectingPeerData&)> f)
+{
+    mSurveyDataManager.modifyPeerData(peer, f);
+}
+
+void
+SurveyManager::recordDroppedPeer(Peer const& peer)
+{
+    mSurveyDataManager.recordDroppedPeer(peer);
+}
+
+void
+SurveyManager::updateSurveyPhase(
+    std::map<NodeID, Peer::pointer> const& inboundPeers,
+    std::map<NodeID, Peer::pointer> const& outboundPeers, Config const& config)
+{
+    mSurveyDataManager.updateSurveyPhase(inboundPeers, outboundPeers, config);
+}
+
+bool
+SurveyManager::surveyIsFinishedReporting()
+{
+    if (!mRunningSurveyReportingPhaseType.has_value())
+    {
+        return true;
+    }
+
+    switch (mRunningSurveyReportingPhaseType.value())
+    {
+    case SURVEY_TOPOLOGY:
+        // Survey is finished if the survey duration has passed and there are no
+        // remaining peers to survey
+        return mApp.getClock().now() > mSurveyExpirationTime &&
+               mPeersToSurvey.empty();
+    case TIME_SLICED_SURVEY_TOPOLOGY:
+    {
+        // Survey is finished when reporting phase ends
+        std::optional<uint32_t> maybeNonce = mSurveyDataManager.getNonce();
+        if (!maybeNonce.has_value())
+        {
+            return true;
+        }
+        return !mSurveyDataManager.nonceIsReporting(maybeNonce.value());
+    }
+    }
+}
+
+#ifdef BUILD_TESTS
+SurveyDataManager&
+SurveyManager::getSurveyDataManagerForTesting()
+{
+    return mSurveyDataManager;
+}
+#endif
+
 }

--- a/src/overlay/SurveyManager.h
+++ b/src/overlay/SurveyManager.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/Peer.h"
+#include "overlay/SurveyDataManager.h"
 #include "overlay/SurveyMessageLimiter.h"
 #include "util/Timer.h"
 #include "util/UnorderedSet.h"
@@ -29,13 +30,22 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
 
     SurveyManager(Application& app);
 
-    bool startSurvey(SurveyMessageCommandType type,
-                     std::chrono::seconds surveyDuration);
-    void stopSurvey();
+    // Start/stop survey reporting. Must be called before/after gathering data
+    // during the reporting phase of a survey. `surveyDuration` must be provided
+    // for old style surveys, and must not be provided for time sliced surveys.
+    bool
+    startSurveyReporting(SurveyMessageCommandType type,
+                         std::optional<std::chrono::seconds> surveyDuration);
+    void stopSurveyReporting();
 
-    void addNodeToRunningSurveyBacklog(SurveyMessageCommandType type,
-                                       std::chrono::seconds surveyDuration,
-                                       NodeID const& nodeToSurvey);
+    // Add a node to the backlog of nodes to survey. inboundPeerIndex and
+    // outboundPeerIndex are mandatory for time sliced surveys and indicate
+    // which peers the node should report on
+    void addNodeToRunningSurveyBacklog(
+        SurveyMessageCommandType type,
+        std::optional<std::chrono::seconds> surveyDuration,
+        NodeID const& nodeToSurvey, std::optional<uint32_t> inboundPeerIndex,
+        std::optional<uint32_t> outboundPeerIndex);
 
     void relayOrProcessResponse(StellarMessage const& msg, Peer::pointer peer);
     void relayOrProcessRequest(StellarMessage const& msg, Peer::pointer peer);
@@ -43,14 +53,64 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
     Json::Value const& getJsonResults();
 
     static std::string getMsgSummary(StellarMessage const& msg);
-    StellarMessage makeSurveyRequest(NodeID const& nodeToSurvey) const;
+
+    StellarMessage makeOldStyleSurveyRequest(NodeID const& nodeToSurvey) const;
+
+    // Start survey collecting with a given nonce. Returns `false` if unable to
+    // start a survey due to an ongoing survey on the network. Otherwise returns
+    // `true`. Note that a `true` result does not guarantee that the survey will
+    // be successful. It is possible that a survey is already ongoing that this
+    // node does not know about.
+    bool broadcastStartSurveyCollecting(uint32_t nonce);
+
+    void relayStartSurveyCollecting(StellarMessage const& msg,
+                                    Peer::pointer peer);
+
+    // Stop survey collecting. Uses nonce of the currently running survey.
+    // Returns `false` if no survey is currently active.
+    bool broadcastStopSurveyCollecting();
+
+    void relayStopSurveyCollecting(StellarMessage const& msg,
+                                   Peer::pointer peer);
+
+    // The following functions expose functions by the same name in
+    // `mSurveyDataManager`
+    void modifyNodeData(std::function<void(CollectingNodeData&)> f);
+    void modifyPeerData(Peer const& peer,
+                        std::function<void(CollectingPeerData&)> f);
+    void recordDroppedPeer(Peer const& peer);
+    void updateSurveyPhase(std::map<NodeID, Peer::pointer> const& inboundPeers,
+                           std::map<NodeID, Peer::pointer> const& outboundPeers,
+                           Config const& config);
+
+#ifdef BUILD_TESTS
+    // Get a reference to the internal `SurveyDataManager` (for testing only)
+    SurveyDataManager& getSurveyDataManagerForTesting();
+#endif
 
   private:
     // topology specific methods
     void sendTopologyRequest(NodeID const& nodeToSurvey);
-    void processTopologyResponse(NodeID const& surveyedPeerID,
-                                 SurveyResponseBody const& body);
-    void processTopologyRequest(SurveyRequestMessage const& request) const;
+    void processOldStyleTopologyResponse(NodeID const& surveyedPeerID,
+                                         SurveyResponseBody const& body);
+    void
+    processOldStyleTopologyRequest(SurveyRequestMessage const& request) const;
+    void processTimeSlicedTopologyResponse(NodeID const& surveyedPeerID,
+                                           SurveyResponseBody const& body);
+    void processTimeSlicedTopologyRequest(
+        TimeSlicedSurveyRequestMessage const& request);
+
+    // Populate `response` with the data from the other parameters.  Returns
+    // `false` on encryption failure.
+    bool populateSurveyResponseMessage(SurveyRequestMessage const& request,
+                                       SurveyMessageCommandType type,
+                                       SurveyResponseBody const& body,
+                                       SurveyResponseMessage& response) const;
+
+    // Populate `request` with the data from the other parameters
+    void populateSurveyRequestMessage(NodeID const& nodeToSurvey,
+                                      SurveyMessageCommandType type,
+                                      SurveyRequestMessage& request) const;
 
     void broadcast(StellarMessage const& msg) const;
     void populatePeerStats(std::vector<Peer::pointer> const& peers,
@@ -60,8 +120,10 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
                        PeerStatList const& peerList) const;
 
     void topOffRequests(SurveyMessageCommandType type);
-    void updateSurveyExpiration(std::chrono::seconds surveyDuration);
+    void updateOldStyleSurveyExpiration(std::chrono::seconds surveyDuration);
 
+    // Add `nodeToSurvey` to the survey backlog. Throws if the node is
+    // already queued up to survey, or if the node itself is the surveyor.
     void addPeerToBacklog(NodeID const& nodeToSurvey);
 
     // returns true if signature is valid
@@ -69,6 +131,24 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
                               ByteSlice const& bin, Peer::pointer peer);
 
     static std::string commandTypeName(SurveyMessageCommandType type);
+
+    // Validate a survey response message. Returns the message if it is valid
+    // and nullopt otherwise.
+    std::optional<SurveyResponseMessage>
+    validateSurveyResponse(StellarMessage const& msg, Peer::pointer peer);
+
+    // Validate a time sliced survey response message. Returns the message if it
+    // is valid and nullopt otherwise.
+    std::optional<SurveyResponseMessage>
+    validateTimeSlicedSurveyResponse(StellarMessage const& msg,
+                                     Peer::pointer peer);
+
+    // Returns `true` if this node's configuration allows it to be surveyed by
+    // `surveyorID`
+    bool surveyorPermitted(NodeID const& surveyorID) const;
+
+    // Returns `true` if the survey has finished the reporting phase
+    bool surveyIsFinishedReporting();
 
     Application& mApp;
 
@@ -78,7 +158,9 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
     uint32_t const NUM_LEDGERS_BEFORE_IGNORE;
     uint32_t const MAX_REQUEST_LIMIT_PER_LEDGER;
 
-    std::optional<SurveyMessageCommandType> mRunningSurveyType;
+    // If a survey is in the reporting phase, this will be set to the type of
+    // the running survey
+    std::optional<SurveyMessageCommandType> mRunningSurveyReportingPhaseType;
     Curve25519Secret mCurve25519SecretKey;
     Curve25519Public mCurve25519PublicKey;
     SurveyMessageLimiter mMessageLimiter;
@@ -86,9 +168,16 @@ class SurveyManager : public std::enable_shared_from_this<SurveyManager>,
     UnorderedSet<NodeID> mPeersToSurvey;
     std::queue<NodeID> mPeersToSurveyQueue;
 
+    // Indices to use when surveying peers for time sliced surveys
+    std::unordered_map<NodeID, uint32_t> mInboundPeerIndices;
+    std::unordered_map<NodeID, uint32_t> mOutboundPeerIndices;
+
     std::chrono::seconds const SURVEY_THROTTLE_TIMEOUT_SEC;
 
     UnorderedSet<NodeID> mBadResponseNodes;
     Json::Value mResults;
+
+    // Manager for time-sliced survey data
+    SurveyDataManager mSurveyDataManager;
 };
 }

--- a/src/overlay/SurveyMessageLimiter.h
+++ b/src/overlay/SurveyMessageLimiter.h
@@ -5,6 +5,7 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/StellarXDR.h" // IWYU pragma: keep
+#include "overlay/SurveyDataManager.h"
 #include "util/UnorderedMap.h"
 #include <functional>
 #include <map>
@@ -38,6 +39,15 @@ class SurveyMessageLimiter
     bool recordAndValidateResponse(SurveyResponseMessage const& response,
                                    std::function<bool()> onSuccessValidation);
     void clearOldLedgers(uint32_t lastClosedledgerSeq);
+
+    bool validateStartSurveyCollecting(
+        TimeSlicedSurveyStartCollectingMessage const& startSurvey,
+        SurveyDataManager& surveyDataManager,
+        std::function<bool()> onSuccessValidation);
+
+    bool validateStopSurveyCollecting(
+        TimeSlicedSurveyStopCollectingMessage const& stopSurvey,
+        std::function<bool()> onSuccessValidation);
 
   private:
     bool surveyLedgerNumValid(uint32_t ledgerNum);

--- a/src/overlay/test/OverlayManagerTests.cpp
+++ b/src/overlay/test/OverlayManagerTests.cpp
@@ -58,6 +58,7 @@ class PeerStub : public Peer
         mPeerID = SecretKey::pseudoRandomForTesting().getPublicKey();
         mState = GOT_AUTH;
         mAddress = address;
+        mRemoteOverlayVersion = app.getConfig().OVERLAY_PROTOCOL_VERSION;
         mFlowControl = std::make_shared<FlowControlStub>(mAppConnector);
     }
     virtual void

--- a/src/overlay/test/SurveyManagerTests.cpp
+++ b/src/overlay/test/SurveyManagerTests.cpp
@@ -6,50 +6,68 @@
 #include "lib/catch.hpp"
 #include "main/CommandHandler.h"
 #include "overlay/OverlayManager.h"
+#include "overlay/SurveyDataManager.h"
 #include "overlay/SurveyManager.h"
 #include "simulation/Simulation.h"
 #include "test/TestUtils.h"
 #include "test/TxTests.h"
 #include "test/test.h"
 
+using namespace std::chrono_literals;
 using namespace stellar;
 
-TEST_CASE("topology encrypted response memory check",
-          "[overlay][survey][topology]")
+namespace
 {
-    SurveyResponseBody body;
-
-    auto doTest = [&](auto& body) {
-        // Fill up the PeerStatLists
-        for (uint32_t i = 0; i < PeerStatList::max_size(); ++i)
-        {
-            PeerStats s;
-            s.versionStr = std::string(s.versionStr.max_size(), 'a');
-            body.inboundPeers.push_back(s);
-            body.outboundPeers.push_back(s);
-        }
-
-        auto publicKey = curve25519DerivePublic(curve25519RandomSecret());
-        // this will throw if EncryptedBody is too small
-        curve25519Encrypt<EncryptedBody::max_size()>(publicKey,
-                                                     xdr::xdr_to_opaque(body));
-    };
-
-    SECTION("V0")
-    {
-        body.type(SURVEY_TOPOLOGY_RESPONSE_V0);
-        auto& topologyBody = body.topologyResponseBodyV0();
-        doTest(topologyBody);
-    }
-    SECTION("V1")
-    {
-        body.type(SURVEY_TOPOLOGY_RESPONSE_V1);
-        auto& topologyBody = body.topologyResponseBodyV1();
-        doTest(topologyBody);
-    }
+// Begin survey collecting from `node`
+void
+startSurveyCollecting(Application& node, uint32_t nonce)
+{
+    std::string const cmd =
+        "startsurveycollecting?nonce=" + std::to_string(nonce);
+    node.getCommandHandler().manualCmd(cmd);
 }
 
-TEST_CASE("topology survey", "[overlay][survey][topology]")
+// Stop survey collecting from `node`
+void
+stopSurveyCollecting(Application& node, uint32_t nonce)
+{
+    std::string const cmd = "stopsurveycollecting";
+    node.getCommandHandler().manualCmd(cmd);
+}
+
+// Request survey data from `surveyed`. Returns `true` iff the request succeeded
+// in adding `surveyed` to the backlog.
+bool
+surveyTopologyTimeSliced(Application& surveyor, PublicKey const& surveyed,
+                         uint32_t inboundPeerIndex, uint32_t outboundPeerIndex)
+{
+    std::string const cmd =
+        "surveytopologytimesliced?node=" + KeyUtils::toStrKey(surveyed) +
+        "&inboundpeerindex=" + std::to_string(inboundPeerIndex) +
+        "&outboundpeerindex=" + std::to_string(outboundPeerIndex);
+    std::string const response = surveyor.getCommandHandler().manualCmd(cmd);
+
+    // Detect failure by looking for the word "failed" in the response
+    return response.find("failed") == std::string::npos;
+}
+
+// Get survey results from `node`
+Json::Value
+getSurveyResult(Application& node)
+{
+    auto const strResult =
+        node.getCommandHandler().manualCmd("getsurveyresult");
+    Json::Value result;
+    Json::Reader reader;
+    REQUIRE(reader.parse(strResult, result));
+    return result;
+}
+
+// Shared setup function for tests with 5 node unchanging network topology
+std::shared_ptr<Simulation>
+setupStaticNetworkTopology(std::vector<Config>& configList,
+                           std::vector<PublicKey>& keyList,
+                           std::vector<std::string>& keyStrList)
 {
     enum
     {
@@ -64,9 +82,6 @@ TEST_CASE("topology survey", "[overlay][survey][topology]")
     auto simulation =
         std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
 
-    std::vector<Config> configList;
-    std::vector<PublicKey> keyList;
-    std::vector<std::string> keyStrList;
     for (int i = A; i <= E; ++i)
     {
         auto cfg = simulation->newConfig();
@@ -110,6 +125,83 @@ TEST_CASE("topology survey", "[overlay][survey][topology]")
         2 * nLedgers * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
 
     REQUIRE(simulation->haveAllExternalized(nLedgers + 1, 1));
+    return simulation;
+}
+
+} // namespace
+
+TEST_CASE("topology encrypted response memory check",
+          "[overlay][survey][topology]")
+{
+    SurveyResponseBody body;
+
+    // Test that `body` is within memory limits by attempting to encrypt it
+    auto doEncryptTest = [&](auto const& body) {
+        auto publicKey = curve25519DerivePublic(curve25519RandomSecret());
+        // this will throw if EncryptedBody is too small
+        curve25519Encrypt<EncryptedBody::max_size()>(publicKey,
+                                                     xdr::xdr_to_opaque(body));
+    };
+
+    auto doOldStyleTest = [&](auto& body) {
+        // Fill up the PeerStatLists
+        for (uint32_t i = 0; i < PeerStatList::max_size(); ++i)
+        {
+            PeerStats s;
+            s.versionStr = std::string(s.versionStr.max_size(), 'a');
+            body.inboundPeers.push_back(s);
+            body.outboundPeers.push_back(s);
+        }
+
+        doEncryptTest(body);
+    };
+
+    SECTION("V0")
+    {
+        body.type(SURVEY_TOPOLOGY_RESPONSE_V0);
+        auto& topologyBody = body.topologyResponseBodyV0();
+        doOldStyleTest(topologyBody);
+    }
+    SECTION("V1")
+    {
+        body.type(SURVEY_TOPOLOGY_RESPONSE_V1);
+        auto& topologyBody = body.topologyResponseBodyV1();
+        doOldStyleTest(topologyBody);
+    }
+    SECTION("V2")
+    {
+        body.type(SURVEY_TOPOLOGY_RESPONSE_V2);
+        auto& topologyBody = body.topologyResponseBodyV2();
+
+        // Fill up the TimeSlicedPeerDataLists
+        for (uint32_t i = 0; i < TimeSlicedPeerDataList::max_size(); ++i)
+        {
+            TimeSlicedPeerData pd;
+            pd.peerStats.versionStr =
+                std::string(pd.peerStats.versionStr.max_size(), 'a');
+            topologyBody.inboundPeers.push_back(pd);
+            topologyBody.outboundPeers.push_back(pd);
+        }
+
+        doEncryptTest(topologyBody);
+    }
+}
+
+TEST_CASE("topology survey", "[overlay][survey][topology]")
+{
+    enum
+    {
+        A,
+        B,
+        C,
+        D, // not in transitive quorum
+        E
+    };
+    std::vector<Config> configList;
+    std::vector<PublicKey> keyList;
+    std::vector<std::string> keyStrList;
+    std::shared_ptr<Simulation> simulation =
+        setupStaticNetworkTopology(configList, keyList, keyStrList);
 
     auto getResults = [&](NodeID const& nodeID) {
         simulation->crankForAtLeast(std::chrono::seconds(1), false);
@@ -244,7 +336,7 @@ TEST_CASE("topology survey", "[overlay][survey][topology]")
 
         // D responds to A's request, even though A did not ask
         // Create a fake request so that D can respond
-        auto request = getSM(keyList[A]).makeSurveyRequest(keyList[D]);
+        auto request = getSM(keyList[A]).makeOldStyleSurveyRequest(keyList[D]);
         auto peers = simulation->getNode(keyList[D])
                          ->getOverlayManager()
                          .getOutboundAuthenticatedPeers();
@@ -328,14 +420,8 @@ TEST_CASE("survey request process order", "[overlay][survey][topology]")
 
     auto getResults = [&](NodeID const& nodeID) {
         simulation->crankForAtLeast(std::chrono::seconds(1), false);
-        auto strResult =
-            simulation->getNode(nodeID)->getCommandHandler().manualCmd(
-                "getsurveyresult");
-
-        Json::Value result;
-        Json::Reader reader;
-        REQUIRE(reader.parse(strResult, result));
-        return result;
+        Application& node = *simulation->getNode(nodeID);
+        return getSurveyResult(node);
     };
 
     auto sendRequest = [&](PublicKey const& surveyor,
@@ -390,4 +476,423 @@ TEST_CASE("survey request process order", "[overlay][survey][topology]")
         }
     }
     simulation->stopAllNodes();
+}
+
+TEST_CASE("Time sliced static topology survey", "[overlay][survey][topology]")
+{
+    enum
+    {
+        A,
+        B,
+        C,
+        D, // not in transitive quorum
+        E
+    };
+    std::vector<Config> configList;
+    std::vector<PublicKey> keyList;
+    std::vector<std::string> keyStrList;
+    std::shared_ptr<Simulation> simulation =
+        setupStaticNetworkTopology(configList, keyList, keyStrList);
+
+    auto crankForSurvey = [&]() {
+        simulation->crankForAtLeast(
+            configList[A].getExpectedLedgerCloseTime() *
+                SurveyManager::SURVEY_THROTTLE_TIMEOUT_MULT * 2,
+            false);
+    };
+
+    // A network survey with no topology changes throughout
+    uint32_t constexpr nonce = 0xDEADBEEF;
+
+    // Check that all nodes have the same survey nonce and phase. Set
+    // `isReporting` to `true` if the nodes should be in the reporting phase.
+    auto checkSurveyState = [&](bool isReporting) {
+        for (int i = A; i <= E; ++i)
+        {
+            auto& surveyDataManager = simulation->getNode(keyList[i])
+                                          ->getOverlayManager()
+                                          .getSurveyManager()
+                                          .getSurveyDataManagerForTesting();
+            REQUIRE(surveyDataManager.surveyIsActive());
+            REQUIRE(surveyDataManager.getNonce().value() == nonce);
+            REQUIRE(surveyDataManager.nonceIsReporting(nonce) == isReporting);
+        }
+    };
+
+    SECTION("Normal static topology survey")
+    {
+        // Start survey collecting
+        Application& surveyor = *simulation->getNode(keyList[A]);
+        startSurveyCollecting(surveyor, nonce);
+
+        // Let survey run for a bit
+        simulation->crankForAtLeast(5min, false);
+
+        // All nodes should have active surveys
+        checkSurveyState(false);
+
+        // Stop survey collecting
+        stopSurveyCollecting(surveyor, nonce);
+
+        // Give the network time to transition to the reporting phase
+        simulation->crankForAtLeast(1min, false);
+
+        // All nodes should still have active surveys. All should be in
+        // reporting mode
+        checkSurveyState(true);
+
+        // Request survey data from B
+        REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[B], 0, 0));
+        crankForSurvey();
+
+        // Check results
+        Json::Value topology = getSurveyResult(surveyor)["topology"];
+        REQUIRE(topology.size() == 1);
+
+        // B responds with 2 new nodes (C and E)
+        REQUIRE(topology[keyStrList[B]]["inboundPeers"][0]["nodeId"] ==
+                keyStrList[A]);
+
+        std::set<std::string> expectedOutboundPeers = {keyStrList[E],
+                                                       keyStrList[C]};
+        std::set<std::string> actualOutboundPeers = {
+            topology[keyStrList[B]]["outboundPeers"][0]["nodeId"].asString(),
+            topology[keyStrList[B]]["outboundPeers"][1]["nodeId"].asString()};
+
+        REQUIRE(expectedOutboundPeers == actualOutboundPeers);
+
+        // Peer counts are correct
+        REQUIRE(topology[keyStrList[B]]["numTotalInboundPeers"].asUInt64() ==
+                1);
+        REQUIRE(topology[keyStrList[B]]["numTotalOutboundPeers"].asUInt64() ==
+                expectedOutboundPeers.size());
+        REQUIRE(topology[keyStrList[B]]["maxInboundPeerCount"].asUInt64() ==
+                simulation->getNode(keyList[B])
+                    ->getConfig()
+                    .MAX_ADDITIONAL_PEER_CONNECTIONS);
+        REQUIRE(topology[keyStrList[B]]["maxOutboundPeerCount"].asUInt64() ==
+                simulation->getNode(keyList[B])
+                    ->getConfig()
+                    .TARGET_PEER_CONNECTIONS);
+        REQUIRE(topology[keyStrList[B]]["addedAuthenticatedPeers"].asUInt() ==
+                0);
+        REQUIRE(topology[keyStrList[B]]["droppedAuthenticatedPeers"].asUInt() ==
+                0);
+
+        // Validator check is correct
+        REQUIRE(topology[keyStrList[B]]["isValidator"].asBool() ==
+                configList[B].NODE_IS_VALIDATOR);
+
+        // Request survey data from C and E
+        REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[C], 0, 0));
+        REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[E], 0, 0));
+        crankForSurvey();
+
+        // In the next round, we sent requests to C and E
+        topology = getSurveyResult(surveyor)["topology"];
+        REQUIRE(topology.size() == 3);
+        REQUIRE(topology[keyStrList[C]]["inboundPeers"][0]["nodeId"] ==
+                keyStrList[B]);
+        REQUIRE(topology[keyStrList[C]]["outboundPeers"].isNull());
+
+        REQUIRE(topology[keyStrList[E]]["inboundPeers"][0]["nodeId"] ==
+                keyStrList[B]);
+        REQUIRE(topology[keyStrList[E]]["outboundPeers"].isNull());
+
+        // Request survey data from B with non-zero peer indices.
+        REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[B], 1, 1));
+        crankForSurvey();
+        topology = getSurveyResult(surveyor)["topology"];
+        REQUIRE(topology.size() == 3);
+        // Should have no inbound peers (requested index was too high)
+        REQUIRE(topology[keyStrList[B]]["inboundPeers"].isNull());
+        // Should have just 1 outbound peer
+        REQUIRE(topology[keyStrList[B]]["outboundPeers"].size() == 1);
+
+        // Request survey data from B twice. The second call (with different
+        // indices) should fail.
+        REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[B], 0, 0));
+        REQUIRE(!surveyTopologyTimeSliced(surveyor, keyList[B], 1, 1));
+        crankForSurvey();
+        topology = getSurveyResult(surveyor)["topology"];
+        REQUIRE(topology.size() == 3);
+        // Should have 1 inbound peer and 2 outbound peers, indicating that the
+        // survey with 0 indices went through
+        REQUIRE(topology[keyStrList[B]]["inboundPeers"].size() == 1);
+        REQUIRE(topology[keyStrList[B]]["outboundPeers"].size() == 2);
+
+        // Start a new survey collection with a different nonce from node B.
+        // Call should fail as B should detect the already running survey.
+        uint32_t constexpr conflictingNonce = 0xCAFE;
+        startSurveyCollecting(*simulation->getNode(keyList[B]),
+                              conflictingNonce);
+
+        // Let survey run (though it shouldn't matter as B shouldn't even
+        // generate a message to send)
+        crankForSurvey();
+
+        // Check that all nodes still have the old nonce
+        checkSurveyState(true);
+
+        // Reduce phase durations
+        std::chrono::minutes constexpr phaseDuration = 1min;
+        for (int i = A; i <= E; ++i)
+        {
+            simulation->getNode(keyList[i])
+                ->getOverlayManager()
+                .getSurveyManager()
+                .getSurveyDataManagerForTesting()
+                .setPhaseMaxDurationsForTesting(phaseDuration);
+        }
+
+        // Advance survey
+        simulation->crankForAtLeast(phaseDuration, false);
+
+        // All surveys should now be inactive
+        for (int i = A; i <= E; ++i)
+        {
+            auto& surveyDataManager = simulation->getNode(keyList[i])
+                                          ->getOverlayManager()
+                                          .getSurveyManager()
+                                          .getSurveyDataManagerForTesting();
+            REQUIRE(!surveyDataManager.surveyIsActive());
+            REQUIRE(!surveyDataManager.getNonce().has_value());
+        }
+
+        // Start new survey collecting phase
+        startSurveyCollecting(surveyor, nonce);
+        crankForSurvey();
+
+        // All nodes should have active surveys
+        checkSurveyState(false);
+
+        // Wait for collecting phase to time out
+        simulation->crankForAtLeast(phaseDuration, false);
+
+        // Surveys should have automatically transitioned to reporting phase
+        for (int i = A; i <= E; ++i)
+        {
+            auto& surveyDataManager = simulation->getNode(keyList[i])
+                                          ->getOverlayManager()
+                                          .getSurveyManager()
+                                          .getSurveyDataManagerForTesting();
+            REQUIRE(surveyDataManager.nonceIsReporting(nonce));
+        }
+    }
+}
+
+// A time sliced survey with changing topology during the collecting phase
+TEST_CASE("Time sliced dynamic topology survey", "[overlay][survey][topology]")
+{
+    enum
+    {
+        A,
+        B,
+        C,
+        D, // not in transitive quorum
+        E, // will disconnect partway through test
+        F  // not initially connected
+    };
+
+    auto networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
+    auto simulation =
+        std::make_shared<Simulation>(Simulation::OVER_LOOPBACK, networkID);
+
+    std::vector<Config> configList;
+    std::vector<PublicKey> keyList;
+    std::vector<std::string> keyStrList;
+    for (int i = A; i <= F; ++i)
+    {
+        auto cfg = simulation->newConfig();
+        configList.emplace_back(cfg);
+
+        keyList.emplace_back(cfg.NODE_SEED.getPublicKey());
+        keyStrList.emplace_back(cfg.NODE_SEED.getStrKeyPublic());
+    }
+
+    // B will only respond to/relay messages from A, D, and F
+    configList[B].SURVEYOR_KEYS.emplace(keyList[A]);
+    configList[B].SURVEYOR_KEYS.emplace(keyList[E]);
+    configList[B].SURVEYOR_KEYS.emplace(keyList[F]);
+
+    // Note that peer D is in SURVEYOR_KEYS of A and B, but is not in transitive
+    // quorum, meaning that it's request messages will be dropped by relay nodes
+    SCPQuorumSet qSet;
+    qSet.threshold = 2;
+    qSet.validators.push_back(keyList[A]);
+    qSet.validators.push_back(keyList[C]);
+    qSet.validators.push_back(keyList[F]);
+
+    // Add all nodes but F to the simulation
+    for (int i = A; i <= E; ++i)
+    {
+        auto const& cfg = configList[i];
+        simulation->addNode(cfg.NODE_SEED, qSet, &cfg);
+    }
+
+    // D->A->B->C B->E (F not connected)
+    simulation->addConnection(keyList[D], keyList[A]);
+    simulation->addConnection(keyList[A], keyList[B]);
+    simulation->addConnection(keyList[B], keyList[C]);
+    simulation->addConnection(keyList[B], keyList[E]);
+
+    simulation->startAllNodes();
+
+    // wait for ledgers to close so nodes get the updated transitive quorum
+    int nLedgers = 1;
+    simulation->crankUntil(
+        [&simulation, nLedgers]() {
+            return simulation->haveAllExternalized(nLedgers + 1, 1);
+        },
+        2 * nLedgers * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);
+
+    REQUIRE(simulation->haveAllExternalized(nLedgers + 1, 1));
+
+    auto crankForSurvey = [&]() {
+        simulation->crankForAtLeast(
+            configList[A].getExpectedLedgerCloseTime() *
+                SurveyManager::SURVEY_THROTTLE_TIMEOUT_MULT * 2,
+            false);
+    };
+
+    uint32_t constexpr nonce = 0xDEADBEEF;
+
+    // Check that all nodes in `indices` have the same survey nonce and phase.
+    // Set `isReporting` to `true` if the nodes should be in the reporting
+    // phase.
+    auto checkSurveyState = [&](std::optional<uint32_t> expectedNonce,
+                                bool isReporting,
+                                std::vector<size_t> const& indices) {
+        for (size_t i : indices)
+        {
+            auto& surveyDataManager = simulation->getNode(keyList[i])
+                                          ->getOverlayManager()
+                                          .getSurveyManager()
+                                          .getSurveyDataManagerForTesting();
+            REQUIRE(surveyDataManager.surveyIsActive() ==
+                    expectedNonce.has_value());
+            REQUIRE(surveyDataManager.nonceIsReporting(nonce) == isReporting);
+            REQUIRE(surveyDataManager.getNonce() == expectedNonce);
+        }
+    };
+
+    // Start survey collection from A
+    Application& surveyor = *simulation->getNode(keyList[A]);
+    startSurveyCollecting(surveyor, nonce);
+    crankForSurvey();
+
+    // A through E should all be in the collecting phase
+    checkSurveyState(nonce, /*isReporting*/ false, {A, B, C, D, E});
+
+    // Add F to the simulation and connect to B
+    simulation->addNode(configList.at(F).NODE_SEED, qSet, &configList.at(F));
+    simulation->getNode(keyList[F])->start();
+    simulation->addConnection(keyList[F], keyList[B]);
+
+    // Disconnect E from B
+    simulation->dropConnection(keyList[B], keyList[E]);
+
+    // Let survey run for a bit
+    crankForSurvey();
+
+    // A through E should all still be in the collecting phase
+    checkSurveyState(nonce, /*isReporting*/ false, {A, B, C, D, E});
+
+    // F should not be aware of the survey
+    checkSurveyState(/*expectedNonce*/ std::nullopt, /*isReporting*/ false,
+                     {F});
+
+    // Stop survey collecting
+    stopSurveyCollecting(surveyor, nonce);
+    crankForSurvey();
+
+    // A through D should be in the reporting phase
+    checkSurveyState(nonce, /*isReporting*/ true, {A, B, C, D});
+
+    // E should remain in the collecting phase
+    checkSurveyState(nonce, /*isReporting*/ false, {E});
+
+    // F's survey state should remain inactive
+    checkSurveyState(/*expectedNonce*/ std::nullopt, /*isReporting*/ false,
+                     {F});
+
+    // Reconnect E
+    simulation->addConnection(keyList[B], keyList[E]);
+    crankForSurvey();
+
+    // Survey states should be unchanged
+    checkSurveyState(nonce, /*isReporting*/ true, {A, B, C, D});
+    checkSurveyState(nonce, /*isReporting*/ false, {E});
+    checkSurveyState(/*expectedNonce*/ std::nullopt, /*isReporting*/ false,
+                     {F});
+
+    // Request survey data from B, E, and F
+    REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[B], 0, 0));
+    REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[E], 0, 0));
+    REQUIRE(surveyTopologyTimeSliced(surveyor, keyList[F], 0, 0));
+    crankForSurvey();
+
+    // Check results
+    Json::Value topology = getSurveyResult(surveyor)["topology"];
+    REQUIRE(topology.size() == 3);
+
+    // B has 1 inbound peer active for entire time slice (A)
+    REQUIRE(topology[keyStrList[B]]["numTotalInboundPeers"].asUInt64() == 1);
+    REQUIRE(topology[keyStrList[B]]["inboundPeers"][0]["nodeId"] ==
+            keyStrList[A]);
+
+    // B only has 1 outbound peer active for entire time slice (C)
+    REQUIRE(topology[keyStrList[B]]["numTotalOutboundPeers"].asUInt64() == 1);
+    REQUIRE(topology[keyStrList[B]]["outboundPeers"][0]["nodeId"] ==
+            keyStrList[C]);
+
+    // B has 1 dropped peer (E)
+    REQUIRE(topology[keyStrList[B]]["droppedAuthenticatedPeers"].asUInt() == 1);
+
+    // B has 1 added peer (F). E does not count as it reconnected after the
+    // end of the collecting phase.
+    REQUIRE(topology[keyStrList[B]]["addedAuthenticatedPeers"].asUInt() == 1);
+
+    // E does not respond as it missed the stop survey collecting message and
+    // remains in the collecting phase
+    REQUIRE(topology[keyStrList[E]].isNull());
+
+    // F does not respond as it did not receive the start survey collecting
+    // message
+    REQUIRE(topology[keyStrList[F]].isNull());
+
+    // F tries to start a new survey. Unlike the static topology test, F will
+    // broadcast the request as it does already have an active survey itself.
+    // All other nodes should ignore the request.
+    uint32_t constexpr conflictingNonce = 0xCAFE;
+    startSurveyCollecting(*simulation->getNode(keyList[F]), conflictingNonce);
+    crankForSurvey();
+
+    // Nodes A through D should still be in the reporting phase with the old
+    // nonce
+    checkSurveyState(nonce, /*isReporting*/ true, {A, B, C, D});
+
+    // Node E should still be in collecting phase with the old nonce
+    checkSurveyState(nonce, /*isReporting*/ false, {E});
+
+    // Node F should be in the collecting phase with the new nonce
+    checkSurveyState(conflictingNonce, /*isReporting*/ false, {F});
+
+    // Reduce phase durations
+    std::chrono::minutes constexpr phaseDuration = 1min;
+    for (int i = A; i <= F; ++i)
+    {
+        simulation->getNode(keyList[i])
+            ->getOverlayManager()
+            .getSurveyManager()
+            .getSurveyDataManagerForTesting()
+            .setPhaseMaxDurationsForTesting(phaseDuration);
+    }
+
+    // Advance survey
+    simulation->crankForAtLeast(phaseDuration * 2, false);
+
+    // All surveys should now be inactive
+    checkSurveyState(/*expectedNonce*/ std::nullopt, /*isReporting*/ false,
+                     {A, B, C, D, E, F});
 }

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -401,6 +401,13 @@ Simulation::crankNode(NodeID const& id, VirtualClock::time_point timeout)
     {
         count += clock->crank(false);
     }
+
+    // Update network survey phase
+    OverlayManager& om = app->getOverlayManager();
+    om.getSurveyManager().updateSurveyPhase(om.getInboundAuthenticatedPeers(),
+                                            om.getOutboundAuthenticatedPeers(),
+                                            app->getConfig());
+
     return count - quantumClicks;
 }
 


### PR DESCRIPTION
# Description

Resolves #4169, #4164. Partially resolves #2592 (script update remains).

This pull request adds a new survey mode that aims to be more deterministic and easier to compare across runs. It also adds some additional fields to the survey schema. It is very faithful to the design outlined in the Unified Network Survey Work Proposal.

While this PR includes all of the new functionality, ~~it is still missing a few things I'd like to do before it's completely done~~:
* [x] Document new schema
* [x] Document new commands / how to run survey
* [x] Document new metrics in `metrics.md`
* [x] Change tests to use HTTP endpoints instead of calling into `SurveyManager`
* [x] Deduplicate shared code between tests
* [x] Update overlay survey script (or open an issue and update this script separately)
    * Opened #4302 to track this. This PR is huge as is and the script changes don't need to land with the release.
* [x] Merge https://github.com/stellar/stellar-xdr/pull/181 and https://github.com/stellar/stellar-xdr/pull/186 and update XDR submodules to point to those instead of my own branch.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
