### PR TITLE
Convert live entries to init entries in lowest level of bucketlist

### DIFF
--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -74,6 +74,7 @@ struct MergeCounters
     uint64_t mDeadEntryShadowElisions{0};
 
     uint64_t mOutputIteratorTombstoneElisions{0};
+    uint64_t mOutputIteratorLiveToInitConversions{0};
     uint64_t mOutputIteratorBufferUpdates{0};
     uint64_t mOutputIteratorActualWrites{0};
     MergeCounters& operator+=(MergeCounters const& delta);

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -66,17 +66,32 @@ BucketOutputIterator::put(BucketEntry const& e)
         ++mMergeCounters.mOutputIteratorTombstoneElisions;
         return;
     }
+    std::optional<BucketEntry> maybeInitEntry;
+    if (!mKeepDeadEntries && e.type() == LIVEENTRY)
+    {
+        // If mKeepDeadEntries is false (lowest level), 
+        // we also want to convert the LIVEENTRY to an INITENTRY.
+        // This is because each level of the bucket list contains 
+        // only one entry per key, and per CAP-0020, INIT ENTRY
+        // implies that either no entry with the same ledger key 
+        // exists in an older bucket. Therefore, all entries of type 
+        // LIVEENTRY in the lowest level are also of type INITENTRY.
+        ++mMergeCounters.mOutputIteratorLiveToInitConversions;
+        // Make a copy of e and set the type of the new entry to INITENTRY.
+        maybeInitEntry.emplace(e);
+        maybeInitEntry->type(INITENTRY);
+    }
 
     // Check to see if there's an existing buffered entry.
     if (mBuf)
     {
         // mCmp(e, *mBuf) means e < *mBuf; this should never be true since
         // it would mean that we're getting entries out of order.
-        releaseAssert(!mCmp(e, *mBuf));
+        releaseAssert(!mCmp(maybeInitEntry.has_value() ? *maybeInitEntry : e, *mBuf));
 
         // Check to see if the new entry should flush (greater identity), or
         // merely replace (same identity), the buffered entry.
-        if (mCmp(*mBuf, e))
+        if (mCmp(*mBuf, maybeInitEntry.has_value() ? *maybeInitEntry : e))
         {
             ++mMergeCounters.mOutputIteratorActualWrites;
             mOut.writeOne(*mBuf, &mHasher, &mBytesPut);
@@ -90,7 +105,7 @@ BucketOutputIterator::put(BucketEntry const& e)
 
     // In any case, replace *mBuf with e.
     ++mMergeCounters.mOutputIteratorBufferUpdates;
-    *mBuf = e;
+    *mBuf = maybeInitEntry.has_value() ? *maybeInitEntry : e;
 }
 
 std::shared_ptr<Bucket>

--- a/src/bucket/test/BucketTests.cpp
+++ b/src/bucket/test/BucketTests.cpp
@@ -399,6 +399,36 @@ TEST_CASE("merges proceed old-style despite newer shadows",
     }
 }
 
+TEST_CASE("lowest level merge converts live to init", "[bucket][bucketinit]")
+{
+    VirtualClock clock;
+    Config const& cfg = getTestConfig();
+    Application::pointer app = createTestApplication(clock, cfg);
+    auto& bm = app->getBucketManager();
+    auto vers = getAppLedgerVersion(app);
+
+    LedgerEntry entry = generateAccount();
+    auto b1 = Bucket::fresh(bm, vers, {}, {entry}, {},
+                               /*countMergeEvents=*/true, clock.getIOContext(),
+                               /*doFsync=*/true);
+    EntryCounts e1(b1);
+    CHECK(e1.nInit == 0);
+    CHECK(e1.nLive == 1);
+    auto b2 = Bucket::fresh(bm, vers, {}, {}, {},
+                               /*countMergeEvents=*/true, clock.getIOContext(),
+                               /*doFsync=*/true);
+
+    // Merge b1 and b2 into a new, lowest-level bucket.
+    // keepDeadEntries = false signfies the lowest level of the bucket list
+    auto bMerged = Bucket::merge(bm, vers, b1, b2, /*shadows=*/{},
+                            /*keepDeadEntries=*/false,
+                            /*countMergeEvents=*/true, clock.getIOContext(),
+                            /*doFsync=*/true);
+    EntryCounts e2(bMerged);
+    CHECK(e2.nInit == 1);
+    CHECK(e2.nLive == 0);
+}
+
 TEST_CASE("merges refuse to exceed max protocol version",
           "[bucket][bucketmaxprotocol]")
 {


### PR DESCRIPTION
# Description
Resolves [#193](https://github.com/stellar/stellar-core-internal/issues/193)

Changes `BucketOutputIterator::put` to convert `LIVEENTRY` to `INITENTRY` if `mKeepDeadEntries == true`. 

Perhaps this variable should be renamed to `mIsLowestLevel` or something now that it affects dead entry persistence and init entry to live entry conversion. 


<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
