### PR TITLE
Remove duplicate `new` and `delete`

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -311,29 +311,6 @@ operator delete(void* ptr) noexcept
     }
     free(ptr);
 }
-
-void*
-operator new[](std::size_t count)
-{
-    auto ptr = malloc(count);
-    std::lock_guard<std::mutex> guard(TRACY_MUTEX);
-    if (tracyEnabled(guard))
-    {
-        TracyAlloc(ptr, count);
-    }
-    return ptr;
-}
-
-void
-operator delete[](void* ptr) noexcept
-{
-    std::lock_guard<std::mutex> guard(TRACY_MUTEX);
-    if (tracyEnabled(guard))
-    {
-        TracyFree(ptr);
-    }
-    free(ptr);
-}
 #endif
 
 int


### PR DESCRIPTION
# Description

Remove duplicate definition of `new` and `delete` when tracy is enabled. 

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
