### PR TITLE
Error and exit on validator configs that contain only `LOW` validators

### DIFF
--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -2467,6 +2467,14 @@ Config::setValidatorWeightConfig(std::vector<ValidatorEntry> const& validators)
         homeDomainsByQuality[v.mQuality].insert(v.mHomeDomain);
     }
 
+    if (NODE_IS_VALIDATOR &&
+        highestQuality == ValidatorQuality::VALIDATOR_LOW_QUALITY)
+    {
+        throw std::invalid_argument(
+            "At least one validator must have a quality "
+            "level higher than LOW");
+    }
+
     // Highest quality level has weight UINT64_MAX
     vwc.mQualityWeights[highestQuality] = UINT64_MAX;
 

--- a/src/main/test/ConfigTests.cpp
+++ b/src/main/test/ConfigTests.cpp
@@ -572,3 +572,35 @@ TEST_CASE("operation filter configuration", "[config]")
         loadConfig(vals);
     }
 }
+
+// Test that the config loader rejects validator configs with all validators
+// marked low quality (including 'self').
+TEST_CASE("reject all low quality validators config", "[config]")
+{
+    Config c;
+    std::string const configStr = R"(
+NODE_SEED="SA7FGJMMUIHNE3ZPI2UO5I632A7O5FBAZTXFAIEVFA4DSSGLHXACLAIT a3"
+NODE_HOME_DOMAIN="domain"
+NODE_IS_VALIDATOR=true
+DEPRECATED_SQL_LEDGER_STATE=false
+UNSAFE_QUORUM=true
+
+[[HOME_DOMAINS]]
+HOME_DOMAIN="domain"
+QUALITY="LOW"
+
+[[VALIDATORS]]
+NAME="a1"
+HOME_DOMAIN="domain"
+PUBLIC_KEY="GDUTST3TG4MNDLY6WLB5CIASIBZAWWWJKZDHA4HFEVKQOVTYQ2F5GKYZ"
+
+[[VALIDATORS]]
+NAME="a2"
+HOME_DOMAIN="domain"
+PUBLIC_KEY="GBVZFVEARURUJTN5ABZPKW36FHKVJK2GHXEVY2SZCCNU5I3CQMTZ3OES"
+)";
+    std::stringstream ss(configStr);
+    REQUIRE_THROWS_WITH(
+        c.load(ss),
+        "At least one validator must have a quality level higher than LOW");
+}


### PR DESCRIPTION
Closes #4526

This change raises an error when a node is a validator and all of the validators in its config (including itself) are marked `LOW` quality. This represents a misconfiguration because `LOW` quality validators cannot win leader election. If every validator is `LOW` quality, then there are no eligible nomination leaders and nomination will stall.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
