### PR TITLE
Evict persistent entries to Hot Archive

### DIFF
--- a/src/bucket/BucketIndexImpl.cpp
+++ b/src/bucket/BucketIndexImpl.cpp
@@ -589,11 +589,22 @@ BucketIndexImpl<IndexT>::operator==(BucketIndex const& inRaw) const
 
     if constexpr (std::is_same_v<IndexT, RangeIndex>)
     {
-        releaseAssert(mData.filter);
-        releaseAssert(in.mData.filter);
-        if (!(*(mData.filter) == *(in.mData.filter)))
+        // If both indexes have a filter, check if they are equal
+        if (mData.filter && in.mData.filter)
         {
-            return false;
+            if (!(*(mData.filter) == *(in.mData.filter)))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            // If both indexes don't fave a filter, check that each filter is
+            // null
+            if (mData.filter || in.mData.filter)
+            {
+                return false;
+            }
         }
     }
     else

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1048,7 +1048,8 @@ BucketManager::maybeSetIndex(std::shared_ptr<BucketBase> b,
 }
 
 void
-BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq)
+BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq,
+                                           uint32_t ledgerVers)
 {
     releaseAssert(mSnapshotManager);
     releaseAssert(!mEvictionFuture.valid());
@@ -1059,14 +1060,15 @@ BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq)
     auto const& cfg = mApp.getLedgerManager().getSorobanNetworkConfigForApply();
     auto const& sas = cfg.stateArchivalSettings();
 
-    using task_t = std::packaged_task<EvictionResult()>;
+    using task_t = std::packaged_task<EvictionResultCandidates()>;
     // MSVC gotcha: searchableBL has to be shared_ptr because MSVC wants to
     // copy this lambda, otherwise we could use unique_ptr.
     auto task = std::make_shared<task_t>(
         [bl = std::move(searchableBL), iter = cfg.evictionIterator(), ledgerSeq,
-         sas, &counters = mBucketListEvictionCounters,
+         ledgerVers, sas, &counters = mBucketListEvictionCounters,
          stats = mEvictionStatistics] {
-            return bl->scanForEviction(ledgerSeq, counters, iter, stats, sas);
+            return bl->scanForEviction(ledgerSeq, counters, iter, stats, sas,
+                                       ledgerVers);
         });
 
     mEvictionFuture = task->get_future();
@@ -1075,10 +1077,11 @@ BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq)
         "SearchableLiveBucketListSnapshot: eviction scan");
 }
 
-void
+EvictedStateVectors
 BucketManager::resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx,
                                              uint32_t ledgerSeq,
-                                             LedgerKeySet const& modifiedKeys)
+                                             LedgerKeySet const& modifiedKeys,
+                                             uint32_t ledgerVers)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -1086,7 +1089,7 @@ BucketManager::resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx,
 
     if (!mEvictionFuture.valid())
     {
-        startBackgroundEvictionScan(ledgerSeq);
+        startBackgroundEvictionScan(ledgerSeq, ledgerVers);
     }
 
     auto evictionCandidates = mEvictionFuture.get();
@@ -1099,44 +1102,60 @@ BucketManager::resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx,
     if (!evictionCandidates.isValid(ledgerSeq,
                                     networkConfig.stateArchivalSettings()))
     {
-        startBackgroundEvictionScan(ledgerSeq);
+        startBackgroundEvictionScan(ledgerSeq, ledgerVers);
         evictionCandidates = mEvictionFuture.get();
     }
 
-    auto& eligibleKeys = evictionCandidates.eligibleKeys;
+    auto& eligibleEntries = evictionCandidates.eligibleEntries;
 
-    for (auto iter = eligibleKeys.begin(); iter != eligibleKeys.end();)
+    for (auto iter = eligibleEntries.begin(); iter != eligibleEntries.end();)
     {
         // If the TTL has not been modified this ledger, we can evict the entry
-        if (modifiedKeys.find(getTTLKey(iter->key)) == modifiedKeys.end())
+        if (modifiedKeys.find(getTTLKey(iter->entry)) == modifiedKeys.end())
         {
             ++iter;
         }
         else
         {
-            iter = eligibleKeys.erase(iter);
+            iter = eligibleEntries.erase(iter);
         }
     }
 
     auto remainingEntriesToEvict =
         networkConfig.stateArchivalSettings().maxEntriesToArchive;
-    auto entryToEvictIter = eligibleKeys.begin();
+    auto entryToEvictIter = eligibleEntries.begin();
     auto newEvictionIterator = evictionCandidates.endOfRegionIterator;
+
+    // Return vectors include both evicted entry and associated TTL
+    std::vector<LedgerKey> deletedKeys;
+    std::vector<LedgerEntry> archivedEntries;
 
     // Only actually evict up to maxEntriesToArchive of the eligible entries
     while (remainingEntriesToEvict > 0 &&
-           entryToEvictIter != eligibleKeys.end())
+           entryToEvictIter != eligibleEntries.end())
     {
-        ltx.erase(entryToEvictIter->key);
-        ltx.erase(getTTLKey(entryToEvictIter->key));
+        ltx.erase(LedgerEntryKey(entryToEvictIter->entry));
+        ltx.erase(getTTLKey(entryToEvictIter->entry));
         --remainingEntriesToEvict;
+
+        if (isTemporaryEntry(entryToEvictIter->entry.data))
+        {
+            deletedKeys.emplace_back(LedgerEntryKey(entryToEvictIter->entry));
+        }
+        else
+        {
+            archivedEntries.emplace_back(entryToEvictIter->entry);
+        }
+
+        // Delete TTL for both types
+        deletedKeys.emplace_back(getTTLKey(entryToEvictIter->entry));
 
         auto age = ledgerSeq - entryToEvictIter->liveUntilLedger;
         mEvictionStatistics->recordEvictedEntry(age);
         mBucketListEvictionCounters.entriesEvicted.inc();
 
         newEvictionIterator = entryToEvictIter->iter;
-        entryToEvictIter = eligibleKeys.erase(entryToEvictIter);
+        entryToEvictIter = eligibleEntries.erase(entryToEvictIter);
     }
 
     // If remainingEntriesToEvict == 0, that means we could not evict the entire
@@ -1149,6 +1168,7 @@ BucketManager::resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx,
     }
 
     networkConfig.updateEvictionIterator(ltx, newEvictionIterator);
+    return EvictedStateVectors{deletedKeys, archivedEntries};
 }
 
 medida::Meter&

--- a/src/bucket/BucketOutputIterator.cpp
+++ b/src/bucket/BucketOutputIterator.cpp
@@ -64,6 +64,7 @@ BucketOutputIterator<BucketT>::BucketOutputIterator(std::string const& tmpDir,
             HotArchiveBucketEntry bme;
             bme.type(HOT_ARCHIVE_METAENTRY);
             bme.metaEntry() = mMeta;
+            releaseAssertOrThrow(bme.metaEntry().ext.v() == 1);
             put(bme);
         }
 

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -85,7 +85,8 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
     Loop scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
                          uint32_t ledgerSeq,
                          std::list<EvictionResultEntry>& evictableKeys,
-                         SearchableLiveBucketListSnapshot const& bl) const;
+                         SearchableLiveBucketListSnapshot const& bl,
+                         uint32_t ledgerVers) const;
 };
 
 class HotArchiveBucketSnapshot : public BucketSnapshotBase<HotArchiveBucket>

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -94,8 +94,8 @@ MergeCounters::operator==(MergeCounters const& other) const
 // Check that eviction scan is based off of current ledger snapshot and that
 // archival settings have not changed
 bool
-EvictionResult::isValid(uint32_t currLedger,
-                        StateArchivalSettings const& currSas) const
+EvictionResultCandidates::isValid(uint32_t currLedger,
+                                  StateArchivalSettings const& currSas) const
 {
     return initialLedger == currLedger &&
            initialSas.maxEntriesToArchive == currSas.maxEntriesToArchive &&

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -11,11 +11,11 @@
 
 namespace stellar
 {
-EvictionResult
+EvictionResultCandidates
 SearchableLiveBucketListSnapshot::scanForEviction(
     uint32_t ledgerSeq, EvictionCounters& counters,
     EvictionIterator evictionIter, std::shared_ptr<EvictionStatistics> stats,
-    StateArchivalSettings const& sas) const
+    StateArchivalSettings const& sas, uint32_t ledgerVers) const
 {
     releaseAssert(mSnapshot);
     releaseAssert(stats);
@@ -30,7 +30,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     LiveBucketList::updateStartingEvictionIterator(
         evictionIter, sas.startingEvictionScanLevel, ledgerSeq);
 
-    EvictionResult result(sas);
+    EvictionResultCandidates result(sas);
     auto startIter = evictionIter;
     auto scanSize = sas.evictionScanSize;
 
@@ -42,7 +42,8 @@ SearchableLiveBucketListSnapshot::scanForEviction(
 
         // If we scan scanSize before hitting bucket EOF, exit early
         if (b.scanForEviction(evictionIter, scanSize, ledgerSeq,
-                              result.eligibleKeys, *this) == Loop::COMPLETE)
+                              result.eligibleEntries, *this,
+                              ledgerVers) == Loop::COMPLETE)
         {
             break;
         }

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -30,11 +30,10 @@ class SearchableLiveBucketListSnapshot
     loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
                        LedgerKeyMeter* lkMeter) const;
 
-    EvictionResult scanForEviction(uint32_t ledgerSeq,
-                                   EvictionCounters& counters,
-                                   EvictionIterator evictionIter,
-                                   std::shared_ptr<EvictionStatistics> stats,
-                                   StateArchivalSettings const& sas) const;
+    EvictionResultCandidates scanForEviction(
+        uint32_t ledgerSeq, EvictionCounters& counters, EvictionIterator iter,
+        std::shared_ptr<EvictionStatistics> stats,
+        StateArchivalSettings const& sas, uint32_t ledgerVers) const;
 
     friend SearchableSnapshotConstPtr
     BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const;

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -617,8 +617,18 @@ TEST_CASE("serialize bucket indexes", "[bucket][bucketindex]")
     auto test = BucketIndexTest(cfg, /*levels=*/3);
     test.buildGeneralTest();
 
-    auto buckets = test.getBM().getBucketListReferencedBuckets();
-    for (auto const& bucketHash : buckets)
+    std::set<Hash> liveBuckets;
+    auto& liveBL = test.getBM().getLiveBucketList();
+    for (auto i = 0; i < LiveBucketList::kNumLevels; ++i)
+    {
+        auto level = liveBL.getLevel(i);
+        for (auto const& b : {level.getCurr(), level.getSnap()})
+        {
+            liveBuckets.emplace(b->getHash());
+        }
+    }
+
+    for (auto const& bucketHash : liveBuckets)
     {
         if (isZero(bucketHash))
         {
@@ -647,7 +657,7 @@ TEST_CASE("serialize bucket indexes", "[bucket][bucketindex]")
     cfg.BUCKETLIST_DB_INDEX_PAGE_SIZE_EXPONENT = 10;
     test.restartWithConfig(cfg);
 
-    for (auto const& bucketHash : buckets)
+    for (auto const& bucketHash : liveBuckets)
     {
         if (isZero(bucketHash))
         {

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -948,14 +948,19 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
     });
 }
 
-TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
+TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
 {
     VirtualClock clock;
     Config cfg(getTestConfig());
     cfg.USE_CONFIG_FOR_GENESIS = true;
 
-    auto app = createTestApplication<BucketTestApplication>(clock, cfg);
-    for_versions_from(20, *app, [&] {
+    auto test = [&](Config& cfg) {
+        auto app = createTestApplication<BucketTestApplication>(clock, cfg);
+
+        bool tempOnly = protocolVersionIsBefore(
+            cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION,
+            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
+
         LedgerManagerForBucketTests& lm = app->getLedgerManager();
         auto& bm = app->getBucketManager();
         auto& bl = bm.getLiveBucketList();
@@ -1020,12 +1025,19 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
         std::set<LedgerKey> tempEntries;
         std::set<LedgerKey> persistentEntries;
         std::vector<LedgerEntry> entries;
+
         for (auto& e :
              LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
-                 {CONTRACT_DATA}, 50))
+                 {CONTRACT_DATA, CONTRACT_CODE}, 50))
         {
-            // Set half of the entries to be persistent, half temporary
-            if (tempEntries.empty() || rand_flip())
+            if (e.data.type() == CONTRACT_CODE)
+            {
+                persistentEntries.emplace(LedgerEntryKey(e));
+            }
+
+            // Set half of the contact data entries to be persistent, half
+            // temporary
+            else if (tempEntries.empty() || rand_flip())
             {
                 e.data.contractData().durability = TEMPORARY;
                 tempEntries.emplace(LedgerEntryKey(e));
@@ -1059,6 +1071,53 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
             closeLedger(*app);
         }
 
+        auto expectedEvictions = tempEntries.size();
+
+        if (!tempOnly)
+        {
+            expectedEvictions += persistentEntries.size();
+        }
+
+        auto checkArchivedBucketList = [&] {
+            if (!tempOnly)
+            {
+                auto archiveSnapshot =
+                    bm.getBucketSnapshotManager()
+                        .copySearchableHotArchiveBucketListSnapshot();
+
+                // Check that persisted entries have been inserted into
+                // HotArchive
+                for (auto const& k : persistentEntries)
+                {
+                    auto archivedEntry = archiveSnapshot->load(k);
+                    REQUIRE(archivedEntry);
+
+                    auto seen = false;
+                    for (auto const& e : entries)
+                    {
+                        if (e == archivedEntry->archivedEntry())
+                        {
+                            seen = true;
+                            break;
+                        }
+                    }
+                    REQUIRE(seen);
+
+                    // Make sure TTL keys are not archived
+                    auto ttl = getTTLKey(k);
+                    auto archivedTTL = archiveSnapshot->load(ttl);
+                    REQUIRE(!archivedTTL);
+                }
+
+                // Temp entries should not be archived
+                for (auto const& k : tempEntries)
+                {
+                    auto archivedEntry = archiveSnapshot->load(k);
+                    REQUIRE(!archivedEntry);
+                }
+            }
+        };
+
         SECTION("basic eviction test")
         {
             // Set eviction to start at level where the entries
@@ -1070,10 +1129,12 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
             closeLedger(*app);
             ++ledgerSeq;
             checkIfEntryExists(tempEntries, false);
-            checkIfEntryExists(persistentEntries, true);
+            checkIfEntryExists(persistentEntries, tempOnly);
 
             auto& entriesEvictedCounter = bm.getEntriesEvictedCounter();
-            REQUIRE(entriesEvictedCounter.count() == tempEntries.size());
+
+            REQUIRE(entriesEvictedCounter.count() == expectedEvictions);
+            checkArchivedBucketList();
 
             // Close ledgers until evicted DEADENTRYs merge with
             // original INITENTRYs. This checks that BucketList
@@ -1087,7 +1148,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
                 closeLedger(*app);
             }
 
-            REQUIRE(entriesEvictedCounter.count() == tempEntries.size());
+            REQUIRE(entriesEvictedCounter.count() == expectedEvictions);
         }
 
         SECTION("shadowed entries not evicted")
@@ -1128,7 +1189,7 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
             auto& entriesEvictedCounter = bm.getEntriesEvictedCounter();
             auto prevIter = evictionIter;
             for (auto prevCount = entriesEvictedCounter.count();
-                 prevCount < tempEntries.size();)
+                 prevCount < expectedEvictions;)
             {
                 closeLedger(*app);
 
@@ -1151,12 +1212,12 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
 
             // All entries should have been evicted
             checkIfEntryExists(tempEntries, false);
-            checkIfEntryExists(persistentEntries, true);
+            checkIfEntryExists(persistentEntries, tempOnly);
+            checkArchivedBucketList();
         }
 
         SECTION("maxEntriesToArchive with entry modified on eviction ledger")
         {
-
             // This test is for an edge case in background eviction.
             // We want to test that if entry n should be the last entry
             // evicted due to maxEntriesToArchive, but that entry is
@@ -1173,17 +1234,25 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
             LedgerKey entryToEvict;
             std::optional<uint64_t> expectedEndIterPosition{};
 
+            auto willBeEvicited = [&](LedgerEntry const& le) {
+                if (tempOnly)
+                {
+                    return isTemporaryEntry(le.data);
+                }
+                else
+                {
+                    return isSorobanEntry(le.data);
+                }
+            };
+
             for (LiveBucketInputIterator in(bl.getLevel(levelToScan).getCurr());
                  in; ++in)
             {
-                // Temp entries should be sorted before persistent in
-                // the Bucket
                 auto be = *in;
                 if (be.type() == INITENTRY || be.type() == LIVEENTRY)
                 {
                     auto le = be.liveEntry();
-                    if (le.data.type() == CONTRACT_DATA &&
-                        le.data.contractData().durability == TEMPORARY)
+                    if (willBeEvicited(le))
                     {
                         if (!entryToUpdate)
                         {
@@ -1389,7 +1458,9 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist]")
                 testIterReset(false);
             }
         }
-    });
+    };
+
+    for_versions(20, Config::CURRENT_LEDGER_PROTOCOL_VERSION, cfg, test);
 }
 
 TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")

--- a/src/ledger/LedgerCloseMetaFrame.h
+++ b/src/ledger/LedgerCloseMetaFrame.h
@@ -30,7 +30,8 @@ class LedgerCloseMetaFrame
 
     void populateTxSet(TxSetXDRFrame const& txSet);
 
-    void populateEvictedEntries(LedgerEntryChanges const& evictionChanges);
+    // Used for populating meta from background eviction scan
+    void populateEvictedEntries(EvictedStateVectors const& evictedState);
 
     void setNetworkConfiguration(SorobanNetworkConfig const& networkConfig,
                                  bool emitExtV1);

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -552,6 +552,21 @@ for_versions(uint32 from, uint32 to, Config const& cfg,
 }
 
 void
+for_versions(uint32 from, uint32 to, Config const& cfg,
+             std::function<void(Config&)> const& f)
+{
+    if (from > to)
+    {
+        return;
+    }
+    auto versions = std::vector<uint32>{};
+    versions.resize(to - from + 1);
+    std::iota(std::begin(versions), std::end(versions), from);
+
+    for_versions(versions, cfg, f);
+}
+
+void
 for_versions(std::vector<uint32> const& versions, Application& app,
              std::function<void(void)> const& f)
 {
@@ -572,6 +587,22 @@ for_versions(std::vector<uint32> const& versions, Application& app,
 void
 for_versions(std::vector<uint32> const& versions, Config const& cfg,
              std::function<void(Config const&)> const& f)
+{
+    REQUIRE(gMustUseTestVersionsWrapper);
+
+    if (std::find(versions.begin(), versions.end(), gTestingVersion) !=
+        versions.end())
+    {
+        REQUIRE(cfg.TESTING_UPGRADE_LEDGER_PROTOCOL_VERSION == gTestingVersion);
+        Config vcfg = cfg;
+        vcfg.LEDGER_PROTOCOL_VERSION = gTestingVersion;
+        f(vcfg);
+    }
+}
+
+void
+for_versions(std::vector<uint32> const& versions, Config const& cfg,
+             std::function<void(Config&)> const& f)
 {
     REQUIRE(gMustUseTestVersionsWrapper);
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -72,8 +72,14 @@ void for_versions(std::vector<uint32> const& versions, Application& app,
 void for_versions(uint32 from, uint32 to, Config const& cfg,
                   std::function<void(Config const&)> const& f);
 
+void for_versions(uint32 from, uint32 to, Config const& cfg,
+                  std::function<void(Config&)> const& f);
+
 void for_versions(std::vector<uint32> const& versions, Config const& cfg,
                   std::function<void(Config const&)> const& f);
+
+void for_versions(std::vector<uint32> const& versions, Config const& cfg,
+                  std::function<void(Config&)> const& f);
 
 void for_all_versions_except(std::vector<uint32> const& versions,
                              Application& app,

--- a/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-current/InvokeHostFunctionTests.json
@@ -1324,6 +1324,9 @@
 		"bKDF6V5IzTo="
 	],
 	"contract storage|footprint|unused readWrite key" : [ "VzQb0aWq2bE=" ],
+	"entry eviction|protocol version 20" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"entry eviction|protocol version 21" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"entry eviction|protocol version 22" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"failure diagnostics" : [ "bKDF6V5IzTo=" ],
 	"ledger entry size limit enforced" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"loadgen Wasm executes properly" : [ "bKDF6V5IzTo=" ],
@@ -1387,7 +1390,6 @@
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo="
 	],
-	"temp entry eviction" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"transaction validation diagnostics" : [ "bKDF6V5IzTo=" ],
 	"version test" : [ "766L+TYsWqA=" ]
 }

--- a/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
+++ b/test-tx-meta-baseline-next/InvokeHostFunctionTests.json
@@ -1325,6 +1325,11 @@
 		"bKDF6V5IzTo="
 	],
 	"contract storage|footprint|unused readWrite key" : [ "VzQb0aWq2bE=" ],
+	"entry eviction|protocol version 20" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"entry eviction|protocol version 21" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"entry eviction|protocol version 22" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"entry eviction|protocol version 23" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
+	"evicted persistent entries" : [ "bKDF6V5IzTo=" ],
 	"failure diagnostics" : [ "bKDF6V5IzTo=" ],
 	"ledger entry size limit enforced" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"loadgen Wasm executes properly" : [ "bKDF6V5IzTo=" ],
@@ -1391,7 +1396,6 @@
 		"bKDF6V5IzTo=",
 		"bKDF6V5IzTo="
 	],
-	"temp entry eviction" : [ "bKDF6V5IzTo=", "bKDF6V5IzTo=" ],
 	"transaction validation diagnostics" : [ "bKDF6V5IzTo=" ],
 	"version test" : [ "766L+TYsWqA=" ]
 }


### PR DESCRIPTION
# Description

Resolves #4395

This PR evicts persitent entries to the Hot Archive in p23. Specifically, the background eviction scan will delete expired persistent entries from the live bucketlist and add them to the hot archive. This change also includes eviction meta for these types.

Operations have not yet been modified to work with the evicted entries. This means that `InvokeHostFunctionOp` does not check the hot archive for the existence of archived entries, and `RestoreFootprintOp` will not be able to restore evicted entries. These changes will be added in a follow up PR.


# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
