### PR TITLE
Track SCP latencies in milliseconds for overlay survey

### DIFF
--- a/src/herder/HerderSCPDriver.cpp
+++ b/src/herder/HerderSCPDriver.cpp
@@ -1038,8 +1038,8 @@ HerderSCPDriver::recordSCPExternalizeEvent(uint64_t slotIndex, NodeID const& id,
                             std::chrono::nanoseconds::zero(), slotIndex);
             mApp.getOverlayManager().getSurveyManager().modifyNodeData(
                 [&](CollectingNodeData& nd) {
-                    nd.mSCPFirstToSelfLatencyNsHistogram.Update(
-                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    nd.mSCPFirstToSelfLatencyMsHistogram.Update(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(
                             now - *timing.mFirstExternalize)
                             .count());
                 });
@@ -1063,8 +1063,8 @@ HerderSCPDriver::recordSCPExternalizeEvent(uint64_t slotIndex, NodeID const& id,
                 std::chrono::nanoseconds::zero(), slotIndex);
             mApp.getOverlayManager().getSurveyManager().modifyNodeData(
                 [&](CollectingNodeData& nd) {
-                    nd.mSCPSelfToOtherLatencyNsHistogram.Update(
-                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    nd.mSCPSelfToOtherLatencyMsHistogram.Update(
+                        std::chrono::duration_cast<std::chrono::milliseconds>(
                             now - *timing.mFirstExternalize)
                             .count());
                 });

--- a/src/overlay/SurveyDataManager.h
+++ b/src/overlay/SurveyDataManager.h
@@ -42,9 +42,9 @@ struct CollectingNodeData
     uint32_t mAddedAuthenticatedPeers = 0;
     uint32_t mDroppedAuthenticatedPeers = 0;
 
-    // SCP stats (in nanoseconds)
-    medida::Histogram mSCPFirstToSelfLatencyNsHistogram;
-    medida::Histogram mSCPSelfToOtherLatencyNsHistogram;
+    // SCP stats (in milliseconds)
+    medida::Histogram mSCPFirstToSelfLatencyMsHistogram;
+    medida::Histogram mSCPSelfToOtherLatencyMsHistogram;
 
     // To compute how many times the node lost sync in the time slice
     uint64_t const mInitialLostSyncCount;

--- a/src/overlay/SurveyManager.cpp
+++ b/src/overlay/SurveyManager.cpp
@@ -19,7 +19,7 @@ namespace stellar
 
 uint32_t const SurveyManager::SURVEY_THROTTLE_TIMEOUT_MULT(3);
 
-uint32_t constexpr TIME_SLICED_SURVEY_MIN_OVERLAY_PROTOCOL_VERSION = 33;
+uint32_t constexpr TIME_SLICED_SURVEY_MIN_OVERLAY_PROTOCOL_VERSION = 34;
 
 namespace
 {

--- a/src/util/numeric.h
+++ b/src/util/numeric.h
@@ -39,6 +39,10 @@ isRepresentableAsInt64(double d)
            (d < static_cast<double>(std::numeric_limits<int64_t>::max()));
 }
 
+// Convert a double to a uint32_t, clamping to the range of uint32_t. Converts
+// NaN to the maximum uint32_t.
+uint32_t doubleToClampedUint32(double d);
+
 // calculates A*B/C when A*B overflows 64bits
 int64_t bigDivideOrThrow(int64_t A, int64_t B, int64_t C, Rounding rounding);
 // no throw version, returns true if result is valid


### PR DESCRIPTION
# Description

Fixes #4333 by recording SCP latencies in milliseconds rather than nanoseconds, which could overflow when placed in a `uint32_t`.

I also checked the other survey data fields for potential overflow and didn't find anything else that could overflow. However, in doing so I noticed that I failed to bump
`TIME_SLICED_SURVEY_MIN_OVERLAY_PROTOCOL_VERSION` to `34` when I bumped the overlay protocol version, so I fixed that as well.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
