### PR TITLE
Update overlay survey script with lessons learned during testnet run

### DIFF
--- a/scripts/OverlaySurvey.py
+++ b/scripts/OverlaySurvey.py
@@ -128,15 +128,14 @@ def get_next_peers(topology):
 
 def update_node(graph, node_info, node_key, results, field_names):
     """
-    For each `(info_field, node_field)` pair in `field_names`, if `info_field`
-    is in `node_info`, modify the node in `graph` with key `node_key` to store
-    the value of `info_field` in `node_field`.
+    For each `field_name` in `field_names`, if `field_name` is in `node_info`,
+    modify `graph` and `results` to contain the field.
     """
-    for (info_field, node_field) in field_names:
-        if info_field in node_info:
-            val = node_info[info_field]
-            results[node_field] = val
-            graph.add_node(node_key, **{node_field: val})
+    for field_name in field_names:
+        if field_name in node_info:
+            val = node_info[field_name]
+            results[field_name] = val
+            graph.add_node(node_key, **{field_name: val})
 
 def update_results(graph, parent_info, parent_key, results, is_inbound):
     direction_tag = "inboundPeers" if is_inbound else "outboundPeers"
@@ -157,16 +156,16 @@ def update_results(graph, parent_info, parent_key, results, is_inbound):
             graph.add_edge(parent_key, other_key, **edge_properties)
 
     # Add survey results to parent node (if available)
-    field_names = [("numTotalInboundPeers", "totalInbound"),
-                   ("numTotalOutboundPeers", "totalOutbound"),
-                   ("maxInboundPeerCount", "maxInboundPeerCount"),
-                   ("maxOutboundPeerCount", "maxOutboundPeerCount"),
-                   ("addedAuthenticatedPeers", "addedAuthenticatedPeers"),
-                   ("droppedAuthenticatedPeers", "droppedAuthenticatedPeers"),
-                   ("p75SCPFirstToSelfLatencyMs", "p75SCPFirstToSelfLatencyMs"),
-                   ("p75SCPSelfToOtherLatencyMs", "p75SCPSelfToOtherLatencyMs"),
-                   ("lostSyncCount", "lostSyncCount"),
-                   ("isValidator", "isValidator")]
+    field_names = ["numTotalInboundPeers",
+                   "numTotalOutboundPeers",
+                   "maxInboundPeerCount",
+                   "maxOutboundPeerCount",
+                   "addedAuthenticatedPeers",
+                   "droppedAuthenticatedPeers",
+                   "p75SCPFirstToSelfLatencyMs",
+                   "p75SCPSelfToOtherLatencyMs",
+                   "lostSyncCount",
+                   "isValidator"]
     update_node(graph, parent_info, parent_key, results, field_names)
 
 
@@ -318,8 +317,8 @@ def augment(args):
 def run_survey(args):
     graph = nx.DiGraph()
     merged_results = defaultdict(lambda: {
-        "totalInbound": 0,
-        "totalOutbound": 0,
+        "numTotalInboundPeers": 0,
+        "numTotalOutboundPeers": 0,
         "maxInboundPeerCount": 0,
         "maxOutboundPeerCount": 0,
         "inboundPeers": {},
@@ -394,8 +393,8 @@ def run_survey(args):
     self_name = get_request(url + "/scp", scp_params).json()["you"]
     graph.add_node(self_name,
                    version=get_request(url + "/info").json()["info"]["build"],
-                   totalInbound=len(peers["inbound"] or []),
-                   totalOutbound=len(peers["outbound"] or []))
+                   numTotalInboundPeers=len(peers["inbound"] or []),
+                   numTotalOutboundPeers=len(peers["outbound"] or []))
 
     sent_requests = set()
     heard_from = set()
@@ -473,8 +472,8 @@ def run_survey(args):
             node = merged_results[key]
             have_inbound = len(node["inboundPeers"])
             have_outbound = len(node["outboundPeers"])
-            if (node["totalInbound"] > have_inbound or
-                node["totalOutbound"] > have_outbound):
+            if (node["numTotalInboundPeers"] > have_inbound or
+                node["numTotalOutboundPeers"] > have_outbound):
                 incomplete_responses.add(key)
                 req = util.PendingRequest(key, have_inbound, have_outbound)
                 peer_list.add(req)

--- a/scripts/overlay_survey/simulation.py
+++ b/scripts/overlay_survey/simulation.py
@@ -41,7 +41,7 @@ def _add_v2_survey_data(node_json):
     Does nothing if the node_json is already a v2 survey result or if the V1
     survey data indicates the node didn't respond to the survey.
     """
-    if "totalInbound" not in node_json:
+    if "numTotalInboundPeers" not in node_json:
         # Node did not respond to the survey. Nothing to do.
         return
 
@@ -62,14 +62,6 @@ def _add_v2_survey_data(node_json):
         peer["averageLatencyMs"] = random.randint(0, 2**32-1)
     for peer in node_json["outboundPeers"]:
         peer["averageLatencyMs"] = random.randint(0, 2**32-1)
-
-def _rename_dictionary_field(dictionary, old_key, new_key):
-    """
-    Rename a field in a dictionary. If the field is not present, do nothing.
-    """
-    if old_key in dictionary:
-        dictionary[new_key] = dictionary[old_key]
-        del dictionary[old_key]
 
 class SurveySimulation:
     """
@@ -212,8 +204,8 @@ class SurveySimulation:
                 ]
             for (node_id, _, data) in inbound_slice:
                 self._addpeer(node_id, data, node_json["inboundPeers"])
-            if ("totalInbound" in node_json and
-                node_json["totalInbound"] != len(in_edges)):
+            if ("numTotalInboundPeers" in node_json and
+                node_json["numTotalInboundPeers"] != len(in_edges)):
                 # The V1 survey contains a race condition in which the number of
                 # peers can change between when a node reports its peer count
                 # and when the surveyor requests the peers themselves. The V2
@@ -230,8 +222,8 @@ class SurveySimulation:
                                "count.",
                                node,
                                len(in_edges),
-                               node_json["totalInbound"])
-                node_json["totalInbound"] = len(in_edges)
+                               node_json["numTotalInboundPeers"])
+                node_json["numTotalInboundPeers"] = len(in_edges)
 
             # Generate outboundPeers list
             node_json["outboundPeers"] = []
@@ -241,8 +233,8 @@ class SurveySimulation:
                 ]
             for (_, node_id, data) in outbound_slice:
                 self._addpeer(node_id, data, node_json["outboundPeers"])
-            if ("totalOutbound" in node_json and
-                node_json["totalOutbound"] != len(out_edges)):
+            if ("numTotalOutboundPeers" in node_json and
+                node_json["numTotalOutboundPeers"] != len(out_edges)):
                 # Patch up peer counts in simulated survey results with real
                 # peer counts (see note on similar conditional for inbound peers
                 # above)
@@ -252,18 +244,10 @@ class SurveySimulation:
                                "count.",
                                node,
                                len(out_edges),
-                               node_json["totalOutbound"])
-                node_json["totalOutbound"] = len(out_edges)
+                               node_json["numTotalOutboundPeers"])
+                node_json["numTotalOutboundPeers"] = len(out_edges)
 
             _add_v2_survey_data(node_json)
-
-            # Rename peer count fields to match stellar-core's response
-            _rename_dictionary_field(node_json,
-                                     "totalInbound",
-                                     "numTotalInboundPeers")
-            _rename_dictionary_field(node_json,
-                                     "totalOutbound",
-                                     "numTotalOutboundPeers")
 
             self._results["topology"][node] = node_json
         return SimulatedResponse(json=self._results)

--- a/scripts/overlay_survey/util.py
+++ b/scripts/overlay_survey/util.py
@@ -26,3 +26,12 @@ STOP_SURVEY_COLLECTING_SUCCESS_TEXT = \
 SURVEY_TOPOLOGY_TIME_SLICED_SUCCESS_START = "Adding node."
 SURVEY_TOPOLOGY_TIME_SLICED_SUCCESS_TEXT = \
     SURVEY_TOPOLOGY_TIME_SLICED_SUCCESS_START + "Survey already running!"
+
+# The error response from the surveytopologytimesliced endpoint when the survey
+# backlog already contains the node requested to be surveyed, or the requested
+# node is the surveyor. stellar-core returns this error JSON object where the
+# error text is contained in the "exception" field.
+SURVEY_TOPOLOGY_TIME_SLICED_ALREADY_IN_BACKLOG_OR_SELF = (
+        "addPeerToBacklog failed: Peer is already in the backlog, or peer "
+        "is self."
+        )


### PR DESCRIPTION
# Description

This change makes a few tweaks to the overlay survey script to fix some small things I noticed after running it on testnet:

* Changes the script's end condition to depend only on responses, and not requests. Without this it was possible for the survey script to run for the full duration of the collecting phase (2 hours) if a node with more than 25 peers stopped responding after the surveyor received the first set of peers.
* Downgrades the severity of "node already in backlog" messages from `error` to `debug`. This is an expected condition that I simply forgot to special-case before.
* Modifies the simulator to occasionally return "node already in backlog" messages to test the script against that case.
* Adds a `--fast` option to the `simulate` mode that skips any `sleep` calls. This makes the script much nicer to test.
* Fixes naming of graphml fields to match JSON result fields.
  * I did most of this in the V2 script update, but missed a couple spots.
  * Most of this change is in the simulator to support the new field names.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
