### PR TITLE
Only run ci on push to real branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
   merge_group:
   push:
+    branches:
+      - master
+      - prod
+      - testnet
+      - acceptance-test-pass
 
 jobs:
 


### PR DESCRIPTION
This is a followup to https://github.com/stellar/stellar-core/pull/4373 fixing yet another issue that seems to be happening with merge queues, it's visible in this screenshot:

![image](https://github.com/stellar/stellar-core/assets/14097/a9fda27f-dc0c-4456-a948-9046c92efce7)

I believe what's happening here is that the merge queue machinery is kicking off _two_ separate groups of actions simultaneously, one corresponding to the `push` event on the temporary integration branch, and the other corresponding to the `merge_group` event "Merge group checks requested". We should really only be triggering on the `merge_group` event, so this PR limits the `push` events that trigger actions to only the _final_ pushes when the integration branch closes and the queue pushes to master (which is still a somewhat redundant build, but the only way we can ensure the cache gets rewritten, and anyways it's only _two_ action-triggers per PR, vs. the current _three_).

(Also note this is really a copy-paste mistake on my part, Leigh did this correctly on the soroban repos)