### PR TITLE
Settings upgrades for increasing the maximum Soroban key size to 250 bytes

### DIFF
--- a/soroban-settings/pubnet_phase4.json
+++ b/soroban-settings/pubnet_phase4.json
@@ -1,0 +1,7 @@
+{
+  "updated_entry": [
+    {
+      "contract_data_key_size_bytes": 250
+    }
+  ]
+}

--- a/soroban-settings/testnet_settings.json
+++ b/soroban-settings/testnet_settings.json
@@ -507,7 +507,7 @@
       ]
     },
     {
-      "contract_data_key_size_bytes": 200
+      "contract_data_key_size_bytes": 250
     },
     {
       "contract_data_entry_size_bytes": 65536


### PR DESCRIPTION
# Description

Settings upgrades for increasing the maximum Soroban key size to 250 bytes.

200 bytes ended up being too conservative and it's not sufficient to support the built-in Stellar Asset contract allowance (that might need up to 204 bytes/key).

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
