### PR TITLE
Add an additional flag protection for the Soroban cost calibration in loadgen

### DIFF
--- a/Builds/VisualStudio/stellar-core.vcxproj
+++ b/Builds/VisualStudio/stellar-core.vcxproj
@@ -623,18 +623,10 @@ exit /b 0
     <ClCompile Include="..\..\src\ledger\LedgerRange.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerStateSnapshot.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxn.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnAccountSQL.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnClaimableBalanceSQL.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnConfigSettingSQL.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnContractCodeSQL.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnContractDataSQL.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnDataSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnEntry.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnTTLSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnHeader.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp" />
     <ClCompile Include="..\..\src\ledger\LedgerTxnOfferSQL.cpp" />
-    <ClCompile Include="..\..\src\ledger\LedgerTxnTrustLineSQL.cpp" />
+    
     <ClCompile Include="..\..\src\ledger\LedgerTypeUtils.cpp" />
     <ClCompile Include="..\..\src\ledger\NetworkConfig.cpp" />
     <ClCompile Include="..\..\src\ledger\test\InMemoryLedgerTxn.cpp" />
@@ -654,7 +646,6 @@ exit /b 0
     <ClCompile Include="..\..\src\main\test\ApplicationUtilsTests.cpp" />
     <ClCompile Include="..\..\src\main\test\CommandHandlerTests.cpp" />
     <ClCompile Include="..\..\src\main\test\ConfigTests.cpp" />
-    <ClCompile Include="..\..\src\main\test\ExternalQueueTests.cpp" />
     <ClCompile Include="..\..\src\main\test\SelfCheckTests.cpp" />
     <ClCompile Include="..\..\src\overlay\BanManagerImpl.cpp" />
     <ClCompile Include="..\..\src\overlay\Floodgate.cpp" />
@@ -868,7 +859,6 @@ exit /b 0
     <ClCompile Include="..\..\src\main\CommandLine.cpp" />
     <ClCompile Include="..\..\src\main\Config.cpp" />
     <ClCompile Include="..\..\src\main\dumpxdr.cpp" />
-    <ClCompile Include="..\..\src\main\ExternalQueue.cpp" />
     <ClCompile Include="..\..\src\main\main.cpp" />
     <ClCompile Include="..\..\src\main\Maintainer.cpp" />
     <ClCompile Include="..\..\src\main\PersistentState.cpp" />
@@ -1197,7 +1187,6 @@ exit /b 0
     <ClInclude Include="..\..\src\main\Config.h" />
     <ClInclude Include="..\..\src\main\dumpxdr.h" />
     <ClInclude Include="..\..\src\main\ErrorMessages.h" />
-    <ClInclude Include="..\..\src\main\ExternalQueue.h" />
     <ClInclude Include="..\..\src\main\Maintainer.h" />
     <ClInclude Include="..\..\src\main\PersistentState.h" />
     <ClInclude Include="..\..\src\main\StellarCoreVersion.h" />

--- a/Builds/VisualStudio/stellar-core.vcxproj.filters
+++ b/Builds/VisualStudio/stellar-core.vcxproj.filters
@@ -405,9 +405,6 @@
     <ClCompile Include="..\..\src\main\dumpxdr.cpp">
       <Filter>main</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\main\ExternalQueue.cpp">
-      <Filter>main</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\main\main.cpp">
       <Filter>main</Filter>
     </ClCompile>
@@ -918,39 +915,15 @@
     <ClCompile Include="..\..\src\ledger\LedgerTxn.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnAccountSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnClaimableBalanceSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnConfigSettingSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnContractCodeSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnContractDataSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnDataSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\ledger\LedgerTxnEntry.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\ledger\LedgerTxnHeader.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnLiquidityPoolSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\ledger\LedgerTxnOfferSQL.cpp">
       <Filter>ledger</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnTrustLineSQL.cpp">
-      <Filter>ledger</Filter>
-    </ClCompile>
+    </ClCompile>    
     <ClCompile Include="..\..\src\ledger\NetworkConfig.cpp">
       <Filter>ledger</Filter>
     </ClCompile>
@@ -967,9 +940,6 @@
       <Filter>main\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\main\test\ConfigTests.cpp">
-      <Filter>main\tests</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\main\test\ExternalQueueTests.cpp">
       <Filter>main\tests</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\main\test\SelfCheckTests.cpp">
@@ -1289,9 +1259,6 @@
     </ClCompile>
     <ClCompile Include="..\..\src\transactions\RestoreFootprintOpFrame.cpp">
       <Filter>transactions</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\ledger\LedgerTxnTTLSQL.cpp">
-      <Filter>ledger</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\util\DebugMetaUtils.cpp">
       <Filter>util</Filter>
@@ -1641,9 +1608,6 @@
       <Filter>main</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\main\ErrorMessages.h">
-      <Filter>main</Filter>
-    </ClInclude>
-    <ClInclude Include="..\..\src\main\ExternalQueue.h">
       <Filter>main</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\main\Maintainer.h">

--- a/src/herder/Upgrades.cpp
+++ b/src/herder/Upgrades.cpp
@@ -1204,7 +1204,9 @@ Upgrades::applyVersionUpgrade(Application& app, AbstractLedgerTxn& ltx,
         // reflect the most recent calibration on p20. This would break
         // if we tried to replay the ledger, but we shouldn't be combining load
         // generation with the ledger replay.
-        if (app.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING)
+        if (app.getConfig().ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING &&
+            app.getConfig()
+                .UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING)
         {
             SorobanNetworkConfig::updateRecalibratedCostTypesForV20(ltx);
         }

--- a/src/main/Config.cpp
+++ b/src/main/Config.cpp
@@ -41,6 +41,7 @@ static const std::unordered_set<std::string> TESTING_ONLY_OPTIONS = {
     "RUN_STANDALONE",
     "MANUAL_CLOSE",
     "ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
+    "UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING",
     "ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING",
     "ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING",
     "ARTIFICIALLY_REPLAY_WITH_NEWEST_BUCKET_LOGIC_FOR_TESTING",
@@ -173,6 +174,7 @@ Config::Config() : NODE_SEED(SecretKey::random())
     // automatic self-check happens once every 3 hours
     AUTOMATIC_SELF_CHECK_PERIOD = std::chrono::seconds{3 * 60 * 60};
     ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = false;
+    UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING = false;
     ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING = false;
     ARTIFICIALLY_SET_CLOSE_TIME_FOR_TESTING = 0;
     ARTIFICIALLY_PESSIMIZE_MERGES_FOR_TESTING = false;
@@ -1149,6 +1151,11 @@ Config::processConfig(std::shared_ptr<cpptoml::table> t)
                 {"ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING",
                  [&]() {
                      ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = readBool(item);
+                 }},
+                {"UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING",
+                 [&]() {
+                     UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING =
+                         readBool(item);
                  }},
                 {"ARTIFICIALLY_ACCELERATE_TIME_FOR_TESTING",
                  [&]() {

--- a/src/main/Config.h
+++ b/src/main/Config.h
@@ -219,6 +219,15 @@ class Config : public std::enable_shared_from_this<Config>
     // production networks.
     bool ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING;
 
+    // A temporary config paramter that when enabled causes the protocol
+    // upgrades to also update the Soroban cost calibration. This will result
+    // in loadgen reflecting more accurate costs and match the real network.
+    // This also makes the node unable to catchup with the real traffic and
+    // thus should only be used in tests that only use loadgen.
+    // This can be defaulted to 'true' and then removed once the stable Core
+    // build supports the new logic.
+    bool UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING;
+
     // A config parameter that reduces ledger close time to 1s and checkpoint
     // frequency to every 8 ledgers. Do not ever set this in production, as it
     // will make your history archives incompatible with those of anyone else.

--- a/src/simulation/test/LoadGeneratorTests.cpp
+++ b/src/simulation/test/LoadGeneratorTests.cpp
@@ -199,6 +199,7 @@ TEST_CASE("generate soroban load", "[loadgen][soroban]")
             auto cfg = getTestConfig(i);
             cfg.USE_CONFIG_FOR_GENESIS = false;
             cfg.ARTIFICIALLY_GENERATE_LOAD_FOR_TESTING = true;
+            cfg.UPDATE_SOROBAN_COSTS_DURING_PROTOCOL_UPGRADE_FOR_TESTING = true;
             //  Use tight bounds to we can verify storage works properly
             cfg.LOADGEN_NUM_DATA_ENTRIES_FOR_TESTING = {numDataEntries};
             cfg.LOADGEN_NUM_DATA_ENTRIES_DISTRIBUTION_FOR_TESTING = {1};


### PR DESCRIPTION
# Description

Add an additional flag protection for the Soroban cost calibration in loadgen.

This is necessary to support tests that compare the current core build with the stable build. Since we only need this for CI and for a relatively short period of time, this is intentionally not added to the docs.

# Checklist
- [ ] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [ ] Rebased on top of master (no merge commits)
- [ ] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [ ] Compiles
- [ ] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
