### PR TITLE
More asan and tracy fixes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -153,6 +153,7 @@ rm -rf llvm-project/
 ### MacOS 
 When building on MacOS, here's some dependencies you'll need:
 - Install xcode
+- Install [Rust](#installing-rust)
 - Install [homebrew](https://brew.sh)
 - `brew install libsodium libtool autoconf automake pkg-config libpq openssl parallel ccache bison gnu-sed perl coreutils`
 

--- a/configure.ac
+++ b/configure.ac
@@ -363,6 +363,10 @@ AC_ARG_ENABLE(tracy-memory-tracking,
     AS_HELP_STRING([--enable-tracy-memory-tracking],
         [Enable 'tracy' profiler/tracer memory tracking code (slow)]))
 AM_CONDITIONAL(USE_TRACY_MEMORY_TRACKING, [test x$enable_tracy_memory_tracking = xyes])
+
+if test x"$enable_tracy" = xyes -a x"$enable_asan" = xyes; then
+       AC_MSG_ERROR([--enable-asan is not compatible with --enable-tracy])
+fi
 if test x"$enable_tracy_memory_tracking" = xyes -a x"$enable_asan" = xyes; then
        AC_MSG_ERROR([--enable-asan is not compatible with --enable-tracy-memory-tracking])
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,13 +17,6 @@ noinst_HEADERS = $(SRC_H_FILES)
 # realize that it needs this setting.
 CXXSTDLIB := $(if $(findstring -stdlib=libc++,$(CXXFLAGS)),c++,$(if $(findstring -stdlib=libstdc++,$(CXXFLAGS)),stdc++,))
 
-# If we are building with -fsanitize=address, any build.rs-built C++ code will
-# depend on asan, so we need to tell rustc to link with in the asan runtime as
-# well. Interestingly, passing -Clink-arg=-fsanitize=address to rustc does not
-# work, despite being the recommended approach, it seems rustc passes some other
-# flags to the linker that conflict with -fsanitize=address.
-RUSTFLAGS_ASAN := $(if $(findstring -fsanitize=address,$(CXXFLAGS)),-Clink-arg=-lasan,)
-
 if USE_TRACY
 # NB: this unfortunately long list has to be provided here and kept in sync with
 # the list of features for tracy-client in src/rust/Cargo.toml.  This is because


### PR DESCRIPTION
A couple fixes to the build system. This doesn't fix all the errors we've been seeing lately. It still seems like .. we basically can't build the tracy-build-by-rust (which is the only tracy we're currently supporting) using g++, or clang-with-libstdc++, only clang-with-libc++. This is not .. exactly a problem, but it's still not ideal. I'll have another go at it tomorrow. But for now this is at least a couple steps that seem to be in the right direction.