### PR TITLE
Stop removing the cargo directory in ci-build.sh

### DIFF
--- a/ci-build.sh
+++ b/ci-build.sh
@@ -119,8 +119,8 @@ export CCACHE_CPP2=true
 # periodically check to see if caches are old and purge them if so
 if [ -d "$CCACHE_DIR" ] ; then
     if [ -n "$(find $CCACHE_DIR -mtime +$CACHE_MAX_DAYS -print -quit)" ] ; then
-        echo Purging old cache dirs $CCACHE_DIR ./target
-        rm -rf $CCACHE_DIR ./target
+        echo Purging old cache dirs $CCACHE_DIR ./target $HOME/.cargo/registry $HOME/.cargo/git
+        rm -rf $CCACHE_DIR ./target $HOME/.cargo/registry $HOME/.cargo/git
     fi
 fi
 

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -119,8 +119,8 @@ export CCACHE_CPP2=true
 # periodically check to see if caches are old and purge them if so
 if [ -d "$CCACHE_DIR" ] ; then
     if [ -n "$(find $CCACHE_DIR -mtime +$CACHE_MAX_DAYS -print -quit)" ] ; then
-        echo Purging old cache dirs $CCACHE_DIR $HOME/.cargo ./target
-        rm -rf $CCACHE_DIR $HOME/.cargo ./target
+        echo Purging old cache dirs $CCACHE_DIR ./target
+        rm -rf $CCACHE_DIR ./target
     fi
 fi
 


### PR DESCRIPTION
# Description

Fixes the CI issues we've been seeing where we fail with `configure: error: cannot find cargo, needed for rust code`.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
