### PR TITLE
Fixed assert failure when banning txs

### DIFF
--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -390,8 +390,7 @@ TransactionQueue::canAdd(
             return result;
         }
         return AddResult(
-            TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER,
-            nullptr);
+            TransactionQueue::AddResultCode::ADD_STATUS_TRY_AGAIN_LATER);
     }
 
     auto closeTime = mApp.getLedgerManager()

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -70,7 +70,7 @@ TransactionQueue::AddResult::AddResult(AddResultCode addCode,
     : code(addCode), txResult(tx->createSuccessResult())
 {
     releaseAssert(txErrorCode != txSUCCESS);
-    txResult.value()->setResultCode(txErrorCode);
+    txResult->setResultCode(txErrorCode);
 }
 
 TransactionQueue::TransactionQueue(Application& app, uint32 pendingDepth,
@@ -358,7 +358,7 @@ TransactionQueue::canAdd(
                     AddResult result(
                         TransactionQueue::AddResultCode::ADD_STATUS_ERROR, tx,
                         txINSUFFICIENT_FEE);
-                    result.txResult.value()->getResult().feeCharged = minFee;
+                    result.txResult->getResult().feeCharged = minFee;
                     return result;
                 }
 
@@ -386,7 +386,7 @@ TransactionQueue::canAdd(
         {
             AddResult result(TransactionQueue::AddResultCode::ADD_STATUS_ERROR,
                              tx, txINSUFFICIENT_FEE);
-            result.txResult.value()->getResult().feeCharged = canAddRes.second;
+            result.txResult->getResult().feeCharged = canAddRes.second;
             return result;
         }
         return AddResult(

--- a/src/herder/TransactionQueue.h
+++ b/src/herder/TransactionQueue.h
@@ -75,7 +75,7 @@ class TransactionQueue
     struct AddResult
     {
         TransactionQueue::AddResultCode code;
-        std::optional<MutableTxResultPtr> txResult;
+        MutableTxResultPtr txResult;
 
         // AddResult with no txResult
         explicit AddResult(TransactionQueue::AddResultCode addCode);

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -1026,7 +1026,7 @@ CommandHandler::tx(std::string const& params, std::string& retStr)
                 std::string resultBase64;
                 releaseAssertOrThrow(addResult.txResult);
 
-                auto const& payload = addResult.txResult.value();
+                auto const& payload = addResult.txResult;
                 auto resultBin = xdr::xdr_to_opaque(payload->getResult());
                 resultBase64.reserve(decoder::encoded_size64(resultBin.size()) +
                                      1);
@@ -1550,9 +1550,8 @@ CommandHandler::testTx(std::string const& params, std::string& retStr)
         if (addResult.code == TransactionQueue::AddResultCode::ADD_STATUS_ERROR)
         {
             releaseAssert(addResult.txResult);
-            root["detail"] =
-                xdrToCerealString(addResult.txResult.value()->getResultCode(),
-                                  "TransactionResultCode");
+            root["detail"] = xdrToCerealString(
+                addResult.txResult->getResultCode(), "TransactionResultCode");
         }
     }
     else

--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -2181,7 +2181,7 @@ LoadGenerator::execute(TransactionTestFramePtr& txf, LoadGenMode mode,
 
         auto resultStr =
             addResult.txResult
-                ? xdrToCerealString(addResult.txResult.value()->getResult(),
+                ? xdrToCerealString(addResult.txResult->getResult(),
                                     "TransactionResult")
                 : "";
         CLOG_INFO(LoadGen, "tx rejected '{}': ===> {}, {}",
@@ -2193,7 +2193,7 @@ LoadGenerator::execute(TransactionTestFramePtr& txf, LoadGenMode mode,
         if (addResult.code == TransactionQueue::AddResultCode::ADD_STATUS_ERROR)
         {
             releaseAssert(addResult.txResult);
-            code = addResult.txResult.value()->getResultCode();
+            code = addResult.txResult->getResultCode();
         }
         txm.mTxnRejected.Mark();
     }


### PR DESCRIPTION
# Description

Resolves #4421

Fixes an assert failure that occurred when a TX that exceeds ledger limits is banned.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
