### PR TITLE
Use TESTDB_IN_MEMORY_OFFERS in BucketListIsConsistentWithDatabaseTests

### DIFF
--- a/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
+++ b/src/invariant/test/BucketListIsConsistentWithDatabaseTests.cpp
@@ -42,7 +42,7 @@ struct BucketListGenerator
   public:
     BucketListGenerator() : mLedgerSeq(1)
     {
-        auto cfg = getTestConfig(0);
+        auto cfg = getTestConfig(0, Config::TESTDB_IN_MEMORY_OFFERS);
         cfg.OVERRIDE_EVICTION_PARAMS_FOR_TESTING = true;
         cfg.TESTING_STARTING_EVICTION_SCAN_LEVEL = 1;
         mAppGenerate = createTestApplication(mClock, cfg);
@@ -101,8 +101,8 @@ struct BucketListGenerator
     applyBuckets(Args&&... args)
     {
         VirtualClock clock;
-        Application::pointer app =
-            createTestApplication(clock, getTestConfig(1));
+        Application::pointer app = createTestApplication(
+            clock, getTestConfig(1, Config::TESTDB_IN_MEMORY_OFFERS));
         applyBuckets<T, Args...>(app, std::forward<Args>(args)...);
     }
 
@@ -937,7 +937,7 @@ TEST_CASE("BucketListIsConsistentWithDatabase merged LIVEENTRY and DEADENTRY",
         return (bool)ltx.load(LedgerEntryKey(le));
     };
 
-    auto cfg = getTestConfig(1);
+    auto cfg = getTestConfig(1, Config::TESTDB_IN_MEMORY_OFFERS);
     cfg.OVERRIDE_EVICTION_PARAMS_FOR_TESTING = true;
     cfg.TESTING_STARTING_EVICTION_SCAN_LEVEL = 1;
 


### PR DESCRIPTION
# Description

Fixes some acceptance tests that were affected by https://github.com/stellar/stellar-core/pull/4462.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
