### PR TITLE
History Archive Support for State Archival

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,7 +81,8 @@ TEST_FILES = $(TESTDATA_DIR)/stellar-core_example.cfg $(TESTDATA_DIR)/stellar-co
              $(TESTDATA_DIR)/stellar-core_testnet.cfg $(TESTDATA_DIR)/stellar-core_testnet_legacy.cfg \
              $(TESTDATA_DIR)/stellar-history.testnet.6714239.json $(TESTDATA_DIR)/stellar-history.livenet.15686975.json \
              $(TESTDATA_DIR)/stellar-core_testnet_validator.cfg $(TESTDATA_DIR)/stellar-core_example_validators.cfg \
-             $(TESTDATA_DIR)/stellar-history.testnet.6714239.networkPassphrase.json
+             $(TESTDATA_DIR)/stellar-history.testnet.6714239.networkPassphrase.json \
+             $(TESTDATA_DIR)/stellar-history.testnet.6714239.networkPassphrase.v2.json
 
 BUILT_SOURCES = $(SRC_X_FILES:.x=.h) main/StellarCoreVersion.cpp main/XDRFilesSha256.cpp $(TEST_FILES)
 

--- a/src/bucket/BucketBase.cpp
+++ b/src/bucket/BucketBase.cpp
@@ -393,7 +393,7 @@ BucketBase<BucketT, IndexT>::merge(
     }
     if (countMergeEvents)
     {
-        bucketManager.incrMergeCounters(mc);
+        bucketManager.incrMergeCounters<BucketT>(mc);
     }
 
     std::vector<Hash> shadowHashes;

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1269,7 +1269,7 @@ BucketManager::assumeState(HistoryArchiveState const& has,
     releaseAssert(threadIsMain());
     releaseAssertOrThrow(mConfig.MODE_ENABLES_BUCKETLIST);
 
-    auto processBucketList = [&](auto& bl, auto const& hasBuckets) {
+    auto processBucketList = [this](auto& bl, auto const& hasBuckets) {
         auto kNumLevels = std::remove_reference<decltype(bl)>::type::kNumLevels;
         using BucketT =
             typename std::remove_reference<decltype(bl)>::type::bucket_type;

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -348,13 +348,6 @@ BucketManager::getBloomLookupMeter() const
         {BucketT::METRIC_STRING, "bloom", "lookups"}, "bloom");
 }
 
-MergeCounters
-BucketManager::readMergeCounters()
-{
-    std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
-    return mMergeCounters;
-}
-
 medida::Meter&
 BucketManager::getCacheHitMeter() const
 {
@@ -367,11 +360,36 @@ BucketManager::getCacheMissMeter() const
     return mCacheMissMeter;
 }
 
-void
-BucketManager::incrMergeCounters(MergeCounters const& delta)
+template <>
+MergeCounters
+BucketManager::readMergeCounters<LiveBucket>()
 {
     std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
-    mMergeCounters += delta;
+    return mLiveMergeCounters;
+}
+
+template <>
+MergeCounters
+BucketManager::readMergeCounters<HotArchiveBucket>()
+{
+    std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
+    return mHotArchiveMergeCounters;
+}
+
+template <>
+void
+BucketManager::incrMergeCounters<LiveBucket>(MergeCounters const& delta)
+{
+    std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
+    mLiveMergeCounters += delta;
+}
+
+template <>
+void
+BucketManager::incrMergeCounters<HotArchiveBucket>(MergeCounters const& delta)
+{
+    std::lock_guard<std::recursive_mutex> lock(mBucketMutex);
+    mHotArchiveMergeCounters += delta;
 }
 
 bool
@@ -653,7 +671,7 @@ BucketManager::getMergeFutureInternal(MergeKey const& key,
                 auto future = promise.get_future().share();
                 promise.set_value(bucket);
                 mc.mFinishedMergeReattachments++;
-                incrMergeCounters(mc);
+                incrMergeCounters<BucketT>(mc);
                 return future;
             }
         }
@@ -668,7 +686,7 @@ BucketManager::getMergeFutureInternal(MergeKey const& key,
         "BucketManager::getMergeFuture returning running future for merge {}",
         key);
     mc.mRunningMergeReattachments++;
-    incrMergeCounters(mc);
+    incrMergeCounters<BucketT>(mc);
     return i->second;
 }
 
@@ -1044,10 +1062,10 @@ BucketManager::snapshotLedger(LedgerHeader& currentHeader)
                 HotArchiveBucket::
                     FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
         {
-            // TODO: Hash Archive Bucket
-            // Dependency: HAS supports Hot Archive BucketList
-
-            hash = mLiveBucketList->getHash();
+            SHA256 hsh;
+            hsh.add(mLiveBucketList->getHash());
+            hsh.add(mHotArchiveBucketList->getHash());
+            hash = hsh.finish();
         }
         else
         {
@@ -1250,46 +1268,59 @@ BucketManager::assumeState(HistoryArchiveState const& has,
     releaseAssert(threadIsMain());
     releaseAssertOrThrow(mConfig.MODE_ENABLES_BUCKETLIST);
 
-    // TODO: Assume archival bucket state
     // Dependency: HAS supports Hot Archive BucketList
-    for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
-    {
-        auto curr = getBucketByHashInternal(
-            hexToBin256(has.currentBuckets.at(i).curr), mSharedLiveBuckets);
-        auto snap = getBucketByHashInternal(
-            hexToBin256(has.currentBuckets.at(i).snap), mSharedLiveBuckets);
-        if (!(curr && snap))
-        {
-            throw std::runtime_error("Missing bucket files while assuming "
-                                     "saved live BucketList state");
-        }
 
-        auto const& nextFuture = has.currentBuckets.at(i).next;
-        std::shared_ptr<LiveBucket> nextBucket = nullptr;
-        if (nextFuture.hasOutputHash())
+    auto processBucketList = [&](auto& bl, auto const& hasBuckets) {
+        auto kNumLevels = std::remove_reference<decltype(bl)>::type::kNumLevels;
+        using BucketT =
+            typename std::remove_reference<decltype(bl)>::type::bucket_type;
+        for (uint32_t i = 0; i < kNumLevels; ++i)
         {
-            nextBucket = getBucketByHashInternal(
-                hexToBin256(nextFuture.getOutputHash()), mSharedLiveBuckets);
-            if (!nextBucket)
+            auto curr =
+                getBucketByHash<BucketT>(hexToBin256(hasBuckets.at(i).curr));
+            auto snap =
+                getBucketByHash<BucketT>(hexToBin256(hasBuckets.at(i).snap));
+            if (!(curr && snap))
             {
-                throw std::runtime_error(
-                    "Missing future bucket files while "
-                    "assuming saved live BucketList state");
+                throw std::runtime_error("Missing bucket files while assuming "
+                                         "saved live BucketList state");
             }
-        }
 
-        // Buckets on the BucketList should always be indexed
-        releaseAssert(curr->isEmpty() || curr->isIndexed());
-        releaseAssert(snap->isEmpty() || snap->isIndexed());
-        if (nextBucket)
-        {
-            releaseAssert(nextBucket->isEmpty() || nextBucket->isIndexed());
-        }
+            auto const& nextFuture = hasBuckets.at(i).next;
+            std::shared_ptr<BucketT> nextBucket = nullptr;
+            if (nextFuture.hasOutputHash())
+            {
+                nextBucket = getBucketByHash<BucketT>(
+                    hexToBin256(nextFuture.getOutputHash()));
+                if (!nextBucket)
+                {
+                    throw std::runtime_error(
+                        "Missing future bucket files while "
+                        "assuming saved live BucketList state");
+                }
+            }
 
-        mLiveBucketList->getLevel(i).setCurr(curr);
-        mLiveBucketList->getLevel(i).setSnap(snap);
-        mLiveBucketList->getLevel(i).setNext(nextFuture);
+            // Buckets on the BucketList should always be indexed
+            releaseAssert(curr->isEmpty() || curr->isIndexed());
+            releaseAssert(snap->isEmpty() || snap->isIndexed());
+            if (nextBucket)
+            {
+                releaseAssert(nextBucket->isEmpty() || nextBucket->isIndexed());
+            }
+
+            bl.getLevel(i).setCurr(curr);
+            bl.getLevel(i).setSnap(snap);
+            bl.getLevel(i).setNext(nextFuture);
+        }
+    };
+
+    processBucketList(*mLiveBucketList, has.currentBuckets);
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    if (has.hasHotArchiveBuckets())
+    {
+        processBucketList(*mHotArchiveBucketList, has.hotArchiveBuckets);
     }
+#endif
 
     mLiveBucketList->maybeInitializeCaches(mConfig);
 
@@ -1297,6 +1328,13 @@ BucketManager::assumeState(HistoryArchiveState const& has,
     {
         mLiveBucketList->restartMerges(mApp, maxProtocolVersion,
                                        has.currentLedger);
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        if (has.hasHotArchiveBuckets())
+        {
+            mHotArchiveBucketList->restartMerges(mApp, maxProtocolVersion,
+                                                 has.currentLedger);
+        }
+#endif
     }
     cleanupStaleFiles(has);
 }
@@ -1600,7 +1638,9 @@ BucketManager::scheduleVerifyReferencedBucketsWork(
     // Persist a map of indexes so we don't have dangling references in
     // VerifyBucketsWork. We don't actually need to use the indexes created by
     // VerifyBucketsWork here, so a throwaway static map is fine.
-    static std::map<int, std::unique_ptr<LiveBucketIndex const>> indexMap;
+    static std::map<int, std::unique_ptr<LiveBucketIndex const>> liveIndexMap;
+    static std::map<int, std::unique_ptr<HotArchiveBucketIndex const>>
+        hotIndexMap;
 
     int i = 0;
     for (auto const& h : hashes)
@@ -1610,19 +1650,49 @@ BucketManager::scheduleVerifyReferencedBucketsWork(
             continue;
         }
 
-        // TODO: Update verify to for ArchiveBucket
-        // Dependency: HAS supports Hot Archive BucketList
-        auto b = getBucketByHashInternal(h, mSharedLiveBuckets);
-        if (!b)
-        {
-            throw std::runtime_error(fmt::format(
-                FMT_STRING("Missing referenced bucket {}"), binToHex(h)));
-        }
+        // Returns filename, hash, and whether it's a hot archive bucket
+        auto loadFilenameAndHash =
+            [&]() -> std::tuple<std::string, Hash, bool> {
+            auto live = getBucketByHashInternal(h, mSharedLiveBuckets);
+            if (!live)
+            {
+                auto hot = getBucketByHashInternal(h, mSharedHotArchiveBuckets);
 
-        auto [indexIter, _] = indexMap.emplace(i++, nullptr);
-        seq.emplace_back(std::make_shared<VerifyBucketWork>(
-            mApp, b->getFilename().string(), b->getHash(), indexIter->second,
-            nullptr));
+                // Check both live and hot archive buckets for hash. If we don't
+                // find it in either, we're missing a bucket. Note that live and
+                // hot archive buckets are guaranteed to have no hash collisions
+                // due to type field in MetaEntry.
+                if (!hot)
+                {
+                    throw std::runtime_error(
+                        fmt::format(FMT_STRING("Missing referenced bucket {}"),
+                                    binToHex(h)));
+                }
+                return std::make_tuple(hot->getFilename().string(),
+                                       hot->getHash(), true);
+            }
+            else
+            {
+                return std::make_tuple(live->getFilename().string(),
+                                       live->getHash(), false);
+            }
+        };
+
+        auto [filename, hash, isHot] = loadFilenameAndHash();
+
+        if (isHot)
+        {
+            auto [indexIter, _] = hotIndexMap.emplace(i++, nullptr);
+            seq.emplace_back(
+                std::make_shared<VerifyBucketWork<HotArchiveBucket>>(
+                    mApp, filename, hash, indexIter->second, nullptr));
+        }
+        else
+        {
+            auto [indexIter, _] = liveIndexMap.emplace(i++, nullptr);
+            seq.emplace_back(std::make_shared<VerifyBucketWork<LiveBucket>>(
+                mApp, filename, hash, indexIter->second, nullptr));
+        }
     }
     return mApp.getWorkScheduler().scheduleWork<WorkSequence>(
         "verify-referenced-buckets", seq);

--- a/src/bucket/BucketManager.cpp
+++ b/src/bucket/BucketManager.cpp
@@ -1372,7 +1372,8 @@ BucketManager::loadCompleteLedgerState(HistoryArchiveState const& has)
     std::vector<std::pair<Hash, std::string>> hashes;
     for (uint32_t i = LiveBucketList::kNumLevels; i > 0; --i)
     {
-        HistoryStateBucket const& hsb = has.currentBuckets.at(i - 1);
+        HistoryStateBucket<LiveBucket> const& hsb =
+            has.currentBuckets.at(i - 1);
         hashes.emplace_back(hexToBin256(hsb.snap),
                             fmt::format(FMT_STRING("snap {:d}"), i - 1));
         hashes.emplace_back(hexToBin256(hsb.curr),
@@ -1549,7 +1550,7 @@ BucketManager::visitLedgerEntries(
     std::vector<std::pair<Hash, std::string>> hashes;
     for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
     {
-        HistoryStateBucket const& hsb = has.currentBuckets.at(i);
+        HistoryStateBucket<LiveBucket> const& hsb = has.currentBuckets.at(i);
         hashes.emplace_back(hexToBin256(hsb.curr),
                             fmt::format(FMT_STRING("curr {:d}"), i));
         hashes.emplace_back(hexToBin256(hsb.snap),

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -111,7 +111,7 @@ class BucketManager : NonMovableOrCopyable
     std::map<LedgerEntryTypeAndDurability, medida::Counter&>
         mBucketListEntrySizeCounters;
 
-    std::future<EvictionResultCandidates> mEvictionFuture{};
+    std::future<std::unique_ptr<EvictionResultCandidates>> mEvictionFuture{};
 
     // Copy app's config for thread-safe access
     Config const mConfig;

--- a/src/bucket/BucketManager.h
+++ b/src/bucket/BucketManager.h
@@ -103,7 +103,8 @@ class BucketManager : NonMovableOrCopyable
     medida::Meter& mCacheHitMeter;
     medida::Meter& mCacheMissMeter;
     EvictionCounters mBucketListEvictionCounters;
-    MergeCounters mMergeCounters;
+    MergeCounters mLiveMergeCounters;
+    MergeCounters mHotArchiveMergeCounters;
     std::shared_ptr<EvictionStatistics> mEvictionStatistics{};
     std::map<LedgerEntryTypeAndDurability, medida::Counter&>
         mBucketListEntryCountCounters;
@@ -204,8 +205,8 @@ class BucketManager : NonMovableOrCopyable
 
     // Reading and writing the merge counters is done in bulk, and takes a lock
     // briefly; this can be done from any thread.
-    MergeCounters readMergeCounters();
-    void incrMergeCounters(MergeCounters const& delta);
+    template <class BucketT> MergeCounters readMergeCounters();
+    template <class BucketT> void incrMergeCounters(MergeCounters const& delta);
 
     // Get a reference to a persistent bucket (in the BucketManager's bucket
     // directory), from the BucketManager's shared bucket-set.

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -136,10 +136,26 @@ MergeCounters::operator==(MergeCounters const& other) const
 // Check that eviction scan is based off of current ledger snapshot and that
 // archival settings have not changed
 bool
-EvictionResultCandidates::isValid(uint32_t currLedger,
+EvictionResultCandidates::isValid(uint32_t currLedgerSeq,
+                                  uint32_t currLedgerVers,
                                   StateArchivalSettings const& currSas) const
 {
-    return initialLedger == currLedger &&
+    // If the eviction scan started before a protocol upgrade, and the protocol
+    // upgrade changes eviction scan behavior during the scan, we need
+    // to restart with the new protocol version. We only care about
+    // `FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION`, other upgrades don't
+    // affect evictions scans.
+    if (protocolVersionIsBefore(
+            initialLedgerVers,
+            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION) &&
+        protocolVersionStartsFrom(
+            currLedgerVers,
+            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+    {
+        return false;
+    }
+
+    return initialLedgerSeq == currLedgerSeq &&
            initialSas.maxEntriesToArchive == currSas.maxEntriesToArchive &&
            initialSas.evictionScanSize == currSas.evictionScanSize &&
            initialSas.startingEvictionScanLevel ==

--- a/src/bucket/BucketUtils.cpp
+++ b/src/bucket/BucketUtils.cpp
@@ -147,10 +147,10 @@ EvictionResultCandidates::isValid(uint32_t currLedgerSeq,
     // affect evictions scans.
     if (protocolVersionIsBefore(
             initialLedgerVers,
-            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION) &&
+            LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION) &&
         protocolVersionStartsFrom(
             currLedgerVers,
-            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
     {
         return false;
     }

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "util/NonCopyable.h"
 #include "xdr/Stellar-ledger-entries.h"
 #include <cstdint>
 #include <list>
@@ -100,7 +101,7 @@ struct EvictionResultEntry
 // Hold the list of entries eligible for eviction on the given ledger. Note that
 // if these entries are updated during the given ledger, they may not actually
 // be evicted.
-struct EvictionResultCandidates
+struct EvictionResultCandidates : public NonMovableOrCopyable
 {
     // List of entries eligible for eviction in the order in which they occur in
     // the bucket

--- a/src/bucket/BucketUtils.h
+++ b/src/bucket/BucketUtils.h
@@ -109,24 +109,28 @@ struct EvictionResultCandidates
     // Eviction iterator at the end of the scan region
     EvictionIterator endOfRegionIterator;
 
-    // LedgerSeq which this scan is based on
-    uint32_t initialLedger{};
+    // LedgerSeq and ledger version which this scan is based on
+    uint32_t const initialLedgerSeq{};
+    uint32_t const initialLedgerVers{};
 
     // State archival settings that this scan is based on
-    StateArchivalSettings initialSas;
+    StateArchivalSettings const initialSas;
 
-    EvictionResultCandidates(StateArchivalSettings const& sas) : initialSas(sas)
+    EvictionResultCandidates(StateArchivalSettings const& sas,
+                             uint32_t initialLedger, uint32_t initialLedgerVers)
+        : initialLedgerSeq(initialLedger)
+        , initialLedgerVers(initialLedgerVers)
+        , initialSas(sas)
     {
     }
 
     // Returns true if this is a valid archival scan for the current ledger
     // and archival settings. This is necessary because we start the scan
     // for ledger N immediately after N - 1 closes. However, ledger N may
-    // contain a network upgrade changing eviction scan settings. Legacy SQL
-    // scans will run based on the changes that occurred during ledger N,
-    // meaning the scan we started at ledger N - 1 is invalid since it was based
-    // off of older settings.
-    bool isValid(uint32_t currLedger,
+    // contain a network upgrade changing eviction scan settings. Eviction scans
+    // must be based on the network settings after applying any upgrades, so if
+    // this occurs we must restart the scan.
+    bool isValid(uint32_t currLedgerSeq, uint32_t currLedgerVers,
                  StateArchivalSettings const& currSas) const;
 };
 

--- a/src/bucket/HotArchiveBucket.cpp
+++ b/src/bucket/HotArchiveBucket.cpp
@@ -36,7 +36,7 @@ HotArchiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
 
     if (countMergeEvents)
     {
-        bucketManager.incrMergeCounters(mc);
+        bucketManager.incrMergeCounters<HotArchiveBucket>(mc);
     }
 
     return out.getBucket(bucketManager);

--- a/src/bucket/HotArchiveBucket.h
+++ b/src/bucket/HotArchiveBucket.h
@@ -27,11 +27,6 @@ class HotArchiveBucket
     : public BucketBase<HotArchiveBucket, HotArchiveBucketIndex>,
       public std::enable_shared_from_this<HotArchiveBucket>
 {
-    static std::vector<HotArchiveBucketEntry>
-    convertToBucketEntry(std::vector<LedgerEntry> const& archivedEntries,
-                         std::vector<LedgerKey> const& restoredEntries,
-                         std::vector<LedgerKey> const& deletedEntries);
-
   public:
     // Entry type that this bucket stores
     using EntryT = HotArchiveBucketEntry;
@@ -97,6 +92,11 @@ class HotArchiveBucket
 
     static std::shared_ptr<LoadT const>
     bucketEntryToLoadResult(std::shared_ptr<EntryT const> const& be);
+
+    static std::vector<HotArchiveBucketEntry>
+    convertToBucketEntry(std::vector<LedgerEntry> const& archivedEntries,
+                         std::vector<LedgerKey> const& restoredEntries,
+                         std::vector<LedgerKey> const& deletedEntries);
 
     friend class HotArchiveBucketSnapshot;
 };

--- a/src/bucket/HotArchiveBucketList.h
+++ b/src/bucket/HotArchiveBucketList.h
@@ -15,6 +15,8 @@ namespace stellar
 class HotArchiveBucketList : public BucketListBase<HotArchiveBucket>
 {
   public:
+    using bucket_type = HotArchiveBucket;
+
     void addBatch(Application& app, uint32_t currLedger,
                   uint32_t currLedgerProtocol,
                   std::vector<LedgerEntry> const& archiveEntries,

--- a/src/bucket/LiveBucket.cpp
+++ b/src/bucket/LiveBucket.cpp
@@ -410,7 +410,7 @@ LiveBucket::fresh(BucketManager& bucketManager, uint32_t protocolVersion,
 
     if (countMergeEvents)
     {
-        bucketManager.incrMergeCounters(mc);
+        bucketManager.incrMergeCounters<LiveBucket>(mc);
     }
 
     return out.getBucket(bucketManager);

--- a/src/bucket/LiveBucketList.h
+++ b/src/bucket/LiveBucketList.h
@@ -17,6 +17,8 @@ namespace stellar
 class LiveBucketList : public BucketListBase<LiveBucket>
 {
   public:
+    using bucket_type = LiveBucket;
+
     // Reset Eviction Iterator position if an incoming spill or upgrade has
     // invalidated the previous position
     static void updateStartingEvictionIterator(EvictionIterator& iter,

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -13,7 +13,7 @@
 
 namespace stellar
 {
-EvictionResultCandidates
+std::unique_ptr<EvictionResultCandidates>
 SearchableLiveBucketListSnapshot::scanForEviction(
     uint32_t ledgerSeq, EvictionCounters& counters,
     EvictionIterator evictionIter, std::shared_ptr<EvictionStatistics> stats,
@@ -32,7 +32,8 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     LiveBucketList::updateStartingEvictionIterator(
         evictionIter, sas.startingEvictionScanLevel, ledgerSeq);
 
-    EvictionResultCandidates result(sas, ledgerSeq, ledgerVers);
+    std::unique_ptr<EvictionResultCandidates> result =
+        std::make_unique<EvictionResultCandidates>(sas, ledgerSeq, ledgerVers);
     auto startIter = evictionIter;
     auto scanSize = sas.evictionScanSize;
 
@@ -44,7 +45,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
 
         // If we scan scanSize before hitting bucket EOF, exit early
         if (b.scanForEviction(evictionIter, scanSize, ledgerSeq,
-                              result.eligibleEntries, *this,
+                              result->eligibleEntries, *this,
                               ledgerVers) == Loop::COMPLETE)
         {
             break;
@@ -59,7 +60,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
         }
     }
 
-    result.endOfRegionIterator = evictionIter;
+    result->endOfRegionIterator = evictionIter;
     return result;
 }
 

--- a/src/bucket/SearchableBucketList.cpp
+++ b/src/bucket/SearchableBucketList.cpp
@@ -32,7 +32,7 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     LiveBucketList::updateStartingEvictionIterator(
         evictionIter, sas.startingEvictionScanLevel, ledgerSeq);
 
-    EvictionResultCandidates result(sas);
+    EvictionResultCandidates result(sas, ledgerSeq, ledgerVers);
     auto startIter = evictionIter;
     auto scanSize = sas.evictionScanSize;
 
@@ -60,7 +60,6 @@ SearchableLiveBucketListSnapshot::scanForEviction(
     }
 
     result.endOfRegionIterator = evictionIter;
-    result.initialLedger = ledgerSeq;
     return result;
 }
 

--- a/src/bucket/SearchableBucketList.h
+++ b/src/bucket/SearchableBucketList.h
@@ -30,7 +30,7 @@ class SearchableLiveBucketListSnapshot
     loadKeysWithLimits(std::set<LedgerKey, LedgerEntryIdCmp> const& inKeys,
                        std::string const& label, LedgerKeyMeter* lkMeter) const;
 
-    EvictionResultCandidates scanForEviction(
+    std::unique_ptr<EvictionResultCandidates> scanForEviction(
         uint32_t ledgerSeq, EvictionCounters& counters, EvictionIterator iter,
         std::shared_ptr<EvictionStatistics> stats,
         StateArchivalSettings const& sas, uint32_t ledgerVers) const;

--- a/src/bucket/test/BucketListTests.cpp
+++ b/src/bucket/test/BucketListTests.cpp
@@ -1141,9 +1141,10 @@ TEST_CASE_VERSIONS("eviction scan", "[bucketlist][archival]")
             // Close ledgers until evicted DEADENTRYs merge with
             // original INITENTRYs. This checks that BucketList
             // invariants are respected
-            for (auto initialDeadMerges =
-                     bm.readMergeCounters().mOldInitEntriesMergedWithNewDead;
-                 bm.readMergeCounters().mOldInitEntriesMergedWithNewDead <
+            for (auto initialDeadMerges = bm.readMergeCounters<LiveBucket>()
+                                              .mOldInitEntriesMergedWithNewDead;
+                 bm.readMergeCounters<LiveBucket>()
+                     .mOldInitEntriesMergedWithNewDead <
                  initialDeadMerges + tempEntries.size();
                  ++ledgerSeq)
             {

--- a/src/bucket/test/BucketManagerTests.cpp
+++ b/src/bucket/test/BucketManagerTests.cpp
@@ -27,7 +27,10 @@
 #include "test/test.h"
 #include "util/GlobalChecks.h"
 #include "util/Math.h"
+#include "util/ProtocolVersion.h"
 #include "util/Timer.h"
+#include "util/UnorderedSet.h"
+#include "xdr/Stellar-ledger-entries.h"
 
 #include <cstdio>
 #include <optional>
@@ -329,11 +332,33 @@ TEST_CASE_VERSIONS("bucketmanager reattach to finished merge",
 
         BucketManager& bm = app->getBucketManager();
         LiveBucketList& bl = bm.getLiveBucketList();
+        HotArchiveBucketList& hotArchive = bm.getHotArchiveBucketList();
         auto vers = getAppLedgerVersion(app);
-
+        bool hasHotArchive = protocolVersionStartsFrom(
+            vers, LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
         // Add some entries to get to a nontrivial merge-state.
         uint32_t ledger = 0;
-        uint32_t level = 3;
+        uint32_t level = 4;
+        UnorderedSet<LedgerKey> addedHotArchiveKeys;
+
+        // To prevent duplicate merges that can interfere with counters, seed
+        // the starting Bucket so that each merge is unique. Otherwise, the
+        // first call to addBatch will merge [{first_batch}, empty_bucket]. We
+        // will then see other instances of [{first_batch}, empty_bucket] merges
+        // later on as the Bucket moves its way down the bl. By providing a
+        // seeded bucket, the first addBatch is a [{first_batch}, seeded_bucket]
+        // merge, which will not be duplicated by empty bucket merges later. The
+        // live BL is automatically seeded with the genesis ledger.
+        if (hasHotArchive)
+        {
+            auto initialHotArchiveBucket =
+                LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
+                    {CONTRACT_CODE}, 10, addedHotArchiveKeys);
+            hotArchive.getLevel(0).setCurr(HotArchiveBucket::fresh(
+                bm, vers, {}, initialHotArchiveBucket, {}, {},
+                clock.getIOContext(), /*doFsync=*/true));
+        }
+
         do
         {
             ++ledger;
@@ -345,6 +370,15 @@ TEST_CASE_VERSIONS("bucketmanager reattach to finished merge",
                 LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
                     {CONFIG_SETTING}, 10),
                 {});
+            if (protocolVersionStartsFrom(
+                    vers,
+                    LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            {
+                addHotArchiveBatchAndUpdateSnapshot(
+                    *app, lh, {}, {},
+                    LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
+                        {CONTRACT_CODE}, 10, addedHotArchiveKeys));
+            }
             bm.forgetUnreferencedBuckets(
                 app->getLedgerManager().getLastClosedLedgerHAS());
         } while (!LiveBucketList::levelShouldSpill(ledger, level - 1));
@@ -354,17 +388,42 @@ TEST_CASE_VERSIONS("bucketmanager reattach to finished merge",
         // eagerly)
         REQUIRE(bl.getLevel(level).getNext().isMerging());
 
+        HistoryArchiveState has;
+        if (hasHotArchive)
+        {
+            REQUIRE(hotArchive.getLevel(level).getNext().isMerging());
+            has = HistoryArchiveState(ledger, bl, hotArchive,
+                                      app->getConfig().NETWORK_PASSPHRASE);
+            REQUIRE(has.hasHotArchiveBuckets());
+        }
+        else
+        {
+            has = HistoryArchiveState(ledger, bl,
+                                      app->getConfig().NETWORK_PASSPHRASE);
+            REQUIRE(!has.hasHotArchiveBuckets());
+        }
+
         // Serialize HAS.
-        HistoryArchiveState has(ledger, bl,
-                                app->getConfig().NETWORK_PASSPHRASE);
         std::string serialHas = has.toString();
 
         // Simulate level committing (and the FutureBucket clearing),
         // followed by the typical ledger-close bucket GC event.
         bl.getLevel(level).commit();
         REQUIRE(!bl.getLevel(level).getNext().isMerging());
-        auto ra = bm.readMergeCounters().mFinishedMergeReattachments;
-        REQUIRE(ra == 0);
+        if (hasHotArchive)
+        {
+            hotArchive.getLevel(level).commit();
+            REQUIRE(!hotArchive.getLevel(level).getNext().isMerging());
+        }
+
+        REQUIRE(
+            bm.readMergeCounters<LiveBucket>().mFinishedMergeReattachments ==
+            0);
+        if (hasHotArchive)
+        {
+            REQUIRE(bm.readMergeCounters<HotArchiveBucket>()
+                        .mFinishedMergeReattachments == 0);
+        }
 
         // Deserialize HAS.
         HistoryArchiveState has2;
@@ -375,12 +434,29 @@ TEST_CASE_VERSIONS("bucketmanager reattach to finished merge",
             *app, vers, LiveBucketList::keepTombstoneEntries(level));
         REQUIRE(has2.currentBuckets[level].next.isMerging());
 
+        if (hasHotArchive)
+        {
+            has2.hotArchiveBuckets[level].next.makeLive(
+                *app, vers, HotArchiveBucketList::keepTombstoneEntries(level));
+            REQUIRE(has2.hotArchiveBuckets[level].next.isMerging());
+
+            // Resolve reattached future.
+            has2.hotArchiveBuckets[level].next.resolve();
+        }
+
         // Resolve reattached future.
         has2.currentBuckets[level].next.resolve();
 
-        // Check that we reattached to a finished merge.
-        ra = bm.readMergeCounters().mFinishedMergeReattachments;
-        REQUIRE(ra != 0);
+        // Check that we reattached to one finished merge per bl.
+        if (hasHotArchive)
+        {
+            REQUIRE(bm.readMergeCounters<HotArchiveBucket>()
+                        .mFinishedMergeReattachments == 1);
+        }
+
+        REQUIRE(
+            bm.readMergeCounters<LiveBucket>().mFinishedMergeReattachments ==
+            1);
     });
 }
 
@@ -397,7 +473,10 @@ TEST_CASE_VERSIONS("bucketmanager reattach to running merge",
 
         BucketManager& bm = app->getBucketManager();
         LiveBucketList& bl = bm.getLiveBucketList();
+        HotArchiveBucketList& hotArchive = bm.getHotArchiveBucketList();
         auto vers = getAppLedgerVersion(app);
+        bool hasHotArchive = protocolVersionStartsFrom(
+            vers, LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
 
         // This test is a race that will (if all goes well) eventually be won:
         // we keep trying to do an immediate-reattach to a running merge and
@@ -420,8 +499,28 @@ TEST_CASE_VERSIONS("bucketmanager reattach to running merge",
         // testsuite with no explanation.
         uint32_t ledger = 0;
         uint32_t limit = 10000;
-        while (ledger < limit &&
-               bm.readMergeCounters().mRunningMergeReattachments == 0)
+
+        // Iterate until we've reached the limit, or stop early if both the Hot
+        // Archive and live BucketList have seen a running merge reattachment.
+        auto cond = [&]() {
+            bool reattachmentsNotFinished;
+            if (hasHotArchive)
+            {
+                reattachmentsNotFinished =
+                    bm.readMergeCounters<HotArchiveBucket>()
+                            .mRunningMergeReattachments < 1 ||
+                    bm.readMergeCounters<LiveBucket>()
+                            .mRunningMergeReattachments < 1;
+            }
+            else
+            {
+                reattachmentsNotFinished = bm.readMergeCounters<LiveBucket>()
+                                               .mRunningMergeReattachments < 1;
+            }
+            return ledger < limit && reattachmentsNotFinished;
+        };
+
+        while (cond())
         {
             ++ledger;
             // Merges will start on one or more levels here, starting a race
@@ -435,12 +534,30 @@ TEST_CASE_VERSIONS("bucketmanager reattach to running merge",
                 LedgerTestUtils::generateValidUniqueLedgerEntriesWithExclusions(
                     {CONFIG_SETTING}, 100),
                 {});
+            if (hasHotArchive)
+            {
+                addHotArchiveBatchAndUpdateSnapshot(
+                    *app, lh,
+                    LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                        {CONTRACT_CODE}, 100),
+                    {}, {});
+            }
 
             bm.forgetUnreferencedBuckets(
                 app->getLedgerManager().getLastClosedLedgerHAS());
 
-            HistoryArchiveState has(ledger, bl,
-                                    app->getConfig().NETWORK_PASSPHRASE);
+            HistoryArchiveState has;
+            if (hasHotArchive)
+            {
+                has = HistoryArchiveState(ledger, bl, hotArchive,
+                                          app->getConfig().NETWORK_PASSPHRASE);
+            }
+            else
+            {
+                has = HistoryArchiveState(ledger, bl,
+                                          app->getConfig().NETWORK_PASSPHRASE);
+            }
+
             std::string serialHas = has.toString();
 
             // Deserialize and reactivate levels of HAS. Races with the merge
@@ -460,12 +577,32 @@ TEST_CASE_VERSIONS("bucketmanager reattach to running merge",
                         LiveBucketList::keepTombstoneEntries(level));
                 }
             }
+
+            for (uint32_t level = 0; level < has2.hotArchiveBuckets.size();
+                 ++level)
+            {
+                if (has2.hotArchiveBuckets[level].next.hasHashes())
+                {
+                    has2.hotArchiveBuckets[level].next.makeLive(
+                        *app, vers,
+                        HotArchiveBucketList::keepTombstoneEntries(level));
+                }
+            }
         }
         CLOG_INFO(Bucket, "reattached to running merge at or around ledger {}",
                   ledger);
         REQUIRE(ledger < limit);
-        auto ra = bm.readMergeCounters().mRunningMergeReattachments;
-        REQUIRE(ra != 0);
+
+        // Because there is a race, we can't guarantee that we'll see exactly 1
+        // reattachment, but we should see at least 1.
+        if (hasHotArchive)
+        {
+            REQUIRE(bm.readMergeCounters<HotArchiveBucket>()
+                        .mRunningMergeReattachments >= 1);
+        }
+
+        REQUIRE(bm.readMergeCounters<LiveBucket>().mRunningMergeReattachments >=
+                1);
     });
 }
 
@@ -555,64 +692,101 @@ TEST_CASE_VERSIONS(
 
     for_versions_with_differing_bucket_logic(cfg, [&](Config const& cfg) {
         VirtualClock clock;
-        Application::pointer app = createTestApplication(clock, cfg);
+        auto app = createTestApplication<BucketTestApplication>(clock, cfg);
         auto vers = getAppLedgerVersion(app);
         auto& hm = app->getHistoryManager();
         auto& bm = app->getBucketManager();
+        auto& lm = app->getLedgerManager();
+        bool hasHotArchive = protocolVersionStartsFrom(
+            vers, LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
         hm.setPublicationEnabled(false);
         app->getHistoryArchiveManager().initializeHistoryArchive(
             tcfg.getArchiveDirName());
+        UnorderedSet<LedgerKey> hotArchiveKeys{};
+        auto lastLcl = lm.getLastClosedLedgerNum();
         while (hm.getPublishQueueCount() < 5)
         {
             // Do not merge this line with the next line: CLOG and
             // readMergeCounters each acquire a mutex, and it's possible to
             // deadlock with one of the worker threads if you try to hold them
             // both at the same time.
-            auto ra = bm.readMergeCounters().mFinishedMergeReattachments;
-            CLOG_INFO(Bucket, "finished-merge reattachments while queueing: {}",
-                      ra);
-            auto lh =
-                app->getLedgerManager().getLastClosedLedgerHeader().header;
-            lh.ledgerSeq++;
-            addLiveBatchAndUpdateSnapshot(
-                *app, lh, {},
-                LedgerTestUtils::generateValidUniqueLedgerEntriesWithExclusions(
-                    {CONFIG_SETTING}, 100),
-                {});
+            auto ra =
+                bm.readMergeCounters<LiveBucket>().mFinishedMergeReattachments;
+            auto raHotArchive = bm.readMergeCounters<HotArchiveBucket>()
+                                    .mFinishedMergeReattachments;
+            CLOG_INFO(Bucket,
+                      "finished-merge reattachments while queueing: live "
+                      "BucketList {}, Hot Archive BucketList {}",
+                      ra, raHotArchive);
+            if (lm.getLastClosedLedgerNum() != lastLcl)
+            {
+                lastLcl = lm.getLastClosedLedgerNum();
+                lm.setNextLedgerEntryBatchForBucketTesting(
+                    {},
+                    LedgerTestUtils::
+                        generateValidUniqueLedgerEntriesWithExclusions(
+                            {CONFIG_SETTING}, 100),
+                    {});
+                if (hasHotArchive)
+                {
+                    lm.setNextArchiveBatchForBucketTesting(
+                        {}, {},
+                        LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
+                            {CONTRACT_CODE}, 10, hotArchiveKeys));
+                }
+            }
+
             clock.crank(false);
             bm.forgetUnreferencedBuckets(
                 app->getLedgerManager().getLastClosedLedgerHAS());
         }
+
         // We should have published nothing and have the first
         // checkpoint still queued.
         REQUIRE(hm.getPublishSuccessCount() == 0);
         REQUIRE(HistoryManager::getMinLedgerQueuedToPublish(app->getConfig()) ==
                 7);
 
-        auto oldReattachments =
-            bm.readMergeCounters().mFinishedMergeReattachments;
+        auto oldLiveReattachments =
+            bm.readMergeCounters<LiveBucket>().mFinishedMergeReattachments;
+        auto oldHotArchiveReattachments =
+            bm.readMergeCounters<HotArchiveBucket>()
+                .mFinishedMergeReattachments;
         auto HASs = HistoryManager::getPublishQueueStates(app->getConfig());
         REQUIRE(HASs.size() == 5);
         for (auto& has : HASs)
         {
             has.prepareForPublish(*app);
+            REQUIRE(has.hasHotArchiveBuckets() == hasHotArchive);
         }
 
-        auto ra = bm.readMergeCounters().mFinishedMergeReattachments;
+        auto liveRa =
+            bm.readMergeCounters<LiveBucket>().mFinishedMergeReattachments;
+        auto hotArchiveRa = bm.readMergeCounters<HotArchiveBucket>()
+                                .mFinishedMergeReattachments;
         if (protocolVersionIsBefore(vers,
                                     LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
         {
             // Versions prior to FIRST_PROTOCOL_SHADOWS_REMOVED re-attach to
             // finished merges
-            REQUIRE(ra > oldReattachments);
+            REQUIRE(liveRa > oldLiveReattachments);
             CLOG_INFO(Bucket,
-                      "finished-merge reattachments after making-live: {}", ra);
+                      "finished-merge reattachments after making-live: {}",
+                      liveRa);
+
+            // Sanity check: Hot archive disabled in older protocols
+            releaseAssert(!hasHotArchive);
         }
         else
         {
             // Versions after FIRST_PROTOCOL_SHADOWS_REMOVED do not re-attach,
             // because merges are cleared
-            REQUIRE(ra == oldReattachments);
+            REQUIRE(liveRa == oldLiveReattachments);
+
+            if (hasHotArchive)
+            {
+                REQUIRE(hotArchiveRa == oldHotArchiveReattachments);
+            }
         }
 
         // Un-cork the publication process, nothing should be broken.
@@ -661,10 +835,11 @@ TEST_CASE_VERSIONS(
 // 2048).
 class StopAndRestartBucketMergesTest
 {
+    template <class BucketListT>
     static void
-    resolveAllMerges(LiveBucketList& bl)
+    resolveAllMerges(BucketListT& bl)
     {
-        for (uint32 i = 0; i < LiveBucketList::kNumLevels; ++i)
+        for (uint32 i = 0; i < BucketListT::kNumLevels; ++i)
         {
             auto& level = bl.getLevel(i);
             auto& next = level.getNext();
@@ -680,226 +855,332 @@ class StopAndRestartBucketMergesTest
         Hash mCurrBucketHash;
         Hash mSnapBucketHash;
         Hash mBucketListHash;
+        Hash mHotArchiveBucketListHash;
         Hash mLedgerHeaderHash;
-        MergeCounters mMergeCounters;
+        MergeCounters mLiveMergeCounters;
+        MergeCounters mHotArchiveMergeCounters;
 
         void
-        dumpMergeCounters(std::string const& label, uint32_t level) const
+        checkEmptyHotArchiveMetrics() const
         {
-            CLOG_INFO(Bucket, "MergeCounters: {} (designated level: {})", label,
-                      level);
-            CLOG_INFO(Bucket, "PreInitEntryProtocolMerges: {}",
-                      mMergeCounters.mPreInitEntryProtocolMerges);
-            CLOG_INFO(Bucket, "PostInitEntryProtocolMerges: {}",
-                      mMergeCounters.mPostInitEntryProtocolMerges);
-            CLOG_INFO(Bucket, "mPreShadowRemovalProtocolMerges: {}",
-                      mMergeCounters.mPreShadowRemovalProtocolMerges);
-            CLOG_INFO(Bucket, "mPostShadowRemovalProtocolMerges: {}",
-                      mMergeCounters.mPostShadowRemovalProtocolMerges);
-            CLOG_INFO(Bucket, "RunningMergeReattachments: {}",
-                      mMergeCounters.mRunningMergeReattachments);
-            CLOG_INFO(Bucket, "FinishedMergeReattachments: {}",
-                      mMergeCounters.mFinishedMergeReattachments);
-            CLOG_INFO(Bucket, "NewMetaEntries: {}",
-                      mMergeCounters.mNewMetaEntries);
-            CLOG_INFO(Bucket, "NewInitEntries: {}",
-                      mMergeCounters.mNewInitEntries);
-            CLOG_INFO(Bucket, "NewLiveEntries: {}",
-                      mMergeCounters.mNewLiveEntries);
-            CLOG_INFO(Bucket, "NewDeadEntries: {}",
-                      mMergeCounters.mNewDeadEntries);
-            CLOG_INFO(Bucket, "OldMetaEntries: {}",
-                      mMergeCounters.mOldMetaEntries);
-            CLOG_INFO(Bucket, "OldInitEntries: {}",
-                      mMergeCounters.mOldInitEntries);
-            CLOG_INFO(Bucket, "OldLiveEntries: {}",
-                      mMergeCounters.mOldLiveEntries);
-            CLOG_INFO(Bucket, "OldDeadEntries: {}",
-                      mMergeCounters.mOldDeadEntries);
-            CLOG_INFO(Bucket, "OldEntriesDefaultAccepted: {}",
-                      mMergeCounters.mOldEntriesDefaultAccepted);
-            CLOG_INFO(Bucket, "NewEntriesDefaultAccepted: {}",
-                      mMergeCounters.mNewEntriesDefaultAccepted);
-            CLOG_INFO(Bucket, "NewInitEntriesMergedWithOldDead: {}",
-                      mMergeCounters.mNewInitEntriesMergedWithOldDead);
-            CLOG_INFO(Bucket, "OldInitEntriesMergedWithNewLive: {}",
-                      mMergeCounters.mOldInitEntriesMergedWithNewLive);
-            CLOG_INFO(Bucket, "OldInitEntriesMergedWithNewDead: {}",
-                      mMergeCounters.mOldInitEntriesMergedWithNewDead);
-            CLOG_INFO(Bucket, "NewEntriesMergedWithOldNeitherInit: {}",
-                      mMergeCounters.mNewEntriesMergedWithOldNeitherInit);
-            CLOG_INFO(Bucket, "ShadowScanSteps: {}",
-                      mMergeCounters.mShadowScanSteps);
-            CLOG_INFO(Bucket, "MetaEntryShadowElisions: {}",
-                      mMergeCounters.mMetaEntryShadowElisions);
-            CLOG_INFO(Bucket, "LiveEntryShadowElisions: {}",
-                      mMergeCounters.mLiveEntryShadowElisions);
-            CLOG_INFO(Bucket, "InitEntryShadowElisions: {}",
-                      mMergeCounters.mInitEntryShadowElisions);
-            CLOG_INFO(Bucket, "DeadEntryShadowElisions: {}",
-                      mMergeCounters.mDeadEntryShadowElisions);
-            CLOG_INFO(Bucket, "OutputIteratorTombstoneElisions: {}",
-                      mMergeCounters.mOutputIteratorTombstoneElisions);
-            CLOG_INFO(Bucket, "OutputIteratorBufferUpdates: {}",
-                      mMergeCounters.mOutputIteratorBufferUpdates);
-            CLOG_INFO(Bucket, "OutputIteratorActualWrites: {}",
-                      mMergeCounters.mOutputIteratorActualWrites);
+            // If before p23, check that all hot archive metrics are zero
+            CHECK(mHotArchiveMergeCounters.mPreInitEntryProtocolMerges == 0);
+            CHECK(mHotArchiveMergeCounters.mPostInitEntryProtocolMerges == 0);
+            CHECK(mHotArchiveMergeCounters.mPreShadowRemovalProtocolMerges ==
+                  0);
+            CHECK(mHotArchiveMergeCounters.mPostShadowRemovalProtocolMerges ==
+                  0);
+            CHECK(mHotArchiveMergeCounters.mNewMetaEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mNewInitEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mNewLiveEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mNewDeadEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mOldMetaEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mOldInitEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mOldLiveEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mOldDeadEntries == 0);
+            CHECK(mHotArchiveMergeCounters.mOldEntriesDefaultAccepted == 0);
+            CHECK(mHotArchiveMergeCounters.mNewEntriesDefaultAccepted == 0);
+            CHECK(mHotArchiveMergeCounters.mNewInitEntriesMergedWithOldDead ==
+                  0);
+            CHECK(mHotArchiveMergeCounters.mOldInitEntriesMergedWithNewLive ==
+                  0);
+            CHECK(mHotArchiveMergeCounters.mOldInitEntriesMergedWithNewDead ==
+                  0);
+            CHECK(
+                mHotArchiveMergeCounters.mNewEntriesMergedWithOldNeitherInit ==
+                0);
+            CHECK(mHotArchiveMergeCounters.mShadowScanSteps == 0);
+            CHECK(mHotArchiveMergeCounters.mMetaEntryShadowElisions == 0);
+            CHECK(mHotArchiveMergeCounters.mLiveEntryShadowElisions == 0);
+            CHECK(mHotArchiveMergeCounters.mInitEntryShadowElisions == 0);
+            CHECK(mHotArchiveMergeCounters.mDeadEntryShadowElisions == 0);
+            CHECK(mHotArchiveMergeCounters.mOutputIteratorBufferUpdates == 0);
+            CHECK(mHotArchiveMergeCounters.mOutputIteratorActualWrites == 0);
+        }
+
+        void
+        dumpMergeCounters(std::string const& label, uint32_t level,
+                          uint32_t protocol) const
+        {
+            auto dumpCounters = [&](std::string const& label, uint32_t level,
+                                    MergeCounters const& counters) {
+                CLOG_INFO(Bucket, "MergeCounters: {} (designated level: {})",
+                          label, level);
+                CLOG_INFO(Bucket, "PreInitEntryProtocolMerges: {}",
+                          counters.mPreInitEntryProtocolMerges);
+                CLOG_INFO(Bucket, "PostInitEntryProtocolMerges: {}",
+                          counters.mPostInitEntryProtocolMerges);
+                CLOG_INFO(Bucket, "mPreShadowRemovalProtocolMerges: {}",
+                          counters.mPreShadowRemovalProtocolMerges);
+                CLOG_INFO(Bucket, "mPostShadowRemovalProtocolMerges: {}",
+                          counters.mPostShadowRemovalProtocolMerges);
+                CLOG_INFO(Bucket, "RunningMergeReattachments: {}",
+                          counters.mRunningMergeReattachments);
+                CLOG_INFO(Bucket, "FinishedMergeReattachments: {}",
+                          counters.mFinishedMergeReattachments);
+                CLOG_INFO(Bucket, "NewMetaEntries: {}",
+                          counters.mNewMetaEntries);
+                CLOG_INFO(Bucket, "NewInitEntries: {}",
+                          counters.mNewInitEntries);
+                CLOG_INFO(Bucket, "NewLiveEntries: {}",
+                          counters.mNewLiveEntries);
+                CLOG_INFO(Bucket, "NewDeadEntries: {}",
+                          counters.mNewDeadEntries);
+                CLOG_INFO(Bucket, "OldMetaEntries: {}",
+                          counters.mOldMetaEntries);
+                CLOG_INFO(Bucket, "OldInitEntries: {}",
+                          counters.mOldInitEntries);
+                CLOG_INFO(Bucket, "OldLiveEntries: {}",
+                          counters.mOldLiveEntries);
+                CLOG_INFO(Bucket, "OldDeadEntries: {}",
+                          counters.mOldDeadEntries);
+                CLOG_INFO(Bucket, "OldEntriesDefaultAccepted: {}",
+                          counters.mOldEntriesDefaultAccepted);
+                CLOG_INFO(Bucket, "NewEntriesDefaultAccepted: {}",
+                          counters.mNewEntriesDefaultAccepted);
+                CLOG_INFO(Bucket, "NewInitEntriesMergedWithOldDead: {}",
+                          counters.mNewInitEntriesMergedWithOldDead);
+                CLOG_INFO(Bucket, "OldInitEntriesMergedWithNewLive: {}",
+                          counters.mOldInitEntriesMergedWithNewLive);
+                CLOG_INFO(Bucket, "OldInitEntriesMergedWithNewDead: {}",
+                          counters.mOldInitEntriesMergedWithNewDead);
+                CLOG_INFO(Bucket, "NewEntriesMergedWithOldNeitherInit: {}",
+                          counters.mNewEntriesMergedWithOldNeitherInit);
+                CLOG_INFO(Bucket, "ShadowScanSteps: {}",
+                          counters.mShadowScanSteps);
+                CLOG_INFO(Bucket, "MetaEntryShadowElisions: {}",
+                          counters.mMetaEntryShadowElisions);
+                CLOG_INFO(Bucket, "LiveEntryShadowElisions: {}",
+                          counters.mLiveEntryShadowElisions);
+                CLOG_INFO(Bucket, "InitEntryShadowElisions: {}",
+                          counters.mInitEntryShadowElisions);
+                CLOG_INFO(Bucket, "DeadEntryShadowElisions: {}",
+                          counters.mDeadEntryShadowElisions);
+                CLOG_INFO(Bucket, "OutputIteratorTombstoneElisions: {}",
+                          counters.mOutputIteratorTombstoneElisions);
+                CLOG_INFO(Bucket, "OutputIteratorBufferUpdates: {}",
+                          counters.mOutputIteratorBufferUpdates);
+                CLOG_INFO(Bucket, "OutputIteratorActualWrites: {}",
+                          counters.mOutputIteratorActualWrites);
+            };
+
+            dumpCounters(label + " (live)", level, mLiveMergeCounters);
+            if (protocolVersionStartsFrom(
+                    protocol,
+                    LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            {
+                dumpCounters(label + " (hot)", level, mHotArchiveMergeCounters);
+            }
         }
 
         void
         checkSensiblePostInitEntryMergeCounters(uint32_t protocol) const
         {
-            CHECK(mMergeCounters.mPostInitEntryProtocolMerges != 0);
+            // Check live merge counters
+            CHECK(mLiveMergeCounters.mPostInitEntryProtocolMerges != 0);
             if (protocolVersionIsBefore(
                     protocol, LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
             {
-                CHECK(mMergeCounters.mPostShadowRemovalProtocolMerges == 0);
+                CHECK(mLiveMergeCounters.mPostShadowRemovalProtocolMerges == 0);
             }
             else
             {
-                CHECK(mMergeCounters.mPostShadowRemovalProtocolMerges != 0);
+                CHECK(mLiveMergeCounters.mPostShadowRemovalProtocolMerges != 0);
             }
 
-            CHECK(mMergeCounters.mNewMetaEntries == 0);
-            CHECK(mMergeCounters.mNewInitEntries != 0);
-            CHECK(mMergeCounters.mNewLiveEntries != 0);
-            CHECK(mMergeCounters.mNewDeadEntries != 0);
+            CHECK(mLiveMergeCounters.mNewMetaEntries == 0);
+            CHECK(mLiveMergeCounters.mNewInitEntries != 0);
+            CHECK(mLiveMergeCounters.mNewLiveEntries != 0);
+            CHECK(mLiveMergeCounters.mNewDeadEntries != 0);
 
-            CHECK(mMergeCounters.mOldMetaEntries == 0);
-            CHECK(mMergeCounters.mOldInitEntries != 0);
-            CHECK(mMergeCounters.mOldLiveEntries != 0);
-            CHECK(mMergeCounters.mOldDeadEntries != 0);
+            CHECK(mLiveMergeCounters.mOldMetaEntries == 0);
+            CHECK(mLiveMergeCounters.mOldInitEntries != 0);
+            CHECK(mLiveMergeCounters.mOldLiveEntries != 0);
+            CHECK(mLiveMergeCounters.mOldDeadEntries != 0);
 
-            CHECK(mMergeCounters.mOldEntriesDefaultAccepted != 0);
-            CHECK(mMergeCounters.mNewEntriesDefaultAccepted != 0);
-            CHECK(mMergeCounters.mNewInitEntriesMergedWithOldDead != 0);
-            CHECK(mMergeCounters.mOldInitEntriesMergedWithNewLive != 0);
-            CHECK(mMergeCounters.mOldInitEntriesMergedWithNewDead != 0);
-            CHECK(mMergeCounters.mNewEntriesMergedWithOldNeitherInit != 0);
+            CHECK(mLiveMergeCounters.mOldEntriesDefaultAccepted != 0);
+            CHECK(mLiveMergeCounters.mNewEntriesDefaultAccepted != 0);
+            CHECK(mLiveMergeCounters.mNewInitEntriesMergedWithOldDead != 0);
+            CHECK(mLiveMergeCounters.mOldInitEntriesMergedWithNewLive != 0);
+            CHECK(mLiveMergeCounters.mOldInitEntriesMergedWithNewDead != 0);
+            CHECK(mLiveMergeCounters.mNewEntriesMergedWithOldNeitherInit != 0);
 
             if (protocolVersionIsBefore(
                     protocol, LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED))
             {
-                CHECK(mMergeCounters.mShadowScanSteps != 0);
-                CHECK(mMergeCounters.mLiveEntryShadowElisions != 0);
+                CHECK(mLiveMergeCounters.mShadowScanSteps != 0);
+                CHECK(mLiveMergeCounters.mLiveEntryShadowElisions != 0);
             }
             else
             {
-                CHECK(mMergeCounters.mShadowScanSteps == 0);
-                CHECK(mMergeCounters.mLiveEntryShadowElisions == 0);
+                CHECK(mLiveMergeCounters.mShadowScanSteps == 0);
+                CHECK(mLiveMergeCounters.mLiveEntryShadowElisions == 0);
             }
 
-            CHECK(mMergeCounters.mMetaEntryShadowElisions == 0);
-            CHECK(mMergeCounters.mInitEntryShadowElisions == 0);
-            CHECK(mMergeCounters.mDeadEntryShadowElisions == 0);
+            CHECK(mLiveMergeCounters.mMetaEntryShadowElisions == 0);
+            CHECK(mLiveMergeCounters.mInitEntryShadowElisions == 0);
+            CHECK(mLiveMergeCounters.mDeadEntryShadowElisions == 0);
 
-            CHECK(mMergeCounters.mOutputIteratorBufferUpdates != 0);
-            CHECK(mMergeCounters.mOutputIteratorActualWrites != 0);
-            CHECK(mMergeCounters.mOutputIteratorBufferUpdates >=
-                  mMergeCounters.mOutputIteratorActualWrites);
+            CHECK(mLiveMergeCounters.mOutputIteratorBufferUpdates != 0);
+            CHECK(mLiveMergeCounters.mOutputIteratorActualWrites != 0);
+            CHECK(mLiveMergeCounters.mOutputIteratorBufferUpdates >=
+                  mLiveMergeCounters.mOutputIteratorActualWrites);
+
+            // Check hot archive merge counters
+            if (protocolVersionStartsFrom(
+                    protocol,
+                    LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            {
+                CHECK(mHotArchiveMergeCounters.mPostInitEntryProtocolMerges ==
+                      0);
+                CHECK(
+                    mHotArchiveMergeCounters.mPostShadowRemovalProtocolMerges ==
+                    0);
+
+                CHECK(mHotArchiveMergeCounters.mNewMetaEntries == 0);
+                CHECK(mHotArchiveMergeCounters.mNewInitEntries == 0);
+                CHECK(mHotArchiveMergeCounters.mNewLiveEntries == 0);
+                CHECK(mHotArchiveMergeCounters.mNewDeadEntries == 0);
+
+                CHECK(mHotArchiveMergeCounters.mOldMetaEntries == 0);
+                CHECK(mHotArchiveMergeCounters.mOldInitEntries == 0);
+                CHECK(mHotArchiveMergeCounters.mOldLiveEntries == 0);
+                CHECK(mHotArchiveMergeCounters.mOldDeadEntries == 0);
+
+                CHECK(mHotArchiveMergeCounters.mOldEntriesDefaultAccepted != 0);
+                CHECK(mHotArchiveMergeCounters.mNewEntriesDefaultAccepted != 0);
+                CHECK(
+                    mHotArchiveMergeCounters.mNewInitEntriesMergedWithOldDead ==
+                    0);
+                CHECK(
+                    mHotArchiveMergeCounters.mOldInitEntriesMergedWithNewLive ==
+                    0);
+                CHECK(
+                    mHotArchiveMergeCounters.mOldInitEntriesMergedWithNewDead ==
+                    0);
+                CHECK(mHotArchiveMergeCounters
+                          .mNewEntriesMergedWithOldNeitherInit == 0);
+
+                CHECK(mHotArchiveMergeCounters.mShadowScanSteps == 0);
+                CHECK(mHotArchiveMergeCounters.mLiveEntryShadowElisions == 0);
+
+                CHECK(mHotArchiveMergeCounters.mMetaEntryShadowElisions == 0);
+                CHECK(mHotArchiveMergeCounters.mInitEntryShadowElisions == 0);
+                CHECK(mHotArchiveMergeCounters.mDeadEntryShadowElisions == 0);
+
+                CHECK(mHotArchiveMergeCounters.mOutputIteratorBufferUpdates !=
+                      0);
+                CHECK(mHotArchiveMergeCounters.mOutputIteratorActualWrites !=
+                      0);
+                CHECK(mHotArchiveMergeCounters.mOutputIteratorBufferUpdates >=
+                      mHotArchiveMergeCounters.mOutputIteratorActualWrites);
+            }
+            else
+            {
+                checkEmptyHotArchiveMetrics();
+            }
         }
 
         void
-        checkSensiblePreInitEntryMergeCounters() const
+        checkSensiblePreInitEntryMergeCounters(uint32_t protocol) const
         {
-            CHECK(mMergeCounters.mPreInitEntryProtocolMerges != 0);
-            CHECK(mMergeCounters.mPreShadowRemovalProtocolMerges != 0);
+            CHECK(mLiveMergeCounters.mPreInitEntryProtocolMerges != 0);
+            CHECK(mLiveMergeCounters.mPreShadowRemovalProtocolMerges != 0);
 
-            CHECK(mMergeCounters.mNewMetaEntries == 0);
-            CHECK(mMergeCounters.mNewInitEntries == 0);
-            CHECK(mMergeCounters.mNewLiveEntries != 0);
-            CHECK(mMergeCounters.mNewDeadEntries != 0);
+            CHECK(mLiveMergeCounters.mNewMetaEntries == 0);
+            CHECK(mLiveMergeCounters.mNewInitEntries == 0);
+            CHECK(mLiveMergeCounters.mNewLiveEntries != 0);
+            CHECK(mLiveMergeCounters.mNewDeadEntries != 0);
 
-            CHECK(mMergeCounters.mOldMetaEntries == 0);
-            CHECK(mMergeCounters.mOldInitEntries == 0);
-            CHECK(mMergeCounters.mOldLiveEntries != 0);
-            CHECK(mMergeCounters.mOldDeadEntries != 0);
+            CHECK(mLiveMergeCounters.mOldMetaEntries == 0);
+            CHECK(mLiveMergeCounters.mOldInitEntries == 0);
+            CHECK(mLiveMergeCounters.mOldLiveEntries != 0);
+            CHECK(mLiveMergeCounters.mOldDeadEntries != 0);
 
-            CHECK(mMergeCounters.mOldEntriesDefaultAccepted != 0);
-            CHECK(mMergeCounters.mNewEntriesDefaultAccepted != 0);
-            CHECK(mMergeCounters.mNewInitEntriesMergedWithOldDead == 0);
-            CHECK(mMergeCounters.mOldInitEntriesMergedWithNewLive == 0);
-            CHECK(mMergeCounters.mOldInitEntriesMergedWithNewDead == 0);
-            CHECK(mMergeCounters.mNewEntriesMergedWithOldNeitherInit != 0);
+            CHECK(mLiveMergeCounters.mOldEntriesDefaultAccepted != 0);
+            CHECK(mLiveMergeCounters.mNewEntriesDefaultAccepted != 0);
+            CHECK(mLiveMergeCounters.mNewInitEntriesMergedWithOldDead == 0);
+            CHECK(mLiveMergeCounters.mOldInitEntriesMergedWithNewLive == 0);
+            CHECK(mLiveMergeCounters.mOldInitEntriesMergedWithNewDead == 0);
+            CHECK(mLiveMergeCounters.mNewEntriesMergedWithOldNeitherInit != 0);
 
-            CHECK(mMergeCounters.mShadowScanSteps != 0);
-            CHECK(mMergeCounters.mMetaEntryShadowElisions == 0);
-            CHECK(mMergeCounters.mLiveEntryShadowElisions != 0);
-            CHECK(mMergeCounters.mInitEntryShadowElisions == 0);
-            CHECK(mMergeCounters.mDeadEntryShadowElisions != 0);
+            CHECK(mLiveMergeCounters.mShadowScanSteps != 0);
+            CHECK(mLiveMergeCounters.mMetaEntryShadowElisions == 0);
+            CHECK(mLiveMergeCounters.mLiveEntryShadowElisions != 0);
+            CHECK(mLiveMergeCounters.mInitEntryShadowElisions == 0);
+            CHECK(mLiveMergeCounters.mDeadEntryShadowElisions != 0);
 
-            CHECK(mMergeCounters.mOutputIteratorBufferUpdates != 0);
-            CHECK(mMergeCounters.mOutputIteratorActualWrites != 0);
-            CHECK(mMergeCounters.mOutputIteratorBufferUpdates >=
-                  mMergeCounters.mOutputIteratorActualWrites);
+            CHECK(mLiveMergeCounters.mOutputIteratorBufferUpdates != 0);
+            CHECK(mLiveMergeCounters.mOutputIteratorActualWrites != 0);
+            CHECK(mLiveMergeCounters.mOutputIteratorBufferUpdates >=
+                  mLiveMergeCounters.mOutputIteratorActualWrites);
         }
 
         void
         checkEqualMergeCounters(Survey const& other) const
         {
-            CHECK(mMergeCounters.mPreInitEntryProtocolMerges ==
-                  other.mMergeCounters.mPreInitEntryProtocolMerges);
-            CHECK(mMergeCounters.mPostInitEntryProtocolMerges ==
-                  other.mMergeCounters.mPostInitEntryProtocolMerges);
+            auto checkCountersEqual = [](auto const& counters,
+                                         auto const& other) {
+                CHECK(counters.mPreInitEntryProtocolMerges ==
+                      other.mPreInitEntryProtocolMerges);
+                CHECK(counters.mPostInitEntryProtocolMerges ==
+                      other.mPostInitEntryProtocolMerges);
 
-            CHECK(mMergeCounters.mPreShadowRemovalProtocolMerges ==
-                  other.mMergeCounters.mPreShadowRemovalProtocolMerges);
-            CHECK(mMergeCounters.mPostShadowRemovalProtocolMerges ==
-                  other.mMergeCounters.mPostShadowRemovalProtocolMerges);
+                CHECK(counters.mPreShadowRemovalProtocolMerges ==
+                      other.mPreShadowRemovalProtocolMerges);
+                CHECK(counters.mPostShadowRemovalProtocolMerges ==
+                      other.mPostShadowRemovalProtocolMerges);
 
-            CHECK(mMergeCounters.mRunningMergeReattachments ==
-                  other.mMergeCounters.mRunningMergeReattachments);
-            CHECK(mMergeCounters.mFinishedMergeReattachments ==
-                  other.mMergeCounters.mFinishedMergeReattachments);
+                CHECK(counters.mRunningMergeReattachments ==
+                      other.mRunningMergeReattachments);
+                CHECK(counters.mFinishedMergeReattachments ==
+                      other.mFinishedMergeReattachments);
 
-            CHECK(mMergeCounters.mNewMetaEntries ==
-                  other.mMergeCounters.mNewMetaEntries);
-            CHECK(mMergeCounters.mNewInitEntries ==
-                  other.mMergeCounters.mNewInitEntries);
-            CHECK(mMergeCounters.mNewLiveEntries ==
-                  other.mMergeCounters.mNewLiveEntries);
-            CHECK(mMergeCounters.mNewDeadEntries ==
-                  other.mMergeCounters.mNewDeadEntries);
-            CHECK(mMergeCounters.mOldMetaEntries ==
-                  other.mMergeCounters.mOldMetaEntries);
-            CHECK(mMergeCounters.mOldInitEntries ==
-                  other.mMergeCounters.mOldInitEntries);
-            CHECK(mMergeCounters.mOldLiveEntries ==
-                  other.mMergeCounters.mOldLiveEntries);
-            CHECK(mMergeCounters.mOldDeadEntries ==
-                  other.mMergeCounters.mOldDeadEntries);
+                CHECK(counters.mNewMetaEntries == other.mNewMetaEntries);
+                CHECK(counters.mNewInitEntries == other.mNewInitEntries);
+                CHECK(counters.mNewLiveEntries == other.mNewLiveEntries);
+                CHECK(counters.mNewDeadEntries == other.mNewDeadEntries);
+                CHECK(counters.mOldMetaEntries == other.mOldMetaEntries);
+                CHECK(counters.mOldInitEntries == other.mOldInitEntries);
+                CHECK(counters.mOldLiveEntries == other.mOldLiveEntries);
+                CHECK(counters.mOldDeadEntries == other.mOldDeadEntries);
 
-            CHECK(mMergeCounters.mOldEntriesDefaultAccepted ==
-                  other.mMergeCounters.mOldEntriesDefaultAccepted);
-            CHECK(mMergeCounters.mNewEntriesDefaultAccepted ==
-                  other.mMergeCounters.mNewEntriesDefaultAccepted);
-            CHECK(mMergeCounters.mNewInitEntriesMergedWithOldDead ==
-                  other.mMergeCounters.mNewInitEntriesMergedWithOldDead);
-            CHECK(mMergeCounters.mOldInitEntriesMergedWithNewLive ==
-                  other.mMergeCounters.mOldInitEntriesMergedWithNewLive);
-            CHECK(mMergeCounters.mOldInitEntriesMergedWithNewDead ==
-                  other.mMergeCounters.mOldInitEntriesMergedWithNewDead);
-            CHECK(mMergeCounters.mNewEntriesMergedWithOldNeitherInit ==
-                  other.mMergeCounters.mNewEntriesMergedWithOldNeitherInit);
+                CHECK(counters.mOldEntriesDefaultAccepted ==
+                      other.mOldEntriesDefaultAccepted);
+                CHECK(counters.mNewEntriesDefaultAccepted ==
+                      other.mNewEntriesDefaultAccepted);
+                CHECK(counters.mNewInitEntriesMergedWithOldDead ==
+                      other.mNewInitEntriesMergedWithOldDead);
+                CHECK(counters.mOldInitEntriesMergedWithNewLive ==
+                      other.mOldInitEntriesMergedWithNewLive);
+                CHECK(counters.mOldInitEntriesMergedWithNewDead ==
+                      other.mOldInitEntriesMergedWithNewDead);
+                CHECK(counters.mNewEntriesMergedWithOldNeitherInit ==
+                      other.mNewEntriesMergedWithOldNeitherInit);
 
-            CHECK(mMergeCounters.mShadowScanSteps ==
-                  other.mMergeCounters.mShadowScanSteps);
-            CHECK(mMergeCounters.mMetaEntryShadowElisions ==
-                  other.mMergeCounters.mMetaEntryShadowElisions);
-            CHECK(mMergeCounters.mLiveEntryShadowElisions ==
-                  other.mMergeCounters.mLiveEntryShadowElisions);
-            CHECK(mMergeCounters.mInitEntryShadowElisions ==
-                  other.mMergeCounters.mInitEntryShadowElisions);
-            CHECK(mMergeCounters.mDeadEntryShadowElisions ==
-                  other.mMergeCounters.mDeadEntryShadowElisions);
+                CHECK(counters.mShadowScanSteps == other.mShadowScanSteps);
+                CHECK(counters.mMetaEntryShadowElisions ==
+                      other.mMetaEntryShadowElisions);
+                CHECK(counters.mLiveEntryShadowElisions ==
+                      other.mLiveEntryShadowElisions);
+                CHECK(counters.mInitEntryShadowElisions ==
+                      other.mInitEntryShadowElisions);
+                CHECK(counters.mDeadEntryShadowElisions ==
+                      other.mDeadEntryShadowElisions);
 
-            CHECK(mMergeCounters.mOutputIteratorTombstoneElisions ==
-                  other.mMergeCounters.mOutputIteratorTombstoneElisions);
-            CHECK(mMergeCounters.mOutputIteratorBufferUpdates ==
-                  other.mMergeCounters.mOutputIteratorBufferUpdates);
-            CHECK(mMergeCounters.mOutputIteratorActualWrites ==
-                  other.mMergeCounters.mOutputIteratorActualWrites);
+                CHECK(counters.mOutputIteratorTombstoneElisions ==
+                      other.mOutputIteratorTombstoneElisions);
+                CHECK(counters.mOutputIteratorBufferUpdates ==
+                      other.mOutputIteratorBufferUpdates);
+                CHECK(counters.mOutputIteratorActualWrites ==
+                      other.mOutputIteratorActualWrites);
+            };
+
+            checkCountersEqual(mLiveMergeCounters, other.mLiveMergeCounters);
+            checkCountersEqual(mHotArchiveMergeCounters,
+                               other.mHotArchiveMergeCounters);
         }
+
         void
         checkEqual(Survey const& other) const
         {
@@ -907,17 +1188,28 @@ class StopAndRestartBucketMergesTest
             CHECK(mSnapBucketHash == other.mSnapBucketHash);
             CHECK(mBucketListHash == other.mBucketListHash);
             CHECK(mLedgerHeaderHash == other.mLedgerHeaderHash);
+            CHECK(mHotArchiveBucketListHash == other.mHotArchiveBucketListHash);
             checkEqualMergeCounters(other);
         }
-        Survey(Application& app, uint32_t level)
+        Survey(Application& app, uint32_t level, uint32_t protocol)
         {
             LedgerManager& lm = app.getLedgerManager();
             BucketManager& bm = app.getBucketManager();
             LiveBucketList& bl = bm.getLiveBucketList();
+            HotArchiveBucketList& hotBl = bm.getHotArchiveBucketList();
             // Complete those merges we're about to inspect.
             resolveAllMerges(bl);
+            if (protocolVersionStartsFrom(
+                    protocol,
+                    LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            {
+                resolveAllMerges(hotBl);
+                mHotArchiveBucketListHash = hotBl.getHash();
+                mHotArchiveMergeCounters =
+                    bm.readMergeCounters<HotArchiveBucket>();
+            }
 
-            mMergeCounters = bm.readMergeCounters();
+            mLiveMergeCounters = bm.readMergeCounters<LiveBucket>();
             mLedgerHeaderHash = lm.getLastClosedLedgerHeader().hash;
             mBucketListHash = bl.getHash();
             BucketLevel<LiveBucket>& blv = bl.getLevel(level);
@@ -931,13 +1223,20 @@ class StopAndRestartBucketMergesTest
     std::set<uint32_t> mDesignatedLedgers;
     std::map<uint32_t, Survey> mControlSurveys;
     std::map<LedgerKey, LedgerEntry> mFinalEntries;
+    std::map<LedgerKey, LedgerEntry> mFinalArchiveEntries;
     std::vector<std::vector<LedgerEntry>> mInitEntryBatches;
     std::vector<std::vector<LedgerEntry>> mLiveEntryBatches;
     std::vector<std::vector<LedgerKey>> mDeadEntryBatches;
+    std::vector<std::vector<LedgerEntry>> mArchiveEntryBatches;
+
+    // Initial entries in Hot Archive BucketList, a "genesis leger" equivalent
+    // for Hot Archive
+    std::vector<LedgerKey> mHotArchiveInitialBatch;
 
     void
     collectLedgerEntries(Application& app,
-                         std::map<LedgerKey, LedgerEntry>& entries)
+                         std::map<LedgerKey, LedgerEntry>& liveEntries,
+                         std::map<LedgerKey, LedgerEntry>& archiveEntries)
     {
         auto bl = app.getBucketManager().getLiveBucketList();
         for (uint32_t i = LiveBucketList::kNumLevels; i > 0; --i)
@@ -951,12 +1250,41 @@ class StopAndRestartBucketMergesTest
                     if (e.type() == LIVEENTRY || e.type() == INITENTRY)
                     {
                         auto le = e.liveEntry();
-                        entries[LedgerEntryKey(le)] = le;
+                        liveEntries[LedgerEntryKey(le)] = le;
                     }
                     else
                     {
                         assert(e.type() == DEADENTRY);
-                        entries.erase(e.deadEntry());
+                        liveEntries.erase(e.deadEntry());
+                    }
+                }
+            }
+        }
+
+        if (protocolVersionStartsFrom(
+                getAppLedgerVersion(app),
+                LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+        {
+            HotArchiveBucketList& hotBl =
+                app.getBucketManager().getHotArchiveBucketList();
+            for (uint32_t i = HotArchiveBucketList::kNumLevels; i > 0; --i)
+            {
+                BucketLevel<HotArchiveBucket> const& level =
+                    hotBl.getLevel(i - 1);
+                for (auto bucket : {level.getSnap(), level.getCurr()})
+                {
+                    for (HotArchiveBucketInputIterator bi(bucket); bi; ++bi)
+                    {
+                        auto const& e = *bi;
+                        if (e.type() == HOT_ARCHIVE_LIVE)
+                        {
+                            archiveEntries.erase(e.key());
+                        }
+                        else
+                        {
+                            archiveEntries[LedgerEntryKey(e.archivedEntry())] =
+                                e.archivedEntry();
+                        }
                     }
                 }
             }
@@ -966,22 +1294,32 @@ class StopAndRestartBucketMergesTest
     void
     collectFinalLedgerEntries(Application& app)
     {
-        collectLedgerEntries(app, mFinalEntries);
-        CLOG_INFO(Bucket, "Collected final ledger state with {} entries.",
-                  mFinalEntries.size());
+        collectLedgerEntries(app, mFinalEntries, mFinalArchiveEntries);
+        CLOG_INFO(Bucket,
+                  "Collected final ledger live state with {} entries, archived "
+                  "state with {} entries",
+                  mFinalEntries.size(), mFinalArchiveEntries.size());
     }
 
     void
     checkAgainstFinalLedgerEntries(Application& app)
     {
         std::map<LedgerKey, LedgerEntry> testEntries;
-        collectLedgerEntries(app, testEntries);
-        CLOG_INFO(Bucket, "Collected test ledger state with {} entries.",
-                  testEntries.size());
+        std::map<LedgerKey, LedgerEntry> testArchiveEntries;
+        collectLedgerEntries(app, testEntries, testArchiveEntries);
+        CLOG_INFO(Bucket,
+                  "Collected test ledger state with {} live entries, {} "
+                  "archived entries",
+                  testEntries.size(), testArchiveEntries.size());
         CHECK(testEntries.size() == mFinalEntries.size());
+        CHECK(testArchiveEntries.size() == mFinalArchiveEntries.size());
         for (auto const& pair : testEntries)
         {
             CHECK(mFinalEntries[pair.first] == pair.second);
+        }
+        for (auto const& pair : testArchiveEntries)
+        {
+            CHECK(mFinalArchiveEntries[pair.first] == pair.second);
         }
     }
 
@@ -1066,10 +1404,37 @@ class StopAndRestartBucketMergesTest
                   "Collecting control surveys in ledger range 2..{} = {:#x}",
                   finalLedger, finalLedger);
         auto app = createTestApplication<BucketTestApplication>(clock, cfg);
+        auto hasHotArchive = protocolVersionStartsFrom(
+            mProtocol,
+            LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
 
         std::vector<LedgerKey> allKeys;
         std::map<LedgerKey, LedgerEntry> currLive;
         std::map<LedgerKey, LedgerEntry> currDead;
+        std::map<LedgerKey, LedgerEntry> currArchive;
+
+        // To prevent duplicate merges that can interfere with counters, seed
+        // the starting Bucket so that each merge is unique. Otherwise, the
+        // first call to addBatch will merge [{first_batch}, empty_bucket]. We
+        // will then see other instances of [{first_batch}, empty_bucket] merges
+        // later on as the Bucket moves its way down the bl. By providing a
+        // seeded bucket, the first addBatch is a [{first_batch}, seeded_bucket]
+        // merge, which will not be duplicated by empty bucket merges later. The
+        // live BL is automatically seeded with the genesis ledger.
+        if (hasHotArchive)
+        {
+            UnorderedSet<LedgerKey> empty;
+            mHotArchiveInitialBatch =
+                LedgerTestUtils::generateValidUniqueLedgerKeysWithTypes(
+                    {CONTRACT_CODE}, 10, empty);
+            app->getBucketManager()
+                .getHotArchiveBucketList()
+                .getLevel(0)
+                .setCurr(HotArchiveBucket::fresh(
+                    app->getBucketManager(), mProtocol, {},
+                    mHotArchiveInitialBatch, {}, {},
+                    app->getClock().getIOContext(), /*doFsync=*/true));
+        }
 
         for (uint32_t i = 2;
              !app->getClock().getIOContext().stopped() && i < finalLedger; ++i)
@@ -1078,6 +1443,7 @@ class StopAndRestartBucketMergesTest
             std::vector<LedgerEntry> initEntries;
             std::vector<LedgerEntry> liveEntries;
             std::vector<LedgerKey> deadEntries;
+            std::vector<LedgerEntry> archiveEntries;
             if (mInitEntryBatches.size() > 2)
             {
                 std::set<LedgerKey> changedEntries;
@@ -1143,6 +1509,22 @@ class StopAndRestartBucketMergesTest
                 allKeys.emplace_back(k);
                 currLive.emplace(std::make_pair(k, e));
             }
+            auto newRandomArchive =
+                LedgerTestUtils::generateValidUniqueLedgerEntriesWithTypes(
+                    {CONTRACT_CODE}, nEntriesInBatch);
+            for (auto const& e : newRandomArchive)
+            {
+                auto k = LedgerEntryKey(e);
+                auto [iter, inserted] =
+                    currArchive.emplace(std::make_pair(k, e));
+
+                // only insert new entries to Archive BucketList
+                if (inserted)
+                {
+                    archiveEntries.emplace_back(e);
+                }
+            }
+
             mInitEntryBatches.emplace_back(initEntries);
             mLiveEntryBatches.emplace_back(liveEntries);
             mDeadEntryBatches.emplace_back(deadEntries);
@@ -1150,13 +1532,20 @@ class StopAndRestartBucketMergesTest
             lm.setNextLedgerEntryBatchForBucketTesting(
                 mInitEntryBatches.back(), mLiveEntryBatches.back(),
                 mDeadEntryBatches.back());
+            if (hasHotArchive)
+            {
+                mArchiveEntryBatches.emplace_back(archiveEntries);
+                lm.setNextArchiveBatchForBucketTesting(
+                    mArchiveEntryBatches.back(), {}, {});
+            }
+
             closeLedger(*app);
             assert(i == lm.getLastClosedLedgerHeader().header.ledgerSeq);
             if (shouldSurveyLedger(i))
             {
                 CLOG_INFO(Bucket, "Taking survey at {} = {:#x}", i, i);
-                mControlSurveys.insert(
-                    std::make_pair(i, Survey(*app, mDesignatedLevel)));
+                mControlSurveys.insert(std::make_pair(
+                    i, Survey(*app, mDesignatedLevel, mProtocol)));
             }
         }
 
@@ -1189,6 +1578,20 @@ class StopAndRestartBucketMergesTest
         CLOG_INFO(Bucket,
                   "Running stop/restart test in ledger range 2..{} = {:#x}",
                   finalLedger, finalLedger2);
+
+        if (protocolVersionStartsFrom(
+                firstProtocol,
+                LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+        {
+            app->getBucketManager()
+                .getHotArchiveBucketList()
+                .getLevel(0)
+                .setCurr(HotArchiveBucket::fresh(
+                    app->getBucketManager(), mProtocol, {},
+                    mHotArchiveInitialBatch, {}, {},
+                    app->getClock().getIOContext(), /*doFsync=*/true));
+        }
+
         for (uint32_t i = 2;
              !app->getClock().getIOContext().stopped() && i < finalLedger; ++i)
         {
@@ -1197,9 +1600,21 @@ class StopAndRestartBucketMergesTest
                 mInitEntryBatches[i - 2], mLiveEntryBatches[i - 2],
                 mDeadEntryBatches[i - 2]);
             resolveAllMerges(app->getBucketManager().getLiveBucketList());
-            auto countersBeforeClose =
-                app->getBucketManager().readMergeCounters();
 
+            if (protocolVersionStartsFrom(
+                    firstProtocol,
+                    LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            {
+                lm.setNextArchiveBatchForBucketTesting(
+                    mArchiveEntryBatches[i - 2], {}, {});
+                resolveAllMerges(
+                    app->getBucketManager().getHotArchiveBucketList());
+            }
+
+            auto liveCountersBeforeClose =
+                app->getBucketManager().readMergeCounters<LiveBucket>();
+            auto archiveCountersBeforeClose =
+                app->getBucketManager().readMergeCounters<HotArchiveBucket>();
             if (firstProtocol != secondProtocol && i == protocolSwitchLedger)
             {
                 CLOG_INFO(Bucket,
@@ -1234,12 +1649,25 @@ class StopAndRestartBucketMergesTest
                     BucketLevel<LiveBucket>& blv =
                         bl.getLevel(mDesignatedLevel);
                     REQUIRE(blv.getNext().isMerging());
+                    if (protocolVersionStartsFrom(
+                            currProtocol,
+                            LiveBucket::
+                                FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                    {
+                        HotArchiveBucketList& hotBl =
+                            app->getBucketManager().getHotArchiveBucketList();
+                        BucketLevel<HotArchiveBucket>& hotBlv =
+                            hotBl.getLevel(mDesignatedLevel);
+                        REQUIRE(hotBlv.getNext().isMerging());
+                    }
                 }
 
                 if (currProtocol == firstProtocol)
                 {
+                    resolveAllMerges(
+                        app->getBucketManager().getHotArchiveBucketList());
                     // Check that the survey matches expectations.
-                    Survey s(*app, mDesignatedLevel);
+                    Survey s(*app, mDesignatedLevel, currProtocol);
                     s.checkEqual(j->second);
                 }
 
@@ -1268,17 +1696,31 @@ class StopAndRestartBucketMergesTest
                     BucketLevel<LiveBucket>& blv =
                         bl.getLevel(mDesignatedLevel);
                     REQUIRE(blv.getNext().isMerging());
+                    if (protocolVersionStartsFrom(
+                            currProtocol,
+                            LiveBucket::
+                                FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                    {
+                        HotArchiveBucketList& hotBl =
+                            app->getBucketManager().getHotArchiveBucketList();
+                        BucketLevel<HotArchiveBucket>& hotBlv =
+                            hotBl.getLevel(mDesignatedLevel);
+                        REQUIRE(hotBlv.getNext().isMerging());
+                    }
                 }
 
                 // If there are restarted merges, we need to reset the counters
                 // to the values they had _before_ the ledger-close so the
                 // restarted merges don't count twice.
-                app->getBucketManager().incrMergeCounters(countersBeforeClose);
+                app->getBucketManager().incrMergeCounters<LiveBucket>(
+                    liveCountersBeforeClose);
+                app->getBucketManager().incrMergeCounters<HotArchiveBucket>(
+                    archiveCountersBeforeClose);
 
                 if (currProtocol == firstProtocol)
                 {
                     // Re-check that the survey matches expectations.
-                    Survey s2(*app, mDesignatedLevel);
+                    Survey s2(*app, mDesignatedLevel, currProtocol);
                     s2.checkEqual(j->second);
                 }
             }
@@ -1303,16 +1745,16 @@ class StopAndRestartBucketMergesTest
                 LiveBucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY))
         {
             mControlSurveys.rbegin()->second.dumpMergeCounters(
-                "control, Post-INITENTRY", mDesignatedLevel);
+                "control, Post-INITENTRY", mDesignatedLevel, mProtocol);
             mControlSurveys.rbegin()
                 ->second.checkSensiblePostInitEntryMergeCounters(mProtocol);
         }
         else
         {
             mControlSurveys.rbegin()->second.dumpMergeCounters(
-                "control, Pre-INITENTRY", mDesignatedLevel);
+                "control, Pre-INITENTRY", mDesignatedLevel, mProtocol);
             mControlSurveys.rbegin()
-                ->second.checkSensiblePreInitEntryMergeCounters();
+                ->second.checkSensiblePreInitEntryMergeCounters(mProtocol);
         }
         runStopAndRestartTest(mProtocol, mProtocol);
         runStopAndRestartTest(mProtocol, mProtocol + 1);
@@ -1328,7 +1770,13 @@ TEST_CASE("bucket persistence over app restart with initentry",
               1,
           static_cast<uint32_t>(
               LiveBucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY),
-          static_cast<uint32_t>(LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED)})
+          static_cast<uint32_t>(LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+              ,
+          static_cast<uint32_t>(
+              HotArchiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION)
+#endif
+         })
     {
         for (uint32_t level : {2, 3})
         {
@@ -1348,7 +1796,13 @@ TEST_CASE("bucket persistence over app restart with initentry - extended",
               1,
           static_cast<uint32_t>(
               LiveBucket::FIRST_PROTOCOL_SUPPORTING_INITENTRY_AND_METAENTRY),
-          static_cast<uint32_t>(LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED)})
+          static_cast<uint32_t>(LiveBucket::FIRST_PROTOCOL_SHADOWS_REMOVED)
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+              ,
+          static_cast<uint32_t>(
+              HotArchiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION)
+#endif
+         })
     {
         for (uint32_t level : {2, 3, 4, 5})
         {

--- a/src/bucket/test/BucketTestUtils.h
+++ b/src/bucket/test/BucketTestUtils.h
@@ -66,6 +66,10 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
     std::vector<LedgerEntry> mTestLiveEntries;
     std::vector<LedgerKey> mTestDeadEntries;
 
+    std::vector<LedgerEntry> mTestArchiveEntries;
+    std::vector<LedgerKey> mTestRestoredEntries;
+    std::vector<LedgerKey> mTestDeletedEntries;
+
   protected:
     void sealLedgerTxnAndTransferEntriesToBucketList(
         AbstractLedgerTxn& ltx,
@@ -83,6 +87,18 @@ class LedgerManagerForBucketTests : public LedgerManagerImpl
         mTestInitEntries = initEntries;
         mTestLiveEntries = liveEntries;
         mTestDeadEntries = deadEntries;
+    }
+
+    void
+    setNextArchiveBatchForBucketTesting(
+        std::vector<LedgerEntry> const& archiveEntries,
+        std::vector<LedgerKey> const& restoredEntries,
+        std::vector<LedgerKey> const& deletedEntries)
+    {
+        mUseTestEntries = true;
+        mTestArchiveEntries = archiveEntries;
+        mTestRestoredEntries = restoredEntries;
+        mTestDeletedEntries = deletedEntries;
     }
 
     LedgerManagerForBucketTests(Application& app) : LedgerManagerImpl(app)

--- a/src/catchup/ApplyBucketsWork.cpp
+++ b/src/catchup/ApplyBucketsWork.cpp
@@ -190,11 +190,15 @@ ApplyBucketsWork::doWork()
 {
     ZoneScoped;
 
-    // Step 1: index buckets. Step 2: apply buckets. Step 3: assume state
+    // Step 1: index live buckets. Step 2: apply buckets. Step 3: assume state
     if (!mIndexBucketsWork)
     {
-        // Spawn indexing work for the first time
-        mIndexBucketsWork = addWork<IndexBucketsWork>(mBucketsToApply);
+        // Spawn indexing work for the first time. Hot Archive buckets aren't
+        // needed for apply (since we only store live state in SQL tables), so
+        // for now only index the live BL. AssumeStateWork will take care of
+        // index hot archive buckets later.
+        mIndexBucketsWork =
+            addWork<IndexBucketsWork<LiveBucket>>(mBucketsToApply);
         return State::WORK_RUNNING;
     }
 

--- a/src/catchup/ApplyBucketsWork.h
+++ b/src/catchup/ApplyBucketsWork.h
@@ -14,7 +14,8 @@ namespace stellar
 class AssumeStateWork;
 class LiveBucketList;
 class Bucket;
-class IndexBucketsWork;
+template <class BucketT> class IndexBucketsWork;
+class LiveBucket;
 struct HistoryArchiveState;
 struct LedgerHeaderHistoryEntry;
 
@@ -25,7 +26,7 @@ class ApplyBucketsWork : public Work
 
     bool mSpawnedAssumeStateWork{false};
     std::shared_ptr<AssumeStateWork> mAssumeStateWork{};
-    std::shared_ptr<IndexBucketsWork> mIndexBucketsWork{};
+    std::shared_ptr<IndexBucketsWork<LiveBucket>> mIndexBucketsWork{};
     size_t mTotalBuckets{0};
     size_t mAppliedBuckets{0};
     size_t mAppliedEntries{0};

--- a/src/catchup/AssumeStateWork.cpp
+++ b/src/catchup/AssumeStateWork.cpp
@@ -25,8 +25,8 @@ AssumeStateWork::AssumeStateWork(Application& app,
 {
     // Maintain reference to all Buckets in HAS to avoid garbage collection,
     // including future buckets that have already finished merging
-    auto& bm = mApp.getBucketManager();
-    auto processBuckets = [&](auto const& hasBuckets, size_t expectedLevels,
+    auto processBuckets = [&bm = mApp.getBucketManager()](
+                              auto const& hasBuckets, size_t expectedLevels,
                               auto& workBuckets) {
         releaseAssert(hasBuckets.size() == expectedLevels);
         using BucketT = typename std::decay_t<
@@ -84,10 +84,8 @@ AssumeStateWork::doWork()
         // Index Bucket files
         seq.push_back(
             std::make_shared<IndexBucketsWork<LiveBucket>>(mApp, mLiveBuckets));
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
         seq.push_back(std::make_shared<IndexBucketsWork<HotArchiveBucket>>(
             mApp, mHotArchiveBuckets));
-#endif
 
         // Add bucket files to BucketList and restart merges
         auto assumeStateCB = [&has = mHas,

--- a/src/catchup/AssumeStateWork.cpp
+++ b/src/catchup/AssumeStateWork.cpp
@@ -26,34 +26,52 @@ AssumeStateWork::AssumeStateWork(Application& app,
     // Maintain reference to all Buckets in HAS to avoid garbage collection,
     // including future buckets that have already finished merging
     auto& bm = mApp.getBucketManager();
-    for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
-    {
-        auto curr = bm.getBucketByHash<LiveBucket>(
-            hexToBin256(mHas.currentBuckets.at(i).curr));
-        auto snap = bm.getBucketByHash<LiveBucket>(
-            hexToBin256(mHas.currentBuckets.at(i).snap));
-        if (!(curr && snap))
+    auto processBuckets = [&](auto const& hasBuckets, size_t expectedLevels,
+                              auto& workBuckets) {
+        releaseAssert(hasBuckets.size() == expectedLevels);
+        using BucketT = typename std::decay_t<
+            decltype(hasBuckets)>::value_type::bucket_type;
+        for (uint32_t i = 0; i < expectedLevels; ++i)
         {
-            throw std::runtime_error("Missing bucket files while "
-                                     "assuming saved BucketList state");
-        }
-
-        mBuckets.emplace_back(curr);
-        mBuckets.emplace_back(snap);
-        auto& nextFuture = mHas.currentBuckets.at(i).next;
-        if (nextFuture.hasOutputHash())
-        {
-            auto nextBucket = bm.getBucketByHash<LiveBucket>(
-                hexToBin256(nextFuture.getOutputHash()));
-            if (!nextBucket)
+            auto curr =
+                bm.getBucketByHash<BucketT>(hexToBin256(hasBuckets.at(i).curr));
+            auto snap =
+                bm.getBucketByHash<BucketT>(hexToBin256(hasBuckets.at(i).snap));
+            if (!(curr && snap))
             {
-                throw std::runtime_error("Missing future bucket files while "
+                throw std::runtime_error("Missing bucket files while "
                                          "assuming saved BucketList state");
             }
 
-            mBuckets.emplace_back(nextBucket);
+            workBuckets.emplace_back(curr);
+            workBuckets.emplace_back(snap);
+            auto& nextFuture = hasBuckets.at(i).next;
+            if (nextFuture.hasOutputHash())
+            {
+                auto nextBucket = bm.getBucketByHash<BucketT>(
+                    hexToBin256(nextFuture.getOutputHash()));
+                if (!nextBucket)
+                {
+                    throw std::runtime_error(
+                        "Missing future bucket files while "
+                        "assuming saved BucketList state");
+                }
+
+                workBuckets.emplace_back(nextBucket);
+            }
         }
+    };
+
+    processBuckets(mHas.currentBuckets, LiveBucketList::kNumLevels,
+                   mLiveBuckets);
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    if (has.hasHotArchiveBuckets())
+    {
+        processBuckets(mHas.hotArchiveBuckets, HotArchiveBucketList::kNumLevels,
+                       mHotArchiveBuckets);
     }
+#endif
 }
 
 BasicWork::State
@@ -64,19 +82,27 @@ AssumeStateWork::doWork()
         std::vector<std::shared_ptr<BasicWork>> seq;
 
         // Index Bucket files
-        seq.push_back(std::make_shared<IndexBucketsWork>(mApp, mBuckets));
+        seq.push_back(
+            std::make_shared<IndexBucketsWork<LiveBucket>>(mApp, mLiveBuckets));
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+        seq.push_back(std::make_shared<IndexBucketsWork<HotArchiveBucket>>(
+            mApp, mHotArchiveBuckets));
+#endif
 
         // Add bucket files to BucketList and restart merges
         auto assumeStateCB = [&has = mHas,
                               maxProtocolVersion = mMaxProtocolVersion,
                               restartMerges = mRestartMerges,
-                              &buckets = mBuckets](Application& app) {
+                              &liveBuckets = mLiveBuckets,
+                              &hotArchiveBuckets =
+                                  mHotArchiveBuckets](Application& app) {
             app.getBucketManager().assumeState(has, maxProtocolVersion,
                                                restartMerges);
 
             // Drop bucket references once assume state complete since buckets
             // now referenced by BucketList
-            buckets.clear();
+            liveBuckets.clear();
+            hotArchiveBuckets.clear();
 
             // Check invariants after state has been assumed
             app.getInvariantManager().checkAfterAssumeState(has.currentLedger);

--- a/src/catchup/AssumeStateWork.h
+++ b/src/catchup/AssumeStateWork.h
@@ -12,6 +12,7 @@ namespace stellar
 class Bucket;
 struct HistoryArchiveState;
 class LiveBucket;
+class HotArchiveBucket;
 
 class AssumeStateWork : public Work
 {
@@ -22,7 +23,8 @@ class AssumeStateWork : public Work
 
     // Keep strong reference to buckets in HAS so they are not garbage
     // collected during indexing
-    std::vector<std::shared_ptr<LiveBucket>> mBuckets{};
+    std::vector<std::shared_ptr<LiveBucket>> mLiveBuckets{};
+    std::vector<std::shared_ptr<HotArchiveBucket>> mHotArchiveBuckets{};
 
   public:
     AssumeStateWork(Application& app, HistoryArchiveState const& has,

--- a/src/catchup/CatchupWork.h
+++ b/src/catchup/CatchupWork.h
@@ -47,7 +47,8 @@ class CatchupWork : public Work
   protected:
     HistoryArchiveState mLocalState;
     std::unique_ptr<TmpDir> mDownloadDir;
-    std::map<std::string, std::shared_ptr<LiveBucket>> mBuckets;
+    std::map<std::string, std::shared_ptr<LiveBucket>> mLiveBuckets;
+    std::map<std::string, std::shared_ptr<HotArchiveBucket>> mHotBuckets;
 
     void doReset() override;
     BasicWork::State doWork() override;
@@ -65,7 +66,6 @@ class CatchupWork : public Work
     static uint32_t const PUBLISH_QUEUE_MAX_SIZE;
 
     CatchupWork(Application& app, CatchupConfiguration catchupConfiguration,
-                std::set<std::shared_ptr<LiveBucket>> bucketsToRetain,
                 std::shared_ptr<HistoryArchive> archive = nullptr);
     virtual ~CatchupWork();
     std::string getStatus() const override;
@@ -128,6 +128,5 @@ class CatchupWork : public Work
 
     std::optional<HistoryArchiveState> mHAS;
     std::optional<HistoryArchiveState> mBucketHAS;
-    std::set<std::shared_ptr<LiveBucket>> mRetainedBuckets;
 };
 }

--- a/src/catchup/IndexBucketsWork.cpp
+++ b/src/catchup/IndexBucketsWork.cpp
@@ -4,9 +4,8 @@
 
 #include "IndexBucketsWork.h"
 #include "bucket/BucketManager.h"
-#include "bucket/DiskIndex.h"
+#include "bucket/HotArchiveBucket.h"
 #include "bucket/LiveBucket.h"
-#include "crypto/SHA.h"
 #include "util/Fs.h"
 #include "util/Logging.h"
 #include "util/UnorderedSet.h"
@@ -14,14 +13,16 @@
 
 namespace stellar
 {
-IndexBucketsWork::IndexWork::IndexWork(Application& app,
-                                       std::shared_ptr<LiveBucket> b)
+template <class BucketT>
+IndexBucketsWork<BucketT>::IndexWork::IndexWork(Application& app,
+                                                std::shared_ptr<BucketT> b)
     : BasicWork(app, "index-work", BasicWork::RETRY_NEVER), mBucket(b)
 {
 }
 
+template <class BucketT>
 BasicWork::State
-IndexBucketsWork::IndexWork::onRun()
+IndexBucketsWork<BucketT>::IndexWork::onRun()
 {
     if (mState == State::WORK_WAITING)
     {
@@ -31,20 +32,23 @@ IndexBucketsWork::IndexWork::onRun()
     return mState;
 }
 
+template <class BucketT>
 bool
-IndexBucketsWork::IndexWork::onAbort()
+IndexBucketsWork<BucketT>::IndexWork::onAbort()
 {
     return true;
 };
 
+template <class BucketT>
 void
-IndexBucketsWork::IndexWork::onReset()
+IndexBucketsWork<BucketT>::IndexWork::onReset()
 {
     mState = BasicWork::State::WORK_WAITING;
 }
 
+template <class BucketT>
 void
-IndexBucketsWork::IndexWork::postWork()
+IndexBucketsWork<BucketT>::IndexWork::postWork()
 {
     Application& app = this->mApp;
     asio::io_context& ctx = app.getWorkerIOContext();
@@ -66,8 +70,8 @@ IndexBucketsWork::IndexWork::postWork()
             if (bm.getConfig().BUCKETLIST_DB_PERSIST_INDEX &&
                 fs::exists(indexFilename))
             {
-                self->mIndex = loadIndex<LiveBucket>(bm, indexFilename,
-                                                     self->mBucket->getSize());
+                self->mIndex = loadIndex<BucketT>(bm, indexFilename,
+                                                  self->mBucket->getSize());
 
                 // If we could not load the index from the file, file is out of
                 // date. Delete and create a new index.
@@ -86,8 +90,7 @@ IndexBucketsWork::IndexWork::postWork()
 
             if (!self->mIndex)
             {
-                // TODO: Fix this when archive BucketLists assume state
-                self->mIndex = createIndex<LiveBucket>(
+                self->mIndex = createIndex<BucketT>(
                     bm, self->mBucket->getFilename(), self->mBucket->getHash(),
                     ctx, nullptr);
             }
@@ -118,14 +121,16 @@ IndexBucketsWork::IndexWork::postWork()
         "IndexWork: starting in background");
 }
 
-IndexBucketsWork::IndexBucketsWork(
-    Application& app, std::vector<std::shared_ptr<LiveBucket>> const& buckets)
+template <class BucketT>
+IndexBucketsWork<BucketT>::IndexBucketsWork(
+    Application& app, std::vector<std::shared_ptr<BucketT>> const& buckets)
     : Work(app, "index-bucketList", BasicWork::RETRY_NEVER), mBuckets(buckets)
 {
 }
 
+template <class BucketT>
 BasicWork::State
-IndexBucketsWork::doWork()
+IndexBucketsWork<BucketT>::doWork()
 {
     if (!mWorkSpawned)
     {
@@ -135,17 +140,19 @@ IndexBucketsWork::doWork()
     return checkChildrenStatus();
 }
 
+template <class BucketT>
 void
-IndexBucketsWork::doReset()
+IndexBucketsWork<BucketT>::doReset()
 {
     mWorkSpawned = false;
 }
 
+template <class BucketT>
 void
-IndexBucketsWork::spawnWork()
+IndexBucketsWork<BucketT>::spawnWork()
 {
     UnorderedSet<Hash> indexedBuckets;
-    auto spawnIndexWork = [&](std::shared_ptr<LiveBucket> const& b) {
+    auto spawnIndexWork = [&](auto const& b) {
         // Don't index empty bucket or buckets that are already being
         // indexed. Sometimes one level's snap bucket may be another
         // level's future bucket. The indexing job may have started but
@@ -168,4 +175,7 @@ IndexBucketsWork::spawnWork()
 
     mWorkSpawned = true;
 }
+
+template class IndexBucketsWork<LiveBucket>;
+template class IndexBucketsWork<HotArchiveBucket>;
 }

--- a/src/catchup/IndexBucketsWork.h
+++ b/src/catchup/IndexBucketsWork.h
@@ -14,20 +14,19 @@ namespace stellar
 class Bucket;
 class LiveBucketIndex;
 class BucketManager;
-class LiveBucket;
 
-class IndexBucketsWork : public Work
+template <class BucketT> class IndexBucketsWork : public Work
 {
     class IndexWork : public BasicWork
     {
-        std::shared_ptr<LiveBucket> mBucket;
-        std::unique_ptr<LiveBucketIndex const> mIndex;
+        std::shared_ptr<BucketT> mBucket;
+        std::unique_ptr<typename BucketT::IndexT const> mIndex;
         BasicWork::State mState{BasicWork::State::WORK_WAITING};
 
         void postWork();
 
       public:
-        IndexWork(Application& app, std::shared_ptr<LiveBucket> b);
+        IndexWork(Application& app, std::shared_ptr<BucketT> b);
 
       protected:
         State onRun() override;
@@ -35,14 +34,14 @@ class IndexBucketsWork : public Work
         void onReset() override;
     };
 
-    std::vector<std::shared_ptr<LiveBucket>> const& mBuckets;
+    std::vector<std::shared_ptr<BucketT>> const& mBuckets;
 
     bool mWorkSpawned{false};
     void spawnWork();
 
   public:
     IndexBucketsWork(Application& app,
-                     std::vector<std::shared_ptr<LiveBucket>> const& buckets);
+                     std::vector<std::shared_ptr<BucketT>> const& buckets);
 
   protected:
     State doWork() override;

--- a/src/catchup/LedgerApplyManager.h
+++ b/src/catchup/LedgerApplyManager.h
@@ -68,10 +68,8 @@ class LedgerApplyManager
     // LedgerManager detects it is desynchronized from SCP's consensus ledger.
     // This method is present in the public interface to permit testing and
     // offline catchups.
-    virtual void
-    startCatchup(CatchupConfiguration configuration,
-                 std::shared_ptr<HistoryArchive> archive,
-                 std::set<std::shared_ptr<LiveBucket>> bucketsToRetain) = 0;
+    virtual void startCatchup(CatchupConfiguration configuration,
+                              std::shared_ptr<HistoryArchive> archive) = 0;
 
     // Return status of catchup for or empty string, if no catchup in progress
     virtual std::string getStatus() const = 0;

--- a/src/catchup/LedgerApplyManagerImpl.cpp
+++ b/src/catchup/LedgerApplyManagerImpl.cpp
@@ -266,9 +266,8 @@ LedgerApplyManagerImpl::processLedger(LedgerCloseData const& ledgerData,
 }
 
 void
-LedgerApplyManagerImpl::startCatchup(
-    CatchupConfiguration configuration, std::shared_ptr<HistoryArchive> archive,
-    std::set<std::shared_ptr<LiveBucket>> bucketsToRetain)
+LedgerApplyManagerImpl::startCatchup(CatchupConfiguration configuration,
+                                     std::shared_ptr<HistoryArchive> archive)
 {
     ZoneScoped;
     releaseAssert(threadIsMain());
@@ -291,7 +290,7 @@ LedgerApplyManagerImpl::startCatchup(
     // NB: if WorkScheduler is aborting this returns nullptr,
     // which means we don't "really" start catchup.
     mCatchupWork = mApp.getWorkScheduler().scheduleWork<CatchupWork>(
-        configuration, bucketsToRetain, archive);
+        configuration, archive);
 }
 
 std::string
@@ -443,7 +442,7 @@ LedgerApplyManagerImpl::startOnlineCatchup()
     auto hash = std::make_optional<Hash>(lcd.getTxSet()->previousLedgerHash());
     startCatchup({LedgerNumHashPair(firstBufferedLedgerSeq - 1, hash),
                   getCatchupCount(), CatchupConfiguration::Mode::ONLINE},
-                 nullptr, {});
+                 nullptr);
 }
 
 void

--- a/src/catchup/LedgerApplyManagerImpl.h
+++ b/src/catchup/LedgerApplyManagerImpl.h
@@ -74,10 +74,8 @@ class LedgerApplyManagerImpl : public LedgerApplyManager
 
     ProcessLedgerResult processLedger(LedgerCloseData const& ledgerData,
                                       bool isLatestSlot) override;
-    void startCatchup(
-        CatchupConfiguration configuration,
-        std::shared_ptr<HistoryArchive> archive,
-        std::set<std::shared_ptr<LiveBucket>> bucketsToRetain) override;
+    void startCatchup(CatchupConfiguration configuration,
+                      std::shared_ptr<HistoryArchive> archive) override;
 
     std::string getStatus() const override;
 

--- a/src/herder/test/UpgradesTests.cpp
+++ b/src/herder/test/UpgradesTests.cpp
@@ -2070,7 +2070,7 @@ TEST_CASE("upgrade to version 11", "[upgrades]")
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             bl.resolveAnyReadyFutures();
         }
-        auto mc = bm.readMergeCounters();
+        auto mc = bm.readMergeCounters<LiveBucket>();
 
         CLOG_INFO(Bucket,
                   "Ledger {} did {} old-protocol merges, {} new-protocol "
@@ -2193,7 +2193,7 @@ TEST_CASE("upgrade to version 12", "[upgrades]")
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
             bl.resolveAnyReadyFutures();
         }
-        auto mc = bm.readMergeCounters();
+        auto mc = bm.readMergeCounters<LiveBucket>();
 
         if (ledgerSeq < 5)
         {

--- a/src/history/FileTransferInfo.h
+++ b/src/history/FileTransferInfo.h
@@ -37,11 +37,13 @@ class FileTransferInfo
     std::string getLocalDir(TmpDir const& localRoot) const;
 
   public:
-    FileTransferInfo(LiveBucket const& bucket)
+    template <typename BucketT>
+    FileTransferInfo(BucketT const& bucket)
         : mType(FileType::HISTORY_FILE_TYPE_BUCKET)
         , mHexDigits(binToHex(bucket.getHash()))
         , mLocalPath(bucket.getFilename().string())
     {
+        BUCKET_TYPE_ASSERT(BucketT);
     }
 
     FileTransferInfo(TmpDir const& snapDir, FileType const& snapType,

--- a/src/history/HistoryArchive.cpp
+++ b/src/history/HistoryArchive.cpp
@@ -171,8 +171,8 @@ HistoryArchiveState::load(std::string const& inFile)
     in.exceptions(std::ios::badbit);
     cereal::JSONInputArchive ar(in);
     serialize(ar);
-    if (version != HISTORY_ARCHIVE_STATE_VERSION_PRE_PROTOCOL_22 &&
-        version != HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22)
+    if (version != HISTORY_ARCHIVE_STATE_VERSION_BEFORE_HOT_ARCHIVE &&
+        version != HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
     {
         CLOG_ERROR(History, "Unexpected history archive state version: {}",
                    version);
@@ -571,7 +571,7 @@ HistoryArchiveState::HistoryArchiveState(uint32_t ledgerSeq,
                                          std::string const& passphrase)
     : HistoryArchiveState(ledgerSeq, liveBuckets, passphrase)
 {
-    version = HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22;
+    version = HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE;
     for (uint32_t i = 0; i < HotArchiveBucketList::kNumLevels; ++i)
     {
         HistoryStateBucket<HotArchiveBucket> b;

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -8,6 +8,8 @@
 #include "bucket/FutureBucket.h"
 #include "bucket/HotArchiveBucket.h"
 #include "bucket/HotArchiveBucketList.h"
+#include "bucket/LiveBucket.h"
+#include "bucket/LiveBucketList.h"
 #include "main/Config.h"
 #include "util/GlobalChecks.h"
 #include "xdr/Stellar-types.h"
@@ -31,10 +33,6 @@ namespace stellar
 {
 
 class Application;
-class LiveBucketList;
-class Bucket;
-class LiveBucketList;
-class HotArchiveBucketList;
 
 template <class BucketT> struct HistoryStateBucket
 {
@@ -149,14 +147,14 @@ struct HistoryArchiveState
             // networkPassphrase wasn't parsed.
             // This is expected when the input file does not contain it, but
             // should only ever happen for older versions of History Archive
-            // State.
-            if (version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
+            // State that do not support HotArchive.
+            if (hasHotArchiveBuckets())
             {
                 throw e;
             }
         }
         ar(CEREAL_NVP(currentBuckets));
-        if (version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
+        if (hasHotArchiveBuckets())
         {
             ar(CEREAL_NVP(hotArchiveBuckets));
         }
@@ -173,13 +171,12 @@ struct HistoryArchiveState
         }
         else
         {
-            // New versions of HistoryArchiveState should always have a
-            // networkPassphrase.
-            releaseAssertOrThrow(
-                version < HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE);
+            // New versions of HistoryArchiveState (i.e. support HotArchive)
+            // should always have a networkPassphrase.
+            releaseAssertOrThrow(!hasHotArchiveBuckets());
         }
         ar(CEREAL_NVP(currentBuckets));
-        if (version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
+        if (hasHotArchiveBuckets())
         {
             ar(CEREAL_NVP(hotArchiveBuckets));
         }

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -87,6 +87,18 @@ struct HistoryArchiveState
     static inline unsigned const
         HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22 = 2;
 
+    struct BucketHashReturnT
+    {
+        std::vector<std::string> live;
+        std::vector<std::string> hot;
+
+        explicit BucketHashReturnT(std::vector<std::string>&& live,
+                                   std::vector<std::string>&& hot)
+            : live(live), hot(hot)
+        {
+        }
+    };
+
     unsigned version{HISTORY_ARCHIVE_STATE_VERSION_PRE_PROTOCOL_22};
     std::string server;
     std::string networkPassphrase;
@@ -96,11 +108,9 @@ struct HistoryArchiveState
 
     HistoryArchiveState();
 
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
     HistoryArchiveState(uint32_t ledgerSeq, LiveBucketList const& liveBuckets,
                         HotArchiveBucketList const& hotBuckets,
                         std::string const& networkPassphrase);
-#endif
 
     HistoryArchiveState(uint32_t ledgerSeq, LiveBucketList const& liveBuckets,
                         std::string const& networkPassphrase);
@@ -119,9 +129,8 @@ struct HistoryArchiveState
     // Return vector of buckets to fetch/apply to turn 'other' into 'this'.
     // Vector is sorted from largest/highest-numbered bucket to smallest/lowest,
     // and with snap buckets occurring before curr buckets. Zero-buckets are
-    // omitted.
-    std::vector<std::string>
-    differingBuckets(HistoryArchiveState const& other) const;
+    // omitted. Hashes are distinguished by live and Hot Archive buckets.
+    BucketHashReturnT differingBuckets(HistoryArchiveState const& other) const;
 
     // Return vector of all buckets referenced by this state.
     std::vector<std::string> allBuckets() const;

--- a/src/history/HistoryArchive.h
+++ b/src/history/HistoryArchive.h
@@ -82,10 +82,10 @@ struct HistoryArchiveState
     static constexpr size_t MAX_HISTORY_ARCHIVE_BUCKET_SIZE =
         1024ull * 1024ull * 1024ull * 100ull; // 100 GB
 
-    static inline unsigned const HISTORY_ARCHIVE_STATE_VERSION_PRE_PROTOCOL_22 =
-        1;
     static inline unsigned const
-        HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22 = 2;
+        HISTORY_ARCHIVE_STATE_VERSION_BEFORE_HOT_ARCHIVE = 1;
+    static inline unsigned const
+        HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE = 2;
 
     struct BucketHashReturnT
     {
@@ -99,7 +99,7 @@ struct HistoryArchiveState
         }
     };
 
-    unsigned version{HISTORY_ARCHIVE_STATE_VERSION_PRE_PROTOCOL_22};
+    unsigned version{HISTORY_ARCHIVE_STATE_VERSION_BEFORE_HOT_ARCHIVE};
     std::string server;
     std::string networkPassphrase;
     uint32_t currentLedger{0};
@@ -150,13 +150,13 @@ struct HistoryArchiveState
             // This is expected when the input file does not contain it, but
             // should only ever happen for older versions of History Archive
             // State.
-            if (version >= HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22)
+            if (version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
             {
                 throw e;
             }
         }
         ar(CEREAL_NVP(currentBuckets));
-        if (version >= HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22)
+        if (version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
         {
             ar(CEREAL_NVP(hotArchiveBuckets));
         }
@@ -176,10 +176,10 @@ struct HistoryArchiveState
             // New versions of HistoryArchiveState should always have a
             // networkPassphrase.
             releaseAssertOrThrow(
-                version < HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22);
+                version < HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE);
         }
         ar(CEREAL_NVP(currentBuckets));
-        if (version >= HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22)
+        if (version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE)
         {
             ar(CEREAL_NVP(hotArchiveBuckets));
         }
@@ -213,7 +213,7 @@ struct HistoryArchiveState
     bool
     hasHotArchiveBuckets() const
     {
-        return version >= HISTORY_ARCHIVE_STATE_VERSION_POST_PROTOCOL_22;
+        return version >= HISTORY_ARCHIVE_STATE_VERSION_WITH_HOT_ARCHIVE;
     }
 };
 

--- a/src/history/HistoryManager.h
+++ b/src/history/HistoryManager.h
@@ -319,14 +319,17 @@ class HistoryManager
     // Calls queueCurrentHistory() if the current ledger is a multiple of
     // getCheckpointFrequency() -- equivalently, the LCL is one _less_ than
     // a multiple of getCheckpointFrequency(). Returns true if checkpoint
-    // publication of the LCL was queued, otherwise false.
-    virtual bool maybeQueueHistoryCheckpoint(uint32_t lcl) = 0;
+    // publication of the LCL was queued, otherwise false. ledgerVers must align
+    // with lcl.
+    virtual bool maybeQueueHistoryCheckpoint(uint32_t lcl,
+                                             uint32_t ledgerVers) = 0;
 
     // Checkpoint the LCL -- both the log of history from the previous
     // checkpoint to it, as well as the bucketlist of its state -- to a
     // publication-queue in the database. This should be followed shortly
-    // (typically after commit) with a call to publishQueuedHistory.
-    virtual void queueCurrentHistory(uint32_t lcl) = 0;
+    // (typically after commit) with a call to publishQueuedHistory. ledgerVers
+    // must align with lcl.
+    virtual void queueCurrentHistory(uint32_t lcl, uint32_t ledgerVers) = 0;
 
     // Return the youngest ledger still in the outgoing publish queue;
     // returns 0 if the publish queue has nothing in it.

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -8,6 +8,7 @@
 #include "util/asio.h"
 
 #include "bucket/BucketManager.h"
+#include "bucket/LiveBucket.h"
 #include "bucket/LiveBucketList.h"
 #include "herder/HerderImpl.h"
 #include <cereal/archives/binary.hpp>
@@ -410,9 +411,9 @@ HistoryManagerImpl::queueCurrentHistory(uint32_t ledger)
     auto ledgerVers = mApp.getLedgerManager()
                           .getLastClosedLedgerHeader()
                           .header.ledgerVersion;
-    if (protocolVersionIsBefore(
+    if (protocolVersionStartsFrom(
             ledgerVers,
-            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
     {
         auto hotBl = mApp.getBucketManager().getHotArchiveBucketList();
         has = HistoryArchiveState(ledger, bl, hotBl,

--- a/src/history/HistoryManagerImpl.cpp
+++ b/src/history/HistoryManagerImpl.cpp
@@ -376,7 +376,8 @@ HistoryManager::getMaxLedgerQueuedToPublish(Config const& cfg)
 }
 
 bool
-HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl)
+HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl,
+                                                uint32_t ledgerVers)
 {
     if (!publishCheckpointOnLedgerClose(lcl, mApp.getConfig()))
     {
@@ -390,12 +391,12 @@ HistoryManagerImpl::maybeQueueHistoryCheckpoint(uint32_t lcl)
         return false;
     }
 
-    queueCurrentHistory(lcl);
+    queueCurrentHistory(lcl, ledgerVers);
     return true;
 }
 
 void
-HistoryManagerImpl::queueCurrentHistory(uint32_t ledger)
+HistoryManagerImpl::queueCurrentHistory(uint32_t ledger, uint32_t ledgerVers)
 {
     ZoneScoped;
 
@@ -408,9 +409,6 @@ HistoryManagerImpl::queueCurrentHistory(uint32_t ledger)
     }
 
     HistoryArchiveState has;
-    auto ledgerVers = mApp.getLedgerManager()
-                          .getLastClosedLedgerHeader()
-                          .header.ledgerVersion;
     if (protocolVersionStartsFrom(
             ledgerVers,
             LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))

--- a/src/history/HistoryManagerImpl.h
+++ b/src/history/HistoryManagerImpl.h
@@ -46,9 +46,10 @@ class HistoryManagerImpl : public HistoryManager
 
     void logAndUpdatePublishStatus() override;
 
-    bool maybeQueueHistoryCheckpoint(uint32_t lcl) override;
+    bool maybeQueueHistoryCheckpoint(uint32_t lcl,
+                                     uint32_t ledgerVers) override;
 
-    void queueCurrentHistory(uint32_t lcl) override;
+    void queueCurrentHistory(uint32_t lcl, uint32_t ledgerVers) override;
 
     void takeSnapshotAndPublish(HistoryArchiveState const& has);
 

--- a/src/history/StateSnapshot.cpp
+++ b/src/history/StateSnapshot.cpp
@@ -120,13 +120,25 @@ StateSnapshot::differingHASFiles(HistoryArchiveState const& other)
     addIfExists(mTransactionResultSnapFile);
     addIfExists(mSCPHistorySnapFile);
 
-    for (auto const& hash : mLocalState.differingBuckets(other))
+    auto hashes = mLocalState.differingBuckets(other);
+
+    for (auto const& hash : hashes.live)
     {
         auto b = mApp.getBucketManager().getBucketByHash<LiveBucket>(
             hexToBin256(hash));
         releaseAssert(b);
         addIfExists(std::make_shared<FileTransferInfo>(*b));
     }
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+    for (auto const& hash : hashes.hot)
+    {
+        auto b = mApp.getBucketManager().getBucketByHash<HotArchiveBucket>(
+            hexToBin256(hash));
+        releaseAssert(b);
+        addIfExists(std::make_shared<FileTransferInfo>(*b));
+    }
+#endif
 
     return files;
 }

--- a/src/history/serialize-tests/stellar-history.testnet.6714239.networkPassphrase.v2.json
+++ b/src/history/serialize-tests/stellar-history.testnet.6714239.networkPassphrase.v2.json
@@ -1,0 +1,184 @@
+{
+    "version": 2,
+    "server": "v9.0.1-dirty",
+    "currentLedger": 6714239,
+    "networkPassphrase": "(V) (;,,;) (V)",
+    "currentBuckets": [
+        {
+            "curr": "0000000000000000000000000000000000000000000000000000000000000000",
+            "next": {
+                "state": 0
+            },
+            "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        {
+            "curr": "c3131b946b5cadf713ca88d299505fe16572ffeefa083b2858a674452fd8ba76",
+            "next": {
+                "state": 1,
+                "output": "0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "snap": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905735"
+        },
+        {
+            "curr": "b767206bf07e3dbbe14cff681234b7ccfd4dab5957ce6d440f692409498ff909",
+            "next": {
+                "state": 1,
+                "output": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905735"
+            },
+            "snap": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d66e"
+        },
+        {
+            "curr": "7a1132e7566dea51a35f6981181ad3f108256bb5f9470f0e9df3222c138c6446",
+            "next": {
+                "state": 1,
+                "output": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d66e"
+            },
+            "snap": "1863067ae6d91218c589b2ccc40a983edc144196ca3a2cd43c7426275a8a3f40"
+        },
+        {
+            "curr": "f4e99dd7c25206f6766911dc812502f0ec2cd5469f4742b7848523aa6e0da03e",
+            "next": {
+                "state": 1,
+                "output": "dd9bcfba61bf17be7093f56eb6e1392d5f25981282d4331cb51961852c11ee16"
+            },
+            "snap": "04a5699bb688ef82e8a352b2ccfa134458c794a0365dddfac00f2e6fc7c159f9"
+        },
+        {
+            "curr": "f9de28d23c53d1affe871a97a5c9747bbc9a208754388dc88cdea96852977471",
+            "next": {
+                "state": 1,
+                "output": "b6d012ce7af5624c24d4ff386ae172516ff0cd13f70cd030edbb503b87ad196b"
+            },
+            "snap": "1fd4b80ec5278fc08269f96728206fcfbf5d3f5efe1bf7f93d4a3d79a75eeca8"
+        },
+        {
+            "curr": "71f4453669ec84632afcdd1f2a97685121cef52a01db58c8d4c810310c07c0d8",
+            "next": {
+                "state": 1,
+                "output": "c0992883bd5f4631f736c5287538342c08e00f80be16b36a5a794772114a3db9"
+            },
+            "snap": "b8913fa01d3b58b763fc04ee1528317c0ec71f250500758e09d0a839ca405be4"
+        },
+        {
+            "curr": "a113930757a7ff48a8898dad74c1446a942b5e5b5f443626a8f943768432ec41",
+            "next": {
+                "state": 1,
+                "output": "9b6feec6e7e366b898a59ad562b31ce3305d7e1545f92bf5fda5c13e032bc0f9"
+            },
+            "snap": "d3b1a36290f39d4cd09e7ef80b7cb871df9a3a5b1e40d8e5cfd26c754914ca84"
+        },
+        {
+            "curr": "e57d1c6342f6e47c2ac0305cd5251bb0fb2cdd40923af87c4657e896e33acdc5",
+            "next": {
+                "state": 1,
+                "output": "de8805e4232fe81c04f5536487e586ab6d3ef38eff93bad5bf6872a3e53ced6b"
+            },
+            "snap": "fcddef737957961d828023a081b84449dc0ab20524e5155837bae12a3b18ac64"
+        },
+        {
+            "curr": "5c3387bcaad3139bb48ff2a99010d6f075cc9b20ba2f22c194fcda2a97926f55",
+            "next": {
+                "state": 1,
+                "output": "3373185b0eb537b909c56e6e16e76e33d966dc7ee1e7168123cfe1114d444e88"
+            },
+            "snap": "2958d66f083ca13ca97a184a5be3a03b3c2e494f832b1ac1a3e16d7b02e9f50c"
+        },
+        {
+            "curr": "ae7e4814b50e176d8e3532e462e2e9db02f218adebd74603d7e349cc19f489e1",
+            "next": {
+                "state": 1,
+                "output": "50abed8a9d86c072cfe8388246b7a378dc355fe996fd7384a5ee57e8da2ad51d"
+            },
+            "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+    ],
+    "hotArchiveBuckets": [
+        {
+            "curr": "0000000000000000000000000000000000000000000000000000000000000000",
+            "next": {
+                "state": 0
+            },
+            "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        {
+            "curr": "c3131b946b5cadf713ca88d299505fe16572ffeefa083b2858a674452fd8ba74",
+            "next": {
+                "state": 1,
+                "output": "0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "snap": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905732"
+        },
+        {
+            "curr": "b767206bf07e3dbbe14cff681234b7ccfd4dab5957ce6d440f692409498ff901",
+            "next": {
+                "state": 1,
+                "output": "e08d65b07ca3cb0999a340247afcf0fedbe1d1e1df6ada0c34422e2d3b905732"
+            },
+            "snap": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d661"
+        },
+        {
+            "curr": "7a1132e7566dea51a35f6981181ad3f108256bb5f9470f0e9df3222c138c6442",
+            "next": {
+                "state": 1,
+                "output": "0bdeee425d0b4c3458353b7b20901e60eb8b5289dd8a714e59f910a47b49d661"
+            },
+            "snap": "1863067ae6d91218c589b2ccc40a983edc144196ca3a2cd43c7426275a8a3f42"
+        },
+        {
+            "curr": "f4e99dd7c25206f6766911dc812502f0ec2cd5469f4742b7848523aa6e0da031",
+            "next": {
+                "state": 1,
+                "output": "dd9bcfba61bf17be7093f56eb6e1392d5f25981282d4331cb51961852c11ee12"
+            },
+            "snap": "04a5699bb688ef82e8a352b2ccfa134458c794a0365dddfac00f2e6fc7c159f1"
+        },
+        {
+            "curr": "f9de28d23c53d1affe871a97a5c9747bbc9a208754388dc88cdea96852977472",
+            "next": {
+                "state": 1,
+                "output": "b6d012ce7af5624c24d4ff386ae172516ff0cd13f70cd030edbb503b87ad1961"
+            },
+            "snap": "1fd4b80ec5278fc08269f96728206fcfbf5d3f5efe1bf7f93d4a3d79a75eeca2"
+        },
+        {
+            "curr": "71f4453669ec84632afcdd1f2a97685121cef52a01db58c8d4c810310c07c0d1",
+            "next": {
+                "state": 1,
+                "output": "c0992883bd5f4631f736c5287538342c08e00f80be16b36a5a794772114a3db2"
+            },
+            "snap": "b8913fa01d3b58b763fc04ee1528317c0ec71f250500758e09d0a839ca405be1"
+        },
+        {
+            "curr": "a113930757a7ff48a8898dad74c1446a942b5e5b5f443626a8f943768432ec42",
+            "next": {
+                "state": 1,
+                "output": "9b6feec6e7e366b898a59ad562b31ce3305d7e1545f92bf5fda5c13e032bc0f1"
+            },
+            "snap": "d3b1a36290f39d4cd09e7ef80b7cb871df9a3a5b1e40d8e5cfd26c754914ca24"
+        },
+        {
+            "curr": "e57d1c6342f6e47c2ac0305cd5251bb0fb2cdd40923af87c4657e896e33acdc1",
+            "next": {
+                "state": 1,
+                "output": "de8805e4232fe81c04f5536487e586ab6d3ef38eff93bad5bf6872a3e53ced62"
+            },
+            "snap": "fcddef737957961d828023a081b84449dc0ab20524e5155837bae12a3b18ac61"
+        },
+        {
+            "curr": "5c3387bcaad3139bb48ff2a99010d6f075cc9b20ba2f22c194fcda2a97926f52",
+            "next": {
+                "state": 1,
+                "output": "3373185b0eb537b909c56e6e16e76e33d966dc7ee1e7168123cfe1114d444e81"
+            },
+            "snap": "2958d66f083ca13ca97a184a5be3a03b3c2e494f832b1ac1a3e16d7b02e9f502"
+        },
+        {
+            "curr": "ae7e4814b50e176d8e3532e462e2e9db02f218adebd74603d7e349cc19f489e2",
+            "next": {
+                "state": 1,
+                "output": "50abed8a9d86c072cfe8388246b7a378dc355fe996fd7384a5ee57e8da2ad52"
+            },
+            "snap": "0000000000000000000000000000000000000000000000000000000000000000"
+        }
+    ]
+}

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -217,35 +217,36 @@ SECTION("both live and hot archive buckets")
 }
 #endif
 }
-SECTION("download fails file not found"){SECTION("live buckets"){
-    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
-        TestBucketState::FILE_NOT_UPLOADED));
-auto verify = wm.executeWork<DownloadBucketsWork>(
-    buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
-REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
-}
-
-#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
-SECTION("hot archive buckets")
+SECTION("download fails file not found")
 {
-    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
-        TestBucketState::FILE_NOT_UPLOADED));
-    auto verify = wm.executeWork<DownloadBucketsWork>(
-        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
-    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
-}
+    SECTION("live buckets")
+    {
+        liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+            TestBucketState::FILE_NOT_UPLOADED));
+        auto verify = wm.executeWork<DownloadBucketsWork>(
+            buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+        REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+    }
 
-SECTION("both live and hot archive buckets")
-{
-    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
-        TestBucketState::FILE_NOT_UPLOADED));
-    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
-        TestBucketState::FILE_NOT_UPLOADED));
-    auto verify = wm.executeWork<DownloadBucketsWork>(
-        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
-    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
-}
-#endif
+    SECTION("hot archive buckets")
+    {
+        hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+            TestBucketState::FILE_NOT_UPLOADED));
+        auto verify = wm.executeWork<DownloadBucketsWork>(
+            buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+        REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+    }
+
+    SECTION("both live and hot archive buckets")
+    {
+        liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+            TestBucketState::FILE_NOT_UPLOADED));
+        hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+            TestBucketState::FILE_NOT_UPLOADED));
+        auto verify = wm.executeWork<DownloadBucketsWork>(
+            buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+        REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+    }
 }
 SECTION("download succeeds but unzip fails"){SECTION("live buckets"){
     liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1248,6 +1248,16 @@ TEST_CASE("Catchup with protocol upgrade", "[catchup][history]")
             testUpgrade(SOROBAN_PROTOCOL_VERSION);
         }
     }
+    SECTION("hot archive bucket upgrade")
+    {
+        if (protocolVersionEquals(
+                Config::CURRENT_LEDGER_PROTOCOL_VERSION,
+                BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+        {
+            testUpgrade(
+                BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
+        }
+    }
 }
 
 TEST_CASE("Catchup fatal failure", "[catchup][history]")

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -174,56 +174,157 @@ TEST_CASE("History bucket verification", "[history][catchup]")
     auto bucketGenerator = TestBucketGenerator{
         *app, app->getHistoryArchiveManager().getHistoryArchive(
                   cg->getArchiveDirName())};
-    std::vector<std::string> hashes;
+    std::vector<std::string> liveHashes;
+    std::vector<std::string> hotHashes;
     auto& wm = app->getWorkScheduler();
-    std::map<std::string, std::shared_ptr<LiveBucket>> mBuckets;
+
+    std::map<std::string, std::shared_ptr<LiveBucket>> buckets;
+    std::map<std::string, std::shared_ptr<HotArchiveBucket>> hotBuckets;
     auto tmpDir =
         std::make_unique<TmpDir>(app->getTmpDirManager().tmpDir("bucket-test"));
 
-    SECTION("successful download and verify")
-    {
-        hashes.push_back(bucketGenerator.generateBucket(
+    SECTION("successful download and verify"){SECTION("live buckets"){
+        liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
             TestBucketState::CONTENTS_AND_HASH_OK));
-        hashes.push_back(bucketGenerator.generateBucket(
-            TestBucketState::CONTENTS_AND_HASH_OK));
-        auto verify =
-            wm.executeWork<DownloadBucketsWork>(mBuckets, hashes, *tmpDir);
-        REQUIRE(verify->getState() == BasicWork::State::WORK_SUCCESS);
-    }
-    SECTION("download fails file not found")
-    {
-        hashes.push_back(
-            bucketGenerator.generateBucket(TestBucketState::FILE_NOT_UPLOADED));
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::CONTENTS_AND_HASH_OK));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_SUCCESS);
+}
 
-        auto verify =
-            wm.executeWork<DownloadBucketsWork>(mBuckets, hashes, *tmpDir);
-        REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
-    }
-    SECTION("download succeeds but unzip fails")
-    {
-        hashes.push_back(bucketGenerator.generateBucket(
-            TestBucketState::CORRUPTED_ZIPPED_FILE));
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+SECTION("hot archive buckets")
+{
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::CONTENTS_AND_HASH_OK));
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::CONTENTS_AND_HASH_OK));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_SUCCESS);
+}
 
-        auto verify =
-            wm.executeWork<DownloadBucketsWork>(mBuckets, hashes, *tmpDir);
-        REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
-    }
-    SECTION("verify fails hash mismatch")
-    {
-        hashes.push_back(
-            bucketGenerator.generateBucket(TestBucketState::HASH_MISMATCH));
+SECTION("both live and hot archive buckets")
+{
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::CONTENTS_AND_HASH_OK));
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::CONTENTS_AND_HASH_OK));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_SUCCESS);
+}
+#endif
+}
+SECTION("download fails file not found"){SECTION("live buckets"){
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::FILE_NOT_UPLOADED));
+auto verify = wm.executeWork<DownloadBucketsWork>(
+    buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
 
-        auto verify =
-            wm.executeWork<DownloadBucketsWork>(mBuckets, hashes, *tmpDir);
-        REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
-    }
-    SECTION("no hashes to verify")
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+SECTION("hot archive buckets")
+{
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::FILE_NOT_UPLOADED));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+
+SECTION("both live and hot archive buckets")
+{
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::FILE_NOT_UPLOADED));
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::FILE_NOT_UPLOADED));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+#endif
+}
+SECTION("download succeeds but unzip fails"){SECTION("live buckets"){
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::CORRUPTED_ZIPPED_FILE));
+auto verify = wm.executeWork<DownloadBucketsWork>(
+    buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+SECTION("hot archive buckets")
+{
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::CORRUPTED_ZIPPED_FILE));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+
+SECTION("both live and hot archive buckets")
+{
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::CORRUPTED_ZIPPED_FILE));
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::CORRUPTED_ZIPPED_FILE));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+#endif
+}
+SECTION("verify fails hash mismatch"){SECTION("live buckets"){
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::HASH_MISMATCH));
+auto verify = wm.executeWork<DownloadBucketsWork>(
+    buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+
+#ifdef ENABLE_NEXT_PROTOCOL_VERSION_UNSAFE_FOR_PRODUCTION
+SECTION("hot archive buckets")
+{
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::HASH_MISMATCH));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+
+SECTION("both live and hot archive buckets")
+{
+    liveHashes.push_back(bucketGenerator.generateBucket<LiveBucket>(
+        TestBucketState::HASH_MISMATCH));
+    hotHashes.push_back(bucketGenerator.generateBucket<HotArchiveBucket>(
+        TestBucketState::HASH_MISMATCH));
+    auto verify = wm.executeWork<DownloadBucketsWork>(
+        buckets, hotBuckets, liveHashes, hotHashes, *tmpDir);
+    REQUIRE(verify->getState() == BasicWork::State::WORK_FAILURE);
+}
+#endif
+}
+SECTION("no hashes to verify")
+{
+    // Ensure proper behavior when no hashes are passed in
+    SECTION("live buckets")
     {
-        // Ensure proper behavior when no hashes are passed in
         auto verify = wm.executeWork<DownloadBucketsWork>(
-            mBuckets, std::vector<std::string>(), *tmpDir);
+            buckets, hotBuckets, std::vector<std::string>(),
+            std::vector<std::string>(), *tmpDir);
         REQUIRE(verify->getState() == BasicWork::State::WORK_SUCCESS);
     }
+
+    SECTION("hot archive buckets")
+    {
+        auto verify = wm.executeWork<DownloadBucketsWork>(
+            buckets, hotBuckets, std::vector<std::string>(),
+            std::vector<std::string>(), *tmpDir);
+        REQUIRE(verify->getState() == BasicWork::State::WORK_SUCCESS);
+    }
+}
 }
 
 TEST_CASE("Ledger chain verification", "[ledgerheaderverification]")
@@ -1205,7 +1306,7 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
 
         // Check that during catchup/replay, we did not use any INITENTRY code,
         // were still on the old protocol.
-        auto mc = a->getBucketManager().readMergeCounters();
+        auto mc = a->getBucketManager().readMergeCounters<LiveBucket>();
         REQUIRE(mc.mPostInitEntryProtocolMerges == 0);
         REQUIRE(mc.mNewInitEntries == 0);
         REQUIRE(mc.mOldInitEntries == 0);
@@ -1247,7 +1348,7 @@ TEST_CASE("Catchup non-initentry buckets to initentry-supporting works",
         }
 
         // Check that we did in fact use INITENTRY code.
-        mc = a->getBucketManager().readMergeCounters();
+        mc = a->getBucketManager().readMergeCounters<LiveBucket>();
         REQUIRE(mc.mPostInitEntryProtocolMerges != 0);
         REQUIRE(mc.mNewInitEntries != 0);
         REQUIRE(mc.mOldInitEntries != 0);
@@ -1348,7 +1449,9 @@ TEST_CASE_VERSIONS(
 
     BucketTestUtils::for_versions_with_differing_bucket_logic(
         cfg, [&](Config const& cfg) {
-            Application::pointer app = createTestApplication(clock, cfg);
+            auto app =
+                createTestApplication<BucketTestUtils::BucketTestApplication>(
+                    clock, cfg);
             auto& hm = app->getHistoryManager();
             auto& lm = app->getLedgerManager();
             auto& bl = app->getBucketManager().getLiveBucketList();
@@ -1357,9 +1460,11 @@ TEST_CASE_VERSIONS(
             {
                 auto lcl = lm.getLastClosedLedgerHeader();
                 lcl.header.ledgerSeq += 1;
-                BucketTestUtils::addLiveBatchAndUpdateSnapshot(
-                    *app, lcl.header, {},
-                    LedgerTestUtils::generateValidUniqueLedgerEntries(8), {});
+                lm.setNextLedgerEntryBatchForBucketTesting(
+                    {},
+                    LedgerTestUtils::generateValidLedgerEntriesWithExclusions(
+                        {LedgerEntryType::CONFIG_SETTING}, 8),
+                    {});
                 clock.crank(true);
             }
 

--- a/src/history/test/HistoryTests.cpp
+++ b/src/history/test/HistoryTests.cpp
@@ -1252,10 +1252,10 @@ TEST_CASE("Catchup with protocol upgrade", "[catchup][history]")
     {
         if (protocolVersionEquals(
                 Config::CURRENT_LEDGER_PROTOCOL_VERSION,
-                BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+                LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
         {
             testUpgrade(
-                BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
+                LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION);
         }
     }
 }

--- a/src/history/test/HistoryTestsUtils.cpp
+++ b/src/history/test/HistoryTestsUtils.cpp
@@ -536,11 +536,11 @@ CatchupSimulation::generateRandomLedger(uint32_t version)
             uint32_t inclusion = 100;
 
             sorobanTxs.push_back(createUploadWasmTx(
-                getApp(), stroopy, inclusion, DEFAULT_TEST_RESOURCE_FEE * 5,
-                res, {}, 0, rand_uniform(101, 2'000)));
+                getApp(), stroopy, inclusion, DEFAULT_TEST_RESOURCE_FEE, res,
+                {}, 0, rand_uniform(101, 2'000)));
             sorobanTxs.push_back(createUploadWasmTx(
-                getApp(), eve, inclusion * 5, DEFAULT_TEST_RESOURCE_FEE * 5,
-                res, {}, 0, rand_uniform(101, 2'000)));
+                getApp(), eve, inclusion * 5, DEFAULT_TEST_RESOURCE_FEE, res,
+                {}, 0, rand_uniform(101, 2'000)));
             check = true;
         }
     }

--- a/src/history/test/HistoryTestsUtils.h
+++ b/src/history/test/HistoryTestsUtils.h
@@ -4,6 +4,7 @@
 // under the Apache License, Version 2.0. See the COPYING file at the root
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 
+#include "bucket/BucketUtils.h"
 #include "bucket/HotArchiveBucketList.h"
 #include "bucket/LiveBucketList.h"
 #include "catchup/VerifyLedgerChainWork.h"
@@ -47,7 +48,7 @@ enum class TestBucketState
 
 class HistoryConfigurator;
 class TestBucketGenerator;
-class BucketOutputIteratorForTesting;
+template <typename BucketT> class BucketOutputIteratorForTesting;
 struct CatchupPerformedWork;
 
 class HistoryConfigurator : NonCopyable
@@ -99,8 +100,11 @@ class RealGenesisTmpDirHistoryConfigurator : public TmpDirHistoryConfigurator
     Config& configure(Config& cfg, bool writable) const override;
 };
 
-class BucketOutputIteratorForTesting : public LiveBucketOutputIterator
+template <typename BucketT>
+class BucketOutputIteratorForTesting : public BucketOutputIterator<BucketT>
 {
+    BUCKET_TYPE_ASSERT(BucketT);
+
     const size_t NUM_ITEMS_PER_BUCKET = 5;
 
   public:
@@ -121,6 +125,7 @@ class TestBucketGenerator
     TestBucketGenerator(Application& app,
                         std::shared_ptr<HistoryArchive> archive);
 
+    template <typename BucketT>
     std::string generateBucket(
         TestBucketState desiredState = TestBucketState::CONTENTS_AND_HASH_OK);
 };

--- a/src/history/test/SerializeTests.cpp
+++ b/src/history/test/SerializeTests.cpp
@@ -15,7 +15,8 @@ TEST_CASE("Serialization round trip", "[history]")
     std::vector<std::string> testFiles = {
         "stellar-history.testnet.6714239.json",
         "stellar-history.livenet.15686975.json",
-        "stellar-history.testnet.6714239.networkPassphrase.json"};
+        "stellar-history.testnet.6714239.networkPassphrase.json",
+        "stellar-history.testnet.6714239.networkPassphrase.v2.json"};
     for (size_t i = 0; i < testFiles.size(); i++)
     {
         std::string fnPath = "testdata/";

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -4,12 +4,14 @@
 
 #include "historywork/DownloadBucketsWork.h"
 #include "bucket/BucketManager.h"
+#include "bucket/HotArchiveBucket.h"
 #include "catchup/LedgerApplyManager.h"
 #include "history/FileTransferInfo.h"
 #include "history/HistoryArchive.h"
 #include "historywork/GetAndUnzipRemoteFileWork.h"
 #include "historywork/VerifyBucketWork.h"
 #include "work/WorkWithCallback.h"
+#include "xdr/Stellar-contract-config-setting.h"
 #include <Tracy.hpp>
 #include <fmt/format.h>
 #include <mutex>
@@ -19,13 +21,17 @@ namespace stellar
 
 DownloadBucketsWork::DownloadBucketsWork(
     Application& app,
-    std::map<std::string, std::shared_ptr<LiveBucket>>& buckets,
-    std::vector<std::string> hashes, TmpDir const& downloadDir,
-    std::shared_ptr<HistoryArchive> archive)
+    std::map<std::string, std::shared_ptr<LiveBucket>>& liveBuckets,
+    std::map<std::string, std::shared_ptr<HotArchiveBucket>>& hotBuckets,
+    std::vector<std::string> liveHashes, std::vector<std::string> hotHashes,
+    TmpDir const& downloadDir, std::shared_ptr<HistoryArchive> archive)
     : BatchWork{app, "download-verify-buckets"}
-    , mBuckets{buckets}
-    , mHashes{hashes}
-    , mNextBucketIter{mHashes.begin()}
+    , mLiveBuckets{liveBuckets}
+    , mHotBuckets{hotBuckets}
+    , mLiveHashes{liveHashes}
+    , mHotHashes{hotHashes}
+    , mNextLiveBucketIter{mLiveHashes.begin()}
+    , mNextHotBucketIter{mHotHashes.begin()}
     , mDownloadDir{downloadDir}
     , mArchive{archive}
 {
@@ -36,11 +42,14 @@ DownloadBucketsWork::getStatus() const
 {
     if (!isDone() && !isAborting())
     {
-        if (!mHashes.empty())
+        if (!mLiveHashes.empty())
         {
-            auto numStarted = std::distance(mHashes.begin(), mNextBucketIter);
+            auto numStarted =
+                std::distance(mLiveHashes.begin(), mNextLiveBucketIter) +
+                std::distance(mHotHashes.begin(), mNextHotBucketIter);
             auto numDone = numStarted - getNumWorksInBatch();
-            auto total = static_cast<uint32_t>(mHashes.size());
+            auto total =
+                static_cast<uint32_t>(mLiveHashes.size() + mHotHashes.size());
             auto pct = (100 * numDone) / total;
             return fmt::format(
                 FMT_STRING(
@@ -54,13 +63,50 @@ DownloadBucketsWork::getStatus() const
 bool
 DownloadBucketsWork::hasNext() const
 {
-    return mNextBucketIter != mHashes.end();
+    return mNextLiveBucketIter != mLiveHashes.end() ||
+           mNextHotBucketIter != mHotHashes.end();
 }
 
 void
 DownloadBucketsWork::resetIter()
 {
-    mNextBucketIter = mHashes.begin();
+    mNextLiveBucketIter = mLiveHashes.begin();
+    mNextHotBucketIter = mHotHashes.begin();
+}
+
+template <typename BucketT>
+bool
+DownloadBucketsWork::onSuccessCb(
+    Application& app, FileTransferInfo const& ft, std::string const& hash,
+    int currId, std::map<std::string, std::shared_ptr<BucketT>>& buckets,
+    std::map<int, std::unique_ptr<typename BucketT::IndexT const>>& indexMap,
+    std::mutex& indexMutex)
+{
+    // To avoid dangling references, maintain a map of index pointers
+    // and do a lookup inside the callback instead of capturing anything
+    // by reference.
+    std::unique_ptr<typename BucketT::IndexT const> index;
+    std::filesystem::path bucketPath;
+    {
+        // Lock for indexMap access
+        std::lock_guard<std::mutex> lock(indexMutex);
+        bucketPath = ft.localPath_nogz();
+        auto indexIter = indexMap.find(currId);
+        releaseAssertOrThrow(indexIter != indexMap.end());
+        releaseAssertOrThrow(indexIter->second);
+        index = std::move(indexIter->second);
+        indexMap.erase(currId);
+    }
+
+    auto b = app.getBucketManager().adoptFileAsBucket<BucketT>(
+        bucketPath, hexToBin256(hash),
+        /*mergeKey=*/nullptr,
+        /*index=*/std::move(index));
+
+    // Lock for buckets access
+    std::lock_guard<std::mutex> lock(indexMutex);
+    buckets[hash] = b;
+    return true;
 }
 
 std::shared_ptr<BasicWork>
@@ -72,13 +118,23 @@ DownloadBucketsWork::yieldMoreWork()
         throw std::runtime_error("Nothing to iterate over!");
     }
 
-    auto hash = *mNextBucketIter;
-    FileTransferInfo ft(mDownloadDir, FileType::HISTORY_FILE_TYPE_BUCKET, hash);
-    auto w1 = std::make_shared<GetAndUnzipRemoteFileWork>(mApp, ft, mArchive);
+    // Every Bucket we need to download goes through three steps each, which are
+    // all handled by a separate work:
+    // 1. Download the bucket file from the archive and unzip it (getFileWork)
+    // 2. Verify and index the bucket file (verifyWork)
+    // 3. Once verified, pass the Bucket to the BucketManager to be adopted and
+    // tracked (adoptWork) First, we iterate through all the live buckets, then
+    // the hot archive buckets.
+    auto isHotHash = mNextLiveBucketIter == mLiveHashes.end();
+    auto hash = isHotHash ? *mNextHotBucketIter : *mNextLiveBucketIter;
 
-    auto getFileWeak = std::weak_ptr<GetAndUnzipRemoteFileWork>(w1);
-    OnFailureCallback failureCb = [getFileWeak, hash]() {
-        auto getFile = getFileWeak.lock();
+    auto const ft = FileTransferInfo(mDownloadDir, FileType::HISTORY_FILE_TYPE_BUCKET, hash);
+    auto getFileWork =
+        std::make_shared<GetAndUnzipRemoteFileWork>(mApp, ft, mArchive);
+
+    auto getFileWeakPtr = std::weak_ptr<GetAndUnzipRemoteFileWork>(getFileWork);
+    OnFailureCallback failureCb = [getFileWeakPtr, hash]() {
+        auto getFile = getFileWeakPtr.lock();
         if (getFile)
         {
             auto ar = getFile->getArchive();
@@ -89,51 +145,76 @@ DownloadBucketsWork::yieldMoreWork()
             }
         }
     };
-    std::weak_ptr<DownloadBucketsWork> weak(
+
+    std::weak_ptr<DownloadBucketsWork> weakSelf(
         std::static_pointer_cast<DownloadBucketsWork>(shared_from_this()));
 
-    auto currId = mIndexId++;
-    mIndexMapMutex.lock();
-    auto [indexIter, inserted] = mIndexMap.emplace(currId, nullptr);
-    mIndexMapMutex.unlock();
-    releaseAssertOrThrow(inserted);
+    std::shared_ptr<BasicWork> verifyWork;
+    std::function<bool(Application & app)> adoptBucketCb;
 
-    auto successCb = [weak, ft, hash, currId](Application& app) -> bool {
-        auto self = weak.lock();
-        if (self)
-        {
-            // To avoid dangling references, maintain a map of index pointers
-            // and do a lookup inside the callback instead of capturing anything
-            // by reference.
-            std::unique_ptr<LiveBucketIndex const> index{};
+    if (isHotHash)
+    {
+        std::lock_guard<std::mutex> lock(mHotMapMutex);
+        auto currId = mHotIndexId++;
+        auto [indexIter, inserted] = mHotIndexMap.emplace(currId, nullptr);
+        releaseAssertOrThrow(inserted);
+        verifyWork = std::make_shared<VerifyBucketWork<HotArchiveBucket>>(
+            mApp, ft.localPath_nogz(), hexToBin256(hash), indexIter->second,
+            failureCb);
+        adoptBucketCb = [weakSelf, ft, hash, currId](Application& app) {
+            auto self = weakSelf.lock();
+            if (self)
             {
-                std::lock_guard<std::mutex> lock(self->mIndexMapMutex);
-                auto indexIter = self->mIndexMap.find(currId);
-                releaseAssertOrThrow(indexIter != self->mIndexMap.end());
-                releaseAssertOrThrow(indexIter->second);
-                index = std::move(indexIter->second);
-                self->mIndexMap.erase(indexIter);
+                return onSuccessCb<HotArchiveBucket>(
+                    app, ft, hash, currId, self->mHotBuckets,
+                    self->mHotIndexMap, self->mHotMapMutex);
             }
+            return false;
+        };
 
-            auto bucketPath = ft.localPath_nogz();
-            auto b = app.getBucketManager().adoptFileAsBucket<LiveBucket>(
-                bucketPath, hexToBin256(hash),
-                /*mergeKey=*/nullptr,
-                /*index=*/std::move(index));
-            self->mBuckets[hash] = b;
-        }
-        return true;
-    };
-    auto w2 = std::make_shared<VerifyBucketWork>(mApp, ft.localPath_nogz(),
-                                                 hexToBin256(hash),
-                                                 indexIter->second, failureCb);
-    auto w3 = std::make_shared<WorkWithCallback>(mApp, "adopt-verified-bucket",
-                                                 successCb);
-    std::vector<std::shared_ptr<BasicWork>> seq{w1, w2, w3};
-    auto w4 = std::make_shared<WorkSequence>(
+        mNextHotBucketIter++;
+    }
+    else
+    {
+        std::lock_guard<std::mutex> lock(mLiveMapMutex);
+        auto currId = mLiveIndexId++;
+        auto [indexIter, inserted] = mLiveIndexMap.emplace(currId, nullptr);
+        releaseAssertOrThrow(inserted);
+        verifyWork = std::make_shared<VerifyBucketWork<LiveBucket>>(
+            mApp, ft.localPath_nogz(), hexToBin256(hash), indexIter->second,
+            failureCb);
+        adoptBucketCb = [weakSelf, ft, hash, currId](Application& app) {
+            auto self = weakSelf.lock();
+            if (self)
+            {
+                return onSuccessCb<LiveBucket>(
+                    app, ft, hash, currId, self->mLiveBuckets,
+                    self->mLiveIndexMap, self->mLiveMapMutex);
+            }
+            return false;
+        };
+
+        mNextLiveBucketIter++;
+    }
+
+    auto adoptWork = std::make_shared<WorkWithCallback>(
+        mApp, "adopt-verified-bucket", adoptBucketCb);
+    std::vector<std::shared_ptr<BasicWork>> seq{getFileWork, verifyWork,
+                                                adoptWork};
+    auto workSequence = std::make_shared<WorkSequence>(
         mApp, "download-verify-sequence-" + hash, seq);
 
-    ++mNextBucketIter;
-    return w4;
+    return workSequence;
 }
+
+// Add explicit template instantiations
+template bool DownloadBucketsWork::onSuccessCb<LiveBucket>(
+    Application&, FileTransferInfo const&, std::string const&, int,
+    std::map<std::string, std::shared_ptr<LiveBucket>>&,
+    std::map<int, std::unique_ptr<LiveBucketIndex const>>&, std::mutex&);
+
+template bool DownloadBucketsWork::onSuccessCb<HotArchiveBucket>(
+    Application&, FileTransferInfo const&, std::string const&, int,
+    std::map<std::string, std::shared_ptr<HotArchiveBucket>>&,
+    std::map<int, std::unique_ptr<HotArchiveBucketIndex const>>&, std::mutex&);
 }

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -126,7 +126,8 @@ DownloadBucketsWork::yieldMoreWork()
     auto isHotHash = mNextLiveBucketIter == mLiveHashes.end();
     auto hash = isHotHash ? *mNextHotBucketIter : *mNextLiveBucketIter;
 
-    auto const ft = FileTransferInfo(mDownloadDir, FileType::HISTORY_FILE_TYPE_BUCKET, hash);
+    auto const ft = FileTransferInfo(mDownloadDir,
+                                     FileType::HISTORY_FILE_TYPE_BUCKET, hash);
     auto getFileWork =
         std::make_shared<GetAndUnzipRemoteFileWork>(mApp, ft, mArchive);
 
@@ -165,7 +166,7 @@ DownloadBucketsWork::yieldMoreWork()
             {
                 onSuccessCb<HotArchiveBucket>(
                     app, ft, hash, currId, self->mHotBuckets,
-                    self->mHotIndexMap, self->mHotIndexMapMutex);
+                    self->mHotIndexMap, self->mHotMapMutex);
             }
             return true;
         };
@@ -187,7 +188,7 @@ DownloadBucketsWork::yieldMoreWork()
             {
                 onSuccessCb<LiveBucket>(app, ft, hash, currId,
                                         self->mLiveBuckets, self->mLiveIndexMap,
-                                        self->mLiveIndexMapMutex);
+                                        self->mLiveMapMutex);
             }
             return true;
         };

--- a/src/historywork/DownloadBucketsWork.cpp
+++ b/src/historywork/DownloadBucketsWork.cpp
@@ -163,10 +163,9 @@ DownloadBucketsWork::yieldMoreWork()
             auto self = weakSelf.lock();
             if (self)
             {
-                onSuccessCb<HotArchiveBucket>(app, ft, hash, currId,
-                                                    self->mHotBuckets,
-                                                    self->mHotIndexMap,
-                                                    self->mHotIndexMapMutex);
+                onSuccessCb<HotArchiveBucket>(
+                    app, ft, hash, currId, self->mHotBuckets,
+                    self->mHotIndexMap, self->mHotIndexMapMutex);
             }
             return true;
         };
@@ -187,9 +186,8 @@ DownloadBucketsWork::yieldMoreWork()
             if (self)
             {
                 onSuccessCb<LiveBucket>(app, ft, hash, currId,
-                                               self->mLiveBuckets,
-                                               self->mLiveIndexMap,
-                                               self->mLiveIndexMapMutex);
+                                        self->mLiveBuckets, self->mLiveIndexMap,
+                                        self->mLiveIndexMapMutex);
             }
             return true;
         };

--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -3,10 +3,9 @@
 // of this distribution or at http://www.apache.org/licenses/LICENSE-2.0
 #pragma once
 
+#include "bucket/HotArchiveBucket.h"
 #include "bucket/LiveBucket.h"
 #include "historywork/Progress.h"
-#include "medida/meter.h"
-#include "medida/metrics_registry.h"
 #include "util/TmpDir.h"
 #include "work/BatchWork.h"
 
@@ -18,39 +17,52 @@ class FileTransferInfo;
 
 class DownloadBucketsWork : public BatchWork
 {
-    // Must hold mLiveMapMutex/mHotMapMutex when accessing
-    // mLiveBuckets/mHotBuckets
-    std::map<std::string, std::shared_ptr<LiveBucket>>& mLiveBuckets;
-    std::map<std::string, std::shared_ptr<HotArchiveBucket>>& mHotBuckets;
+    // Wrapper around state associated with each BucketList
+    template <typename BucketT> struct BucketState
+    {
+        // Must hold mutex when accessing buckets
+        std::map<std::string, std::shared_ptr<BucketT>>& buckets;
 
-    std::vector<std::string> mLiveHashes;
-    std::vector<std::string> mHotHashes;
-    std::vector<std::string>::const_iterator mNextLiveBucketIter;
-    std::vector<std::string>::const_iterator mNextHotBucketIter;
+        std::vector<std::string> hashes;
+        std::vector<std::string>::const_iterator nextIter;
+
+        // Store indexes of downloaded buckets. Child processes will actually
+        // create the indexes, but DownloadBucketsWork needs to maintain actual
+        // ownership of the pointers so that the success callback can pass them
+        // to the BucketManager. Must be protected by mutex.
+        std::map<int, std::unique_ptr<typename BucketT::IndexT const>> indexMap;
+
+        std::mutex mutex;
+        int indexId{0};
+
+        BucketState(std::map<std::string, std::shared_ptr<BucketT>>& bucketMap,
+                    std::vector<std::string> bucketHashes)
+            : buckets(bucketMap)
+            , hashes(std::move(bucketHashes))
+            , nextIter(hashes.begin())
+        {
+        }
+    };
+
+    BucketState<LiveBucket> mLiveBucketsState;
+    BucketState<HotArchiveBucket> mHotBucketsState;
+
     TmpDir const& mDownloadDir;
     std::shared_ptr<HistoryArchive> mArchive;
 
-    // Store indexes of downloaded buckets. Child processes will actually create
-    // the indexes, but DownloadBucketsWork needs to maintain actual ownership
-    // of the pointers so that the success callback can pass them to the
-    // BucketManager. Must be protected by a mutex to avoid race conditions.
-    std::map<int, std::unique_ptr<LiveBucketIndex const>> mLiveIndexMap;
-    std::map<int, std::unique_ptr<HotArchiveBucketIndex const>> mHotIndexMap;
-
-    // Must be held when accessing mIndexMaps and bucketMaps
-    std::mutex mLiveMapMutex;
-    std::mutex mHotMapMutex;
-    int mLiveIndexId{0};
-    int mHotIndexId{0};
-
     template <typename BucketT>
-    static void
-    onSuccessCb(Application& app, FileTransferInfo const& ft,
-                std::string const& hash, int currId,
-                std::map<std::string, std::shared_ptr<BucketT>>& buckets,
-                std::map<int, std::unique_ptr<typename BucketT::IndexT const>>&
-                    indexMap,
-                std::mutex& indexMutex);
+    static void onSuccessCb(Application& app, FileTransferInfo const& ft,
+                            std::string const& hash, int currId,
+                            BucketState<BucketT>& state);
+
+    // Helper function returns pair of verifyBucketWork and a callback to adopt
+    // the verified BucketList.
+    template <typename BucketT>
+    std::pair<std::shared_ptr<BasicWork>, std::function<bool(Application&)>>
+    prepareWorkForBucketType(std::string const& hash,
+                             FileTransferInfo const& ft,
+                             OnFailureCallback const& failureCb,
+                             BucketState<BucketT>& state);
 
   public:
     // Note: hashes must contain both live and hot archive bucket hashes

--- a/src/historywork/DownloadBucketsWork.h
+++ b/src/historywork/DownloadBucketsWork.h
@@ -14,27 +14,49 @@ namespace stellar
 {
 
 class HistoryArchive;
+class FileTransferInfo;
 
 class DownloadBucketsWork : public BatchWork
 {
-    std::map<std::string, std::shared_ptr<LiveBucket>>& mBuckets;
-    std::vector<std::string> mHashes;
-    std::vector<std::string>::const_iterator mNextBucketIter;
+    // Must hold mLiveMapMutex/mHotMapMutex when accessing
+    // mLiveBuckets/mHotBuckets
+    std::map<std::string, std::shared_ptr<LiveBucket>>& mLiveBuckets;
+    std::map<std::string, std::shared_ptr<HotArchiveBucket>>& mHotBuckets;
+
+    std::vector<std::string> mLiveHashes;
+    std::vector<std::string> mHotHashes;
+    std::vector<std::string>::const_iterator mNextLiveBucketIter;
+    std::vector<std::string>::const_iterator mNextHotBucketIter;
     TmpDir const& mDownloadDir;
     std::shared_ptr<HistoryArchive> mArchive;
 
-    // Store indexes of downloaded buckets
-    std::map<int, std::unique_ptr<LiveBucketIndex const>> mIndexMap;
+    // Store indexes of downloaded buckets, must hold mutex when accessing
+    std::map<int, std::unique_ptr<LiveBucketIndex const>> mLiveIndexMap;
+    std::map<int, std::unique_ptr<HotArchiveBucketIndex const>> mHotIndexMap;
 
-    // Must be held when accessing mIndexMap
-    std::mutex mIndexMapMutex;
-    int mIndexId{0};
+    // Must be held when accessing mIndexMaps and bucketMaps
+    std::mutex mLiveMapMutex;
+    std::mutex mHotMapMutex;
+    int mLiveIndexId{0};
+    int mHotIndexId{0};
+
+    template <typename BucketT>
+    static bool
+    onSuccessCb(Application& app, FileTransferInfo const& ft,
+                std::string const& hash, int currId,
+                std::map<std::string, std::shared_ptr<BucketT>>& buckets,
+                std::map<int, std::unique_ptr<typename BucketT::IndexT const>>&
+                    indexMap,
+                std::mutex& indexMutex);
 
   public:
+    // Note: hashes must contain both live and hot archive bucket hashes
     DownloadBucketsWork(
         Application& app,
-        std::map<std::string, std::shared_ptr<LiveBucket>>& buckets,
-        std::vector<std::string> hashes, TmpDir const& downloadDir,
+        std::map<std::string, std::shared_ptr<LiveBucket>>& liveBuckets,
+        std::map<std::string, std::shared_ptr<HotArchiveBucket>>& hotBuckets,
+        std::vector<std::string> liveHashes, std::vector<std::string> hotHashes,
+        TmpDir const& downloadDir,
         std::shared_ptr<HistoryArchive> archive = nullptr);
     ~DownloadBucketsWork() = default;
     std::string getStatus() const override;

--- a/src/historywork/VerifyBucketWork.h
+++ b/src/historywork/VerifyBucketWork.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "bucket/BucketUtils.h"
 #include "work/Work.h"
 #include "xdr/Stellar-types.h"
 
@@ -19,13 +20,15 @@ class LiveBucketIndex;
 
 class Bucket;
 
-class VerifyBucketWork : public BasicWork
+template <typename BucketT> class VerifyBucketWork : public BasicWork
 {
+    BUCKET_TYPE_ASSERT(BucketT);
+
     std::string mBucketFile;
     uint256 mHash;
     bool mDone{false};
     std::error_code mEc;
-    std::unique_ptr<LiveBucketIndex const>& mIndex;
+    std::unique_ptr<typename BucketT::IndexT const>& mIndex;
     void spawnVerifier();
 
     OnFailureCallback mOnFailure;
@@ -33,7 +36,7 @@ class VerifyBucketWork : public BasicWork
   public:
     VerifyBucketWork(Application& app, std::string const& bucketFile,
                      uint256 const& hash,
-                     std::unique_ptr<LiveBucketIndex const>& index,
+                     std::unique_ptr<typename BucketT::IndexT const>& index,
                      OnFailureCallback failureCb);
     ~VerifyBucketWork() = default;
 

--- a/src/ledger/LedgerManager.h
+++ b/src/ledger/LedgerManager.h
@@ -285,10 +285,8 @@ class LedgerManager
     // LedgerManager detects it is desynchronized from SCP's consensus ledger.
     // This method is present in the public interface to permit testing and
     // offline catchups.
-    virtual void
-    startCatchup(CatchupConfiguration configuration,
-                 std::shared_ptr<HistoryArchive> archive,
-                 std::set<std::shared_ptr<LiveBucket>> bucketsToRetain) = 0;
+    virtual void startCatchup(CatchupConfiguration configuration,
+                              std::shared_ptr<HistoryArchive> archive) = 0;
 
     // Forcibly apply `ledgerData` to the current ledger, causing it to close.
     // This is normally done automatically as part of `valueExternalized()`

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1926,8 +1926,20 @@ LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
     // Store the current HAS in the database; this is really just to
     // checkpoint the bucketlist so we can survive a restart and re-attach
     // to the buckets.
-    HistoryArchiveState has(header.ledgerSeq, bl,
-                            mApp.getConfig().NETWORK_PASSPHRASE);
+    HistoryArchiveState has;
+    if (protocolVersionStartsFrom(
+            header.ledgerVersion,
+            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+    {
+        auto hotBl = mApp.getBucketManager().getHotArchiveBucketList();
+        has = HistoryArchiveState(header.ledgerSeq, bl, hotBl,
+                                  mApp.getConfig().NETWORK_PASSPHRASE);
+    }
+    else
+    {
+        has = HistoryArchiveState(header.ledgerSeq, bl,
+                                  mApp.getConfig().NETWORK_PASSPHRASE);
+    }
 
     mApp.getPersistentState().setState(PersistentState::kHistoryArchiveState,
                                        has.toString(), sess);

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -1235,9 +1235,15 @@ LedgerManagerImpl::applyLedger(LedgerCloseData const& ledgerData,
 
     // Step 1. Maybe queue the current checkpoint file for publishing; this
     // should not race with main, since publish on main begins strictly _after_
-    // this call.
+    // this call. There is a bug in the upgrade path where the initial
+    // ledgerVers is used in some places during ledgerClose, and the upgraded
+    // ledgerVers is used in other places (see comment in ledgerClosed).
+    // On the ledger when an upgrade occurs, the ledger header will contain the
+    // newly incremented ledgerVers. Because the history checkpoint must be
+    // consistent with the ledger header, we must base checkpoints off the new
+    // ledgerVers here and not the initial ledgerVers.
     auto& hm = mApp.getHistoryManager();
-    hm.maybeQueueHistoryCheckpoint(ledgerSeq);
+    hm.maybeQueueHistoryCheckpoint(ledgerSeq, maybeNewVersion);
 
     // step 2
     ltx.commit();

--- a/src/ledger/LedgerManagerImpl.cpp
+++ b/src/ledger/LedgerManagerImpl.cpp
@@ -831,14 +831,12 @@ LedgerManagerImpl::valueExternalized(LedgerCloseData const& ledgerData,
 }
 
 void
-LedgerManagerImpl::startCatchup(
-    CatchupConfiguration configuration, std::shared_ptr<HistoryArchive> archive,
-    std::set<std::shared_ptr<LiveBucket>> bucketsToRetain)
+LedgerManagerImpl::startCatchup(CatchupConfiguration configuration,
+                                std::shared_ptr<HistoryArchive> archive)
 {
     ZoneScoped;
     setState(LM_CATCHING_UP_STATE);
-    mApp.getLedgerApplyManager().startCatchup(configuration, archive,
-                                              bucketsToRetain);
+    mApp.getLedgerApplyManager().startCatchup(configuration, archive);
 }
 
 uint64_t
@@ -1929,7 +1927,7 @@ LedgerManagerImpl::storePersistentStateAndLedgerHeaderInDB(
     HistoryArchiveState has;
     if (protocolVersionStartsFrom(
             header.ledgerVersion,
-            BucketBase::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
+            LiveBucket::FIRST_PROTOCOL_SUPPORTING_PERSISTENT_EVICTION))
     {
         auto hotBl = mApp.getBucketManager().getHotArchiveBucketList();
         has = HistoryArchiveState(header.ledgerSeq, bl, hotBl,

--- a/src/ledger/LedgerManagerImpl.h
+++ b/src/ledger/LedgerManagerImpl.h
@@ -282,10 +282,8 @@ class LedgerManagerImpl : public LedgerManager
 
     Database& getDatabase() override;
 
-    void startCatchup(
-        CatchupConfiguration configuration,
-        std::shared_ptr<HistoryArchive> archive,
-        std::set<std::shared_ptr<LiveBucket>> bucketsToRetain) override;
+    void startCatchup(CatchupConfiguration configuration,
+                      std::shared_ptr<HistoryArchive> archive) override;
 
     void applyLedger(LedgerCloseData const& ledgerData,
                      bool calledViaExternalize) override;

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -490,7 +490,7 @@ dumpStateArchivalStatistics(Config cfg)
     std::vector<Hash> hashes;
     for (uint32_t i = 0; i < LiveBucketList::kNumLevels; ++i)
     {
-        HistoryStateBucket const& hsb = has.currentBuckets.at(i);
+        HistoryStateBucket<LiveBucket> const& hsb = has.currentBuckets.at(i);
         hashes.emplace_back(hexToBin256(hsb.curr));
         hashes.emplace_back(hexToBin256(hsb.snap));
     }

--- a/src/main/ApplicationUtils.cpp
+++ b/src/main/ApplicationUtils.cpp
@@ -950,7 +950,7 @@ catchup(Application::pointer app, CatchupConfiguration cc,
 
     try
     {
-        app->getLedgerManager().startCatchup(cc, archive, {});
+        app->getLedgerManager().startCatchup(cc, archive);
     }
     catch (std::invalid_argument const&)
     {

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-23-soroban.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-23-soroban.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "4f21924817cb8b1dfaaf48fbc2a73709c18a542b250fcd3ab3b9410c012a6d52",
+                "hash": "cb834ca4ae28c05d99f9ef7dff06b848882222f09bcb31cb0d18697d9701c8f8",
                 "header": {
                     "ledgerVersion": 23,
-                    "previousLedgerHash": "ee872847f3f34a75dabb6eef566b5d859de7840dec58e3b57d8f892c089a68f1",
+                    "previousLedgerHash": "5e2b9dfe59b580e6d9a340521979c9843792d408ad34be0d893308735cb5bea5",
                     "scpValue": {
-                        "txSetHash": "86d3e65c307af9e7b478479e6674ecccd9a0f3c3b30262ab2215280553c4ba5d",
+                        "txSetHash": "c8e5a99666ca14d4b8a56d7fd49d595061a53e22ecccf534f1b5130b7009c349",
                         "closeTime": 1451692801,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "400c9c3187a8b85a42759c86721942e149d86cec3709c0ca64874b3801a58bda6a568dab9e47af49300416ba4ad31ec9cea30aa6df6e89ea797b7f231fcaa306"
+                                "signature": "14be6f02d17d9a31519b01a7e0b6da414b44d388f2d48f1872837eae12cca99009c526513de8f576a41dc87ce58b227e24195ed5c4b8478efc663b4f31b3b008"
                             }
                         }
                     },
                     "txSetResultHash": "6e60d4ec375cfe4112e6aa083a44c2a59c7f87a10be6488375290b66b63971a7",
-                    "bucketListHash": "7e2dce6f08479912c08d87cc5f10c9ec17210232a28ff0d1870ed52055c32cc1",
+                    "bucketListHash": "cc39e6bc0918c16dc3f2681dfc31f9041a74615772a58579edeafe1d8a00f8cf",
                     "ledgerSeq": 31,
                     "totalCoins": 1000000000000000000,
                     "feePool": 1070731,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "ee872847f3f34a75dabb6eef566b5d859de7840dec58e3b57d8f892c089a68f1",
+                    "previousLedgerHash": "5e2b9dfe59b580e6d9a340521979c9843792d408ad34be0d893308735cb5bea5",
                     "phases": [
                         {
                             "v": 0,

--- a/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-23.json
+++ b/src/testdata/ledger-close-meta-enable-classic-events-v1-protocol-23.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "7192d5e089fc6a021e22880358737cb8af7b3a40efbfe62f1831d37ed1e17612",
+                "hash": "c0354d7274d376fe48aefe6260a1ca64b30e6cba433324f84757d23cf15b8997",
                 "header": {
                     "ledgerVersion": 23,
-                    "previousLedgerHash": "04557df4dda107c7324ca64be8df8d7ffaa0fb15336563da786b7d45c323497e",
+                    "previousLedgerHash": "0e6a10f0871d575e8ddaf72a5058368f701ed2064831fa9c90ac4967fe9c086d",
                     "scpValue": {
-                        "txSetHash": "75f223424a07316c4a3b6ad5ec78dac8c25c6dbb529538e9e8faa183e78106b4",
+                        "txSetHash": "610aaa609785490a3881ed87a1d4600a671e03bd904461b5657e36735852146e",
                         "closeTime": 1451692801,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "3a533a79d86995b38d1c6945e882d0e358d7a9e2367c7b8eb5b9148478a4f11ce695c4af2dfd20444d3e1be52cdff0841176704151a6f5965ea267b815cbd705"
+                                "signature": "028d19140339a7a3782aea0c2be965ea8ed1470f507951e9e39997b5621e10717966b81fc1b1479a960825e85979a6de5f82fc39d45eb08668894f8b2bc51909"
                             }
                         }
                     },
                     "txSetResultHash": "2faeae31b9d73430feb6398a535833e52b512c0822da128266d3327e43928625",
-                    "bucketListHash": "80cbee174fe132ada3c01da9453b09ba67ab027d03e3c5e34916522f62fb255d",
+                    "bucketListHash": "0b66aa1505a34adbed7489a5ce579a0ccc592e7381f04f1c972c406febbe17cf",
                     "ledgerSeq": 10,
                     "totalCoins": 1000000000000000000,
                     "feePool": 267011,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "04557df4dda107c7324ca64be8df8d7ffaa0fb15336563da786b7d45c323497e",
+                    "previousLedgerHash": "0e6a10f0871d575e8ddaf72a5058368f701ed2064831fa9c90ac4967fe9c086d",
                     "phases": [
                         {
                             "v": 0,

--- a/src/testdata/ledger-close-meta-v1-protocol-23-soroban.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-23-soroban.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "4f21924817cb8b1dfaaf48fbc2a73709c18a542b250fcd3ab3b9410c012a6d52",
+                "hash": "cb834ca4ae28c05d99f9ef7dff06b848882222f09bcb31cb0d18697d9701c8f8",
                 "header": {
                     "ledgerVersion": 23,
-                    "previousLedgerHash": "ee872847f3f34a75dabb6eef566b5d859de7840dec58e3b57d8f892c089a68f1",
+                    "previousLedgerHash": "5e2b9dfe59b580e6d9a340521979c9843792d408ad34be0d893308735cb5bea5",
                     "scpValue": {
-                        "txSetHash": "86d3e65c307af9e7b478479e6674ecccd9a0f3c3b30262ab2215280553c4ba5d",
+                        "txSetHash": "c8e5a99666ca14d4b8a56d7fd49d595061a53e22ecccf534f1b5130b7009c349",
                         "closeTime": 1451692801,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "400c9c3187a8b85a42759c86721942e149d86cec3709c0ca64874b3801a58bda6a568dab9e47af49300416ba4ad31ec9cea30aa6df6e89ea797b7f231fcaa306"
+                                "signature": "14be6f02d17d9a31519b01a7e0b6da414b44d388f2d48f1872837eae12cca99009c526513de8f576a41dc87ce58b227e24195ed5c4b8478efc663b4f31b3b008"
                             }
                         }
                     },
                     "txSetResultHash": "6e60d4ec375cfe4112e6aa083a44c2a59c7f87a10be6488375290b66b63971a7",
-                    "bucketListHash": "7e2dce6f08479912c08d87cc5f10c9ec17210232a28ff0d1870ed52055c32cc1",
+                    "bucketListHash": "cc39e6bc0918c16dc3f2681dfc31f9041a74615772a58579edeafe1d8a00f8cf",
                     "ledgerSeq": 31,
                     "totalCoins": 1000000000000000000,
                     "feePool": 1070731,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "ee872847f3f34a75dabb6eef566b5d859de7840dec58e3b57d8f892c089a68f1",
+                    "previousLedgerHash": "5e2b9dfe59b580e6d9a340521979c9843792d408ad34be0d893308735cb5bea5",
                     "phases": [
                         {
                             "v": 0,

--- a/src/testdata/ledger-close-meta-v1-protocol-23.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-23.json
@@ -996,6 +996,356 @@
                             "diagnosticEvents": []
                         }
                     }
+                },
+                {
+                    "result": {
+                        "transactionHash": "324d0628e2a215d367f181f0e3aacbaa26fa638e676e73fb9ad26a360314a7b7",
+                        "result": {
+                            "feeCharged": 300,
+                            "result": {
+                                "code": "txFEE_BUMP_INNER_SUCCESS",
+                                "innerResultPair": {
+                                    "transactionHash": "b28c171f9658320b5ce8d50e4e1a36b74afbb2a92eec7df92a8981067131b025",
+                                    "result": {
+                                        "feeCharged": 200,
+                                        "result": {
+                                            "code": "txSUCCESS",
+                                            "results": [
+                                                {
+                                                    "code": "opINNER",
+                                                    "tr": {
+                                                        "type": "PAYMENT",
+                                                        "paymentResult": {
+                                                            "code": "PAYMENT_SUCCESS"
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "code": "opINNER",
+                                                    "tr": {
+                                                        "type": "PAYMENT",
+                                                        "paymentResult": {
+                                                            "code": "PAYMENT_SUCCESS"
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            },
+                            "ext": {
+                                "v": 0
+                            }
+                        }
+                    },
+                    "feeProcessing": [
+                        {
+                            "type": "LEDGER_ENTRY_STATE",
+                            "state": {
+                                "lastModifiedLedgerSeq": 4,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 400000000,
+                                        "seqNum": 17179869184,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        },
+                        {
+                            "type": "LEDGER_ENTRY_UPDATED",
+                            "updated": {
+                                "lastModifiedLedgerSeq": 7,
+                                "data": {
+                                    "type": "ACCOUNT",
+                                    "account": {
+                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                        "balance": 399999700,
+                                        "seqNum": 17179869184,
+                                        "numSubEntries": 0,
+                                        "inflationDest": null,
+                                        "flags": 0,
+                                        "homeDomain": "",
+                                        "thresholds": "01000000",
+                                        "signers": [],
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                "ext": {
+                                    "v": 0
+                                }
+                            }
+                        }
+                    ],
+                    "txApplyProcessing": {
+                        "v": 3,
+                        "v3": {
+                            "ext": {
+                                "v": 0
+                            },
+                            "txChangesBefore": [
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 7,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399999700,
+                                                "seqNum": 17179869184,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 7,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
+                                                "balance": 399999700,
+                                                "seqNum": 17179869184,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_STATE",
+                                    "state": {
+                                        "lastModifiedLedgerSeq": 5,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
+                                                "balance": 200010000,
+                                                "seqNum": 21474836480,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "LEDGER_ENTRY_UPDATED",
+                                    "updated": {
+                                        "lastModifiedLedgerSeq": 7,
+                                        "data": {
+                                            "type": "ACCOUNT",
+                                            "account": {
+                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
+                                                "balance": 200010000,
+                                                "seqNum": 21474836481,
+                                                "numSubEntries": 0,
+                                                "inflationDest": null,
+                                                "flags": 0,
+                                                "homeDomain": "",
+                                                "thresholds": "01000000",
+                                                "signers": [],
+                                                "ext": {
+                                                    "v": 1,
+                                                    "v1": {
+                                                        "liabilities": {
+                                                            "buying": 0,
+                                                            "selling": 0
+                                                        },
+                                                        "ext": {
+                                                            "v": 2,
+                                                            "v2": {
+                                                                "numSponsored": 0,
+                                                                "numSponsoring": 0,
+                                                                "signerSponsoringIDs": [],
+                                                                "ext": {
+                                                                    "v": 3,
+                                                                    "v3": {
+                                                                        "ext": {
+                                                                            "v": 0
+                                                                        },
+                                                                        "seqLedger": 7,
+                                                                        "seqTime": 0
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "ext": {
+                                            "v": 0
+                                        }
+                                    }
+                                }
+                            ],
+                            "operations": [
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 6,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 0,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 7,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 50,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "changes": [
+                                        {
+                                            "type": "LEDGER_ENTRY_STATE",
+                                            "state": {
+                                                "lastModifiedLedgerSeq": 7,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 50,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "type": "LEDGER_ENTRY_UPDATED",
+                                            "updated": {
+                                                "lastModifiedLedgerSeq": 7,
+                                                "data": {
+                                                    "type": "TRUSTLINE",
+                                                    "trustLine": {
+                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
+                                                        "asset": {
+                                                            "assetCode": "CUR1",
+                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
+                                                        },
+                                                        "balance": 100,
+                                                        "limit": 100,
+                                                        "flags": 1,
+                                                        "ext": {
+                                                            "v": 0
+                                                        }
+                                                    }
+                                                },
+                                                "ext": {
+                                                    "v": 0
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "txChangesAfter": [],
+                            "sorobanMeta": null
+                        }
+                    }
                 }
             ],
             "upgradesProcessing": [],

--- a/src/testdata/ledger-close-meta-v1-protocol-23.json
+++ b/src/testdata/ledger-close-meta-v1-protocol-23.json
@@ -6,24 +6,24 @@
                 "v": 0
             },
             "ledgerHeader": {
-                "hash": "7192d5e089fc6a021e22880358737cb8af7b3a40efbfe62f1831d37ed1e17612",
+                "hash": "c0354d7274d376fe48aefe6260a1ca64b30e6cba433324f84757d23cf15b8997",
                 "header": {
                     "ledgerVersion": 23,
-                    "previousLedgerHash": "04557df4dda107c7324ca64be8df8d7ffaa0fb15336563da786b7d45c323497e",
+                    "previousLedgerHash": "0e6a10f0871d575e8ddaf72a5058368f701ed2064831fa9c90ac4967fe9c086d",
                     "scpValue": {
-                        "txSetHash": "75f223424a07316c4a3b6ad5ec78dac8c25c6dbb529538e9e8faa183e78106b4",
+                        "txSetHash": "610aaa609785490a3881ed87a1d4600a671e03bd904461b5657e36735852146e",
                         "closeTime": 1451692801,
                         "upgrades": [],
                         "ext": {
                             "v": "STELLAR_VALUE_SIGNED",
                             "lcValueSignature": {
                                 "nodeID": "GDDOUW25MRFLNXQMN3OODP6JQEXSGLMHAFZV4XPQ2D3GA4QFIDMEJG2O",
-                                "signature": "3a533a79d86995b38d1c6945e882d0e358d7a9e2367c7b8eb5b9148478a4f11ce695c4af2dfd20444d3e1be52cdff0841176704151a6f5965ea267b815cbd705"
+                                "signature": "028d19140339a7a3782aea0c2be965ea8ed1470f507951e9e39997b5621e10717966b81fc1b1479a960825e85979a6de5f82fc39d45eb08668894f8b2bc51909"
                             }
                         }
                     },
                     "txSetResultHash": "2faeae31b9d73430feb6398a535833e52b512c0822da128266d3327e43928625",
-                    "bucketListHash": "80cbee174fe132ada3c01da9453b09ba67ab027d03e3c5e34916522f62fb255d",
+                    "bucketListHash": "0b66aa1505a34adbed7489a5ce579a0ccc592e7381f04f1c972c406febbe17cf",
                     "ledgerSeq": 10,
                     "totalCoins": 1000000000000000000,
                     "feePool": 267011,
@@ -49,7 +49,7 @@
             "txSet": {
                 "v": 1,
                 "v1TxSet": {
-                    "previousLedgerHash": "04557df4dda107c7324ca64be8df8d7ffaa0fb15336563da786b7d45c323497e",
+                    "previousLedgerHash": "0e6a10f0871d575e8ddaf72a5058368f701ed2064831fa9c90ac4967fe9c086d",
                     "phases": [
                         {
                             "v": 0,
@@ -994,356 +994,6 @@
                             "sorobanMeta": null,
                             "events": [],
                             "diagnosticEvents": []
-                        }
-                    }
-                },
-                {
-                    "result": {
-                        "transactionHash": "324d0628e2a215d367f181f0e3aacbaa26fa638e676e73fb9ad26a360314a7b7",
-                        "result": {
-                            "feeCharged": 300,
-                            "result": {
-                                "code": "txFEE_BUMP_INNER_SUCCESS",
-                                "innerResultPair": {
-                                    "transactionHash": "b28c171f9658320b5ce8d50e4e1a36b74afbb2a92eec7df92a8981067131b025",
-                                    "result": {
-                                        "feeCharged": 200,
-                                        "result": {
-                                            "code": "txSUCCESS",
-                                            "results": [
-                                                {
-                                                    "code": "opINNER",
-                                                    "tr": {
-                                                        "type": "PAYMENT",
-                                                        "paymentResult": {
-                                                            "code": "PAYMENT_SUCCESS"
-                                                        }
-                                                    }
-                                                },
-                                                {
-                                                    "code": "opINNER",
-                                                    "tr": {
-                                                        "type": "PAYMENT",
-                                                        "paymentResult": {
-                                                            "code": "PAYMENT_SUCCESS"
-                                                        }
-                                                    }
-                                                }
-                                            ]
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            },
-                            "ext": {
-                                "v": 0
-                            }
-                        }
-                    },
-                    "feeProcessing": [
-                        {
-                            "type": "LEDGER_ENTRY_STATE",
-                            "state": {
-                                "lastModifiedLedgerSeq": 4,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 400000000,
-                                        "seqNum": 17179869184,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        },
-                        {
-                            "type": "LEDGER_ENTRY_UPDATED",
-                            "updated": {
-                                "lastModifiedLedgerSeq": 7,
-                                "data": {
-                                    "type": "ACCOUNT",
-                                    "account": {
-                                        "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                        "balance": 399999700,
-                                        "seqNum": 17179869184,
-                                        "numSubEntries": 0,
-                                        "inflationDest": null,
-                                        "flags": 0,
-                                        "homeDomain": "",
-                                        "thresholds": "01000000",
-                                        "signers": [],
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                "ext": {
-                                    "v": 0
-                                }
-                            }
-                        }
-                    ],
-                    "txApplyProcessing": {
-                        "v": 3,
-                        "v3": {
-                            "ext": {
-                                "v": 0
-                            },
-                            "txChangesBefore": [
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 7,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399999700,
-                                                "seqNum": 17179869184,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 7,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCAEBM3GKNR6SV6N73FSGBXU6NSMZ2URQVMJQHXFQFY2PJPX6YBCSAKZ",
-                                                "balance": 399999700,
-                                                "seqNum": 17179869184,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_STATE",
-                                    "state": {
-                                        "lastModifiedLedgerSeq": 5,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
-                                                "balance": 200010000,
-                                                "seqNum": 21474836480,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                },
-                                {
-                                    "type": "LEDGER_ENTRY_UPDATED",
-                                    "updated": {
-                                        "lastModifiedLedgerSeq": 7,
-                                        "data": {
-                                            "type": "ACCOUNT",
-                                            "account": {
-                                                "accountID": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q",
-                                                "balance": 200010000,
-                                                "seqNum": 21474836481,
-                                                "numSubEntries": 0,
-                                                "inflationDest": null,
-                                                "flags": 0,
-                                                "homeDomain": "",
-                                                "thresholds": "01000000",
-                                                "signers": [],
-                                                "ext": {
-                                                    "v": 1,
-                                                    "v1": {
-                                                        "liabilities": {
-                                                            "buying": 0,
-                                                            "selling": 0
-                                                        },
-                                                        "ext": {
-                                                            "v": 2,
-                                                            "v2": {
-                                                                "numSponsored": 0,
-                                                                "numSponsoring": 0,
-                                                                "signerSponsoringIDs": [],
-                                                                "ext": {
-                                                                    "v": 3,
-                                                                    "v3": {
-                                                                        "ext": {
-                                                                            "v": 0
-                                                                        },
-                                                                        "seqLedger": 7,
-                                                                        "seqTime": 0
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        "ext": {
-                                            "v": 0
-                                        }
-                                    }
-                                }
-                            ],
-                            "operations": [
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 6,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 0,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 7,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 50,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "changes": [
-                                        {
-                                            "type": "LEDGER_ENTRY_STATE",
-                                            "state": {
-                                                "lastModifiedLedgerSeq": 7,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 50,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "type": "LEDGER_ENTRY_UPDATED",
-                                            "updated": {
-                                                "lastModifiedLedgerSeq": 7,
-                                                "data": {
-                                                    "type": "TRUSTLINE",
-                                                    "trustLine": {
-                                                        "accountID": "GB6MXQ5262ZJGDQNA6BL4TWE5SADVZXIKLPELFXKUE27X4SQTGQS44ZB",
-                                                        "asset": {
-                                                            "assetCode": "CUR1",
-                                                            "issuer": "GCGE27HU2VYQANKL2VZWLCAOJYMEFST5DXPBWQ7BRRPOHUPK626DNG4Q"
-                                                        },
-                                                        "balance": 100,
-                                                        "limit": 100,
-                                                        "flags": 1,
-                                                        "ext": {
-                                                            "v": 0
-                                                        }
-                                                    }
-                                                },
-                                                "ext": {
-                                                    "v": 0
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "txChangesAfter": [],
-                            "sorobanMeta": null
                         }
                     }
                 }


### PR DESCRIPTION
# Description

Resolves #4593

This adds support for the Hot Archive BucketList in History Archives. This includes changes to publish, catchup, and assume state. 

~TODO: More robust p23 upgrade testing, specifically around upgrades that occur on or during checkpoint boundaries.~

Upgrade tests have been added, so unit tests should have complete coverage now.

# Checklist
- [x] Reviewed the [contributing](https://github.com/stellar/stellar-core/blob/master/CONTRIBUTING.md#submitting-changes) document
- [x] Rebased on top of master (no merge commits)
- [x] Ran `clang-format` v8.0.0 (via `make format` or the Visual Studio extension)
- [x] Compiles
- [x] Ran all tests
- [ ] If change impacts performance, include supporting evidence per the [performance document](https://github.com/stellar/stellar-core/blob/master/performance-eval/performance-eval.md)
