### PR TITLE
bugfix: guard access to mNoOutboundCapacity

### DIFF
--- a/src/bucket/BucketApplicator.h
+++ b/src/bucket/BucketApplicator.h
@@ -28,7 +28,7 @@ class BucketApplicator
     size_t mCount{0};
     std::function<bool(LedgerEntryType)> mEntryTypeFilter;
     std::unordered_set<LedgerKey>& mSeenKeys;
-    std::streamoff mUpperBoundOffset;
+    std::streamoff mUpperBoundOffset{0};
     bool mOffersRemaining{true};
 
   public:

--- a/src/overlay/FlowControl.cpp
+++ b/src/overlay/FlowControl.cpp
@@ -55,6 +55,14 @@ FlowControl::hasOutboundCapacity(StellarMessage const& msg,
            mFlowControlBytesCapacity.hasOutboundCapacity(msg);
 }
 
+bool
+FlowControl::noOutboundCapacityTimeout(VirtualClock::time_point now,
+                                       std::chrono::seconds timeout) const
+{
+    std::lock_guard<std::mutex> guard(mFlowControlMutex);
+    return mNoOutboundCapacity && now - *mNoOutboundCapacity >= timeout;
+}
+
 void
 FlowControl::setPeerID(NodeID const& peerID)
 {

--- a/src/overlay/FlowControl.h
+++ b/src/overlay/FlowControl.h
@@ -164,14 +164,10 @@ class FlowControl
     SendMoreCapacity endMessageProcessing(StellarMessage const& msg);
     bool canRead() const;
 
-    // This method return last timestamp (if any) when peer had no available
-    // outbound capacity (useful to diagnose if the connection is stuck for any
-    // reason)
-    std::optional<VirtualClock::time_point>
-    getOutboundCapacityTimestamp() const
-    {
-        return mNoOutboundCapacity;
-    }
+    // This method checks whether a peer has not requested new data within a
+    // `timeout` (useful to diagnose if the connection is stuck for any reason)
+    bool noOutboundCapacityTimeout(VirtualClock::time_point now,
+                                   std::chrono::seconds timeout) const;
 
     Json::Value getFlowControlJsonInfo(bool compact) const;
 

--- a/src/overlay/Peer.cpp
+++ b/src/overlay/Peer.cpp
@@ -291,9 +291,8 @@ Peer::recurrentTimerExpired(asio::error_code const& error)
             mOverlayMetrics.mTimeoutIdle.Mark();
             drop("idle timeout", Peer::DropDirection::WE_DROPPED_REMOTE);
         }
-        else if (mFlowControl && mFlowControl->getOutboundCapacityTimestamp() &&
-                 (now - *(mFlowControl->getOutboundCapacityTimestamp())) >=
-                     Peer::PEER_SEND_MODE_IDLE_TIMEOUT)
+        else if (mFlowControl && mFlowControl->noOutboundCapacityTimeout(
+                                     now, Peer::PEER_SEND_MODE_IDLE_TIMEOUT))
         {
             drop("idle timeout (no new flood requests)",
                  Peer::DropDirection::WE_DROPPED_REMOTE);

--- a/src/overlay/Peer.h
+++ b/src/overlay/Peer.h
@@ -247,6 +247,8 @@ class Peer : public std::enable_shared_from_this<Peer>,
     // with methods running on background threads might access this
     // unsynchronized state. All methods that access this private state should
     // assert that they are running on the main
+    // IOW, all methods using these private variables and functions below must
+    // synchronize access manually
   private:
     PeerState mState;
     NodeID mPeerID;


### PR DESCRIPTION
Fix issue discovered by static analysis (data race on `mNoOutboundCapacity`). This variable is used to trigger recovery in case flow control gets stuck. In practice, this triggers very rarely (if at all), which is probably why we did not catch this before. 