### PR TITLE
Mandate flow control in bytes

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -530,11 +530,6 @@ PEER_FLOOD_READING_CAPACITY_BYTES=300000
 # processes `FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES` bytes
 FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES=100000
 
-# Enable flow control in bytes. This config allows core to process large
-# transactions on the network more efficiently and apply back pressure if
-# needed.
-ENABLE_FLOW_CONTROL_BYTES=true
-
 # Byte limit for outbound transaction queue.
 OUTBOUND_TX_QUEUE_BYTE_LIMIT=3145728
 

--- a/src/herder/Herder.h
+++ b/src/herder/Herder.h
@@ -153,6 +153,7 @@ class Herder
 
     virtual VirtualTimer const& getTriggerTimer() const = 0;
     virtual void setMaxClassicTxSize(uint32 bytes) = 0;
+    virtual void setMaxTxSize(uint32 bytes) = 0;
     virtual void setFlowControlExtraBufferSize(uint32 bytes) = 0;
 
     virtual ClassicTransactionQueue& getTransactionQueue() = 0;

--- a/src/herder/HerderImpl.h
+++ b/src/herder/HerderImpl.h
@@ -126,6 +126,11 @@ class HerderImpl : public Herder
     {
         mMaxClassicTxSize = std::make_optional<uint32_t>(bytes);
     }
+    void
+    setMaxTxSize(uint32 bytes) override
+    {
+        mMaxTxSize = bytes;
+    }
     std::optional<uint32_t> mFlowControlExtraBuffer;
     void
     setFlowControlExtraBufferSize(uint32 bytes) override

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -151,8 +151,8 @@ Config::Config() : NODE_SEED(SecretKey::random())
     LEDGER_PROTOCOL_VERSION = CURRENT_LEDGER_PROTOCOL_VERSION;
     LEDGER_PROTOCOL_MIN_VERSION_INTERNAL_ERROR_REPORT = 18;
 
-    OVERLAY_PROTOCOL_MIN_VERSION = 32;
-    OVERLAY_PROTOCOL_VERSION = 34;
+    OVERLAY_PROTOCOL_MIN_VERSION = 33;
+    OVERLAY_PROTOCOL_VERSION = 35;
 
     VERSION_STR = STELLAR_CORE_VERSION;
 
@@ -261,7 +261,6 @@ Config::Config() : NODE_SEED(SecretKey::random())
     PEER_FLOOD_READING_CAPACITY_BYTES = 0;
     FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES = 0;
     OUTBOUND_TX_QUEUE_BYTE_LIMIT = 1024 * 1024 * 3;
-    ENABLE_FLOW_CONTROL_BYTES = true;
 
     // WORKER_THREADS: setting this too low risks a form of priority inversion
     // where a long-running background task occupies all worker threads and
@@ -1030,10 +1029,6 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
             {
                 FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES =
                     readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "ENABLE_FLOW_CONTROL_BYTES")
-            {
-                ENABLE_FLOW_CONTROL_BYTES = readBool(item);
             }
             else if (item.first == "OUTBOUND_TX_QUEUE_BYTE_LIMIT")
             {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -324,11 +324,6 @@ class Config : public std::enable_shared_from_this<Config>
     uint32_t PEER_FLOOD_READING_CAPACITY_BYTES;
     uint32_t FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES;
 
-    // Enable flow control in bytes. This config allows core to process large
-    // transactions on the network more efficiently and apply back pressure if
-    // needed.
-    bool ENABLE_FLOW_CONTROL_BYTES;
-
     // Byte limit for outbound transaction queue.
     uint32_t OUTBOUND_TX_QUEUE_BYTE_LIMIT;
 

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -16,8 +16,8 @@ namespace stellar
 class OverlayAppConnector;
 struct OverlayMetrics;
 
-// num messages, optional bytes if enabled
-using SendMoreCapacity = std::pair<uint64_t, std::optional<uint64_t>>;
+// num messages, bytes
+using SendMoreCapacity = std::pair<uint64_t, uint64_t>;
 
 // The FlowControl class allows core to throttle flood traffic among its
 // connections. If a connections wants to use flow control, it should maintain
@@ -62,8 +62,8 @@ class FlowControl
     std::optional<VirtualClock::time_point> mLastThrottle;
 
     NodeID mNodeID;
-    std::shared_ptr<FlowControlCapacity> mFlowControlCapacity;
-    std::shared_ptr<FlowControlByteCapacity> mFlowControlBytesCapacity;
+    FlowControlMessageCapacity mFlowControlCapacity;
+    FlowControlByteCapacity mFlowControlBytesCapacity;
 
     OverlayMetrics& mOverlayMetrics;
     OverlayAppConnector& mAppConnector;
@@ -107,14 +107,14 @@ class FlowControl
                           VirtualClock::time_point const& timePlaced);
 
 #ifdef BUILD_TESTS
-    std::shared_ptr<FlowControlCapacity>
-    getCapacity() const
+    FlowControlCapacity&
+    getCapacity()
     {
         return mFlowControlCapacity;
     }
 
-    std::shared_ptr<FlowControlCapacity>
-    getCapacityBytes() const
+    FlowControlCapacity&
+    getCapacityBytes()
     {
         return mFlowControlBytesCapacity;
     }
@@ -175,7 +175,8 @@ class FlowControl
 
     Json::Value getFlowControlJsonInfo(bool compact) const;
 
-    void start(NodeID const& peerID, std::optional<uint32_t> enableFCBytes);
+    // Stores `peerID` to produce more useful log messages.
+    void setPeerID(NodeID const& peerID);
 
     // Stop reading from this peer until capacity is released
     bool maybeThrottleRead();

--- a/src/overlay/FlowControlCapacity.cpp
+++ b/src/overlay/FlowControlCapacity.cpp
@@ -36,7 +36,7 @@ void
 FlowControlMessageCapacity::releaseOutboundCapacity(StellarMessage const& msg)
 {
     ZoneScoped;
-    releaseAssert(msg.type() == SEND_MORE || msg.type() == SEND_MORE_EXTENDED);
+    releaseAssert(msg.type() == SEND_MORE_EXTENDED);
     auto numMessages = FlowControl::getNumMessages(msg);
     if (!hasOutboundCapacity(msg) && numMessages != 0)
     {

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -156,14 +156,10 @@ Peer::endMessageProcessing(StellarMessage const& msg)
     // We may release reading capacity, which gets taken by the background
     // thread immediately, so we can't assert `canRead` here
     auto res = mFlowControl->endMessageProcessing(msg);
-    if (res.second)
+    if (res.first > 0 || res.second > 0)
     {
         sendSendMore(static_cast<uint32>(res.first),
-                     static_cast<uint32>(*res.second));
-    }
-    else if (res.first > 0)
-    {
-        sendSendMore(static_cast<uint32>(res.first));
+                     static_cast<uint32>(res.second));
     }
 
     // Now that we've released some capacity, maybe schedule more reads
@@ -389,10 +385,7 @@ Peer::sendAuth()
     ZoneScoped;
     StellarMessage msg;
     msg.type(AUTH);
-    if (mAppConnector.getConfig().ENABLE_FLOW_CONTROL_BYTES)
-    {
-        msg.auth().flags = AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED;
-    }
+    msg.auth().flags = AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED;
     auto msgPtr = std::make_shared<StellarMessage const>(msg);
     sendMessage(msgPtr);
 }
@@ -591,18 +584,6 @@ Peer::sendErrorAndDrop(ErrorCode error, std::string const& message)
     releaseAssert(threadIsMain());
     sendError(error, message);
     drop(message, DropDirection::WE_DROPPED_REMOTE);
-}
-
-void
-Peer::sendSendMore(uint32_t numMessages)
-{
-    ZoneScoped;
-    releaseAssert(threadIsMain());
-
-    auto m = std::make_shared<StellarMessage>();
-    m->type(SEND_MORE);
-    m->sendMoreMessage().numMessages = numMessages;
-    sendMessage(m);
 }
 
 void
@@ -1597,6 +1578,7 @@ Peer::recvHello(Hello const& elo)
     mRemoteOverlayVersion = elo.overlayVersion;
     mRemoteVersion = elo.versionStr;
     mPeerID = elo.peerID;
+    mFlowControl->setPeerID(mPeerID);
     mRecvNonce = elo.nonce;
     mHmac.setSendMackey(peerAuth.getSendingMacKey(elo.cert.pubkey, mSendNonce,
                                                   mRecvNonce, mRole));
@@ -1746,35 +1728,19 @@ Peer::recvAuth(StellarMessage const& msg)
         return;
     }
 
-    bool enableBytes =
-        (mAppConnector.getConfig().OVERLAY_PROTOCOL_VERSION >=
-             Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL_IN_BYTES &&
-         getRemoteOverlayVersion() >=
-             Peer::FIRST_VERSION_SUPPORTING_FLOW_CONTROL_IN_BYTES);
-    bool bothWantBytes =
-        enableBytes &&
-        msg.auth().flags == AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED &&
-        mAppConnector.getConfig().ENABLE_FLOW_CONTROL_BYTES;
+    if (msg.auth().flags != AUTH_MSG_FLAG_FLOW_CONTROL_BYTES_REQUESTED)
+    {
+        sendErrorAndDrop(ERR_CONF, "flow control bytes disabled");
+        return;
+    }
 
-    std::optional<uint32_t> fcBytes =
-        bothWantBytes
-            ? std::optional<uint32_t>(mAppConnector.getOverlayManager()
-                                          .getFlowControlBytesConfig()
-                                          .mTotal)
-            : std::nullopt;
-    mFlowControl->start(mPeerID, fcBytes);
+    uint32_t fcBytes =
+        mAppConnector.getOverlayManager().getFlowControlBytesConfig().mTotal;
 
     // Subtle: after successful auth, must send sendMore message first to
     // tell the other peer about the local node's reading capacity.
-    if (fcBytes)
-    {
-        sendSendMore(mAppConnector.getConfig().PEER_FLOOD_READING_CAPACITY,
-                     *fcBytes);
-    }
-    else
-    {
-        sendSendMore(mAppConnector.getConfig().PEER_FLOOD_READING_CAPACITY);
-    }
+    sendSendMore(mAppConnector.getConfig().PEER_FLOOD_READING_CAPACITY,
+                 fcBytes);
 
     auto weakSelf = std::weak_ptr<Peer>(shared_from_this());
     mTxAdverts->start([weakSelf](std::shared_ptr<StellarMessage const> msg) {

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -71,8 +71,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
         std::chrono::milliseconds(1);
     static constexpr std::chrono::nanoseconds PEER_METRICS_RATE_UNIT =
         std::chrono::seconds(1);
-    static constexpr uint32_t FIRST_VERSION_SUPPORTING_FLOW_CONTROL_IN_BYTES =
-        28;
     static constexpr uint32_t FIRST_VERSION_REQUIRED_FOR_PROTOCOL_20 = 32;
 
     // The reporting will be based on the previous
@@ -352,7 +350,6 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // Queue up an advert to send, return true if the advert was queued, and
     // false otherwise (if advert is a duplicate, for example)
     bool sendAdvert(Hash const& txHash);
-    void sendSendMore(uint32_t numMessages);
     void sendSendMore(uint32_t numMessages, uint32_t numBytes);
 
     virtual void sendMessage(std::shared_ptr<StellarMessage const> msg,

--- a/src/overlay/test/LoopbackPeer.cpp
+++ b/src/overlay/test/LoopbackPeer.cpp
@@ -562,19 +562,11 @@ bool
 LoopbackPeer::checkCapacity(std::shared_ptr<LoopbackPeer> otherPeer) const
 {
     // Outbound capacity is equal to the config on the other node
-    bool flowControlInBytes = getFlowControl()->getCapacityBytes() &&
-                              otherPeer->getFlowControl()->getCapacityBytes();
-    bool isValid = otherPeer->getConfig().PEER_FLOOD_READING_CAPACITY ==
-                   getFlowControl()->getCapacity()->getOutboundCapacity();
-    if (flowControlInBytes)
-    {
-        isValid = isValid &&
-                  (otherPeer->mAppConnector.getOverlayManager()
-                       .getFlowControlBytesConfig()
-                       .mTotal ==
-                   getFlowControl()->getCapacityBytes()->getOutboundCapacity());
-    }
-
-    return isValid;
+    return otherPeer->getConfig().PEER_FLOOD_READING_CAPACITY ==
+               getFlowControl()->getCapacity().getOutboundCapacity() &&
+           otherPeer->mAppConnector.getOverlayManager()
+                   .getFlowControlBytesConfig()
+                   .mTotal ==
+               getFlowControl()->getCapacityBytes().getOutboundCapacity();
 }
 }

--- a/src/overlay/test/LoopbackPeer.h
+++ b/src/overlay/test/LoopbackPeer.h
@@ -139,7 +139,7 @@ class LoopbackPeer : public Peer
     uint64_t
     getOutboundCapacity()
     {
-        return getFlowControl()->getCapacity()->getOutboundCapacity();
+        return getFlowControl()->getCapacity().getOutboundCapacity();
     }
 
     Config const&


### PR DESCRIPTION
Resolves #3781 and #4374.

This change removes the `ENABLE_FLOW_CONTROL_BYTES` config option and always uses flow control in bytes.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
