### PR TITLE
Change github action files to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,13 @@ jobs:
   complete:
     if: always()
     needs: [fmt, cargo-deny, rust-check-git-rev-deps, build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
       run: exit 1
 
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - run: rustup component add rustfmt
@@ -29,7 +29,7 @@ jobs:
     - run: cargo fmt --all --check
 
   cargo-deny:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         checks:
@@ -47,13 +47,13 @@ jobs:
         arguments:
 
   rust-check-git-rev-deps:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: stellar/actions/rust-check-git-rev-deps@main
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       CACHED_PATHS: |
         ~/.ccache


### PR DESCRIPTION
# Description

`ubuntu-latest` in github actions has recently migrated to Ubuntu 24.04. This version doesn't package `clang-format-12`, so this update changes our actions to `ubuntu-22.04`

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
