### PR TITLE
Fix prefetch tests

### DIFF
--- a/src/ledger/test/LedgerTxnTests.cpp
+++ b/src/ledger/test/LedgerTxnTests.cpp
@@ -2613,6 +2613,9 @@ TEST_CASE("LedgerTxnRoot prefetch classic entries", "[ledgertxn]")
 
         UnorderedSet<LedgerKey> keysToPrefetch;
         auto app = createTestApplication(clock, cfg);
+        auto ledgerVers = app->getLedgerManager()
+                              .getLastClosedLedgerHeader()
+                              .header.ledgerVersion;
 
         auto& root = app->getLedgerTxnRoot();
 
@@ -2634,7 +2637,8 @@ TEST_CASE("LedgerTxnRoot prefetch classic entries", "[ledgertxn]")
         {
             std::vector<LedgerEntry> ledgerVect{entrySet.begin(),
                                                 entrySet.end()};
-            app->getBucketManager().addBatch(*app, 2, 20, {}, ledgerVect, {});
+            app->getBucketManager().addBatch(*app, 2, ledgerVers, {},
+                                             ledgerVect, {});
         }
         ltx.commit();
 
@@ -2860,10 +2864,14 @@ TEST_CASE("LedgerTxnRoot prefetch soroban entries", "[ledgertxn]")
     ltx.eraseWithoutLoading(deadKey);
 
     // Insert all entries into the database.
+    auto ledgerVers = app->getLedgerManager()
+                          .getLastClosedLedgerHeader()
+                          .header.ledgerVersion;
     std::vector<LedgerEntry> ledgerVect{classicEntry, contractDataEntry,
                                         TTLEntry};
     std::vector<LedgerKey> deadKeyVect{deadKey};
-    app->getBucketManager().addBatch(*app, 2, 20, {}, ledgerVect, deadKeyVect);
+    app->getBucketManager().addBatch(*app, 2, ledgerVers, {}, ledgerVect,
+                                     deadKeyVect);
     ltx.commit();
 
     auto addTxn = [&](bool enoughQuota, std::vector<LedgerEntry> entries,


### PR DESCRIPTION
# Description

Prefetch tests currently hardcode protocol version 20, meaning they break in other protocols. This removes the hardcoded version.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
