### PR TITLE
Only test SCP driver with the current and prev protocol.

### DIFF
--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -2618,14 +2618,9 @@ testSCPDriver(uint32 protocolVersion, uint32_t maxTxSetSize, size_t expectedOps)
 
 TEST_CASE("SCP Driver", "[herder][acceptance]")
 {
-    SECTION("before generalized tx set protocol")
+    SECTION("previous protocol")
     {
-        testSCPDriver(static_cast<uint32>(SOROBAN_PROTOCOL_VERSION) - 1, 1000,
-                      15);
-    }
-    SECTION("generalized tx set protocol")
-    {
-        testSCPDriver(static_cast<uint32>(SOROBAN_PROTOCOL_VERSION), 1000, 15);
+        testSCPDriver(Config::CURRENT_LEDGER_PROTOCOL_VERSION - 1, 1000, 15);
     }
     SECTION("protocol current")
     {


### PR DESCRIPTION
# Description

Only test SCP driver with the current and previous  protocols.

We no longer need to support the generalized tx set migration scenarios, and it makes sense to only cover the two protocols that any given Core build might run.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
