### PR TITLE
Split out --enable-tracy-memory-tracking, disabled by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,6 +359,14 @@ if test x"$enable_tracy" = xyes; then
 fi
 AC_SUBST(tracy_CFLAGS)
 
+AC_ARG_ENABLE(tracy-memory-tracking,
+    AS_HELP_STRING([--enable-tracy-memory-tracking],
+        [Enable 'tracy' profiler/tracer memory tracking code (slow)]))
+AM_CONDITIONAL(USE_TRACY_MEMORY_TRACKING, [test x$enable_tracy_memory_tracking = xyes])
+if test x"$enable_tracy_memory_tracking" = xyes -a x"$enable_asan" = xyes; then
+       AC_MSG_ERROR([--enable-asan is not compatible with --enable-tracy-memory-tracking])
+fi
+
 AC_ARG_ENABLE(tracy-gui,
     AS_HELP_STRING([--enable-tracy-gui],
         [Enable 'tracy' profiler/tracer server GUI]))

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -278,7 +278,7 @@ checkStellarCoreMajorVersionProtocolIdentity()
     }
 }
 
-#ifdef USE_TRACY
+#ifdef USE_TRACY_MEMORY_TRACKING
 
 #ifdef __has_feature
 #if __has_feature(address_sanitizer)
@@ -290,7 +290,9 @@ checkStellarCoreMajorVersionProtocolIdentity()
 #endif
 #endif
 
-#ifndef ASAN_ENABLED
+#ifdef ASAN_ENABLED
+#error "ASAN_ENABLED and USE_TRACY_MEMORY_TRACKING are mutually exclusive"
+#else
 void*
 operator new(std::size_t count)
 {
@@ -322,8 +324,8 @@ operator delete[](void* ptr) noexcept
     TracySecureFree(ptr);
     free(ptr);
 }
-#endif // ASAN_ENABLED
-#endif // USE_TRACY
+#endif // !ASAN_ENABLED
+#endif // USE_TRACY_MEMORY_TRACKING
 
 int
 main(int argc, char* const* argv)


### PR DESCRIPTION
This splits out the memory-tracking machinery of tracy and disables it by default unless the user configures with `--enable-tracy-memory-tracking`. In practice we seem to use this much less often than normal tracy, and it has a much higher overhead -- enough to become nonresponsive under load -- so turning it off makes tracy more usable more of the time.

It's also mutually exclusive with asan, and we used to just silently disable the memory-tracking part of tracy when asan was on, but I changed it to notice and complain when you use asan with this new flag specifically. Seems a better (less head-scratching) experience than just silently not-getting the instrumentation.