### PR TITLE
Update weight function to fix bias in nomination

### DIFF
--- a/docs/stellar-core_example.cfg
+++ b/docs/stellar-core_example.cfg
@@ -634,6 +634,10 @@ EMIT_SOROBAN_TRANSACTION_META_EXT_V1=false
 # https://github.com/stellar/stellar-xdr/commit/cdc339f5e74a75e8e558fd1a853397da71f1659a
 EMIT_LEDGER_CLOSE_META_EXT_V1=false
 
+# When set to true, Core will revert to using the old, application-agnostic
+# nomination weight function for SCP leader election.
+FORCE_OLD_STYLE_LEADER_ELECTION=false
+
 # EXCLUDE_TRANSACTIONS_CONTAINING_OPERATION_TYPE (list of strings) default is empty
 # Setting this will cause the node to reject transactions that it receives if
 # they contain any operation in this list. It will not, however, stop the node

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -216,6 +216,67 @@ TEST_CASE("load validators config", "[config]")
     REQUIRE(c.KNOWN_PEERS.size() == 13);
     REQUIRE(c.PREFERRED_PEERS.size() == 2); // 2 other "domainA" validators
     REQUIRE(c.HISTORY.size() == 20);
+
+    // Check that VALIDATOR_WEIGHT_CONFIG is correctly loaded
+    SECTION("VALIDATOR_WEIGHT_CONFIG")
+    {
+        REQUIRE(c.VALIDATOR_WEIGHT_CONFIG.has_value());
+        ValidatorWeightConfig const& vwc = c.VALIDATOR_WEIGHT_CONFIG.value();
+
+        // Should be 30 validators, counting 'self'
+        REQUIRE(vwc.mValidatorEntries.size() == 30);
+
+        // Check a validator with a home domain defined in [[HOME_DOMAINS]]
+        NodeID const e2 = KeyUtils::fromStrKey<NodeID>(
+            "GCBEPQHP3D42OHQMA54NRF3E4BAJ6T7NZP7Q7URI2VWNQDJPXTDA3SBJ");
+        ValidatorEntry const& e2Entry = vwc.mValidatorEntries.at(e2);
+        REQUIRE(e2Entry.mName == "e2");
+        REQUIRE(e2Entry.mHomeDomain == "domainE");
+        REQUIRE(e2Entry.mQuality == ValidatorQuality::VALIDATOR_LOW_QUALITY);
+        REQUIRE(e2Entry.mKey == e2);
+        REQUIRE(!e2Entry.mHasHistory);
+
+        // Check a validator with a home domain not defined in [[HOME_DOMAINS]]
+        NodeID const d1 = KeyUtils::fromStrKey<NodeID>(
+            "GDD3QN464732BXOZ7UZ43I5KR76X5YPNCUZMUCI4HJXRYQL4EJR6QAZL");
+        ValidatorEntry const& d1Entry = vwc.mValidatorEntries.at(d1);
+        REQUIRE(d1Entry.mName == "d1");
+        REQUIRE(d1Entry.mHomeDomain == "domainD");
+        REQUIRE(d1Entry.mQuality == ValidatorQuality::VALIDATOR_MED_QUALITY);
+        REQUIRE(d1Entry.mKey == d1);
+        REQUIRE(!d1Entry.mHasHistory);
+
+        // Check self
+        NodeID const self = c.NODE_SEED.getPublicKey();
+        ValidatorEntry const& selfEntry = vwc.mValidatorEntries.at(self);
+        REQUIRE(selfEntry.mName == "self");
+        REQUIRE(selfEntry.mHomeDomain == "domainA");
+        REQUIRE(selfEntry.mQuality == ValidatorQuality::VALIDATOR_HIGH_QUALITY);
+        REQUIRE(selfEntry.mKey == self);
+        REQUIRE(!selfEntry.mHasHistory);
+
+        // Check home-domain count for each domain
+        UnorderedMap<std::string, uint64> const expectedHomeDomainSizes = {
+            {"domainA", 3}, {"domainB", 3}, {"domainC", 2}, {"domainD", 2},
+            {"domainE", 3}, {"domainF", 1}, {"domainG", 1}, {"domainH", 1},
+            {"domainI", 1}, {"domainJ", 1}, {"domainK", 3}, {"domainL", 3},
+            {"domainM", 3}, {"domainN", 3}};
+        REQUIRE(vwc.mHomeDomainSizes == expectedHomeDomainSizes);
+
+        // Check quality weights
+        UnorderedMap<ValidatorQuality, uint64> const expectedQualityWeights = {
+            {ValidatorQuality::VALIDATOR_LOW_QUALITY, 0},
+            // Denominator is 1600 because there are 3 HIGH orgs + 1 virtual org
+            // containing the MED orgs. This means the quality level should be
+            // HIGH_QUALITY_WEIGHT / (4 * 10), or
+            // UINT64_MAX / 40 / (4 * 10), which is UINT64_MAX / 1600
+            {ValidatorQuality::VALIDATOR_MED_QUALITY, UINT64_MAX / 1600},
+            // Denominator is 40 because there are 3 CRITICAL orgs + 1 virtual
+            // org containing the HIGH quality orgs
+            {ValidatorQuality::VALIDATOR_HIGH_QUALITY, UINT64_MAX / 40},
+            {ValidatorQuality::VALIDATOR_CRITICAL_QUALITY, UINT64_MAX}};
+        REQUIRE(vwc.mQualityWeights == expectedQualityWeights);
+    }
 }
 
 TEST_CASE("bad validators configs", "[config]")

--- a/src/scp/LocalNode.cpp
+++ b/src/scp/LocalNode.cpp
@@ -89,50 +89,6 @@ LocalNode::forAllNodes(SCPQuorumSet const& qset,
     return true;
 }
 
-uint64
-LocalNode::computeWeight(uint64 m, uint64 total, uint64 threshold)
-{
-    uint64 res;
-    releaseAssert(threshold <= total);
-    // Since threshold <= total, calculating res=m*threshold/total will always
-    // produce res <= m, and we do not need to handle the possibility of this
-    // call returning false (indicating overflow).
-    bool noOverflow = bigDivideUnsigned(res, m, threshold, total, ROUND_UP);
-    releaseAssert(noOverflow);
-    return res;
-}
-
-// if a validator is repeated multiple times its weight is only the
-// weight of the first occurrence
-uint64
-LocalNode::getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset)
-{
-    uint64 n = qset.threshold;
-    uint64 d = qset.innerSets.size() + qset.validators.size();
-    uint64 res;
-
-    for (auto const& qsetNode : qset.validators)
-    {
-        if (qsetNode == nodeID)
-        {
-            res = computeWeight(UINT64_MAX, d, n);
-            return res;
-        }
-    }
-
-    for (auto const& q : qset.innerSets)
-    {
-        uint64 leafW = getNodeWeight(nodeID, q);
-        if (leafW)
-        {
-            res = computeWeight(leafW, d, n);
-            return res;
-        }
-    }
-
-    return 0;
-}
-
 bool
 LocalNode::isQuorumSliceInternal(SCPQuorumSet const& qset,
                                  std::vector<NodeID> const& nodeSet)

--- a/src/scp/LocalNode.h
+++ b/src/scp/LocalNode.h
@@ -50,10 +50,6 @@ class LocalNode
     static bool forAllNodes(SCPQuorumSet const& qset,
                             std::function<bool(NodeID const&)> proc);
 
-    // returns the weight of the node within the qset
-    // normalized between 0-UINT64_MAX
-    static uint64 getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset);
-
     // Tests this node against nodeSet for the specified qSethash.
     static bool isQuorumSlice(SCPQuorumSet const& qSet,
                               std::vector<NodeID> const& nodeSet);
@@ -107,8 +103,6 @@ class LocalNode
     static SCPQuorumSet fromJson(Json::Value const& qSetJson);
 
     std::string to_string(SCPQuorumSet const& qSet) const;
-
-    static uint64 computeWeight(uint64 m, uint64 total, uint64 threshold);
 
   protected:
     // returns a quorum set {{ nodeID }}

--- a/src/scp/SCPDriver.h
+++ b/src/scp/SCPDriver.h
@@ -179,6 +179,12 @@ class SCPDriver
     // quorum can exchange 4 messages
     virtual std::chrono::milliseconds computeTimeout(uint32 roundNumber);
 
+    // returns the weight of the node within the qset normalized between
+    // 0-UINT64_MAX. If `nodeID` is the local node, then set `isLocalNode` to
+    // `true`.
+    virtual uint64 getNodeWeight(NodeID const& nodeID, SCPQuorumSet const& qset,
+                                 bool isLocalNode) const;
+
     // Inform about events happening within the consensus algorithm.
 
     // `valueExternalized` is called at most once per slot when the slot

--- a/src/scp/test/SCPUnitTests.cpp
+++ b/src/scp/test/SCPUnitTests.cpp
@@ -15,40 +15,6 @@ isNear(uint64 r, double target)
     return (std::abs(v - target) < .01);
 }
 
-TEST_CASE("nomination weight", "[scp]")
-{
-    SIMULATION_CREATE_NODE(0);
-    SIMULATION_CREATE_NODE(1);
-    SIMULATION_CREATE_NODE(2);
-    SIMULATION_CREATE_NODE(3);
-    SIMULATION_CREATE_NODE(4);
-    SIMULATION_CREATE_NODE(5);
-
-    SCPQuorumSet qSet;
-    qSet.threshold = 3;
-    qSet.validators.push_back(v0NodeID);
-    qSet.validators.push_back(v1NodeID);
-    qSet.validators.push_back(v2NodeID);
-    qSet.validators.push_back(v3NodeID);
-
-    uint64 result = LocalNode::getNodeWeight(v2NodeID, qSet);
-
-    REQUIRE(isNear(result, .75));
-
-    result = LocalNode::getNodeWeight(v4NodeID, qSet);
-    REQUIRE(result == 0);
-
-    SCPQuorumSet iQSet;
-    iQSet.threshold = 1;
-    iQSet.validators.push_back(v4NodeID);
-    iQSet.validators.push_back(v5NodeID);
-    qSet.innerSets.push_back(iQSet);
-
-    result = LocalNode::getNodeWeight(v4NodeID, qSet);
-
-    REQUIRE(isNear(result, .6 * .5));
-}
-
 class TestNominationSCP : public SCPDriver
 {
   public:
@@ -134,6 +100,42 @@ class TestNominationSCP : public SCPDriver
         return hasher.finish();
     }
 };
+
+TEST_CASE("nomination weight", "[scp]")
+{
+    SIMULATION_CREATE_NODE(0);
+    SIMULATION_CREATE_NODE(1);
+    SIMULATION_CREATE_NODE(2);
+    SIMULATION_CREATE_NODE(3);
+    SIMULATION_CREATE_NODE(4);
+    SIMULATION_CREATE_NODE(5);
+
+    SCPQuorumSet qSet;
+    qSet.threshold = 3;
+    qSet.validators.push_back(v0NodeID);
+    qSet.validators.push_back(v1NodeID);
+    qSet.validators.push_back(v2NodeID);
+    qSet.validators.push_back(v3NodeID);
+
+    TestNominationSCP const nomSCP(v0NodeID, qSet);
+
+    uint64 result = nomSCP.getNodeWeight(v2NodeID, qSet, false);
+
+    REQUIRE(isNear(result, .75));
+
+    result = nomSCP.getNodeWeight(v4NodeID, qSet, false);
+    REQUIRE(result == 0);
+
+    SCPQuorumSet iQSet;
+    iQSet.threshold = 1;
+    iQSet.validators.push_back(v4NodeID);
+    iQSet.validators.push_back(v5NodeID);
+    qSet.innerSets.push_back(iQSet);
+
+    result = nomSCP.getNodeWeight(v4NodeID, qSet, false);
+
+    REQUIRE(isNear(result, .6 * .5));
+}
 
 class NominationTestHandler : public NominationProtocol
 {


### PR DESCRIPTION
# Description

Part of #4387

This change adds an application-specific
`HerderSCPDriver::getNodeWeight` function that computes a validator's weight based on its quality as described in the config file. Much of this change is in the testing infrastructure, which stresses the new algorithm to demonstrate that it avoids biasing towards larger orgs.

The remaining work (to be done in follow up PRs) is:
* Documentation explaining the new algorithm in `src/herder/readme.md`
* A supercluster mission testing the upgrade from the old weight function to the new one.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
