### PR TITLE
Rework github action caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,6 +136,12 @@ jobs:
       - name: install rustup components
         if: steps.cache.outputs.cache-hit != 'true'
         run: rustup component add rustfmt
+      - name: install cargo-cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-cache --version 0.8.3
+      - name: install cargo-sweep
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-sweep --version 0.7.0
       - name: install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev sed perl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,12 @@ on:
   pull_request:
   merge_group:
   push:
-    branches:
-      - auto
+
+  # At 17 minutes past the hour every hour we do a run to prime the cache.
+  # If nothing has changed, the commit SHA will cause a cache-probe hit and
+  # this run will conclude the cache is already primed and exit quickly.
+  schedule:
+    - cron: '17 * * * *'
 
 jobs:
 
@@ -18,6 +22,7 @@ jobs:
       run: exit 1
 
   fmt:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -26,6 +31,7 @@ jobs:
     - run: cargo fmt --all --check
 
   cackle:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -33,6 +39,7 @@ jobs:
       - run: cargo acl -n test
 
   cargo-deny:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -51,6 +58,7 @@ jobs:
         arguments:
 
   rust-check-git-rev-deps:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -58,7 +66,14 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-
+    env:
+      CACHED_PATHS: |
+        ~/.ccache
+        ~/.cargo/registry/index/
+        ~/.cargo/registry/cache/
+        ~/.cargo/git/db/
+        ~/.cargo/target/
+        src/rust/target/
     strategy:
       fail-fast: false
       matrix:
@@ -71,35 +86,46 @@ jobs:
         # high-entropy ASLR in much newer kernels that GitHub runners are
         # using leading to random crashes: https://reviews.llvm.org/D148280
         run: sudo sysctl vm.mmap_rnd_bits=28
-      - name: Compute cache key
-        # this step works around a limitation in actions/cache
-        # that does not allow updating a cache
-        # so what we do here instead is
-        #  1. generate a new id that gets refreshed every hour
-        #   the limit is to reduce the chance of hitting the
-        #   global 5GB limit per repo
-        #  2. use that id as part of the cache identifier
-        #  3. fallback (restore-keys) to the most recent cache
-        id: cache_extra_id
-        run: |
-          echo "id=$(( $(date +'%s') / 60 / 60 ))" >> $GITHUB_OUTPUT
-      - name: Cache
-        uses: actions/cache@v3.3.1
+
+      # We start with as cheap as possible a cache probe to see if we have an exact hit on this
+      # git commit ID (for a given OS/toolchain/protocol). If so we can skip all subsequent
+      # steps: we already tested this exact SHA.
+      #
+      # Unfortunately due to the way github actions control flow works, we have to repeat the
+      # step 'if' condition in each step, and cannot actually "exit early" and skip the job.
+      # There are a lot of duplicate bug reports filed on this aspect of github actions, don't
+      # bother filing another.
+      - name: Probe Cache
+        id: cache
+        uses: actions/cache/restore@v3.3.1
         with:
-          path: |
-            /home/runner/.ccache
-          key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-${{ steps.cache_extra_id.outputs.id }}
+          path: ${{ env.CACHED_PATHS }}
+          key: ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-${{ github.sha }}
+          lookup-only: true
+
+      # When we have a cache miss on the exact commit SHA, we restore from the prefix without it.
+      # This will restore the most-recently-written cache (github does this date ordering itself).
+      - name: Restore Cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/restore@v3.3.1
+        with:
+          path: ${{ env.CACHED_PATHS }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}-cacheID-
+            ${{ runner.os }}-${{ matrix.toolchain }}-${{ matrix.protocol }}
+
       - uses: actions/checkout@v3.5.2
+        if: steps.cache.outputs.cache-hit != 'true'
         with:
            fetch-depth: 200
            submodules: true
       - name: install core packages
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get -y install --no-install-recommends apt-utils dialog git iproute2 procps lsb-release
       - name: install tool chain
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get -y install libstdc++-10-dev clang-format-12 ccache lldb
           if test "${{ matrix.toolchain }}" = "gcc" ; then
@@ -108,10 +134,13 @@ jobs:
             sudo apt-get -y install clang-12 llvm-12
           fi
       - name: install rustup components
+        if: steps.cache.outputs.cache-hit != 'true'
         run: rustup component add rustfmt
       - name: install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: sudo apt-get -y install postgresql git build-essential pkg-config autoconf automake libtool bison flex libpq-dev parallel libunwind-dev sed perl
       - name: Build
+        if: steps.cache.outputs.cache-hit != 'true'
         run: |
           if test "${{ matrix.toolchain }}" = "gcc" ; then
             export CC='gcc'
@@ -122,3 +151,11 @@ jobs:
           fi
           echo Build with $CC and $CXX
           ./ci-build.sh --use-temp-db --protocol ${{ matrix.protocol }} ${{ matrix.scenario }}
+
+      # We only _save_ to the cache when we had a cache miss and are running on schedule, which
+      # only happens on the default master branch. No other caches get saved.
+      - uses: actions/cache/save@v3.3.1
+        if: ${{ steps.cache.outputs.cache-hit != 'true' && github.event_name == 'schedule' }}
+        with:
+          path: ${{ env.CACHED_PATHS }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ min-testcases/
 # Rust specific
 /src/rust/bin
 /src/rust/target
+/target
 **/target/
 /ra-target
 /src/rust/RustBridge.cpp

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -128,11 +128,11 @@ export CCACHE_COMPRESSLEVEL=9
 export CCACHE_MAXSIZE=500M
 export CCACHE_CPP2=true
 
-# purge cache if it's too old
+# periodically check to see if caches are old and purge them if so
 if [ -d "$CCACHE_DIR" ] ; then
     if [ -n "$(find $CCACHE_DIR -mtime +$CACHE_MAX_DAYS -print -quit)" ] ; then
-        echo Purging old cache $CCACHE_DIR
-        rm -rf $CCACHE_DIR
+        echo Purging old cache dirs $CCACHE_DIR $HOME/.cargo ./target
+        rm -rf $CCACHE_DIR $HOME/.cargo ./target
     fi
 fi
 
@@ -163,6 +163,9 @@ date
 time make -j$(($NPROCS + 1))
 
 ccache -s
+### incrementally purge old content from cargo source cache and target directory
+cargo cache trim --limit 100M
+cargo sweep --maxsize 500MB
 
 if [ $WITH_TESTS -eq 0 ] ; then
     echo "Build done, skipping tests"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -77,7 +77,7 @@ stellar_core_SOURCES += rust/RustBridge.h rust/RustBridge.cpp
 
 RUST_BUILD_DIR=$(top_builddir)/src/rust
 RUST_BIN_DIR=$(RUST_BUILD_DIR)/bin
-RUST_TARGET_DIR=$(RUST_BUILD_DIR)/target
+RUST_TARGET_DIR=$(top_builddir)/target
 RUST_CXXBRIDGE=$(RUST_BIN_DIR)/cxxbridge
 RUST_PROFILE=release
 RUST_HOST_DEPFILES=rust/Cargo.toml $(top_srcdir)/Cargo.toml $(top_srcdir)/Cargo.lock rust/src/host-dep-tree-curr.txt rust/src/host-dep-tree-prev.txt
@@ -97,7 +97,7 @@ rust/RustBridge.cpp: rust/src/lib.rs $(SRC_RUST_FILES) Makefile $(RUST_CXXBRIDGE
 	if cmp -s $@.tmp $@; then rm -v $@.tmp; else mv -v $@.tmp $@; fi
 
 $(LIBRUST_STELLAR_CORE): $(RUST_HOST_DEPFILES) $(SRC_RUST_FILES) Makefile
-	cd $(RUST_BUILD_DIR) && CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --locked --$(RUST_PROFILE) --target-dir $(abspath $(RUST_TARGET_DIR)) $(CARGO_FEATURES)
+	CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --locked --$(RUST_PROFILE) --target-dir $(abspath $(RUST_TARGET_DIR)) $(CARGO_FEATURES)
 	ranlib $@
 
 $(srcdir)/src.mk: $(top_srcdir)/make-mks


### PR DESCRIPTION
Quite a lot is going wrong with our current github actions artifact caching:

  - I'm not sure if it's been getting any cache hits on PRs for a long time. A PR hit would need a master-seeded cache and those are not being generated.
  - The "hour-number-qualified cache key" we were generating was/is both inaccurate enough to represent changes we _want_ to invalidate the cache, and also redundant: github always falls back to recency-order when accessing prefix restore keys on a cache miss
  - Latobarita's auto branch was getting hits, and getting seeded, but we're not running latobarita anymore.
  - The PR branches were making their own cache entries so they'd get a hit against themselves if you did multiple pushes but only then. Otherwise they'd be filling up the cache set with cache entries that never get hits again.
  - The new merge queues are the same: never hit, fill up the cache set with stale entries.
  - We weren't caching any of the Rust stuff

So this PR overhauls this quite a bit:
  - We split cache probing, retrieving and saving
  - We key the cache on OS/toolchain/protocol as before (and use that prefix for restore-prefix fallback) but use the commit SHA as the exact-hit suffix
  - We also add a run on master on a cron schedule, every hour
  - We only save the cache at the end of a run on schedule, on master, so no pollution from other branches
  - All runs probe for a cache hit on the commit SHA, and do nothing if there is a hit: we already tested this SHA and saved its cache. So the hourly run should be very cheap/quick/quiet most of the time
  - Any cache _miss_ falls back to restoring from the last cache written, which will have been written on master on schedule and be fairly similar to whatever the runner is doing (any PR has to be fairly close to it to work)
  - We cache the Rust stuff

Hopefully this will speed up everything. Suggestions on further improvements welcome.