### PR TITLE
Add `redis-tools` as a test-only docker dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,10 +12,10 @@ EXPOSE 11626
 VOLUME /data
 VOLUME /postgresql-unix-sockets
 
+ARG STELLAR_CORE_VERSION
+
 ADD setup /
 RUN /setup
-
-ARG STELLAR_CORE_VERSION
 
 #install stellar-core
 RUN wget -qO - https://apt.stellar.org/SDF.asc | apt-key add -

--- a/docker/setup
+++ b/docker/setup
@@ -11,6 +11,11 @@ apt-get install -y wget curl python-six python3-colorama python3-pip postgresql-
 
 pip3 install awscli --upgrade  # for uploading history to s3
 
+# install test dependencies if STELLAR_CORE_VERSION ends with '~buildtests'
+if [[ "$STELLAR_CORE_VERSION" == *~buildtests ]]; then
+  apt-get install -y redis-tools
+fi
+
 # purge stuff we don't directly need
 apt-get purge -y sgml-base ucf gcc g++ xz-utils libpod-latex-perl dbus
 apt-get autoremove -y


### PR DESCRIPTION
# Description

`redis-cli` is needed for the container to communicate to the Redis host. 
The new parallel catchup mission https://github.com/stellar/supercluster/pull/178 requires access to Redis task queue.
This is only added as a test dependency i.e. package version with `*~buildtests`, and does not affect production stellar-core packages.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
