### PR TITLE
[Draft] Running experiments using latest env in core and flipping curr to latest env in rust bridge 

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -69,7 +69,7 @@ rev = "93120b6b32cd910fcc224cbf6aec1333f771a8bc"
 [dependencies.soroban-env-host-latest]
 git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
-branch = "main"
+rev = "cd534ed18dc44368b26e0c5089756cd1bcde0bc1"
 
 [dependencies.soroban-test-wasms]
 version = "=21.0.0"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -62,6 +62,15 @@ git = "https://github.com/stellar/rs-soroban-env"
 package = "soroban-env-host"
 rev = "93120b6b32cd910fcc224cbf6aec1333f771a8bc"
 
+# This copy of the soroban host is for testing the latest env changes.
+# This could be unstable so will only be used in our vnext job for 
+# early testing of env changes.
+
+[dependencies.soroban-env-host-latest]
+git = "https://github.com/stellar/rs-soroban-env"
+package = "soroban-env-host"
+branch = "main"
+
 [dependencies.soroban-test-wasms]
 version = "=21.0.0"
 git = "https://github.com/stellar/rs-soroban-env"
@@ -83,4 +92,4 @@ features = ["dependency-tree"]
 [features]
 soroban-env-host-prev = ["dep:soroban-env-host-prev"]
 tracy = ["dep:tracy-client", "soroban-env-host-curr/tracy"]
-core-vnext = ["soroban-env-host-curr/next"]
+core-vnext = ["soroban-env-host-latest/next"]

--- a/src/rust/src/host-dep-tree-latest.txt
+++ b/src/rust/src/host-dep-tree-latest.txt
@@ -1,4 +1,4 @@
-soroban-env-host 21.0.0 git+https://github.com/stellar/rs-soroban-env?branch=main#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c
+soroban-env-host 21.0.0 git+https://github.com/stellar/rs-soroban-env?branch=main#cd534ed18dc44368b26e0c5089756cd1bcde0bc1
 ├── wasmparser 0.116.1 checksum:a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50
 │   ├── semver 1.0.17 checksum:bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed
 │   │   └── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001

--- a/src/rust/src/host-dep-tree-latest.txt
+++ b/src/rust/src/host-dep-tree-latest.txt
@@ -1,0 +1,186 @@
+soroban-env-host 21.0.0 git+https://github.com/stellar/rs-soroban-env?branch=main#4d9b1020f7b5baa0f972eb08ed8aa2cd3343ad7c
+├── wasmparser 0.116.1 checksum:a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50
+│   ├── semver 1.0.17 checksum:bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed
+│   │   └── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001
+│   │       └── serde_derive 1.0.192 checksum:d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1
+│   │           ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
+│   │           │   ├── unicode-ident 1.0.9 checksum:b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0
+│   │           │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   │           │   │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│   │           │   │       └── unicode-ident 1.0.9 checksum:b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0
+│   │           │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│   │           ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   │           └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│   └── indexmap 2.0.2 checksum:8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897
+│       ├── hashbrown 0.14.1 checksum:7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12
+│       └── equivalent 1.0.1 checksum:5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5
+├── stellar-strkey 0.0.8 checksum:12d2bf45e114117ea91d820a846fd1afbe3ba7d717988fee094ce8227a3bf8bd
+│   ├── thiserror 1.0.40 checksum:978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac
+│   │   └── thiserror-impl 1.0.40 checksum:f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f
+│   │       ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
+│   │       ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   │       └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│   ├── crate-git-revision 0.0.6 checksum:c521bf1f43d31ed2f73441775ed31935d77901cb3451e44b38a1c1612fcbaf98
+│   │   ├── serde_json 1.0.108 checksum:3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b
+│   │   │   ├── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001
+│   │   │   ├── ryu 1.0.13 checksum:f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041
+│   │   │   └── itoa 1.0.6 checksum:453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6
+│   │   ├── serde_derive 1.0.192 checksum:d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1
+│   │   └── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001
+│   └── base32 0.4.0 checksum:23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa
+├── static_assertions 1.1.0 checksum:a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f
+├── soroban-wasmi 0.31.1-soroban.20.0.1 git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0
+│   ├── wasmparser-nostd 0.100.1 checksum:9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724
+│   │   └── indexmap-nostd 0.4.0 checksum:8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590
+│   ├── wasmi_core 0.13.0 git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0
+│   │   ├── paste 1.0.12 checksum:9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79
+│   │   ├── num-traits 0.2.17 checksum:39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c
+│   │   │   └── autocfg 1.1.0 checksum:d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa
+│   │   ├── libm 0.2.7 checksum:f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4
+│   │   └── downcast-rs 1.2.0 checksum:9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650
+│   ├── wasmi_arena 0.4.0 git+https://github.com/stellar/wasmi?rev=0ed3f3dee30dc41ebe21972399e0a73a41944aa0#0ed3f3dee30dc41ebe21972399e0a73a41944aa0
+│   ├── spin 0.9.8 checksum:6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67
+│   └── smallvec 1.10.0 checksum:a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0
+├── sha3 0.10.8 checksum:75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60
+│   ├── keccak 0.1.4 checksum:8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940
+│   │   └── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
+│   │       └── libc 0.2.150 checksum:89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c
+│   └── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│       ├── crypto-common 0.1.6 checksum:1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3
+│       │   ├── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
+│       │   └── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│       │       ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│       │       ├── version_check 0.9.4 checksum:49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f
+│       │       └── typenum 1.16.0 checksum:497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba
+│       ├── const-oid 0.9.2 checksum:520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913
+│       └── block-buffer 0.10.4 checksum:3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71
+│           └── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+├── sha2 0.10.8 checksum:793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8
+│   ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   ├── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
+│   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+├── sec1 0.7.2 checksum:f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e
+│   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   ├── pkcs8 0.10.2 checksum:f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7
+│   │   ├── spki 0.7.2 checksum:9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a
+│   │   │   ├── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+│   │   │   │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │   │   │   └── const-oid 0.9.2 checksum:520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913
+│   │   │   └── base64ct 1.6.0 checksum:8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b
+│   │   └── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+│   ├── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│   ├── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+│   └── base16ct 0.2.0 checksum:4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf
+├── rand_chacha 0.3.1 checksum:e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+│   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │   └── getrandom 0.2.11 checksum:fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f
+│   │       ├── wasm-bindgen 0.2.87 checksum:7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342
+│   │       │   ├── wasm-bindgen-macro 0.2.87 checksum:dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d
+│   │       │   │   ├── wasm-bindgen-macro-support 0.2.87 checksum:54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b
+│   │       │   │   │   ├── wasm-bindgen-shared 0.2.87 checksum:ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1
+│   │       │   │   │   ├── wasm-bindgen-backend 0.2.87 checksum:5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd
+│   │       │   │   │   │   ├── wasm-bindgen-shared 0.2.87 checksum:ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1
+│   │       │   │   │   │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
+│   │       │   │   │   │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   │       │   │   │   │   ├── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│   │       │   │   │   │   ├── once_cell 1.18.0 checksum:dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d
+│   │       │   │   │   │   ├── log 0.4.19 checksum:b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4
+│   │       │   │   │   │   └── bumpalo 3.13.0 checksum:a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1
+│   │       │   │   │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
+│   │       │   │   │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   │       │   │   │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│   │       │   │   └── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   │       │   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   │       ├── wasi 0.11.0+wasi-snapshot-preview1 checksum:9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423
+│   │       ├── libc 0.2.150 checksum:89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c
+│   │       ├── js-sys 0.3.64 checksum:c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a
+│   │       │   └── wasm-bindgen 0.2.87 checksum:7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342
+│   │       └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+│   └── ppv-lite86 0.2.17 checksum:5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de
+├── rand 0.8.5 checksum:34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404
+│   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   ├── rand_chacha 0.3.1 checksum:e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+│   └── libc 0.2.150 checksum:89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c
+├── p256 0.13.2 checksum:c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b
+│   ├── sha2 0.10.8 checksum:793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8
+│   ├── primeorder 0.13.3 checksum:c7dbe9ed3b56368bd99483eb32fe9c17fdd3730aebadc906918ce78d54c7eeb4
+│   │   └── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+│   │       ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │       ├── sec1 0.7.2 checksum:f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e
+│   │       ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │       ├── pkcs8 0.10.2 checksum:f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7
+│   │       ├── group 0.13.0 checksum:f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63
+│   │       │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │       │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │       │   └── ff 0.13.0 checksum:ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449
+│   │       │       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │       │       └── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │       ├── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│   │       ├── ff 0.13.0 checksum:ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449
+│   │       ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│   │       ├── crypto-bigint 0.5.2 checksum:cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15
+│   │       │   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   │       │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│   │       │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   │       │   └── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+│   │       └── base16ct 0.2.0 checksum:4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf
+│   ├── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+│   └── ecdsa 0.16.7 checksum:0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428
+│       ├── spki 0.7.2 checksum:9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a
+│       ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
+│       │   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│       │   └── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       ├── rfc6979 0.4.0 checksum:f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2
+│       │   ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│       │   └── hmac 0.12.1 checksum:6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e
+│       │       └── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       ├── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+│       ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       └── der 0.7.6 checksum:56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17
+├── num-traits 0.2.17 checksum:39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c
+├── num-integer 0.1.45 checksum:225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9
+│   ├── num-traits 0.2.17 checksum:39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c
+│   └── autocfg 1.1.0 checksum:d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa
+├── num-derive 0.4.1 checksum:cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712
+│   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
+│   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+├── k256 0.13.1 checksum:cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc
+│   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
+│   ├── sha2 0.10.8 checksum:793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8
+│   ├── once_cell 1.18.0 checksum:dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d
+│   ├── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+│   ├── ecdsa 0.16.7 checksum:0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428
+│   └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+├── hmac 0.12.1 checksum:6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e
+├── hex-literal 0.4.1 checksum:6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46
+├── getrandom 0.2.11 checksum:fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f
+├── generic-array 0.14.7 checksum:85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+├── elliptic-curve 0.13.5 checksum:968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b
+├── ed25519-dalek 2.0.0 checksum:7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980
+│   ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│   ├── sha2 0.10.8 checksum:793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8
+│   ├── serde 1.0.192 checksum:bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001
+│   ├── rand_core 0.6.4 checksum:ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+│   ├── ed25519 2.2.2 checksum:60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d
+│   │   ├── signature 2.1.0 checksum:5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500
+│   │   └── pkcs8 0.10.2 checksum:f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7
+│   └── curve25519-dalek 4.1.1 checksum:e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c
+│       ├── zeroize 1.6.0 checksum:2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9
+│       ├── subtle 2.5.0 checksum:81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc
+│       ├── rustc_version 0.4.0 checksum:bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366
+│       │   └── semver 1.0.17 checksum:bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed
+│       ├── platforms 3.0.2 checksum:e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630
+│       ├── fiat-crypto 0.2.5 checksum:27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7
+│       ├── digest 0.10.7 checksum:9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+│       ├── curve25519-dalek-derive 0.1.0 checksum:83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b
+│       │   ├── syn 2.0.39 checksum:23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a
+│       │   ├── quote 1.0.33 checksum:5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae
+│       │   └── proc-macro2 1.0.69 checksum:134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da
+│       ├── cpufeatures 0.2.8 checksum:03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c
+│       └── cfg-if 1.0.0 checksum:baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd
+├── ecdsa 0.16.7 checksum:0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428
+└── curve25519-dalek 4.1.1 checksum:e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -661,7 +661,7 @@ pub fn check_lockfile_has_expected_dep_trees(curr_max_protocol_version: u32) {
         &lockfile,
         "latest",
         soroban_env_host_curr::VERSION.rev,
-        EXPECTED_HOST_DEP_TREE_CURR,
+        EXPECTED_HOST_DEP_TREE_LATEST,
     );    
 
 


### PR DESCRIPTION
### What?
Running an experiment to see if core can be build with latest env and curr can point to that in the rust bridge. Doing this experiment only for core-vnext feature.
On limitation is that when latest env is bumped to a new version which hasn't been released, we will see errors like this,
```
anuppani@Anups-MBP stellar-core % ./src/stellar-core version                                                                                                
thread '<unnamed>' panicked at src/rust/src/lib.rs:594:10:
calculating global dep tree of Cargo.lock: Resolution("failed to find dependency: soroban-env-macros 21.0.0 (git+https://github.com/stellar/rs-soroban-env?branch=main)")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
fatal runtime error: failed to initiate panic, error 5
zsh: abort      ./src/stellar-core version
```

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
