### PR TITLE
 Validate non-Soroban txs with Soroban ext in checkValid

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -603,6 +603,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\FlowControl.cpp" />
     <ClCompile Include="..\..\src\overlay\FlowControlCapacity.cpp" />
     <ClCompile Include="..\..\src\overlay\ItemFetcher.cpp" />
+    <ClCompile Include="..\..\src\overlay\OverlayAppConnector.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayManagerImpl.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayMetrics.cpp" />
     <ClCompile Include="..\..\src\overlay\Peer.cpp" />
@@ -627,9 +628,10 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\test\SurveyMessageLimiterTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TCPPeerTests.cpp" />
     <ClCompile Include="..\..\src\overlay\test\TrackerTests.cpp" />
-    <ClCompile Include="..\..\src\overlay\test\TxAdvertQueueTests.cpp" />
+    <ClCompile Include="..\..\src\overlay\test\TxAdvertsTests.cpp" />
     <ClCompile Include="..\..\src\overlay\Tracker.cpp" />
-    <ClCompile Include="..\..\src\overlay\TxAdvertQueue.cpp" />
+    <ClCompile Include="..\..\src\overlay\TxAdverts.cpp" />
+    <ClCompile Include="..\..\src\overlay\TxDemandsManager.cpp" />
     <ClCompile Include="..\..\src\test\FuzzerImpl.cpp" />
     <ClCompile Include="..\..\src\transactions\AllowTrustOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\BeginSponsoringFutureReservesOpFrame.cpp" />
@@ -1017,6 +1019,7 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\FlowControl.h" />
     <ClInclude Include="..\..\src\overlay\FlowControlCapacity.h" />
     <ClInclude Include="..\..\src\overlay\ItemFetcher.h" />
+    <ClInclude Include="..\..\src\overlay\OverlayAppConnector.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManager.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManagerImpl.h" />
     <ClInclude Include="..\..\src\overlay\OverlayMetrics.h" />
@@ -1034,7 +1037,8 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\test\LoopbackPeer.h" />
     <ClInclude Include="..\..\src\overlay\test\OverlayTestUtils.h" />
     <ClInclude Include="..\..\src\overlay\Tracker.h" />
-    <ClInclude Include="..\..\src\overlay\TxAdvertQueue.h" />
+    <ClInclude Include="..\..\src\overlay\TxAdverts.h" />
+    <ClInclude Include="..\..\src\overlay\TxDemandsManager.h" />
     <ClInclude Include="..\..\src\test\Fuzzer.h" />
     <ClInclude Include="..\..\src\test\FuzzerImpl.h" />
     <ClInclude Include="..\..\src\transactions\AllowTrustOpFrame.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1023,9 +1023,6 @@
     <ClCompile Include="..\..\src\overlay\test\TrackerTests.cpp">
       <Filter>overlay\tests</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\overlay\test\TxAdvertQueueTests.cpp">
-      <Filter>overlay\tests</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
@@ -1078,9 +1075,6 @@
       <Filter>overlay</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\overlay\Tracker.cpp">
-      <Filter>overlay</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\overlay\TxAdvertQueue.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\transactions\test\AllowTrustTests.cpp">
@@ -1334,6 +1328,18 @@
     </ClCompile>
     <ClCompile Include="..\..\src\bucket\BucketSnapshotManager.cpp">
       <Filter>bucket</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\test\TxAdvertsTests.cpp">
+      <Filter>overlay\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\TxAdverts.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\OverlayAppConnector.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\overlay\TxDemandsManager.cpp">
+      <Filter>overlay</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -2162,9 +2168,6 @@
     <ClInclude Include="..\..\src\overlay\Tracker.h">
       <Filter>overlay</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\overlay\TxAdvertQueue.h">
-      <Filter>overlay</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\src\transactions\test\SponsorshipTestUtils.h">
       <Filter>transactions\tests</Filter>
     </ClInclude>
@@ -2320,6 +2323,15 @@
     </ClInclude>
     <ClInclude Include="..\..\src\bucket\BucketSnapshotManager.h">
       <Filter>bucket</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\TxAdverts.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\OverlayAppConnector.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\TxDemandsManager.h">
+      <Filter>overlay</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -93,8 +93,8 @@ TEST_CASE("generate load with unique accounts", "[loadgen]")
 
 TEST_CASE("generate soroban load", "[loadgen][soroban]")
 {
-    auto const numDataEntries = 5;
-    auto const ioKiloBytes = 15;
+    uint32_t const numDataEntries = 5;
+    uint32_t const ioKiloBytes = 15;
 
     Hash networkID = sha256(getTestConfig().NETWORK_PASSPHRASE);
     Simulation::pointer simulation =

--- a/src/transactions/TransactionFrame.cpp
+++ b/src/transactions/TransactionFrame.cpp
@@ -1195,6 +1195,18 @@ TransactionFrame::commonValidPreSeqNum(
             return false;
         }
     }
+    else
+    {
+        if (protocolVersionStartsFrom(ledgerVersion, ProtocolVersion::V_21))
+        {
+            if (mEnvelope.type() == ENVELOPE_TYPE_TX &&
+                mEnvelope.v1().tx.ext.v() != 0)
+            {
+                getResult().result.code(txMALFORMED);
+                return false;
+            }
+        }
+    }
 
     auto header = ltx.loadHeader();
     if (isTooEarly(header, lowerBoundCloseTimeOffset))


### PR DESCRIPTION
# Description

Validate non-Soroban txs with Soroban ext in checkValid. This check is already present in tx queue, so the observed behavior shouldn't change.

Also fixed VS build.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
