### PR TITLE
Fixed assert failure when Soroban tx was sumbitted pre p20

### DIFF
--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -619,7 +619,9 @@ HerderImpl::recvTransaction(TransactionFrameBasePtr tx, bool submittedFromSelf)
     {
         // Received Soroban transaction before protocol 20; since this
         // transaction isn't supported yet, return ERROR
-        result.code = TransactionQueue::AddResultCode::ADD_STATUS_ERROR;
+        result = TransactionQueue::AddResult(
+            TransactionQueue::AddResultCode::ADD_STATUS_ERROR, tx,
+            txNOT_SUPPORTED);
     }
 
     if (result.code == TransactionQueue::AddResultCode::ADD_STATUS_PENDING)


### PR DESCRIPTION
# Description

Following the TX frame refactor, there is an assertion failure when submitting Soroban TXs pre protocol 20. This was actually a bug before the refactor, where a Soroban TX would fail to get added to the queue with `ADD_STATUS_ERROR`, but the diagnostics would report `txSUCCESS`. The assert is correct, but the queue now rejects the transaction and sets `txNOT_SUPPORTED`. This is TX queue behavior so this won't effect TX replay. 

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
