### PR TITLE
Un-downgrade tracy-client-sys accidentally caused by feature selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,16 +1340,7 @@ checksum = "82da0d50d9df1106619b1e5b118f39de779f7d8b9c3504485b291cb16fabd20f"
 dependencies = [
  "loom",
  "once_cell",
- "tracy-client-sys 0.22.1",
-]
-
-[[package]]
-name = "tracy-client-sys"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078c7ed72141b0e4369671a7f7af0eecffe18d753bf0296adca9c7add7276c9d"
-dependencies = [
- "cc",
+ "tracy-client-sys",
 ]
 
 [[package]]

--- a/lib/tracy-client-sys/Cargo.toml
+++ b/lib/tracy-client-sys/Cargo.toml
@@ -16,9 +16,20 @@ Low level bindings to the client libraries for the Tracy profiler
 
 [features]
 default = [ "enable" ]
+
+manual-lifetime = []
+delayed-init = []
 enable = []
-broadcast = []
-code-transfer = []
+flush-on-exit = []
+system-tracing = []
 context-switch-tracing = []
 sampling = []
-system-tracing = []
+code-transfer = []
+broadcast = []
+only-localhost = []
+only-ipv4 = []
+timer-fallback = []
+ondemand = []
+fibers = []
+callstack-inlines = []
+

--- a/lib/tracy-client-sys/src/generated.rs
+++ b/lib/tracy-client-sys/src/generated.rs
@@ -350,7 +350,7 @@ pub struct ___tracy_gpu_new_context_data {
     pub period: f32,
     pub context: u8,
     pub flags: u8,
-    type_: u8,
+    pub type_: u8,
 }
 #[test]
 fn bindgen_test_layout____tracy_gpu_new_context_data() {

--- a/lib/tracy-client-sys/src/regenerate.sh
+++ b/lib/tracy-client-sys/src/regenerate.sh
@@ -1,3 +1,2 @@
 #!/bin/sh
 bindgen "../../tracy/public/tracy/TracyC.h"   -o 'generated.rs'   --allowlist-function='.*[Tt][Rr][Aa][Cc][Yy].*'   --allowlist-type='.*[Tt][Rr][Aa][Cc][Yy].*'  -- -DTRACY_ENABLE -DTRACY_MANUAL_LIFETIME -DTRACY_FIBERS
-sed -i 's/pub type/type/g' 'generated.rs'

--- a/src/rust/src/host-dep-tree-curr.txt
+++ b/src/rust/src/host-dep-tree-curr.txt
@@ -15,8 +15,7 @@ soroban-env-host 21.1.0 git+https://github.com/stellar/rs-soroban-env?rev=8d76e4
 │       ├── hashbrown 0.14.1 checksum:7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12
 │       └── equivalent 1.0.1 checksum:5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5
 ├── tracy-client 0.16.4 checksum:82da0d50d9df1106619b1e5b118f39de779f7d8b9c3504485b291cb16fabd20f
-│   ├── tracy-client-sys 0.22.1 checksum:078c7ed72141b0e4369671a7f7af0eecffe18d753bf0296adca9c7add7276c9d
-│   │   └── cc 1.0.98 checksum:41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f
+│   ├── tracy-client-sys 0.22.2 inexact
 │   ├── once_cell 1.18.0 checksum:dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d
 │   └── loom 0.5.6 checksum:ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5
 │       ├── tracing-subscriber 0.3.17 checksum:30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77


### PR DESCRIPTION
I failed to copy from upstream all the cargo features visible in tracy-client-sys when updating our [local override of it](https://github.com/stellar/stellar-core/blob/master/lib/tracy-client-sys/Cargo.toml)

As a result, when doing a recent build, cargo helpfully failed to satisfy `tracy-client`'s dependency on `tracy-client-sys` using the locked `tracy-client-sys 0.22.2` (which selects the local override) and instead added an additional downgraded dependency on `tracy-client-sys 0.22.1`. Of course this also has the unfortunate side effect of _not using our local copy of the C++ tracy client library at all_, including any local patching we've had to do to make it build (eg. [ignoring an fscanf return value as required by gcc 11](https://github.com/stellar/tracy/pull/3)).

Anyway short story long the fix is just to add the necessary features, delete the auxiliary tracy-client-sys 0.22.1 dependency, and fix any fallout.

(Note that this also causes the host-dep-tree-curr.txt entry to change to `inexact` -- because it's just pointing to an in-tree patched version of `tracy-client-sys` -- which on the one hand it's never been before, but on the other hand is _probably_ correct-ish? I.e. I think it's probably the case that the hash we had in there before for 0.20.0 was wrong, because it would have been the checksum of the crates.io package and we literally never built against that, I think it just wound up in the lockfile by accident while I was originally iterating on getting the cross-language tracy build working.)