### PR TITLE
Revert downgrading of log error->warn->error

### DIFF
--- a/src/historywork/CheckSingleLedgerHeaderWork.cpp
+++ b/src/historywork/CheckSingleLedgerHeaderWork.cpp
@@ -7,6 +7,7 @@
 #include "history/HistoryArchive.h"
 #include "history/HistoryManager.h"
 #include "historywork/GetAndUnzipRemoteFileWork.h"
+#include "main/ErrorMessages.h"
 #include "util/GlobalChecks.h"
 #include "util/Logging.h"
 #include "util/TmpDir.h"
@@ -84,9 +85,16 @@ CheckSingleLedgerHeaderWork::doWork()
     }
     else if (mGetLedgerFileWork->getState() != State::WORK_SUCCESS)
     {
-        CLOG_WARNING(History,
-                     "Failed to download ledger checkpoint {} from archive {}",
-                     mFt->baseName_gz(), mArchive->getName());
+        CLOG_ERROR(
+            History,
+            "Failed to download ledger checkpoint {} from archive {}: {}",
+            mFt->baseName_gz(), mArchive->getName(),
+            POSSIBLY_CORRUPTED_HISTORY);
+        CLOG_ERROR(
+            History,
+            "If this occurs often, consider notifying the archive "
+            "owner. As long as your configuration has any valid history "
+            "archives, this error does NOT mean your node is unhealthy.");
         return mGetLedgerFileWork->getState();
     }
 

--- a/src/main/ErrorMessages.h
+++ b/src/main/ErrorMessages.h
@@ -11,7 +11,7 @@ constexpr auto const REPORT_INTERNAL_BUG =
     "Please report this bug along with this log file if this was not expected";
 constexpr auto const POSSIBLY_CORRUPTED_HISTORY =
     "One or more of history archives may be corrupted. Update HISTORY "
-    "configuration entry to only contain valid ones";
+    "configuration entry to only contain valid ones.";
 constexpr auto const POSSIBLY_CORRUPTED_LOCAL_FS =
     "There may be a problem with the local filesystem. Ensure that there is "
     "enough space to perform that operation and that disc is behaving "


### PR DESCRIPTION
# Description
Reverts downgrading of error to warning in `CheckSingleLedgerHeaderWork`

https://github.com/stellar/stellar-core/pull/4508#discussion_r1809573062

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
