### PR TITLE
Wait on merges in apply-load

### DIFF
--- a/src/bucket/BucketList.cpp
+++ b/src/bucket/BucketList.cpp
@@ -447,6 +447,21 @@ BucketList::getLevel(uint32_t i)
     return mLevels.at(i);
 }
 
+#ifdef BUILD_TESTS
+void
+BucketList::resolveAllFutures()
+{
+    ZoneScoped;
+    for (auto& level : mLevels)
+    {
+        if (level.getNext().isMerging())
+        {
+            level.getNext().resolve();
+        }
+    }
+}
+#endif
+
 void
 BucketList::resolveAnyReadyFutures()
 {

--- a/src/bucket/BucketList.h
+++ b/src/bucket/BucketList.h
@@ -502,6 +502,12 @@ class BucketList
     // HistoryArchiveStates, that can cause repeated merges when re-activated.
     void resolveAnyReadyFutures();
 
+#ifdef BUILD_TESTS
+    // Same as the function above, except we don't check if the buckets are
+    // done merging.
+    void resolveAllFutures();
+#endif
+
     // returns true if levels [0, maxLevel] are resolved
     bool futuresAllResolved(uint32_t maxLevel = kNumLevels - 1) const;
 

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1884,6 +1884,7 @@ runApplyLoad(CommandLineArgs const& args)
         [&] {
             auto config = configOption.getConfig();
             config.RUN_STANDALONE = true;
+            config.MANUAL_CLOSE = true;
             config.USE_CONFIG_FOR_GENESIS = true;
             config.TESTING_UPGRADE_MAX_TX_SET_SIZE = 1000;
             config.LEDGER_PROTOCOL_VERSION =
@@ -1926,6 +1927,10 @@ runApplyLoad(CommandLineArgs const& args)
 
                 for (size_t i = 0; i < 100; ++i)
                 {
+                    app.getBucketManager().getBucketList().resolveAllFutures();
+                    releaseAssert(app.getBucketManager()
+                                      .getBucketList()
+                                      .futuresAllResolved());
                     al.benchmark();
                 }
 

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -843,7 +843,6 @@ TEST_CASE("apply load", "[loadgen][applyload]")
 
     VirtualClock clock(VirtualClock::REAL_TIME);
     auto app = createTestApplication(clock, cfg);
-    auto const& lm = app->getLedgerManager();
 
     uint64_t ledgerMaxInstructions = 500'000'000;
     uint64_t ledgerMaxReadLedgerEntries = 2000;
@@ -871,6 +870,10 @@ TEST_CASE("apply load", "[loadgen][applyload]")
     cpuInsRatioExclVm.Clear();
     for (size_t i = 0; i < 100; ++i)
     {
+        app->getBucketManager().getBucketList().resolveAllFutures();
+        releaseAssert(
+            app->getBucketManager().getBucketList().futuresAllResolved());
+
         al.benchmark();
     }
     REQUIRE(al.successRate() - 1.0 < std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
# Description

Related to https://github.com/stellar/stellar-core/issues/4520.

The goal here is to make sure buckets aren't being merged during calls to `benchmark`.

<!---

Describe what this pull request does, which issue it's resolving (usually applicable for code changes).

--->

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
