### PR TITLE
Fix exception-safety in callbacks from Rust to C++

### DIFF
--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -276,9 +276,13 @@ mod rust_bridge {
         // shared type declared above.
         type LogLevel;
         #[cfg(not(test))]
-        fn shim_isLogLevelAtLeast(partition: &CxxString, level: LogLevel) -> bool;
+        fn shim_isLogLevelAtLeast(partition: &CxxString, level: LogLevel) -> Result<bool>;
         #[cfg(not(test))]
-        fn shim_logAtPartitionAndLevel(partition: &CxxString, level: LogLevel, msg: &CxxString);
+        fn shim_logAtPartitionAndLevel(
+            partition: &CxxString,
+            level: LogLevel,
+            msg: &CxxString,
+        ) -> Result<()>;
     }
 }
 


### PR DESCRIPTION
We've been using cxx slightly wrong around callbacks from Rust to C++. This isn't likely a problem as we only have two such callbacks and they call into the C++ logging system which rarely if ever throws, but just to be on the safe side we should define these functions as returning `cxx::Result` not a plain Rust type. It turns out cxx puts a `noexcept` wrapper around all such callbacks to ensure they don't throw (and confuse Rust ABIs) and by doing this it means any throw in the C++ side would wind up causing the C++ runtime to call `std::terminate` (which is what it does when a `noexcept` function throws anyways).

The fix is very straightforward.