### PR TITLE
refactor some overlay interfaces

### DIFF
--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -3,7 +3,6 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "overlay/FlowControlCapacity.h"
-#include "main/Application.h"
 #include "overlay/FlowControl.h"
 #include "overlay/OverlayManager.h"
 #include "util/Logging.h"
@@ -12,9 +11,9 @@
 namespace stellar
 {
 
-FlowControlMessageCapacity::FlowControlMessageCapacity(Application& app,
+FlowControlMessageCapacity::FlowControlMessageCapacity(Config const& cfg,
                                                        NodeID const& nodeID)
-    : FlowControlCapacity(app, nodeID)
+    : FlowControlCapacity(cfg, nodeID)
 {
     mCapacity = getCapacityLimits();
 }
@@ -29,9 +28,8 @@ FlowControlMessageCapacity::getMsgResourceCount(StellarMessage const& msg) const
 FlowControlCapacity::ReadingCapacity
 FlowControlMessageCapacity::getCapacityLimits() const
 {
-    return {
-        mApp.getConfig().PEER_FLOOD_READING_CAPACITY,
-        std::make_optional<uint64_t>(mApp.getConfig().PEER_READING_CAPACITY)};
+    return {mConfig.PEER_FLOOD_READING_CAPACITY,
+            std::make_optional<uint64_t>(mConfig.PEER_READING_CAPACITY)};
 }
 
 void
@@ -43,7 +41,7 @@ FlowControlMessageCapacity::releaseOutboundCapacity(StellarMessage const& msg)
     if (!hasOutboundCapacity(msg) && numMessages != 0)
     {
         CLOG_DEBUG(Overlay, "Got outbound message capacity for peer {}",
-                   mApp.getConfig().toShortString(mNodeID));
+                   mConfig.toShortString(mNodeID));
     }
     mOutboundCapacity += numMessages;
 }
@@ -56,12 +54,10 @@ FlowControlMessageCapacity::canRead() const
     return *mCapacity.mTotalCapacity > 0;
 }
 
-FlowControlByteCapacity::FlowControlByteCapacity(Application& app,
-                                                 NodeID const& nodeID)
-    : FlowControlCapacity(app, nodeID)
-    , mCapacityLimits{
-          app.getOverlayManager().getFlowControlBytesConfig().mTotal,
-          std::nullopt}
+FlowControlByteCapacity::FlowControlByteCapacity(Config const& cfg,
+                                                 NodeID const& nodeID,
+                                                 uint32_t capacity)
+    : FlowControlCapacity(cfg, nodeID), mCapacityLimits{capacity, std::nullopt}
 {
     mCapacity = mCapacityLimits;
 }
@@ -87,7 +83,7 @@ FlowControlByteCapacity::releaseOutboundCapacity(StellarMessage const& msg)
         (msg.sendMoreExtendedMessage().numBytes != 0))
     {
         CLOG_DEBUG(Overlay, "Got outbound byte capacity for peer {}",
-                   mApp.getConfig().toShortString(mNodeID));
+                   mConfig.toShortString(mNodeID));
     }
     mOutboundCapacity += msg.sendMoreExtendedMessage().numBytes;
 };
@@ -106,9 +102,11 @@ FlowControlByteCapacity::handleTxSizeIncrease(uint32_t increase)
     mCapacityLimits.mFloodCapacity += increase;
 }
 
-FlowControlCapacity::FlowControlCapacity(Application& app, NodeID const& nodeID)
-    : mApp(app), mNodeID(nodeID)
+FlowControlCapacity::FlowControlCapacity(Config const& cfg,
+                                         NodeID const& nodeID)
+    : mConfig(cfg), mNodeID(nodeID)
 {
+    releaseAssert(threadIsMain());
 }
 
 void
@@ -164,7 +162,7 @@ FlowControlCapacity::lockLocalCapacity(StellarMessage const& msg)
         if (mCapacity.mFloodCapacity == 0)
         {
             CLOG_DEBUG(Overlay, "No flood capacity for peer {}",
-                       mApp.getConfig().toShortString(mNodeID));
+                       mConfig.toShortString(mNodeID));
         }
     }
 
@@ -175,6 +173,7 @@ uint64_t
 FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
+
     uint64_t releasedFloodCapacity = 0;
     size_t resourcesFreed = getMsgResourceCount(msg);
     if (mCapacity.mTotalCapacity)
@@ -187,7 +186,7 @@ FlowControlCapacity::releaseLocalCapacity(StellarMessage const& msg)
         if (mCapacity.mFloodCapacity == 0)
         {
             CLOG_DEBUG(Overlay, "Got flood capacity for peer {} ({})",
-                       mApp.getConfig().toShortString(mNodeID),
+                       mConfig.toShortString(mNodeID),
                        mCapacity.mFloodCapacity + resourcesFreed);
         }
         releasedFloodCapacity = resourcesFreed;

--- a/src/overlay/FlowControlCapacity.h
+++ b/src/overlay/FlowControlCapacity.h
@@ -4,18 +4,17 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "main/Config.h"
 #include "overlay/StellarXDR.h"
 #include <optional>
 
 namespace stellar
 {
 
-class Application;
-
 class FlowControlCapacity
 {
   protected:
-    Application& mApp;
+    Config const mConfig;
 
     struct ReadingCapacity
     {
@@ -67,7 +66,7 @@ class FlowControlCapacity
     }
 #endif
 
-    FlowControlCapacity(Application& app, NodeID const& nodeID);
+    FlowControlCapacity(Config const& cfg, NodeID const& nodeID);
 };
 
 class FlowControlByteCapacity : public FlowControlCapacity
@@ -77,7 +76,8 @@ class FlowControlByteCapacity : public FlowControlCapacity
     ReadingCapacity mCapacityLimits;
 
   public:
-    FlowControlByteCapacity(Application& app, NodeID const& nodeID);
+    FlowControlByteCapacity(Config const& cfg, NodeID const& nodeID,
+                            uint32_t capacity);
     virtual ~FlowControlByteCapacity() = default;
     virtual uint64_t
     getMsgResourceCount(StellarMessage const& msg) const override;
@@ -90,7 +90,7 @@ class FlowControlByteCapacity : public FlowControlCapacity
 class FlowControlMessageCapacity : public FlowControlCapacity
 {
   public:
-    FlowControlMessageCapacity(Application& app, NodeID const& nodeID);
+    FlowControlMessageCapacity(Config const& cfg, NodeID const& nodeID);
     virtual ~FlowControlMessageCapacity() = default;
     virtual uint64_t
     getMsgResourceCount(StellarMessage const& msg) const override;

--- a/src/overlay/OverlayAppConnector.cpp
+++ b/src/overlay/OverlayAppConnector.cpp
@@ -1,0 +1,76 @@
+#include "overlay/OverlayAppConnector.h"
+#include "herder/Herder.h"
+#include "ledger/LedgerManager.h"
+#include "main/Application.h"
+#include "overlay/BanManager.h"
+#include "overlay/OverlayManager.h"
+#include "util/Timer.h"
+
+namespace stellar
+{
+
+Herder&
+OverlayAppConnector::getHerder()
+{
+    releaseAssert(threadIsMain());
+    return mApp.getHerder();
+}
+
+LedgerManager&
+OverlayAppConnector::getLedgerManager()
+{
+    releaseAssert(threadIsMain());
+    return mApp.getLedgerManager();
+}
+
+OverlayManager&
+OverlayAppConnector::getOverlayManager()
+{
+    releaseAssert(threadIsMain());
+    return mApp.getOverlayManager();
+}
+
+BanManager&
+OverlayAppConnector::getBanManager()
+{
+    releaseAssert(threadIsMain());
+    return mApp.getBanManager();
+}
+
+void
+OverlayAppConnector::postOnMainThread(std::function<void()>&& f,
+                                      std::string&& message,
+                                      Scheduler::ActionType type)
+{
+    releaseAssert(threadIsMain());
+    mApp.postOnMainThread(std::move(f), std::move(message), type);
+}
+
+Config const&
+OverlayAppConnector::getConfig() const
+{
+    releaseAssert(threadIsMain());
+    return mApp.getConfig();
+}
+
+bool
+OverlayAppConnector::overlayShuttingDown() const
+{
+    releaseAssert(threadIsMain());
+    return mApp.getOverlayManager().isShuttingDown();
+}
+
+VirtualClock::time_point
+OverlayAppConnector::now() const
+{
+    releaseAssert(threadIsMain());
+    return mApp.getClock().now();
+}
+
+bool
+OverlayAppConnector::shouldYield() const
+{
+    releaseAssert(threadIsMain());
+    return mApp.getClock().shouldYield();
+}
+}

--- a/src/overlay/OverlayAppConnector.h
+++ b/src/overlay/OverlayAppConnector.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "main/Config.h"
+#include "util/GlobalChecks.h"
+
+namespace stellar
+{
+class Application;
+class OverlayManager;
+class LedgerManager;
+class Herder;
+class BanManager;
+
+// Helper class to isolate access to Application; all function helpers must
+// either be called from main or be thread-sade
+class OverlayAppConnector
+{
+    Application& mApp;
+
+  public:
+    OverlayAppConnector(Application& app) : mApp(app)
+    {
+    }
+
+    /* Methods that can only be called from main thread */
+    Herder& getHerder();
+    LedgerManager& getLedgerManager();
+    OverlayManager& getOverlayManager();
+    BanManager& getBanManager();
+
+    void postOnMainThread(
+        std::function<void()>&& f, std::string&& message,
+        Scheduler::ActionType type = Scheduler::ActionType::NORMAL_ACTION);
+
+    VirtualClock::time_point now() const;
+    Config const& getConfig() const;
+    bool overlayShuttingDown() const;
+    bool shouldYield() const;
+};
+}

--- a/src/overlay/TxAdverts.h
+++ b/src/overlay/TxAdverts.h
@@ -12,7 +12,6 @@
 namespace stellar
 {
 
-class Peer;
 class Application;
 
 // TxAdverts class stores and properly trims incoming advertised transaction
@@ -37,14 +36,14 @@ class TxAdverts
     RandomEvictionCache<Hash, uint32_t> mAdvertHistory;
     TxAdvertVector mOutgoingTxHashes;
     VirtualTimer mAdvertTimer;
-    std::weak_ptr<Peer> mWeakPeer;
+    std::function<void(std::shared_ptr<StellarMessage const>)> mSendCb;
 
     void rememberHash(Hash const& hash, uint32_t ledgerSeq);
     void flushAdvert();
     void startAdvertTimer();
 
   public:
-    TxAdverts(Application& app, std::weak_ptr<Peer> peer);
+    TxAdverts(Application& app);
 
     // Total transaction hashes to process including demand retries.
     size_t size() const;
@@ -63,6 +62,8 @@ class TxAdverts
 
     bool seenAdvert(Hash const& hash);
     void clearBelow(uint32_t ledgerSeq);
+    void
+    start(std::function<void(std::shared_ptr<StellarMessage const>)> sendCb);
     void shutdown();
 
 #ifdef BUILD_TESTS

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -137,6 +137,12 @@ class LoopbackPeer : public Peer
         return getFlowControl()->getCapacity()->getOutboundCapacity();
     }
 
+    Config const&
+    getConfig()
+    {
+        return mAppConnector.getConfig();
+    }
+
     bool checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const;
 
     std::string getIP() const;

--- a/src/overlay/test/TxAdvertsTests.cpp
+++ b/src/overlay/test/TxAdvertsTests.cpp
@@ -17,8 +17,7 @@ TEST_CASE("advert queue", "[flood][pullmode][acceptance]")
     Config cfg = getTestConfig(0);
     cfg.TESTING_UPGRADE_MAX_TX_SET_SIZE = 200;
     auto app = createTestApplication(clock, cfg);
-    std::weak_ptr<Peer> weak;
-    TxAdverts pullMode(*app, weak);
+    TxAdverts pullMode(*app);
     auto limit = app->getLedgerManager().getLastMaxTxSetSizeOps();
     auto getHash = [](auto i) { return sha256(std::to_string(i)); };
 
@@ -105,7 +104,7 @@ TEST_CASE("advert queue", "[flood][pullmode][acceptance]")
             cfg2.TESTING_UPGRADE_MAX_TX_SET_SIZE =
                 TX_ADVERT_VECTOR_MAX_SIZE * 100;
             auto app2 = createTestApplication(clock2, cfg2);
-            TxAdverts pullMode2(*app2, weak);
+            TxAdverts pullMode2(*app2);
             // getMaxAdvertSize takes the limit into account
             REQUIRE(pullMode2.getMaxAdvertSize() <= TX_ADVERT_VECTOR_MAX_SIZE);
 

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -213,12 +213,10 @@ Simulation::dropAllConnections(NodeID const& id)
                                // use app's IDs here as connections may be
                                // incomplete
                                return c->getAcceptor()
-                                              ->getApp()
-                                              .getConfig()
+                                              ->getConfig()
                                               .NODE_SEED.getPublicKey() == id ||
                                       c->getInitiator()
-                                              ->getApp()
-                                              .getConfig()
+                                              ->getConfig()
                                               .NODE_SEED.getPublicKey() == id;
                            }),
             mLoopbackConnections.end());
@@ -286,14 +284,10 @@ Simulation::getLoopbackConnection(NodeID const& initiator,
     auto it = std::find_if(
         std::begin(mLoopbackConnections), std::end(mLoopbackConnections),
         [&](std::shared_ptr<LoopbackPeerConnection> const& conn) {
-            return conn->getInitiator()
-                           ->getApp()
-                           .getConfig()
-                           .NODE_SEED.getPublicKey() == initiator &&
-                   conn->getAcceptor()
-                           ->getApp()
-                           .getConfig()
-                           .NODE_SEED.getPublicKey() == acceptor;
+            return conn->getInitiator()->getConfig().NODE_SEED.getPublicKey() ==
+                       initiator &&
+                   conn->getAcceptor()->getConfig().NODE_SEED.getPublicKey() ==
+                       acceptor;
         });
 
     return it == std::end(mLoopbackConnections) ? nullptr : *it;
@@ -305,14 +299,10 @@ Simulation::dropLoopbackConnection(NodeID initiator, NodeID acceptor)
     auto it = std::find_if(
         std::begin(mLoopbackConnections), std::end(mLoopbackConnections),
         [&](std::shared_ptr<LoopbackPeerConnection> const& conn) {
-            return conn->getInitiator()
-                           ->getApp()
-                           .getConfig()
-                           .NODE_SEED.getPublicKey() == initiator &&
-                   conn->getAcceptor()
-                           ->getApp()
-                           .getConfig()
-                           .NODE_SEED.getPublicKey() == acceptor;
+            return conn->getInitiator()->getConfig().NODE_SEED.getPublicKey() ==
+                       initiator &&
+                   conn->getAcceptor()->getConfig().NODE_SEED.getPublicKey() ==
+                       acceptor;
         });
     if (it != std::end(mLoopbackConnections))
     {

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -2110,12 +2110,14 @@ OverlayFuzzer::inject(std::string const& filename)
     auto initiator = loopbackPeerConnection->getInitiator();
     auto acceptor = loopbackPeerConnection->getAcceptor();
 
-    initiator->getApp().getClock().postAction(
-        [initiator, msg]() {
-            initiator->Peer::sendMessage(
-                std::make_shared<StellarMessage const>(msg));
-        },
-        "main", Scheduler::ActionType::NORMAL_ACTION);
+    mSimulation->getNode(initiator->getPeerID())
+        ->getClock()
+        .postAction(
+            [initiator, msg]() {
+                initiator->Peer::sendMessage(
+                    std::make_shared<StellarMessage const>(msg));
+            },
+            "main", Scheduler::ActionType::NORMAL_ACTION);
 
     mSimulation->crankForAtMost(std::chrono::milliseconds{500}, false);
 
@@ -2123,9 +2125,13 @@ OverlayFuzzer::inject(std::string const& filename)
     initiator->clearInAndOutQueues();
     acceptor->clearInAndOutQueues();
 
-    while (initiator->getApp().getClock().cancelAllEvents())
+    while (mSimulation->getNode(initiator->getPeerID())
+               ->getClock()
+               .cancelAllEvents())
         ;
-    while (acceptor->getApp().getClock().cancelAllEvents())
+    while (mSimulation->getNode(acceptor->getPeerID())
+               ->getClock()
+               .cancelAllEvents())
         ;
 }
 


### PR DESCRIPTION
Note: Review/land this change _after_ pull mode refactor https://github.com/stellar/stellar-core/pull/4294

Continuing to extract changes addressing tech debt to simplify https://github.com/stellar/stellar-core/pull/4258

This PR implements the following changes:
* It removes direct references to Application (and any of Application's managers) from Peer, FlowControl and FlowControlCapacity. Any interaction with App has to be done via new class `OverlayAppConnector`, which requires its methods to either be only called from main thread (e.g. manager getter, like getHerder) or be thread-safe.
* It better isolates throttling logic: previously, Peer was manually keeping track of throttling. In this change, the FlowControl implements throttling and gives Peer controls via `throttleRead`, `stopThrottling` and `isThrottled`.
* it removes FlowControl's dependency on Peer class, better separating responsibilities. Removing the circular dependency should make reasoning about synchronization easier, and allows acquiring locks in the same order. Currently, there's only one place left where flow control can impact Peer, and that is the send callback passed during construction. The caller fully controls the callback though, and can ensure its safety once we add synchronization primitives.  
* It slightly re-arranges Peer's API, making many of its previously protected functions private: this way when we add multi-threading to concrete implementation of Peer (TCPPeer), we only need to synchronize a narrow set of functions that TCPPeer might invoke. Note that there are still public API methods: some of those will be extracted into a separate class as part of https://github.com/stellar/stellar-core/pull/3687 next, and some will be guarded with threadIsMain assertions to ensure execution can only be done on main.

Resolves https://github.com/stellar/stellar-core/issues/4287