### PR TITLE
Fix `runHistoricalSnapshotTest` LE generation.

### DIFF
--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -111,7 +111,9 @@ class BucketIndexTest
     runHistoricalSnapshotTest()
     {
         uint32_t ledger = 0;
-        auto canonicalEntry = LedgerTestUtils::generateValidLedgerEntry();
+        auto canonicalEntry =
+            LedgerTestUtils::generateValidLedgerEntryWithExclusions(
+                {LedgerEntryType::CONFIG_SETTING});
         canonicalEntry.lastModifiedLedgerSeq = 0;
 
         do


### PR DESCRIPTION
# Description

Fix `runHistoricalSnapshotTest` LE generation.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
