### PR TITLE
Update p22 submodule to rs-soroban-env v22.0.0-rc.3 to release/v22.0.0 branch stellar-core rc3

### DIFF
--- a/src/rust/src/dep-trees/p22-expect.txt
+++ b/src/rust/src/dep-trees/p22-expect.txt
@@ -1,4 +1,4 @@
-soroban-env-host v22.0.0-rc.2 (src/rust/soroban/p22/soroban-env-host)
+soroban-env-host v22.0.0-rc.3 (src/rust/soroban/p22/soroban-env-host)
 ├── ark-bls12-381 v0.4.0
 │   ├── ark-ec v0.4.2
 │   │   ├── ark-ff v0.4.2
@@ -222,17 +222,17 @@ soroban-env-host v22.0.0-rc.2 (src/rust/soroban/p22/soroban-env-host)
 │   ├── digest v0.10.7 (*)
 │   └── keccak v0.1.4
 │       └── cpufeatures v0.2.8 (*)
-├── soroban-builtin-sdk-macros v22.0.0-rc.2 (proc-macro) (src/rust/soroban/p22/soroban-builtin-sdk-macros)
+├── soroban-builtin-sdk-macros v22.0.0-rc.3 (proc-macro) (src/rust/soroban/p22/soroban-builtin-sdk-macros)
 │   ├── itertools v0.10.5
 │   │   └── either v1.8.1
 │   ├── proc-macro2 v1.0.69 (*)
 │   ├── quote v1.0.33 (*)
 │   └── syn v2.0.39 (*)
-├── soroban-env-common v22.0.0-rc.2 (src/rust/soroban/p22/soroban-env-common)
+├── soroban-env-common v22.0.0-rc.3 (src/rust/soroban/p22/soroban-env-common)
 │   ├── ethnum v1.5.0
 │   ├── num-derive v0.4.1 (proc-macro) (*)
 │   ├── num-traits v0.2.17 (*)
-│   ├── soroban-env-macros v22.0.0-rc.2 (proc-macro) (src/rust/soroban/p22/soroban-env-macros)
+│   ├── soroban-env-macros v22.0.0-rc.3 (proc-macro) (src/rust/soroban/p22/soroban-env-macros)
 │   │   ├── itertools v0.10.5 (*)
 │   │   ├── proc-macro2 v1.0.69 (*)
 │   │   ├── quote v1.0.33 (*)


### PR DESCRIPTION
### What:
Update p22 submodule to rs-soroban-env v22.0.0-rc.3 to release/v22.0.0 branch stellar-core rc3.

We will need to build stellar-core rc3 from this release/v22.0.0 branch instead of master.