### PR TITLE
Update soroban p21 version to 21.2.2, taking binary-search change.

### DIFF
--- a/src/rust/src/dep-trees/p21-expect.txt
+++ b/src/rust/src/dep-trees/p21-expect.txt
@@ -1,4 +1,4 @@
-soroban-env-host v21.2.1 (src/rust/soroban/p21/soroban-env-host)
+soroban-env-host v21.2.2 (src/rust/soroban/p21/soroban-env-host)
 ├── curve25519-dalek v4.1.1
 │   ├── cfg-if v1.0.0
 │   ├── cpufeatures v0.2.8
@@ -141,17 +141,17 @@ soroban-env-host v21.2.1 (src/rust/soroban/p21/soroban-env-host)
 │   ├── digest v0.10.7 (*)
 │   └── keccak v0.1.4
 │       └── cpufeatures v0.2.8 (*)
-├── soroban-builtin-sdk-macros v21.2.1 (proc-macro) (src/rust/soroban/p21/soroban-builtin-sdk-macros)
+├── soroban-builtin-sdk-macros v21.2.2 (proc-macro) (src/rust/soroban/p21/soroban-builtin-sdk-macros)
 │   ├── itertools v0.11.0
 │   │   └── either v1.8.1
 │   ├── proc-macro2 v1.0.69 (*)
 │   ├── quote v1.0.33 (*)
 │   └── syn v2.0.39 (*)
-├── soroban-env-common v21.2.1 (src/rust/soroban/p21/soroban-env-common)
+├── soroban-env-common v21.2.2 (src/rust/soroban/p21/soroban-env-common)
 │   ├── ethnum v1.5.0
 │   ├── num-derive v0.4.1 (proc-macro) (*)
 │   ├── num-traits v0.2.17 (*)
-│   ├── soroban-env-macros v21.2.1 (proc-macro) (src/rust/soroban/p21/soroban-env-macros)
+│   ├── soroban-env-macros v21.2.2 (proc-macro) (src/rust/soroban/p21/soroban-env-macros)
 │   │   ├── itertools v0.11.0 (*)
 │   │   ├── proc-macro2 v1.0.69 (*)
 │   │   ├── quote v1.0.33 (*)


### PR DESCRIPTION
This is a critical update. Stellar-core packages from before this update, if built with rust 1.82, will diverge from the network. They must not be deployed in production validators.

Rust 1.82 changed the implementation of binary search in its standard library in a way that soroban observes. This change modifies soroban to use a local copy of binary search that is the same as the one in rust 1.81, so that soroban is no longer sensitive to the difference between 1.81 and 1.82.

Existing SDF-built release packages of stellar-core were built with rust 1.81, but it is possible that other builds of stellar-core built after the release of rust 1.82 might exist in the field. These must all update to this change, or later, to avoid diverging from peers built with rust 1.81.

(cherry picked from commit edaad40b16d1ec3cf8b9ea54d9e50c65453f1f40)