### PR TITLE
Fail loadgen when pending accounts are found in available accounts list

### DIFF
--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -306,7 +306,13 @@ class LoadGenerator
     // queue (to avoid source account collisions during tx submission)
     std::unordered_set<uint64_t> mAccountsInUse;
     std::unordered_set<uint64_t> mAccountsAvailable;
-    uint64_t getNextAvailableAccount();
+
+    // Get an account ID not currently in use. This can fail when there are no
+    // available accounts, or when the node/network is overloaded to the point
+    // where previously banned transactions are unbanned but still circulating
+    // on the network. This function returns nullopt and marks loadgen as failed
+    // when it fails to to produce an account.
+    std::optional<uint64_t> getNextAvailableAccount(uint32_t ledgerNum);
 
     // For account creation only: allocate a few accounts for creation purposes
     // (with sufficient balance to create new accounts) to avoid source account

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -307,12 +307,8 @@ class LoadGenerator
     std::unordered_set<uint64_t> mAccountsInUse;
     std::unordered_set<uint64_t> mAccountsAvailable;
 
-    // Get an account ID not currently in use. This can fail when there are no
-    // available accounts, or when the node/network is overloaded to the point
-    // where previously banned transactions are unbanned but still circulating
-    // on the network. This function returns nullopt and marks loadgen as failed
-    // when it fails to to produce an account.
-    std::optional<uint64_t> getNextAvailableAccount(uint32_t ledgerNum);
+    // Get an account ID not currently in use.
+    uint64_t getNextAvailableAccount(uint32_t ledgerNum);
 
     // For account creation only: allocate a few accounts for creation purposes
     // (with sufficient balance to create new accounts) to avoid source account


### PR DESCRIPTION
# Description

Although `mAccountsAvailable` shouldn't contain pending accounts, it is possible when the network is overloaded. Consider the following scenario:
1. A node generates a transaction `t` using account `a` and broadcasts it on. In doing so, loadgen marks `a` as in use, removing it from `mAccountsAvailable.
2. For whatever reason, `t` never makes it out of the queue and the node bans it.
3. After some period of time, the node unbans `t` because bans only last for so many ledgers.
4. Loadgen marks `a` available, moving it back into `mAccountsAvailable`.
5. The node hears about `t` again on the network and (as it is no longer banned) adds it back to the queue
6. getNextAvailableAccount draws `a` from `mAccountsAvailable`. However, `a` is no longer available as `t` is in the transaction queue!

In this scenario, returning `a` results in an assertion failure later. This change instead detects this and marks the loadgen run as failed.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
