### PR TITLE
Remove extra arg in LedgerCloseData constructor call for non buildtest

### DIFF
--- a/src/catchup/ApplyCheckpointWork.cpp
+++ b/src/catchup/ApplyCheckpointWork.cpp
@@ -323,11 +323,14 @@ ApplyCheckpointWork::getNextLedgerCloseData()
         bm.setNextCloseVersionAndHashForTesting(
             mApp.getConfig().LEDGER_PROTOCOL_VERSION, header.bucketListHash);
     }
-#endif
-
     return std::make_shared<LedgerCloseData>(
         header.ledgerSeq, txset, header.scpValue,
         std::make_optional<Hash>(mHeaderHistoryEntry.hash), txres);
+#else
+    return std::make_shared<LedgerCloseData>(
+        header.ledgerSeq, txset, header.scpValue,
+        std::make_optional<Hash>(mHeaderHistoryEntry.hash));
+#endif
 }
 
 BasicWork::State


### PR DESCRIPTION
# Description
https://github.com/stellar/stellar-core/pull/4536 broke the non `BUILD_TEST` builds as a `BUILD_TEST` version of `LedgerCloseData`'s constructor was called from non `BUILD_TEST` code. We don't build  non `BUILD_TEST` versions in github CI, and I had built preview packages with a revision before I added the `BUILD_TEST` conditionals, so this wasn't caught pre merge.


## Testing:
* locally build with `./configure CXXFLAGS="-DBUILD_TESTS=0"`
* run package builder on this branch https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-core-package-builder/2186/ 

## Error:

From https://buildmeister-v3.stellar-ops.com/job/Core/job/stellar-core-package-builder/2185/consoleText 

```
n file included from catchup/ApplyCheckpointWork.cpp:5:
In file included from ./catchup/ApplyCheckpointWork.h:7:
In file included from ./herder/LedgerCloseData.h:7:
In file included from ./herder/TxSetFrame.h:7:
In file included from ./herder/SurgePricingUtils.h:7:
In file included from /usr/lib/llvm-12/bin/../include/c++/v1/set:429:
In file included from /usr/lib/llvm-12/bin/../include/c++/v1/__tree:15:
/usr/lib/llvm-12/bin/../include/c++/v1/memory:2596:37: error: no matching constructor for initialization of 'stellar::LedgerCloseData'
        ::new ((void*)__get_elem()) _Tp(_VSTD::forward<_Args>(__args)...);
                                    ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/llvm-12/bin/../include/c++/v1/memory:3360:55: note: in instantiation of function template specialization 'std::__shared_ptr_emplace<stellar::LedgerCloseData, std::allocator<stellar::LedgerCloseData>>::__shared_ptr_emplace<unsigned int &, std::shared_ptr<const stellar::TxSetXDRFrame> &, stellar::StellarValue &, std::optional<xdr::opaque_array<32>>, std::optional<stellar::TransactionResultSet> &>' requested here
    ::new ((void*)_VSTD::addressof(*__guard.__get())) _ControlBlock(__a, _VSTD::forward<_Args>(__args)...);
                                                      ^
/usr/lib/llvm-12/bin/../include/c++/v1/memory:3369:19: note: in instantiation of function template specialization 'std::allocate_shared<stellar::LedgerCloseData, std::allocator<stellar::LedgerCloseData>, unsigned int &, std::shared_ptr<const stellar::TxSetXDRFrame> &, stellar::StellarValue &, std::optional<xdr::opaque_array<32>>, std::optional<stellar::TransactionResultSet> &, void>' requested here
    return _VSTD::allocate_shared<_Tp>(allocator<_Tp>(), _VSTD::forward<_Args>(__args)...);
                  ^
catchup/ApplyCheckpointWork.cpp:328:17: note: in instantiation of function template specialization 'std::make_shared<stellar::LedgerCloseData, unsigned int &, std::shared_ptr<const stellar::TxSetXDRFrame> &, stellar::StellarValue &, std::optional<xdr::opaque_array<32>>, std::optional<stellar::TransactionResultSet> &, void>' requested here
    return std::make_shared<LedgerCloseData>(
                ^
./herder/LedgerCloseData.h:27:5: note: candidate constructor not viable: requires at most 4 arguments, but 5 were provided
    LedgerCloseData(
    ^
./herder/LedgerCloseData.h:24:7: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 5 were provided
class LedgerCloseData
      ^
./herder/LedgerCloseData.h:24:7: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 5 were provided
depbase=`echo catchup/IndexBucketsWork.o | sed 's|[^/]*$|.deps/&|;s|\.o$||'`;\
clang++-12 -std=c++17 -DHAVE_CONFIG_H -I. -I..  -isystem ".." -I"../src" -I"../src" -isystem /build/stellar-core-22.0.1/lib/libsodium/src/libsodium/include -isystem ../lib/libsodium/src/libsodium/include -isystem ../lib/libsodium/src/libsodium/include/sodium -isystem /build/stellar-core-22.0.1/lib/xdrpp -isystem /build/stellar-core-22.0.1/lib/xdrpp -isystem ../lib/libmedida/src -isystem ../lib/soci/src/core -isystem ../lib/sqlite -DSQLITE_CORE -DSQLITE_OMIT_LOAD_EXTENSION=1 -DASIO_SEPARATE_COMPILATION=1 -DASIO_STANDALONE -isystem ../lib/asio/asio/include  -isystem "../lib" -isystem "../lib/autocheck/include" -isystem "../lib/cereal/include" -isystem "../lib/util" -isystem "../lib/fmt/include" -isystem "../lib/soci/src/core" -isystem "../lib/tracy/public/tracy" -isystem "../lib/spdlog/include" -isystem "../rust/src" -DUSE_POSTGRES=1 -I/usr/include/postgresql  -I"../src/protocol-curr" -DCEREAL_THREAD_SAFE   -DUSE_SPDLOG  -Wdate-time -D_FORTIFY_SOURCE=2  -stdlib=libc++ -fno-omit-frame-pointer -isystem /usr/include/libcxxabi -ggdb -O3 -fstack-protector-strong -Wformat -Werror=format-security  -pthread -DFMT_HEADER_ONLY=1 -Wall -Wno-unused-command-line-argument -Qunused-arguments -Wno-unused-local-typedef -Wno-unknown-warning-option -Werror=unused-result -MT catchup/IndexBucketsWork.o -MD -MP -MF $depbase.Tpo -c -o catchup/IndexBucketsWork.o catchup/IndexBucketsWork.cpp &&\
mv -f $depbase.Tpo $depbase.Po
```

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
