### PR TITLE
postgresql backend deprecation warning

### DIFF
--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -759,6 +759,13 @@ ApplicationImpl::validateAndLogConfig()
             "in-memory mode is enabled. This feature is deprecated! Node "
             "may see performance degredation and lose sync with the network.");
     }
+    if (!mDatabase->isSqlite())
+    {
+        CLOG_WARNING(Database,
+                     "Non-sqlite3 database detected. Support for other sql "
+                     "backends is deprecated and will be removed in a future "
+                     "release. Please use sqlite3 for non-ledger state data.");
+    }
 
     if (mConfig.DEPRECATED_SQL_LEDGER_STATE)
     {


### PR DESCRIPTION
# Description

[Resolves #X
](https://github.com/stellar/stellar-core-internal/issues/272)

Example output:

config.cfg:
```
DATABASE="postgresql://foobar"
````
output: 
```
 % ./src/stellar-core catchup current/1 --conf=config.cfg
Warning: running non-release version v21.0.0-76-g91d3468dd of stellar-core
2024-06-05T10:51:22.443 [default INFO] Config from config.cfg
2024-06-05T10:51:22.444 [Database WARNING] Support for postgresql backend is deprecated and will be removed in a future release of stellar-core.
```

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
