### PR TITLE
Bucket entry counters and metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -32,6 +32,8 @@ bucket.memory.shared                      | counter   | number of buckets refere
 bucket.merge-time.level-<X>               | timer     | time to merge two buckets on level <X>
 bucket.snap.merge                         | timer     | time to merge two buckets
 bucketlist.size.bytes                     | counter   | total size of the BucketList in bytes
+bucketlist.entryCounts.-<X>               | counter   | number of entries of type <X> in the BucketList
+bucketlist.entrySizes.-<X>                | counter   | size of entries of type <X> in the BucketList
 bucketlistDB.bloom.lookups                | meter     | number of bloom filter lookups
 bucketlistDB.bloom.misses                 | meter     | number of bloom filter false positives
 bucketlistDB.bulk.loads                   | meter     | number of entries BucketListDB queried to prefetch

--- a/src/bucket/Bucket.cpp
+++ b/src/bucket/Bucket.cpp
@@ -863,4 +863,38 @@ Bucket::getBucketVersion(std::shared_ptr<Bucket const> const& bucket)
     BucketInputIterator it(bucket);
     return it.getMetadata().ledgerVersion;
 }
+
+BucketEntryCounters const&
+Bucket::getBucketEntryCounters() const
+{
+    releaseAssert(mIndex);
+    return mIndex->getBucketEntryCounters();
+}
+
+BucketEntryCounters&
+BucketEntryCounters::operator+=(BucketEntryCounters const& other)
+{
+    for (auto [type, count] : other.entryTypeCounts)
+    {
+        this->entryTypeCounts[type] += count;
+    }
+    for (auto [type, size] : other.entryTypeSizes)
+    {
+        this->entryTypeSizes[type] += size;
+    }
+    return *this;
+}
+
+bool
+BucketEntryCounters::operator==(BucketEntryCounters const& other) const
+{
+    return this->entryTypeCounts == other.entryTypeCounts &&
+           this->entryTypeSizes == other.entryTypeSizes;
+}
+
+bool
+BucketEntryCounters::operator!=(BucketEntryCounters const& other) const
+{
+    return !(*this == other);
+}
 }

--- a/src/bucket/Bucket.h
+++ b/src/bucket/Bucket.h
@@ -9,6 +9,7 @@
 #include "util/ProtocolVersion.h"
 #include "xdr/Stellar-ledger.h"
 #include <list>
+#include <map>
 #include <optional>
 #include <string>
 
@@ -43,6 +44,7 @@ class BucketManager;
 class SearchableBucketListSnapshot;
 struct EvictionResultEntry;
 class EvictionStatistics;
+struct BucketEntryCounters;
 
 class Bucket : public std::enable_shared_from_this<Bucket>,
                public NonMovableOrCopyable
@@ -179,7 +181,25 @@ class Bucket : public std::enable_shared_from_this<Bucket>,
     static uint32_t getBucketVersion(std::shared_ptr<Bucket> const& bucket);
     static uint32_t
     getBucketVersion(std::shared_ptr<Bucket const> const& bucket);
-
+    BucketEntryCounters const& getBucketEntryCounters() const;
     friend class BucketSnapshot;
+};
+
+enum class LedgerEntryTypeAndDurability : uint32_t;
+struct BucketEntryCounters
+{
+    std::map<LedgerEntryTypeAndDurability, size_t> entryTypeCounts;
+    std::map<LedgerEntryTypeAndDurability, size_t> entryTypeSizes;
+
+    BucketEntryCounters& operator+=(BucketEntryCounters const& other);
+    bool operator==(BucketEntryCounters const& other) const;
+    bool operator!=(BucketEntryCounters const& other) const;
+
+    template <class Archive>
+    void
+    serialize(Archive& ar)
+    {
+        ar(entryTypeCounts, entryTypeSizes);
+    }
 };
 }

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -33,6 +33,7 @@ namespace stellar
  */
 
 class BucketManager;
+struct BucketEntryCounters;
 
 // BucketIndex abstract interface
 class BucketIndex : public NonMovableOrCopyable
@@ -74,7 +75,7 @@ class BucketIndex : public NonMovableOrCopyable
                                   IndividualIndex::const_iterator>;
 
     inline static const std::string DB_BACKEND_STATE = "bl";
-    inline static const uint32_t BUCKET_INDEX_VERSION = 3;
+    inline static const uint32_t BUCKET_INDEX_VERSION = 4;
 
     // Returns true if LedgerEntryType not supported by BucketListDB
     static bool typeNotSupported(LedgerEntryType t);
@@ -132,7 +133,7 @@ class BucketIndex : public NonMovableOrCopyable
 
     virtual void markBloomMiss() const = 0;
     virtual void markBloomLookup() const = 0;
-
+    virtual BucketEntryCounters const& getBucketEntryCounters() const = 0;
 #ifdef BUILD_TESTS
     virtual bool operator==(BucketIndex const& inRaw) const = 0;
 #endif

--- a/src/bucket/BucketIndexImpl.cpp
+++ b/src/bucket/BucketIndexImpl.cpp
@@ -7,6 +7,7 @@
 #include "bucket/BucketManager.h"
 #include "crypto/Hex.h"
 #include "crypto/ShortHash.h"
+#include "ledger/LedgerTypeUtils.h"
 #include "main/Config.h"
 #include "util/BinaryFuseFilter.h"
 #include "util/Fs.h"
@@ -100,6 +101,17 @@ BucketIndexImpl<IndexT>::BucketIndexImpl(BucketManager& bm,
         std::vector<uint64_t> keyHashes;
         auto seed = shortHash::getShortHashInitKey();
 
+        auto countEntry = [&](BucketEntry const& be) {
+            if (be.type() == METAENTRY)
+            {
+                // Do not count meta entries.
+                return;
+            }
+            auto ledt = bucketEntryToLedgerEntryAndDurabilityType(be);
+            mData.counters.entryTypeCounts[ledt]++;
+            mData.counters.entryTypeSizes[ledt] += xdr::xdr_size(be);
+        };
+
         while (in && in.readOne(be))
         {
             // peridocially check if bucket manager is exiting to stop indexing
@@ -170,6 +182,7 @@ BucketIndexImpl<IndexT>::BucketIndexImpl(BucketManager& bm,
                 {
                     mData.keysToOffset.emplace_back(key, pos);
                 }
+                countEntry(be);
             }
 
             pos = in.pos();
@@ -551,6 +564,11 @@ BucketIndexImpl<IndexT>::operator==(BucketIndex const& inRaw) const
         }
     }
 
+    if (mData.counters != in.mData.counters)
+    {
+        return false;
+    }
+
     return true;
 }
 #endif
@@ -579,5 +597,12 @@ void
 BucketIndexImpl<BucketIndex::RangeIndex>::markBloomLookup() const
 {
     mBloomLookupMeter.Mark();
+}
+
+template <class IndexT>
+BucketEntryCounters const&
+BucketIndexImpl<IndexT>::getBucketEntryCounters() const
+{
+    return mData.counters;
 }
 }

--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -4,6 +4,7 @@
 
 #include "BucketList.h"
 #include "bucket/Bucket.h"
+#include "bucket/BucketIndexImpl.h"
 #include "bucket/BucketInputIterator.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketSnapshot.h"
@@ -629,6 +630,24 @@ BucketList::addBatch(Application& app, uint32_t currLedger,
     {
         resolveAnyReadyFutures();
     }
+}
+
+BucketEntryCounters
+BucketList::sumBucketEntryCounters() const
+{
+    BucketEntryCounters counters;
+    for (auto const& lev : mLevels)
+    {
+        for (auto const& b : {lev.getCurr(), lev.getSnap()})
+        {
+            if (b->isIndexed())
+            {
+                auto c = b->getBucketEntryCounters();
+                counters += c;
+            }
+        }
+    }
+    return counters;
 }
 
 void

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -345,6 +345,7 @@ namespace stellar
 class AbstractLedgerTxn;
 class Application;
 class Bucket;
+struct BucketEntryCounters;
 class Config;
 struct EvictionCounters;
 struct InflationWinner;
@@ -523,5 +524,6 @@ class BucketList
                   std::vector<LedgerEntry> const& initEntries,
                   std::vector<LedgerEntry> const& liveEntries,
                   std::vector<LedgerKey> const& deadEntries);
+    BucketEntryCounters sumBucketEntryCounters() const;
 };
 }

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -385,5 +385,6 @@ class BucketManager : NonMovableOrCopyable
     // Get bucketlist snapshot
     virtual std::shared_ptr<SearchableBucketListSnapshot>
     getSearchableBucketListSnapshot() = 0;
+    virtual void reportBucketEntryCountMetrics() = 0;
 };
 }

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -31,6 +31,9 @@ class Application;
 class Bucket;
 class BucketList;
 class BucketSnapshotManager;
+struct BucketEntryCounters;
+enum class LedgerEntryTypeAndDurability : uint32_t;
+
 struct HistoryArchiveState;
 
 class BucketManagerImpl : public BucketManager
@@ -61,6 +64,10 @@ class BucketManagerImpl : public BucketManager
     EvictionCounters mBucketListEvictionCounters;
     MergeCounters mMergeCounters;
     std::shared_ptr<EvictionStatistics> mEvictionStatistics{};
+    std::map<LedgerEntryTypeAndDurability, medida::Counter&>
+        mBucketListEntryCountCounters;
+    std::map<LedgerEntryTypeAndDurability, medida::Counter&>
+        mBucketListEntrySizeCounters;
 
     std::future<EvictionResult> mEvictionFuture{};
 
@@ -192,6 +199,7 @@ class BucketManagerImpl : public BucketManager
 
     std::shared_ptr<SearchableBucketListSnapshot>
     getSearchableBucketListSnapshot() override;
+    void reportBucketEntryCountMetrics() override;
 };
 
 #define SKIP_1 50

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -663,6 +663,17 @@ TEST_CASE("serialize bucket indexes", "[bucket][bucketindex]")
 
         auto& inMemoryIndex = b->getIndexForTesting();
         REQUIRE(inMemoryIndex.getPageSize() == (1UL << 10));
+        auto inMemoryCoutners = inMemoryIndex.getBucketEntryCounters();
+        // Ensure the inMemoryIndex has some non-zero counters.
+        REQUIRE(!inMemoryCoutners.entryTypeCounts.empty());
+        REQUIRE(!inMemoryCoutners.entryTypeSizes.empty());
+        bool allZero = true;
+        for (auto const& [k, v] : inMemoryCoutners.entryTypeCounts)
+        {
+            allZero = allZero && (v == 0);
+            allZero = allZero && (inMemoryCoutners.entryTypeSizes.at(k) == 0);
+        }
+        REQUIRE(!allZero);
 
         // Check if on-disk index rewritten with correct config params
         auto indexFilename = test.getBM().bucketIndexFilename(bucketHash);

--- a/src/ledger/LedgerTypeUtils.cpp
+++ b/src/ledger/LedgerTypeUtils.cpp
@@ -8,6 +8,7 @@
 #include "util/UnorderedMap.h"
 #include "util/UnorderedSet.h"
 #include "util/types.h"
+#include <fmt/format.h>
 
 namespace stellar
 {
@@ -33,5 +34,93 @@ getTTLKey(LedgerKey const& e)
     k.type(TTL);
     k.ttl().keyHash = sha256(xdr::xdr_to_opaque(e));
     return k;
+}
+
+LedgerEntryTypeAndDurability
+bucketEntryToLedgerEntryAndDurabilityType(BucketEntry const& be)
+{
+    auto bet = be.type();
+    LedgerEntryType let;
+    bool isTemp = false;
+    if (bet == INITENTRY || bet == LIVEENTRY)
+    {
+        auto le = be.liveEntry().data;
+        let = le.type();
+        isTemp = isTemporaryEntry(le);
+    }
+    else if (bet == DEADENTRY)
+    {
+        auto lk = be.deadEntry();
+        let = lk.type();
+        isTemp = isTemporaryEntry(lk);
+    }
+    else
+    {
+        auto label = xdr::xdr_traits<BucketEntryType>::enum_name(bet);
+        throw std::runtime_error(
+            fmt::format("Unsupported BucketEntryType {}", label));
+    }
+    switch (let)
+    {
+    case ACCOUNT:
+        return LedgerEntryTypeAndDurability::ACCOUNT;
+    case TRUSTLINE:
+        return LedgerEntryTypeAndDurability::TRUSTLINE;
+    case OFFER:
+        return LedgerEntryTypeAndDurability::OFFER;
+    case DATA:
+        return LedgerEntryTypeAndDurability::DATA;
+    case CLAIMABLE_BALANCE:
+        return LedgerEntryTypeAndDurability::CLAIMABLE_BALANCE;
+    case LIQUIDITY_POOL:
+        return LedgerEntryTypeAndDurability::LIQUIDITY_POOL;
+    case CONTRACT_DATA:
+        return isTemp ? LedgerEntryTypeAndDurability::TEMPORARY_CONTRACT_DATA
+                      : LedgerEntryTypeAndDurability::PERSISTENT_CONTRACT_DATA;
+    case CONTRACT_CODE:
+        return LedgerEntryTypeAndDurability::CONTRACT_CODE;
+    case CONFIG_SETTING:
+        return LedgerEntryTypeAndDurability::CONFIG_SETTING;
+    case TTL:
+        return LedgerEntryTypeAndDurability::TTL;
+    default:
+        auto label = xdr::xdr_traits<LedgerEntryType>::enum_name(let);
+        throw std::runtime_error(
+            fmt::format("Unknown LedgerEntryType {}", label));
+    }
+}
+
+std::string
+toString(LedgerEntryTypeAndDurability const type)
+{
+    switch (type)
+    {
+    case LedgerEntryTypeAndDurability::ACCOUNT:
+        return "ACCOUNT";
+    case LedgerEntryTypeAndDurability::TRUSTLINE:
+        return "TRUSTLINE";
+    case LedgerEntryTypeAndDurability::OFFER:
+        return "OFFER";
+    case LedgerEntryTypeAndDurability::DATA:
+        return "DATA";
+    case LedgerEntryTypeAndDurability::CLAIMABLE_BALANCE:
+        return "CLAIMABLE_BALANCE";
+    case LedgerEntryTypeAndDurability::LIQUIDITY_POOL:
+        return "LIQUIDITY_POOL";
+    case LedgerEntryTypeAndDurability::TEMPORARY_CONTRACT_DATA:
+        return "TEMPORARY_CONTRACT_DATA";
+    case LedgerEntryTypeAndDurability::PERSISTENT_CONTRACT_DATA:
+        return "PERSISTENT_CONTRACT_DATA";
+    case LedgerEntryTypeAndDurability::CONTRACT_CODE:
+        return "CONTRACT_CODE";
+    case LedgerEntryTypeAndDurability::CONFIG_SETTING:
+        return "CONFIG_SETTING";
+    case LedgerEntryTypeAndDurability::TTL:
+        return "TTL";
+    default:
+        throw std::runtime_error(
+            fmt::format(FMT_STRING("unknown LedgerEntryTypeAndDurability {:d}"),
+                        static_cast<uint32_t>(type)));
+    }
 }
 };

--- a/src/ledger/LedgerTypeUtils.h
+++ b/src/ledger/LedgerTypeUtils.h
@@ -80,4 +80,24 @@ isPersistentEntry(T const& e)
            (e.type() == CONTRACT_DATA &&
             e.contractData().durability == PERSISTENT);
 }
+
+enum class LedgerEntryTypeAndDurability : uint32_t
+{
+    ACCOUNT = 0,
+    TRUSTLINE = 1,
+    OFFER = 2,
+    DATA = 3,
+    CLAIMABLE_BALANCE = 4,
+    LIQUIDITY_POOL = 5,
+    TEMPORARY_CONTRACT_DATA = 6,
+    PERSISTENT_CONTRACT_DATA = 7,
+    CONTRACT_CODE = 8,
+    CONFIG_SETTING = 9,
+    TTL = 10,
+    NUM_TYPES = 11,
+};
+
+LedgerEntryTypeAndDurability
+bucketEntryToLedgerEntryAndDurabilityType(BucketEntry const& be);
+std::string toString(LedgerEntryTypeAndDurability let);
 }


### PR DESCRIPTION
# Description

Resolves https://github.com/stellar/stellar-core/issues/4426

* Adds `BucketEntryCounters` to `BucketIndexImpl` to count entry types and duration. 
* Adds functionality to `BucketList` to accumulate the counters for all buckets
* Adds functionality to LedgerManager to emit these metrics to medida 

Still TODO:
* Local testing of serialization of indexes with counters 

Out of scope:
* XDR Changes for including counters in ledger close meta
* grafana updates

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
