### PR TITLE
High performance `getledgerentry`

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -58,6 +58,7 @@ PREFETCH_BATCH_SIZE=1000
 # HTTP_PORT (integer) default 11626
 # What port stellar-core listens for commands on.
 # If set to 0, disable HTTP interface entirely
+# Must not be the same as HTTP_QUERY_PORT if not 0.
 HTTP_PORT=11626
 
 # PUBLIC_HTTP_PORT (true or false) default false
@@ -75,6 +76,27 @@ HTTP_MAX_CLIENT=128
 COMMANDS=[
 "ll?level=info&partition=Herder"
 ]
+
+# HTTP_QUERY_PORT (integer) default 0
+# What port stellar-core listens for query commands on,
+# such as getledgerentryraw.
+# If set to 0, disable HTTP query interface entirely.
+# Must not be the same as HTTP_PORT if not 0.
+HTTP_QUERY_PORT=0
+
+# QUERY_THREAD_POOL_SIZE (integer) default 4
+# Number of threads available for processing query commands.
+# If HTTP_QUERY_PORT == 0, this option is ignored.
+QUERY_THREAD_POOL_SIZE=4
+
+# QUERY_SNAPSHOT_LEDGERS (integer) default 0
+# Number of historical ledger snapshots to maintain for
+# query commands. Note: Setting this to large values may
+# significantly impact performance. Additionally, these
+# snapshots are a "best effort" only and not persisted on
+# restart. On restart, only the current ledger will be
+# available, with snapshots avaiable as ledgers close.
+QUERY_SNAPSHOT_LEDGERS = 0
 
 # convenience mapping of common names to node IDs. The common names can be used
 #  in the .cfg. `$common_name`. If set, they will also appear in your logs

--- a/lib/httpthreaded/connection.cpp
+++ b/lib/httpthreaded/connection.cpp
@@ -1,0 +1,98 @@
+//
+// connection.cpp
+// ~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "connection.hpp"
+#include "server.hpp"
+#include <utility>
+#include <vector>
+
+#define MAX_REQUEST_SIZE (1024 * 1024 * 10) // 10 MB
+
+namespace httpThreaded
+{
+namespace server
+{
+
+connection::connection(asio::ip::tcp::socket socket, server& handler)
+    : socket_(std::move(socket)), request_handler_(handler), received_count_(0)
+{
+}
+
+void
+connection::start()
+{
+    do_read();
+}
+
+void
+connection::do_read()
+{
+    auto self(shared_from_this());
+    socket_.async_read_some(
+        asio::buffer(buffer_),
+        [this, self](asio::error_code ec, std::size_t bytes_transferred) {
+            if (!ec)
+            {
+                request_parser::result_type result;
+                std::tie(result, std::ignore) =
+                    request_parser_.parse(request_, buffer_.data(),
+                                          buffer_.data() + bytes_transferred);
+                received_count_ += bytes_transferred;
+
+                if (result == request_parser::bad ||
+                    received_count_ > MAX_REQUEST_SIZE)
+                {
+                    reply_ = reply::stock_reply(reply::bad_request);
+                    do_write();
+                }
+                else if (result == request_parser::good)
+                {
+                    request_handler_.handle_request(request_, reply_);
+                    do_write();
+                }
+                else
+                {
+                    do_read();
+                }
+            }
+            // If an error occurs then no new asynchronous operations are
+            // started. This means that all shared_ptr references to the
+            // connection object will disappear and the object will be
+            // destroyed automatically after this handler returns. The
+            // connection class's destructor closes the socket.
+        });
+}
+
+void
+connection::do_write()
+{
+    auto self(shared_from_this());
+    asio::async_write(socket_, reply_.to_buffers(),
+                      [this, self](asio::error_code ec, std::size_t) {
+                          if (!ec)
+                          {
+                              // Initiate graceful connection closure.
+                              asio::error_code ignored_ec;
+                              socket_.shutdown(
+                                  asio::ip::tcp::socket::shutdown_both,
+                                  ignored_ec);
+                          }
+
+                          // No new asynchronous operations are started. This
+                          // means that all shared_ptr references to the
+                          // connection object will disappear and the object
+                          // will be destroyed automatically after this handler
+                          // returns. The connection class's destructor closes
+                          // the socket.
+                      });
+}
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/connection.hpp
+++ b/lib/httpthreaded/connection.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+//
+// connection.hpp
+// ~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// ASIO is somewhat particular about when it gets included -- it wants to be the
+// first to include <windows.h> -- so we try to include it before everything
+// else.
+#include "util/asio.h"
+
+#include "reply.hpp"
+#include "request.hpp"
+#include "request_parser.hpp"
+#include <array>
+#include <memory>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+class server;
+
+/// Represents a single connection from a client.
+class connection : public std::enable_shared_from_this<connection>
+{
+  public:
+    connection(const connection&) = delete;
+    connection& operator=(const connection&) = delete;
+
+    /// Construct a connection with the given socket.
+    explicit connection(asio::ip::tcp::socket socket, server& handler);
+
+    /// Start the first asynchronous operation for the connection.
+    void start();
+
+  private:
+    /// Perform an asynchronous read operation.
+    void do_read();
+
+    /// Perform an asynchronous write operation.
+    void do_write();
+
+    /// Socket for the connection.
+    asio::ip::tcp::socket socket_;
+
+    /// The handler used to process the incoming request.
+    server& request_handler_;
+
+    /// Buffer for incoming data.
+    std::array<char, 8192> buffer_;
+
+    /// Size of received data
+    size_t received_count_;
+
+    /// The incoming request.
+    request request_;
+
+    /// The parser for the incoming request.
+    request_parser request_parser_;
+
+    /// The reply to be sent back to the client.
+    reply reply_;
+};
+
+typedef std::shared_ptr<connection> connection_ptr;
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/header.hpp
+++ b/lib/httpthreaded/header.hpp
@@ -1,0 +1,30 @@
+//
+// header.hpp
+// ~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef HTTP_THREADED_HEADER_HPP
+#define HTTP_THREADED_HEADER_HPP
+
+#include <string>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+struct header
+{
+    std::string name;
+    std::string value;
+};
+
+} // namespace server
+} // namespace httpThreaded
+
+#endif // HTTP_THREADED_HEADER_HPP

--- a/lib/httpthreaded/reply.cpp
+++ b/lib/httpthreaded/reply.cpp
@@ -1,0 +1,236 @@
+//
+// reply.cpp
+// ~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "reply.hpp"
+#include <string>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+namespace status_strings
+{
+
+const std::string ok = "HTTP/1.0 200 OK\r\n";
+const std::string created = "HTTP/1.0 201 Created\r\n";
+const std::string accepted = "HTTP/1.0 202 Accepted\r\n";
+const std::string no_content = "HTTP/1.0 204 No Content\r\n";
+const std::string multiple_choices = "HTTP/1.0 300 Multiple Choices\r\n";
+const std::string moved_permanently = "HTTP/1.0 301 Moved Permanently\r\n";
+const std::string moved_temporarily = "HTTP/1.0 302 Moved Temporarily\r\n";
+const std::string not_modified = "HTTP/1.0 304 Not Modified\r\n";
+const std::string bad_request = "HTTP/1.0 400 Bad Request\r\n";
+const std::string unauthorized = "HTTP/1.0 401 Unauthorized\r\n";
+const std::string forbidden = "HTTP/1.0 403 Forbidden\r\n";
+const std::string not_found = "HTTP/1.0 404 Not Found\r\n";
+const std::string internal_server_error =
+    "HTTP/1.0 500 Internal Server Error\r\n";
+const std::string not_implemented = "HTTP/1.0 501 Not Implemented\r\n";
+const std::string bad_gateway = "HTTP/1.0 502 Bad Gateway\r\n";
+const std::string service_unavailable = "HTTP/1.0 503 Service Unavailable\r\n";
+
+asio::const_buffer
+to_buffer(reply::status_type status)
+{
+    switch (status)
+    {
+    case reply::ok:
+        return asio::buffer(ok);
+    case reply::created:
+        return asio::buffer(created);
+    case reply::accepted:
+        return asio::buffer(accepted);
+    case reply::no_content:
+        return asio::buffer(no_content);
+    case reply::multiple_choices:
+        return asio::buffer(multiple_choices);
+    case reply::moved_permanently:
+        return asio::buffer(moved_permanently);
+    case reply::moved_temporarily:
+        return asio::buffer(moved_temporarily);
+    case reply::not_modified:
+        return asio::buffer(not_modified);
+    case reply::bad_request:
+        return asio::buffer(bad_request);
+    case reply::unauthorized:
+        return asio::buffer(unauthorized);
+    case reply::forbidden:
+        return asio::buffer(forbidden);
+    case reply::not_found:
+        return asio::buffer(not_found);
+    case reply::internal_server_error:
+        return asio::buffer(internal_server_error);
+    case reply::not_implemented:
+        return asio::buffer(not_implemented);
+    case reply::bad_gateway:
+        return asio::buffer(bad_gateway);
+    case reply::service_unavailable:
+        return asio::buffer(service_unavailable);
+    default:
+        return asio::buffer(internal_server_error);
+    }
+}
+
+} // namespace status_strings
+
+namespace misc_strings
+{
+
+const char name_value_separator[] = {':', ' '};
+const char crlf[] = {'\r', '\n'};
+
+} // namespace misc_strings
+
+std::vector<asio::const_buffer>
+reply::to_buffers()
+{
+    std::vector<asio::const_buffer> buffers;
+    buffers.push_back(status_strings::to_buffer(status));
+    for (std::size_t i = 0; i < headers.size(); ++i)
+    {
+        header& h = headers[i];
+        buffers.push_back(asio::buffer(h.name));
+        buffers.push_back(asio::buffer(misc_strings::name_value_separator));
+        buffers.push_back(asio::buffer(h.value));
+        buffers.push_back(asio::buffer(misc_strings::crlf));
+    }
+    buffers.push_back(asio::buffer(misc_strings::crlf));
+    buffers.push_back(asio::buffer(content));
+    return buffers;
+}
+
+namespace stock_replies
+{
+
+const char ok[] = "";
+const char created[] = "<html>"
+                       "<head><title>Created</title></head>"
+                       "<body><h1>201 Created</h1></body>"
+                       "</html>";
+const char accepted[] = "<html>"
+                        "<head><title>Accepted</title></head>"
+                        "<body><h1>202 Accepted</h1></body>"
+                        "</html>";
+const char no_content[] = "<html>"
+                          "<head><title>No Content</title></head>"
+                          "<body><h1>204 Content</h1></body>"
+                          "</html>";
+const char multiple_choices[] = "<html>"
+                                "<head><title>Multiple Choices</title></head>"
+                                "<body><h1>300 Multiple Choices</h1></body>"
+                                "</html>";
+const char moved_permanently[] = "<html>"
+                                 "<head><title>Moved Permanently</title></head>"
+                                 "<body><h1>301 Moved Permanently</h1></body>"
+                                 "</html>";
+const char moved_temporarily[] = "<html>"
+                                 "<head><title>Moved Temporarily</title></head>"
+                                 "<body><h1>302 Moved Temporarily</h1></body>"
+                                 "</html>";
+const char not_modified[] = "<html>"
+                            "<head><title>Not Modified</title></head>"
+                            "<body><h1>304 Not Modified</h1></body>"
+                            "</html>";
+const char bad_request[] = "<html>"
+                           "<head><title>Bad Request</title></head>"
+                           "<body><h1>400 Bad Request</h1></body>"
+                           "</html>";
+const char unauthorized[] = "<html>"
+                            "<head><title>Unauthorized</title></head>"
+                            "<body><h1>401 Unauthorized</h1></body>"
+                            "</html>";
+const char forbidden[] = "<html>"
+                         "<head><title>Forbidden</title></head>"
+                         "<body><h1>403 Forbidden</h1></body>"
+                         "</html>";
+const char not_found[] = "<html>"
+                         "<head><title>Not Found</title></head>"
+                         "<body><h1>404 Not Found</h1></body>"
+                         "</html>";
+const char internal_server_error[] =
+    "<html>"
+    "<head><title>Internal Server Error</title></head>"
+    "<body><h1>500 Internal Server Error</h1></body>"
+    "</html>";
+const char not_implemented[] = "<html>"
+                               "<head><title>Not Implemented</title></head>"
+                               "<body><h1>501 Not Implemented</h1></body>"
+                               "</html>";
+const char bad_gateway[] = "<html>"
+                           "<head><title>Bad Gateway</title></head>"
+                           "<body><h1>502 Bad Gateway</h1></body>"
+                           "</html>";
+const char service_unavailable[] =
+    "<html>"
+    "<head><title>Service Unavailable</title></head>"
+    "<body><h1>503 Service Unavailable</h1></body>"
+    "</html>";
+
+std::string
+to_string(reply::status_type status)
+{
+    switch (status)
+    {
+    case reply::ok:
+        return ok;
+    case reply::created:
+        return created;
+    case reply::accepted:
+        return accepted;
+    case reply::no_content:
+        return no_content;
+    case reply::multiple_choices:
+        return multiple_choices;
+    case reply::moved_permanently:
+        return moved_permanently;
+    case reply::moved_temporarily:
+        return moved_temporarily;
+    case reply::not_modified:
+        return not_modified;
+    case reply::bad_request:
+        return bad_request;
+    case reply::unauthorized:
+        return unauthorized;
+    case reply::forbidden:
+        return forbidden;
+    case reply::not_found:
+        return not_found;
+    case reply::internal_server_error:
+        return internal_server_error;
+    case reply::not_implemented:
+        return not_implemented;
+    case reply::bad_gateway:
+        return bad_gateway;
+    case reply::service_unavailable:
+        return service_unavailable;
+    default:
+        return internal_server_error;
+    }
+}
+
+} // namespace stock_replies
+
+reply
+reply::stock_reply(reply::status_type status)
+{
+    reply rep;
+    rep.status = status;
+    rep.content = stock_replies::to_string(status);
+    rep.headers.resize(2);
+    rep.headers[0].name = "Content-Length";
+    rep.headers[0].value = std::to_string(rep.content.size());
+    rep.headers[1].name = "Content-Type";
+    rep.headers[1].value = "text/html";
+    return rep;
+}
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/reply.cpp
+++ b/lib/httpthreaded/reply.cpp
@@ -93,17 +93,17 @@ std::vector<asio::const_buffer>
 reply::to_buffers()
 {
     std::vector<asio::const_buffer> buffers;
-    buffers.push_back(status_strings::to_buffer(status));
+    buffers.emplace_back(status_strings::to_buffer(status));
     for (std::size_t i = 0; i < headers.size(); ++i)
     {
         header& h = headers[i];
-        buffers.push_back(asio::buffer(h.name));
-        buffers.push_back(asio::buffer(misc_strings::name_value_separator));
-        buffers.push_back(asio::buffer(h.value));
-        buffers.push_back(asio::buffer(misc_strings::crlf));
+        buffers.emplace_back(asio::buffer(h.name));
+        buffers.emplace_back(asio::buffer(misc_strings::name_value_separator));
+        buffers.emplace_back(asio::buffer(h.value));
+        buffers.emplace_back(asio::buffer(misc_strings::crlf));
     }
-    buffers.push_back(asio::buffer(misc_strings::crlf));
-    buffers.push_back(asio::buffer(content));
+    buffers.emplace_back(asio::buffer(misc_strings::crlf));
+    buffers.emplace_back(asio::buffer(content));
     return buffers;
 }
 

--- a/lib/httpthreaded/reply.hpp
+++ b/lib/httpthreaded/reply.hpp
@@ -1,0 +1,66 @@
+#pragma once
+//
+// reply.hpp
+// ~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// ASIO is somewhat particular about when it gets included -- it wants to be the
+// first to include <windows.h> -- so we try to include it before everything
+// else.
+#include "util/asio.h"
+
+#include "header.hpp"
+#include <string>
+#include <vector>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+/// A reply to be sent to a client.
+struct reply
+{
+    /// The status of the reply.
+    enum status_type
+    {
+        ok = 200,
+        created = 201,
+        accepted = 202,
+        no_content = 204,
+        multiple_choices = 300,
+        moved_permanently = 301,
+        moved_temporarily = 302,
+        not_modified = 304,
+        bad_request = 400,
+        unauthorized = 401,
+        forbidden = 403,
+        not_found = 404,
+        internal_server_error = 500,
+        not_implemented = 501,
+        bad_gateway = 502,
+        service_unavailable = 503
+    } status;
+
+    /// The headers to be included in the reply.
+    std::vector<header> headers;
+
+    /// The content to be sent in the reply.
+    std::string content;
+
+    /// Convert the reply into a vector of buffers. The buffers do not own the
+    /// underlying memory blocks, therefore the reply object must remain valid
+    /// and not be changed until the write operation has completed.
+    std::vector<asio::const_buffer> to_buffers();
+
+    /// Get a stock reply.
+    static reply stock_reply(status_type status);
+};
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/request.hpp
+++ b/lib/httpthreaded/request.hpp
@@ -1,0 +1,36 @@
+//
+// request.hpp
+// ~~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef HTTP_THREADED_REQUEST_HPP
+#define HTTP_THREADED_REQUEST_HPP
+
+#include "header.hpp"
+#include <string>
+#include <vector>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+/// A request received from a client.
+struct request
+{
+    std::string method;
+    std::string uri;
+    int http_version_major;
+    int http_version_minor;
+    std::vector<header> headers;
+};
+
+} // namespace server
+} // namespace httpThreaded
+
+#endif // HTTP_THREADED_REQUEST_HPP

--- a/lib/httpthreaded/request.hpp
+++ b/lib/httpthreaded/request.hpp
@@ -28,6 +28,7 @@ struct request
     int http_version_major;
     int http_version_minor;
     std::vector<header> headers;
+    std::string body{};
 };
 
 } // namespace server

--- a/lib/httpthreaded/request_parser.cpp
+++ b/lib/httpthreaded/request_parser.cpp
@@ -1,0 +1,337 @@
+//
+// request_parser.cpp
+// ~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#include "request_parser.hpp"
+#include "request.hpp"
+
+namespace httpThreaded
+{
+namespace server
+{
+
+request_parser::request_parser() : state_(method_start)
+{
+}
+
+void
+request_parser::reset()
+{
+    state_ = method_start;
+}
+
+request_parser::result_type
+request_parser::consume(request& req, char input)
+{
+    switch (state_)
+    {
+    case method_start:
+        if (!is_char(input) || is_ctl(input) || is_tspecial(input))
+        {
+            return bad;
+        }
+        else
+        {
+            state_ = method;
+            req.method.push_back(input);
+            return indeterminate;
+        }
+    case method:
+        if (input == ' ')
+        {
+            state_ = uri;
+            return indeterminate;
+        }
+        else if (!is_char(input) || is_ctl(input) || is_tspecial(input))
+        {
+            return bad;
+        }
+        else
+        {
+            req.method.push_back(input);
+            return indeterminate;
+        }
+    case uri:
+        if (input == ' ')
+        {
+            state_ = http_version_h;
+            return indeterminate;
+        }
+        else if (is_ctl(input))
+        {
+            return bad;
+        }
+        else
+        {
+            req.uri.push_back(input);
+            return indeterminate;
+        }
+    case http_version_h:
+        if (input == 'H')
+        {
+            state_ = http_version_t_1;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_t_1:
+        if (input == 'T')
+        {
+            state_ = http_version_t_2;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_t_2:
+        if (input == 'T')
+        {
+            state_ = http_version_p;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_p:
+        if (input == 'P')
+        {
+            state_ = http_version_slash;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_slash:
+        if (input == '/')
+        {
+            req.http_version_major = 0;
+            req.http_version_minor = 0;
+            state_ = http_version_major_start;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_major_start:
+        if (is_digit(input))
+        {
+            req.http_version_major = req.http_version_major * 10 + input - '0';
+            state_ = http_version_major;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_major:
+        if (input == '.')
+        {
+            state_ = http_version_minor_start;
+            return indeterminate;
+        }
+        else if (is_digit(input))
+        {
+            req.http_version_major = req.http_version_major * 10 + input - '0';
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_minor_start:
+        if (is_digit(input))
+        {
+            req.http_version_minor = req.http_version_minor * 10 + input - '0';
+            state_ = http_version_minor;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case http_version_minor:
+        if (input == '\r')
+        {
+            state_ = expecting_newline_1;
+            return indeterminate;
+        }
+        else if (is_digit(input))
+        {
+            req.http_version_minor = req.http_version_minor * 10 + input - '0';
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case expecting_newline_1:
+        if (input == '\n')
+        {
+            state_ = header_line_start;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case header_line_start:
+        if (input == '\r')
+        {
+            state_ = expecting_newline_3;
+            return indeterminate;
+        }
+        else if (!req.headers.empty() && (input == ' ' || input == '\t'))
+        {
+            state_ = header_lws;
+            return indeterminate;
+        }
+        else if (!is_char(input) || is_ctl(input) || is_tspecial(input))
+        {
+            return bad;
+        }
+        else
+        {
+            req.headers.push_back(header());
+            req.headers.back().name.push_back(input);
+            state_ = header_name;
+            return indeterminate;
+        }
+    case header_lws:
+        if (input == '\r')
+        {
+            state_ = expecting_newline_2;
+            return indeterminate;
+        }
+        else if (input == ' ' || input == '\t')
+        {
+            return indeterminate;
+        }
+        else if (is_ctl(input))
+        {
+            return bad;
+        }
+        else
+        {
+            state_ = header_value;
+            req.headers.back().value.push_back(input);
+            return indeterminate;
+        }
+    case header_name:
+        if (input == ':')
+        {
+            state_ = space_before_header_value;
+            return indeterminate;
+        }
+        else if (!is_char(input) || is_ctl(input) || is_tspecial(input))
+        {
+            return bad;
+        }
+        else
+        {
+            req.headers.back().name.push_back(input);
+            return indeterminate;
+        }
+    case space_before_header_value:
+        if (input == ' ')
+        {
+            state_ = header_value;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case header_value:
+        if (input == '\r')
+        {
+            state_ = expecting_newline_2;
+            return indeterminate;
+        }
+        else if (is_ctl(input))
+        {
+            return bad;
+        }
+        else
+        {
+            req.headers.back().value.push_back(input);
+            return indeterminate;
+        }
+    case expecting_newline_2:
+        if (input == '\n')
+        {
+            state_ = header_line_start;
+            return indeterminate;
+        }
+        else
+        {
+            return bad;
+        }
+    case expecting_newline_3:
+        return (input == '\n') ? good : bad;
+    default:
+        return bad;
+    }
+}
+
+bool
+request_parser::is_char(int c)
+{
+    return c >= 0 && c <= 127;
+}
+
+bool
+request_parser::is_ctl(int c)
+{
+    return (c >= 0 && c <= 31) || (c == 127);
+}
+
+bool
+request_parser::is_tspecial(int c)
+{
+    switch (c)
+    {
+    case '(':
+    case ')':
+    case '<':
+    case '>':
+    case '@':
+    case ',':
+    case ';':
+    case ':':
+    case '\\':
+    case '"':
+    case '/':
+    case '[':
+    case ']':
+    case '?':
+    case '=':
+    case '{':
+    case '}':
+    case ' ':
+    case '\t':
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool
+request_parser::is_digit(int c)
+{
+    return c >= '0' && c <= '9';
+}
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/request_parser.hpp
+++ b/lib/httpthreaded/request_parser.hpp
@@ -1,0 +1,103 @@
+//
+// request_parser.hpp
+// ~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef HTTP_THREADED_REQUEST_PARSER_HPP
+#define HTTP_THREADED_REQUEST_PARSER_HPP
+
+#include <tuple>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+struct request;
+
+/// Parser for incoming requests.
+class request_parser
+{
+  public:
+    /// Construct ready to parse the request method.
+    request_parser();
+
+    /// Reset to initial parser state.
+    void reset();
+
+    /// Result of parse.
+    enum result_type
+    {
+        good,
+        bad,
+        indeterminate
+    };
+
+    /// Parse some data. The enum return value is good when a complete request
+    /// has been parsed, bad if the data is invalid, indeterminate when more
+    /// data is required. The InputIterator return value indicates how much of
+    /// the input has been consumed.
+    template <typename InputIterator>
+    std::tuple<result_type, InputIterator>
+    parse(request& req, InputIterator begin, InputIterator end)
+    {
+        while (begin != end)
+        {
+            result_type result = consume(req, *begin++);
+            if (result == good || result == bad)
+                return std::make_tuple(result, begin);
+        }
+        return std::make_tuple(indeterminate, begin);
+    }
+
+  private:
+    /// Handle the next character of input.
+    result_type consume(request& req, char input);
+
+    /// Check if a byte is an HTTP character.
+    static bool is_char(int c);
+
+    /// Check if a byte is an HTTP control character.
+    static bool is_ctl(int c);
+
+    /// Check if a byte is defined as an HTTP tspecial character.
+    static bool is_tspecial(int c);
+
+    /// Check if a byte is a digit.
+    static bool is_digit(int c);
+
+    /// The current state of the parser.
+    enum state
+    {
+        method_start,
+        method,
+        uri,
+        http_version_h,
+        http_version_t_1,
+        http_version_t_2,
+        http_version_p,
+        http_version_slash,
+        http_version_major_start,
+        http_version_major,
+        http_version_minor_start,
+        http_version_minor,
+        expecting_newline_1,
+        header_line_start,
+        header_lws,
+        header_name,
+        space_before_header_value,
+        header_value,
+        expecting_newline_2,
+        expecting_newline_3
+    } state_;
+};
+
+} // namespace server
+} // namespace httpThreaded
+
+#endif // HTTP_THREADED_REQUEST_PARSER_HPP

--- a/lib/httpthreaded/server.cpp
+++ b/lib/httpthreaded/server.cpp
@@ -1,0 +1,267 @@
+//
+// server.cpp
+// ~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+#include "server.hpp"
+
+#include "util/GlobalChecks.h"
+#include "util/Thread.h"
+
+#include <signal.h>
+#include <sstream>
+#include <thread>
+#include <utility>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+server::server(const std::string& address, unsigned short port, int maxClient,
+               std::size_t threadPoolSize)
+    : thread_pool_size_(threadPoolSize)
+    , signals_(io_context_)
+    , acceptor_(io_context_)
+{
+    releaseAssertOrThrow(threadPoolSize > 0);
+    // Register to handle the signals that indicate when the server should exit.
+    // It is safe to register for the same signal multiple times in a program,
+    // provided all registration for the specified signal is made through Asio.
+    signals_.add(SIGINT);
+    signals_.add(SIGTERM);
+#if defined(SIGQUIT)
+    signals_.add(SIGQUIT);
+#endif // defined(SIGQUIT)
+
+    do_await_stop();
+
+    asio::ip::tcp::endpoint endpoint(asio::ip::address::from_string(address),
+                                     port);
+    // Open the acceptor with the option to reuse the address (i.e.
+    // SO_REUSEADDR).
+    acceptor_.open(endpoint.protocol());
+    acceptor_.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+    acceptor_.bind(endpoint);
+    acceptor_.listen(maxClient);
+    do_accept();
+}
+
+std::vector<std::thread::id>
+server::start()
+{
+    std::vector<std::thread::id> pids;
+
+    // Create a pool of threads to run the io_context.
+    for (std::size_t i = 0; i < thread_pool_size_; ++i)
+    {
+        worker_threads_.emplace_back([this] {
+            stellar::runCurrentThreadWithMediumPriority();
+            io_context_.run();
+        });
+        pids.emplace_back(worker_threads_[i].get_id());
+    }
+
+    return pids;
+}
+
+void
+server::add404(routeHandler callback)
+{
+    addRoute("404", callback);
+}
+
+void
+server::addRoute(const std::string& routeName, routeHandler callback)
+{
+    mRoutes[routeName] = callback;
+}
+
+void
+server::do_accept()
+{
+    // The newly accepted socket is put into its own strand to ensure that all
+    // completion handlers associated with the connection do not run
+    // concurrently.
+    acceptor_.async_accept(
+        asio::make_strand(io_context_),
+        [this](std::error_code ec, asio::ip::tcp::socket socket) {
+            // Check whether the server was stopped by a signal before this
+            // completion handler had a chance to run.
+            if (!acceptor_.is_open())
+            {
+                return;
+            }
+
+            if (!ec)
+            {
+                std::make_shared<connection>(std::move(socket), *this)->start();
+            }
+
+            do_accept();
+        });
+}
+
+void
+server::stop()
+{
+    io_context_.stop();
+    for (auto& t : worker_threads_)
+    {
+        t.join();
+    }
+}
+
+void
+server::do_await_stop()
+{
+    signals_.async_wait(
+        [this](std::error_code /*ec*/, int /*signo*/) { this->stop(); });
+}
+
+server::~server()
+{
+    stop();
+}
+
+void
+server::handle_request(const request& req, reply& rep)
+{
+    // Decode url to path.
+    std::string request_path;
+    if (!url_decode(req.uri, request_path))
+    {
+        rep = reply::stock_reply(reply::bad_request);
+        return;
+    }
+
+    if (request_path.size() && request_path[0] == '/')
+        request_path = request_path.substr(1);
+
+    std::string command;
+    std::string params;
+    auto pos = request_path.find('?');
+    if (pos == std::string::npos)
+        command = request_path;
+    else
+    {
+        command = request_path.substr(0, pos);
+        params = request_path.substr(pos);
+    }
+
+    auto it = mRoutes.find(command);
+    if (it != mRoutes.end())
+    {
+        it->second(params, rep.content);
+
+        rep.status = reply::ok;
+        rep.headers.resize(2);
+        rep.headers[0].name = "Content-Length";
+        rep.headers[0].value = std::to_string(rep.content.size());
+        rep.headers[1].name = "Content-Type";
+        rep.headers[1].value = "application/json";
+    }
+    else
+    {
+        it = mRoutes.find("404");
+        if (it != mRoutes.end())
+        {
+            it->second(params, rep.content);
+
+            rep.status = reply::not_found;
+            rep.headers.resize(2);
+            rep.headers[0].name = "Content-Length";
+            rep.headers[0].value = std::to_string(rep.content.size());
+            rep.headers[1].name = "Content-Type";
+            rep.headers[1].value = "text/html";
+        }
+        else
+        {
+            rep = reply::stock_reply(reply::not_found);
+            return;
+        }
+    }
+}
+
+bool
+server::url_decode(const std::string& in, std::string& out)
+{
+    out.clear();
+    out.reserve(in.size());
+    for (std::size_t i = 0; i < in.size(); ++i)
+    {
+        if (in[i] == '%')
+        {
+            if (i + 3 <= in.size())
+            {
+                int value = 0;
+                std::istringstream is(in.substr(i + 1, 2));
+                if (is >> std::hex >> value)
+                {
+                    out += static_cast<char>(value);
+                    i += 2;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+        else if (in[i] == '+')
+        {
+            out += ' ';
+        }
+        else
+        {
+            out += in[i];
+        }
+    }
+    return true;
+}
+
+void
+server::parseParams(const std::string& params,
+                    std::map<std::string, std::string>& retMap)
+{
+    bool buildingName = true;
+    std::string name, value;
+    for (auto c : params)
+    {
+        if (c == '?')
+        {
+        }
+        else if (c == '=')
+        {
+            buildingName = false;
+        }
+        else if (c == '&')
+        {
+            buildingName = true;
+            retMap[name] = value;
+            name = "";
+            value = "";
+        }
+        else
+        {
+            if (buildingName)
+                name += c;
+            else
+                value += c;
+        }
+    }
+    if (name.size() && value.size())
+    {
+        retMap[name] = value;
+    }
+}
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/server.hpp
+++ b/lib/httpthreaded/server.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+//
+// server.hpp
+// ~~~~~~~~~~
+//
+// Copyright (c) 2003-2024 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// ASIO is somewhat particular about when it gets included -- it wants to be the
+// first to include <windows.h> -- so we try to include it before everything
+// else.
+#include "util/asio.h"
+
+#include "connection.hpp"
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace httpThreaded
+{
+namespace server
+{
+
+/// The top-level class of the HTTP server.
+class server
+{
+
+  public:
+    typedef std::function<void(const std::string&, std::string&)> routeHandler;
+    server(const server&) = delete;
+    server& operator=(const server&) = delete;
+
+    /// Construct the server to listen on the specified TCP address and port.
+    explicit server(const std::string& address, unsigned short port,
+                    int maxClient, std::size_t threadPoolSize);
+    ~server();
+
+    void addRoute(const std::string& routeName, routeHandler callback);
+    void add404(routeHandler callback);
+
+    void handle_request(const request& req, reply& rep);
+
+    /// Start the server's io_context loop. Returns PIDs of all worker threads.
+    std::vector<std::thread::id> start();
+
+    static void parseParams(const std::string& params,
+                            std::map<std::string, std::string>& retMap);
+
+  private:
+    /// Perform an asynchronous accept operation.
+    void do_accept();
+
+    void stop();
+
+    /// Wait for a request to stop the server.
+    void do_await_stop();
+
+    /// Perform URL-decoding on a string. Returns false if the encoding was
+    /// invalid.
+    static bool url_decode(const std::string& in, std::string& out);
+
+    /// The number of threads that will call io_context::run().
+    std::size_t thread_pool_size_;
+
+    /// The io_context used to perform asynchronous operations.
+    asio::io_context io_context_;
+
+    /// The signal_set is used to register for process termination
+    /// notifications.
+    asio::signal_set signals_;
+
+    /// Acceptor used to listen for incoming connections.
+    asio::ip::tcp::acceptor acceptor_;
+
+    std::vector<std::thread> worker_threads_{};
+
+    std::map<std::string, routeHandler> mRoutes;
+};
+
+} // namespace server
+} // namespace httpThreaded

--- a/lib/httpthreaded/server.hpp
+++ b/lib/httpthreaded/server.hpp
@@ -31,7 +31,11 @@ class server
 {
 
   public:
-    typedef std::function<void(const std::string&, std::string&)> routeHandler;
+    // If route handler returns true, send response with 200 OK status.
+    // Otherwise, send 404 Not Found.
+    typedef std::function<bool(const std::string&, const std::string&,
+                               std::string&)>
+        routeHandler;
     server(const server&) = delete;
     server& operator=(const server&) = delete;
 
@@ -50,6 +54,9 @@ class server
 
     static void parseParams(const std::string& params,
                             std::map<std::string, std::string>& retMap);
+    static void
+    parsePostParams(const std::string& params,
+                    std::map<std::string, std::vector<std::string>>& retMap);
 
   private:
     /// Perform an asynchronous accept operation.

--- a/make-mks
+++ b/make-mks
@@ -59,7 +59,7 @@ listall() {
  echo SOCI_PG_FILES = $(listall soci/src/backends/postgresql)
 
  echo SQLITE3_FILES = $(listall sqlite)
- echo UTIL_FILES = $(listall util http)
+ echo UTIL_FILES = $(listall util http httpthreaded)
  echo ASIO_H_FILES = $(listall asio/asio/include)
  # The following does not work without boost or -DASIO_STANDALONE=1
  #echo ASIO_CXX_FILES = asio/src/*.cpp

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -127,7 +127,8 @@ BucketManagerImpl::initialize()
         if (mApp.getConfig().isUsingBucketListDB())
         {
             mSnapshotManager = std::make_unique<BucketSnapshotManager>(
-                mApp, std::make_unique<BucketListSnapshot>(*mBucketList, 0));
+                mApp, std::make_unique<BucketListSnapshot>(*mBucketList, 0),
+                mApp.getConfig().QUERY_SNAPSHOT_LEDGERS);
         }
     }
 }
@@ -994,7 +995,7 @@ BucketManagerImpl::startBackgroundEvictionScan(uint32_t ledgerSeq)
     releaseAssert(!mEvictionFuture.valid());
     releaseAssert(mEvictionStatistics);
 
-    auto searchableBL = mSnapshotManager->getSearchableBucketListSnapshot();
+    auto searchableBL = mSnapshotManager->copySearchableBucketListSnapshot();
     auto const& cfg = mApp.getLedgerManager().getSorobanNetworkConfig();
     auto const& sas = cfg.stateArchivalSettings();
 

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -9,14 +9,18 @@
 
 #include "medida/meter.h"
 #include "medida/metrics_registry.h"
+#include <shared_mutex>
 
 namespace stellar
 {
 
 BucketSnapshotManager::BucketSnapshotManager(
-    Application& app, std::unique_ptr<BucketListSnapshot const>&& snapshot)
+    Application& app, std::unique_ptr<BucketListSnapshot const>&& snapshot,
+    uint32_t numHistoricalSnapshots)
     : mApp(app)
     , mCurrentSnapshot(std::move(snapshot))
+    , mHistoricalSnapshots()
+    , mNumHistoricalSnapshots(numHistoricalSnapshots)
     , mBulkLoadMeter(app.getMetrics().NewMeter(
           {"bucketlistDB", "query", "loads"}, "query"))
     , mBloomMisses(app.getMetrics().NewMeter(
@@ -27,11 +31,11 @@ BucketSnapshotManager::BucketSnapshotManager(
     releaseAssert(threadIsMain());
 }
 
-std::shared_ptr<SearchableBucketListSnapshot>
-BucketSnapshotManager::getSearchableBucketListSnapshot() const
+std::unique_ptr<SearchableBucketListSnapshot>
+BucketSnapshotManager::copySearchableBucketListSnapshot() const
 {
-    // Can't use std::make_shared due to private constructor
-    return std::shared_ptr<SearchableBucketListSnapshot>(
+    // Can't use std::make_unique due to private constructor
+    return std::unique_ptr<SearchableBucketListSnapshot>(
         new SearchableBucketListSnapshot(*this));
 }
 
@@ -61,9 +65,16 @@ BucketSnapshotManager::recordBulkLoadMetrics(std::string const& label,
 
 void
 BucketSnapshotManager::maybeUpdateSnapshot(
-    std::unique_ptr<BucketListSnapshot const>& snapshot) const
+    std::unique_ptr<BucketListSnapshot const>& snapshot,
+    std::map<uint32_t, std::unique_ptr<BucketListSnapshot const>>&
+        historicalSnapshots) const
 {
-    std::lock_guard<std::recursive_mutex> lock(mSnapshotMutex);
+    // The canonical snapshot held by the BucketSnapshotManager is not being
+    // modified. Rather, a thread is checking it's copy against the canonical
+    // snapshot, so use a shared lock.
+    std::shared_lock<std::shared_mutex> lock(mSnapshotMutex);
+
+    // First update current snapshot
     if (!snapshot ||
         snapshot->getLedgerSeq() != mCurrentSnapshot->getLedgerSeq())
     {
@@ -71,6 +82,27 @@ BucketSnapshotManager::maybeUpdateSnapshot(
         releaseAssert(!snapshot || snapshot->getLedgerSeq() <
                                        mCurrentSnapshot->getLedgerSeq());
         snapshot = std::make_unique<BucketListSnapshot>(*mCurrentSnapshot);
+    }
+
+    // Then update historical snapshots (if any exist)
+    if (mHistoricalSnapshots.empty())
+    {
+        return;
+    }
+
+    // If size of manager's history map is different, or if the oldest snapshot
+    // ledger seq is different, we need to update.
+    if (mHistoricalSnapshots.size() != historicalSnapshots.size() ||
+        mHistoricalSnapshots.begin()->first !=
+            historicalSnapshots.begin()->first)
+    {
+        // Copy current snapshot map into historicalSnapshots
+        historicalSnapshots.clear();
+        for (auto const& [ledgerSeq, snapshot] : mHistoricalSnapshots)
+        {
+            historicalSnapshots.emplace(
+                ledgerSeq, std::make_unique<BucketListSnapshot>(*snapshot));
+        }
     }
 }
 
@@ -80,9 +112,27 @@ BucketSnapshotManager::updateCurrentSnapshot(
 {
     releaseAssert(newSnapshot);
     releaseAssert(threadIsMain());
-    std::lock_guard<std::recursive_mutex> lock(mSnapshotMutex);
+
+    // Updating the BucketSnapshotManager canonical snapshot, must lock
+    // exclusively for write access.
+    std::unique_lock<std::shared_mutex> lock(mSnapshotMutex);
     releaseAssert(!mCurrentSnapshot || newSnapshot->getLedgerSeq() >=
                                            mCurrentSnapshot->getLedgerSeq());
+
+    // First update historical snapshots
+    if (mNumHistoricalSnapshots != 0)
+    {
+        // If historical snapshots are full, delete the oldest one
+        if (mHistoricalSnapshots.size() == mNumHistoricalSnapshots)
+        {
+            mHistoricalSnapshots.erase(mHistoricalSnapshots.begin());
+        }
+
+        mHistoricalSnapshots.emplace(mCurrentSnapshot->getLedgerSeq(),
+                                     std::move(mCurrentSnapshot));
+        mCurrentSnapshot = nullptr;
+    }
+
     mCurrentSnapshot.swap(newSnapshot);
 }
 

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -1243,7 +1243,7 @@ TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")
     entry.data.claimableBalance().amount = 0;
 
     auto searchableBL =
-        bm.getBucketSnapshotManager().getSearchableBucketListSnapshot();
+        bm.getBucketSnapshotManager().copySearchableBucketListSnapshot();
 
     // Update entry every 5 ledgers so we can see bucket merge events
     for (auto ledgerSeq = 1; ledgerSeq < 101; ++ledgerSeq)

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -3494,7 +3494,7 @@ LedgerTxnRoot::Impl::getSearchableBucketListSnapshot() const
     {
         mSearchableBucketListSnapshot = mApp.getBucketManager()
                                             .getBucketSnapshotManager()
-                                            .getSearchableBucketListSnapshot();
+                                            .copySearchableBucketListSnapshot();
     }
 
     return *mSearchableBucketListSnapshot;

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -737,7 +737,7 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
-    mutable std::shared_ptr<SearchableBucketListSnapshot>
+    mutable std::unique_ptr<SearchableBucketListSnapshot>
         mSearchableBucketListSnapshot{};
 
     size_t mBulkLoadBatchSize;

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -15,6 +15,7 @@
 // else.
 #include "util/asio.h"
 #include "bucket/Bucket.h"
+#include "bucket/BucketListSnapshot.h"
 #include "bucket/BucketManager.h"
 #include "catchup/ApplyBucketsWork.h"
 #include "crypto/Hex.h"
@@ -843,6 +844,35 @@ ApplicationImpl::validateAndLogConfig()
             throw std::invalid_argument(
                 "EXPERIMENTAL_BACKGROUND_EVICTION_SCAN requires "
                 "WORKER_THREADS > 1");
+        }
+    }
+
+    if (mConfig.HTTP_QUERY_PORT != 0)
+    {
+        if (isNetworkedValidator)
+        {
+            throw std::invalid_argument("HTTP_QUERY_PORT is non-zero, "
+                                        "NODE_IS_VALIDATOR is set, and "
+                                        "RUN_STANDALONE is not set");
+        }
+
+        if (mConfig.HTTP_QUERY_PORT == mConfig.HTTP_PORT)
+        {
+            throw std::invalid_argument(
+                "HTTP_QUERY_PORT must be different from HTTP_PORT");
+        }
+
+        if (!mConfig.isUsingBucketListDB())
+        {
+            throw std::invalid_argument(
+                "HTTP_QUERY_PORT requires DEPRECATED_SQL_LEDGER_STATE to be "
+                "false");
+        }
+
+        if (mConfig.QUERY_THREAD_POOL_SIZE == 0)
+        {
+            throw std::invalid_argument(
+                "HTTP_QUERY_PORT requires QUERY_THREAD_POOL_SIZE > 0");
         }
     }
 

--- a/src/main/CommandHandler.h
+++ b/src/main/CommandHandler.h
@@ -5,7 +5,10 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
 #include "lib/http/server.hpp"
+#include "main/QueryServer.h"
 #include "util/ProtocolVersion.h"
+#include <map>
+#include <memory>
 #include <string>
 
 /*
@@ -24,8 +27,10 @@ class CommandHandler
 
     Application& mApp;
     std::unique_ptr<http::server::server> mServer;
+    std::unique_ptr<QueryServer> mQueryServer;
 
     void addRoute(std::string const& name, HandlerRoute route);
+
     void safeRouter(HandlerRoute route, std::string const& params,
                     std::string& retStr);
 
@@ -60,7 +65,6 @@ class CommandHandler
     void getcursor(std::string const& params, std::string& retStr);
     void scpInfo(std::string const& params, std::string& retStr);
     void tx(std::string const& params, std::string& retStr);
-    void getLedgerEntry(std::string const& params, std::string& retStr);
     void unban(std::string const& params, std::string& retStr);
     void upgrades(std::string const& params, std::string& retStr);
     void dumpProposedSettings(std::string const& params, std::string& retStr);

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -223,6 +223,10 @@ Config::Config() : NODE_SEED(SecretKey::random())
     TESTING_UPGRADE_FLAGS = 0;
 
     HTTP_PORT = DEFAULT_PEER_PORT + 1;
+
+    QUERY_THREAD_POOL_SIZE = 4;
+    QUERY_SNAPSHOT_LEDGERS = 5;
+    HTTP_QUERY_PORT = 0;
     PUBLIC_HTTP_PORT = false;
     HTTP_MAX_CLIENT = 128;
     PEER_PORT = DEFAULT_PEER_PORT;
@@ -1042,6 +1046,10 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 HTTP_PORT = readInt<unsigned short>(item);
             }
+            else if (item.first == "HTTP_QUERY_PORT")
+            {
+                HTTP_QUERY_PORT = readInt<unsigned short>(item);
+            }
             else if (item.first == "HTTP_MAX_CLIENT")
             {
                 HTTP_MAX_CLIENT = readInt<unsigned short>(item, 0);
@@ -1368,6 +1376,14 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             else if (item.first == "WORKER_THREADS")
             {
                 WORKER_THREADS = readInt<int>(item, 2, 1000);
+            }
+            else if (item.first == "QUERY_THREAD_POOL_SIZE")
+            {
+                QUERY_THREAD_POOL_SIZE = readInt<int>(item, 1, 1000);
+            }
+            else if (item.first == "QUERY_SNAPSHOT_LEDGERS")
+            {
+                QUERY_SNAPSHOT_LEDGERS = readInt<uint32_t>(item, 0, 10);
             }
             else if (item.first == "MAX_CONCURRENT_SUBPROCESSES")
             {
@@ -2352,6 +2368,7 @@ Config::setNoListen()
     // prevent opening up a port for other peers
     RUN_STANDALONE = true;
     HTTP_PORT = 0;
+    HTTP_QUERY_PORT = 0;
     MANUAL_CLOSE = true;
 }
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -505,8 +505,10 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t TESTING_UPGRADE_FLAGS;
 
     unsigned short HTTP_PORT; // what port to listen for commands
-    bool PUBLIC_HTTP_PORT;    // if you accept commands from not localhost
-    int HTTP_MAX_CLIENT;      // maximum number of http clients, i.e backlog
+    unsigned short
+        HTTP_QUERY_PORT;   // what port to listen for RPC related commands
+    bool PUBLIC_HTTP_PORT; // if you accept commands from not localhost
+    int HTTP_MAX_CLIENT;   // maximum number of http clients, i.e backlog
     std::string NETWORK_PASSPHRASE; // identifier for the network
 
     // overlay config
@@ -549,6 +551,12 @@ class Config : public std::enable_shared_from_this<Config>
 
     // thread-management config
     int WORKER_THREADS;
+
+    // Number of threads to serve query commands
+    int QUERY_THREAD_POOL_SIZE;
+
+    // Number of ledger snapshots to maintain for querying
+    uint32_t QUERY_SNAPSHOT_LEDGERS;
 
     // process-management config
     size_t MAX_CONCURRENT_SUBPROCESSES;

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -1,0 +1,187 @@
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "main/QueryServer.h"
+#include "bucket/BucketListSnapshot.h"
+#include "bucket/BucketSnapshotManager.h"
+#include "ledger/LedgerTxnImpl.h"
+#include "util/Logging.h"
+#include "util/XDRStream.h" // IWYU pragma: keep
+#include <exception>
+#include <json/json.h>
+
+using std::placeholders::_1;
+using std::placeholders::_2;
+using std::placeholders::_3;
+
+namespace
+{
+template <typename T>
+std::optional<T>
+parseOptionalParam(std::map<std::string, std::vector<std::string>> const& map,
+                   std::string const& key)
+{
+    auto i = map.find(key);
+    if (i != map.end())
+    {
+        if (i->second.size() != 1)
+        {
+            std::string errorMsg = fmt::format(
+                FMT_STRING("Expected exactly one '{}' argument"), key);
+            throw std::runtime_error(errorMsg);
+        }
+
+        std::stringstream str(i->second.at(0));
+        T val;
+        str >> val;
+
+        // Throw an error if not all bytes were loaded into `val`
+        if (str.fail() || !str.eof())
+        {
+            std::string errorMsg =
+                fmt::format(FMT_STRING("Failed to parse '{}' argument"), key);
+            throw std::runtime_error(errorMsg);
+        }
+        return std::make_optional<T>(val);
+    }
+
+    return std::nullopt;
+}
+}
+
+namespace stellar
+{
+QueryServer::QueryServer(const std::string& address, unsigned short port,
+                         int maxClient, size_t threadPoolSize,
+                         BucketSnapshotManager& bucketSnapshotManager)
+    : mServer(address, port, maxClient, threadPoolSize)
+{
+    LOG_INFO(DEFAULT_LOG, "Listening on {}:{} for Query requests", address,
+             port);
+
+    mServer.add404(std::bind(&QueryServer::notFound, this, _1, _2, _3));
+    addRoute("getledgerentryraw", &QueryServer::getLedgerEntryRaw);
+
+    auto workerPids = mServer.start();
+    for (auto pid : workerPids)
+    {
+        mBucketListSnapshots[pid] =
+            std::move(bucketSnapshotManager.copySearchableBucketListSnapshot());
+    }
+}
+
+bool
+QueryServer::notFound(std::string const& params, std::string const& body,
+                      std::string& retStr)
+{
+    retStr = "<b>Welcome to stellar-core!</b><p>";
+    retStr +=
+        "Supported HTTP queries are listed in the <a href=\""
+        "https://github.com/stellar/stellar-core/blob/master/docs/software/"
+        "commands.md#http-commands"
+        "\">docs</a> as well as in the man pages.</p>"
+        "<p>Note that this port is for HTTP queries only, not commands.</p>"
+        "<p>Have fun!</p>";
+
+    // 404 never fails
+    return true;
+}
+
+void
+QueryServer::addRoute(std::string const& name, HandlerRoute route)
+{
+    mServer.addRoute(
+        name, std::bind(&QueryServer::safeRouter, this, route, _1, _2, _3));
+}
+
+bool
+QueryServer::safeRouter(HandlerRoute route, std::string const& params,
+                        std::string const& body, std::string& retStr)
+{
+    try
+    {
+        ZoneNamedN(httpQueryZone, "HTTP query handler", true);
+        return route(this, params, body, retStr);
+    }
+    catch (std::exception& e)
+    {
+        retStr = fmt::format("exception: {}", e.what());
+    }
+    catch (...)
+    {
+        retStr = R"({"exception": "generic"})";
+    }
+
+    // Return error
+    return false;
+}
+
+bool
+QueryServer::getLedgerEntryRaw(std::string const& params,
+                               std::string const& body, std::string& retStr)
+{
+    ZoneScoped;
+    Json::Value root;
+
+    std::map<std::string, std::vector<std::string>> paramMap;
+    httpThreaded::server::server::parsePostParams(body, paramMap);
+
+    auto keys = paramMap["key"];
+    auto snapshotLedger = parseOptionalParam<uint32_t>(paramMap, "ledgerSeq");
+
+    if (!keys.empty())
+    {
+        auto& bl = *mBucketListSnapshots.at(std::this_thread::get_id());
+
+        LedgerKeySet orderedKeys;
+        for (auto const& key : keys)
+        {
+            LedgerKey k;
+            fromOpaqueBase64(k, key);
+            orderedKeys.emplace(k);
+        }
+
+        std::vector<LedgerEntry> loadedKeys;
+
+        // If a snapshot ledger is specified, use it to get the ledger entry
+        if (snapshotLedger)
+        {
+            root["ledgerSeq"] = *snapshotLedger;
+
+            bool snapshotExists;
+            std::tie(loadedKeys, snapshotExists) =
+                bl.loadKeysFromLedger(orderedKeys, *snapshotLedger);
+
+            // Return 404 if ledgerSeq not found
+            if (!snapshotExists)
+            {
+                retStr = "LedgerSeq not found";
+                return false;
+            }
+        }
+        // Otherwise default to current ledger
+        else
+        {
+            loadedKeys =
+                bl.loadKeysWithLimits(orderedKeys, /*lkMeter=*/nullptr);
+            root["ledgerSeq"] = bl.getLedgerSeq();
+        }
+
+        for (auto const& le : loadedKeys)
+        {
+            Json::Value entry;
+            entry["le"] = toOpaqueBase64(le);
+            root["entries"].append(entry);
+        }
+    }
+    else
+    {
+        throw std::invalid_argument(
+            "Must specify ledger key in POST body: key=<LedgerKey in base64 "
+            "XDR format>");
+    }
+    retStr = Json::FastWriter().write(root);
+    return true;
+}
+}

--- a/src/main/QueryServer.h
+++ b/src/main/QueryServer.h
@@ -1,0 +1,50 @@
+#pragma once
+
+// Copyright 2024 Stellar Development Foundation and contributors. Licensed
+// under the Apache License, Version 2.0. See the COPYING file at the root
+// of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
+
+#include "lib/httpthreaded/server.hpp"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+namespace stellar
+{
+class SearchableBucketListSnapshot;
+class BucketSnapshotManager;
+
+class QueryServer
+{
+  private:
+    using HandlerRoute = std::function<bool(QueryServer*, std::string const&,
+                                            std::string const&, std::string&)>;
+
+    httpThreaded::server::server mServer;
+
+    std::unordered_map<std::thread::id,
+                       std::unique_ptr<SearchableBucketListSnapshot>>
+        mBucketListSnapshots;
+
+    bool safeRouter(HandlerRoute route, std::string const& params,
+                    std::string const& body, std::string& retStr);
+
+    bool notFound(std::string const& params, std::string const& body,
+                  std::string& retStr);
+
+    void addRoute(std::string const& name, HandlerRoute route);
+
+    // Returns raw LedgerKeys for the given keys from the Live BucketList. Does
+    // not query other BucketLists or reason about archival.
+    bool getLedgerEntryRaw(std::string const& params, std::string const& body,
+                           std::string& retStr);
+
+  public:
+    QueryServer(const std::string& address, unsigned short port, int maxClient,
+                size_t threadPoolSize,
+                BucketSnapshotManager& bucketSnapshotManager);
+};
+}

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -312,6 +312,10 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         // Tests default to using SQL for ledger state
         thisConfig.DEPRECATED_SQL_LEDGER_STATE = true;
 
+        // Disable RPC endpoint in tests
+        thisConfig.HTTP_QUERY_PORT = 0;
+        thisConfig.QUERY_SNAPSHOT_LEDGERS = 0;
+
 #ifdef BEST_OFFER_DEBUGGING
         thisConfig.BEST_OFFER_DEBUGGING_ENABLED = true;
 #endif

--- a/src/util/GlobalChecks.h
+++ b/src/util/GlobalChecks.h
@@ -27,13 +27,13 @@ void dbgAbort();
 #define releaseAssert(e) \
     (static_cast<bool>(e) \
          ? void(0) \
-         : printAssertFailureAndAbort(#e, __FILE__, __LINE__))
+         : stellar::printAssertFailureAndAbort(#e, __FILE__, __LINE__))
 
 // Same as above, but throwing rather than aborting.
 #define releaseAssertOrThrow(e) \
     (static_cast<bool>(e) \
          ? void(0) \
-         : printAssertFailureAndThrow(#e, __FILE__, __LINE__))
+         : stellar::printAssertFailureAndThrow(#e, __FILE__, __LINE__))
 
 #ifdef NDEBUG
 


### PR DESCRIPTION
# Description

Resolves #4306

Note: the following interface is now outdated. Please refer to `docs/software/commands.md` for the up to date interface. The performance measurements are still accurate.

Previous interface:

`getledgerentry` core endpoint is now high performance, non blocking and served by a multi-threaded HTTP server that does not interact with the main thread. This enables down stream systems to query this endpoint at high rates without `captive-core` nodes losing sync. Note that this endpoint is served by a different port and separated from stellar-core's other endpoints. The following config options have been added supporting this feature:

```
RPC_HTTP_PORT = 11627 # default listening port
RPC_THREADS = 4 # default threads serving getledgerentry endpoint
RPC_SNAPSHOT_LEDGERS = 5 # default number of ledgers retained in history
```
The HTTP request string is as follows:

```
getledgerentry?key=Base64&ledgerSeq=NUM
```

`key` is required, and is the Base64 XDR of the LedgerKey being queried. `ledgerSeq` is optional. If not set, stellar-core will return the LedgerEntry based on the most recent ledger. If `ledgerSeq` is set, stellar-core will return an entry based on a historical ledger snapshot at the given ledger. The return payload is a JSON object in the following format:

```
"ledger": ledgerSeq, // Required
"state": ["not_found" | "live" | "dead"], // Required
"entry": Base64 // Optional
```

`ledger` is the ledgerSeq that the query is based on, and is always returned. `state` returns "live" if a live LedgerEntry was found, or "dead" if the LedgerEntry does not exist. Additionally, if `ledgerSeq` is set to a snapshot that stellar-core does not currently have, "not_found" is returned. Finally, if `state==live`, "entry" is returned with the Base64 XDR encoding of the full LedgerEntry.

To measure performance, I used a parallel go script  (thanks @Shaptic) with `stellar/go/clients/stellarcore` to send requests at a very high rate over local host. 1 million LedgerEntries of type ContractCode, ContractData, and Trustline were randomly sampled from the BucketList (such that all entries exist) for these requests, and no caching was used. Test was ran on `test-core-003a.dev.stellar002` with a `captive-core` instance in sync with pubnet with the following benchmarks:

```
Request Rate: 2731 / sec
total queries: 100910, failed: 0, success: 100910
success rate: 100.000000
average latency: 366.163µs
min latency: 256.861µs

Request Rate: 11836 / sec
total queries: 103390, failed: 0, success: 103390
success rate: 100.000000
average latency: 422.453µs
min latency: 204.412µs

Request Rate: 18245 / sec
total queries: 100740, failed: 0, success: 100740
success rate: 100.000000
average latency: 548.105µs
min latency: 214.905µs
```

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
