### PR TITLE
Add new catchup mode to use transaction results to skip failed transaction and signature verification

### DIFF
--- a/src/catchup/ApplyCheckpointWork.h
+++ b/src/catchup/ApplyCheckpointWork.h
@@ -21,20 +21,24 @@ class TmpDir;
 struct LedgerHeaderHistoryEntry;
 
 /**
- * This class is responsible for applying transactions stored in files on
- * temporary directory (downloadDir) to local ledger. It requires two sets of
- * files - ledgers and transactions - int .xdr format. Transaction files are
- * used to read transactions that will be used and ledger files are used to
+ * This class is responsible for applying transactions stored in files in the
+ * temporary directory (downloadDir) to local the ledger. It requires two sets
+ * of files - ledgers and transactions - in .xdr format. Transaction files are
+ * used to read transactions that will be applied and ledger files are used to
  * check if ledger hashes are matching.
  *
- * In each run it skips or applies transactions from one ledger. Skipping occurs
- * when ledger to be applied is older than LCL from local ledger. At LCL
- * boundary checks are made to confirm that ledgers from files knit up with
- * LCL. If everything is OK, an apply ledger operation is performed. Then
- * another check is made - if new local ledger matches corresponding ledger from
- * file.
+ * It may also require a third set of files - transaction results - to use in
+ * accelerated replay, where failed transactions are not applied and successful
+ * transactions are applied without verifying their signatures.
  *
- * Constructor of this class takes some important parameters:
+ * In each run it skips or applies transactions from one ledger. Skipping occurs
+ * when the ledger to be applied is older than the LCL of the local ledger. At
+ * LCL, boundary checks are made to confirm that the ledgers from the files knit
+ * up with LCL. If everything is OK, an apply ledger operation is performed.
+ * Then another check is made - if the new local ledger matches corresponding
+ * the ledger from file.
+ *
+ * The constructor of this class takes some important parameters:
  * * downloadDir - directory containing ledger and transaction files
  * * range - LedgerRange to apply, must be checkpoint-aligned,
  * and cover at most one checkpoint.
@@ -49,6 +53,10 @@ class ApplyCheckpointWork : public BasicWork
     XDRInputFileStream mHdrIn;
     XDRInputFileStream mTxIn;
     TransactionHistoryEntry mTxHistoryEntry;
+#ifdef BUILD_TESTS
+    std::optional<XDRInputFileStream> mTxResultIn;
+    std::optional<TransactionHistoryResultEntry> mTxHistoryResultEntry;
+#endif // BUILD_TESTS
     LedgerHeaderHistoryEntry mHeaderHistoryEntry;
     OnFailureCallback mOnFailure;
 
@@ -57,6 +65,9 @@ class ApplyCheckpointWork : public BasicWork
     std::shared_ptr<ConditionalWork> mConditionalWork;
 
     TxSetXDRFrameConstPtr getCurrentTxSet();
+#ifdef BUILD_TESTS
+    std::optional<TransactionResultSet> getCurrentTxResultSet();
+#endif // BUILD_TESTS
     void openInputFiles();
 
     std::shared_ptr<LedgerCloseData> getNextLedgerCloseData();

--- a/src/catchup/CatchupConfiguration.h
+++ b/src/catchup/CatchupConfiguration.h
@@ -13,7 +13,7 @@
 namespace stellar
 {
 
-// Each catchup can be configured by two parameters destination ledger
+// Each catchup can be configured by two parameters: destination ledger
 // (and its hash, if known) and count of ledgers to apply.
 // Value of count can be adjusted in different ways during catchup. If applying
 // count ledgers would mean going before the last closed ledger - it is
@@ -31,12 +31,13 @@ namespace stellar
 // and catchup to that instead of destination ledger. This is useful when
 // doing offline commandline catchups with stellar-core catchup command.
 //
-// Catchup can be done in two modes - ONLINE nad OFFLINE. In ONLINE mode node
-// is connected to the network. If receives ledgers during catchup and applies
-// them after history is applied. Also additional closing ledger is required
-// to mark catchup as complete and node as synced. In OFFLINE mode node is not
-// connected to network, so new ledgers are not being externalized. Only
-// buckets and transactions from history archives are applied.
+// Catchup can be done in two modes - ONLINE and OFFLINE. In ONLINE mode, the
+// node is connected to the network. It receives ledgers during catchup and
+// applies them after history is applied. Also, an additional closing ledger is
+// required to mark catchup as complete and the node as synced. In OFFLINE mode,
+// the node is not connected to network, so new ledgers are not being
+// externalized. Only buckets and transactions from history archives are
+// applied.
 class CatchupConfiguration
 {
   public:

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -24,22 +24,22 @@ using WorkSeqPtr = std::shared_ptr<WorkSequence>;
 
 // CatchupWork does all the necessary work to perform any type of catchup.
 // It accepts CatchupConfiguration structure to know from which ledger to which
-// one do the catchup and if it involves only applying ledgers or ledgers and
+// one to do the catchup and if it involves only applying ledgers or ledgers and
 // buckets.
 //
-// First thing it does is to get a history state which allows to calculate
-// proper destination ledger (in case CatchupConfiguration::CURRENT) was used
-// and to get list of buckets that should be in database on that ledger.
+// First, it gets a history state, which allows it to calculate a
+// proper destination ledger (in case CatchupConfiguration::CURRENT)
+// and get a list of buckets that should be in the database on that ledger.
 //
-// Next step is downloading and verifying ledgers (if verifyMode is set to
-// VERIFY_BUFFERED_LEDGERS it can also verify against ledgers currently
+// Next, it downloads and verifies ledgers (if verifyMode is set to
+// VERIFY_BUFFERED_LEDGERS, it can also verify against ledgers currently
 // buffered in LedgerManager).
 //
 // Then, depending on configuration, it can download, verify and apply buckets
 // (as in MINIMAL and RECENT catchups), and then download and apply
 // transactions (as in COMPLETE and RECENT catchups).
 //
-// After that, catchup is done and node can replay buffered ledgers and take
+// After that, catchup is done and the node can replay buffered ledgers and take
 // part in consensus protocol.
 
 class CatchupWork : public Work

--- a/src/herder/LedgerCloseData.cpp
+++ b/src/herder/LedgerCloseData.cpp
@@ -26,6 +26,21 @@ LedgerCloseData::LedgerCloseData(uint32_t ledgerSeq,
     releaseAssert(txSet->getContentsHash() == mValue.txSetHash);
 }
 
+#ifdef BUILD_TESTS
+LedgerCloseData::LedgerCloseData(
+    uint32_t ledgerSeq, TxSetXDRFrameConstPtr txSet, StellarValue const& v,
+    std::optional<Hash> const& expectedLedgerHash,
+    std::optional<TransactionResultSet> const& expectedResults)
+    : mLedgerSeq(ledgerSeq)
+    , mTxSet(txSet)
+    , mValue(v)
+    , mExpectedLedgerHash(expectedLedgerHash)
+    , mExpectedResults(expectedResults)
+{
+    releaseAssert(txSet->getContentsHash() == mValue.txSetHash);
+}
+#endif // BUILD_TESTS
+
 std::string
 stellarValueToString(Config const& c, StellarValue const& sv)
 {

--- a/src/herder/LedgerCloseData.h
+++ b/src/herder/LedgerCloseData.h
@@ -28,6 +28,13 @@ class LedgerCloseData
         uint32_t ledgerSeq, TxSetXDRFrameConstPtr txSet, StellarValue const& v,
         std::optional<Hash> const& expectedLedgerHash = std::nullopt);
 
+#ifdef BUILD_TESTS
+    LedgerCloseData(uint32_t ledgerSeq, TxSetXDRFrameConstPtr txSet,
+                    StellarValue const& v,
+                    std::optional<Hash> const& expectedLedgerHash,
+                    std::optional<TransactionResultSet> const& expectedResults);
+#endif // BUILD_TESTS
+
     uint32_t
     getLedgerSeq() const
     {
@@ -48,6 +55,13 @@ class LedgerCloseData
     {
         return mExpectedLedgerHash;
     }
+#ifdef BUILD_TESTS
+    std::optional<TransactionResultSet> const&
+    getExpectedResults() const
+    {
+        return mExpectedResults;
+    }
+#endif // BUILD_TESTS
 
     StoredDebugTransactionSet
     toXDR() const
@@ -81,7 +95,10 @@ class LedgerCloseData
     uint32_t mLedgerSeq;
     TxSetXDRFrameConstPtr mTxSet;
     StellarValue mValue;
-    std::optional<Hash> mExpectedLedgerHash;
+    std::optional<Hash> mExpectedLedgerHash = std::nullopt;
+#ifdef BUILD_TESTS
+    std::optional<TransactionResultSet> mExpectedResults = std::nullopt;
+#endif // BUILD_TESTS
 };
 
 std::string stellarValueToString(Config const& c, StellarValue const& sv);

--- a/src/historywork/GetAndUnzipRemoteFileWork.h
+++ b/src/historywork/GetAndUnzipRemoteFileWork.h
@@ -20,6 +20,7 @@ class GetAndUnzipRemoteFileWork : public Work
 
     FileTransferInfo mFt;
     std::shared_ptr<HistoryArchive> const mArchive;
+    bool mLogErrorOnFailure;
 
     bool validateFile();
 
@@ -29,7 +30,8 @@ class GetAndUnzipRemoteFileWork : public Work
     // retries.
     GetAndUnzipRemoteFileWork(Application& app, FileTransferInfo ft,
                               std::shared_ptr<HistoryArchive> archive = nullptr,
-                              size_t retry = BasicWork::RETRY_A_LOT);
+                              size_t retry = BasicWork::RETRY_A_LOT,
+                              bool logErrorOnFailure = true);
     ~GetAndUnzipRemoteFileWork() = default;
     std::string getStatus() const override;
     std::shared_ptr<HistoryArchive> getArchive() const;

--- a/src/historywork/GetRemoteFileWork.cpp
+++ b/src/historywork/GetRemoteFileWork.cpp
@@ -42,6 +42,7 @@ GetRemoteFileWork::getCommand()
     releaseAssert(mCurrentArchive);
     releaseAssert(mCurrentArchive->hasGetCmd());
     auto cmdLine = mCurrentArchive->getFileCmd(mRemote, mLocal);
+    CLOG_DEBUG(History, "Downloading file: cmd: {}", cmdLine);
 
     return CommandInfo{cmdLine, std::string()};
 }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -77,7 +77,8 @@ class LedgerManagerImpl : public LedgerManager
     std::vector<MutableTxResultPtr> processFeesSeqNums(
         std::vector<TransactionFrameBasePtr> const& txs,
         AbstractLedgerTxn& ltxOuter, ApplicableTxSetFrame const& txSet,
-        std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta);
+        std::unique_ptr<LedgerCloseMetaFrame> const& ledgerCloseMeta,
+        LedgerCloseData const& ledgerData);
 
     void applyTransactions(
         ApplicableTxSetFrame const& txSet,

--- a/src/ledger/test/LedgerCloseMetaStreamTests.cpp
+++ b/src/ledger/test/LedgerCloseMetaStreamTests.cpp
@@ -294,6 +294,11 @@ TEST_CASE("LedgerCloseMetaStream file descriptor - REPLAY_IN_MEMORY",
         cfg.RUN_STANDALONE = true;
         cfg.setInMemoryMode();
         cfg.EXPERIMENTAL_PRECAUTION_DELAY_META = delayMeta;
+        SECTION("skip mode")
+        {
+            cfg.MODE_STORES_HISTORY_MISC = true;
+            cfg.CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = true;
+        }
         VirtualClock clock;
         auto app = createTestApplication(clock, cfg, /*newdb=*/false);
 

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -306,6 +306,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
 
 #ifdef BUILD_TESTS
     TEST_CASES_ENABLED = false;
+    CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = false;
 #endif
 
 #ifdef BEST_OFFER_DEBUGGING
@@ -1151,6 +1152,12 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                      CATCHUP_RECENT =
                          readInt<uint32_t>(item, 0, UINT32_MAX - 1);
                  }},
+#ifdef BUILD_TESTS
+                {"CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING",
+                 [&]() {
+                     CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING = readBool(item);
+                 }},
+#endif // BUILD_TESTS
                 {"ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
                  [&]() {
                      ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = readBool(item);

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -203,6 +203,13 @@ class Config : public std::enable_shared_from_this<Config>
     // If you want, say, a week of history, set this to 120000.
     uint32_t CATCHUP_RECENT;
 
+#ifdef BUILD_TESTS
+    // Mode for "accelerated" catchup. If set to true, the node will skip
+    // application of failed transactions and will not verify signatures of
+    // successful transactions.
+    bool CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING;
+#endif // BUILD_TESTS
+
     // Interval between automatic maintenance executions
     std::chrono::seconds AUTOMATIC_MAINTENANCE_PERIOD;
 

--- a/src/transactions/MutableTransactionResult.cpp
+++ b/src/transactions/MutableTransactionResult.cpp
@@ -314,6 +314,21 @@ MutableTransactionResult::isSuccess() const
     return getResult().result.code() == txSUCCESS;
 }
 
+#ifdef BUILD_TESTS
+void
+MutableTransactionResult::setReplayTransactionResult(
+    TransactionResult const& replayResult)
+{
+    mReplayTransactionResult = std::make_optional(replayResult);
+}
+
+std::optional<TransactionResult> const&
+MutableTransactionResult::getReplayTransactionResult() const
+{
+    return mReplayTransactionResult;
+}
+#endif // BUILD_TESTS
+
 FeeBumpMutableTransactionResult::FeeBumpMutableTransactionResult(
     MutableTxResultPtr innerTxResult)
     : MutableTransactionResultBase(), mInnerTxResult(innerTxResult)
@@ -447,4 +462,19 @@ FeeBumpMutableTransactionResult::isSuccess() const
 {
     return mTxResult->result.code() == txFEE_BUMP_INNER_SUCCESS;
 }
+
+#ifdef BUILD_TESTS
+void
+FeeBumpMutableTransactionResult::setReplayTransactionResult(
+    TransactionResult const& replayResult)
+{
+    /* NO-OP */
+}
+
+std::optional<TransactionResult> const&
+FeeBumpMutableTransactionResult::getReplayTransactionResult() const
+{
+    return mReplayTransactionResult;
+}
+#endif // BUILD_TESTS
 }

--- a/src/transactions/MutableTransactionResult.h
+++ b/src/transactions/MutableTransactionResult.h
@@ -71,6 +71,7 @@ class MutableTransactionResultBase : public NonMovableOrCopyable
 {
   protected:
     std::unique_ptr<TransactionResult> mTxResult;
+    std::optional<TransactionResult> mReplayTransactionResult{std::nullopt};
 
     MutableTransactionResultBase();
     MutableTransactionResultBase(MutableTransactionResultBase&& rhs);
@@ -97,8 +98,13 @@ class MutableTransactionResultBase : public NonMovableOrCopyable
 
     virtual void refundSorobanFee(int64_t feeRefund,
                                   uint32_t ledgerVersion) = 0;
-
     virtual bool isSuccess() const = 0;
+#ifdef BUILD_TESTS
+    virtual std::optional<TransactionResult> const&
+    getReplayTransactionResult() const = 0;
+    virtual void
+    setReplayTransactionResult(TransactionResult const& replayResult) = 0;
+#endif
 };
 
 class MutableTransactionResult : public MutableTransactionResultBase
@@ -124,6 +130,12 @@ class MutableTransactionResult : public MutableTransactionResultBase
     TransactionResult const& getResult() const override;
     TransactionResultCode getResultCode() const override;
     void setResultCode(TransactionResultCode code) override;
+#ifdef BUILD_TESTS
+    void
+    setReplayTransactionResult(TransactionResult const& replayResult) override;
+    std::optional<TransactionResult> const&
+    getReplayTransactionResult() const override;
+#endif // BUILD_TESTS
 
     OperationResult& getOpResultAt(size_t index) override;
     std::shared_ptr<SorobanTxData> getSorobanData() override;
@@ -177,5 +189,12 @@ class FeeBumpMutableTransactionResult : public MutableTransactionResultBase
 
     void refundSorobanFee(int64_t feeRefund, uint32_t ledgerVersion) override;
     bool isSuccess() const override;
+
+#ifdef BUILD_TESTS
+    void
+    setReplayTransactionResult(TransactionResult const& replayResult) override;
+    std::optional<TransactionResult> const&
+    getReplayTransactionResult() const override;
+#endif // BUILD_TESTS
 };
 }

--- a/src/transactions/SignatureChecker.h
+++ b/src/transactions/SignatureChecker.h
@@ -15,18 +15,21 @@
 
 namespace stellar
 {
-
 class SignatureChecker
 {
   public:
     explicit SignatureChecker(
         uint32_t protocolVersion, Hash const& contentsHash,
         xdr::xvector<DecoratedSignature, 20> const& signatures);
-
+#ifdef BUILD_TESTS
+    virtual bool checkSignature(std::vector<Signer> const& signersV,
+                                int32_t neededWeight);
+    virtual bool checkAllSignaturesUsed() const;
+#else
     bool checkSignature(std::vector<Signer> const& signersV,
                         int32_t neededWeight);
     bool checkAllSignaturesUsed() const;
-
+#endif // BUILD_TESTS
   private:
     uint32_t mProtocolVersion;
     Hash const& mContentsHash;
@@ -34,4 +37,28 @@ class SignatureChecker
 
     std::vector<bool> mUsedSignatures;
 };
+
+#ifdef BUILD_TESTS
+class AlwaysValidSignatureChecker : public SignatureChecker
+{
+  public:
+    AlwaysValidSignatureChecker(
+        uint32_t protocolVersion, Hash const& contentsHash,
+        xdr::xvector<DecoratedSignature, 20> const& signatures)
+        : SignatureChecker(protocolVersion, contentsHash, signatures)
+    {
+    }
+
+    bool
+    checkSignature(std::vector<Signer> const&, int32_t) override
+    {
+        return true;
+    }
+    bool
+    checkAllSignaturesUsed() const override
+    {
+        return true;
+    }
 };
+#endif // BUILD_TESTS
+}


### PR DESCRIPTION
# Description

Resolves [#X](https://github.com/stellar/stellar-core/issues/2814#issuecomment-2458213080)

Adds a new config option, `CATCHUP_SKIP_KNOWN_RESULTS_FOR_TESTING`. When this config option is enabled, transaction results are downloaded from history archives for the catchup range. Failed transactions are not applied, and signatures are not verified. This mode is only available in test builds. The plan is to make this mode configurable when launching supercluster runs from jenkins, with it being enabled by default but disabled specifically for release validation when we want a more comprehensive catchup. I'll raise a separate PR for that. 

## Perf testing 

### Locally running catchup on 1000 ledgers:

```
user/system/total time seconds

*Baseline (no skipping):*     429 / 115 / 138s
*Skip Failed:*                373 / 99  / 114s  (1.14x / 1.16x / 1.21x speedup over baseline)
*Skip Failed + verification:* 334 / 88  / 95s   (1.28x / 1.30x / 1.45x speedup over baseline)
```

### Supercluster PubnetParallelCatchup

Completed in 14h 47min (vs ~24 hours with recent releases / master HEAD).

https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-supercluster/1055/

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
