### PR TITLE
Ensure unique preimages during loadgen upgrade setup

### DIFF
--- a/src/simulation/LoadGenerator.cpp
+++ b/src/simulation/LoadGenerator.cpp
@@ -1260,11 +1260,8 @@ LoadGenerator::createContractTransaction(uint32_t ledgerNum, uint64_t accountId,
     createResources.readBytes = mContactOverheadBytes;
     createResources.writeBytes = 300;
 
-    auto salt = sha256(
-        std::to_string(mContractInstanceKeys.size()) + "run" +
-        std::to_string(mApp.getMetrics()
-                           .NewMeter({"loadgen", "run", "complete"}, "run")
-                           .count()));
+    auto salt = sha256("upgrade" +
+                       std::to_string(++mNumCreateContractTransactionCalls));
     auto contractIDPreimage = makeContractIDPreimage(*account, salt);
 
     auto tx = makeSorobanCreateContractTx(

--- a/src/simulation/LoadGenerator.h
+++ b/src/simulation/LoadGenerator.h
@@ -327,6 +327,10 @@ class LoadGenerator
     int64_t mPreLoadgenApplySorobanSuccess = 0;
     int64_t mPreLoadgenApplySorobanFailure = 0;
 
+    // Number of times `createContractTransaction` has been called. Used to
+    // ensure unique preimages for all `SOROBAN_UPGRADE_SETUP` runs.
+    uint32_t mNumCreateContractTransactionCalls = 0;
+
     bool mFailed{false};
     bool mStarted{false};
     bool mInitialAccountsCreated{false};


### PR DESCRIPTION
Currently, loadgen can produce duplicate preimages during `SOROBAN_UPGRADE_SETUP` if metrics have been cleared between `SOROBAN_UPGRADE_SETUP` calls. This scenario causes the setup to fail. This change fixes this by using an internal counter as part of the preimage instead of using medida metrics.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
