### PR TITLE
Use re-calibrated costs for loadgen.

### DIFF
--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1199,6 +1199,16 @@ Upgrades::applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
     if (needUpgradeToVersion(SOROBAN_PROTOCOL_VERSION, prevVersion, newVersion))
     {
         SorobanNetworkConfig::createLedgerEntriesForV20(ltx, app);
+#ifdef BUILD_TESTS
+        // Update the costs in case if we're in loadgen mode, so that the costs
+        // reflect the most recent calibration on p20. This would break
+        // if we tried to replay the ledger, but we shouldn't be combining load
+        // generation with the ledger replay.
+        if (app.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
+        {
+            SorobanNetworkConfig::updateRecalibratedCostTypesForV20(ltx);
+        }
+#endif
     }
     if (needUpgradeToVersion(ProtocolVersion::V_21, prevVersion, newVersion))
     {


### PR DESCRIPTION
# Description

Use re-calibrated costs for loadgen.

Also update the `generate soroban load` test to not use the config for genesis and go through the protocol upgrade instead, so that it resembles the supercluster missions closer.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
