### PR TITLE
Improve performance of dump-ledger

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -602,6 +602,7 @@ exit /b 0
     <ClCompile Include="..\..\src\overlay\Floodgate.cpp" />
     <ClCompile Include="..\..\src\overlay\FlowControl.cpp" />
     <ClCompile Include="..\..\src\overlay\FlowControlCapacity.cpp" />
+    <ClCompile Include="..\..\src\overlay\Hmac.cpp" />
     <ClCompile Include="..\..\src\overlay\ItemFetcher.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayAppConnector.cpp" />
     <ClCompile Include="..\..\src\overlay\OverlayManagerImpl.cpp" />
@@ -1019,6 +1020,7 @@ exit /b 0
     <ClInclude Include="..\..\src\overlay\Floodgate.h" />
     <ClInclude Include="..\..\src\overlay\FlowControl.h" />
     <ClInclude Include="..\..\src\overlay\FlowControlCapacity.h" />
+    <ClInclude Include="..\..\src\overlay\Hmac.h" />
     <ClInclude Include="..\..\src\overlay\ItemFetcher.h" />
     <ClInclude Include="..\..\src\overlay\OverlayAppConnector.h" />
     <ClInclude Include="..\..\src\overlay\OverlayManager.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -1344,6 +1344,9 @@
     <ClCompile Include="..\..\src\overlay\TxDemandsManager.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\overlay\Hmac.cpp">
+      <Filter>overlay</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2337,6 +2340,9 @@
       <Filter>overlay</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\TxDemandsManager.h">
+      <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\overlay\Hmac.h">
       <Filter>overlay</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -95,8 +95,8 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
               ? std::make_unique<asio::io_context::work>(*mEvictionIOContext)
               : nullptr)
     , mOverlayIOContext(mConfig.EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING
-                            ? std::make_optional<asio::io_context>(1)
-                            : std::nullopt)
+                            ? std::make_unique<asio::io_context>(1)
+                            : nullptr)
     , mOverlayWork(mOverlayIOContext ? std::make_unique<asio::io_context::work>(
                                            *mOverlayIOContext)
                                      : nullptr)

--- a/src/main/ApplicationImpl.h
+++ b/src/main/ApplicationImpl.h
@@ -153,7 +153,7 @@ class ApplicationImpl : public Application
     std::unique_ptr<asio::io_context::work> mWork;
     std::unique_ptr<asio::io_context::work> mEvictionWork;
 
-    std::optional<asio::io_context> mOverlayIOContext;
+    std::unique_ptr<asio::io_context> mOverlayIOContext;
     std::unique_ptr<asio::io_context::work> mOverlayWork;
 
     std::unique_ptr<BucketManager> mBucketManager;


### PR DESCRIPTION
# Description

This PR changes how dump-ledger operate as to use a lot less memory:

previously running a command such as `stellar-core dump-ledger --output-file out.json --group-by "data.type" --agg "count()"` against pubnet would crash nodes by using up all memory (16GB).

This version uses much less memory (peaks at 4GB) by not storing the current bucket in memory and not storing all seen keys from the bucket list in RAM.

This PR also includes a couple compile/link fixes for Windows.
