### PR TITLE
Thread local prngs

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -1788,15 +1788,13 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
         mLastQuorumMapIntersectionState.mCheckingQuorumMapHash = curr;
         auto& cfg = mApp.getConfig();
         releaseAssert(threadIsMain());
-        auto seed = gRandomEngine();
         auto qic = QuorumIntersectionChecker::create(
-            qmap, cfg, mLastQuorumMapIntersectionState.mInterruptFlag, seed);
+            qmap, cfg, mLastQuorumMapIntersectionState.mInterruptFlag);
         auto ledger = trackingConsensusLedgerIndex();
         auto nNodes = qmap.size();
         auto& hState = mLastQuorumMapIntersectionState;
         auto& app = mApp;
-        auto worker = [curr, ledger, nNodes, qic, qmap, cfg, seed, &app,
-                       &hState] {
+        auto worker = [curr, ledger, nNodes, qic, qmap, cfg, &app, &hState] {
             try
             {
                 ZoneScoped;
@@ -1809,8 +1807,8 @@ HerderImpl::checkAndMaybeReanalyzeQuorumMap()
                     // intersecting; if not intersecting we should finish ASAP
                     // and raise an alarm.
                     critical = QuorumIntersectionChecker::
-                        getIntersectionCriticalGroups(
-                            qmap, cfg, hState.mInterruptFlag, seed);
+                        getIntersectionCriticalGroups(qmap, cfg,
+                                                      hState.mInterruptFlag);
                 }
                 app.postOnMainThread(
                     [ok, curr, ledger, nNodes, split, critical, &hState] {

--- a/src/herder/QuorumIntersectionChecker.h
+++ b/src/herder/QuorumIntersectionChecker.h
@@ -23,24 +23,21 @@ class QuorumIntersectionChecker
     static std::shared_ptr<QuorumIntersectionChecker>
     create(QuorumTracker::QuorumMap const& qmap,
            std::optional<stellar::Config> const& cfg,
-           std::atomic<bool>& interruptFlag,
-           stellar_default_random_engine::result_type seed, bool quiet = false);
+           std::atomic<bool>& interruptFlag, bool quiet = false);
 
     static std::shared_ptr<QuorumIntersectionChecker>
     create(QuorumSetMap const& qmap, std::optional<stellar::Config> const& cfg,
-           std::atomic<bool>& interruptFlag,
-           stellar_default_random_engine::result_type seed, bool quiet = false);
+           std::atomic<bool>& interruptFlag, bool quiet = false);
 
-    static std::set<std::set<NodeID>> getIntersectionCriticalGroups(
-        QuorumTracker::QuorumMap const& qmap,
-        std::optional<stellar::Config> const& cfg,
-        std::atomic<bool>& interruptFlag,
-        stellar_default_random_engine::result_type seed);
+    static std::set<std::set<NodeID>>
+    getIntersectionCriticalGroups(QuorumTracker::QuorumMap const& qmap,
+                                  std::optional<stellar::Config> const& cfg,
+                                  std::atomic<bool>& interruptFlag);
 
-    static std::set<std::set<NodeID>> getIntersectionCriticalGroups(
-        QuorumSetMap const& qmap, std::optional<stellar::Config> const& cfg,
-        std::atomic<bool>& interruptFlag,
-        stellar_default_random_engine::result_type seed);
+    static std::set<std::set<NodeID>>
+    getIntersectionCriticalGroups(QuorumSetMap const& qmap,
+                                  std::optional<stellar::Config> const& cfg,
+                                  std::atomic<bool>& interruptFlag);
 
     virtual ~QuorumIntersectionChecker(){};
     virtual bool networkEnjoysQuorumIntersection() const = 0;

--- a/src/herder/QuorumIntersectionCheckerImpl.h
+++ b/src/herder/QuorumIntersectionCheckerImpl.h
@@ -427,8 +427,7 @@ class MinQuorumEnumerator
     QuorumIntersectionCheckerImpl const& mQic;
 
     // Select the next node in mRemaining to split recursive cases between.
-    size_t
-    pickSplitNode(stellar::stellar_default_random_engine& randEngine) const;
+    size_t pickSplitNode() const;
 
     // Size limit for mCommitted beyond which we should stop scanning.
     size_t maxCommit() const;
@@ -534,9 +533,7 @@ class QuorumIntersectionCheckerImpl : public stellar::QuorumIntersectionChecker
     QuorumIntersectionCheckerImpl(
         stellar::QuorumIntersectionChecker::QuorumSetMap const& qmap,
         std::optional<stellar::Config> const& cfg,
-        std::atomic<bool>& interruptFlag,
-        stellar::stellar_default_random_engine::result_type seed,
-        bool quiet = false);
+        std::atomic<bool>& interruptFlag, bool quiet = false);
     bool networkEnjoysQuorumIntersection() const override;
 
     std::pair<std::vector<stellar::NodeID>, std::vector<stellar::NodeID>>

--- a/src/herder/test/QuorumIntersectionTests.cpp
+++ b/src/herder/test/QuorumIntersectionTests.cpp
@@ -882,8 +882,7 @@ TEST_CASE("quorum intersection interruption", "[herder][quorumintersection]")
     Config cfg(getTestConfig());
     cfg = configureShortNames(cfg, orgs);
     std::atomic<bool> interruptFlag{false};
-    auto qic = QuorumIntersectionChecker::create(qm, cfg, interruptFlag,
-                                                 gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, interruptFlag);
     std::thread canceller([&interruptFlag]() {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         interruptFlag = true;
@@ -897,9 +896,9 @@ TEST_CASE("quorum intersection interruption", "[herder][quorumintersection]")
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         interruptFlag = true;
     });
-    REQUIRE_THROWS_AS(qic->getIntersectionCriticalGroups(qm, cfg, interruptFlag,
-                                                         gRandomEngine()),
-                      QuorumIntersectionChecker::InterruptedException);
+    REQUIRE_THROWS_AS(
+        qic->getIntersectionCriticalGroups(qm, cfg, interruptFlag),
+        QuorumIntersectionChecker::InterruptedException);
     canceller2.join();
 }
 
@@ -982,12 +981,11 @@ TEST_CASE("quorum intersection criticality",
     cfg = configureShortNames(cfg, orgs);
     debugQmap(cfg, qm);
     std::atomic<bool> flag{false};
-    auto qic =
-        QuorumIntersectionChecker::create(qm, cfg, flag, gRandomEngine());
+    auto qic = QuorumIntersectionChecker::create(qm, cfg, flag);
     REQUIRE(qic->networkEnjoysQuorumIntersection());
 
-    auto groups = QuorumIntersectionChecker::getIntersectionCriticalGroups(
-        qm, cfg, flag, gRandomEngine());
+    auto groups =
+        QuorumIntersectionChecker::getIntersectionCriticalGroups(qm, cfg, flag);
     REQUIRE(groups.size() == 1);
     REQUIRE(groups == std::set<std::set<PublicKey>>{{orgs[3][0]}});
 }

--- a/src/util/Math.h
+++ b/src/util/Math.h
@@ -25,7 +25,7 @@ bool rand_flip();
 
 typedef std::minstd_rand stellar_default_random_engine;
 
-extern stellar_default_random_engine gRandomEngine;
+extern thread_local stellar_default_random_engine gRandomEngine;
 
 template <typename T>
 T
@@ -76,7 +76,8 @@ void initializeAllGlobalState();
 // shouldn't be resetting globals like this mid-run -- especially not things
 // like hash function keys.
 void reinitializeAllGlobalStateWithSeed(unsigned int seed);
-unsigned int getLastGlobalStateSeed();
 #endif
+
+unsigned int getLastGlobalStateSeed();
 
 }


### PR DESCRIPTION
This moves the global PRNG to thread-local, removes the separate PRNG inside the QIC, and also moves the global signature-verification cache to be thread-local (it probably doesn't have to be, but less inter-thread pollution and contention is probably better).

This is motivated by some work going on in #4258 -- where that PR moved the global signature cache to have yet another sub-PRNG, I decided to sketch out what it might look like to go the other way and just make the global PRNGs (and the signature cache) all thread-local. It _seems_ to me a nicer approach, and more likely to avoid having to plumb PRNG-seeding paths through future stuff that happens to take random decisions. But it might also strike some as distasteful. Happy to discuss!