### PR TITLE
Add SOROBAN_TEST_EXTRA_PROTOCOL for side-by-side testing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,16 +8,18 @@ include $(srcdir)/src.mk
 
 noinst_HEADERS = $(SRC_H_FILES)
 
-if BUILD_TESTS
-stellar_core_SOURCES = main/StellarCoreVersion.cpp main/XDRFilesSha256.cpp $(SRC_CXX_FILES) $(SRC_TEST_CXX_FILES)
-else # !BUILD_TESTS
-stellar_core_SOURCES = main/StellarCoreVersion.cpp main/XDRFilesSha256.cpp $(SRC_CXX_FILES)
-endif # !BUILD_TESTS
-
 CARGO_FEATURES =
 if USE_TRACY
 CARGO_FEATURES += --features tracy
 endif
+
+if BUILD_TESTS
+stellar_core_SOURCES = main/StellarCoreVersion.cpp main/XDRFilesSha256.cpp $(SRC_CXX_FILES) $(SRC_TEST_CXX_FILES)
+CARGO_FEATURES += --features testutils
+else # !BUILD_TESTS
+stellar_core_SOURCES = main/StellarCoreVersion.cpp main/XDRFilesSha256.cpp $(SRC_CXX_FILES)
+endif # !BUILD_TESTS
+
 
 if ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
 CARGO_FEATURES += --features core-vnext

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -98,3 +98,9 @@ tracy = ["dep:tracy-client", "soroban-env-host-p21/tracy", "soroban-env-host-p22
 # feature is not enabled by default, and is only intended for temporary use when
 # staging work across intra-protocol releases.
 core-vnext = ["soroban-env-host-p22/next"]
+
+# the testutils feature turns on stuff that should only be available in a core
+# BUILD_TESTS build, such as the code to support transaction re-execution on
+# a secondary host. If necessary it can also turn on "testutils" features in
+# any of the hosts.
+testutils = []

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -188,6 +188,7 @@ fn non_metered_xdr_to_rust_buf<T: WriteXdr>(t: &T) -> Result<RustBuf, HostError>
 // It's intended for use when modifying the cost parameters of the CxxLedgerInfo
 // when invoking a contract twice with different protocols.
 #[allow(dead_code)]
+#[cfg(feature = "testutils")]
 pub(crate) fn inplace_modify_cxxbuf_encoded_type<T: ReadXdr + WriteXdr>(
     buf: &mut CxxBuf,
     modify: impl FnOnce(&mut T) -> Result<(), Box<dyn Error>>,
@@ -382,11 +383,13 @@ fn make_trace_hook_fn<'a>() -> super::soroban_env_host::TraceHook {
 }
 
 #[allow(dead_code)]
+#[cfg(feature = "testutils")]
 fn decode_contract_cost_params(buf: &CxxBuf) -> Result<ContractCostParams, Box<dyn Error>> {
     Ok(non_metered_xdr_from_cxx_buf::<ContractCostParams>(buf)?)
 }
 
 #[allow(dead_code)]
+#[cfg(feature = "testutils")]
 fn encode_contract_cost_params(params: &ContractCostParams) -> Result<RustBuf, Box<dyn Error>> {
     Ok(non_metered_xdr_to_rust_buf(params)?)
 }
@@ -555,6 +558,7 @@ fn invoke_host_function_or_maybe_panic(
 }
 
 #[allow(dead_code)]
+#[cfg(feature = "testutils")]
 pub(crate) fn rustbuf_containing_scval_to_string(buf: &RustBuf) -> String {
     if let Ok(val) = ScVal::read_xdr(&mut xdr::Limited::new(
         Cursor::new(buf.data.as_slice()),
@@ -570,6 +574,7 @@ pub(crate) fn rustbuf_containing_scval_to_string(buf: &RustBuf) -> String {
 }
 
 #[allow(dead_code)]
+#[cfg(feature = "testutils")]
 pub(crate) fn rustbuf_containing_diagnostic_event_to_string(buf: &RustBuf) -> String {
     if let Ok(val) = DiagnosticEvent::read_xdr(&mut xdr::Limited::new(
         Cursor::new(buf.data.as_slice()),

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -185,7 +185,7 @@ mod rust_bridge {
             enable_diagnostics: bool,
             instruction_limit: u32,
             hf_buf: &CxxBuf,
-            resources: &CxxBuf,
+            resources: CxxBuf,
             source_account: &CxxBuf,
             auth_entries: &Vec<CxxBuf>,
             ledger_info: CxxLedgerInfo,
@@ -294,11 +294,26 @@ impl AsRef<[u8]> for CxxBuf {
     }
 }
 
+impl CxxBuf {
+    #[cfg(feature = "testutils")]
+    fn replace_data_with(&mut self, slice: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
+        if self.data.is_null() {
+            return Err("CxxBuf::replace_data_with: data is null".into());
+        }
+        while self.data.len() > 0 {
+            self.data.pin_mut().pop();
+        }
+        for byte in slice {
+            self.data.pin_mut().push(*byte);
+        }
+        Ok(())
+    }
+}
+
 // Then we import various implementations to this module, for export through the bridge.
 mod b64;
 
 use core::panic;
-use std::hash::Hasher;
 use std::str::FromStr;
 
 use b64::{from_base64, to_base64};
@@ -487,8 +502,11 @@ use rust_bridge::RustBuf;
 use rust_bridge::SorobanVersionInfo;
 
 mod log;
+#[cfg(feature = "testutils")]
 use ::log::{info, warn};
-use log::{init_logging, partition::TX};
+use log::init_logging;
+#[cfg(feature = "testutils")]
+use log::partition::TX;
 
 // We have multiple copies of soroban linked into stellar-core here. This is
 // accomplished using an adaptor module -- contract.rs -- mounted multiple times
@@ -714,7 +732,9 @@ struct HostModule {
     compute_write_fee_per_1kb:
         fn(bucket_list_size: i64, fee_config: CxxWriteFeeConfiguration) -> i64,
     can_parse_transaction: fn(&CxxBuf, depth_limit: u32) -> bool,
+    #[cfg(feature = "testutils")]
     rustbuf_containing_scval_to_string: fn(&RustBuf) -> String,
+    #[cfg(feature = "testutils")]
     rustbuf_containing_diagnostic_event_to_string: fn(&RustBuf) -> String,
 }
 
@@ -730,8 +750,10 @@ macro_rules! proto_versioned_functions_for_module {
             compute_rent_fee: $module::contract::compute_rent_fee,
             compute_write_fee_per_1kb: $module::contract::compute_write_fee_per_1kb,
             can_parse_transaction: $module::contract::can_parse_transaction,
+            #[cfg(feature = "testutils")]
             rustbuf_containing_scval_to_string:
                 $module::contract::rustbuf_containing_scval_to_string,
+            #[cfg(feature = "testutils")]
             rustbuf_containing_diagnostic_event_to_string:
                 $module::contract::rustbuf_containing_diagnostic_event_to_string,
         }
@@ -788,10 +810,10 @@ pub(crate) fn invoke_host_function(
     enable_diagnostics: bool,
     instruction_limit: u32,
     hf_buf: &CxxBuf,
-    resources_buf: &CxxBuf,
+    resources_buf: CxxBuf,
     source_account_buf: &CxxBuf,
     auth_entries: &Vec<CxxBuf>,
-    mut ledger_info: CxxLedgerInfo,
+    ledger_info: CxxLedgerInfo,
     ledger_entries: &Vec<CxxBuf>,
     ttl_entries: &Vec<CxxBuf>,
     base_prng_seed: &CxxBuf,
@@ -802,7 +824,7 @@ pub(crate) fn invoke_host_function(
         enable_diagnostics,
         instruction_limit,
         hf_buf,
-        resources_buf,
+        &resources_buf,
         source_account_buf,
         auth_entries,
         &ledger_info,
@@ -812,103 +834,269 @@ pub(crate) fn invoke_host_function(
         &rent_fee_configuration,
     );
 
-    // The rest of this is for divergence / comparison testing between protocols
-    if let Ok(extra) = std::env::var("SOROBAN_TEST_EXTRA_PROTOCOL") {
-        if let Ok(proto) = u32::from_str(&extra) {
-            info!(target: TX, "comparing soroban host for protocol {} with {}", ledger_info.protocol_version, proto);
-            if let Ok(hm2) = get_host_module_for_protocol(proto, proto) {
-                ledger_info.protocol_version = proto;
-                let res2 = (hm2.invoke_host_function)(
-                    /*enable_diagnostics=*/ true,
-                    instruction_limit,
-                    hf_buf,
-                    resources_buf,
-                    source_account_buf,
-                    auth_entries,
-                    &ledger_info,
-                    ledger_entries,
-                    ttl_entries,
-                    base_prng_seed,
-                    &rent_fee_configuration,
-                );
-                fn hash_rustbuf(buf: &RustBuf) -> u16 {
-                    use std::hash::Hash;
-                    let mut hasher = std::hash::DefaultHasher::new();
-                    buf.data.hash(&mut hasher);
-                    hasher.finish() as u16
-                }
-                fn hash_rustbufs(bufs: &Vec<RustBuf>) -> u16 {
-                    use std::hash::Hash;
-                    let mut hasher = std::hash::DefaultHasher::new();
-                    for buf in bufs.iter() {
-                        buf.data.hash(&mut hasher);
+    #[cfg(feature = "testutils")]
+    test_extra_protocol::maybe_invoke_host_function_again_and_compare_outputs(
+        &res,
+        &hm,
+        config_max_protocol,
+        enable_diagnostics,
+        instruction_limit,
+        hf_buf,
+        resources_buf,
+        source_account_buf,
+        auth_entries,
+        ledger_info,
+        ledger_entries,
+        ttl_entries,
+        base_prng_seed,
+        rent_fee_configuration,
+    );
+
+    res
+}
+
+// This module contains helper code to assist in comparing two versions of
+// soroban against one another by running the same transaction twice on
+// different hosts, and comparing its output for divergence or changes to costs.
+// All this functionality is gated by the "testutils" feature.
+#[cfg(feature = "testutils")]
+mod test_extra_protocol {
+
+    use super::*;
+    use std::hash::Hasher;
+
+    pub(super) fn maybe_invoke_host_function_again_and_compare_outputs(
+        res1: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
+        hm1: &HostModule,
+        _config_max_protocol: u32,
+        _enable_diagnostics: bool,
+        mut instruction_limit: u32,
+        hf_buf: &CxxBuf,
+        mut resources_buf: CxxBuf,
+        source_account_buf: &CxxBuf,
+        auth_entries: &Vec<CxxBuf>,
+        mut ledger_info: CxxLedgerInfo,
+        ledger_entries: &Vec<CxxBuf>,
+        ttl_entries: &Vec<CxxBuf>,
+        base_prng_seed: &CxxBuf,
+        rent_fee_configuration: CxxRentFeeConfiguration,
+    ) {
+        if let Ok(extra) = std::env::var("SOROBAN_TEST_EXTRA_PROTOCOL") {
+            if let Ok(proto) = u32::from_str(&extra) {
+                info!(target: TX, "comparing soroban host for protocol {} with {}", ledger_info.protocol_version, proto);
+                if let Ok(hm2) = get_host_module_for_protocol(proto, proto) {
+                    if let Err(e) =
+                        modify_ledger_info_for_extra_test_execution(&mut ledger_info, proto)
+                    {
+                        warn!(target: TX, "modifying ledger info for protocol {} re-execution failed: {:?}", proto, e);
+                        return;
                     }
-                    hasher.finish() as u16
-                }
-                fn mostly_the_same(
-                    res: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
-                    res2: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
-                ) -> bool {
-                    match (res, res2) {
-                        (Ok(res), Ok(res2)) => {
-                            res.success == res2.success
-                                && hash_rustbuf(&res.result_value)
-                                    == hash_rustbuf(&res2.result_value)
-                                && hash_rustbufs(&res.contract_events)
-                                    == hash_rustbufs(&res2.contract_events)
-                                && hash_rustbufs(&res.modified_ledger_entries)
-                                    == hash_rustbufs(&res2.modified_ledger_entries)
-                                && res.rent_fee == res2.rent_fee
-                        }
-                        (Err(e), Err(e2)) => format!("{:?}", e) == format!("{:?}", e2),
-                        _ => false,
+                    if let Err(e) = modify_resources_for_extra_test_execution(
+                        &mut instruction_limit,
+                        &mut resources_buf,
+                        proto,
+                    ) {
+                        warn!(target: TX, "modifying resources for protocol {} re-execution failed: {:?}", proto, e);
+                        return;
                     }
-                }
-                fn summarize(
-                    hm: &HostModule,
-                    res: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
-                ) -> String {
-                    match res {
-                        Ok(res) if res.success => format!(
-                            "proto={}, ok/succ, res={:x}/{}, events={:x}, entries={:x}, rent={}, cpu={}, mem={}, nsec={}",
-                            hm.max_proto,
-                            hash_rustbuf(&res.result_value),
-                            (hm.rustbuf_containing_scval_to_string)(&res.result_value),
-                            hash_rustbufs(&res.contract_events),
-                            hash_rustbufs(&res.modified_ledger_entries),
-                            res.rent_fee,
-                            res.cpu_insns,
-                            res.mem_bytes,
-                            res.time_nsecs
-                        ),
-                        Ok(res) => format!(
-                            "proto={}, ok/fail, cpu={}, mem={}, nsec={}, diag={:?}",
-                            hm.max_proto,
-                            res.cpu_insns,
-                            res.mem_bytes,
-                            res.time_nsecs,
-                            res.diagnostic_events.iter().map(|d|
-                                (hm.rustbuf_containing_diagnostic_event_to_string)(d)).collect::<Vec<String>>()
-                        ),
-                        Err(e) => format!("proto={}, error={:?}", hm.max_proto, e),
+                    let res2 = (hm2.invoke_host_function)(
+                        /*enable_diagnostics=*/ true,
+                        instruction_limit,
+                        hf_buf,
+                        &resources_buf,
+                        source_account_buf,
+                        auth_entries,
+                        &ledger_info,
+                        ledger_entries,
+                        ttl_entries,
+                        base_prng_seed,
+                        &rent_fee_configuration,
+                    );
+                    if mostly_the_same_host_function_output(&res1, &res2) {
+                        info!(target: TX, "{}", summarize_host_function_output(hm1, &res1));
+                        info!(target: TX, "{}", summarize_host_function_output(hm2, &res2));
+                    } else {
+                        warn!(target: TX, "{}", summarize_host_function_output(hm1, &res1));
+                        warn!(target: TX, "{}", summarize_host_function_output(hm2, &res2));
                     }
-                }
-                if mostly_the_same(&res, &res2) {
-                    info!(target: TX, "{}", summarize(hm, &res));
-                    info!(target: TX, "{}", summarize(hm2, &res2));
                 } else {
-                    warn!(target: TX, "{}", summarize(hm, &res));
-                    warn!(target: TX, "{}", summarize(hm2, &res2));
+                    warn!(target: TX, "SOROBAN_TEST_EXTRA_PROTOCOL={} not supported", proto);
                 }
             } else {
-                warn!(target: TX, "SOROBAN_TEST_EXTRA_PROTOCOL={} not supported", proto);
+                warn!(target: TX, "invalid protocol number in SOROBAN_TEST_EXTRA_PROTOCOL");
             }
-        } else {
-            warn!(target: TX, "invalid protocol number in SOROBAN_TEST_EXTRA_PROTOCOL");
         }
     }
 
-    res
+    fn modify_resources_for_extra_test_execution(
+        instruction_limit: &mut u32,
+        resources_buf: &mut CxxBuf,
+        new_protocol: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match new_protocol {
+            22 => {
+                use soroban_p22::contract::{
+                    inplace_modify_cxxbuf_encoded_type, xdr::SorobanResources,
+                };
+                if let Ok(extra) = std::env::var("SOROBAN_TEST_CPU_BUDGET_FACTOR") {
+                    if let Ok(factor) = u32::from_str(&extra) {
+                        inplace_modify_cxxbuf_encoded_type::<SorobanResources>(
+                            resources_buf,
+                            |resources: &mut SorobanResources| {
+                                info!(target: TX, "multiplying CPU budget for re-execution by {}: {} -> {} (and {} -> {} in limit)",
+                                        factor, resources.instructions, resources.instructions * factor, *instruction_limit, *instruction_limit * factor);
+                                resources.instructions *= factor;
+                                *instruction_limit *= factor;
+                                Ok(())
+                            },
+                        )?;
+                    } else {
+                        warn!(target: TX, "SOROBAN_TEST_CPU_BUDGET_FACTOR={} not valid", extra);
+                    }
+                }
+            }
+            _ => (),
+        }
+        Ok(())
+    }
+
+    fn modify_ledger_info_for_extra_test_execution(
+        ledger_info: &mut CxxLedgerInfo,
+        new_protocol: u32,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Here we need to simulate any upgrade that would be done in the ledger
+        // info to migrate from the old protocol to the new one. This is somewhat
+        // protocol-specific so we just write it by hand.
+
+        // At very least, we always need to upgrade the protocol version in the
+        // ledger info.
+        ledger_info.protocol_version = new_protocol;
+
+        match new_protocol {
+            22 => {
+                use soroban_p22::contract::{
+                    inplace_modify_cxxbuf_encoded_type, xdr::ContractCostParams,
+                    xdr::ContractCostType as CT,
+                };
+                // We have to modify some cost parameters in the ledger info and
+                // add some new ones to simulate p22. Note that a p21
+                // ContractCostParams structure will decode properly as a p22
+                // one, so we can just use the inplace-modify helper function.
+                inplace_modify_cxxbuf_encoded_type::<ContractCostParams>(
+                    &mut ledger_info.cpu_cost_params,
+                    |params: &mut ContractCostParams| {
+                        let mut cpu = params.0.to_vec();
+
+                        // We only adjust the cost types that changed dramatically
+                        // between 21 and 22. The rest are left as-is, they're close
+                        // enough to not matter for side-by-side testing.
+
+                        cpu[CT::VmInstantiation as usize].const_term = 31271;
+                        cpu[CT::VmInstantiation as usize].linear_term = 57504;
+
+                        cpu[CT::ParseWasmInstructions as usize].const_term = 37421;
+                        cpu[CT::ParseWasmInstructions as usize].linear_term = 32;
+
+                        cpu[CT::ParseWasmFunctions as usize].const_term = 0;
+                        cpu[CT::ParseWasmFunctions as usize].linear_term = 84156;
+
+                        cpu[CT::ParseWasmDataSegmentBytes as usize].const_term = 0;
+                        cpu[CT::ParseWasmDataSegmentBytes as usize].linear_term = 14;
+
+                        params.0 = cpu
+                            .try_into()
+                            .map_err(|_| "failed to convert VecM back to array")?;
+                        Ok(())
+                    },
+                )?;
+
+                inplace_modify_cxxbuf_encoded_type::<ContractCostParams>(
+                    &mut ledger_info.mem_cost_params,
+                    |params: &mut ContractCostParams| {
+                        let mut mem = params.0.to_vec();
+
+                        mem[CT::ParseWasmInstructions as usize].const_term = 13980;
+                        mem[CT::ParseWasmInstructions as usize].linear_term = 215;
+
+                        mem[CT::ParseWasmFunctions as usize].const_term = 0;
+                        mem[CT::ParseWasmFunctions as usize].linear_term = 23056;
+
+                        mem[CT::ParseWasmDataSegmentBytes as usize].const_term = 0;
+                        mem[CT::ParseWasmDataSegmentBytes as usize].linear_term = 129;
+
+                        params.0 = mem
+                            .try_into()
+                            .map_err(|_| "failed to convert VecM back to array")?;
+                        Ok(())
+                    },
+                )?;
+            }
+            _ => (),
+        }
+
+        Ok(())
+    }
+
+    fn hash_rustbuf(buf: &RustBuf) -> u16 {
+        use std::hash::Hash;
+        let mut hasher = std::hash::DefaultHasher::new();
+        buf.data.hash(&mut hasher);
+        hasher.finish() as u16
+    }
+    fn hash_rustbufs(bufs: &Vec<RustBuf>) -> u16 {
+        use std::hash::Hash;
+        let mut hasher = std::hash::DefaultHasher::new();
+        for buf in bufs.iter() {
+            buf.data.hash(&mut hasher);
+        }
+        hasher.finish() as u16
+    }
+    fn mostly_the_same_host_function_output(
+        res: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
+        res2: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
+    ) -> bool {
+        match (res, res2) {
+            (Ok(res), Ok(res2)) => {
+                res.success == res2.success
+                    && hash_rustbuf(&res.result_value) == hash_rustbuf(&res2.result_value)
+                    && hash_rustbufs(&res.contract_events) == hash_rustbufs(&res2.contract_events)
+                    && hash_rustbufs(&res.modified_ledger_entries)
+                        == hash_rustbufs(&res2.modified_ledger_entries)
+                    && res.rent_fee == res2.rent_fee
+            }
+            (Err(e), Err(e2)) => format!("{:?}", e) == format!("{:?}", e2),
+            _ => false,
+        }
+    }
+    fn summarize_host_function_output(
+        hm: &HostModule,
+        res: &Result<InvokeHostFunctionOutput, Box<dyn std::error::Error>>,
+    ) -> String {
+        match res {
+            Ok(res) if res.success => format!(
+                "proto={}, ok/succ, res={:x}/{}, events={:x}, entries={:x}, rent={}, cpu={}, mem={}, nsec={}",
+                hm.max_proto,
+                hash_rustbuf(&res.result_value),
+                (hm.rustbuf_containing_scval_to_string)(&res.result_value),
+                hash_rustbufs(&res.contract_events),
+                hash_rustbufs(&res.modified_ledger_entries),
+                res.rent_fee,
+                res.cpu_insns,
+                res.mem_bytes,
+                res.time_nsecs
+            ),
+            Ok(res) => format!(
+                "proto={}, ok/fail, cpu={}, mem={}, nsec={}, diag={:?}",
+                hm.max_proto,
+                res.cpu_insns,
+                res.mem_bytes,
+                res.time_nsecs,
+                res.diagnostic_events.iter().map(|d|
+                    (hm.rustbuf_containing_diagnostic_event_to_string)(d)).collect::<Vec<String>>()
+            ),
+            Err(e) => format!("proto={}, error={:?}", hm.max_proto, e),
+        }
+    }
 }
 
 pub(crate) fn compute_transaction_resource_fee(


### PR DESCRIPTION
This implements an idea @MonsieurNicolas proposed recently: now that we have fairly easy "by version number" selection among different soroban hosts, we can run any given transaction _twice_ during offline replay to see (a) whether it produces the same side effects and (b) whether it performs the same or different.

It works during any tx application -- offilne catchup or online execution -- you just set `SOROBAN_TEST_EXTRA_PROTOCOL=22` (say) and while replaying a p21 tx it'll also execute it on p22 and report a summary of both txs side by side. You may also need to set `SOROBAN_TEST_CPU_BUDGET_FACTOR=2` or so to give a bit more budget wiggle room to txs that might have higher execution costs.