### PR TITLE
Harden publishing

### DIFF
--- a/src/history/CheckpointBuilder.h
+++ b/src/history/CheckpointBuilder.h
@@ -57,8 +57,9 @@ class CheckpointBuilder
     std::unique_ptr<XDROutputFileStream> mLedgerHeaders;
     bool mOpen{false};
     bool mStartupValidationComplete{false};
+    bool mPublishWasDisabled{false};
 
-    void ensureOpen(uint32_t ledgerSeq);
+    bool ensureOpen(uint32_t ledgerSeq);
 
   public:
     CheckpointBuilder(Application& app);

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -80,13 +80,13 @@ HistoryManager::createPublishQueueDir(Config const& cfg)
 std::filesystem::path
 publishQueueFileName(uint32_t seq)
 {
-    return fs::hexStr(seq) + ".json";
+    return fs::hexStr(seq) + ".checkpoint";
 }
 
 std::filesystem::path
 publishQueueTmpFileName(uint32_t seq)
 {
-    return fs::hexStr(seq) + ".json.dirty";
+    return fs::hexStr(seq) + ".checkpoint.dirty";
 }
 
 void
@@ -271,7 +271,7 @@ HistoryManagerImpl::logAndUpdatePublishStatus()
 bool
 isPublishFile(std::string const& name)
 {
-    std::regex re("^[a-z0-9]{8}\\.json$");
+    std::regex re("^[a-z0-9]{8}\\.checkpoint$");
     auto a = regex_match(name, re);
     return a;
 }
@@ -279,7 +279,7 @@ isPublishFile(std::string const& name)
 bool
 isPublishTmpFile(std::string const& name)
 {
-    std::regex re("^[a-z0-9]{8}\\.json.dirty$");
+    std::regex re("^[a-z0-9]{8}\\.checkpoint.dirty$");
     auto a = regex_match(name, re);
     return a;
 }

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -39,6 +39,7 @@
 #include <catch.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/cereal.hpp>
+#include <cereal/types/vector.hpp>
 
 #ifdef BUILD_TESTS
 #include "simulation/ApplyLoad.h"

--- a/src/main/CommandLine.cpp
+++ b/src/main/CommandLine.cpp
@@ -1386,6 +1386,26 @@ getSettingsUpgradeTransactions(CommandLineArgs const& args)
 }
 
 int
+runPrintPublishQueue(CommandLineArgs const& args)
+{
+    CommandLine::ConfigOption configOption;
+
+    return runWithHelp(args, {configurationParser(configOption)}, [&] {
+        auto cfg = configOption.getConfig();
+        VirtualClock clock(VirtualClock::REAL_TIME);
+        cfg.setNoListen();
+        Application::pointer app = Application::create(clock, cfg, false);
+        cereal::JSONOutputArchive archive(std::cout);
+        archive.makeArray();
+        for (auto const& has : app->getHistoryManager().getPublishQueueStates())
+        {
+            has.serialize(archive);
+        }
+        return 0;
+    });
+}
+
+int
 runCheckQuorumIntersection(CommandLineArgs const& args)
 {
     CommandLine::ConfigOption configOption;
@@ -2058,6 +2078,8 @@ handleCommandLine(int argc, char* const* argv)
           "check that a given network specified as a JSON file enjoys a quorum "
           "intersection",
           runCheckQuorumIntersection},
+         {"print-publish-queue", "print all checkpoints scheduled for publish",
+          runPrintPublishQueue},
 #ifdef BUILD_TESTS
          {"load-xdr", "load an XDR bucket file, for testing", runLoadXDR},
          {"rebuild-ledger-from-buckets",

--- a/src/main/dumpxdr.cpp
+++ b/src/main/dumpxdr.cpp
@@ -66,7 +66,7 @@ void
 dumpXdrStream(std::string const& filename, bool compact)
 {
     std::regex rx(
-        R"(.*\b(debug-tx-set|(?:(ledger|bucket|transactions|results|meta-debug|scp)-.+))\.xdr$)");
+        R"(.*\b(debug-tx-set|(?:(ledger|bucket|transactions|results|meta-debug|scp)-.+))\.xdr(?:\.dirty)?$)");
     std::smatch sm;
     if (std::regex_match(filename, sm, rx))
     {

--- a/src/util/BufferedAsioCerealOutputArchive.h
+++ b/src/util/BufferedAsioCerealOutputArchive.h
@@ -3,6 +3,7 @@
 #include "util/XDRStream.h"
 #include <cereal/archives/binary.hpp>
 #include <cereal/cereal.hpp>
+#include <cereal/types/string.hpp>
 
 namespace cereal
 {


### PR DESCRIPTION
This PR contains two changes:
* Properly fsync HAS files that act as a "publish queue". Note that the checkpoints themselves are using XDR streams with fsync turned on already, so this change impacts HAS files only. 
* Gracefully handle situations where nodes enable publish mid-checkpoint. Core will wait until the _next_ checkpoint to begin publishing. Without this change, nodes would need to rebuild state before enabling publishing (although it's unclear how often partial archives occur in practice).

Additionally, I added a few more thing to aid debugging, such as printing checkpoint files with dump-xdr and an offline command to dump all checkpoints scheduled to publish.