### PR TITLE
Visual Studio/MSVC build fixes

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -125,7 +125,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>CEREAL_THREAD_SAFE;USE_POSTGRES;ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION=1;USE_SPDLOG;FMT_HEADER_ONLY=1;BUILD_TESTS;WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_NO_BROADCAST;TRACY_ONLY_LOCALHOST;TRACY_DELAYED_INIT;TRACY_MANUAL_LIFETIME;USE_TRACY;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../../lib/util;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -186,7 +186,7 @@ exit /b 0
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>CEREAL_THREAD_SAFE;USE_POSTGRES;USE_SPDLOG;FMT_HEADER_ONLY=1;BUILD_TESTS;WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_NO_BROADCAST;TRACY_ONLY_LOCALHOST;TRACY_DELAYED_INIT;TRACY_MANUAL_LIFETIME;USE_TRACY;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../../lib/util;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -248,7 +248,7 @@ exit /b 0
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>CEREAL_THREAD_SAFE;ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION=1;USE_SPDLOG;FMT_HEADER_ONLY=1;BUILD_TESTS;WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_NO_BROADCAST;TRACY_ONLY_LOCALHOST;TRACY_DELAYED_INIT;TRACY_MANUAL_LIFETIME;USE_TRACY;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../../lib/util;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <MinimalRebuild>false</MinimalRebuild>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -314,7 +314,7 @@ exit /b 0
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>CEREAL_THREAD_SAFE;USE_POSTGRES;ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION=1;USE_SPDLOG;FMT_HEADER_ONLY=1;BUILD_TESTS;WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_NO_BROADCAST;TRACY_ONLY_LOCALHOST;TRACY_DELAYED_INIT;TRACY_MANUAL_LIFETIME;USE_TRACY;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../../lib/util;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <BrowseInformation>false</BrowseInformation>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -375,7 +375,7 @@ exit /b 0
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>CEREAL_THREAD_SAFE;USE_POSTGRES;USE_SPDLOG;FMT_HEADER_ONLY=1;BUILD_TESTS;WIN32_LEAN_AND_MEAN;NOMINMAX;ASIO_STANDALONE;_WINSOCK_DEPRECATED_NO_WARNINGS;SODIUM_STATIC;ASIO_SEPARATE_COMPILATION;ASIO_ERROR_CATEGORY_NOEXCEPT=noexcept;TRACY_ENABLE;TRACY_ON_DEMAND;TRACY_NO_BROADCAST;TRACY_ONLY_LOCALHOST;TRACY_DELAYED_INIT;TRACY_MANUAL_LIFETIME;USE_TRACY;_CRT_SECURE_NO_WARNINGS;_WIN32_WINNT=0x0601;WIN32;_MBCS;_CRT_NONSTDC_NO_DEPRECATE;YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>src;../../src;../../lib;../../lib/tracy/public/tracy;../../lib/spdlog/include;../../lib/libmedida/src;../../lib/soci/src/core;../../lib/autocheck/include;../../lib/cereal/include;../../lib/asio/asio/include;../../lib/xdrpp;../../lib/libsodium/src/libsodium/include;../../lib/fmt/include;../../lib/util;../..;src/$(Configuration)/generated;../../lib/sqlite;c:\Program Files\PostgreSQL\15\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <BrowseInformation>false</BrowseInformation>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DisableSpecificWarnings>4060;4100;4127;4324;4408;4510;4512;4582;4583;4592</DisableSpecificWarnings>
@@ -430,6 +430,34 @@ exit /b 0
     </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\lib\httpthreaded\connection.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\reply.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\request_parser.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\server.cpp">
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugCurrV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='DebugNoPostgres|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='ReleaseNextV|x64'">$(IntDir)\httpthreaded\</ObjectFileName>
+    </ClCompile>
     <ClCompile Include="..\..\lib\spdlog.cpp" />
     <ClCompile Include="..\..\lib\tracy\public\TracyClient.cpp" />
     <ClCompile Include="..\..\lib\util\siphash.cpp" />
@@ -592,6 +620,7 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\SorobanMetrics.cpp" />
     <ClCompile Include="..\..\src\ledger\TrustLineWrapper.cpp" />
     <ClCompile Include="..\..\src\main\Diagnostics.cpp" />
+    <ClCompile Include="..\..\src\main\QueryServer.cpp" />
     <ClCompile Include="..\..\src\main\SettingsUpgradeUtils.cpp" />
     <ClCompile Include="..\..\src\main\test\ApplicationUtilsTests.cpp" />
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp" />
@@ -657,6 +686,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\ManageOfferOpFrameBase.cpp" />
     <ClCompile Include="..\..\src\transactions\ManageSellOfferOpFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\MergeOpFrame.cpp" />
+    <ClCompile Include="..\..\src\transactions\MutableTransactionResult.cpp" />
     <ClCompile Include="..\..\src\transactions\OfferExchange.cpp" />
     <ClCompile Include="..\..\src\transactions\OperationFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\PathPaymentOpFrameBase.cpp" />
@@ -699,6 +729,7 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\test\SignatureUtilsTest.cpp" />
     <ClCompile Include="..\..\src\transactions\test\SorobanTxTestUtils.cpp" />
     <ClCompile Include="..\..\src\transactions\test\SponsorshipTestUtils.cpp" />
+    <ClCompile Include="..\..\src\transactions\test\TransactionTestFrame.cpp" />
     <ClCompile Include="..\..\src\transactions\test\TxEnvelopeTests.cpp" />
     <ClCompile Include="..\..\src\transactions\test\TxResultsTests.cpp" />
     <ClCompile Include="..\..\src\transactions\TransactionBridge.cpp" />
@@ -709,12 +740,14 @@ exit /b 0
     <ClCompile Include="..\..\src\transactions\TransactionUtils.cpp" />
     <ClCompile Include="..\..\src\transactions\TrustFlagsOpFrameBase.cpp" />
     <ClCompile Include="..\..\src\util\Backtrace.cpp" />
+    <ClCompile Include="..\..\src\util\BinaryFuseFilter.cpp" />
     <ClCompile Include="..\..\src\util\DebugMetaUtils.cpp" />
     <ClCompile Include="..\..\src\util\FileSystemException.cpp" />
     <ClCompile Include="..\..\src\util\ProtocolVersion.cpp" />
     <ClCompile Include="..\..\src\util\LogSlowExecution.cpp" />
     <ClCompile Include="..\..\src\util\RandHasher.cpp" />
     <ClCompile Include="..\..\src\util\Scheduler.cpp" />
+    <ClCompile Include="..\..\src\util\test\BinaryFuseTests.cpp" />
     <ClCompile Include="..\..\src\util\test\MetricTests.cpp" />
     <ClCompile Include="..\..\src\util\test\SchedulerTests.cpp" />
     <ClCompile Include="..\..\src\util\TxResource.cpp" />
@@ -875,6 +908,12 @@ exit /b 0
   <ItemGroup>
     <ClInclude Include="..\..\lib\catch.hpp" />
     <ClInclude Include="..\..\lib\clara.hpp" />
+    <ClInclude Include="..\..\lib\httpthreaded\connection.hpp" />
+    <ClInclude Include="..\..\lib\httpthreaded\header.hpp" />
+    <ClInclude Include="..\..\lib\httpthreaded\reply.hpp" />
+    <ClInclude Include="..\..\lib\httpthreaded\request.hpp" />
+    <ClInclude Include="..\..\lib\httpthreaded\request_parser.hpp" />
+    <ClInclude Include="..\..\lib\httpthreaded\server.hpp" />
     <ClInclude Include="..\..\lib\util\finally.h" />
     <ClInclude Include="..\..\lib\fmt\include\fmt\format.h" />
     <ClInclude Include="..\..\lib\util\siphash.h" />
@@ -1013,6 +1052,7 @@ exit /b 0
     <ClInclude Include="..\..\src\ledger\SorobanMetrics.h" />
     <ClInclude Include="..\..\src\ledger\TrustLineWrapper.h" />
     <ClInclude Include="..\..\src\main\Diagnostics.h" />
+    <ClInclude Include="..\..\src\main\QueryServer.h" />
     <ClInclude Include="..\..\src\main\SettingsUpgradeUtils.h" />
     <ClInclude Include="..\..\src\overlay\BanManager.h" />
     <ClInclude Include="..\..\src\overlay\BanManagerImpl.h" />
@@ -1066,6 +1106,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\ManageOfferOpFrameBase.h" />
     <ClInclude Include="..\..\src\transactions\ManageSellOfferOpFrame.h" />
     <ClInclude Include="..\..\src\transactions\MergeOpFrame.h" />
+    <ClInclude Include="..\..\src\transactions\MutableTransactionResult.h" />
     <ClInclude Include="..\..\src\transactions\OfferExchange.h" />
     <ClInclude Include="..\..\src\transactions\OperationFrame.h" />
     <ClInclude Include="..\..\src\transactions\PathPaymentOpFrameBase.h" />
@@ -1081,6 +1122,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\SponsorshipUtils.h" />
     <ClInclude Include="..\..\src\transactions\test\SorobanTxTestUtils.h" />
     <ClInclude Include="..\..\src\transactions\test\SponsorshipTestUtils.h" />
+    <ClInclude Include="..\..\src\transactions\test\TransactionTestFrame.h" />
     <ClInclude Include="..\..\src\transactions\TransactionBridge.h" />
     <ClInclude Include="..\..\src\transactions\TransactionFrame.h" />
     <ClInclude Include="..\..\src\transactions\TransactionFrameBase.h" />
@@ -1089,6 +1131,7 @@ exit /b 0
     <ClInclude Include="..\..\src\transactions\TransactionUtils.h" />
     <ClInclude Include="..\..\src\transactions\TrustFlagsOpFrameBase.h" />
     <ClInclude Include="..\..\src\util\Backtrace.h" />
+    <ClInclude Include="..\..\src\util\BinaryFuseFilter.h" />
     <ClInclude Include="..\..\src\util\DebugMetaUtils.h" />
     <ClInclude Include="..\..\src\util\Decoder.h" />
     <ClInclude Include="..\..\src\util\ProtocolVersion.h" />
@@ -1584,8 +1627,8 @@ exit /b 0
     <None Include="..\..\src\rust\Cargo.toml" />
     <CustomBuild Include="..\..\src\rust\src\lib.rs">
       <FileType>Document</FileType>
-      <Command>$(OutDir)\bin\cxxbridge.exe ..\..\src\rust\src\lib.rs --header --output src\$(Configuration)\generated\rust\RustBridge.h
-$(OutDir)\bin\cxxbridge.exe ..\..\src\rust\src\lib.rs --output src\$(Configuration)\generated\rust\RustBridge.cpp</Command>
+      <Command>$(OutDir)\bin\cxxbridge.exe ..\..\src\rust\src\lib.rs --cfg test=false --header --output src\$(Configuration)\generated\rust\RustBridge.h
+$(OutDir)\bin\cxxbridge.exe ..\..\src\rust\src\lib.rs --cfg test=false --output src\$(Configuration)\generated\rust\RustBridge.cpp</Command>
       <Message>running cxxbridge to generate RustBridge.h and RustBridge.cpp</Message>
       <Outputs>src\$(Configuration)\generated\rust\RustBridge.h;src\$(Configuration)\generated\rust\RustBridge.cpp</Outputs>
       <OutputItemType>ClInclude</OutputItemType>

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -178,6 +178,9 @@
     <Filter Include="generated">
       <UniqueIdentifier>{f421dda1-de1d-43af-b5b8-138a24c87cd2}</UniqueIdentifier>
     </Filter>
+    <Filter Include="lib\httpthreaded">
+      <UniqueIdentifier>{feb33c2b-4955-4db8-b62d-72cbc3129a44}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\lib\util\getopt_long.c">
@@ -1347,6 +1350,33 @@
     <ClCompile Include="..\..\src\overlay\Hmac.cpp">
       <Filter>overlay</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\transactions\test\TransactionTestFrame.cpp">
+      <Filter>transactions\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\BinaryFuseFilter.cpp">
+      <Filter>util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\util\test\BinaryFuseTests.cpp">
+      <Filter>util\tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\transactions\MutableTransactionResult.cpp">
+      <Filter>transactions</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\connection.cpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\reply.cpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\request_parser.cpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\httpthreaded\server.cpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\main\QueryServer.cpp">
+      <Filter>main</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\util\cpptoml.h">
@@ -2341,6 +2371,36 @@
     </ClInclude>
     <ClInclude Include="..\..\src\overlay\Hmac.h">
       <Filter>overlay</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\transactions\test\TransactionTestFrame.h">
+      <Filter>transactions\tests</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\util\BinaryFuseFilter.h">
+      <Filter>util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\transactions\MutableTransactionResult.h">
+      <Filter>transactions</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\httpthreaded\connection.hpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\httpthreaded\header.hpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\httpthreaded\reply.hpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\httpthreaded\request.hpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\httpthreaded\request_parser.hpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\httpthreaded\server.hpp">
+      <Filter>lib\httpthreaded</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\main\QueryServer.h">
+      <Filter>main</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/lib/binaryfusefilter.h
+++ b/lib/binaryfusefilter.h
@@ -41,7 +41,7 @@ sip_hash24(uint64_t key, binary_fuse_seed_t const& seed)
 static inline uint64_t
 binary_fuse_rotl64(uint64_t n, unsigned int c)
 {
-    return (n << (c & 63)) | (n >> ((-c) & 63));
+    return (n << (c & 63)) | (n >> ((0u - c) & 63));
 }
 static inline uint32_t
 binary_fuse_reduce(uint32_t hash, uint32_t n)

--- a/src/bucket/BucketIndexImpl.cpp
+++ b/src/bucket/BucketIndexImpl.cpp
@@ -84,7 +84,7 @@ BucketIndexImpl<IndexT>::BucketIndexImpl(BucketManager& bm,
         // the page size ahead of time
         if constexpr (std::is_same<IndexT, RangeIndex>::value)
         {
-            auto fileSize = fs::size(filename);
+            auto fileSize = std::filesystem::file_size(filename);
             auto estimatedIndexEntries = fileSize / mData.pageSize;
             mData.keysToOffset.reserve(estimatedIndexEntries);
         }

--- a/src/bucket/BucketListSnapshot.h
+++ b/src/bucket/BucketListSnapshot.h
@@ -64,7 +64,7 @@ class SearchableBucketListSnapshot : public NonMovableOrCopyable
 
     SearchableBucketListSnapshot(BucketSnapshotManager const& snapshotManager);
 
-    friend std::unique_ptr<SearchableBucketListSnapshot>
+    friend std::shared_ptr<SearchableBucketListSnapshot>
     BucketSnapshotManager::copySearchableBucketListSnapshot() const;
 
   public:

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -1000,6 +1000,8 @@ BucketManagerImpl::startBackgroundEvictionScan(uint32_t ledgerSeq)
     auto const& sas = cfg.stateArchivalSettings();
 
     using task_t = std::packaged_task<EvictionResult()>;
+    // MSVC gotcha: searchableBL has to be shared_ptr because MSVC wants to
+    // copy this lambda, otherwise we could use unique_ptr.
     auto task = std::make_shared<task_t>(
         [bl = std::move(searchableBL), iter = cfg.evictionIterator(), ledgerSeq,
          sas, &counters = mBucketListEvictionCounters,

--- a/src/bucket/BucketSnapshotManager.cpp
+++ b/src/bucket/BucketSnapshotManager.cpp
@@ -31,11 +31,11 @@ BucketSnapshotManager::BucketSnapshotManager(
     releaseAssert(threadIsMain());
 }
 
-std::unique_ptr<SearchableBucketListSnapshot>
+std::shared_ptr<SearchableBucketListSnapshot>
 BucketSnapshotManager::copySearchableBucketListSnapshot() const
 {
-    // Can't use std::make_unique due to private constructor
-    return std::unique_ptr<SearchableBucketListSnapshot>(
+    // Can't use std::make_shared due to private constructor
+    return std::shared_ptr<SearchableBucketListSnapshot>(
         new SearchableBucketListSnapshot(*this));
 }
 

--- a/src/bucket/BucketSnapshotManager.h
+++ b/src/bucket/BucketSnapshotManager.h
@@ -81,7 +81,7 @@ class BucketSnapshotManager : NonMovableOrCopyable
                           std::unique_ptr<BucketListSnapshot const>&& snapshot,
                           uint32_t numHistoricalLedgers);
 
-    std::unique_ptr<SearchableBucketListSnapshot>
+    std::shared_ptr<SearchableBucketListSnapshot>
     copySearchableBucketListSnapshot() const;
 
     // Checks if snapshot is out of date with mCurrentSnapshot and updates

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -737,7 +737,7 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
-    mutable std::unique_ptr<SearchableBucketListSnapshot>
+    mutable std::shared_ptr<SearchableBucketListSnapshot>
         mSearchableBucketListSnapshot{};
 
     size_t mBulkLoadBatchSize;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -996,6 +996,17 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
         }
         std::vector<ValidatorEntry> validators;
         UnorderedMap<std::string, ValidatorQuality> domainQualityMap;
+        UnorderedMap<std::string, uint32_t*> uint32WithMax1Flags = {
+            {"PEER_READING_CAPACITY", &PEER_READING_CAPACITY},
+            {"PEER_FLOOD_READING_CAPACITY", &PEER_FLOOD_READING_CAPACITY},
+            {"FLOW_CONTROL_SEND_MORE_BATCH_SIZE",
+             &FLOW_CONTROL_SEND_MORE_BATCH_SIZE},
+            {"PEER_FLOOD_READING_CAPACITY_BYTES",
+             &PEER_FLOOD_READING_CAPACITY_BYTES},
+            {"FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES",
+             &FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES},
+            {"OUTBOUND_TX_QUEUE_BYTE_LIMIT", &OUTBOUND_TX_QUEUE_BYTE_LIMIT},
+        };
 
         // cpptoml returns the items in non-deterministic order
         // so we need to process items that are potential dependencies first
@@ -1012,33 +1023,14 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 logIfSet(item,
                          "node may not function properly with most networks");
             }
+            auto uint32WithMax1It = uint32WithMax1Flags.find(item.first);
+            if (uint32WithMax1It != uint32WithMax1Flags.end())
+            {
+                *uint32WithMax1It->second = readInt<uint32_t>(item, 1);
+                continue;
+            }
 
-            if (item.first == "PEER_READING_CAPACITY")
-            {
-                PEER_READING_CAPACITY = readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "PEER_FLOOD_READING_CAPACITY")
-            {
-                PEER_FLOOD_READING_CAPACITY = readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "FLOW_CONTROL_SEND_MORE_BATCH_SIZE")
-            {
-                FLOW_CONTROL_SEND_MORE_BATCH_SIZE = readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "PEER_FLOOD_READING_CAPACITY_BYTES")
-            {
-                PEER_FLOOD_READING_CAPACITY_BYTES = readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES")
-            {
-                FLOW_CONTROL_SEND_MORE_BATCH_SIZE_BYTES =
-                    readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "OUTBOUND_TX_QUEUE_BYTE_LIMIT")
-            {
-                OUTBOUND_TX_QUEUE_BYTE_LIMIT = readInt<uint32_t>(item, 1);
-            }
-            else if (item.first == "PEER_PORT")
+            if (item.first == "PEER_PORT")
             {
                 PEER_PORT = readInt<unsigned short>(item, 1);
             }

--- a/src/main/QueryServer.h
+++ b/src/main/QueryServer.h
@@ -26,7 +26,7 @@ class QueryServer
     httpThreaded::server::server mServer;
 
     std::unordered_map<std::thread::id,
-                       std::unique_ptr<SearchableBucketListSnapshot>>
+                       std::shared_ptr<SearchableBucketListSnapshot>>
         mBucketListSnapshots;
 
     bool safeRouter(HandlerRoute route, std::string const& params,

--- a/src/rust/src/contract.rs
+++ b/src/rust/src/contract.rs
@@ -204,9 +204,9 @@ pub fn get_soroban_version_info(core_max_proto: u32) -> SorobanVersionInfo {
             }
             if core_max_proto != env_max_proto {
                 warn!(
-                    "soroban version {} XDR module built with 'next' feature, \
+                    "soroban version {} XDR module for env version {} built with 'next' feature, \
                        even though this is not the newest core protocol ({})",
-                    VERSION.pkg, core_max_proto
+                    VERSION.pkg, env_max_proto, core_max_proto
                 );
                 warn!(
                     "this can happen if multiple soroban crates depend on the \


### PR DESCRIPTION
# Description

This solves a number of issue that have broken MSVC build:

- VS project fixes
- Duplicate object names
- Some MSVC-exclusive compile errors
  - Notably, MSVC has reached the limit of the code branching in Config.cpp. I did a small fix, but probably we should adapt the map pattern to more parameters

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
