### PR TITLE
Switch action push trigger from allow-list to ignore-list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,8 @@ on:
   pull_request:
   merge_group:
   push:
-    branches:
-      - master
-      - prod
-      - testnet
-      - acceptance-test-pass
+    branches-ignore:
+      - 'gh-readonly-queue/**'
 
 jobs:
 


### PR DESCRIPTION
PR https://github.com/stellar/stellar-core/pull/4375 limited the github action to run on pushes to specific branches, so as to avoid the double-execution of CI on merge-queue activity (it was triggering on both the `merge_group` event _and_ the merge queue's push to a throwaway `gh-readonly-queue/...` branch). Of course we also still trigger on the `pull_request` event which fires on any change to a PR.

This was a bit too strict. @dmkozh noted that he often likes to push to a branch on his own fork just to get some CI before opening a PR. So my proposed change here switches from an explicit list of branches to trigger the `push` event to an explicit pattern of branches to _not_ trigger the `push` event.

(Probably this should wait until the release is done, since if I made a mistake it might disrupt normal operations while figuring it out, @marta-lokhova and/or @SirTyson could you make a note here / merge this PR when you're done?)