### PR TITLE
Add sorobaninfo option that dumps current upgradeable settings as a ConfigUpgradeSet

### DIFF
--- a/docs/software/commands.md
+++ b/docs/software/commands.md
@@ -346,6 +346,21 @@ format.
         ConfigUpgradeSet will be used to update the existing network ConfigSettingEntry
         that exists at the corresponding CONFIG_SETTING LedgerKey.
 
+* **sorobaninfo**
+  `sorobaninfo?[format=basic,detailed,upgrade_xdr]`
+    Retrieves the current Soroban settings in different formats.
+
+    * `basic` is the default if the `format` parameter is not specified. It
+      will dump a subset of the Soroban settings in an easy to read format.
+    * `detailed` will insert every setting into a `ConfigUpgradeSet` and dump
+      it in the same format as the **dumpproposedsettings** command, which lets
+      a user easily compare the existing settings against a proposal.
+    * `upgrade_xdr` will insert the current upgradeable settings into a `ConfigUpgradeSet`
+      and dump it as base64 xdr. This can be used along with the `stellar-xdr` command line tool
+      to dump the current settings in the same format as the JSON file we use for upgrades. This
+      is helpful if you want to make settings changes off of the current settings.
+      Ex. `curl -s "127.0.0.1:11626/sorobaninfo?format=upgrade_xdr" | stellar-xdr decode --type ConfigUpgradeSet`
+
 * **dumpproposedsettings**
   `dumpproposedsettings?blob=Base64`<br>
   blob is a base64 encoded XDR serialized `ConfigUpgradeSetKey`.

--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -836,13 +836,18 @@ bool
 SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
     ConfigSettingEntry const& cfg)
 {
+    return isNonUpgradeableConfigSettingEntry(cfg.configSettingID());
+}
+
+bool
+SorobanNetworkConfig::isNonUpgradeableConfigSettingEntry(
+    ConfigSettingID const& cfg)
+{
     // While the BucketList size window and eviction iterator are stored in a
     // ConfigSetting entry, the BucketList defines these values, they should
     // never be changed via upgrade
-    return cfg.configSettingID() ==
-               ConfigSettingID::CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW ||
-           cfg.configSettingID() ==
-               ConfigSettingID::CONFIG_SETTING_EVICTION_ITERATOR;
+    return cfg == ConfigSettingID::CONFIG_SETTING_BUCKETLIST_SIZE_WINDOW ||
+           cfg == ConfigSettingID::CONFIG_SETTING_EVICTION_ITERATOR;
 }
 
 void

--- a/src/ledger/NetworkConfig.h
+++ b/src/ledger/NetworkConfig.h
@@ -306,6 +306,8 @@ class SorobanNetworkConfig
     static bool
     isNonUpgradeableConfigSettingEntry(ConfigSettingEntry const& cfg);
 
+    static bool isNonUpgradeableConfigSettingEntry(ConfigSettingID const& cfg);
+
     // Cost model parameters of the Soroban host
     ContractCostParams const& cpuCostParams() const;
     ContractCostParams const& memCostParams() const;


### PR DESCRIPTION
Use with `stellar-xdr` to get the json format required to do soroban settings upgrades.

Example - 
```
curl -s "127.0.0.1:11626/sorobaninfo?format=upgrade_xdr" | stellar-xdr decode --type ConfigUpgradeSet
```
