### PR TITLE
Bump env to version with wasmi 0.36.1

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -53,8 +53,6 @@ exclude = [
    # subsystems also winds up pulling in conflicts, but again, just
    # dev-deps or non-produciton configs.
    "tracking-allocator",
-   # Temporary
-   "curve25519-dalek"
 ]
 
 # If true, metadata will be collected with `--all-features`. Note that this can't

--- a/src/rust/src/dep-trees/p22-expect.txt
+++ b/src/rust/src/dep-trees/p22-expect.txt
@@ -70,7 +70,7 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   │   │   │   ├── block-buffer v0.10.4
 │   │   │   │   │   │   └── generic-array v0.14.7
 │   │   │   │   │   │       ├── typenum v1.16.0
-│   │   │   │   │   │       └── zeroize v1.6.0
+│   │   │   │   │   │       └── zeroize v1.8.1
 │   │   │   │   │   │           └── zeroize_derive v1.4.2 (proc-macro)
 │   │   │   │   │   │               ├── proc-macro2 v1.0.69 (*)
 │   │   │   │   │   │               ├── quote v1.0.33 (*)
@@ -94,7 +94,7 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   │   ├── num-bigint v0.4.4 (*)
 │   │   │   ├── num-traits v0.2.17 (*)
 │   │   │   ├── paste v1.0.12 (proc-macro)
-│   │   │   └── zeroize v1.6.0 (*)
+│   │   │   └── zeroize v1.8.1 (*)
 │   │   │   [build-dependencies]
 │   │   │   └── rustc_version v0.4.0
 │   │   │       └── semver v1.0.17
@@ -120,14 +120,14 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   ├── hashbrown v0.13.2 (*)
 │   │   ├── itertools v0.10.5 (*)
 │   │   ├── num-traits v0.2.17 (*)
-│   │   └── zeroize v1.6.0 (*)
+│   │   └── zeroize v1.8.1 (*)
 │   ├── ark-ff v0.4.2 (*)
 │   ├── ark-serialize v0.4.2 (*)
 │   └── ark-std v0.4.0 (*)
 ├── ark-ec v0.4.2 (*)
 ├── ark-ff v0.4.2 (*)
 ├── ark-serialize v0.4.2 (*)
-├── curve25519-dalek v4.1.1
+├── curve25519-dalek v4.1.3
 │   ├── cfg-if v1.0.0
 │   ├── cpufeatures v0.2.8
 │   │   └── libc v0.2.150
@@ -138,22 +138,21 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   ├── digest v0.10.7 (*)
 │   ├── fiat-crypto v0.2.5
 │   ├── subtle v2.5.0
-│   └── zeroize v1.6.0 (*)
+│   └── zeroize v1.8.1 (*)
 │   [build-dependencies]
-│   ├── platforms v3.0.2
 │   └── rustc_version v0.4.0 (*)
-├── ecdsa v0.16.7
+├── ecdsa v0.16.9
 │   ├── der v0.7.6
 │   │   ├── const-oid v0.9.2
-│   │   └── zeroize v1.6.0 (*)
+│   │   └── zeroize v1.8.1 (*)
 │   ├── digest v0.10.7 (*)
-│   ├── elliptic-curve v0.13.5
+│   ├── elliptic-curve v0.13.8
 │   │   ├── base16ct v0.2.0
 │   │   ├── crypto-bigint v0.5.2
 │   │   │   ├── generic-array v0.14.7 (*)
 │   │   │   ├── rand_core v0.6.4 (*)
 │   │   │   ├── subtle v2.5.0
-│   │   │   └── zeroize v1.6.0 (*)
+│   │   │   └── zeroize v1.8.1 (*)
 │   │   ├── digest v0.10.7 (*)
 │   │   ├── ff v0.13.0
 │   │   │   ├── rand_core v0.6.4 (*)
@@ -169,9 +168,9 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   │   ├── der v0.7.6 (*)
 │   │   │   ├── generic-array v0.14.7 (*)
 │   │   │   ├── subtle v2.5.0
-│   │   │   └── zeroize v1.6.0 (*)
+│   │   │   └── zeroize v1.8.1 (*)
 │   │   ├── subtle v2.5.0
-│   │   └── zeroize v1.6.0 (*)
+│   │   └── zeroize v1.8.1 (*)
 │   ├── rfc6979 v0.4.0
 │   │   ├── hmac v0.12.1
 │   │   │   └── digest v0.10.7 (*)
@@ -179,8 +178,8 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   └── signature v2.1.0
 │       ├── digest v0.10.7 (*)
 │       └── rand_core v0.6.4 (*)
-├── ed25519-dalek v2.0.0
-│   ├── curve25519-dalek v4.1.1 (*)
+├── ed25519-dalek v2.1.1
+│   ├── curve25519-dalek v4.1.3 (*)
 │   ├── ed25519 v2.2.2
 │   │   └── signature v2.1.0 (*)
 │   ├── rand_core v0.6.4 (*)
@@ -188,16 +187,17 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   ├── cfg-if v1.0.0
 │   │   ├── cpufeatures v0.2.8 (*)
 │   │   └── digest v0.10.7 (*)
-│   └── zeroize v1.6.0 (*)
-├── elliptic-curve v0.13.5 (*)
+│   ├── subtle v2.5.0
+│   └── zeroize v1.8.1 (*)
+├── elliptic-curve v0.13.8 (*)
 ├── generic-array v0.14.7 (*)
 ├── getrandom v0.2.11 (*)
 ├── hex-literal v0.4.1
 ├── hmac v0.12.1 (*)
-├── k256 v0.13.1
+├── k256 v0.13.4
 │   ├── cfg-if v1.0.0
-│   ├── ecdsa v0.16.7 (*)
-│   ├── elliptic-curve v0.13.5 (*)
+│   ├── ecdsa v0.16.9 (*)
+│   ├── elliptic-curve v0.13.8 (*)
 │   └── sha2 v0.10.8 (*)
 ├── num-derive v0.4.1 (proc-macro)
 │   ├── proc-macro2 v1.0.69 (*)
@@ -209,10 +209,10 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   └── autocfg v1.1.0
 ├── num-traits v0.2.17 (*)
 ├── p256 v0.13.2
-│   ├── ecdsa v0.16.7 (*)
-│   ├── elliptic-curve v0.13.5 (*)
+│   ├── ecdsa v0.16.9 (*)
+│   ├── elliptic-curve v0.13.8 (*)
 │   ├── primeorder v0.13.3
-│   │   └── elliptic-curve v0.13.5 (*)
+│   │   └── elliptic-curve v0.13.8 (*)
 │   └── sha2 v0.10.8 (*)
 ├── rand v0.8.5 (*)
 ├── rand_chacha v0.3.1 (*)
@@ -263,14 +263,14 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   │   [build-dependencies]
 │   │   │   └── crate-git-revision v0.0.6 (*)
 │   │   └── syn v2.0.39 (*)
-│   ├── soroban-wasmi v0.36.0-soroban.22.0.0 (https://github.com/stellar/wasmi?rev=122a74a7c491929e5ac9de876099154ef7c06d06#122a74a7)
+│   ├── soroban-wasmi v0.36.1-soroban.22.0.0
 │   │   ├── arrayvec v0.7.4
 │   │   ├── multi-stash v0.2.0
 │   │   ├── num-derive v0.4.1 (proc-macro) (*)
 │   │   ├── num-traits v0.2.17 (*)
 │   │   ├── smallvec v1.13.2
 │   │   ├── spin v0.9.8
-│   │   ├── wasmi_collections v0.36.0-soroban.22.0.0 (https://github.com/stellar/wasmi?rev=122a74a7c491929e5ac9de876099154ef7c06d06#122a74a7)
+│   │   ├── wasmi_collections v0.36.1
 │   │   │   ├── ahash v0.8.11 (*)
 │   │   │   ├── hashbrown v0.14.1
 │   │   │   │   └── ahash v0.8.11 (*)
@@ -279,7 +279,7 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │   │   │       ├── hashbrown v0.14.1 (*)
 │   │   │       └── serde v1.0.192
 │   │   │           └── serde_derive v1.0.192 (proc-macro) (*)
-│   │   ├── wasmi_core v0.36.0-soroban.22.0.0 (https://github.com/stellar/wasmi?rev=122a74a7c491929e5ac9de876099154ef7c06d06#122a74a7)
+│   │   ├── wasmi_core v0.36.1
 │   │   │   ├── downcast-rs v1.2.0
 │   │   │   ├── libm v0.2.8
 │   │   │   ├── num-traits v0.2.17 (*)
@@ -301,7 +301,7 @@ soroban-env-host v22.0.0 (src/rust/soroban/p22/soroban-env-host)
 │       └── semver v1.0.17
 │   [build-dependencies]
 │   └── crate-git-revision v0.0.6 (*)
-├── soroban-wasmi v0.36.0-soroban.22.0.0 (https://github.com/stellar/wasmi?rev=122a74a7c491929e5ac9de876099154ef7c06d06#122a74a7) (*)
+├── soroban-wasmi v0.36.1-soroban.22.0.0 (*)
 ├── static_assertions v1.1.0
 ├── stellar-strkey v0.0.9 (*)
 └── wasmparser v0.116.1 (*)


### PR DESCRIPTION
This also brings in p22 updates for k256 and dalek libraries.