### PR TITLE
Enable background eviction by default & drop support for EXPERIMENTAL_BACKGROUND_EVICTION_SCAN

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -258,10 +258,10 @@ BUCKETLIST_DB_INDEX_CUTOFF = 20
 # this value is ingnored and indexes are never persisted.
 BUCKETLIST_DB_PERSIST_INDEX = true
 
-# EXPERIMENTAL_BACKGROUND_EVICTION_SCAN (bool) default false
+# BACKGROUND_EVICTION_SCAN (bool) default true
 # Determines whether eviction scans occur in the background thread. Requires
-# that EXPERIMENTAL_BACKGROUND_EVICTION_SCAN is set to true.
-EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = false
+# that DEPRECATED_SQL_LEDGER_STATE is set to false.
+BACKGROUND_EVICTION_SCAN = true
 
 # EXPERIMENTAL_BACKGROUND_OVERLAY_PROCESSING (bool) default false
 # Determines whether some of overlay processing occurs in the background

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -763,7 +763,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
         // BucketTestApplication writes directly to BL and circumvents LedgerTxn
         // interface, so we have to use BucketListDB for lookups
         cfg.DEPRECATED_SQL_LEDGER_STATE = false;
-        cfg.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = backgroundScan;
+        cfg.BACKGROUND_EVICTION_SCAN = backgroundScan;
 
         auto app = createTestApplication<BucketTestApplication>(clock, cfg);
         for_versions_from(20, *app, [&] {

--- a/src/bucket/test/BucketTestUtils.cpp
+++ b/src/bucket/test/BucketTestUtils.cpp
@@ -148,7 +148,7 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
                 }
 
                 LedgerTxn ltxEvictions(ltx);
-                if (mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
+                if (mApp.getConfig().isUsingBackgroundEviction())
                 {
                     mApp.getBucketManager().resolveBackgroundEvictionScan(
                         ltxEvictions, ledgerSeq, keys);
@@ -175,7 +175,9 @@ LedgerManagerForBucketTests::transferLedgerEntriesToBucketList(
 
         // Add dead entries from ltx to entries that will be added to BucketList
         // so we can test background eviction properly
-        if (mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
+        if (protocolVersionStartsFrom(initialLedgerVers,
+                                      SOROBAN_PROTOCOL_VERSION) &&
+            mApp.getConfig().isUsingBackgroundEviction())
         {
             for (auto const& k : dead)
             {

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1039,7 +1039,7 @@ LedgerManagerImpl::closeLedger(LedgerCloseData const& ledgerData)
     // step 3
     if (protocolVersionStartsFrom(initialLedgerVers,
                                   SOROBAN_PROTOCOL_VERSION) &&
-        mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
+        mApp.getConfig().isUsingBackgroundEviction())
     {
         mApp.getBucketManager().startBackgroundEvictionScan(ledgerSeq + 1);
     }
@@ -1675,7 +1675,7 @@ LedgerManagerImpl::transferLedgerEntriesToBucketList(
             auto keys = ltx.getAllTTLKeysWithoutSealing();
             LedgerTxn ltxEvictions(ltx);
 
-            if (mApp.getConfig().EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
+            if (mApp.getConfig().isUsingBackgroundEviction())
             {
                 mApp.getBucketManager().resolveBackgroundEvictionScan(
                     ltxEvictions, ledgerSeq, keys);

--- a/src/main/ApplicationImpl.cpp
+++ b/src/main/ApplicationImpl.cpp
@@ -84,10 +84,10 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     : mVirtualClock(clock)
     , mConfig(cfg)
     // Allocate one worker to eviction when background eviction enabled
-    , mWorkerIOContext(mConfig.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN
+    , mWorkerIOContext(mConfig.isUsingBackgroundEviction()
                            ? mConfig.WORKER_THREADS - 1
                            : mConfig.WORKER_THREADS)
-    , mEvictionIOContext(mConfig.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN
+    , mEvictionIOContext(mConfig.isUsingBackgroundEviction()
                              ? std::make_unique<asio::io_context>(1)
                              : nullptr)
     , mWork(std::make_unique<asio::io_context::work>(mWorkerIOContext))
@@ -157,7 +157,7 @@ ApplicationImpl::ApplicationImpl(VirtualClock& clock, Config const& cfg)
     auto t = mConfig.WORKER_THREADS;
     LOG_DEBUG(DEFAULT_LOG, "Application constructing (worker threads: {})", t);
 
-    if (mConfig.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
+    if (mConfig.isUsingBackgroundEviction())
     {
         releaseAssert(mConfig.WORKER_THREADS > 0);
         releaseAssert(mEvictionIOContext);
@@ -830,20 +830,21 @@ ApplicationImpl::validateAndLogConfig()
         }
     }
 
-    if (mConfig.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN)
+    if (mConfig.BACKGROUND_EVICTION_SCAN)
     {
         if (!mConfig.isUsingBucketListDB())
         {
             throw std::invalid_argument(
-                "DEPRECATED_SQL_LEDGER_STATE must be false to use "
-                "EXPERIMENTAL_BACKGROUND_EVICTION_SCAN");
+                "BACKGROUND_EVICTION_SCAN set to true but "
+                "DEPRECATED_SQL_LEDGER_STATE is set to true. "
+                "DEPRECATED_SQL_LEDGER_STATE must be set to false to enable "
+                "background eviction.");
         }
 
         if (mConfig.WORKER_THREADS < 2)
         {
-            throw std::invalid_argument(
-                "EXPERIMENTAL_BACKGROUND_EVICTION_SCAN requires "
-                "WORKER_THREADS > 1");
+            throw std::invalid_argument("BACKGROUND_EVICTION_SCAN requires "
+                                        "WORKER_THREADS > 1");
         }
     }
 

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -371,7 +371,7 @@ class Config : public std::enable_shared_from_this<Config>
 
     // When set to true, eviction scans occur on the background thread,
     // increasing performance. Requires EXPERIMENTAL_BUCKETLIST_DB.
-    bool EXPERIMENTAL_BACKGROUND_EVICTION_SCAN;
+    bool BACKGROUND_EVICTION_SCAN;
 
     // A config parameter that stores historical data, such as transactions,
     // fees, and scp history in the database
@@ -675,6 +675,7 @@ class Config : public std::enable_shared_from_this<Config>
     bool isInMemoryMode() const;
     bool isInMemoryModeWithoutMinimalDB() const;
     bool isUsingBucketListDB() const;
+    bool isUsingBackgroundEviction() const;
     bool isPersistingBucketListDBIndexes() const;
     bool modeStoresAllHistory() const;
     bool modeStoresAnyHistory() const;

--- a/src/test/FuzzerImpl.cpp
+++ b/src/test/FuzzerImpl.cpp
@@ -864,6 +864,7 @@ getFuzzConfig(int instanceNumber)
     Config cfg = getTestConfig(instanceNumber);
     cfg.MANUAL_CLOSE = true;
     cfg.CATCHUP_COMPLETE = false;
+    cfg.BACKGROUND_EVICTION_SCAN = false;
     cfg.CATCHUP_RECENT = 0;
     cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
     cfg.ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = UINT32_MAX;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -301,7 +301,7 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         // disable self-check
         thisConfig.AUTOMATIC_SELF_CHECK_PERIOD = std::chrono::seconds(0);
         // only spin up a small number of worker threads
-        thisConfig.WORKER_THREADS = 2;
+        thisConfig.WORKER_THREADS = 3;
         thisConfig.QUORUM_INTERSECTION_CHECKER = false;
         thisConfig.METADATA_DEBUG_LEDGERS = 0;
 
@@ -315,6 +315,10 @@ getTestConfig(int instanceNumber, Config::TestDbMode mode)
         // Disable RPC endpoint in tests
         thisConfig.HTTP_QUERY_PORT = 0;
         thisConfig.QUERY_SNAPSHOT_LEDGERS = 0;
+
+        // TODO: Change this to true when DEPRECATED_SQL_LEDGER_STATE is changed
+        // to default false in test configs
+        thisConfig.BACKGROUND_EVICTION_SCAN = false;
 
 #ifdef BEST_OFFER_DEBUGGING
         thisConfig.BEST_OFFER_DEBUGGING_ENABLED = true;

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -2512,7 +2512,7 @@ TEST_CASE("temp entry eviction", "[tx][soroban]")
 
         cfg.METADATA_OUTPUT_STREAM = metaPath;
         cfg.DEPRECATED_SQL_LEDGER_STATE = !enableBucketListDB;
-        cfg.EXPERIMENTAL_BACKGROUND_EVICTION_SCAN = backgroundEviction;
+        cfg.BACKGROUND_EVICTION_SCAN = backgroundEviction;
 
         // overrideSorobanNetworkConfigForTest commits directly to the database,
         // will not work if BucketListDB is enabled so we must use the cfg


### PR DESCRIPTION
# Description

Resolves #4415

Drops "experimental" from background eviction flag and enables it by default.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
