### PR TITLE
Make sure test actually modifies LedgerEntry

### DIFF
--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -318,7 +318,7 @@ struct SelectBucketListGenerator : public BucketListGenerator
 class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
 {
   private:
-    LedgerEntry mEntry;
+    LedgerEntry const mEntry;
     bool mAdded;
 
   public:
@@ -371,8 +371,8 @@ class ApplyBucketsWorkAddEntry : public ApplyBucketsWork
 class ApplyBucketsWorkDeleteEntry : public ApplyBucketsWork
 {
   private:
-    LedgerKey mKey;
-    LedgerEntry mEntry;
+    LedgerKey const mKey;
+    LedgerEntry const mEntry;
     bool mDeleted;
 
   public:
@@ -414,8 +414,8 @@ class ApplyBucketsWorkDeleteEntry : public ApplyBucketsWork
 class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
 {
   private:
-    LedgerKey mKey;
-    LedgerEntry mEntry;
+    LedgerKey const mKey;
+    LedgerEntry const mEntry;
     bool mModified;
 
     void
@@ -552,7 +552,7 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
         {
             LedgerTxn ltx(mApp.getLedgerTxnRoot(), false);
             auto entry = ltx.load(mKey);
-            if (entry && entry.current() == mEntry)
+            while (entry && entry.current() == mEntry)
             {
                 switch (mEntry.data.type())
                 {
@@ -589,8 +589,12 @@ class ApplyBucketsWorkModifyEntry : public ApplyBucketsWork
                 default:
                     REQUIRE(false);
                 }
-                ltx.commit();
                 mModified = true;
+            }
+
+            if (mModified)
+            {
+                ltx.commit();
             }
         }
         auto r = ApplyBucketsWork::doWork();


### PR DESCRIPTION
# Description

`ApplyBucketsWorkModifyEntry` can regenerate the same entry value, causing failures in tests that expected a modification. In the case we saw today, The same `val` was being generated for `ContractDataEntry` [here](https://github.com/stellar/stellar-core/blob/87cba09cda2bedb8a6db0e411c33331c6cba43b9/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp#L498-L506).
<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
