### PR TITLE
Move tracy FrameMark macro so it occurs during replay as well as online consensus

### DIFF
--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -679,7 +679,6 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData)
                    lcl, getLastClosedLedgerNum());
         mApp.getHerder().lastClosedLedgerIncreased(appliedLatest);
     }
-    FrameMark;
 }
 
 void
@@ -1080,6 +1079,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
 
     std::chrono::duration<double> ledgerTimeSeconds = ledgerTime.Stop();
     CLOG_DEBUG(Perf, "Applied ledger in {} seconds", ledgerTimeSeconds.count());
+    FrameMark;
 }
 
 void


### PR DESCRIPTION
This is a tiny change that just moves the place we mark a "frame ending" to tracy from a place that only happens during online consensus to a deeper place in the ledger-close path so that we get "frames" representing ledger boundaries when doing replay as well.