### PR TITLE
BucketList cache

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -24,7 +24,7 @@ AM_CPPFLAGS += -I"$(top_builddir)/src/protocol-curr"
 endif
 
 # Unconditionally add CEREAL_THREAD_SAFE, we always want it.
-AM_CPPFLAGS += -DCEREAL_THREAD_SAFE
+#AM_CPPFLAGS += -DCEREAL_THREAD_SAFE
 
 # USE_TRACY and tracy_CFLAGS here represent the case of enabling
 # tracy at configure-time; but even when it is disabled we want

--- a/src/bucket/BucketIndex.h
+++ b/src/bucket/BucketIndex.h
@@ -80,7 +80,9 @@ class BucketIndex : public NonMovableOrCopyable
                                   IndividualIndex::const_iterator>;
 
     inline static const std::string DB_BACKEND_STATE = "bl";
-    inline static const uint32_t BUCKET_INDEX_VERSION = 4;
+    inline static const uint32_t BUCKET_INDEX_VERSION = 5;
+    inline static const uint32_t CACHE_SIZE = 1'000'000;
+    inline static const uint64_t INDIVIDUAL_CACHE_CUTOFF_SIZE = 100'000'000'000;
 
     // Returns true if LedgerEntryType not supported by BucketListDB
     static bool typeNotSupported(LedgerEntryType t);
@@ -130,12 +132,20 @@ class BucketIndex : public NonMovableOrCopyable
     virtual std::optional<std::pair<std::streamoff, std::streamoff>>
     getOfferRange() const = 0;
 
+    // Returns true if cache hit occurred
+    virtual std::pair<std::shared_ptr<BucketEntry>, bool>
+    getFromCache(LedgerKey const& k) const = 0;
+
+    virtual void addToCache(std::shared_ptr<BucketEntry> be) const = 0;
+
     // Returns page size for index. InidividualIndex returns 0 for page size
     virtual std::streamoff getPageSize() const = 0;
 
     virtual Iterator begin() const = 0;
 
     virtual Iterator end() const = 0;
+
+    virtual bool isFullyCached() const = 0;
 
     virtual void markBloomMiss() const = 0;
     virtual void markBloomLookup() const = 0;

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -162,7 +162,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     DEPRECATED_SQL_LEDGER_STATE = false;
     BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 14; // 2^14 == 16 kb
     BUCKETLIST_DB_INDEX_CUTOFF = 20;             // 20 mb
-    BUCKETLIST_DB_PERSIST_INDEX = true;
+    BUCKETLIST_DB_PERSIST_INDEX = false;
     BACKGROUND_EVICTION_SCAN = true;
     PUBLISH_TO_ARCHIVE_DELAY = std::chrono::seconds{0};
     // automatic maintenance settings:


### PR DESCRIPTION
# Description

Resolves #3696

This adds a persistent cache to BucketListDB at the bucket level. If a bucket is small, the entire bucket contents are cached in memory. For larger buckets, a random eviction cache is used instead.

Currently in draft form for max TPS tests, as I need to clean up the BucketIndex classes given that there's a fair bit of dead code now that caches are used.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
