### PR TITLE
Harden survey script to various failures

### DIFF
--- a/scripts/overlay_survey/util.py
+++ b/scripts/overlay_survey/util.py
@@ -35,3 +35,7 @@ SURVEY_TOPOLOGY_TIME_SLICED_ALREADY_IN_BACKLOG_OR_SELF = (
         "addPeerToBacklog failed: Peer is already in the backlog, or peer "
         "is self."
         )
+
+# Response from the stopsurvey endpoint. This is the response regardless of
+# whether or not a survey was running prior to calling this endpoint.
+STOP_SURVEY_SUCCESS_TEXT = "survey stopped"


### PR DESCRIPTION
Closes #4404

This change makes a few improvements to the survey script to enable it to better handle errors encountered during execution. Specifically, it:

* Adds a periodic ping to the `/info` endpoint to keep any SSH tunnels the script may be running through alive.
* Adds a flag `--startPhase` to allow the script to be attached to an already running survey. This ensures that if the script crashes it can pick up where it left off.
  * Additionally, the script now clears stellar-core's survey results cache when resuming gathering survey results.
* Catches errors in `write_graph_stats` and logs them rather than crashing.
* Writes out the graphml file as soon as the graph is complete so that any unhandled errors don't throw away the graph.
* Batches survey requests into smaller batches.
* Renames `--collect-duration` to `--collectDuration` for consistency with the other long option names.

I tested these changes using the script's `simulate` mode.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
