### PR TITLE
Make read-only ledger state const

### DIFF
--- a/src/bucket/BucketListSnapshotBase.cpp
+++ b/src/bucket/BucketListSnapshotBase.cpp
@@ -51,10 +51,9 @@ BucketListSnapshot<BucketT>::getLedgerSeq() const
 
 template <class BucketT>
 LedgerHeader const&
-SearchableBucketListSnapshotBase<BucketT>::getLedgerHeader()
+SearchableBucketListSnapshotBase<BucketT>::getLedgerHeader() const
 {
     releaseAssert(mSnapshot);
-    mSnapshotManager.maybeUpdateSnapshot(mSnapshot, mHistoricalSnapshots);
     return mSnapshot->getLedgerHeader();
 }
 
@@ -85,7 +84,7 @@ SearchableBucketListSnapshotBase<BucketT>::loopAllBuckets(
 
 template <class BucketT>
 std::shared_ptr<typename BucketT::LoadT>
-SearchableBucketListSnapshotBase<BucketT>::load(LedgerKey const& k)
+SearchableBucketListSnapshotBase<BucketT>::load(LedgerKey const& k) const
 {
     ZoneScoped;
 
@@ -108,7 +107,6 @@ SearchableBucketListSnapshotBase<BucketT>::load(LedgerKey const& k)
         }
     };
 
-    mSnapshotManager.maybeUpdateSnapshot(mSnapshot, mHistoricalSnapshots);
     if (threadIsMain())
     {
         mSnapshotManager.startPointLoadTimer();
@@ -127,7 +125,8 @@ SearchableBucketListSnapshotBase<BucketT>::load(LedgerKey const& k)
 template <class BucketT>
 std::optional<std::vector<typename BucketT::LoadT>>
 SearchableBucketListSnapshotBase<BucketT>::loadKeysFromLedger(
-    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys, uint32_t ledgerSeq)
+    std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
+    uint32_t ledgerSeq) const
 {
     return loadKeysInternal(inKeys, /*lkMeter=*/nullptr, ledgerSeq);
 }
@@ -141,11 +140,13 @@ BucketLevelSnapshot<BucketT>::BucketLevelSnapshot(
 
 template <class BucketT>
 SearchableBucketListSnapshotBase<BucketT>::SearchableBucketListSnapshotBase(
-    BucketSnapshotManager const& snapshotManager)
-    : mSnapshotManager(snapshotManager), mHistoricalSnapshots()
+    BucketSnapshotManager const& snapshotManager,
+    SnapshotPtrT<BucketT>&& snapshot,
+    std::map<uint32_t, SnapshotPtrT<BucketT>>&& historicalSnapshots)
+    : mSnapshotManager(snapshotManager)
+    , mSnapshot(std::move(snapshot))
+    , mHistoricalSnapshots(std::move(historicalSnapshots))
 {
-
-    mSnapshotManager.maybeUpdateSnapshot(mSnapshot, mHistoricalSnapshots);
 }
 
 template <class BucketT>

--- a/src/bucket/BucketListSnapshotBase.h
+++ b/src/bucket/BucketListSnapshotBase.h
@@ -97,12 +97,14 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
                         BucketListSnapshot<BucketT> const& snapshot) const;
 
     SearchableBucketListSnapshotBase(
-        BucketSnapshotManager const& snapshotManager);
+        BucketSnapshotManager const& snapshotManager,
+        SnapshotPtrT<BucketT>&& snapshot,
+        std::map<uint32_t, SnapshotPtrT<BucketT>>&& historicalSnapshots);
 
     std::optional<std::vector<typename BucketT::LoadT>>
     loadKeysInternal(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
                      LedgerKeyMeter* lkMeter,
-                     std::optional<uint32_t> ledgerSeq);
+                     std::optional<uint32_t> ledgerSeq) const;
 
   public:
     uint32_t
@@ -111,7 +113,7 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
         return mSnapshot->getLedgerSeq();
     }
 
-    LedgerHeader const& getLedgerHeader();
+    LedgerHeader const& getLedgerHeader() const;
 
     // Loads inKeys from the specified historical snapshot. Returns
     // load_result_vec if the snapshot for the given ledger is
@@ -121,8 +123,8 @@ class SearchableBucketListSnapshotBase : public NonMovableOrCopyable
     // in the BucketList is N - 1.
     std::optional<std::vector<typename BucketT::LoadT>>
     loadKeysFromLedger(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
-                       uint32_t ledgerSeq);
+                       uint32_t ledgerSeq) const;
 
-    std::shared_ptr<typename BucketT::LoadT> load(LedgerKey const& k);
+    std::shared_ptr<typename BucketT::LoadT> load(LedgerKey const& k) const;
 };
 }

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1056,7 +1056,7 @@ BucketManager::startBackgroundEvictionScan(uint32_t ledgerSeq)
 
     auto searchableBL =
         mSnapshotManager->copySearchableLiveBucketListSnapshot();
-    auto const& cfg = mApp.getLedgerManager().getSorobanNetworkConfig();
+    auto const& cfg = mApp.getLedgerManager().getSorobanNetworkConfigForApply();
     auto const& sas = cfg.stateArchivalSettings();
 
     using task_t = std::packaged_task<EvictionResult()>;
@@ -1092,7 +1092,7 @@ BucketManager::resolveBackgroundEvictionScan(AbstractLedgerTxn& ltx,
     auto evictionCandidates = mEvictionFuture.get();
 
     auto const& networkConfig =
-        mApp.getLedgerManager().getSorobanNetworkConfig();
+        mApp.getLedgerManager().getSorobanNetworkConfigForApply();
 
     // If eviction related settings changed during the ledger, we have to
     // restart the scan
@@ -1578,20 +1578,6 @@ Config const&
 BucketManager::getConfig() const
 {
     return mConfig;
-}
-
-std::shared_ptr<SearchableLiveBucketListSnapshot>
-BucketManager::getSearchableLiveBucketListSnapshot()
-{
-    // Any other threads must maintain their own snapshot
-    releaseAssert(threadIsMain());
-    if (!mSearchableBucketListSnapshot)
-    {
-        mSearchableBucketListSnapshot =
-            mSnapshotManager->copySearchableLiveBucketListSnapshot();
-    }
-
-    return mSearchableBucketListSnapshot;
 }
 
 void

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -78,8 +78,6 @@ class BucketManager : NonMovableOrCopyable
     std::unique_ptr<TmpDir> mWorkDir;
     BucketMapT<LiveBucket> mSharedLiveBuckets;
     BucketMapT<HotArchiveBucket> mSharedHotArchiveBuckets;
-    std::shared_ptr<SearchableLiveBucketListSnapshot>
-        mSearchableBucketListSnapshot{};
 
     // Lock for managing raw Bucket files or the bucket directory. This lock is
     // only required for file access, but is not required for logical changes to
@@ -380,10 +378,6 @@ class BucketManager : NonMovableOrCopyable
     std::shared_ptr<BasicWork> scheduleVerifyReferencedBucketsWork();
 
     Config const& getConfig() const;
-
-    // Get bucketlist snapshot
-    std::shared_ptr<SearchableLiveBucketListSnapshot>
-    getSearchableLiveBucketListSnapshot();
 
     void reportBucketEntryCountMetrics();
 };

--- a/src/bucket/BucketSnapshot.cpp
+++ b/src/bucket/BucketSnapshot.cpp
@@ -180,7 +180,7 @@ Loop
 LiveBucketSnapshot::scanForEviction(
     EvictionIterator& iter, uint32_t& bytesToScan, uint32_t ledgerSeq,
     std::list<EvictionResultEntry>& evictableKeys,
-    SearchableLiveBucketListSnapshot& bl) const
+    SearchableLiveBucketListSnapshot const& bl) const
 {
     ZoneScoped;
     if (isEmpty() || protocolVersionIsBefore(mBucket->getBucketVersion(),

--- a/src/bucket/BucketSnapshot.h
+++ b/src/bucket/BucketSnapshot.h
@@ -85,7 +85,7 @@ class LiveBucketSnapshot : public BucketSnapshotBase<LiveBucket>
     Loop scanForEviction(EvictionIterator& iter, uint32_t& bytesToScan,
                          uint32_t ledgerSeq,
                          std::list<EvictionResultEntry>& evictableKeys,
-                         SearchableLiveBucketListSnapshot& bl) const;
+                         SearchableLiveBucketListSnapshot const& bl) const;
 };
 
 class HotArchiveBucketSnapshot : public BucketSnapshotBase<HotArchiveBucket>

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -14,27 +14,29 @@ class SearchableLiveBucketListSnapshot
     : public SearchableBucketListSnapshotBase<LiveBucket>
 {
     SearchableLiveBucketListSnapshot(
-        BucketSnapshotManager const& snapshotManager);
+        BucketSnapshotManager const& snapshotManager,
+        SnapshotPtrT<LiveBucket>&& snapshot,
+        std::map<uint32_t, SnapshotPtrT<LiveBucket>>&& historicalSnapshots);
 
   public:
     std::vector<LedgerEntry>
     loadPoolShareTrustLinesByAccountAndAsset(AccountID const& accountID,
-                                             Asset const& asset);
+                                             Asset const& asset) const;
 
     std::vector<InflationWinner> loadInflationWinners(size_t maxWinners,
-                                                      int64_t minBalance);
+                                                      int64_t minBalance) const;
 
     std::vector<LedgerEntry>
     loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
-                       LedgerKeyMeter* lkMeter);
+                       LedgerKeyMeter* lkMeter) const;
 
     EvictionResult scanForEviction(uint32_t ledgerSeq,
                                    EvictionCounters& counters,
                                    EvictionIterator evictionIter,
                                    std::shared_ptr<EvictionStatistics> stats,
-                                   StateArchivalSettings const& sas);
+                                   StateArchivalSettings const& sas) const;
 
-    friend std::shared_ptr<SearchableLiveBucketListSnapshot>
+    friend SearchableSnapshotConstPtr
     BucketSnapshotManager::copySearchableLiveBucketListSnapshot() const;
 };
 
@@ -42,13 +44,16 @@ class SearchableHotArchiveBucketListSnapshot
     : public SearchableBucketListSnapshotBase<HotArchiveBucket>
 {
     SearchableHotArchiveBucketListSnapshot(
-        BucketSnapshotManager const& snapshotManager);
+        BucketSnapshotManager const& snapshotManager,
+        SnapshotPtrT<HotArchiveBucket>&& snapshot,
+        std::map<uint32_t, SnapshotPtrT<HotArchiveBucket>>&&
+            historicalSnapshots);
 
   public:
     std::vector<HotArchiveBucketEntry>
-    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys);
+    loadKeys(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys) const;
 
-    friend std::shared_ptr<SearchableHotArchiveBucketListSnapshot>
+    friend SearchableHotArchiveSnapshotConstPtr
     BucketSnapshotManager::copySearchableHotArchiveBucketListSnapshot() const;
 };
 }

--- a/src/bucket/test/BucketIndexTests.cpp
+++ b/src/bucket/test/BucketIndexTests.cpp
@@ -803,6 +803,9 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
             BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
         addHotArchiveBatchAndUpdateSnapshot(*app, header, archivedEntries,
                                             restoredEntries, deletedEntries);
+        app->getBucketManager()
+            .getBucketSnapshotManager()
+            .maybeCopySearchableHotArchiveBucketListSnapshot(searchableBL);
         checkResult();
 
         // Add a few batches so that entries are no longer in the top bucket
@@ -810,6 +813,9 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         {
             header.ledgerSeq += 1;
             addHotArchiveBatchAndUpdateSnapshot(*app, header, {}, {}, {});
+            app->getBucketManager()
+                .getBucketSnapshotManager()
+                .maybeCopySearchableHotArchiveBucketListSnapshot(searchableBL);
         }
 
         // Shadow entries via liveEntry
@@ -819,6 +825,9 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         header.ledgerSeq += 1;
         addHotArchiveBatchAndUpdateSnapshot(*app, header, {},
                                             {liveShadow1, liveShadow2}, {});
+        app->getBucketManager()
+            .getBucketSnapshotManager()
+            .maybeCopySearchableHotArchiveBucketListSnapshot(searchableBL);
 
         // Point load
         for (auto const& k : {liveShadow1, liveShadow2})
@@ -838,6 +847,9 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         header.ledgerSeq += 1;
         addHotArchiveBatchAndUpdateSnapshot(*app, header, {}, {},
                                             {deletedShadow});
+        app->getBucketManager()
+            .getBucketSnapshotManager()
+            .maybeCopySearchableHotArchiveBucketListSnapshot(searchableBL);
 
         // Point load
         auto entryPtr = searchableBL->load(deletedShadow);
@@ -859,6 +871,9 @@ TEST_CASE("hot archive bucket lookups", "[bucket][bucketindex][archive]")
         header.ledgerSeq += 1;
         addHotArchiveBatchAndUpdateSnapshot(*app, header, {archivedShadow}, {},
                                             {});
+        app->getBucketManager()
+            .getBucketSnapshotManager()
+            .maybeCopySearchableHotArchiveBucketListSnapshot(searchableBL);
 
         // Point load
         entryPtr = searchableBL->load(LedgerEntryKey(archivedShadow));

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -868,7 +868,8 @@ TEST_CASE_VERSIONS("network config snapshots BucketList size", "[bucketlist]")
     for_versions_from(20, *app, [&] {
         LedgerManagerForBucketTests& lm = app->getLedgerManager();
 
-        auto& networkConfig = app->getLedgerManager().getSorobanNetworkConfig();
+        auto& networkConfig =
+            app->getLedgerManager().getSorobanNetworkConfigReadOnly();
 
         uint32_t windowSize = networkConfig.stateArchivalSettings()
                                   .bucketListSizeWindowSampleSize;
@@ -1404,9 +1405,6 @@ TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")
         LedgerTestUtils::generateValidLedgerEntryOfType(CLAIMABLE_BALANCE);
     entry.data.claimableBalance().amount = 0;
 
-    auto searchableBL =
-        bm.getBucketSnapshotManager().copySearchableLiveBucketListSnapshot();
-
     // Update entry every 5 ledgers so we can see bucket merge events
     for (auto ledgerSeq = 1; ledgerSeq < 101; ++ledgerSeq)
     {
@@ -1422,6 +1420,8 @@ TEST_CASE_VERSIONS("Searchable BucketListDB snapshots", "[bucketlist]")
         }
 
         closeLedger(*app);
+        auto searchableBL = bm.getBucketSnapshotManager()
+                                .copySearchableLiveBucketListSnapshot();
 
         // Snapshot should automatically update with latest version
         auto loadedEntry = searchableBL->load(LedgerEntryKey(entry));

--- a/src/herder/HerderImpl.cpp
+++ b/src/herder/HerderImpl.cpp
@@ -2101,7 +2101,8 @@ HerderImpl::maybeHandleUpgrade()
             // no-op on any earlier protocol
             return;
         }
-        auto const& conf = mApp.getLedgerManager().getSorobanNetworkConfig();
+        auto const& conf =
+            mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
 
         auto maybeNewMaxTxSize =
             conf.txMaxSizeBytes() + getFlowControlExtraBuffer();
@@ -2153,7 +2154,7 @@ HerderImpl::start()
         if (protocolVersionStartsFrom(version, SOROBAN_PROTOCOL_VERSION))
         {
             auto const& conf =
-                mApp.getLedgerManager().getSorobanNetworkConfig();
+                mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
             mMaxTxSize = std::max(mMaxTxSize, conf.txMaxSizeBytes() +
                                                   getFlowControlExtraBuffer());
         }

--- a/src/herder/TransactionQueue.cpp
+++ b/src/herder/TransactionQueue.cpp
@@ -382,6 +382,8 @@ TransactionQueue::canAdd(
                 if (!tx->checkSorobanResourceAndSetError(
                         mApp.getAppConnector(),
                         mApp.getLedgerManager()
+                            .getSorobanNetworkConfigReadOnly(),
+                        mApp.getLedgerManager()
                             .getLastClosedLedgerHeader()
                             .header.ledgerVersion,
                         txResult))

--- a/src/herder/test/HerderTests.cpp
+++ b/src/herder/test/HerderTests.cpp
@@ -1007,7 +1007,8 @@ TEST_CASE("tx set hits overlay byte limit during construction",
         cfg.mLedgerMaxInstructions = max;
     });
 
-    auto const& conf = app->getLedgerManager().getSorobanNetworkConfig();
+    auto const& conf =
+        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
     uint32_t maxContractSize = 0;
     maxContractSize = conf.maxContractSizeBytes();
 
@@ -1162,7 +1163,7 @@ TEST_CASE("surge pricing", "[herder][txset][soroban]")
         auto tx = makeMultiPayment(acc1, root, 1, 100, 0, 1);
 
         SorobanNetworkConfig conf =
-            app->getLedgerManager().getSorobanNetworkConfig();
+            app->getLedgerManager().getSorobanNetworkConfigReadOnly();
 
         uint32_t const baseFee = 10'000'000;
         SorobanResources resources;
@@ -3361,7 +3362,7 @@ TEST_CASE("soroban txs accepted by the network",
             for (auto node : nodes)
             {
                 REQUIRE(node->getLedgerManager()
-                            .getSorobanNetworkConfig()
+                            .getSorobanNetworkConfigReadOnly()
                             .ledgerMaxTxCount() == ledgerWideLimit * 10);
             }
 

--- a/src/herder/test/TransactionQueueTests.cpp
+++ b/src/herder/test/TransactionQueueTests.cpp
@@ -1259,7 +1259,7 @@ TEST_CASE("Soroban TransactionQueue limits",
     auto account2 = root.create("a2", minBalance2);
 
     SorobanNetworkConfig conf =
-        app->getLedgerManager().getSorobanNetworkConfig();
+        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
 
     SorobanResources resources;
     resources.instructions = 2'000'000;

--- a/src/herder/test/TxSetTests.cpp
+++ b/src/herder/test/TxSetTests.cpp
@@ -1087,7 +1087,7 @@ TEST_CASE("txset nomination", "[txset]")
             });
 
             auto const& sorobanConfig =
-                app->getLedgerManager().getSorobanNetworkConfig();
+                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
             stellar::uniform_int_distribution<> txReadEntriesDistr(
                 1, sorobanConfig.txMaxReadLedgerEntries());
 

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -251,7 +251,7 @@ makeBucketListSizeWindowSampleSizeTestUpgrade(Application& app,
 {
     // Modify window size
     auto sas = app.getLedgerManager()
-                   .getSorobanNetworkConfig()
+                   .getSorobanNetworkConfigReadOnly()
                    .stateArchivalSettings();
     sas.bucketListSizeWindowSampleSize = newWindowSize;
 
@@ -837,7 +837,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
     executeUpgrade(*app, makeProtocolVersionUpgrade(
                              static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION)));
     auto const& sorobanConfig =
-        app->getLedgerManager().getSorobanNetworkConfig();
+        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
     SECTION("unknown config upgrade set is ignored")
     {
         auto contractID = autocheck::generator<Hash>()(5);
@@ -905,7 +905,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             auto const newSize = 20;
             populateValuesAndUpgradeSize(newSize);
             auto const& cfg2 =
-                app->getLedgerManager().getSorobanNetworkConfig();
+                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
 
             // Verify that we popped the 10 oldest values
             auto sum = 0;
@@ -927,7 +927,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             auto const newSize = 40;
             populateValuesAndUpgradeSize(newSize);
             auto const& cfg2 =
-                app->getLedgerManager().getSorobanNetworkConfig();
+                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
 
             // Verify that we backfill 10 copies of the oldest value
             auto sum = 0;
@@ -957,7 +957,7 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
                 LedgerTxn ltx2(app->getLedgerTxnRoot());
 
                 auto const& cfg =
-                    app->getLedgerManager().getSorobanNetworkConfig();
+                    app->getLedgerManager().getSorobanNetworkConfigReadOnly();
                 initialSize =
                     cfg.mStateArchivalSettings.bucketListSizeWindowSampleSize;
                 initialWindow = cfg.mBucketListSizeSnapshots;
@@ -972,7 +972,8 @@ TEST_CASE("config upgrades applied to ledger", "[soroban][upgrades]")
             REQUIRE(configUpgradeSet);
             executeUpgrade(*app, makeConfigUpgrade(*configUpgradeSet));
 
-            auto const& cfg = app->getLedgerManager().getSorobanNetworkConfig();
+            auto const& cfg =
+                app->getLedgerManager().getSorobanNetworkConfigReadOnly();
             REQUIRE(cfg.mStateArchivalSettings.bucketListSizeWindowSampleSize ==
                     initialSize);
             REQUIRE(cfg.mBucketListSizeSnapshots == initialWindow);
@@ -1086,7 +1087,7 @@ TEST_CASE("Soroban max tx set size upgrade applied to ledger",
                              static_cast<uint32_t>(SOROBAN_PROTOCOL_VERSION)));
 
     auto const& sorobanConfig =
-        app->getLedgerManager().getSorobanNetworkConfig();
+        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
 
     executeUpgrade(*app, makeMaxSorobanTxSizeUpgrade(123));
     REQUIRE(sorobanConfig.ledgerMaxTxCount() == 123);
@@ -2245,7 +2246,8 @@ TEST_CASE("configuration initialized in version upgrade", "[upgrades]")
             InitialSorobanNetworkConfig::MAX_CONTRACT_SIZE);
 
     // Check that BucketList size window initialized with current BL size
-    auto& networkConfig = app->getLedgerManager().getSorobanNetworkConfig();
+    auto& networkConfig =
+        app->getLedgerManager().getSorobanNetworkConfigReadOnly();
     REQUIRE(networkConfig.getAverageBucketListSize() == blSize);
 
     // Check in memory window

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -96,6 +96,10 @@ class LedgerManager
     virtual LedgerHeaderHistoryEntry const&
     getLastClosedLedgerHeader() const = 0;
 
+    // Get bucketlist snapshot
+    virtual std::shared_ptr<SearchableLiveBucketListSnapshot const>
+    getCurrentLedgerStateSnaphot() = 0;
+
     // return the HAS that corresponds to the last closed ledger as persisted in
     // the database
     virtual HistoryArchiveState getLastClosedLedgerHAS() = 0;

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -97,8 +97,7 @@ class LedgerManager
     getLastClosedLedgerHeader() const = 0;
 
     // Get bucketlist snapshot
-    virtual std::shared_ptr<SearchableLiveBucketListSnapshot const>
-    getCurrentLedgerStateSnaphot() = 0;
+    virtual SearchableSnapshotConstPtr getCurrentLedgerStateSnaphot() = 0;
 
     // return the HAS that corresponds to the last closed ledger as persisted in
     // the database
@@ -132,7 +131,9 @@ class LedgerManager
     // The config is automatically refreshed on protocol upgrades.
     // Ledger txn here is needed for the sake of lazy load; it won't be
     // used most of the time.
-    virtual SorobanNetworkConfig const& getSorobanNetworkConfig() = 0;
+    virtual SorobanNetworkConfig const& getSorobanNetworkConfigReadOnly() = 0;
+    virtual SorobanNetworkConfig const& getSorobanNetworkConfigForApply() = 0;
+
     virtual bool hasSorobanNetworkConfig() const = 0;
 
 #ifdef BUILD_TESTS

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -68,6 +68,8 @@ class LedgerManagerImpl : public LedgerManager
     medida::Timer& mMetaStreamWriteTime;
     VirtualClock::time_point mLastClose;
     bool mRebuildInMemoryState{false};
+    std::shared_ptr<SearchableLiveBucketListSnapshot const>
+        mReadOnlyLedgerStateSnapshot;
 
     std::unique_ptr<VirtualClock::time_point> mStartCatchup;
     medida::Timer& mCatchupDuration;
@@ -202,5 +204,7 @@ class LedgerManagerImpl : public LedgerManager
     void maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq);
 
     SorobanMetrics& getSorobanMetrics() override;
+    std::shared_ptr<SearchableLiveBucketListSnapshot const>
+    getCurrentLedgerStateSnaphot() override;
 };
 }

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -50,7 +50,20 @@ class LedgerManagerImpl : public LedgerManager
 
   private:
     LedgerHeaderHistoryEntry mLastClosedLedger;
-    std::optional<SorobanNetworkConfig> mSorobanNetworkConfig;
+
+    // Read-only Soroban network configuration, accessible by main thread only.
+    // This config has to match the read-only ledger state snapshot managed by
+    // LedgerManager. Today this is only accessed by the main thread, but it can
+    // be used by multiple threads as long snapshot consistency
+    // requirement is preserved (though synchronization should be added in this
+    // case)
+    std::shared_ptr<SorobanNetworkConfig const> mSorobanNetworkConfigReadOnly;
+
+    // Latest Soroban config during apply (should not be used outside of
+    // application, as it may be in half-valid state). Note that access to this
+    // variable is not synchronized, since it should only be used by one thread
+    // (main or ledger close).
+    std::shared_ptr<SorobanNetworkConfig> mSorobanNetworkConfigForApply;
 
     SorobanMetrics mSorobanMetrics;
     medida::Timer& mTransactionApply;
@@ -68,8 +81,7 @@ class LedgerManagerImpl : public LedgerManager
     medida::Timer& mMetaStreamWriteTime;
     VirtualClock::time_point mLastClose;
     bool mRebuildInMemoryState{false};
-    std::shared_ptr<SearchableLiveBucketListSnapshot const>
-        mReadOnlyLedgerStateSnapshot;
+    SearchableSnapshotConstPtr mReadOnlyLedgerStateSnapshot;
 
     std::unique_ptr<VirtualClock::time_point> mStartCatchup;
     medida::Timer& mCatchupDuration;
@@ -113,8 +125,6 @@ class LedgerManagerImpl : public LedgerManager
     void setState(State s);
 
     void emitNextMeta();
-
-    SorobanNetworkConfig& getSorobanNetworkConfigInternal();
 
     // Publishes soroban metrics, including select network config limits as well
     // as the actual ledger usage.
@@ -160,7 +170,9 @@ class LedgerManagerImpl : public LedgerManager
     uint32_t getLastReserve() const override;
     uint32_t getLastTxFee() const override;
     uint32_t getLastClosedLedgerNum() const override;
-    SorobanNetworkConfig const& getSorobanNetworkConfig() override;
+    SorobanNetworkConfig const& getSorobanNetworkConfigReadOnly() override;
+    SorobanNetworkConfig const& getSorobanNetworkConfigForApply() override;
+
     bool hasSorobanNetworkConfig() const override;
 
 #ifdef BUILD_TESTS
@@ -204,7 +216,6 @@ class LedgerManagerImpl : public LedgerManager
     void maybeResetLedgerCloseMetaDebugStream(uint32_t ledgerSeq);
 
     SorobanMetrics& getSorobanMetrics() override;
-    std::shared_ptr<SearchableLiveBucketListSnapshot const>
-    getCurrentLedgerStateSnaphot() override;
+    SearchableSnapshotConstPtr getCurrentLedgerStateSnaphot() override;
 };
 }

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -163,7 +163,8 @@ LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
 }
 
 BucketSnapshotState::BucketSnapshotState(BucketManager& bm)
-    : mSnapshot(bm.getSearchableLiveBucketListSnapshot())
+    : mSnapshot(
+          bm.getBucketSnapshotManager().copySearchableLiveBucketListSnapshot())
     , mLedgerHeader(LedgerHeaderWrapper(
           std::make_shared<LedgerHeader>(mSnapshot->getLedgerHeader())))
 {

--- a/src/ledger/LedgerStateSnapshot.cpp
+++ b/src/ledger/LedgerStateSnapshot.cpp
@@ -5,6 +5,7 @@
 #include "ledger/LedgerStateSnapshot.h"
 #include "bucket/BucketManager.h"
 #include "bucket/BucketSnapshotManager.h"
+#include "ledger/LedgerManager.h"
 #include "ledger/LedgerTxn.h"
 #include "main/Application.h"
 #include "transactions/TransactionFrame.h"
@@ -162,9 +163,8 @@ LedgerTxnReadOnly::executeWithMaybeInnerSnapshot(
     return f(lsg);
 }
 
-BucketSnapshotState::BucketSnapshotState(BucketManager& bm)
-    : mSnapshot(
-          bm.getBucketSnapshotManager().copySearchableLiveBucketListSnapshot())
+BucketSnapshotState::BucketSnapshotState(SearchableSnapshotConstPtr snapshot)
+    : mSnapshot(snapshot)
     , mLedgerHeader(LedgerHeaderWrapper(
           std::make_shared<LedgerHeader>(mSnapshot->getLedgerHeader())))
 {
@@ -223,6 +223,7 @@ LedgerSnapshot::LedgerSnapshot(AbstractLedgerTxn& ltx)
 
 LedgerSnapshot::LedgerSnapshot(Application& app)
 {
+    releaseAssert(threadIsMain());
 #ifdef BUILD_TESTS
     if (app.getConfig().MODE_USES_IN_MEMORY_LEDGER)
     {
@@ -234,7 +235,8 @@ LedgerSnapshot::LedgerSnapshot(Application& app)
     }
     else
 #endif
-        mGetter = std::make_unique<BucketSnapshotState>(app.getBucketManager());
+        mGetter = std::make_unique<BucketSnapshotState>(
+            app.getLedgerManager().getCurrentLedgerStateSnaphot());
 }
 
 LedgerHeaderWrapper

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -106,7 +106,7 @@ class LedgerTxnReadOnly : public AbstractLedgerStateSnapshot
 // A concrete implementation of read-only BucketList snapshot wrapper
 class BucketSnapshotState : public AbstractLedgerStateSnapshot
 {
-    std::shared_ptr<SearchableLiveBucketListSnapshot> mSnapshot;
+    std::shared_ptr<SearchableLiveBucketListSnapshot const> const mSnapshot;
     // Store a copy of the header from mSnapshot. This is needed for
     // validation flow where for certain validation scenarios the header needs
     // to be modified

--- a/src/ledger/LedgerStateSnapshot.h
+++ b/src/ledger/LedgerStateSnapshot.h
@@ -106,14 +106,14 @@ class LedgerTxnReadOnly : public AbstractLedgerStateSnapshot
 // A concrete implementation of read-only BucketList snapshot wrapper
 class BucketSnapshotState : public AbstractLedgerStateSnapshot
 {
-    std::shared_ptr<SearchableLiveBucketListSnapshot const> const mSnapshot;
+    SearchableSnapshotConstPtr const mSnapshot;
     // Store a copy of the header from mSnapshot. This is needed for
     // validation flow where for certain validation scenarios the header needs
     // to be modified
     LedgerHeaderWrapper mLedgerHeader;
 
   public:
-    BucketSnapshotState(BucketManager& bm);
+    BucketSnapshotState(SearchableSnapshotConstPtr snapshot);
     ~BucketSnapshotState() override;
 
     LedgerHeaderWrapper getLedgerHeader() const override;

--- a/src/ledger/LedgerTxn.cpp
+++ b/src/ledger/LedgerTxn.cpp
@@ -2660,6 +2660,9 @@ LedgerTxnRoot::Impl::commitChild(EntryIterator iter,
 
     mPrefetchHits = 0;
     mPrefetchMisses = 0;
+
+    // std::shared_ptr<...>::reset does not throw
+    mSearchableBucketListSnapshot.reset();
 }
 
 uint64_t
@@ -3054,7 +3057,7 @@ LedgerTxnRoot::Impl::areEntriesMissingInCacheForOffer(OfferEntry const& oe)
     return false;
 }
 
-SearchableLiveBucketListSnapshot&
+SearchableLiveBucketListSnapshot const&
 LedgerTxnRoot::Impl::getSearchableLiveBucketListSnapshot() const
 {
     if (!mSearchableBucketListSnapshot)
@@ -3373,6 +3376,7 @@ LedgerTxnRoot::Impl::rollbackChild() noexcept
     mChild = nullptr;
     mPrefetchHits = 0;
     mPrefetchMisses = 0;
+    mSearchableBucketListSnapshot.reset();
 }
 
 std::shared_ptr<InternalLedgerEntry const>

--- a/src/ledger/LedgerTxnImpl.h
+++ b/src/ledger/LedgerTxnImpl.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/BucketSnapshotManager.h"
 #include "database/Database.h"
 #include "ledger/LedgerTxn.h"
 #include "util/RandomEvictionCache.h"
@@ -616,8 +617,7 @@ class LedgerTxnRoot::Impl
     mutable BestOffers mBestOffers;
     mutable uint64_t mPrefetchHits{0};
     mutable uint64_t mPrefetchMisses{0};
-    mutable std::shared_ptr<SearchableLiveBucketListSnapshot>
-        mSearchableBucketListSnapshot{};
+    mutable SearchableSnapshotConstPtr mSearchableBucketListSnapshot;
 
     size_t mBulkLoadBatchSize;
     std::unique_ptr<soci::transaction> mTransaction;
@@ -684,7 +684,7 @@ class LedgerTxnRoot::Impl
 
     bool areEntriesMissingInCacheForOffer(OfferEntry const& oe);
 
-    SearchableLiveBucketListSnapshot&
+    SearchableLiveBucketListSnapshot const&
     getSearchableLiveBucketListSnapshot() const;
 
     uint32_t prefetchInternal(UnorderedSet<LedgerKey> const& keys,

--- a/src/main/AppConnector.cpp
+++ b/src/main/AppConnector.cpp
@@ -47,10 +47,10 @@ AppConnector::getBanManager()
 }
 
 SorobanNetworkConfig const&
-AppConnector::getSorobanNetworkConfig() const
+AppConnector::getSorobanNetworkConfigReadOnly() const
 {
     releaseAssert(threadIsMain());
-    return mApp.getLedgerManager().getSorobanNetworkConfig();
+    return mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
 }
 
 medida::MetricsRegistry&

--- a/src/main/AppConnector.h
+++ b/src/main/AppConnector.h
@@ -34,7 +34,7 @@ class AppConnector
     OverlayManager& getOverlayManager();
     BanManager& getBanManager();
     bool shouldYield() const;
-    SorobanNetworkConfig const& getSorobanNetworkConfig() const;
+    SorobanNetworkConfig const& getSorobanNetworkConfigReadOnly() const;
     medida::MetricsRegistry& getMetrics() const;
     SorobanMetrics& getSorobanMetrics() const;
     void checkOnOperationApply(Operation const& operation,

--- a/src/main/CommandHandler.cpp
+++ b/src/main/CommandHandler.cpp
@@ -761,7 +761,7 @@ CommandHandler::sorobanInfo(std::string const& params, std::string& retStr)
         if (format == "basic")
         {
             Json::Value res;
-            auto const& conf = lm.getSorobanNetworkConfig();
+            auto const& conf = lm.getSorobanNetworkConfigReadOnly();
 
             // Contract size
             res["max_contract_size"] = conf.maxContractSizeBytes();

--- a/src/main/QueryServer.cpp
+++ b/src/main/QueryServer.cpp
@@ -56,6 +56,7 @@ QueryServer::QueryServer(const std::string& address, unsigned short port,
                          int maxClient, size_t threadPoolSize,
                          BucketSnapshotManager& bucketSnapshotManager)
     : mServer(address, port, maxClient, threadPoolSize)
+    , mBucketSnapshotManager(bucketSnapshotManager)
 {
     LOG_INFO(DEFAULT_LOG, "Listening on {}:{} for Query requests", address,
              port);
@@ -132,7 +133,11 @@ QueryServer::getLedgerEntryRaw(std::string const& params,
 
     if (!keys.empty())
     {
-        auto& bl = *mBucketListSnapshots.at(std::this_thread::get_id());
+        auto& snapshotPtr = mBucketListSnapshots.at(std::this_thread::get_id());
+        mBucketSnapshotManager.maybeCopySearchableBucketListSnapshot(
+            snapshotPtr);
+
+        auto& bl = *snapshotPtr;
 
         LedgerKeySet orderedKeys;
         for (auto const& key : keys)

--- a/src/main/QueryServer.h
+++ b/src/main/QueryServer.h
@@ -6,6 +6,7 @@
 
 #include "lib/httpthreaded/server.hpp"
 
+#include "bucket/BucketSnapshotManager.h"
 #include <functional>
 #include <memory>
 #include <string>
@@ -25,9 +26,10 @@ class QueryServer
 
     httpThreaded::server::server mServer;
 
-    std::unordered_map<std::thread::id,
-                       std::shared_ptr<SearchableLiveBucketListSnapshot>>
+    std::unordered_map<std::thread::id, SearchableSnapshotConstPtr>
         mBucketListSnapshots;
+
+    BucketSnapshotManager& mBucketSnapshotManager;
 
     bool safeRouter(HandlerRoute route, std::string const& params,
                     std::string const& body, std::string& retStr);

--- a/src/overlay/TxAdverts.cpp
+++ b/src/overlay/TxAdverts.cpp
@@ -203,7 +203,8 @@ TxAdverts::getMaxAdvertSize() const
                                           .header.ledgerVersion,
                                       SOROBAN_PROTOCOL_VERSION))
         {
-            auto limits = mApp.getLedgerManager().getSorobanNetworkConfig();
+            auto limits =
+                mApp.getLedgerManager().getSorobanNetworkConfigReadOnly();
             opsToFloodPerLedger += getOpsFloodLedger(
                 limits.ledgerMaxTxCount(), cfg.FLOOD_SOROBAN_RATE_PER_LEDGER);
         }

--- a/src/simulation/TxGenerator.cpp
+++ b/src/simulation/TxGenerator.cpp
@@ -1018,7 +1018,7 @@ TxGenerator::sorobanRandomUploadResources()
     // the chance that this instruction count is sufficient.
     ContractCostParamEntry const& vmInstantiationCosts =
         mApp.getLedgerManager()
-            .getSorobanNetworkConfig()
+            .getSorobanNetworkConfigReadOnly()
             .cpuCostParams()[VmInstantiation];
     // Amount to right shift `vmInstantiationCosts.linearTerm * wasmSize` by
     uint32_t constexpr vmShiftTerm = 7;

--- a/src/test/TestUtils.cpp
+++ b/src/test/TestUtils.cpp
@@ -230,7 +230,7 @@ upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
         LoadGenMode::SOROBAN_CREATE_UPGRADE, 1, 1, 1);
     createUpgradeLoadGenConfig.offset = offset;
     // Get current network config.
-    auto cfg = nodes[0]->getLedgerManager().getSorobanNetworkConfig();
+    auto cfg = nodes[0]->getLedgerManager().getSorobanNetworkConfigReadOnly();
     modifyFn(cfg);
     createUpgradeLoadGenConfig.copySorobanNetworkConfigToUpgradeConfig(cfg);
     auto upgradeSetKey = lg.getConfigUpgradeSetKey(
@@ -258,7 +258,8 @@ upgradeSorobanNetworkConfig(std::function<void(SorobanNetworkConfig&)> modifyFn,
         // Wait for upgrade to be applied
         simulation->crankUntil(
             [&]() {
-                auto netCfg = app.getLedgerManager().getSorobanNetworkConfig();
+                auto netCfg =
+                    app.getLedgerManager().getSorobanNetworkConfigReadOnly();
                 return netCfg == cfg;
             },
             2 * Herder::EXP_LEDGER_TIMESPAN_SECONDS, false);

--- a/src/test/TxTests.cpp
+++ b/src/test/TxTests.cpp
@@ -929,7 +929,8 @@ sorobanResourceFee(Application& app, SorobanResources const& resources,
     auto feePair = TransactionFrame::computeSorobanResourceFee(
         app.getLedgerManager().getLastClosedLedgerHeader().header.ledgerVersion,
         resources, static_cast<uint32>(txSize), eventsSize,
-        app.getLedgerManager().getSorobanNetworkConfig(), app.getConfig());
+        app.getLedgerManager().getSorobanNetworkConfigReadOnly(),
+        app.getConfig());
     return feePair.non_refundable_fee + feePair.refundable_fee;
 }
 

--- a/src/testdata/ledger-close-meta-v1-protocol-20.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-20.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "a50c06f398679584d4acff68de5130502114df913f41c270a4bce9e1d6cd5c36",
+                "hash": "96bbf541d371216daf6d52718c6c80c40cbfa67b51e578df821c238af37fcf6b",
                 "header": {
                     "ledgerVersion": 20,
-                    "previousLedgerHash": "ab3ae955a234c8b03bbd42f5a7ba9b98989ea9fa6e380b00d9bb47abc11fd9f7",
+                    "previousLedgerHash": "635da5e96def44947953c1612b480ac47ce81eaa51bf49b10ce705585fef5820",
                     "scpValue": {
-                        "txSetHash": "748fee17bde220a1e44a917ac6ae9cf70bedb749bc2a2bf440fffbe04d7a46cf",
+                        "txSetHash": "d36dc1b5b4eb0bd5adbf019a5ca575fbcf1453668c8c9e8a74b31d85b4044cb8",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "db221f42903acae8fa8f38251516df81257687c301729f00fe8c9f377af298181a8f18b9b5a690f3c6c05f8fe168c30081d1ad0c4b8dcbd34f194300e9aa830a"
+                                "signature": "c1f4dacc73f38778c4a2fa20eef4d10c469dc78eeba64946bd2028a6b0315d3b9a09f311fed3e20b9b4a3446fab3c3ea62c7773b6e826527b1dc48ba22d13a0f"
                             }
                         }
                     },
-                    "txSetResultHash": "249b974bacf8b5c4a8f0b5598194c1b9eca64af0b5c1506daa871c1533b6baac",
-                    "bucketListHash": "7c28bf01c1eb9bf17fae213218f9cffeea048d5b261b57bb1092ee39a3afe1c3",
+                    "txSetResultHash": "f66233c106977a4cc148e019411ff6ddfaf76c337d004ed9a304a70407b161d0",
+                    "bucketListHash": "69afd589321f0d78146910460d3a54c07213593f39edd7fe95b9e71e53b4b0fc",
                     "ledgerSeq": 7,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "ab3ae955a234c8b03bbd42f5a7ba9b98989ea9fa6e380b00d9bb47abc11fd9f7",
+                    "previousLedgerHash": "635da5e96def44947953c1612b480ac47ce81eaa51bf49b10ce705585fef5820",
                     "phases": [
                         {
                             "v": 0,
@@ -183,6 +183,356 @@
                 }
             },
             "txProcessing": [
+                {
+                    "result": {
+                        "transactionHash": "324d0628e2a215d367f181f0e3aacbaa26fa638e676e73fb9ad26a360314a7b7",
+                        "result": {
+                            "feeCharged": 300,
+                            "result": {
+                                "code": "txFEE_BUMP_INNER_SUCCESS",
+                                "innerResultPair": {
+                                    "transactionHash": "b28c171f9658320b5ce8d50e4e1a36b74afbb2a92eec7df92a8981067131b025",
+                                    "result": {
+                                        "feeCharged": 200,
+                                        "result": {
+                                            "code": "txSUCCESS",
+                                            "results": [
+                                                {
+                                                    "code": "opINNER",
+                                                    "tr": {
+                                                        "type": "PAYMENT",
+                                                        "paymentResult": {
+                                                            "code": "PAYMENT_SUCCESS"
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "code": "opINNER",
+                                                    "tr": {
+                                                        "type": "PAYMENT",
+                                                        "paymentResult": {
+                                                            "code": "PAYMENT_SUCCESS"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            },
+                            "ext": {
+                                "v": 0
+                            }
+                        }
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 4,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 400000000,
+                                        "seqNum": 17179869184,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 7,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 399999700,
+                                        "seqNum": 17179869184,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "ext": {
+                                "v": 0
+                            },
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 7,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399999700,
+                                                "seqNum": 17179869184,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 7,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399999700,
+                                                "seqNum": 17179869184,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 5,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
+                                                "balance": 200010000,
+                                                "seqNum": 21474836480,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 7,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
+                                                "balance": 200010000,
+                                                "seqNum": 21474836481,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 7,
+                                                                        "seqTime": 0
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 0,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 7,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 50,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 7,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 50,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 7,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 100,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "txChangesAfter": [],
+                            "sorobanMeta": null
+                        }
+                    }
+                },
                 {
                     "result": {
                         "transactionHash": "0db2322d85e9d8ea2421559922bb6107429650ebdad304c907480853d465c10d",
@@ -627,361 +977,11 @@
                             "sorobanMeta": null
                         }
                     }
-                },
-                {
-                    "result": {
-                        "transactionHash": "324d0628e2a215d367f181f0e3aacbaa26fa638e676e73fb9ad26a360314a7b7",
-                        "result": {
-                            "feeCharged": 300,
-                            "result": {
-                                "code": "txFEE_BUMP_INNER_SUCCESS",
-                                "innerResultPair": {
-                                    "transactionHash": "b28c171f9658320b5ce8d50e4e1a36b74afbb2a92eec7df92a8981067131b025",
-                                    "result": {
-                                        "feeCharged": 200,
-                                        "result": {
-                                            "code": "txSUCCESS",
-                                            "results": [
-                                                {
-                                                    "code": "opINNER",
-                                                    "tr": {
-                                                        "type": "PAYMENT",
-                                                        "paymentResult": {
-                                                            "code": "PAYMENT_SUCCESS"
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "code": "opINNER",
-                                                    "tr": {
-                                                        "type": "PAYMENT",
-                                                        "paymentResult": {
-                                                            "code": "PAYMENT_SUCCESS"
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            },
-                            "ext": {
-                                "v": 0
-                            }
-                        }
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 4,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 400000000,
-                                        "seqNum": 17179869184,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 7,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 399999700,
-                                        "seqNum": 17179869184,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "ext": {
-                                "v": 0
-                            },
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 7,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399999700,
-                                                "seqNum": 17179869184,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 7,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399999700,
-                                                "seqNum": 17179869184,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 5,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
-                                                "balance": 200010000,
-                                                "seqNum": 21474836480,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 7,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
-                                                "balance": 200010000,
-                                                "seqNum": 21474836481,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 7,
-                                                                        "seqTime": 0
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 0,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 7,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 50,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 7,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 50,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 7,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 100,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "txChangesAfter": [],
-                            "sorobanMeta": null
-                        }
-                    }
                 }
             ],
             "upgradesProcessing": [],
             "scpInfo": [],
-            "totalByteSizeOfBucketList": 583,
+            "totalByteSizeOfBucketList": 703,
             "evictedTemporaryLedgerKeys": [],
             "evictedPersistentLedgerEntries": []
         }

--- a/src/testdata/ledger-close-meta-v1-protocol-21.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-21.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "52f4e92f487154e485346c691585a082a9733ebab749c580734e9b13be42c963",
+                "hash": "d56f69daf91565e2406a47123f52892e7834185aa0d78a3660ffc32c1036d015",
                 "header": {
                     "ledgerVersion": 21,
-                    "previousLedgerHash": "4d6b671a994888a7276f1bd0ebf844b678284f483258f6e11378fafe7262ea6c",
+                    "previousLedgerHash": "1d27adc177601684904a5bf656515bafcfa2ffce524bc281413623139314ef95",
                     "scpValue": {
-                        "txSetHash": "ecd3150886583d2df7c8e2da0043cdb5cba4f8a9371283bec5f3856e019df40c",
+                        "txSetHash": "9e6dcfc6f718670287c0954be6c0b939b5c8ac20536fb12c5423136a15923414",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "28f38eed1571b69f23307a87c67fdabf7e619bb0cef976bc460bb40aa68f1fa97db858aef8484c35837ce8794e2d2a492bff14ee4ca75b67d4f10646a04e000b"
+                                "signature": "0eef18d50abb7d872f2ac853dfde0ae96d44891ae171e756445e44e8dd358c0377a24829f6ca688e9ca342052793f986836e40982dcfe7d38580994706262104"
                             }
                         }
                     },
                     "txSetResultHash": "f66233c106977a4cc148e019411ff6ddfaf76c337d004ed9a304a70407b161d0",
-                    "bucketListHash": "ade00de2089f5d22038df58ed0acab53cd53079fc0980d423b8edf61506c6481",
+                    "bucketListHash": "88546625d1d5d78e0ed0045e3c52b5f3672ca5ebc8a5be12901ac1911139973d",
                     "ledgerSeq": 7,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "4d6b671a994888a7276f1bd0ebf844b678284f483258f6e11378fafe7262ea6c",
+                    "previousLedgerHash": "1d27adc177601684904a5bf656515bafcfa2ffce524bc281413623139314ef95",
                     "phases": [
                         {
                             "v": 0,
@@ -981,7 +981,7 @@
             ],
             "upgradesProcessing": [],
             "scpInfo": [],
-            "totalByteSizeOfBucketList": 788,
+            "totalByteSizeOfBucketList": 967,
             "evictedTemporaryLedgerKeys": [],
             "evictedPersistentLedgerEntries": []
         }

--- a/src/testdata/ledger-close-meta-v1-protocol-22.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-22.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "bb89aefaf31b3f03f6f7623c75dd055f4e58773b557eda1118b5a9d2b80b33b9",
+                "hash": "7bf914c410e40b5786de0a4ace2ea5598d05e60ba1161d307a7e177a811510fa",
                 "header": {
                     "ledgerVersion": 22,
-                    "previousLedgerHash": "7571e5186d594475cfb7107be2ac14b4aa70e6ccf31810dd961eb91168443ac3",
+                    "previousLedgerHash": "ffff85c9cbc23a80ea78a0fe604bbd9f7b7095633404316e6b006897f88b7fb0",
                     "scpValue": {
-                        "txSetHash": "833ee1e2b95263731bc434c06c0878aa93b2466b3ec05cbda1c4c60881249301",
+                        "txSetHash": "f85d6ccae5bd0c965cc8553fbef82fd48b1a69b30cb9fcdd5f1be865411cb64c",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "6d0af8ae88d6cf05d4ef0fbd85e3e0676fc9f5334e8630cced3ca1f9521c34e6f6ae7c4a7ad296a1a1a092bbe9b40802462511ec99e389b7d953ba7695339802"
+                                "signature": "4fd0dc0a9185eec8f1c6dbe5360a7be605cf83e28f0fd603a320b919ae6b80d685a2b684241eecd12e36b0f62cbef3de70e64137fe1321831fb15a1c1388bf0d"
                             }
                         }
                     },
                     "txSetResultHash": "f66233c106977a4cc148e019411ff6ddfaf76c337d004ed9a304a70407b161d0",
-                    "bucketListHash": "bfe580088e8d44d0f6be8f0dd5d55ffdd22931b66a80c88407b169eeca70aa5c",
+                    "bucketListHash": "8a070de26600d61a4ad4c09455ae13d621b5f53698a9710013bda2932118a474",
                     "ledgerSeq": 7,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "7571e5186d594475cfb7107be2ac14b4aa70e6ccf31810dd961eb91168443ac3",
+                    "previousLedgerHash": "ffff85c9cbc23a80ea78a0fe604bbd9f7b7095633404316e6b006897f88b7fb0",
                     "phases": [
                         {
                             "v": 0,
@@ -981,7 +981,7 @@
             ],
             "upgradesProcessing": [],
             "scpInfo": [],
-            "totalByteSizeOfBucketList": 1021,
+            "totalByteSizeOfBucketList": 1267,
             "evictedTemporaryLedgerKeys": [],
             "evictedPersistentLedgerEntries": []
         }

--- a/src/testdata/ledger-close-meta-v1-protocol-23.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-23.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "1f1a643fd94c3ec834009d049a7e82053f22ae0f4571f123e7ef0a80463a6c38",
+                "hash": "ad4e4f78e0ef6393e3c3f8dec293ee556975f6d875c693e7007d8743492bc519",
                 "header": {
                     "ledgerVersion": 23,
-                    "previousLedgerHash": "bd01346128a3d366530ceed22c4e6d07f299fd2723fe5f5fa7fd9217cdb14bc4",
+                    "previousLedgerHash": "fe02c7ce491811bb67777598e698a8f900bab0394eb867bce954de9e92ab3238",
                     "scpValue": {
-                        "txSetHash": "f0c030c5a4294f8a0df3e91468c7a7a3a0f7b0ebd370cf9b2a08e78146be7fc5",
+                        "txSetHash": "fa9e787622c23e48d464a24a9afd46003a24aa2e0a6174da2d81d3bb7db6708a",
                         "closeTime": 0,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "3fa08aaa2ad7f9d98f6298bce516627b41dd49b3436f09a48dedd45e4228c1b4ea8815353ae2dcf86740e66d2a6dc8eae9a405eb7e2cc6957c899024b96b190f"
+                                "signature": "cfa36fec93baadf4370108f9e0f6c6cc8d5a431300610e855920e0436fd1f61045e632e45c1fa5bc01759f2d86d75b43f2c57a212e087becc32a4305e1b94400"
                             }
                         }
                     },
                     "txSetResultHash": "f66233c106977a4cc148e019411ff6ddfaf76c337d004ed9a304a70407b161d0",
-                    "bucketListHash": "2cad5583e8417a71e3ab5033de493900a0febc5bb540240b3ef2367c4f04339e",
+                    "bucketListHash": "4410716bd1c3816c8fdb2c0e6f6674015f18aac4e4ea105efcdfca9b172ef639",
                     "ledgerSeq": 7,
                     "totalCoins": 1000000000000000000,
                     "feePool": 800,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "bd01346128a3d366530ceed22c4e6d07f299fd2723fe5f5fa7fd9217cdb14bc4",
+                    "previousLedgerHash": "fe02c7ce491811bb67777598e698a8f900bab0394eb867bce954de9e92ab3238",
                     "phases": [
                         {
                             "v": 0,
@@ -981,7 +981,7 @@
             ],
             "upgradesProcessing": [],
             "scpInfo": [],
-            "totalByteSizeOfBucketList": 1023,
+            "totalByteSizeOfBucketList": 1269,
             "evictedTemporaryLedgerKeys": [],
             "evictedPersistentLedgerEntries": []
         }

--- a/src/transactions/ExtendFootprintTTLOpFrame.cpp
+++ b/src/transactions/ExtendFootprintTTLOpFrame.cpp
@@ -57,14 +57,13 @@ ExtendFootprintTTLOpFrame::doApply(
     releaseAssertOrThrow(sorobanData);
     ZoneNamedN(applyZone, "ExtendFootprintTTLOpFrame apply", true);
 
-    ExtendFootprintTTLMetrics metrics(
-        app.getLedgerManager().getSorobanMetrics());
+    ExtendFootprintTTLMetrics metrics(app.getSorobanMetrics());
     auto timeScope = metrics.getExecTimer();
 
     auto const& resources = mParentTx.sorobanResources();
     auto const& footprint = resources.footprint;
     auto const& sorobanConfig =
-        app.getLedgerManager().getSorobanNetworkConfig();
+        app.getLedgerManager().getSorobanNetworkConfigForApply();
 
     rust::Vec<CxxLedgerEntryRentChange> rustEntryRentChanges;
     rustEntryRentChanges.reserve(footprint.readOnly.size());

--- a/src/transactions/FeeBumpTransactionFrame.cpp
+++ b/src/transactions/FeeBumpTransactionFrame.cpp
@@ -158,7 +158,9 @@ FeeBumpTransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
                                     uint64_t lowerBoundCloseTimeOffset,
                                     uint64_t upperBoundCloseTimeOffset) const
 {
-    if (!isTransactionXDRValidForCurrentProtocol(app, mEnvelope) ||
+    if (!isTransactionXDRValidForProtocol(
+            ls.getLedgerHeader().current().ledgerVersion, app.getConfig(),
+            mEnvelope) ||
         !XDRProvidesValidFee())
     {
         auto txResult = createSuccessResult();
@@ -196,10 +198,10 @@ FeeBumpTransactionFrame::checkValid(AppConnector& app, LedgerSnapshot const& ls,
 
 bool
 FeeBumpTransactionFrame::checkSorobanResourceAndSetError(
-    AppConnector& app, uint32_t ledgerVersion,
+    AppConnector& app, SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
     MutableTxResultPtr txResult) const
 {
-    return mInnerTx->checkSorobanResourceAndSetError(app, ledgerVersion,
+    return mInnerTx->checkSorobanResourceAndSetError(app, cfg, ledgerVersion,
                                                      txResult);
 }
 

--- a/src/transactions/FeeBumpTransactionFrame.h
+++ b/src/transactions/FeeBumpTransactionFrame.h
@@ -80,9 +80,9 @@ class FeeBumpTransactionFrame : public TransactionFrameBase
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset) const override;
-    bool
-    checkSorobanResourceAndSetError(AppConnector& app, uint32_t ledgerVersion,
-                                    MutableTxResultPtr txResult) const override;
+    bool checkSorobanResourceAndSetError(
+        AppConnector& app, SorobanNetworkConfig const& cfg,
+        uint32_t ledgerVersion, MutableTxResultPtr txResult) const override;
 
     MutableTxResultPtr createSuccessResult() const override;
 

--- a/src/transactions/InvokeHostFunctionOpFrame.cpp
+++ b/src/transactions/InvokeHostFunctionOpFrame.cpp
@@ -330,10 +330,10 @@ InvokeHostFunctionOpFrame::doApply(
     ZoneNamedN(applyZone, "InvokeHostFunctionOpFrame apply", true);
 
     Config const& appConfig = app.getConfig();
-    HostFunctionMetrics metrics(app.getLedgerManager().getSorobanMetrics());
+    HostFunctionMetrics metrics(app.getSorobanMetrics());
     auto timeScope = metrics.getExecTimer();
     auto const& sorobanConfig =
-        app.getLedgerManager().getSorobanNetworkConfig();
+        app.getLedgerManager().getSorobanNetworkConfigForApply();
 
     // Get the entries for the footprint
     rust::Vec<CxxBuf> ledgerEntryCxxBufs;

--- a/src/transactions/OperationFrame.cpp
+++ b/src/transactions/OperationFrame.cpp
@@ -263,7 +263,7 @@ OperationFrame::checkValid(AppConnector& app,
         {
             releaseAssertOrThrow(sorobanData);
             auto const& sorobanConfig =
-                app.getLedgerManager().getSorobanNetworkConfig();
+                app.getLedgerManager().getSorobanNetworkConfigForApply();
 
             validationResult =
                 doCheckValidForSoroban(sorobanConfig, app.getConfig(),

--- a/src/transactions/RestoreFootprintOpFrame.cpp
+++ b/src/transactions/RestoreFootprintOpFrame.cpp
@@ -50,6 +50,7 @@ RestoreFootprintOpFrame::isOpSupported(LedgerHeader const& header) const
     return header.ledgerVersion >= 20;
 }
 
+// Soroban network config -> backgorund has its own snapshot -> 
 bool
 RestoreFootprintOpFrame::doApply(
     AppConnector& app, AbstractLedgerTxn& ltx, Hash const& sorobanBasePrngSeed,

--- a/src/transactions/TransactionFrame.h
+++ b/src/transactions/TransactionFrame.h
@@ -94,8 +94,9 @@ class TransactionFrame : public TransactionFrameBase
                               LedgerEntryWrapper const& sourceAccount,
                               uint64_t lowerBoundCloseTimeOffset) const;
 
-    bool commonValidPreSeqNum(AppConnector& app, LedgerSnapshot const& ls,
-                              bool chargeFee,
+    bool commonValidPreSeqNum(AppConnector& app,
+                              std::optional<SorobanNetworkConfig> const& cfg,
+                              LedgerSnapshot const& ls, bool chargeFee,
                               uint64_t lowerBoundCloseTimeOffset,
                               uint64_t upperBoundCloseTimeOffset,
                               std::optional<FeePair> sorobanResourceFee,
@@ -105,6 +106,7 @@ class TransactionFrame : public TransactionFrameBase
                           int64_t seqNum) const;
 
     ValidationType commonValid(AppConnector& app,
+                               std::optional<SorobanNetworkConfig> const& cfg,
                                SignatureChecker& signatureChecker,
                                LedgerSnapshot const& ls, SequenceNumber current,
                                bool applying, bool chargeFee,
@@ -215,9 +217,9 @@ class TransactionFrame : public TransactionFrameBase
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset) const override;
-    bool
-    checkSorobanResourceAndSetError(AppConnector& app, uint32_t ledgerVersion,
-                                    MutableTxResultPtr txResult) const override;
+    bool checkSorobanResourceAndSetError(
+        AppConnector& app, SorobanNetworkConfig const& cfg,
+        uint32_t ledgerVersion, MutableTxResultPtr txResult) const override;
 
     MutableTxResultPtr createSuccessResult() const override;
 

--- a/src/transactions/TransactionFrameBase.h
+++ b/src/transactions/TransactionFrameBase.h
@@ -49,9 +49,9 @@ class TransactionFrameBase
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset) const = 0;
-    virtual bool
-    checkSorobanResourceAndSetError(AppConnector& app, uint32_t ledgerVersion,
-                                    MutableTxResultPtr txResult) const = 0;
+    virtual bool checkSorobanResourceAndSetError(
+        AppConnector& app, SorobanNetworkConfig const& cfg,
+        uint32_t ledgerVersion, MutableTxResultPtr txResult) const = 0;
 
     virtual MutableTxResultPtr createSuccessResult() const = 0;
 

--- a/src/transactions/TransactionUtils.cpp
+++ b/src/transactions/TransactionUtils.cpp
@@ -1980,12 +1980,10 @@ hasMuxedAccount(TransactionEnvelope const& e)
 }
 
 bool
-isTransactionXDRValidForCurrentProtocol(AppConnector& app,
-                                        TransactionEnvelope const& envelope)
+isTransactionXDRValidForProtocol(uint32_t currProtocol, Config const& cfg,
+                                 TransactionEnvelope const& envelope)
 {
-    uint32_t maxProtocol = app.getConfig().CURRENT_LEDGER_PROTOCOL_VERSION;
-    uint32_t currProtocol =
-        app.getLedgerManager().getLastClosedLedgerHeader().header.ledgerVersion;
+    uint32_t maxProtocol = cfg.CURRENT_LEDGER_PROTOCOL_VERSION;
     // If we could parse the XDR when ledger is using the maximum supported
     // protocol version, then XDR has to be valid.
     // This check also is pointless before protocol 21 as Soroban environment

--- a/src/transactions/TransactionUtils.h
+++ b/src/transactions/TransactionUtils.h
@@ -261,9 +261,8 @@ bool accountFlagMaskCheckIsValid(uint32_t flag, uint32_t ledgerVersion);
 
 bool hasMuxedAccount(TransactionEnvelope const& e);
 
-bool
-isTransactionXDRValidForCurrentProtocol(AppConnector& app,
-                                        TransactionEnvelope const& envelope);
+bool isTransactionXDRValidForProtocol(uint32_t currProtocol, Config const& cfg,
+                                      TransactionEnvelope const& envelope);
 
 uint64_t getUpperBoundCloseTimeOffset(Application& app, uint64_t lastCloseTime);
 

--- a/src/transactions/test/InvokeHostFunctionTests.cpp
+++ b/src/transactions/test/InvokeHostFunctionTests.cpp
@@ -1027,7 +1027,7 @@ TEST_CASE("Soroban non-refundable resource fees are stable", "[tx][soroban]")
                 app.getLedgerManager()
                     .getLastClosedLedgerHeader()
                     .header.ledgerVersion,
-                app.getLedgerManager().getSorobanNetworkConfig(),
+                app.getLedgerManager().getSorobanNetworkConfigReadOnly(),
                 app.getConfig());
         REQUIRE(expectedNonRefundableFee == actualFeePair.non_refundable_fee);
 
@@ -3086,7 +3086,7 @@ TEST_CASE("settings upgrade command line utils", "[tx][soroban][upgrades]")
     // Update bucketListTargetSizeBytes so bucketListWriteFeeGrowthFactor comes
     // into play
     auto const& blSize = app->getLedgerManager()
-                             .getSorobanNetworkConfig()
+                             .getSorobanNetworkConfigReadOnly()
                              .getAverageBucketListSize();
     {
         LedgerTxn ltx(app->getLedgerTxnRoot());

--- a/src/transactions/test/SorobanTxTestUtils.cpp
+++ b/src/transactions/test/SorobanTxTestUtils.cpp
@@ -1055,7 +1055,7 @@ SorobanTest::getDummyAccount()
 SorobanNetworkConfig const&
 SorobanTest::getNetworkCfg()
 {
-    return getApp().getLedgerManager().getSorobanNetworkConfig();
+    return getApp().getLedgerManager().getSorobanNetworkConfigReadOnly();
 }
 
 uint32_t

--- a/src/transactions/test/TransactionTestFrame.cpp
+++ b/src/transactions/test/TransactionTestFrame.cpp
@@ -142,11 +142,11 @@ TransactionTestFrame::checkValidForTesting(AppConnector& app,
 
 bool
 TransactionTestFrame::checkSorobanResourceAndSetError(
-    AppConnector& app, uint32_t ledgerVersion,
+    AppConnector& app, SorobanNetworkConfig const& cfg, uint32_t ledgerVersion,
     MutableTxResultPtr txResult) const
 {
     auto ret = mTransactionFrame->checkSorobanResourceAndSetError(
-        app, ledgerVersion, txResult);
+        app, cfg, ledgerVersion, txResult);
     mTransactionTxResult = txResult;
     return ret;
 }

--- a/src/transactions/test/TransactionTestFrame.h
+++ b/src/transactions/test/TransactionTestFrame.h
@@ -70,9 +70,9 @@ class TransactionTestFrame : public TransactionFrameBase
     checkValid(AppConnector& app, LedgerSnapshot const& ls,
                SequenceNumber current, uint64_t lowerBoundCloseTimeOffset,
                uint64_t upperBoundCloseTimeOffset) const override;
-    bool
-    checkSorobanResourceAndSetError(AppConnector& app, uint32_t ledgerVersion,
-                                    MutableTxResultPtr txResult) const override;
+    bool checkSorobanResourceAndSetError(
+        AppConnector& app, SorobanNetworkConfig const& cfg,
+        uint32_t ledgerVersion, MutableTxResultPtr txResult) const override;
 
     MutableTxResultPtr createSuccessResult() const override;
 


### PR DESCRIPTION
Improve access to ledger state, to better support parallelization changes in #4543 

Note that management of SorobanNetworkConfig is still not great, as currently LM manages multiple versions of the config. Ideally, soroban network config lives inside of the state snapshot (either BucketList snapshot or LedgerTxn), but this was too tricky to implement at this time due to how network config is currently implemented. We may need to clean this up later. 

This change also partially addresses https://github.com/stellar/stellar-core/issues/4318