### PR TITLE
Cache BL snapshot for re-use

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -381,5 +381,9 @@ class BucketManager : NonMovableOrCopyable
     scheduleVerifyReferencedBucketsWork() = 0;
 
     virtual Config const& getConfig() const = 0;
+
+    // Get bucketlist snapshot
+    virtual std::shared_ptr<SearchableBucketListSnapshot>
+    getSearchableBucketListSnapshot() = 0;
 };
 }

--- a/src/bucket/BucketManagerImpl.cpp
+++ b/src/bucket/BucketManagerImpl.cpp
@@ -1509,4 +1509,19 @@ BucketManagerImpl::getConfig() const
 {
     return mApp.getConfig();
 }
+
+std::shared_ptr<SearchableBucketListSnapshot>
+BucketManagerImpl::getSearchableBucketListSnapshot()
+{
+    releaseAssert(mApp.getConfig().isUsingBucketListDB());
+    // Any other threads must maintain their own snapshot
+    releaseAssert(threadIsMain());
+    if (!mSearchableBucketListSnapshot)
+    {
+        mSearchableBucketListSnapshot =
+            mSnapshotManager->copySearchableBucketListSnapshot();
+    }
+
+    return mSearchableBucketListSnapshot;
+}
 }

--- a/src/bucket/BucketManagerImpl.h
+++ b/src/bucket/BucketManagerImpl.h
@@ -43,6 +43,8 @@ class BucketManagerImpl : public BucketManager
     std::unique_ptr<TmpDirManager> mTmpDirManager;
     std::unique_ptr<TmpDir> mWorkDir;
     std::map<Hash, std::shared_ptr<Bucket>> mSharedBuckets;
+    std::shared_ptr<SearchableBucketListSnapshot>
+        mSearchableBucketListSnapshot{};
 
     // Lock for managing raw Bucket files or the bucket directory. This lock is
     // only required for file access, but is not required for logical changes to
@@ -187,6 +189,9 @@ class BucketManagerImpl : public BucketManager
     std::shared_ptr<BasicWork> scheduleVerifyReferencedBucketsWork() override;
 
     Config const& getConfig() const override;
+
+    std::shared_ptr<SearchableBucketListSnapshot>
+    getSearchableBucketListSnapshot() override;
 };
 
 #define SKIP_1 50

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -165,6 +165,8 @@ LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
 
 BucketSnapshotState::BucketSnapshotState(BucketSnapshotManager& bsm)
     : mSnapshot(bsm.copySearchableBucketListSnapshot())
+    , mLedgerHeader(LedgerHeaderWrapper(
+          std::make_shared<LedgerHeader>(mSnapshot->getLedgerHeader())))
 {
 }
 
@@ -175,8 +177,7 @@ BucketSnapshotState::~BucketSnapshotState()
 LedgerHeaderWrapper
 BucketSnapshotState::getLedgerHeader() const
 {
-    return LedgerHeaderWrapper(
-        std::make_shared<LedgerHeader>(mSnapshot->getLedgerHeader()));
+    return LedgerHeaderWrapper(std::get<1>(mLedgerHeader.mHeader));
 }
 
 LedgerEntryWrapper

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -163,8 +163,8 @@ LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
     return f(lsg);
 }
 
-BucketSnapshotState::BucketSnapshotState(BucketSnapshotManager& bsm)
-    : mSnapshot(bsm.copySearchableBucketListSnapshot())
+BucketSnapshotState::BucketSnapshotState(BucketManager& bm)
+    : mSnapshot(bm.getSearchableBucketListSnapshot())
     , mLedgerHeader(LedgerHeaderWrapper(
           std::make_shared<LedgerHeader>(mSnapshot->getLedgerHeader())))
 {
@@ -233,8 +233,7 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
     }
     else
     {
-        mGetter = std::make_unique<BucketSnapshotState>(
-            app.getBucketManager().getBucketSnapshotManager());
+        mGetter = std::make_unique<BucketSnapshotState>(app.getBucketManager());
     }
 }
 

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -112,7 +112,7 @@ class BucketSnapshotState : public AbstractLedgerStateSnapshot
     LedgerHeaderWrapper mLedgerHeader;
 
   public:
-    BucketSnapshotState(BucketSnapshotManager& bsm);
+    BucketSnapshotState(BucketManager& bm);
     ~BucketSnapshotState() override;
 
     LedgerHeaderWrapper getLedgerHeader() const override;

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -43,6 +43,7 @@ class LedgerEntryWrapper
 class LedgerHeaderWrapper
 {
     std::variant<LedgerTxnHeader, std::shared_ptr<LedgerHeader>> mHeader;
+    friend class BucketSnapshotState;
 
   public:
     explicit LedgerHeaderWrapper(LedgerTxnHeader&& header);
@@ -105,6 +106,10 @@ class LedgerTxnReadOnly : public AbstractLedgerStateSnapshot
 class BucketSnapshotState : public AbstractLedgerStateSnapshot
 {
     std::shared_ptr<SearchableBucketListSnapshot> mSnapshot;
+    // Store a copy of the header from mSnapshot. This is needed for
+    // validation flow where for certain validation scenarios the header needs
+    // to be modified
+    LedgerHeaderWrapper mLedgerHeader;
 
   public:
     BucketSnapshotState(BucketSnapshotManager& bsm);


### PR DESCRIPTION
Improve performance of snapshot loads, allow re-using the same snapshot kept by BucketManager from main thread only. All other threads will need to maintain their own snapshot. 