### PR TITLE
Fix upgrade validation

### DIFF
--- a/src/ledger/NetworkConfig.cpp
+++ b/src/ledger/NetworkConfig.cpp
@@ -2047,11 +2047,25 @@ bool
 SorobanNetworkConfig::isValidCostParams(ContractCostParams const& params,
                                         uint32_t ledgerVersion)
 {
-    auto numberOfCostTypes =
-        protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_21)
-            ? static_cast<uint32_t>(ContractCostType::ChaCha20DrawBytes) + 1
-            : xdr::xdr_traits<ContractCostType>::enum_values().size();
-    if (params.size() != numberOfCostTypes)
+    auto getNumCostTypes = [](uint32_t ledgerVersion) -> uint32_t {
+        if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_21))
+        {
+            return static_cast<uint32_t>(ContractCostType::ChaCha20DrawBytes) +
+                   1;
+        }
+        else if (protocolVersionIsBefore(ledgerVersion, ProtocolVersion::V_22))
+        {
+            return static_cast<uint32_t>(
+                       ContractCostType::VerifyEcdsaSecp256r1Sig) +
+                   1;
+        }
+        else
+        {
+            return static_cast<uint32_t>(ContractCostType::Bls12381FrInv) + 1;
+        }
+    };
+
+    if (params.size() != getNumCostTypes(ledgerVersion))
     {
         return false;
     }


### PR DESCRIPTION
# Description

Fix the upgrade validation to handle settings upgrades for the previous protocol. Also rewrote the condition so our test cases will catch this issue next time settings are added.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
