### PR TITLE
Overlay stability fixes

### DIFF
--- a/src/overlay/OverlayManagerImpl.cpp
+++ b/src/overlay/OverlayManagerImpl.cpp
@@ -1206,12 +1206,14 @@ OverlayManagerImpl::shutdown()
     {
         return;
     }
-    mShuttingDown = true;
     mDoor.close();
     mFloodGate.shutdown();
     mInboundPeers.shutdown();
     mOutboundPeers.shutdown();
 
+    // Switch overlay to "shutting down" state _after_ shutting down peers to
+    // allow graceful connection drop
+    mShuttingDown = true;
     mDemandTimer.cancel();
 
     // Stop ticking and resolving peers

--- a/src/overlay/TCPPeer.cpp
+++ b/src/overlay/TCPPeer.cpp
@@ -61,6 +61,12 @@ TCPPeer::initiate(Application& app, PeerBareAddress const& address)
         asio::ip::address::from_string(address.getIP()), address.getPort());
     socket->next_layer().async_connect(
         endpoint, [result](asio::error_code const& error) {
+            // Handler is invoked asynchronously, so check if connection got
+            // dropped in the meantime
+            if (result->shouldAbort())
+            {
+                return;
+            }
             asio::error_code ec;
             asio::error_code lingerEc;
             if (!error)


### PR DESCRIPTION
Discovered while implementing https://github.com/stellar/stellar-core/pull/4258:
* During core shutdown, we weren't gracefully dropping peers because OverlayManager was marking itself as shutdown too early (causing peers to no-op)
* We weren't checking if peer got dropped during async connect flow, causing the handler to "resurrect" the peer. 