### PR TITLE
Remove the bors-auto-branch short circuit from ci-build.sh

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -68,18 +68,6 @@ NPROCS=$(getconf _NPROCESSORS_ONLN)
 echo "Found $NPROCS processors"
 date
 
-# Short-circuit transient 'auto-initialization' builds
-git fetch origin master
-MASTER=$(git describe --always FETCH_HEAD)
-HEAD=$(git describe --always HEAD)
-echo $MASTER
-echo $HEAD
-if [ $HEAD == $MASTER ]
-then
-    echo "HEAD SHA1 equals master; probably just establishing merge, exiting build early"
-    exit 1
-fi
-
 # Try to ensure we're using the real g++ and clang++ versions we want
 mkdir bin
 


### PR DESCRIPTION
In the old bors/latobarita world we had a short circuit in ci-build.sh to avoid a build when the `auto` branch _first_ moved, before the merge. This is (a) no longer necessary and (b) actually interfering with the new hourly cache-seeding scheduled actions on master. So this PR removes it.