### PR TITLE
Write line identifying Catch2 test interface in --help output of test builds

### DIFF
--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -35,6 +35,7 @@
 #include "util/types.h"
 #include "work/WorkScheduler.h"
 
+#include <catch.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/cereal.hpp>
 
@@ -686,6 +687,10 @@ CommandLine::selectCommand(std::string const& commandName)
 void
 CommandLine::writeToStream(std::string const& exeName, std::ostream& os) const
 {
+#ifdef BUILD_TESTS
+    std::cout << "Catch2 v" << CATCH_VERSION_MAJOR << "." << CATCH_VERSION_MINOR
+              << "." << CATCH_VERSION_PATCH << std::endl;
+#endif
     os << "usage:\n"
        << "  " << exeName << " "
        << "COMMAND";

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -688,6 +688,8 @@ void
 CommandLine::writeToStream(std::string const& exeName, std::ostream& os) const
 {
 #ifdef BUILD_TESTS
+    // Printing this line enables automatic test discovery in VSCode, and
+    // it is generally harmless otherwise (only shown in a BUILD_TESTS build).
     std::cout << "Catch2 v" << CATCH_VERSION_MAJOR << "." << CATCH_VERSION_MINOR
               << "." << CATCH_VERSION_PATCH << std::endl;
 #endif


### PR DESCRIPTION
This adds code to print a single identifying prefix line `Catch2 v2.13.10` when you run `stellar-core --help` on a `BUILD_TESTS` build.

This, along with a small amount of configuration, is enough to enable vscode and [this common C++ testing extension](https://marketplace.visualstudio.com/items?itemName=piotrkosek.vscode-gtest-test-adapter-with-code-lens) to do automatic unit test discovery and integration with vscode's test system. This gives you:

  - A searchable list of tests in the sidebar
  - One-click access from that list jump to a test, run a test, or (most importantly) **run the debugger** on a test
  - A little button in the source code at the test header to do the same
  - Log capture and display of each test run and its results

The configuration required in `.vscode/settings.json` is just the following:

~~~
{
    "testMate.cpp.test.advancedExecutables": [
        {
            "pattern": "${workspaceFolder}/src/stellar-core",
            "catch2": {
                "prependTestListingArgs": ["test"],
                "prependTestRunningArgs": ["test"],
                "ignoreTestEnumerationStdErr": true,
                "testGrouping": {
                    "groupBySource": {}
                }
            }
        }
    ]
}
~~~

You then get this splendid experience:

![image](https://github.com/stellar/stellar-core/assets/14097/c4760c8b-ea93-48ee-a256-c1fd55f8f027)

