### PR TITLE
Remove protocol-specific assert from TxSetUtils::getInvalidTxList

### DIFF
--- a/src/herder/TxSetUtils.cpp
+++ b/src/herder/TxSetUtils.cpp
@@ -144,15 +144,6 @@ TxSetUtils::getInvalidTxList(TxSetTransactions const& txs, Application& app,
     ZoneScoped;
     LedgerTxn ltx(app.getLedgerTxnRoot(), /* shouldUpdateLastModified */ true,
                   TransactionMode::READ_ONLY_WITHOUT_SQL_TXN);
-#ifdef BUILD_TESTS
-    if (protocolVersionIsBefore(ltx.loadHeader().current().ledgerVersion,
-                                ProtocolVersion::V_20))
-    {
-        return {};
-    }
-#endif
-    releaseAssert(protocolVersionStartsFrom(
-        ltx.loadHeader().current().ledgerVersion, ProtocolVersion::V_20));
     // This is done so minSeqLedgerGap is validated against the next
     // ledgerSeq, which is what will be used at apply time
     ltx.loadHeader().current().ledgerSeq =


### PR DESCRIPTION
This assert isn't quite right, as nodes may still call this functionality when out-of-sync/catching up. I think there are two scenarios where this can be triggered:
* Node externalized latest (p21) ledger, but it's at genesis (p0), so tx queue cleanup crashes at the assert. 
* Validator starts at genesis with force_scp=true, which causes it to crash while trying to nominate a block for ledger 2 (which gets ignored by the network). It's not crashed right now given how the code is written (the function is not called if the transaction set is empty), but it's still a footgun.

I removed the assert - for out-of-sync nodes, this path _should_ be harmless, as we don't accept any invalid/unsupported transactions in the transaction queue to begin with. I believe this is how it was handled in previous protocols as well.